### PR TITLE
chore: accept recorded-intentional maturity baselines (closes #2159)

### DIFF
--- a/plans/PR-Maturity-Baseline-Debt.md
+++ b/plans/PR-Maturity-Baseline-Debt.md
@@ -10,7 +10,11 @@ again on #2158/#2161/#2163). Verified against current main:
   deliberate — `events[0]` sits behind explicit `if not events` /
   `len(events) == 1` guards (sweep false-positive), and both swallowed
   excepts are commented intentional fallbacks ("Already logged as
-  CRITICAL").
+  CRITICAL"). The `NO_RAISES_TESTS` component is ALSO accepted
+  deliberately: the tool's failure paths are log-and-degrade fallbacks by
+  design (voice-assistant convenience surface, no caller depends on
+  raises); adding failure-path raise tests is recorded below as deferred
+  test-debt rather than silently suppressed.
 - `scripts/import_eom_customers_live.py` (score 9): reviewed per-record
   operator patterns from the 18-round #2158 gauntlet, deliberately NOT
   baselined inside that PR per its round-4 review direction ("move the
@@ -42,6 +46,15 @@ Slice phase: vertical slice
      "ratchet gate passed" both).
   2. The diff contains ONLY the two entries + this doc (name-status
      verified).
+- Affected surfaces: CI maturity ratchet jobs for the `atlas_brain/tools`
+  and `scripts` lanes ONLY (baseline JSON inputs); no runtime, API, DB,
+  deploy, or money surface is touched.
+- Risk areas: (a) masking a FUTURE regression in the two named files — the
+  ratchet still fails on ANY score increase above these recorded values,
+  and capped-category counts cannot grow past their caps without raising
+  the total, so the guard's increase detection remains live; (b) test-debt
+  suppression — mitigated by recording the calendar raise-test debt as an
+  explicit deferred item below.
 - Reachability proof: CI ratchet jobs consume the baselines directly.
 - Reviewer rules triggered: R12, R14.
   - R12: CI config/baseline change only; no behavior, no secrets.
@@ -65,7 +78,10 @@ entry except the two named files to origin/main's values.
 
 ## Deferred
 
-- Nothing; closes #2159.
+- Failure-path raise tests for `atlas_brain/tools/calendar.py` (the
+  accepted `NO_RAISES_TESTS` debt) — a tools-lane test slice, deliberately
+  not smuggled into a baseline chore.
+- Otherwise nothing; closes #2159.
 
 ## Verification
 

--- a/plans/PR-Maturity-Baseline-Debt.md
+++ b/plans/PR-Maturity-Baseline-Debt.md
@@ -100,7 +100,7 @@ entry except the two named files to origin/main's values.
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Maturity-Baseline-Debt.md` | 108 |
+| `plans/PR-Maturity-Baseline-Debt.md` | 106 |
 | `tests/maturity_sweep/baseline_atlas_brain_tools.json` | 3 |
 | `tests/maturity_sweep/baseline_scripts.json` | 7 |
-| **Total** | **118** |
+| **Total** | **116** |

--- a/plans/PR-Maturity-Baseline-Debt.md
+++ b/plans/PR-Maturity-Baseline-Debt.md
@@ -1,0 +1,82 @@
+# PR-Maturity-Baseline-Debt
+
+## Why this slice exists
+
+Two pre-existing, unbaselined maturity findings on main turn the advisory
+ratchet red for EVERY PR that wakes their lanes (tracked in #2159; surfaced
+again on #2158/#2161/#2163). Verified against current main:
+
+- `atlas_brain/tools/calendar.py` (score 15): the flagged patterns are
+  deliberate — `events[0]` sits behind explicit `if not events` /
+  `len(events) == 1` guards (sweep false-positive), and both swallowed
+  excepts are commented intentional fallbacks ("Already logged as
+  CRITICAL").
+- `scripts/import_eom_customers_live.py` (score 9): reviewed per-record
+  operator patterns from the 18-round #2158 gauntlet, deliberately NOT
+  baselined inside that PR per its round-4 review direction ("move the
+  baseline acceptance to its owning PR") — this is that owning PR.
+
+### Problem-derived contract
+
+- Root cause: recorded-intentional patterns without baseline entries make
+  the ratchet cry wolf on unrelated PRs.
+- Correct fix must touch/change: exactly two baseline entries (tools lane:
+  calendar.py; scripts lane: import script), accepted deliberately with the
+  rationale above. No production code changes.
+- Must NOT change: any Python source; any other baseline entry (surgically
+  verified against origin/main).
+
+## Scope (this PR)
+
+Ownership lane: ci/maturity-baselines
+Slice phase: vertical slice
+
+1. `tests/maturity_sweep/baseline_atlas_brain_tools.json`: calendar.py entry.
+2. `tests/maturity_sweep/baseline_scripts.json`: import script entry.
+3. This plan doc.
+
+### Review Contract
+
+- Acceptance criteria:
+  1. Both ratchet lanes pass locally against these baselines (verified:
+     "ratchet gate passed" both).
+  2. The diff contains ONLY the two entries + this doc (name-status
+     verified).
+- Reachability proof: CI ratchet jobs consume the baselines directly.
+- Reviewer rules triggered: R12, R14.
+  - R12: CI config/baseline change only; no behavior, no secrets.
+  - R14: this contract is the reviewer checklist.
+
+### Files touched
+
+- `plans/PR-Maturity-Baseline-Debt.md`
+- `tests/maturity_sweep/baseline_atlas_brain_tools.json`
+- `tests/maturity_sweep/baseline_scripts.json`
+
+## Mechanism
+
+`--update-baseline` runs for both lanes, then a surgical pass restores every
+entry except the two named files to origin/main's values.
+
+## Intentional
+
+- Baseline acceptance over code churn: the flagged patterns are correct as
+  written; "fixing" them would add noise to reviewed code.
+
+## Deferred
+
+- Nothing; closes #2159.
+
+## Verification
+
+- Local ratchet runs: both lanes "ratchet gate passed".
+- `git diff --stat`: 2 baseline files, +9/-1.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Maturity-Baseline-Debt.md` | 75 |
+| `tests/maturity_sweep/baseline_atlas_brain_tools.json` | 3 |
+| `tests/maturity_sweep/baseline_scripts.json` | 7 |
+| **Total** | **85** |

--- a/plans/PR-Maturity-Baseline-Debt.md
+++ b/plans/PR-Maturity-Baseline-Debt.md
@@ -50,11 +50,15 @@ Slice phase: vertical slice
   and `scripts` lanes ONLY (baseline JSON inputs); no runtime, API, DB,
   deploy, or money surface is touched.
 - Risk areas: (a) masking a FUTURE regression in the two named files — the
-  ratchet still fails on ANY score increase above these recorded values,
-  and capped-category counts cannot grow past their caps without raising
-  the total, so the guard's increase detection remains live; (b) test-debt
-  suppression — mitigated by recording the calendar raise-test debt as an
-  explicit deferred item below.
+  ratchet still fails on any TOTAL score increase above these recorded
+  values; however, categories ALREADY AT THEIR CAP (`UNGUARDED_INDEX`,
+  `WEAK_CONTRACT` in the scripts entry) are a genuine ratchet blind spot:
+  further additions in a capped-out category do not raise the total. This
+  is a mechanism-level property affecting every baselined file, not
+  introduced here; recorded honestly (corrected per review) and mitigations
+  (per-category ratcheting or sensitive-listing these codes for the
+  scripts lane) are deferred below. (b) test-debt suppression — mitigated
+  by recording the calendar raise-test debt as an explicit deferred item.
 - Reachability proof: CI ratchet jobs consume the baselines directly.
 - Reviewer rules triggered: R12, R14.
   - R12: CI config/baseline change only; no behavior, no secrets.
@@ -81,6 +85,10 @@ entry except the two named files to origin/main's values.
 - Failure-path raise tests for `atlas_brain/tools/calendar.py` (the
   accepted `NO_RAISES_TESTS` debt) — a tools-lane test slice, deliberately
   not smuggled into a baseline chore.
+- Per-category ratcheting (or sensitive-listing `UNGUARDED_INDEX` /
+  `WEAK_CONTRACT` for the scripts lane) to close the capped-category blind
+  spot — a `scripts/maturity_sweep.py` change, out of a baseline chore's
+  scope.
 - Otherwise nothing; closes #2159.
 
 ## Verification
@@ -92,7 +100,7 @@ entry except the two named files to origin/main's values.
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Maturity-Baseline-Debt.md` | 75 |
+| `plans/PR-Maturity-Baseline-Debt.md` | 108 |
 | `tests/maturity_sweep/baseline_atlas_brain_tools.json` | 3 |
 | `tests/maturity_sweep/baseline_scripts.json` | 7 |
-| **Total** | **85** |
+| **Total** | **118** |

--- a/tests/maturity_sweep/baseline_atlas_brain_tools.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_tools.json
@@ -1,10 +1,11 @@
 {
   "atlas_brain/tools/calendar.py": {
     "counts": {
+      "NO_RAISES_TESTS": 1,
       "SWALLOWED_EXCEPT": 2,
       "UNGUARDED_INDEX": 1
     },
-    "score": 12
+    "score": 15
   },
   "atlas_brain/tools/display.py": {
     "counts": {

--- a/tests/maturity_sweep/baseline_scripts.json
+++ b/tests/maturity_sweep/baseline_scripts.json
@@ -1942,5 +1942,12 @@
       "UNGUARDED_INDEX": 3
     },
     "score": 14
+  },
+  "scripts/import_eom_customers_live.py": {
+    "counts": {
+      "UNGUARDED_INDEX": 7,
+      "WEAK_CONTRACT": 4
+    },
+    "score": 9
   }
 }


### PR DESCRIPTION
Plan: plans/PR-Maturity-Baseline-Debt.md
Slice phase: vertical slice
Ownership lane: ci/maturity-baselines

Closes #2159. Deliberate baseline acceptance of two pre-existing, recorded-intentional findings that turn the advisory maturity ratchet red on every PR waking their lanes: `atlas_brain/tools/calendar.py` (guarded index the sweep can't see + commented intentional except fallbacks) and `scripts/import_eom_customers_live.py` (reviewed operator patterns from the 18-round #2158 gauntlet, deferred to its owning PR per that review's direction — this is it). No code changes; both lanes verified green locally; diff surgically limited to the two entries.

## Intentional
- Baseline over churn: the flagged patterns are correct as written.

## Deferred
- Nothing; closes #2159.

## Parked hardening
- None.

## Cold diff reconstruction
- Two baseline entries + the plan doc; every other baseline value byte-identical to origin/main (surgical restore verified).
- Gaps: none.

## Verification
- Both lane ratchets pass locally against these baselines.
- git diff --stat: 2 baseline files, +9/-1.

## AI reconciliation

AI findings reviewed: yes (Codex round 1, 3 findings). All fixed or waived: yes — all three addressed in the plan, none waived.

- R1/R12 "Rationalize the calendar test-debt baseline" -> fixed: the `NO_RAISES_TESTS` acceptance now has an explicit rationale (log-and-degrade fallbacks by design) and the raise-test debt is a recorded deferred item, not a silent suppression.
- R1 "Review Contract risk fields" -> fixed: affected-surfaces and risk-areas bullets added (CI-baseline-only surface; increase-detection stays live; test-debt recorded).
- R12 "Ratchet sensitivity for capped categories" -> addressed in the risk bullet: capped counts cannot grow past caps without raising the total score, so the ratchet's increase detection on these files remains effective at the recorded values.

Round 2 (2 findings). All fixed or waived: yes — both fixed, none waived.

- R12 "capped counts bypassing the ratchet" -> fixed as a CORRECTION: the reviewer is right that capped-out categories are invisible to further growth; the risk bullet now states the blind spot honestly (mechanism-level, affects every baselined file) and defers the per-category-ratchet/sensitive-list mitigation as an explicit item.
- R14 "stale diff-size table" -> fixed: recomputed.

## Diff size
3 files, +~90 / -1
