### PR TITLE
Add EOM receivables ledger and payment API

### DIFF
--- a/.github/workflows/atlas_invoicing_checks.yml
+++ b/.github/workflows/atlas_invoicing_checks.yml
@@ -15,11 +15,18 @@ on:
       - "atlas_brain/mcp/invoicing_readonly_oauth.py"
       - "atlas_brain/mcp/invoicing_draft_writer_oauth.py"
       - "atlas_brain/mcp/auth.py"
+      - "atlas_brain/api/invoicing/**"
+      - "atlas_brain/config.py"
       - "atlas_brain/config_defaults.py"
       - "atlas_brain/services/__init__.py"
+      - "atlas_brain/services/receivables.py"
+      - "atlas_brain/storage/migrations/344_receivables_payments.sql"
+      - "atlas_brain/storage/migrations/345_receivables_event_key_lookup.sql"
       - "atlas_brain/storage/repositories/invoice.py"
       - "atlas_brain/templates/email/__init__.py"
       - "tests/test_monthly_invoice_generation.py"
+      - "tests/test_invoice_repository.py"
+      - "tests/test_receivables.py"
       - "tests/test_invoicing_readonly_mcp.py"
       - "tests/test_invoicing_readonly_oauth.py"
       - "tests/test_invoicing_draft_writer_mcp.py"
@@ -37,11 +44,18 @@ on:
       - "atlas_brain/mcp/invoicing_readonly_oauth.py"
       - "atlas_brain/mcp/invoicing_draft_writer_oauth.py"
       - "atlas_brain/mcp/auth.py"
+      - "atlas_brain/api/invoicing/**"
+      - "atlas_brain/config.py"
       - "atlas_brain/config_defaults.py"
       - "atlas_brain/services/__init__.py"
+      - "atlas_brain/services/receivables.py"
+      - "atlas_brain/storage/migrations/344_receivables_payments.sql"
+      - "atlas_brain/storage/migrations/345_receivables_event_key_lookup.sql"
       - "atlas_brain/storage/repositories/invoice.py"
       - "atlas_brain/templates/email/__init__.py"
       - "tests/test_monthly_invoice_generation.py"
+      - "tests/test_invoice_repository.py"
+      - "tests/test_receivables.py"
       - "tests/test_invoicing_readonly_mcp.py"
       - "tests/test_invoicing_readonly_oauth.py"
       - "tests/test_invoicing_draft_writer_mcp.py"
@@ -50,6 +64,22 @@ on:
 jobs:
   atlas-invoicing-checks:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: atlas_receivables_test
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_USER: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d atlas_receivables_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      ATLAS_RECEIVABLES_TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/atlas_receivables_test
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -71,6 +101,13 @@ jobs:
           python -m pytest \
             tests/test_monthly_invoice_generation.py \
             -k "update_invoice_clears_needs_hours_when_line_items_are_billable or line_items_are_billable_requires_all_positive_quantities" \
+            -q
+
+      - name: Run receivables ledger and repository tests
+        run: |
+          python -m pytest \
+            tests/test_receivables.py \
+            tests/test_invoice_repository.py \
             -q
 
       - name: Run invoicing MCP + OAuth surface tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ accepted plan docs, and explicit operator decisions choose what to build next.
 | **B2B Churn Intelligence** | `atlas-churn-ui`, `atlas-intel-ui`, MCP `b2b_churn_server` (83 tools), 19 review sources, displacement graph, weekly reports, calibration loop, webhooks | **Shipped** — Intelligence Platform Roadmap phases 0–7 complete |
 | **Consumer Intelligence** | MCP `intelligence_server` (33 tools), brand registry, displacement edges, market reports, PDF export | **Shipped** — Consumer Roadmap phases 0–6+ complete |
 | **Content Ops Pipeline** | `extracted_content_pipeline/` (~77 KLOC), blog post + B2B campaign + landing page + report + sales-brief generation, signal extraction, generated-asset review API | **Active iteration** — 39 of 65 open plans; signal extraction + scope wiring + landing-page wired; 4 more generators pending LLM/repo factories |
-| **Communications + CRM + Calendar + Invoicing** | MCP servers (CRM 10, Email 9, Twilio 10, Calendar 8, Invoicing 18), Postgres `contacts`/`appointments`, Gmail/IMAP/Resend, Google Calendar/CalDAV, NocoDB admin UI | **Shipped** |
+| **Communications + CRM + Calendar + Invoicing** | MCP servers (CRM 10, Email 9, Twilio 10, Calendar 8, Invoicing 19), Postgres `contacts`/`appointments`, Gmail/IMAP/Resend, Google Calendar/CalDAV, NocoDB admin UI | **Shipped** |
 | **Knowledge graph memory** | MCP `memory_server` (15 tools), Postgres short-term + Neo4j/Graphiti long-term via `graphiti-wrapper` (port 8001) | **Shipped** |
 | **Universal scraper** | MCP `scraper_server` (5 tools), LLM-driven schema extraction, Playwright JS rendering | **Shipped** |
 | **Voice + Home Automation** | `atlas_brain/voice/`, ASR (Nemotron 0.6B, port 8081), wake-word + VAD + capture, Home Assistant + MQTT capability registry, intent dispatch | **Built but not yet routed through agent** — historical voice-to-voice context remains in `BUILD_SPEC.md`, but current work is governed by active issues/plans and `docs/CURRENT_PRODUCT_DISCIPLINE.md` |
@@ -240,7 +240,7 @@ atlas_brain/
 | Email                   | 8057 | 9     | `atlas_brain.mcp.email_server`        |
 | Twilio                  | 8058 | 10    | `atlas_brain.mcp.twilio_server`       |
 | Calendar                | 8059 | 8     | `atlas_brain.mcp.calendar_server`     |
-| Invoicing               | 8060 | 18    | `atlas_brain.mcp.invoicing_server`    |
+| Invoicing               | 8060 | 19    | `atlas_brain.mcp.invoicing_server`    |
 | Invoicing Readonly      | 8065 | 8     | `atlas_brain.mcp.invoicing_readonly_server` |
 | Content Ops Deflection Readonly | 8067 | 3 | `atlas_brain.mcp.content_ops_deflection_readonly_server` |
 | Content Ops Marketer Verify | 8068 | 1 | `atlas_brain.mcp.content_ops_marketer_verify_server` |
@@ -510,20 +510,28 @@ ATLAS_TOOLS_CALDAV_CALENDAR_URL=   # optional; auto-discovered via PROPFIND if b
 ATLAS_MCP_CALENDAR_PORT=8059  # Calendar MCP server (SSE mode only)
 ```
 
-### Invoicing MCP Server (18 tools)
+### Invoicing MCP Server (19 tools)
 ```bash
 # stdio mode (Claude Desktop / Cursor)
 python -m atlas_brain.mcp.invoicing_server
 
-# SSE HTTP mode (port 8060)
-python -m atlas_brain.mcp.invoicing_server --sse
+# SSE HTTP mode (port 8060; bearer token is mandatory)
+ATLAS_MCP_AUTH_TOKEN=<long-random-token> python -m atlas_brain.mcp.invoicing_server --sse
 ```
 
 Tools: `create_invoice`, `get_invoice`, `list_invoices`, `update_invoice`,
-`send_invoice`, `record_payment`, `mark_void`, `customer_balance`,
+`send_invoice`, `record_customer_payment`, `record_payment`, `mark_void`, `customer_balance`,
 `payment_history`, `create_service`, `list_services`, `get_service`,
 `update_service`, `set_service_status`, `search_invoices`,
 `list_pending_drafts`, `approve_and_send`, `export_invoice_pdf`
+
+The EOM admin portal uses the separate FastAPI receivables surface, not MCP.
+Enable it only with a dedicated service token:
+
+```bash
+ATLAS_INVOICING_RECEIVABLES_API_ENABLED=true
+ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN=<long-random-service-token>
+```
 
 ### Invoicing Readonly MCP Server (8 tools)
 ```bash

--- a/atlas_brain/api/invoicing/__init__.py
+++ b/atlas_brain/api/invoicing/__init__.py
@@ -1,5 +1,13 @@
 """Invoicing API endpoints."""
 
-from .actions import router
+from fastapi import APIRouter
+
+from .actions import retired_router, router as actions_router
+from .receivables import router as receivables_router
+
+router = APIRouter()
+router.include_router(retired_router)
+router.include_router(actions_router)
+router.include_router(receivables_router)
 
 __all__ = ["router"]

--- a/atlas_brain/api/invoicing/actions.py
+++ b/atlas_brain/api/invoicing/actions.py
@@ -5,18 +5,29 @@ Provides endpoints triggered by ntfy action buttons:
 - GET  /{invoice_id}              -- view invoice details
 - POST /{invoice_id}/send         -- send invoice via email
 - POST /{invoice_id}/send-reminder -- send payment reminder
-- POST /{invoice_id}/mark-paid    -- quick-pay: record full amount
+- POST /{invoice_id}/mark-paid    -- retired quick-pay (always 410)
 """
 
 import logging
 from datetime import datetime, timezone
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
+
+from .auth import require_receivables_api
 
 logger = logging.getLogger("atlas.api.invoicing")
 
-router = APIRouter(prefix="/invoicing", tags=["invoicing"])
+retired_router = APIRouter(
+    prefix="/invoicing",
+    tags=["invoicing"],
+)
+
+router = APIRouter(
+    prefix="/invoicing",
+    tags=["invoicing"],
+    dependencies=[Depends(require_receivables_api)],
+)
 
 
 async def _load_invoice(invoice_id: str) -> dict:
@@ -189,47 +200,13 @@ async def send_reminder(invoice_id: str):
 # POST /invoicing/{invoice_id}/mark-paid  -- Quick Pay
 # ---------------------------------------------------------------------------
 
-@router.post("/{invoice_id}/mark-paid")
+@retired_router.post("/{invoice_id}/mark-paid")
 async def mark_paid(invoice_id: str):
-    """Quick-pay: record full remaining amount as paid."""
-    from ...storage.repositories.invoice import get_invoice_repo
-
-    inv = await _load_invoice(invoice_id)
-    repo = get_invoice_repo()
-
-    if inv["status"] in ("paid", "void"):
-        raise HTTPException(400, f"Invoice already {inv['status']}")
-
-    amount_due = float(inv["amount_due"])
-    if amount_due <= 0:
-        raise HTTPException(400, "No amount due")
-
-    # Record payment for the full remaining amount
-    payment = await repo.record_payment(
-        invoice_id=inv["id"],
-        amount=amount_due,
-        payment_method="other",
-        notes="Quick-pay via ntfy action",
+    """Retired unsafe quick-pay endpoint."""
+    raise HTTPException(
+        status_code=410,
+        detail=(
+            "Quick-pay was retired. Record a receipt with explicit customer, "
+            "method, date, and confirmed invoice allocations."
+        ),
     )
-
-    # CRM log
-    contact_id = inv.get("contact_id")
-    if contact_id:
-        try:
-            from ...services.crm_provider import get_crm_provider
-            crm = get_crm_provider()
-            await crm.log_interaction(
-                contact_id=str(contact_id),
-                interaction_type="invoice",
-                summary=f"Payment ${amount_due:.2f} on {inv['invoice_number']} (quick-pay)",
-            )
-        except Exception as e:
-            logger.warning("CRM log failed: %s", e)
-
-    logger.info("Invoice %s marked paid ($%.2f)", inv["invoice_number"], amount_due)
-    return {
-        "action": "mark_paid",
-        "invoice_number": inv["invoice_number"],
-        "amount_paid": amount_due,
-        "status": "paid",
-    }

--- a/atlas_brain/api/invoicing/auth.py
+++ b/atlas_brain/api/invoicing/auth.py
@@ -1,0 +1,73 @@
+"""Dedicated fail-closed authentication for invoicing and receivables routes."""
+
+from __future__ import annotations
+
+import hmac
+
+from fastapi import Depends, Header, HTTPException
+
+from ...config import InvoicingConfig, settings
+
+_MIN_TOKEN_LENGTH = 24
+_PLACEHOLDER_TOKENS = {
+    "<token>",
+    "change-me",
+    "changeme",
+    "password",
+    "secret",
+    "test-token",
+    "token",
+}
+
+
+def validate_receivables_api_config(
+    config: InvoicingConfig | None = None,
+) -> None:
+    """Fail startup when an enabled finance API has an unsafe token."""
+    resolved = config or settings.invoicing
+    if not resolved.receivables_api_enabled:
+        return
+    token = resolved.receivables_service_token.strip()
+    if not token:
+        raise RuntimeError(
+            "ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN is required when "
+            "ATLAS_INVOICING_RECEIVABLES_API_ENABLED=true"
+        )
+    if token.lower() in _PLACEHOLDER_TOKENS:
+        raise RuntimeError("Receivables service token must not be a placeholder")
+    if len(token) < _MIN_TOKEN_LENGTH:
+        raise RuntimeError(
+            f"Receivables service token must be at least {_MIN_TOKEN_LENGTH} characters"
+        )
+
+
+def get_receivables_api_config() -> InvoicingConfig:
+    """Return the runtime config through an overrideable request boundary."""
+    return settings.invoicing
+
+
+async def require_receivables_api(
+    authorization: str = Header(default="", alias="Authorization"),
+    config: InvoicingConfig = Depends(get_receivables_api_config),
+) -> None:
+    """Require the configured bearer token; disabled is unavailable, not open."""
+    if not config.receivables_api_enabled:
+        raise HTTPException(status_code=503, detail="Receivables API is disabled")
+    validate_receivables_api_config(config)
+    scheme, separator, provided = authorization.partition(" ")
+    expected = config.receivables_service_token.strip()
+    if separator != " " or scheme.lower() != "bearer" or not provided.strip():
+        raise HTTPException(status_code=401, detail="Bearer token required")
+    if not hmac.compare_digest(provided.strip(), expected):
+        raise HTTPException(status_code=401, detail="Invalid bearer token")
+
+
+def require_actor(
+    x_eom_actor: str = Header(default="", alias="X-EOM-Actor"),
+) -> str:
+    actor = x_eom_actor.strip()
+    if not actor:
+        raise HTTPException(status_code=422, detail="X-EOM-Actor is required")
+    if len(actor) > 128:
+        raise HTTPException(status_code=422, detail="X-EOM-Actor is too long")
+    return actor

--- a/atlas_brain/api/invoicing/receivables.py
+++ b/atlas_brain/api/invoicing/receivables.py
@@ -1,0 +1,341 @@
+"""Strict service-to-service HTTP surface for the EOM receivables portal."""
+
+from __future__ import annotations
+
+import errno
+import socket
+from datetime import date
+from decimal import Decimal
+from typing import Annotated, Literal, Optional
+from uuid import UUID
+
+import asyncpg
+from fastapi import APIRouter, Depends, Header, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from ...services.receivables import (
+    ReceivablesConflictError,
+    ReceivablesError,
+    ReceivablesNotFoundError,
+    ReceivablesService,
+    ReceivablesValidationError,
+    get_receivables_service,
+)
+from ...storage.exceptions import DatabaseUnavailableError
+from .auth import require_actor, require_receivables_api
+
+_DATABASE_UNAVAILABLE_ERRORS = (
+    DatabaseUnavailableError,
+    asyncpg.PostgresConnectionError,
+    asyncpg.CannotConnectNowError,
+    asyncpg.TooManyConnectionsError,
+    asyncpg.AdminShutdownError,
+    asyncpg.CrashShutdownError,
+)
+_UNAVAILABLE_INTERFACE_PREFIXES = (
+    "connection is closed",
+    "pool is closed",
+    "pool is closing",
+    "pool is not initialized",
+    "pool is being initialized, but not yet ready",
+)
+_UNAVAILABLE_INTERFACE_SUFFIXES = (
+    ": the underlying connection is closed",
+)
+_NETWORK_UNAVAILABLE_ERRNOS = frozenset(
+    {
+        errno.ECONNABORTED,
+        errno.ECONNREFUSED,
+        errno.ECONNRESET,
+        errno.EHOSTDOWN,
+        errno.EHOSTUNREACH,
+        errno.ENETDOWN,
+        errno.ENETRESET,
+        errno.ENETUNREACH,
+        errno.ENOTCONN,
+        errno.EPIPE,
+        errno.ETIMEDOUT,
+    }
+)
+
+router = APIRouter(
+    prefix="/receivables",
+    tags=["receivables"],
+    dependencies=[Depends(require_receivables_api)],
+)
+
+PositiveCents = Annotated[int, Field(strict=True, gt=0)]
+
+
+class AllocationRequest(BaseModel):
+    invoice_id: UUID
+    amount_cents: PositiveCents
+
+
+class CreatePaymentRequest(BaseModel):
+    contact_id: UUID
+    payer_name: str = Field(min_length=1, max_length=256)
+    total_amount_cents: PositiveCents
+    payment_method: Literal["check", "ach", "square"]
+    received_date: date
+    reference: Optional[str] = Field(default=None, max_length=256)
+    notes: Optional[str] = None
+    allocations: list[AllocationRequest] = Field(min_length=1, max_length=100)
+
+
+class AdjustAllocationsRequest(BaseModel):
+    allocations: list[AllocationRequest] = Field(min_length=1, max_length=100)
+    reason: str = Field(min_length=1, max_length=1000)
+
+
+class PaymentActionRequest(BaseModel):
+    reason: str = Field(min_length=1, max_length=1000)
+
+
+class CreateDepositBatchRequest(BaseModel):
+    payment_ids: list[UUID] = Field(min_length=1, max_length=500)
+    deposit_date: date
+    bank_reference: Optional[str] = Field(default=None, max_length=256)
+
+
+def _dollars(amount_cents: int) -> Decimal:
+    return Decimal(amount_cents) / Decimal(100)
+
+
+def _allocations(items: list[AllocationRequest]) -> list[dict]:
+    return [
+        {"invoice_id": item.invoice_id, "amount": _dollars(item.amount_cents)}
+        for item in items
+    ]
+
+
+def _is_database_unavailable_error(exc: Exception) -> bool:
+    if isinstance(exc, _DATABASE_UNAVAILABLE_ERRORS):
+        return True
+    if isinstance(exc, asyncpg.InterfaceError):
+        message = str(exc).casefold()
+        return (
+            any(
+                message.startswith(prefix)
+                for prefix in _UNAVAILABLE_INTERFACE_PREFIXES
+            )
+            or any(
+                message.endswith(suffix)
+                for suffix in _UNAVAILABLE_INTERFACE_SUFFIXES
+            )
+        )
+    if isinstance(exc, (ConnectionError, TimeoutError, socket.gaierror)):
+        return True
+    return isinstance(exc, OSError) and exc.errno in _NETWORK_UNAVAILABLE_ERRNOS
+
+
+async def _call(awaitable):
+    try:
+        return await awaitable
+    except ReceivablesValidationError as exc:
+        raise HTTPException(
+            status_code=422, detail={"code": exc.code, "message": str(exc)}
+        ) from exc
+    except ReceivablesNotFoundError as exc:
+        raise HTTPException(
+            status_code=404, detail={"code": exc.code, "message": str(exc)}
+        ) from exc
+    except ReceivablesConflictError as exc:
+        raise HTTPException(
+            status_code=409, detail={"code": exc.code, "message": str(exc)}
+        ) from exc
+    except ReceivablesError as exc:
+        raise HTTPException(
+            status_code=400, detail={"code": exc.code, "message": str(exc)}
+        ) from exc
+    except Exception as exc:
+        if not _is_database_unavailable_error(exc):
+            raise
+        message = (
+            str(exc)
+            if isinstance(exc, DatabaseUnavailableError)
+            else "Receivables database unavailable"
+        )
+        raise HTTPException(
+            status_code=503,
+            detail={"code": "database_unavailable", "message": message},
+        ) from exc
+
+
+@router.get("/ready")
+async def ready() -> dict:
+    service = get_receivables_service()
+    try:
+        schema_ready = await service.is_ready()
+    except Exception as exc:
+        raise HTTPException(
+            status_code=503, detail="Receivables database unavailable"
+        ) from exc
+    if not schema_ready:
+        raise HTTPException(status_code=503, detail="Receivables schema unavailable")
+    return {"status": "ready"}
+
+
+@router.get("/open-invoices")
+async def list_open_invoices(
+    contact_id: Optional[UUID] = None,
+    search: Optional[str] = Query(default=None, max_length=256),
+) -> list[dict]:
+    return await _call(
+        get_receivables_service().list_open_invoices(
+            contact_id=contact_id, search=search
+        )
+    )
+
+
+@router.get("/allocation-suggestions")
+async def allocation_suggestions(
+    contact_id: UUID,
+    total_amount_cents: int = Query(gt=0),
+) -> list[dict]:
+    return await _call(
+        get_receivables_service().suggest_allocations(
+            contact_id=contact_id,
+            total_amount=_dollars(total_amount_cents),
+        )
+    )
+
+
+@router.post("/payments", status_code=201)
+async def create_payment(
+    body: CreatePaymentRequest,
+    actor: Annotated[str, Depends(require_actor)],
+    idempotency_key: Annotated[
+        str, Header(alias="Idempotency-Key", min_length=1, max_length=128)
+    ],
+    service: ReceivablesService = Depends(get_receivables_service),
+) -> dict:
+    return await _call(
+        service.create_payment(
+            contact_id=body.contact_id,
+            payer_name=body.payer_name,
+            total_amount=_dollars(body.total_amount_cents),
+            payment_method=body.payment_method,
+            received_date=body.received_date,
+            reference=body.reference,
+            notes=body.notes,
+            allocations=_allocations(body.allocations),
+            recorded_by=actor,
+            idempotency_key=idempotency_key,
+        )
+    )
+
+
+@router.get("/payments")
+async def list_payments(
+    status: Optional[str] = Query(default=None, max_length=16),
+    search: Optional[str] = Query(default=None, max_length=256),
+    limit: int = Query(default=100, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+) -> list[dict]:
+    return await _call(
+        get_receivables_service().list_payments(
+            status=status, search=search, limit=limit, offset=offset
+        )
+    )
+
+
+@router.put("/payments/{payment_id}/allocations")
+async def adjust_allocations(
+    payment_id: UUID,
+    body: AdjustAllocationsRequest,
+    actor: Annotated[str, Depends(require_actor)],
+    idempotency_key: Annotated[
+        str, Header(alias="Idempotency-Key", min_length=1, max_length=128)
+    ],
+) -> dict:
+    return await _call(
+        get_receivables_service().adjust_allocations(
+            payment_id=payment_id,
+            allocations=_allocations(body.allocations),
+            reason=body.reason,
+            actor=actor,
+            idempotency_key=idempotency_key,
+        )
+    )
+
+
+@router.post("/payments/{payment_id}/return")
+async def return_payment(
+    payment_id: UUID,
+    body: PaymentActionRequest,
+    actor: Annotated[str, Depends(require_actor)],
+    idempotency_key: Annotated[
+        str, Header(alias="Idempotency-Key", min_length=1, max_length=128)
+    ],
+) -> dict:
+    return await _call(
+        get_receivables_service().return_payment(
+            payment_id=payment_id,
+            reason=body.reason,
+            actor=actor,
+            idempotency_key=idempotency_key,
+        )
+    )
+
+
+@router.post("/payments/{payment_id}/void")
+async def void_payment(
+    payment_id: UUID,
+    body: PaymentActionRequest,
+    actor: Annotated[str, Depends(require_actor)],
+    idempotency_key: Annotated[
+        str, Header(alias="Idempotency-Key", min_length=1, max_length=128)
+    ],
+) -> dict:
+    return await _call(
+        get_receivables_service().void_payment(
+            payment_id=payment_id,
+            reason=body.reason,
+            actor=actor,
+            idempotency_key=idempotency_key,
+        )
+    )
+
+
+@router.get("/deposit-batches")
+async def list_deposit_batches(
+    limit: int = Query(default=100, ge=1, le=500),
+) -> list[dict]:
+    return await _call(get_receivables_service().list_deposit_batches(limit=limit))
+
+
+@router.post("/deposit-batches", status_code=201)
+async def create_deposit_batch(
+    body: CreateDepositBatchRequest,
+    actor: Annotated[str, Depends(require_actor)],
+    idempotency_key: Annotated[
+        str, Header(alias="Idempotency-Key", min_length=1, max_length=128)
+    ],
+) -> dict:
+    return await _call(
+        get_receivables_service().create_deposit_batch(
+            payment_ids=body.payment_ids,
+            deposit_date=body.deposit_date,
+            bank_reference=body.bank_reference,
+            actor=actor,
+            idempotency_key=idempotency_key,
+        )
+    )
+
+
+@router.post("/deposit-batches/{batch_id}/clear")
+async def clear_deposit_batch(
+    batch_id: UUID,
+    actor: Annotated[str, Depends(require_actor)],
+    idempotency_key: Annotated[
+        str, Header(alias="Idempotency-Key", min_length=1, max_length=128)
+    ],
+) -> dict:
+    return await _call(
+        get_receivables_service().clear_deposit_batch(
+            batch_id=batch_id,
+            actor=actor,
+            idempotency_key=idempotency_key,
+        )
+    )

--- a/atlas_brain/config.py
+++ b/atlas_brain/config.py
@@ -2238,6 +2238,14 @@ class InvoicingConfig(BaseSettings):
         env_prefix="ATLAS_INVOICING_", env_file=ENV_FILES, extra="ignore"
     )
     enabled: bool = Field(default=False, description="Enable invoicing system")
+    receivables_api_enabled: bool = Field(
+        default=False,
+        description="Enable the authenticated EOM receivables service API",
+    )
+    receivables_service_token: str = Field(
+        default="",
+        description="Bearer token accepted by the EOM receivables service API",
+    )
     default_payment_terms_days: int = Field(default=30, ge=1, le=365, description="Default days until due")
     default_tax_rate: float = Field(default=0.0, ge=0.0, le=1.0, description="Default tax rate (0.0-1.0)")
     reminders_enabled: bool = Field(default=True, description="Master toggle for the payment-reminder cron task")

--- a/atlas_brain/main.py
+++ b/atlas_brain/main.py
@@ -287,6 +287,9 @@ async def lifespan(app: FastAPI):
     # --- Startup ---
     logger.info("Atlas Brain starting up...")
     _enforce_paid_funnel_alert_channel(settings)
+    from .api.invoicing.auth import validate_receivables_api_config
+
+    validate_receivables_api_config(settings.invoicing)
 
     # Initialize database connection pool
     if db_settings.enabled:

--- a/atlas_brain/mcp/invoicing_server.py
+++ b/atlas_brain/mcp/invoicing_server.py
@@ -12,6 +12,7 @@ Tools:
     send_invoice        -- mark sent; optionally send via email
     approve_and_send    -- batch approve drafts: generate PDF, email, mark sent
     export_invoice_pdf  -- generate PDF for an invoice and save to disk
+    record_customer_payment -- record one receipt across several invoices
     record_payment      -- record manual payment, auto-update status
     mark_void           -- void/cancel an invoice with reason
     customer_balance    -- outstanding balance by contact_id/phone/email
@@ -31,9 +32,11 @@ import sys
 import uuid as _uuid
 from contextlib import asynccontextmanager
 from datetime import date, datetime, timedelta, timezone
-from typing import Optional
+from decimal import Decimal
+from typing import Annotated, Any, Literal, Optional
 
 from mcp.server.fastmcp import FastMCP
+from pydantic import BaseModel, Field
 
 logger = logging.getLogger("atlas.mcp.invoicing")
 
@@ -44,16 +47,71 @@ _BLOCKER_NEEDS_HOURS = "needs_hours"
 _BLOCKER_NO_EMAIL = "no_email"
 _WARNING_SUBTOTAL_ZERO = "subtotal_zero"
 _WARNING_NO_CONTACT = "no_contact_id"
+_MIN_HTTP_AUTH_TOKEN_LENGTH = 24
+_PLACEHOLDER_HTTP_AUTH_TOKENS = {
+    "<token>",
+    "change-me",
+    "changeme",
+    "password",
+    "secret",
+    "test-token",
+    "token",
+}
+
+
+PositiveCents = Annotated[int, Field(strict=True, gt=0)]
+
+
+class CustomerPaymentAllocation(BaseModel):
+    """Integer-cent allocation accepted by the multi-invoice payment tool."""
+
+    invoice_id: str = Field(min_length=1)
+    amount_cents: PositiveCents
+
+
+@asynccontextmanager
+async def _database_lifespan(
+    *,
+    init_database_fn,
+    get_db_pool_fn,
+    run_migrations_fn,
+    receivables_ready_fn,
+    close_database_fn,
+):
+    """Prepare the standalone finance writer before exposing any tools."""
+    try:
+        await init_database_fn()
+        pool = get_db_pool_fn()
+        if not pool.is_initialized:
+            raise RuntimeError("Invoicing MCP requires an initialized database pool")
+        await run_migrations_fn(pool)
+        if not await receivables_ready_fn(pool):
+            raise RuntimeError(
+                "Invoicing MCP requires a complete receivables schema"
+            )
+        logger.info(
+            "Invoicing MCP: DB pool initialized, migrated, and schema-ready"
+        )
+        yield
+    finally:
+        await close_database_fn()
 
 
 @asynccontextmanager
 async def _lifespan(server):
-    """Initialize DB pool on startup, close on shutdown."""
-    from ..storage.database import init_database, close_database
-    await init_database()
-    logger.info("Invoicing MCP: DB pool initialized")
-    yield
-    await close_database()
+    """Initialize and migrate the DB before serving, then close on shutdown."""
+    from ..services.receivables import ReceivablesService
+    from ..storage.database import close_database, get_db_pool, init_database
+    from ..storage.migrations import run_migrations
+
+    async with _database_lifespan(
+        init_database_fn=init_database,
+        get_db_pool_fn=get_db_pool,
+        run_migrations_fn=run_migrations,
+        receivables_ready_fn=lambda pool: ReceivablesService(pool).is_ready(),
+        close_database_fn=close_database,
+    ):
+        yield
 
 
 mcp = FastMCP(
@@ -84,6 +142,32 @@ def _is_uuid(value: str) -> bool:
         return True
     except (ValueError, AttributeError):
         return False
+
+
+def _authenticated_streamable_http_app(token: str, app_factory: Any):
+    """Validate HTTP auth before constructing the write-capable MCP app."""
+    from .auth import BearerAuthMiddleware
+
+    token = token.strip()
+    if not token:
+        raise RuntimeError("ATLAS_MCP_AUTH_TOKEN is required for invoicing HTTP")
+    if token.lower() in _PLACEHOLDER_HTTP_AUTH_TOKENS:
+        raise RuntimeError("ATLAS_MCP_AUTH_TOKEN must not be a placeholder")
+    if len(token) < _MIN_HTTP_AUTH_TOKEN_LENGTH:
+        raise RuntimeError(
+            f"ATLAS_MCP_AUTH_TOKEN must be at least {_MIN_HTTP_AUTH_TOKEN_LENGTH} characters"
+        )
+    return BearerAuthMiddleware(app_factory(), token=token)
+
+
+def _streamable_http_app():
+    """Build the full write-capable HTTP surface with mandatory bearer auth."""
+    from ..config import settings
+
+    return _authenticated_streamable_http_app(
+        settings.mcp.auth_token,
+        mcp.streamable_http_app,
+    )
 
 
 async def _resolve_contact_id(
@@ -408,24 +492,130 @@ async def send_invoice(
 # Tool: record_payment
 # ---------------------------------------------------------------------------
 
+
+async def _record_customer_payment_with_service(
+    *,
+    service: Any,
+    contact_id: str,
+    payer_name: str,
+    total_amount_cents: int,
+    payment_method: str,
+    allocations: list[CustomerPaymentAllocation],
+    idempotency_key: str,
+    reference: Optional[str] = None,
+    notes: Optional[str] = None,
+    payment_date: Optional[str] = None,
+) -> str:
+    try:
+        if (
+            isinstance(total_amount_cents, bool)
+            or not isinstance(total_amount_cents, int)
+            or total_amount_cents <= 0
+        ):
+            raise ValueError("total_amount_cents must be a positive integer")
+        normalized_payer = payer_name.strip()
+        if not normalized_payer or len(normalized_payer) > 256:
+            raise ValueError("payer_name must contain 1 to 256 characters")
+        normalized_key = idempotency_key.strip()
+        if not normalized_key or len(normalized_key) > 128:
+            raise ValueError("idempotency_key must contain 1 to 128 characters")
+        if reference is not None and len(reference) > 256:
+            raise ValueError("reference must contain at most 256 characters")
+        if not 1 <= len(allocations) <= 100:
+            raise ValueError("allocations must contain 1 to 100 items")
+
+        normalized_allocations = []
+        for item in allocations:
+            allocation = (
+                item
+                if isinstance(item, CustomerPaymentAllocation)
+                else CustomerPaymentAllocation.model_validate(item)
+            )
+            normalized_allocations.append(
+                {
+                    "invoice_id": _uuid.UUID(allocation.invoice_id),
+                    "amount": Decimal(allocation.amount_cents) / Decimal(100),
+                }
+            )
+
+        payment = await service.create_payment(
+            contact_id=_uuid.UUID(contact_id),
+            payer_name=normalized_payer,
+            total_amount=Decimal(total_amount_cents) / Decimal(100),
+            payment_method=payment_method,
+            received_date=(
+                date.fromisoformat(payment_date) if payment_date else date.today()
+            ),
+            allocations=normalized_allocations,
+            idempotency_key=normalized_key,
+            reference=reference,
+            notes=notes,
+            recorded_by="atlas-invoicing-mcp",
+            source="invoicing_mcp",
+        )
+        return json.dumps({"success": True, "payment": payment}, default=str)
+    except Exception as exc:
+        logger.warning("record_customer_payment rejected: %s", exc)
+        return json.dumps({"success": False, "error": str(exc)})
+
+
 @mcp.tool()
-async def record_payment(
+async def record_customer_payment(
+    contact_id: str,
+    payer_name: Annotated[str, Field(min_length=1, max_length=256)],
+    total_amount_cents: PositiveCents,
+    payment_method: Literal["check", "ach", "square"],
+    allocations: Annotated[
+        list[CustomerPaymentAllocation], Field(min_length=1, max_length=100)
+    ],
+    idempotency_key: Annotated[str, Field(min_length=1, max_length=128)],
+    reference: Annotated[Optional[str], Field(max_length=256)] = None,
+    notes: Optional[str] = None,
+    payment_date: Optional[str] = None,
+) -> str:
+    """Record one check, ACH, or Square receipt across multiple invoices.
+
+    allocations is a list of {"invoice_id": UUID, "amount_cents": integer}.
+    Atlas validates that every invoice belongs to contact_id and leaves any
+    remainder unapplied. ACH and Square entries are recorded as already cleared.
+    """
+    from ..services.receivables import get_receivables_service
+
+    return await _record_customer_payment_with_service(
+        service=get_receivables_service(),
+        contact_id=contact_id,
+        payer_name=payer_name,
+        total_amount_cents=total_amount_cents,
+        payment_method=payment_method,
+        allocations=allocations,
+        idempotency_key=idempotency_key,
+        reference=reference,
+        notes=notes,
+        payment_date=payment_date,
+    )
+
+
+async def _record_payment_with_dependencies(
+    *,
+    repo: Any,
+    crm_logger: Any,
     invoice_id: str,
     amount: float,
     payment_method: str = "other",
     reference: Optional[str] = None,
     notes: Optional[str] = None,
     payment_date: Optional[str] = None,
+    idempotency_key: Optional[str] = None,
 ) -> str:
-    """
-    Record a manual payment on an invoice. Auto-updates status to partial/paid.
+    normalized_idempotency_key = None
+    if idempotency_key is not None:
+        normalized_idempotency_key = idempotency_key.strip()
+        if not normalized_idempotency_key or len(normalized_idempotency_key) > 128:
+            message = "idempotency_key must contain 1 to 128 characters"
+            logger.warning("record_payment rejected: %s", message)
+            return json.dumps({"success": False, "error": message})
 
-    payment_method: cash | check | card | zelle | venmo | other
-    reference: check number, transaction ID, etc.
-    payment_date: ISO date (YYYY-MM-DD), defaults to today
-    """
     try:
-        repo = _repo()
         # Resolve invoice by UUID or number
         if _is_uuid(invoice_id):
             iid = _uuid.UUID(invoice_id)
@@ -439,25 +629,30 @@ async def record_payment(
 
         pd = date.fromisoformat(payment_date) if payment_date else None
 
-        payment = await repo.record_payment(
+        payment_outcome = await repo.record_payment_with_outcome(
             invoice_id=iid,
             amount=amount,
             payment_method=payment_method,
             payment_date=pd,
             reference=reference,
             notes=notes,
+            idempotency_key=normalized_idempotency_key,
         )
+        payment = payment_outcome.payment
 
         # Refresh invoice to get updated status
         updated_inv = await repo.get_by_id(iid)
 
-        # CRM log
-        contact_id = inv.get("contact_id")
-        ref_text = f" ({reference})" if reference else ""
-        await _log_crm(
-            str(contact_id) if contact_id else None, "invoice",
-            f"Payment ${amount:.2f} on {inv['invoice_number']} via {payment_method}{ref_text}",
-        )
+        # The receipt transaction owns replay classification, so a retry does
+        # not duplicate this secondary customer-history side effect.
+        if not payment_outcome.replayed:
+            contact_id = inv.get("contact_id")
+            ref_text = f" ({reference})" if reference else ""
+            await crm_logger(
+                str(contact_id) if contact_id else None,
+                "invoice",
+                f"Payment ${amount:.2f} on {inv['invoice_number']} via {payment_method}{ref_text}",
+            )
 
         return json.dumps({
             "success": True,
@@ -468,6 +663,41 @@ async def record_payment(
     except Exception as exc:
         logger.exception("record_payment error")
         return json.dumps({"success": False, "error": "Internal error"})
+
+
+@mcp.tool()
+async def record_payment(
+    invoice_id: str,
+    amount: float,
+    payment_method: str = "other",
+    reference: Optional[str] = None,
+    notes: Optional[str] = None,
+    payment_date: Optional[str] = None,
+    idempotency_key: Annotated[
+        Optional[str], Field(min_length=1, max_length=128)
+    ] = None,
+) -> str:
+    """
+    Record a manual payment on an invoice. Auto-updates status to partial/paid.
+
+    payment_method: cash | check | card | zelle | venmo | other
+    reference: check number, transaction ID, etc.
+    payment_date: ISO date (YYYY-MM-DD), defaults to today
+    idempotency_key: supply a unique operation key on the first call and reuse it
+        when retrying the same payment. Calls without a key remain compatible but
+        are treated as distinct receipts.
+    """
+    return await _record_payment_with_dependencies(
+        repo=_repo(),
+        crm_logger=_log_crm,
+        invoice_id=invoice_id,
+        amount=amount,
+        payment_method=payment_method,
+        reference=reference,
+        notes=notes,
+        payment_date=payment_date,
+        idempotency_key=idempotency_key,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1197,14 +1427,13 @@ async def export_invoice_pdf(
 if __name__ == "__main__":
     if "--sse" in sys.argv:
         # Streamable HTTP transport (preferred by claude.ai connectors;
-        # mcp.sse_app() is being deprecated). Bearer auth via
-        # apply_auth_middleware when ATLAS_MCP_AUTH_TOKEN is set.
+        # mcp.sse_app() is being deprecated). This write-capable surface
+        # refuses to start without a non-placeholder bearer token.
         import anyio
         import uvicorn
         from mcp.server.transport_security import TransportSecuritySettings
 
         from ..config import settings
-        from .auth import apply_auth_middleware
 
         mcp.settings.host = settings.mcp.host
         mcp.settings.port = settings.mcp.invoicing_port
@@ -1213,7 +1442,7 @@ if __name__ == "__main__":
         mcp.settings.transport_security = TransportSecuritySettings(
             enable_dns_rebinding_protection=False,
         )
-        secured_app = apply_auth_middleware(mcp.streamable_http_app())
+        secured_app = _streamable_http_app()
 
         async def _serve():
             config = uvicorn.Config(

--- a/atlas_brain/services/receivables.py
+++ b/atlas_brain/services/receivables.py
@@ -1,0 +1,1629 @@
+"""Atomic receivables ledger for customer receipts and invoice allocations."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from decimal import Decimal, InvalidOperation
+from typing import Any, Iterable, Optional
+from uuid import UUID, uuid4
+
+from ..storage.database import DatabasePool, get_db_pool
+from ..storage.exceptions import DatabaseUnavailableError
+
+ACTIVE_PAYMENT_STATUSES = ("legacy", "received", "deposited", "cleared")
+OPEN_INVOICE_STATUSES = ("sent", "partial", "overdue")
+API_PAYMENT_METHODS = ("check", "ach", "square")
+_CENT = Decimal("0.01")
+_MAX_DATABASE_MONEY = Decimal("9999999999.99")
+_RECEIVABLES_REQUIRED_COLUMNS = {
+    "customer_payments": (
+        "id",
+        "contact_id",
+        "payer_name",
+        "total_amount",
+        "payment_method",
+        "reference",
+        "received_date",
+        "status",
+        "source",
+        "idempotency_key",
+        "request_fingerprint",
+        "notes",
+        "recorded_by",
+        "deposited_at",
+        "cleared_at",
+        "returned_at",
+        "return_reason",
+        "voided_at",
+        "void_reason",
+        "metadata",
+        "created_at",
+        "updated_at",
+    ),
+    "invoice_payments": (
+        "payment_id",
+        "reversed_at",
+        "reversed_by",
+        "reversal_reason",
+    ),
+    "payment_deposit_batches": (
+        "id",
+        "deposit_date",
+        "bank_reference",
+        "status",
+        "idempotency_key",
+        "request_fingerprint",
+        "clear_idempotency_key",
+        "clear_request_fingerprint",
+        "created_by",
+        "cleared_at",
+        "cleared_by",
+        "voided_at",
+        "voided_by",
+        "void_reason",
+        "metadata",
+        "created_at",
+        "updated_at",
+    ),
+    "payment_deposit_items": (
+        "batch_id",
+        "payment_id",
+        "created_at",
+    ),
+    "payment_events": (
+        "id",
+        "payment_id",
+        "event_type",
+        "previous_status",
+        "new_status",
+        "effective_date",
+        "actor",
+        "reason",
+        "idempotency_key",
+        "request_fingerprint",
+        "metadata",
+        "created_at",
+    ),
+}
+_RECEIVABLES_REQUIRED_INDEXES = (
+    (
+        "customer_payments",
+        "customer_payments_pkey",
+        True,
+        ("id",),
+        None,
+        "p",
+    ),
+    (
+        "customer_payments",
+        "idx_customer_payments_idempotency",
+        True,
+        ("source", "idempotency_key"),
+        "idempotency_key IS NOT NULL",
+        None,
+    ),
+    (
+        "customer_payments",
+        "idx_customer_payments_contact_received",
+        False,
+        ("contact_id", "received_date", "created_at"),
+        None,
+        None,
+    ),
+    (
+        "customer_payments",
+        "idx_customer_payments_status_received",
+        False,
+        ("status", "received_date"),
+        None,
+        None,
+    ),
+    (
+        "invoice_payments",
+        "idx_invoice_payments_payment_id",
+        False,
+        ("payment_id",),
+        None,
+        None,
+    ),
+    (
+        "invoice_payments",
+        "idx_invoice_payments_active_payment_invoice",
+        True,
+        ("payment_id", "invoice_id"),
+        "payment_id IS NOT NULL AND reversed_at IS NULL",
+        None,
+    ),
+    (
+        "payment_deposit_batches",
+        "payment_deposit_batches_pkey",
+        True,
+        ("id",),
+        None,
+        "p",
+    ),
+    (
+        "payment_deposit_batches",
+        "idx_payment_deposit_batches_idempotency",
+        True,
+        ("idempotency_key",),
+        "idempotency_key IS NOT NULL",
+        None,
+    ),
+    (
+        "payment_deposit_batches",
+        "idx_payment_deposit_batches_clear_idempotency",
+        True,
+        ("clear_idempotency_key",),
+        "clear_idempotency_key IS NOT NULL",
+        None,
+    ),
+    (
+        "payment_deposit_batches",
+        "idx_payment_deposit_batches_status_date",
+        False,
+        ("status", "deposit_date"),
+        None,
+        None,
+    ),
+    (
+        "payment_deposit_items",
+        "payment_deposit_items_pkey",
+        True,
+        ("batch_id", "payment_id"),
+        None,
+        "p",
+    ),
+    (
+        "payment_deposit_items",
+        "payment_deposit_items_payment_id_key",
+        True,
+        ("payment_id",),
+        None,
+        "u",
+    ),
+    (
+        "payment_events",
+        "payment_events_pkey",
+        True,
+        ("id",),
+        None,
+        "p",
+    ),
+    (
+        "payment_events",
+        "idx_payment_events_idempotency",
+        True,
+        ("payment_id", "idempotency_key"),
+        "idempotency_key IS NOT NULL",
+        None,
+    ),
+    (
+        "payment_events",
+        "idx_payment_events_payment_created",
+        False,
+        ("payment_id", "created_at"),
+        None,
+        None,
+    ),
+    (
+        "payment_events",
+        "idx_payment_events_key_lookup",
+        False,
+        ("idempotency_key",),
+        "idempotency_key IS NOT NULL",
+        None,
+    ),
+)
+
+
+@dataclass(frozen=True)
+class PaymentCreationOutcome:
+    """Internal payment write result; public transports emit only ``payment``."""
+
+    payment: dict[str, Any]
+    replayed: bool
+
+
+class ReceivablesError(Exception):
+    """Base error with a stable machine-readable code."""
+
+    code = "receivables_error"
+
+
+class ReceivablesValidationError(ReceivablesError):
+    code = "validation_error"
+
+
+class ReceivablesNotFoundError(ReceivablesError):
+    code = "not_found"
+
+
+class ReceivablesConflictError(ReceivablesError):
+    code = "conflict"
+
+
+def money(value: Any) -> Decimal:
+    """Normalize a value to finite, two-decimal currency."""
+    try:
+        raw = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError) as exc:
+        raise ReceivablesValidationError("Amount must be valid currency") from exc
+    if not raw.is_finite():
+        raise ReceivablesValidationError("Amount must be finite")
+    try:
+        normalized = raw.quantize(_CENT)
+    except InvalidOperation as exc:
+        raise ReceivablesValidationError("Amount must be valid currency") from exc
+    if raw != normalized:
+        raise ReceivablesValidationError("Amount must use cent precision")
+    if abs(normalized) > _MAX_DATABASE_MONEY:
+        raise ReceivablesValidationError("Amount exceeds the supported currency range")
+    return normalized
+
+
+def cents(value: Any) -> int:
+    """Convert a database currency value to integer cents."""
+    return int(money(value) * 100)
+
+
+def _jsonable(value: Any) -> Any:
+    if isinstance(value, Decimal):
+        return str(value)
+    if isinstance(value, (date, datetime, UUID)):
+        return str(value)
+    if isinstance(value, dict):
+        return {key: _jsonable(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(item) for item in value]
+    return value
+
+
+def request_fingerprint(payload: dict[str, Any]) -> str:
+    encoded = json.dumps(
+        _jsonable(payload), sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _normalize_index_predicate(predicate: Optional[str]) -> str:
+    """Normalize simple catalog predicates without hiding semantic tokens."""
+    return re.sub(r"[\s()]+", "", predicate or "").lower()
+
+
+def _serialize_row(row: Any) -> dict[str, Any]:
+    if not row:
+        return {}
+    result = dict(row)
+    for key, value in list(result.items()):
+        if isinstance(value, UUID):
+            result[key] = str(value)
+        elif isinstance(value, Decimal):
+            result[key] = float(value)
+        elif isinstance(value, str) and key == "metadata":
+            try:
+                result[key] = json.loads(value)
+            except (TypeError, json.JSONDecodeError):
+                result[key] = {}
+    return result
+
+
+class ReceivablesService:
+    """Owns receipt, allocation, return, and deposit lifecycle transactions."""
+
+    def __init__(self, pool: Optional[DatabasePool] = None) -> None:
+        self._configured_pool = pool
+
+    @property
+    def pool(self) -> DatabasePool:
+        pool = self._configured_pool or get_db_pool()
+        if not pool.is_initialized:
+            raise DatabaseUnavailableError("receivables ledger")
+        return pool
+
+    async def is_ready(self) -> bool:
+        """Return whether every required ledger column and index is usable."""
+        required = [
+            (table_name, column_name)
+            for table_name, columns in _RECEIVABLES_REQUIRED_COLUMNS.items()
+            for column_name in columns
+        ]
+        columns_ready = bool(
+            await self.pool.fetchval(
+                """
+                SELECT NOT EXISTS (
+                    SELECT 1
+                    FROM unnest($1::text[], $2::text[])
+                        AS required(table_name, column_name)
+                    WHERE NOT EXISTS (
+                        SELECT 1
+                        FROM information_schema.columns AS actual
+                        WHERE actual.table_schema = current_schema()
+                          AND actual.table_name = required.table_name
+                          AND actual.column_name = required.column_name
+                    )
+                )
+                """,
+                [table_name for table_name, _column_name in required],
+                [column_name for _table_name, column_name in required],
+            )
+        )
+        if not columns_ready:
+            return False
+
+        index_rows = await self.pool.fetch(
+            """
+            SELECT
+                table_class.relname AS table_name,
+                index_class.relname AS index_name,
+                index_state.indisunique AS is_unique,
+                index_state.indisvalid AS is_valid,
+                index_state.indisready AS is_ready,
+                ARRAY(
+                    SELECT attribute.attname
+                    FROM unnest(index_state.indkey::smallint[])
+                        WITH ORDINALITY AS key(attnum, position)
+                    JOIN pg_attribute AS attribute
+                      ON attribute.attrelid = table_class.oid
+                     AND attribute.attnum = key.attnum
+                    WHERE key.position <= index_state.indnkeyatts
+                    ORDER BY key.position
+                ) AS key_columns,
+                pg_get_expr(index_state.indpred, index_state.indrelid) AS predicate,
+                constraint_state.contype::text AS constraint_type
+            FROM pg_index AS index_state
+            JOIN pg_class AS table_class
+              ON table_class.oid = index_state.indrelid
+            JOIN pg_namespace AS table_namespace
+              ON table_namespace.oid = table_class.relnamespace
+            JOIN pg_class AS index_class
+              ON index_class.oid = index_state.indexrelid
+            LEFT JOIN pg_constraint AS constraint_state
+              ON constraint_state.conrelid = index_state.indrelid
+             AND constraint_state.conindid = index_state.indexrelid
+            WHERE table_namespace.nspname = current_schema()
+              AND index_class.relname = ANY($1::text[])
+            """,
+            [
+                index_name
+                for _table_name, index_name, *_rest in _RECEIVABLES_REQUIRED_INDEXES
+            ],
+        )
+        actual_indexes = {
+            row["index_name"]: (
+                row["table_name"],
+                bool(row["is_unique"]),
+                tuple(row["key_columns"]),
+                _normalize_index_predicate(row["predicate"]),
+                row["constraint_type"],
+                bool(row["is_valid"]),
+                bool(row["is_ready"]),
+            )
+            for row in index_rows
+        }
+        return all(
+            actual_indexes.get(index_name)
+            == (
+                table_name,
+                is_unique,
+                key_columns,
+                _normalize_index_predicate(predicate),
+                constraint_type,
+                True,
+                True,
+            )
+            for (
+                table_name,
+                index_name,
+                is_unique,
+                key_columns,
+                predicate,
+                constraint_type,
+            ) in _RECEIVABLES_REQUIRED_INDEXES
+        )
+
+    async def list_open_invoices(
+        self,
+        *,
+        contact_id: Optional[UUID] = None,
+        search: Optional[str] = None,
+        limit: int = 500,
+    ) -> list[dict[str, Any]]:
+        """List allocatable invoices in deterministic oldest-due-first order."""
+        conditions = [
+            "contact_id IS NOT NULL",
+            "status = ANY($1::varchar[])",
+            "amount_due > 0",
+        ]
+        args: list[Any] = [list(OPEN_INVOICE_STATUSES)]
+        if contact_id:
+            args.append(contact_id)
+            conditions.append(f"contact_id = ${len(args)}")
+        if search and search.strip():
+            args.append(f"%{search.strip()}%")
+            conditions.append(
+                f"(customer_name ILIKE ${len(args)} "
+                f"OR invoice_number ILIKE ${len(args)})"
+            )
+        args.append(max(1, min(limit, 1000)))
+        rows = await self.pool.fetch(
+            f"""
+            SELECT id, invoice_number, contact_id, customer_name, issue_date,
+                   due_date, status, total_amount, amount_paid, amount_due
+            FROM invoices
+            WHERE {' AND '.join(conditions)}
+            ORDER BY due_date, issue_date, customer_name, invoice_number
+            LIMIT ${len(args)}
+            """,
+            *args,
+        )
+        return [self._invoice_view(row) for row in rows]
+
+    async def suggest_allocations(
+        self, *, contact_id: UUID, total_amount: Decimal
+    ) -> list[dict[str, Any]]:
+        """Suggest oldest-first allocations without writing any state."""
+        remaining = money(total_amount)
+        if remaining <= 0:
+            raise ReceivablesValidationError("Payment total must be positive")
+        suggestions: list[dict[str, Any]] = []
+        for invoice in await self.list_open_invoices(contact_id=contact_id):
+            if remaining <= 0:
+                break
+            allocation = min(remaining, money(invoice["amount_due"]))
+            suggestions.append(
+                {
+                    "invoice_id": invoice["id"],
+                    "invoice_number": invoice["invoice_number"],
+                    "amount_cents": cents(allocation),
+                }
+            )
+            remaining -= allocation
+        return suggestions
+
+    async def create_payment(
+        self,
+        *,
+        contact_id: Optional[UUID],
+        payer_name: str,
+        total_amount: Decimal,
+        payment_method: str,
+        received_date: date,
+        allocations: list[dict[str, Any]],
+        idempotency_key: str,
+        reference: Optional[str] = None,
+        notes: Optional[str] = None,
+        recorded_by: Optional[str] = None,
+        source: str = "eom_admin",
+        metadata: Optional[dict[str, Any]] = None,
+        enforce_api_methods: bool = True,
+    ) -> dict[str, Any]:
+        """Create one receipt and all of its allocations atomically."""
+        outcome = await self.create_payment_with_outcome(
+            contact_id=contact_id,
+            payer_name=payer_name,
+            total_amount=total_amount,
+            payment_method=payment_method,
+            received_date=received_date,
+            allocations=allocations,
+            idempotency_key=idempotency_key,
+            reference=reference,
+            notes=notes,
+            recorded_by=recorded_by,
+            source=source,
+            metadata=metadata,
+            enforce_api_methods=enforce_api_methods,
+        )
+        return outcome.payment
+
+    async def create_payment_with_outcome(
+        self,
+        *,
+        contact_id: Optional[UUID],
+        payer_name: str,
+        total_amount: Decimal,
+        payment_method: str,
+        received_date: date,
+        allocations: list[dict[str, Any]],
+        idempotency_key: str,
+        reference: Optional[str] = None,
+        notes: Optional[str] = None,
+        recorded_by: Optional[str] = None,
+        source: str = "eom_admin",
+        metadata: Optional[dict[str, Any]] = None,
+        enforce_api_methods: bool = True,
+    ) -> PaymentCreationOutcome:
+        """Create a receipt and report whether this call replayed its first write."""
+        total = money(total_amount)
+        if total <= 0:
+            raise ReceivablesValidationError("Payment total must be positive")
+        method = payment_method.strip().lower()
+        if enforce_api_methods and method not in API_PAYMENT_METHODS:
+            raise ReceivablesValidationError(
+                f"Payment method must be one of: {', '.join(API_PAYMENT_METHODS)}"
+            )
+        if not method:
+            raise ReceivablesValidationError("Payment method is required")
+        payer = payer_name.strip()
+        if not payer:
+            raise ReceivablesValidationError("Payer name is required")
+        key = idempotency_key.strip()
+        if not key or len(key) > 128:
+            raise ReceivablesValidationError(
+                "Idempotency key must contain 1 to 128 characters"
+            )
+
+        normalized = self._normalize_allocations(allocations)
+        allocated_total = sum((item["amount"] for item in normalized), Decimal("0"))
+        if allocated_total > total:
+            raise ReceivablesValidationError(
+                "Allocated amount cannot exceed the payment total"
+            )
+        initial_status = "received" if method == "check" else "cleared"
+        payload = {
+            "contact_id": contact_id,
+            "payer_name": payer,
+            "total_amount": total,
+            "payment_method": method,
+            "received_date": received_date,
+            "allocations": normalized,
+            "reference": (reference or "").strip() or None,
+            "notes": (notes or "").strip() or None,
+        }
+        fingerprint = request_fingerprint(payload)
+
+        async with self.pool.transaction() as conn:
+            await self._lock_operation_key(conn, "payment-event", key)
+            await self._lock_operation_key(
+                conn, "payment-create", f"{source}:{key}"
+            )
+            existing = await conn.fetchrow(
+                """
+                SELECT id, request_fingerprint
+                FROM customer_payments
+                WHERE source = $1 AND idempotency_key = $2
+                FOR UPDATE
+                """,
+                source,
+                key,
+            )
+            if existing:
+                self._assert_idempotent(existing, fingerprint)
+                return PaymentCreationOutcome(
+                    payment=await self._payment_view(conn, existing["id"]),
+                    replayed=True,
+                )
+            await self._assert_event_key_available(
+                conn, key=key, fingerprint=fingerprint
+            )
+
+            invoices = await self._lock_and_validate_invoices(
+                conn,
+                contact_id=contact_id,
+                allocations=normalized,
+            )
+            # A same-key create can arrive while the first transaction is still
+            # holding these invoice locks. Reconcile again after the wait, before
+            # validating the now-reduced balances, so a true retry returns the
+            # original receipt instead of an over-allocation error.
+            existing = await conn.fetchrow(
+                """
+                SELECT id, request_fingerprint
+                FROM customer_payments
+                WHERE source = $1 AND idempotency_key = $2
+                FOR UPDATE
+                """,
+                source,
+                key,
+            )
+            if existing:
+                self._assert_idempotent(existing, fingerprint)
+                return PaymentCreationOutcome(
+                    payment=await self._payment_view(conn, existing["id"]),
+                    replayed=True,
+                )
+
+            invoice_by_id = {str(row["id"]): row for row in invoices}
+            for allocation in normalized:
+                invoice = invoice_by_id[str(allocation["invoice_id"])]
+                if allocation["amount"] > money(invoice["amount_due"]):
+                    raise ReceivablesValidationError(
+                        f"Allocation exceeds balance for {invoice['invoice_number']}"
+                    )
+
+            payment_id = uuid4()
+            payment_row = await conn.fetchrow(
+                """
+                INSERT INTO customer_payments (
+                    id, contact_id, payer_name, total_amount, payment_method,
+                    reference, received_date, status, source, idempotency_key,
+                    request_fingerprint, notes, recorded_by, cleared_at,
+                    metadata, created_at, updated_at
+                )
+                VALUES (
+                    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12,
+                    $13, CASE WHEN $8::varchar = 'cleared'
+                        THEN $14::timestamptz ELSE NULL END,
+                    $15::jsonb, $14, $14
+                )
+                ON CONFLICT (source, idempotency_key)
+                    WHERE idempotency_key IS NOT NULL
+                DO NOTHING
+                RETURNING id
+                """,
+                payment_id,
+                contact_id,
+                payer,
+                total,
+                method,
+                payload["reference"],
+                received_date,
+                initial_status,
+                source,
+                key,
+                fingerprint,
+                payload["notes"],
+                recorded_by,
+                datetime.now(timezone.utc),
+                json.dumps(metadata or {}),
+            )
+            if not payment_row:
+                existing = await conn.fetchrow(
+                    """
+                    SELECT id, request_fingerprint FROM customer_payments
+                    WHERE source = $1 AND idempotency_key = $2
+                    """,
+                    source,
+                    key,
+                )
+                if not existing:
+                    raise ReceivablesConflictError(
+                        "Payment idempotency conflict could not be reconciled"
+                    )
+                self._assert_idempotent(existing, fingerprint)
+                return PaymentCreationOutcome(
+                    payment=await self._payment_view(conn, existing["id"]),
+                    replayed=True,
+                )
+
+            now = datetime.now(timezone.utc)
+            for allocation in normalized:
+                await conn.execute(
+                    """
+                    INSERT INTO invoice_payments (
+                        id, invoice_id, payment_id, amount, payment_date,
+                        payment_method, reference, notes, recorded_by,
+                        created_at, metadata
+                    )
+                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::jsonb)
+                    """,
+                    uuid4(),
+                    allocation["invoice_id"],
+                    payment_id,
+                    allocation["amount"],
+                    received_date,
+                    method,
+                    payload["reference"],
+                    payload["notes"],
+                    recorded_by,
+                    now,
+                    json.dumps(metadata or {}),
+                )
+            await self._insert_event(
+                conn,
+                payment_id=payment_id,
+                event_type="payment_recorded",
+                previous_status=None,
+                new_status=initial_status,
+                effective_date=received_date,
+                actor=recorded_by,
+                idempotency_key=key,
+                fingerprint=fingerprint,
+                metadata={"allocated_amount": str(allocated_total)},
+            )
+            await self._recalculate_invoices(
+                conn, [item["invoice_id"] for item in normalized]
+            )
+            return PaymentCreationOutcome(
+                payment=await self._payment_view(conn, payment_id),
+                replayed=False,
+            )
+
+    async def list_payments(
+        self,
+        *,
+        status: Optional[str] = None,
+        search: Optional[str] = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        conditions: list[str] = []
+        args: list[Any] = []
+        if status:
+            args.append(status)
+            conditions.append(f"cp.status = ${len(args)}")
+        if search and search.strip():
+            args.append(f"%{search.strip()}%")
+            conditions.append(
+                f"(cp.payer_name ILIKE ${len(args)} "
+                f"OR cp.reference ILIKE ${len(args)})"
+            )
+        where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+        args.extend([max(1, min(limit, 500)), max(0, offset)])
+        rows = await self.pool.fetch(
+            f"""
+            SELECT cp.*, pdi.batch_id
+            FROM customer_payments cp
+            LEFT JOIN payment_deposit_items pdi ON pdi.payment_id = cp.id
+            {where}
+            ORDER BY cp.received_date DESC, cp.created_at DESC
+            LIMIT ${len(args) - 1} OFFSET ${len(args)}
+            """,
+            *args,
+        )
+        if not rows:
+            return []
+        payment_ids = [row["id"] for row in rows]
+        allocation_rows = await self.pool.fetch(
+            """
+            SELECT ip.payment_id, ip.id, ip.invoice_id, i.invoice_number,
+                   ip.amount, ip.payment_date, ip.payment_method, ip.reference,
+                   ip.notes, ip.recorded_by, ip.created_at, ip.metadata,
+                   ip.reversed_at, ip.reversal_reason
+            FROM invoice_payments ip
+            JOIN invoices i ON i.id = ip.invoice_id
+            WHERE ip.payment_id = ANY($1::uuid[])
+            ORDER BY i.due_date, i.invoice_number, ip.created_at
+            """,
+            payment_ids,
+        )
+        grouped: dict[str, list[Any]] = {str(item): [] for item in payment_ids}
+        for allocation in allocation_rows:
+            grouped[str(allocation["payment_id"])].append(allocation)
+        return [
+            self._compose_payment(row, grouped.get(str(row["id"]), [])) for row in rows
+        ]
+
+    async def adjust_allocations(
+        self,
+        *,
+        payment_id: UUID,
+        allocations: list[dict[str, Any]],
+        reason: str,
+        actor: str,
+        idempotency_key: str,
+    ) -> dict[str, Any]:
+        """Replace active allocations while retaining reversed audit rows."""
+        normalized = self._normalize_allocations(allocations)
+        why = reason.strip()
+        if not why:
+            raise ReceivablesValidationError("Adjustment reason is required")
+        key = idempotency_key.strip()
+        if not key:
+            raise ReceivablesValidationError("Idempotency key is required")
+        fingerprint = request_fingerprint(
+            {"payment_id": payment_id, "allocations": normalized, "reason": why}
+        )
+
+        async with self.pool.transaction() as conn:
+            await self._lock_operation_key(conn, "payment-event", key)
+            payment = await conn.fetchrow(
+                "SELECT * FROM customer_payments WHERE id = $1 FOR UPDATE",
+                payment_id,
+            )
+            if not payment:
+                raise ReceivablesNotFoundError("Payment not found")
+            existing_event = await self._event_for_key(conn, key)
+            if existing_event:
+                self._assert_idempotent(existing_event, fingerprint)
+                return await self._payment_view(conn, payment_id)
+            if payment["status"] not in ACTIVE_PAYMENT_STATUSES:
+                raise ReceivablesConflictError(
+                    f"Cannot adjust a {payment['status']} payment"
+                )
+
+            old_rows = await conn.fetch(
+                """
+                SELECT invoice_id, amount FROM invoice_payments
+                WHERE payment_id = $1 AND reversed_at IS NULL
+                FOR UPDATE
+                """,
+                payment_id,
+            )
+            current = {str(row["invoice_id"]): money(row["amount"]) for row in old_rows}
+            invoices = await self._lock_and_validate_invoices(
+                conn,
+                contact_id=payment["contact_id"],
+                allocations=normalized,
+                current_allocations=current,
+                additional_invoice_ids=[row["invoice_id"] for row in old_rows],
+            )
+            invoice_by_id = {str(row["id"]): row for row in invoices}
+            for allocation in normalized:
+                available = money(
+                    invoice_by_id[str(allocation["invoice_id"])]["amount_due"]
+                ) + current.get(str(allocation["invoice_id"]), Decimal("0"))
+                if allocation["amount"] > available:
+                    raise ReceivablesValidationError(
+                        "Replacement allocation exceeds an invoice balance"
+                    )
+            if sum((item["amount"] for item in normalized), Decimal("0")) > money(
+                payment["total_amount"]
+            ):
+                raise ReceivablesValidationError(
+                    "Allocated amount cannot exceed the payment total"
+                )
+
+            now = datetime.now(timezone.utc)
+            await conn.execute(
+                """
+                UPDATE invoice_payments
+                SET reversed_at = $2, reversed_by = $3, reversal_reason = $4
+                WHERE payment_id = $1 AND reversed_at IS NULL
+                """,
+                payment_id,
+                now,
+                actor,
+                why,
+            )
+            for allocation in normalized:
+                await conn.execute(
+                    """
+                    INSERT INTO invoice_payments (
+                        id, invoice_id, payment_id, amount, payment_date,
+                        payment_method, reference, notes, recorded_by,
+                        created_at, metadata
+                    )
+                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, '{}'::jsonb)
+                    """,
+                    uuid4(),
+                    allocation["invoice_id"],
+                    payment_id,
+                    allocation["amount"],
+                    payment["received_date"],
+                    payment["payment_method"],
+                    payment["reference"],
+                    f"Allocation adjustment: {why}",
+                    actor,
+                    now,
+                )
+            await self._insert_event(
+                conn,
+                payment_id=payment_id,
+                event_type="allocations_adjusted",
+                previous_status=payment["status"],
+                new_status=payment["status"],
+                effective_date=date.today(),
+                actor=actor,
+                reason=why,
+                idempotency_key=key,
+                fingerprint=fingerprint,
+                metadata={
+                    "previous": [dict(row) for row in old_rows],
+                    "replacement": normalized,
+                },
+            )
+            affected = {row["invoice_id"] for row in old_rows}
+            affected.update(item["invoice_id"] for item in normalized)
+            await self._recalculate_invoices(conn, affected)
+            return await self._payment_view(conn, payment_id)
+
+    async def return_payment(
+        self,
+        *,
+        payment_id: UUID,
+        reason: str,
+        actor: str,
+        idempotency_key: str,
+    ) -> dict[str, Any]:
+        return await self._deactivate_payment(
+            payment_id=payment_id,
+            target_status="returned",
+            reason=reason,
+            actor=actor,
+            idempotency_key=idempotency_key,
+        )
+
+    async def void_payment(
+        self,
+        *,
+        payment_id: UUID,
+        reason: str,
+        actor: str,
+        idempotency_key: str,
+    ) -> dict[str, Any]:
+        return await self._deactivate_payment(
+            payment_id=payment_id,
+            target_status="voided",
+            reason=reason,
+            actor=actor,
+            idempotency_key=idempotency_key,
+        )
+
+    async def _deactivate_payment(
+        self,
+        *,
+        payment_id: UUID,
+        target_status: str,
+        reason: str,
+        actor: str,
+        idempotency_key: str,
+    ) -> dict[str, Any]:
+        why = reason.strip()
+        if not why:
+            raise ReceivablesValidationError("Reason is required")
+        key = idempotency_key.strip()
+        if not key:
+            raise ReceivablesValidationError("Idempotency key is required")
+        fingerprint = request_fingerprint(
+            {"payment_id": payment_id, "status": target_status, "reason": why}
+        )
+        timestamp_column = "returned_at" if target_status == "returned" else "voided_at"
+        reason_column = (
+            "return_reason" if target_status == "returned" else "void_reason"
+        )
+
+        async with self.pool.transaction() as conn:
+            await self._lock_operation_key(conn, "payment-event", key)
+            payment = await conn.fetchrow(
+                "SELECT * FROM customer_payments WHERE id = $1 FOR UPDATE",
+                payment_id,
+            )
+            if not payment:
+                raise ReceivablesNotFoundError("Payment not found")
+            event = await self._event_for_key(conn, key)
+            if event:
+                self._assert_idempotent(event, fingerprint)
+                if payment["status"] == target_status:
+                    return await self._payment_view(conn, payment_id)
+                raise ReceivablesConflictError(
+                    "Idempotency key already belongs to another payment event"
+                )
+            if payment["status"] == target_status:
+                raise ReceivablesConflictError(f"Payment is already {target_status}")
+            if payment["status"] not in ACTIVE_PAYMENT_STATUSES:
+                action = "return" if target_status == "returned" else "void"
+                raise ReceivablesConflictError(
+                    f"Cannot {action} a {payment['status']} payment"
+                )
+            if target_status == "voided":
+                deposit_batch_id = await conn.fetchval(
+                    """
+                    SELECT batch_id FROM payment_deposit_items
+                    WHERE payment_id = $1
+                    """,
+                    payment_id,
+                )
+                if deposit_batch_id:
+                    raise ReceivablesConflictError(
+                        "A deposited payment cannot be voided; record it as returned"
+                    )
+            now = datetime.now(timezone.utc)
+            await conn.execute(
+                f"""
+                UPDATE customer_payments
+                SET status = $2, {timestamp_column} = $3, {reason_column} = $4,
+                    updated_at = $3
+                WHERE id = $1
+                """,
+                payment_id,
+                target_status,
+                now,
+                why,
+            )
+            await self._insert_event(
+                conn,
+                payment_id=payment_id,
+                event_type=f"payment_{target_status}",
+                previous_status=payment["status"],
+                new_status=target_status,
+                effective_date=date.today(),
+                actor=actor,
+                reason=why,
+                idempotency_key=key,
+                fingerprint=fingerprint,
+            )
+            rows = await conn.fetch(
+                """
+                SELECT invoice_id FROM invoice_payments
+                WHERE payment_id = $1 AND reversed_at IS NULL
+                """,
+                payment_id,
+            )
+            await self._recalculate_invoices(conn, [row["invoice_id"] for row in rows])
+            return await self._payment_view(conn, payment_id)
+
+    async def create_deposit_batch(
+        self,
+        *,
+        payment_ids: list[UUID],
+        deposit_date: date,
+        bank_reference: Optional[str],
+        actor: str,
+        idempotency_key: str,
+    ) -> dict[str, Any]:
+        ids = sorted(set(payment_ids), key=str)
+        if not ids:
+            raise ReceivablesValidationError("Select at least one payment")
+        if len(ids) != len(payment_ids):
+            raise ReceivablesValidationError("A payment may only appear once")
+        key = idempotency_key.strip()
+        if not key:
+            raise ReceivablesValidationError("Idempotency key is required")
+        reference = (bank_reference or "").strip() or None
+        fingerprint = request_fingerprint(
+            {
+                "payment_ids": ids,
+                "deposit_date": deposit_date,
+                "bank_reference": reference,
+            }
+        )
+
+        async with self.pool.transaction() as conn:
+            await self._lock_operation_key(conn, "payment-event", key)
+            await self._lock_operation_key(conn, "deposit-create", key)
+            existing = await conn.fetchrow(
+                """
+                SELECT id, request_fingerprint FROM payment_deposit_batches
+                WHERE idempotency_key = $1 FOR UPDATE
+                """,
+                key,
+            )
+            if existing:
+                self._assert_idempotent(existing, fingerprint)
+                return await self._batch_view(conn, existing["id"])
+            payments = await conn.fetch(
+                """
+                SELECT id, status, payment_method FROM customer_payments
+                WHERE id = ANY($1::uuid[])
+                ORDER BY id FOR UPDATE
+                """,
+                ids,
+            )
+            # A concurrent same-key retry waits on these payment locks. Recheck
+            # the batch key after that wait so the retry returns the committed
+            # batch instead of treating its now-deposited checks as a conflict.
+            existing = await conn.fetchrow(
+                """
+                SELECT id, request_fingerprint FROM payment_deposit_batches
+                WHERE idempotency_key = $1 FOR UPDATE
+                """,
+                key,
+            )
+            if existing:
+                self._assert_idempotent(existing, fingerprint)
+                return await self._batch_view(conn, existing["id"])
+            if len(payments) != len(ids):
+                raise ReceivablesNotFoundError("One or more payments were not found")
+            await self._assert_event_key_available(
+                conn, key=key, fingerprint=fingerprint
+            )
+            for payment in payments:
+                if (
+                    payment["status"] != "received"
+                    or payment["payment_method"] != "check"
+                ):
+                    raise ReceivablesConflictError(
+                        "Only received check payments can be deposited"
+                    )
+            already_batched = await conn.fetchval(
+                """
+                SELECT EXISTS(
+                    SELECT 1 FROM payment_deposit_items
+                    WHERE payment_id = ANY($1::uuid[])
+                )
+                """,
+                ids,
+            )
+            if already_batched:
+                raise ReceivablesConflictError(
+                    "A payment is already in a deposit batch"
+                )
+
+            batch_id = uuid4()
+            now = datetime.now(timezone.utc)
+            await conn.execute(
+                """
+                INSERT INTO payment_deposit_batches (
+                    id, deposit_date, bank_reference, status, idempotency_key,
+                    request_fingerprint, created_by, created_at, updated_at
+                )
+                VALUES ($1, $2, $3, 'deposited', $4, $5, $6, $7, $7)
+                """,
+                batch_id,
+                deposit_date,
+                reference,
+                key,
+                fingerprint,
+                actor,
+                now,
+            )
+            for payment_id in ids:
+                await conn.execute(
+                    """
+                    INSERT INTO payment_deposit_items (batch_id, payment_id)
+                    VALUES ($1, $2)
+                    """,
+                    batch_id,
+                    payment_id,
+                )
+                await conn.execute(
+                    """
+                    UPDATE customer_payments
+                    SET status = 'deposited', deposited_at = $2, updated_at = $2
+                    WHERE id = $1
+                    """,
+                    payment_id,
+                    now,
+                )
+                await self._insert_event(
+                    conn,
+                    payment_id=payment_id,
+                    event_type="payment_deposited",
+                    previous_status="received",
+                    new_status="deposited",
+                    effective_date=deposit_date,
+                    actor=actor,
+                    idempotency_key=key,
+                    fingerprint=fingerprint,
+                    metadata={"batch_id": batch_id},
+                )
+            return await self._batch_view(conn, batch_id)
+
+    async def clear_deposit_batch(
+        self,
+        *,
+        batch_id: UUID,
+        actor: str,
+        idempotency_key: str,
+    ) -> dict[str, Any]:
+        key = idempotency_key.strip()
+        if not key:
+            raise ReceivablesValidationError("Idempotency key is required")
+        fingerprint = request_fingerprint({"batch_id": batch_id, "action": "clear"})
+        async with self.pool.transaction() as conn:
+            await self._lock_operation_key(conn, "payment-event", key)
+            await self._lock_operation_key(conn, "deposit-clear", key)
+            existing_clear = await conn.fetchrow(
+                """
+                SELECT id, clear_request_fingerprint AS request_fingerprint
+                FROM payment_deposit_batches
+                WHERE clear_idempotency_key = $1
+                FOR UPDATE
+                """,
+                key,
+            )
+            if existing_clear:
+                self._assert_idempotent(existing_clear, fingerprint)
+                return await self._batch_view(conn, existing_clear["id"])
+            batch = await conn.fetchrow(
+                "SELECT * FROM payment_deposit_batches WHERE id = $1 FOR UPDATE",
+                batch_id,
+            )
+            if not batch:
+                raise ReceivablesNotFoundError("Deposit batch not found")
+            if batch["status"] == "cleared":
+                if batch["clear_idempotency_key"] != key:
+                    raise ReceivablesConflictError("Deposit batch is already cleared")
+                self._assert_idempotent(
+                    {"request_fingerprint": batch["clear_request_fingerprint"]},
+                    fingerprint,
+                )
+                return await self._batch_view(conn, batch_id)
+            if batch["status"] != "deposited":
+                raise ReceivablesConflictError(
+                    f"Cannot clear a {batch['status']} deposit batch"
+                )
+            payments = await conn.fetch(
+                """
+                SELECT cp.id, cp.status
+                FROM customer_payments cp
+                JOIN payment_deposit_items pdi ON pdi.payment_id = cp.id
+                WHERE pdi.batch_id = $1
+                ORDER BY cp.id FOR UPDATE
+                """,
+                batch_id,
+            )
+            if not payments:
+                raise ReceivablesConflictError("Deposit batch has no payments")
+            if any(payment["status"] != "deposited" for payment in payments):
+                raise ReceivablesConflictError(
+                    "Every payment in the batch must still be deposited before clearing"
+                )
+            await self._assert_event_key_available(
+                conn,
+                key=key,
+                fingerprint=fingerprint,
+            )
+            now = datetime.now(timezone.utc)
+            await conn.execute(
+                """
+                UPDATE payment_deposit_batches
+                SET status = 'cleared', cleared_at = $2, cleared_by = $3,
+                    clear_idempotency_key = $4, clear_request_fingerprint = $5,
+                    updated_at = $2
+                WHERE id = $1
+                """,
+                batch_id,
+                now,
+                actor,
+                key,
+                fingerprint,
+            )
+            for payment in payments:
+                await conn.execute(
+                    """
+                    UPDATE customer_payments
+                    SET status = 'cleared', cleared_at = $2, updated_at = $2
+                    WHERE id = $1
+                    """,
+                    payment["id"],
+                    now,
+                )
+                await self._insert_event(
+                    conn,
+                    payment_id=payment["id"],
+                    event_type="payment_cleared",
+                    previous_status="deposited",
+                    new_status="cleared",
+                    effective_date=date.today(),
+                    actor=actor,
+                    idempotency_key=key,
+                    fingerprint=fingerprint,
+                    metadata={"batch_id": batch_id},
+                )
+            return await self._batch_view(conn, batch_id)
+
+    async def list_deposit_batches(self, *, limit: int = 100) -> list[dict[str, Any]]:
+        rows = await self.pool.fetch(
+            """
+            SELECT b.*, COUNT(i.payment_id) AS payment_count,
+                   COALESCE(SUM(p.total_amount), 0) AS total_amount
+            FROM payment_deposit_batches b
+            LEFT JOIN payment_deposit_items i ON i.batch_id = b.id
+            LEFT JOIN customer_payments p ON p.id = i.payment_id
+            GROUP BY b.id
+            ORDER BY b.deposit_date DESC, b.created_at DESC
+            LIMIT $1
+            """,
+            max(1, min(limit, 500)),
+        )
+        return [self._batch_summary(row) for row in rows]
+
+    async def recalculate_invoice(self, invoice_id: UUID) -> None:
+        """Compatibility entry point for legacy repository callers."""
+        async with self.pool.transaction() as conn:
+            await self._recalculate_invoices(conn, [invoice_id])
+
+    @staticmethod
+    def _normalize_allocations(
+        allocations: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        if not allocations:
+            raise ReceivablesValidationError(
+                "At least one invoice allocation is required"
+            )
+        normalized: list[dict[str, Any]] = []
+        seen: set[str] = set()
+        for allocation in allocations:
+            try:
+                invoice_id = UUID(str(allocation["invoice_id"]))
+                amount = money(allocation["amount"])
+            except (KeyError, TypeError, ValueError) as exc:
+                raise ReceivablesValidationError(
+                    "Each allocation requires a valid invoice_id and amount"
+                ) from exc
+            if amount <= 0:
+                raise ReceivablesValidationError("Allocation amounts must be positive")
+            if str(invoice_id) in seen:
+                raise ReceivablesValidationError(
+                    "An invoice may only appear once in a payment"
+                )
+            seen.add(str(invoice_id))
+            normalized.append({"invoice_id": invoice_id, "amount": amount})
+        return sorted(normalized, key=lambda item: str(item["invoice_id"]))
+
+    async def _lock_and_validate_invoices(
+        self,
+        conn: Any,
+        *,
+        contact_id: Optional[UUID],
+        allocations: list[dict[str, Any]],
+        current_allocations: Optional[dict[str, Decimal]] = None,
+        additional_invoice_ids: Optional[Iterable[UUID]] = None,
+    ) -> list[Any]:
+        allocated_ids = {item["invoice_id"] for item in allocations}
+        invoice_ids = sorted(allocated_ids.union(additional_invoice_ids or []), key=str)
+        rows = await conn.fetch(
+            """
+            SELECT id, invoice_number, contact_id, status, amount_due
+            FROM invoices
+            WHERE id = ANY($1::uuid[])
+            ORDER BY id FOR UPDATE
+            """,
+            invoice_ids,
+        )
+        if len(rows) != len(invoice_ids):
+            raise ReceivablesNotFoundError("One or more invoices were not found")
+        current_allocations = current_allocations or {}
+        for row in rows:
+            if contact_id is None:
+                same_customer = len(invoice_ids) == 1 and row["contact_id"] is None
+            else:
+                same_customer = (
+                    row["contact_id"] is not None
+                    and str(row["contact_id"]) == str(contact_id)
+                )
+            if not same_customer:
+                raise ReceivablesValidationError(
+                    "All allocated invoices must belong to the same customer"
+                )
+            if row["id"] not in allocated_ids:
+                continue
+            eligible = row["status"] in OPEN_INVOICE_STATUSES
+            if row["status"] == "paid" and str(row["id"]) in current_allocations:
+                eligible = True
+            if not eligible:
+                raise ReceivablesConflictError(
+                    f"Invoice {row['invoice_number']} is not open for payment"
+                )
+        return rows
+
+    @staticmethod
+    def _assert_idempotent(row: Any, fingerprint: str) -> None:
+        if row["request_fingerprint"] != fingerprint:
+            raise ReceivablesConflictError(
+                "Idempotency key was already used for a different request"
+            )
+
+    @staticmethod
+    async def _event_for_key(conn: Any, key: str) -> Optional[Any]:
+        return await conn.fetchrow(
+            """
+            SELECT payment_id, request_fingerprint
+            FROM payment_events
+            WHERE idempotency_key = $1
+            ORDER BY payment_id
+            LIMIT 1
+            """,
+            key,
+        )
+
+    async def _assert_event_key_available(
+        self,
+        conn: Any,
+        *,
+        key: str,
+        fingerprint: str,
+    ) -> None:
+        event = await self._event_for_key(conn, key)
+        if not event:
+            return
+        self._assert_idempotent(event, fingerprint)
+        # Matching endpoint retries reconcile through their payment/batch parent
+        # before reaching this guard. An orphaned same-fingerprint event is not
+        # safe evidence that the requested state transition completed.
+        raise ReceivablesConflictError(
+            "Idempotency key already belongs to a payment event"
+        )
+
+    @staticmethod
+    async def _insert_event(
+        conn: Any,
+        *,
+        payment_id: UUID,
+        event_type: str,
+        previous_status: Optional[str],
+        new_status: Optional[str],
+        effective_date: Optional[date],
+        actor: Optional[str],
+        idempotency_key: str,
+        fingerprint: str,
+        reason: Optional[str] = None,
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> None:
+        await conn.execute(
+            """
+            INSERT INTO payment_events (
+                id, payment_id, event_type, previous_status, new_status,
+                effective_date, actor, reason, idempotency_key,
+                request_fingerprint, metadata
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::jsonb)
+            """,
+            uuid4(),
+            payment_id,
+            event_type,
+            previous_status,
+            new_status,
+            effective_date,
+            actor,
+            reason,
+            idempotency_key,
+            fingerprint,
+            json.dumps(_jsonable(metadata or {})),
+        )
+
+    @staticmethod
+    async def _lock_operation_key(conn: Any, scope: str, key: str) -> None:
+        """Serialize equal idempotency keys before checking their persisted row."""
+        await conn.fetchval(
+            "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+            f"{scope}:{key}",
+        )
+
+    @staticmethod
+    async def _recalculate_invoices(conn: Any, invoice_ids: Iterable[UUID]) -> None:
+        ids = sorted(set(invoice_ids), key=str)
+        if not ids:
+            return
+        # Serialize every balance recomputation on the invoice rows themselves.
+        # In particular, a return/void must take this lock before its aggregate
+        # snapshot so it cannot overwrite a concurrently-created allocation with
+        # a stale amount_paid value after waiting on the UPDATE row lock.
+        await conn.fetch(
+            """
+            SELECT id
+            FROM invoices
+            WHERE id = ANY($1::uuid[])
+            ORDER BY id FOR UPDATE
+            """,
+            ids,
+        )
+        await conn.execute(
+            """
+            WITH totals AS (
+                SELECT i.id,
+                       COALESCE(SUM(ip.amount) FILTER (
+                           WHERE ip.reversed_at IS NULL
+                             AND (
+                                 ip.payment_id IS NULL
+                                 OR cp.status = ANY($2::varchar[])
+                             )
+                       ), 0) AS paid
+                FROM invoices i
+                LEFT JOIN invoice_payments ip ON ip.invoice_id = i.id
+                LEFT JOIN customer_payments cp ON cp.id = ip.payment_id
+                WHERE i.id = ANY($1::uuid[])
+                GROUP BY i.id
+            )
+            UPDATE invoices i
+            SET amount_paid = totals.paid,
+                status = CASE
+                    WHEN i.status IN ('draft', 'void') THEN i.status
+                    WHEN i.total_amount - totals.paid <= 0 THEN 'paid'
+                    WHEN i.due_date < $3 THEN 'overdue'
+                    WHEN totals.paid > 0 THEN 'partial'
+                    ELSE 'sent'
+                END,
+                paid_at = CASE
+                    WHEN i.total_amount - totals.paid <= 0
+                        THEN COALESCE(i.paid_at, $4)
+                    ELSE NULL
+                END,
+                updated_at = $4
+            FROM totals
+            WHERE i.id = totals.id
+            """,
+            ids,
+            list(ACTIVE_PAYMENT_STATUSES),
+            date.today(),
+            datetime.now(timezone.utc),
+        )
+
+    async def _payment_view(self, conn: Any, payment_id: UUID) -> dict[str, Any]:
+        row = await conn.fetchrow(
+            """
+            SELECT cp.*, pdi.batch_id
+            FROM customer_payments cp
+            LEFT JOIN payment_deposit_items pdi ON pdi.payment_id = cp.id
+            WHERE cp.id = $1
+            """,
+            payment_id,
+        )
+        if not row:
+            raise ReceivablesNotFoundError("Payment not found")
+        allocations = await conn.fetch(
+            """
+            SELECT ip.payment_id, ip.id, ip.invoice_id, i.invoice_number,
+                   ip.amount, ip.payment_date, ip.payment_method, ip.reference,
+                   ip.notes, ip.recorded_by, ip.created_at, ip.metadata,
+                   ip.reversed_at, ip.reversal_reason
+            FROM invoice_payments ip
+            JOIN invoices i ON i.id = ip.invoice_id
+            WHERE ip.payment_id = $1
+            ORDER BY i.due_date, i.invoice_number, ip.created_at
+            """,
+            payment_id,
+        )
+        return self._compose_payment(row, allocations)
+
+    @staticmethod
+    def _compose_payment(row: Any, allocations: list[Any]) -> dict[str, Any]:
+        result = _serialize_row(row)
+        allocation_views = [_serialize_row(item) for item in allocations]
+        active_allocated = Decimal("0")
+        is_active = row["status"] in ACTIVE_PAYMENT_STATUSES
+        if is_active:
+            active_allocated = sum(
+                (
+                    money(item["amount"])
+                    for item in allocations
+                    if item["reversed_at"] is None
+                ),
+                Decimal("0"),
+            )
+        result["total_amount_cents"] = cents(row["total_amount"])
+        result["allocated_amount_cents"] = cents(active_allocated)
+        available_unapplied = (
+            money(row["total_amount"]) - active_allocated
+            if is_active
+            else Decimal("0")
+        )
+        result["unapplied_amount_cents"] = cents(available_unapplied)
+        for view in allocation_views:
+            view["amount_cents"] = cents(view["amount"])
+        result["allocations"] = allocation_views
+        return result
+
+    @staticmethod
+    def _invoice_view(row: Any) -> dict[str, Any]:
+        result = _serialize_row(row)
+        for field in ("total_amount", "amount_paid", "amount_due"):
+            result[f"{field}_cents"] = cents(row[field])
+        return result
+
+    async def _batch_view(self, conn: Any, batch_id: UUID) -> dict[str, Any]:
+        row = await conn.fetchrow(
+            """
+            SELECT b.*, COUNT(i.payment_id) AS payment_count,
+                   COALESCE(SUM(p.total_amount), 0) AS total_amount
+            FROM payment_deposit_batches b
+            LEFT JOIN payment_deposit_items i ON i.batch_id = b.id
+            LEFT JOIN customer_payments p ON p.id = i.payment_id
+            WHERE b.id = $1
+            GROUP BY b.id
+            """,
+            batch_id,
+        )
+        if not row:
+            raise ReceivablesNotFoundError("Deposit batch not found")
+        result = self._batch_summary(row)
+        payments = await conn.fetch(
+            """
+            SELECT p.id, p.payer_name, p.reference, p.total_amount, p.status
+            FROM customer_payments p
+            JOIN payment_deposit_items i ON i.payment_id = p.id
+            WHERE i.batch_id = $1
+            ORDER BY p.payer_name, p.received_date, p.id
+            """,
+            batch_id,
+        )
+        result["payments"] = [
+            {
+                **_serialize_row(payment),
+                "total_amount_cents": cents(payment["total_amount"]),
+            }
+            for payment in payments
+        ]
+        return result
+
+    @staticmethod
+    def _batch_summary(row: Any) -> dict[str, Any]:
+        result = _serialize_row(row)
+        result["total_amount_cents"] = cents(row["total_amount"])
+        return result
+
+
+_receivables_service: Optional[ReceivablesService] = None
+
+
+def get_receivables_service() -> ReceivablesService:
+    global _receivables_service
+    if _receivables_service is None:
+        _receivables_service = ReceivablesService()
+    return _receivables_service

--- a/atlas_brain/storage/migrations/344_receivables_payments.sql
+++ b/atlas_brain/storage/migrations/344_receivables_payments.sql
@@ -1,0 +1,221 @@
+-- First-class customer receipts, invoice allocations, and deposit lifecycle.
+-- Existing invoice_payments rows remain the compatibility allocation surface.
+
+CREATE TABLE IF NOT EXISTS customer_payments (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    contact_id          UUID REFERENCES contacts(id) ON DELETE SET NULL,
+    payer_name          VARCHAR(256) NOT NULL,
+    total_amount        NUMERIC(12,2) NOT NULL,
+    payment_method      VARCHAR(32) NOT NULL,
+    reference           VARCHAR(256),
+    received_date       DATE NOT NULL,
+    status              VARCHAR(16) NOT NULL,
+    source              VARCHAR(32) NOT NULL DEFAULT 'manual',
+    idempotency_key     VARCHAR(128),
+    request_fingerprint VARCHAR(64),
+    notes               TEXT,
+    recorded_by         VARCHAR(128),
+    deposited_at        TIMESTAMPTZ,
+    cleared_at          TIMESTAMPTZ,
+    returned_at         TIMESTAMPTZ,
+    return_reason       TEXT,
+    voided_at           TIMESTAMPTZ,
+    void_reason         TEXT,
+    metadata            JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT customer_payments_status_check
+        CHECK (status IN ('legacy', 'received', 'deposited', 'cleared', 'returned', 'voided')),
+    CONSTRAINT customer_payments_positive_new_amount_check
+        CHECK (source = 'legacy' OR total_amount > 0)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_customer_payments_idempotency
+    ON customer_payments(source, idempotency_key)
+    WHERE idempotency_key IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_customer_payments_contact_received
+    ON customer_payments(contact_id, received_date DESC, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_customer_payments_status_received
+    ON customer_payments(status, received_date DESC);
+
+ALTER TABLE invoice_payments
+    ADD COLUMN IF NOT EXISTS payment_id UUID,
+    ADD COLUMN IF NOT EXISTS reversed_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS reversed_by VARCHAR(128),
+    ADD COLUMN IF NOT EXISTS reversal_reason TEXT;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'invoice_payments_payment_id_fkey'
+          AND conrelid = 'invoice_payments'::regclass
+    ) THEN
+        ALTER TABLE invoice_payments
+            ADD CONSTRAINT invoice_payments_payment_id_fkey
+            FOREIGN KEY (payment_id) REFERENCES customer_payments(id) ON DELETE RESTRICT;
+    END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_invoice_payments_payment_id
+    ON invoice_payments(payment_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_invoice_payments_active_payment_invoice
+    ON invoice_payments(payment_id, invoice_id)
+    WHERE payment_id IS NOT NULL AND reversed_at IS NULL;
+
+-- Preserve history conservatively: one parent per existing allocation. Matching
+-- references are not proof that two rows represent the same physical receipt.
+INSERT INTO customer_payments (
+    id, contact_id, payer_name, total_amount, payment_method, reference,
+    received_date, status, source, notes, recorded_by, metadata,
+    created_at, updated_at
+)
+SELECT
+    ip.id,
+    i.contact_id,
+    i.customer_name,
+    ip.amount,
+    ip.payment_method,
+    ip.reference,
+    ip.payment_date,
+    'legacy',
+    'legacy',
+    ip.notes,
+    ip.recorded_by,
+    COALESCE(ip.metadata, '{}'::jsonb),
+    ip.created_at,
+    ip.created_at
+FROM invoice_payments ip
+JOIN invoices i ON i.id = ip.invoice_id
+WHERE ip.payment_id IS NULL
+ON CONFLICT (id) DO NOTHING;
+
+UPDATE invoice_payments ip
+SET payment_id = ip.id
+WHERE ip.payment_id IS NULL
+  AND EXISTS (SELECT 1 FROM customer_payments cp WHERE cp.id = ip.id);
+
+CREATE TABLE IF NOT EXISTS payment_deposit_batches (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    deposit_date        DATE NOT NULL,
+    bank_reference      VARCHAR(256),
+    status              VARCHAR(16) NOT NULL DEFAULT 'deposited',
+    idempotency_key     VARCHAR(128),
+    request_fingerprint VARCHAR(64),
+    clear_idempotency_key VARCHAR(128),
+    clear_request_fingerprint VARCHAR(64),
+    created_by          VARCHAR(128),
+    cleared_at          TIMESTAMPTZ,
+    cleared_by          VARCHAR(128),
+    voided_at           TIMESTAMPTZ,
+    voided_by           VARCHAR(128),
+    void_reason         TEXT,
+    metadata            JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT payment_deposit_batches_status_check
+        CHECK (status IN ('deposited', 'cleared', 'voided'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_payment_deposit_batches_idempotency
+    ON payment_deposit_batches(idempotency_key)
+    WHERE idempotency_key IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_payment_deposit_batches_clear_idempotency
+    ON payment_deposit_batches(clear_idempotency_key)
+    WHERE clear_idempotency_key IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_payment_deposit_batches_status_date
+    ON payment_deposit_batches(status, deposit_date DESC);
+
+CREATE TABLE IF NOT EXISTS payment_deposit_items (
+    batch_id    UUID NOT NULL REFERENCES payment_deposit_batches(id) ON DELETE RESTRICT,
+    payment_id  UUID NOT NULL REFERENCES customer_payments(id) ON DELETE RESTRICT,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (batch_id, payment_id),
+    UNIQUE (payment_id)
+);
+
+CREATE TABLE IF NOT EXISTS payment_events (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    payment_id          UUID NOT NULL REFERENCES customer_payments(id) ON DELETE RESTRICT,
+    event_type          VARCHAR(32) NOT NULL,
+    previous_status     VARCHAR(16),
+    new_status          VARCHAR(16),
+    effective_date      DATE,
+    actor               VARCHAR(128),
+    reason              TEXT,
+    idempotency_key     VARCHAR(128),
+    request_fingerprint VARCHAR(64),
+    metadata            JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_payment_events_idempotency
+    ON payment_events(payment_id, idempotency_key)
+    WHERE idempotency_key IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_payment_events_payment_created
+    ON payment_events(payment_id, created_at DESC);
+
+-- If an older process writes the legacy invoice_payments shape before the
+-- deployment drain completes, adopt that row in the same transaction so it is
+-- immediately visible in global payment history. This is a visibility bridge,
+-- not permission to overlap old and new finance writers: the old process's
+-- separate balance refresh is not lock-safe. A late check is operationally
+-- "received" and can enter a deposit batch; other old methods remain
+-- conservatively classified as legacy.
+CREATE OR REPLACE FUNCTION adopt_legacy_invoice_payment()
+RETURNS TRIGGER AS $$
+DECLARE
+    invoice_row RECORD;
+    adopted_at TIMESTAMPTZ;
+BEGIN
+    IF NEW.payment_id IS NOT NULL THEN
+        RETURN NEW;
+    END IF;
+
+    SELECT contact_id, customer_name
+    INTO invoice_row
+    FROM invoices
+    WHERE id = NEW.invoice_id;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'Invoice % not found for legacy payment adoption', NEW.invoice_id;
+    END IF;
+
+    adopted_at := COALESCE(NEW.created_at, CURRENT_TIMESTAMP);
+    INSERT INTO customer_payments (
+        id, contact_id, payer_name, total_amount, payment_method, reference,
+        received_date, status, source, notes, recorded_by, metadata,
+        created_at, updated_at
+    ) VALUES (
+        NEW.id,
+        invoice_row.contact_id,
+        invoice_row.customer_name,
+        NEW.amount,
+        COALESCE(NULLIF(lower(btrim(NEW.payment_method)), ''), 'other'),
+        NEW.reference,
+        NEW.payment_date,
+        CASE
+            WHEN NEW.amount > 0 AND lower(btrim(NEW.payment_method)) = 'check'
+            THEN 'received'
+            ELSE 'legacy'
+        END,
+        'legacy',
+        NEW.notes,
+        NEW.recorded_by,
+        COALESCE(NEW.metadata, '{}'::jsonb)
+            || jsonb_build_object('adopted_rolling_writer', true),
+        adopted_at,
+        adopted_at
+    )
+    ON CONFLICT (id) DO NOTHING;
+
+    NEW.payment_id := NEW.id;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_adopt_legacy_invoice_payment ON invoice_payments;
+CREATE TRIGGER trg_adopt_legacy_invoice_payment
+BEFORE INSERT ON invoice_payments
+FOR EACH ROW
+WHEN (NEW.payment_id IS NULL)
+EXECUTE FUNCTION adopt_legacy_invoice_payment();

--- a/atlas_brain/storage/migrations/345_receivables_event_key_lookup.sql
+++ b/atlas_brain/storage/migrations/345_receivables_event_key_lookup.sql
@@ -1,0 +1,7 @@
+-- Support global payment-event idempotency checks added after migration 344.
+-- This must remain a separate migration so databases that ran an earlier
+-- receivables preview still receive the lookup index.
+
+CREATE INDEX IF NOT EXISTS idx_payment_events_key_lookup
+    ON payment_events(idempotency_key)
+    WHERE idempotency_key IS NOT NULL;

--- a/atlas_brain/storage/repositories/invoice.py
+++ b/atlas_brain/storage/repositories/invoice.py
@@ -6,15 +6,24 @@ Provides CRUD operations for invoices and payments stored in PostgreSQL.
 
 import json
 import logging
+from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from decimal import Decimal
-from typing import Optional
+from typing import Any, Optional
 from uuid import UUID, uuid4
 
 from ..database import get_db_pool
 from ..exceptions import DatabaseUnavailableError, DatabaseOperationError
 
 logger = logging.getLogger("atlas.storage.invoice")
+
+
+@dataclass(frozen=True)
+class InvoicePaymentRecordOutcome:
+    """Internal singular-payment result with atomic replay classification."""
+
+    payment: dict[str, Any]
+    replayed: bool
 
 
 def _line_items_are_billable(items: list[dict]) -> bool:
@@ -47,6 +56,27 @@ def _line_items_with_amounts(items: list[dict], *, overwrite: bool) -> list[dict
 class InvoiceRepository:
     """Repository for invoice and payment storage and retrieval."""
 
+    def __init__(
+        self,
+        *,
+        pool: Any = None,
+        receivables_service: Any = None,
+    ) -> None:
+        self._pool_override = pool
+        self._receivables_service_override = receivables_service
+
+    def _get_pool(self) -> Any:
+        if self._pool_override is not None:
+            return self._pool_override
+        return get_db_pool()
+
+    def _get_receivables_service(self) -> Any:
+        if self._receivables_service_override is not None:
+            return self._receivables_service_override
+        from ...services.receivables import get_receivables_service
+
+        return get_receivables_service()
+
     # -- Invoice CRUD ----------------------------------------------
 
     async def create(
@@ -78,7 +108,7 @@ class InvoiceRepository:
         day of the period when invoicing past work (e.g. April 1 for an
         April-billing invoice issued in early May).
         """
-        pool = get_db_pool()
+        pool = self._get_pool()
         if not pool.is_initialized:
             raise DatabaseUnavailableError("create invoice")
 
@@ -161,7 +191,7 @@ class InvoiceRepository:
 
     async def get_by_id(self, invoice_id: UUID) -> Optional[dict]:
         """Get an invoice by ID."""
-        pool = get_db_pool()
+        pool = self._get_pool()
         if not pool.is_initialized:
             raise DatabaseUnavailableError("get invoice by id")
 
@@ -175,7 +205,7 @@ class InvoiceRepository:
 
     async def get_by_source_ref(self, source_ref: str) -> Optional[dict]:
         """Get an invoice by source_ref (for deduplication)."""
-        pool = get_db_pool()
+        pool = self._get_pool()
         if not pool.is_initialized:
             raise DatabaseUnavailableError("get invoice by source_ref")
 
@@ -191,7 +221,7 @@ class InvoiceRepository:
 
     async def get_by_number(self, invoice_number: str) -> Optional[dict]:
         """Get an invoice by invoice number (e.g. INV-2026-0001)."""
-        pool = get_db_pool()
+        pool = self._get_pool()
         if not pool.is_initialized:
             raise DatabaseUnavailableError("get invoice by number")
 
@@ -208,7 +238,7 @@ class InvoiceRepository:
 
     async def get_by_contact_id(self, contact_id: UUID, limit: int = 20) -> list[dict]:
         """Get invoices for a CRM contact."""
-        pool = get_db_pool()
+        pool = self._get_pool()
         if not pool.is_initialized:
             raise DatabaseUnavailableError("get invoices by contact")
 
@@ -240,7 +270,7 @@ class InvoiceRepository:
         void_reason: Optional[str] = None,
     ) -> None:
         """Update invoice status and related timestamps."""
-        pool = get_db_pool()
+        pool = self._get_pool()
         if not pool.is_initialized:
             raise DatabaseUnavailableError("update invoice status")
 
@@ -283,7 +313,7 @@ class InvoiceRepository:
         contact_name: Optional[str] = None,
     ) -> Optional[dict]:
         """Update a draft invoice. Only draft invoices can be edited."""
-        pool = get_db_pool()
+        pool = self._get_pool()
         if not pool.is_initialized:
             raise DatabaseUnavailableError("update invoice")
 
@@ -366,7 +396,7 @@ class InvoiceRepository:
         limit: int = 50,
     ) -> list[dict]:
         """Get outstanding invoices (sent, partial, overdue)."""
-        pool = get_db_pool()
+        pool = self._get_pool()
         if not pool.is_initialized:
             raise DatabaseUnavailableError("get outstanding invoices")
 
@@ -401,7 +431,7 @@ class InvoiceRepository:
 
     async def get_overdue(self, as_of_date: Optional[date] = None) -> list[dict]:
         """Get invoices past due date that are still unpaid."""
-        pool = get_db_pool()
+        pool = self._get_pool()
         if not pool.is_initialized:
             raise DatabaseUnavailableError("get overdue invoices")
 
@@ -411,7 +441,8 @@ class InvoiceRepository:
                 """
                 SELECT * FROM invoices
                 WHERE due_date < $1
-                  AND status IN ('sent', 'partial')
+                  AND status IN ('sent', 'partial', 'overdue')
+                  AND amount_due > 0
                 ORDER BY due_date ASC
                 LIMIT 500
                 """,
@@ -429,7 +460,7 @@ class InvoiceRepository:
 
     async def update_reminder(self, invoice_id: UUID) -> None:
         """Increment reminder count and update last_reminder_at."""
-        pool = get_db_pool()
+        pool = self._get_pool()
         if not pool.is_initialized:
             raise DatabaseUnavailableError("update invoice reminder")
 
@@ -460,7 +491,7 @@ class InvoiceRepository:
         limit: int = 50,
     ) -> list[dict]:
         """Search invoices with multiple filters."""
-        pool = get_db_pool()
+        pool = self._get_pool()
         if not pool.is_initialized:
             raise DatabaseUnavailableError("search invoices")
 
@@ -522,55 +553,84 @@ class InvoiceRepository:
         notes: Optional[str] = None,
         recorded_by: Optional[str] = None,
         metadata: Optional[dict] = None,
+        idempotency_key: Optional[str] = None,
     ) -> dict:
-        """Record a payment and auto-update invoice status."""
-        pool = get_db_pool()
-        if not pool.is_initialized:
-            raise DatabaseUnavailableError("record payment")
+        """Compatibility wrapper for a one-invoice receipt."""
+        outcome = await self.record_payment_with_outcome(
+            invoice_id=invoice_id,
+            amount=amount,
+            payment_method=payment_method,
+            payment_date=payment_date,
+            reference=reference,
+            notes=notes,
+            recorded_by=recorded_by,
+            metadata=metadata,
+            idempotency_key=idempotency_key,
+        )
+        return outcome.payment
 
-        payment_id = uuid4()
-        pay_date = payment_date or date.today()
-        now = datetime.now(timezone.utc)
-
+    async def record_payment_with_outcome(
+        self,
+        invoice_id: UUID,
+        amount: float,
+        payment_method: str = "other",
+        payment_date: Optional[date] = None,
+        reference: Optional[str] = None,
+        notes: Optional[str] = None,
+        recorded_by: Optional[str] = None,
+        metadata: Optional[dict] = None,
+        idempotency_key: Optional[str] = None,
+    ) -> InvoicePaymentRecordOutcome:
+        """Record one invoice payment and retain first-write/replay state internally."""
+        invoice = await self.get_by_id(invoice_id)
+        if not invoice:
+            raise DatabaseOperationError(
+                "record payment", Exception(f"Invoice not found: {invoice_id}")
+            )
         try:
-            # Insert payment
-            pay_row = await pool.fetchrow(
-                """
-                INSERT INTO invoice_payments (
-                    id, invoice_id, amount, payment_date, payment_method,
-                    reference, notes, recorded_by, created_at, metadata
+            # The long-lived singular MCP tool historically accepted calls without
+            # an idempotency key. Preserve that surface and its append semantics:
+            # two identical-looking receipts may be two real payments. Callers that
+            # need retry deduplication must supply and reuse an operation key.
+            compatibility_key = idempotency_key or f"invoice-repository-{uuid4()}"
+
+            receipt_outcome = (
+                await self._get_receivables_service().create_payment_with_outcome(
+                    contact_id=invoice.get("contact_id"),
+                    payer_name=invoice["customer_name"],
+                    total_amount=Decimal(str(amount)),
+                    payment_method=payment_method,
+                    received_date=payment_date or date.today(),
+                    allocations=[{"invoice_id": invoice_id, "amount": amount}],
+                    reference=reference,
+                    notes=notes,
+                    recorded_by=recorded_by,
+                    metadata=metadata,
+                    source="invoice_repository",
+                    idempotency_key=compatibility_key,
+                    enforce_api_methods=False,
                 )
-                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb)
-                RETURNING *
-                """,
-                payment_id,
-                invoice_id,
-                amount,
-                pay_date,
-                payment_method,
-                reference,
-                notes,
-                recorded_by,
-                now,
-                json.dumps(metadata or {}),
             )
-
-            # Recalculate amount_paid from all payments
-            await self._recalculate_amount_paid(invoice_id)
-
-            # Auto-derive status
-            inv = await self.get_by_id(invoice_id)
-            if inv:
-                if float(inv["amount_due"]) <= 0:
-                    await self.update_status(invoice_id, "paid", paid_at=now)
-                elif float(inv["amount_paid"]) > 0 and inv["status"] in ("sent", "overdue"):
-                    await self.update_status(invoice_id, "partial")
-
-            logger.info(
-                "Recorded payment %s on invoice %s: $%.2f via %s",
-                payment_id, invoice_id, amount, payment_method,
+            receipt = receipt_outcome.payment
+            allocation = next(
+                item
+                for item in receipt["allocations"]
+                if str(item["invoice_id"]) == str(invoice_id)
             )
-            return self._payment_row_to_dict(pay_row) if pay_row else {}
+            return InvoicePaymentRecordOutcome(
+                payment={
+                    **allocation,
+                    "payment_id": receipt["id"],
+                    "payment_date": receipt["received_date"],
+                    "payment_method": receipt["payment_method"],
+                    "reference": receipt.get("reference"),
+                    "notes": receipt.get("notes"),
+                    "recorded_by": receipt.get("recorded_by"),
+                    "idempotency_key": receipt.get("idempotency_key"),
+                    "status": receipt["status"],
+                },
+                replayed=receipt_outcome.replayed,
+            )
         except (DatabaseUnavailableError, DatabaseOperationError):
             raise
         except Exception as e:
@@ -579,15 +639,19 @@ class InvoiceRepository:
 
     async def get_payments(self, invoice_id: UUID) -> list[dict]:
         """Get all payments for an invoice."""
-        pool = get_db_pool()
+        pool = self._get_pool()
         if not pool.is_initialized:
             raise DatabaseUnavailableError("get payments")
 
         try:
             rows = await pool.fetch(
                 """
-                SELECT * FROM invoice_payments
-                WHERE invoice_id = $1
+                SELECT ip.*, COALESCE(cp.status, 'legacy') AS payment_status,
+                       COALESCE(cp.total_amount, ip.amount) AS receipt_total_amount
+                FROM invoice_payments ip
+                LEFT JOIN customer_payments cp ON cp.id = ip.payment_id
+                WHERE ip.invoice_id = $1
+                  AND ip.reversed_at IS NULL
                 ORDER BY payment_date DESC
                 LIMIT 200
                 """,
@@ -601,7 +665,7 @@ class InvoiceRepository:
 
     async def get_customer_balance(self, contact_id: UUID) -> dict:
         """Get aggregate balance for a customer."""
-        pool = get_db_pool()
+        pool = self._get_pool()
         if not pool.is_initialized:
             raise DatabaseUnavailableError("get customer balance")
 
@@ -631,7 +695,7 @@ class InvoiceRepository:
 
     async def get_payment_behavior(self, contact_id: UUID) -> dict:
         """Analyze payment behavior: on-time rate, avg days to pay."""
-        pool = get_db_pool()
+        pool = self._get_pool()
         if not pool.is_initialized:
             raise DatabaseUnavailableError("get payment behavior")
 
@@ -645,9 +709,14 @@ class InvoiceRepository:
                         i.status,
                         i.total_amount,
                         i.amount_paid,
-                        MIN(p.payment_date) AS first_payment_date
+                        MIN(p.payment_date) FILTER (
+                            WHERE p.payment_id IS NULL
+                               OR cp.status IN ('legacy', 'received', 'deposited', 'cleared')
+                        ) AS first_payment_date
                     FROM invoices i
-                    LEFT JOIN invoice_payments p ON p.invoice_id = i.id
+                    LEFT JOIN invoice_payments p
+                      ON p.invoice_id = i.id AND p.reversed_at IS NULL
+                    LEFT JOIN customer_payments cp ON cp.id = p.payment_id
                     WHERE i.contact_id = $1
                       AND i.status NOT IN ('void', 'draft')
                     GROUP BY i.id
@@ -678,20 +747,8 @@ class InvoiceRepository:
     # -- Helpers ---------------------------------------------------
 
     async def _recalculate_amount_paid(self, invoice_id: UUID) -> None:
-        """Recalculate amount_paid from sum of payments."""
-        pool = get_db_pool()
-        await pool.execute(
-            """
-            UPDATE invoices
-            SET amount_paid = COALESCE(
-                (SELECT SUM(amount) FROM invoice_payments WHERE invoice_id = $1), 0
-            ),
-            updated_at = $2
-            WHERE id = $1
-            """,
-            invoice_id,
-            datetime.now(timezone.utc),
-        )
+        """Recalculate via the lifecycle-aware receivables ledger."""
+        await self._get_receivables_service().recalculate_invoice(invoice_id)
 
     def _row_to_dict(self, row) -> dict:
         """Convert an invoice database row to a dict."""

--- a/plans/PR-Receivables-Ledger.md
+++ b/plans/PR-Receivables-Ledger.md
@@ -1,0 +1,215 @@
+# EOM Receivables Ledger and Authenticated Payment API
+
+## Why this slice exists
+
+Atlas stores each invoice application as an unrelated payment row. That loses the identity of a physical check covering several invoices, cannot preserve unapplied credit or deposit state, and performs balance/status updates outside a transaction. The current HTTP invoice actions are also unauthenticated, so extending them directly would widen a money-write risk.
+
+Post-open review found four invariant-placement gaps in the first implementation: the retired quick-pay route inherited the live API's router-level auth gate, the shared currency helper rounded sub-cent inputs, event-key lookup and locking were scoped too narrowly to prevent cross-payment reuse, and payment summaries treated every unreversed allocation as active even after return or void. The fixes place each rule at its authoritative boundary rather than special-casing the reported examples.
+
+Exact-head review and CI then exposed two more root causes in the follow-up: allocation adjustment treated mutable payment status as authoritative before consulting the immutable idempotency event ledger, so a completed adjustment could stop replaying after a later return or void; and several new tests replaced first-party components or asserted fake SQL text, increasing the repository's maturity debt instead of proving behavior through supported boundaries. This fix moves replay ownership ahead of state-dependent admission and replaces those new internal mocks with explicit request/runtime dependency seams plus real PostgreSQL behavior checks. It does not accept a weaker maturity baseline.
+
+The exact-head security scan also identified the literal test operation key `mcp-boundary-1` as a generic API key at the commit where that fixture entered the branch. It was not a credential, but the PR scanner evaluates the full commit range, so deleting the literal only at the branch tip could not reconcile the historical false positive. A PR-owned `.gitleaksignore` entry was also not a trustworthy fix because the trusted `pull_request_target` job ran the base branch's checker, which did not yet protect ignore growth. The corrected publication is one clean commit based directly on the reviewed base, contains no `.gitleaksignore`, and retains the UUID fixture already present in the final source. The future trusted checker rejects every first or later ignore addition unless a labeled security-only rotation authorizes it.
+
+The repo-wide Unit Gate subsequently exposed shared-process test contamination rather than an MCP contract regression. Legacy B2B test modules install a passthrough `FastMCP` fake with `sys.modules.setdefault(...)` during collection; when that fake wins the collection order, the new receivables test sees no real tool registry and fails while the same schema and validation contract pass with the CI-pinned MCP 1.28.1/Pydantic 2.13.4 runtime. The regression proof therefore runs the real MCP boundary in a clean child interpreter and uses the supported `list_tools`/`call_tool` surface instead of reading the process-global private registry.
+
+Live reconciliation then found two deployment-readiness omissions on the same reviewed head. The invoicing workflow enrolled migration 344 but not its required follow-up migration 345, so a future 345-only change could skip the PostgreSQL receivables suite. The readiness query also treated table existence plus `invoice_payments.payment_id` as the complete schema contract even though the write path dereferences additional allocation-reversal, deposit-clear, lifecycle, and audit columns. The fix enrolls 345 in both workflow triggers and makes readiness compare the current schema to one explicit manifest of every receivables table column introduced by migration 344.
+
+The next exact-head review found three related outcome-classification gaps. Returned or voided receipts suppressed active allocations but reported the entire inactive receipt as available unapplied credit; idempotent singular-MCP retries deduplicated money but repeated their CRM side effect; and compatibility-only non-check methods were classified as `received`, placing cash/card/Zelle/Venmo/other rows in the check-deposit queue that later rejects them. The root fix makes availability and deposit eligibility derive from lifecycle/method state, and carries the transaction's replay outcome through the repository boundary so secondary effects run only on the first commit without changing the MCP response shape.
+
+A later exact-head review exposed four deployment-boundary gaps. The standalone invoicing MCP initializes a pool but, unlike the FastAPI process, never applies the migrations required by its payment compatibility writer. Readiness models only columns even though write safety and `ON CONFLICT` inference depend on migration-created indexes. The HTTP adapter recognizes an uninitialized pool but not live asyncpg connection, capacity, shutdown, interface, or timeout failures. Finally, the exact historical `.gitleaksignore` exception is consumed directly from a PR checkout while the trusted `pull_request_target` guard protects only the JSON baseline. These are root contract omissions: each boundary advertises or permits a finance write without proving the prerequisite it actually relies on. The fix makes MCP startup migration-gated, expands readiness to the required migration indexes, maps only database-availability runtime classes to 503, and extends the trusted-base Gitleaks rotation policy to reject unapproved ignore growth.
+
+Cold review of that repair found two remaining overclaims. First, its availability classifier was broader than the contract: every `asyncpg.InterfaceError` and every `OSError` became a 503 even though those families also represent transaction/API misuse and non-network programming failures. Second, its readiness manifest covered only literal `CREATE INDEX` statements, not the primary-key and unique indexes created by migration table constraints. The corrected boundaries recognize only unavailable pool/connection interface states—including a connection resource unwinding after its backend closes—plus concrete network and timeout failures, and require the complete explicit plus constraint-backed migration index set; unrelated interface/OS errors still escape and any missing primary-key or unique index now fails readiness.
+
+The latest exact-head review found four final boundary-ordering gaps. The proposed ignore bootstrap was still PR-controlled on its first adoption; standalone MCP startup ran migrations but did not prove the full receivables schema ready; the singular payment tool accepted an unbounded idempotency key even though storage is limited to 128 characters; and allocation suggestions inherited customer-name-first ordering from the open-invoice feed instead of honoring their oldest-due-first contract. The root fixes remove the ignore entirely through clean-history publication, require service readiness before the MCP yields, reject empty or oversized singular keys before repository access (with a matching service invariant), and order the authoritative invoice feed by due date before customer name.
+
+### Problem-derived contract
+
+- Root cause: the persistence and service contract model an invoice-local row, not a customer payment with allocations and lifecycle. Transport-specific writers call that non-atomic repository method directly.
+- A correct fix must add one authoritative payment parent, explicit allocations, unapplied credit, deposit/audit lifecycle, idempotent transactional writes, deterministic invoice recomputation, a fail-closed server-to-server API, and compatibility wrappers for existing callers.
+- Completed operation keys must be reconciled from the immutable event ledger before mutable lifecycle status can reject the same request; mismatched reuse must still conflict after the lifecycle advances.
+- CI proof must exercise SQL behavior against PostgreSQL and inject configuration, service, repository, or transport collaborators only through explicit supported boundaries rather than patching first-party module globals.
+- Secret-scan reconciliation must not rely on a PR-controlled ignore: the published range must contain no flagged fixture, and the trusted checker must reject every new ignore unless an explicit labeled security-only rotation authorizes it.
+- MCP boundary proof must be independent of collection-order `sys.modules` fakes and must exercise the registered tool through public FastMCP APIs.
+- Every receivables migration file covered by the PostgreSQL bundle must trigger the invoicing workflow, and readiness must fail closed when any required ledger column is missing.
+- Returned or voided receipts must expose neither active allocation nor available unapplied credit; only physical checks may enter the received/check-deposit queue.
+- An idempotent singular payment retry must reuse the receipt without repeating CRM history; the atomic replay outcome must cross the service/repository boundary without changing the public MCP payload.
+- Every standalone finance-writer startup must apply pending migrations and prove the complete receivables schema ready before exposing MCP tools; migration or readiness failure must prevent that writer from starting.
+- Readiness must prove both required columns and every explicit or constraint-backed migration index used for identity, uniqueness, idempotency, lookup, and deposit invariants.
+- Live database availability failures must map to the structured 503 contract without converting validation, not-found, conflict, transaction/API misuse, or unrelated OS/programming failures.
+- Gitleaks ignore growth must be evaluated by the trusted-base `pull_request_target` guard; any first or later addition requires a labeled, security-only rotation.
+- Singular MCP idempotency keys must contain 1 to 128 characters and fail at the transport/service boundary before repository access.
+- Allocation suggestions must be deterministic oldest-due-first even when one contact has invoices under different customer-name snapshots.
+- It must also repair overdue selection because returned payments must re-enter the real reminder path.
+- It must not change invoice generation, PDFs, email content, CRM ownership, customer-facing invoice shape, SaaS authentication, the read-only/draft-writer MCP permissions, or unrelated product lanes.
+
+## Scope (this PR)
+
+Ownership lane: eom-receivables
+
+Slice phase: Vertical slice
+
+Max files: 18
+
+1. Add an additive, rerunnable payment-parent/allocation/deposit/audit migration with conservative legacy backfill.
+2. Centralize atomic payment creation, allocation adjustment, deposit, clear, return, and void behavior in a receivables service.
+3. Add a typed, fail-closed `/api/v1/receivables` surface for the EOM backend.
+4. Preserve singular MCP behavior and add one explicit multi-invoice MCP tool through the same service.
+5. Remove the unauthenticated quick-pay write and protect retained legacy invoice actions.
+6. Fix balance-derived overdue/reminder selection and enroll the new behavior in invoicing CI.
+7. Close the exact-head adjustment-replay finding and restore all maturity ratchets without updating their baselines.
+8. Reconcile the historical test-fixture Gitleaks false positive by publishing a clean one-commit range with no ignore, without weakening the trusted baseline or scanner rule.
+9. Make the strict multi-invoice MCP contract regression proof hermetic against repo-wide test-module contamination.
+10. Enroll migration 345 in invoicing CI and close partial-schema readiness gaps without broadening the feature surface.
+11. Make inactive-credit, non-check deposit eligibility, and singular-MCP replay side effects agree with the authoritative payment outcome.
+12. Run all pending migrations before the standalone invoicing MCP exposes payment tools.
+13. Require every explicit and constraint-backed receivables migration index in `/receivables/ready`, not columns alone.
+14. Preserve the structured database-unavailable 503 contract for live driver/runtime outages.
+15. Extend the trusted Gitleaks rotation gate to reject unexpected `.gitleaksignore` fingerprint growth.
+16. Require full receivables readiness before standalone MCP serving, bound singular idempotency keys before repository access, and preserve oldest-due-first allocation suggestions.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [x] One customer payment atomically allocates across two or three invoices and preserves an unapplied remainder.
+  - [x] Same-request retries do not duplicate money; mismatched or cross-payment event-key reuse conflicts, including concurrent deposit/clear attempts.
+  - [x] An allocation-adjustment retry returns the committed result even after a later return or void, while changed or cross-payment replay payloads still conflict.
+  - [x] Cross-customer, draft/void, non-positive, sub-cent, duplicate, and over-allocation inputs fail before mutation.
+  - [x] Received, deposited, cleared, returned, and voided transitions deterministically recalculate balances and invoice statuses; returned/voided payment summaries expose allocations as history with zero active allocation and zero available credit.
+  - [x] Legacy payment rows retain their public fields and continue contributing without inferred grouping.
+  - [x] New HTTP routes reject missing/wrong credentials before repository access and report database unavailability.
+  - [x] Legacy quick-pay returns 410 without writing even when the finance feature is disabled or unauthenticated; retained legacy actions require the new credential.
+  - [x] Existing singular MCP calls retain their payload shape, reject idempotency keys outside 1 to 128 characters before repository access, log CRM history once across retries, bypass the check-deposit queue for compatibility-only non-check methods, and delegate multi-invoice writes to the domain service.
+  - [x] Every balance recomputation locks affected invoices before its aggregate snapshot; a real two-connection PostgreSQL test covers concurrent create-versus-return.
+  - [x] Already-overdue invoices remain visible to reminder processing.
+  - [x] SQL behavior tests use real PostgreSQL, request/runtime tests use explicit dependency boundaries, and the API, storage, and MCP maturity ratchets pass without baseline changes.
+  - [x] The clean one-commit PR history contains neither the flagged test-code occurrence of `mcp-boundary-1` nor a root `.gitleaksignore`, and the secret scan still uses the trusted base-branch baseline.
+  - [x] The multi-invoice MCP schema and strict validation proof passes under the repo-wide Unit Gate even when the parent pytest process contains a legacy `FastMCP` fake.
+  - [x] Both pull-request and main-push workflow filters enroll migration 345 in the receivables PostgreSQL checks.
+  - [x] `/receivables/ready` returns unavailable when any migration-added ledger column is absent, including deposit-clear and allocation-reversal fields.
+  - [x] Standalone invoicing MCP startup applies migrations after pool initialization, proves full receivables readiness, and fails before serving tools when migration or readiness fails.
+  - [x] `/receivables/ready` fails closed for each required explicit or constraint-backed migration index, including every new table primary key, deposit-item uniqueness, and the partial unique index required by payment `ON CONFLICT` inference.
+  - [x] Database connection, shutdown, capacity, closed/uninitialized pool, connection, or connection resource, OS-network, and timeout failures map to structured 503 responses while domain, released-resource/API-misuse, and unrelated OS/programming errors retain their existing handling.
+  - [x] The trusted-base Gitleaks guard rejects every first or later ignore addition unless a labeled security-only rotation authorizes it.
+  - [x] Suggested allocations are deterministic oldest-due-first for the selected contact even when invoice customer-name snapshots differ.
+- Reachability proof: an authenticated FastAPI route test proves bearer/actor/idempotency propagation into the service; PostgreSQL tests prove parent/allocation persistence, same-key replay, invoice recomputation, deposit/clear/return, allocation adjustment, anomaly rejection, and create-versus-return serialization against the real query path.
+- Affected surfaces: database migration, invoice repository/service, API, authentication, MCP, reminders, configuration, CI.
+- Risk areas: money correctness, migration/backfill, authorization, concurrency, idempotency, backward compatibility, deployment ordering.
+- Reviewer rules triggered: R1, R2, R3, R4, R5, R6, R7, R8, R10, R11, R12, R14.
+
+### Files touched
+
+- `.github/workflows/atlas_invoicing_checks.yml`
+- `CLAUDE.md`
+- `atlas_brain/api/invoicing/__init__.py`
+- `atlas_brain/api/invoicing/actions.py`
+- `atlas_brain/api/invoicing/auth.py`
+- `atlas_brain/api/invoicing/receivables.py`
+- `atlas_brain/config.py`
+- `atlas_brain/main.py`
+- `atlas_brain/mcp/invoicing_server.py`
+- `atlas_brain/services/receivables.py`
+- `atlas_brain/storage/migrations/344_receivables_payments.sql`
+- `atlas_brain/storage/migrations/345_receivables_event_key_lookup.sql`
+- `atlas_brain/storage/repositories/invoice.py`
+- `plans/PR-Receivables-Ledger.md`
+- `scripts/check_gitleaks_baseline_rotation.py`
+- `tests/test_check_gitleaks_baseline_rotation.py`
+- `tests/test_invoice_repository.py`
+- `tests/test_receivables.py`
+
+## Mechanism
+
+`customer_payments` owns the physical/electronic receipt. Existing `invoice_payments` rows become compatible allocations by gaining a nullable parent ID and reversal fields. Deposit membership and lifecycle events are additive tables. New writes validate and lock all affected invoices in stable order inside one database transaction, write the parent/allocations/event, and recalculate invoice balances and state before commit.
+
+Every event-producing mutation also takes one global advisory lock for its idempotency key before querying all payment events, so the same key cannot transition another payment under either sequential or concurrent requests. Currency normalization rejects values that are not already exact cents. Returned and voided responses retain allocation rows for audit while excluding them from active allocated/unapplied calculations. The retired quick-pay tombstone is registered on a separate ungated router, while all live invoice and receivables actions remain fail-closed.
+
+Only checks begin in `received`; API ACH/Square and compatibility-only non-check methods begin in `cleared`, so deposit worklists cannot contain a method the deposit writer rejects. Payment creation also returns a typed internal first-write/replay outcome to the invoice repository. The singular MCP consumes that internal outcome to skip duplicate CRM logging on a retry, then emits the same payment dictionary as before.
+
+Allocation adjustment reads and validates any existing event immediately after locking and loading the payment, before applying status-dependent admission to a new mutation. The replay contract therefore survives later lifecycle changes, while fingerprint validation continues to reject changed or cross-payment reuse. Repository SQL behavior is verified through a connection-scoped real PostgreSQL adapter; FastAPI configuration/service overrides and MCP core helpers expose only deliberate test/runtime seams, so tests no longer replace first-party module globals.
+
+The receivables router is feature-gated and uses a dedicated typed service token with constant-time bearer comparison. The EOM backend supplies an idempotency key and trusted admin actor headers. New HTTP and multi-invoice MCP write-request inputs accept strict integer cents while PostgreSQL retains `NUMERIC(12,2)`; response dictionaries retain legacy dollar-valued compatibility fields alongside authoritative `*_cents` fields, and the portal consumes only cents. The existing singular MCP keeps its dollar-float argument for compatibility.
+
+The MCP contract test starts a clean child interpreter so repo-wide collection-time `sys.modules` fakes cannot replace the installed SDK. Inside that process it discovers `record_customer_payment` through `FastMCP.list_tools`, checks the published input schema, and calls the tool through `FastMCP.call_tool` to prove coercive, non-positive, oversized, and empty inputs are rejected at the registered transport boundary. The existing real-PostgreSQL MCP test separately proves that valid multi-invoice input reaches the receivables service and persists correctly.
+
+Readiness owns a declarative `(table, column)` manifest for every relation introduced or extended by migration 344. A single `information_schema.columns` anti-join returns false if any manifest entry is absent, so partially created preview tables cannot expose money controls. Real-PostgreSQL regression proof derives the expected table set independently from migration SQL, matches every introduced column, and proves that either missing fields or a wholly missing event table fail closed. Migration 345 is named explicitly in both invoicing workflow path lists; the test parses those event blocks directly and proves removing either enrollment is detected.
+
+The standalone MCP lifecycle now initializes the pool, applies the repository migration runner, constructs the receivables service, and proves its complete schema readiness before yielding the tool server; any migration or readiness failure closes the pool and aborts startup. Readiness also compares the live catalog to a declarative signature for every explicit and constraint-backed index in migrations 344 and 345, including its table, uniqueness, ordered key columns, predicate, validity/readiness, and required primary-key/unique constraint type. The API adapter keeps domain errors ahead of a narrow database-availability classifier covering asyncpg connection/capacity/shutdown failures, explicit closed/closing/uninitialized pool or connection states, connection resources whose underlying connection closed, and concrete runtime network/timeout failures. Released-to-pool resources and other `InterfaceError` or `OSError` values remain visible as 500s with ordinary PostgreSQL/data/programming errors.
+
+The existing `pull_request_target` Gitleaks growth job checks out and executes the trusted base script against the fetched PR head. The future trusted script treats non-comment `.gitleaksignore` fingerprints as a second protected set: removals are safe, while every first or later addition requires the `security-rotation` label plus the existing security-only path restriction. This PR publishes a clean single-commit range without a root ignore, so its own checker change is not relied upon to excuse this PR's scan.
+
+The singular MCP validates its optional idempotency key at 1 to 128 characters in the registered schema and normalizes it before any repository lookup; the service repeats the limit as the authoritative write invariant. Open invoices are ordered by due date, issue date, customer name, and invoice number, so the greedy suggestion loop cannot prefer a newer invoice merely because its customer-name snapshot sorts first.
+
+## Intentional
+
+- Legacy rows are backfilled one-to-one as `legacy`; matching references are never grouped.
+- `payment_id` remains nullable for one release; balance recomputation treats a null parent as an active legacy allocation and the adoption trigger gives a late legacy row a visible parent. This is a data-visibility bridge only. Old and new finance writers must not overlap because the pre-receivables writer performs an unlocked, separate balance refresh that can overwrite a newer total.
+- Unapplied credit is visible at customer/payment level but does not reduce an invoice until explicitly allocated.
+- Check images and automatic ACH/Square provider sync are not part of this slice.
+- The dedicated internal token is separate from SaaS auth and MCP auth because those dependencies have different fail-open/scope contracts.
+- Maturity baselines are not updated; the new debt is removed at its source.
+- No root `.gitleaksignore` is added. The historical false-positive commit is removed from the published PR range while the trusted JSON baseline and scanner rule remain untouched.
+- The required status context remains named `Gitleaks baseline growth guard`; its trusted checker now covers both the JSON baseline and root ignore growth so branch-protection configuration does not drift.
+
+## Deferred
+
+- A later contract migration may make `invoice_payments.payment_id` non-null after every writer has rolled forward.
+- Provider webhooks, bank-file matching, parent-payer accounts, and check-image storage require separate operator-approved slices.
+- EOM proxy and portal changes ship in their own repository branches but are part of the coordinated release.
+- Parked hardening: none; auth, idempotency, migration safety, and lifecycle audit are required money-risk controls for this vertical path.
+
+## Coordinated deployment and rollback
+
+Production token and environment provisioning are external prerequisites and are not asserted by this code change. The code-derived safe rollout order is:
+
+1. Start a finance-write maintenance window: disable portal/MCP payment entry and drain every pre-receivables Atlas application and invoicing-MCP writer. Do not enable the new API while any old writer can still accept payment calls.
+2. Deploy this Atlas revision to every finance-writer process with the receivables API disabled. Let startup apply migrations 344 and 345 in both application and standalone MCP processes, and verify that no old process remains. Then configure a non-placeholder `ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN`, set `ATLAS_INVOICING_RECEIVABLES_API_ENABLED=true`, restart, and require an authenticated `/api/v1/receivables/ready` response before ending the maintenance window.
+3. Deploy the EOM backend with the matching `ATLAS_RECEIVABLES_SERVICE_TOKEN` and an `ATLAS_RECEIVABLES_BASE_URL` ending in `/api/v1`. Require `/api/health` and an authenticated `/api/admin/receivables/ready` response before exposing the portal UI.
+4. Deploy the EOM portal last and run the operator smoke against the backend. The base portal has no receivables UI, so deploying it before the proxy would expose controls whose routes do not yet exist.
+
+Normal disablement reverses the consumer order: roll back the portal first to remove money-write controls, roll back/disable the EOM proxy second, and disable the Atlas feature flag last. Migration 344 and this Atlas writer implementation must remain in place once new receipt, reversal, or allocation-history rows exist; restarting the pre-receivables writer can miscount reversed allocations and is not a supported rollback. Rollback never deletes receipt history. For an emergency write stop, disabling the Atlas feature flag immediately makes the finance API fail closed with 503 while the UI/backend may remain deployed for diagnosis.
+
+## Verification
+
+- Clean-process MCP contract probe passes under Python 3.11.15 with the CI-pinned MCP 1.28.1/Pydantic 2.13.4 runtime; the exact pytest node also passes with the parent process preloaded with the legacy passthrough `FastMCP` fake.
+- `python -m pytest tests/test_receivables.py tests/test_invoice_repository.py -q` with `ATLAS_RECEIVABLES_TEST_DATABASE_URL` against ephemeral PostgreSQL 16 (62 passed, including the real-PostgreSQL tests and the review regressions). The entrypoint proof observes one first-write/one replay outcome under concurrency, one CRM call across a singular retry, zero inactive available credit, a compatibility card receipt absent from the received-check worklist, and oldest-due-first suggestion across differing customer-name snapshots while preserving the public MCP payload.
+- Migration/readiness proof parses both exact workflow path lists with negative controls, derives the table set from migration 344, matches every introduced column, and proves missing deposit-clear fields, allocation-reversal fields, or the complete events table each fail closed.
+- MCP lifecycle proof observes initialization, migration, and full readiness in order, and proves either migration failure or incomplete-schema readiness aborts startup and closes the pool.
+- Real-PostgreSQL readiness proof transactionally removes every explicit and constraint-backed migration index, proving each omission fails closed before rollback restores the schema.
+- Parametrized API proof covers multiple asyncpg connection/capacity/shutdown classes, explicit unavailable pool/connection interface states, network errnos, and timeouts. A real PostgreSQL probe terminates a backend inside a live transaction and proves the resulting closed-resource interface error maps to 503; negative controls preserve domain statuses and let released-resource/API misuse, unrelated OS failures, and unexpected errors escape.
+- Trusted Gitleaks rotation tests reject unapproved initial and later growth, permit comments/removals, and allow only labeled security-only rotation.
+- Focused receivables, repository, and rotation unit suite passes (72 passed, six expected database skips); security policy/workflow coverage passes (85 passed, 43 subtests).
+- Invoicing MCP/OAuth surface suite (43 passed).
+- Monthly invoice approval-blocker selection (2 passed).
+- API, storage, and MCP maturity ratchets pass without baseline changes.
+- Gitleaks PR-range scan passes the clean single-commit branch against the trusted baseline with no `.gitleaksignore` and reports no leaks.
+- Real-PostgreSQL migration parse, one-to-one legacy backfill, and rolling-writer adoption in a temporary schema dropped after the test.
+- Real-PostgreSQL receipt/replay/deposit/clear/return, adjustment/anomaly, and concurrent-key flows in temporary schemas dropped after each test.
+- Companion backend suite `python -m pytest -q` (116 passed) covers canonical deposit retries, duplicate-ID rejection, Pydantic v2 runtime requirements, and retryable non-JSON upstream outages in addition to the original proxy contract.
+- Companion portal suite `npm test` (12 passed) includes a jsdom reachability test that loads the real `portal.html`, initializes the real receivables module, clicks the actual payment control, verifies the two-invoice cents payload/idempotency key, and observes in-flight control locking; it also proves failed refreshes invalidate every stale money surface and definitive 4xx payment rejections refresh authoritative invoices before unlocking. The production-like coordinated browser smoke remains a release-time gate in the deployment sequence above and is not asserted by this PR.
+- `python scripts/sync_pr_plan.py plans/PR-Receivables-Ledger.md --check` after synchronizing the plan.
+- `git diff --check`.
+- Atlas pre-push/local-review gate through the repository wrapper if publishing is requested.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_invoicing_checks.yml` | 37 |
+| `CLAUDE.md` | 20 |
+| `atlas_brain/api/invoicing/__init__.py` | 10 |
+| `atlas_brain/api/invoicing/actions.py` | 67 |
+| `atlas_brain/api/invoicing/auth.py` | 73 |
+| `atlas_brain/api/invoicing/receivables.py` | 341 |
+| `atlas_brain/config.py` | 8 |
+| `atlas_brain/main.py` | 3 |
+| `atlas_brain/mcp/invoicing_server.py` | 283 |
+| `atlas_brain/services/receivables.py` | 1629 |
+| `atlas_brain/storage/migrations/344_receivables_payments.sql` | 221 |
+| `atlas_brain/storage/migrations/345_receivables_event_key_lookup.sql` | 7 |
+| `atlas_brain/storage/repositories/invoice.py` | 211 |
+| `plans/PR-Receivables-Ledger.md` | 215 |
+| `scripts/check_gitleaks_baseline_rotation.py` | 99 |
+| `tests/test_check_gitleaks_baseline_rotation.py` | 91 |
+| `tests/test_invoice_repository.py` | 225 |
+| `tests/test_receivables.py` | 2101 |
+| **Total** | **5641** |

--- a/scripts/check_gitleaks_baseline_rotation.py
+++ b/scripts/check_gitleaks_baseline_rotation.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Gate Gitleaks baseline changes to an explicit rotation path."""
+"""Gate Gitleaks baseline and ignore growth from a trusted base checkout."""
 
 from __future__ import annotations
 
@@ -10,11 +10,12 @@ import subprocess
 import sys
 from dataclasses import dataclass
 
-
 BASELINE_PATH = "docs/security/gitleaks-baseline.json"
+IGNORE_PATH = ".gitleaksignore"
 DEFAULT_ROTATION_LABEL = "security-rotation"
 ALLOWED_ROTATION_PATHS = {
     BASELINE_PATH,
+    IGNORE_PATH,
     "HARDENING.md",
     "docs/SECURITY_GUARDRAILS.md",
 }
@@ -27,6 +28,7 @@ class Decision:
     reason: str
     disallowed_paths: tuple[str, ...] = ()
     missing_fingerprints: tuple[str, ...] = ()
+    added_ignore_fingerprints: tuple[str, ...] = ()
 
 
 def parse_labels(raw: str | None) -> set[str]:
@@ -57,40 +59,66 @@ def evaluate_baseline_rotation(
     base_has_baseline: bool,
     base_fingerprints: set[str] | None = None,
     candidate_fingerprints: set[str] | None = None,
+    base_ignore_fingerprints: set[str] | None = None,
+    candidate_ignore_fingerprints: set[str] | None = None,
     rotation_label: str = DEFAULT_ROTATION_LABEL,
 ) -> Decision:
-    if not base_has_baseline:
-        return Decision(True, "No trusted-base Gitleaks baseline exists; initial adoption is allowed.")
+    baseline_changed = BASELINE_PATH in changed_paths
+    base_ignores = base_ignore_fingerprints or set()
+    candidate_ignores = candidate_ignore_fingerprints or set()
+    added_ignores = (
+        candidate_ignores - base_ignores if IGNORE_PATH in changed_paths else set()
+    )
+    baseline_requires_rotation = baseline_changed and base_has_baseline
+    ignore_requires_rotation = bool(added_ignores)
 
-    if BASELINE_PATH not in changed_paths:
-        return Decision(True, "Gitleaks baseline unchanged.")
+    if not baseline_requires_rotation and not ignore_requires_rotation:
+        if baseline_changed and not base_has_baseline:
+            return Decision(
+                True,
+                "No trusted-base Gitleaks baseline exists; initial adoption is allowed.",
+            )
+        return Decision(True, "Gitleaks baseline and ignore fingerprints unchanged.")
 
     if rotation_label not in labels:
         return Decision(
             False,
             (
-                "Gitleaks baseline changes require the "
+                "Gitleaks baseline changes or ignore growth require the "
                 f"`{rotation_label}` PR label after provider rotation/revocation."
             ),
+            added_ignore_fingerprints=tuple(sorted(added_ignores)),
         )
 
-    disallowed = tuple(sorted(path for path in changed_paths if not is_rotation_path_allowed(path)))
+    disallowed = tuple(
+        sorted(path for path in changed_paths if not is_rotation_path_allowed(path))
+    )
     if disallowed:
         return Decision(
             False,
-            "Baseline rotation PRs may only touch the baseline, hardening/security docs, and their plan.",
+            "Gitleaks rotation PRs may only touch the baseline, ignore file, hardening/security docs, and their plan.",
             disallowed,
+            added_ignore_fingerprints=tuple(sorted(added_ignores)),
         )
 
-    missing = tuple(sorted((base_fingerprints or set()) - (candidate_fingerprints or set())))
+    missing = tuple(
+        sorted((base_fingerprints or set()) - (candidate_fingerprints or set()))
+        if baseline_changed
+        else ()
+    )
     if missing:
         return Decision(
             False,
             "Proposed Gitleaks baseline drops trusted-base fingerprints.",
             missing_fingerprints=missing,
+            added_ignore_fingerprints=tuple(sorted(added_ignores)),
         )
 
-    return Decision(True, f"Gitleaks baseline rotation accepted with `{rotation_label}` label.")
+    return Decision(
+        True,
+        f"Gitleaks baseline/ignore rotation accepted with `{rotation_label}` label.",
+        added_ignore_fingerprints=tuple(sorted(added_ignores)),
+    )
 
 
 def run_git(args: list[str]) -> subprocess.CompletedProcess[str]:
@@ -98,7 +126,11 @@ def run_git(args: list[str]) -> subprocess.CompletedProcess[str]:
 
 
 def ref_has_baseline(ref: str) -> bool:
-    proc = run_git(["cat-file", "-e", f"{ref}:{BASELINE_PATH}"])
+    return ref_has_path(ref, BASELINE_PATH)
+
+
+def ref_has_path(ref: str, path: str) -> bool:
+    proc = run_git(["cat-file", "-e", f"{ref}:{path}"])
     return proc.returncode == 0
 
 
@@ -120,6 +152,21 @@ def baseline_fingerprints(ref: str) -> set[str]:
         if isinstance(fingerprint, str) and fingerprint:
             fingerprints.add(fingerprint)
     return fingerprints
+
+
+def parse_ignore_fingerprints(raw: str) -> set[str]:
+    return {
+        line.strip()
+        for line in raw.splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+
+
+def ignore_fingerprints(ref: str) -> set[str]:
+    proc = run_git(["show", f"{ref}:{IGNORE_PATH}"])
+    if proc.returncode != 0:
+        return set()
+    return parse_ignore_fingerprints(proc.stdout)
 
 
 def changed_paths(base_ref: str, head_ref: str = "HEAD") -> set[str]:
@@ -156,10 +203,26 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         paths = changed_paths(args.base_ref, args.head_ref)
-        labels = parse_labels_json(args.labels_json) if args.labels_json else parse_labels(args.labels)
-        base_fps = baseline_fingerprints(args.base_ref) if ref_has_baseline(args.base_ref) else set()
+        labels = (
+            parse_labels_json(args.labels_json)
+            if args.labels_json
+            else parse_labels(args.labels)
+        )
+        base_fps = (
+            baseline_fingerprints(args.base_ref)
+            if ref_has_baseline(args.base_ref)
+            else set()
+        )
         candidate_fps = (
-            baseline_fingerprints(args.head_ref) if BASELINE_PATH in paths and ref_has_baseline(args.head_ref) else set()
+            baseline_fingerprints(args.head_ref)
+            if BASELINE_PATH in paths and ref_has_baseline(args.head_ref)
+            else set()
+        )
+        base_ignore_fps = ignore_fingerprints(args.base_ref)
+        candidate_ignore_fps = (
+            ignore_fingerprints(args.head_ref)
+            if IGNORE_PATH in paths and ref_has_path(args.head_ref, IGNORE_PATH)
+            else set()
         )
     except (RuntimeError, ValueError, json.JSONDecodeError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
@@ -171,6 +234,8 @@ def main(argv: list[str] | None = None) -> int:
         base_has_baseline=ref_has_baseline(args.base_ref),
         base_fingerprints=base_fps,
         candidate_fingerprints=candidate_fps,
+        base_ignore_fingerprints=base_ignore_fps,
+        candidate_ignore_fingerprints=candidate_ignore_fps,
         rotation_label=args.rotation_label,
     )
     print(decision.reason)
@@ -181,6 +246,10 @@ def main(argv: list[str] | None = None) -> int:
     if decision.missing_fingerprints:
         print("Missing trusted-base fingerprints:")
         for fingerprint in decision.missing_fingerprints:
+            print(f"- {fingerprint}")
+    if decision.added_ignore_fingerprints:
+        print("Added Gitleaks ignore fingerprints:")
+        for fingerprint in decision.added_ignore_fingerprints:
             print(f"- {fingerprint}")
     return 0 if decision.allowed else 1
 

--- a/tests/test_check_gitleaks_baseline_rotation.py
+++ b/tests/test_check_gitleaks_baseline_rotation.py
@@ -116,6 +116,97 @@ def test_allows_initial_adoption_when_base_has_no_baseline() -> None:
     assert "initial adoption" in decision.reason
 
 
+def test_rejects_initial_ignore_growth_without_trusted_rotation() -> None:
+    checker = load_checker()
+    decision = checker.evaluate_baseline_rotation(
+        _changed(checker.IGNORE_PATH, "app/api/foo.py"),
+        labels=set(),
+        base_has_baseline=True,
+        candidate_ignore_fingerprints={"first-ignore-fingerprint"},
+    )
+
+    assert decision.allowed is False
+    assert "security-rotation" in decision.reason
+    assert decision.added_ignore_fingerprints == ("first-ignore-fingerprint",)
+
+
+def test_rejects_unapproved_initial_ignore_fingerprint_without_label() -> None:
+    checker = load_checker()
+    decision = checker.evaluate_baseline_rotation(
+        _changed(checker.IGNORE_PATH),
+        labels=set(),
+        base_has_baseline=True,
+        candidate_ignore_fingerprints={"unexpected-fingerprint"},
+    )
+
+    assert decision.allowed is False
+    assert decision.added_ignore_fingerprints == ("unexpected-fingerprint",)
+
+
+def test_rejects_ignore_growth_without_rotation_label() -> None:
+    checker = load_checker()
+    decision = checker.evaluate_baseline_rotation(
+        _changed(checker.IGNORE_PATH),
+        labels=set(),
+        base_has_baseline=True,
+        base_ignore_fingerprints={"kept"},
+        candidate_ignore_fingerprints={"kept", "added"},
+    )
+
+    assert decision.allowed is False
+    assert "security-rotation" in decision.reason
+    assert decision.added_ignore_fingerprints == ("added",)
+
+
+def test_allows_labeled_ignore_growth_in_security_only_rotation() -> None:
+    checker = load_checker()
+    decision = checker.evaluate_baseline_rotation(
+        _changed(checker.IGNORE_PATH, "plans/PR-Gitleaks-Baseline-Rotation.md"),
+        labels={"security-rotation"},
+        base_has_baseline=True,
+        base_ignore_fingerprints={"kept"},
+        candidate_ignore_fingerprints={"kept", "added"},
+    )
+
+    assert decision.allowed is True
+    assert "accepted" in decision.reason
+
+
+def test_rejects_labeled_ignore_growth_that_changes_product_code() -> None:
+    checker = load_checker()
+    decision = checker.evaluate_baseline_rotation(
+        _changed(checker.IGNORE_PATH, "atlas_brain/main.py"),
+        labels={"security-rotation"},
+        base_has_baseline=True,
+        base_ignore_fingerprints={"kept"},
+        candidate_ignore_fingerprints={"kept", "added"},
+    )
+
+    assert decision.allowed is False
+    assert decision.disallowed_paths == ("atlas_brain/main.py",)
+
+
+def test_allows_ignore_removal_without_rotation_label() -> None:
+    checker = load_checker()
+    decision = checker.evaluate_baseline_rotation(
+        _changed(checker.IGNORE_PATH),
+        labels=set(),
+        base_has_baseline=True,
+        base_ignore_fingerprints={"remove-me"},
+        candidate_ignore_fingerprints=set(),
+    )
+
+    assert decision.allowed is True
+    assert "unchanged" in decision.reason
+
+
+def test_ignore_parser_excludes_comments_and_blank_lines() -> None:
+    checker = load_checker()
+    assert checker.parse_ignore_fingerprints(
+        "# explanation\n\n fingerprint-a \n  # another comment\nfingerprint-b\n"
+    ) == {"fingerprint-a", "fingerprint-b"}
+
+
 def test_parse_labels_strips_empty_entries() -> None:
     checker = load_checker()
     assert checker.parse_labels(" security-rotation, ,docs-only ") == {

--- a/tests/test_invoice_repository.py
+++ b/tests/test_invoice_repository.py
@@ -1,44 +1,205 @@
 from __future__ import annotations
 
+import os
+from contextlib import asynccontextmanager
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+from uuid import uuid4
+
 import pytest
 
+from atlas_brain.services.receivables import ReceivablesService
 from atlas_brain.storage.repositories import invoice as invoice_repo_mod
 
 
-class _InvoiceLookupPool:
+class _SchemaPool:
+    """Connection-scoped adapter that keeps repository calls in one test schema."""
+
     is_initialized = True
 
-    def __init__(self) -> None:
-        self.fetchrow_calls: list[tuple[str, tuple[object, ...]]] = []
+    def __init__(self, conn, schema: str) -> None:
+        self.conn = conn
+        self.schema = schema
 
-    async def fetchrow(self, query: str, *args: object) -> dict[str, object] | None:
-        self.fetchrow_calls.append((query, args))
-        invoice_number = args[0]
-        if (
-            "lower(invoice_number) = lower($1)" in query
-            and invoice_number == "INV-2026-May-0185"
-        ):
-            return {
-                "id": "invoice-1",
-                "invoice_number": "INV-2026-May-0185",
-                "line_items": [],
-                "metadata": {},
-            }
-        return None
+    @asynccontextmanager
+    async def transaction(self):
+        async with self.conn.transaction():
+            await self.conn.execute(f'SET LOCAL search_path TO "{self.schema}"')
+            yield self.conn
+
+    async def fetch(self, query, *args):
+        async with self.conn.transaction():
+            await self.conn.execute(f'SET LOCAL search_path TO "{self.schema}"')
+            return await self.conn.fetch(query, *args)
+
+    async def fetchrow(self, query, *args):
+        async with self.conn.transaction():
+            await self.conn.execute(f'SET LOCAL search_path TO "{self.schema}"')
+            return await self.conn.fetchrow(query, *args)
+
+    async def execute(self, query, *args):
+        async with self.conn.transaction():
+            await self.conn.execute(f'SET LOCAL search_path TO "{self.schema}"')
+            return await self.conn.execute(query, *args)
+
+
+def _migration_sql(name: str) -> str:
+    return (
+        Path(__file__).parents[1] / f"atlas_brain/storage/migrations/{name}"
+    ).read_text(encoding="utf-8")
 
 
 @pytest.mark.asyncio
-async def test_get_by_number_finds_mixed_case_generated_invoice_numbers(monkeypatch):
-    pool = _InvoiceLookupPool()
-    monkeypatch.setattr(invoice_repo_mod, "get_db_pool", lambda: pool)
+async def test_real_postgres_invoice_lookup_overdue_history_and_singular_payments():
+    asyncpg = pytest.importorskip("asyncpg")
+    database_url = os.environ.get("ATLAS_RECEIVABLES_TEST_DATABASE_URL")
+    if not database_url:
+        pytest.skip("ATLAS_RECEIVABLES_TEST_DATABASE_URL not set")
 
-    invoice = await invoice_repo_mod.InvoiceRepository().get_by_number(
-        " INV-2026-May-0185 "
-    )
+    schema = f"invoice_repository_{uuid4().hex}"
+    conn = await asyncpg.connect(database_url)
+    try:
+        await conn.execute(f'CREATE SCHEMA "{schema}"')
+        await conn.execute(f'SET search_path TO "{schema}"')
+        await conn.execute("CREATE TABLE contacts (id uuid PRIMARY KEY)")
+        await conn.execute(_migration_sql("045_invoices.sql"))
+        await conn.execute(_migration_sql("344_receivables_payments.sql"))
 
-    assert invoice is not None
-    assert invoice["invoice_number"] == "INV-2026-May-0185"
-    assert len(pool.fetchrow_calls) == 1
-    query, args = pool.fetchrow_calls[0]
-    assert "lower(invoice_number) = lower($1)" in query
-    assert args == ("INV-2026-May-0185",)
+        contact_id = uuid4()
+        lookup_id = uuid4()
+        overdue_id = uuid4()
+        legacy_id = uuid4()
+        contactless_id = uuid4()
+        await conn.execute("INSERT INTO contacts (id) VALUES ($1)", contact_id)
+        await conn.executemany(
+            """
+            INSERT INTO invoices (
+                id, invoice_number, contact_id, customer_name, total_amount,
+                amount_paid, due_date, status
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            """,
+            [
+                (
+                    lookup_id,
+                    "INV-2026-May-0185",
+                    contact_id,
+                    "Acme Lookup",
+                    Decimal("50"),
+                    Decimal("0"),
+                    date(2026, 8, 1),
+                    "sent",
+                ),
+                (
+                    overdue_id,
+                    "INV-OVERDUE",
+                    contact_id,
+                    "Acme Overdue",
+                    Decimal("75"),
+                    Decimal("25"),
+                    date(2026, 7, 1),
+                    "overdue",
+                ),
+                (
+                    legacy_id,
+                    "INV-LEGACY",
+                    contact_id,
+                    "Acme Legacy",
+                    Decimal("100"),
+                    Decimal("100"),
+                    date(2026, 7, 16),
+                    "paid",
+                ),
+                (
+                    contactless_id,
+                    "INV-CONTACTLESS",
+                    None,
+                    "Walk-in customer",
+                    Decimal("100"),
+                    Decimal("0"),
+                    date(2026, 8, 1),
+                    "sent",
+                ),
+            ],
+        )
+
+        legacy_payment_id = uuid4()
+        await conn.execute(
+            "ALTER TABLE invoice_payments DISABLE TRIGGER trg_adopt_legacy_invoice_payment"
+        )
+        await conn.execute(
+            """
+            INSERT INTO invoice_payments (
+                id, invoice_id, amount, payment_date, payment_method,
+                reference, created_at
+            ) VALUES ($1, $2, 100, $3, 'check', 'legacy-1001', NOW())
+            """,
+            legacy_payment_id,
+            legacy_id,
+            date(2026, 7, 16),
+        )
+        await conn.execute(
+            "ALTER TABLE invoice_payments ENABLE TRIGGER trg_adopt_legacy_invoice_payment"
+        )
+
+        pool = _SchemaPool(conn, schema)
+        service = ReceivablesService(pool)
+        repository = invoice_repo_mod.InvoiceRepository(
+            pool=pool,
+            receivables_service=service,
+        )
+
+        invoice = await repository.get_by_number(" INV-2026-MAY-0185 ")
+        assert invoice is not None
+        assert invoice["invoice_number"] == "INV-2026-May-0185"
+
+        overdue = await repository.get_overdue(as_of_date=date(2026, 7, 16))
+        assert [item["id"] for item in overdue] == [overdue_id]
+
+        history = await repository.get_payments(legacy_id)
+        assert len(history) == 1
+        assert history[0]["id"] == legacy_payment_id
+        assert history[0]["payment_status"] == "legacy"
+        assert history[0]["receipt_total_amount"] == Decimal("100.00")
+
+        behavior = await repository.get_payment_behavior(contact_id)
+        assert behavior["paid_on_time"] == 1
+        assert behavior["paid_late"] == 0
+
+        first = await repository.record_payment(
+            invoice_id=contactless_id,
+            amount=25,
+            payment_method="check",
+            reference="1001",
+        )
+        second = await repository.record_payment(
+            invoice_id=contactless_id,
+            amount=25,
+            payment_method="check",
+            reference="1001",
+        )
+        assert first["payment_id"] != second["payment_id"]
+        assert first["idempotency_key"].startswith("invoice-repository-")
+        assert second["idempotency_key"].startswith("invoice-repository-")
+
+        replay_first = await repository.record_payment(
+            invoice_id=contactless_id,
+            amount=10,
+            payment_method="check",
+            reference="1002",
+            idempotency_key="mcp-payment-retry-1",
+        )
+        replay_second = await repository.record_payment(
+            invoice_id=contactless_id,
+            amount=10,
+            payment_method="check",
+            reference="1002",
+            idempotency_key="mcp-payment-retry-1",
+        )
+        assert replay_first["payment_id"] == replay_second["payment_id"]
+        assert replay_first["id"] == replay_second["id"]
+        assert replay_second["idempotency_key"] == "mcp-payment-retry-1"
+    finally:
+        await conn.execute("SET search_path TO public")
+        await conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        await conn.close()

--- a/tests/test_receivables.py
+++ b/tests/test_receivables.py
@@ -1,0 +1,2101 @@
+from __future__ import annotations
+
+import asyncio
+import errno
+import json
+import os
+import re
+import subprocess
+import sys
+from contextlib import asynccontextmanager
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+from types import SimpleNamespace
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from atlas_brain.api.invoicing import actions
+from atlas_brain.api.invoicing import auth as receivables_auth
+from atlas_brain.services.receivables import (
+    _RECEIVABLES_REQUIRED_COLUMNS,
+    _RECEIVABLES_REQUIRED_INDEXES,
+    ReceivablesConflictError,
+    ReceivablesError,
+    ReceivablesNotFoundError,
+    ReceivablesService,
+    ReceivablesValidationError,
+    money,
+)
+from atlas_brain.storage.exceptions import DatabaseUnavailableError
+
+
+class _CreatePaymentConnection:
+    def __init__(self, invoices: list[dict]) -> None:
+        self.invoices = invoices
+        self.parent_args = None
+        self.allocations: list[dict] = []
+        self.executions: list[tuple[str, tuple]] = []
+
+    async def fetchrow(self, query: str, *args):
+        if "WHERE source = $1 AND idempotency_key = $2" in query:
+            return None
+        if "FROM payment_events" in query:
+            return None
+        if "INSERT INTO customer_payments" in query:
+            self.parent_args = args
+            return {"id": args[0]}
+        if "SELECT cp.*, pdi.batch_id" in query:
+            assert self.parent_args is not None
+            parent = self.parent_args
+            return {
+                "id": parent[0],
+                "contact_id": parent[1],
+                "payer_name": parent[2],
+                "total_amount": parent[3],
+                "payment_method": parent[4],
+                "reference": parent[5],
+                "received_date": parent[6],
+                "status": parent[7],
+                "source": parent[8],
+                "idempotency_key": parent[9],
+                "request_fingerprint": parent[10],
+                "notes": parent[11],
+                "recorded_by": parent[12],
+                "metadata": {},
+                "batch_id": None,
+            }
+        raise AssertionError(f"Unexpected fetchrow query: {query}")
+
+    async def fetchval(self, query: str, *_args):
+        assert "pg_advisory_xact_lock" in query
+        return None
+
+    async def fetch(self, query: str, *args):
+        if "FROM invoices" in query and "ORDER BY id FOR UPDATE" in query:
+            selected = {str(item) for item in args[0]}
+            return [row for row in self.invoices if str(row["id"]) in selected]
+        if "FROM invoice_payments ip" in query and "JOIN invoices" in query:
+            return self.allocations
+        raise AssertionError(f"Unexpected fetch query: {query}")
+
+    async def execute(self, query: str, *args):
+        self.executions.append((query, args))
+        if "INSERT INTO invoice_payments" in query:
+            invoice = next(row for row in self.invoices if row["id"] == args[1])
+            self.allocations.append(
+                {
+                    "payment_id": args[2],
+                    "id": args[0],
+                    "invoice_id": args[1],
+                    "invoice_number": invoice["invoice_number"],
+                    "amount": args[3],
+                    "reversed_at": None,
+                    "reversal_reason": None,
+                }
+            )
+        return "OK"
+
+
+class _CreatePaymentPool:
+    is_initialized = True
+
+    def __init__(self, invoices: list[dict]) -> None:
+        self.conn = _CreatePaymentConnection(invoices)
+        self.transaction_count = 0
+
+    @asynccontextmanager
+    async def transaction(self):
+        self.transaction_count += 1
+        yield self.conn
+
+
+class _TransactionPool:
+    is_initialized = True
+
+    def __init__(self, conn) -> None:
+        self.conn = conn
+
+    @asynccontextmanager
+    async def transaction(self):
+        yield self.conn
+
+
+def _invoice(
+    invoice_number: str,
+    contact_id: UUID,
+    amount_due: str,
+) -> dict:
+    return {
+        "id": uuid4(),
+        "invoice_number": invoice_number,
+        "contact_id": contact_id,
+        "status": "sent",
+        "amount_due": Decimal(amount_due),
+    }
+
+
+@pytest.mark.asyncio
+async def test_create_payment_records_multi_invoice_receipt_in_one_transaction():
+    contact_id = uuid4()
+    first = _invoice("INV-1", contact_id, "125.00")
+    second = _invoice("INV-2", contact_id, "175.00")
+    pool = _CreatePaymentPool([first, second])
+
+    payment = await ReceivablesService(pool).create_payment(
+        contact_id=contact_id,
+        payer_name="Acme Offices",
+        total_amount=Decimal("300.00"),
+        payment_method="ach",
+        received_date=date(2026, 7, 16),
+        allocations=[
+            {"invoice_id": first["id"], "amount": Decimal("100.00")},
+            {"invoice_id": second["id"], "amount": Decimal("150.00")},
+        ],
+        idempotency_key="payment-create-1",
+        recorded_by="Juan Canfield",
+    )
+
+    assert pool.transaction_count == 1
+    assert payment["status"] == "cleared"
+    assert payment["allocated_amount_cents"] == 25_000
+    assert payment["unapplied_amount_cents"] == 5_000
+    assert len(payment["allocations"]) == 2
+    assert (
+        sum(
+            "INSERT INTO invoice_payments" in query
+            for query, _args in pool.conn.executions
+        )
+        == 2
+    )
+    assert any("WITH totals AS" in query for query, _args in pool.conn.executions)
+    event = next(
+        args
+        for query, args in pool.conn.executions
+        if "INSERT INTO payment_events" in query
+    )
+    assert event[8] == "payment-create-1"
+
+
+@pytest.mark.asyncio
+async def test_create_payment_rejects_cross_customer_allocations_before_insert():
+    selected_contact = uuid4()
+    first = _invoice("INV-1", selected_contact, "100.00")
+    second = _invoice("INV-2", uuid4(), "100.00")
+    pool = _CreatePaymentPool([first, second])
+
+    with pytest.raises(ReceivablesValidationError, match="same customer"):
+        await ReceivablesService(pool).create_payment(
+            contact_id=selected_contact,
+            payer_name="Acme Offices",
+            total_amount=Decimal("100.00"),
+            payment_method="check",
+            received_date=date(2026, 7, 16),
+            allocations=[
+                {"invoice_id": first["id"], "amount": Decimal("50.00")},
+                {"invoice_id": second["id"], "amount": Decimal("50.00")},
+            ],
+            idempotency_key="payment-create-2",
+        )
+
+    assert pool.conn.parent_args is None
+    assert not pool.conn.executions
+
+
+@pytest.mark.asyncio
+async def test_create_payment_rejects_allocation_above_receipt_before_transaction():
+    contact_id = uuid4()
+    invoice = _invoice("INV-1", contact_id, "100.00")
+    pool = _CreatePaymentPool([invoice])
+
+    with pytest.raises(ReceivablesValidationError, match="cannot exceed"):
+        await ReceivablesService(pool).create_payment(
+            contact_id=contact_id,
+            payer_name="Acme",
+            total_amount=Decimal("10.00"),
+            payment_method="check",
+            received_date=date(2026, 7, 16),
+            allocations=[{"invoice_id": invoice["id"], "amount": "10.01"}],
+            idempotency_key="over-allocated",
+        )
+
+    assert pool.transaction_count == 0
+
+
+@pytest.mark.parametrize(
+    "invalid_key",
+    ["", "   ", "x" * 129, "long-prefix-" + "y" * 256],
+)
+@pytest.mark.asyncio
+async def test_create_payment_rejects_invalid_idempotency_key_before_transaction(
+    invalid_key,
+):
+    contact_id = uuid4()
+    invoice = _invoice("INV-1", contact_id, "100.00")
+    pool = _CreatePaymentPool([invoice])
+
+    with pytest.raises(ReceivablesValidationError, match="1 to 128"):
+        await ReceivablesService(pool).create_payment(
+            contact_id=contact_id,
+            payer_name="Acme",
+            total_amount=Decimal("10.00"),
+            payment_method="check",
+            received_date=date(2026, 7, 16),
+            allocations=[{"invoice_id": invoice["id"], "amount": "10.00"}],
+            idempotency_key=invalid_key,
+        )
+
+    assert pool.transaction_count == 0
+
+
+@pytest.mark.asyncio
+async def test_open_invoice_feed_orders_due_date_before_customer_name():
+    class _Pool:
+        is_initialized = True
+
+        def __init__(self):
+            self.query = ""
+
+        async def fetch(self, query, *_args):
+            self.query = " ".join(query.split())
+            return []
+
+    pool = _Pool()
+    await ReceivablesService(pool).suggest_allocations(
+        contact_id=uuid4(), total_amount=Decimal("10.00")
+    )
+
+    assert (
+        "ORDER BY due_date, issue_date, customer_name, invoice_number"
+        in pool.query
+    )
+
+
+def test_money_rejects_nan_and_duplicate_invoice_allocations():
+    with pytest.raises(ReceivablesValidationError, match="finite"):
+        money("NaN")
+    with pytest.raises(ReceivablesValidationError, match="cent precision"):
+        money("10.005")
+
+    invoice_id = uuid4()
+    with pytest.raises(ReceivablesValidationError, match="only appear once"):
+        ReceivablesService._normalize_allocations(
+            [
+                {"invoice_id": invoice_id, "amount": "1.00"},
+                {"invoice_id": invoice_id, "amount": "2.00"},
+            ]
+        )
+
+
+def test_idempotency_key_reuse_with_different_request_conflicts():
+    with pytest.raises(ReceivablesConflictError, match="different request"):
+        ReceivablesService._assert_idempotent(
+            {"request_fingerprint": "first"}, "second"
+        )
+
+
+@pytest.mark.asyncio
+async def test_payment_event_key_lookup_is_global_across_payments():
+    class _Connection:
+        def __init__(self):
+            self.query = ""
+            self.args = ()
+
+        async def fetchrow(self, query, *args):
+            self.query = query
+            self.args = args
+            return {"payment_id": uuid4(), "request_fingerprint": "first"}
+
+    conn = _Connection()
+    event = await ReceivablesService._event_for_key(conn, "shared-event-key")
+
+    assert event["request_fingerprint"] == "first"
+    assert "payment_id = ANY" not in conn.query
+    assert "WHERE idempotency_key = $1" in conn.query
+    assert conn.args == ("shared-event-key",)
+
+
+@pytest.mark.parametrize("status", ["returned", "voided"])
+def test_inactive_payment_summary_excludes_historical_allocations(status):
+    result = ReceivablesService._compose_payment(
+        {"id": uuid4(), "status": status, "total_amount": Decimal("100.00")},
+        [
+            {
+                "id": uuid4(),
+                "invoice_id": uuid4(),
+                "amount": Decimal("75.00"),
+                "reversed_at": None,
+            }
+        ],
+    )
+
+    assert result["allocated_amount_cents"] == 0
+    assert result["unapplied_amount_cents"] == 0
+    assert result["allocations"][0]["amount_cents"] == 7_500
+
+
+class _InvoiceLockConnection:
+    def __init__(self, rows):
+        self.rows = rows
+        self.locked_ids = []
+
+    async def fetch(self, _query, invoice_ids):
+        self.locked_ids = invoice_ids
+        return self.rows
+
+
+@pytest.mark.asyncio
+async def test_adjustment_lock_includes_invoice_removed_from_replacement():
+    contact_id = uuid4()
+    kept = _invoice("INV-1", contact_id, "20.00")
+    removed = _invoice("INV-2", contact_id, "0.00")
+    removed["status"] = "paid"
+    conn = _InvoiceLockConnection([kept, removed])
+
+    await ReceivablesService._lock_and_validate_invoices(
+        ReceivablesService(),
+        conn,
+        contact_id=contact_id,
+        allocations=[{"invoice_id": kept["id"], "amount": Decimal("10.00")}],
+        current_allocations={str(removed["id"]): Decimal("10.00")},
+        additional_invoice_ids=[removed["id"]],
+    )
+
+    assert set(conn.locked_ids) == {kept["id"], removed["id"]}
+
+
+class _RecalculationConnection:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    async def fetch(self, query, *_args):
+        self.calls.append(query)
+        return []
+
+    async def execute(self, query, *_args):
+        self.calls.append(query)
+        return "UPDATE 1"
+
+
+@pytest.mark.asyncio
+async def test_recalculation_locks_before_reading_totals_and_counts_null_parent_rows():
+    conn = _RecalculationConnection()
+
+    await ReceivablesService._recalculate_invoices(conn, [uuid4()])
+
+    assert "FOR UPDATE" in conn.calls[0]
+    assert "WITH totals AS" in conn.calls[1]
+    assert "ip.payment_id IS NULL" in conn.calls[1]
+
+
+@pytest.mark.asyncio
+async def test_draft_invoice_cannot_receive_an_allocation():
+    contact_id = uuid4()
+    draft = _invoice("INV-DRAFT", contact_id, "20.00")
+    draft["status"] = "draft"
+
+    with pytest.raises(ReceivablesConflictError, match="not open"):
+        await ReceivablesService._lock_and_validate_invoices(
+            ReceivablesService(),
+            _InvoiceLockConnection([draft]),
+            contact_id=contact_id,
+            allocations=[{"invoice_id": draft["id"], "amount": Decimal("10.00")}],
+        )
+
+
+class _ClearBatchConnection:
+    def __init__(self, batch_id, payment_id) -> None:
+        self.batch_id = batch_id
+        self.payment_id = payment_id
+        self.executions = []
+
+    async def fetchrow(self, query, *_args):
+        if "WHERE clear_idempotency_key" in query:
+            return None
+        if "FROM payment_events" in query:
+            return None
+        return {
+            "id": self.batch_id,
+            "status": "deposited",
+            "clear_idempotency_key": None,
+            "clear_request_fingerprint": None,
+        }
+
+    async def execute(self, query, *args):
+        self.executions.append((query, args))
+        return "OK"
+
+    async def fetch(self, _query, *_args):
+        return [{"id": self.payment_id, "status": "returned"}]
+
+    async def fetchval(self, query, *_args):
+        assert "pg_advisory_xact_lock" in query
+        return None
+
+
+@pytest.mark.asyncio
+async def test_clear_batch_rejects_a_returned_check_instead_of_skipping_it():
+    batch_id = uuid4()
+    conn = _ClearBatchConnection(batch_id, uuid4())
+
+    with pytest.raises(ReceivablesConflictError, match="must still be deposited"):
+        await ReceivablesService(_TransactionPool(conn)).clear_deposit_batch(
+            batch_id=batch_id,
+            actor="Juan",
+            idempotency_key="clear-batch-1",
+        )
+
+    assert not any(
+        "UPDATE customer_payments" in query for query, _args in conn.executions
+    )
+
+
+def test_receivables_migration_keeps_legacy_rows_one_to_one():
+    migration = (
+        Path(__file__).parents[1]
+        / "atlas_brain/storage/migrations/344_receivables_payments.sql"
+    ).read_text(encoding="utf-8")
+
+    assert "id, contact_id, payer_name" in migration
+    assert "SELECT\n    ip.id," in migration
+    assert (
+        "GROUP BY"
+        not in migration.split("CREATE TABLE IF NOT EXISTS payment_deposit_batches")[0]
+    )
+    assert "clear_idempotency_key" in migration
+    customer_table = migration.split("CREATE TABLE IF NOT EXISTS customer_payments", 1)[
+        1
+    ]
+    customer_table = customer_table.split(");", 1)[0]
+    assert "clear_idempotency_key" not in customer_table
+    assert "CREATE TRIGGER trg_adopt_legacy_invoice_payment" in migration
+    assert "WHEN (NEW.payment_id IS NULL)" in migration
+    assert "adopted_rolling_writer" in migration
+    assert (
+        "COALESCE(NULLIF(lower(btrim(NEW.payment_method)), ''), 'other')" in migration
+    )
+    assert "NEW.amount > 0 AND lower(btrim(NEW.payment_method)) = 'check'" in migration
+
+
+def test_global_payment_event_key_lookup_has_a_followup_migration():
+    migration = (
+        Path(__file__).parents[1]
+        / "atlas_brain/storage/migrations/345_receivables_event_key_lookup.sql"
+    ).read_text(encoding="utf-8")
+
+    assert "CREATE INDEX IF NOT EXISTS idx_payment_events_key_lookup" in migration
+    assert "ON payment_events(idempotency_key)" in migration
+
+
+@pytest.mark.asyncio
+async def test_standalone_mcp_applies_migrations_before_serving_and_closes():
+    from atlas_brain.mcp import invoicing_server
+
+    events = []
+    pool = SimpleNamespace(is_initialized=True)
+
+    async def initialize():
+        events.append("initialize")
+
+    def get_pool():
+        events.append("get-pool")
+        return pool
+
+    async def migrate(candidate):
+        assert candidate is pool
+        events.append("migrate")
+
+    async def ready(candidate):
+        assert candidate is pool
+        events.append("ready")
+        return True
+
+    async def close():
+        events.append("close")
+
+    async with invoicing_server._database_lifespan(
+        init_database_fn=initialize,
+        get_db_pool_fn=get_pool,
+        run_migrations_fn=migrate,
+        receivables_ready_fn=ready,
+        close_database_fn=close,
+    ):
+        events.append("serving")
+
+    assert events == [
+        "initialize",
+        "get-pool",
+        "migrate",
+        "ready",
+        "serving",
+        "close",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_standalone_mcp_migration_failure_aborts_startup_and_closes():
+    from atlas_brain.mcp import invoicing_server
+
+    events = []
+    pool = SimpleNamespace(is_initialized=True)
+
+    async def initialize():
+        events.append("initialize")
+
+    async def migrate(candidate):
+        assert candidate is pool
+        events.append("migrate")
+        raise RuntimeError("migration failed")
+
+    async def ready(_candidate):
+        raise AssertionError("readiness must not run after migration failure")
+
+    async def close():
+        events.append("close")
+
+    with pytest.raises(RuntimeError, match="migration failed"):
+        async with invoicing_server._database_lifespan(
+            init_database_fn=initialize,
+            get_db_pool_fn=lambda: pool,
+            run_migrations_fn=migrate,
+            receivables_ready_fn=ready,
+            close_database_fn=close,
+        ):
+            events.append("serving")
+
+    assert events == ["initialize", "migrate", "close"]
+
+
+@pytest.mark.asyncio
+async def test_standalone_mcp_incomplete_schema_aborts_startup_and_closes():
+    from atlas_brain.mcp import invoicing_server
+
+    events = []
+    pool = SimpleNamespace(is_initialized=True)
+
+    async def initialize():
+        events.append("initialize")
+
+    async def migrate(candidate):
+        assert candidate is pool
+        events.append("migrate")
+
+    async def ready(candidate):
+        assert candidate is pool
+        events.append("ready")
+        return False
+
+    async def close():
+        events.append("close")
+
+    with pytest.raises(RuntimeError, match="complete receivables schema"):
+        async with invoicing_server._database_lifespan(
+            init_database_fn=initialize,
+            get_db_pool_fn=lambda: pool,
+            run_migrations_fn=migrate,
+            receivables_ready_fn=ready,
+            close_database_fn=close,
+        ):
+            events.append("serving")
+
+    assert events == ["initialize", "migrate", "ready", "close"]
+
+
+def _workflow_event_paths(workflow: str, event_name: str) -> tuple[str, ...]:
+    event_start = re.search(rf"^  {re.escape(event_name)}:\n", workflow, re.MULTILINE)
+    assert event_start is not None
+    event_end = re.search(
+        r"^  [a-z_]+:\n|^jobs:\n",
+        workflow[event_start.end() :],
+        re.MULTILINE,
+    )
+    event_block = (
+        workflow[event_start.end() :]
+        if event_end is None
+        else workflow[event_start.end() : event_start.end() + event_end.start()]
+    )
+    paths_start = re.search(r"^    paths:\n", event_block, re.MULTILINE)
+    assert paths_start is not None
+    paths_end = re.search(
+        r"^    [a-z_]+:\n", event_block[paths_start.end() :], re.MULTILINE
+    )
+    paths_block = (
+        event_block[paths_start.end() :]
+        if paths_end is None
+        else event_block[paths_start.end() : paths_start.end() + paths_end.start()]
+    )
+    return tuple(
+        match.group("path")
+        for match in re.finditer(
+            r'^      - "(?P<path>[^"]+)"\s*$', paths_block, re.MULTILINE
+        )
+    )
+
+
+def test_followup_receivables_migration_is_enrolled_in_invoicing_ci():
+    workflow = (
+        Path(__file__).parents[1] / ".github/workflows/atlas_invoicing_checks.yml"
+    ).read_text(encoding="utf-8")
+    migration_path = "atlas_brain/storage/migrations/345_receivables_event_key_lookup.sql"
+    entry = f'      - "{migration_path}"\n'
+
+    assert migration_path in _workflow_event_paths(workflow, "pull_request")
+    assert migration_path in _workflow_event_paths(workflow, "push")
+
+    without_pull_enrollment = workflow.replace(entry, "", 1)
+    assert migration_path not in _workflow_event_paths(
+        without_pull_enrollment, "pull_request"
+    )
+    before_push_entry, separator, after_push_entry = workflow.rpartition(entry)
+    assert separator == entry
+    without_push_enrollment = before_push_entry + after_push_entry
+    assert migration_path not in _workflow_event_paths(without_push_enrollment, "push")
+    misplaced_under_branches = without_push_enrollment.replace(
+        "  push:\n    branches:\n",
+        "  push:\n    branches:\n" + entry,
+        1,
+    )
+    assert migration_path not in _workflow_event_paths(
+        misplaced_under_branches, "push"
+    )
+
+
+class _SingleConnectionPool:
+    is_initialized = True
+
+    def __init__(self, conn, schema: str) -> None:
+        self.conn = conn
+        self.schema = schema
+
+    @asynccontextmanager
+    async def transaction(self):
+        async with self.conn.transaction():
+            await self.conn.execute(f'SET LOCAL search_path TO "{self.schema}"')
+            yield self.conn
+
+    async def fetch(self, query, *args):
+        async with self.conn.transaction():
+            await self.conn.execute(f'SET LOCAL search_path TO "{self.schema}"')
+            return await self.conn.fetch(query, *args)
+
+    async def fetchrow(self, query, *args):
+        async with self.conn.transaction():
+            await self.conn.execute(f'SET LOCAL search_path TO "{self.schema}"')
+            return await self.conn.fetchrow(query, *args)
+
+    async def fetchval(self, query, *args):
+        async with self.conn.transaction():
+            await self.conn.execute(f'SET LOCAL search_path TO "{self.schema}"')
+            return await self.conn.fetchval(query, *args)
+
+
+async def _create_pre_receivables_schema(conn, schema: str) -> None:
+    await conn.execute(f'CREATE SCHEMA "{schema}"')
+    await conn.execute(f'SET search_path TO "{schema}"')
+    await conn.execute("CREATE TABLE contacts (id uuid PRIMARY KEY)")
+    invoice_migration = (
+        Path(__file__).parents[1] / "atlas_brain/storage/migrations/045_invoices.sql"
+    ).read_text(encoding="utf-8")
+    await conn.execute(invoice_migration)
+
+
+def _receivables_migration_sql() -> str:
+    migrations = Path(__file__).parents[1] / "atlas_brain/storage/migrations"
+    return "\n".join(
+        (migrations / filename).read_text(encoding="utf-8")
+        for filename in (
+            "344_receivables_payments.sql",
+            "345_receivables_event_key_lookup.sql",
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_real_migration_backfills_and_adopts_late_rolling_writer_checks():
+    asyncpg = pytest.importorskip("asyncpg")
+    database_url = os.environ.get("ATLAS_RECEIVABLES_TEST_DATABASE_URL")
+    if not database_url:
+        pytest.skip("ATLAS_RECEIVABLES_TEST_DATABASE_URL not set")
+
+    schema = f"receivables_migration_{uuid4().hex}"
+    conn = await asyncpg.connect(database_url)
+    try:
+        await _create_pre_receivables_schema(conn, schema)
+        contact_id = uuid4()
+        invoice_a, invoice_b = uuid4(), uuid4()
+        await conn.execute("INSERT INTO contacts (id) VALUES ($1)", contact_id)
+        await conn.executemany(
+            """
+            INSERT INTO invoices (
+                id, invoice_number, contact_id, customer_name, total_amount,
+                due_date, status
+            ) VALUES ($1, $2, $3, 'Acme', 100, CURRENT_DATE + 30, 'sent')
+            """,
+            [
+                (invoice_a, "INV-MIG-A", contact_id),
+                (invoice_b, "INV-MIG-B", contact_id),
+            ],
+        )
+        legacy_a, legacy_b = uuid4(), uuid4()
+        await conn.executemany(
+            """
+            INSERT INTO invoice_payments (
+                id, invoice_id, amount, payment_date, payment_method,
+                reference, created_at
+            ) VALUES ($1, $2, 10, CURRENT_DATE, 'check', 'same-reference', NOW())
+            """,
+            [(legacy_a, invoice_a), (legacy_b, invoice_b)],
+        )
+        pre_migration_invoice_payment_columns = {
+            row["column_name"]
+            for row in await conn.fetch(
+                """
+                SELECT column_name
+                FROM information_schema.columns
+                WHERE table_schema = current_schema()
+                  AND table_name = 'invoice_payments'
+                """
+            )
+        }
+
+        migration_sql = _receivables_migration_sql()
+        await conn.execute(migration_sql)
+
+        created_tables = set(
+            re.findall(r"CREATE TABLE IF NOT EXISTS ([a-z_]+)", migration_sql)
+        )
+        assert set(_RECEIVABLES_REQUIRED_COLUMNS) == created_tables | {
+            "invoice_payments"
+        }
+
+        for table_name, required_columns in _RECEIVABLES_REQUIRED_COLUMNS.items():
+            actual_columns = {
+                row["column_name"]
+                for row in await conn.fetch(
+                    """
+                    SELECT column_name
+                    FROM information_schema.columns
+                    WHERE table_schema = current_schema()
+                      AND table_name = $1
+                    """,
+                    table_name,
+                )
+            }
+            if table_name == "invoice_payments":
+                actual_columns -= pre_migration_invoice_payment_columns
+            assert actual_columns == set(required_columns)
+
+        backfilled = await conn.fetch(
+            """
+            SELECT ip.id, ip.payment_id, cp.id AS parent_id, cp.status
+            FROM invoice_payments ip
+            JOIN customer_payments cp ON cp.id = ip.payment_id
+            WHERE ip.id = ANY($1::uuid[])
+            ORDER BY ip.id
+            """,
+            [legacy_a, legacy_b],
+        )
+        assert len(backfilled) == 2
+        assert all(
+            row["id"] == row["payment_id"] == row["parent_id"] for row in backfilled
+        )
+        assert {row["status"] for row in backfilled} == {"legacy"}
+
+        late_check, malformed_check = uuid4(), uuid4()
+        await conn.execute(
+            """
+            INSERT INTO invoice_payments (
+                id, invoice_id, amount, payment_date, payment_method,
+                reference, recorded_by, created_at, metadata
+            ) VALUES
+                ($1, $3, 25, CURRENT_DATE, ' Check ', 'late-1001', 'old-node', NOW(), '{}'),
+                ($2, $3, 0, CURRENT_DATE, 'Check', 'bad-zero', 'old-node', NOW(), '{}')
+            """,
+            late_check,
+            malformed_check,
+            invoice_a,
+        )
+        adopted = await conn.fetch(
+            """
+            SELECT ip.id, ip.payment_id, cp.status, cp.payment_method,
+                   cp.total_amount, cp.metadata
+            FROM invoice_payments ip
+            JOIN customer_payments cp ON cp.id = ip.payment_id
+            WHERE ip.id = ANY($1::uuid[])
+            ORDER BY cp.total_amount DESC
+            """,
+            [late_check, malformed_check],
+        )
+        assert adopted[0]["id"] == adopted[0]["payment_id"] == late_check
+        assert adopted[0]["status"] == "received"
+        assert adopted[0]["payment_method"] == "check"
+        assert json.loads(adopted[0]["metadata"])["adopted_rolling_writer"] is True
+        assert adopted[1]["status"] == "legacy"
+
+        service = ReceivablesService(_SingleConnectionPool(conn, schema))
+        received = await service.list_payments(status="received")
+        assert [item["id"] for item in received] == [str(late_check)]
+        batch = await service.create_deposit_batch(
+            payment_ids=[late_check],
+            deposit_date=date.today(),
+            bank_reference="late-writer-deposit",
+            actor="Migration test",
+            idempotency_key="late-writer-batch",
+        )
+        assert batch["payment_count"] == 1
+        assert batch["payments"][0]["id"] == str(late_check)
+
+        assert await service.is_ready() is True
+        explicit_migration_index_names = set(
+            re.findall(
+                r"CREATE (?:UNIQUE )?INDEX IF NOT EXISTS ([a-z_]+)",
+                migration_sql,
+            )
+        )
+        migration_table_names = set(
+            re.findall(r"CREATE TABLE IF NOT EXISTS ([a-z_]+)", migration_sql)
+        )
+        constraint_index_rows = await conn.fetch(
+            """
+            SELECT
+                table_class.relname AS table_name,
+                constraint_state.conname AS index_name
+            FROM pg_constraint AS constraint_state
+            JOIN pg_class AS table_class
+              ON table_class.oid = constraint_state.conrelid
+            JOIN pg_namespace AS table_namespace
+              ON table_namespace.oid = table_class.relnamespace
+            WHERE table_namespace.nspname = current_schema()
+              AND table_class.relname = ANY($1::text[])
+              AND constraint_state.contype IN ('p', 'u')
+              AND constraint_state.conindid <> 0
+            """,
+            sorted(migration_table_names),
+        )
+        constraint_indexes = {
+            row["index_name"]: row["table_name"] for row in constraint_index_rows
+        }
+        migration_index_names = explicit_migration_index_names | set(
+            constraint_indexes
+        )
+        required_index_names = {
+            index_name
+            for _table_name, index_name, *_rest in _RECEIVABLES_REQUIRED_INDEXES
+        }
+        assert required_index_names == migration_index_names
+        for index_name in sorted(required_index_names):
+            transaction = conn.transaction()
+            await transaction.start()
+            try:
+                if index_name in constraint_indexes:
+                    table_name = constraint_indexes[index_name]
+                    await conn.execute(
+                        f'ALTER TABLE "{table_name}" '
+                        f'DROP CONSTRAINT "{index_name}" CASCADE'
+                    )
+                else:
+                    await conn.execute(f'DROP INDEX "{index_name}"')
+                assert await service.is_ready() is False
+            finally:
+                await transaction.rollback()
+            assert await service.is_ready() is True
+
+        await conn.execute(
+            "ALTER TABLE payment_deposit_batches "
+            "DROP COLUMN clear_request_fingerprint"
+        )
+        assert await service.is_ready() is False
+        await conn.execute(
+            "ALTER TABLE payment_deposit_batches "
+            "ADD COLUMN clear_request_fingerprint VARCHAR(64)"
+        )
+        assert await service.is_ready() is True
+        await conn.execute(
+            "ALTER TABLE invoice_payments DROP COLUMN reversal_reason"
+        )
+        assert await service.is_ready() is False
+        await conn.execute(
+            "ALTER TABLE invoice_payments ADD COLUMN reversal_reason TEXT"
+        )
+        assert await service.is_ready() is True
+        await conn.execute("DROP TABLE payment_events")
+        assert await service.is_ready() is False
+    finally:
+        await conn.execute("SET search_path TO public")
+        await conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_real_postgres_receivables_lifecycle_and_concurrent_replays():
+    asyncpg = pytest.importorskip("asyncpg")
+    database_url = os.environ.get("ATLAS_RECEIVABLES_TEST_DATABASE_URL")
+    if not database_url:
+        pytest.skip("ATLAS_RECEIVABLES_TEST_DATABASE_URL not set")
+
+    schema = f"receivables_e2e_{uuid4().hex}"
+    observer = await asyncpg.connect(database_url)
+    conn_a = await asyncpg.connect(database_url)
+    conn_b = await asyncpg.connect(database_url)
+    try:
+        await _create_pre_receivables_schema(observer, schema)
+        await observer.execute(_receivables_migration_sql())
+        contact_id = uuid4()
+        invoice_ids = [uuid4() for _ in range(4)]
+        await observer.execute("INSERT INTO contacts (id) VALUES ($1)", contact_id)
+        await observer.executemany(
+            """
+            INSERT INTO invoices (
+                id, invoice_number, contact_id, customer_name, total_amount,
+                due_date, status
+            ) VALUES ($1, $2, $3, 'Acme', $4, CURRENT_DATE + 30, 'sent')
+            """,
+            [
+                (invoice_ids[0], "INV-E2E-1", contact_id, Decimal("60")),
+                (invoice_ids[1], "INV-E2E-2", contact_id, Decimal("80")),
+                (invoice_ids[2], "INV-E2E-3", contact_id, Decimal("10")),
+                (invoice_ids[3], "INV-E2E-4", contact_id, Decimal("10")),
+            ],
+        )
+        service_a = ReceivablesService(_SingleConnectionPool(conn_a, schema))
+        service_b = ReceivablesService(_SingleConnectionPool(conn_b, schema))
+        create_args = {
+            "contact_id": contact_id,
+            "payer_name": "Acme",
+            "total_amount": Decimal("100"),
+            "payment_method": "check",
+            "received_date": date.today(),
+            "allocations": [
+                {"invoice_id": invoice_ids[0], "amount": Decimal("50")},
+                {"invoice_id": invoice_ids[1], "amount": Decimal("30")},
+            ],
+            "reference": "e2e-1001",
+            "idempotency_key": "e2e-payment-create",
+        }
+        outcomes = await asyncio.gather(
+            service_a.create_payment_with_outcome(**create_args),
+            service_b.create_payment_with_outcome(**create_args),
+        )
+        assert sorted(outcome.replayed for outcome in outcomes) == [False, True]
+        first, replay = (outcome.payment for outcome in outcomes)
+        assert first["id"] == replay["id"]
+        assert first["allocated_amount_cents"] == 8_000
+        assert first["unapplied_amount_cents"] == 2_000
+        assert (
+            await observer.fetchval(
+                "SELECT COUNT(*) FROM customer_payments WHERE idempotency_key = 'e2e-payment-create'"
+            )
+            == 1
+        )
+
+        with pytest.raises(ReceivablesConflictError, match="different request"):
+            await service_a.create_payment(
+                **{**create_args, "total_amount": Decimal("99")}
+            )
+
+        payment_id = UUID(first["id"])
+        with pytest.raises(ReceivablesConflictError, match="Idempotency key"):
+            await service_a.return_payment(
+                payment_id=payment_id,
+                reason="Cross-operation key reuse",
+                actor="E2E admin",
+                idempotency_key="e2e-payment-create",
+            )
+        assert (
+            await observer.fetchval(
+                "SELECT status FROM customer_payments WHERE id = $1", payment_id
+            )
+            == "received"
+        )
+
+        adjusted = await service_a.adjust_allocations(
+            payment_id=payment_id,
+            allocations=[
+                {"invoice_id": invoice_ids[0], "amount": Decimal("60")},
+                {"invoice_id": invoice_ids[1], "amount": Decimal("40")},
+            ],
+            reason="Apply remainder",
+            actor="E2E admin",
+            idempotency_key="e2e-adjust",
+        )
+        assert adjusted["unapplied_amount_cents"] == 0
+
+        with pytest.raises(ReceivablesConflictError, match="different request"):
+            await service_a.create_deposit_batch(
+                payment_ids=[payment_id],
+                deposit_date=date.today(),
+                bank_reference="cross-operation",
+                actor="E2E admin",
+                idempotency_key="e2e-payment-create",
+            )
+        assert (
+            await observer.fetchval(
+                "SELECT status FROM customer_payments WHERE id = $1", payment_id
+            )
+            == "received"
+        )
+
+        deposit_a, deposit_replay = await asyncio.gather(
+            service_a.create_deposit_batch(
+                payment_ids=[payment_id],
+                deposit_date=date.today(),
+                bank_reference="bank-1",
+                actor="E2E admin",
+                idempotency_key="e2e-deposit",
+            ),
+            service_b.create_deposit_batch(
+                payment_ids=[payment_id],
+                deposit_date=date.today(),
+                bank_reference="bank-1",
+                actor="E2E admin",
+                idempotency_key="e2e-deposit",
+            ),
+        )
+        assert deposit_a["id"] == deposit_replay["id"]
+        batch_id = UUID(deposit_a["id"])
+        with pytest.raises(ReceivablesConflictError, match="different request"):
+            await service_a.clear_deposit_batch(
+                batch_id=batch_id,
+                actor="E2E admin",
+                idempotency_key="e2e-deposit",
+            )
+        assert (
+            await observer.fetchval(
+                "SELECT status FROM payment_deposit_batches WHERE id = $1", batch_id
+            )
+            == "deposited"
+        )
+
+        clear_a, clear_replay = await asyncio.gather(
+            service_a.clear_deposit_batch(
+                batch_id=batch_id,
+                actor="E2E admin",
+                idempotency_key="e2e-clear",
+            ),
+            service_b.clear_deposit_batch(
+                batch_id=batch_id,
+                actor="E2E admin",
+                idempotency_key="e2e-clear",
+            ),
+        )
+        assert clear_a["id"] == clear_replay["id"]
+        assert clear_a["status"] == "cleared"
+
+        returned = await service_a.return_payment(
+            payment_id=payment_id,
+            reason="NSF",
+            actor="E2E admin",
+            idempotency_key="e2e-return",
+        )
+        assert returned["status"] == "returned"
+        balances = await observer.fetch(
+            """
+            SELECT invoice_number, amount_paid, status
+            FROM invoices
+            WHERE id = ANY($1::uuid[])
+            ORDER BY invoice_number
+            """,
+            invoice_ids[:2],
+        )
+        assert [(row["amount_paid"], row["status"]) for row in balances] == [
+            (Decimal("0.00"), "sent"),
+            (Decimal("0.00"), "sent"),
+        ]
+
+        returned_adjustment_replay = await service_b.adjust_allocations(
+            payment_id=payment_id,
+            allocations=[
+                {"invoice_id": invoice_ids[0], "amount": Decimal("60")},
+                {"invoice_id": invoice_ids[1], "amount": Decimal("40")},
+            ],
+            reason="Apply remainder",
+            actor="Retrying E2E admin",
+            idempotency_key="e2e-adjust",
+        )
+        assert returned_adjustment_replay["status"] == "returned"
+        assert returned_adjustment_replay["allocated_amount_cents"] == 0
+        assert returned_adjustment_replay["unapplied_amount_cents"] == 0
+        for changed in (
+            {
+                "allocations": [
+                    {"invoice_id": invoice_ids[0], "amount": Decimal("59")},
+                    {"invoice_id": invoice_ids[1], "amount": Decimal("40")},
+                ],
+                "reason": "Apply remainder",
+            },
+            {
+                "allocations": [
+                    {"invoice_id": invoice_ids[0], "amount": Decimal("60")},
+                    {"invoice_id": invoice_ids[1], "amount": Decimal("40")},
+                ],
+                "reason": "Changed replay reason",
+            },
+        ):
+            with pytest.raises(ReceivablesConflictError, match="different request"):
+                await service_a.adjust_allocations(
+                    payment_id=payment_id,
+                    allocations=changed["allocations"],
+                    reason=changed["reason"],
+                    actor="E2E admin",
+                    idempotency_key="e2e-adjust",
+                )
+
+        void_candidate = await service_a.create_payment(
+            contact_id=contact_id,
+            payer_name="Acme",
+            total_amount=Decimal("20"),
+            payment_method="check",
+            received_date=date.today(),
+            allocations=[{"invoice_id": invoice_ids[0], "amount": Decimal("15")}],
+            reference="e2e-void-candidate",
+            idempotency_key="e2e-void-create",
+        )
+        void_payment_id = UUID(void_candidate["id"])
+        void_adjustment = {
+            "payment_id": void_payment_id,
+            "allocations": [{"invoice_id": invoice_ids[0], "amount": Decimal("10")}],
+            "reason": "Leave part unapplied",
+            "actor": "E2E admin",
+            "idempotency_key": "e2e-void-adjust",
+        }
+        await service_a.adjust_allocations(**void_adjustment)
+        await service_a.void_payment(
+            payment_id=void_payment_id,
+            reason="Entry mistake",
+            actor="E2E admin",
+            idempotency_key="e2e-void",
+        )
+        void_adjustment_replay = await service_b.adjust_allocations(
+            **{**void_adjustment, "actor": "Retrying E2E admin"}
+        )
+        assert void_adjustment_replay["status"] == "voided"
+        assert void_adjustment_replay["allocated_amount_cents"] == 0
+        assert void_adjustment_replay["unapplied_amount_cents"] == 0
+
+        with pytest.raises(ReceivablesConflictError, match="different request"):
+            await service_a.adjust_allocations(
+                **{
+                    **void_adjustment,
+                    "allocations": [
+                        {"invoice_id": invoice_ids[0], "amount": Decimal("9")}
+                    ],
+                }
+            )
+        with pytest.raises(ReceivablesConflictError, match="different request"):
+            await service_a.adjust_allocations(
+                **{
+                    **void_adjustment,
+                    "idempotency_key": "e2e-adjust",
+                }
+            )
+
+        extra_payments = []
+        for index in (2, 3):
+            extra = await service_a.create_payment(
+                contact_id=contact_id,
+                payer_name="Acme",
+                total_amount=Decimal("10"),
+                payment_method="check",
+                received_date=date.today(),
+                allocations=[
+                    {"invoice_id": invoice_ids[index], "amount": Decimal("10")}
+                ],
+                reference=f"e2e-extra-{index}",
+                idempotency_key=f"e2e-extra-{index}",
+            )
+            extra_payments.append(UUID(extra["id"]))
+        with pytest.raises(ReceivablesConflictError, match="different request"):
+            await service_a.void_payment(
+                payment_id=extra_payments[0],
+                reason="Cross-payment key reuse",
+                actor="E2E admin",
+                idempotency_key="e2e-return",
+            )
+        assert (
+            await observer.fetchval(
+                "SELECT status FROM customer_payments WHERE id = $1", extra_payments[0]
+            )
+            == "received"
+        )
+        collision = await asyncio.gather(
+            service_a.create_deposit_batch(
+                payment_ids=[extra_payments[0]],
+                deposit_date=date.today(),
+                bank_reference="collision-a",
+                actor="E2E admin",
+                idempotency_key="e2e-deposit-collision",
+            ),
+            service_b.create_deposit_batch(
+                payment_ids=[extra_payments[1]],
+                deposit_date=date.today(),
+                bank_reference="collision-b",
+                actor="E2E admin",
+                idempotency_key="e2e-deposit-collision",
+            ),
+            return_exceptions=True,
+        )
+        assert sum(isinstance(item, dict) for item in collision) == 1
+        assert (
+            sum(isinstance(item, ReceivablesConflictError) for item in collision) == 1
+        )
+        assert await observer.fetchval("""
+            SELECT COUNT(*) FROM payment_deposit_batches
+            WHERE idempotency_key = 'e2e-deposit-collision'
+            """) == 1
+
+        collision_batch = next(item for item in collision if isinstance(item, dict))
+        deposited_payment = UUID(collision_batch["payments"][0]["id"])
+        remaining_payment = next(
+            item for item in extra_payments if item != deposited_payment
+        )
+        other_batch = await service_a.create_deposit_batch(
+            payment_ids=[remaining_payment],
+            deposit_date=date.today(),
+            bank_reference="collision-other",
+            actor="E2E admin",
+            idempotency_key="e2e-deposit-other",
+        )
+        clear_collision = await asyncio.gather(
+            service_a.clear_deposit_batch(
+                batch_id=UUID(collision_batch["id"]),
+                actor="E2E admin",
+                idempotency_key="e2e-clear-collision",
+            ),
+            service_b.clear_deposit_batch(
+                batch_id=UUID(other_batch["id"]),
+                actor="E2E admin",
+                idempotency_key="e2e-clear-collision",
+            ),
+            return_exceptions=True,
+        )
+        assert sum(isinstance(item, dict) for item in clear_collision) == 1
+        assert (
+            sum(isinstance(item, ReceivablesConflictError) for item in clear_collision)
+            == 1
+        )
+    finally:
+        await conn_a.close()
+        await conn_b.close()
+        await observer.execute("SET search_path TO public")
+        await observer.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        await observer.close()
+
+
+@pytest.mark.asyncio
+async def test_return_waits_for_concurrent_create_before_balance_snapshot():
+    """A return cannot overwrite a concurrently-created active allocation."""
+    asyncpg = pytest.importorskip("asyncpg")
+    database_url = os.environ.get("ATLAS_RECEIVABLES_TEST_DATABASE_URL")
+    if not database_url:
+        pytest.skip("ATLAS_RECEIVABLES_TEST_DATABASE_URL not set")
+
+    schema = f"receivables_concurrency_{uuid4().hex}"
+    contact_id = uuid4()
+    invoice_id = uuid4()
+    returned_payment_id = uuid4()
+    concurrent_payment_id = uuid4()
+    conn_a = await asyncpg.connect(database_url)
+    conn_b = await asyncpg.connect(database_url)
+    observer = await asyncpg.connect(database_url)
+    task = None
+    tx_b = None
+    try:
+        await observer.execute(f'CREATE SCHEMA "{schema}"')
+        await observer.execute(f'SET search_path TO "{schema}"')
+        await observer.execute("""
+            CREATE TABLE invoices (
+                id uuid PRIMARY KEY, invoice_number varchar NOT NULL,
+                contact_id uuid, customer_name varchar NOT NULL,
+                total_amount numeric(12,2) NOT NULL,
+                amount_paid numeric(12,2) NOT NULL,
+                due_date date NOT NULL, status varchar NOT NULL,
+                paid_at timestamptz, updated_at timestamptz NOT NULL
+            );
+            CREATE TABLE customer_payments (
+                id uuid PRIMARY KEY, contact_id uuid, payer_name varchar NOT NULL,
+                total_amount numeric(12,2) NOT NULL, payment_method varchar NOT NULL,
+                reference varchar, received_date date NOT NULL, status varchar NOT NULL,
+                source varchar NOT NULL, idempotency_key varchar,
+                request_fingerprint varchar, notes text, recorded_by varchar,
+                deposited_at timestamptz, cleared_at timestamptz,
+                returned_at timestamptz, return_reason text,
+                voided_at timestamptz, void_reason text,
+                metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+                created_at timestamptz NOT NULL, updated_at timestamptz NOT NULL
+            );
+            CREATE TABLE invoice_payments (
+                id uuid PRIMARY KEY, invoice_id uuid NOT NULL,
+                payment_id uuid, amount numeric(12,2) NOT NULL,
+                payment_date date NOT NULL, payment_method varchar NOT NULL,
+                reference varchar, notes text, recorded_by varchar,
+                created_at timestamptz NOT NULL,
+                metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+                reversed_at timestamptz, reversed_by varchar, reversal_reason text
+            );
+            CREATE TABLE payment_events (
+                id uuid PRIMARY KEY, payment_id uuid NOT NULL, event_type varchar NOT NULL,
+                previous_status varchar, new_status varchar, effective_date date,
+                actor varchar, reason text, idempotency_key varchar,
+                request_fingerprint varchar, metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+                created_at timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE TABLE payment_deposit_items (
+                batch_id uuid NOT NULL, payment_id uuid PRIMARY KEY,
+                created_at timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+            """)
+        await observer.execute(
+            """
+            INSERT INTO invoices (
+                id, invoice_number, contact_id, customer_name, total_amount,
+                amount_paid, due_date, status, updated_at
+            ) VALUES ($1, 'INV-RACE', $2, 'Acme', 100, 60, CURRENT_DATE, 'partial', NOW())
+            """,
+            invoice_id,
+            contact_id,
+        )
+        await observer.execute(
+            """
+            INSERT INTO customer_payments (
+                id, contact_id, payer_name, total_amount, payment_method,
+                received_date, status, source, idempotency_key,
+                request_fingerprint, created_at, updated_at
+            ) VALUES ($1, $2, 'Acme', 60, 'check', CURRENT_DATE, 'received',
+                      'test', 'old-payment', 'old-fingerprint', NOW(), NOW())
+            """,
+            returned_payment_id,
+            contact_id,
+        )
+        await observer.execute(
+            """
+            INSERT INTO invoice_payments (
+                id, invoice_id, payment_id, amount, payment_date,
+                payment_method, created_at
+            ) VALUES ($1, $2, $3, 60, CURRENT_DATE, 'check', NOW())
+            """,
+            uuid4(),
+            invoice_id,
+            returned_payment_id,
+        )
+
+        tx_b = conn_b.transaction()
+        await tx_b.start()
+        await conn_b.execute(f'SET LOCAL search_path TO "{schema}"')
+        await conn_b.fetch(
+            "SELECT id FROM invoices WHERE id = $1 FOR UPDATE", invoice_id
+        )
+        await conn_b.execute(
+            """
+            INSERT INTO customer_payments (
+                id, contact_id, payer_name, total_amount, payment_method,
+                received_date, status, source, idempotency_key,
+                request_fingerprint, created_at, updated_at
+            ) VALUES ($1, $2, 'Acme', 40, 'ach', CURRENT_DATE, 'cleared',
+                      'test', 'concurrent-payment', 'concurrent-fingerprint', NOW(), NOW())
+            """,
+            concurrent_payment_id,
+            contact_id,
+        )
+        await conn_b.execute(
+            """
+            INSERT INTO invoice_payments (
+                id, invoice_id, payment_id, amount, payment_date,
+                payment_method, created_at
+            ) VALUES ($1, $2, $3, 40, CURRENT_DATE, 'ach', NOW())
+            """,
+            uuid4(),
+            invoice_id,
+            concurrent_payment_id,
+        )
+
+        reached_recalculation = asyncio.Event()
+
+        class _SignallingService(ReceivablesService):
+            async def _recalculate_invoices(self, conn, invoice_ids):
+                reached_recalculation.set()
+                return await ReceivablesService._recalculate_invoices(conn, invoice_ids)
+
+        service = _SignallingService(_SingleConnectionPool(conn_a, schema))
+        task = asyncio.create_task(
+            service.return_payment(
+                payment_id=returned_payment_id,
+                reason="NSF",
+                actor="Concurrency test",
+                idempotency_key="return-race-test",
+            )
+        )
+        await asyncio.wait_for(reached_recalculation.wait(), timeout=3)
+
+        for _ in range(300):
+            wait_type = await observer.fetchval(
+                "SELECT wait_event_type FROM pg_stat_activity WHERE pid = $1",
+                conn_a.get_server_pid(),
+            )
+            if wait_type == "Lock":
+                break
+            await asyncio.sleep(0.01)
+        else:
+            pytest.fail("return transaction did not wait on the invoice lock")
+
+        await tx_b.commit()
+        tx_b = None
+        await asyncio.wait_for(task, timeout=3)
+        task = None
+
+        stored, active = await observer.fetchrow(
+            """
+            SELECT i.amount_paid AS stored,
+                   COALESCE(SUM(ip.amount) FILTER (
+                       WHERE ip.reversed_at IS NULL
+                         AND (ip.payment_id IS NULL OR cp.status = ANY($2::varchar[]))
+                   ), 0) AS active
+            FROM invoices i
+            LEFT JOIN invoice_payments ip ON ip.invoice_id = i.id
+            LEFT JOIN customer_payments cp ON cp.id = ip.payment_id
+            WHERE i.id = $1
+            GROUP BY i.id
+            """,
+            invoice_id,
+            list(("legacy", "received", "deposited", "cleared")),
+        )
+        assert stored == Decimal("40.00")
+        assert stored == active
+    finally:
+        if task is not None:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+        if tx_b is not None:
+            await tx_b.rollback()
+        await conn_a.close()
+        await conn_b.close()
+        await observer.execute("SET search_path TO public")
+        await observer.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        await observer.close()
+
+
+def test_enabled_receivables_api_rejects_missing_placeholder_and_short_tokens():
+    for token, message in (
+        ("", "is required"),
+        ("change-me", "placeholder"),
+        ("still-too-short", "at least 24"),
+    ):
+        config = SimpleNamespace(
+            receivables_api_enabled=True,
+            receivables_service_token=token,
+        )
+        with pytest.raises(RuntimeError, match=message):
+            receivables_auth.validate_receivables_api_config(config)
+
+
+@pytest.mark.asyncio
+async def test_receivables_api_is_fail_closed():
+    config = SimpleNamespace(
+        receivables_api_enabled=True,
+        receivables_service_token="a-valid-service-token-for-tests",
+    )
+
+    with pytest.raises(HTTPException) as missing:
+        await receivables_auth.require_receivables_api("", config=config)
+    assert missing.value.status_code == 401
+
+    with pytest.raises(HTTPException) as invalid:
+        await receivables_auth.require_receivables_api(
+            "Bearer wrong",
+            config=config,
+        )
+    assert invalid.value.status_code == 401
+
+    assert (
+        await receivables_auth.require_receivables_api(
+            "Bearer a-valid-service-token-for-tests",
+            config=config,
+        )
+        is None
+    )
+    with pytest.raises(HTTPException) as disabled:
+        await receivables_auth.require_receivables_api(
+            "Bearer a-valid-service-token-for-tests",
+            config=SimpleNamespace(
+                receivables_api_enabled=False,
+                receivables_service_token="",
+            ),
+        )
+    assert disabled.value.status_code == 503
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error_name",
+    (
+        "database-unavailable",
+        "ConnectionDoesNotExistError",
+        "ClientCannotConnectError",
+        "CannotConnectNowError",
+        "TooManyConnectionsError",
+        "AdminShutdownError",
+        "CrashShutdownError",
+        "connection-closed",
+        "pool-closed",
+        "pool-closing",
+        "pool-uninitialized",
+        "pool-initializing",
+        "resource-connection-closed",
+        "timeout",
+        "connection-reset",
+        "network-unreachable",
+    ),
+)
+async def test_receivables_api_maps_database_outage_classes_to_503(error_name):
+    asyncpg = pytest.importorskip("asyncpg")
+    from atlas_brain.api.invoicing import receivables as routes
+
+    if error_name == "database-unavailable":
+        error = DatabaseUnavailableError("receivables ledger")
+    elif error_name == "connection-closed":
+        error = asyncpg.InterfaceError("connection is closed")
+    elif error_name == "pool-closed":
+        error = asyncpg.InterfaceError("pool is closed")
+    elif error_name == "pool-closing":
+        error = asyncpg.InterfaceError("pool is closing")
+    elif error_name == "pool-uninitialized":
+        error = asyncpg.InterfaceError("pool is not initialized")
+    elif error_name == "pool-initializing":
+        error = asyncpg.InterfaceError(
+            "pool is being initialized, but not yet ready: likely there is a race"
+        )
+    elif error_name == "resource-connection-closed":
+        error = asyncpg.InterfaceError(
+            "cannot call Transaction.__aexit__(): the underlying connection is closed"
+        )
+    elif error_name == "timeout":
+        error = TimeoutError("database operation timed out")
+    elif error_name == "connection-reset":
+        error = ConnectionResetError("database socket reset")
+    elif error_name == "network-unreachable":
+        error = OSError(errno.ENETUNREACH, "database network unreachable")
+    else:
+        error = getattr(asyncpg, error_name)("database unavailable")
+
+    async def fail():
+        raise error
+
+    with pytest.raises(HTTPException) as exc:
+        await routes._call(fail())
+
+    assert exc.value.status_code == 503
+    assert exc.value.detail["code"] == "database_unavailable"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("error", "status_code"),
+    (
+        (ReceivablesValidationError("invalid"), 422),
+        (ReceivablesNotFoundError("missing"), 404),
+        (ReceivablesConflictError("conflict"), 409),
+        (ReceivablesError("other domain error"), 400),
+    ),
+)
+async def test_receivables_api_preserves_domain_error_statuses(error, status_code):
+    from atlas_brain.api.invoicing import receivables as routes
+
+    async def fail():
+        raise error
+
+    with pytest.raises(HTTPException) as exc:
+        await routes._call(fail())
+
+    assert exc.value.status_code == status_code
+
+
+@pytest.mark.asyncio
+async def test_receivables_api_does_not_hide_non_availability_failures():
+    asyncpg = pytest.importorskip("asyncpg")
+    from atlas_brain.api.invoicing import receivables as routes
+
+    for error in (
+        asyncpg.UniqueViolationError("duplicate data"),
+        asyncpg.InterfaceError("cannot start; the transaction is already started"),
+        asyncpg.InterfaceError(
+            "cannot call Transaction.__aexit__(): the underlying connection has "
+            "been released back to the pool"
+        ),
+        OSError(errno.ENOENT, "unrelated file is missing"),
+        OSError("unclassified OS failure"),
+        RuntimeError("programming defect"),
+    ):
+
+        async def fail():
+            raise error
+
+        with pytest.raises(type(error)):
+            await routes._call(fail())
+
+
+@pytest.mark.asyncio
+async def test_real_postgres_backend_termination_maps_closed_resource_to_503():
+    asyncpg = pytest.importorskip("asyncpg")
+    database_url = os.environ.get("ATLAS_RECEIVABLES_TEST_DATABASE_URL")
+    if not database_url:
+        pytest.skip("ATLAS_RECEIVABLES_TEST_DATABASE_URL not set")
+
+    from atlas_brain.api.invoicing import receivables as routes
+
+    victim = await asyncpg.connect(database_url)
+    terminator = await asyncpg.connect(database_url)
+
+    async def terminate_inside_transaction():
+        async with victim.transaction():
+            terminated = await terminator.fetchval(
+                "SELECT pg_terminate_backend($1)", victim.get_server_pid()
+            )
+            assert terminated is True
+            await victim.execute("SELECT 1")
+
+    try:
+        with pytest.raises(HTTPException) as exc:
+            await routes._call(terminate_inside_transaction())
+        assert exc.value.status_code == 503
+        assert exc.value.detail["code"] == "database_unavailable"
+    finally:
+        await terminator.close()
+        if not victim.is_closed():
+            await victim.close()
+
+
+@pytest.mark.asyncio
+async def test_legacy_quick_pay_is_gone():
+    with pytest.raises(HTTPException) as exc:
+        await actions.mark_paid("INV-1")
+    assert exc.value.status_code == 410
+
+
+def test_legacy_quick_pay_returns_gone_without_feature_flag_or_auth():
+    from atlas_brain.api.invoicing import router as invoicing_router
+
+    app = FastAPI()
+    app.include_router(invoicing_router)
+
+    response = TestClient(app).post("/invoicing/INV-1/mark-paid")
+
+    assert response.status_code == 410
+
+
+def test_all_invoicing_action_routes_require_service_auth():
+    for route in actions.router.routes:
+        dependency_calls = [
+            dependency.call for dependency in route.dependant.dependencies
+        ]
+        assert receivables_auth.require_receivables_api in dependency_calls
+
+
+@pytest.mark.parametrize(
+    "invalid_key",
+    ["", "\t", "x" * 129, "operation-" + "z" * 256],
+)
+@pytest.mark.asyncio
+async def test_singular_mcp_rejects_invalid_key_before_repository_access(
+    invalid_key,
+):
+    from atlas_brain.mcp import invoicing_server
+
+    class _NoRepositoryAccess:
+        async def get_by_id(self, *_args):
+            raise AssertionError("repository must not be queried")
+
+        async def get_by_number(self, *_args):
+            raise AssertionError("repository must not be queried")
+
+    async def no_crm(*_args):
+        raise AssertionError("CRM must not be called")
+
+    result = json.loads(
+        await invoicing_server._record_payment_with_dependencies(
+            repo=_NoRepositoryAccess(),
+            crm_logger=no_crm,
+            invoice_id="INV-1",
+            amount=10.0,
+            idempotency_key=invalid_key,
+        )
+    )
+
+    assert result == {
+        "success": False,
+        "error": "idempotency_key must contain 1 to 128 characters",
+    }
+
+
+@pytest.mark.asyncio
+async def test_real_postgres_http_and_mcp_entrypoints_use_supported_dependencies():
+    asyncpg = pytest.importorskip("asyncpg")
+    database_url = os.environ.get("ATLAS_RECEIVABLES_TEST_DATABASE_URL")
+    if not database_url:
+        pytest.skip("ATLAS_RECEIVABLES_TEST_DATABASE_URL not set")
+
+    from atlas_brain.api.invoicing import receivables as routes
+    from atlas_brain.mcp import invoicing_server
+    from atlas_brain.storage.repositories.invoice import InvoiceRepository
+
+    schema = f"receivables_entrypoints_{uuid4().hex}"
+    conn = await asyncpg.connect(database_url)
+    try:
+        await _create_pre_receivables_schema(conn, schema)
+        await conn.execute(_receivables_migration_sql())
+        contact_id = uuid4()
+        invoice_ids = [uuid4() for _ in range(3)]
+        await conn.execute("INSERT INTO contacts (id) VALUES ($1)", contact_id)
+        await conn.executemany(
+            """
+            INSERT INTO invoices (
+                id, invoice_number, contact_id, customer_name, total_amount,
+                due_date, status
+            ) VALUES ($1, $2, $3, 'Acme', 200, CURRENT_DATE + 30, 'sent')
+            """,
+            [
+                (invoice_ids[0], "INV-HTTP-1", contact_id),
+                (invoice_ids[1], "INV-HTTP-2", contact_id),
+                (invoice_ids[2], "INV-MCP-1", contact_id),
+            ],
+        )
+
+        allocation_contact_id = uuid4()
+        older_due_invoice, newer_due_invoice = uuid4(), uuid4()
+        await conn.execute(
+            "INSERT INTO contacts (id) VALUES ($1)", allocation_contact_id
+        )
+        await conn.executemany(
+            """
+            INSERT INTO invoices (
+                id, invoice_number, contact_id, customer_name, total_amount,
+                issue_date, due_date, status
+            ) VALUES ($1, $2, $3, $4, 100, $5, $6, 'sent')
+            """,
+            [
+                (
+                    older_due_invoice,
+                    "INV-ORDER-OLDER",
+                    allocation_contact_id,
+                    "Zulu Office",
+                    date(2026, 6, 1),
+                    date(2026, 6, 30),
+                ),
+                (
+                    newer_due_invoice,
+                    "INV-ORDER-NEWER",
+                    allocation_contact_id,
+                    "Alpha Office",
+                    date(2026, 7, 1),
+                    date(2026, 7, 31),
+                ),
+            ],
+        )
+
+        pool = _SingleConnectionPool(conn, schema)
+        service = ReceivablesService(pool)
+        repository = InvoiceRepository(pool=pool, receivables_service=service)
+        suggestions = await service.suggest_allocations(
+            contact_id=allocation_contact_id,
+            total_amount=Decimal("50.00"),
+        )
+        assert [item["invoice_id"] for item in suggestions] == [
+            str(older_due_invoice)
+        ]
+        config = SimpleNamespace(
+            receivables_api_enabled=True,
+            receivables_service_token="a-valid-service-token-for-tests",
+        )
+        app = FastAPI()
+        app.include_router(routes.router)
+        app.dependency_overrides[receivables_auth.get_receivables_api_config] = (
+            lambda: config
+        )
+        app.dependency_overrides[routes.get_receivables_service] = lambda: service
+        body = {
+            "contact_id": str(contact_id),
+            "payer_name": "Acme",
+            "total_amount_cents": 20_000,
+            "payment_method": "check",
+            "received_date": "2026-07-16",
+            "allocations": [
+                {"invoice_id": str(invoice_ids[0]), "amount_cents": 12_500},
+                {"invoice_id": str(invoice_ids[1]), "amount_cents": 5_000},
+            ],
+        }
+
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://receivables.test",
+        ) as client:
+            unauthorized = await client.post("/receivables/payments", json=body)
+            assert unauthorized.status_code == 401
+            assert await conn.fetchval("SELECT COUNT(*) FROM customer_payments") == 0
+
+            response = await client.post(
+                "/receivables/payments",
+                headers={
+                    "Authorization": "Bearer a-valid-service-token-for-tests",
+                    "X-EOM-Actor": "Juan Canfield",
+                    "Idempotency-Key": "http-payment-1",
+                },
+                json=body,
+            )
+
+        assert response.status_code == 201
+        assert response.json()["status"] == "received"
+        http_payment = await conn.fetchrow("""
+            SELECT idempotency_key, total_amount, recorded_by
+            FROM customer_payments
+            WHERE source = 'eom_admin' AND idempotency_key = 'http-payment-1'
+            """)
+        assert http_payment["total_amount"] == Decimal("200.00")
+        assert http_payment["recorded_by"] == "Juan Canfield"
+        http_allocations = await conn.fetch("""
+            SELECT amount FROM invoice_payments ip
+            JOIN customer_payments cp ON cp.id = ip.payment_id
+            WHERE cp.idempotency_key = 'http-payment-1'
+            ORDER BY amount DESC
+            """)
+        assert [row["amount"] for row in http_allocations] == [
+            Decimal("125.00"),
+            Decimal("50.00"),
+        ]
+
+        crm_calls = []
+
+        async def record_crm_call(*args):
+            crm_calls.append(args)
+
+        singular_first = json.loads(
+            await invoicing_server._record_payment_with_dependencies(
+                repo=repository,
+                crm_logger=record_crm_call,
+                invoice_id="INV-MCP-1",
+                amount=25.0,
+                payment_method="card",
+                idempotency_key="mcp-payment-retry-1",
+            )
+        )
+        singular_replay = json.loads(
+            await invoicing_server._record_payment_with_dependencies(
+                repo=repository,
+                crm_logger=record_crm_call,
+                invoice_id="INV-MCP-1",
+                amount=25.0,
+                payment_method="card",
+                idempotency_key="mcp-payment-retry-1",
+            )
+        )
+        assert singular_first["success"] is True
+        assert (
+            singular_first["payment"]["payment_id"]
+            == singular_replay["payment"]["payment_id"]
+        )
+        assert singular_first["payment"]["status"] == "cleared"
+        assert "replayed" not in singular_first["payment"]
+        assert "replayed" not in singular_replay["payment"]
+        assert len(crm_calls) == 1
+        received_payment_ids = {
+            payment["id"] for payment in await service.list_payments(status="received")
+        }
+        assert singular_first["payment"]["payment_id"] not in received_payment_ids
+
+        multi_result = json.loads(
+            await invoicing_server._record_customer_payment_with_service(
+                service=service,
+                contact_id=str(contact_id),
+                payer_name="Acme",
+                total_amount_cents=10_000,
+                payment_method="check",
+                allocations=[
+                    {"invoice_id": str(invoice_ids[0]), "amount_cents": 7_500},
+                    {"invoice_id": str(invoice_ids[1]), "amount_cents": 500},
+                ],
+                idempotency_key="mcp-multi-1",
+                reference="1001",
+            )
+        )
+        assert multi_result["success"] is True
+        assert multi_result["payment"]["total_amount_cents"] == 10_000
+        assert sorted(
+            item["amount_cents"] for item in multi_result["payment"]["allocations"]
+        ) == [500, 7_500]
+
+        before_invalid = await conn.fetchval("SELECT COUNT(*) FROM customer_payments")
+        invalid = json.loads(
+            await invoicing_server._record_customer_payment_with_service(
+                service=service,
+                contact_id=str(contact_id),
+                payer_name="Acme",
+                total_amount_cents=100.5,
+                payment_method="check",
+                allocations=[{"invoice_id": str(invoice_ids[0]), "amount_cents": 100}],
+                idempotency_key="mcp-multi-invalid",
+            )
+        )
+        assert invalid["success"] is False
+        assert (
+            await conn.fetchval("SELECT COUNT(*) FROM customer_payments")
+            == before_invalid
+        )
+    finally:
+        await conn.execute("SET search_path TO public")
+        await conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        await conn.close()
+
+
+def test_full_invoicing_mcp_http_refuses_to_start_without_strong_auth():
+    from atlas_brain.mcp import invoicing_server
+    from atlas_brain.mcp.auth import BearerAuthMiddleware
+
+    app_calls = []
+
+    def app_factory():
+        app_calls.append(True)
+        return object()
+
+    for token, message in (
+        ("", "is required"),
+        ("change-me", "placeholder"),
+        ("still-too-short", "at least 24"),
+    ):
+        with pytest.raises(RuntimeError, match=message):
+            invoicing_server._authenticated_streamable_http_app(token, app_factory)
+    assert app_calls == []
+
+    app = invoicing_server._authenticated_streamable_http_app(
+        "strong-invoicing-mcp-token-for-tests",
+        app_factory,
+    )
+    assert isinstance(app, BearerAuthMiddleware)
+    assert app_calls == [True]
+
+
+def test_payment_http_models_reject_coercive_cent_values():
+    from atlas_brain.api.invoicing.receivables import CreatePaymentRequest
+
+    base = {
+        "contact_id": str(uuid4()),
+        "payer_name": "Acme",
+        "total_amount_cents": 100,
+        "payment_method": "check",
+        "received_date": "2026-07-16",
+        "reference": "1001",
+        "allocations": [{"invoice_id": str(uuid4()), "amount_cents": 100}],
+    }
+    assert CreatePaymentRequest.model_validate(base).total_amount_cents == 100
+
+    for invalid in (True, False, 100.0, 100.5, "100", 0, -1):
+        with pytest.raises(ValueError):
+            CreatePaymentRequest.model_validate({**base, "total_amount_cents": invalid})
+        with pytest.raises(ValueError):
+            CreatePaymentRequest.model_validate(
+                {
+                    **base,
+                    "allocations": [
+                        {"invoice_id": str(uuid4()), "amount_cents": invalid}
+                    ],
+                }
+            )
+
+
+def test_multi_invoice_mcp_is_registered_with_bounded_strict_schema():
+    probe = r'''
+import asyncio
+from uuid import uuid4
+
+from mcp.server.fastmcp.exceptions import ToolError
+
+from atlas_brain.mcp import invoicing_server
+
+
+async def main():
+    tools = await invoicing_server.mcp.list_tools()
+    matching = [tool for tool in tools if tool.name == "record_customer_payment"]
+    assert len(matching) == 1
+    properties = matching[0].inputSchema["properties"]
+    assert properties["total_amount_cents"]["type"] == "integer"
+    assert properties["total_amount_cents"]["exclusiveMinimum"] == 0
+    assert properties["allocations"]["minItems"] == 1
+    assert properties["allocations"]["maxItems"] == 100
+    assert properties["payer_name"]["maxLength"] == 256
+    assert properties["idempotency_key"]["maxLength"] == 128
+
+    singular = [tool for tool in tools if tool.name == "record_payment"]
+    assert len(singular) == 1
+    singular_key = singular[0].inputSchema["properties"]["idempotency_key"]
+    singular_string = next(
+        branch for branch in singular_key["anyOf"] if branch.get("type") == "string"
+    )
+    assert singular_string["minLength"] == 1
+    assert singular_string["maxLength"] == 128
+
+    base = {
+        "contact_id": str(uuid4()),
+        "payer_name": "Acme",
+        "total_amount_cents": 100,
+        "payment_method": "check",
+        "allocations": [{"invoice_id": str(uuid4()), "amount_cents": 100}],
+        "idempotency_key": str(uuid4()),
+        "reference": "1001",
+    }
+
+    async def assert_rejected(candidate, expected_field):
+        try:
+            await invoicing_server.mcp.call_tool(
+                "record_customer_payment", candidate
+            )
+        except ToolError as exc:
+            message = str(exc)
+            assert "1 validation error" in message, message
+            assert f"\n{expected_field}\n" in message, message
+        else:
+            raise AssertionError(f"MCP accepted invalid arguments: {candidate!r}")
+
+    for invalid in (True, False, 100.0, 100.5, "100", 0, -1):
+        await assert_rejected(
+            {**base, "total_amount_cents": invalid},
+            "total_amount_cents",
+        )
+        await assert_rejected(
+            {
+                **base,
+                "allocations": [
+                    {"invoice_id": str(uuid4()), "amount_cents": invalid}
+                ],
+            },
+            "allocations.0.amount_cents",
+        )
+
+    for field, value in (
+        ("payer_name", "x" * 257),
+        ("idempotency_key", "x" * 129),
+        ("reference", "x" * 257),
+        ("allocations", []),
+        (
+            "allocations",
+            [{"invoice_id": str(uuid4()), "amount_cents": 1}] * 101,
+        ),
+    ):
+        await assert_rejected({**base, field: value}, field)
+
+
+asyncio.run(main())
+'''
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=Path(__file__).resolve().parents[1],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        "clean-process MCP contract probe failed\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )


### PR DESCRIPTION
Plan: plans/PR-Receivables-Ledger.md
Slice phase: Vertical slice
Ownership lane: eom-receivables

Atlas previously stored invoice applications as unrelated payment rows, so one mailed check covering two or three invoices had no authoritative receipt identity, allocation ledger, unapplied balance, or transactional lifecycle. This vertical slice adds that money-safe path while preserving legacy callers. The latest repair closes four exact-head findings at their authoritative boundaries: trusted secret-scan history, standalone MCP readiness, singular idempotency-key size, and oldest-due-first allocation ordering.

## Intentional

- `customer_payments` owns a physical or electronic receipt; invoice applications are explicit allocations and may leave unapplied customer credit.
- Checks start in `received` and follow deposit/clear lifecycle; ACH and Square compatibility receipts start cleared so they never enter the physical-check deposit queue.
- Legacy invoice-payment rows remain readable and are conservatively adopted one-to-one. `invoice_payments.payment_id` remains nullable for one rollout so old data is not hidden.
- New receivables HTTP writes are feature-gated and bearer-authenticated; the retired unauthenticated quick-pay route remains a non-writing 410 tombstone.
- The standalone invoicing MCP applies migrations and proves full receivables readiness before exposing tools.
- No root `.gitleaksignore` is added. The final PR range is one clean commit without the flagged test-code fixture occurrence, while the future trusted-base guard rejects every first or later ignore addition unless a labeled security-only rotation authorizes it.

## Deferred

- Make `invoice_payments.payment_id` non-null only after all finance writers and legacy rows have rolled forward.
- Provider webhooks, bank-file matching, payer-account modeling, and check-image storage remain separate operator-approved slices.
- The EOM backend and portal consumers remain coordinated companion-repository deployments.

## Parked hardening

None. Authentication, idempotency, atomic allocation, lifecycle audit, migration ordering, complete readiness, and secret-ignore governance are required in this money-write slice rather than waived.

## Cold diff reconstruction

Ground truth is the exact-head code, not earlier findings or plan prose.

- Confirmed before repair, now fixed: the initial-ignore exception was PR-controlled because the trusted workflow checks out and executes the base checker (`.github/workflows/gitleaks_baseline_growth_guard.yml:21-40`), while the base checker did not protect `.gitleaksignore`. The published tree contains no root ignore, and `scripts/check_gitleaks_baseline_rotation.py:55-101,221-239` now treats every first or later ignore addition as rotation-gated. `tests/test_check_gitleaks_baseline_rotation.py:119-186` covers unapproved initial/later growth and the labeled security-only path restriction.
- Confirmed before repair, now fixed: standalone MCP startup ran migrations but could serve after a partially applied schema. `atlas_brain/mcp/invoicing_server.py:72-114` now requires `ReceivablesService.is_ready()` before yielding and always closes the pool. `tests/test_receivables.py:495-599` proves success order, migration abort, and incomplete-schema abort.
- Confirmed before repair, now fixed: singular `record_payment` accepted an unbounded key before inserting into a 128-character column. `atlas_brain/mcp/invoicing_server.py:598-616,668-699` publishes the 1-to-128 schema and rejects an invalid helper call before repository access; `atlas_brain/services/receivables.py:540-558` repeats the invariant at the authoritative write boundary. `tests/test_receivables.py:229-246,1690-1717,2004-2023` covers service, repository-access, and real FastMCP schema boundaries.
- Confirmed before repair, now fixed: the greedy allocation loop consumed a customer-name-first invoice feed. `atlas_brain/services/receivables.py:429-486` orders by due date, issue date, customer name, and invoice number before suggesting allocations. `tests/test_receivables.py:249-269,1753-1794` proves the query contract and real PostgreSQL behavior for one contact whose newer invoice alphabetically sorts first.
- Confirmed before repair, still fixed: readiness validates every migration-added column and all 16 explicit or constraint-backed indexes; the API maps only concrete live database-unavailability states to 503; singular retries do not repeat CRM history; inactive receipts expose no available credit; and only physical checks enter the deposit queue.
- Contradicted during earlier cold review and corrected before publication: claims that a PR-owned initial ignore was trusted, that migrations alone proved standalone MCP readiness, and that the prior customer-name-first query implemented oldest-due-first suggestions were overstated. No waiver remains.
- Could not determine from code: production token provisioning, maintenance-window execution, deployed process versions, and companion-repository rollout state. Those remain release-time operational prerequisites and are not claimed here.

## Verification

- Ephemeral PostgreSQL 16: `python -m pytest tests/test_receivables.py tests/test_invoice_repository.py -q` with `ATLAS_RECEIVABLES_TEST_DATABASE_URL` — 62 passed, including oldest-due-first allocation across differing customer-name snapshots, removal of every required index, and live backend termination during a transaction.
- Focused receivables/repository/Gitleaks-rotation suite — 72 passed, 6 expected PostgreSQL-environment skips.
- Python compile and `git diff --check` — passed.
- Plan synchronization — passed.
- Invoicing MCP/OAuth surface — 43 passed; monthly invoice approval blockers — 2 passed, 41 deselected.
- Gitleaks clean PR range — 1 commit, 221,096 bytes, no leaks.
- Maturity ratchets and repository pre-push review are rerun or revalidated by the publication wrapper and GitHub checks.

## Diff size

- 18 files changed; 5,438 insertions and 203 deletions (5,641 total changed lines).
- Diff-budget override: The ledger schema, atomic receipt/allocation service, authenticated HTTP and MCP entrypoints, compatibility bridge, readiness contract, secret-ignore governance, and real PostgreSQL regression proofs must ship together so no deployment can expose a partial money-write path.
- The plan's explicit 18-file override covers the money-write boundaries and their regression proofs. No maturity or secret baseline is enlarged.

## AI reconciliation

- Initial `.gitleaksignore` trust finding: fixed by removing the ignore and republishing one clean commit; future ignore growth is rotation-gated.
- Standalone MCP schema-readiness finding: fixed with readiness-gated lifespan and failure cleanup proof.
- Singular MCP idempotency-key bound finding: fixed at registered transport, helper pre-repository, and service boundaries.
- Oldest-due-first suggestion finding: fixed in the authoritative query and proven against real PostgreSQL.
- All earlier recorded automated-review findings remain fixed; none are waived.
- All findings fixed or waived: yes.
