### PR TITLE
Content Factory copy-verification gate (Phase 4.1)

### DIFF
--- a/atlas_brain/services/content_factory_copy_verification.py
+++ b/atlas_brain/services/content_factory_copy_verification.py
@@ -49,8 +49,10 @@ _RULES: dict[str, list[tuple[str, str]]] = {
         # "guaranteed savings", "guaranteed cost/monthly savings", "guaranteed 30%
         # savings", "guarantees savings". Up to 3 tokens (incl. numeric/percent ones)
         # may sit between the guarantee verb and "savings".
-        ("guaranteed-savings", r"\bguarante(?:e|es|ed)\b(?:\s+[\w%$.,-]+){0,3}\s+savings\b"),
-        ("guaranteed-rankings", r"\bguarante(?:e|es|ed)\b(?:\s+[\w%$.,-]+){0,3}\s+rankings\b"),
+        # Gap tokens allow digits/percent (e.g. "30%") but NOT sentence punctuation, so a
+        # modifier gap cannot bridge a sentence boundary ("guarantee X. Savings ...").
+        ("guaranteed-savings", r"\bguarante(?:e|es|ed)\b(?:\s+[\w%$-]+){0,3}\s+savings\b"),
+        ("guaranteed-rankings", r"\bguarante(?:e|es|ed)\b(?:\s+[\w%$-]+){0,3}\s+rankings\b"),
         # Fixed deflection percentage, "%" or spelled-out "percent".
         ("fixed-deflection-percent", r"\b\d{1,3}\s*(?:%|percent)\s+deflection\b"),
         # Fixed ticket reductions: "reduce (support) tickets/ticket volume by N%/percent".
@@ -100,8 +102,10 @@ _RULES: dict[str, list[tuple[str, str]]] = {
 _EMAIL_RE = re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.I)
 _PHONE_RE = re.compile(r"\b(?:\+?1[-.\s]?)?(?:\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4})\b")
 
-# A negation directly before the claim (no/not/never/without, or an -n't contraction).
-_NEGATION_RE = re.compile(r"\b(?:no|not|never|without)\b|n't\b", re.I)
+# A negation directly before the claim (no/not/never/without/cannot, or an -n't
+# contraction). "not only"/"not just" are emphatic, NOT negations, and are excluded.
+_NEGATION_RE = re.compile(r"\b(?:no|not|never|without|cannot)\b|n't\b", re.I)
+_EMPHATIC_RE = re.compile(r"\bnot\s+(?:only|just)\b", re.I)
 
 
 def _is_negated(text: str, start: int) -> bool:
@@ -109,25 +113,36 @@ def _is_negated(text: str, start: int) -> bool:
 
     Only the last two words of the current segment are considered (a segment ends at
     ``.!?;,`` or newline), so a real negation ("no guaranteed savings", "does not promise
-    guaranteed savings") suppresses the hit, but an UNRELATED earlier negation in the same
-    sentence ("No setup fee, and guaranteed savings ...", "does not delay launch and
-    guarantees savings") does not -- the source tool scanned the whole prefix and leaked
-    those false negatives."""
+    guaranteed savings", "we cannot guarantee savings") suppresses the hit, but an
+    UNRELATED earlier negation in the same sentence ("No setup fee, and guaranteed savings
+    ...") does not, and emphatic "not only"/"not just" is not read as a negation ("not only
+    guarantees savings" is still a hit)."""
     segment_start = max(text.rfind(mark, 0, start) for mark in ".!?;,\n")
     prefix = text[segment_start + 1 : start]
     window = " ".join(prefix.split()[-2:])
+    if _EMPHATIC_RE.search(window):
+        return False
     return bool(_NEGATION_RE.search(window))
+
+
+def _redact_pii(evidence: str) -> str:
+    """Strip any email/phone out of matched claim evidence before it is recorded, so a
+    claim that happens to span a contact string ("Guaranteed 618-555-9876 savings") does
+    not persist raw PII into the git-backed audit metadata via the claim hit."""
+    evidence = _EMAIL_RE.sub("<redacted-email>", evidence)
+    evidence = _PHONE_RE.sub("<redacted-phone>", evidence)
+    return evidence
 
 
 def _claim_hits(text: str) -> list[str]:
     """"code: evidence" for each non-negated forbidden-claim match. Claim evidence is the
-    marketing phrase itself (safe and useful for a human reviewer), not PII."""
+    marketing phrase itself (useful for a human reviewer), with any PII redacted out."""
     hits: list[str] = []
     for category in ("outcomes", "automation", "replacing_agents"):
         for code, pattern in _RULES[category]:
             for match in re.finditer(pattern, text, re.I):
                 if not _is_negated(text, match.start()):
-                    hits.append(f"{code}: {match.group(0)}")
+                    hits.append(f"{code}: {_redact_pii(match.group(0))}")
     return hits
 
 

--- a/atlas_brain/services/content_factory_copy_verification.py
+++ b/atlas_brain/services/content_factory_copy_verification.py
@@ -46,10 +46,11 @@ from atlas_brain.schemas.content_factory import CopyVerification
 # best-effort backstop (see module docstring): a novel paraphrase can pass.
 _RULES: dict[str, list[tuple[str, str]]] = {
     "outcomes": [
-        # "guaranteed savings", "guaranteed cost/monthly savings", "guarantees savings".
-        # Up to 3 words may sit between the guarantee verb and "savings".
-        ("guaranteed-savings", r"\bguarante(?:e|es|ed)\b(?:\s+\w+){0,3}\s+savings\b"),
-        ("guaranteed-rankings", r"\bguarante(?:e|es|ed)\b(?:\s+\w+){0,3}\s+rankings\b"),
+        # "guaranteed savings", "guaranteed cost/monthly savings", "guaranteed 30%
+        # savings", "guarantees savings". Up to 3 tokens (incl. numeric/percent ones)
+        # may sit between the guarantee verb and "savings".
+        ("guaranteed-savings", r"\bguarante(?:e|es|ed)\b(?:\s+[\w%$.,-]+){0,3}\s+savings\b"),
+        ("guaranteed-rankings", r"\bguarante(?:e|es|ed)\b(?:\s+[\w%$.,-]+){0,3}\s+rankings\b"),
         # Fixed deflection percentage, "%" or spelled-out "percent".
         ("fixed-deflection-percent", r"\b\d{1,3}\s*(?:%|percent)\s+deflection\b"),
         # Fixed ticket reductions: "reduce (support) tickets/ticket volume by N%/percent".
@@ -76,15 +77,19 @@ _RULES: dict[str, list[tuple[str, str]]] = {
         ("answers-tickets-automatically", r"\banswers?\s+tickets?\s+automatically\b"),
     ],
     "replacing_agents": [
-        # "replace (your/our/the) (support) agents".
+        # "replace (your/our/the) (support) agents" as the direct object. The negative
+        # lookahead excludes a possessive ("replace your agents' spreadsheet"), where the
+        # thing replaced is not the agents.
         (
             "replace-agents",
-            r"\breplac(?:e|es|ing)\s+(?:your\s+|our\s+|the\s+)?(?:support\s+)?agents?\b",
+            r"\breplac(?:e|es|ing)\s+(?:your\s+|our\s+|the\s+)?(?:support\s+)?agents?\b(?![\u0027\u2019])",
         ),
-        # "avoid a support hire", "avoid hiring (another) (support) agent".
+        # "avoid a support hire", "avoid hiring (another) (support) agent". Anchored on
+        # hire/hiring semantics -- NOT any nearby "agents" (which would match benign copy
+        # like "avoid distracting your agents").
         (
             "avoid-support-hire",
-            r"\bavoid(?:s|ing)?\s+(?:\w+\s+){0,3}(?:hire|hiring|agents?)\b",
+            r"\bavoid(?:s|ing)?\s+(?:\w+\s+){0,3}(?:hire|hiring)\b",
         ),
     ],
 }

--- a/atlas_brain/services/content_factory_copy_verification.py
+++ b/atlas_brain/services/content_factory_copy_verification.py
@@ -1,0 +1,118 @@
+"""Deterministic copy-verification gate for Content Factory drafts (Phase 4.1).
+
+The #2116 contract gave ``EditorialAudit`` a ``copy_verification`` field and a rule
+that a draft may not be promoted unless ``copy_verification.verdict == "pass"`` -- but
+nothing PRODUCED that verdict, so the gate was a shape with no teeth. This module is the
+producer: a pure, deterministic scan of draft text that fails the verdict when the copy
+contains a forbidden marketing claim or raw contact PII.
+
+The banned-claim catalogue and PII patterns are ported VERBATIM from the operator's
+"Resolution Audit Draft Verifier" copy_verification tool (authored by Juan Canfield /
+Codex), which lived only in the Open WebUI database and was therefore un-versioned. This
+is the blocker core of that tool -- the categories it marks "Do not post yet":
+
+  - forbidden OUTCOME claims (guaranteed savings, fixed deflection %, ticket reductions),
+  - forbidden AUTOMATION claims (auto-publishing / auto-answering the help center),
+  - REPLACING-AGENTS / avoided-hire claims,
+  - raw contact PII (email addresses, phone-number-shaped strings).
+
+Matching is negation-aware (``no guaranteed savings`` is not a hit), matching the source
+tool. The tool's softer "needs human review" layer (answer/ownership qualifiers, owner-
+routing coverage, CTA reminder) is intentionally NOT ported here -- those are warnings,
+not promote-blockers, and are a later slice. Wiring this producer into the runner /
+Phase 4.2 Filter is also a later slice; this is the deterministic core those will call.
+"""
+
+from __future__ import annotations
+
+import re
+
+from atlas_brain.schemas.content_factory import CopyVerification
+
+# Forbidden-claim catalogue, ported verbatim from the operator's copy_verification tool.
+# A match in any category blocks promotion (verdict "fail").
+_RULES: dict[str, list[tuple[str, str]]] = {
+    "outcomes": [
+        ("guaranteed-savings", r"\bguaranteed\s+savings\b"),
+        ("guarantees-savings", r"\bguarantees?\s+savings\b"),
+        ("guaranteed-rankings", r"\bguaranteed\s+rankings\b"),
+        ("fixed-deflection-percent", r"\b\d{1,3}\s*%\s+deflection\b"),
+        (
+            "fixed-ticket-volume-reduction",
+            r"\b(?:cut|cuts|reduce|reduces|lower|lowers|drop|drops|shrink|shrinks)\s+ticket\s+volume\s+by\s+\d{1,3}\s*(?:%|percent)\b",
+        ),
+        (
+            "fixed-fewer-tickets",
+            r"\b\d{1,3}\s*(?:%|percent)\s+(?:fewer|less)\s+tickets?\b",
+        ),
+    ],
+    "automation": [
+        ("live-help-center-publishing", r"\blive\s+help[- ]center\s+publishing\b"),
+        ("automatic-help-center-updates", r"\bautomatic\s+help[- ]center\s+updates\b"),
+        ("automatic-ticket-answering", r"\bautomatic\s+ticket\s+answering\b"),
+        ("auto-published", r"\bauto[- ]published\b"),
+        (
+            "automatically-updates-help-center",
+            r"\bautomatically\s+updates?\s+(?:your\s+)?help[- ]center\b",
+        ),
+        ("answers-tickets-automatically", r"\banswers?\s+tickets?\s+automatically\b"),
+    ],
+    "replacing_agents": [
+        ("replace-agents", r"\breplac(?:e|es|ing)\s+(support\s+)?agents?\b"),
+        ("avoid-support-hire", r"\bavoid\s+a\s+support\s+hire\b"),
+    ],
+}
+
+# Raw contact PII, ported verbatim. A match blocks promotion.
+_EMAIL_RE = re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.I)
+_PHONE_RE = re.compile(r"\b(?:\+?1[-.\s]?)?(?:\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4})\b")
+
+
+def _is_negated(text: str, start: int) -> bool:
+    """A claim is not a hit when its clause is negated (no/not/never/without/does not
+    promise ...). Ported verbatim from the source tool so parity is exact."""
+    clause_start = max(text.rfind(mark, 0, start) for mark in ".!?;\n")
+    prefix = text[clause_start + 1 : start].lower()
+    if re.search(r"\b(?:but|however)\b", prefix):
+        prefix = re.split(r"\b(?:but|however)\b", prefix)[-1]
+    return bool(
+        re.search(
+            r"\b(no|not|never|without)\b|\bdo(?:es)?\s+not\s+promise\b|\bdoesn't\s+promise\b",
+            prefix,
+        )
+    )
+
+
+def _pattern_hits(text: str, rules: list[tuple[str, str]]) -> list[tuple[str, str]]:
+    """(code, evidence) for each non-negated pattern match. Ported verbatim."""
+    hits: list[tuple[str, str]] = []
+    for code, pattern in rules:
+        for match in re.finditer(pattern, text, re.I):
+            if not _is_negated(text, match.start()):
+                hits.append((code, match.group(0)))
+    return hits
+
+
+def verify_copy(text: str) -> CopyVerification:
+    """Deterministically verify draft copy, producing the ``CopyVerification`` verdict
+    the #2116 EditorialAudit contract requires for promotion.
+
+    The verdict is ``"fail"`` when the copy contains any forbidden marketing claim
+    (outcome / automation / replacing-agents) or raw contact PII (email / phone), and
+    ``"pass"`` otherwise. Each hit is recorded as ``"code: evidence"``. A ``fail`` verdict
+    makes ``recommendation == "promote"`` invalid, so a model cannot self-promote copy
+    that overclaims or leaks PII."""
+    if not isinstance(text, str):
+        raise TypeError("verify_copy requires a string; draft body is text")
+
+    hits: list[str] = []
+    for category in ("outcomes", "automation", "replacing_agents"):
+        for code, evidence in _pattern_hits(text, _RULES[category]):
+            hits.append(f"{code}: {evidence}")
+    for match in _EMAIL_RE.finditer(text):
+        hits.append(f"email: {match.group(0)}")
+    for match in _PHONE_RE.finditer(text):
+        hits.append(f"phone: {match.group(0)}")
+
+    verdict = "fail" if hits else "pass"
+    return CopyVerification(verdict=verdict, hits=hits)

--- a/atlas_brain/services/content_factory_copy_verification.py
+++ b/atlas_brain/services/content_factory_copy_verification.py
@@ -8,8 +8,11 @@ contains a forbidden marketing claim or raw contact PII.
 
 The banned-claim catalogue and PII patterns are ported VERBATIM from the operator's
 "Resolution Audit Draft Verifier" copy_verification tool (authored by Juan Canfield /
-Codex), which lived only in the Open WebUI database and was therefore un-versioned. This
-is the blocker core of that tool -- the categories it marks "Do not post yet":
+Codex), which lived only in the Open WebUI database and was therefore un-versioned --
+with ONE operator-authorized fix, annotated at the ``fixed-ticket-volume-reduction`` rule,
+that closes a ``%``-boundary gap so "30%" is caught like "30 percent" (a strict tightening).
+This repo module is now the canonical gate; the Open WebUI copy is superseded. This is the
+blocker core of that tool -- the categories it marks "Do not post yet":
 
   - forbidden OUTCOME claims (guaranteed savings, fixed deflection %, ticket reductions),
   - forbidden AUTOMATION claims (auto-publishing / auto-answering the help center),
@@ -38,8 +41,15 @@ _RULES: dict[str, list[tuple[str, str]]] = {
         ("guaranteed-rankings", r"\bguaranteed\s+rankings\b"),
         ("fixed-deflection-percent", r"\b\d{1,3}\s*%\s+deflection\b"),
         (
+            # Operator-authorized fix to the one source quirk: the source ended this
+            # rule `(?:%|percent)\b`, but `\b` after `%` can never match (`%` before a
+            # space is two non-word chars), so "30%" slipped through while "30 percent"
+            # did not. Moving `\b` inside the alternation guards only the word "percent"
+            # and lets a bare "%" match -- a strict tightening of the gate, not a
+            # loosening. (The other percent rules anchor `%` with following text, so
+            # they never had this gap.)
             "fixed-ticket-volume-reduction",
-            r"\b(?:cut|cuts|reduce|reduces|lower|lowers|drop|drops|shrink|shrinks)\s+ticket\s+volume\s+by\s+\d{1,3}\s*(?:%|percent)\b",
+            r"\b(?:cut|cuts|reduce|reduces|lower|lowers|drop|drops|shrink|shrinks)\s+ticket\s+volume\s+by\s+\d{1,3}\s*(?:%|percent\b)",
         ),
         (
             "fixed-fewer-tickets",

--- a/atlas_brain/services/content_factory_copy_verification.py
+++ b/atlas_brain/services/content_factory_copy_verification.py
@@ -6,24 +6,33 @@ nothing PRODUCED that verdict, so the gate was a shape with no teeth. This modul
 producer: a pure, deterministic scan of draft text that fails the verdict when the copy
 contains a forbidden marketing claim or raw contact PII.
 
-The banned-claim catalogue and PII patterns are ported VERBATIM from the operator's
-"Resolution Audit Draft Verifier" copy_verification tool (authored by Juan Canfield /
-Codex), which lived only in the Open WebUI database and was therefore un-versioned --
-with ONE operator-authorized fix, annotated at the ``fixed-ticket-volume-reduction`` rule,
-that closes a ``%``-boundary gap so "30%" is caught like "30 percent" (a strict tightening).
-This repo module is now the canonical gate; the Open WebUI copy is superseded. This is the
-blocker core of that tool -- the categories it marks "Do not post yet":
+WHAT THIS GATE IS -- and is not. It is a deterministic BEST-EFFORT BACKSTOP that catches
+the common wordings of the operator's promote-blocking claim categories. It is NOT a
+complete natural-language classifier: no regex catalogue can enumerate every paraphrase
+of "guaranteed savings", so a novel wording can still pass. The real safety guarantee is
+the human approval step before publish (nothing leaves the box unapproved); this gate
+reduces that reviewer's load and hard-blocks the obvious overclaims and PII. It fails the
+verdict conservatively (any hit blocks promotion) but a "pass" means "no known-bad pattern
+matched", not "provably clean".
 
-  - forbidden OUTCOME claims (guaranteed savings, fixed deflection %, ticket reductions),
-  - forbidden AUTOMATION claims (auto-publishing / auto-answering the help center),
-  - REPLACING-AGENTS / avoided-hire claims,
-  - raw contact PII (email addresses, phone-number-shaped strings).
+The claim categories and PII patterns originate from the operator's "Resolution Audit
+Draft Verifier" tool (authored by Juan Canfield / Codex), which lived only in the Open
+WebUI database and was therefore un-versioned. This repo module is now the canonical gate
+(the OWUI copy is superseded and should be re-synced from here). Relative to the source it
+carries operator-authorized corrections and same-category coverage broadening:
 
-Matching is negation-aware (``no guaranteed savings`` is not a hit), matching the source
-tool. The tool's softer "needs human review" layer (answer/ownership qualifiers, owner-
-routing coverage, CTA reminder) is intentionally NOT ported here -- those are warnings,
-not promote-blockers, and are a later slice. Wiring this producer into the runner /
-Phase 4.2 Filter is also a later slice; this is the deterministic core those will call.
+  - the ``%``-boundary gap is closed (``30%`` is caught like ``30 percent``);
+  - negation detection is scoped to the words immediately before the claim, so an
+    unrelated earlier negation ("No setup fee, and guaranteed savings ...") no longer
+    suppresses a real hit;
+  - each category matches common inflections/modifiers, not one fixture wording.
+
+Categories (all promote-blocking -- "Do not post yet"): forbidden OUTCOME claims
+(guaranteed savings, fixed deflection %, ticket reductions), forbidden AUTOMATION claims
+(auto-publishing / auto-answering), REPLACING-AGENTS / avoided-hire claims, and raw
+contact PII (email / phone). The source tool's softer "needs human review" layer
+(answer/ownership qualifiers, owner-routing coverage, CTA reminder) is a later slice, as
+is wiring this producer into the runner / Phase 4.2 Filter.
 """
 
 from __future__ import annotations
@@ -32,74 +41,88 @@ import re
 
 from atlas_brain.schemas.content_factory import CopyVerification
 
-# Forbidden-claim catalogue, ported verbatim from the operator's copy_verification tool.
-# A match in any category blocks promotion (verdict "fail").
+# Forbidden-claim catalogue. Each pattern targets a promote-blocking category and matches
+# the common inflections/modifiers of that category, not a single fixture wording. Still a
+# best-effort backstop (see module docstring): a novel paraphrase can pass.
 _RULES: dict[str, list[tuple[str, str]]] = {
     "outcomes": [
-        ("guaranteed-savings", r"\bguaranteed\s+savings\b"),
-        ("guarantees-savings", r"\bguarantees?\s+savings\b"),
-        ("guaranteed-rankings", r"\bguaranteed\s+rankings\b"),
-        ("fixed-deflection-percent", r"\b\d{1,3}\s*%\s+deflection\b"),
+        # "guaranteed savings", "guaranteed cost/monthly savings", "guarantees savings".
+        # Up to 3 words may sit between the guarantee verb and "savings".
+        ("guaranteed-savings", r"\bguarante(?:e|es|ed)\b(?:\s+\w+){0,3}\s+savings\b"),
+        ("guaranteed-rankings", r"\bguarante(?:e|es|ed)\b(?:\s+\w+){0,3}\s+rankings\b"),
+        # Fixed deflection percentage, "%" or spelled-out "percent".
+        ("fixed-deflection-percent", r"\b\d{1,3}\s*(?:%|percent)\s+deflection\b"),
+        # Fixed ticket reductions: "reduce (support) tickets/ticket volume by N%/percent".
         (
-            # Operator-authorized fix to the one source quirk: the source ended this
-            # rule `(?:%|percent)\b`, but `\b` after `%` can never match (`%` before a
-            # space is two non-word chars), so "30%" slipped through while "30 percent"
-            # did not. Moving `\b` inside the alternation guards only the word "percent"
-            # and lets a bare "%" match -- a strict tightening of the gate, not a
-            # loosening. (The other percent rules anchor `%` with following text, so
-            # they never had this gap.)
-            "fixed-ticket-volume-reduction",
-            r"\b(?:cut|cuts|reduce|reduces|lower|lowers|drop|drops|shrink|shrinks)\s+ticket\s+volume\s+by\s+\d{1,3}\s*(?:%|percent\b)",
+            "fixed-ticket-reduction",
+            r"\b(?:cut|cuts|reduce|reduces|lower|lowers|drop|drops|shrink|shrinks)\s+(?:your\s+|the\s+)?(?:support\s+)?tickets?(?:\s+volume)?\s+by\s+\d{1,3}\s*(?:%|percent\b)",
         ),
+        # "N% fewer/less (support) tickets".
         (
             "fixed-fewer-tickets",
-            r"\b\d{1,3}\s*(?:%|percent)\s+(?:fewer|less)\s+tickets?\b",
+            r"\b\d{1,3}\s*(?:%|percent)\s+(?:fewer|less)\s+(?:support\s+)?tickets?\b",
         ),
     ],
     "automation": [
         ("live-help-center-publishing", r"\blive\s+help[- ]center\s+publishing\b"),
         ("automatic-help-center-updates", r"\bautomatic\s+help[- ]center\s+updates\b"),
         ("automatic-ticket-answering", r"\bautomatic\s+ticket\s+answering\b"),
-        ("auto-published", r"\bauto[- ]published\b"),
+        # auto-publish / auto-publishes / auto-publishing / auto-published.
+        ("auto-publish", r"\bauto[- ]publish(?:es|ing|ed)?\b"),
         (
             "automatically-updates-help-center",
-            r"\bautomatically\s+updates?\s+(?:your\s+)?help[- ]center\b",
+            r"\bautomatically\s+(?:updates?|publish(?:es)?)\s+(?:your\s+)?help[- ]center\b",
         ),
         ("answers-tickets-automatically", r"\banswers?\s+tickets?\s+automatically\b"),
     ],
     "replacing_agents": [
-        ("replace-agents", r"\breplac(?:e|es|ing)\s+(support\s+)?agents?\b"),
-        ("avoid-support-hire", r"\bavoid\s+a\s+support\s+hire\b"),
+        # "replace (your/our/the) (support) agents".
+        (
+            "replace-agents",
+            r"\breplac(?:e|es|ing)\s+(?:your\s+|our\s+|the\s+)?(?:support\s+)?agents?\b",
+        ),
+        # "avoid a support hire", "avoid hiring (another) (support) agent".
+        (
+            "avoid-support-hire",
+            r"\bavoid(?:s|ing)?\s+(?:\w+\s+){0,3}(?:hire|hiring|agents?)\b",
+        ),
     ],
 }
 
-# Raw contact PII, ported verbatim. A match blocks promotion.
+# Raw contact PII. A match blocks promotion; the matched value is NEVER copied into the
+# verdict's hits (that JSON is persisted in the git-backed job folder), only a redacted
+# marker -- otherwise the gate would duplicate the very PII it exists to block.
 _EMAIL_RE = re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.I)
 _PHONE_RE = re.compile(r"\b(?:\+?1[-.\s]?)?(?:\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4})\b")
 
+# A negation directly before the claim (no/not/never/without, or an -n't contraction).
+_NEGATION_RE = re.compile(r"\b(?:no|not|never|without)\b|n't\b", re.I)
+
 
 def _is_negated(text: str, start: int) -> bool:
-    """A claim is not a hit when its clause is negated (no/not/never/without/does not
-    promise ...). Ported verbatim from the source tool so parity is exact."""
-    clause_start = max(text.rfind(mark, 0, start) for mark in ".!?;\n")
-    prefix = text[clause_start + 1 : start].lower()
-    if re.search(r"\b(?:but|however)\b", prefix):
-        prefix = re.split(r"\b(?:but|however)\b", prefix)[-1]
-    return bool(
-        re.search(
-            r"\b(no|not|never|without)\b|\bdo(?:es)?\s+not\s+promise\b|\bdoesn't\s+promise\b",
-            prefix,
-        )
-    )
+    """True when the claim at ``start`` is negated by the words IMMEDIATELY before it.
+
+    Only the last two words of the current segment are considered (a segment ends at
+    ``.!?;,`` or newline), so a real negation ("no guaranteed savings", "does not promise
+    guaranteed savings") suppresses the hit, but an UNRELATED earlier negation in the same
+    sentence ("No setup fee, and guaranteed savings ...", "does not delay launch and
+    guarantees savings") does not -- the source tool scanned the whole prefix and leaked
+    those false negatives."""
+    segment_start = max(text.rfind(mark, 0, start) for mark in ".!?;,\n")
+    prefix = text[segment_start + 1 : start]
+    window = " ".join(prefix.split()[-2:])
+    return bool(_NEGATION_RE.search(window))
 
 
-def _pattern_hits(text: str, rules: list[tuple[str, str]]) -> list[tuple[str, str]]:
-    """(code, evidence) for each non-negated pattern match. Ported verbatim."""
-    hits: list[tuple[str, str]] = []
-    for code, pattern in rules:
-        for match in re.finditer(pattern, text, re.I):
-            if not _is_negated(text, match.start()):
-                hits.append((code, match.group(0)))
+def _claim_hits(text: str) -> list[str]:
+    """"code: evidence" for each non-negated forbidden-claim match. Claim evidence is the
+    marketing phrase itself (safe and useful for a human reviewer), not PII."""
+    hits: list[str] = []
+    for category in ("outcomes", "automation", "replacing_agents"):
+        for code, pattern in _RULES[category]:
+            for match in re.finditer(pattern, text, re.I):
+                if not _is_negated(text, match.start()):
+                    hits.append(f"{code}: {match.group(0)}")
     return hits
 
 
@@ -109,20 +132,20 @@ def verify_copy(text: str) -> CopyVerification:
 
     The verdict is ``"fail"`` when the copy contains any forbidden marketing claim
     (outcome / automation / replacing-agents) or raw contact PII (email / phone), and
-    ``"pass"`` otherwise. Each hit is recorded as ``"code: evidence"``. A ``fail`` verdict
-    makes ``recommendation == "promote"`` invalid, so a model cannot self-promote copy
-    that overclaims or leaks PII."""
+    ``"pass"`` otherwise. A ``fail`` verdict makes ``recommendation == "promote"`` invalid,
+    so a model cannot self-promote copy that overclaims or leaks PII. PII hits record only a
+    redacted marker, so the verdict (persisted in the job folder) never re-exposes the
+    contact data. A ``"pass"`` means no known-bad pattern matched, not provably clean -- the
+    human approval step remains the real gate (see module docstring)."""
     if not isinstance(text, str):
         raise TypeError("verify_copy requires a string; draft body is text")
 
-    hits: list[str] = []
-    for category in ("outcomes", "automation", "replacing_agents"):
-        for code, evidence in _pattern_hits(text, _RULES[category]):
-            hits.append(f"{code}: {evidence}")
-    for match in _EMAIL_RE.finditer(text):
-        hits.append(f"email: {match.group(0)}")
-    for match in _PHONE_RE.finditer(text):
-        hits.append(f"phone: {match.group(0)}")
+    hits = _claim_hits(text)
+    # PII: block on a match, but redact the value out of the persisted hit.
+    if _EMAIL_RE.search(text):
+        hits.append("email: <redacted>")
+    if _PHONE_RE.search(text):
+        hits.append("phone: <redacted>")
 
     verdict = "fail" if hits else "pass"
     return CopyVerification(verdict=verdict, hits=hits)

--- a/plans/PR-Content-Factory-Copy-Verification.md
+++ b/plans/PR-Content-Factory-Copy-Verification.md
@@ -64,11 +64,10 @@ will call.
   verdict). This gate is an incomplete-by-nature NL backstop, not a complete classifier.
 
 ### Files touched
-- `atlas_brain/services/content_factory_copy_verification.py`
-- `tests/test_content_factory_copy_verification.py`
-- `plans/PR-Content-Factory-Copy-Verification.md`
 
-Max files: 3
+- `atlas_brain/services/content_factory_copy_verification.py`
+- `plans/PR-Content-Factory-Copy-Verification.md`
+- `tests/test_content_factory_copy_verification.py`
 
 ## Mechanism
 
@@ -120,13 +119,9 @@ and the verdict gates promotion through the #2116 EditorialAudit contract.
 
 ## Estimated diff size
 
-| File | Lines |
-|---|---|
-| atlas_brain/services/content_factory_copy_verification.py | 150 |
-| tests/test_content_factory_copy_verification.py | 175 |
-| plans/PR-Content-Factory-Copy-Verification.md | 120 |
-| **Total** | **445** |
-
-Over the 400 soft cap: a content-safety gate whose value is real coverage across each
-category plus a false-positive guard, so the module and its two-sided tests ship together;
-splitting the catalogue from its tests would ship safety code without its evidence.
+| File | LOC |
+|---|---:|
+| `atlas_brain/services/content_factory_copy_verification.py` | 151 |
+| `plans/PR-Content-Factory-Copy-Verification.md` | 132 |
+| `tests/test_content_factory_copy_verification.py` | 180 |
+| **Total** | **463** |

--- a/plans/PR-Content-Factory-Copy-Verification.md
+++ b/plans/PR-Content-Factory-Copy-Verification.md
@@ -105,7 +105,7 @@ recommended for revise).
 
 | File | LOC |
 |---|---:|
-| `atlas_brain/services/content_factory_copy_verification.py` | 118 |
-| `plans/PR-Content-Factory-Copy-Verification.md` | 112 |
+| `atlas_brain/services/content_factory_copy_verification.py` | 128 |
+| `plans/PR-Content-Factory-Copy-Verification.md` | 111 |
 | `tests/test_content_factory_copy_verification.py` | 116 |
-| **Total** | **346** |
+| **Total** | **355** |

--- a/plans/PR-Content-Factory-Copy-Verification.md
+++ b/plans/PR-Content-Factory-Copy-Verification.md
@@ -125,7 +125,7 @@ promotion through the #2116 EditorialAudit contract.
 
 | File | LOC |
 |---|---:|
-| `atlas_brain/services/content_factory_copy_verification.py` | 151 |
-| `plans/PR-Content-Factory-Copy-Verification.md` | 132 |
-| `tests/test_content_factory_copy_verification.py` | 180 |
-| **Total** | **463** |
+| `atlas_brain/services/content_factory_copy_verification.py` | 156 |
+| `plans/PR-Content-Factory-Copy-Verification.md` | 131 |
+| `tests/test_content_factory_copy_verification.py` | 184 |
+| **Total** | **471** |

--- a/plans/PR-Content-Factory-Copy-Verification.md
+++ b/plans/PR-Content-Factory-Copy-Verification.md
@@ -95,11 +95,11 @@ draft that overclaims or leaks PII cannot be promoted.
 ```
 python -m pytest tests/test_content_factory_copy_verification.py -q
 ```
-22 tests pass: clean copy passes; each forbidden claim category and each PII shape fails
-with the hit recorded; negated claims pass; multiple hits are all recorded; a non-string
-is rejected; and the produced verdict gates promotion through the #2116 EditorialAudit
-contract (forbidden copy cannot be promoted, clean copy can, forbidden copy may still be
-recommended for revise).
+23 tests pass: clean copy passes; each forbidden claim category (incl. ticket-volume in
+both "30%" and "30 percent" forms) and each PII shape fails with the hit recorded; negated
+claims pass; multiple hits are all recorded; a non-string is rejected; and the produced
+verdict gates promotion through the #2116 EditorialAudit contract (forbidden copy cannot be
+promoted, clean copy can, forbidden copy may still be recommended for revise).
 
 ## Estimated diff size
 

--- a/plans/PR-Content-Factory-Copy-Verification.md
+++ b/plans/PR-Content-Factory-Copy-Verification.md
@@ -5,23 +5,29 @@
 The #2116 Content Factory contract gave `EditorialAudit` a `copy_verification` field and
 a rule that a draft may not be promoted unless `copy_verification.verdict == "pass"` --
 but nothing PRODUCED that verdict, so the promote guard was a shape with no teeth. The
-real deterministic gate (banned marketing claims + PII) existed only as the operator's
-"Resolution Audit Draft Verifier" tool inside the Open WebUI database, un-versioned and
-un-testable. This slice (plan Phase 4.1) ports that gate's blocker core into the repo as
-a deterministic producer of the `CopyVerification` verdict, so a draft that overclaims or
-leaks contact PII cannot be promoted.
+deterministic claim/PII catalogue existed only as the operator's "Resolution Audit Draft
+Verifier" tool inside the Open WebUI database, un-versioned and un-testable. This slice
+(plan Phase 4.1) builds the producer in the repo: a deterministic BEST-EFFORT BACKSTOP
+that fails the verdict when copy contains a forbidden marketing claim or raw contact PII,
+so the obvious overclaims are hard-blocked and the human approval step (the real safety
+guarantee) sees less noise.
 
 ### Problem-derived contract
 
 A correct fix must:
 - Produce a `CopyVerification` (verdict + hits) from draft text, deterministically.
-- Fail the verdict when the copy contains a forbidden OUTCOME claim (guaranteed savings,
-  fixed deflection %, ticket reductions), a forbidden AUTOMATION claim (auto-publishing /
-  auto-answering), a REPLACING-AGENTS / avoided-hire claim, or raw contact PII (email /
-  phone) -- the categories the source tool marks "Do not post yet".
-- Be negation-aware ("no guaranteed savings" is not a hit), matching the source tool.
-- Port the catalogue and PII patterns VERBATIM -- this is the operator's safety policy,
-  not a place to author or "improve" rules.
+- Fail the verdict on the operator's promote-blocking categories -- forbidden OUTCOME
+  claims (guaranteed savings, fixed deflection %, ticket reductions), AUTOMATION claims
+  (auto-publishing / auto-answering), REPLACING-AGENTS / avoided-hire claims, and raw
+  contact PII (email / phone) -- matching the COMMON wordings of each, not one fixture
+  phrase.
+- Scope negation to the claim: a negation immediately governing a claim suppresses it,
+  but an unrelated earlier negation must not, and an ambiguous-scope negation errs toward
+  flagging (fail closed).
+- Never persist the raw PII it blocks: PII hits record only a redacted marker.
+- Not over-claim: a regex catalogue cannot enumerate every paraphrase of a natural-
+  language claim, so the gate is a backstop, not a complete classifier; human approval
+  remains the real gate.
 - Make the produced verdict actually gate promotion through the existing #2116 contract.
 
 ## Scope (this PR)
@@ -29,57 +35,69 @@ A correct fix must:
 Ownership lane: content-factory
 Slice phase: vertical slice
 
-One new service module (`content_factory_copy_verification.py`) with the verbatim blocker
-catalogue, PII patterns, negation-aware scanner, and `verify_copy(text) -> CopyVerification`,
-plus tests. No pipeline wiring yet; the producer is the deterministic core the runner /
-Phase 4.2 Filter will call.
+One new service module (`content_factory_copy_verification.py`) -- the claim/PII catalogue,
+negation-aware scanner, and `verify_copy(text) -> CopyVerification` -- plus tests. No
+pipeline wiring yet; the producer is the deterministic core the runner / Phase 4.2 Filter
+will call.
 
 ### Review Contract
 
 - Acceptance criteria:
-  - [ ] Clean copy yields verdict "pass" with no hits.
-  - [ ] Each forbidden category (outcome / automation / replacing-agents) and each PII
-        shape (email / phone) yields verdict "fail" with the hit recorded.
-  - [ ] A negated forbidden claim yields "pass" (source-tool parity).
+  - [ ] Clean/legitimate copy yields "pass" (false-positive guard on non-claim uses of
+        "guarantee", "auto-", "replace", "reduce tickets", "avoid").
+  - [ ] Each promote-blocking category fails on its common wordings, including modifier
+        and inflection variants (guaranteed cost/monthly savings; 40% or 40 percent
+        deflection; reduce tickets/ticket volume by N%; N% fewer support tickets;
+        auto-publish/publishes/published; replace your agents; avoid hiring another agent).
+  - [ ] A directly-governing negation passes; an unrelated earlier negation still fails;
+        an ambiguous-scope negation fails (conservative).
+  - [ ] PII fails the verdict but the raw email/phone never appears in `hits` (only a
+        redacted marker).
   - [ ] A "fail" verdict makes `recommendation == "promote"` invalid via the #2116
         EditorialAudit guard; a "pass" verdict allows promotion.
 - Reachability proof: consumed by `EditorialAudit`'s promote-requires-pass validator
   (merged #2116); proof is the test suite, including the promotion-gating tests.
 - Affected surfaces: one new service module and its test file; nothing calls it yet.
-- Risk areas: fidelity of the ported catalogue/PII patterns (copied verbatim); the
-  negation logic; the verdict -> promote-guard wiring.
-- Reviewer rules triggered: R14 (a content safety gate / classifier producing a
-  promote-blocking verdict).
+- Risk areas: pattern coverage vs false positives (both sides tested); negation scope;
+  PII never persisted; the verdict -> promote-guard wiring.
+- Reviewer rules triggered: R14 (a content safety gate producing a promote-blocking
+  verdict). This gate is an incomplete-by-nature NL backstop, not a complete classifier.
 
 ### Files touched
-
 - `atlas_brain/services/content_factory_copy_verification.py`
-- `plans/PR-Content-Factory-Copy-Verification.md`
 - `tests/test_content_factory_copy_verification.py`
+- `plans/PR-Content-Factory-Copy-Verification.md`
+
+Max files: 3
 
 ## Mechanism
 
-`_RULES` (outcomes / automation / replacing_agents), `_EMAIL_RE`, and `_PHONE_RE` are the
-verbatim catalogue and PII patterns from the source tool. `_is_negated` and `_pattern_hits`
-are ported verbatim so a negated claim is skipped. `verify_copy(text)` collects every
-non-negated banned-claim hit plus every PII match as `"code: evidence"` strings and returns
-`CopyVerification(verdict="fail" if hits else "pass", hits=hits)`. Because #2116's
-`EditorialAudit` rejects `recommendation == "promote"` unless the verdict is "pass", a
-draft that overclaims or leaks PII cannot be promoted.
+`_RULES` (outcomes / automation / replacing_agents) holds per-category regex that match
+the common inflections/modifiers of each promote-blocking category. `_is_negated` checks
+only the two words immediately before a match (segment-bounded by `.!?;,` / newline), so a
+directly-governing negation suppresses the hit while an unrelated earlier negation does
+not. `_claim_hits` records `"code: evidence"` for non-negated claim matches; `verify_copy`
+adds a REDACTED PII marker (`"email: <redacted>"` / `"phone: <redacted>"`) when a raw
+email/phone is present, then returns `CopyVerification(verdict="fail" if hits else "pass",
+hits=hits)`. Because #2116's `EditorialAudit` rejects `recommendation == "promote"` unless
+the verdict is "pass", a draft that overclaims or leaks PII cannot be promoted.
 
 ## Intentional
 
-- Patterns are ported VERBATIM except ONE operator-authorized fix: the source
-  `fixed-ticket-volume-reduction` rule ended `(?:%|percent)\b`, and `%\b` can never match a
-  `%` before a space, so "30%" slipped through while "30 percent" was caught. Moving the
-  boundary inside the alternation (`(?:%|percent\b)`) closes the gap -- a strict tightening
-  of the gate, never a loosening. This repo module is now the canonical gate; the Open
-  WebUI copy is superseded and should be re-synced from here.
-- Only the source tool's BLOCKER categories are ported. Its softer "needs human review"
-  layer (answer/ownership qualifiers, owner-routing coverage, CTA reminder) produces
-  warnings, not promote-blocks, and is a later slice.
-- The producer is unwired: it returns the verdict; the runner / Phase 4.2 Filter that
-  calls it on the editor stage is a separate slice.
+- The gate is a deterministic BEST-EFFORT BACKSTOP, not a complete NL classifier: a novel
+  paraphrase can pass, so the module and Review Contract say so explicitly and point at
+  human approval as the real guarantee. This is the honest answer to the open-category
+  nature of banned-claim detection -- broaden common coverage, do not pretend completeness.
+- Negation is scoped to the immediately-preceding words and errs toward FLAGGING when a
+  negation's scope is ambiguous (fail closed): a false positive only routes to human
+  review; a false negative would ship an overclaim.
+- PII evidence is redacted out of `hits` because that verdict is persisted in the git-
+  backed job folder -- the gate must not duplicate the PII it blocks.
+- Derived from the operator's tool but not a byte-for-byte copy: this repo module is now
+  the canonical gate (carrying the %-boundary fix, negation-scope fix, and same-category
+  coverage broadening); the OWUI copy is superseded and should be re-synced from here.
+- Only the promote-BLOCKING categories are implemented; the source tool's softer "needs
+  human review" warning layer is a later slice.
 
 ## Deferred
 
@@ -87,25 +105,28 @@ draft that overclaims or leaks PII cannot be promoted.
   qualifiers, honest-CTA reminder) from the source tool -- a later slice.
 - Wiring `verify_copy` into the stage runner and the Phase 4.2 Editor Filter (fail-closed
   when the gate is unavailable).
-- Re-syncing the Open WebUI copy_verification tool from this now-canonical repo module
-  (ops step) so the `%`-boundary fix is reflected there too.
+- Re-syncing the Open WebUI copy_verification tool from this now-canonical repo module.
 
 ## Verification
 
 ```
 python -m pytest tests/test_content_factory_copy_verification.py -q
 ```
-23 tests pass: clean copy passes; each forbidden claim category (incl. ticket-volume in
-both "30%" and "30 percent" forms) and each PII shape fails with the hit recorded; negated
-claims pass; multiple hits are all recorded; a non-string is rejected; and the produced
-verdict gates promotion through the #2116 EditorialAudit contract (forbidden copy cannot be
-promoted, clean copy can, forbidden copy may still be recommended for revise).
+43 tests pass: legitimate copy (incl. non-claim uses of the trigger words) passes; each
+promote-blocking category fails on its common variants; a directly-governing negation
+passes while an unrelated earlier negation and an ambiguous-scope negation fail; PII fails
+but is redacted out of the hits (the raw value never appears); a non-string is rejected;
+and the verdict gates promotion through the #2116 EditorialAudit contract.
 
 ## Estimated diff size
 
-| File | LOC |
-|---|---:|
-| `atlas_brain/services/content_factory_copy_verification.py` | 128 |
-| `plans/PR-Content-Factory-Copy-Verification.md` | 111 |
-| `tests/test_content_factory_copy_verification.py` | 116 |
-| **Total** | **355** |
+| File | Lines |
+|---|---|
+| atlas_brain/services/content_factory_copy_verification.py | 150 |
+| tests/test_content_factory_copy_verification.py | 175 |
+| plans/PR-Content-Factory-Copy-Verification.md | 120 |
+| **Total** | **445** |
+
+Over the 400 soft cap: a content-safety gate whose value is real coverage across each
+category plus a false-positive guard, so the module and its two-sided tests ship together;
+splitting the catalogue from its tests would ship safety code without its evidence.

--- a/plans/PR-Content-Factory-Copy-Verification.md
+++ b/plans/PR-Content-Factory-Copy-Verification.md
@@ -125,7 +125,7 @@ promotion through the #2116 EditorialAudit contract.
 
 | File | LOC |
 |---|---:|
-| `atlas_brain/services/content_factory_copy_verification.py` | 156 |
+| `atlas_brain/services/content_factory_copy_verification.py` | 171 |
 | `plans/PR-Content-Factory-Copy-Verification.md` | 131 |
-| `tests/test_content_factory_copy_verification.py` | 184 |
-| **Total** | **471** |
+| `tests/test_content_factory_copy_verification.py` | 194 |
+| **Total** | **496** |

--- a/plans/PR-Content-Factory-Copy-Verification.md
+++ b/plans/PR-Content-Factory-Copy-Verification.md
@@ -1,0 +1,109 @@
+# PR-Content-Factory-Copy-Verification
+
+## Why this slice exists
+
+The #2116 Content Factory contract gave `EditorialAudit` a `copy_verification` field and
+a rule that a draft may not be promoted unless `copy_verification.verdict == "pass"` --
+but nothing PRODUCED that verdict, so the promote guard was a shape with no teeth. The
+real deterministic gate (banned marketing claims + PII) existed only as the operator's
+"Resolution Audit Draft Verifier" tool inside the Open WebUI database, un-versioned and
+un-testable. This slice (plan Phase 4.1) ports that gate's blocker core into the repo as
+a deterministic producer of the `CopyVerification` verdict, so a draft that overclaims or
+leaks contact PII cannot be promoted.
+
+### Problem-derived contract
+
+A correct fix must:
+- Produce a `CopyVerification` (verdict + hits) from draft text, deterministically.
+- Fail the verdict when the copy contains a forbidden OUTCOME claim (guaranteed savings,
+  fixed deflection %, ticket reductions), a forbidden AUTOMATION claim (auto-publishing /
+  auto-answering), a REPLACING-AGENTS / avoided-hire claim, or raw contact PII (email /
+  phone) -- the categories the source tool marks "Do not post yet".
+- Be negation-aware ("no guaranteed savings" is not a hit), matching the source tool.
+- Port the catalogue and PII patterns VERBATIM -- this is the operator's safety policy,
+  not a place to author or "improve" rules.
+- Make the produced verdict actually gate promotion through the existing #2116 contract.
+
+## Scope (this PR)
+
+Ownership lane: content-factory
+Slice phase: vertical slice
+
+One new service module (`content_factory_copy_verification.py`) with the verbatim blocker
+catalogue, PII patterns, negation-aware scanner, and `verify_copy(text) -> CopyVerification`,
+plus tests. No pipeline wiring yet; the producer is the deterministic core the runner /
+Phase 4.2 Filter will call.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Clean copy yields verdict "pass" with no hits.
+  - [ ] Each forbidden category (outcome / automation / replacing-agents) and each PII
+        shape (email / phone) yields verdict "fail" with the hit recorded.
+  - [ ] A negated forbidden claim yields "pass" (source-tool parity).
+  - [ ] A "fail" verdict makes `recommendation == "promote"` invalid via the #2116
+        EditorialAudit guard; a "pass" verdict allows promotion.
+- Reachability proof: consumed by `EditorialAudit`'s promote-requires-pass validator
+  (merged #2116); proof is the test suite, including the promotion-gating tests.
+- Affected surfaces: one new service module and its test file; nothing calls it yet.
+- Risk areas: fidelity of the ported catalogue/PII patterns (copied verbatim); the
+  negation logic; the verdict -> promote-guard wiring.
+- Reviewer rules triggered: R14 (a content safety gate / classifier producing a
+  promote-blocking verdict).
+
+### Files touched
+
+- `atlas_brain/services/content_factory_copy_verification.py`
+- `plans/PR-Content-Factory-Copy-Verification.md`
+- `tests/test_content_factory_copy_verification.py`
+
+## Mechanism
+
+`_RULES` (outcomes / automation / replacing_agents), `_EMAIL_RE`, and `_PHONE_RE` are the
+verbatim catalogue and PII patterns from the source tool. `_is_negated` and `_pattern_hits`
+are ported verbatim so a negated claim is skipped. `verify_copy(text)` collects every
+non-negated banned-claim hit plus every PII match as `"code: evidence"` strings and returns
+`CopyVerification(verdict="fail" if hits else "pass", hits=hits)`. Because #2116's
+`EditorialAudit` rejects `recommendation == "promote"` unless the verdict is "pass", a
+draft that overclaims or leaks PII cannot be promoted.
+
+## Intentional
+
+- Patterns are ported VERBATIM, including a quirk: the `fixed-ticket-volume-reduction`
+  rule ends `(?:%|percent)\b`, and `%\b` cannot match a `%` before a space, so it catches
+  "30 percent" but not "30%". Preserving source behavior is correct for a port; tightening
+  the regex is the operator's content-policy call, deferred below.
+- Only the source tool's BLOCKER categories are ported. Its softer "needs human review"
+  layer (answer/ownership qualifiers, owner-routing coverage, CTA reminder) produces
+  warnings, not promote-blocks, and is a later slice.
+- The producer is unwired: it returns the verdict; the runner / Phase 4.2 Filter that
+  calls it on the editor stage is a separate slice.
+
+## Deferred
+
+- The "needs human review" warning layer (owner-routing coverage, answer/ownership
+  qualifiers, honest-CTA reminder) from the source tool -- a later slice.
+- Wiring `verify_copy` into the stage runner and the Phase 4.2 Editor Filter (fail-closed
+  when the gate is unavailable).
+- Tightening the ported patterns (e.g. the `%`-before-space quirk) -- an operator
+  content-policy decision, tracked as a follow-up, not changed inside a verbatim port.
+
+## Verification
+
+```
+python -m pytest tests/test_content_factory_copy_verification.py -q
+```
+22 tests pass: clean copy passes; each forbidden claim category and each PII shape fails
+with the hit recorded; negated claims pass; multiple hits are all recorded; a non-string
+is rejected; and the produced verdict gates promotion through the #2116 EditorialAudit
+contract (forbidden copy cannot be promoted, clean copy can, forbidden copy may still be
+recommended for revise).
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/services/content_factory_copy_verification.py` | 118 |
+| `plans/PR-Content-Factory-Copy-Verification.md` | 112 |
+| `tests/test_content_factory_copy_verification.py` | 116 |
+| **Total** | **346** |

--- a/plans/PR-Content-Factory-Copy-Verification.md
+++ b/plans/PR-Content-Factory-Copy-Verification.md
@@ -114,7 +114,7 @@ the verdict is "pass", a draft that overclaims or leaks PII cannot be promoted.
 ```
 python -m pytest tests/test_content_factory_copy_verification.py -q
 ```
-47 tests pass: legitimate copy (incl. non-claim uses of the trigger words and possessive/
+51 tests pass: legitimate copy (incl. non-claim uses of the trigger words and possessive/
 benign agent copy) passes; each promote-blocking category fails on its common variants
 (incl. numeric guaranteed savings); a directly-governing negation passes while an unrelated
 earlier negation and an ambiguous-scope negation fail; PII fails but is redacted out of the

--- a/plans/PR-Content-Factory-Copy-Verification.md
+++ b/plans/PR-Content-Factory-Copy-Verification.md
@@ -60,8 +60,11 @@ will call.
 - Affected surfaces: one new service module and its test file; nothing calls it yet.
 - Risk areas: pattern coverage vs false positives (both sides tested); negation scope;
   PII never persisted; the verdict -> promote-guard wiring.
-- Reviewer rules triggered: R14 (a content safety gate producing a promote-blocking
-  verdict). This gate is an incomplete-by-nature NL backstop, not a complete classifier.
+- Reviewer rules triggered: R2, R13, R14. R14 (guard/gate) and R2 (a guard/validator
+  change requires failure-branch test evidence) pair for this promote-blocking validator;
+  R13 (class-closure) because the diff responds to same-class review findings. PII handling
+  is covered by the redaction acceptance criterion above. This gate is an incomplete-by-
+  nature NL backstop, not a complete classifier.
 
 ### Files touched
 
@@ -111,11 +114,12 @@ the verdict is "pass", a draft that overclaims or leaks PII cannot be promoted.
 ```
 python -m pytest tests/test_content_factory_copy_verification.py -q
 ```
-43 tests pass: legitimate copy (incl. non-claim uses of the trigger words) passes; each
-promote-blocking category fails on its common variants; a directly-governing negation
-passes while an unrelated earlier negation and an ambiguous-scope negation fail; PII fails
-but is redacted out of the hits (the raw value never appears); a non-string is rejected;
-and the verdict gates promotion through the #2116 EditorialAudit contract.
+47 tests pass: legitimate copy (incl. non-claim uses of the trigger words and possessive/
+benign agent copy) passes; each promote-blocking category fails on its common variants
+(incl. numeric guaranteed savings); a directly-governing negation passes while an unrelated
+earlier negation and an ambiguous-scope negation fail; PII fails but is redacted out of the
+hits (the raw value never appears); a non-string is rejected; and the verdict gates
+promotion through the #2116 EditorialAudit contract.
 
 ## Estimated diff size
 

--- a/plans/PR-Content-Factory-Copy-Verification.md
+++ b/plans/PR-Content-Factory-Copy-Verification.md
@@ -69,10 +69,12 @@ draft that overclaims or leaks PII cannot be promoted.
 
 ## Intentional
 
-- Patterns are ported VERBATIM, including a quirk: the `fixed-ticket-volume-reduction`
-  rule ends `(?:%|percent)\b`, and `%\b` cannot match a `%` before a space, so it catches
-  "30 percent" but not "30%". Preserving source behavior is correct for a port; tightening
-  the regex is the operator's content-policy call, deferred below.
+- Patterns are ported VERBATIM except ONE operator-authorized fix: the source
+  `fixed-ticket-volume-reduction` rule ended `(?:%|percent)\b`, and `%\b` can never match a
+  `%` before a space, so "30%" slipped through while "30 percent" was caught. Moving the
+  boundary inside the alternation (`(?:%|percent\b)`) closes the gap -- a strict tightening
+  of the gate, never a loosening. This repo module is now the canonical gate; the Open
+  WebUI copy is superseded and should be re-synced from here.
 - Only the source tool's BLOCKER categories are ported. Its softer "needs human review"
   layer (answer/ownership qualifiers, owner-routing coverage, CTA reminder) produces
   warnings, not promote-blocks, and is a later slice.
@@ -85,8 +87,8 @@ draft that overclaims or leaks PII cannot be promoted.
   qualifiers, honest-CTA reminder) from the source tool -- a later slice.
 - Wiring `verify_copy` into the stage runner and the Phase 4.2 Editor Filter (fail-closed
   when the gate is unavailable).
-- Tightening the ported patterns (e.g. the `%`-before-space quirk) -- an operator
-  content-policy decision, tracked as a follow-up, not changed inside a verbatim port.
+- Re-syncing the Open WebUI copy_verification tool from this now-canonical repo module
+  (ops step) so the `%`-boundary fix is reflected there too.
 
 ## Verification
 

--- a/tests/test_content_factory_copy_verification.py
+++ b/tests/test_content_factory_copy_verification.py
@@ -1,8 +1,11 @@
 """Tests for the deterministic Content Factory copy-verification gate (Phase 4.1).
 
-Both sides of the guard: clean copy passes; each forbidden-claim category and each PII
-shape fails; negated claims pass (parity with the source tool); and the produced verdict
-actually gates promotion through the #2116 EditorialAudit contract.
+Both sides of the guard: clean/legitimate copy passes (false-positive guard); each
+promote-blocking category's common wordings fail (incl. the variants Codex flagged);
+negation is scoped to the claim (unrelated earlier negations no longer suppress a real
+hit, and the gate errs toward flagging when a negation's scope is ambiguous -- fail
+closed); PII is blocked but redacted out of the persisted hits; and the verdict gates
+promotion through the #2116 EditorialAudit contract.
 """
 
 from __future__ import annotations
@@ -13,39 +16,68 @@ from pydantic import ValidationError
 from atlas_brain.schemas.content_factory import EditorialAudit
 from atlas_brain.services.content_factory_copy_verification import verify_copy
 
-CLEAN = (
-    "Support and CX leaders: the Resolution Audit ranks your most repeated tickets and "
-    "drafts owner-routed next steps so the right team can review the fix."
+
+# --- clean / legitimate copy must PASS (false-positive guard) ---
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Support and CX leaders: the Resolution Audit ranks your most repeated tickets "
+        "and drafts owner-routed next steps so the right team can review the fix.",
+        "We help teams understand where their support workload concentrates.",
+        "Our guarantee is honest, evidence-backed reporting.",  # 'guarantee' but not savings
+        "Auto-save keeps your draft safe as you write.",  # 'auto-' but not auto-publish
+        "Replace your old spreadsheet with a single source of truth.",  # replace, not agents
+        "Deflection improved noticeably this quarter.",  # deflection, no fixed %
+        "Reduce back-and-forth by triaging tickets faster.",  # reduce tickets, no %
+        "Avoid a stockout with better forecasting.",  # avoid, not a hire/agent
+    ],
 )
+def test_legitimate_copy_passes(text):
+    assert verify_copy(text).verdict == "pass", verify_copy(text).hits
 
 
-def test_clean_copy_passes_with_no_hits():
-    r = verify_copy(CLEAN)
-    assert r.verdict == "pass"
-    assert r.hits == []
+# --- forbidden claims (incl. the variants Codex flagged) must FAIL ---
 
 
 @pytest.mark.parametrize(
     "text,code_fragment",
     [
+        # guaranteed savings + modifiers
         ("We deliver guaranteed savings on every plan.", "guaranteed-savings"),
-        ("Our tool guarantees savings for your team.", "guarantees-savings"),
+        ("Enjoy guaranteed cost savings from month one.", "guaranteed-savings"),
+        ("You get guaranteed monthly savings.", "guaranteed-savings"),
+        ("Our tool guarantees savings for your team.", "guaranteed-savings"),
+        # deflection %, both forms
         ("Expect 40% deflection from day one.", "fixed-deflection-percent"),
-        # Both forms hit after the operator-authorized %-boundary fix.
-        ("We cut ticket volume by 30 percent in a month.", "fixed-ticket-volume-reduction"),
-        ("We cut ticket volume by 30% in a month.", "fixed-ticket-volume-reduction"),
+        ("Expect 40 percent deflection from day one.", "fixed-deflection-percent"),
+        # ticket reductions, direct + volume + fewer, both % forms
+        ("We cut ticket volume by 30% in a month.", "fixed-ticket-reduction"),
+        ("We reduce tickets by 30%.", "fixed-ticket-reduction"),
+        ("We reduce support tickets by 20 percent.", "fixed-ticket-reduction"),
         ("Customers see 25% fewer tickets.", "fixed-fewer-tickets"),
+        ("Customers see 25% fewer support tickets.", "fixed-fewer-tickets"),
+        # automation
         ("Enjoy automatic ticket answering out of the box.", "automatic-ticket-answering"),
-        ("Your help center is auto-published nightly.", "auto-published"),
+        ("Your help center is auto-published nightly.", "auto-publish"),
+        ("We auto-publish your help center nightly.", "auto-publish"),
+        ("Atlas auto-publishes your help center.", "auto-publish"),
         ("It answers tickets automatically for you.", "answers-tickets-automatically"),
+        # replacing agents / avoided hire
         ("This lets you replace agents entirely.", "replace-agents"),
+        ("Replace your agents entirely.", "replace-agents"),
         ("You can avoid a support hire this year.", "avoid-support-hire"),
+        ("Avoid hiring another support agent this year.", "avoid-support-hire"),
     ],
 )
 def test_forbidden_claims_fail(text, code_fragment):
     r = verify_copy(text)
-    assert r.verdict == "fail"
+    assert r.verdict == "fail", text
     assert any(code_fragment in h for h in r.hits), r.hits
+
+
+# --- negation scoping ---
 
 
 @pytest.mark.parametrize(
@@ -53,32 +85,59 @@ def test_forbidden_claims_fail(text, code_fragment):
     [
         "We make no guaranteed savings claims.",
         "This does not promise guaranteed savings.",
-        "We never promise a fixed 40% deflection.",
+        "We will not guarantee savings.",
+        "We don't guarantee savings.",
     ],
 )
-def test_negated_claims_pass(text):
-    # Parity with the source tool: a negated claim is not a hit.
-    assert verify_copy(text).verdict == "pass"
+def test_direct_negation_passes(text):
+    # A negation immediately governing the claim suppresses the hit.
+    assert verify_copy(text).verdict == "pass", verify_copy(text).hits
 
 
 @pytest.mark.parametrize(
-    "text,code",
+    "text",
     [
-        ("Reach me at jane.doe@example.com for details.", "email"),
-        ("Call the owner at (618) 555-1234 today.", "phone"),
-        ("Direct line: 618-555-9876.", "phone"),
+        "No setup fee, and guaranteed savings are included.",
+        "This does not delay launch and guarantees savings.",
     ],
 )
-def test_raw_contact_pii_fails(text, code):
+def test_unrelated_earlier_negation_does_not_suppress(text):
+    # The P1 fix: an unrelated negation earlier in the sentence must NOT hide a real
+    # claim (the source tool scanned the whole prefix and leaked these).
+    assert verify_copy(text).verdict == "fail", verify_copy(text).hits
+
+
+def test_far_scope_negation_flags_conservatively():
+    # When a negation is too far from the claim to attribute cheaply, the gate errs
+    # toward flagging (fail closed) -- a false positive only routes to human review,
+    # whereas a false negative would ship an overclaim.
+    assert verify_copy("We never promise a fixed 40% deflection.").verdict == "fail"
+
+
+# --- PII: blocked, but redacted out of the persisted hits ---
+
+
+@pytest.mark.parametrize(
+    "text,code,secret",
+    [
+        ("Reach me at jane.doe@example.com for details.", "email", "jane.doe@example.com"),
+        ("Call the owner at (618) 555-1234 today.", "phone", "555-1234"),
+        ("Direct line: 618-555-9876.", "phone", "555-9876"),
+    ],
+)
+def test_raw_contact_pii_fails_and_is_redacted(text, code, secret):
     r = verify_copy(text)
     assert r.verdict == "fail"
-    assert any(h.startswith(code + ":") for h in r.hits), r.hits
+    assert f"{code}: <redacted>" in r.hits
+    # the actual PII must never appear in the persisted verdict
+    assert all(secret not in h for h in r.hits), r.hits
 
 
 def test_multiple_hits_all_recorded():
     r = verify_copy("Guaranteed savings! Email us at x@y.com.")
     assert r.verdict == "fail"
     assert len(r.hits) >= 2
+    assert all("x@y.com" not in h for h in r.hits)
 
 
 def test_non_string_rejected():
@@ -98,6 +157,12 @@ def _audit(text, recommendation):
     }
 
 
+CLEAN = (
+    "Support and CX leaders: the Resolution Audit ranks your most repeated tickets and "
+    "drafts owner-routed next steps so the right team can review the fix."
+)
+
+
 def test_clean_copy_can_be_promoted():
     audit = EditorialAudit.model_validate(_audit(CLEAN, "promote"))
     assert audit.recommendation == "promote"
@@ -105,7 +170,6 @@ def test_clean_copy_can_be_promoted():
 
 
 def test_forbidden_copy_cannot_be_promoted():
-    # verify_copy -> fail -> EditorialAudit's promote-requires-pass guard rejects it.
     with pytest.raises(ValidationError):
         EditorialAudit.model_validate(_audit("Guaranteed savings for all.", "promote"))
 

--- a/tests/test_content_factory_copy_verification.py
+++ b/tests/test_content_factory_copy_verification.py
@@ -27,6 +27,7 @@ from atlas_brain.services.content_factory_copy_verification import verify_copy
         "and drafts owner-routed next steps so the right team can review the fix.",
         "We help teams understand where their support workload concentrates.",
         "Our guarantee is honest, evidence-backed reporting.",  # 'guarantee' but not savings
+        "We guarantee honest reporting. Savings summaries are reviewed by your team.",  # cross-sentence
         "Auto-save keeps your draft safe as you write.",  # 'auto-' but not auto-publish
         "Replace your old spreadsheet with a single source of truth.",  # replace, not agents
         "Replace your agents' spreadsheet with a dashboard.",  # possessive: object is spreadsheet
@@ -53,6 +54,7 @@ def test_legitimate_copy_passes(text):
         ("Our tool guarantees savings for your team.", "guaranteed-savings"),
         ("Guaranteed 30% savings from day one.", "guaranteed-savings"),
         ("We guarantee 30% savings.", "guaranteed-savings"),
+        ("Atlas not only guarantees savings for teams.", "guaranteed-savings"),  # emphatic, not negation
         # deflection %, both forms
         ("Expect 40% deflection from day one.", "fixed-deflection-percent"),
         ("Expect 40 percent deflection from day one.", "fixed-deflection-percent"),
@@ -91,6 +93,7 @@ def test_forbidden_claims_fail(text, code_fragment):
         "This does not promise guaranteed savings.",
         "We will not guarantee savings.",
         "We don't guarantee savings.",
+        "We cannot guarantee savings.",
     ],
 )
 def test_direct_negation_passes(text):
@@ -142,6 +145,13 @@ def test_multiple_hits_all_recorded():
     assert r.verdict == "fail"
     assert len(r.hits) >= 2
     assert all("x@y.com" not in h for h in r.hits)
+
+
+def test_pii_inside_claim_evidence_is_redacted():
+    # PII that falls INSIDE a matched claim phrase must not persist via the claim hit.
+    r = verify_copy("Guaranteed 618-555-9876 savings.")
+    assert r.verdict == "fail"
+    assert all("618-555-9876" not in h for h in r.hits), r.hits
 
 
 def test_non_string_rejected():

--- a/tests/test_content_factory_copy_verification.py
+++ b/tests/test_content_factory_copy_verification.py
@@ -29,6 +29,8 @@ from atlas_brain.services.content_factory_copy_verification import verify_copy
         "Our guarantee is honest, evidence-backed reporting.",  # 'guarantee' but not savings
         "Auto-save keeps your draft safe as you write.",  # 'auto-' but not auto-publish
         "Replace your old spreadsheet with a single source of truth.",  # replace, not agents
+        "Replace your agents' spreadsheet with a dashboard.",  # possessive: object is spreadsheet
+        "Avoid distracting your agents with repetitive triage.",  # avoid, not a hire
         "Deflection improved noticeably this quarter.",  # deflection, no fixed %
         "Reduce back-and-forth by triaging tickets faster.",  # reduce tickets, no %
         "Avoid a stockout with better forecasting.",  # avoid, not a hire/agent
@@ -49,6 +51,8 @@ def test_legitimate_copy_passes(text):
         ("Enjoy guaranteed cost savings from month one.", "guaranteed-savings"),
         ("You get guaranteed monthly savings.", "guaranteed-savings"),
         ("Our tool guarantees savings for your team.", "guaranteed-savings"),
+        ("Guaranteed 30% savings from day one.", "guaranteed-savings"),
+        ("We guarantee 30% savings.", "guaranteed-savings"),
         # deflection %, both forms
         ("Expect 40% deflection from day one.", "fixed-deflection-percent"),
         ("Expect 40 percent deflection from day one.", "fixed-deflection-percent"),

--- a/tests/test_content_factory_copy_verification.py
+++ b/tests/test_content_factory_copy_verification.py
@@ -31,9 +31,9 @@ def test_clean_copy_passes_with_no_hits():
         ("We deliver guaranteed savings on every plan.", "guaranteed-savings"),
         ("Our tool guarantees savings for your team.", "guarantees-savings"),
         ("Expect 40% deflection from day one.", "fixed-deflection-percent"),
-        # Source pattern ends `(?:%|percent)\b`; `%\b` cannot match a `%` before a
-        # space, so the rule catches "30 percent" (not "30%") -- ported verbatim.
+        # Both forms hit after the operator-authorized %-boundary fix.
         ("We cut ticket volume by 30 percent in a month.", "fixed-ticket-volume-reduction"),
+        ("We cut ticket volume by 30% in a month.", "fixed-ticket-volume-reduction"),
         ("Customers see 25% fewer tickets.", "fixed-fewer-tickets"),
         ("Enjoy automatic ticket answering out of the box.", "automatic-ticket-answering"),
         ("Your help center is auto-published nightly.", "auto-published"),

--- a/tests/test_content_factory_copy_verification.py
+++ b/tests/test_content_factory_copy_verification.py
@@ -1,0 +1,116 @@
+"""Tests for the deterministic Content Factory copy-verification gate (Phase 4.1).
+
+Both sides of the guard: clean copy passes; each forbidden-claim category and each PII
+shape fails; negated claims pass (parity with the source tool); and the produced verdict
+actually gates promotion through the #2116 EditorialAudit contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from atlas_brain.schemas.content_factory import EditorialAudit
+from atlas_brain.services.content_factory_copy_verification import verify_copy
+
+CLEAN = (
+    "Support and CX leaders: the Resolution Audit ranks your most repeated tickets and "
+    "drafts owner-routed next steps so the right team can review the fix."
+)
+
+
+def test_clean_copy_passes_with_no_hits():
+    r = verify_copy(CLEAN)
+    assert r.verdict == "pass"
+    assert r.hits == []
+
+
+@pytest.mark.parametrize(
+    "text,code_fragment",
+    [
+        ("We deliver guaranteed savings on every plan.", "guaranteed-savings"),
+        ("Our tool guarantees savings for your team.", "guarantees-savings"),
+        ("Expect 40% deflection from day one.", "fixed-deflection-percent"),
+        # Source pattern ends `(?:%|percent)\b`; `%\b` cannot match a `%` before a
+        # space, so the rule catches "30 percent" (not "30%") -- ported verbatim.
+        ("We cut ticket volume by 30 percent in a month.", "fixed-ticket-volume-reduction"),
+        ("Customers see 25% fewer tickets.", "fixed-fewer-tickets"),
+        ("Enjoy automatic ticket answering out of the box.", "automatic-ticket-answering"),
+        ("Your help center is auto-published nightly.", "auto-published"),
+        ("It answers tickets automatically for you.", "answers-tickets-automatically"),
+        ("This lets you replace agents entirely.", "replace-agents"),
+        ("You can avoid a support hire this year.", "avoid-support-hire"),
+    ],
+)
+def test_forbidden_claims_fail(text, code_fragment):
+    r = verify_copy(text)
+    assert r.verdict == "fail"
+    assert any(code_fragment in h for h in r.hits), r.hits
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "We make no guaranteed savings claims.",
+        "This does not promise guaranteed savings.",
+        "We never promise a fixed 40% deflection.",
+    ],
+)
+def test_negated_claims_pass(text):
+    # Parity with the source tool: a negated claim is not a hit.
+    assert verify_copy(text).verdict == "pass"
+
+
+@pytest.mark.parametrize(
+    "text,code",
+    [
+        ("Reach me at jane.doe@example.com for details.", "email"),
+        ("Call the owner at (618) 555-1234 today.", "phone"),
+        ("Direct line: 618-555-9876.", "phone"),
+    ],
+)
+def test_raw_contact_pii_fails(text, code):
+    r = verify_copy(text)
+    assert r.verdict == "fail"
+    assert any(h.startswith(code + ":") for h in r.hits), r.hits
+
+
+def test_multiple_hits_all_recorded():
+    r = verify_copy("Guaranteed savings! Email us at x@y.com.")
+    assert r.verdict == "fail"
+    assert len(r.hits) >= 2
+
+
+def test_non_string_rejected():
+    with pytest.raises(TypeError):
+        verify_copy(None)
+
+
+# --- the verdict actually gates promotion (wires to the #2116 contract) ---
+
+
+def _audit(text, recommendation):
+    return {
+        "schema": "editorial_audit.v1",
+        "project_id": "resolution-audit",
+        "recommendation": recommendation,
+        "copy_verification": verify_copy(text).model_dump(),
+    }
+
+
+def test_clean_copy_can_be_promoted():
+    audit = EditorialAudit.model_validate(_audit(CLEAN, "promote"))
+    assert audit.recommendation == "promote"
+    assert audit.copy_verification.verdict == "pass"
+
+
+def test_forbidden_copy_cannot_be_promoted():
+    # verify_copy -> fail -> EditorialAudit's promote-requires-pass guard rejects it.
+    with pytest.raises(ValidationError):
+        EditorialAudit.model_validate(_audit("Guaranteed savings for all.", "promote"))
+
+
+def test_forbidden_copy_may_still_recommend_revise():
+    audit = EditorialAudit.model_validate(_audit("Guaranteed savings for all.", "revise"))
+    assert audit.recommendation == "revise"
+    assert audit.copy_verification.verdict == "fail"


### PR DESCRIPTION
Plan: plans/PR-Content-Factory-Copy-Verification.md
Slice phase: vertical slice
Ownership lane: content-factory

Phase 4.1: the deterministic copy-verification gate that PRODUCES the CopyVerification
verdict the #2116 EditorialAudit promote-guard requires (until now a shape with no teeth).
A deterministic BEST-EFFORT BACKSTOP that fails the verdict on the operator's promote-
blocking categories (banned marketing claims + PII), so overclaiming/PII-leaking copy
cannot be promoted; human approval before publish remains the real safety guarantee. Built
from the operator's "Resolution Audit Draft Verifier" (which lived only in webui.db); this
repo module is now the canonical gate. No pipeline wiring yet.

## Intentional
- BEST-EFFORT BACKSTOP, not a complete NL classifier: a novel paraphrase can pass, so the module + Review Contract say so and point at human approval as the real gate. Broaden common coverage per category; do not pretend completeness (the honest answer to open-category banned-claim detection). Negation is scoped to the immediately-preceding words and errs toward FLAGGING when scope is ambiguous (fail closed -- a false positive routes to human review; a false negative ships an overclaim). PII evidence is REDACTED out of hits (the verdict is persisted in the git-backed job folder; the gate must not duplicate the PII it blocks). Canonical gate carrying the %-boundary fix, negation-scope fix, and same-category coverage broadening; OWUI copy superseded. Only promote-BLOCKING categories; the softer "needs human review" layer is a later slice.

## Deferred
- The "needs human review" warning layer (owner-routing coverage, answer/ownership qualifiers, honest-CTA reminder). Wiring verify_copy into the stage runner + Phase 4.2 Editor Filter (fail-closed when unavailable). Re-syncing the OWUI copy_verification tool from this now-canonical repo module.

## Parked hardening
- None.

## Cold diff reconstruction
- New atlas_brain/services/content_factory_copy_verification.py: _RULES per-category regex (common inflections/modifiers), _is_negated (2-word segment-bounded window), _claim_hits, verify_copy(text) -> CopyVerification with REDACTED PII markers. New tests/test_content_factory_copy_verification.py: both-sides probes (legit copy passes; category variants fail; negation scope; PII redaction; promotion-gating via #2116). No existing file modified; nothing calls the module yet.

## Verification
- python -m pytest tests/test_content_factory_copy_verification.py -q  ->  51 passed. Legit copy (incl. non-claim uses of trigger words + possessive/benign agent copy) passes; each category fails on common variants (incl. numeric guaranteed savings); directly-governing negation passes while unrelated earlier + ambiguous-scope negations fail; PII fails but is redacted (raw value never in hits); non-string rejected; verdict gates promotion through #2116. scripts/check_ascii_python.sh passes.

## Diff size
- ~445 lines (module + two-sided tests + plan doc), over the 400 soft cap: a content-safety gate whose value is real per-category coverage plus a false-positive guard, so the catalogue ships with its two-sided tests; splitting them would ship safety code without evidence.
Diff-budget override: content-safety gate; the regex catalogue and its both-sides tests (coverage + false-positive guard) are one reviewable unit and must ship together.

## AI reconciliation

Codex reviewed #2135 across 3 rounds; 15 findings, all fixed and threads resolved. All
were genuine correctness/security issues (no waivers) -- several were false positives/
negatives introduced by the round-1/2 coverage broadening, now corrected with both-sides
tests.

Round 3:
- Do not suppress not-only claims (P2) -- FIXED: "not only"/"not just" excluded from negation, so "not only guarantees savings" fails.
- Constrain guarantee modifiers to one segment (P2) -- FIXED: dropped sentence punctuation from the modifier gap, so "guarantee X. Savings ..." across sentences no longer false-fails.
- Recognize cannot as direct negation (P2) -- FIXED: "cannot" added, so "We cannot guarantee savings" passes.
- Redact PII inside claim evidence (P2) -- FIXED: matched claim evidence is redacted, so a phone/email inside a claim ("Guaranteed 618-555-9876 savings") never persists into hits.

Round 2:
- Exclude possessive agent workflows from replace hits (P2) -- FIXED: negative lookahead so "Replace your agents' spreadsheet" passes; "Replace your agents entirely" still fails.
- Tighten avoided-hire matching (P2) -- FIXED: anchored on hire/hiring, not any nearby "agents", so "Avoid distracting your agents" passes; "Avoid hiring another support agent" still fails.
- Recognize percentage modifiers in guaranteed savings (P2) -- FIXED: the bounded modifier gap now allows numeric/percent tokens, so "Guaranteed 30% savings" / "We guarantee 30% savings" fail.
- Declare the guard rules this slice triggers (R2/R13) -- FIXED: the Review Contract now declares R2, R13, R14 (PII redaction covered by an acceptance criterion).


Round 1:
- Limit negation detection to the matched claim (P1) -- FIXED: _is_negated now checks only the two words immediately before the claim (segment-bounded), so an unrelated earlier negation ("No setup fee, and guaranteed savings") no longer suppresses a real hit; ambiguous-scope negations flag conservatively.
- Redact PII evidence in verification hits (P2) -- FIXED: PII hits record only "email: <redacted>" / "phone: <redacted>"; the raw value is never copied into the persisted verdict.
- Cover auto-publish inflections (P2) -- FIXED: auto-publish/publishes/publishing/published all match.
- Recognize spelled-out deflection percentages (P2) -- FIXED: the deflection rule accepts "%" or "percent".
- Cover ticket-reduction claims beyond ticket volume (P2) -- FIXED: reduce (support) tickets/ticket volume by N%; N% fewer (support) tickets.
- Cover common replacing-agent wording (P2) -- FIXED: replace your/our/the (support) agents; avoid hiring another (support) agent/hire.
- Cover modified guaranteed-savings claims (P2) -- FIXED: bounded modifiers between the guarantee verb and "savings" (guaranteed cost/monthly savings).
- Design note (open-category R13): a regex catalogue cannot close a natural-language claim category; the gate is reframed as a best-effort backstop with human approval as the real guarantee, and both-sides tests guard against false positives. Broadened common coverage rather than claiming completeness.

All fixed or waived: Yes