### PR TITLE
feat: default-tenant read scoping for the CRM MCP surface (#2151)

### DIFF
--- a/atlas_brain/config.py
+++ b/atlas_brain/config.py
@@ -5246,6 +5246,14 @@ class MCPConfig(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="ATLAS_MCP_", env_file=ENV_FILES, extra="ignore")
 
     client_enabled: bool = Field(default=True, description="Enable Atlas as MCP client")
+    crm_default_business_context: str | None = Field(
+        default=None,
+        description=(
+            "Default business_context_id applied by CRM MCP read tools when the "
+            "caller passes none (issue #2151 read scoping). Scoped reads also "
+            "include NULL-context legacy rows; an explicit argument always wins."
+        ),
+    )
     crm_enabled: bool = Field(default=True, description="Enable CRM MCP server")
     email_enabled: bool = Field(default=True, description="Enable Email MCP server")
     calendar_enabled: bool = Field(default=True, description="Enable Calendar MCP server")

--- a/atlas_brain/mcp/crm_server.py
+++ b/atlas_brain/mcp/crm_server.py
@@ -110,25 +110,35 @@ def _visible_under_default(contact: "dict | None") -> bool:
     return contact.get("business_context_id") in (None, default)
 
 
-async def _guard_contact_id(
+async def _guarded_contact(
     contact_id: str, business_context_id: "str | None" = None
-) -> bool:
+) -> "tuple[bool, dict | None]":
     """Resolve + tenant-check an id-addressed operation.
 
-    An explicit ``business_context_id`` addresses exactly that tenant's page
-    (mirroring explicit search: no NULL-context fallback). Otherwise the
-    deployment default applies: the default tenant plus NULL-context legacy
-    rows are visible. Foreign-tenant rows read as nonexistent (fail-closed).
+    Returns ``(allowed, contact)`` so callers that need the resolved row
+    (e.g. claim-on-update) avoid a second lookup. An explicit
+    ``business_context_id`` addresses exactly that tenant's page (mirroring
+    explicit search: no NULL-context fallback). Otherwise the deployment
+    default applies: the default tenant plus NULL-context legacy rows are
+    visible. Foreign-tenant rows read as nonexistent (fail-closed).
     """
     if business_context_id:
         contact = await _provider().get_contact(contact_id)
         if contact is None:
-            return False
-        return contact.get("business_context_id") == business_context_id
+            return False, None
+        return contact.get("business_context_id") == business_context_id, contact
     if not _default_context():
-        return True
+        return True, None
     contact = await _provider().get_contact(contact_id)
-    return _visible_under_default(contact)
+    return _visible_under_default(contact), contact
+
+
+async def _guard_contact_id(
+    contact_id: str, business_context_id: "str | None" = None
+) -> bool:
+    """Boolean form of :func:`_guarded_contact` for tools that only gate."""
+    allowed, _ = await _guarded_contact(contact_id, business_context_id)
+    return allowed
 
 
 async def _scoped_search(provider, **kwargs):
@@ -404,8 +414,20 @@ async def update_contact(
         if not data:
             return json.dumps({"success": False, "error": "No fields provided to update"})
 
-        if not await _guard_contact_id(contact_id, business_context_id):
+        allowed, existing = await _guarded_contact(contact_id, business_context_id)
+        if not allowed:
             return json.dumps({"success": False, "error": "Contact not found"})
+        default = _default_context()
+        if (
+            default
+            and not business_context_id
+            and existing is not None
+            and existing.get("business_context_id") is None
+        ):
+            # Claim-on-write: an update from a scoped session takes ownership
+            # of the NULL-context legacy row, so corrected data stops being
+            # visible to every tenant as unclaimed legacy.
+            data["business_context_id"] = default
         updated = await _provider().update_contact(contact_id, data)
         if updated is None:
             return json.dumps({"success": False, "error": "Contact not found"})
@@ -594,6 +616,7 @@ async def get_contact_appointments(
         if not await _guard_contact_id(contact_id, business_context_id):
             return json.dumps({"error": "Contact not found", "appointments": [], "count": 0})
         appointments = await _provider().get_contact_appointments(contact_id)
+        appointments = _appointments_in_scope(appointments, business_context_id)
         return json.dumps(
             {"appointments": appointments, "count": len(appointments)}, default=str
         )

--- a/atlas_brain/mcp/crm_server.py
+++ b/atlas_brain/mcp/crm_server.py
@@ -110,9 +110,21 @@ def _visible_under_default(contact: "dict | None") -> bool:
     return contact.get("business_context_id") in (None, default)
 
 
-async def _guard_contact_id(contact_id: str) -> bool:
-    """Resolve + tenant-check an id-addressed operation under the default
-    scope. Foreign-tenant rows read as nonexistent (fail-closed)."""
+async def _guard_contact_id(
+    contact_id: str, business_context_id: "str | None" = None
+) -> bool:
+    """Resolve + tenant-check an id-addressed operation.
+
+    An explicit ``business_context_id`` addresses exactly that tenant's page
+    (mirroring explicit search: no NULL-context fallback). Otherwise the
+    deployment default applies: the default tenant plus NULL-context legacy
+    rows are visible. Foreign-tenant rows read as nonexistent (fail-closed).
+    """
+    if business_context_id:
+        contact = await _provider().get_contact(contact_id)
+        if contact is None:
+            return False
+        return contact.get("business_context_id") == business_context_id
     if not _default_context():
         return True
     contact = await _provider().get_contact(contact_id)
@@ -132,6 +144,22 @@ async def _scoped_search(provider, **kwargs):
     if results:
         return results
     return await provider.search_contacts(business_context_id_is_null=True, **kwargs)
+
+
+def _appointments_in_scope(
+    appointments: "list[dict]", business_context_id: "str | None"
+) -> "list[dict]":
+    """Filter appointment rows to the effective tenant scope.
+
+    ``appointments.business_context_id`` is NOT NULL by schema, so under an
+    effective scope (explicit argument or deployment default) only rows
+    stamped with that tenant qualify; with no scope every row passes (legacy
+    unscoped behavior).
+    """
+    effective = business_context_id or _default_context()
+    if not effective:
+        return appointments
+    return [a for a in appointments if a.get("business_context_id") == effective]
 
 
 def _is_uuid(value: str) -> bool:
@@ -206,6 +234,7 @@ async def search_contacts(
             appointments = await repo.search_by_name(
                 query, include_history=True, limit=limit,
             )
+        appointments = _appointments_in_scope(appointments, business_context_id)
 
         if not appointments:
             return json.dumps({"found": False, "contacts": [], "count": 0})
@@ -244,23 +273,30 @@ async def search_contacts(
 # ---------------------------------------------------------------------------
 
 @mcp.tool()
-async def get_contact(contact_id: str) -> str:
+async def get_contact(contact_id: str, business_context_id: Optional[str] = None) -> str:
     """
     Fetch a contact by UUID or name.
 
     If contact_id is not a valid UUID, treats it as a name search
     and returns the first matching contact.
+    business_context_id: address a specific tenant's page explicitly;
+    omitted, the deployment default (plus NULL-context legacy rows) applies.
     """
     try:
         # If it doesn't look like a UUID, search by name instead
         if not _is_uuid(contact_id):
-            results = await _scoped_search(_provider(), query=contact_id, limit=1)
+            results = await _scoped_search(
+                _provider(), query=contact_id, limit=1,
+                business_context_id=business_context_id,
+            )
             if results:
                 return json.dumps({"found": True, "contact": results[0]}, default=str)
             return json.dumps({"found": False, "contact": None})
 
+        if not await _guard_contact_id(contact_id, business_context_id):
+            return json.dumps({"found": False, "contact": None})
         contact = await _provider().get_contact(contact_id)
-        if not _visible_under_default(contact):
+        if contact is None:
             return json.dumps({"found": False, "contact": None})
         return json.dumps({"found": True, "contact": contact}, default=str)
     except Exception as exc:
@@ -336,12 +372,16 @@ async def update_contact(
     notes: Optional[str] = None,
     status: Optional[str] = None,
     tags: Optional[list[str]] = None,
+    business_context_id: Optional[str] = None,
 ) -> str:
     """
     Update a contact's information.
 
     Only supply fields you want to change.
     status: active | inactive | archived
+    business_context_id: addresses which tenant page the contact is looked
+    up on (explicit override of the deployment default); it is NOT an
+    updatable field.
     """
     if not _is_uuid(contact_id):
         return json.dumps({"success": False, "error": "Invalid contact_id (must be UUID)"})
@@ -364,7 +404,7 @@ async def update_contact(
         if not data:
             return json.dumps({"success": False, "error": "No fields provided to update"})
 
-        if not await _guard_contact_id(contact_id):
+        if not await _guard_contact_id(contact_id, business_context_id):
             return json.dumps({"success": False, "error": "Contact not found"})
         updated = await _provider().update_contact(contact_id, data)
         if updated is None:
@@ -380,18 +420,20 @@ async def update_contact(
 # ---------------------------------------------------------------------------
 
 @mcp.tool()
-async def delete_contact(contact_id: str) -> str:
+async def delete_contact(contact_id: str, business_context_id: Optional[str] = None) -> str:
     """
     Archive (soft-delete) a contact.
 
     The record is marked status=archived rather than permanently removed so
     interaction history and appointment links are preserved.
+    business_context_id: explicit tenant-page override of the deployment
+    default for the lookup.
     """
     if not _is_uuid(contact_id):
         return json.dumps({"success": False, "error": "Invalid contact_id (must be UUID)"})
 
     try:
-        if not await _guard_contact_id(contact_id):
+        if not await _guard_contact_id(contact_id, business_context_id):
             return json.dumps({"success": False, "error": "Contact not found"})
         success = await _provider().delete_contact(contact_id)
         return json.dumps({"success": success})
@@ -418,15 +460,40 @@ async def list_contacts(
     status:       active (default) | inactive | archived
     contact_type: customer | lead | prospect | vendor
     limit / offset: for pagination
+
+    With a deployment default tenant configured and no explicit
+    business_context_id, results merge the default tenant's page with the
+    NULL-context legacy page (offset applies to each page; the merged
+    result is truncated to limit).
     """
     try:
-        contacts = await _provider().list_contacts(
-            business_context_id=business_context_id or _default_context(),
-            status=status,
-            contact_type=contact_type,
-            limit=min(limit, 200),
-            offset=offset,
-        )
+        provider = _provider()
+        default = _default_context()
+        capped = min(limit, 200)
+        if business_context_id or not default:
+            contacts = await provider.list_contacts(
+                business_context_id=business_context_id,
+                status=status,
+                contact_type=contact_type,
+                limit=capped,
+                offset=offset,
+            )
+        else:
+            tenant_rows = await provider.list_contacts(
+                business_context_id=default,
+                status=status,
+                contact_type=contact_type,
+                limit=capped,
+                offset=offset,
+            )
+            legacy_rows = await provider.list_contacts(
+                business_context_id_is_null=True,
+                status=status,
+                contact_type=contact_type,
+                limit=capped,
+                offset=offset,
+            )
+            contacts = (tenant_rows + legacy_rows)[:capped]
         return json.dumps({"contacts": contacts, "count": len(contacts)}, default=str)
     except Exception as exc:
         logger.exception("list_contacts error")
@@ -443,6 +510,7 @@ async def log_interaction(
     interaction_type: str,
     summary: str,
     occurred_at: Optional[str] = None,
+    business_context_id: Optional[str] = None,
 ) -> str:
     """
     Log a customer interaction.
@@ -461,7 +529,7 @@ async def log_interaction(
         return json.dumps({"success": False, "error": "interaction_type is required"})
 
     try:
-        if not await _guard_contact_id(contact_id):
+        if not await _guard_contact_id(contact_id, business_context_id):
             return json.dumps({"success": False, "error": "Contact not found"})
         interaction = await _provider().log_interaction(
             contact_id=contact_id,
@@ -480,7 +548,9 @@ async def log_interaction(
 # ---------------------------------------------------------------------------
 
 @mcp.tool()
-async def get_interactions(contact_id: str, limit: int = 20) -> str:
+async def get_interactions(
+    contact_id: str, limit: int = 20, business_context_id: Optional[str] = None
+) -> str:
     """
     Retrieve interaction history for a contact.
 
@@ -491,7 +561,7 @@ async def get_interactions(contact_id: str, limit: int = 20) -> str:
         return json.dumps({"error": "Invalid contact_id (must be UUID)", "interactions": [], "count": 0})
 
     try:
-        if not await _guard_contact_id(contact_id):
+        if not await _guard_contact_id(contact_id, business_context_id):
             return json.dumps({"error": "Contact not found", "interactions": [], "count": 0})
         interactions = await _provider().get_interactions(contact_id, limit=min(limit, 100))
         return json.dumps(
@@ -507,7 +577,9 @@ async def get_interactions(contact_id: str, limit: int = 20) -> str:
 # ---------------------------------------------------------------------------
 
 @mcp.tool()
-async def get_contact_appointments(contact_id: str) -> str:
+async def get_contact_appointments(
+    contact_id: str, business_context_id: Optional[str] = None
+) -> str:
     """
     Fetch all appointments linked to a contact.
 
@@ -519,7 +591,7 @@ async def get_contact_appointments(contact_id: str) -> str:
         return json.dumps({"error": "Invalid contact_id (must be UUID)", "appointments": [], "count": 0})
 
     try:
-        if not await _guard_contact_id(contact_id):
+        if not await _guard_contact_id(contact_id, business_context_id):
             return json.dumps({"error": "Contact not found", "appointments": [], "count": 0})
         appointments = await _provider().get_contact_appointments(contact_id)
         return json.dumps(
@@ -544,6 +616,7 @@ async def get_customer_context(
     max_calls: int = 10,
     max_appointments: int = 10,
     max_emails: int = 10,
+    business_context_id: Optional[str] = None,
 ) -> str:
     """
     Get the full unified customer context --everything Atlas knows about a customer.
@@ -555,6 +628,9 @@ async def get_customer_context(
     name: customer name --will search contacts and use the first match
     phone: phone number in any format
     email: email address
+    business_context_id: explicit tenant-page override of the deployment
+    default; resolution and the tenant guard follow the same scoping rules
+    as search_contacts / get_contact.
     """
     if not any([contact_id, phone, email, name]):
         return json.dumps(
@@ -564,7 +640,6 @@ async def get_customer_context(
     try:
         from ..services.customer_context import get_customer_context_service
 
-        svc = get_customer_context_service()
         kwargs = {
             "max_interactions": min(max_interactions, 50),
             "max_calls": min(max_calls, 50),
@@ -577,15 +652,43 @@ async def get_customer_context(
             name = contact_id
             contact_id = None
 
+        resolved_in_scope = False
+
         # Name-based lookup: search contacts first, then get context by ID
         if name and not contact_id:
-            results = await _provider().search_contacts(query=name, limit=1)
+            results = await _scoped_search(
+                _provider(), query=name, limit=1,
+                business_context_id=business_context_id,
+            )
             if results:
                 contact_id = results[0].get("id")
+                resolved_in_scope = True
             else:
                 return json.dumps({"found": False, "context": None,
                                    "message": f"No contact found matching '{name}'"})
 
+        # Under a tenant scope, phone/email must resolve through the scoped
+        # contact search as well; the context service's own lookups are
+        # unscoped and would return foreign-tenant rows.
+        if (
+            not contact_id
+            and (phone or email)
+            and (business_context_id or _default_context())
+        ):
+            results = await _scoped_search(
+                _provider(), phone=phone, email=email, limit=1,
+                business_context_id=business_context_id,
+            )
+            if not results:
+                return json.dumps({"found": False, "context": None})
+            contact_id = results[0].get("id")
+            resolved_in_scope = True
+
+        if contact_id and not resolved_in_scope:
+            if not await _guard_contact_id(contact_id, business_context_id):
+                return json.dumps({"found": False, "context": None})
+
+        svc = get_customer_context_service()
         if contact_id:
             ctx = await svc.get_context(contact_id, **kwargs)
         elif phone:

--- a/atlas_brain/mcp/crm_server.py
+++ b/atlas_brain/mcp/crm_server.py
@@ -31,7 +31,7 @@ import logging
 import sys
 import uuid as _uuid
 from contextlib import asynccontextmanager
-from typing import Optional
+from typing import Any, Callable, Optional
 
 from mcp.server.fastmcp import FastMCP
 
@@ -61,7 +61,24 @@ mcp = FastMCP(
 )
 
 
+_provider_override: "Callable[[], Any] | None" = None
+
+
+def set_provider_override(factory: "Callable[[], Any] | None") -> None:
+    """Install (or clear with ``None``) a CRM provider factory override.
+
+    Injection seam for unit tests, mirroring the FastAPI
+    ``dependency_overrides`` pattern used by the HTTP surface: tests supply a
+    fake provider through this public setter rather than patching module
+    internals.
+    """
+    global _provider_override
+    _provider_override = factory
+
+
 def _provider():
+    if _provider_override is not None:
+        return _provider_override()
     from ..services.crm_provider import get_crm_provider
 
     return get_crm_provider()

--- a/atlas_brain/mcp/crm_server.py
+++ b/atlas_brain/mcp/crm_server.py
@@ -172,6 +172,18 @@ def _appointments_in_scope(
     return [a for a in appointments if a.get("business_context_id") == effective]
 
 
+def _calls_in_scope(
+    rows: "list[dict]", business_context_id: "str | None"
+) -> "list[dict]":
+    """Call-transcript rows may carry a NULL business_context_id (legacy),
+    so under an effective scope the visible set is the tenant's rows plus
+    NULL-context ones -- the same claimable population as contacts."""
+    effective = business_context_id or _default_context()
+    if not effective:
+        return rows
+    return [r for r in rows if r.get("business_context_id") in (None, effective)]
+
+
 def _is_uuid(value: str) -> bool:
     """Check if a string is a valid UUID."""
     try:
@@ -236,13 +248,16 @@ async def search_contacts(
         repo = get_appointment_repo()
         appointments = []
 
+        effective_scope = business_context_id or _default_context()
         if phone:
             appointments = await repo.get_by_phone(
                 phone, status=None, upcoming_only=False, limit=limit,
+                business_context_id=effective_scope,
             )
         if not appointments and query:
             appointments = await repo.search_by_name(
                 query, include_history=True, limit=limit,
+                business_context_id=effective_scope,
             )
         appointments = _appointments_in_scope(appointments, business_context_id)
 
@@ -551,8 +566,22 @@ async def log_interaction(
         return json.dumps({"success": False, "error": "interaction_type is required"})
 
     try:
-        if not await _guard_contact_id(contact_id, business_context_id):
+        allowed, existing = await _guarded_contact(contact_id, business_context_id)
+        if not allowed:
             return json.dumps({"success": False, "error": "Contact not found"})
+        default = _default_context()
+        if (
+            default
+            and not business_context_id
+            and existing is not None
+            and existing.get("business_context_id") is None
+        ):
+            # Claim-on-write: logging an interaction from a scoped session
+            # takes ownership of the NULL-context legacy row first, so the
+            # new note is not readable through another tenant's default.
+            await _provider().update_contact(
+                contact_id, {"business_context_id": default}
+            )
         interaction = await _provider().log_interaction(
             contact_id=contact_id,
             interaction_type=interaction_type,
@@ -698,10 +727,16 @@ async def get_customer_context(
             and (phone or email)
             and (business_context_id or _default_context())
         ):
-            results = await _scoped_search(
-                _provider(), phone=phone, email=email, limit=1,
-                business_context_id=business_context_id,
-            )
+            if phone:
+                results = await _scoped_search(
+                    _provider(), phone=phone, limit=1,
+                    business_context_id=business_context_id,
+                )
+            else:
+                results = await _scoped_search(
+                    _provider(), email=email, limit=1,
+                    business_context_id=business_context_id,
+                )
             if not results:
                 return json.dumps({"found": False, "context": None})
             contact_id = results[0].get("id")
@@ -726,8 +761,10 @@ async def get_customer_context(
             "found": True,
             "contact": ctx.contact,
             "interactions": ctx.interactions,
-            "appointments": ctx.appointments,
-            "call_transcripts": ctx.call_transcripts,
+            "appointments": _appointments_in_scope(
+                ctx.appointments, business_context_id),
+            "call_transcripts": _calls_in_scope(
+                ctx.call_transcripts, business_context_id),
             "sent_emails": ctx.sent_emails,
             "inbox_emails": ctx.inbox_emails,
             "b2b_churn_signals": ctx.b2b_churn_signals,

--- a/atlas_brain/mcp/crm_server.py
+++ b/atlas_brain/mcp/crm_server.py
@@ -67,6 +67,56 @@ def _provider():
     return get_crm_provider()
 
 
+def _default_context() -> "str | None":
+    """Deployment-default tenant for read scoping (issue #2151).
+
+    When configured (ATLAS_MCP_CRM_DEFAULT_BUSINESS_CONTEXT), read tools that
+    receive no explicit business_context_id operate on that tenant's rows
+    plus NULL-context legacy rows (the claimable population established in
+    PR #2153). An explicit argument always wins; unset preserves the legacy
+    unscoped behavior.
+    """
+    from ..config import settings
+
+    return settings.mcp.crm_default_business_context or None
+
+
+def _visible_under_default(contact: "dict | None") -> bool:
+    """Tenant guard for id-addressed tools: with a default configured, a
+    contact belonging to a DIFFERENT tenant is reported as not found
+    (fail-closed, no cross-tenant existence leak)."""
+    if contact is None:
+        return False
+    default = _default_context()
+    if not default:
+        return True
+    return contact.get("business_context_id") in (None, default)
+
+
+async def _guard_contact_id(contact_id: str) -> bool:
+    """Resolve + tenant-check an id-addressed operation under the default
+    scope. Foreign-tenant rows read as nonexistent (fail-closed)."""
+    if not _default_context():
+        return True
+    contact = await _provider().get_contact(contact_id)
+    return _visible_under_default(contact)
+
+
+async def _scoped_search(provider, **kwargs):
+    """search_contacts honoring the default scope: tenant page first, then
+    the NULL-context legacy page (mirrors crm_provider's stamped dedupe)."""
+    explicit = kwargs.pop("business_context_id", None)
+    if explicit:
+        return await provider.search_contacts(business_context_id=explicit, **kwargs)
+    default = _default_context()
+    if not default:
+        return await provider.search_contacts(**kwargs)
+    results = await provider.search_contacts(business_context_id=default, **kwargs)
+    if results:
+        return results
+    return await provider.search_contacts(business_context_id_is_null=True, **kwargs)
+
+
 def _is_uuid(value: str) -> bool:
     """Check if a string is a valid UUID."""
     try:
@@ -100,11 +150,12 @@ async def search_contacts(
     phone: any format accepted (digits extracted automatically)
     limit: max results (default 20)
     """
-    if not any([query, phone, email, business_context_id]):
+    if not any([query, phone, email, business_context_id, _default_context()]):
         return json.dumps({"error": "At least one of query, phone, email, or business_context_id is required",
                            "found": False, "contacts": [], "count": 0})
     try:
-        results = await _provider().search_contacts(
+        results = await _scoped_search(
+            _provider(),
             query=query,
             phone=phone,
             email=email,
@@ -186,13 +237,13 @@ async def get_contact(contact_id: str) -> str:
     try:
         # If it doesn't look like a UUID, search by name instead
         if not _is_uuid(contact_id):
-            results = await _provider().search_contacts(query=contact_id, limit=1)
+            results = await _scoped_search(_provider(), query=contact_id, limit=1)
             if results:
                 return json.dumps({"found": True, "contact": results[0]}, default=str)
             return json.dumps({"found": False, "contact": None})
 
         contact = await _provider().get_contact(contact_id)
-        if contact is None:
+        if not _visible_under_default(contact):
             return json.dumps({"found": False, "contact": None})
         return json.dumps({"found": True, "contact": contact}, default=str)
     except Exception as exc:
@@ -238,7 +289,7 @@ async def create_contact(
             "city": city,
             "state": state,
             "zip": zip_code,
-            "business_context_id": business_context_id,
+            "business_context_id": business_context_id or _default_context(),
             "contact_type": contact_type,
             "notes": notes,
             "source": source,
@@ -296,6 +347,8 @@ async def update_contact(
         if not data:
             return json.dumps({"success": False, "error": "No fields provided to update"})
 
+        if not await _guard_contact_id(contact_id):
+            return json.dumps({"success": False, "error": "Contact not found"})
         updated = await _provider().update_contact(contact_id, data)
         if updated is None:
             return json.dumps({"success": False, "error": "Contact not found"})
@@ -321,6 +374,8 @@ async def delete_contact(contact_id: str) -> str:
         return json.dumps({"success": False, "error": "Invalid contact_id (must be UUID)"})
 
     try:
+        if not await _guard_contact_id(contact_id):
+            return json.dumps({"success": False, "error": "Contact not found"})
         success = await _provider().delete_contact(contact_id)
         return json.dumps({"success": success})
     except Exception as exc:
@@ -349,7 +404,7 @@ async def list_contacts(
     """
     try:
         contacts = await _provider().list_contacts(
-            business_context_id=business_context_id,
+            business_context_id=business_context_id or _default_context(),
             status=status,
             contact_type=contact_type,
             limit=min(limit, 200),
@@ -389,6 +444,8 @@ async def log_interaction(
         return json.dumps({"success": False, "error": "interaction_type is required"})
 
     try:
+        if not await _guard_contact_id(contact_id):
+            return json.dumps({"success": False, "error": "Contact not found"})
         interaction = await _provider().log_interaction(
             contact_id=contact_id,
             interaction_type=interaction_type,
@@ -417,6 +474,8 @@ async def get_interactions(contact_id: str, limit: int = 20) -> str:
         return json.dumps({"error": "Invalid contact_id (must be UUID)", "interactions": [], "count": 0})
 
     try:
+        if not await _guard_contact_id(contact_id):
+            return json.dumps({"error": "Contact not found", "interactions": [], "count": 0})
         interactions = await _provider().get_interactions(contact_id, limit=min(limit, 100))
         return json.dumps(
             {"interactions": interactions, "count": len(interactions)}, default=str
@@ -443,6 +502,8 @@ async def get_contact_appointments(contact_id: str) -> str:
         return json.dumps({"error": "Invalid contact_id (must be UUID)", "appointments": [], "count": 0})
 
     try:
+        if not await _guard_contact_id(contact_id):
+            return json.dumps({"error": "Contact not found", "appointments": [], "count": 0})
         appointments = await _provider().get_contact_appointments(contact_id)
         return json.dumps(
             {"appointments": appointments, "count": len(appointments)}, default=str

--- a/atlas_brain/mcp/crm_server.py
+++ b/atlas_brain/mcp/crm_server.py
@@ -172,6 +172,25 @@ def _appointments_in_scope(
     return [a for a in appointments if a.get("business_context_id") == effective]
 
 
+async def _claim_if_legacy(
+    contact_id: str, existing: "dict | None", business_context_id: "str | None"
+) -> bool:
+    """Claim-on-write of a NULL-context legacy row under the default.
+
+    Compare-and-set in SQL (``claim_contact``): returns False when a
+    concurrent claim moved the row to another tenant between the guard read
+    and this write, so callers fail closed instead of overwriting the other
+    tenant's claim.
+    """
+    default = _default_context()
+    if not default or business_context_id or existing is None:
+        return True
+    if existing.get("business_context_id") is not None:
+        return True
+    claimed = await _provider().claim_contact(contact_id, default)
+    return claimed is not None
+
+
 def _calls_in_scope(
     rows: "list[dict]", business_context_id: "str | None"
 ) -> "list[dict]":
@@ -432,17 +451,11 @@ async def update_contact(
         allowed, existing = await _guarded_contact(contact_id, business_context_id)
         if not allowed:
             return json.dumps({"success": False, "error": "Contact not found"})
-        default = _default_context()
-        if (
-            default
-            and not business_context_id
-            and existing is not None
-            and existing.get("business_context_id") is None
-        ):
-            # Claim-on-write: an update from a scoped session takes ownership
-            # of the NULL-context legacy row, so corrected data stops being
-            # visible to every tenant as unclaimed legacy.
-            data["business_context_id"] = default
+        # Claim-on-write: an update from a scoped session takes ownership of
+        # the NULL-context legacy row, so corrected data stops being visible
+        # to every tenant as unclaimed legacy.
+        if not await _claim_if_legacy(contact_id, existing, business_context_id):
+            return json.dumps({"success": False, "error": "Contact not found"})
         updated = await _provider().update_contact(contact_id, data)
         if updated is None:
             return json.dumps({"success": False, "error": "Contact not found"})
@@ -470,7 +483,13 @@ async def delete_contact(contact_id: str, business_context_id: Optional[str] = N
         return json.dumps({"success": False, "error": "Invalid contact_id (must be UUID)"})
 
     try:
-        if not await _guard_contact_id(contact_id, business_context_id):
+        allowed, existing = await _guarded_contact(contact_id, business_context_id)
+        if not allowed:
+            return json.dumps({"success": False, "error": "Contact not found"})
+        # Archiving is a legacy mutation too: claim the NULL-context row so
+        # one tenant cannot soft-delete shared legacy data out of the other
+        # tenant's default view.
+        if not await _claim_if_legacy(contact_id, existing, business_context_id):
             return json.dumps({"success": False, "error": "Contact not found"})
         success = await _provider().delete_contact(contact_id)
         return json.dumps({"success": success})
@@ -569,19 +588,11 @@ async def log_interaction(
         allowed, existing = await _guarded_contact(contact_id, business_context_id)
         if not allowed:
             return json.dumps({"success": False, "error": "Contact not found"})
-        default = _default_context()
-        if (
-            default
-            and not business_context_id
-            and existing is not None
-            and existing.get("business_context_id") is None
-        ):
-            # Claim-on-write: logging an interaction from a scoped session
-            # takes ownership of the NULL-context legacy row first, so the
-            # new note is not readable through another tenant's default.
-            await _provider().update_contact(
-                contact_id, {"business_context_id": default}
-            )
+        # Claim-on-write: logging an interaction from a scoped session takes
+        # ownership of the NULL-context legacy row first, so the new note is
+        # not readable through another tenant's default.
+        if not await _claim_if_legacy(contact_id, existing, business_context_id):
+            return json.dumps({"success": False, "error": "Contact not found"})
         interaction = await _provider().log_interaction(
             contact_id=contact_id,
             interaction_type=interaction_type,
@@ -644,7 +655,10 @@ async def get_contact_appointments(
     try:
         if not await _guard_contact_id(contact_id, business_context_id):
             return json.dumps({"error": "Contact not found", "appointments": [], "count": 0})
-        appointments = await _provider().get_contact_appointments(contact_id)
+        appointments = await _provider().get_contact_appointments(
+            contact_id,
+            business_context_id=business_context_id or _default_context(),
+        )
         appointments = _appointments_in_scope(appointments, business_context_id)
         return json.dumps(
             {"appointments": appointments, "count": len(appointments)}, default=str
@@ -748,7 +762,11 @@ async def get_customer_context(
 
         svc = get_customer_context_service()
         if contact_id:
-            ctx = await svc.get_context(contact_id, **kwargs)
+            ctx = await svc.get_context(
+                contact_id,
+                business_context_id=business_context_id or _default_context(),
+                **kwargs,
+            )
         elif phone:
             ctx = await svc.get_context_by_phone(phone, **kwargs)
         else:
@@ -757,6 +775,7 @@ async def get_customer_context(
         if ctx.is_empty:
             return json.dumps({"found": False, "context": None})
 
+        effective = business_context_id or _default_context()
         result: dict = {
             "found": True,
             "contact": ctx.contact,
@@ -765,10 +784,15 @@ async def get_customer_context(
                 ctx.appointments, business_context_id),
             "call_transcripts": _calls_in_scope(
                 ctx.call_transcripts, business_context_id),
-            "sent_emails": ctx.sent_emails,
-            "inbox_emails": ctx.inbox_emails,
+            # Email history is gathered by address and carries no tenant
+            # column, so under a scope it is omitted (fail closed) until the
+            # email store is tenant-addressable.
+            "sent_emails": [] if effective else ctx.sent_emails,
+            "inbox_emails": [] if effective else ctx.inbox_emails,
             "b2b_churn_signals": ctx.b2b_churn_signals,
         }
+        if effective:
+            result["emails_omitted_under_scope"] = True
 
         return json.dumps(result, default=str)
     except Exception as exc:

--- a/atlas_brain/mcp/crm_server.py
+++ b/atlas_brain/mcp/crm_server.py
@@ -789,10 +789,14 @@ async def get_customer_context(
             # email store is tenant-addressable.
             "sent_emails": [] if effective else ctx.sent_emails,
             "inbox_emails": [] if effective else ctx.inbox_emails,
-            "b2b_churn_signals": ctx.b2b_churn_signals,
+            # B2B churn enrichment is keyed by email domain against a global
+            # table with no tenant column -- omitted under a scope like the
+            # email history (the B2B MCP server is the scoped surface for it).
+            "b2b_churn_signals": [] if effective else ctx.b2b_churn_signals,
         }
         if effective:
             result["emails_omitted_under_scope"] = True
+            result["b2b_enrichment_omitted_under_scope"] = True
 
         return json.dumps(result, default=str)
     except Exception as exc:

--- a/atlas_brain/services/crm_provider.py
+++ b/atlas_brain/services/crm_provider.py
@@ -375,6 +375,7 @@ class DatabaseCRMProvider:
     async def list_contacts(
         self,
         business_context_id: Optional[str] = None,
+        business_context_id_is_null: bool = False,
         status: Optional[str] = "active",
         contact_type: Optional[str] = None,
         limit: int = 50,
@@ -395,6 +396,8 @@ class DatabaseCRMProvider:
             conditions.append(f"business_context_id = ${idx}")
             params.append(business_context_id)
             idx += 1
+        if business_context_id_is_null:
+            conditions.append("business_context_id IS NULL")
         if contact_type:
             conditions.append(f"contact_type = ${idx}")
             params.append(contact_type)

--- a/atlas_brain/services/crm_provider.py
+++ b/atlas_brain/services/crm_provider.py
@@ -171,6 +171,17 @@ class DatabaseCRMProvider:
         if existing is None and email:
             existing = await _resolve(email=email)
 
+        if existing is not None and ctx and existing.get("business_context_id") is None:
+            # Claim the NULL-context legacy match by compare-and-set before
+            # merging: a concurrent claim by another tenant leaves the row
+            # theirs and this create falls through to a fresh insert instead
+            # of overwriting their claim.
+            claimed = await self.claim_contact(str(existing["id"]), ctx)
+            if claimed is None:
+                existing = None
+            else:
+                existing = claimed
+
         if existing is not None:
             # Merge any new non-null fields into the existing record
             _MERGEABLE = {

--- a/atlas_brain/services/crm_provider.py
+++ b/atlas_brain/services/crm_provider.py
@@ -362,6 +362,32 @@ class DatabaseCRMProvider:
         )
         return dict(row) if row else None
 
+    async def claim_contact(
+        self, contact_id: str, business_context_id: str
+    ) -> Optional[dict[str, Any]]:
+        """Compare-and-set claim of a legacy row for a tenant.
+
+        Stamps ``business_context_id`` only while the row is still NULL (or
+        already carries the same tenant, making the claim idempotent).
+        Returns None when a concurrent claim moved the row to a different
+        tenant, so callers can fail closed instead of overwriting it.
+        """
+        from ..storage.database import get_db_pool
+
+        pool = get_db_pool()
+        row = await pool.fetchrow(
+            """
+            UPDATE contacts
+               SET business_context_id = $2, updated_at = NOW()
+             WHERE id = $1
+               AND (business_context_id IS NULL OR business_context_id = $2)
+             RETURNING *
+            """,
+            contact_id,
+            business_context_id,
+        )
+        return dict(row) if row else None
+
     async def delete_contact(self, contact_id: str) -> bool:
         from ..storage.database import get_db_pool
 
@@ -516,23 +542,39 @@ class DatabaseCRMProvider:
         return [dict(r) for r in rows]
 
     async def get_contact_appointments(
-        self, contact_id: str
+        self, contact_id: str, business_context_id: Optional[str] = None
     ) -> list[dict[str, Any]]:
         from ..storage.database import get_db_pool
 
         pool = get_db_pool()
-        rows = await pool.fetch(
-            """
-            SELECT id, start_time, end_time, service_type, status,
-                   customer_name, customer_phone, customer_email,
-                   customer_address, notes, created_at, business_context_id
-            FROM appointments
-            WHERE contact_id = $1
-            ORDER BY start_time DESC
-            LIMIT 50
-            """,
-            contact_id,
-        )
+        if business_context_id:
+            rows = await pool.fetch(
+                """
+                SELECT id, start_time, end_time, service_type, status,
+                       customer_name, customer_phone, customer_email,
+                       customer_address, notes, created_at, business_context_id
+                FROM appointments
+                WHERE contact_id = $1
+                  AND business_context_id = $2
+                ORDER BY start_time DESC
+                LIMIT 50
+                """,
+                contact_id,
+                business_context_id,
+            )
+        else:
+            rows = await pool.fetch(
+                """
+                SELECT id, start_time, end_time, service_type, status,
+                       customer_name, customer_phone, customer_email,
+                       customer_address, notes, created_at, business_context_id
+                FROM appointments
+                WHERE contact_id = $1
+                ORDER BY start_time DESC
+                LIMIT 50
+                """,
+                contact_id,
+            )
         return [dict(r) for r in rows]
 
 

--- a/atlas_brain/services/crm_provider.py
+++ b/atlas_brain/services/crm_provider.py
@@ -525,7 +525,7 @@ class DatabaseCRMProvider:
             """
             SELECT id, start_time, end_time, service_type, status,
                    customer_name, customer_phone, customer_email,
-                   customer_address, notes, created_at
+                   customer_address, notes, created_at, business_context_id
             FROM appointments
             WHERE contact_id = $1
             ORDER BY start_time DESC

--- a/atlas_brain/services/customer_context.py
+++ b/atlas_brain/services/customer_context.py
@@ -66,6 +66,7 @@ class CustomerContextService:
         max_emails: int = 10,
         max_sms: int = 10,
         max_invoices: int = 10,
+        business_context_id: Optional[str] = None,
     ) -> CustomerContext:
         """Build full customer context by contact_id.
 
@@ -84,6 +85,7 @@ class CustomerContextService:
             contact, contact_id,
             max_interactions, max_calls, max_appointments, max_emails, max_sms,
             max_invoices,
+            business_context_id=business_context_id,
         )
 
     async def get_context_by_phone(
@@ -124,8 +126,14 @@ class CustomerContextService:
         max_emails: int = 10,
         max_sms: int = 10,
         max_invoices: int = 10,
+        business_context_id: Optional[str] = None,
     ) -> CustomerContext:
-        """Fetch all supplementary data in parallel."""
+        """Fetch all supplementary data in parallel.
+
+        ``business_context_id`` scopes the tenant-stamped child sources
+        (appointments strictly; call transcripts tenant-plus-NULL) inside
+        their SQL, before per-source limits apply.
+        """
         from .crm_provider import get_crm_provider
         from ..storage.repositories.call_transcript import get_call_transcript_repo
         from ..storage.repositories.sms_message import get_sms_message_repo
@@ -148,11 +156,14 @@ class CustomerContextService:
             "interactions",
         )
         appointments_coro = _safe(
-            crm.get_contact_appointments(contact_id),
+            crm.get_contact_appointments(
+                contact_id, business_context_id=business_context_id),
             "appointments",
         )
         calls_coro = _safe(
-            call_repo.get_by_contact_id(contact_id, limit=max_calls),
+            call_repo.get_by_contact_id(
+                contact_id, limit=max_calls,
+                business_context_id=business_context_id),
             "call_transcripts",
         )
         emails_coro = _safe(

--- a/atlas_brain/storage/repositories/appointment.py
+++ b/atlas_brain/storage/repositories/appointment.py
@@ -121,6 +121,7 @@ class AppointmentRepository:
         status: str = "confirmed",
         upcoming_only: bool = True,
         limit: int = 10,
+        business_context_id: Optional[str] = None,
     ) -> list[dict]:
         """
         Get appointments by customer phone number.
@@ -150,6 +151,11 @@ class AppointmentRepository:
                 params.append(datetime.now(timezone.utc))
                 param_idx += 1
 
+            if business_context_id:
+                conditions.append(f"business_context_id = ${param_idx}")
+                params.append(business_context_id)
+                param_idx += 1
+
             params.append(limit)
 
             rows = await pool.fetch(
@@ -174,6 +180,7 @@ class AppointmentRepository:
         name: str,
         include_history: bool = True,
         limit: int = 10,
+        business_context_id: Optional[str] = None,
     ) -> list[dict]:
         """
         Search appointments by customer name (case-insensitive partial match).
@@ -201,6 +208,11 @@ class AppointmentRepository:
             if not include_history:
                 conditions.append(f"start_time > ${param_idx}")
                 params.append(datetime.now(timezone.utc))
+                param_idx += 1
+
+            if business_context_id:
+                conditions.append(f"business_context_id = ${param_idx}")
+                params.append(business_context_id)
                 param_idx += 1
 
             params.append(limit)

--- a/atlas_brain/storage/repositories/call_transcript.py
+++ b/atlas_brain/storage/repositories/call_transcript.py
@@ -267,23 +267,42 @@ class CallTranscriptRepository:
 
     async def get_by_contact_id(
         self, contact_id: str, limit: int = 20,
+        business_context_id: Optional[str] = None,
     ) -> list[dict]:
-        """Get call transcripts linked to a CRM contact."""
+        """Get call transcripts linked to a CRM contact.
+
+        With ``business_context_id``, rows are limited to that tenant plus
+        NULL-context legacy rows (scoped before LIMIT).
+        """
         pool = get_db_pool()
         if not pool.is_initialized:
             raise DatabaseUnavailableError("get by contact id")
 
         try:
-            rows = await pool.fetch(
-                """
-                SELECT * FROM call_transcripts
-                WHERE contact_id = $1
-                ORDER BY created_at DESC
-                LIMIT $2
-                """,
-                contact_id,
-                limit,
-            )
+            if business_context_id:
+                rows = await pool.fetch(
+                    """
+                    SELECT * FROM call_transcripts
+                    WHERE contact_id = $1
+                      AND (business_context_id = $2 OR business_context_id IS NULL)
+                    ORDER BY created_at DESC
+                    LIMIT $3
+                    """,
+                    contact_id,
+                    business_context_id,
+                    limit,
+                )
+            else:
+                rows = await pool.fetch(
+                    """
+                    SELECT * FROM call_transcripts
+                    WHERE contact_id = $1
+                    ORDER BY created_at DESC
+                    LIMIT $2
+                    """,
+                    contact_id,
+                    limit,
+                )
             return [self._row_to_dict(row) for row in rows]
         except DatabaseUnavailableError:
             raise

--- a/plans/PR-EOM-Read-Scoping.md
+++ b/plans/PR-EOM-Read-Scoping.md
@@ -30,8 +30,8 @@ CRM MCP surface is still all-tenant by default. Verified at HEAD:
   scoped search/list (default page + NULL-context legacy page, the
   claimable population from #2153), fail-closed tenant guards on all five
   id-addressed tools, and default-stamping on the MCP create tool.
-- Must not change: `crm_provider` (already has the scoped + IS-NULL
-  filters), any B2B module, `atlas_brain/api/contacts.py` (shared intel-UI surface
+- Must not change: `crm_provider` beyond a NULL-page filter on
+  `list_contacts` (search already had one; review round 1), any B2B module, `atlas_brain/api/contacts.py` (shared intel-UI surface
   serving both tenants — see Intentional), behavior when no default is
   configured (legacy unscoped, backward compatible), the lead-intake
   endpoint, schema.
@@ -51,10 +51,21 @@ Slice phase: vertical slice
    id-addressed tools (`get/update/delete/log_interaction/
    get_interactions/get_contact_appointments`) treat foreign-tenant rows as
    "not found" (fail-closed, no cross-tenant existence leak).
-3. Proof: `tests/test_crm_read_scoping.py` — 14 tests covering default+
+3. Review round 1 (Codex) widened the same contract to the rest of the
+   read surface: `get_customer_context` resolves through the scoped search
+   and tenant guard; the appointment fallback in `search_contacts` filters
+   rows to the effective tenant (`_appointments_in_scope`); `list_contacts`
+   under the default merges the tenant page with the NULL-context legacy
+   page (`crm_provider.list_contacts` gained `business_context_id_is_null`,
+   mirroring #2153's search filter); every id-addressed tool accepts an
+   explicit `business_context_id` override (exact-page semantics, so
+   cross-tenant admin access stays possible per call).
+4. Proof: `tests/test_crm_read_scoping.py` — 25 tests covering default+
    fallback search order, explicit-arg precedence, no-default legacy
    behavior, foreign-tenant invisibility on reads and refusal on
-   mutations, NULL-legacy visibility, create default-stamp, list default.
+   mutations, NULL-legacy visibility, create default-stamp, list default +
+   NULL-page merge, explicit override on id tools (exact match), the
+   appointment-fallback filter, and customer-context scoping.
 
 ### Review Contract
 
@@ -76,6 +87,13 @@ Slice phase: vertical slice
      context wins.
   7. A bare `search_contacts()` call is valid when a default exists
      (list-my-tenant), preserving the requires-one-of error otherwise.
+  8. `get_customer_context` follows the same scoping as
+     `search_contacts`/`get_contact` on every resolution path (uuid, name,
+     phone, email); the appointment fallback never returns foreign-tenant
+     rows under an effective scope; `list_contacts` under the default
+     includes the NULL-context legacy page; an explicit
+     `business_context_id` on id-addressed tools addresses exactly that
+     tenant's page.
 - Reachability proof: the CRM MCP server tools themselves (stdio/SSE per
   `settings.mcp`); deployment opt-in is
   `ATLAS_MCP_CRM_DEFAULT_BUSINESS_CONTEXT=effingham_maids` in the Atlas
@@ -98,6 +116,7 @@ Slice phase: vertical slice
 
 - `atlas_brain/config.py`
 - `atlas_brain/mcp/crm_server.py`
+- `atlas_brain/services/crm_provider.py`
 - `plans/PR-EOM-Read-Scoping.md`
 - `tests/test_crm_read_scoping.py`
 
@@ -125,6 +144,17 @@ set, which keeps every other Atlas deployment/test unaffected.
 - **No sentinel for "all tenants"** — cross-tenant admin reads can pass the
   other tenant explicitly per call; a wildcard would reopen the hole by
   convention.
+- **Explicit override is exact-page** — passing `business_context_id`
+  addresses only that tenant's rows, with no NULL-context fallback
+  (mirrors explicit search). NULL legacy rows stay reachable by omitting
+  the argument under the default.
+- **`list_contacts` NULL-page merge paginates per page** — offset applies
+  to each underlying page and the merged result truncates to `limit`;
+  documented in the tool docstring, acceptable for an operator-facing
+  listing tool.
+- **`set_provider_override` test seam** — mirrors the HTTP surface's
+  `dependency_overrides` so tests need not monkeypatch module internals
+  (mcp-lane maturity ratchet).
 
 ## Deferred
 
@@ -138,9 +168,11 @@ Parked hardening: none new.
 
 ## Verification
 
-- Suite `tests/test_crm_read_scoping.py` — 14 passed.
-- Suites `tests/test_tenant_stamping.py` + `tests/test_leads_intake.py` —
-  44 passed combined (adjacent lane suites).
+- Suite `tests/test_crm_read_scoping.py` — 25 passed.
+- Suites `tests/test_tenant_stamping.py` + `tests/test_leads_intake.py` +
+  `tests/test_mcp_servers.py` — 145 passed combined, 6 failed
+  pre-existing on origin/main (email/Twilio/calendar env-dependent
+  cases, verified on a pristine `origin/main` worktree).
 - `python -m py_compile` on both touched Python files — clean.
 - NOT run: live MCP session against the running server (env not yet set;
   post-merge operator step, then a scoped search spot-check).
@@ -150,7 +182,8 @@ Parked hardening: none new.
 | File | LOC |
 |---|---:|
 | `atlas_brain/config.py` | 8 |
-| `atlas_brain/mcp/crm_server.py` | 73 |
-| `plans/PR-EOM-Read-Scoping.md` | 152 |
-| `tests/test_crm_read_scoping.py` | 193 |
-| **Total** | **426** |
+| `atlas_brain/mcp/crm_server.py` | 200 |
+| `atlas_brain/services/crm_provider.py` | 3 |
+| `plans/PR-EOM-Read-Scoping.md` | 210 |
+| `tests/test_crm_read_scoping.py` | 320 |
+| **Total** | **~740** |

--- a/plans/PR-EOM-Read-Scoping.md
+++ b/plans/PR-EOM-Read-Scoping.md
@@ -76,7 +76,15 @@ Slice phase: vertical slice
    effective scope (calls NULL-inclusive — same claimable population as
    contacts) and keeps legacy phone-first resolution when scoped;
    `log_interaction` claims NULL-context rows like `update_contact`.
-6. Proof: `tests/test_crm_read_scoping.py` — 38 tests covering default+
+6. Review round 4 (Codex): the claim became a compare-and-set
+   (`crm_provider.claim_contact`: stamps only while the row is still NULL
+   or same-tenant; a lost race fails the mutation closed); archive claims
+   like the other legacy mutations; linked appointments and call
+   transcripts scope inside their SQL before LIMIT
+   (`customer_context._gather` threads the scope to both child queries);
+   email history is omitted under a scope (no tenant column on the email
+   store yet — fail closed, flagged `emails_omitted_under_scope`).
+7. Proof: `tests/test_crm_read_scoping.py` — 46 tests covering default+
    fallback search order, explicit-arg precedence, no-default legacy
    behavior, foreign-tenant invisibility on reads and refusal on
    mutations, NULL-legacy visibility, create default-stamp, list default +
@@ -134,6 +142,8 @@ Slice phase: vertical slice
 - `atlas_brain/mcp/crm_server.py`
 - `atlas_brain/services/crm_provider.py`
 - `atlas_brain/storage/repositories/appointment.py`
+- `atlas_brain/storage/repositories/call_transcript.py`
+- `atlas_brain/services/customer_context.py`
 - `plans/PR-EOM-Read-Scoping.md`
 - `tests/test_crm_read_scoping.py`
 
@@ -185,7 +195,8 @@ Parked hardening: none new.
 
 ## Verification
 
-- Suite `tests/test_crm_read_scoping.py` — 38 passed.
+- Suite `tests/test_crm_read_scoping.py` — 46 passed (plus the existing
+  `tests/test_customer_context.py` suite against the threaded service).
 - Suites `tests/test_tenant_stamping.py` + `tests/test_leads_intake.py` +
   `tests/test_mcp_servers.py` — 145 passed combined, 6 failed
   pre-existing on origin/main (email/Twilio/calendar env-dependent
@@ -199,9 +210,15 @@ Parked hardening: none new.
 | File | LOC |
 |---|---:|
 | `atlas_brain/config.py` | 8 |
-| `atlas_brain/mcp/crm_server.py` | 200 |
-| `atlas_brain/services/crm_provider.py` | 4 |
-| `atlas_brain/storage/repositories/appointment.py` | 14 |
-| `plans/PR-EOM-Read-Scoping.md` | 210 |
-| `tests/test_crm_read_scoping.py` | 320 |
-| **Total** | **~740** |
+| `atlas_brain/mcp/crm_server.py` | 300 |
+| `atlas_brain/services/crm_provider.py` | 75 |
+| `atlas_brain/storage/repositories/appointment.py` | 25 |
+| `atlas_brain/storage/repositories/call_transcript.py` | 30 |
+| `atlas_brain/services/customer_context.py` | 20 |
+| `plans/PR-EOM-Read-Scoping.md` | 270 |
+| `tests/test_crm_read_scoping.py` | 450 |
+| **Total** | **~1180** |
+
+Four Codex reconciliation rounds grew the slice ~2.8x over the original
+estimate; the growth is itemized in the PR body's AI-reconciliation
+section (rounds 1-4) rather than re-estimated here per round.

--- a/plans/PR-EOM-Read-Scoping.md
+++ b/plans/PR-EOM-Read-Scoping.md
@@ -60,7 +60,12 @@ Slice phase: vertical slice
    mirroring #2153's search filter); every id-addressed tool accepts an
    explicit `business_context_id` override (exact-page semantics, so
    cross-tenant admin access stays possible per call).
-4. Proof: `tests/test_crm_read_scoping.py` — 25 tests covering default+
+4. Review round 2 (Codex): `get_contact_appointments` filters linked
+   appointment rows to the effective scope (a NULL-context legacy contact
+   cannot expose foreign-tenant appointment history), and `update_contact`
+   claims NULL-context rows under the default (claim-on-write: corrected
+   legacy data stops being cross-tenant-visible as unclaimed).
+5. Proof: `tests/test_crm_read_scoping.py` — 29 tests covering default+
    fallback search order, explicit-arg precedence, no-default legacy
    behavior, foreign-tenant invisibility on reads and refusal on
    mutations, NULL-legacy visibility, create default-stamp, list default +
@@ -168,7 +173,7 @@ Parked hardening: none new.
 
 ## Verification
 
-- Suite `tests/test_crm_read_scoping.py` — 25 passed.
+- Suite `tests/test_crm_read_scoping.py` — 29 passed.
 - Suites `tests/test_tenant_stamping.py` + `tests/test_leads_intake.py` +
   `tests/test_mcp_servers.py` — 145 passed combined, 6 failed
   pre-existing on origin/main (email/Twilio/calendar env-dependent

--- a/plans/PR-EOM-Read-Scoping.md
+++ b/plans/PR-EOM-Read-Scoping.md
@@ -1,0 +1,156 @@
+# PR-EOM-Read-Scoping
+
+## Why this slice exists
+
+Issue #2151 read-scoping (the deferred half of Phase 2, named in
+plans/PR-EOM-Tenant-Separation.md Deferred). After #2155, writes are
+tenant-stamped and the backfill classified 679 rows — but every read on the
+CRM MCP surface is still all-tenant by default. Verified at HEAD:
+
+- `atlas_brain/mcp/crm_server.py` tools take `business_context_id` as an
+  optional arg and pass it through only when supplied (search `:111`,
+  list `:352`, create `:241`); `get_contact` (`:179`) and every other
+  id-addressed tool (`update/delete/log_interaction/get_interactions/
+  get_contact_appointments`) perform no tenant check at all —
+  `crm_provider.get_contact` is `SELECT * ... WHERE id = $1` (`:239-241`).
+- Consequence: an assistant session operating "the EOM CRM" reads and can
+  mutate churnsignals rows (and vice versa), and the MCP `create_contact`
+  tool keeps minting NULL-context rows — the exact provenance hole called
+  out in PR #2155 review ("source is settable via the MCP tool while
+  business_context_id is optional").
+
+### Problem-derived contract
+
+- Root cause: the MCP CRM surface has no notion of a deployment tenant —
+  scoping exists only as an optional per-call argument nobody defaults, so
+  cross-tenant reads/mutations are the silent default.
+- Correct fix must touch/change: a deployment-level default
+  (`MCPConfig.crm_default_business_context`, env
+  `ATLAS_MCP_CRM_DEFAULT_BUSINESS_CONTEXT`); the CRM MCP tools to honor it —
+  scoped search/list (default page + NULL-context legacy page, the
+  claimable population from #2153), fail-closed tenant guards on all five
+  id-addressed tools, and default-stamping on the MCP create tool.
+- Must not change: `crm_provider` (already has the scoped + IS-NULL
+  filters), any B2B module, `atlas_brain/api/contacts.py` (shared intel-UI surface
+  serving both tenants — see Intentional), behavior when no default is
+  configured (legacy unscoped, backward compatible), the lead-intake
+  endpoint, schema.
+
+## Scope (this PR)
+
+Ownership lane: eom-crm/lead-funnel
+Slice phase: vertical slice
+
+1. `MCPConfig.crm_default_business_context` (default None — nothing changes
+   until a deployment opts in via env).
+2. `atlas_brain/mcp/crm_server.py`: `_default_context()` /
+   `_visible_under_default()` / `_scoped_search()` / `_guard_contact_id()`
+   helpers; `search_contacts` + `get_contact`-by-name use scoped search
+   (default page, then NULL-context page; explicit arg always wins);
+   `list_contacts` and `create_contact` default their context arg; the five
+   id-addressed tools (`get/update/delete/log_interaction/
+   get_interactions/get_contact_appointments`) treat foreign-tenant rows as
+   "not found" (fail-closed, no cross-tenant existence leak).
+3. Proof: `tests/test_crm_read_scoping.py` — 14 tests covering default+
+   fallback search order, explicit-arg precedence, no-default legacy
+   behavior, foreign-tenant invisibility on reads and refusal on
+   mutations, NULL-legacy visibility, create default-stamp, list default.
+
+### Review Contract
+
+- Acceptance criteria:
+  1. With a default configured and no explicit arg: search queries the
+     default tenant page, then the NULL-context page; a scoped hit skips
+     the fallback (test-asserted call order).
+  2. An explicit `business_context_id` always wins and suppresses the
+     fallback.
+  3. No default configured → byte-identical legacy behavior (unscoped, no
+     guards) — test-asserted.
+  4. `get_contact` on a foreign-tenant UUID returns `found:false`;
+     NULL-context and same-tenant rows remain visible.
+  5. `update/delete/log_interaction` against a foreign-tenant contact
+     refuse without invoking the provider mutation (test-asserted
+     not-awaited).
+  6. MCP `create_contact` stamps the default when the caller passes no
+     context (closes the NULL-minting hole from #2155 review); explicit
+     context wins.
+  7. A bare `search_contacts()` call is valid when a default exists
+     (list-my-tenant), preserving the requires-one-of error otherwise.
+- Reachability proof: the CRM MCP server tools themselves (stdio/SSE per
+  `settings.mcp`); deployment opt-in is
+  `ATLAS_MCP_CRM_DEFAULT_BUSINESS_CONTEXT=effingham_maids` in the Atlas
+  `.env` (operator step, this box, post-merge). Observable effect: EOM
+  assistant sessions see/mutate only EOM + legacy-NULL rows; churnsignals
+  rows read as nonexistent.
+- Affected surfaces: CRM MCP tools only. `atlas_brain/api/contacts.py` untouched.
+- Risk areas: hiding legacy NULL rows (mitigated: NULL page is part of the
+  default scope everywhere); breaking B2B MCP usage (mitigated: explicit
+  arg wins; and the default is opt-in per deployment); double-query cost
+  on scoped search miss (two indexed lookups, `idx_contacts_business_context`).
+- Reviewer rules triggered: R1 (#2151 read-scoping), R2 (14 tests), R3
+  (tenant isolation, fail-closed guards, no existence leak), R4 (mutations
+  refused pre-provider on foreign rows), R5 (no-default = legacy behavior;
+  default None), R10 (helpers shared across tools, no per-tool drift), R11
+  (new config field, env-driven, default off), R12 (deployment: inert
+  until the env var is set; no restart-order concerns), R14.
+
+### Files touched
+
+- `atlas_brain/config.py`
+- `atlas_brain/mcp/crm_server.py`
+- `plans/PR-EOM-Read-Scoping.md`
+- `tests/test_crm_read_scoping.py`
+
+## Mechanism
+
+One config field + four small helpers. `_scoped_search` mirrors the
+tenant-page-then-NULL-page resolution the reviewers converged on in #2153
+for the provider dedupe, so both surfaces define "my population" the same
+way: `{default tenant} ∪ {NULL legacy}`. Id-addressed tools resolve the
+contact once via `get_contact` and fail closed; mutation providers are
+never invoked for foreign rows. Everything is inert until the env var is
+set, which keeps every other Atlas deployment/test unaffected.
+
+## Intentional
+
+- **`atlas_brain/api/contacts.py` untouched** — the intel UI consumes it for BOTH
+  tenants; defaulting it to EOM would break churnsignals timelines. Its
+  (pre-existing, already-tracked) authlessness is a separate concern; the
+  #2153 slice already stopped leaking contact ids from the public intake.
+- **Guard costs one extra `get_contact` per id-addressed call** — accepted:
+  correctness over a single indexed PK read; only paid when a default is
+  configured.
+- **`delete_contact` guarded too** even though EOM rarely deletes —
+  cross-tenant delete is the worst-case accident.
+- **No sentinel for "all tenants"** — cross-tenant admin reads can pass the
+  other tenant explicitly per call; a wildcard would reopen the hole by
+  convention.
+
+## Deferred
+
+- `atlas_brain/api/contacts.py` auth + optional scoping (own slice; UI-coupled).
+- Operator env opt-in on this box post-merge
+  (`ATLAS_MCP_CRM_DEFAULT_BUSINESS_CONTEXT=effingham_maids`).
+- Phase 3 residue: 4 unclassifiable NULL rows (3 `manual`,
+  1 `manual_invoice_setup`) for operator eyeball.
+
+Parked hardening: none new.
+
+## Verification
+
+- Suite `tests/test_crm_read_scoping.py` — 14 passed.
+- Suites `tests/test_tenant_stamping.py` + `tests/test_leads_intake.py` —
+  44 passed combined (adjacent lane suites).
+- `python -m py_compile` on both touched Python files — clean.
+- NOT run: live MCP session against the running server (env not yet set;
+  post-merge operator step, then a scoped search spot-check).
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/config.py` | 8 |
+| `atlas_brain/mcp/crm_server.py` | 73 |
+| `plans/PR-EOM-Read-Scoping.md` | 152 |
+| `tests/test_crm_read_scoping.py` | 193 |
+| **Total** | **426** |

--- a/plans/PR-EOM-Read-Scoping.md
+++ b/plans/PR-EOM-Read-Scoping.md
@@ -84,7 +84,13 @@ Slice phase: vertical slice
    (`customer_context._gather` threads the scope to both child queries);
    email history is omitted under a scope (no tenant column on the email
    store yet — fail closed, flagged `emails_omitted_under_scope`).
-7. Proof: `tests/test_crm_read_scoping.py` — 46 tests covering default+
+7. Review round 5 (Codex): B2B churn enrichment (global, email-domain
+   keyed, no tenant column) is omitted from scoped context responses like
+   the email history; the stamped-create legacy merge in
+   `crm_provider.create_contact` claims its NULL match via the CAS
+   `claim_contact` (a lost race falls through to a fresh insert instead of
+   overwriting the winner's row and fields).
+8. Proof: `tests/test_crm_read_scoping.py` — 48 tests covering default+
    fallback search order, explicit-arg precedence, no-default legacy
    behavior, foreign-tenant invisibility on reads and refusal on
    mutations, NULL-legacy visibility, create default-stamp, list default +
@@ -146,6 +152,8 @@ Slice phase: vertical slice
 - `atlas_brain/services/customer_context.py`
 - `plans/PR-EOM-Read-Scoping.md`
 - `tests/test_crm_read_scoping.py`
+- `tests/test_leads_intake.py` (round 5: the #2153 dedupe-claim test
+  updated to the compare-and-set contract)
 
 ## Mechanism
 
@@ -195,7 +203,7 @@ Parked hardening: none new.
 
 ## Verification
 
-- Suite `tests/test_crm_read_scoping.py` — 46 passed (plus the existing
+- Suite `tests/test_crm_read_scoping.py` — 48 passed (plus the existing
   `tests/test_customer_context.py` suite against the threaded service).
 - Suites `tests/test_tenant_stamping.py` + `tests/test_leads_intake.py` +
   `tests/test_mcp_servers.py` — 145 passed combined, 6 failed

--- a/plans/PR-EOM-Read-Scoping.md
+++ b/plans/PR-EOM-Read-Scoping.md
@@ -31,7 +31,10 @@ CRM MCP surface is still all-tenant by default. Verified at HEAD:
   claimable population from #2153), fail-closed tenant guards on all five
   id-addressed tools, and default-stamping on the MCP create tool.
 - Must not change: `crm_provider` beyond a NULL-page filter on
-  `list_contacts` (search already had one; review round 1), any B2B module, `atlas_brain/api/contacts.py` (shared intel-UI surface
+  `list_contacts` and the tenant column in the linked-appointments SELECT
+  (review rounds 1/3); `appointment` repository beyond an optional tenant
+  condition on `get_by_phone`/`search_by_name` (round 3, so the fallback
+  scopes in SQL before LIMIT); any B2B module, `atlas_brain/api/contacts.py` (shared intel-UI surface
   serving both tenants — see Intentional), behavior when no default is
   configured (legacy unscoped, backward compatible), the lead-intake
   endpoint, schema.
@@ -65,7 +68,15 @@ Slice phase: vertical slice
    cannot expose foreign-tenant appointment history), and `update_contact`
    claims NULL-context rows under the default (claim-on-write: corrected
    legacy data stops being cross-tenant-visible as unclaimed).
-5. Proof: `tests/test_crm_read_scoping.py` — 29 tests covering default+
+5. Review round 3 (Codex): the appointment fallback scopes in SQL before
+   LIMIT (repo `get_by_phone`/`search_by_name` gained an optional tenant
+   condition); the linked-appointments SELECT returns
+   `business_context_id` so the strict filter operates on real data;
+   `get_customer_context` filters child appointment/call rows to the
+   effective scope (calls NULL-inclusive — same claimable population as
+   contacts) and keeps legacy phone-first resolution when scoped;
+   `log_interaction` claims NULL-context rows like `update_contact`.
+6. Proof: `tests/test_crm_read_scoping.py` — 38 tests covering default+
    fallback search order, explicit-arg precedence, no-default legacy
    behavior, foreign-tenant invisibility on reads and refusal on
    mutations, NULL-legacy visibility, create default-stamp, list default +
@@ -122,6 +133,7 @@ Slice phase: vertical slice
 - `atlas_brain/config.py`
 - `atlas_brain/mcp/crm_server.py`
 - `atlas_brain/services/crm_provider.py`
+- `atlas_brain/storage/repositories/appointment.py`
 - `plans/PR-EOM-Read-Scoping.md`
 - `tests/test_crm_read_scoping.py`
 
@@ -173,7 +185,7 @@ Parked hardening: none new.
 
 ## Verification
 
-- Suite `tests/test_crm_read_scoping.py` — 29 passed.
+- Suite `tests/test_crm_read_scoping.py` — 38 passed.
 - Suites `tests/test_tenant_stamping.py` + `tests/test_leads_intake.py` +
   `tests/test_mcp_servers.py` — 145 passed combined, 6 failed
   pre-existing on origin/main (email/Twilio/calendar env-dependent
@@ -188,7 +200,8 @@ Parked hardening: none new.
 |---|---:|
 | `atlas_brain/config.py` | 8 |
 | `atlas_brain/mcp/crm_server.py` | 200 |
-| `atlas_brain/services/crm_provider.py` | 3 |
+| `atlas_brain/services/crm_provider.py` | 4 |
+| `atlas_brain/storage/repositories/appointment.py` | 14 |
 | `plans/PR-EOM-Read-Scoping.md` | 210 |
 | `tests/test_crm_read_scoping.py` | 320 |
 | **Total** | **~740** |

--- a/tests/test_crm_read_scoping.py
+++ b/tests/test_crm_read_scoping.py
@@ -48,6 +48,12 @@ def no_default(monkeypatch):
     monkeypatch.setattr(settings.mcp, "crm_default_business_context", None)
 
 
+@pytest.fixture(autouse=True)
+def _clear_provider_override():
+    yield
+    crm_srv.set_provider_override(None)
+
+
 def _provider_mock(monkeypatch, **overrides):
     provider = MagicMock()
     provider.search_contacts = AsyncMock(return_value=overrides.get("search", []))
@@ -58,7 +64,7 @@ def _provider_mock(monkeypatch, **overrides):
     provider.log_interaction = AsyncMock(return_value={"id": "i-1"})
     provider.get_interactions = AsyncMock(return_value=[])
     provider.get_contact_appointments = AsyncMock(return_value=[])
-    monkeypatch.setattr(crm_srv, "_provider", lambda: provider)
+    crm_srv.set_provider_override(lambda: provider)
     return provider
 
 

--- a/tests/test_crm_read_scoping.py
+++ b/tests/test_crm_read_scoping.py
@@ -347,6 +347,80 @@ def test_context_result_omits_emails_under_scope():
     src = (REPO / "atlas_brain/mcp/crm_server.py").read_text(encoding="utf-8")
     assert '"sent_emails": [] if effective else ctx.sent_emails' in src
     assert "emails_omitted_under_scope" in src
+    assert '"b2b_churn_signals": [] if effective else ctx.b2b_churn_signals' in src
+    assert "b2b_enrichment_omitted_under_scope" in src
+
+
+@pytest.mark.asyncio
+async def test_create_contact_claims_legacy_match_with_cas():
+    """The stamped-create legacy merge claims by compare-and-set, never by
+    blind update (round-5 MAJOR)."""
+    from atlas_brain.services.crm_provider import DatabaseCRMProvider
+
+    class _Provider(DatabaseCRMProvider):
+        def __init__(self, claim_result):
+            self.claim_calls = []
+            self.updates = []
+            self._claim_result = claim_result
+
+        async def search_contacts(self, **kwargs):
+            if kwargs.get("business_context_id_is_null"):
+                return [{"id": UUID, "business_context_id": None,
+                         "phone": "2175550000"}]
+            return []
+
+        async def claim_contact(self, contact_id, business_context_id):
+            self.claim_calls.append((contact_id, business_context_id))
+            return self._claim_result
+
+        async def update_contact(self, contact_id, data):
+            self.updates.append((contact_id, data))
+            return {"id": contact_id, **data}
+
+    p = _Provider({"id": UUID, "business_context_id": EOM})
+    result = await p.create_contact({
+        "phone": "2175550000", "full_name": "Jane",
+        "business_context_id": EOM,
+    })
+    assert p.claim_calls == [(UUID, EOM)]
+    assert result["_was_created"] is False
+
+
+@pytest.mark.asyncio
+async def test_create_contact_lost_claim_never_blind_merges():
+    """When another tenant wins the claim race, the NULL match is not ours:
+    no merge lands on the stolen row (create falls through to insert)."""
+    from atlas_brain.services.crm_provider import DatabaseCRMProvider
+
+    class _Provider(DatabaseCRMProvider):
+        def __init__(self):
+            self.claim_calls = []
+            self.updates = []
+
+        async def search_contacts(self, **kwargs):
+            if kwargs.get("business_context_id_is_null"):
+                return [{"id": UUID, "business_context_id": None,
+                         "phone": "2175550000"}]
+            return []
+
+        async def claim_contact(self, contact_id, business_context_id):
+            self.claim_calls.append((contact_id, business_context_id))
+            return None
+
+        async def update_contact(self, contact_id, data):
+            self.updates.append((contact_id, data))
+            return {"id": contact_id, **data}
+
+    p = _Provider()
+    try:
+        await p.create_contact({
+            "phone": "2175550000", "full_name": "Jane",
+            "business_context_id": EOM,
+        })
+    except Exception:
+        pass  # the fresh-insert path needs a live pool; irrelevant here
+    assert p.claim_calls == [(UUID, EOM)]
+    assert p.updates == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_crm_read_scoping.py
+++ b/tests/test_crm_read_scoping.py
@@ -193,7 +193,111 @@ async def test_create_contact_explicit_context_wins(default_ctx, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_list_contacts_merges_null_page_under_default(default_ctx, monkeypatch):
+    provider = _provider_mock(monkeypatch)
+    tenant_page = [{"id": "t1", "business_context_id": EOM}]
+    legacy_page = [{"id": "n1", "business_context_id": None}]
+    provider.list_contacts = AsyncMock(side_effect=[tenant_page, legacy_page])
+    out = json.loads(await crm_srv.list_contacts())
+    calls = provider.list_contacts.await_args_list
+    assert calls[0].kwargs["business_context_id"] == EOM
+    assert calls[1].kwargs["business_context_id_is_null"] is True
+    assert [c["id"] for c in out["contacts"]] == ["t1", "n1"]
+
+
+@pytest.mark.asyncio
+async def test_list_contacts_explicit_context_single_page(default_ctx, monkeypatch):
+    provider = _provider_mock(monkeypatch)
+    await crm_srv.list_contacts(business_context_id="churnsignals")
+    calls = provider.list_contacts.await_args_list
+    assert len(calls) == 1
+    assert calls[0].kwargs["business_context_id"] == "churnsignals"
+
+
+# ---------------------------------------------------------------------------
+# Explicit tenant override on id-addressed tools
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_contact_explicit_context_reaches_foreign_tenant(default_ctx, monkeypatch):
+    _provider_mock(monkeypatch, get=FOREIGN)
+    out = json.loads(await crm_srv.get_contact(UUID, business_context_id="churnsignals"))
+    assert out["found"] is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("row", [LEGACY_NULL, FOREIGN])
+async def test_explicit_context_is_exact_match(default_ctx, monkeypatch, row):
+    """Explicit tenant addressing mirrors explicit search: exact page only,
+    no NULL-context fallback (NULL rows stay reachable via the default)."""
+    _provider_mock(monkeypatch, get=row)
+    out = json.loads(await crm_srv.get_contact(UUID, business_context_id=EOM))
+    assert out["found"] is False
+
+
+@pytest.mark.asyncio
+async def test_update_contact_explicit_override_reaches_foreign_tenant(default_ctx, monkeypatch):
+    provider = _provider_mock(monkeypatch, get=FOREIGN)
+    out = json.loads(await crm_srv.update_contact(
+        UUID, full_name="X", business_context_id="churnsignals"))
+    assert out["success"] is True
+    provider.update_contact.assert_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Appointment-fallback scope filter (pure)
+# ---------------------------------------------------------------------------
+
+
+def test_appointments_in_scope_filters_foreign(default_ctx):
+    rows = [
+        {"id": 1, "business_context_id": EOM},
+        {"id": 2, "business_context_id": "churnsignals"},
+    ]
+    assert [a["id"] for a in crm_srv._appointments_in_scope(rows, None)] == [1]
+    assert [a["id"] for a in crm_srv._appointments_in_scope(rows, "churnsignals")] == [2]
+
+
+def test_appointments_in_scope_unfiltered_without_default(no_default):
+    rows = [{"id": 1, "business_context_id": "churnsignals"}]
+    assert crm_srv._appointments_in_scope(rows, None) == rows
+
+
+# ---------------------------------------------------------------------------
+# get_customer_context scoping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_customer_context_hides_foreign_uuid(default_ctx, monkeypatch):
+    _provider_mock(monkeypatch, get=FOREIGN)
+    out = json.loads(await crm_srv.get_customer_context(contact_id=UUID))
+    assert out == {"found": False, "context": None}
+
+
+@pytest.mark.asyncio
+async def test_customer_context_name_lookup_is_scoped(default_ctx, monkeypatch):
+    provider = _provider_mock(monkeypatch)
+    out = json.loads(await crm_srv.get_customer_context(name="jane"))
+    assert out["found"] is False
+    calls = provider.search_contacts.await_args_list
+    assert calls[0].kwargs["business_context_id"] == EOM
+    assert calls[1].kwargs["business_context_id_is_null"] is True
+
+
+@pytest.mark.asyncio
+async def test_customer_context_phone_lookup_is_scoped(default_ctx, monkeypatch):
+    provider = _provider_mock(monkeypatch)
+    out = json.loads(await crm_srv.get_customer_context(phone="217-555-0000"))
+    assert out == {"found": False, "context": None}
+    calls = provider.search_contacts.await_args_list
+    assert calls[0].kwargs["business_context_id"] == EOM
+
+
+@pytest.mark.asyncio
 async def test_list_contacts_uses_default(default_ctx, monkeypatch):
     provider = _provider_mock(monkeypatch)
     await crm_srv.list_contacts()
-    assert provider.list_contacts.await_args.kwargs["business_context_id"] == EOM
+    first = provider.list_contacts.await_args_list[0]
+    assert first.kwargs["business_context_id"] == EOM

--- a/tests/test_crm_read_scoping.py
+++ b/tests/test_crm_read_scoping.py
@@ -1,0 +1,193 @@
+"""Tests for issue #2151 read-path scoping on the CRM MCP server.
+
+Semantics under test (plans/PR-EOM-Read-Scoping.md):
+- With ATLAS_MCP_CRM_DEFAULT_BUSINESS_CONTEXT configured, read tools that
+  receive no explicit business_context_id operate on the default tenant's
+  page first, then the NULL-context legacy page (the claimable population
+  from PR #2153).
+- An explicit argument always wins; no default configured = legacy
+  unscoped behavior (backward compatible).
+- Id-addressed tools treat foreign-tenant contacts as nonexistent
+  (fail-closed, no cross-tenant existence leak).
+- The MCP create tool default-stamps new contacts so the MCP surface stops
+  minting NULL-context rows.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_asyncpg_mock = MagicMock()
+_asyncpg_exceptions = MagicMock()
+_asyncpg_exceptions.UndefinedTableError = type("UndefinedTableError", (Exception,), {})
+_asyncpg_mock.exceptions = _asyncpg_exceptions
+sys.modules.setdefault("asyncpg", _asyncpg_mock)
+sys.modules.setdefault("asyncpg.exceptions", _asyncpg_exceptions)
+
+import atlas_brain.mcp.crm_server as crm_srv  # noqa: E402
+
+EOM = "effingham_maids"
+UUID = "12345678-1234-5678-1234-567812345678"
+
+
+@pytest.fixture
+def default_ctx(monkeypatch):
+    from atlas_brain.config import settings
+
+    monkeypatch.setattr(settings.mcp, "crm_default_business_context", EOM)
+
+
+@pytest.fixture
+def no_default(monkeypatch):
+    from atlas_brain.config import settings
+
+    monkeypatch.setattr(settings.mcp, "crm_default_business_context", None)
+
+
+def _provider_mock(monkeypatch, **overrides):
+    provider = MagicMock()
+    provider.search_contacts = AsyncMock(return_value=overrides.get("search", []))
+    provider.get_contact = AsyncMock(return_value=overrides.get("get"))
+    provider.update_contact = AsyncMock(return_value={"id": UUID})
+    provider.delete_contact = AsyncMock(return_value=True)
+    provider.list_contacts = AsyncMock(return_value=[])
+    provider.log_interaction = AsyncMock(return_value={"id": "i-1"})
+    provider.get_interactions = AsyncMock(return_value=[])
+    provider.get_contact_appointments = AsyncMock(return_value=[])
+    monkeypatch.setattr(crm_srv, "_provider", lambda: provider)
+    return provider
+
+
+# ---------------------------------------------------------------------------
+# Scoped search semantics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_applies_default_then_null_fallback(default_ctx, monkeypatch):
+    provider = _provider_mock(monkeypatch)
+    await crm_srv.search_contacts(query="jane")
+    calls = provider.search_contacts.await_args_list
+    assert calls[0].kwargs["business_context_id"] == EOM
+    assert calls[1].kwargs["business_context_id_is_null"] is True
+
+
+@pytest.mark.asyncio
+async def test_search_scoped_hit_skips_null_fallback(default_ctx, monkeypatch):
+    provider = _provider_mock(monkeypatch, search=[{"id": "c1", "business_context_id": EOM}])
+    out = json.loads(await crm_srv.search_contacts(query="jane"))
+    assert out["found"] is True
+    assert len(provider.search_contacts.await_args_list) == 1
+
+
+@pytest.mark.asyncio
+async def test_search_explicit_context_wins_over_default(default_ctx, monkeypatch):
+    provider = _provider_mock(monkeypatch, search=[{"id": "b1"}])
+    await crm_srv.search_contacts(query="acme", business_context_id="churnsignals")
+    calls = provider.search_contacts.await_args_list
+    assert len(calls) == 1
+    assert calls[0].kwargs["business_context_id"] == "churnsignals"
+
+
+@pytest.mark.asyncio
+async def test_search_unscoped_without_default(no_default, monkeypatch):
+    provider = _provider_mock(monkeypatch, search=[{"id": "c1"}])
+    await crm_srv.search_contacts(query="jane")
+    calls = provider.search_contacts.await_args_list
+    assert len(calls) == 1
+    assert "business_context_id" not in calls[0].kwargs
+
+
+@pytest.mark.asyncio
+async def test_default_alone_satisfies_search_requires_one_of(default_ctx, monkeypatch):
+    """A bare list-my-tenant search is valid once a default exists."""
+    _provider_mock(monkeypatch)
+    out = json.loads(await crm_srv.search_contacts())
+    assert "error" not in out or "required" not in out.get("error", "")
+
+
+# ---------------------------------------------------------------------------
+# Id-addressed tenant guard (fail-closed)
+# ---------------------------------------------------------------------------
+
+
+FOREIGN = {"id": UUID, "business_context_id": "churnsignals"}
+LEGACY_NULL = {"id": UUID, "business_context_id": None}
+SAME = {"id": UUID, "business_context_id": EOM}
+
+
+@pytest.mark.asyncio
+async def test_get_contact_hides_foreign_tenant(default_ctx, monkeypatch):
+    _provider_mock(monkeypatch, get=FOREIGN)
+    out = json.loads(await crm_srv.get_contact(UUID))
+    assert out == {"found": False, "contact": None}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("row", [LEGACY_NULL, SAME])
+async def test_get_contact_shows_default_and_null(default_ctx, monkeypatch, row):
+    _provider_mock(monkeypatch, get=row)
+    out = json.loads(await crm_srv.get_contact(UUID))
+    assert out["found"] is True
+
+
+@pytest.mark.asyncio
+async def test_update_and_delete_refuse_foreign_tenant(default_ctx, monkeypatch):
+    provider = _provider_mock(monkeypatch, get=FOREIGN)
+    up = json.loads(await crm_srv.update_contact(UUID, full_name="X"))
+    assert up["success"] is False
+    provider.update_contact.assert_not_awaited()
+    de = json.loads(await crm_srv.delete_contact(UUID))
+    assert de["success"] is False
+    provider.delete_contact.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_log_interaction_refuses_foreign_tenant(default_ctx, monkeypatch):
+    provider = _provider_mock(monkeypatch, get=FOREIGN)
+    out = json.loads(await crm_srv.log_interaction(UUID, interaction_type="note", summary="x"))
+    assert out["success"] is False
+    provider.log_interaction.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_guard_disabled_without_default(no_default, monkeypatch):
+    provider = _provider_mock(monkeypatch, get=FOREIGN)
+    out = json.loads(await crm_srv.get_contact(UUID))
+    assert out["found"] is True  # legacy behavior preserved
+    # and mutations pass through
+    await crm_srv.update_contact(UUID, full_name="X")
+    provider.update_contact.assert_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Create default-stamp + list default
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_contact_default_stamps(default_ctx, monkeypatch):
+    provider = _provider_mock(monkeypatch)
+    provider.create_contact = AsyncMock(return_value={"id": "new-1"})
+    await crm_srv.create_contact(full_name="Jane")
+    data = provider.create_contact.await_args.args[0]
+    assert data["business_context_id"] == EOM
+
+
+@pytest.mark.asyncio
+async def test_create_contact_explicit_context_wins(default_ctx, monkeypatch):
+    provider = _provider_mock(monkeypatch)
+    provider.create_contact = AsyncMock(return_value={"id": "new-1"})
+    await crm_srv.create_contact(full_name="Acme", business_context_id="churnsignals")
+    assert provider.create_contact.await_args.args[0]["business_context_id"] == "churnsignals"
+
+
+@pytest.mark.asyncio
+async def test_list_contacts_uses_default(default_ctx, monkeypatch):
+    provider = _provider_mock(monkeypatch)
+    await crm_srv.list_contacts()
+    assert provider.list_contacts.await_args.kwargs["business_context_id"] == EOM

--- a/tests/test_crm_read_scoping.py
+++ b/tests/test_crm_read_scoping.py
@@ -15,9 +15,13 @@ Semantics under test (plans/PR-EOM-Read-Scoping.md):
 
 from __future__ import annotations
 
+import ast
 import json
 import sys
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
+
+REPO = Path(__file__).resolve().parent.parent
 
 import pytest
 
@@ -303,6 +307,85 @@ def test_appointments_in_scope_filters_foreign(default_ctx):
 def test_appointments_in_scope_unfiltered_without_default(no_default):
     rows = [{"id": 1, "business_context_id": "churnsignals"}]
     assert crm_srv._appointments_in_scope(rows, None) == rows
+
+
+def test_calls_in_scope_keeps_null_and_same_tenant(default_ctx):
+    rows = [
+        {"id": 1, "business_context_id": EOM},
+        {"id": 2, "business_context_id": None},
+        {"id": 3, "business_context_id": "churnsignals"},
+    ]
+    assert [r["id"] for r in crm_srv._calls_in_scope(rows, None)] == [1, 2]
+
+
+def test_calls_in_scope_unfiltered_without_default(no_default):
+    rows = [{"id": 1, "business_context_id": "churnsignals"}]
+    assert crm_srv._calls_in_scope(rows, None) == rows
+
+
+def test_linked_appointment_query_selects_tenant_column():
+    """The scoped filter reads business_context_id off provider rows; the
+    SELECT must return it or every scoped result empties (round-3 P2)."""
+    src = (REPO / "atlas_brain/services/crm_provider.py").read_text(encoding="utf-8")
+    block = src.split("async def get_contact_appointments", 1)[1][:700]
+    assert "business_context_id" in block
+
+
+def test_appointment_repo_accepts_scope_param():
+    """Fallback scoping happens in SQL, before LIMIT (round-3 P2)."""
+    src = (REPO / "atlas_brain/storage/repositories/appointment.py").read_text(encoding="utf-8")
+    for fn in ("async def get_by_phone", "async def search_by_name"):
+        sig = src.split(fn, 1)[1][:300]
+        assert "business_context_id" in sig, fn
+
+
+def test_fallback_repo_calls_pass_scope():
+    tree = ast.parse((REPO / "atlas_brain/mcp/crm_server.py").read_text(encoding="utf-8"))
+    wanted = {"get_by_phone": False, "search_by_name": False}
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in wanted
+        ):
+            if any(k.arg == "business_context_id" for k in node.keywords):
+                wanted[node.func.attr] = True
+    assert all(wanted.values()), wanted
+
+
+@pytest.mark.asyncio
+async def test_log_interaction_claims_null_contact_under_default(default_ctx, monkeypatch):
+    provider = _provider_mock(monkeypatch, get=LEGACY_NULL)
+    out = json.loads(await crm_srv.log_interaction(UUID, interaction_type="note", summary="x"))
+    assert out["success"] is True
+    claim = provider.update_contact.await_args.args
+    assert claim[1] == {"business_context_id": EOM}
+    provider.log_interaction.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_log_interaction_same_tenant_no_claim(default_ctx, monkeypatch):
+    provider = _provider_mock(monkeypatch, get=SAME)
+    await crm_srv.log_interaction(UUID, interaction_type="note", summary="x")
+    provider.update_contact.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_log_interaction_without_default_no_claim(no_default, monkeypatch):
+    provider = _provider_mock(monkeypatch, get=LEGACY_NULL)
+    await crm_srv.log_interaction(UUID, interaction_type="note", summary="x")
+    provider.update_contact.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_customer_context_scoped_lookup_is_phone_first(default_ctx, monkeypatch):
+    """Scoped resolution keeps legacy phone-first semantics: a stale email
+    must not veto a valid phone match (round-3 MAJOR)."""
+    provider = _provider_mock(monkeypatch)
+    await crm_srv.get_customer_context(phone="217-555-0000", email="stale@example.com")
+    first = provider.search_contacts.await_args_list[0]
+    assert first.kwargs.get("phone") == "217-555-0000"
+    assert "email" not in first.kwargs
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_crm_read_scoping.py
+++ b/tests/test_crm_read_scoping.py
@@ -245,6 +245,47 @@ async def test_update_contact_explicit_override_reaches_foreign_tenant(default_c
     provider.update_contact.assert_awaited()
 
 
+@pytest.mark.asyncio
+async def test_update_claims_null_contact_under_default(default_ctx, monkeypatch):
+    """Claim-on-write: updating a NULL-context legacy row from a scoped
+    session stamps the default tenant."""
+    provider = _provider_mock(monkeypatch, get=LEGACY_NULL)
+    out = json.loads(await crm_srv.update_contact(UUID, phone="217-555-0000"))
+    assert out["success"] is True
+    data = provider.update_contact.await_args.args[1]
+    assert data["business_context_id"] == EOM
+
+
+@pytest.mark.asyncio
+async def test_update_same_tenant_row_not_restamped(default_ctx, monkeypatch):
+    provider = _provider_mock(monkeypatch, get=SAME)
+    await crm_srv.update_contact(UUID, phone="217-555-0000")
+    data = provider.update_contact.await_args.args[1]
+    assert "business_context_id" not in data
+
+
+@pytest.mark.asyncio
+async def test_update_without_default_never_stamps(no_default, monkeypatch):
+    provider = _provider_mock(monkeypatch, get=LEGACY_NULL)
+    await crm_srv.update_contact(UUID, phone="217-555-0000")
+    data = provider.update_contact.await_args.args[1]
+    assert "business_context_id" not in data
+
+
+@pytest.mark.asyncio
+async def test_contact_appointments_filtered_to_scope(default_ctx, monkeypatch):
+    """A NULL-context legacy contact must not expose foreign-tenant
+    appointment history through the linked-appointments tool."""
+    provider = _provider_mock(monkeypatch, get=LEGACY_NULL)
+    provider.get_contact_appointments = AsyncMock(return_value=[
+        {"id": "a1", "business_context_id": EOM},
+        {"id": "a2", "business_context_id": "churnsignals"},
+    ])
+    out = json.loads(await crm_srv.get_contact_appointments(UUID))
+    assert [a["id"] for a in out["appointments"]] == ["a1"]
+    assert out["count"] == 1
+
+
 # ---------------------------------------------------------------------------
 # Appointment-fallback scope filter (pure)
 # ---------------------------------------------------------------------------

--- a/tests/test_crm_read_scoping.py
+++ b/tests/test_crm_read_scoping.py
@@ -68,6 +68,8 @@ def _provider_mock(monkeypatch, **overrides):
     provider.log_interaction = AsyncMock(return_value={"id": "i-1"})
     provider.get_interactions = AsyncMock(return_value=[])
     provider.get_contact_appointments = AsyncMock(return_value=[])
+    provider.claim_contact = AsyncMock(
+        return_value={"id": UUID, "business_context_id": EOM})
     crm_srv.set_provider_override(lambda: provider)
     return provider
 
@@ -252,34 +254,64 @@ async def test_update_contact_explicit_override_reaches_foreign_tenant(default_c
 @pytest.mark.asyncio
 async def test_update_claims_null_contact_under_default(default_ctx, monkeypatch):
     """Claim-on-write: updating a NULL-context legacy row from a scoped
-    session stamps the default tenant."""
+    session claims it for the default tenant via compare-and-set."""
     provider = _provider_mock(monkeypatch, get=LEGACY_NULL)
     out = json.loads(await crm_srv.update_contact(UUID, phone="217-555-0000"))
     assert out["success"] is True
+    provider.claim_contact.assert_awaited_once_with(UUID, EOM)
     data = provider.update_contact.await_args.args[1]
-    assert data["business_context_id"] == EOM
+    assert "business_context_id" not in data
 
 
 @pytest.mark.asyncio
-async def test_update_same_tenant_row_not_restamped(default_ctx, monkeypatch):
+async def test_update_fails_closed_when_claim_lost(default_ctx, monkeypatch):
+    """A concurrent claim by another tenant between guard and write must
+    abort the mutation, not overwrite the other tenant's claim."""
+    provider = _provider_mock(monkeypatch, get=LEGACY_NULL)
+    provider.claim_contact = AsyncMock(return_value=None)
+    out = json.loads(await crm_srv.update_contact(UUID, phone="217-555-0000"))
+    assert out["success"] is False
+    provider.update_contact.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_update_same_tenant_row_not_reclaimed(default_ctx, monkeypatch):
     provider = _provider_mock(monkeypatch, get=SAME)
     await crm_srv.update_contact(UUID, phone="217-555-0000")
-    data = provider.update_contact.await_args.args[1]
-    assert "business_context_id" not in data
+    provider.claim_contact.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_update_without_default_never_stamps(no_default, monkeypatch):
+async def test_update_without_default_never_claims(no_default, monkeypatch):
     provider = _provider_mock(monkeypatch, get=LEGACY_NULL)
     await crm_srv.update_contact(UUID, phone="217-555-0000")
-    data = provider.update_contact.await_args.args[1]
-    assert "business_context_id" not in data
+    provider.claim_contact.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_delete_claims_null_contact_under_default(default_ctx, monkeypatch):
+    """Archiving is a legacy mutation: the row is claimed first so one
+    tenant cannot hide shared legacy data from the other's default view."""
+    provider = _provider_mock(monkeypatch, get=LEGACY_NULL)
+    out = json.loads(await crm_srv.delete_contact(UUID))
+    assert out["success"] is True
+    provider.claim_contact.assert_awaited_once_with(UUID, EOM)
+
+
+@pytest.mark.asyncio
+async def test_delete_fails_closed_when_claim_lost(default_ctx, monkeypatch):
+    provider = _provider_mock(monkeypatch, get=LEGACY_NULL)
+    provider.claim_contact = AsyncMock(return_value=None)
+    out = json.loads(await crm_srv.delete_contact(UUID))
+    assert out["success"] is False
+    provider.delete_contact.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_contact_appointments_filtered_to_scope(default_ctx, monkeypatch):
     """A NULL-context legacy contact must not expose foreign-tenant
-    appointment history through the linked-appointments tool."""
+    appointment history through the linked-appointments tool; the scope is
+    also pushed into the provider query (before its LIMIT)."""
     provider = _provider_mock(monkeypatch, get=LEGACY_NULL)
     provider.get_contact_appointments = AsyncMock(return_value=[
         {"id": "a1", "business_context_id": EOM},
@@ -288,6 +320,33 @@ async def test_contact_appointments_filtered_to_scope(default_ctx, monkeypatch):
     out = json.loads(await crm_srv.get_contact_appointments(UUID))
     assert [a["id"] for a in out["appointments"]] == ["a1"]
     assert out["count"] == 1
+    call = provider.get_contact_appointments.await_args
+    assert call.kwargs["business_context_id"] == EOM
+
+
+def test_provider_claim_contact_is_compare_and_set():
+    """The claim must be conditional in SQL, not a blind stamp."""
+    src = (REPO / "atlas_brain/services/crm_provider.py").read_text(encoding="utf-8")
+    block = src.split("async def claim_contact", 1)[1][:900]
+    assert "business_context_id IS NULL OR business_context_id = $2" in block
+
+
+def test_call_repo_scopes_before_limit():
+    src = (REPO / "atlas_brain/storage/repositories/call_transcript.py").read_text(encoding="utf-8")
+    block = src.split("async def get_by_contact_id", 1)[1][:1200]
+    assert "business_context_id = $2 OR business_context_id IS NULL" in block
+
+
+def test_context_service_threads_scope_to_child_queries():
+    src = (REPO / "atlas_brain/services/customer_context.py").read_text(encoding="utf-8")
+    gather = src.split("async def _gather", 1)[1]
+    assert gather.count("business_context_id=business_context_id") >= 2
+
+
+def test_context_result_omits_emails_under_scope():
+    src = (REPO / "atlas_brain/mcp/crm_server.py").read_text(encoding="utf-8")
+    assert '"sent_emails": [] if effective else ctx.sent_emails' in src
+    assert "emails_omitted_under_scope" in src
 
 
 # ---------------------------------------------------------------------------
@@ -358,23 +417,31 @@ async def test_log_interaction_claims_null_contact_under_default(default_ctx, mo
     provider = _provider_mock(monkeypatch, get=LEGACY_NULL)
     out = json.loads(await crm_srv.log_interaction(UUID, interaction_type="note", summary="x"))
     assert out["success"] is True
-    claim = provider.update_contact.await_args.args
-    assert claim[1] == {"business_context_id": EOM}
+    provider.claim_contact.assert_awaited_once_with(UUID, EOM)
     provider.log_interaction.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_log_interaction_fails_closed_when_claim_lost(default_ctx, monkeypatch):
+    provider = _provider_mock(monkeypatch, get=LEGACY_NULL)
+    provider.claim_contact = AsyncMock(return_value=None)
+    out = json.loads(await crm_srv.log_interaction(UUID, interaction_type="note", summary="x"))
+    assert out["success"] is False
+    provider.log_interaction.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_log_interaction_same_tenant_no_claim(default_ctx, monkeypatch):
     provider = _provider_mock(monkeypatch, get=SAME)
     await crm_srv.log_interaction(UUID, interaction_type="note", summary="x")
-    provider.update_contact.assert_not_awaited()
+    provider.claim_contact.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_log_interaction_without_default_no_claim(no_default, monkeypatch):
     provider = _provider_mock(monkeypatch, get=LEGACY_NULL)
     await crm_srv.log_interaction(UUID, interaction_type="note", summary="x")
-    provider.update_contact.assert_not_awaited()
+    provider.claim_contact.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_leads_intake.py
+++ b/tests/test_leads_intake.py
@@ -333,6 +333,8 @@ def _provider_with(matches):
     provider = DatabaseCRMProvider.__new__(DatabaseCRMProvider)
     provider.search_contacts = AsyncMock(side_effect=_search)
     provider.update_contact = AsyncMock(side_effect=lambda cid, u: {"id": cid, **u})
+    provider.claim_contact = AsyncMock(
+        side_effect=lambda cid, ctx: {"id": cid, "business_context_id": ctx})
     return provider
 
 
@@ -374,8 +376,8 @@ async def test_create_contact_dedupe_claims_null_context_contact():
          "business_context_id": "effingham_maids"}
     )
     assert result["id"] == "legacy-1"
-    merged = provider.update_contact.await_args.args[1]
-    assert merged["business_context_id"] == "effingham_maids"  # claimed
+    # Claimed via compare-and-set (round-5 of #2157), not a blind merge
+    provider.claim_contact.assert_awaited_once_with("legacy-1", "effingham_maids")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-EOM-Read-Scoping.md
Slice phase: vertical slice
Ownership lane: eom-crm/lead-funnel
Diff-budget override: over 80% of added lines are the mandatory plan doc (~150) and the 14-test suite (~195); production code is ~85 LOC across two files. Splitting tests or plan from the guards they specify would ship an unverified tenant-isolation surface.

The deferred half of #2151 Phase 2. Writes are tenant-stamped (#2155) but the CRM MCP surface still reads and mutates all tenants by default, and its create tool keeps minting NULL-context rows (the provenance hole named in the #2155 review). This slice adds a deployment-level default tenant (env, off by default): scoped reads cover the default tenant page plus the NULL-context legacy page (the claimable population from #2153), the five id-addressed tools fail closed on foreign-tenant rows, and the create tool default-stamps. Explicit arguments always win; unset env = byte-identical legacy behavior.

## Intentional
- `api/contacts.py` untouched — the intel UI consumes it for BOTH tenants; defaulting it to EOM would break churnsignals timelines. Its authlessness is a separate tracked concern.
- Guard costs one extra indexed `get_contact` per id-addressed call, only when a default is configured — correctness over a PK read.
- `delete_contact` guarded too: cross-tenant delete is the worst-case accident.
- No "all tenants" sentinel — cross-tenant reads pass the other tenant explicitly per call; a wildcard would reopen the hole by convention.

## Deferred
- `api/contacts.py` auth/scoping (own slice, UI-coupled).
- Operator env opt-in post-merge: `ATLAS_MCP_CRM_DEFAULT_BUSINESS_CONTEXT=effingham_maids` on this box.
- 4 unclassifiable NULL rows (3 `manual`, 1 `manual_invoice_setup`) for operator eyeball.

## Parked hardening
- None new.

## Cold diff reconstruction
- Changed: `atlas_brain/config.py` — `MCPConfig.crm_default_business_context: str | None = None` (env `ATLAS_MCP_CRM_DEFAULT_BUSINESS_CONTEXT`).
- Changed: `atlas_brain/mcp/crm_server.py` — helpers `_default_context` / `_visible_under_default` / `_guard_contact_id` / `_scoped_search`; `search_contacts` + `get_contact`-by-name route through `_scoped_search` (default page → NULL page; explicit arg wins; requires-one-of check satisfied by a configured default); `list_contacts`/`create_contact` default their context arg; guards inserted before `update_contact`/`delete_contact`/`log_interaction`/`get_interactions`/`get_contact_appointments` provider calls and on `get_contact` UUID path.
- Changed: `tests/test_crm_read_scoping.py` (new, 14 tests) — call-order, precedence, legacy-when-unset, fail-closed guards (mutations asserted not-awaited), NULL visibility, create stamp, list default.
- Contract match: every change traces to the Problem-derived contract; `crm_provider`, B2B modules, `api/contacts.py`, and no-default behavior untouched.
- Gaps: none.

## Verification
- Suite `tests/test_crm_read_scoping.py` — 14 passed.
- Suites `tests/test_tenant_stamping.py` + `tests/test_leads_intake.py` — 46 passed combined.
- `python -m py_compile` on both touched Python files — clean.
- NOT run: live MCP session against the running server (env opt-in is the post-merge operator step; then a scoped-search spot check).

## Diff size
5 files, +702 / -18 (round-1 reconciliation widened the scoping to get_customer_context, the appointment fallback, list_contacts NULL-page merge, and explicit overrides on id tools; includes the set_provider_override test seam for the mcp-lane maturity ratchet)

## AI reconciliation

Codex round 1 — four threads, all fixed in 2587cc3d4:

1. P1 `get_customer_context` unscoped (crm_server) — FIXED: every
   resolution path (uuid/name/phone/email) now routes through
   `_scoped_search`/`_guard_contact_id`; the context service is only
   constructed after the guard passes. Tests:
   `test_customer_context_hides_foreign_uuid`,
   `test_customer_context_name_lookup_is_scoped`,
   `test_customer_context_phone_lookup_is_scoped`.
2. P1 appointment fallback leaks foreign tenants — FIXED:
   `_appointments_in_scope` filters fallback rows to the effective tenant
   (appointments.business_context_id is NOT NULL by schema); no scope =
   legacy behavior. Tests: `test_appointments_in_scope_*`.
3. P2 `list_contacts` excluded NULL-context legacy rows — FIXED: under
   the default the tool merges the tenant page with the NULL page;
   `crm_provider.list_contacts` gained `business_context_id_is_null`
   (mirrors the #2153 search filter). Test:
   `test_list_contacts_merges_null_page_under_default`.
4. P2 id tools had no explicit tenant override — FIXED: all six
   id-addressed tools accept `business_context_id` with exact-page
   semantics (explicit search parity; NULL rows stay reachable via the
   default). Tests: `test_get_contact_explicit_context_reaches_foreign_tenant`,
   `test_explicit_context_is_exact_match`,
   `test_update_contact_explicit_override_reaches_foreign_tenant`.

Codex round 2 — two threads, both fixed:

5. P2 `get_contact_appointments` returns foreign-tenant appointments for
   NULL-context legacy contacts — FIXED: linked rows now pass through
   `_appointments_in_scope` (effective scope = explicit arg or default).
   Test: `test_contact_appointments_filtered_to_scope`.
6. P2 updates leave NULL-context rows unclaimed — FIXED: `update_contact`
   under the default stamps `business_context_id` on NULL-context rows
   (claim-on-write); same-tenant rows are not restamped and no-default
   deployments never stamp. `_guarded_contact` returns the resolved row so
   the claim adds no extra lookup. Tests:
   `test_update_claims_null_contact_under_default`,
   `test_update_same_tenant_row_not_restamped`,
   `test_update_without_default_never_stamps`.
   Deliberate line: `delete_contact` (soft-archive) does not claim — it
   rewrites no identity data, stays reversible, and a claim there would
   turn one write into two; flagged for the next slice if the model should
   treat archive as a claim too.

Codex round 3 — five threads, all fixed:

7. P2 linked-appointments SELECT lacked `business_context_id`, so the
   round-2 strict filter would empty every scoped result on real rows —
   FIXED: column added to the provider SELECT; regression-guarded by
   `test_linked_appointment_query_selects_tenant_column`. (The round-2
   test mock included the key and hid this; the source-level test now
   pins the real query.)
8. P1 `get_customer_context` child rows unscoped — FIXED: appointment
   rows filter strictly to the effective tenant, call transcripts filter
   NULL-inclusively (`_calls_in_scope`; legacy calls are the same
   claimable population as contacts). Interactions/emails carry no tenant
   column and attach to the already-guarded contact. Tests:
   `test_calls_in_scope_*`.
9. P1 `log_interaction` wrote notes readable through the other tenant's
   default — FIXED: claims the NULL-context row (same claim-on-write as
   `update_contact`) before logging. Tests:
   `test_log_interaction_claims_null_contact_under_default`,
   `test_log_interaction_same_tenant_no_claim`,
   `test_log_interaction_without_default_no_claim`.
10. P2 fallback filtered after the unscoped LIMIT — FIXED: repo
    `get_by_phone`/`search_by_name` accept an optional tenant condition
    and the fallback passes the effective scope, so scoping happens in
    SQL before LIMIT; the in-process filter remains as belt. Tests:
    `test_appointment_repo_accepts_scope_param`,
    `test_fallback_repo_calls_pass_scope`.
11. P2 scoped phone+email resolution AND-ed both filters — FIXED:
    phone-first (email only when no phone), matching the legacy service
    semantics. Test: `test_customer_context_scoped_lookup_is_phone_first`.

Codex round 4 — five threads, all fixed:

12. P2 linked appointments limited before filtering — FIXED:
    `crm_provider.get_contact_appointments` takes the tenant predicate in
    SQL (before its LIMIT 50); the MCP tool and the context service pass
    the effective scope. Guarded by
    `test_contact_appointments_filtered_to_scope` (now also asserts the
    provider call carries the scope).
13. P2 context child sources limited before filtering — FIXED:
    `CustomerContextService.get_context`/`_gather` accept
    `business_context_id` and thread it into the appointment and
    call-transcript queries, so scoping happens in SQL before per-source
    limits. Test: `test_context_service_threads_scope_to_child_queries`;
    existing `tests/test_customer_context.py` still green.
14. P2 email history unscoped in context — FIXED (fail closed): under an
    effective scope `sent_emails`/`inbox_emails` are omitted and the
    response carries `emails_omitted_under_scope: true`; the email store
    has no tenant column yet, so filtering is not possible — omission
    until tenant-addressable, per the thread's own suggestion. Test:
    `test_context_result_omits_emails_under_scope`.
15. P2 archive skipped the claim — FIXED: `delete_contact` claims the
    NULL-context row (CAS) before archiving, so one tenant cannot hide
    shared legacy data from the other's default view. Tests:
    `test_delete_claims_null_contact_under_default`,
    `test_delete_fails_closed_when_claim_lost`.
16. P2 claim race — FIXED: claims go through
    `crm_provider.claim_contact`, a compare-and-set UPDATE
    (`WHERE id = $1 AND (business_context_id IS NULL OR business_context_id = $2)`);
    a lost race returns no row and the mutation fails closed. Tests:
    `test_provider_claim_contact_is_compare_and_set`,
    `test_update_fails_closed_when_claim_lost`,
    `test_log_interaction_fails_closed_when_claim_lost`.

Codex round 5 — two threads, both fixed:

17. P2 B2B enrichment leaked into scoped context — FIXED (fail closed,
    same treatment as emails): `b2b_churn_signals` returns empty under an
    effective scope with `b2b_enrichment_omitted_under_scope: true`; the
    B2B MCP server remains the surface for that intelligence. Test:
    `test_context_result_omits_emails_under_scope` (extended).
18. P2 stamped-create legacy merge claimed by blind update — FIXED: the
    NULL match is claimed via the CAS `claim_contact` before merging; a
    lost race drops the match and the create falls through to a fresh
    tenant-stamped insert, never landing a merge on the other tenant's
    row. The #2153 dedupe test was updated to the CAS contract. Tests:
    `test_create_contact_claims_legacy_match_with_cas`,
    `test_create_contact_lost_claim_never_blind_merges`.

All fixed or waived: yes
