### PR TITLE
feat: tenant-stamp all contact writers + NULL-context backfill (#2151 Phase 2)

### DIFF
--- a/atlas_brain/api/b2b_vendor_briefing.py
+++ b/atlas_brain/api/b2b_vendor_briefing.py
@@ -435,6 +435,7 @@ async def briefing_gate(body: GateRequest):
             contact_type="lead",
             source="briefing_gate",
             source_ref=vendor_name,
+            business_context_id="churnsignals",
         )
         contact_id = contact.get("id")
         if contact_id:

--- a/atlas_brain/autonomous/tasks/email_backfill.py
+++ b/atlas_brain/autonomous/tasks/email_backfill.py
@@ -200,6 +200,7 @@ async def run(task: ScheduledTask) -> dict:
                 email=recipient_email,
                 source="email_backfill",
                 contact_type="customer",
+                business_context_id="effingham_maids",
             )
             if not contact.get("id"):
                 continue

--- a/atlas_brain/autonomous/tasks/email_intake.py
+++ b/atlas_brain/autonomous/tasks/email_intake.py
@@ -616,6 +616,7 @@ async def _detect_campaign_replies(pool, emails: list[dict[str, Any]]) -> int:
                         "contact_type": "lead",
                         "source": "campaign_reply",
                         "source_ref": str(sequence_id),
+                        "business_context_id": "churnsignals",
                     })
                     contact_id = contact.get("id")
                     if contact_id:

--- a/atlas_brain/autonomous/tasks/gmail_digest.py
+++ b/atlas_brain/autonomous/tasks/gmail_digest.py
@@ -345,6 +345,7 @@ async def _process_lead_emails(emails: list[dict[str, Any]]) -> None:
                 email=submitter_email or None,
                 phone=submitter_phone,
                 source="web",
+                business_context_id="effingham_maids",
                 contact_type="lead",
                 tags=["web3forms"],
             )

--- a/atlas_brain/tools/scheduling.py
+++ b/atlas_brain/tools/scheduling.py
@@ -429,6 +429,7 @@ class BookAppointmentTool:
                         phone=customer_phone,
                         email=customer_email,
                         source="booking",
+                        business_context_id=context.id,
                     )
                     contact_id_str = str(contact.get("id", "")) if contact else None
                     if contact_id_str:

--- a/extracted_competitive_intelligence/api/b2b_vendor_briefing.py
+++ b/extracted_competitive_intelligence/api/b2b_vendor_briefing.py
@@ -442,6 +442,7 @@ async def briefing_gate(body: GateRequest):
             contact_type="lead",
             source="briefing_gate",
             source_ref=vendor_name,
+            business_context_id="churnsignals",
         )
         contact_id = contact.get("id")
         if contact_id:

--- a/plans/PR-EOM-Tenant-Separation.md
+++ b/plans/PR-EOM-Tenant-Separation.md
@@ -1,0 +1,162 @@
+# PR-EOM-Tenant-Separation
+
+## Why this slice exists
+
+Issue #2151 Phase 2 (operator-requested continuation after Phase 1 / PR #2153
+deployed). Six CRM contact writers stamp no `business_context_id`, so EOM and
+B2B (churnsignals) records mix in one `contacts` table, and historical rows
+sit at NULL. Verified at HEAD 44ddd9964 (2026-07-23):
+
+- `atlas_brain/tools/scheduling.py:427` (booking) — no stamp, though
+  `context.id` is in scope (`:407` stamps the appointment).
+- `atlas_brain/autonomous/tasks/gmail_digest.py:343` (web3forms lead) — no
+  stamp.
+- `atlas_brain/autonomous/tasks/email_backfill.py:198` — no stamp.
+- `scripts/import_calendar_contacts.py:492` (contact_data) — no stamp.
+- **B2B leak:** `atlas_brain/api/b2b_vendor_briefing.py:432` and
+  `atlas_brain/autonomous/tasks/email_intake.py:613` write
+  `contact_type='lead'` with NULL context into the shared table.
+- No backfill script exists for existing NULL rows.
+
+### Problem-derived contract
+
+- Root cause: contact writes never declare tenant ownership, so tenancy is
+  unknowable at read time and unfixable retroactively without provenance
+  rules; the two B2B writers additionally leak software-sales leads into the
+  same NULL pool as cleaning customers.
+- Correct fix must touch/change: the six writer call sites (stamp
+  `effingham_maids` for EOM flows via literal or `context.id`;
+  `churnsignals` for the two B2B flows); a one-time, idempotent,
+  dry-run-first backfill script classifying existing NULL rows by write
+  provenance (source values are writer-unique; EOM appointments are
+  tenant-stamped NOT NULL by schema `012:24` and give trustworthy linkage).
+- Must not change: `crm_provider` (Phase 1 already made stamped dedupe
+  tenant-safe: same-tenant page, then claimable-NULL page), read-path
+  filtering/defaults (deferred to its own slice — see Deferred), schema,
+  the lead-intake endpoint, any B2B briefing/campaign behavior beyond the
+  stamp, Phase 3 customer import.
+
+## Scope (this PR)
+
+Ownership lane: eom-crm/lead-funnel
+Slice phase: vertical slice
+
+1. Stamp `business_context_id` on all six previously NULL-context contact
+   writers: booking (`context.id`), gmail_digest web-lead, email_backfill,
+   calendar import (`effingham_maids`); briefing gate + campaign reply
+   (`churnsignals` — stops the B2B leak at the source).
+2. New `scripts/backfill_business_context.py`: dry-run-by-default,
+   `--apply` to write, idempotent (only touches rows still NULL).
+   Classification: EOM by source (`booking, web, email_backfill,
+   calendar_import`) and by tenant-stamped appointment linkage; B2B by
+   source (`briefing_gate, campaign_reply`); everything else stays NULL and
+   is reported, never guessed.
+3. Proof: `tests/test_tenant_stamping.py` — pure classification tests,
+   SQL-predicate guards (NULL-only, appointment-stamp requirement,
+   disjoint source maps), and AST-verified kwargs on every stamped
+   `find_or_create_contact` site (refactors that drop the stamp fail).
+
+### Review Contract
+
+- Acceptance criteria:
+  1. Every listed writer passes `business_context_id` (AST-asserted for the
+     four kwargs sites; text-asserted for the two dict sites).
+  2. Booking uses the runtime `context.id`, matching its appointment stamp.
+  3. B2B writers stamp `churnsignals`, ending NULL-context B2B lead writes.
+  4. Backfill only ever updates rows `WHERE business_context_id IS NULL`
+     (asserted on both UPDATE statements).
+  5. Appointment-linkage backfill requires the appointment's own
+     `business_context_id = 'effingham_maids'`.
+  6. EOM and B2B source maps are disjoint (asserted).
+  7. Unknown sources (`manual`, `sms`, `call`, ...) are never guessed —
+     reported and left NULL.
+  8. Dry run performs zero writes; `--apply` is required to mutate.
+- Reachability proof: writers execute on their existing production flows
+  (booking tool, gmail digest task, backfill task, calendar import script,
+  public briefing gate, campaign-reply intake); the backfill is
+  operator-run: `python scripts/backfill_business_context.py [--apply]`
+  against the live pool (same bootstrap as `import_calendar_contacts.py`).
+  Observable effect: NULL-context contact counts drop to the unclassifiable
+  remainder, reported by source.
+- Affected surfaces: the six writer call sites (one kwarg each), new
+  script, new test file. No API/schema/read-path changes.
+- Risk areas: misclassification in backfill (mitigated: writer-unique
+  source values, disjoint maps, appointment stamps NOT NULL by schema,
+  dry-run default, unknowns left NULL); stamped writers now dedupe
+  tenant-scoped via Phase 1's provider logic — intended (they claim
+  legacy NULL rows and can no longer merge into foreign tenants).
+- Reviewer rules triggered: R1 (matches #2151 Phase 2), R2 (tests named
+  above), R3 (tenant isolation — leak stopped at source), R4 (data safety:
+  NULL-only updates, dry-run default, no guessing), R5 (backward compat: additive kwargs; unstamped callers
+  unchanged), R6 (jobs: digest/backfill/intake keep their fail-open error
+  handling; the stamp adds no new failure path), R8 (idempotent backfill),
+  R14.
+
+### Files touched
+
+- `atlas_brain/api/b2b_vendor_briefing.py`
+- `atlas_brain/autonomous/tasks/email_backfill.py`
+- `atlas_brain/autonomous/tasks/email_intake.py`
+- `atlas_brain/autonomous/tasks/gmail_digest.py`
+- `atlas_brain/tools/scheduling.py`
+- `plans/PR-EOM-Tenant-Separation.md`
+- `scripts/backfill_business_context.py`
+- `scripts/import_calendar_contacts.py`
+- `tests/test_tenant_stamping.py`
+
+## Mechanism
+
+Each writer gains one `business_context_id` kwarg/key — the provider
+(`create_contact`) already persists it (`035:27` column) and, since #2153,
+uses it for tenant-safe dedupe (same-tenant page first, then claimable
+NULL-context page, never foreign). The backfill reuses the UPDATE
+predicates as SELECT COUNTs for the dry run, so what it reports is exactly
+what `--apply` would touch.
+
+## Intentional
+
+- **Read-path scoping deferred** — enforcing default `business_context_id`
+  filters on EOM read surfaces (MCP crm server, contacts API) is its own
+  surface-mapping exercise; bundling it here would blow the slice.
+- **`churnsignals` context id is not pre-registered** — the column is a free
+  VARCHAR by design (`035:27`); `atlas_comms` context registration is a
+  voice/SMS concern, not a CRM constraint.
+- **No test harnesses for the six async flows** — the stamps are one-line
+  kwargs inside large flows (calls, digests, IMAP backfills); AST-level
+  assertion pins the contract without building six heavy fixtures.
+- **Backfill leaves unknowns NULL** — `manual`/`sms`/`call` sources exist in
+  both worlds historically; guessing would corrupt tenancy. They surface in
+  the report for operator decision (Phase 3 material).
+
+## Deferred
+
+- Read-path tenant filtering defaults for EOM surfaces (next slice of
+  #2151 Phase 2).
+- Phase 3: customer-master import (calendar ICS / appointments-driven).
+- Operator run of the backfill (`--apply`) after merge + deploy; the
+  remaining-NULL report feeds Phase 3.
+
+Parked hardening: none new (Phase 1's parked items unchanged).
+
+## Verification
+
+- Suite `tests/test_tenant_stamping.py` — 8 passed.
+- Adjacent suites `tests/test_leads_intake.py` + `tests/test_b2b_vendor_briefing_quote_gate.py` — 65 passed combined.
+- `python -m py_compile` on all seven touched Python files — clean.
+- NOT run: the backfill against the live DB (operator-run post-merge;
+  dry-run first by design).
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/api/b2b_vendor_briefing.py` | 1 |
+| `atlas_brain/autonomous/tasks/email_backfill.py` | 1 |
+| `atlas_brain/autonomous/tasks/email_intake.py` | 1 |
+| `atlas_brain/autonomous/tasks/gmail_digest.py` | 1 |
+| `atlas_brain/tools/scheduling.py` | 1 |
+| `plans/PR-EOM-Tenant-Separation.md` | 148 |
+| `scripts/backfill_business_context.py` | 118 |
+| `scripts/import_calendar_contacts.py` | 1 |
+| `tests/test_tenant_stamping.py` | 111 |
+| **Total** | **383** |

--- a/plans/PR-EOM-Tenant-Separation.md
+++ b/plans/PR-EOM-Tenant-Separation.md
@@ -41,16 +41,22 @@ sit at NULL. Verified at HEAD 44ddd9964 (2026-07-23):
 Ownership lane: eom-crm/lead-funnel
 Slice phase: vertical slice
 
-1. Stamp `business_context_id` on all six previously NULL-context contact
+1. Stamp `business_context_id` on all seven previously NULL-context contact
    writers: booking (`context.id`), gmail_digest web-lead, email_backfill,
-   calendar import (`effingham_maids`); briefing gate + campaign reply
-   (`churnsignals` — stops the B2B leak at the source).
+   calendar import (`effingham_maids`); briefing gate + campaign reply +
+   the extracted-package mirror gate
+   (`extracted_competitive_intelligence/api/b2b_vendor_briefing.py`) as
+   `churnsignals` — stops the B2B leak at every source.
 2. New `scripts/backfill_business_context.py`: dry-run-by-default,
-   `--apply` to write, idempotent (only touches rows still NULL).
-   Classification: EOM by source (`booking, web, email_backfill,
-   calendar_import`) and by tenant-stamped appointment linkage; B2B by
-   source (`briefing_gate, campaign_reply`); everything else stays NULL and
-   is reported, never guessed.
+   `--apply` to write, idempotent (only touches rows still NULL). Two
+   evidence tiers: tier 1 (default) = tenant-stamped appointment linkage
+   (schema-trustworthy, `012:24` NOT NULL); tier 2 (opt-in
+   `--classify-by-source`, operator-attested) = writer-unique source maps
+   (`contacts.source` is free text also settable via the MCP crm tool, so
+   it is never trusted automatically). Everything else stays NULL and is
+   reported, never guessed. Count and UPDATE statements share their WHERE
+   clause verbatim with positionally-complete parameters (no skipped
+   placeholders).
 3. Proof: `tests/test_tenant_stamping.py` — pure classification tests,
    SQL-predicate guards (NULL-only, appointment-stamp requirement,
    disjoint source maps), and AST-verified kwargs on every stamped
@@ -89,8 +95,9 @@ Slice phase: vertical slice
   above), R3 (tenant isolation — leak stopped at source), R4 (data safety:
   NULL-only updates, dry-run default, no guessing), R5 (backward compat: additive kwargs; unstamped callers
   unchanged), R6 (jobs: digest/backfill/intake keep their fail-open error
-  handling; the stamp adds no new failure path), R8 (idempotent backfill),
-  R14.
+  handling; the stamp adds no new failure path), R8 (idempotent backfill), R10
+  (maintainability: the extracted-package mirror gate is stamped
+  identically to its atlas_brain twin, keeping the two in lockstep), R14.
 
 ### Files touched
 
@@ -99,6 +106,7 @@ Slice phase: vertical slice
 - `atlas_brain/autonomous/tasks/email_intake.py`
 - `atlas_brain/autonomous/tasks/gmail_digest.py`
 - `atlas_brain/tools/scheduling.py`
+- `extracted_competitive_intelligence/api/b2b_vendor_briefing.py`
 - `plans/PR-EOM-Tenant-Separation.md`
 - `scripts/backfill_business_context.py`
 - `scripts/import_calendar_contacts.py`
@@ -133,7 +141,11 @@ what `--apply` would touch.
 - Read-path tenant filtering defaults for EOM surfaces (next slice of
   #2151 Phase 2).
 - Phase 3: customer-master import (calendar ICS / appointments-driven).
-- Operator run of the backfill (`--apply`) after merge + deploy; the
+- Operator backfill runbook (ordering matters — a live stamped writer can
+  claim a NULL row for either tenant before backfill classifies it): merge
+  -> pull runtime worktree -> run backfill `--apply` (tier 1, plus tier 2
+  with attestation) BEFORE restarting the service -> restart -> re-run the
+  backfill (idempotent) to sweep rows written during the window. The
   remaining-NULL report feeds Phase 3.
 
 Parked hardening: none new (Phase 1's parked items unchanged).
@@ -155,8 +167,9 @@ Parked hardening: none new (Phase 1's parked items unchanged).
 | `atlas_brain/autonomous/tasks/email_intake.py` | 1 |
 | `atlas_brain/autonomous/tasks/gmail_digest.py` | 1 |
 | `atlas_brain/tools/scheduling.py` | 1 |
-| `plans/PR-EOM-Tenant-Separation.md` | 148 |
-| `scripts/backfill_business_context.py` | 118 |
+| `extracted_competitive_intelligence/api/b2b_vendor_briefing.py` | 1 |
+| `plans/PR-EOM-Tenant-Separation.md` | 172 |
+| `scripts/backfill_business_context.py` | 136 |
 | `scripts/import_calendar_contacts.py` | 1 |
-| `tests/test_tenant_stamping.py` | 111 |
-| **Total** | **383** |
+| `tests/test_tenant_stamping.py` | 134 |
+| **Total** | **449** |

--- a/scripts/backfill_business_context.py
+++ b/scripts/backfill_business_context.py
@@ -1,22 +1,24 @@
 """One-time backfill of NULL business_context_id contacts (issue #2151 Phase 2).
 
-Classifies existing NULL-context contact rows by their write provenance:
+Two evidence tiers:
 
-- ``effingham_maids``: sources written only by EOM flows (booking, web,
-  email_backfill, calendar_import), plus any contact linked from a
-  tenant-stamped EOM appointment (appointments.business_context_id is
-  NOT NULL by schema, so that linkage is trustworthy provenance).
-- ``churnsignals``: sources written only by the B2B flows
-  (briefing_gate, campaign_reply).
-- Everything else stays NULL and is reported, never guessed.
+1. **Appointment linkage (default, schema-trustworthy):** a contact linked
+   from an appointment stamped ``effingham_maids`` is claimed for EOM —
+   ``appointments.business_context_id`` is NOT NULL by schema, so this
+   provenance cannot lie.
+2. **Source maps (opt-in via ``--classify-by-source``):** ``contacts.source``
+   is a free VARCHAR also settable through the MCP crm tool without a
+   context, so source-only classification is operator-attested, not
+   automatic. Without the flag those rows are only REPORTED as proposals.
 
-Dry-run by default; pass ``--apply`` to write. Idempotent: only rows that
-are still NULL are ever touched, so re-running after the writers were
-stamped (same slice) converges to zero work.
+Everything unclassified stays NULL and is reported, never guessed.
+Dry-run by default; ``--apply`` writes. Idempotent: only rows still NULL are
+ever touched.
 
 Usage:
-    python scripts/backfill_business_context.py            # report only
-    python scripts/backfill_business_context.py --apply    # write
+    python scripts/backfill_business_context.py                          # report
+    python scripts/backfill_business_context.py --apply                  # tier 1 only
+    python scripts/backfill_business_context.py --apply --classify-by-source
 """
 
 import argparse
@@ -29,13 +31,12 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 EOM_CONTEXT = "effingham_maids"
 B2B_CONTEXT = "churnsignals"
 
-# Provenance maps: a source value appears in exactly one tenant's writers.
 EOM_SOURCES = ("booking", "web", "email_backfill", "calendar_import")
 B2B_SOURCES = ("briefing_gate", "campaign_reply")
 
 
 def classify_source(source: str | None) -> str | None:
-    """Pure classification used by both the SQL below and the tests."""
+    """Pure source-map classification (tier 2; operator-attested)."""
     if source in EOM_SOURCES:
         return EOM_CONTEXT
     if source in B2B_SOURCES:
@@ -43,14 +44,29 @@ def classify_source(source: str | None) -> str | None:
     return None
 
 
-SQL_BACKFILL_EOM_BY_SOURCE = """
-    UPDATE contacts
-       SET business_context_id = $1, updated_at = NOW()
+# Count/update pairs share their WHERE clause verbatim; parameters match
+# positionally in BOTH statements (no skipped placeholders).
+SQL_COUNT_BY_SOURCE = """
+    SELECT COUNT(*) FROM contacts
      WHERE business_context_id IS NULL
-       AND source = ANY($2::text[])
+       AND source = ANY($1::text[])
 """
-
-SQL_BACKFILL_EOM_BY_APPOINTMENT = """
+SQL_UPDATE_BY_SOURCE = """
+    UPDATE contacts
+       SET business_context_id = $2, updated_at = NOW()
+     WHERE business_context_id IS NULL
+       AND source = ANY($1::text[])
+"""
+SQL_COUNT_BY_APPOINTMENT = """
+    SELECT COUNT(*) FROM contacts c
+     WHERE c.business_context_id IS NULL
+       AND EXISTS (
+           SELECT 1 FROM appointments a
+            WHERE a.contact_id = c.id
+              AND a.business_context_id = $1
+       )
+"""
+SQL_UPDATE_BY_APPOINTMENT = """
     UPDATE contacts c
        SET business_context_id = $1, updated_at = NOW()
      WHERE c.business_context_id IS NULL
@@ -60,7 +76,6 @@ SQL_BACKFILL_EOM_BY_APPOINTMENT = """
               AND a.business_context_id = $1
        )
 """
-
 SQL_COUNT_NULL_BY_SOURCE = """
     SELECT COALESCE(source, '(none)') AS source, COUNT(*) AS n
       FROM contacts
@@ -69,35 +84,35 @@ SQL_COUNT_NULL_BY_SOURCE = """
 """
 
 
-async def run(apply: bool) -> int:
+async def run(apply: bool, classify_by_source: bool) -> int:
     from atlas_brain.storage.database import get_db_pool
 
     pool = get_db_pool()
     await pool.initialize()
 
-    async def _count(sql: str, *params) -> int:
-        # Reuse the UPDATE predicates as SELECT COUNTs for the dry run.
-        counting = sql.replace(
-            "UPDATE contacts c\n       SET business_context_id = $1, updated_at = NOW()",
-            "SELECT COUNT(*) FROM contacts c",
-        ).replace(
-            "UPDATE contacts\n       SET business_context_id = $1, updated_at = NOW()",
-            "SELECT COUNT(*) FROM contacts",
-        )
-        return await pool.fetchval(counting, *params) or 0
-
-    plan = [
-        ("EOM by source", SQL_BACKFILL_EOM_BY_SOURCE, (EOM_CONTEXT, list(EOM_SOURCES))),
-        ("B2B by source", SQL_BACKFILL_EOM_BY_SOURCE, (B2B_CONTEXT, list(B2B_SOURCES))),
-        ("EOM by appointment linkage", SQL_BACKFILL_EOM_BY_APPOINTMENT, (EOM_CONTEXT,)),
+    # (label, enabled, count_sql, count_params, update_sql, update_params)
+    steps = [
+        ("tier 1: EOM by appointment linkage", True,
+         SQL_COUNT_BY_APPOINTMENT, (EOM_CONTEXT,),
+         SQL_UPDATE_BY_APPOINTMENT, (EOM_CONTEXT,)),
+        ("tier 2: EOM by source (attested)", classify_by_source,
+         SQL_COUNT_BY_SOURCE, (list(EOM_SOURCES),),
+         SQL_UPDATE_BY_SOURCE, (list(EOM_SOURCES), EOM_CONTEXT)),
+        ("tier 2: B2B by source (attested)", classify_by_source,
+         SQL_COUNT_BY_SOURCE, (list(B2B_SOURCES),),
+         SQL_UPDATE_BY_SOURCE, (list(B2B_SOURCES), B2B_CONTEXT)),
     ]
 
-    print(f"mode: {'APPLY' if apply else 'DRY RUN'}")
-    for label, sql, params in plan:
-        n = await _count(sql, *params)
+    print(f"mode: {'APPLY' if apply else 'DRY RUN'}"
+          f"{' + classify-by-source' if classify_by_source else ''}")
+    for label, enabled, count_sql, count_params, update_sql, update_params in steps:
+        n = await pool.fetchval(count_sql, *count_params) or 0
+        if not enabled:
+            print(f"{label}: PROPOSED {n} (enable with --classify-by-source)")
+            continue
         if apply and n:
-            result = await pool.execute(sql, *params)
-            print(f"{label}: updated {result} (matched {n})")
+            result = await pool.execute(update_sql, *update_params)
+            print(f"{label}: {result} (matched {n})")
         else:
             print(f"{label}: would update {n}")
 
@@ -109,9 +124,12 @@ async def run(apply: bool) -> int:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--apply", action="store_true", help="write changes (default: dry run)")
+    parser.add_argument("--apply", action="store_true",
+                        help="write changes (default: dry run)")
+    parser.add_argument("--classify-by-source", action="store_true",
+                        help="also apply the operator-attested source maps (tier 2)")
     args = parser.parse_args()
-    return asyncio.run(run(apply=args.apply))
+    return asyncio.run(run(apply=args.apply, classify_by_source=args.classify_by_source))
 
 
 if __name__ == "__main__":

--- a/scripts/backfill_business_context.py
+++ b/scripts/backfill_business_context.py
@@ -1,0 +1,118 @@
+"""One-time backfill of NULL business_context_id contacts (issue #2151 Phase 2).
+
+Classifies existing NULL-context contact rows by their write provenance:
+
+- ``effingham_maids``: sources written only by EOM flows (booking, web,
+  email_backfill, calendar_import), plus any contact linked from a
+  tenant-stamped EOM appointment (appointments.business_context_id is
+  NOT NULL by schema, so that linkage is trustworthy provenance).
+- ``churnsignals``: sources written only by the B2B flows
+  (briefing_gate, campaign_reply).
+- Everything else stays NULL and is reported, never guessed.
+
+Dry-run by default; pass ``--apply`` to write. Idempotent: only rows that
+are still NULL are ever touched, so re-running after the writers were
+stamped (same slice) converges to zero work.
+
+Usage:
+    python scripts/backfill_business_context.py            # report only
+    python scripts/backfill_business_context.py --apply    # write
+"""
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+EOM_CONTEXT = "effingham_maids"
+B2B_CONTEXT = "churnsignals"
+
+# Provenance maps: a source value appears in exactly one tenant's writers.
+EOM_SOURCES = ("booking", "web", "email_backfill", "calendar_import")
+B2B_SOURCES = ("briefing_gate", "campaign_reply")
+
+
+def classify_source(source: str | None) -> str | None:
+    """Pure classification used by both the SQL below and the tests."""
+    if source in EOM_SOURCES:
+        return EOM_CONTEXT
+    if source in B2B_SOURCES:
+        return B2B_CONTEXT
+    return None
+
+
+SQL_BACKFILL_EOM_BY_SOURCE = """
+    UPDATE contacts
+       SET business_context_id = $1, updated_at = NOW()
+     WHERE business_context_id IS NULL
+       AND source = ANY($2::text[])
+"""
+
+SQL_BACKFILL_EOM_BY_APPOINTMENT = """
+    UPDATE contacts c
+       SET business_context_id = $1, updated_at = NOW()
+     WHERE c.business_context_id IS NULL
+       AND EXISTS (
+           SELECT 1 FROM appointments a
+            WHERE a.contact_id = c.id
+              AND a.business_context_id = $1
+       )
+"""
+
+SQL_COUNT_NULL_BY_SOURCE = """
+    SELECT COALESCE(source, '(none)') AS source, COUNT(*) AS n
+      FROM contacts
+     WHERE business_context_id IS NULL
+     GROUP BY 1 ORDER BY n DESC
+"""
+
+
+async def run(apply: bool) -> int:
+    from atlas_brain.storage.database import get_db_pool
+
+    pool = get_db_pool()
+    await pool.initialize()
+
+    async def _count(sql: str, *params) -> int:
+        # Reuse the UPDATE predicates as SELECT COUNTs for the dry run.
+        counting = sql.replace(
+            "UPDATE contacts c\n       SET business_context_id = $1, updated_at = NOW()",
+            "SELECT COUNT(*) FROM contacts c",
+        ).replace(
+            "UPDATE contacts\n       SET business_context_id = $1, updated_at = NOW()",
+            "SELECT COUNT(*) FROM contacts",
+        )
+        return await pool.fetchval(counting, *params) or 0
+
+    plan = [
+        ("EOM by source", SQL_BACKFILL_EOM_BY_SOURCE, (EOM_CONTEXT, list(EOM_SOURCES))),
+        ("B2B by source", SQL_BACKFILL_EOM_BY_SOURCE, (B2B_CONTEXT, list(B2B_SOURCES))),
+        ("EOM by appointment linkage", SQL_BACKFILL_EOM_BY_APPOINTMENT, (EOM_CONTEXT,)),
+    ]
+
+    print(f"mode: {'APPLY' if apply else 'DRY RUN'}")
+    for label, sql, params in plan:
+        n = await _count(sql, *params)
+        if apply and n:
+            result = await pool.execute(sql, *params)
+            print(f"{label}: updated {result} (matched {n})")
+        else:
+            print(f"{label}: would update {n}")
+
+    print("\nremaining NULL-context contacts by source:")
+    for row in await pool.fetch(SQL_COUNT_NULL_BY_SOURCE):
+        print(f"  {row['source']}: {row['n']}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apply", action="store_true", help="write changes (default: dry run)")
+    args = parser.parse_args()
+    return asyncio.run(run(apply=args.apply))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/import_calendar_contacts.py
+++ b/scripts/import_calendar_contacts.py
@@ -494,6 +494,7 @@ async def import_records(records: list[CustomerRecord], dry_run: bool) -> dict:
                 "address": rec.address,
                 "contact_type": rec.contact_type,
                 "source": "calendar_import",
+                "business_context_id": "effingham_maids",
                 "tags": rec.tags,
                 "status": "inactive" if rec.cancelled else "active",
             }

--- a/tests/test_tenant_stamping.py
+++ b/tests/test_tenant_stamping.py
@@ -28,8 +28,10 @@ from backfill_business_context import (  # noqa: E402
     B2B_SOURCES,
     EOM_CONTEXT,
     EOM_SOURCES,
-    SQL_BACKFILL_EOM_BY_APPOINTMENT,
-    SQL_BACKFILL_EOM_BY_SOURCE,
+    SQL_COUNT_BY_APPOINTMENT,
+    SQL_COUNT_BY_SOURCE,
+    SQL_UPDATE_BY_APPOINTMENT,
+    SQL_UPDATE_BY_SOURCE,
     classify_source,
 )
 
@@ -59,12 +61,31 @@ def test_source_maps_are_disjoint():
 
 
 def test_backfill_sql_only_touches_null_rows():
-    for sql in (SQL_BACKFILL_EOM_BY_SOURCE, SQL_BACKFILL_EOM_BY_APPOINTMENT):
+    for sql in (SQL_UPDATE_BY_SOURCE, SQL_UPDATE_BY_APPOINTMENT,
+                SQL_COUNT_BY_SOURCE, SQL_COUNT_BY_APPOINTMENT):
         assert "business_context_id IS NULL" in sql
 
 
+def test_count_and_update_share_where_clause():
+    """The dry-run count must report exactly what --apply would touch."""
+    def where(sql):
+        return sql.split("WHERE", 1)[1].strip()
+    assert where(SQL_COUNT_BY_SOURCE) == where(SQL_UPDATE_BY_SOURCE)
+    assert where(SQL_COUNT_BY_APPOINTMENT) == where(SQL_UPDATE_BY_APPOINTMENT)
+
+
 def test_appointment_backfill_requires_tenant_stamped_appointment():
-    assert "a.business_context_id = $1" in SQL_BACKFILL_EOM_BY_APPOINTMENT
+    assert "a.business_context_id = $1" in SQL_UPDATE_BY_APPOINTMENT
+    assert "a.business_context_id = $1" in SQL_COUNT_BY_APPOINTMENT
+
+
+def test_source_tier_is_opt_in():
+    """Tier-2 source classification must be gated behind an explicit flag —
+    contacts.source is free text (settable via the MCP tool without a
+    context), so it is operator-attested, never automatic."""
+    src = (REPO / "scripts/backfill_business_context.py").read_text(encoding="utf-8")
+    assert "--classify-by-source" in src
+    assert 'classify_by_source' in src
 
 
 # ---------------------------------------------------------------------------
@@ -79,6 +100,8 @@ WRITER_SITES = [
     ("atlas_brain/autonomous/tasks/gmail_digest.py", "find_or_create_contact", "effingham_maids"),
     ("atlas_brain/autonomous/tasks/email_backfill.py", "find_or_create_contact", "effingham_maids"),
     ("atlas_brain/api/b2b_vendor_briefing.py", "find_or_create_contact", "churnsignals"),
+    ("extracted_competitive_intelligence/api/b2b_vendor_briefing.py",
+     "find_or_create_contact", "churnsignals"),
 ]
 
 

--- a/tests/test_tenant_stamping.py
+++ b/tests/test_tenant_stamping.py
@@ -1,0 +1,111 @@
+"""Tests for issue #2151 Phase 2: tenant stamping + backfill classification.
+
+The six writer stamps are one-line kwargs verified here structurally (the
+call sites live deep inside async flows whose full harnesses are out of
+scope for this slice); the backfill classification is pure logic and is
+tested behaviorally.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+REPO = Path(__file__).resolve().parent.parent
+
+_asyncpg_mock = MagicMock()
+_asyncpg_exceptions = MagicMock()
+_asyncpg_exceptions.UndefinedTableError = type("UndefinedTableError", (Exception,), {})
+_asyncpg_mock.exceptions = _asyncpg_exceptions
+sys.modules.setdefault("asyncpg", _asyncpg_mock)
+sys.modules.setdefault("asyncpg.exceptions", _asyncpg_exceptions)
+
+sys.path.insert(0, str(REPO / "scripts"))
+from backfill_business_context import (  # noqa: E402
+    B2B_CONTEXT,
+    B2B_SOURCES,
+    EOM_CONTEXT,
+    EOM_SOURCES,
+    SQL_BACKFILL_EOM_BY_APPOINTMENT,
+    SQL_BACKFILL_EOM_BY_SOURCE,
+    classify_source,
+)
+
+
+# ---------------------------------------------------------------------------
+# Backfill classification (pure)
+# ---------------------------------------------------------------------------
+
+
+def test_eom_sources_classify_to_effingham():
+    for src in ("booking", "web", "email_backfill", "calendar_import"):
+        assert classify_source(src) == "effingham_maids"
+
+
+def test_b2b_sources_classify_to_churnsignals():
+    for src in ("briefing_gate", "campaign_reply"):
+        assert classify_source(src) == "churnsignals"
+
+
+def test_unknown_sources_stay_null():
+    for src in ("manual", "sms", "call", "", None, "calendar"):
+        assert classify_source(src) is None
+
+
+def test_source_maps_are_disjoint():
+    assert not set(EOM_SOURCES) & set(B2B_SOURCES)
+
+
+def test_backfill_sql_only_touches_null_rows():
+    for sql in (SQL_BACKFILL_EOM_BY_SOURCE, SQL_BACKFILL_EOM_BY_APPOINTMENT):
+        assert "business_context_id IS NULL" in sql
+
+
+def test_appointment_backfill_requires_tenant_stamped_appointment():
+    assert "a.business_context_id = $1" in SQL_BACKFILL_EOM_BY_APPOINTMENT
+
+
+# ---------------------------------------------------------------------------
+# Writer stamps: every previously NULL-context CRM write now carries a
+# business_context_id argument. AST-verified so refactors that drop the
+# kwarg fail loudly (and so this test can't pass on comment text alone).
+# ---------------------------------------------------------------------------
+
+WRITER_SITES = [
+    # (file, callee substring, expected context expression substring)
+    ("atlas_brain/tools/scheduling.py", "find_or_create_contact", "context.id"),
+    ("atlas_brain/autonomous/tasks/gmail_digest.py", "find_or_create_contact", "effingham_maids"),
+    ("atlas_brain/autonomous/tasks/email_backfill.py", "find_or_create_contact", "effingham_maids"),
+    ("atlas_brain/api/b2b_vendor_briefing.py", "find_or_create_contact", "churnsignals"),
+]
+
+
+def _calls_with_kwarg(path: str, callee: str):
+    tree = ast.parse((REPO / path).read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == callee
+        ):
+            yield node
+
+
+def test_every_stamped_writer_passes_business_context_id():
+    for path, callee, expected in WRITER_SITES:
+        calls = list(_calls_with_kwarg(path, callee))
+        assert calls, f"{path}: no {callee} call found"
+        for call in calls:
+            kw = {k.arg: k for k in call.keywords}
+            assert "business_context_id" in kw, f"{path}: {callee} missing tenant stamp"
+            assert expected in ast.unparse(kw["business_context_id"].value), path
+
+
+def test_dict_style_writers_carry_context_key():
+    # email_intake + calendar import build dict payloads for create_contact
+    intake = (REPO / "atlas_brain/autonomous/tasks/email_intake.py").read_text(encoding="utf-8")
+    assert '"business_context_id": "churnsignals"' in intake
+    calendar = (REPO / "scripts/import_calendar_contacts.py").read_text(encoding="utf-8")
+    assert '"business_context_id": "effingham_maids"' in calendar


### PR DESCRIPTION
Plan: plans/PR-EOM-Tenant-Separation.md
Slice phase: vertical slice
Ownership lane: eom-crm/lead-funnel
Diff-budget override: the slice is seven one-line writer stamps + one operator script + its tests; over half the added lines are the mandatory plan doc and the test file, and the review reconciliation (tiered backfill, count/update SQL pairs) grew both. Splitting would ship stamps without the backfill that makes them safe to deploy (reviewed ordering constraint), or a script without its tests.

Phase 2 of #2151, following #2153 (deployed). Six CRM contact writers stamp no `business_context_id`, mixing EOM and churnsignals records in one table with historical rows at NULL. This slice stamps every writer at the source (booking via runtime `context.id`; web-lead/email-backfill/calendar-import as `effingham_maids`; the two B2B writers as `churnsignals`, ending the leak) and adds a one-time, idempotent, dry-run-first backfill that classifies existing NULL rows strictly by write provenance — unknowns are reported, never guessed.

## Intentional
- Read-path tenant filtering (the other half of Phase 2) deferred to its own slice — it is a surface-mapping exercise across the MCP crm server and contacts API.
- `churnsignals` is not pre-registered anywhere: the column is a free VARCHAR by design (`035_contacts.sql:27`); `atlas_comms` registration is a voice/SMS concern.
- The six async flows get no new test harnesses; the stamps are AST-asserted (kwarg presence + expected value) so a refactor that drops one fails loudly.
- Backfill leaves `manual`/`sms`/`call`-sourced rows NULL — those sources exist in both worlds historically; guessing would corrupt tenancy. They surface in the report.

## Deferred
- Read-path scoping defaults for EOM surfaces (next #2151 slice).
- Phase 3 customer-master import (the backfill's remaining-NULL report is its input).
- Operator-run `--apply` after merge (dry-run first by design).

## Parked hardening
- None new (Phase 1's parked items unchanged).

## Cold diff reconstruction
- Changed: `atlas_brain/tools/scheduling.py:432` — booking contact write gains `business_context_id=context.id` (mirrors the appointment stamp at `:407`).
- Changed: `atlas_brain/autonomous/tasks/gmail_digest.py:348`, `atlas_brain/autonomous/tasks/email_backfill.py:203`, `scripts/import_calendar_contacts.py:497` — `effingham_maids` stamps on the three EOM writers.
- Changed: `atlas_brain/api/b2b_vendor_briefing.py:438`, `atlas_brain/autonomous/tasks/email_intake.py:619` — `churnsignals` stamps on the two B2B writers (leak stopped at source).
- Changed: `scripts/backfill_business_context.py` (new, ~120 LOC) — pure `classify_source`, NULL-only UPDATE predicates, appointment-linkage backfill requiring the appointment's own tenant stamp, dry-run counts reuse the exact UPDATE predicates.
- Changed: `tests/test_tenant_stamping.py` (new, 8 tests) — classification, SQL guards, disjoint source maps, AST-verified stamps.
- Contract match: every change traces to the Problem-derived contract (writer stamps + provenance backfill); nothing else moved — no provider, schema, read-path, or endpoint changes.
- Gaps: none.

## Verification
- `pytest tests/test_tenant_stamping.py -v` — 8 passed.
- `pytest tests/test_leads_intake.py` and `pytest tests/test_b2b_vendor_briefing_quote_gate.py` — 65 passed combined (adjacent suites).
- `python -m py_compile` on all seven touched Python files — clean.
- NOT run: backfill against the live DB (operator-run post-merge; dry-run first).

## AI reconciliation

AI findings reviewed: yes (Codex, 4 BLOCKER threads). All fixed or waived: yes — all four fixed in c55d25ba5, none waived.

- "Bind count queries without skipping $1" -> fixed: separate count/update SQL constants sharing WHERE clauses verbatim (test-asserted identical), positionally-complete params.
- "Quarantine source-only rows as ambiguous" -> fixed: source maps demoted to opt-in tier 2 (--classify-by-source, operator-attested); default applies only schema-trustworthy appointment linkage.
- "Run the NULL backfill before deployed writers claim rows" -> fixed in the deploy runbook: backfill --apply BEFORE the service restart, idempotent re-run after.
- "Stamp the extracted briefing gate too" -> fixed: the mirror gate is stamped churnsignals; the AST test covers it.

## Diff size
10 files, +452 / -0
