### PR TITLE
feat: portal->CRM customer sync — the portal defines active (#2156 slice A2)

### DIFF
--- a/atlas_brain/config.py
+++ b/atlas_brain/config.py
@@ -728,6 +728,15 @@ class ToolsConfig(BaseSettings):
         default=None, description="EOM One-Time Cleanings calendar id"
     )
 
+    # EOM portal sync (scripts/sync_eom_portal_customers.py). Optional
+    # non-interactive auth + base URL; the script prompts when absent.
+    eom_portal_token: str | None = Field(
+        default=None, description="Pre-obtained EOM portal admin token"
+    )
+    eom_portal_base_url: str | None = Field(
+        default=None, description="EOM portal backend base URL override"
+    )
+
     # CalDAV calendar (provider-agnostic alternative to Google Calendar)
     # Works with Nextcloud, Apple Calendar, Fastmail, Proton Calendar, SOGo, Baikal, etc.
     caldav_url: str | None = Field(

--- a/plans/PR-EOM-Portal-Customer-Sync.md
+++ b/plans/PR-EOM-Portal-Customer-Sync.md
@@ -80,6 +80,12 @@ Slice phase: vertical slice
       the CAS (the id link is the identity); a link to a FOREIGN tenant is
       ignored (reported) and resolution falls to the ladder (both
       asserted; Codex A2 round 1, BLOCKER).
+  19. Dry-runs probe metadata-blind fallback links too, and malformed
+      (non-UUID) atlasContactId values are ignored with a note instead of
+      crashing the UUID lookup (both asserted; Codex A2 round 9); the
+      remaining in-statement-guard and collision-preflight hardening is
+      tracked in #2162 — all three residuals are already fail-closed by
+      the stamp UPDATE's in-SQL relink guard.
   18. Metadata-blind (address-fallback) matches probe the existing link
       BEFORE any matched write; non-string locationType is both preflighted
       and safe in the helper (all asserted; Codex A2 round 8).
@@ -186,7 +192,7 @@ run's matched ids.
 
 ## Verification
 
-- `tests/test_sync_eom_portal_customers.py` — 37 passed.
+- `tests/test_sync_eom_portal_customers.py` — 39 passed.
 - Maturity note: the scripts-lane ratchet baseline gains ONLY this PR's
   new script (deliberate per-record operator patterns recorded); the
   pre-existing unbaselined `import_eom_customers_live.py` (main's code,
@@ -202,8 +208,8 @@ run's matched ids.
 | File | LOC |
 |---|---:|
 | `atlas_brain/config.py` | 10 |
-| `plans/PR-EOM-Portal-Customer-Sync.md` | 211 |
-| `scripts/sync_eom_portal_customers.py` | 556 |
+| `plans/PR-EOM-Portal-Customer-Sync.md` | 217 |
+| `scripts/sync_eom_portal_customers.py` | 570 |
 | `tests/maturity_sweep/baseline_scripts.json` | 8 |
-| `tests/test_sync_eom_portal_customers.py` | 488 |
-| **Total** | **1273** |
+| `tests/test_sync_eom_portal_customers.py` | 514 |
+| **Total** | **1319** |

--- a/plans/PR-EOM-Portal-Customer-Sync.md
+++ b/plans/PR-EOM-Portal-Customer-Sync.md
@@ -80,6 +80,9 @@ Slice phase: vertical slice
       the CAS (the id link is the identity); a link to a FOREIGN tenant is
       ignored (reported) and resolution falls to the ladder (both
       asserted; Codex A2 round 1, BLOCKER).
+  18. Metadata-blind (address-fallback) matches probe the existing link
+      BEFORE any matched write; non-string locationType is both preflighted
+      and safe in the helper (all asserted; Codex A2 round 8).
   17. The relink guard also lives INSIDE the stamp SQL (metadata-blind
       address-fallback rows are protected), the refusal error names the
       existing link, dry-runs preview link conflicts when metadata is
@@ -183,7 +186,7 @@ run's matched ids.
 
 ## Verification
 
-- `tests/test_sync_eom_portal_customers.py` — 35 passed.
+- `tests/test_sync_eom_portal_customers.py` — 37 passed.
 - Maturity note: the scripts-lane ratchet baseline gains ONLY this PR's
   new script (deliberate per-record operator patterns recorded); the
   pre-existing unbaselined `import_eom_customers_live.py` (main's code,
@@ -199,8 +202,8 @@ run's matched ids.
 | File | LOC |
 |---|---:|
 | `atlas_brain/config.py` | 10 |
-| `plans/PR-EOM-Portal-Customer-Sync.md` | 200 |
-| `scripts/sync_eom_portal_customers.py` | 359 |
+| `plans/PR-EOM-Portal-Customer-Sync.md` | 211 |
+| `scripts/sync_eom_portal_customers.py` | 556 |
 | `tests/maturity_sweep/baseline_scripts.json` | 8 |
-| `tests/test_sync_eom_portal_customers.py` | 252 |
-| **Total** | **829** |
+| `tests/test_sync_eom_portal_customers.py` | 488 |
+| **Total** | **1273** |

--- a/plans/PR-EOM-Portal-Customer-Sync.md
+++ b/plans/PR-EOM-Portal-Customer-Sync.md
@@ -80,6 +80,14 @@ Slice phase: vertical slice
       the CAS (the id link is the identity); a link to a FOREIGN tenant is
       ignored (reported) and resolution falls to the ladder (both
       asserted; Codex A2 round 1, BLOCKER).
+  14. Resolution checks the STAMPED portal id first (the stable key after
+      a create -- channel drift can never duplicate a synced customer);
+      managed tags (portal/segments/past_customer) are REPLACED on portal
+      matches while foreign tags survive (an active match sheds
+      past_customer); dry-run computes the real diff + stamp need so clean
+      re-runs preview zero updates; the config surface is the single typed
+      ATLAS_TOOLS_* name; nameless records cannot crash the run loop (all
+      asserted; Codex A2 round 4).
   13. Portal-id and name validation precede ANY write; nameless active
       records are run errors (gating demotion), and the already-stamped
       fallback carries the same archive/tenant guards as the stamp itself
@@ -159,7 +167,7 @@ run's matched ids.
 
 ## Verification
 
-- `tests/test_sync_eom_portal_customers.py` — 23 passed.
+- `tests/test_sync_eom_portal_customers.py` — 26 passed.
 - Maturity note: the scripts-lane ratchet baseline gains ONLY this PR's
   new script (deliberate per-record operator patterns recorded); the
   pre-existing unbaselined `import_eom_customers_live.py` (main's code,

--- a/plans/PR-EOM-Portal-Customer-Sync.md
+++ b/plans/PR-EOM-Portal-Customer-Sync.md
@@ -80,6 +80,14 @@ Slice phase: vertical slice
       the CAS (the id link is the identity); a link to a FOREIGN tenant is
       ignored (reported) and resolution falls to the ladder (both
       asserted; Codex A2 round 1, BLOCKER).
+  12. An empty (or all-inactive) portal roster fails closed -- it would
+      demote the entire base (asserted); inactive customers are belt-
+      filtered client-side; portal emails normalize to provider casing
+      before diffing; a missing portal id is a run error, not a silent
+      predicate gap; clean re-runs neither rewrite the stamp nor error
+      (IS DISTINCT FROM guard + already-stamped check); and the demotion
+      UPDATE itself re-checks tenant/type/active/provenance (all
+      asserted; Codex A2 round 2).
   11. The portal token/base-url resolve through typed
       `ATLAS_TOOLS_EOM_PORTAL_*` settings with process-env override
       (live-parse verified; Codex A2 round 1, R11).
@@ -147,7 +155,7 @@ run's matched ids.
 
 ## Verification
 
-- `tests/test_sync_eom_portal_customers.py` — 16 passed.
+- `tests/test_sync_eom_portal_customers.py` — 22 passed.
 - Maturity note: the scripts-lane ratchet baseline gains ONLY this PR's
   new script (deliberate per-record operator patterns recorded); the
   pre-existing unbaselined `import_eom_customers_live.py` (main's code,

--- a/plans/PR-EOM-Portal-Customer-Sync.md
+++ b/plans/PR-EOM-Portal-Customer-Sync.md
@@ -80,6 +80,11 @@ Slice phase: vertical slice
       the CAS (the id link is the identity); a link to a FOREIGN tenant is
       ignored (reported) and resolution falls to the ladder (both
       asserted; Codex A2 round 1, BLOCKER).
+  16. The WHOLE roster validates before any write (a malformed record
+      aborts the run with nothing written); a contact already linked to a
+      DIFFERENT portal id is never relinked (run error); whitespace-only
+      portal channels are treated as absent (all asserted; Codex A2
+      round 6).
   15. Boolean portal ids are rejected (bool subclasses int); string JSONB
       metadata parses instead of crashing dry-runs; the create path never
       exposes a raw phone to create_contact's weaker dedupe (it rides the
@@ -173,7 +178,7 @@ run's matched ids.
 
 ## Verification
 
-- `tests/test_sync_eom_portal_customers.py` — 29 passed.
+- `tests/test_sync_eom_portal_customers.py` — 32 passed.
 - Maturity note: the scripts-lane ratchet baseline gains ONLY this PR's
   new script (deliberate per-record operator patterns recorded); the
   pre-existing unbaselined `import_eom_customers_live.py` (main's code,

--- a/plans/PR-EOM-Portal-Customer-Sync.md
+++ b/plans/PR-EOM-Portal-Customer-Sync.md
@@ -80,6 +80,12 @@ Slice phase: vertical slice
       the CAS (the id link is the identity); a link to a FOREIGN tenant is
       ignored (reported) and resolution falls to the ladder (both
       asserted; Codex A2 round 1, BLOCKER).
+  15. Boolean portal ids are rejected (bool subclasses int); string JSONB
+      metadata parses instead of crashing dry-runs; the create path never
+      exposes a raw phone to create_contact's weaker dedupe (it rides the
+      controlled stamp); the portal-id stamp REQUIRES the EOM tenant; and
+      the display path lives inside the per-record error guard (all
+      asserted; Codex A2 round 5).
   14. Resolution checks the STAMPED portal id first (the stable key after
       a create -- channel drift can never duplicate a synced customer);
       managed tags (portal/segments/past_customer) are REPLACED on portal
@@ -167,7 +173,7 @@ run's matched ids.
 
 ## Verification
 
-- `tests/test_sync_eom_portal_customers.py` — 26 passed.
+- `tests/test_sync_eom_portal_customers.py` — 29 passed.
 - Maturity note: the scripts-lane ratchet baseline gains ONLY this PR's
   new script (deliberate per-record operator patterns recorded); the
   pre-existing unbaselined `import_eom_customers_live.py` (main's code,

--- a/plans/PR-EOM-Portal-Customer-Sync.md
+++ b/plans/PR-EOM-Portal-Customer-Sync.md
@@ -80,6 +80,11 @@ Slice phase: vertical slice
       the CAS (the id link is the identity); a link to a FOREIGN tenant is
       ignored (reported) and resolution falls to the ladder (both
       asserted; Codex A2 round 1, BLOCKER).
+  17. The relink guard also lives INSIDE the stamp SQL (metadata-blind
+      address-fallback rows are protected), the refusal error names the
+      existing link, dry-runs preview link conflicts when metadata is
+      visible, and roster preflight rejects malformed site shapes (all
+      asserted; Codex A2 round 7).
   16. The WHOLE roster validates before any write (a malformed record
       aborts the run with nothing written); a contact already linked to a
       DIFFERENT portal id is never relinked (run error); whitespace-only
@@ -178,7 +183,7 @@ run's matched ids.
 
 ## Verification
 
-- `tests/test_sync_eom_portal_customers.py` — 32 passed.
+- `tests/test_sync_eom_portal_customers.py` — 35 passed.
 - Maturity note: the scripts-lane ratchet baseline gains ONLY this PR's
   new script (deliberate per-record operator patterns recorded); the
   pre-existing unbaselined `import_eom_customers_live.py` (main's code,

--- a/plans/PR-EOM-Portal-Customer-Sync.md
+++ b/plans/PR-EOM-Portal-Customer-Sync.md
@@ -1,0 +1,149 @@
+# PR-EOM-Portal-Customer-Sync
+
+## Why this slice exists
+
+Issue #2156 slice A2 (owner correction after slice A ran): the calendar
+import's 24-month window necessarily contains ended customer relationships
+(service stops without CANCELLED markers), so calendar history cannot define
+who is a CURRENT customer, and the slice-B watcher would treat lapsed
+customers as known-active. The owner's canonical roster is the portal's
+server-owned Customer aggregate. Verified on wiw backend main (5062a70):
+`GET /api/admin/customers` returns active customers with nested sites
+(`locationType` = Residential/Commercial), `atlasContactId` is a first-class
+designed cross-system link, and auth is `POST /api/auth/login` -> Bearer
+token behind `get_current_admin`.
+
+### Problem-derived contract
+
+- Root cause: slice A let calendar history define `status='active'`; the
+  CRM cannot distinguish a current customer from a past one.
+- Correct fix must touch/change: a new operator script that authenticates
+  to the backend at RUNTIME (getpass or a pre-obtained env token; no
+  credential ever stored/printed), fetches the active Customer aggregate,
+  resolves each customer to a CRM contact (`atlasContactId` first, then the
+  slice-A identity ladder phone -> email -> site addresses), writes through
+  the slice-A guarded machinery (diffed, archive/tenant-guarded, source and
+  tags only via controlled paths), stamps `metadata.portal_customer_id`
+  (the slice-B watcher predicate) via a guarded jsonb merge, and demotes
+  previously-imported active "customers" that matched no portal customer to
+  `status='inactive'` + `past_customer` tag — provenance-scoped to
+  `calendar_import`/`portal_sync` rows only. Dry-run by default with
+  `--apply` (demotion-bearing; #2155 convention); non-zero exit on errors.
+- Must NOT change: the wiw backend (strictly read-only consumer);
+  `scripts/import_eom_customers_live.py` (helpers imported, not modified);
+  `atlas_brain/services/crm_provider.py`; `atlas_brain/api/leads.py`;
+  schema (no migrations — metadata is existing jsonb); money paths; leads,
+  manual, web, and every non-pipeline source (never demoted); no credential
+  written to disk, argv, env files, or logs.
+
+## Scope (this PR)
+
+Ownership lane: eom-crm/lead-funnel
+Slice phase: vertical slice
+
+1. New `scripts/sync_eom_portal_customers.py`: portal -> CRM customer sync
+   with demotion, dry-run default, `--apply`, `--base-url`.
+2. New `tests/test_eom_portal_customer_sync.py`: 13 behavioural tests on
+   the slice-A stub harness.
+3. This plan doc.
+
+### Review Contract
+
+- Acceptance criteria:
+  1. Every synced contact carries `business_context_id='effingham_maids'`,
+     `contact_type='customer'`, `status='active'`, segment tags from active
+     sites' `locationType` + `portal` (asserted).
+  2. `atlasContactId` resolution wins over the channel ladder and
+     short-circuits it (asserted).
+  3. Creates strip `source`/`tags` (slice-A race rules) and stamp
+     `source='portal_sync'` + tags post-create; matched rows keep their
+     recorded provenance (both asserted).
+  4. `metadata.portal_customer_id` is stamped through a guarded jsonb
+     merge (archive + tenant predicates inside the UPDATE); a rejected
+     stamp is a run error (both asserted).
+  5. Demotion candidates are provenance-scoped in SQL
+     (`contact_type='customer' AND status='active' AND source = ANY
+     (calendar_import, portal_sync)`); matched ids are excluded; demoted
+     rows get `status='inactive'` + `past_customer` tag through the
+     archive/tenant-guarded update (all asserted).
+  6. Dry-run performs zero writes while reporting accurate create/update/
+     demote previews (matched ids feed the demotion preview; asserted).
+  7. Runtime auth only: an env token short-circuits any prompt (asserted);
+     the login body contains no file writes and the password is never
+     printed (source-asserted).
+  8. Non-zero exit when any record errored (reuses slice-A
+     `exit_code_for` semantics via the errors counter).
+- Reachability proof: operator script, invoked directly; the fetch/auth
+  seam is exercised at the client boundary (stub client), and the
+  write paths run the same slice-A machinery already live-proven by the
+  #2158 production run.
+- Reviewer rules triggered: R1, R2, R4, R6, R8, R12, R14.
+  - R1: behavior implements the #2156 A2 owner correction (portal defines
+    active; calendar is enrichment).
+  - R2: every criterion has a named test; the slice-A machinery reused
+    here was live-verified in production by #2158.
+  - R4: data safety — guarded writes, provenance-scoped demotion,
+    fail-closed claim identity, no credential persistence.
+  - R6: errors surface and fail the run; auth/fetch failures exit
+    non-zero via SystemExit.
+  - R8: idempotency — diffed no-op-free updates, stable portal-id stamp,
+    re-runs converge (matched set stable).
+  - R12: env/config — only `EOM_PORTAL_TOKEN` (optional, never written)
+    and `--base-url`; no secrets in the repo.
+  - R14: this contract is the reviewer checklist.
+
+### Files touched
+
+- `plans/PR-EOM-Portal-Customer-Sync.md`
+- `scripts/sync_eom_portal_customers.py`
+- `tests/test_eom_portal_customer_sync.py`
+
+## Mechanism
+
+`portal_login` (env token else getpass -> `POST /api/auth/login`) ->
+`fetch_portal_customers` (`GET /api/admin/customers`, active-only default)
+-> per customer: `customer_to_contact_data` (stamped payload; segment tags
+from active sites) -> `resolve_contact` (`atlasContactId` by id with
+archived guard, else slice-A ladder reusing `_phone_digits`,
+`_search_channel`, `resolve_by_address`, with `claim_legacy_row` CAS for
+NULL-context rows) -> writes via `_update_matched` / create-then-stamp
+(`_guarded_update`) -> `stamp_portal_id` guarded jsonb merge ->
+`demote_unmatched` over the provenance-scoped candidate set minus this
+run's matched ids.
+
+## Intentional
+
+- The backend is strictly read-only here; the `atlasContactId` write-back
+  (PATCH to the portal so the link becomes bidirectional) is DEFERRED —
+  it mutates the ops system and deserves its own slice.
+- Demotion never touches leads or non-pipeline sources: only rows this
+  pipeline itself claimed as active customers are eligible.
+- `metadata.portal_customer_id` (not a new column) keeps the slice
+  migration-free; the slice-B watcher predicate reads it.
+- Credentials: getpass at runtime or a pre-obtained env token; the
+  password variable is function-local and never persisted or printed.
+
+## Deferred
+
+- Portal write-back of `atlasContactId` (own slice; mutates the backend).
+- The #2156 slice B watcher (this provides its predicate).
+- Operator run post-merge: dry-run first, review the demotion preview,
+  then `--apply`.
+
+## Verification
+
+- `tests/test_eom_portal_customer_sync.py` — 13 passed.
+- `tests/test_eom_live_calendar_import.py` — 55 passed (adjacent; the
+  imported slice-A machinery is unmodified).
+- `python -m py_compile` on the script — clean.
+- NOT run pre-merge: the live sync (operator-run; needs the portal admin
+  password at the prompt; dry-run first by design).
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-EOM-Portal-Customer-Sync.md` | 150 |
+| `scripts/sync_eom_portal_customers.py` | 310 |
+| `tests/test_eom_portal_customer_sync.py` | 215 |
+| **Total** | **675** |

--- a/plans/PR-EOM-Portal-Customer-Sync.md
+++ b/plans/PR-EOM-Portal-Customer-Sync.md
@@ -80,6 +80,10 @@ Slice phase: vertical slice
       the CAS (the id link is the identity); a link to a FOREIGN tenant is
       ignored (reported) and resolution falls to the ladder (both
       asserted; Codex A2 round 1, BLOCKER).
+  13. Portal-id and name validation precede ANY write; nameless active
+      records are run errors (gating demotion), and the already-stamped
+      fallback carries the same archive/tenant guards as the stamp itself
+      (all asserted; Codex A2 round 3).
   12. An empty (or all-inactive) portal roster fails closed -- it would
       demote the entire base (asserted); inactive customers are belt-
       filtered client-side; portal emails normalize to provider casing
@@ -155,7 +159,7 @@ run's matched ids.
 
 ## Verification
 
-- `tests/test_sync_eom_portal_customers.py` — 22 passed.
+- `tests/test_sync_eom_portal_customers.py` — 23 passed.
 - Maturity note: the scripts-lane ratchet baseline gains ONLY this PR's
   new script (deliberate per-record operator patterns recorded); the
   pre-existing unbaselined `import_eom_customers_live.py` (main's code,

--- a/plans/PR-EOM-Portal-Customer-Sync.md
+++ b/plans/PR-EOM-Portal-Customer-Sync.md
@@ -43,7 +43,7 @@ Slice phase: vertical slice
 
 1. New `scripts/sync_eom_portal_customers.py`: portal -> CRM customer sync
    with demotion, dry-run default, `--apply`, `--base-url`.
-2. New `tests/test_eom_portal_customer_sync.py`: 13 behavioural tests on
+2. New `tests/test_sync_eom_portal_customers.py`: 16 behavioural tests on
    the slice-A stub harness.
 3. This plan doc.
 
@@ -73,11 +73,21 @@ Slice phase: vertical slice
      printed (source-asserted).
   8. Non-zero exit when any record errored (reuses slice-A
      `exit_code_for` semantics via the errors counter).
+  9. Demotion is SKIPPED entirely when any sync error occurred -- a
+     partial match set never drives demotions (source-asserted; Codex A2
+     round 1, BLOCKER).
+  10. An `atlasContactId` link to a NULL-context legacy row is claimed via
+      the CAS (the id link is the identity); a link to a FOREIGN tenant is
+      ignored (reported) and resolution falls to the ladder (both
+      asserted; Codex A2 round 1, BLOCKER).
+  11. The portal token/base-url resolve through typed
+      `ATLAS_TOOLS_EOM_PORTAL_*` settings with process-env override
+      (live-parse verified; Codex A2 round 1, R11).
 - Reachability proof: operator script, invoked directly; the fetch/auth
   seam is exercised at the client boundary (stub client), and the
   write paths run the same slice-A machinery already live-proven by the
   #2158 production run.
-- Reviewer rules triggered: R1, R2, R4, R6, R8, R12, R14.
+- Reviewer rules triggered: R1, R2, R4, R6, R8, R11, R12, R14.
   - R1: behavior implements the #2156 A2 owner correction (portal defines
     active; calendar is enrichment).
   - R2: every criterion has a named test; the slice-A machinery reused
@@ -88,15 +98,20 @@ Slice phase: vertical slice
     non-zero via SystemExit.
   - R8: idempotency — diffed no-op-free updates, stable portal-id stamp,
     re-runs converge (matched set stable).
+  - R11: dependencies & config -- two optional typed
+    `ATLAS_TOOLS_EOM_PORTAL_*` fields on `ToolsConfig`, default None;
+    absent config changes no behavior.
   - R12: env/config — only `EOM_PORTAL_TOKEN` (optional, never written)
     and `--base-url`; no secrets in the repo.
   - R14: this contract is the reviewer checklist.
 
 ### Files touched
 
+- `atlas_brain/config.py`
 - `plans/PR-EOM-Portal-Customer-Sync.md`
 - `scripts/sync_eom_portal_customers.py`
-- `tests/test_eom_portal_customer_sync.py`
+- `tests/maturity_sweep/baseline_scripts.json`
+- `tests/test_sync_eom_portal_customers.py`
 
 ## Mechanism
 
@@ -132,7 +147,11 @@ run's matched ids.
 
 ## Verification
 
-- `tests/test_eom_portal_customer_sync.py` — 13 passed.
+- `tests/test_sync_eom_portal_customers.py` — 16 passed.
+- Maturity note: the scripts-lane ratchet baseline gains ONLY this PR's
+  new script (deliberate per-record operator patterns recorded); the
+  pre-existing unbaselined `import_eom_customers_live.py` (main's code,
+  untouched here) stays advisory-red and is tracked with #2159.
 - `tests/test_eom_live_calendar_import.py` — 55 passed (adjacent; the
   imported slice-A machinery is unmodified).
 - `python -m py_compile` on the script — clean.
@@ -143,7 +162,9 @@ run's matched ids.
 
 | File | LOC |
 |---|---:|
-| `plans/PR-EOM-Portal-Customer-Sync.md` | 150 |
-| `scripts/sync_eom_portal_customers.py` | 310 |
-| `tests/test_eom_portal_customer_sync.py` | 215 |
-| **Total** | **675** |
+| `atlas_brain/config.py` | 10 |
+| `plans/PR-EOM-Portal-Customer-Sync.md` | 200 |
+| `scripts/sync_eom_portal_customers.py` | 359 |
+| `tests/maturity_sweep/baseline_scripts.json` | 8 |
+| `tests/test_sync_eom_portal_customers.py` | 252 |
+| **Total** | **829** |

--- a/scripts/sync_eom_portal_customers.py
+++ b/scripts/sync_eom_portal_customers.py
@@ -16,7 +16,7 @@ calendar history (slice A) is enrichment, not the active set. This script:
 
 Dry-run by default; pass --apply to write (demotion-bearing script, #2155
 convention). Non-interactive runs may supply a pre-obtained token via the
-EOM_PORTAL_TOKEN environment variable. Credentials are never written to
+ATLAS_TOOLS_EOM_PORTAL_TOKEN setting/env. Credentials are never written to
 disk, argv, or logs.
 
 Usage:
@@ -40,6 +40,9 @@ import import_eom_customers_live as live  # noqa: E402  (slice-A machinery)
 EOM_CONTEXT_ID = live.EOM_CONTEXT_ID
 DEFAULT_BASE_URL = "https://eom-timetracker.onrender.com"
 DEMOTABLE_SOURCES = ("calendar_import", "portal_sync")
+# Tags this pipeline manages: the portal replaces them on a match; every
+# other (foreign) tag is preserved (Codex A2 round 4).
+MANAGED_TAGS = {"portal", "residential", "commercial", "one_time", "past_customer"}
 
 
 def settings_default(attr: str):
@@ -56,7 +59,7 @@ def portal_login(client, base_url: str, env: dict):
     """Runtime auth: env or typed-settings token when provided
     (non-interactive), else a getpass prompt. The password variable never
     leaves this function and is never printed or persisted."""
-    token = env.get("EOM_PORTAL_TOKEN") or settings_default("eom_portal_token")
+    token = env.get("ATLAS_TOOLS_EOM_PORTAL_TOKEN") or settings_default("eom_portal_token")
     if token:
         return token
     name = input("Portal admin name: ")
@@ -132,6 +135,25 @@ async def resolve_contact(customer: dict, data: dict, crm, pool):
     """atlasContactId first (the designed cross-system link), then the
     slice-A identity ladder. Returns (existing_row_or_None, needs_claim,
     identity_tuple_or_None)."""
+    pid = customer.get("id")
+    if isinstance(pid, int):
+        row = await pool.fetchrow(
+            """
+            SELECT id, full_name, address, contact_type, business_context_id,
+                   tags, status, phone, email, notes, source, metadata
+            FROM contacts
+            WHERE metadata->>'portal_customer_id' = $1
+              AND business_context_id = $2
+              AND status != 'archived'
+            ORDER BY updated_at DESC
+            LIMIT 1
+            """,
+            str(pid),
+            EOM_CONTEXT_ID,
+        )
+        if row:
+            return row, False, None
+
     atlas_id = customer.get("atlasContactId")
     if atlas_id:
         row = await pool.fetchrow(
@@ -174,6 +196,31 @@ async def resolve_contact(customer: dict, data: dict, crm, pool):
         if existing is not None:
             return existing, needs_claim, ("address", addr)
     return None, False, None
+
+
+def portal_final_tags(existing: dict, data: dict) -> list:
+    prior = set(existing.get("tags") or [])
+    return sorted((prior - MANAGED_TAGS) | set(data["tags"]))
+
+
+async def _update_matched_portal(pool, existing: dict, data: dict):
+    """Portal-authoritative matched write: managed tags are REPLACED (an
+    active portal match sheds past_customer), foreign tags preserved;
+    provenance and tenant stamps never resent; diffed; archive/tenant
+    guards inside the UPDATE (Codex A2 round 4)."""
+    contact_id = str(existing["id"])
+    payload = dict(data)
+    payload["tags"] = portal_final_tags(existing, data)
+    payload.pop("source", None)
+    payload.pop("business_context_id", None)
+    updates = live._diff_updates(existing, payload)
+    if not updates:
+        return contact_id, "unchanged"
+    row = await live._guarded_update(pool, contact_id, updates)
+    if row is None:
+        print(f"    note: contact {contact_id} archived mid-run; write skipped")
+        return contact_id, "skipped"
+    return contact_id, "updated"
 
 
 async def stamp_portal_id(pool, contact_id: str, portal_id: int):
@@ -232,11 +279,22 @@ async def sync_one(customer: dict, crm, pool, apply: bool) -> tuple:
 
     existing, needs_claim, identity = await resolve_contact(customer, data, crm, pool)
     if not apply:
-        # Dry-run still reports the matched id so the demotion preview is
-        # accurate (a matched contact is NOT a demotion candidate).
-        if existing is not None:
+        # Dry-run reports the matched id (demotion preview accuracy) AND
+        # computes the real diff/stamp need, so a clean re-run previews
+        # zero updates (Codex A2 round 4).
+        if existing is None:
+            return "create-planned", None
+        payload = dict(data)
+        payload["tags"] = portal_final_tags(existing, data)
+        payload.pop("source", None)
+        payload.pop("business_context_id", None)
+        updates = live._diff_updates(existing, payload)
+        stamped = ("metadata" in existing and
+                   str((existing.get("metadata") or {}).get("portal_customer_id",
+                       "")) == str(customer.get("id")))
+        if updates or not stamped:
             return "update-planned", str(existing["id"])
-        return "create-planned", None
+        return "unchanged", str(existing["id"])
 
     if existing is not None and needs_claim:
         existing = await live.claim_legacy_row(
@@ -246,7 +304,7 @@ async def sync_one(customer: dict, crm, pool, apply: bool) -> tuple:
         )
 
     if existing is not None:
-        contact_id, outcome = await live._update_matched(pool, existing, data)
+        contact_id, outcome = await _update_matched_portal(pool, existing, data)
         if outcome == "skipped":
             return "skipped", contact_id
     else:
@@ -267,7 +325,7 @@ async def sync_one(customer: dict, crm, pool, apply: bool) -> tuple:
                           "provenance stamp; left unstamped")
                     return "errors", contact_id
         else:
-            contact_id, outcome = await live._update_matched(pool, result, data)
+            contact_id, outcome = await _update_matched_portal(pool, result, data)
             if outcome == "skipped":
                 return "skipped", contact_id
 
@@ -351,7 +409,7 @@ async def run(args) -> int:
 
     matched_ids: set = set()
     for customer in sorted(customers, key=lambda c: str(c.get("name") or "").lower()):
-        print(f"  {customer.get('name'):<45} sites={len(active_sites(customer))} "
+        print(f"  {str(customer.get('name') or '(unnamed)'):<45} sites={len(active_sites(customer))} "
               f"[{','.join(segment_tags(customer))}]")
         try:
             outcome, contact_id = await sync_one(customer, crm, pool, args.apply)
@@ -394,7 +452,7 @@ def main():
                         help="Write changes (default is dry-run)")
     parser.add_argument(
         "--base-url",
-        default=os.environ.get("EOM_PORTAL_BASE_URL")
+        default=os.environ.get("ATLAS_TOOLS_EOM_PORTAL_BASE_URL")
         or settings_default("eom_portal_base_url")
         or DEFAULT_BASE_URL,
     )

--- a/scripts/sync_eom_portal_customers.py
+++ b/scripts/sync_eom_portal_customers.py
@@ -82,7 +82,13 @@ def fetch_portal_customers(client, base_url: str, token: str) -> list:
     payload = resp.json() or {}
     if not payload.get("success"):
         raise SystemExit("Customer fetch returned success=false")
-    return payload.get("customers") or []
+    customers = [c for c in (payload.get("customers") or [])
+                 if c.get("active", True)]
+    if not customers:
+        # An empty roster would demote the entire base -- refuse to
+        # proceed rather than trust it (Codex A2 round 2).
+        raise SystemExit("Portal returned 0 active customers; refusing to sync")
+    return customers
 
 
 def active_sites(customer: dict) -> list:
@@ -113,7 +119,7 @@ def customer_to_contact_data(customer: dict) -> dict:
     if customer.get("primaryPhone"):
         data["phone"] = customer["primaryPhone"]
     if customer.get("primaryEmail"):
-        data["email"] = customer["primaryEmail"]
+        data["email"] = str(customer["primaryEmail"]).strip().lower()
     sites = active_sites(customer)
     if sites and sites[0].get("address"):
         data["address"] = str(sites[0]["address"])
@@ -182,12 +188,22 @@ async def stamp_portal_id(pool, contact_id: str, portal_id: int):
          WHERE id = $1
            AND status != 'archived'
            AND (business_context_id IS NULL OR business_context_id = $3)
+           AND COALESCE(metadata->>'portal_customer_id', '')
+               IS DISTINCT FROM $2::text
         RETURNING id
         """,
         contact_id,
         portal_id,
         EOM_CONTEXT_ID,
     )
+
+
+async def portal_id_already_stamped(pool, contact_id: str, portal_id: int) -> bool:
+    row = await pool.fetchrow(
+        "SELECT metadata->>'portal_customer_id' AS pid FROM contacts WHERE id = $1",
+        contact_id,
+    )
+    return bool(row) and row.get("pid") == str(portal_id)
 
 
 async def sync_one(customer: dict, crm, pool, apply: bool) -> tuple:
@@ -238,9 +254,16 @@ async def sync_one(customer: dict, crm, pool, apply: bool) -> tuple:
                 return "skipped", contact_id
 
     portal_id = customer.get("id")
-    if contact_id and isinstance(portal_id, int):
+    if not isinstance(portal_id, int):
+        # A contact synced without the watcher predicate is a failure, not
+        # a silent skip (Codex A2 round 2).
+        print(f"    ERROR: portal customer {customer.get('name')!r} has no "
+              "usable id; predicate not stamped")
+        return "errors", contact_id
+    if contact_id:
         stamped = await stamp_portal_id(pool, contact_id, portal_id)
-        if stamped is None:
+        if stamped is None and not await portal_id_already_stamped(
+                pool, contact_id, portal_id):
             print(f"    ERROR: portal-id stamp rejected for contact {contact_id}")
             return "errors", contact_id
     return outcome, contact_id
@@ -272,8 +295,21 @@ async def demote_unmatched(pool, matched_ids: set, apply: bool) -> tuple:
             demoted += 1
             continue
         tags = sorted(set(row["tags"] or []) | {"past_customer"})
-        result = await live._guarded_update(
-            pool, str(row["id"]), {"status": "inactive", "tags": tags}
+        result = await pool.fetchrow(
+            """
+            UPDATE contacts
+               SET status = 'inactive', tags = $2, updated_at = NOW()
+             WHERE id = $1
+               AND business_context_id = $3
+               AND contact_type = 'customer'
+               AND status = 'active'
+               AND source = ANY($4::text[])
+            RETURNING id
+            """,
+            str(row["id"]),
+            tags,
+            EOM_CONTEXT_ID,
+            list(DEMOTABLE_SOURCES),
         )
         if result is not None:
             demoted += 1

--- a/scripts/sync_eom_portal_customers.py
+++ b/scripts/sync_eom_portal_customers.py
@@ -27,6 +27,7 @@ Usage:
 
 import argparse
 import asyncio
+import json
 import getpass
 import os
 import sys
@@ -136,7 +137,7 @@ async def resolve_contact(customer: dict, data: dict, crm, pool):
     slice-A identity ladder. Returns (existing_row_or_None, needs_claim,
     identity_tuple_or_None)."""
     pid = customer.get("id")
-    if isinstance(pid, int):
+    if isinstance(pid, int) and not isinstance(pid, bool):
         row = await pool.fetchrow(
             """
             SELECT id, full_name, address, contact_type, business_context_id,
@@ -234,7 +235,7 @@ async def stamp_portal_id(pool, contact_id: str, portal_id: int):
                updated_at = NOW()
          WHERE id = $1
            AND status != 'archived'
-           AND (business_context_id IS NULL OR business_context_id = $3)
+           AND business_context_id = $3
            AND COALESCE(metadata->>'portal_customer_id', '')
                IS DISTINCT FROM $2::text
         RETURNING id
@@ -270,7 +271,7 @@ async def sync_one(customer: dict, crm, pool, apply: bool) -> tuple:
         print("    ERROR: active portal customer with blank name; run failed closed")
         return "errors", None
     portal_id = customer.get("id")
-    if not isinstance(portal_id, int):
+    if not isinstance(portal_id, int) or isinstance(portal_id, bool):
         # Validate BEFORE any write: --apply must not activate a contact and
         # only then discover it cannot stamp the predicate (Codex A2 r3).
         print(f"    ERROR: portal customer {customer.get('name')!r} has no "
@@ -289,9 +290,15 @@ async def sync_one(customer: dict, crm, pool, apply: bool) -> tuple:
         payload.pop("source", None)
         payload.pop("business_context_id", None)
         updates = live._diff_updates(existing, payload)
+        meta = existing.get("metadata") if "metadata" in existing else None
+        if isinstance(meta, str):
+            try:
+                meta = json.loads(meta or "{}")
+            except ValueError:
+                meta = {}
         stamped = ("metadata" in existing and
-                   str((existing.get("metadata") or {}).get("portal_customer_id",
-                       "")) == str(customer.get("id")))
+                   str((meta or {}).get("portal_customer_id", ""))
+                   == str(customer.get("id")))
         if updates or not stamped:
             return "update-planned", str(existing["id"])
         return "unchanged", str(existing["id"])
@@ -311,14 +318,21 @@ async def sync_one(customer: dict, crm, pool, apply: bool) -> tuple:
         create_data = dict(data)
         create_data.pop("source", None)
         create_data.pop("tags", None)
+        # The resolver already proved no match with its extension-stripped
+        # semantics; create_contact's internal %last-10% dedupe is WEAKER
+        # and could wrong-match a raw/ext-bearing phone -- so the phone
+        # rides the controlled post-create stamp instead (Codex A2 r5).
+        create_data.pop("phone", None)
         result = await crm.create_contact(create_data)
         contact_id = str(result.get("id", ""))
         if result.get("_was_created"):
             outcome = "created"
             if contact_id:
+                stamp_payload = {"source": "portal_sync", "tags": data["tags"]}
+                if data.get("phone"):
+                    stamp_payload["phone"] = data["phone"]
                 stamp = await live._guarded_update(
-                    pool, contact_id,
-                    {"source": "portal_sync", "tags": data["tags"]},
+                    pool, contact_id, stamp_payload,
                 )
                 if stamp is None:
                     print(f"    ERROR: contact {contact_id} changed before the "
@@ -409,9 +423,10 @@ async def run(args) -> int:
 
     matched_ids: set = set()
     for customer in sorted(customers, key=lambda c: str(c.get("name") or "").lower()):
-        print(f"  {str(customer.get('name') or '(unnamed)'):<45} sites={len(active_sites(customer))} "
-              f"[{','.join(segment_tags(customer))}]")
         try:
+            print(f"  {str(customer.get('name') or '(unnamed)'):<45} "
+                  f"sites={len(active_sites(customer))} "
+                  f"[{','.join(segment_tags(customer))}]")
             outcome, contact_id = await sync_one(customer, crm, pool, args.apply)
             counts[outcome] += 1
             if contact_id:

--- a/scripts/sync_eom_portal_customers.py
+++ b/scripts/sync_eom_portal_customers.py
@@ -250,6 +250,8 @@ async def stamp_portal_id(pool, contact_id: str, portal_id: int):
          WHERE id = $1
            AND status != 'archived'
            AND business_context_id = $3
+           AND (metadata->>'portal_customer_id' IS NULL
+                OR metadata->>'portal_customer_id' = $2::text)
            AND COALESCE(metadata->>'portal_customer_id', '')
                IS DISTINCT FROM $2::text
         RETURNING id
@@ -260,7 +262,8 @@ async def stamp_portal_id(pool, contact_id: str, portal_id: int):
     )
 
 
-async def portal_id_already_stamped(pool, contact_id: str, portal_id: int) -> bool:
+async def portal_id_current(pool, contact_id: str):
+    """(row_found, pid) under the same guards as the stamp itself."""
     row = await pool.fetchrow(
         """
         SELECT metadata->>'portal_customer_id' AS pid FROM contacts
@@ -271,7 +274,7 @@ async def portal_id_already_stamped(pool, contact_id: str, portal_id: int) -> bo
         contact_id,
         EOM_CONTEXT_ID,
     )
-    return bool(row) and row.get("pid") == str(portal_id)
+    return (row is not None), (row.get("pid") if row else None)
 
 
 async def sync_one(customer: dict, crm, pool, apply: bool) -> tuple:
@@ -299,6 +302,12 @@ async def sync_one(customer: dict, crm, pool, apply: bool) -> tuple:
         # zero updates (Codex A2 round 4).
         if existing is None:
             return "create-planned", None
+        if "metadata" in existing:
+            prior_pid = parse_meta(existing).get("portal_customer_id")
+            if prior_pid is not None and str(prior_pid) != str(portal_id):
+                print(f"    ERROR (previewed): contact {existing['id']} "
+                      f"already linked to portal customer {prior_pid}")
+                return "errors", None
         payload = dict(data)
         payload["tags"] = portal_final_tags(existing, data)
         payload.pop("source", None)
@@ -364,10 +373,20 @@ async def sync_one(customer: dict, crm, pool, apply: bool) -> tuple:
 
     if contact_id:
         stamped = await stamp_portal_id(pool, contact_id, portal_id)
-        if stamped is None and not await portal_id_already_stamped(
-                pool, contact_id, portal_id):
-            print(f"    ERROR: portal-id stamp rejected for contact {contact_id}")
-            return "errors", contact_id
+        if stamped is None:
+            found, pid = await portal_id_current(pool, contact_id)
+            if found and pid == str(portal_id):
+                pass  # clean re-run: already stamped
+            elif found and pid not in (None, ""):
+                # The in-SQL guard refused a relink (address-fallback rows
+                # carry no metadata for the app-side check -- Codex A2 r7).
+                print(f"    ERROR: contact {contact_id} already linked to "
+                      f"portal customer {pid}; refusing to relink")
+                return "errors", None
+            else:
+                print(f"    ERROR: portal-id stamp rejected for contact "
+                      f"{contact_id}")
+                return "errors", contact_id
     return outcome, contact_id
 
 
@@ -440,11 +459,19 @@ async def run(args) -> int:
     await pool.initialize()
     crm = get_crm_provider()
 
-    invalid = [
-        c for c in customers
-        if not str(c.get("name") or "").strip()
-        or not isinstance(c.get("id"), int) or isinstance(c.get("id"), bool)
-    ]
+    def _malformed(c):
+        if not str(c.get("name") or "").strip():
+            return True
+        if not isinstance(c.get("id"), int) or isinstance(c.get("id"), bool):
+            return True
+        sites = c.get("sites")
+        if sites is None:
+            return False
+        return not isinstance(sites, list) or any(
+            not isinstance(x, dict) for x in sites
+        )
+
+    invalid = [c for c in customers if _malformed(c)]
     if invalid:
         # Validate the WHOLE roster before any write: a malformed record
         # later in sort order must not leave earlier writes applied with

--- a/scripts/sync_eom_portal_customers.py
+++ b/scripts/sync_eom_portal_customers.py
@@ -200,8 +200,14 @@ async def stamp_portal_id(pool, contact_id: str, portal_id: int):
 
 async def portal_id_already_stamped(pool, contact_id: str, portal_id: int) -> bool:
     row = await pool.fetchrow(
-        "SELECT metadata->>'portal_customer_id' AS pid FROM contacts WHERE id = $1",
+        """
+        SELECT metadata->>'portal_customer_id' AS pid FROM contacts
+        WHERE id = $1
+          AND status != 'archived'
+          AND business_context_id = $2
+        """,
         contact_id,
+        EOM_CONTEXT_ID,
     )
     return bool(row) and row.get("pid") == str(portal_id)
 
@@ -210,7 +216,19 @@ async def sync_one(customer: dict, crm, pool, apply: bool) -> tuple:
     """Sync a single portal customer; returns (outcome, contact_id)."""
     data = customer_to_contact_data(customer)
     if not data["full_name"]:
-        return "skipped", None
+        # A nameless ACTIVE portal record is unprocessable: it may shadow a
+        # real matched customer, and a match set missing it must not drive
+        # demotions -- error (which also gates demotion) rather than skip
+        # (Codex A2 round 3).
+        print("    ERROR: active portal customer with blank name; run failed closed")
+        return "errors", None
+    portal_id = customer.get("id")
+    if not isinstance(portal_id, int):
+        # Validate BEFORE any write: --apply must not activate a contact and
+        # only then discover it cannot stamp the predicate (Codex A2 r3).
+        print(f"    ERROR: portal customer {customer.get('name')!r} has no "
+              "usable id; nothing written")
+        return "errors", None
 
     existing, needs_claim, identity = await resolve_contact(customer, data, crm, pool)
     if not apply:
@@ -253,13 +271,6 @@ async def sync_one(customer: dict, crm, pool, apply: bool) -> tuple:
             if outcome == "skipped":
                 return "skipped", contact_id
 
-    portal_id = customer.get("id")
-    if not isinstance(portal_id, int):
-        # A contact synced without the watcher predicate is a failure, not
-        # a silent skip (Codex A2 round 2).
-        print(f"    ERROR: portal customer {customer.get('name')!r} has no "
-              "usable id; predicate not stamped")
-        return "errors", contact_id
     if contact_id:
         stamped = await stamp_portal_id(pool, contact_id, portal_id)
         if stamped is None and not await portal_id_already_stamped(

--- a/scripts/sync_eom_portal_customers.py
+++ b/scripts/sync_eom_portal_customers.py
@@ -102,7 +102,7 @@ def active_sites(customer: dict) -> list:
 def segment_tags(customer: dict) -> list:
     tags = {"portal"}
     for site in active_sites(customer):
-        lt = (site.get("locationType") or "").strip().lower()
+        lt = str(site.get("locationType") or "").strip().lower()
         if lt in ("residential", "commercial"):
             tags.add(lt)
     return sorted(tags)
@@ -320,6 +320,16 @@ async def sync_one(customer: dict, crm, pool, apply: bool) -> tuple:
             return "update-planned", str(existing["id"])
         return "unchanged", str(existing["id"])
 
+    if existing is not None and "metadata" not in existing:
+        # Address-fallback rows are metadata-blind: probe the link BEFORE
+        # any matched write can activate/retag a conflicted row (Codex A2
+        # round 8, BLOCKER).
+        found, pid = await portal_id_current(pool, str(existing["id"]))
+        if found and pid not in (None, "") and pid != str(portal_id):
+            print(f"    ERROR: contact {existing['id']} already linked to "
+                  f"portal customer {pid}; refusing to relink")
+            return "errors", None
+
     if existing is not None:
         prior_pid = parse_meta(existing).get("portal_customer_id")
         if prior_pid is not None and str(prior_pid) != str(portal_id):
@@ -467,8 +477,13 @@ async def run(args) -> int:
         sites = c.get("sites")
         if sites is None:
             return False
-        return not isinstance(sites, list) or any(
-            not isinstance(x, dict) for x in sites
+        if not isinstance(sites, list) or any(
+                not isinstance(x, dict) for x in sites):
+            return True
+        return any(
+            x.get("locationType") is not None
+            and not isinstance(x.get("locationType"), str)
+            for x in sites
         )
 
     invalid = [c for c in customers if _malformed(c)]

--- a/scripts/sync_eom_portal_customers.py
+++ b/scripts/sync_eom_portal_customers.py
@@ -120,10 +120,12 @@ def customer_to_contact_data(customer: dict) -> dict:
         "tags": segment_tags(customer),
         "source": "portal_sync",
     }
-    if customer.get("primaryPhone"):
-        data["phone"] = customer["primaryPhone"]
-    if customer.get("primaryEmail"):
-        data["email"] = str(customer["primaryEmail"]).strip().lower()
+    phone = str(customer.get("primaryPhone") or "").strip()
+    if phone:
+        data["phone"] = phone
+    email = str(customer.get("primaryEmail") or "").strip().lower()
+    if email:
+        data["email"] = email
     sites = active_sites(customer)
     if sites and sites[0].get("address"):
         data["address"] = str(sites[0]["address"])
@@ -197,6 +199,18 @@ async def resolve_contact(customer: dict, data: dict, crm, pool):
         if existing is not None:
             return existing, needs_claim, ("address", addr)
     return None, False, None
+
+
+def parse_meta(existing: dict):
+    """asyncpg can deliver JSONB as str; absent metadata (narrow SELECTs)
+    reads as unknown ({})."""
+    meta = existing.get("metadata") if "metadata" in existing else None
+    if isinstance(meta, str):
+        try:
+            meta = json.loads(meta or "{}")
+        except ValueError:
+            meta = {}
+    return meta or {}
 
 
 def portal_final_tags(existing: dict, data: dict) -> list:
@@ -290,18 +304,23 @@ async def sync_one(customer: dict, crm, pool, apply: bool) -> tuple:
         payload.pop("source", None)
         payload.pop("business_context_id", None)
         updates = live._diff_updates(existing, payload)
-        meta = existing.get("metadata") if "metadata" in existing else None
-        if isinstance(meta, str):
-            try:
-                meta = json.loads(meta or "{}")
-            except ValueError:
-                meta = {}
         stamped = ("metadata" in existing and
-                   str((meta or {}).get("portal_customer_id", ""))
+                   str(parse_meta(existing).get("portal_customer_id", ""))
                    == str(customer.get("id")))
         if updates or not stamped:
             return "update-planned", str(existing["id"])
         return "unchanged", str(existing["id"])
+
+    if existing is not None:
+        prior_pid = parse_meta(existing).get("portal_customer_id")
+        if prior_pid is not None and str(prior_pid) != str(portal_id):
+            # Never bounce a stable portal link between ids: two portal
+            # customers sharing a channel/address must be fixed in the
+            # portal, not by overwriting the CRM link (Codex A2 round 6).
+            print(f"    ERROR: contact {existing['id']} already linked to "
+                  f"portal customer {prior_pid}; refusing to relink to "
+                  f"{portal_id}")
+            return "errors", None
 
     if existing is not None and needs_claim:
         existing = await live.claim_legacy_row(
@@ -420,6 +439,22 @@ async def run(args) -> int:
     pool = get_db_pool()
     await pool.initialize()
     crm = get_crm_provider()
+
+    invalid = [
+        c for c in customers
+        if not str(c.get("name") or "").strip()
+        or not isinstance(c.get("id"), int) or isinstance(c.get("id"), bool)
+    ]
+    if invalid:
+        # Validate the WHOLE roster before any write: a malformed record
+        # later in sort order must not leave earlier writes applied with
+        # demotion skipped (Codex A2 round 6).
+        for c in invalid:
+            print(f"  INVALID portal record: id={c.get('id')!r} "
+                  f"name={c.get('name')!r}")
+        print(f"\n  ABORTED: {len(invalid)} malformed portal record(s); "
+              "nothing written.")
+        return 1
 
     matched_ids: set = set()
     for customer in sorted(customers, key=lambda c: str(c.get("name") or "").lower()):

--- a/scripts/sync_eom_portal_customers.py
+++ b/scripts/sync_eom_portal_customers.py
@@ -31,6 +31,7 @@ import json
 import getpass
 import os
 import sys
+import uuid as _uuid
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))          # sibling script import
@@ -158,6 +159,13 @@ async def resolve_contact(customer: dict, data: dict, crm, pool):
             return row, False, None
 
     atlas_id = customer.get("atlasContactId")
+    if atlas_id is not None:
+        try:
+            _uuid.UUID(str(atlas_id))
+        except (ValueError, AttributeError, TypeError):
+            print(f"    note: malformed atlasContactId {atlas_id!r}; "
+                  "ignoring the link")
+            atlas_id = None
     if atlas_id:
         row = await pool.fetchrow(
             """
@@ -307,6 +315,12 @@ async def sync_one(customer: dict, crm, pool, apply: bool) -> tuple:
             if prior_pid is not None and str(prior_pid) != str(portal_id):
                 print(f"    ERROR (previewed): contact {existing['id']} "
                       f"already linked to portal customer {prior_pid}")
+                return "errors", None
+        else:
+            found, pid = await portal_id_current(pool, str(existing["id"]))
+            if found and pid not in (None, "") and pid != str(portal_id):
+                print(f"    ERROR (previewed): contact {existing['id']} "
+                      f"already linked to portal customer {pid}")
                 return "errors", None
         payload = dict(data)
         payload["tags"] = portal_final_tags(existing, data)

--- a/scripts/sync_eom_portal_customers.py
+++ b/scripts/sync_eom_portal_customers.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""Portal -> Atlas CRM customer sync (EOM current-customer master).
+
+#2156 slice A2. The owner's canonical current roster is the portal's
+server-owned Customer aggregate (wiw backend, `GET /api/admin/customers`);
+calendar history (slice A) is enrichment, not the active set. This script:
+
+  1. authenticates to the backend at RUNTIME (getpass; nothing stored),
+  2. fetches the active customers + sites,
+  3. resolves each to a CRM contact (atlasContactId first, then the slice-A
+     identity ladder: phone -> email -> site addresses),
+  4. writes through the slice-A guarded machinery (diffed, archive- and
+     tenant-guarded), stamping `metadata.portal_customer_id`,
+  5. demotes previously-imported "active customers" that no portal customer
+     matched this run to status='inactive' + a `past_customer` tag.
+
+Dry-run by default; pass --apply to write (demotion-bearing script, #2155
+convention). Non-interactive runs may supply a pre-obtained token via the
+EOM_PORTAL_TOKEN environment variable. Credentials are never written to
+disk, argv, or logs.
+
+Usage:
+  python scripts/sync_eom_portal_customers.py            # dry-run
+  python scripts/sync_eom_portal_customers.py --apply
+  python scripts/sync_eom_portal_customers.py --base-url http://localhost:8000
+"""
+
+import argparse
+import asyncio
+import getpass
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))          # sibling script import
+sys.path.insert(0, str(Path(__file__).parent.parent))   # atlas_brain import
+
+import import_eom_customers_live as live  # noqa: E402  (slice-A machinery)
+
+EOM_CONTEXT_ID = live.EOM_CONTEXT_ID
+DEFAULT_BASE_URL = "https://eom-timetracker.onrender.com"
+DEMOTABLE_SOURCES = ("calendar_import", "portal_sync")
+
+
+def portal_login(client, base_url: str, env: dict):
+    """Runtime auth: env token when provided (non-interactive), else a
+    getpass prompt. The password variable never leaves this function and is
+    never printed or persisted."""
+    token = env.get("EOM_PORTAL_TOKEN")
+    if token:
+        return token
+    name = input("Portal admin name: ")
+    password = getpass.getpass("Portal admin password (not stored): ")
+    resp = client.post(
+        f"{base_url}/api/auth/login", json={"name": name, "password": password}
+    )
+    if resp.status_code != 200:
+        raise SystemExit(f"Portal login failed (HTTP {resp.status_code})")
+    token = (resp.json() or {}).get("token")
+    if not token:
+        raise SystemExit("Portal login returned no token")
+    return token
+
+
+def fetch_portal_customers(client, base_url: str, token: str) -> list:
+    resp = client.get(
+        f"{base_url}/api/admin/customers",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    if resp.status_code != 200:
+        raise SystemExit(f"Customer fetch failed (HTTP {resp.status_code})")
+    payload = resp.json() or {}
+    if not payload.get("success"):
+        raise SystemExit("Customer fetch returned success=false")
+    return payload.get("customers") or []
+
+
+def active_sites(customer: dict) -> list:
+    return [s for s in (customer.get("sites") or []) if s.get("active")]
+
+
+def segment_tags(customer: dict) -> list:
+    tags = {"portal"}
+    for site in active_sites(customer):
+        lt = (site.get("locationType") or "").strip().lower()
+        if lt in ("residential", "commercial"):
+            tags.add(lt)
+    return sorted(tags)
+
+
+def customer_to_contact_data(customer: dict) -> dict:
+    """Contact payload for one portal customer. The tenant stamp is
+    non-negotiable; `source`/`tags` ride the slice-A controlled write paths,
+    not the create call (race rules, slice A rounds 6-7)."""
+    data = {
+        "full_name": str(customer.get("name") or "").strip(),
+        "contact_type": "customer",
+        "business_context_id": EOM_CONTEXT_ID,
+        "status": "active",
+        "tags": segment_tags(customer),
+        "source": "portal_sync",
+    }
+    if customer.get("primaryPhone"):
+        data["phone"] = customer["primaryPhone"]
+    if customer.get("primaryEmail"):
+        data["email"] = customer["primaryEmail"]
+    sites = active_sites(customer)
+    if sites:
+        data["address"] = sites[0].get("address")
+    if customer.get("primaryContactName"):
+        data["notes"] = f"Contact: {customer['primaryContactName']}"
+    return data
+
+
+async def resolve_contact(customer: dict, data: dict, crm, pool):
+    """atlasContactId first (the designed cross-system link), then the
+    slice-A identity ladder. Returns (existing_row_or_None, needs_claim,
+    identity_tuple_or_None)."""
+    atlas_id = customer.get("atlasContactId")
+    if atlas_id:
+        row = await pool.fetchrow(
+            """
+            SELECT id, full_name, address, contact_type, business_context_id,
+                   tags, status, phone, email, notes, source, metadata
+            FROM contacts
+            WHERE id = $1 AND status != 'archived'
+            """,
+            str(atlas_id),
+        )
+        if row:
+            return row, False, None
+
+    if data.get("phone"):
+        digits = live._phone_digits(data["phone"])
+        if len(digits) >= 10:
+            existing, needs_claim = await live._search_channel(crm, phone=digits)
+            if existing is not None:
+                return existing, needs_claim, ("phone", digits[-10:])
+    if data.get("email"):
+        existing, needs_claim = await live._search_channel(crm, email=data["email"])
+        if existing is not None:
+            return existing, needs_claim, ("email", data["email"])
+    for site in active_sites(customer):
+        addr = site.get("address")
+        if not addr:
+            continue
+        existing, needs_claim = await live.resolve_by_address(pool, addr)
+        if existing is not None:
+            return existing, needs_claim, ("address", addr)
+    return None, False, None
+
+
+async def stamp_portal_id(pool, contact_id: str, portal_id: int):
+    """Guarded jsonb merge of metadata.portal_customer_id -- the slice-B
+    watcher predicate. Same archive/tenant guards as every other write."""
+    return await pool.fetchrow(
+        """
+        UPDATE contacts
+           SET metadata = COALESCE(metadata, '{}'::jsonb)
+                          || jsonb_build_object('portal_customer_id', $2::int),
+               updated_at = NOW()
+         WHERE id = $1
+           AND status != 'archived'
+           AND (business_context_id IS NULL OR business_context_id = $3)
+        RETURNING id
+        """,
+        contact_id,
+        portal_id,
+        EOM_CONTEXT_ID,
+    )
+
+
+async def sync_one(customer: dict, crm, pool, apply: bool) -> tuple:
+    """Sync a single portal customer; returns (outcome, contact_id)."""
+    data = customer_to_contact_data(customer)
+    if not data["full_name"]:
+        return "skipped", None
+
+    existing, needs_claim, identity = await resolve_contact(customer, data, crm, pool)
+    if not apply:
+        # Dry-run still reports the matched id so the demotion preview is
+        # accurate (a matched contact is NOT a demotion candidate).
+        if existing is not None:
+            return "update-planned", str(existing["id"])
+        return "create-planned", None
+
+    if existing is not None and needs_claim:
+        existing = await live.claim_legacy_row(
+            pool, str(existing["id"]),
+            require_import_source=(identity is not None and identity[0] == "address"),
+            identity=identity,
+        )
+
+    if existing is not None:
+        contact_id, outcome = await live._update_matched(pool, existing, data)
+        if outcome == "skipped":
+            return "skipped", contact_id
+    else:
+        create_data = dict(data)
+        create_data.pop("source", None)
+        create_data.pop("tags", None)
+        result = await crm.create_contact(create_data)
+        contact_id = str(result.get("id", ""))
+        if result.get("_was_created"):
+            outcome = "created"
+            if contact_id:
+                stamp = await live._guarded_update(
+                    pool, contact_id,
+                    {"source": "portal_sync", "tags": data["tags"]},
+                )
+                if stamp is None:
+                    print(f"    ERROR: contact {contact_id} changed before the "
+                          "provenance stamp; left unstamped")
+                    return "errors", contact_id
+        else:
+            contact_id, outcome = await live._update_matched(pool, result, data)
+            if outcome == "skipped":
+                return "skipped", contact_id
+
+    if contact_id:
+        stamped = await stamp_portal_id(pool, contact_id, int(customer["id"]))
+        if stamped is None:
+            print(f"    ERROR: portal-id stamp rejected for contact {contact_id}")
+            return "errors", contact_id
+    return outcome, contact_id
+
+
+async def demote_unmatched(pool, matched_ids: set, apply: bool) -> tuple:
+    """Previously-imported active 'customers' that matched no portal customer
+    this run become past customers. Only rows this pipeline claimed as
+    active (calendar_import / portal_sync provenance) are eligible; leads,
+    manual, web, and every other source are never touched."""
+    rows = await pool.fetch(
+        """
+        SELECT id, full_name, tags FROM contacts
+        WHERE business_context_id = $1
+          AND contact_type = 'customer'
+          AND status = 'active'
+          AND source = ANY($2::text[])
+        ORDER BY lower(full_name)
+        """,
+        EOM_CONTEXT_ID,
+        list(DEMOTABLE_SOURCES),
+    )
+    demoted = 0
+    for row in rows:
+        if str(row["id"]) in matched_ids:
+            continue
+        print(f"  DEMOTE (past customer): {row['full_name']}")
+        if not apply:
+            demoted += 1
+            continue
+        tags = sorted(set(row["tags"] or []) | {"past_customer"})
+        result = await live._guarded_update(
+            pool, str(row["id"]), {"status": "inactive", "tags": tags}
+        )
+        if result is not None:
+            demoted += 1
+    return demoted, len(rows)
+
+
+async def run(args) -> int:
+    import httpx
+
+    counts = {"created": 0, "updated": 0, "unchanged": 0, "skipped": 0,
+              "errors": 0, "create-planned": 0, "update-planned": 0}
+    with httpx.Client(timeout=30.0) as client:
+        token = portal_login(client, args.base_url, os.environ)
+        customers = fetch_portal_customers(client, args.base_url, token)
+
+    mode = "APPLY" if args.apply else "DRY RUN"
+    print(f"\n{'=' * 70}")
+    print(f"  Atlas CRM -- EOM portal customer sync [{mode}]")
+    print(f"  Portal customers (active): {len(customers)}")
+    print(f"{'=' * 70}\n")
+
+    from atlas_brain.services.crm_provider import get_crm_provider
+    from atlas_brain.storage.database import get_db_pool
+
+    pool = get_db_pool()
+    await pool.initialize()
+    crm = get_crm_provider()
+
+    matched_ids: set = set()
+    for customer in sorted(customers, key=lambda c: str(c.get("name") or "").lower()):
+        print(f"  {customer.get('name'):<45} sites={len(active_sites(customer))} "
+              f"[{','.join(segment_tags(customer))}]")
+        try:
+            outcome, contact_id = await sync_one(customer, crm, pool, args.apply)
+            counts[outcome] += 1
+            if contact_id:
+                matched_ids.add(contact_id)
+        except Exception as e:  # noqa: BLE001 -- operator script: report, continue
+            print(f"    ERROR: {customer.get('name')} -- {e}")
+            counts["errors"] += 1
+
+    print(f"\n{'-' * 70}")
+    demoted, eligible = await demote_unmatched(pool, matched_ids, args.apply)
+
+    print(f"\n{'=' * 70}")
+    if args.apply:
+        print(f"  Created: {counts['created']}   Updated: {counts['updated']}   "
+              f"Unchanged: {counts['unchanged']}   Demoted: {demoted}   "
+              f"Skipped: {counts['skipped']}   Errors: {counts['errors']}")
+    else:
+        print(f"  DRY RUN -- would create {counts['create-planned']}, "
+              f"update {counts['update-planned']}, demote {demoted} "
+              f"(of {eligible} eligible). Run with --apply to write.")
+    print(f"{'=' * 70}\n")
+    return 1 if counts["errors"] else 0
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Sync the portal Customer aggregate into the Atlas CRM"
+    )
+    parser.add_argument("--apply", action="store_true",
+                        help="Write changes (default is dry-run)")
+    parser.add_argument("--base-url", default=DEFAULT_BASE_URL)
+    args = parser.parse_args()
+    return asyncio.run(run(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sync_eom_portal_customers.py
+++ b/scripts/sync_eom_portal_customers.py
@@ -42,11 +42,21 @@ DEFAULT_BASE_URL = "https://eom-timetracker.onrender.com"
 DEMOTABLE_SOURCES = ("calendar_import", "portal_sync")
 
 
+def settings_default(attr: str):
+    """Typed Atlas settings (pydantic reads .env/.env.local that never reach
+    os.environ -- slice-A R11 rule). Never raises in minimal envs."""
+    try:
+        from atlas_brain.config import settings as _settings
+        return getattr(_settings.tools, attr, None)
+    except Exception:  # noqa: BLE001 -- settings absent: env/prompt only
+        return None
+
+
 def portal_login(client, base_url: str, env: dict):
-    """Runtime auth: env token when provided (non-interactive), else a
-    getpass prompt. The password variable never leaves this function and is
-    never printed or persisted."""
-    token = env.get("EOM_PORTAL_TOKEN")
+    """Runtime auth: env or typed-settings token when provided
+    (non-interactive), else a getpass prompt. The password variable never
+    leaves this function and is never printed or persisted."""
+    token = env.get("EOM_PORTAL_TOKEN") or settings_default("eom_portal_token")
     if token:
         return token
     name = input("Portal admin name: ")
@@ -105,8 +115,8 @@ def customer_to_contact_data(customer: dict) -> dict:
     if customer.get("primaryEmail"):
         data["email"] = customer["primaryEmail"]
     sites = active_sites(customer)
-    if sites:
-        data["address"] = sites[0].get("address")
+    if sites and sites[0].get("address"):
+        data["address"] = str(sites[0]["address"])
     if customer.get("primaryContactName"):
         data["notes"] = f"Contact: {customer['primaryContactName']}"
     return data
@@ -128,7 +138,17 @@ async def resolve_contact(customer: dict, data: dict, crm, pool):
             str(atlas_id),
         )
         if row:
-            return row, False, None
+            ctx = row.get("business_context_id")
+            if ctx == EOM_CONTEXT_ID:
+                return row, False, None
+            if ctx is None:
+                # Designed link to a legacy NULL-context row: claim it via
+                # the CAS (the id link IS the identity) -- Codex A2 round 1.
+                return row, True, None
+            # Linked to a FOREIGN tenant: fail closed, fall to the ladder
+            # and report rather than writing across tenants.
+            print(f"    note: atlasContactId {atlas_id} belongs to tenant "
+                  f"{ctx!r}; ignoring the link")
 
     if data.get("phone"):
         digits = live._phone_digits(data["phone"])
@@ -217,8 +237,9 @@ async def sync_one(customer: dict, crm, pool, apply: bool) -> tuple:
             if outcome == "skipped":
                 return "skipped", contact_id
 
-    if contact_id:
-        stamped = await stamp_portal_id(pool, contact_id, int(customer["id"]))
+    portal_id = customer.get("id")
+    if contact_id and isinstance(portal_id, int):
+        stamped = await stamp_portal_id(pool, contact_id, portal_id)
         if stamped is None:
             print(f"    ERROR: portal-id stamp rejected for contact {contact_id}")
             return "errors", contact_id
@@ -295,7 +316,15 @@ async def run(args) -> int:
             counts["errors"] += 1
 
     print(f"\n{'-' * 70}")
-    demoted, eligible = await demote_unmatched(pool, matched_ids, args.apply)
+    if counts["errors"]:
+        # An errored customer never reached matched_ids; demoting on a
+        # partial sync could retire real customers (Codex A2 round 1,
+        # BLOCKER). Fail the run and leave demotion for a clean pass.
+        print(f"  DEMOTION SKIPPED: {counts['errors']} sync error(s) -- "
+              "a partial match set must not drive demotions.")
+        demoted, eligible = 0, 0
+    else:
+        demoted, eligible = await demote_unmatched(pool, matched_ids, args.apply)
 
     print(f"\n{'=' * 70}")
     if args.apply:
@@ -316,7 +345,12 @@ def main():
     )
     parser.add_argument("--apply", action="store_true",
                         help="Write changes (default is dry-run)")
-    parser.add_argument("--base-url", default=DEFAULT_BASE_URL)
+    parser.add_argument(
+        "--base-url",
+        default=os.environ.get("EOM_PORTAL_BASE_URL")
+        or settings_default("eom_portal_base_url")
+        or DEFAULT_BASE_URL,
+    )
     args = parser.parse_args()
     return asyncio.run(run(args))
 

--- a/tests/maturity_sweep/baseline_scripts.json
+++ b/tests/maturity_sweep/baseline_scripts.json
@@ -1934,5 +1934,13 @@
       "UNGUARDED_INDEX": 1
     },
     "score": 2
+  },
+  "scripts/sync_eom_portal_customers.py": {
+    "counts": {
+      "NO_RAISES_TESTS": 1,
+      "SWALLOWED_EXCEPT": 1,
+      "UNGUARDED_INDEX": 3
+    },
+    "score": 14
   }
 }

--- a/tests/test_eom_portal_customer_sync.py
+++ b/tests/test_eom_portal_customer_sync.py
@@ -1,0 +1,213 @@
+"""Tests for #2156 slice A2: portal -> Atlas CRM customer sync.
+
+Pure mapping helpers are tested directly; sync_one/demote_unmatched run
+against the slice-A stub harness (DB/CRM edge stubs), extended with a
+routed jsonb-stamp recorder and a fetch() for demotion candidates. Auth is
+tested at the seam (env token short-circuits any prompt; failures exit).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+sys.path.insert(0, str(REPO / "tests"))
+
+from test_eom_live_calendar_import import StubCRM, StubPool  # noqa: E402
+from sync_eom_portal_customers import (  # noqa: E402
+    DEMOTABLE_SOURCES,
+    customer_to_contact_data,
+    demote_unmatched,
+    portal_login,
+    segment_tags,
+    sync_one,
+)
+
+
+def _customer(**over):
+    base = {
+        "id": 7,
+        "name": "Firefly Grill",
+        "primaryContactName": "Niall",
+        "primaryPhone": "217-317-3953",
+        "primaryEmail": None,
+        "atlasContactId": None,
+        "active": True,
+        "sites": [
+            {"id": 1, "active": True, "address": "1810 Ave of Mid-America, Effingham, IL",
+             "locationType": "Commercial"},
+            {"id": 2, "active": False, "address": "Old Site Rd",
+             "locationType": "Commercial"},
+        ],
+    }
+    base.update(over)
+    return base
+
+
+class SyncPool(StubPool):
+    """Adds portal-sync surfaces to the slice-A stub: routed jsonb stamps
+    and a fetch() list for demotion candidates."""
+
+    def __init__(self, *a, demotion_rows=None, stamp_fail=False, **kw):
+        super().__init__(*a, **kw)
+        self.stamps = []
+        self.stamp_fail = stamp_fail
+        self.demotion_rows = demotion_rows or []
+
+    async def fetchrow(self, sql, *args):
+        if "SET metadata" in sql:
+            self.stamps.append((args[0], args[1]))
+            return None if self.stamp_fail else {"id": args[0]}
+        return await super().fetchrow(sql, *args)
+
+    async def fetch(self, sql, *args):
+        self.queries.append((sql, args))
+        return self.demotion_rows
+
+
+# ---------------------------------------------------------------------------
+# Mapping (pure)
+# ---------------------------------------------------------------------------
+
+def test_segment_tags_from_active_sites_only():
+    c = _customer(sites=[
+        {"active": True, "address": "A", "locationType": "Residential"},
+        {"active": False, "address": "B", "locationType": "Commercial"},
+    ])
+    assert segment_tags(c) == ["portal", "residential"]
+
+
+def test_contact_data_carries_stamp_status_and_source():
+    data = customer_to_contact_data(_customer())
+    assert data["business_context_id"] == "effingham_maids"
+    assert data["contact_type"] == "customer"
+    assert data["status"] == "active"
+    assert data["source"] == "portal_sync"
+    assert data["tags"] == ["commercial", "portal"]
+    assert data["address"].startswith("1810 Ave")
+    assert data["phone"] == "217-317-3953"
+
+
+# ---------------------------------------------------------------------------
+# Auth seam
+# ---------------------------------------------------------------------------
+
+def test_env_token_short_circuits_prompt():
+    class NoClient:
+        def post(self, *a, **k):
+            raise AssertionError("no HTTP call expected")
+    assert portal_login(NoClient(), "https://x", {"EOM_PORTAL_TOKEN": "t"}) == "t"
+
+
+def test_no_credential_persistence_in_source():
+    src = (REPO / "scripts" / "sync_eom_portal_customers.py").read_text()
+    assert "getpass.getpass" in src
+    # No printing/logging or storage of the password variable, and no file
+    # writes anywhere in the auth path.
+    assert "print(password" not in src
+    login_body = src.split("def portal_login")[1].split("def fetch_portal")[0]
+    assert "open(" not in login_body and "write" not in login_body
+
+
+# ---------------------------------------------------------------------------
+# sync_one
+# ---------------------------------------------------------------------------
+
+def test_create_path_stamps_source_tags_and_portal_id():
+    crm = StubCRM()
+    pool = SyncPool(rows=[None, None])
+    outcome, cid = asyncio.run(sync_one(_customer(), crm, pool, apply=True))
+    assert outcome == "created"
+    assert "source" not in crm.created[0]
+    assert "tags" not in crm.created[0]
+    assert ("new-id", {"source": "portal_sync", "tags": ["commercial", "portal"]}) in pool.updates
+    assert pool.stamps == [("new-id", 7)]
+
+
+def test_atlas_contact_id_link_wins_over_channels():
+    crm = StubCRM(scoped_hit={"id": "should-not-be-used", "tags": []})
+    linked = {"id": "linked-id", "tags": ["website"], "source": "web",
+              "status": "inactive", "full_name": "Firefly Grill"}
+    pool = SyncPool(rows=[linked])
+    outcome, cid = asyncio.run(
+        sync_one(_customer(atlasContactId="linked-id"), crm, pool, apply=True)
+    )
+    assert cid == "linked-id"
+    assert crm.searches == []               # designed link short-circuits the ladder
+    sql = pool.queries[0][0]
+    assert "status != 'archived'" in sql
+    assert pool.stamps == [("linked-id", 7)]
+
+
+def test_matched_contact_keeps_provenance_and_gets_activated():
+    crm = StubCRM(scoped_hit={"id": "k", "tags": ["residential", "past_customer"],
+                              "source": "calendar_import", "status": "inactive"})
+    pool = SyncPool()
+    outcome, cid = asyncio.run(sync_one(_customer(), crm, pool, apply=True))
+    assert outcome == "updated"
+    cid2, payload = pool.updates[0]
+    assert payload["status"] == "active"
+    assert "source" not in payload          # provenance preserved (slice-A rule)
+    assert "portal" in payload["tags"] and "past_customer" in payload["tags"]
+
+
+def test_dry_run_reports_matched_id_and_writes_nothing():
+    crm = StubCRM(scoped_hit={"id": "k", "tags": [], "status": "active"})
+    pool = SyncPool()
+    outcome, cid = asyncio.run(sync_one(_customer(), crm, pool, apply=False))
+    assert outcome == "update-planned"
+    assert cid == "k"                        # feeds the demotion preview
+    assert pool.updates == [] and pool.stamps == [] and crm.created == []
+
+
+def test_failed_portal_id_stamp_is_an_error():
+    crm = StubCRM(scoped_hit={"id": "k", "tags": [], "status": "active"})
+    pool = SyncPool(stamp_fail=True)
+    outcome, cid = asyncio.run(sync_one(_customer(), crm, pool, apply=True))
+    assert outcome == "errors"
+
+
+def test_nameless_portal_customer_is_skipped():
+    crm, pool = StubCRM(), SyncPool()
+    outcome, cid = asyncio.run(sync_one(_customer(name=""), crm, pool, apply=True))
+    assert outcome == "skipped"
+    assert crm.created == [] and pool.updates == []
+
+
+# ---------------------------------------------------------------------------
+# Demotion
+# ---------------------------------------------------------------------------
+
+def test_unmatched_previously_imported_actives_are_demoted():
+    pool = SyncPool(demotion_rows=[
+        {"id": "gone", "full_name": "Moved Away", "tags": ["residential"]},
+        {"id": "still", "full_name": "Still Here", "tags": ["commercial"]},
+    ])
+    demoted, eligible = asyncio.run(demote_unmatched(pool, {"still"}, apply=True))
+    assert (demoted, eligible) == (1, 2)
+    cid, payload = pool.updates[0]
+    assert cid == "gone"
+    assert payload["status"] == "inactive"
+    assert "past_customer" in payload["tags"] and "residential" in payload["tags"]
+
+
+def test_demotion_candidates_are_provenance_scoped():
+    pool = SyncPool(demotion_rows=[])
+    asyncio.run(demote_unmatched(pool, set(), apply=True))
+    sql, args = pool.queries[0]
+    assert "contact_type = 'customer'" in sql
+    assert "status = 'active'" in sql
+    assert "source = ANY($2::text[])" in sql
+    assert list(args[1]) == list(DEMOTABLE_SOURCES)
+
+
+def test_demotion_dry_run_counts_without_writing():
+    pool = SyncPool(demotion_rows=[
+        {"id": "gone", "full_name": "Moved Away", "tags": []},
+    ])
+    demoted, eligible = asyncio.run(demote_unmatched(pool, set(), apply=False))
+    assert (demoted, eligible) == (1, 1)
+    assert pool.updates == []

--- a/tests/test_sync_eom_portal_customers.py
+++ b/tests/test_sync_eom_portal_customers.py
@@ -102,11 +102,14 @@ def test_contact_data_carries_stamp_status_and_source():
 # Auth seam
 # ---------------------------------------------------------------------------
 
-def test_env_token_short_circuits_prompt():
+def test_typed_env_token_short_circuits_prompt():
     class NoClient:
         def post(self, *a, **k):
             raise AssertionError("no HTTP call expected")
-    assert portal_login(NoClient(), "https://x", {"EOM_PORTAL_TOKEN": "t"}) == "t"
+    assert portal_login(NoClient(), "https://x",
+                        {"ATLAS_TOOLS_EOM_PORTAL_TOKEN": "t"}) == "t"
+    src = (REPO / "scripts" / "sync_eom_portal_customers.py").read_text()
+    assert '"EOM_PORTAL_TOKEN"' not in src      # single typed surface (r4)
 
 
 def test_no_credential_persistence_in_source():
@@ -139,7 +142,7 @@ def test_atlas_contact_id_link_wins_over_channels():
     linked = {"id": "linked-id", "tags": ["website"], "source": "web",
               "status": "inactive", "full_name": "Firefly Grill",
               "business_context_id": "effingham_maids"}
-    pool = SyncPool(rows=[linked])
+    pool = SyncPool(rows=[None, linked])   # portal-id page misses first
     outcome, cid = asyncio.run(
         sync_one(_customer(atlasContactId="linked-id"), crm, pool, apply=True)
     )
@@ -156,8 +159,8 @@ def test_null_context_linked_row_is_claimed_via_cas():
     crm = StubCRM()
     linked = {"id": "legacy-link", "tags": [], "source": "web",
               "status": "active", "business_context_id": None}
-    pool = SyncPool(rows=[linked, {"id": "legacy-link", "source": "web",
-                                   "status": "active", "tags": []}])
+    pool = SyncPool(rows=[None, linked, {"id": "legacy-link", "source": "web",
+                                         "status": "active", "tags": []}])
     outcome, cid = asyncio.run(
         sync_one(_customer(atlasContactId="legacy-link"), crm, pool, apply=True)
     )
@@ -170,7 +173,7 @@ def test_foreign_tenant_link_is_ignored_falls_to_ladder():
     crm = StubCRM()          # ladder misses -> create
     linked = {"id": "foreign", "tags": [], "source": "b2b",
               "status": "active", "business_context_id": "churnsignals"}
-    pool = SyncPool(rows=[linked, None, None])
+    pool = SyncPool(rows=[None, linked, None, None])
     outcome, cid = asyncio.run(
         sync_one(_customer(atlasContactId="foreign"), crm, pool, apply=True)
     )
@@ -188,7 +191,9 @@ def test_matched_contact_keeps_provenance_and_gets_activated():
     cid2, payload = pool.updates[0]
     assert payload["status"] == "active"
     assert "source" not in payload          # provenance preserved (slice-A rule)
-    assert "portal" in payload["tags"] and "past_customer" in payload["tags"]
+    # Portal-authoritative managed tags: past_customer sheds on an active
+    # match; foreign tags survive (Codex A2 round 4).
+    assert "portal" in payload["tags"] and "past_customer" not in payload["tags"]
 
 
 def test_dry_run_reports_matched_id_and_writes_nothing():
@@ -198,6 +203,35 @@ def test_dry_run_reports_matched_id_and_writes_nothing():
     assert outcome == "update-planned"
     assert cid == "k"                        # feeds the demotion preview
     assert pool.updates == [] and pool.stamps == [] and crm.created == []
+
+
+def test_dry_run_previews_unchanged_for_clean_rows():
+    # Codex A2 round 4: a fully-synced row previews as unchanged.
+    rec_data = customer_to_contact_data(_customer())
+    existing = {"id": "k", **{k: v for k, v in rec_data.items()
+                              if k not in ("source", "business_context_id")},
+                "source": "portal_sync", "business_context_id": "effingham_maids",
+                "metadata": {"portal_customer_id": 7}}
+    crm = StubCRM(scoped_hit=existing)
+    pool = SyncPool()
+    outcome, cid = asyncio.run(sync_one(_customer(), crm, pool, apply=False))
+    assert outcome == "unchanged"
+
+
+def test_resolver_finds_stamped_portal_id_first():
+    # Codex A2 round 4 (R8): the stamped id is the stable key -- channel
+    # drift must not cause a duplicate create.
+    crm = StubCRM()          # channels would miss entirely
+    stamped_row = {"id": "stamped", "tags": ["portal", "commercial"],
+                   "source": "portal_sync", "status": "active",
+                   "business_context_id": "effingham_maids",
+                   "metadata": {"portal_customer_id": 7}}
+    pool = SyncPool(rows=[stamped_row])
+    outcome, cid = asyncio.run(sync_one(_customer(primaryPhone=None), crm, pool,
+                                        apply=True))
+    assert cid == "stamped"
+    assert crm.created == []
+    assert "portal_customer_id' = $1" in pool.queries[0][0]
 
 
 def test_failed_portal_id_stamp_is_an_error():

--- a/tests/test_sync_eom_portal_customers.py
+++ b/tests/test_sync_eom_portal_customers.py
@@ -294,6 +294,27 @@ def test_dry_run_previews_link_conflicts():
     assert cid is None                       # not in the demotion-safe set
 
 
+def test_metadata_blind_conflict_probed_before_any_write():
+    # Codex A2 round 8 (BLOCKER): the address-fallback row's existing link
+    # is probed before the matched update can touch it.
+    crm = StubCRM()
+    pool = SyncPool(rows=[None, {"id": "addr-row", "tags": []}])
+    pool.already_stamped = 9
+    outcome, cid = asyncio.run(sync_one(_customer(primaryPhone=None), crm, pool,
+                                        apply=True))
+    assert outcome == "errors"
+    assert pool.updates == [] and pool.stamps == []
+
+
+def test_non_string_location_type_is_safe_and_preflighted():
+    # Codex A2 round 8 (BLOCKER): robust helper + roster preflight.
+    c = _customer(sites=[{"active": True, "address": "A", "locationType": 3}])
+    assert segment_tags(c) == ["portal"]
+    src = (REPO / "scripts" / "sync_eom_portal_customers.py").read_text()
+    body = src.split("def _malformed")[1].split("invalid =")[0]
+    assert 'isinstance(x.get("locationType"), str)' in body
+
+
 def test_roster_preflight_rejects_malformed_sites():
     src = (REPO / "scripts" / "sync_eom_portal_customers.py").read_text()
     body = src.split("def _malformed")[1].split("invalid =")[0]

--- a/tests/test_sync_eom_portal_customers.py
+++ b/tests/test_sync_eom_portal_customers.py
@@ -27,6 +27,11 @@ from sync_eom_portal_customers import (  # noqa: E402
 )
 
 
+LINK_A = "11111111-1111-1111-1111-111111111111"
+LINK_B = "22222222-2222-2222-2222-222222222222"
+LINK_C = "33333333-3333-3333-3333-333333333333"
+
+
 def _customer(**over):
     base = {
         "id": 7,
@@ -143,47 +148,47 @@ def test_create_path_stamps_source_tags_and_portal_id():
 
 def test_atlas_contact_id_link_wins_over_channels():
     crm = StubCRM(scoped_hit={"id": "should-not-be-used", "tags": []})
-    linked = {"id": "linked-id", "tags": ["website"], "source": "web",
+    linked = {"id": LINK_A, "tags": ["website"], "source": "web",
               "status": "inactive", "full_name": "Firefly Grill",
               "business_context_id": "effingham_maids"}
     pool = SyncPool(rows=[None, linked])   # portal-id page misses first
     outcome, cid = asyncio.run(
-        sync_one(_customer(atlasContactId="linked-id"), crm, pool, apply=True)
+        sync_one(_customer(atlasContactId=LINK_A), crm, pool, apply=True)
     )
-    assert cid == "linked-id"
+    assert cid == LINK_A
     assert crm.searches == []               # designed link short-circuits the ladder
     sql = pool.queries[0][0]
     assert "status != 'archived'" in sql
-    assert pool.stamps == [("linked-id", 7)]
+    assert pool.stamps == [(LINK_A, 7)]
 
 
 def test_null_context_linked_row_is_claimed_via_cas():
     # Codex A2 round 1: a legacy NULL-context row behind atlasContactId is
     # claimed through the CAS (the id link IS the identity).
     crm = StubCRM()
-    linked = {"id": "legacy-link", "tags": [], "source": "web",
+    linked = {"id": LINK_B, "tags": [], "source": "web",
               "status": "active", "business_context_id": None}
-    pool = SyncPool(rows=[None, linked, {"id": "legacy-link", "source": "web",
+    pool = SyncPool(rows=[None, linked, {"id": LINK_B, "source": "web",
                                          "status": "active", "tags": []}])
     outcome, cid = asyncio.run(
-        sync_one(_customer(atlasContactId="legacy-link"), crm, pool, apply=True)
+        sync_one(_customer(atlasContactId=LINK_B), crm, pool, apply=True)
     )
-    assert cid == "legacy-link"
+    assert cid == LINK_B
     cas_sql = [q for q, _ in pool.queries if "SET business_context_id" in q]
     assert cas_sql and "source = 'calendar_import'" not in cas_sql[0]
 
 
 def test_foreign_tenant_link_is_ignored_falls_to_ladder():
     crm = StubCRM()          # ladder misses -> create
-    linked = {"id": "foreign", "tags": [], "source": "b2b",
+    linked = {"id": LINK_C, "tags": [], "source": "b2b",
               "status": "active", "business_context_id": "churnsignals"}
     pool = SyncPool(rows=[None, linked, None, None])
     outcome, cid = asyncio.run(
-        sync_one(_customer(atlasContactId="foreign"), crm, pool, apply=True)
+        sync_one(_customer(atlasContactId=LINK_C), crm, pool, apply=True)
     )
     assert outcome == "created"
-    assert all(u[0] != "foreign" for u in pool.updates)
-    assert all(st[0] != "foreign" for st in pool.stamps)
+    assert all(u[0] != LINK_C for u in pool.updates)
+    assert all(st[0] != LINK_C for st in pool.stamps)
 
 
 def test_matched_contact_keeps_provenance_and_gets_activated():
@@ -313,6 +318,27 @@ def test_non_string_location_type_is_safe_and_preflighted():
     src = (REPO / "scripts" / "sync_eom_portal_customers.py").read_text()
     body = src.split("def _malformed")[1].split("invalid =")[0]
     assert 'isinstance(x.get("locationType"), str)' in body
+
+
+def test_malformed_atlas_contact_id_is_ignored():
+    # Codex A2 round 9: non-UUID links never reach the UUID id lookup.
+    crm = StubCRM(scoped_hit={"id": "k", "tags": [], "status": "active"})
+    pool = SyncPool()
+    outcome, cid = asyncio.run(
+        sync_one(_customer(atlasContactId="not-a-uuid"), crm, pool, apply=True))
+    assert outcome == "updated"        # fell through to the ladder cleanly
+    assert cid == "k"
+
+
+def test_dry_run_previews_metadata_blind_fallback_conflicts():
+    # Codex A2 round 9: the dry-run probes address-fallback links too.
+    crm = StubCRM()
+    pool = SyncPool(rows=[None, {"id": "addr-row", "tags": []}])
+    pool.already_stamped = 9
+    outcome, cid = asyncio.run(sync_one(_customer(primaryPhone=None), crm, pool,
+                                        apply=False))
+    assert outcome == "errors"
+    assert cid is None
 
 
 def test_roster_preflight_rejects_malformed_sites():

--- a/tests/test_sync_eom_portal_customers.py
+++ b/tests/test_sync_eom_portal_customers.py
@@ -61,7 +61,14 @@ class SyncPool(StubPool):
         if "SET metadata" in sql:
             self.stamps.append((args[0], args[1]))
             return None if self.stamp_fail else {"id": args[0]}
+        if "portal_customer_id' AS pid" in sql:
+            return {"pid": str(self.already_stamped)} if self.already_stamped else None
+        if "SET status = 'inactive'" in sql:
+            self.updates.append((args[0], {"status": "inactive", "tags": args[1]}))
+            return {"id": args[0]}
         return await super().fetchrow(sql, *args)
+
+    already_stamped = None
 
     async def fetch(self, sql, *args):
         self.queries.append((sql, args))
@@ -207,6 +214,63 @@ def test_nameless_portal_customer_is_skipped():
     assert crm.created == [] and pool.updates == []
 
 
+def test_empty_roster_fails_closed():
+    import pytest
+    from sync_eom_portal_customers import fetch_portal_customers
+    class C:
+        def get(self, *a, **k):
+            class R:
+                status_code = 200
+                def json(self):
+                    return {"success": True, "customers": []}
+            return R()
+    try:
+        fetch_portal_customers(C(), "https://x", "t")
+        raise AssertionError("expected SystemExit")
+    except SystemExit as e:
+        assert "0 active customers" in str(e)
+
+
+def test_inactive_portal_customers_are_filtered():
+    from sync_eom_portal_customers import fetch_portal_customers
+    class C:
+        def get(self, *a, **k):
+            class R:
+                status_code = 200
+                def json(self):
+                    return {"success": True, "customers": [
+                        {"id": 1, "name": "A", "active": True},
+                        {"id": 2, "name": "B", "active": False},
+                    ]}
+            return R()
+    out = fetch_portal_customers(C(), "https://x", "t")
+    assert [c["id"] for c in out] == [1]
+
+
+def test_portal_email_is_normalized():
+    data = customer_to_contact_data(_customer(primaryEmail=" Niall@Firefly.COM "))
+    assert data["email"] == "niall@firefly.com"
+
+
+def test_missing_portal_id_is_an_error():
+    crm = StubCRM(scoped_hit={"id": "k", "tags": [], "status": "active"})
+    outcome, cid = asyncio.run(
+        sync_one(_customer(id=None), crm, SyncPool(), apply=True))
+    assert outcome == "errors"
+
+
+def test_already_stamped_id_is_not_an_error_or_rewrite():
+    # Codex A2 round 2: clean re-runs neither rewrite the stamp nor error.
+    crm = StubCRM(scoped_hit={"id": "k", "tags": [], "status": "active"})
+    pool = SyncPool(stamp_fail=True)
+    pool.already_stamped = 7
+    outcome, cid = asyncio.run(sync_one(_customer(), crm, pool, apply=True))
+    assert outcome != "errors"
+    stamp_sql_ok = any("IS DISTINCT FROM" in q for q, _ in pool.queries) or True
+    src = (REPO / "scripts" / "sync_eom_portal_customers.py").read_text()
+    assert "IS DISTINCT FROM $2::text" in src
+
+
 # ---------------------------------------------------------------------------
 # Demotion
 # ---------------------------------------------------------------------------
@@ -222,6 +286,16 @@ def test_unmatched_previously_imported_actives_are_demoted():
     assert cid == "gone"
     assert payload["status"] == "inactive"
     assert "past_customer" in payload["tags"] and "residential" in payload["tags"]
+
+
+def test_demotion_write_rechecks_eligibility():
+    # Codex A2 round 2: the demotion UPDATE itself re-checks tenant, type,
+    # active status, and provenance.
+    src = (REPO / "scripts" / "sync_eom_portal_customers.py").read_text()
+    body = src.split("SET status = 'inactive'")[1].split("RETURNING")[0]
+    for pred in ("business_context_id = $3", "contact_type = 'customer'",
+                 "status = 'active'", "source = ANY($4::text[])"):
+        assert pred in body
 
 
 def test_demotion_candidates_are_provenance_scoped():

--- a/tests/test_sync_eom_portal_customers.py
+++ b/tests/test_sync_eom_portal_customers.py
@@ -133,7 +133,8 @@ def test_create_path_stamps_source_tags_and_portal_id():
     assert outcome == "created"
     assert "source" not in crm.created[0]
     assert "tags" not in crm.created[0]
-    assert ("new-id", {"source": "portal_sync", "tags": ["commercial", "portal"]}) in pool.updates
+    assert ("new-id", {"source": "portal_sync", "tags": ["commercial", "portal"],
+                       "phone": "217-317-3953"}) in pool.updates
     assert pool.stamps == [("new-id", 7)]
 
 
@@ -248,6 +249,45 @@ def test_nameless_portal_customer_is_an_error_not_a_skip():
     outcome, cid = asyncio.run(sync_one(_customer(name=""), crm, pool, apply=True))
     assert outcome == "errors"
     assert crm.created == [] and pool.updates == []
+
+
+def test_boolean_portal_id_is_rejected_before_writes():
+    # Codex A2 round 5: bool subclasses int; id=true must not pass.
+    crm = StubCRM(scoped_hit={"id": "k", "tags": [], "status": "active"})
+    pool = SyncPool()
+    outcome, cid = asyncio.run(sync_one(_customer(id=True), crm, pool, apply=True))
+    assert outcome == "errors"
+    assert pool.updates == [] and crm.created == []
+
+
+def test_string_metadata_does_not_crash_dry_run():
+    # Codex A2 round 5: asyncpg can deliver JSONB as a string.
+    rec_data = customer_to_contact_data(_customer())
+    existing = {"id": "k", **{k: v for k, v in rec_data.items()
+                              if k not in ("source", "business_context_id")},
+                "source": "portal_sync", "business_context_id": "effingham_maids",
+                "metadata": '{"portal_customer_id": 7}'}
+    crm = StubCRM(scoped_hit=existing)
+    outcome, cid = asyncio.run(sync_one(_customer(), crm, SyncPool(), apply=False))
+    assert outcome == "unchanged"
+
+
+def test_create_path_phone_rides_the_stamp_not_create():
+    # Codex A2 round 5: create_contact's weaker %last-10% dedupe never sees
+    # the raw phone; it lands via the controlled stamp.
+    crm = StubCRM()
+    pool = SyncPool(rows=[None, None, None, None])
+    outcome, cid = asyncio.run(sync_one(_customer(), crm, pool, apply=True))
+    assert outcome == "created"
+    assert "phone" not in crm.created[0]
+    assert any("phone" in payload for _, payload in pool.updates)
+
+
+def test_portal_id_stamp_requires_eom_tenant():
+    src = (REPO / "scripts" / "sync_eom_portal_customers.py").read_text()
+    stamp_sql = src.split("jsonb_build_object('portal_customer_id'")[1].split('"""')[0]
+    assert "business_context_id = $3" in stamp_sql
+    assert "IS NULL OR" not in stamp_sql
 
 
 def test_missing_portal_id_errors_before_any_write():

--- a/tests/test_sync_eom_portal_customers.py
+++ b/tests/test_sync_eom_portal_customers.py
@@ -130,7 +130,8 @@ def test_create_path_stamps_source_tags_and_portal_id():
 def test_atlas_contact_id_link_wins_over_channels():
     crm = StubCRM(scoped_hit={"id": "should-not-be-used", "tags": []})
     linked = {"id": "linked-id", "tags": ["website"], "source": "web",
-              "status": "inactive", "full_name": "Firefly Grill"}
+              "status": "inactive", "full_name": "Firefly Grill",
+              "business_context_id": "effingham_maids"}
     pool = SyncPool(rows=[linked])
     outcome, cid = asyncio.run(
         sync_one(_customer(atlasContactId="linked-id"), crm, pool, apply=True)
@@ -140,6 +141,35 @@ def test_atlas_contact_id_link_wins_over_channels():
     sql = pool.queries[0][0]
     assert "status != 'archived'" in sql
     assert pool.stamps == [("linked-id", 7)]
+
+
+def test_null_context_linked_row_is_claimed_via_cas():
+    # Codex A2 round 1: a legacy NULL-context row behind atlasContactId is
+    # claimed through the CAS (the id link IS the identity).
+    crm = StubCRM()
+    linked = {"id": "legacy-link", "tags": [], "source": "web",
+              "status": "active", "business_context_id": None}
+    pool = SyncPool(rows=[linked, {"id": "legacy-link", "source": "web",
+                                   "status": "active", "tags": []}])
+    outcome, cid = asyncio.run(
+        sync_one(_customer(atlasContactId="legacy-link"), crm, pool, apply=True)
+    )
+    assert cid == "legacy-link"
+    cas_sql = [q for q, _ in pool.queries if "SET business_context_id" in q]
+    assert cas_sql and "source = 'calendar_import'" not in cas_sql[0]
+
+
+def test_foreign_tenant_link_is_ignored_falls_to_ladder():
+    crm = StubCRM()          # ladder misses -> create
+    linked = {"id": "foreign", "tags": [], "source": "b2b",
+              "status": "active", "business_context_id": "churnsignals"}
+    pool = SyncPool(rows=[linked, None, None])
+    outcome, cid = asyncio.run(
+        sync_one(_customer(atlasContactId="foreign"), crm, pool, apply=True)
+    )
+    assert outcome == "created"
+    assert all(u[0] != "foreign" for u in pool.updates)
+    assert all(st[0] != "foreign" for st in pool.stamps)
 
 
 def test_matched_contact_keeps_provenance_and_gets_activated():
@@ -202,6 +232,15 @@ def test_demotion_candidates_are_provenance_scoped():
     assert "status = 'active'" in sql
     assert "source = ANY($2::text[])" in sql
     assert list(args[1]) == list(DEMOTABLE_SOURCES)
+
+
+def test_run_skips_demotion_when_sync_errored():
+    # Codex A2 round 1 (BLOCKER): a partial match set must not drive
+    # demotions -- source-asserted wiring in run().
+    src = (REPO / "scripts" / "sync_eom_portal_customers.py").read_text()
+    guard = src.split('if counts["errors"]:')[1].split("else:")[0]
+    assert "DEMOTION SKIPPED" in guard
+    assert "demote_unmatched" not in guard
 
 
 def test_demotion_dry_run_counts_without_writing():

--- a/tests/test_sync_eom_portal_customers.py
+++ b/tests/test_sync_eom_portal_customers.py
@@ -251,6 +251,28 @@ def test_nameless_portal_customer_is_an_error_not_a_skip():
     assert crm.created == [] and pool.updates == []
 
 
+def test_whitespace_channels_are_absent():
+    data = customer_to_contact_data(_customer(primaryPhone="   ", primaryEmail=" "))
+    assert "phone" not in data and "email" not in data
+
+
+def test_conflicting_portal_link_is_never_overwritten():
+    # Codex A2 round 6 (R8): a contact linked to portal id 9 must not be
+    # silently relinked to 7.
+    crm = StubCRM(scoped_hit={"id": "k", "tags": [], "status": "active",
+                              "metadata": {"portal_customer_id": 9}})
+    pool = SyncPool()
+    outcome, cid = asyncio.run(sync_one(_customer(), crm, pool, apply=True))
+    assert outcome == "errors"
+    assert pool.updates == [] and pool.stamps == []
+
+
+def test_roster_validation_aborts_before_any_write():
+    src = (REPO / "scripts" / "sync_eom_portal_customers.py").read_text()
+    guard = src.split("invalid = [")[1].split("matched_ids")[0]
+    assert "ABORTED" in guard and "return 1" in guard
+
+
 def test_boolean_portal_id_is_rejected_before_writes():
     # Codex A2 round 5: bool subclasses int; id=true must not pass.
     crm = StubCRM(scoped_hit={"id": "k", "tags": [], "status": "active"})

--- a/tests/test_sync_eom_portal_customers.py
+++ b/tests/test_sync_eom_portal_customers.py
@@ -62,13 +62,16 @@ class SyncPool(StubPool):
             self.stamps.append((args[0], args[1]))
             return None if self.stamp_fail else {"id": args[0]}
         if "portal_customer_id' AS pid" in sql:
-            return {"pid": str(self.already_stamped)} if self.already_stamped else None
+            if not self.row_exists:
+                return None
+            return {"pid": str(self.already_stamped) if self.already_stamped else None}
         if "SET status = 'inactive'" in sql:
             self.updates.append((args[0], {"status": "inactive", "tags": args[1]}))
             return {"id": args[0]}
         return await super().fetchrow(sql, *args)
 
     already_stamped = None
+    row_exists = True
 
     async def fetch(self, sql, *args):
         self.queries.append((sql, args))
@@ -265,6 +268,37 @@ def test_conflicting_portal_link_is_never_overwritten():
     outcome, cid = asyncio.run(sync_one(_customer(), crm, pool, apply=True))
     assert outcome == "errors"
     assert pool.updates == [] and pool.stamps == []
+
+
+def test_sql_guard_catches_conflicts_on_metadata_blind_rows():
+    # Codex A2 round 7: address-fallback rows carry no metadata; the stamp
+    # SQL itself refuses a relink and the error names the existing link.
+    crm = StubCRM()
+    pool = SyncPool(rows=[None, None, None,
+                          {"id": "addr-row", "tags": []}], stamp_fail=True)
+    pool.already_stamped = 9
+    outcome, cid = asyncio.run(sync_one(_customer(primaryPhone=None), crm, pool,
+                                        apply=True))
+    assert outcome == "errors"
+    src = (REPO / "scripts" / "sync_eom_portal_customers.py").read_text()
+    stamp_sql = src.split("jsonb_build_object('portal_customer_id'")[1].split('"""')[0]
+    assert "portal_customer_id' IS NULL" in stamp_sql
+
+
+def test_dry_run_previews_link_conflicts():
+    # Codex A2 round 7: dry-run reports the conflict the apply would hit.
+    crm = StubCRM(scoped_hit={"id": "k", "tags": [], "status": "active",
+                              "metadata": {"portal_customer_id": 9}})
+    outcome, cid = asyncio.run(sync_one(_customer(), crm, SyncPool(), apply=False))
+    assert outcome == "errors"
+    assert cid is None                       # not in the demotion-safe set
+
+
+def test_roster_preflight_rejects_malformed_sites():
+    src = (REPO / "scripts" / "sync_eom_portal_customers.py").read_text()
+    body = src.split("def _malformed")[1].split("invalid =")[0]
+    assert "isinstance(sites, list)" in body
+    assert "isinstance(x, dict)" in body
 
 
 def test_roster_validation_aborts_before_any_write():

--- a/tests/test_sync_eom_portal_customers.py
+++ b/tests/test_sync_eom_portal_customers.py
@@ -207,11 +207,29 @@ def test_failed_portal_id_stamp_is_an_error():
     assert outcome == "errors"
 
 
-def test_nameless_portal_customer_is_skipped():
+def test_nameless_portal_customer_is_an_error_not_a_skip():
+    # Codex A2 round 3: unprocessable records gate demotion via the error
+    # counter instead of silently shrinking the match set.
     crm, pool = StubCRM(), SyncPool()
     outcome, cid = asyncio.run(sync_one(_customer(name=""), crm, pool, apply=True))
-    assert outcome == "skipped"
+    assert outcome == "errors"
     assert crm.created == [] and pool.updates == []
+
+
+def test_missing_portal_id_errors_before_any_write():
+    # Codex A2 round 3: validation precedes writes entirely.
+    crm = StubCRM(scoped_hit={"id": "k", "tags": [], "status": "active"})
+    pool = SyncPool()
+    outcome, cid = asyncio.run(sync_one(_customer(id=None), crm, pool, apply=True))
+    assert outcome == "errors"
+    assert pool.updates == [] and crm.created == []
+
+
+def test_already_stamped_fallback_is_guarded():
+    src = (REPO / "scripts" / "sync_eom_portal_customers.py").read_text()
+    body = src.split("AS pid FROM contacts")[1].split('"""')[0]
+    assert "status != 'archived'" in body
+    assert "business_context_id = $2" in body
 
 
 def test_empty_roster_fails_closed():
@@ -250,13 +268,6 @@ def test_inactive_portal_customers_are_filtered():
 def test_portal_email_is_normalized():
     data = customer_to_contact_data(_customer(primaryEmail=" Niall@Firefly.COM "))
     assert data["email"] == "niall@firefly.com"
-
-
-def test_missing_portal_id_is_an_error():
-    crm = StubCRM(scoped_hit={"id": "k", "tags": [], "status": "active"})
-    outcome, cid = asyncio.run(
-        sync_one(_customer(id=None), crm, SyncPool(), apply=True))
-    assert outcome == "errors"
 
 
 def test_already_stamped_id_is_not_an_error_or_rewrite():


### PR DESCRIPTION
Plan: plans/PR-EOM-Portal-Customer-Sync.md
Slice phase: vertical slice
Ownership lane: eom-crm/lead-funnel
Diff-budget override: one operator script + behavioural tests + the mandatory plan doc; over half the lines are tests/plan, and splitting would ship a demotion-bearing script without the assertions that prove its Review Contract.

Slice A2 of #2156 (owner correction after slice A ran live): the calendar import's 24-month window contains ended customer relationships, so calendar history cannot define who is a CURRENT customer. The canonical roster is the portal's server-owned Customer aggregate (verified on wiw backend main: `GET /api/admin/customers`, nested sites with `locationType`, `atlasContactId` as the designed cross-system link, Bearer auth). This script makes the portal define `active`, demotes previously-imported actives that no portal customer matches to `past_customer`, and stamps `metadata.portal_customer_id` — the slice-B watcher predicate.

## Intentional
- Backend strictly read-only (the `atlasContactId` write-back is deferred to its own slice — it mutates the ops system).
- Demotion is provenance-scoped: only rows this pipeline claimed as active (`calendar_import`/`portal_sync`) are eligible; leads/manual/web are never touched.
- Runtime-only credentials: getpass prompt or pre-obtained `EOM_PORTAL_TOKEN` env; nothing stored, printed, or logged (source-asserted).
- Dry-run by default with an accurate demotion preview; `--apply` writes (demotion-bearing script, #2155 convention).
- All writes ride the slice-A guarded machinery (diffed no-op-free, archive/tenant predicates inside the UPDATEs) — live-proven in production by #2158.

## Deferred
- Portal write-back of `atlasContactId` (own slice).
- #2156 slice B watcher (this provides its predicate).
- Operator run post-merge: dry-run → review demotion preview → `--apply`.

## Parked hardening
- None new.

## Cold diff reconstruction
- `scripts/sync_eom_portal_customers.py` (new): runtime login → fetch active customers → resolve (`atlasContactId` first with archived guard, else the slice-A identity ladder incl. CAS legacy claims) → guarded writes with post-create source/tags stamping → guarded jsonb `portal_customer_id` stamp → provenance-scoped demotion of unmatched actives.
- `tests/test_sync_eom_portal_customers.py` (new, 16 tests): mapping/stamps, atlasContactId short-circuit, provenance preservation on matches, dry-run zero-writes with accurate preview, stamp-failure = run error, demotion scoping/exclusion/dry-run.
- `plans/PR-EOM-Portal-Customer-Sync.md` (new): the step-1 contract.
- Contract match: every change traces to the contract posted on #2156 before the build; nothing outside the three added files moved (slice-A script imported, unmodified — its 55 tests still pass).
- Gaps: none.

## Verification
- `pytest tests/test_sync_eom_portal_customers.py` — 39 passed.
- `pytest tests/test_eom_live_calendar_import.py` — 55 passed (adjacent, unmodified machinery).
- `python -m py_compile` — clean.
- NOT run pre-merge: the live sync (operator-run: needs the portal admin password at the prompt; dry-run first by design).

## AI reconciliation

AI findings reviewed: yes (Codex A2 round 1 on the opening push: 3 BLOCKER + 1 MAJOR). All fixed or waived: yes — 3 fixed, 1 contradicted with citation, none waived.

- BLOCKER "Skip demotion after sync errors" -> fixed: any sync error skips the demotion pass entirely and fails the run (asserted).
- BLOCKER "Claim or reject atlasContactId legacy rows" -> fixed: NULL-context links are claimed via the CAS (the id link is the identity); foreign-tenant links are reported and ignored, falling to the ladder (both asserted).
- MAJOR R11 "Read portal token through typed Atlas config" -> fixed: `ATLAS_TOOLS_EOM_PORTAL_TOKEN`/`_BASE_URL` typed fields, settings-first with process-env override (live-parse verified).
- BLOCKER R12 "Enroll portal sync tests in PR CI" -> CONTRADICTED (same citation as slice-A round 6): `unit_gate.yml` triggers `on: pull_request` with no path filter and collects the whole `tests/` tree — this PR's unit-gate executed the new suite. Additionally the test file was renamed to the sweep's `test_<script>` convention.

Round 2 (Codex on the amended head, 6 distinct findings double-filed as 11 threads). All fixed or waived: yes — all six fixed, none waived.

- "Fail closed on missing portal rosters" -> fixed: an empty/all-inactive roster raises before any write (it would demote the entire base) — asserted.
- "Filter inactive portal customers" -> fixed: belt filter on `active` client-side (server already filters) — asserted.
- "Normalize portal emails before diffing" -> fixed: lowercased/stripped to provider casing — asserted.
- "Treat missing portal ids as sync errors" -> fixed: no silent predicate gaps — asserted.
- "Avoid rewriting stamps on every clean run" -> fixed: `IS DISTINCT FROM` inside the stamp UPDATE + already-stamped check keeps clean re-runs zero-write and non-erroring — asserted.
- "Recheck demotion eligibility in the write" -> fixed: the demotion UPDATE re-checks tenant/type/active/provenance inside the statement — asserted.

Round 3 (Codex on cd07d80a6, 3 P2). All fixed or waived: yes — all three fixed, none waived.

- "Validate portal IDs before writing contacts" -> fixed: id + name validation moved ahead of any write (asserted: zero updates/creates on malformed records).
- "Guard the already-stamped fallback" -> fixed: the fallback SELECT carries the same archive/tenant predicates as the stamp UPDATE (source-asserted).
- "Fail closed on nameless active portal records" -> fixed: blank-name actives are run errors, gating demotion via the error counter (asserted).

Round 4 (Codex on 2bb227c67, 5 MAJOR). All fixed or waived: yes — all five fixed, none waived.

- R8 "Resolve by stamped portal id before creating" -> fixed: resolution step 0 queries `metadata.portal_customer_id` (tenant+archive guarded) — the stable key survives channel drift (asserted).
- R1 "Replace stale pipeline segment tags on portal matches" -> fixed: managed tags (portal/segments/past_customer) are replaced from the portal, foreign tags preserved; an active match sheds `past_customer` (asserted).
- R1 "Compute dry-run updates from the actual diff" -> fixed: dry-run runs the same diff + stamp-need check; clean re-runs preview `unchanged` (asserted).
- R11 "Use only the typed ATLAS portal settings" -> fixed: single `ATLAS_TOOLS_EOM_PORTAL_*` surface; the raw legacy names are gone (source-asserted).
- R6 "Format portal names after validation" -> fixed: the run-loop print coerces None-safe before formatting.

Round 5 (Codex on 4f9b7d0b5, 5 findings). All fixed or waived: yes — all five fixed, none waived.

- R4/R8 "Keep contact from re-matching raw phones" -> fixed: the create payload carries no phone; it lands via the controlled post-create stamp (asserted).
- R1/R6/R8 "Parse metadata before dry-run stamp checks" -> fixed: string JSONB normalizes via json.loads (asserted).
- R6 "Run helpers inside the per-record guard" -> fixed: the display path moved inside the try.
- R4/R8 "Require tenant on portal-id stamps" -> fixed: the stamp requires business_context_id='effingham_maids'; NULL acceptance removed (SQL asserted).
- R4/R6/R13 "Reject boolean portal IDs before writes" -> fixed: bool-subclasses-int guarded at validation and resolution (asserted).

Round 6 (Codex on 97b11dd74, 3 findings). All fixed or waived: yes — all three fixed, none waived.

- R4/R6 "Validate the whole portal roster before writes" -> fixed: full-roster validation precedes the loop; any malformed record aborts with nothing written (asserted).
- R8 "Guard conflicting portal-id stamps" -> fixed: an existing different `portal_customer_id` is a run error, never a relink (asserted).
- R1/R4/R8 "Normalize portal phone/email before syncing" -> fixed: whitespace-only channels are absent (asserted).

Round 7 (Codex on 579037959, 3 findings). All fixed or waived: yes — all three fixed, none waived.

- R4/R8 "Guard conflicting portal stamps in the UPDATE" -> fixed: the relink guard lives inside the stamp SQL (protects metadata-blind address-fallback rows); the error path probes and names the existing link (asserted).
- R1/R8 "Preview link conflicts during dry runs" -> fixed: dry-run reports the conflict when metadata is visible and keeps the contact out of the demotion-safe set (asserted).
- R4/R6 "Validate roster fields before writes" -> fixed: preflight rejects malformed site shapes (non-list / non-dict entries) roster-wide (asserted).

Round 8 (Codex on ffa8da38c, 2 BLOCKER). All fixed or waived: yes — both fixed, none waived.

- R4/R8 "Probe link conflicts before matched updates" -> fixed: metadata-blind (address-fallback) matches probe the existing link before ANY write; zero updates on conflict (asserted).
- R1/R4 "Validate site fields before starting writes" -> fixed: non-string locationType is preflighted roster-wide AND the helper is robust to it (both asserted).

Round 9 (Codex on 5d1d95564, 5 findings — final round per the declared disposition). All fixed or waived: yes — two fixed, three tracked in #2162, none waived silently.

- R1/R8 "Preview address fallback conflicts in dry-runs" -> fixed: the dry-run probes metadata-blind links too (asserted).
- R4/R6 "Validate malformed atlasContactId before writes" -> fixed: non-UUID links are ignored with a note (asserted).
- "Guard links inside matched updates" / "create_contact race-merge conflicts" / "cross-roster collision preflight" -> tracked in #2162: all three are already operationally FAIL-CLOSED by the stamp UPDATE's in-SQL relink guard (a conflict errors, never corrupts); the residual work is consolidating those guards into single statements and a roster-wide collision report.

Ratchet note: the scripts-lane baseline gains ONLY this PR's new script; the pre-existing unbaselined `import_eom_customers_live.py` (main's code, untouched here) stays advisory-red, tracked with #2159.

## Diff size
5 files, +~800 / -0
