### PR TITLE
fix: merge legacy page into scoped search + close UUID read TOCTOU (#2151)

### DIFF
--- a/atlas_brain/mcp/crm_server.py
+++ b/atlas_brain/mcp/crm_server.py
@@ -110,6 +110,23 @@ def _visible_under_default(contact: "dict | None") -> bool:
     return contact.get("business_context_id") in (None, default)
 
 
+def _row_visible(
+    contact: "dict | None", business_context_id: "str | None"
+) -> bool:
+    """Visibility of a FETCHED contact row under the effective addressing.
+
+    Explicit tenant = exact page; default = tenant plus NULL-context legacy;
+    no scope = everything. Callers must apply this to the same row object
+    they return or act on -- checking one fetch and returning another
+    reopens the claim race (#2157 post-merge review).
+    """
+    if contact is None:
+        return False
+    if business_context_id:
+        return contact.get("business_context_id") == business_context_id
+    return _visible_under_default(contact)
+
+
 async def _guarded_contact(
     contact_id: str, business_context_id: "str | None" = None
 ) -> "tuple[bool, dict | None]":
@@ -122,15 +139,10 @@ async def _guarded_contact(
     default applies: the default tenant plus NULL-context legacy rows are
     visible. Foreign-tenant rows read as nonexistent (fail-closed).
     """
-    if business_context_id:
-        contact = await _provider().get_contact(contact_id)
-        if contact is None:
-            return False, None
-        return contact.get("business_context_id") == business_context_id, contact
-    if not _default_context():
+    if not business_context_id and not _default_context():
         return True, None
     contact = await _provider().get_contact(contact_id)
-    return _visible_under_default(contact), contact
+    return _row_visible(contact, business_context_id), contact
 
 
 async def _guard_contact_id(
@@ -142,18 +154,26 @@ async def _guard_contact_id(
 
 
 async def _scoped_search(provider, **kwargs):
-    """search_contacts honoring the default scope: tenant page first, then
-    the NULL-context legacy page (mirrors crm_provider's stamped dedupe)."""
+    """search_contacts honoring the default scope.
+
+    The visible population is the default tenant's page PLUS the
+    NULL-context legacy page: both are queried and merged (tenant rows
+    first, truncated to the caller's limit). A tenant hit must not hide
+    claimable legacy rows (#2157 post-merge review) -- the earlier
+    first-page-wins shape did exactly that. An explicit argument addresses
+    exactly one page; no default preserves legacy unscoped behavior.
+    """
     explicit = kwargs.pop("business_context_id", None)
     if explicit:
         return await provider.search_contacts(business_context_id=explicit, **kwargs)
     default = _default_context()
     if not default:
         return await provider.search_contacts(**kwargs)
-    results = await provider.search_contacts(business_context_id=default, **kwargs)
-    if results:
-        return results
-    return await provider.search_contacts(business_context_id_is_null=True, **kwargs)
+    tenant_rows = await provider.search_contacts(business_context_id=default, **kwargs)
+    legacy_rows = await provider.search_contacts(business_context_id_is_null=True, **kwargs)
+    merged = list(tenant_rows) + list(legacy_rows)
+    limit = kwargs.get("limit")
+    return merged[:limit] if limit else merged
 
 
 def _appointments_in_scope(
@@ -337,10 +357,10 @@ async def get_contact(contact_id: str, business_context_id: Optional[str] = None
                 return json.dumps({"found": True, "contact": results[0]}, default=str)
             return json.dumps({"found": False, "contact": None})
 
-        if not await _guard_contact_id(contact_id, business_context_id):
-            return json.dumps({"found": False, "contact": None})
+        # Single fetch: the row that is validated IS the row that is
+        # returned (a guard-then-refetch pair loses to a concurrent claim).
         contact = await _provider().get_contact(contact_id)
-        if contact is None:
+        if not _row_visible(contact, business_context_id):
             return json.dumps({"found": False, "contact": None})
         return json.dumps({"found": True, "contact": contact}, default=str)
     except Exception as exc:
@@ -625,7 +645,10 @@ async def get_interactions(
     try:
         if not await _guard_contact_id(contact_id, business_context_id):
             return json.dumps({"error": "Contact not found", "interactions": [], "count": 0})
-        interactions = await _provider().get_interactions(contact_id, limit=min(limit, 100))
+        interactions = await _provider().get_interactions(
+            contact_id, limit=min(limit, 100),
+            business_context_id=business_context_id or _default_context(),
+        )
         return json.dumps(
             {"interactions": interactions, "count": len(interactions)}, default=str
         )
@@ -773,6 +796,15 @@ async def get_customer_context(
             ctx = await svc.get_context_by_email(email, **kwargs)
 
         if ctx.is_empty:
+            return json.dumps({"found": False, "context": None})
+
+        # Validate the row the service actually fetched: its read and the
+        # guard's read are separate awaits, and a concurrent claim between
+        # them must not let a now-foreign contact serialize (#2157
+        # post-merge review).
+        if (business_context_id or _default_context()) and not _row_visible(
+            ctx.contact, business_context_id
+        ):
             return json.dumps({"found": False, "context": None})
 
         effective = business_context_id or _default_context()

--- a/atlas_brain/services/crm_provider.py
+++ b/atlas_brain/services/crm_provider.py
@@ -535,21 +535,41 @@ class DatabaseCRMProvider:
         return result
 
     async def get_interactions(
-        self, contact_id: str, limit: int = 20
+        self, contact_id: str, limit: int = 20,
+        business_context_id: Optional[str] = None,
     ) -> list[dict[str, Any]]:
         from ..storage.database import get_db_pool
 
         pool = get_db_pool()
-        rows = await pool.fetch(
-            """
-            SELECT * FROM contact_interactions
-            WHERE contact_id = $1
-            ORDER BY occurred_at DESC
-            LIMIT $2
-            """,
-            contact_id,
-            limit,
-        )
+        if business_context_id:
+            # Atomic tenant predicate: the page only returns while the
+            # owning contact is still visible to this tenant (tenant page
+            # plus NULL-context legacy), closing the window between a
+            # caller's guard read and this query.
+            rows = await pool.fetch(
+                """
+                SELECT ci.* FROM contact_interactions ci
+                JOIN contacts c ON c.id = ci.contact_id
+                WHERE ci.contact_id = $1
+                  AND (c.business_context_id = $2 OR c.business_context_id IS NULL)
+                ORDER BY ci.occurred_at DESC
+                LIMIT $3
+                """,
+                contact_id,
+                business_context_id,
+                limit,
+            )
+        else:
+            rows = await pool.fetch(
+                """
+                SELECT * FROM contact_interactions
+                WHERE contact_id = $1
+                ORDER BY occurred_at DESC
+                LIMIT $2
+                """,
+                contact_id,
+                limit,
+            )
         return [dict(r) for r in rows]
 
     async def get_contact_appointments(

--- a/atlas_brain/services/customer_context.py
+++ b/atlas_brain/services/customer_context.py
@@ -152,7 +152,9 @@ class CustomerContextService:
                 return default if default is not None else []
 
         interactions_coro = _safe(
-            crm.get_interactions(contact_id, limit=max_interactions),
+            crm.get_interactions(
+                contact_id, limit=max_interactions,
+                business_context_id=business_context_id),
             "interactions",
         )
         appointments_coro = _safe(

--- a/plans/PR-EOM-Read-Scoping-Fixes.md
+++ b/plans/PR-EOM-Read-Scoping-Fixes.md
@@ -1,0 +1,161 @@
+# PR-EOM-Read-Scoping-Fixes
+
+## Why this slice exists
+
+PR #2157 merged with two defects Codex reported two minutes after the
+merge (post-merge review round 6), both independently reproduced by the
+operator's boundary probes against the deployed runtime:
+
+1. **Bare scoped search omitted legacy rows.** `_scoped_search` was
+   first-page-wins: it returned the default tenant's page and queried the
+   NULL-context legacy page only when the tenant page was empty. Any
+   tenant hit therefore hid claimable legacy customers, contradicting the
+   promised `{tenant} ∪ {NULL legacy}` population. Probe result:
+   one EOM row + one NULL row supplied, only the EOM row returned, the
+   NULL page never queried.
+2. **UUID reads had a guard-then-refetch race.** `_guard_contact_id`
+   fetched and validated a row, discarded it, and the tool re-fetched by
+   id without a tenant predicate. A NULL row claimed by another tenant
+   between the awaits passed the guard and serialized as the now-foreign
+   row. Probe result: guard fetch NULL, second fetch churnsignals,
+   response `found=true` with `returned_context=churnsignals`.
+
+### Problem-derived contract
+
+- Root cause: (1) the scoped-search helper modeled the population as a
+  fallback order instead of a union; (2) read tools validated a different
+  fetch than the one they returned (time-of-check/time-of-use).
+- Correct fix must: query and merge BOTH pages on every default-scoped
+  search (truncated to the caller's limit, tenant rows first); make each
+  read validate the exact row object it returns (single fetch for
+  `get_contact`; post-validate `ctx.contact` for `get_customer_context`),
+  and make child reads whose rows carry no tenant column
+  (`contact_interactions`) atomic in SQL via a join on the owning
+  contact's context.
+- Must not change: explicit-argument exact-page semantics, no-default
+  legacy behavior, mutation CAS-claim paths (already race-safe via
+  `claim_contact`), appointment/call child queries (already atomic in
+  SQL from #2157 rounds 3-4).
+
+## Scope (this PR)
+
+Ownership lane: eom-crm/read-scoping
+Slice phase: production hardening
+
+1. `atlas_brain/mcp/crm_server.py`: `_scoped_search` merges the tenant
+   and NULL-context pages (both queried, tenant first, truncated to
+   limit); new `_row_visible()` predicate applied to the same row object
+   a tool returns — `get_contact` is single-fetch-validate,
+   `get_customer_context` validates `ctx.contact` after the service
+   fetch, `_guarded_contact` routes through the same predicate;
+   `get_interactions` passes the effective scope to the provider.
+2. `atlas_brain/services/crm_provider.py`: `get_interactions` gains an
+   optional atomic tenant predicate (join on the owning contact,
+   tenant-plus-NULL) so the interaction page cannot outlive the guard.
+3. `atlas_brain/services/customer_context.py`: `_gather` threads the
+   scope into the interactions query as well (appointments and calls
+   already threaded).
+4. Proof: `tests/test_crm_read_scoping.py` — the wrong-behavior pin
+   (`test_search_scoped_hit_skips_null_fallback`) is REPLACED by
+   merge-semantics tests; TOCTOU regression test asserts the validated
+   row is the returned row with exactly one fetch.
+
+### Review Contract
+
+- Acceptance criteria:
+  1. A default-scoped search with hits on BOTH pages returns tenant rows
+     followed by NULL-context rows, truncated to the caller's limit
+     (test-asserted call pair + merge order + truncation).
+  2. `get_contact` on a UUID performs exactly one provider fetch and
+     validates that row object; a sequence NULL-then-foreign can no
+     longer serialize the foreign row (test-asserted await count 1).
+  3. `get_customer_context` refuses when the service-fetched
+     `ctx.contact` is no longer visible under the effective addressing.
+  4. `get_interactions` is atomic: the SQL page joins the owning contact
+     and applies tenant-plus-NULL in the same statement.
+  5. Explicit-argument and no-default behaviors are byte-identical to
+     #2157 (existing tests unchanged and green).
+- Reachability proof: deployed CRM MCP surface on this box (default
+  tenant already live via `ATLAS_MCP_CRM_DEFAULT_BUSINESS_CONTEXT`);
+  post-merge deploy = pull runtime worktree + restart `atlas-api`.
+- Affected surfaces: CRM MCP read paths only; mutations untouched.
+- Risk areas: double query on every default-scoped search (two indexed
+  lookups, accepted in #2157 for the miss case, now paid on every scoped
+  search — correctness over one indexed read); pagination semantics of
+  the merged search page (limit applies per page then merged-truncated,
+  same shape as `list_contacts`).
+- Reviewer rules triggered: R1 (#2151/#2157 follow-up), R2 (regression
+  tests for both probes), R3 (tenant isolation, fail-closed, TOCTOU
+  closed), R4 (no mutation-path changes), R5 (explicit/no-default
+  behavior preserved, test-asserted), R8 (race closed atomically in SQL,
+  not by re-checking), R10 (one `_row_visible` predicate shared across
+  tools), R14.
+
+### Files touched
+
+- `atlas_brain/mcp/crm_server.py`
+- `atlas_brain/services/crm_provider.py`
+- `atlas_brain/services/customer_context.py`
+- `plans/PR-EOM-Read-Scoping-Fixes.md`
+- `tests/test_crm_read_scoping.py`
+
+## Mechanism
+
+`_scoped_search` becomes a union (the same population definition
+`list_contacts` already uses), so every resolution path that rides it —
+search, get-by-name, customer-context name/phone/email — inherits the
+fix. `_row_visible` is the single visibility predicate for fetched rows;
+tools apply it to the object they serialize, which is the only shape that
+survives a concurrent claim. Interactions join their owning contact's
+context in one statement, so there is no second read to race against.
+
+## Intentional
+
+- **Interactions predicate is tenant-plus-NULL even under an explicit
+  argument** — the pre-guard already enforced exact-page for explicit
+  callers; rows cannot move tenant→NULL (claims only go NULL→tenant), so
+  the NULL branch is unreachable for explicit reads and one SQL shape
+  serves both. Documented here rather than split into two statements.
+- **`get_contact_appointments` keeps guard + atomic child query** — its
+  child rows carry their own NOT-NULL tenant stamp and the query is
+  already scoped in SQL (#2157 round 4); the contact row itself is not
+  returned, so there is no row-identity to validate.
+- **Mutations unchanged** — `update/delete/log` already resolve races via
+  the compare-and-set `claim_contact` (#2157 rounds 4-5): a row stolen
+  between guard and write fails the CAS and the mutation aborts.
+
+## Deferred
+
+- Tenant-addressable email store (context omits emails under scope until
+  then; #2157 round 4).
+- `atlas_brain/api/contacts.py` auth/scoping (own slice; UI-coupled).
+- `claude-review` commit status for this lane (advisory per
+  `docs/REVIEWER_MERGE_GATE.md` until made a required branch-protection
+  check; flagged to the operator).
+
+Parked hardening: none new.
+
+## Verification
+
+- Suite `tests/test_crm_read_scoping.py` — 54 passed, including the two
+  probe regressions.
+- Suites `tests/test_mcp_servers.py` + `tests/test_leads_intake.py` +
+  `tests/test_tenant_stamping.py` + `tests/test_customer_context.py` —
+  176 passed combined; 6 failures pre-existing on `origin/main`
+  (email/Twilio/calendar env-dependent, verified on a pristine worktree
+  during #2157).
+- Maturity ratchets (mcp + storage lanes, CI flags) — clean.
+- Post-merge: pull runtime worktree, restart `atlas-api`, re-run the
+  operator's two boundary probes (EOM+NULL search must return both;
+  guard/refetch race no longer constructible — single fetch).
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/mcp/crm_server.py` | 90 |
+| `atlas_brain/services/crm_provider.py` | 35 |
+| `atlas_brain/services/customer_context.py` | 5 |
+| `plans/PR-EOM-Read-Scoping-Fixes.md` | 150 |
+| `tests/test_crm_read_scoping.py` | 100 |
+| **Total** | **~380** |

--- a/tests/test_crm_read_scoping.py
+++ b/tests/test_crm_read_scoping.py
@@ -89,11 +89,29 @@ async def test_search_applies_default_then_null_fallback(default_ctx, monkeypatc
 
 
 @pytest.mark.asyncio
-async def test_search_scoped_hit_skips_null_fallback(default_ctx, monkeypatch):
-    provider = _provider_mock(monkeypatch, search=[{"id": "c1", "business_context_id": EOM}])
+async def test_search_merges_tenant_and_legacy_pages(default_ctx, monkeypatch):
+    """A tenant hit must NOT hide claimable legacy rows: both pages are
+    queried and merged, tenant rows first (#2157 post-merge review)."""
+    provider = _provider_mock(monkeypatch)
+    provider.search_contacts = AsyncMock(side_effect=[
+        [{"id": "t1", "business_context_id": EOM}],
+        [{"id": "n1", "business_context_id": None}],
+    ])
     out = json.loads(await crm_srv.search_contacts(query="jane"))
     assert out["found"] is True
-    assert len(provider.search_contacts.await_args_list) == 1
+    assert [c["id"] for c in out["contacts"]] == ["t1", "n1"]
+    assert len(provider.search_contacts.await_args_list) == 2
+
+
+@pytest.mark.asyncio
+async def test_search_merge_truncates_to_limit(default_ctx, monkeypatch):
+    provider = _provider_mock(monkeypatch)
+    provider.search_contacts = AsyncMock(side_effect=[
+        [{"id": "t1", "business_context_id": EOM}],
+        [{"id": "n1", "business_context_id": None}],
+    ])
+    out = json.loads(await crm_srv.search_contacts(query="jane", limit=1))
+    assert [c["id"] for c in out["contacts"]] == ["t1"]
 
 
 @pytest.mark.asyncio
@@ -220,6 +238,51 @@ async def test_list_contacts_explicit_context_single_page(default_ctx, monkeypat
     assert calls[0].kwargs["business_context_id"] == "churnsignals"
 
 
+@pytest.mark.asyncio
+async def test_get_contact_single_fetch_validates_returned_row(default_ctx, monkeypatch):
+    """TOCTOU regression (#2157 post-merge review): the row validated must
+    be the row returned. With guard-then-refetch, a NULL row claimed by
+    another tenant between the awaits serialized as found=true foreign."""
+    provider = _provider_mock(monkeypatch)
+    provider.get_contact = AsyncMock(side_effect=[LEGACY_NULL, FOREIGN])
+    out = json.loads(await crm_srv.get_contact(UUID))
+    assert out["found"] is True
+    assert out["contact"]["business_context_id"] is None
+    assert provider.get_contact.await_count == 1
+
+
+def test_row_visible_semantics(default_ctx):
+    assert crm_srv._row_visible(None, None) is False
+    assert crm_srv._row_visible(SAME, None) is True
+    assert crm_srv._row_visible(LEGACY_NULL, None) is True
+    assert crm_srv._row_visible(FOREIGN, None) is False
+    assert crm_srv._row_visible(FOREIGN, "churnsignals") is True
+    assert crm_srv._row_visible(LEGACY_NULL, EOM) is False  # explicit = exact
+
+
+def test_customer_context_validates_fetched_row_source():
+    """get_customer_context must validate ctx.contact (the service's own
+    fetch), not only the pre-guard read."""
+    src = (REPO / "atlas_brain/mcp/crm_server.py").read_text(encoding="utf-8")
+    validation = src.split("if ctx.is_empty:", 1)[1][:600]
+    assert "_row_visible(" in validation and "ctx.contact" in validation
+
+
+def test_provider_interactions_scope_is_atomic():
+    src = (REPO / "atlas_brain/services/crm_provider.py").read_text(encoding="utf-8")
+    block = src.split("async def get_interactions", 1)[1][:1400]
+    assert "JOIN contacts c ON c.id = ci.contact_id" in block
+    assert "c.business_context_id = $2 OR c.business_context_id IS NULL" in block
+
+
+@pytest.mark.asyncio
+async def test_get_interactions_passes_scope(default_ctx, monkeypatch):
+    provider = _provider_mock(monkeypatch, get=SAME)
+    await crm_srv.get_interactions(UUID)
+    call = provider.get_interactions.await_args
+    assert call.kwargs["business_context_id"] == EOM
+
+
 # ---------------------------------------------------------------------------
 # Explicit tenant override on id-addressed tools
 # ---------------------------------------------------------------------------
@@ -340,7 +403,7 @@ def test_call_repo_scopes_before_limit():
 def test_context_service_threads_scope_to_child_queries():
     src = (REPO / "atlas_brain/services/customer_context.py").read_text(encoding="utf-8")
     gather = src.split("async def _gather", 1)[1]
-    assert gather.count("business_context_id=business_context_id") >= 2
+    assert gather.count("business_context_id=business_context_id") >= 3
 
 
 def test_context_result_omits_emails_under_scope():


### PR DESCRIPTION
Plan: plans/PR-EOM-Read-Scoping-Fixes.md
Slice phase: production hardening
Ownership lane: eom-crm/read-scoping

Repairs the two defects Codex reported on #2157 two minutes after merge
(post-merge review round 6), both independently reproduced by operator
boundary probes against the deployed runtime.

## What this fixes

1. **Bare scoped search omitted legacy rows**
   (#2157 discussion r3637029344). `_scoped_search` was first-page-wins:
   any default-tenant hit suppressed the NULL-context legacy page
   entirely. Probe: one EOM row + one NULL row → only the EOM row
   returned, NULL page never queried. Now both pages are queried and
   merged (tenant rows first, truncated to the caller's limit) — the same
   population definition `list_contacts` already used. The old behavior
   was pinned by a test; that pin is replaced, not deleted silently.
2. **Guard-then-refetch race on UUID reads**
   (#2157 discussion r3637029350). The boolean guard validated one fetch
   and the tool returned a second, unguarded fetch. Probe: guard saw
   NULL, refetch saw churnsignals → `found=true` foreign. Now
   `get_contact` is single-fetch-validate via the shared `_row_visible`
   predicate (regression test asserts await-count 1 on the
   NULL-then-foreign sequence); `get_customer_context` validates the
   service-fetched `ctx.contact`; `get_interactions` becomes atomic in
   SQL (join on the owning contact's context, tenant-plus-NULL, same
   statement as the page read).

## Intentional

- Interactions SQL keeps one shape (tenant-plus-NULL) for both explicit
  and default addressing: the pre-guard enforces exact-page for explicit
  callers and rows can never move tenant→NULL, so the NULL branch is
  unreachable there.
- Mutations untouched: update/delete/log already close this race via the
  compare-and-set `claim_contact` from #2157 rounds 4-5.
- Double query on every default-scoped search accepted (two indexed
  lookups; #2157 accepted the same cost for the miss case).

## Deferred

- Tenant-addressable email store (context omits emails under scope).
- `atlas_brain/api/contacts.py` auth/scoping (own slice).
- `claude-review` commit status remains advisory for this lane per
  docs/REVIEWER_MERGE_GATE.md (never set on #2153/#2155/#2157); flagged
  to the operator to promote to a required check if wanted.

## Parked hardening

None new. Standing parked items stay on #2151: tenant-addressable email
store, api/contacts.py auth slice.

## Cold diff reconstruction

`_scoped_search` union + truncation; `_row_visible` predicate replacing
the explicit/default visibility branches in `_guarded_contact` and
`get_contact`; post-fetch validation in `get_customer_context`; scope
kwarg threaded through MCP `get_interactions` →
`crm_provider.get_interactions` (new conditional join SQL) and
`customer_context._gather`; tests: wrong-behavior pin replaced by merge
tests, TOCTOU regression, `_row_visible` semantics, atomic-SQL and
threading pins.

## Verification

- `tests/test_crm_read_scoping.py`: 54 passed (includes both probe
  regressions).
- Adjacent suites (`test_mcp_servers`, `test_leads_intake`,
  `test_tenant_stamping`, `test_customer_context`): 176 passed combined;
  6 pre-existing env failures (verified pre-existing on origin/main
  during #2157).
- Maturity ratchets (mcp + storage lanes, CI flags): clean.

## Diff size

5 files, ~150 insertions / ~33 deletions (plus this plan doc).

## AI reconciliation

Round 6 threads live on #2157 (post-merge): both are fixed by this PR
and will be replied/resolved there referencing these commits.

All fixed or waived: yes
