### PR TITLE
test: pin the B2B omission flag behaviorally (#2151)

### DIFF
--- a/plans/PR-EOM-B2B-Omission-Flag-Pin.md
+++ b/plans/PR-EOM-B2B-Omission-Flag-Pin.md
@@ -1,0 +1,67 @@
+# PR-EOM-B2B-Omission-Flag-Pin
+
+## Why this slice exists
+
+The operator's review of #2166 found one overstatement in its evidence:
+the positive behavioral customer-context test pinned
+`emails_omitted_under_scope` but not the second runtime flag,
+`b2b_enrichment_omitted_under_scope`. The runtime returns both; the test
+pinned one.
+
+### Problem-derived contract
+
+- Root cause: the #2166 positive-path test asserted a subset of the
+  scoped-omission contract.
+- Correct fix must: assert the B2B flag and the emptied
+  `b2b_churn_signals` list in the same behavioral test.
+- Must not change: production code, other tests.
+
+## Scope (this PR)
+
+Ownership lane: eom-crm/read-scoping
+Slice phase: robust testing
+
+1. `tests/test_crm_read_scoping.py`: two asserts appended to
+   `test_customer_context_serializes_still_visible_row` pinning
+   `b2b_enrichment_omitted_under_scope` and `b2b_churn_signals == []`.
+
+### Review Contract
+
+- Acceptance criteria: the positive scoped-context test fails if either
+  omission flag or the emptied enrichment list regresses.
+- Reachability proof: pytest suite.
+- Affected surfaces: one test.
+- Risk areas: none (test-only).
+- Reviewer rules triggered: R2, R14.
+
+### Files touched
+
+- `plans/PR-EOM-B2B-Omission-Flag-Pin.md`
+- `tests/test_crm_read_scoping.py`
+
+## Mechanism
+
+Two asserts in the existing behavioral test, which already executes the
+real MCP path with a stub service.
+
+## Intentional
+
+- Test-only two-line change; no production edits.
+
+## Deferred
+
+- Nothing new.
+
+Parked hardening: none new.
+
+## Verification
+
+- `tests/test_crm_read_scoping.py` — 57 passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-EOM-B2B-Omission-Flag-Pin.md` | 60 |
+| `tests/test_crm_read_scoping.py` | 2 |
+| **Total** | **~62** |

--- a/tests/test_crm_read_scoping.py
+++ b/tests/test_crm_read_scoping.py
@@ -294,12 +294,19 @@ async def test_customer_context_refuses_row_claimed_mid_gather(default_ctx, monk
 
 @pytest.mark.asyncio
 async def test_customer_context_serializes_still_visible_row(default_ctx, monkeypatch):
+    """The omission assertions only prove something if the stub SEEDS each
+    omitted source non-empty -- an empty-in/empty-out check passes even
+    when the serializer regresses (Codex, #2172)."""
     _provider_mock(monkeypatch, get=SAME)
     from atlas_brain.services import customer_context as ccx
 
     class _Svc:
         async def get_context(self, contact_id, **kwargs):
-            return _StubCtx(dict(SAME))
+            ctx = _StubCtx(dict(SAME))
+            ctx.sent_emails = [{"subject": "old estimate thread"}]
+            ctx.inbox_emails = [{"subject": "customer reply"}]
+            ctx.b2b_churn_signals = [{"vendor": "acme-saas"}]
+            return ctx
 
     monkeypatch.setattr(ccx, "get_customer_context_service", lambda: _Svc())
     out = json.loads(await crm_srv.get_customer_context(contact_id=UUID))
@@ -307,6 +314,8 @@ async def test_customer_context_serializes_still_visible_row(default_ctx, monkey
     assert out["contact"]["business_context_id"] == EOM
     assert out["emails_omitted_under_scope"] is True
     assert out["b2b_enrichment_omitted_under_scope"] is True
+    assert out["sent_emails"] == []
+    assert out["inbox_emails"] == []
     assert out["b2b_churn_signals"] == []
 
 

--- a/tests/test_crm_read_scoping.py
+++ b/tests/test_crm_read_scoping.py
@@ -306,6 +306,8 @@ async def test_customer_context_serializes_still_visible_row(default_ctx, monkey
     assert out["found"] is True
     assert out["contact"]["business_context_id"] == EOM
     assert out["emails_omitted_under_scope"] is True
+    assert out["b2b_enrichment_omitted_under_scope"] is True
+    assert out["b2b_churn_signals"] == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-EOM-B2B-Omission-Flag-Pin.md
Slice phase: robust testing
Ownership lane: eom-crm/read-scoping

One-assert amendment from the operator's review of #2166: the positive
behavioral customer-context test pinned `emails_omitted_under_scope` but
not the second flag. It now asserts `b2b_enrichment_omitted_under_scope`
and the emptied `b2b_churn_signals` list as well, so both scoped
omissions are behaviorally pinned.

## Intentional

- Test-only; two assert lines + a plan-doc amendment note.

## Deferred

- Nothing new.

## Parked hardening

None new.

## Cold diff reconstruction

Two asserts appended to
`test_customer_context_serializes_still_visible_row`; dedicated micro
plan doc added.

## Verification

- tests/test_crm_read_scoping.py: 57 passed.

## Diff size

2 files, +8 LOC.

## AI reconciliation

Codex round 1 — one thread, fixed: the `b2b_churn_signals == []` assert
was vacuous because the stub already defaulted the list empty. The stub
now SEEDS all three omitted sources non-empty (sent/inbox emails + B2B
signal) and the test asserts each is emptied plus both flags, so a
serializer regression on any of them fails the test.

All fixed or waived: yes
