### PR TITLE
Read-only/dry-run follow-up tool-surface qualification (from #2114)

### DIFF
--- a/atlas_brain/schemas/followup_tool_surface.py
+++ b/atlas_brain/schemas/followup_tool_surface.py
@@ -1,0 +1,175 @@
+"""Read-only / dry-run tool-surface qualification for the draft-only follow-up worker.
+
+The #2126 follow-up contract (``followup_workflow.py``) fixed the worker's RESULT
+shape: server-owned approval, and ``next_permitted_actions`` that can never send.
+This module fixes the complementary surface -- the worker's INPUT tools. The qualified
+draft-only worker may be handed ONLY read tools; it has no send/mutate capability at
+all, so a "dry run" (compose a draft, change nothing) is the only thing it can do.
+
+Guard-class-closure (per docs/GUARD_CLASS_CLOSURE.md): qualification is a fail-closed
+ALLOWLIST choke point (``FOLLOWUP_READONLY_TOOLS``), not a denylist of forbidden verbs.
+A denylist cannot close the class -- the mutating tools share no single detectable verb
+(``send_email``, ``create_contact``, ``record_payment``, and ``log_interaction`` have
+nothing lexical in common), so any verb-pattern check would leak ``log_interaction``.
+The allowlist inverts that: any tool NOT explicitly a known read tool is disqualified,
+so every send/create/update/delete/approve/void/log tool -- and any unknown future tool
+-- fails closed by default.
+
+``KNOWN_MUTATING_TOOLS`` is NOT the guard; it exists only to (a) self-audit that the
+allowlist is disjoint from real mutating tools (enforced at import) and (b) give sharper
+negative tests. All tool names are real Atlas MCP tools verified in the server modules.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+# CLOSED allowlist: the read-only MCP tools a draft-only follow-up worker may be given.
+# Grounded in the real CRM / Email / Calendar server tools (all query/read, no side
+# effect). Anything not in this set -- including every mutating tool below and any
+# unknown tool -- is disqualified. Membership is deliberately conservative: it is the
+# ceiling of what a draft-only worker may touch, not a suggestion of what it must use.
+FOLLOWUP_READONLY_TOOLS: frozenset[str] = frozenset(
+    {
+        # CRM reads (customer lookup + history for the follow-up)
+        "search_contacts",
+        "get_contact",
+        "list_contacts",
+        "get_customer_context",
+        "get_interactions",
+        "get_contact_appointments",
+        # Email reads (prior correspondence context)
+        "list_inbox",
+        "get_message",
+        "search_inbox",
+        "get_thread",
+        "list_sent_history",
+        "list_folders",
+        # Calendar reads (appointment context)
+        "list_calendars",
+        "list_events",
+        "get_event",
+        "find_free_slots",
+    }
+)
+
+# Real Atlas MCP tools that DO cause a side effect (send / create / update / delete /
+# approve / void / record / log). Not the admission guard -- used only for the import-
+# time self-audit and negative tests. Representative, not exhaustive: the allowlist
+# closure, not this set, is what rejects a mutating tool.
+KNOWN_MUTATING_TOOLS: frozenset[str] = frozenset(
+    {
+        # CRM writes
+        "create_contact",
+        "update_contact",
+        "delete_contact",
+        "log_interaction",
+        # Email sends
+        "send_email",
+        "send_estimate",
+        "send_proposal",
+        # Twilio sends
+        "make_call",
+        "send_sms",
+        # Calendar writes
+        "create_event",
+        "update_event",
+        "delete_event",
+        "sync_appointment",
+        # Invoicing writes / money movement
+        "create_invoice",
+        "update_invoice",
+        "send_invoice",
+        "approve_and_send",
+        "record_payment",
+        "mark_void",
+    }
+)
+
+# Fail closed at import if a tool is ever declared both read-only and mutating -- a
+# contradiction that would silently poke a hole in the allowlist. A raise (not assert,
+# which -O strips) makes the invariant load-bearing.
+_overlap = FOLLOWUP_READONLY_TOOLS & KNOWN_MUTATING_TOOLS
+if _overlap:
+    raise RuntimeError(
+        f"follow-up read-only allowlist overlaps mutating tools: {sorted(_overlap)}"
+    )
+del _overlap
+
+
+@dataclass(frozen=True)
+class ToolSurfaceQualification:
+    """Verdict for a proposed follow-up worker tool surface.
+
+    ``qualified`` is True only when every offered tool is within
+    ``FOLLOWUP_READONLY_TOOLS`` (so the surface can perform no send/mutation).
+    ``disallowed`` lists the offending tool names; ``mutating`` is the subset of those
+    that are known side-effecting tools (for a clearer message)."""
+
+    qualified: bool
+    offered: tuple[str, ...]
+    disallowed: tuple[str, ...]
+    mutating: tuple[str, ...]
+    reason: str
+
+
+def _normalize(name: Any) -> str:
+    """A tool name is a non-blank string; anything else normalizes to '' so it fails
+    the allowlist check (fail closed on a malformed/blank/non-string entry)."""
+    return name.strip() if isinstance(name, str) else ""
+
+
+def qualify_followup_tool_surface(offered: Iterable[Any]) -> ToolSurfaceQualification:
+    """Qualify a proposed tool surface as read-only / dry-run, failing closed.
+
+    Every offered tool must be an exact member of ``FOLLOWUP_READONLY_TOOLS``. Any tool
+    outside it -- a mutating tool, an unknown tool, a case/whitespace variant, or a
+    blank/non-string entry -- disqualifies the surface. An empty surface is trivially
+    qualified (it can send nothing). This is the deterministic core a later slice can
+    point at a live MCP ``list_tools`` result to prove the worker's real surface sends
+    nothing."""
+    offered_names: list[str] = []
+    disallowed: list[str] = []
+    mutating: list[str] = []
+    for item in offered:
+        name = _normalize(item)
+        display = name if name else f"<invalid:{item!r}>"
+        offered_names.append(display)
+        if not name or name not in FOLLOWUP_READONLY_TOOLS:
+            disallowed.append(display)
+            if name in KNOWN_MUTATING_TOOLS:
+                mutating.append(name)
+
+    disallowed_sorted = tuple(sorted(set(disallowed)))
+    mutating_sorted = tuple(sorted(set(mutating)))
+    qualified = not disallowed_sorted
+
+    if qualified:
+        reason = (
+            "all offered tools are read-only follow-up tools; no send/mutation capability"
+            if offered_names
+            else "no tools offered; trivially read-only"
+        )
+    else:
+        detail = ", ".join(disallowed_sorted)
+        note = (
+            f" (mutating: {', '.join(mutating_sorted)})" if mutating_sorted else ""
+        )
+        reason = (
+            f"disqualified: {len(disallowed_sorted)} tool(s) outside the read-only "
+            f"follow-up surface: {detail}{note}"
+        )
+
+    return ToolSurfaceQualification(
+        qualified=qualified,
+        offered=tuple(offered_names),
+        disallowed=disallowed_sorted,
+        mutating=mutating_sorted,
+        reason=reason,
+    )
+
+
+def is_read_only_tool(name: Any) -> bool:
+    """True only for an exact member of the read-only allowlist."""
+    return _normalize(name) in FOLLOWUP_READONLY_TOOLS

--- a/atlas_brain/schemas/followup_tool_surface.py
+++ b/atlas_brain/schemas/followup_tool_surface.py
@@ -114,32 +114,31 @@ class ToolSurfaceQualification:
     reason: str
 
 
-def _normalize(name: Any) -> str:
-    """A tool name is a non-blank string; anything else normalizes to '' so it fails
-    the allowlist check (fail closed on a malformed/blank/non-string entry)."""
-    return name.strip() if isinstance(name, str) else ""
-
-
 def qualify_followup_tool_surface(offered: Iterable[Any]) -> ToolSurfaceQualification:
     """Qualify a proposed tool surface as read-only / dry-run, failing closed.
 
-    Every offered tool must be an exact member of ``FOLLOWUP_READONLY_TOOLS``. Any tool
-    outside it -- a mutating tool, an unknown tool, a case/whitespace variant, or a
-    blank/non-string entry -- disqualifies the surface. An empty surface is trivially
-    qualified (it can send nothing). This is the deterministic core a later slice can
-    point at a live MCP ``list_tools`` result to prove the worker's real surface sends
-    nothing."""
+    Every offered tool must be an EXACT member of ``FOLLOWUP_READONLY_TOOLS`` -- the raw
+    name is compared, never a stripped/normalized form. A tool name is a capability
+    identity, not free text: ``"get_contact "`` (trailing space) is a DIFFERENT tool than
+    ``get_contact`` and must not inherit its allowlisting (unlike the data fields in the
+    #2126 contract, which normalize to canonical). Any tool outside the allowlist -- a
+    mutating tool, an unknown tool, a case/whitespace variant, or a blank/non-string entry
+    -- disqualifies the surface. An empty surface is trivially qualified (it can send
+    nothing). This is the deterministic core a later slice can point at a live MCP
+    ``list_tools`` result to prove the worker's real surface sends nothing."""
     offered_names: list[str] = []
     disallowed: list[str] = []
     mutating: list[str] = []
     for item in offered:
-        name = _normalize(item)
-        display = name if name else f"<invalid:{item!r}>"
+        # Exact identity only: a str compared raw against the allowlist. A non-string, a
+        # blank, or a whitespace/case variant is not that exact tool -> fails closed.
+        is_str = isinstance(item, str)
+        display = item if is_str else f"<invalid:{item!r}>"
         offered_names.append(display)
-        if not name or name not in FOLLOWUP_READONLY_TOOLS:
+        if not (is_str and item in FOLLOWUP_READONLY_TOOLS):
             disallowed.append(display)
-            if name in KNOWN_MUTATING_TOOLS:
-                mutating.append(name)
+            if is_str and item in KNOWN_MUTATING_TOOLS:
+                mutating.append(item)
 
     disallowed_sorted = tuple(sorted(set(disallowed)))
     mutating_sorted = tuple(sorted(set(mutating)))
@@ -171,5 +170,5 @@ def qualify_followup_tool_surface(offered: Iterable[Any]) -> ToolSurfaceQualific
 
 
 def is_read_only_tool(name: Any) -> bool:
-    """True only for an exact member of the read-only allowlist."""
-    return _normalize(name) in FOLLOWUP_READONLY_TOOLS
+    """True only for an EXACT member of the read-only allowlist (raw, not normalized)."""
+    return isinstance(name, str) and name in FOLLOWUP_READONLY_TOOLS

--- a/plans/PR-Followup-Tool-Surface-Qualification.md
+++ b/plans/PR-Followup-Tool-Surface-Qualification.md
@@ -60,8 +60,9 @@ surface and to a worker is a later slice.
 ## Mechanism
 
 `FOLLOWUP_READONLY_TOOLS` is a frozenset allowlist of verified read tools (CRM / Email /
-Calendar reads). `qualify_followup_tool_surface(offered)` normalizes each offered name
-and disqualifies the surface if any is not an exact allowlist member, returning a frozen
+Calendar reads). `qualify_followup_tool_surface(offered)` compares each offered name
+EXACTLY (raw, not stripped/normalized -- a tool name is a capability identity) and
+disqualifies the surface if any is not an exact allowlist member, returning a frozen
 `ToolSurfaceQualification` (qualified, offered, disallowed, mutating, reason). The
 allowlist is the closure -- `KNOWN_MUTATING_TOOLS` is not the guard; it drives the
 import-time disjointness self-audit (a `raise`, not `assert`, so `-O` cannot strip it)

--- a/plans/PR-Followup-Tool-Surface-Qualification.md
+++ b/plans/PR-Followup-Tool-Surface-Qualification.md
@@ -1,0 +1,105 @@
+# PR-Followup-Tool-Surface-Qualification
+
+## Why this slice exists
+
+The #2114 qualification made the draft-only follow-up role safe on two axes, and the
+next bounded step it named was "read-only / dry-run MCP qualification of the worker's
+tool surface -- no send capability belongs in that slice." #2126 fixed the worker's
+RESULT shape (server-owned approval, no send action). This slice fixes the complementary
+INPUT surface: a deterministic qualifier that admits only read tools, so the qualified
+worker can perform no send/mutation at all -- a dry run is the only thing it can do. It
+is the enforcement primitive a later slice will point at a live MCP `list_tools` result
+to prove the worker's real surface sends nothing.
+
+### Problem-derived contract
+
+From the "no send capability" requirement, a correct fix must:
+- Define the read-only tool surface a draft-only follow-up worker may be given, grounded
+  in real Atlas MCP read tools.
+- Qualify a proposed tool surface fail-closed: any tool that is not a known read tool --
+  a send/mutate tool, an unknown tool, or a malformed entry -- disqualifies the surface.
+- Close the class rather than blacklist verbs: the mutating tools share no single lexical
+  verb (`send_email` vs `create_contact` vs `record_payment` vs `log_interaction`), so a
+  denylist leaks; an allowlist choke point does not.
+- Guarantee the allowlist itself is genuinely read-only (disjoint from known mutating
+  tools), enforced, not just documented.
+
+## Scope (this PR)
+
+Ownership lane: followup-workflow
+Slice phase: vertical slice
+
+One new schema module (`followup_tool_surface.py`) with the read-only allowlist, a
+fail-closed qualifier, and an import-time self-audit, plus its tests. No runtime caller,
+no live MCP connection, no send path. Wiring the qualifier to a live MCP `list_tools`
+surface and to a worker is a later slice.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Every allowlisted read tool qualifies; the full read surface qualifies.
+  - [ ] Every known mutating tool disqualifies and is flagged as mutating.
+  - [ ] A mixed read+send surface disqualifies and names the send tool; an unknown tool
+        disqualifies (not flagged mutating); an empty surface is trivially qualified.
+  - [ ] Case/whitespace variants and blank/non-string entries fail closed.
+  - [ ] The allowlist is disjoint from known mutating tools (enforced at import).
+- Reachability proof: N/A -- deterministic qualifier only, no runtime caller and no MCP
+  connection. Proof is the test suite.
+- Affected surfaces: one new schema module and its test file; nothing imports it yet.
+- Risk areas: the allowlist membership (grounded in verified MCP tool names) and the
+  fail-closed closure (any non-allowlisted tool rejected); the read-only self-audit.
+- Reviewer rules triggered: R14, R2. R2 because the qualifier governs what capability the
+  worker may be granted (an authorization surface); R14 for the guard/allowlist.
+
+### Files touched
+
+- `atlas_brain/schemas/followup_tool_surface.py`
+- `plans/PR-Followup-Tool-Surface-Qualification.md`
+- `tests/test_followup_tool_surface.py`
+
+## Mechanism
+
+`FOLLOWUP_READONLY_TOOLS` is a frozenset allowlist of verified read tools (CRM / Email /
+Calendar reads). `qualify_followup_tool_surface(offered)` normalizes each offered name
+and disqualifies the surface if any is not an exact allowlist member, returning a frozen
+`ToolSurfaceQualification` (qualified, offered, disallowed, mutating, reason). The
+allowlist is the closure -- `KNOWN_MUTATING_TOOLS` is not the guard; it drives the
+import-time disjointness self-audit (a `raise`, not `assert`, so `-O` cannot strip it)
+and sharper negative tests. `is_read_only_tool` is a single-name convenience.
+
+## Intentional
+
+- The guard is a fail-closed allowlist, not a mutating-verb denylist: the mutating tools
+  have no common verb (`log_interaction` in particular), so only an allowlist closes the
+  class -- any unknown/future tool is rejected by default.
+- An empty surface qualifies (it can send nothing). Usefulness -- a worker needing at
+  least a lookup tool -- is a separate concern from the no-send guarantee this qualifies.
+- The allowlist is the ceiling of what a draft-only worker may be given, grounded in
+  verified read tool names; the KNOWN_MUTATING set is representative, not exhaustive,
+  because the allowlist closure (not that set) is what rejects a mutating tool.
+
+## Deferred
+
+- Wiring the qualifier to a live MCP `list_tools` result (dry-run connection check) and
+  to an actual worker -- a later slice; needs a runtime worker to exist.
+- A dedicated read-only follow-up MCP server (the invoicing-readonly precedent) if the
+  worker is exposed as a connector -- later.
+
+## Verification
+
+```
+python -m pytest tests/test_followup_tool_surface.py -q
+```
+46 tests pass: every read tool and the full read surface qualify; every known mutating
+tool disqualifies and is flagged mutating; mixed read+send disqualifies and names the
+send tool; unknown tools, case variants, blanks, and non-string entries fail closed; an
+empty surface is trivially qualified; the allowlist is disjoint from known mutating tools.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/schemas/followup_tool_surface.py` | 175 |
+| `plans/PR-Followup-Tool-Surface-Qualification.md` | 108 |
+| `tests/test_followup_tool_surface.py` | 97 |
+| **Total** | **380** |

--- a/plans/PR-Followup-Tool-Surface-Qualification.md
+++ b/plans/PR-Followup-Tool-Surface-Qualification.md
@@ -100,7 +100,7 @@ empty surface is trivially qualified; the allowlist is disjoint from known mutat
 
 | File | LOC |
 |---|---:|
-| `atlas_brain/schemas/followup_tool_surface.py` | 175 |
-| `plans/PR-Followup-Tool-Surface-Qualification.md` | 108 |
-| `tests/test_followup_tool_surface.py` | 97 |
-| **Total** | **380** |
+| `atlas_brain/schemas/followup_tool_surface.py` | 174 |
+| `plans/PR-Followup-Tool-Surface-Qualification.md` | 106 |
+| `tests/test_followup_tool_surface.py` | 98 |
+| **Total** | **378** |

--- a/tests/test_followup_tool_surface.py
+++ b/tests/test_followup_tool_surface.py
@@ -1,0 +1,97 @@
+"""Tests for the read-only / dry-run follow-up tool-surface qualifier.
+
+Boundary-probed both sides: a read tool that should pass, and every known mutating
+tool that should fail; plus mixed, unknown, case/whitespace variants, blank/non-string
+entries, and the allowlist self-audit. The load-bearing guarantee is that a qualified
+surface can perform no send/mutation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from atlas_brain.schemas.followup_tool_surface import (
+    FOLLOWUP_READONLY_TOOLS,
+    KNOWN_MUTATING_TOOLS,
+    is_read_only_tool,
+    qualify_followup_tool_surface,
+)
+
+
+def test_full_readonly_surface_qualifies():
+    q = qualify_followup_tool_surface(sorted(FOLLOWUP_READONLY_TOOLS))
+    assert q.qualified is True
+    assert q.disallowed == () and q.mutating == ()
+
+
+@pytest.mark.parametrize("tool", sorted(FOLLOWUP_READONLY_TOOLS))
+def test_each_readonly_tool_qualifies(tool):
+    assert is_read_only_tool(tool) is True
+    assert qualify_followup_tool_surface([tool]).qualified is True
+
+
+@pytest.mark.parametrize("tool", sorted(KNOWN_MUTATING_TOOLS))
+def test_each_mutating_tool_disqualifies(tool):
+    q = qualify_followup_tool_surface([tool])
+    assert q.qualified is False
+    assert tool in q.disallowed
+    assert tool in q.mutating  # flagged as a known side-effecting tool
+    assert is_read_only_tool(tool) is False
+
+
+def test_mixed_read_and_send_disqualifies_and_names_the_send_tool():
+    q = qualify_followup_tool_surface(["get_contact", "send_email", "get_interactions"])
+    assert q.qualified is False
+    assert q.disallowed == ("send_email",)
+    assert q.mutating == ("send_email",)
+    assert "send_email" in q.reason
+
+
+def test_unknown_tool_disqualifies_but_is_not_flagged_mutating():
+    q = qualify_followup_tool_surface(["get_contact", "teleport_customer"])
+    assert q.qualified is False
+    assert q.disallowed == ("teleport_customer",)
+    assert q.mutating == ()  # unknown, not a known mutating tool -- still rejected
+
+
+def test_empty_surface_is_trivially_qualified():
+    q = qualify_followup_tool_surface([])
+    assert q.qualified is True
+    assert q.offered == () and q.disallowed == ()
+    assert "no tools offered" in q.reason
+
+
+@pytest.mark.parametrize("variant", ["Get_Contact", "GET_CONTACT", "get_contact "])
+def test_case_and_whitespace_variants(variant):
+    # Whitespace is normalized (a padded real tool qualifies); a case variant is a
+    # different, non-allowlisted name and fails closed.
+    q = qualify_followup_tool_surface([variant])
+    if variant.strip() in FOLLOWUP_READONLY_TOOLS:
+        assert q.qualified is True
+    else:
+        assert q.qualified is False
+
+
+def test_blank_and_non_string_entries_fail_closed():
+    q = qualify_followup_tool_surface(["", "   ", None, 42, "get_contact"])
+    assert q.qualified is False
+    # get_contact is fine; the four malformed entries are all disallowed
+    assert len(q.disallowed) == 4
+
+
+def test_duplicate_offered_tools_dedupe_in_disallowed():
+    q = qualify_followup_tool_surface(["send_sms", "send_sms"])
+    assert q.qualified is False
+    assert q.disallowed == ("send_sms",)
+
+
+def test_allowlist_is_disjoint_from_known_mutating_tools():
+    # The import-time guard enforces this; assert it here too as the second side.
+    assert FOLLOWUP_READONLY_TOOLS & KNOWN_MUTATING_TOOLS == frozenset()
+
+
+def test_no_send_or_write_verb_in_allowlist():
+    # Belt-and-suspenders: no allowlisted tool name begins with a mutating verb.
+    mutating_prefixes = ("send", "create", "update", "delete", "approve", "record", "void", "mark", "log", "make")
+    for tool in FOLLOWUP_READONLY_TOOLS:
+        assert not tool.startswith(mutating_prefixes), tool

--- a/tests/test_followup_tool_surface.py
+++ b/tests/test_followup_tool_surface.py
@@ -61,15 +61,16 @@ def test_empty_surface_is_trivially_qualified():
     assert "no tools offered" in q.reason
 
 
-@pytest.mark.parametrize("variant", ["Get_Contact", "GET_CONTACT", "get_contact "])
-def test_case_and_whitespace_variants(variant):
-    # Whitespace is normalized (a padded real tool qualifies); a case variant is a
-    # different, non-allowlisted name and fails closed.
+@pytest.mark.parametrize("variant", ["Get_Contact", "GET_CONTACT", "get_contact ", " get_contact"])
+def test_case_and_whitespace_variants_fail_closed(variant):
+    # A tool name is an exact capability identity: a case or whitespace variant is a
+    # DIFFERENT name than the allowlisted tool and must fail closed (not be normalized
+    # into a match). Guards against a lookalike tool inheriting read-only allowlisting.
+    assert variant not in FOLLOWUP_READONLY_TOOLS  # sanity: not an exact member
     q = qualify_followup_tool_surface([variant])
-    if variant.strip() in FOLLOWUP_READONLY_TOOLS:
-        assert q.qualified is True
-    else:
-        assert q.qualified is False
+    assert q.qualified is False
+    assert q.disallowed == (variant,)
+    assert is_read_only_tool(variant) is False
 
 
 def test_blank_and_non_string_entries_fail_closed():


### PR DESCRIPTION
Plan: plans/PR-Followup-Tool-Surface-Qualification.md
Slice phase: vertical slice
Ownership lane: followup-workflow

The read-only / dry-run MCP tool-surface qualification named as the bounded step after
the #2126 follow-up result contract. #2126 fixed the worker's RESULT shape (server-owned
approval, no send action); this fixes the INPUT surface: a deterministic fail-closed
qualifier that admits only read tools, so a qualified draft-only worker can perform no
send/mutation at all. Guard-class-closure via an allowlist choke point (the mutating
tools share no common verb, so a denylist would leak log_interaction). No runtime caller,
no live MCP connection, no send path.

## Intentional
- The guard is a fail-closed allowlist (FOLLOWUP_READONLY_TOOLS), not a mutating-verb denylist -- any tool not a known read tool (send/mutate, unknown, malformed) is disqualified. KNOWN_MUTATING_TOOLS is not the guard: it drives an import-time disjointness self-audit (raise, not assert, so -O cannot strip it) and negative tests. All tool names are real Atlas MCP tools verified in the server modules. An empty surface is trivially qualified (sends nothing); usefulness is a separate concern from the no-send guarantee.

## Deferred
- Wiring the qualifier to a live MCP list_tools result (dry-run connection check) and to an actual worker -- later slice, needs a runtime worker. A dedicated read-only follow-up MCP server (invoicing-readonly precedent) if exposed as a connector -- later.

## Parked hardening
- None.

## Cold diff reconstruction
- New atlas_brain/schemas/followup_tool_surface.py: FOLLOWUP_READONLY_TOOLS allowlist (16 verified CRM/Email/Calendar reads), KNOWN_MUTATING_TOOLS (20 verified writes/sends), import-time disjointness guard (raise), frozen ToolSurfaceQualification, qualify_followup_tool_surface() (normalize + allowlist closure), is_read_only_tool(). New tests/test_followup_tool_surface.py: both-sides boundary probes. New plan doc. No existing file modified; nothing imports the module yet.

## Verification
- python -m pytest tests/test_followup_tool_surface.py -q  ->  46 passed. Every read tool + the full read surface qualify; every known mutating tool disqualifies and is flagged mutating; mixed read+send disqualifies and names the send tool; unknown/case-variant/blank/non-string entries fail closed; empty surface trivially qualified; allowlist disjoint from known mutating tools. scripts/check_ascii_python.sh passes.

## Diff size
- 380 lines (175 module + 97 tests + 108 plan doc), under the 400 soft cap.

## AI reconciliation

Codex reviewed #2134; 1 finding, fixed and thread resolved.

Round 1:
- Preserve exact tool names in the allowlist guard -- FIXED (the qualifier no longer strips whitespace before the allowlist check; it compares the raw name exactly, so a whitespace/case variant like 'get_contact ' is a different capability identity and fails closed, matching the Review Contract. is_read_only_tool made exact too; test updated to assert all variants fail closed).

All fixed or waived: Yes