### PR TITLE
Wire copy-verification gate into the runner (Phase 4.2)

### DIFF
--- a/atlas_brain/services/content_factory_runner.py
+++ b/atlas_brain/services/content_factory_runner.py
@@ -97,8 +97,9 @@ def call_worker(
 
 
 def _enforce_copy_verification(artifact: dict[str, Any]) -> None:
-    """For an editorial audit, OVERWRITE copy_verification with the deterministic verdict
-    computed from the edited copy, discarding any value the worker reported.
+    """For ANY editorial audit (gated by schema, not stage name -- see below), OVERWRITE
+    copy_verification with the deterministic verdict computed from the edited copy,
+    discarding any value the worker reported.
 
     This is what makes the model unable to self-promote: #2116's EditorialAudit contract
     rejects ``recommendation == "promote"`` unless ``copy_verification.verdict == "pass"``,
@@ -106,10 +107,25 @@ def _enforce_copy_verification(artifact: dict[str, Any]) -> None:
     the edited copy overclaims or leaks PII, the injected "fail" verdict makes a
     worker-asserted "promote" invalid and the store rejects the artifact (fail closed);
     a "revise" recommendation still persists with the recorded hits.
+
+    Gating is by SCHEMA (``editorial_audit.v1``), not by the canonical "audit" stage name:
+    the store lets a custom stage carry any artifact, and any editorial_audit.v1 can
+    promote, so gating by stage name would let a custom-stage audit bypass the gate.
+
+    Empty/blank edited copy fails closed: with nothing to verify, the audit cannot carry a
+    passing verdict (otherwise a worker could self-promote by omitting the edited body).
+    Verifying the parent draft body in that case is a later refinement (#2136).
     """
-    if artifact.get("schema") == _EDITOR_SCHEMA:
-        edited = artifact.get("edited_body_markdown") or ""
-        artifact["copy_verification"] = verify_copy(str(edited)).model_dump()
+    if artifact.get("schema") != _EDITOR_SCHEMA:
+        return
+    edited = str(artifact.get("edited_body_markdown") or "")
+    if not edited.strip():
+        artifact["copy_verification"] = {
+            "verdict": "fail",
+            "hits": ["unverified-copy: edited_body_markdown is empty; nothing was verified"],
+        }
+        return
+    artifact["copy_verification"] = verify_copy(edited).model_dump()
 
 
 def run_stage(

--- a/atlas_brain/services/content_factory_runner.py
+++ b/atlas_brain/services/content_factory_runner.py
@@ -17,9 +17,14 @@ import urllib.request
 from pathlib import Path
 from typing import Any
 
+from atlas_brain.services.content_factory_copy_verification import verify_copy
 from atlas_brain.services.content_factory_store import DEFAULT_ROOT, write_artifact
 
 DEFAULT_OWUI_URL = "http://127.0.0.1:8080"
+
+# The editor stage's artifact schema. Its promote decision is gated (via #2116's
+# EditorialAudit contract) on copy_verification.verdict == "pass".
+_EDITOR_SCHEMA = "editorial_audit.v1"
 
 # A leading ```/```json fence and a trailing fence, so a fenced reply still
 # yields its JSON body.
@@ -91,6 +96,22 @@ def call_worker(
     return content or ""
 
 
+def _enforce_copy_verification(artifact: dict[str, Any]) -> None:
+    """For an editorial audit, OVERWRITE copy_verification with the deterministic verdict
+    computed from the edited copy, discarding any value the worker reported.
+
+    This is what makes the model unable to self-promote: #2116's EditorialAudit contract
+    rejects ``recommendation == "promote"`` unless ``copy_verification.verdict == "pass"``,
+    and after this the verdict is the deterministic gate's, not the worker's claim. So if
+    the edited copy overclaims or leaks PII, the injected "fail" verdict makes a
+    worker-asserted "promote" invalid and the store rejects the artifact (fail closed);
+    a "revise" recommendation still persists with the recorded hits.
+    """
+    if artifact.get("schema") == _EDITOR_SCHEMA:
+        edited = artifact.get("edited_body_markdown") or ""
+        artifact["copy_verification"] = verify_copy(str(edited)).model_dump()
+
+
 def run_stage(
     job_id: str,
     stage: str,
@@ -101,12 +122,13 @@ def run_stage(
     base_url: str = DEFAULT_OWUI_URL,
     root: Path | str = DEFAULT_ROOT,
 ) -> dict[str, Any]:
-    """Run one stage end to end: call the worker, extract its JSON artifact, then
-    validate + persist it via the store. Returns the store's record.
+    """Run one stage end to end: call the worker, extract its JSON artifact, enforce the
+    deterministic copy-verification verdict on an editor audit, then validate + persist it
+    via the store. Returns the store's record.
 
     Raises WorkerError if the worker call fails or returns no JSON object, and
     ValueError / pydantic ValidationError (from the store) if the artifact fails
-    its contract -- so a malformed stage output is never persisted.
+    its contract -- so a malformed or self-promoting stage output is never persisted.
     """
     reply = call_worker(model, user_content, api_key=api_key, base_url=base_url)
     artifact = extract_json(reply)
@@ -114,4 +136,5 @@ def run_stage(
         raise WorkerError(
             f"stage {stage!r}: worker {model!r} returned no JSON artifact"
         )
+    _enforce_copy_verification(artifact)
     return write_artifact(job_id, stage, artifact, root=root)

--- a/plans/PR-Content-Factory-Gate-Wiring.md
+++ b/plans/PR-Content-Factory-Gate-Wiring.md
@@ -102,7 +102,7 @@ non-audit-schema stages get no copy_verification.
 
 | File | LOC |
 |---|---:|
-| `atlas_brain/services/content_factory_runner.py` | 29 |
-| `plans/PR-Content-Factory-Gate-Wiring.md` | 104 |
-| `tests/test_content_factory_runner.py` | 61 |
-| **Total** | **194** |
+| `atlas_brain/services/content_factory_runner.py` | 45 |
+| `plans/PR-Content-Factory-Gate-Wiring.md` | 108 |
+| `tests/test_content_factory_runner.py` | 88 |
+| **Total** | **241** |

--- a/plans/PR-Content-Factory-Gate-Wiring.md
+++ b/plans/PR-Content-Factory-Gate-Wiring.md
@@ -39,7 +39,9 @@ separate step (needs LM Studio serving the qualified model).
         rejected and nothing is persisted; a `revise` recommendation persists with the
         fail verdict + hits.
   - [ ] Clean edited copy may promote.
-  - [ ] Non-editor stages get no `copy_verification` injected.
+  - [ ] Empty/blank edited copy fails closed (a fail verdict; cannot promote unverified copy).
+  - [ ] Gating is by SCHEMA (any `editorial_audit.v1`), so a custom-stage audit is also
+        gated and cannot bypass; a non-audit-schema stage gets no injection.
 - Reachability proof: `run_stage` is the pipeline's stage entry point; the store persists
   what it returns. Proof is the test suite (worker mocked, real store + contracts + gate).
 - Affected surfaces: `content_factory_runner.run_stage` (one added helper call) and its
@@ -69,9 +71,13 @@ now fails validation in the store and is never persisted.
   advisory at best and never trusted, matching the "model cannot self-promote" invariant.
 - Enforcement reuses the existing #2116 guard rather than adding new gating: injecting the
   real verdict is enough; the contract already rejects promote-without-pass.
-- The gate verifies `edited_body_markdown` (the copy the editor would promote); if the
-  editor leaves it empty, there is nothing to verify (a degenerate case a later slice can
-  tighten by also checking the parent draft).
+- The gate verifies `edited_body_markdown` (the copy the editor would promote). Empty/blank
+  edited copy FAILS CLOSED (a fail verdict) so a worker cannot self-promote by omitting the
+  edited body; verifying the parent draft body in that case is a later refinement (#2136).
+- Gating is by SCHEMA, not the "audit" stage name: any `editorial_audit.v1` can promote, and
+  the store allows a custom stage to carry any artifact, so gating by stage name would let a
+  custom-stage audit bypass the deterministic gate. The Review Contract's "non-editor stage"
+  means non-audit-SCHEMA, not non-"audit"-stage.
 
 ## Deferred
 
@@ -85,11 +91,12 @@ now fails validation in the store and is never persisted.
 ```
 python -m pytest tests/test_content_factory_runner.py -q
 ```
-21 tests pass (16 existing + 5 new): an editor audit's copy_verification is the
+24 tests pass (16 existing + 8 new): an editor audit's copy_verification is the
 deterministic verdict of its edited copy; a worker cannot self-promote overclaiming copy
 (rejected, nothing persisted) while a revise recommendation persists with the fail verdict
-and hits; clean copy may promote; a worker-claimed verdict is overridden; non-editor stages
-get no copy_verification.
+and hits; clean copy may promote; empty edited copy fails closed (cannot promote); a
+custom-stage audit is also gated by schema; a worker-claimed verdict is overridden;
+non-audit-schema stages get no copy_verification.
 
 ## Estimated diff size
 

--- a/plans/PR-Content-Factory-Gate-Wiring.md
+++ b/plans/PR-Content-Factory-Gate-Wiring.md
@@ -1,0 +1,101 @@
+# PR-Content-Factory-Gate-Wiring
+
+## Why this slice exists
+
+#2135 built the deterministic copy-verification gate (`verify_copy`) but nothing called
+it, so the #2116 promote guard still ran on the worker's OWN `copy_verification` claim --
+a model could self-report `verdict: "pass"` and promote overclaiming copy. This slice
+(part of #2136, Phase 4.2) wires the gate into the stage runner: when the editor stage
+produces an `editorial_audit.v1`, the runner recomputes `copy_verification` deterministically
+from the edited copy and overwrites the worker's value before validation. Now the promote
+decision is gated on the gate's verdict, not the worker's, so a model cannot self-promote.
+
+### Problem-derived contract
+
+A correct fix must:
+- Recompute `copy_verification` deterministically (via `verify_copy` on the edited copy)
+  for an editor audit and discard any worker-supplied value.
+- Do this before the artifact is validated/persisted, so #2116's promote-requires-pass
+  guard sees the deterministic verdict.
+- Fail closed: a worker that asserts `promote` on overclaiming/PII copy is rejected (not
+  persisted); a `revise` recommendation still persists with the recorded hits.
+- Touch only the editor stage; other stages are unaffected.
+
+## Scope (this PR)
+
+Ownership lane: content-factory
+Slice phase: vertical slice
+
+One helper in `content_factory_runner` called from `run_stage`, plus tests. No new module,
+no change to the contracts or the gate. Live end-to-end validation against the model is a
+separate step (needs LM Studio serving the qualified model).
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] An editor audit's `copy_verification` is the deterministic `verify_copy` result of
+        its `edited_body_markdown`, regardless of what the worker reported.
+  - [ ] A worker asserting `promote` (and a passing verdict) on overclaiming copy is
+        rejected and nothing is persisted; a `revise` recommendation persists with the
+        fail verdict + hits.
+  - [ ] Clean edited copy may promote.
+  - [ ] Non-editor stages get no `copy_verification` injected.
+- Reachability proof: `run_stage` is the pipeline's stage entry point; the store persists
+  what it returns. Proof is the test suite (worker mocked, real store + contracts + gate).
+- Affected surfaces: `content_factory_runner.run_stage` (one added helper call) and its
+  test file.
+- Risk areas: the deterministic override actually replacing the worker's claim; fail-closed
+  on self-promote; only the editor stage touched.
+- Reviewer rules triggered: R14 (wires a safety gate into the enforcement path).
+
+### Files touched
+
+- `atlas_brain/services/content_factory_runner.py`
+- `plans/PR-Content-Factory-Gate-Wiring.md`
+- `tests/test_content_factory_runner.py`
+
+## Mechanism
+
+`_enforce_copy_verification(artifact)` sets `artifact["copy_verification"]` to
+`verify_copy(edited_body_markdown).model_dump()` when the artifact's schema is
+`editorial_audit.v1`, discarding any worker value. `run_stage` calls it after extracting
+the JSON and before `write_artifact`. Because #2116's `EditorialAudit` rejects
+`recommendation == "promote"` unless the verdict is `"pass"`, a self-promoting overclaim
+now fails validation in the store and is never persisted.
+
+## Intentional
+
+- The override is unconditional for the editor stage: the worker's `copy_verification` is
+  advisory at best and never trusted, matching the "model cannot self-promote" invariant.
+- Enforcement reuses the existing #2116 guard rather than adding new gating: injecting the
+  real verdict is enough; the contract already rejects promote-without-pass.
+- The gate verifies `edited_body_markdown` (the copy the editor would promote); if the
+  editor leaves it empty, there is nothing to verify (a degenerate case a later slice can
+  tighten by also checking the parent draft).
+
+## Deferred
+
+- Live end-to-end validation through the model (needs LM Studio serving the qualified
+  model) -- an ops step, tracked in #2136.
+- An OWUI Editor Filter enforcing the same gate at the OWUI boundary, and verifying the
+  parent draft body when the audit's edited copy is empty -- later, #2136.
+
+## Verification
+
+```
+python -m pytest tests/test_content_factory_runner.py -q
+```
+21 tests pass (16 existing + 5 new): an editor audit's copy_verification is the
+deterministic verdict of its edited copy; a worker cannot self-promote overclaiming copy
+(rejected, nothing persisted) while a revise recommendation persists with the fail verdict
+and hits; clean copy may promote; a worker-claimed verdict is overridden; non-editor stages
+get no copy_verification.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/services/content_factory_runner.py` | 29 |
+| `plans/PR-Content-Factory-Gate-Wiring.md` | 104 |
+| `tests/test_content_factory_runner.py` | 61 |
+| **Total** | **194** |

--- a/plans/PR-Content-Factory-Gate-Wiring.md
+++ b/plans/PR-Content-Factory-Gate-Wiring.md
@@ -48,7 +48,9 @@ separate step (needs LM Studio serving the qualified model).
   test file.
 - Risk areas: the deterministic override actually replacing the worker's claim; fail-closed
   on self-promote; only the editor stage touched.
-- Reviewer rules triggered: R14 (wires a safety gate into the enforcement path).
+- Reviewer rules triggered: R2, R14. R14 (safety gate wired into the enforcement path) and
+  R2 (a guard/gate change requires failure-branch + boundary test evidence -- the
+  self-promote-rejected, empty-copy-fail-closed, and custom-stage-gated tests provide it).
 
 ### Files touched
 

--- a/tests/test_content_factory_runner.py
+++ b/tests/test_content_factory_runner.py
@@ -184,3 +184,30 @@ def test_non_editor_stage_gets_no_copy_verification(tmp_path, monkeypatch):
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: BRIEF_JSON)
     rec = runner.run_stage("job1", "brief", "m", "req", api_key="k", root=tmp_path)
     assert "copy_verification" not in _stored(rec)
+
+
+def test_empty_edited_copy_cannot_promote(tmp_path, monkeypatch):
+    # Fail closed: an empty edited body means nothing was verified, so a worker cannot
+    # self-promote by omitting the edited copy.
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: _editor_json("", "promote"))
+    with pytest.raises(ValidationError):
+        runner.run_stage("job1", "audit", "m", "req", api_key="k", root=tmp_path)
+    assert not job_dir("job1", root=tmp_path).exists()
+
+
+def test_empty_edited_copy_revise_persists_with_fail(tmp_path, monkeypatch):
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: _editor_json("   ", "revise"))
+    rec = runner.run_stage("job1", "audit", "m", "req", api_key="k", root=tmp_path)
+    stored = _stored(rec)
+    assert stored["copy_verification"]["verdict"] == "fail"
+    assert any("unverified-copy" in h for h in stored["copy_verification"]["hits"])
+
+
+def test_custom_stage_audit_is_also_gated(tmp_path, monkeypatch):
+    # A custom (non-"audit") stage emitting editorial_audit.v1 must not bypass the gate:
+    # gating is by schema, so its self-promotion of overclaiming copy is still rejected.
+    reply = _editor_json(_BAD_BODY, "promote", copy_verification={"verdict": "pass", "hits": []})
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
+    with pytest.raises(ValidationError):
+        runner.run_stage("job1", "audit-v2", "m", "req", api_key="k", root=tmp_path)
+    assert not job_dir("job1", root=tmp_path).exists()

--- a/tests/test_content_factory_runner.py
+++ b/tests/test_content_factory_runner.py
@@ -123,3 +123,64 @@ def test_run_stage_invalid_artifact_not_persisted(tmp_path, monkeypatch):
     with pytest.raises(ValidationError):
         runner.run_stage("job1", "evidence", "m", "req", api_key="k", root=tmp_path)
     assert not job_dir("job1", root=tmp_path).exists()
+
+
+# --- editor stage: deterministic copy-verification enforcement (Phase 4.2) ---
+
+_CLEAN_BODY = "Support leaders: the Resolution Audit ranks your repeated tickets."
+_BAD_BODY = "Guaranteed savings for every team."
+
+
+def _editor_json(body, recommendation="revise", **extra):
+    audit = {
+        "schema": "editorial_audit.v1",
+        "project_id": "resolution-audit",
+        "edited_body_markdown": body,
+        "recommendation": recommendation,
+    }
+    audit.update(extra)
+    return json.dumps(audit)
+
+
+def _stored(rec):
+    return json.loads(Path(rec["path"]).read_text())
+
+
+def test_editor_stage_injects_deterministic_pass(tmp_path, monkeypatch):
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: _editor_json(_CLEAN_BODY, "promote"))
+    rec = runner.run_stage("job1", "audit", "cf-editor", "req", api_key="k", root=tmp_path)
+    stored = _stored(rec)
+    assert stored["copy_verification"]["verdict"] == "pass"
+    assert stored["recommendation"] == "promote"  # clean copy may promote
+
+
+def test_editor_worker_cannot_self_promote_overclaim(tmp_path, monkeypatch):
+    # Worker claims a passing verdict + promote on copy that actually overclaims.
+    reply = _editor_json(_BAD_BODY, "promote", copy_verification={"verdict": "pass", "hits": []})
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
+    with pytest.raises(ValidationError):  # injected fail vs promote -> #2116 guard rejects
+        runner.run_stage("job1", "audit", "m", "req", api_key="k", root=tmp_path)
+    assert not job_dir("job1", root=tmp_path).exists()
+
+
+def test_editor_overclaim_revise_persists_with_fail(tmp_path, monkeypatch):
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: _editor_json(_BAD_BODY, "revise"))
+    rec = runner.run_stage("job1", "audit", "m", "req", api_key="k", root=tmp_path)
+    stored = _stored(rec)
+    assert stored["copy_verification"]["verdict"] == "fail"
+    assert any("guaranteed-savings" in h for h in stored["copy_verification"]["hits"])
+
+
+def test_editor_worker_claimed_verdict_is_overridden(tmp_path, monkeypatch):
+    # Worker asserts pass on bad copy but only recommends revise; the deterministic
+    # verdict must still overwrite the worker's claim.
+    reply = _editor_json(_BAD_BODY, "revise", copy_verification={"verdict": "pass", "hits": []})
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
+    rec = runner.run_stage("job1", "audit", "m", "req", api_key="k", root=tmp_path)
+    assert _stored(rec)["copy_verification"]["verdict"] == "fail"
+
+
+def test_non_editor_stage_gets_no_copy_verification(tmp_path, monkeypatch):
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: BRIEF_JSON)
+    rec = runner.run_stage("job1", "brief", "m", "req", api_key="k", root=tmp_path)
+    assert "copy_verification" not in _stored(rec)


### PR DESCRIPTION
Plan: plans/PR-Content-Factory-Gate-Wiring.md
Slice phase: vertical slice
Ownership lane: content-factory

Phase 4.2 (part of #2136): wire the #2135 copy-verification gate into the stage runner so
it actually enforces. When the editor stage produces an editorial_audit.v1, the runner
recomputes copy_verification deterministically from the edited copy (via verify_copy) and
overwrites the worker's value before validation. The #2116 promote-requires-pass guard now
runs on the gate's verdict, not the worker's claim -- a model can no longer self-promote
overclaiming or PII-leaking copy. CPU-only wiring; live model validation is a separate step.

## Intentional
- The editor stage's copy_verification is unconditionally overridden with the deterministic verify_copy result; the worker's value is never trusted (the "model cannot self-promote" invariant). Enforcement reuses the existing #2116 guard -- injecting the real verdict is enough; the contract already rejects promote-without-pass, so a self-promoting overclaim fails validation in the store and is never persisted (fail closed). The gate verifies edited_body_markdown (the copy that would be promoted).

## Deferred
- Live end-to-end validation through the model (needs LM Studio serving the qualified model) -- ops step, #2136. An OWUI Editor Filter enforcing the same gate at the OWUI boundary, and verifying the parent draft body when the audit's edited copy is empty -- later, #2136.

## Parked hardening
- None.

## Cold diff reconstruction
- atlas_brain/services/content_factory_runner.py: import verify_copy; add _EDITOR_SCHEMA and _enforce_copy_verification(artifact) (overwrites copy_verification with verify_copy(edited_body_markdown).model_dump() for editorial_audit.v1); run_stage calls it before write_artifact. tests/test_content_factory_runner.py: 5 new tests (deterministic pass injected; self-promote overclaim rejected + not persisted; overclaim+revise persists with fail+hits; worker-claimed verdict overridden; non-editor stage untouched).

## Verification
- python -m pytest tests/test_content_factory_runner.py -q  ->  24 passed (16 existing + 8 new). Editor audit copy_verification is the deterministic verdict of its edited copy; worker cannot self-promote overclaim (rejected, nothing persisted); revise persists with fail+hits; clean copy may promote; worker-claimed verdict overridden; non-editor stages get no copy_verification. scripts/check_ascii_python.sh passes.

## Diff size
- ~230 lines (runner + tests + plan doc), under the 400 soft cap.

## AI reconciliation

Codex reviewed #2137 across 2 rounds; 3 findings, all fixed and threads resolved.

Round 2:
- Add R2 to the gate contract (P2) -- FIXED: the Review Contract now declares R2, R14 (the failure-branch + boundary tests provide the R2 evidence).

Round 1:
- Fail closed on empty editor copy (P2) -- FIXED: an empty/blank edited_body_markdown now injects a fail verdict, so a worker cannot self-promote by omitting the edited copy. Verifying the parent draft in that case is a later refinement (#2136).
- Scope the copy gate to the audit stage (P2) -- resolved by fixing the CONTRACT, not narrowing the code: gating is intentionally by SCHEMA (any editorial_audit.v1), because the store lets a custom stage carry any artifact and any audit can promote -- narrowing to stage=="audit" would OPEN a bypass (a custom-stage audit could self-promote). The plan wording now says by-schema; added a test proving a custom-stage audit is also gated.

All fixed or waived: Yes