### PR TITLE
test: behavioral evidence for #2165 aggregate-path regressions (#2151)

### DIFF
--- a/plans/PR-EOM-Read-Scoping-Test-Evidence.md
+++ b/plans/PR-EOM-Read-Scoping-Test-Evidence.md
@@ -1,0 +1,102 @@
+# PR-EOM-Read-Scoping-Test-Evidence
+
+## Why this slice exists
+
+The operator's review of #2165 confirmed the fixes but graded two of the
+regressions as structural evidence: the `get_customer_context`
+post-validation and the atomic interaction query were pinned by source-text
+search (`_row_visible(ctx.contact)` substring, SQL fragments), not by
+executing the behavior. This slice upgrades both to behavioral tests.
+
+### Problem-derived contract
+
+- Root cause: the two aggregate paths were hard to execute in unit tests
+  (service constructed inside the tool; SQL built inside the provider), so
+  #2165 pinned their source instead of their behavior.
+- Correct fix must: execute the TOCTOU refusal end-to-end through the MCP
+  tool with a stub service whose fetch returns a foreign row, and execute
+  the provider's scoped interaction query against a capturing pool,
+  asserting the join + bound parameters land in one statement.
+- Must not change: any production code (test-only slice), the existing
+  structural pins (kept as belt).
+
+## Scope (this PR)
+
+Ownership lane: eom-crm/read-scoping
+Slice phase: robust testing
+
+1. `tests/test_crm_read_scoping.py`: behavioral TOCTOU pair (guard sees a
+   claimable NULL row, service fetch returns the claimed-foreign row →
+   refusal; still-visible row → serialized with scope flags) and a
+   behavioral provider test executing `get_interactions` against a
+   capturing fake pool (scoped: join + `(contact, tenant, limit)` params
+   in one statement; unscoped: legacy statement).
+2. `tests/maturity_sweep/baseline_atlas_brain_storage.json`: recorded
+   intentional +1 INTERNAL_MOCK on `atlas_brain/storage/database.py` (the fake pool
+   monkeypatches `get_db_pool`, the provider's only seam), plus ratchet
+   DECREASES the sweep re-recorded from earlier test additions.
+
+### Review Contract
+
+- Acceptance criteria:
+  1. The TOCTOU test constructs the actual race (different rows on the
+     two fetches) through the real MCP tool code path and asserts
+     refusal; its positive twin proves the same wiring serializes a
+     visible row.
+  2. The provider test asserts tenant + limit are bound parameters of
+     one statement containing the contact join, and that unscoped calls
+     keep the legacy SQL.
+  3. No production file changes.
+- Reachability proof: pytest suite (CI + local); no runtime deploy needed.
+- Affected surfaces: tests + one sweep baseline.
+- Risk areas: baseline acceptance grows database.py's recorded
+  INTERNAL_MOCK 31→32 (documented here; the alternative was leaving the
+  provider path structurally pinned).
+- Reviewer rules triggered: R1 (#2165 review follow-up), R2 (this IS the
+  test slice), R5 (no behavior change), R14.
+
+### Files touched
+
+- `plans/PR-EOM-Read-Scoping-Test-Evidence.md`
+- `tests/test_crm_read_scoping.py`
+- `tests/maturity_sweep/baseline_atlas_brain_storage.json`
+
+## Mechanism
+
+The stub service returns a minimal `CustomerContext` stand-in whose
+`contact` is the foreign row, so the tool's post-validation runs against
+exactly the artifact the race produces. The capturing pool records the SQL
+and parameters the provider actually executes, which is the strongest
+DB-free evidence that scoping and pagination share one statement.
+
+## Intentional
+
+- **Structural pins kept** — cheap belt under the new behavioral tests.
+- **Baseline acceptance over a new production seam** — injecting a pool
+  seam into the provider just for tests would be production churn on a
+  hot path; one recorded INTERNAL_MOCK on a file already carrying 31 is
+  the smaller cost, and the sweep re-record also captured several ratchet
+  decreases.
+
+## Deferred
+
+- True database-integration tests (live Postgres) for the scoped queries —
+  no DB harness exists in this suite today.
+
+Parked hardening: none new.
+
+## Verification
+
+- `tests/test_crm_read_scoping.py` — 57 passed (3 new behavioral).
+- Adjacent suites — 179 passed combined; 6 pre-existing env failures.
+- Maturity ratchets (mcp + storage, CI flags) — clean after the recorded
+  acceptance.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-EOM-Read-Scoping-Test-Evidence.md` | 100 |
+| `tests/test_crm_read_scoping.py` | 85 |
+| `tests/maturity_sweep/baseline_atlas_brain_storage.json` | 18 |
+| **Total** | **~205** |

--- a/tests/maturity_sweep/baseline_atlas_brain_storage.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_storage.json
@@ -1,26 +1,22 @@
 {
   "atlas_brain/storage/config.py": {
     "counts": {
-      "HAPPY_PATH_TESTS": 1,
-      "INTERNAL_MOCK": 1,
-      "NO_RAISES_TESTS": 1
+      "INTERNAL_MOCK": 1
     },
-    "score": 11
+    "score": 4
   },
   "atlas_brain/storage/database.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
-      "INTERNAL_MOCK": 31
+      "INTERNAL_MOCK": 32
     },
-    "score": 128
+    "score": 132
   },
   "atlas_brain/storage/models.py": {
     "counts": {
-      "HAPPY_PATH_TESTS": 1,
-      "NO_RAISES_TESTS": 1,
       "UNGUARDED_INPUT": 1
     },
-    "score": 11
+    "score": 4
   },
   "atlas_brain/storage/repositories/appointment.py": {
     "counts": {
@@ -85,11 +81,11 @@
   "atlas_brain/storage/repositories/invoice.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
-      "INTERNAL_MOCK": 5,
+      "INTERNAL_MOCK": 4,
       "NO_RAISES_TESTS": 1,
       "SWALLOWED_EXCEPT": 1
     },
-    "score": 32
+    "score": 28
   },
   "atlas_brain/storage/repositories/reminder.py": {
     "counts": {

--- a/tests/test_crm_read_scoping.py
+++ b/tests/test_crm_read_scoping.py
@@ -260,6 +260,84 @@ def test_row_visible_semantics(default_ctx):
     assert crm_srv._row_visible(LEGACY_NULL, EOM) is False  # explicit = exact
 
 
+class _StubCtx:
+    """Minimal CustomerContext stand-in for behavioral TOCTOU tests."""
+
+    def __init__(self, contact):
+        self.is_empty = False
+        self.contact = contact
+        self.interactions = []
+        self.appointments = []
+        self.call_transcripts = []
+        self.sent_emails = []
+        self.inbox_emails = []
+        self.b2b_churn_signals = []
+
+
+@pytest.mark.asyncio
+async def test_customer_context_refuses_row_claimed_mid_gather(default_ctx, monkeypatch):
+    """Behavioral TOCTOU regression (#2165 review): the pre-guard sees a
+    claimable NULL row, but the service's own fetch returns the row already
+    claimed by the other tenant -- the response must refuse, not serialize
+    the foreign contact."""
+    _provider_mock(monkeypatch, get=LEGACY_NULL)
+    from atlas_brain.services import customer_context as ccx
+
+    class _Svc:
+        async def get_context(self, contact_id, **kwargs):
+            return _StubCtx(dict(FOREIGN))
+
+    monkeypatch.setattr(ccx, "get_customer_context_service", lambda: _Svc())
+    out = json.loads(await crm_srv.get_customer_context(contact_id=UUID))
+    assert out == {"found": False, "context": None}
+
+
+@pytest.mark.asyncio
+async def test_customer_context_serializes_still_visible_row(default_ctx, monkeypatch):
+    _provider_mock(monkeypatch, get=SAME)
+    from atlas_brain.services import customer_context as ccx
+
+    class _Svc:
+        async def get_context(self, contact_id, **kwargs):
+            return _StubCtx(dict(SAME))
+
+    monkeypatch.setattr(ccx, "get_customer_context_service", lambda: _Svc())
+    out = json.loads(await crm_srv.get_customer_context(contact_id=UUID))
+    assert out["found"] is True
+    assert out["contact"]["business_context_id"] == EOM
+    assert out["emails_omitted_under_scope"] is True
+
+
+@pytest.mark.asyncio
+async def test_provider_interactions_scoped_query_executes_atomically(monkeypatch):
+    """Behavioral (#2165 review): the tenant predicate is bound in the SAME
+    statement as the page read -- join + bound params -- not applied after
+    the query; unscoped callers keep the legacy statement."""
+    from atlas_brain.services.crm_provider import DatabaseCRMProvider
+    from atlas_brain.storage import database
+
+    captured = {}
+
+    class _Pool:
+        async def fetch(self, sql, *params):
+            captured["sql"] = " ".join(sql.split())
+            captured["params"] = params
+            return [{"id": "i-1"}]
+
+    monkeypatch.setattr(database, "get_db_pool", lambda: _Pool())
+    provider = DatabaseCRMProvider.__new__(DatabaseCRMProvider)
+
+    rows = await provider.get_interactions(UUID, limit=5, business_context_id=EOM)
+    assert rows == [{"id": "i-1"}]
+    assert "JOIN contacts c ON c.id = ci.contact_id" in captured["sql"]
+    assert "(c.business_context_id = $2 OR c.business_context_id IS NULL)" in captured["sql"]
+    assert captured["params"] == (UUID, EOM, 5)
+
+    await provider.get_interactions(UUID, limit=5)
+    assert "JOIN" not in captured["sql"]
+    assert captured["params"] == (UUID, 5)
+
+
 def test_customer_context_validates_fetched_row_source():
     """get_customer_context must validate ctx.contact (the service's own
     fetch), not only the pre-guard read."""


### PR DESCRIPTION
Plan: plans/PR-EOM-Read-Scoping-Test-Evidence.md
Slice phase: robust testing
Ownership lane: eom-crm/read-scoping

Upgrades the two structurally-pinned #2165 regressions to behavioral
tests, per the operator's review of that PR ("a stronger fix would
include behavioral provider/database tests").

## Intentional

- Behavioral TOCTOU pair executes the real MCP tool path with a stub
  service returning the claimed-foreign row (refusal) and a visible row
  (serialization with scope flags).
- Behavioral provider test executes get_interactions against a capturing
  pool: scoped = contact join + (contact, tenant, limit) bound in ONE
  statement; unscoped = legacy SQL.
- Structural source pins kept as belt.
- Storage sweep baseline records +1 INTERNAL_MOCK on database.py
  (fake pool monkeypatches get_db_pool, the provider's only seam) —
  chosen over adding a production pool seam for tests; the re-record also
  captured several ratchet DECREASES earned by earlier test additions.

## Deferred

- Live-Postgres integration tests for scoped queries (no DB harness in
  this suite).

## Parked hardening

None new.

## Cold diff reconstruction

Three new tests + one stub class in tests/test_crm_read_scoping.py; one
sweep baseline re-record. Zero production code changes.

## Verification

- tests/test_crm_read_scoping.py: 57 passed (3 new behavioral).
- Adjacent suites: 179 passed combined; 6 pre-existing env failures
  (verified pre-existing on origin/main during #2157).
- Maturity ratchets (mcp + storage lanes, CI flags): clean.

## Diff size

3 files, ~205 LOC (tests + plan + baseline).

## AI reconciliation

No reviewer threads yet at open time; will reconcile any that arrive.

All fixed or waived: yes
