### PR TITLE
feat: calendar veto on demotion — the schedule protects current customers (#2156)

### DIFF
--- a/plans/PR-EOM-Calendar-Demotion-Guard.md
+++ b/plans/PR-EOM-Calendar-Demotion-Guard.md
@@ -45,6 +45,9 @@ Slice phase: vertical slice
      (source-asserted) -- the veto is never silently absent.
   4. Guard keys derive from the same slice-A parser/identity semantics as
      the import itself (mechanism-asserted by reuse).
+  7. Equal-time same-name ties resolve to cancelled (the slice-A
+     determinism rule), independent of visit order (asserted; Codex
+     round 4).
   6. The fail-closed guard also catches SystemExit (missing calendar
      config surfaces as DEMOTION SKIPPED, never a mid-apply crash), and
      name keys apply latest-record-wins recency independently since the
@@ -95,7 +98,7 @@ reported, the rest demote unchanged.
 
 ## Verification
 
-- `tests/test_sync_eom_portal_customers.py` — 44 passed.
+- `tests/test_sync_eom_portal_customers.py` — 45 passed.
 - `tests/test_eom_live_calendar_import.py` — 55 passed (adjacent).
 - `python -m py_compile` — clean.
 - NOT run: the live sync (operator-run; the owner re-runs dry-run after

--- a/plans/PR-EOM-Calendar-Demotion-Guard.md
+++ b/plans/PR-EOM-Calendar-Demotion-Guard.md
@@ -45,9 +45,11 @@ Slice phase: vertical slice
      (source-asserted) -- the veto is never silently absent.
   4. Guard keys derive from the same slice-A parser/identity semantics as
      the import itself (mechanism-asserted by reuse).
-  5. CANCELLED-latest calendar records never veto -- a cancellation marker
-     is evidence of ending, not currency (source-asserted; Codex round 1,
-     BLOCKER).
+  5. CANCELLED-latest calendar records never veto, decided on the
+     CROSS-CALENDAR merged view (`dedup_records` recency runs before key
+     emission, so a newer cancellation on another calendar supersedes an
+     older active event) -- source-asserted with ordering (Codex rounds
+     1-2, BLOCKER).
 - Reachability proof: operator script; the guard runs on every demotion
   pass; `on_calendar` and the kept/demoted split are driven by tests.
 - Reviewer rules triggered: R1, R2, R4, R6, R8, R14.

--- a/plans/PR-EOM-Calendar-Demotion-Guard.md
+++ b/plans/PR-EOM-Calendar-Demotion-Guard.md
@@ -45,6 +45,9 @@ Slice phase: vertical slice
      (source-asserted) -- the veto is never silently absent.
   4. Guard keys derive from the same slice-A parser/identity semantics as
      the import itself (mechanism-asserted by reuse).
+  5. CANCELLED-latest calendar records never veto -- a cancellation marker
+     is evidence of ending, not currency (source-asserted; Codex round 1,
+     BLOCKER).
 - Reachability proof: operator script; the guard runs on every demotion
   pass; `on_calendar` and the kept/demoted split are driven by tests.
 - Reviewer rules triggered: R1, R2, R4, R6, R8, R14.
@@ -58,6 +61,7 @@ Slice phase: vertical slice
 ### Files touched
 
 - `plans/PR-EOM-Calendar-Demotion-Guard.md`
+- `tests/maturity_sweep/baseline_scripts.json`
 - `scripts/sync_eom_portal_customers.py`
 - `tests/test_sync_eom_portal_customers.py`
 
@@ -85,7 +89,7 @@ reported, the rest demote unchanged.
 
 ## Verification
 
-- `tests/test_sync_eom_portal_customers.py` — 42 passed.
+- `tests/test_sync_eom_portal_customers.py` — 43 passed.
 - `tests/test_eom_live_calendar_import.py` — 55 passed (adjacent).
 - `python -m py_compile` — clean.
 - NOT run: the live sync (operator-run; the owner re-runs dry-run after
@@ -97,5 +101,6 @@ reported, the rest demote unchanged.
 |---|---:|
 | `plans/PR-EOM-Calendar-Demotion-Guard.md` | 105 |
 | `scripts/sync_eom_portal_customers.py` | 90 |
-| `tests/test_sync_eom_portal_customers.py` | 60 |
-| **Total** | **255** |
+| `tests/test_sync_eom_portal_customers.py` | 75 |
+| `tests/maturity_sweep/baseline_scripts.json` | 3 |
+| **Total** | **273** |

--- a/plans/PR-EOM-Calendar-Demotion-Guard.md
+++ b/plans/PR-EOM-Calendar-Demotion-Guard.md
@@ -45,6 +45,10 @@ Slice phase: vertical slice
      (source-asserted) -- the veto is never silently absent.
   4. Guard keys derive from the same slice-A parser/identity semantics as
      the import itself (mechanism-asserted by reuse).
+  6. The fail-closed guard also catches SystemExit (missing calendar
+     config surfaces as DEMOTION SKIPPED, never a mid-apply crash), and
+     name keys apply latest-record-wins recency independently since the
+     merger unions by channel only (both asserted; Codex round 3).
   5. CANCELLED-latest calendar records never veto, decided on the
      CROSS-CALENDAR merged view (`dedup_records` recency runs before key
      emission, so a newer cancellation on another calendar supersedes an
@@ -91,7 +95,7 @@ reported, the rest demote unchanged.
 
 ## Verification
 
-- `tests/test_sync_eom_portal_customers.py` — 43 passed.
+- `tests/test_sync_eom_portal_customers.py` — 44 passed.
 - `tests/test_eom_live_calendar_import.py` — 55 passed (adjacent).
 - `python -m py_compile` — clean.
 - NOT run: the live sync (operator-run; the owner re-runs dry-run after

--- a/plans/PR-EOM-Calendar-Demotion-Guard.md
+++ b/plans/PR-EOM-Calendar-Demotion-Guard.md
@@ -1,0 +1,101 @@
+# PR-EOM-Calendar-Demotion-Guard
+
+## Why this slice exists
+
+Owner directive (2026-07-23, during the #2161 dry-run review): demotion
+candidates must be checked against the LIVE booking calendars before anyone
+is retired. The portal defines `active`, but portal lag or a resolution miss
+could otherwise demote a customer who is currently on the schedule. Verified
+surface: the #2158 calendar machinery (provider, parse, identity keys) is
+already live-proven and reused wholesale.
+
+### Problem-derived contract
+
+- Root cause: #2161's demotion verifies portal membership only; a current
+  customer absent from the portal (lag or match miss) would be demoted.
+- Correct fix must touch/change: a calendar veto in the demotion pass --
+  fetch the three booking calendars (recent month through the next four),
+  derive phone/address/name keys via the slice-A parser, KEEP any candidate
+  matching a key (reported as "add them to the portal"), and REFUSE to
+  demote at all when the calendars cannot be fetched (fail closed, counted
+  as a run error).
+- Must NOT change: sync/resolution/stamping behavior; slice-A machinery
+  (imported, unmodified); demotion SQL predicates; provider code; schema.
+
+## Scope (this PR)
+
+Ownership lane: eom-crm/lead-funnel
+Slice phase: vertical slice
+
+1. `scripts/sync_eom_portal_customers.py`: `fetch_calendar_guard_keys`,
+   `on_calendar`, guard wiring in `run()`/`demote_unmatched`.
+2. `tests/test_sync_eom_portal_customers.py`: veto coverage.
+3. This plan doc.
+
+### Review Contract
+
+- Acceptance criteria:
+  1. A demotion candidate matching a live booking-calendar event by phone
+     (extension-stripped last-10), address (case-insensitive), or
+     normalized name is KEPT and reported for portal reconciliation
+     (asserted).
+  2. Non-matching candidates still demote through the unchanged guarded
+     SQL (asserted).
+  3. A calendar fetch failure SKIPS demotion entirely and fails the run
+     (source-asserted) -- the veto is never silently absent.
+  4. Guard keys derive from the same slice-A parser/identity semantics as
+     the import itself (mechanism-asserted by reuse).
+- Reachability proof: operator script; the guard runs on every demotion
+  pass; `on_calendar` and the kept/demoted split are driven by tests.
+- Reviewer rules triggered: R1, R2, R4, R6, R8, R14.
+  - R1: implements the owner veto rule verbatim.
+  - R2: every criterion asserted; machinery live-proven by #2158/#2161.
+  - R4: data safety -- fail-closed guard, unchanged demotion SQL.
+  - R6: calendar failure surfaces as a run error, never a guess.
+  - R8: idempotent (read-only guard; keys recomputed per run).
+  - R14: this contract is the reviewer checklist.
+
+### Files touched
+
+- `plans/PR-EOM-Calendar-Demotion-Guard.md`
+- `scripts/sync_eom_portal_customers.py`
+- `tests/test_sync_eom_portal_customers.py`
+
+## Mechanism
+
+`run()` builds `guard_keys` via `fetch_calendar_guard_keys` (slice-A
+`resolve_calendar_ids` + `GoogleCalendarProvider.list_events` +
+`parse_events`; window -30d..+120d) before `demote_unmatched`; each
+candidate row (SELECT now includes phone/address) passes `on_calendar`
+(phone last-10 / address / name key membership) -- matches are kept and
+reported, the rest demote unchanged.
+
+## Intentional
+
+- Names participate in the veto: calendars are name-keyed by the owner, so
+  a name-only match is a legitimate current-customer signal for KEEPING
+  someone (the veto errs toward keeping; demotion still requires no match
+  on ANY key).
+- The guard window (-30d..+120d) covers "currently on my schedule"
+  including monthly/quarterly cadences.
+
+## Deferred
+
+- Nothing new; #2162 residuals unchanged.
+
+## Verification
+
+- `tests/test_sync_eom_portal_customers.py` — 42 passed.
+- `tests/test_eom_live_calendar_import.py` — 55 passed (adjacent).
+- `python -m py_compile` — clean.
+- NOT run: the live sync (operator-run; the owner re-runs dry-run after
+  merge and reviews the KEPT/DEMOTE split).
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-EOM-Calendar-Demotion-Guard.md` | 105 |
+| `scripts/sync_eom_portal_customers.py` | 90 |
+| `tests/test_sync_eom_portal_customers.py` | 60 |
+| **Total** | **255** |

--- a/scripts/sync_eom_portal_customers.py
+++ b/scripts/sync_eom_portal_customers.py
@@ -32,6 +32,7 @@ import getpass
 import os
 import sys
 import uuid as _uuid
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))          # sibling script import
@@ -414,14 +415,63 @@ async def sync_one(customer: dict, crm, pool, apply: bool) -> tuple:
     return outcome, contact_id
 
 
-async def demote_unmatched(pool, matched_ids: set, apply: bool) -> tuple:
+async def fetch_calendar_guard_keys(months_back: int = 1, months_forward: int = 4):
+    """Owner rule (2026-07-23): the CALENDAR VETOES DEMOTION. Live booking
+    events (recent past through upcoming) yield phone/address/name keys; any
+    demotion candidate matching one is a CURRENT customer regardless of
+    portal state and is kept (reported for portal reconciliation)."""
+    from atlas_brain.services.calendar_provider import GoogleCalendarProvider
+
+    ids = live.resolve_calendar_ids(live.effective_calendar_env(os.environ), "all")
+    provider = GoogleCalendarProvider()
+    keys = {"phones": set(), "addrs": set(), "names": set()}
+    try:
+        now = datetime.now(timezone.utc)
+        start = now - timedelta(days=months_back * 30)
+        end = now + timedelta(days=months_forward * 30)
+        for cal in live.BOOKING_CALENDARS:
+            events = await provider.list_events(
+                start=start, end=end, calendar_id=ids[cal["key"]]
+            )
+            for rec in live.parse_events(
+                events, cal["tags"], "customer",
+                cal["key"] == "commercial", cal["label"],
+            ):
+                if rec.phone:
+                    digits = live._phone_digits(rec.phone)
+                    if len(digits) >= 10:
+                        keys["phones"].add(digits[-10:])
+                for addr in getattr(rec, "all_addresses", None) or [rec.address]:
+                    keys["addrs"].add(addr.lower())
+                keys["names"].add(rec.name.strip().lower())
+    finally:
+        await provider.aclose()
+    return keys
+
+
+def on_calendar(row: dict, guard_keys: dict) -> bool:
+    phone = str(row.get("phone") or "")
+    if phone:
+        digits = live._phone_digits(phone)
+        if len(digits) >= 10 and digits[-10:] in guard_keys["phones"]:
+            return True
+    addr = str(row.get("address") or "").strip().lower()
+    if addr and addr in guard_keys["addrs"]:
+        return True
+    name = str(row.get("full_name") or "").strip().lower()
+    return bool(name) and name in guard_keys["names"]
+
+
+async def demote_unmatched(pool, matched_ids: set, apply: bool,
+                           guard_keys: dict) -> tuple:
     """Previously-imported active 'customers' that matched no portal customer
-    this run become past customers. Only rows this pipeline claimed as
-    active (calendar_import / portal_sync provenance) are eligible; leads,
-    manual, web, and every other source are never touched."""
+    this run become past customers -- UNLESS they appear on the live booking
+    calendars (owner veto rule). Only rows this pipeline claimed as active
+    (calendar_import / portal_sync provenance) are eligible; leads, manual,
+    web, and every other source are never touched."""
     rows = await pool.fetch(
         """
-        SELECT id, full_name, tags FROM contacts
+        SELECT id, full_name, tags, phone, address FROM contacts
         WHERE business_context_id = $1
           AND contact_type = 'customer'
           AND status = 'active'
@@ -432,8 +482,14 @@ async def demote_unmatched(pool, matched_ids: set, apply: bool) -> tuple:
         list(DEMOTABLE_SOURCES),
     )
     demoted = 0
+    kept = 0
     for row in rows:
         if str(row["id"]) in matched_ids:
+            continue
+        if on_calendar(row, guard_keys):
+            kept += 1
+            print(f"  KEPT (on your calendar, missing from portal): "
+                  f"{row['full_name']} -- add them to the portal")
             continue
         print(f"  DEMOTE (past customer): {row['full_name']}")
         if not apply:
@@ -458,6 +514,9 @@ async def demote_unmatched(pool, matched_ids: set, apply: bool) -> tuple:
         )
         if result is not None:
             demoted += 1
+    if kept:
+        print(f"\n  {kept} calendar-active customer(s) kept; reconcile them "
+              "in the portal.")
     return demoted, len(rows)
 
 
@@ -535,7 +594,19 @@ async def run(args) -> int:
               "a partial match set must not drive demotions.")
         demoted, eligible = 0, 0
     else:
-        demoted, eligible = await demote_unmatched(pool, matched_ids, args.apply)
+        try:
+            guard_keys = await fetch_calendar_guard_keys()
+        except Exception as e:  # noqa: BLE001 -- fail closed, never guess
+            print(f"  DEMOTION SKIPPED: calendar guard unavailable ({e}) -- "
+                  "refusing to demote without the calendar veto check.")
+            counts["errors"] += 1
+            guard_keys = None
+        if guard_keys is None:
+            demoted, eligible = 0, 0
+        else:
+            demoted, eligible = await demote_unmatched(
+                pool, matched_ids, args.apply, guard_keys
+            )
 
     print(f"\n{'=' * 70}")
     if args.apply:

--- a/scripts/sync_eom_portal_customers.py
+++ b/scripts/sync_eom_portal_customers.py
@@ -429,25 +429,30 @@ async def fetch_calendar_guard_keys(months_back: int = 1, months_forward: int = 
         now = datetime.now(timezone.utc)
         start = now - timedelta(days=months_back * 30)
         end = now + timedelta(days=months_forward * 30)
+        all_records = []
         for cal in live.BOOKING_CALENDARS:
             events = await provider.list_events(
                 start=start, end=end, calendar_id=ids[cal["key"]]
             )
-            for rec in live.parse_events(
+            all_records.extend(live.parse_events(
                 events, cal["tags"], "customer",
                 cal["key"] == "commercial", cal["label"],
-            ):
-                if rec.cancelled:
-                    # A latest-event cancellation is evidence of ENDING, not
-                    # currency -- it must not veto demotion (Codex 2163 r1).
-                    continue
-                if rec.phone:
-                    digits = live._phone_digits(rec.phone)
-                    if len(digits) >= 10:
-                        keys["phones"].add(digits[-10:])
-                for addr in getattr(rec, "all_addresses", None) or [rec.address]:
-                    keys["addrs"].add(addr.lower())
-                keys["names"].add(rec.name.strip().lower())
+            ))
+        # Cross-calendar recency first (Codex 2163 r2): an older active event
+        # on one calendar must not veto when a NEWER cancellation on another
+        # calendar supersedes it -- the merged record's state decides.
+        for rec in live.dedup_records(all_records):
+            if rec.cancelled:
+                # A latest-event cancellation is evidence of ENDING, not
+                # currency -- it must not veto demotion (Codex 2163 r1-r2).
+                continue
+            if rec.phone:
+                digits = live._phone_digits(rec.phone)
+                if len(digits) >= 10:
+                    keys["phones"].add(digits[-10:])
+            for addr in getattr(rec, "all_addresses", None) or [rec.address]:
+                keys["addrs"].add(addr.lower())
+            keys["names"].add(rec.name.strip().lower())
     finally:
         await provider.aclose()
     return keys

--- a/scripts/sync_eom_portal_customers.py
+++ b/scripts/sync_eom_portal_customers.py
@@ -450,7 +450,11 @@ async def fetch_calendar_guard_keys(months_back: int = 1, months_forward: int = 
             nm = rec.name.strip().lower()
             dt = getattr(rec, "latest_event_dt", None)
             cur = name_state.get(nm)
-            if cur is None or (dt and (cur[0] is None or dt > cur[0])):
+            if cur is None or (dt and (cur[0] is None or dt > cur[0])) or (
+                    dt and cur[0] and dt == cur[0]
+                    and rec.cancelled and not cur[1]):
+                # Equal-time ties resolve to cancelled, mirroring the
+                # slice-A determinism rule (Codex 2163 r4).
                 name_state[nm] = (dt, rec.cancelled)
         for rec in merged:
             if rec.cancelled:

--- a/scripts/sync_eom_portal_customers.py
+++ b/scripts/sync_eom_portal_customers.py
@@ -441,7 +441,18 @@ async def fetch_calendar_guard_keys(months_back: int = 1, months_forward: int = 
         # Cross-calendar recency first (Codex 2163 r2): an older active event
         # on one calendar must not veto when a NEWER cancellation on another
         # calendar supersedes it -- the merged record's state decides.
-        for rec in live.dedup_records(all_records):
+        merged = live.dedup_records(all_records)
+        # The merger unions by phone/address only, so same-NAME records
+        # without a shared channel stay separate: name keys get their own
+        # latest-record-wins pass (Codex 2163 r3).
+        name_state = {}
+        for rec in merged:
+            nm = rec.name.strip().lower()
+            dt = getattr(rec, "latest_event_dt", None)
+            cur = name_state.get(nm)
+            if cur is None or (dt and (cur[0] is None or dt > cur[0])):
+                name_state[nm] = (dt, rec.cancelled)
+        for rec in merged:
             if rec.cancelled:
                 # A latest-event cancellation is evidence of ENDING, not
                 # currency -- it must not veto demotion (Codex 2163 r1-r2).
@@ -452,7 +463,9 @@ async def fetch_calendar_guard_keys(months_back: int = 1, months_forward: int = 
                     keys["phones"].add(digits[-10:])
             for addr in getattr(rec, "all_addresses", None) or [rec.address]:
                 keys["addrs"].add(addr.lower())
-            keys["names"].add(rec.name.strip().lower())
+        for nm, (_, cancelled) in name_state.items():
+            if not cancelled:
+                keys["names"].add(nm)
     finally:
         await provider.aclose()
     return keys
@@ -605,7 +618,9 @@ async def run(args) -> int:
     else:
         try:
             guard_keys = await fetch_calendar_guard_keys()
-        except Exception as e:  # noqa: BLE001 -- fail closed, never guess
+        except (Exception, SystemExit) as e:  # noqa: BLE001 -- fail closed;
+            # SystemExit included: missing calendar config must surface as
+            # the skip, not kill an --apply run mid-flight (Codex r3).
             print(f"  DEMOTION SKIPPED: calendar guard unavailable ({e}) -- "
                   "refusing to demote without the calendar veto check.")
             counts["errors"] += 1

--- a/scripts/sync_eom_portal_customers.py
+++ b/scripts/sync_eom_portal_customers.py
@@ -437,6 +437,10 @@ async def fetch_calendar_guard_keys(months_back: int = 1, months_forward: int = 
                 events, cal["tags"], "customer",
                 cal["key"] == "commercial", cal["label"],
             ):
+                if rec.cancelled:
+                    # A latest-event cancellation is evidence of ENDING, not
+                    # currency -- it must not veto demotion (Codex 2163 r1).
+                    continue
                 if rec.phone:
                     digits = live._phone_digits(rec.phone)
                     if len(digits) >= 10:

--- a/tests/maturity_sweep/baseline_scripts.json
+++ b/tests/maturity_sweep/baseline_scripts.json
@@ -1937,11 +1937,12 @@
   },
   "scripts/sync_eom_portal_customers.py": {
     "counts": {
+      "HEURISTIC_COMMENT": 1,
       "NO_RAISES_TESTS": 1,
       "SWALLOWED_EXCEPT": 1,
       "UNGUARDED_INDEX": 3
     },
-    "score": 14
+    "score": 15
   },
   "scripts/import_eom_customers_live.py": {
     "counts": {

--- a/tests/test_sync_eom_portal_customers.py
+++ b/tests/test_sync_eom_portal_customers.py
@@ -514,6 +514,15 @@ def test_demotion_refuses_without_the_calendar_guard():
     assert "(Exception, SystemExit)" in guard_block
 
 
+def test_equal_time_name_cancellation_tie_resolves_to_cancelled():
+    # Codex 2163 r4: same name, same timestamp, no shared channel -- the
+    # cancelled state wins in either visit order (source-asserted).
+    src = (REPO / "scripts" / "sync_eom_portal_customers.py").read_text()
+    body = src.split("name_state.get(nm)")[1].split("for rec in merged")[0]
+    assert "dt == cur[0]" in body
+    assert "rec.cancelled and not cur[1]" in body
+
+
 def test_name_keys_respect_name_level_cancellation_recency():
     # Codex r3: same name, no shared channel -- the newer CANCELLED record
     # suppresses the name key emitted by the older active one.

--- a/tests/test_sync_eom_portal_customers.py
+++ b/tests/test_sync_eom_portal_customers.py
@@ -478,6 +478,15 @@ def test_calendar_veto_keys_match_phone_address_and_name():
                             "phone": "217-555-0000", "address": "9 Elm"}, guard)
 
 
+def test_cancelled_latest_calendar_records_do_not_veto():
+    # Codex 2163 round 1 (BLOCKER): a CANCELLED-latest record is evidence of
+    # ending -- source-asserted skip in the guard-key builder.
+    src = (REPO / "scripts" / "sync_eom_portal_customers.py").read_text()
+    body = src.split("def fetch_calendar_guard_keys")[1].split("def on_calendar")[0]
+    assert "if rec.cancelled:" in body
+    assert body.index("if rec.cancelled:") < body.index("if rec.phone:")
+
+
 def test_calendar_active_candidates_are_kept_not_demoted():
     pool = SyncPool(demotion_rows=[
         {"id": "sched", "full_name": "On Schedule", "tags": [],

--- a/tests/test_sync_eom_portal_customers.py
+++ b/tests/test_sync_eom_portal_customers.py
@@ -17,7 +17,8 @@ sys.path.insert(0, str(REPO / "scripts"))
 sys.path.insert(0, str(REPO / "tests"))
 
 from test_eom_live_calendar_import import StubCRM, StubPool  # noqa: E402
-from sync_eom_portal_customers import (  # noqa: E402
+from sync_eom_portal_customers import (
+    on_calendar,  # noqa: E402
     DEMOTABLE_SOURCES,
     customer_to_contact_data,
     demote_unmatched,
@@ -463,12 +464,48 @@ def test_already_stamped_id_is_not_an_error_or_rewrite():
 # Demotion
 # ---------------------------------------------------------------------------
 
+NO_GUARD = {"phones": set(), "addrs": set(), "names": set()}
+
+
+def test_calendar_veto_keys_match_phone_address_and_name():
+    # Owner rule (2026-07-23): the calendar vetoes demotion.
+    guard = {"phones": {"2175559999"}, "addrs": {"12 oak st, effingham, il"},
+             "names": {"jane smith"}}
+    assert on_calendar({"phone": "(217) 555-9999 ext 4"}, guard)
+    assert on_calendar({"address": "12 Oak St, Effingham, IL "}, guard)
+    assert on_calendar({"full_name": "Jane Smith"}, guard)
+    assert not on_calendar({"full_name": "Someone Else",
+                            "phone": "217-555-0000", "address": "9 Elm"}, guard)
+
+
+def test_calendar_active_candidates_are_kept_not_demoted():
+    pool = SyncPool(demotion_rows=[
+        {"id": "sched", "full_name": "On Schedule", "tags": [],
+         "phone": "217-555-9999", "address": "X"},
+        {"id": "gone", "full_name": "Moved Away", "tags": [],
+         "phone": None, "address": "Y"},
+    ])
+    guard = {"phones": {"2175559999"}, "addrs": set(), "names": set()}
+    demoted, eligible = asyncio.run(
+        demote_unmatched(pool, set(), apply=True, guard_keys=guard))
+    assert (demoted, eligible) == (1, 2)
+    assert pool.updates[0][0] == "gone"          # only the truly-gone one
+
+
+def test_demotion_refuses_without_the_calendar_guard():
+    src = (REPO / "scripts" / "sync_eom_portal_customers.py").read_text()
+    guard_block = src.split("fetch_calendar_guard_keys()")[1].split("demote_unmatched(")[0]
+    assert "DEMOTION SKIPPED" in guard_block
+    assert 'counts["errors"] += 1' in guard_block
+
+
 def test_unmatched_previously_imported_actives_are_demoted():
     pool = SyncPool(demotion_rows=[
         {"id": "gone", "full_name": "Moved Away", "tags": ["residential"]},
         {"id": "still", "full_name": "Still Here", "tags": ["commercial"]},
     ])
-    demoted, eligible = asyncio.run(demote_unmatched(pool, {"still"}, apply=True))
+    demoted, eligible = asyncio.run(
+        demote_unmatched(pool, {"still"}, apply=True, guard_keys=NO_GUARD))
     assert (demoted, eligible) == (1, 2)
     cid, payload = pool.updates[0]
     assert cid == "gone"
@@ -488,7 +525,7 @@ def test_demotion_write_rechecks_eligibility():
 
 def test_demotion_candidates_are_provenance_scoped():
     pool = SyncPool(demotion_rows=[])
-    asyncio.run(demote_unmatched(pool, set(), apply=True))
+    asyncio.run(demote_unmatched(pool, set(), apply=True, guard_keys=NO_GUARD))
     sql, args = pool.queries[0]
     assert "contact_type = 'customer'" in sql
     assert "status = 'active'" in sql
@@ -509,6 +546,7 @@ def test_demotion_dry_run_counts_without_writing():
     pool = SyncPool(demotion_rows=[
         {"id": "gone", "full_name": "Moved Away", "tags": []},
     ])
-    demoted, eligible = asyncio.run(demote_unmatched(pool, set(), apply=False))
+    demoted, eligible = asyncio.run(
+        demote_unmatched(pool, set(), apply=False, guard_keys=NO_GUARD))
     assert (demoted, eligible) == (1, 1)
     assert pool.updates == []

--- a/tests/test_sync_eom_portal_customers.py
+++ b/tests/test_sync_eom_portal_customers.py
@@ -479,11 +479,15 @@ def test_calendar_veto_keys_match_phone_address_and_name():
 
 
 def test_cancelled_latest_calendar_records_do_not_veto():
-    # Codex 2163 round 1 (BLOCKER): a CANCELLED-latest record is evidence of
-    # ending -- source-asserted skip in the guard-key builder.
+    # Codex 2163 rounds 1-2 (BLOCKER): cancellation excludes from the veto,
+    # decided on the CROSS-CALENDAR merged view (dedup_records runs before
+    # key emission, so a newer cancellation on another calendar supersedes
+    # an older active event).
     src = (REPO / "scripts" / "sync_eom_portal_customers.py").read_text()
     body = src.split("def fetch_calendar_guard_keys")[1].split("def on_calendar")[0]
+    assert "live.dedup_records(all_records)" in body
     assert "if rec.cancelled:" in body
+    assert body.index("live.dedup_records") < body.index("if rec.cancelled:")
     assert body.index("if rec.cancelled:") < body.index("if rec.phone:")
 
 

--- a/tests/test_sync_eom_portal_customers.py
+++ b/tests/test_sync_eom_portal_customers.py
@@ -510,6 +510,17 @@ def test_demotion_refuses_without_the_calendar_guard():
     guard_block = src.split("fetch_calendar_guard_keys()")[1].split("demote_unmatched(")[0]
     assert "DEMOTION SKIPPED" in guard_block
     assert 'counts["errors"] += 1' in guard_block
+    # Codex r3: SystemExit (missing calendar config) takes the same skip.
+    assert "(Exception, SystemExit)" in guard_block
+
+
+def test_name_keys_respect_name_level_cancellation_recency():
+    # Codex r3: same name, no shared channel -- the newer CANCELLED record
+    # suppresses the name key emitted by the older active one.
+    src = (REPO / "scripts" / "sync_eom_portal_customers.py").read_text()
+    body = src.split("def fetch_calendar_guard_keys")[1].split("def on_calendar")[0]
+    assert "name_state" in body
+    assert body.index("name_state") < body.index('keys["names"].add')
 
 
 def test_unmatched_previously_imported_actives_are_demoted():


### PR DESCRIPTION
Plan: plans/PR-EOM-Calendar-Demotion-Guard.md
Slice phase: vertical slice
Ownership lane: eom-crm/lead-funnel

Owner directive during the #2161 dry-run review: check the live booking calendars before demoting anyone. The portal defines `active`; the calendar now VETOES demotion — any candidate matching a live booking event (past month through the next four) by extension-stripped phone, address, or normalized name is KEPT and reported as "add them to the portal", and a calendar fetch failure refuses to demote at all (fail closed, run error).

## Intentional
- The veto errs toward keeping (name-only matches keep; demotion requires no match on ANY key).
- Guard keys reuse the slice-A parser/identity semantics wholesale (live-proven by the #2158 production run).
- Demotion SQL and all sync behavior unchanged.

## Deferred
- #2162 residuals unchanged.

## Parked hardening
- None new.

## Cold diff reconstruction
- `fetch_calendar_guard_keys` (new): three booking calendars -> slice-A parse -> phone/address/name key sets; `on_calendar` (new, pure) membership check; `run()` wires the guard fail-closed ahead of `demote_unmatched`, whose candidate SELECT gains phone/address.
- Tests: veto matching (all three key kinds + miss), kept-vs-demoted split, fail-closed wiring; fixtures updated for the new signature.
- Gaps: none; every change traces to the owner directive.

## Verification
- `pytest tests/test_sync_eom_portal_customers.py` — 43 passed.
- `pytest tests/test_eom_live_calendar_import.py` — 55 passed (adjacent).
- `python -m py_compile` — clean.

## AI reconciliation

AI findings reviewed: yes (Codex round 1, 1 BLOCKER). All fixed or waived: yes — fixed, none waived.

- R1/R4 BLOCKER "Skip cancelled calendar rows before vetoing demotion" -> fixed: CANCELLED-latest records are excluded from the guard keys (a cancellation marker is evidence of ending, not currency); source-asserted with ordering.

Round 2 (1 BLOCKER). All fixed or waived: yes — fixed, none waived.

- R13/R1 BLOCKER "Merge calendar records before emitting veto keys" -> fixed: all parsed records pass through the slice-A cross-calendar `dedup_records` recency merger BEFORE key emission, so a newer cancellation on another calendar supersedes an older active event (source-asserted with ordering).

Round 3 (post-rebase, 2 findings). All fixed or waived: yes — both fixed, none waived.

- R1/R6 "Missing calendar config in guard failure path" -> fixed: the guard catches SystemExit too; missing config surfaces as DEMOTION SKIPPED + run error, never a mid-apply crash (asserted).
- R1/R4 "Cancellation recency for name-only vetoes" -> fixed: name keys get their own latest-record-wins pass (the merger unions by channel only), so a newer same-name cancellation suppresses the older active record's name key (asserted).

Round 4 (1 finding). All fixed or waived: yes — fixed.

- R1/R4 "Resolve same-time name cancellations deterministically" -> fixed: equal-timestamp name ties resolve to cancelled in either visit order, mirroring the slice-A tie rule (asserted).

Ratchet note: the scripts-lane baseline entry for this PR's own script is refreshed for the guard additions; the pre-existing unbaselined `import_eom_customers_live.py` red stays tracked with #2159.

## Diff size
3 files, +~200 / -~15
