### PR TITLE
feat: EOM website lead-intake endpoint + request-acknowledgement email (#2151 Phase 1)

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,5 @@
+# False positive: gitleaks generic-api-key matched review-contract prose
+# ("security: ... honeypot/validation/CORS scoping") in the PR plan doc.
+# The line is documentation text, not a credential; it is also reworded in
+# the follow-up commit, but the original commit remains in PR history.
+4f5204e85cd3049f20083d16c15b0261e8444d1b:plans/PR-EOM-Lead-Intake.md:generic-api-key:102

--- a/atlas_brain/api/__init__.py
+++ b/atlas_brain/api/__init__.py
@@ -27,6 +27,7 @@ from .email_actions import router as email_actions_router
 from .inbox_rules import router as inbox_rules_router
 from .invoicing import router as invoicing_router
 from .contacts import router as contacts_router
+from .leads import router as leads_router
 from .reasoning import router as reasoning_router
 from .security import router as security_router
 from .settings import router as settings_router
@@ -104,6 +105,7 @@ router.include_router(email_actions_router)
 router.include_router(inbox_rules_router)
 router.include_router(invoicing_router)
 router.include_router(contacts_router)
+router.include_router(leads_router)
 router.include_router(reasoning_router)
 router.include_router(security_router)
 router.include_router(system_router)

--- a/atlas_brain/api/leads.py
+++ b/atlas_brain/api/leads.py
@@ -22,6 +22,10 @@ router = APIRouter(prefix="/leads", tags=["leads"])
 EOM_BUSINESS_CONTEXT_ID = "effingham_maids"
 
 _EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+_MIN_PHONE_DIGITS = 7
+# Server-side throttle (PR #2152 review, R3/R8): max submissions per
+# email-or-phone identity per rolling day, enforced BEFORE any side effect.
+MAX_DAILY_SUBMISSIONS = 5
 
 
 class LeadIntakeRequest(BaseModel):
@@ -41,6 +45,31 @@ class LeadIntakeRequest(BaseModel):
 
 class LeadValidationError(ValueError):
     """Raised when a payload is structurally unusable as a lead."""
+
+
+class LeadRateLimitedError(RuntimeError):
+    """Raised when an identity exceeds the daily submission cap."""
+
+
+async def _daily_submission_count(email: str, phone: str) -> int:
+    """Count today's web_form submissions for this identity (EOM-scoped)."""
+    from ..storage.database import get_db_pool
+
+    pool = get_db_pool()
+    return await pool.fetchval(
+        """
+        SELECT COUNT(*)
+        FROM contact_interactions ci
+        JOIN contacts c ON c.id = ci.contact_id
+        WHERE ci.interaction_type = 'web_form'
+          AND ci.occurred_at > NOW() - INTERVAL '1 day'
+          AND c.business_context_id = $1
+          AND (($2 <> '' AND LOWER(c.email) = $2) OR ($3 <> '' AND c.phone = $3))
+        """,
+        EOM_BUSINESS_CONTEXT_ID,
+        email,
+        phone,
+    ) or 0
 
 
 def _build_summary(payload: LeadIntakeRequest) -> str:
@@ -65,6 +94,7 @@ async def _process_lead_intake(
     payload: LeadIntakeRequest,
     crm: Any,
     email_provider: Any,
+    daily_count: Optional[Any] = None,
 ) -> dict[str, Any]:
     """Core intake flow with injectable providers (unit-testable sans HTTP)."""
     if payload.website.strip():
@@ -74,10 +104,23 @@ async def _process_lead_intake(
 
     email = payload.email.strip().lower()
     phone = payload.phone.strip()
+    # A phone with no dialable digits ("n/a", "-") is not a contact channel
+    # (PR #2152 review, R1/R2).
+    if phone and len(re.sub(r"\D", "", phone)) < _MIN_PHONE_DIGITS:
+        phone = ""
     if not email and not phone:
-        raise LeadValidationError("Provide an email address or phone number")
+        raise LeadValidationError(
+            "Provide an email address or a phone number with at least "
+            f"{_MIN_PHONE_DIGITS} digits"
+        )
     if email and not _EMAIL_RE.match(email):
         raise LeadValidationError("Invalid email address")
+
+    # Throttle BEFORE any side effect (CRM write or email).
+    if daily_count is not None:
+        recent = await daily_count(email, phone)
+        if recent >= MAX_DAILY_SUBMISSIONS:
+            raise LeadRateLimitedError("Daily submission limit reached")
 
     contact = await crm.find_or_create_contact(
         full_name=payload.name.strip(),
@@ -105,9 +148,9 @@ async def _process_lead_intake(
             "source_page": payload.source_page,
         },
     )
-    # log_interaction dedupes identical same-day rows (_inserted=False on
-    # conflict) — a double-submit shouldn't double-email the lead.
-    freshly_logged = bool((interaction or {}).get("_inserted", True))
+    # log_interaction dedupes identical same-day rows and reports it via the
+    # public "inserted" flag — a double-submit shouldn't double-email the lead.
+    freshly_logged = bool((interaction or {}).get("inserted", True))
 
     email_sent = False
     if email and freshly_logged:
@@ -145,9 +188,12 @@ async def lead_intake(payload: LeadIntakeRequest) -> dict[str, Any]:
             payload,
             crm=get_crm_provider(),
             email_provider=get_email_provider(),
+            daily_count=_daily_submission_count,
         )
     except LeadValidationError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except LeadRateLimitedError as exc:
+        raise HTTPException(status_code=429, detail="Too many requests — try again tomorrow") from exc
     except Exception:
         logger.exception("lead_intake: intake failed")
         raise HTTPException(status_code=503, detail="Lead intake temporarily unavailable")

--- a/atlas_brain/api/leads.py
+++ b/atlas_brain/api/leads.py
@@ -1,0 +1,153 @@
+"""Public lead-intake endpoint for the EOM website estimate form.
+
+Issue #2151 Phase 1. The website form POSTs here at submit time (in parallel
+with the existing Web3Forms email relay), giving Atlas a real-time CRM write
+plus an instant customer acknowledgement. Public by design — same trust model
+as the b2b briefing gate (a browser form cannot hold a secret); abuse guards
+are the honeypot field, payload length caps, and same-day duplicate
+suppression via the contact_interactions dedupe key.
+"""
+
+import logging
+import re
+from typing import Any, Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/leads", tags=["leads"])
+
+EOM_BUSINESS_CONTEXT_ID = "effingham_maids"
+
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+
+class LeadIntakeRequest(BaseModel):
+    """Payload mirroring the website estimate form."""
+
+    name: str = Field(min_length=1, max_length=200)
+    email: str = Field(default="", max_length=320)
+    phone: str = Field(default="", max_length=40)
+    service: str = Field(default="", max_length=120)
+    frequency: str = Field(default="", max_length=120)
+    square_feet: str = Field(default="", max_length=40)
+    message: str = Field(default="", max_length=8000)
+    source_page: str = Field(default="", max_length=300)
+    # Honeypot: hidden on the real form; humans leave it empty.
+    website: str = Field(default="", max_length=300)
+
+
+class LeadValidationError(ValueError):
+    """Raised when a payload is structurally unusable as a lead."""
+
+
+def _build_summary(payload: LeadIntakeRequest) -> str:
+    """Full, untruncated interaction summary (the gmail_digest path's 200-char
+    truncation is one of the defects this endpoint exists to bypass)."""
+    parts = ["Website estimate request"]
+    if payload.service:
+        parts.append(f"service: {payload.service}")
+    if payload.frequency:
+        parts.append(f"frequency: {payload.frequency}")
+    if payload.square_feet:
+        parts.append(f"square feet: {payload.square_feet}")
+    if payload.source_page:
+        parts.append(f"page: {payload.source_page}")
+    summary = " — ".join([parts[0], "; ".join(parts[1:])]) if len(parts) > 1 else parts[0]
+    if payload.message:
+        summary += f"\nMessage: {payload.message}"
+    return summary
+
+
+async def _process_lead_intake(
+    payload: LeadIntakeRequest,
+    crm: Any,
+    email_provider: Any,
+) -> dict[str, Any]:
+    """Core intake flow with injectable providers (unit-testable sans HTTP)."""
+    if payload.website.strip():
+        # Honeypot tripped: report success so bots learn nothing, touch nothing.
+        logger.info("lead_intake: honeypot tripped; dropping submission silently")
+        return {"success": True, "contact_id": None, "email_sent": False}
+
+    email = payload.email.strip().lower()
+    phone = payload.phone.strip()
+    if not email and not phone:
+        raise LeadValidationError("Provide an email address or phone number")
+    if email and not _EMAIL_RE.match(email):
+        raise LeadValidationError("Invalid email address")
+
+    contact = await crm.find_or_create_contact(
+        full_name=payload.name.strip(),
+        email=email or None,
+        phone=phone or None,
+        contact_type="lead",
+        source="web",
+        source_ref="website_estimate_form",
+        business_context_id=EOM_BUSINESS_CONTEXT_ID,
+        tags=["website", "estimate_request"],
+    )
+    contact_id = contact.get("id")
+    if not contact_id:
+        raise RuntimeError("CRM returned contact without id")
+
+    interaction = await crm.log_interaction(
+        contact_id=str(contact_id),
+        interaction_type="web_form",
+        summary=_build_summary(payload),
+        intent="estimate_request",
+        metadata={
+            "service": payload.service,
+            "frequency": payload.frequency,
+            "square_feet": payload.square_feet,
+            "source_page": payload.source_page,
+        },
+    )
+    # log_interaction dedupes identical same-day rows (_inserted=False on
+    # conflict) — a double-submit shouldn't double-email the lead.
+    freshly_logged = bool((interaction or {}).get("_inserted", True))
+
+    email_sent = False
+    if email and freshly_logged:
+        try:
+            from ..templates.email import BUSINESS_EMAIL, format_request_acknowledgement
+
+            subject, body = format_request_acknowledgement(
+                client_name=payload.name,
+                service=payload.service,
+                frequency=payload.frequency,
+            )
+            result = await email_provider.send(
+                to=[email],
+                subject=subject,
+                body=body,
+                reply_to=BUSINESS_EMAIL,
+            )
+            email_sent = bool(result.get("success", True)) if isinstance(result, dict) else True
+        except Exception:
+            # Acknowledgement is best-effort; the CRM write is the source of
+            # truth and must not be rolled back or reported as failed.
+            logger.exception("lead_intake: acknowledgement email failed for contact %s", contact_id)
+
+    return {"success": True, "contact_id": str(contact_id), "email_sent": email_sent}
+
+
+@router.post("/intake")
+async def lead_intake(payload: LeadIntakeRequest) -> dict[str, Any]:
+    """Receive an estimate-form submission from the public website."""
+    from ..services.crm_provider import get_crm_provider
+    from ..services.email_provider import get_email_provider
+
+    try:
+        return await _process_lead_intake(
+            payload,
+            crm=get_crm_provider(),
+            email_provider=get_email_provider(),
+        )
+    except LeadValidationError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except Exception:
+        logger.exception("lead_intake: intake failed")
+        raise HTTPException(status_code=503, detail="Lead intake temporarily unavailable")

--- a/atlas_brain/main.py
+++ b/atlas_brain/main.py
@@ -957,7 +957,13 @@ async def _inject_rate_limit_identity(request, call_next):
 
 # CORS middleware for dashboard dev servers + production (Vercel, etc.)
 from fastapi.middleware.cors import CORSMiddleware
-_cors_origins = ["http://localhost:5174", "http://localhost:5173", "http://localhost:5175"]
+_cors_origins = [
+    "http://localhost:5174",
+    "http://localhost:5173",
+    "http://localhost:5175",
+    "https://effinghamofficemaids.com",
+    "https://www.effinghamofficemaids.com",
+]
 if settings.saas_auth.cors_origins:
     _cors_origins.extend(o.strip() for o in settings.saas_auth.cors_origins.split(",") if o.strip())
 app.add_middleware(

--- a/atlas_brain/services/crm_provider.py
+++ b/atlas_brain/services/crm_provider.py
@@ -124,13 +124,21 @@ class DatabaseCRMProvider:
         email = raw_email.lower() if raw_email else None
         phone = data.get("phone")
 
+        # Tenant-scoped dedup: when the caller stamps a business_context_id,
+        # only match contacts within that tenant -- an EOM web lead must never
+        # resolve to (and mutate) a contact belonging to another context
+        # (PR #2152 review finding, R3/R4).
+        _scope: dict[str, Any] = {}
+        if data.get("business_context_id"):
+            _scope["business_context_id"] = data["business_context_id"]
+
         existing: Optional[dict[str, Any]] = None
         if phone:
-            matches = await self.search_contacts(phone=phone)
+            matches = await self.search_contacts(phone=phone, **_scope)
             if matches:
                 existing = matches[0]
         if existing is None and email:
-            matches = await self.search_contacts(email=email)
+            matches = await self.search_contacts(email=email, **_scope)
             if matches:
                 existing = matches[0]
 
@@ -426,6 +434,9 @@ class DatabaseCRMProvider:
         )
         result = dict(row) if row else {}
         inserted = bool(result.pop("_inserted", False))
+        # Public flag for callers that gate side effects (e.g. acknowledgement
+        # emails) on first-time-vs-duplicate; the raw column is stripped above.
+        result["inserted"] = inserted
 
         if inserted:
             # Emit event for reasoning agent only for new interactions.

--- a/atlas_brain/skills/email/cleaning_confirmation.md
+++ b/atlas_brain/skills/email/cleaning_confirmation.md
@@ -43,6 +43,6 @@ Compose the email in this exact order:
 - For **residential**: warmer, more personal tone
 - For **commercial**: slightly more formal, mention point of contact if known
 - Keep the entire email body under **175 words**
-- Always include business contact: (217) 821-2370 or info@effinghamofficemaids.com
+- Always include business contact: (217) 207-3097 or info@effinghamofficemaids.com
 - Subject line format: Your [Service Type] is Confirmed -- [Date]
 - Do NOT use markdown formatting in the email body -- plain text with line breaks only

--- a/atlas_brain/skills/email/estimate_confirmation.md
+++ b/atlas_brain/skills/email/estimate_confirmation.md
@@ -41,6 +41,6 @@ Compose the email in this exact order:
 - For **residential** estimates: mention that pricing is typically provided during the visit
 - For **commercial** estimates: mention that a detailed proposal will follow the visit
 - Keep the entire email body under **150 words**
-- Always include business contact: (217) 821-2370 or info@effinghamofficemaids.com
+- Always include business contact: (217) 207-3097 or info@effinghamofficemaids.com
 - Subject line format: Your Estimate Appointment is Confirmed -- [Date]
 - Do NOT use markdown formatting in the email body -- plain text with line breaks only

--- a/atlas_brain/skills/email/proposal.md
+++ b/atlas_brain/skills/email/proposal.md
@@ -40,7 +40,7 @@ Compose the email in this exact order:
 - If frequency pricing differs, show each option clearly
 - If only one price is provided, present it with the stated frequency
 - Keep the entire email body under **300 words** -- proposals should be scannable, not dense
-- Always include business contact: (217) 821-2370 or info@effinghamofficemaids.com
+- Always include business contact: (217) 207-3097 or info@effinghamofficemaids.com
 - Subject line format: Cleaning Proposal for [Business Name]
 - Do NOT use markdown formatting in the email body -- plain text with line breaks only
 - Do NOT include legal disclaimers or warranty language unless explicitly provided

--- a/atlas_brain/templates/email/__init__.py
+++ b/atlas_brain/templates/email/__init__.py
@@ -12,6 +12,10 @@ from .estimate_confirmation import (
     format_residential_email,
 )
 
+from .request_acknowledgement import (
+    format_request_acknowledgement,
+)
+
 from .proposal import (
     format_business_proposal,
     format_residential_proposal,
@@ -29,6 +33,7 @@ __all__ = [
     "BUSINESS_WEBSITE",
     "format_business_email",
     "format_residential_email",
+    "format_request_acknowledgement",
     "format_business_proposal",
     "format_residential_proposal",
     "render_invoice_html",

--- a/atlas_brain/templates/email/estimate_confirmation.py
+++ b/atlas_brain/templates/email/estimate_confirmation.py
@@ -6,7 +6,7 @@ Templates use Python string formatting with named placeholders.
 
 # Business contact info
 BUSINESS_NAME = "Effingham Office Maids"
-BUSINESS_ADDRESS = "503 S. 5th Street, Effingham IL, 62401"
+BUSINESS_ADDRESS = "1901 S. 4th St. Ste #1, Effingham IL 62401"
 BUSINESS_PHONE = "(217) 207-3097"
 BUSINESS_EMAIL = "info@effinghamofficemaids.com"
 BUSINESS_WEBSITE = "effinghamofficemaids.com"

--- a/atlas_brain/templates/email/request_acknowledgement.py
+++ b/atlas_brain/templates/email/request_acknowledgement.py
@@ -1,0 +1,66 @@
+"""Request-acknowledgement email for website estimate submissions.
+
+Sent immediately when a lead submits the estimate form on
+effinghamofficemaids.com (issue #2151 Phase 1). Deliberately price-free and
+date-free: at request time no walkthrough has happened, so the message only
+sets expectations. Copy guardrails (operator, 2026-07): no dollar figures, no
+clock promises beyond "within 24 hours", "estimate" never "quote", sell the
+team (separate areas at once) without per-size time claims.
+"""
+
+from .estimate_confirmation import (
+    BUSINESS_EMAIL,
+    BUSINESS_NAME,
+    BUSINESS_PHONE,
+    BUSINESS_WEBSITE,
+)
+
+ACK_SUBJECT = "We received your estimate request - " + BUSINESS_NAME
+
+ACK_TEMPLATE = """Hi {client_name},
+
+Thanks for requesting a free estimate from {business_name} - it just landed \
+with a real person, and we'll get back to you within 24 hours.
+
+{request_line}Here's what happens next:
+
+1. We reach out to ask a few quick questions about your home and which rooms
+   you'd like covered - the whole home or just the spaces you actually use.
+2. You get a free estimate specific to your home. Every home is different,
+   so we don't price from a one-size rate card.
+3. If it works for you, we schedule your first clean. We send a team that
+   works separate areas at once - in and out fast, your space back sooner.
+
+There's no obligation and no pressure - the estimate is free either way.
+
+Questions in the meantime? Call us at {business_phone}, or just reply to
+this email.
+
+Talk soon,
+The {business_name} Team
+{business_phone} | {business_email}
+{business_website}
+"""
+
+
+def format_request_acknowledgement(
+    client_name: str,
+    service: str = "",
+    frequency: str = "",
+) -> tuple[str, str]:
+    """Render (subject, body) for the request acknowledgement.
+
+    ``service``/``frequency`` echo the form selections back when present so
+    the lead sees their request was captured accurately; both are optional.
+    """
+    details = ", ".join(part for part in (service.strip(), frequency.strip()) if part)
+    request_line = f"Your request: {details}.\n\n" if details else ""
+    body = ACK_TEMPLATE.format(
+        client_name=client_name.strip() or "there",
+        business_name=BUSINESS_NAME,
+        business_phone=BUSINESS_PHONE,
+        business_email=BUSINESS_EMAIL,
+        business_website=BUSINESS_WEBSITE,
+        request_line=request_line,
+    )
+    return ACK_SUBJECT, body

--- a/plans/PR-EOM-Lead-Intake.md
+++ b/plans/PR-EOM-Lead-Intake.md
@@ -18,6 +18,27 @@ against code 2026-07-22):
   price + service date (`send_estimate`, `mcp/email_server.py:125-133`); no
   price-free request-acknowledgement template exists.
 
+### Contract revision (2026-07-23, post-Codex review)
+
+Review evidence proved two provider behaviors the original contract wrongly
+declared out of scope, plus three endpoint gaps:
+
+- `DatabaseCRMProvider.log_interaction` pops `_inserted` before returning, so
+  the endpoint's duplicate-email gate read a field production never returns.
+  Revised surface: expose a public `inserted` key (additive; callers
+  unaffected).
+- `create_contact` dedupes by phone/email globally and merges incoming fields
+  (including `business_context_id`, `contact_type`, `tags`) into whatever
+  contact matches — an EOM web lead sharing an email with a non-EOM contact
+  would mutate that foreign-tenant record. Revised surface: when the caller
+  stamps `business_context_id`, scope both dedupe searches to that tenant
+  (unstamped callers keep legacy global dedupe).
+- Endpoint additions: pre-side-effect daily submission throttle (429),
+  dialable-digit phone validation, and a mounted-route smoke test.
+
+`crm_provider` is therefore no longer blanket non-scope; only these two
+surgical additions are in scope, nothing else in the provider moved.
+
 ### Problem-derived contract
 
 - Root cause: Atlas has **no ingress for website lead submissions** — the
@@ -32,7 +53,7 @@ against code 2026-07-22):
   effinghamofficemaids.com; the stale contact data in adjacent email content
   (3 skills docs' phone, 1 template address).
 - Must not change: `gmail_digest`/`email_classifier` (remain as redundant
-  backfill), `crm_provider` internals, `email_provider` transport, any B2B
+  backfill), `email_provider` transport, any B2B
   endpoint, invoicing/receivables (#2133), schema/migrations, other writers'
   tenant stamping (Phase 2), customer backfill (Phase 3), the website repo
   (named follow-up PR).
@@ -65,7 +86,14 @@ Slice phase: vertical slice
    `1901 S. 4th St. Ste #1, Effingham IL 62401` in
    `atlas_brain/templates/email/estimate_confirmation.py` (matches
    `atlas_brain/templates/email/invoice.py` + the live website).
-5. Proof: `tests/test_leads_intake.py` (repo unit style, mocked CRM/email).
+5. Post-review hardening (Codex reconciliation): tenant-scoped dedupe in
+   `create_contact` when `business_context_id` is stamped; public `inserted`
+   flag on `log_interaction` returns; pre-side-effect daily submission
+   throttle (HTTP 429, cap 5/identity/day); phone must carry >=7 digits to
+   count as a contact channel; route-level smoke test for the mounted path.
+6. Proof: `tests/test_leads_intake.py` (repo unit style, mocked CRM/email) —
+   18 tests including provider-level dedupe-scoping regressions and the
+   mounted-route smoke (200/422/429).
 
 ### Review Contract
 
@@ -85,6 +113,11 @@ Slice phase: vertical slice
      send call wires `reply_to=info@effinghamofficemaids.com`.
   8. Only additive `include_router` in `atlas_brain/api/__init__.py`; no
      existing router moved.
+  9. Daily cap blocks BEFORE any side effect (test-asserted: no CRM call, no
+     email on 429 path).
+  10. `create_contact` dedupe searches carry `business_context_id` when the
+      caller stamps one, and stay unscoped when not (both test-asserted).
+  11. Mounted `POST /api/v1/leads/intake` returns 200/422/429 via TestClient.
 - Reachability proof: entrypoint `POST /api/v1/leads/intake` on the
   atlas_brain app (port 8012), already publicly proxied by Tailscale Funnel
   (`https://atlas-brain.tailc7bd29.ts.net/api` → `127.0.0.1:8012/api`;
@@ -99,8 +132,8 @@ Slice phase: vertical slice
   `b2b/briefings/gate`; CORS additions are origin-scoped; email misconfig
   degrades to CRM-only capture (capture > acknowledgement).
 - Reviewer rules triggered: R1 (requirements match #2151 Phase 1), R2 (test
-  evidence: 11 unit tests), R3 (security: new public unauthenticated endpoint,
-  honeypot/validation/CORS scoping), R5 (backward compatibility: additive
+  evidence: 11 unit tests), R3 (security review of the new public endpoint: honeypot,
+  input validation, origin-scoped CORS, daily throttle), R5 (backward compatibility: additive
   router only; no existing API surface changed), R6 (error handling: email best-effort,
   503 path), R8 (idempotency: same-day dedupe via interaction dedupe key),
   R11 (config: CORS origin list), R12 (deployment: endpoint live on next
@@ -108,9 +141,11 @@ Slice phase: vertical slice
 
 ### Files touched
 
+- `.gitleaksignore`
 - `atlas_brain/api/__init__.py`
 - `atlas_brain/api/leads.py`
 - `atlas_brain/main.py`
+- `atlas_brain/services/crm_provider.py`
 - `atlas_brain/skills/email/cleaning_confirmation.md`
 - `atlas_brain/skills/email/estimate_confirmation.md`
 - `atlas_brain/skills/email/proposal.md`
@@ -177,15 +212,17 @@ Parked hardening: per-IP/email rate-limit table (above).
 
 | File | LOC |
 |---|---:|
+| `.gitleaksignore` | 5 |
 | `atlas_brain/api/__init__.py` | 2 |
-| `atlas_brain/api/leads.py` | 153 |
+| `atlas_brain/api/leads.py` | 199 |
 | `atlas_brain/main.py` | 8 |
+| `atlas_brain/services/crm_provider.py` | 15 |
 | `atlas_brain/skills/email/cleaning_confirmation.md` | 2 |
 | `atlas_brain/skills/email/estimate_confirmation.md` | 2 |
 | `atlas_brain/skills/email/proposal.md` | 2 |
 | `atlas_brain/templates/email/__init__.py` | 5 |
 | `atlas_brain/templates/email/estimate_confirmation.py` | 2 |
 | `atlas_brain/templates/email/request_acknowledgement.py` | 66 |
-| `plans/PR-EOM-Lead-Intake.md` | 169 |
-| `tests/test_leads_intake.py` | 241 |
-| **Total** | **652** |
+| `plans/PR-EOM-Lead-Intake.md` | 224 |
+| `tests/test_leads_intake.py` | 368 |
+| **Total** | **900** |

--- a/plans/PR-EOM-Lead-Intake.md
+++ b/plans/PR-EOM-Lead-Intake.md
@@ -1,0 +1,191 @@
+# PR-EOM-Lead-Intake
+
+## Why this slice exists
+
+Issue #2151 Phase 1 (operator-requested 2026-07-22). The EOM website estimate
+form's only backend is a third-party email relay (Web3Forms); Atlas never sees
+the lead at submit time. Verified current state (citations re-confirmed
+against code 2026-07-22):
+
+- Website `script.js:106` posts to a dead `/api/atlas-notify` (endpoint exists
+  nowhere) carrying only `{type, form_type, timestamp}` — no lead fields.
+- The only lead→CRM path is `gmail_digest._process_lead_emails`: default-off
+  (`autonomous.enabled=False`, `config.py:2045`), once daily (cron
+  `5 7 * * *`, `scheduler.py:356`), drops service/frequency/square_feet
+  (`_parse_form_fields`, `gmail_digest.py:290-301`), truncates message to 200
+  chars (`:360`), stamps no `business_context_id` (`:343-350`).
+- No customer acknowledgement is possible: every EOM email template requires
+  price + service date (`send_estimate`, `mcp/email_server.py:125-133`); no
+  price-free request-acknowledgement template exists.
+
+### Problem-derived contract
+
+- Root cause: Atlas has **no ingress for website lead submissions** — the
+  funnel's write path terminates at a third-party email relay, so the CRM
+  write and the instant customer acknowledgement are structurally unreachable
+  at submit time regardless of scheduler/config tuning.
+- Correct fix must touch/change: a new public intake endpoint under
+  `atlas_brain/api/` (mounted via `atlas_brain/api/__init__.py` under `/api/v1`); a
+  price-free/date-free acknowledgement template under
+  `atlas_brain/templates/email/` (+ `__init__` exports); CORS origins in
+  `main.py` so the browser can call the endpoint from
+  effinghamofficemaids.com; the stale contact data in adjacent email content
+  (3 skills docs' phone, 1 template address).
+- Must not change: `gmail_digest`/`email_classifier` (remain as redundant
+  backfill), `crm_provider` internals, `email_provider` transport, any B2B
+  endpoint, invoicing/receivables (#2133), schema/migrations, other writers'
+  tenant stamping (Phase 2), customer backfill (Phase 3), the website repo
+  (named follow-up PR).
+
+## Scope (this PR)
+
+Ownership lane: eom-crm/lead-funnel
+Slice phase: vertical slice
+
+1. New public endpoint `POST /api/v1/leads/intake` (`atlas_brain/api/leads.py`)
+   accepting the full estimate-form payload (name/email/phone/service/
+   frequency/square_feet/message + honeypot `website` + `source_page`):
+   upserts the lead via `find_or_create_contact` with `contact_type="lead"`,
+   `source="web"`, `source_ref="website_estimate_form"`,
+   `business_context_id="effingham_maids"`,
+   `tags=["website","estimate_request"]`; logs an **untruncated** `web_form`
+   interaction; best-effort sends the acknowledgement email (reply-to
+   `info@effinghamofficemaids.com`) when an email is present and the
+   interaction isn't a same-day duplicate (`log_interaction` `_inserted`
+   flag); email failure never fails the request.
+2. New template `atlas_brain/templates/email/request_acknowledgement.py` —
+   price-free, date-free, guardrail-compliant — exported via
+   `atlas_brain/templates/email/__init__.py`.
+3. `main.py`: add `https://effinghamofficemaids.com` +
+   `https://www.effinghamofficemaids.com` to `_cors_origins`.
+4. Data hygiene shipped with the email content: phone `(217) 821-2370` →
+   `(217) 207-3097` in `atlas_brain/skills/email/cleaning_confirmation.md`,
+   `atlas_brain/skills/email/estimate_confirmation.md`, and
+   `atlas_brain/skills/email/proposal.md`; address `503 S. 5th Street` →
+   `1901 S. 4th St. Ste #1, Effingham IL 62401` in
+   `atlas_brain/templates/email/estimate_confirmation.py` (matches
+   `atlas_brain/templates/email/invoice.py` + the live website).
+5. Proof: `tests/test_leads_intake.py` (repo unit style, mocked CRM/email).
+
+### Review Contract
+
+- Acceptance criteria:
+  1. Valid payload → contact upserted with kwargs
+     `business_context_id="effingham_maids"`, `contact_type="lead"`,
+     `source="web"` (test-asserted).
+  2. Logged interaction summary contains service, frequency, square_feet, and
+     the FULL message (test uses >200-char message; asserts no truncation).
+  3. Honeypot-filled submission returns success, touches neither CRM nor
+     email.
+  4. Same-day duplicate (`_inserted=False`) does not re-send the
+     acknowledgement.
+  5. Email-provider exception still returns success with `email_sent=false`.
+  6. Submission with neither email nor phone → 422.
+  7. Template contains `(217) 207-3097`, no `$`, no price/quote language;
+     send call wires `reply_to=info@effinghamofficemaids.com`.
+  8. Only additive `include_router` in `atlas_brain/api/__init__.py`; no
+     existing router moved.
+- Reachability proof: entrypoint `POST /api/v1/leads/intake` on the
+  atlas_brain app (port 8012), already publicly proxied by Tailscale Funnel
+  (`https://atlas-brain.tailc7bd29.ts.net/api` → `127.0.0.1:8012/api`;
+  `tailscale serve status` verified 2026-07-22). Observable effects:
+  `contacts` + `contact_interactions` rows, acknowledgement email. Website JS
+  pointing at it is the named follow-up in the site repo.
+- Affected surfaces: `atlas_brain/api/__init__.py` router list;
+  `atlas_brain/main.py` CORS origin list; `atlas_brain/templates/email/__init__.py`
+  exports; skills email docs (contact line only).
+- Risk areas: public unauthenticated POST (spam) — honeypot + length caps +
+  same-day dedupe, same trust model as the existing public
+  `b2b/briefings/gate`; CORS additions are origin-scoped; email misconfig
+  degrades to CRM-only capture (capture > acknowledgement).
+- Reviewer rules triggered: R1 (requirements match #2151 Phase 1), R2 (test
+  evidence: 11 unit tests), R3 (security: new public unauthenticated endpoint,
+  honeypot/validation/CORS scoping), R5 (backward compatibility: additive
+  router only; no existing API surface changed), R6 (error handling: email best-effort,
+  503 path), R8 (idempotency: same-day dedupe via interaction dedupe key),
+  R11 (config: CORS origin list), R12 (deployment: endpoint live on next
+  restart, no migration), R14 (verify against codebase).
+
+### Files touched
+
+- `atlas_brain/api/__init__.py`
+- `atlas_brain/api/leads.py`
+- `atlas_brain/main.py`
+- `atlas_brain/skills/email/cleaning_confirmation.md`
+- `atlas_brain/skills/email/estimate_confirmation.md`
+- `atlas_brain/skills/email/proposal.md`
+- `atlas_brain/templates/email/__init__.py`
+- `atlas_brain/templates/email/estimate_confirmation.py`
+- `atlas_brain/templates/email/request_acknowledgement.py`
+- `plans/PR-EOM-Lead-Intake.md`
+- `tests/test_leads_intake.py`
+
+## Mechanism
+
+`leads.py` keeps logic in an injectable async core
+`_process_lead_intake(payload, crm, email_provider)` with a thin FastAPI route
+supplying real providers — matching the repo's unit-test style (no HTTP
+client). The CRM write uses `find_or_create_contact`'s `**extra` passthrough,
+proven by `comms/webhooks.py:1545` (business_context_id),
+`gmail_digest.py:343` (tags), `b2b_vendor_briefing.py:432`
+(source/source_ref). Duplicate suppression rides the existing
+`contact_interactions` dedupe key: `log_interaction` returns
+`_inserted=False` for a same-day identical submission → skip the repeat
+email. Sending goes through `get_email_provider().send(...,
+reply_to=BUSINESS_EMAIL)` exactly like `mcp/email_server.py:169-174`.
+
+## Intentional
+
+- **No auth on the endpoint** — public form target, same trust model as the
+  existing public `b2b/briefings/gate`; a browser form cannot hold a secret.
+  Guards are honeypot + length caps + dedupe, not tokens.
+- **Email awaited inline, not BackgroundTasks** — caller is fire-and-forget
+  JS; 1–2s latency invisible; inline lets the response report `email_sent`
+  truthfully.
+- **`from_email` not forced** — Gmail sends from the authenticated account;
+  forcing `info@...` risks send-as-alias rejection. Reply-To is
+  `info@effinghamofficemaids.com` (send_estimate's proven pattern);
+  From-address alignment is deploy env `ATLAS_EMAIL_DEFAULT_FROM` (Deferred).
+- **Web3Forms untouched** — remains the operator-notification channel in
+  parallel; cutover is a later operator decision.
+- **No new config flags** — endpoint always mounted; with
+  `EmailConfig.enabled=False` (default) the send degrades gracefully and the
+  CRM write still lands.
+
+## Deferred
+
+- Website-repo follow-up PR pointing the form JS at this endpoint (same arc).
+- Per-IP/email rate-limit table beyond honeypot+dedupe.
+- Operator notification from Atlas (Web3Forms already emails the operator;
+  duplicate channel deferred until Web3Forms cutover).
+- Phases 2–3 of issue #2151 (tenant stamping/read scoping; customer backfill).
+- Deploy env note: `ATLAS_EMAIL_DEFAULT_FROM=info@effinghamofficemaids.com`.
+
+Parked hardening: per-IP/email rate-limit table (above).
+
+## Verification
+
+- Pending before push: `pytest tests/test_leads_intake.py -v`;
+  `pytest tests/test_b2b_vendor_briefing_quote_gate.py -v` (adjacent suite);
+  `python -m py_compile` on touched Python files. Results recorded here after
+  runs.
+- Manual against the live 8012 process: NOT run (production; deploy follows
+  merge). Post-deploy smoke: POST a test payload via the Funnel URL, verify
+  `contacts` row + acknowledgement email.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/api/__init__.py` | 2 |
+| `atlas_brain/api/leads.py` | 153 |
+| `atlas_brain/main.py` | 8 |
+| `atlas_brain/skills/email/cleaning_confirmation.md` | 2 |
+| `atlas_brain/skills/email/estimate_confirmation.md` | 2 |
+| `atlas_brain/skills/email/proposal.md` | 2 |
+| `atlas_brain/templates/email/__init__.py` | 5 |
+| `atlas_brain/templates/email/estimate_confirmation.py` | 2 |
+| `atlas_brain/templates/email/request_acknowledgement.py` | 66 |
+| `plans/PR-EOM-Lead-Intake.md` | 169 |
+| `tests/test_leads_intake.py` | 241 |
+| **Total** | **652** |

--- a/tests/test_leads_intake.py
+++ b/tests/test_leads_intake.py
@@ -1,0 +1,241 @@
+"""Tests for the EOM website lead-intake endpoint (issue #2151 Phase 1).
+
+Covers the Review Contract in plans/PR-EOM-Lead-Intake.md:
+  1. tenant/source stamping on the CRM upsert
+  2. untruncated interaction logging (service/frequency/sqft + full message)
+  3. honeypot silent drop (no CRM, no email)
+  4. same-day duplicate does not re-send the acknowledgement
+  5. email failure never fails the request
+  6. neither email nor phone -> validation error
+  7. template guardrails: correct phone, no price/quote language; reply-to wiring
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_asyncpg_mock = MagicMock()
+_asyncpg_exceptions = MagicMock()
+_asyncpg_exceptions.UndefinedTableError = type("UndefinedTableError", (Exception,), {})
+_asyncpg_mock.exceptions = _asyncpg_exceptions
+sys.modules.setdefault("asyncpg", _asyncpg_mock)
+sys.modules.setdefault("asyncpg.exceptions", _asyncpg_exceptions)
+
+from atlas_brain.api.leads import (  # noqa: E402
+    EOM_BUSINESS_CONTEXT_ID,
+    LeadIntakeRequest,
+    LeadValidationError,
+    _process_lead_intake,
+)
+from atlas_brain.templates.email.request_acknowledgement import (  # noqa: E402
+    format_request_acknowledgement,
+)
+
+
+LONG_MESSAGE = (
+    "We have a three-story home with a finished basement and two dogs. "
+    "Mostly interested in the main floor and the upstairs bathrooms, the "
+    "basement only occasionally. Hardwood throughout the main level that "
+    "needs gentle treatment, and we'd prefer visits while we're at work. "
+    "Please also note the bonus room over the garage is rarely used."
+)
+assert len(LONG_MESSAGE) > 200  # guards the truncation regression test
+
+
+def _payload(**overrides):
+    base = dict(
+        name="Jane Doe",
+        email="jane@example.com",
+        phone="217-555-0100",
+        service="residential",
+        frequency="bi-weekly",
+        square_feet="2400",
+        message=LONG_MESSAGE,
+        source_page="/house-cleaning-services/",
+    )
+    base.update(overrides)
+    return LeadIntakeRequest(**base)
+
+
+def _crm(inserted: bool = True):
+    crm = MagicMock()
+    crm.find_or_create_contact = AsyncMock(return_value={"id": "c-123"})
+    crm.log_interaction = AsyncMock(return_value={"id": "i-1", "_inserted": inserted})
+    return crm
+
+
+def _email_provider(success: bool = True):
+    provider = MagicMock()
+    provider.send = AsyncMock(return_value={"success": success})
+    return provider
+
+
+# ---------------------------------------------------------------------------
+# 1. Tenant + source stamping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_contact_stamped_with_eom_tenant_and_web_source():
+    crm, provider = _crm(), _email_provider()
+    result = await _process_lead_intake(_payload(), crm=crm, email_provider=provider)
+
+    assert result["success"] is True
+    assert result["contact_id"] == "c-123"
+    kwargs = crm.find_or_create_contact.call_args.kwargs
+    assert kwargs["business_context_id"] == EOM_BUSINESS_CONTEXT_ID == "effingham_maids"
+    assert kwargs["contact_type"] == "lead"
+    assert kwargs["source"] == "web"
+    assert kwargs["source_ref"] == "website_estimate_form"
+    assert kwargs["tags"] == ["website", "estimate_request"]
+    assert kwargs["email"] == "jane@example.com"
+
+
+# ---------------------------------------------------------------------------
+# 2. Untruncated interaction logging
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_interaction_summary_keeps_all_fields_untruncated():
+    crm, provider = _crm(), _email_provider()
+    await _process_lead_intake(_payload(), crm=crm, email_provider=provider)
+
+    kwargs = crm.log_interaction.call_args.kwargs
+    assert kwargs["interaction_type"] == "web_form"
+    assert kwargs["intent"] == "estimate_request"
+    summary = kwargs["summary"]
+    # The gmail_digest path drops these three and truncates to 200 chars;
+    # this endpoint must not.
+    assert "residential" in summary
+    assert "bi-weekly" in summary
+    assert "2400" in summary
+    assert LONG_MESSAGE in summary  # full message, no truncation
+    assert kwargs["metadata"]["square_feet"] == "2400"
+
+
+# ---------------------------------------------------------------------------
+# 3. Honeypot
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_honeypot_drops_silently_without_crm_or_email():
+    crm, provider = _crm(), _email_provider()
+    result = await _process_lead_intake(
+        _payload(website="http://spam.example"), crm=crm, email_provider=provider
+    )
+
+    assert result == {"success": True, "contact_id": None, "email_sent": False}
+    crm.find_or_create_contact.assert_not_awaited()
+    crm.log_interaction.assert_not_awaited()
+    provider.send.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# 4. Same-day duplicate does not re-send the acknowledgement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_duplicate_submission_skips_acknowledgement_email():
+    crm, provider = _crm(inserted=False), _email_provider()
+    result = await _process_lead_intake(_payload(), crm=crm, email_provider=provider)
+
+    assert result["success"] is True
+    assert result["email_sent"] is False
+    provider.send.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# 5. Email failure never fails the request
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_email_provider_exception_still_returns_success():
+    crm = _crm()
+    provider = MagicMock()
+    provider.send = AsyncMock(side_effect=RuntimeError("smtp down"))
+
+    result = await _process_lead_intake(_payload(), crm=crm, email_provider=provider)
+
+    assert result["success"] is True
+    assert result["email_sent"] is False
+    crm.log_interaction.assert_awaited()  # CRM write happened regardless
+
+
+@pytest.mark.asyncio
+async def test_phone_only_lead_skips_email_but_succeeds():
+    crm, provider = _crm(), _email_provider()
+    result = await _process_lead_intake(
+        _payload(email=""), crm=crm, email_provider=provider
+    )
+
+    assert result["success"] is True
+    assert result["email_sent"] is False
+    provider.send.assert_not_awaited()
+    assert crm.find_or_create_contact.call_args.kwargs["email"] is None
+
+
+# ---------------------------------------------------------------------------
+# 6. Validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_email_and_phone_rejected():
+    crm, provider = _crm(), _email_provider()
+    with pytest.raises(LeadValidationError):
+        await _process_lead_intake(
+            _payload(email="", phone=""), crm=crm, email_provider=provider
+        )
+    crm.find_or_create_contact.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_malformed_email_rejected():
+    crm, provider = _crm(), _email_provider()
+    with pytest.raises(LeadValidationError):
+        await _process_lead_intake(
+            _payload(email="not-an-email"), crm=crm, email_provider=provider
+        )
+
+
+# ---------------------------------------------------------------------------
+# 7. Acknowledgement template guardrails + send wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_acknowledgement_send_wiring_reply_to_business_email():
+    crm, provider = _crm(), _email_provider()
+    await _process_lead_intake(_payload(), crm=crm, email_provider=provider)
+
+    send_kwargs = provider.send.call_args.kwargs
+    assert send_kwargs["to"] == ["jane@example.com"]
+    assert send_kwargs["reply_to"] == "info@effinghamofficemaids.com"
+    assert "estimate request" in send_kwargs["subject"].lower()
+
+
+def test_template_guardrails_no_prices_no_quotes_correct_phone():
+    subject, body = format_request_acknowledgement(
+        client_name="Jane", service="residential", frequency="bi-weekly"
+    )
+    combined = subject + body
+    assert "(217) 207-3097" in body
+    assert "(217) 821-2370" not in combined  # the stale number this PR retires
+    assert "$" not in combined  # no dollar figures, ever (operator rule)
+    assert "quote" not in combined.lower()  # "estimate" is the approved word
+    assert "same-day" not in combined.lower()
+    assert "within 24 hours" in body
+    assert "Your request: residential, bi-weekly." in body
+
+
+def test_template_omits_request_line_when_fields_empty():
+    _, body = format_request_acknowledgement(client_name="")
+    assert "Your request:" not in body
+    assert "Hi there," in body  # empty name falls back gracefully

--- a/tests/test_leads_intake.py
+++ b/tests/test_leads_intake.py
@@ -26,9 +26,12 @@ sys.modules.setdefault("asyncpg.exceptions", _asyncpg_exceptions)
 
 from atlas_brain.api.leads import (  # noqa: E402
     EOM_BUSINESS_CONTEXT_ID,
+    MAX_DAILY_SUBMISSIONS,
     LeadIntakeRequest,
+    LeadRateLimitedError,
     LeadValidationError,
     _process_lead_intake,
+    router,
 )
 from atlas_brain.templates.email.request_acknowledgement import (  # noqa: E402
     format_request_acknowledgement,
@@ -63,7 +66,7 @@ def _payload(**overrides):
 def _crm(inserted: bool = True):
     crm = MagicMock()
     crm.find_or_create_contact = AsyncMock(return_value={"id": "c-123"})
-    crm.log_interaction = AsyncMock(return_value={"id": "i-1", "_inserted": inserted})
+    crm.log_interaction = AsyncMock(return_value={"id": "i-1", "inserted": inserted})
     return crm
 
 
@@ -239,3 +242,127 @@ def test_template_omits_request_line_when_fields_empty():
     _, body = format_request_acknowledgement(client_name="")
     assert "Your request:" not in body
     assert "Hi there," in body  # empty name falls back gracefully
+
+
+# ---------------------------------------------------------------------------
+# PR #2152 review reconciliation — throttle, phone digits, scoped dedupe,
+# route smoke
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_daily_cap_blocks_before_any_side_effect():
+    crm, provider = _crm(), _email_provider()
+    counter = AsyncMock(return_value=MAX_DAILY_SUBMISSIONS)
+    with pytest.raises(LeadRateLimitedError):
+        await _process_lead_intake(
+            _payload(), crm=crm, email_provider=provider, daily_count=counter
+        )
+    crm.find_or_create_contact.assert_not_awaited()
+    crm.log_interaction.assert_not_awaited()
+    provider.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_daily_cap_under_limit_proceeds():
+    crm, provider = _crm(), _email_provider()
+    counter = AsyncMock(return_value=MAX_DAILY_SUBMISSIONS - 1)
+    result = await _process_lead_intake(
+        _payload(), crm=crm, email_provider=provider, daily_count=counter
+    )
+    assert result["success"] is True
+    counter.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_phone_without_dialable_digits_rejected_as_only_channel():
+    crm, provider = _crm(), _email_provider()
+    with pytest.raises(LeadValidationError):
+        await _process_lead_intake(
+            _payload(email="", phone="n/a"), crm=crm, email_provider=provider
+        )
+    crm.find_or_create_contact.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_garbage_phone_dropped_when_email_present():
+    crm, provider = _crm(), _email_provider()
+    result = await _process_lead_intake(
+        _payload(phone="—"), crm=crm, email_provider=provider
+    )
+    assert result["success"] is True
+    assert crm.find_or_create_contact.call_args.kwargs["phone"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_contact_dedupe_is_tenant_scoped():
+    """Provider-level regression for the cross-tenant mutation finding:
+    when data carries business_context_id, both dedupe searches must be
+    scoped to that tenant."""
+    from atlas_brain.services.crm_provider import DatabaseCRMProvider
+
+    provider = DatabaseCRMProvider.__new__(DatabaseCRMProvider)
+    provider.search_contacts = AsyncMock(return_value=[{"id": "existing-eom"}])
+    provider.update_contact = AsyncMock(return_value={"id": "existing-eom"})
+
+    result = await provider.create_contact(
+        {
+            "full_name": "Jane Doe",
+            "email": "jane@example.com",
+            "phone": "2175550100",
+            "business_context_id": "effingham_maids",
+        }
+    )
+    assert result["id"] == "existing-eom"
+    for call in provider.search_contacts.await_args_list:
+        assert call.kwargs.get("business_context_id") == "effingham_maids"
+
+
+@pytest.mark.asyncio
+async def test_create_contact_dedupe_unscoped_without_context():
+    """Without a stamped tenant the legacy global dedupe is preserved."""
+    from atlas_brain.services.crm_provider import DatabaseCRMProvider
+
+    provider = DatabaseCRMProvider.__new__(DatabaseCRMProvider)
+    provider.search_contacts = AsyncMock(return_value=[{"id": "existing-any"}])
+    provider.update_contact = AsyncMock(return_value={"id": "existing-any"})
+
+    await provider.create_contact({"full_name": "X", "email": "x@example.com"})
+    for call in provider.search_contacts.await_args_list:
+        assert "business_context_id" not in call.kwargs
+
+
+def test_route_smoke_mounted_path_statuses(monkeypatch):
+    """Route-level smoke: the mounted POST /api/v1/leads/intake path maps
+    outcomes to 200 / 422 / 429 (the injectable-core tests can't see this)."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    import atlas_brain.api.leads as leads_mod
+    from atlas_brain.services import crm_provider as crm_mod
+    from atlas_brain.services import email_provider as email_mod
+
+    monkeypatch.setattr(crm_mod, "get_crm_provider", lambda: _crm())
+    monkeypatch.setattr(email_mod, "get_email_provider", lambda: _email_provider())
+    counter = {"n": 0}
+
+    async def fake_count(email, phone):
+        return counter["n"]
+
+    monkeypatch.setattr(leads_mod, "_daily_submission_count", fake_count)
+
+    app = FastAPI()
+    app.include_router(leads_mod.router, prefix="/api/v1")
+    client = TestClient(app)
+
+    ok = client.post("/api/v1/leads/intake", json={"name": "Jane", "email": "jane@example.com"})
+    assert ok.status_code == 200 and ok.json()["success"] is True
+
+    bad = client.post("/api/v1/leads/intake", json={"name": "Jane"})
+    assert bad.status_code == 422
+
+    counter["n"] = MAX_DAILY_SUBMISSIONS
+    throttled = client.post(
+        "/api/v1/leads/intake", json={"name": "Jane", "email": "jane@example.com"}
+    )
+    assert throttled.status_code == 429


### PR DESCRIPTION
Plan: plans/PR-EOM-Lead-Intake.md
Slice phase: vertical slice
Ownership lane: eom-crm/lead-funnel
Diff-budget override: vertical slice is indivisible — 432 of 669 added lines are the mandatory plan doc (191) + the Review-Contract test suite (241); production code is ~237 LOC. Splitting endpoint/template/wiring would ship an unmounted route or an untested public surface, both forbidden by AGENTS.md. Overage pre-flagged in the plan's Estimated diff size section.

Phase 1 of #2151 (EOM lead funnel). The website estimate form's only backend is a third-party email relay; Atlas never sees the lead at submit time, no tenant-stamped CRM write exists, and no price-free acknowledgement template exists. This slice adds the real-time ingress: `POST /api/v1/leads/intake` (public, honeypot + length caps + same-day dedupe) upserting an `effingham_maids`-stamped lead with an untruncated interaction log, plus a guardrail-compliant request-acknowledgement email (reply-to `info@effinghamofficemaids.com`), CORS for effinghamofficemaids.com, and the stale phone/address hygiene fixes in adjacent email content.

## Intentional
- No auth on the endpoint — public form target, same trust model as the existing public `b2b/briefings/gate`; a browser form cannot hold a secret. Guards are honeypot + length caps + dedupe, not tokens.
- Email awaited inline (not BackgroundTasks) — caller is fire-and-forget JS; inline lets the response report `email_sent` truthfully.
- `from_email` not forced — reply-to `info@effinghamofficemaids.com` per `send_estimate`'s proven pattern; From alignment is deploy env `ATLAS_EMAIL_DEFAULT_FROM` (Deferred).
- Web3Forms untouched — remains the operator-notification channel in parallel; cutover is a later operator decision.
- No new config flags — endpoint always mounted; with `EmailConfig.enabled=False` (default) the send degrades gracefully and the CRM write still lands.

## Deferred
- Website-repo follow-up PR pointing the form JS at this endpoint (same arc).
- Per-IP/email rate-limit table beyond honeypot+dedupe.
- Operator notification from Atlas (Web3Forms already emails the operator).
- Phases 2-3 of #2151 (tenant stamping of remaining writers + read scoping; customer backfill).
- Deploy env note: `ATLAS_EMAIL_DEFAULT_FROM=info@effinghamofficemaids.com`.

## Parked hardening
- Per-IP/email rate-limit table (named in plan Deferred; honeypot + dedupe cover the v1 spam surface).

## Cold diff reconstruction
- Changed: `atlas_brain/api/leads.py` (new, 153 lines) — `LeadIntakeRequest` model with length caps + honeypot field; injectable `_process_lead_intake` (honeypot silent-drop at :74; validation :79-83; tenant-stamped `find_or_create_contact` :86-95; untruncated `log_interaction` :101-112; `_inserted`-gated best-effort email :117-135); thin route `POST /leads/intake` mapping `LeadValidationError`→422, other failures→503.
- Changed: `atlas_brain/templates/email/request_acknowledgement.py` (new, 66 lines) — `ACK_SUBJECT`/`ACK_TEMPLATE` + `format_request_acknowledgement`; price-free, date-free, "within 24 hours" only; imports branding constants from `estimate_confirmation`.
- Changed: `atlas_brain/api/__init__.py:30,108` — import + additive `include_router(leads_router)`; no existing router moved.
- Changed: `atlas_brain/main.py:957-963` — two production origins appended to `_cors_origins` (origin-scoped, no wildcard).
- Changed: `atlas_brain/templates/email/__init__.py` — export `format_request_acknowledgement`.
- Changed: `atlas_brain/templates/email/estimate_confirmation.py:9` — address `503 S. 5th Street` → `1901 S. 4th St. Ste #1, Effingham IL 62401`.
- Changed: `atlas_brain/skills/email/{cleaning_confirmation.md:46, estimate_confirmation.md:44, proposal.md:43}` — phone `(217) 821-2370` → `(217) 207-3097`.
- Changed: `tests/test_leads_intake.py` (new, 241 lines) — 11 tests covering the Review Contract 1:1.
- Changed: `plans/PR-EOM-Lead-Intake.md` (new) — the plan this body mirrors.
- Contract match: every change traces to the Problem-derived contract (ingress endpoint + acknowledgement template + CORS + adjacent-content hygiene); nothing outside it moved.
- Gaps: none.
- Changed (reconciliation commit c04092c58): `atlas_brain/services/crm_provider.py` — tenant-scoped dedupe in `create_contact` when `business_context_id` is stamped (both searches carry the scope; unstamped callers keep legacy global dedupe) + public `inserted` flag on `log_interaction` returns; `atlas_brain/api/leads.py` — pre-side-effect daily throttle (429, cap 5/identity/day, injectable counter), >=7-digit phone validation, duplicate gate reads the public `inserted` flag; `.gitleaksignore` — false-positive fingerprint for plan prose; `tests/test_leads_intake.py` — 7 new tests (throttle x2, phone x2, dedupe scoping x2, mounted-route smoke 200/422/429).

## Verification
- `pytest tests/test_leads_intake.py -v` — 11 passed.
- `pytest tests/test_b2b_vendor_briefing_quote_gate.py` — 29 passed (adjacent email suite).
- `python -m py_compile` on all touched Python files — clean.
- NOT run: live smoke against the production 8012 process (deploy follows merge). Post-deploy smoke: POST test payload via the Funnel URL, verify `contacts` row + acknowledgement email.

## AI reconciliation

AI findings reviewed: yes (Codex, 5 threads on the initial commit). All fixed or waived: yes — all five fixed in c04092c58, none waived.

- P1 "Scope lead upserts to the EOM tenant" -> fixed: `create_contact` dedupe is tenant-scoped when `business_context_id` is stamped; regression tests assert the scope is passed (and absent for unstamped callers).
- P1 "Add server-side throttling before side effects" -> fixed: daily cap (5/identity/day) enforced before any CRM/email side effect; 429 at the route; tests assert no side effects on the throttled path.
- P2 "Preserve the CRM inserted flag before emailing" -> fixed: provider now returns a public `inserted` key; the email gate reads it (finding was correct — production popped `_inserted`, so the gate previously defaulted open).
- P2 "Add a real route smoke test" -> fixed: TestClient against the mounted `/api/v1/leads/intake` path asserts 200/422/429.
- P2 "Reject unusable phone-only leads" -> fixed: phone must carry >=7 dialable digits to count as a contact channel; "n/a"-style values are rejected when they are the only channel.

## Diff size
13 files, +897 / -7
