### PR TITLE
EOM CRM: add tenant-scoped lead pipeline fields

### DIFF
--- a/.github/workflows/atlas_eom_lead_pipeline_checks.yml
+++ b/.github/workflows/atlas_eom_lead_pipeline_checks.yml
@@ -1,0 +1,74 @@
+name: Atlas EOM Lead Pipeline Checks
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/atlas_eom_lead_pipeline_checks.yml"
+      - "atlas_brain/api/leads.py"
+      - "atlas_brain/mcp/crm_server.py"
+      - "atlas_brain/services/crm_provider.py"
+      - "atlas_brain/storage/migrations/346_contact_lead_pipeline.sql"
+      - "tests/test_crm_read_scoping.py"
+      - "tests/test_eom_lead_pipeline_integration.py"
+      - "tests/test_leads_intake.py"
+      - "tests/test_migrations_runner.py"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/atlas_eom_lead_pipeline_checks.yml"
+      - "atlas_brain/api/leads.py"
+      - "atlas_brain/mcp/crm_server.py"
+      - "atlas_brain/services/crm_provider.py"
+      - "atlas_brain/storage/migrations/346_contact_lead_pipeline.sql"
+      - "tests/test_crm_read_scoping.py"
+      - "tests/test_eom_lead_pipeline_integration.py"
+      - "tests/test_leads_intake.py"
+      - "tests/test_migrations_runner.py"
+
+jobs:
+  eom-lead-pipeline:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16@sha256:081f1bc7bd5e143dbb6e487b710bbc27712cdcfaced4c071b8e47349aa1b4171
+        env:
+          POSTGRES_USER: atlas
+          POSTGRES_PASSWORD: atlas
+          POSTGRES_DB: atlas_migration_tests
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U atlas -d atlas_migration_tests"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      ATLAS_MIGRATION_TEST_DATABASE_URL: postgresql://atlas:atlas@localhost:5432/atlas_migration_tests
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          python -m pip install pytest pytest-asyncio
+
+      - name: Run EOM lead pipeline checks
+        run: |
+          python -m pytest \
+            tests/test_crm_read_scoping.py \
+            tests/test_eom_lead_pipeline_integration.py \
+            tests/test_leads_intake.py \
+            tests/test_migrations_runner.py \
+            -q

--- a/atlas_brain/api/leads.py
+++ b/atlas_brain/api/leads.py
@@ -266,6 +266,7 @@ async def _process_lead_intake(
             source_ref="website_estimate_form",
             business_context_id=EOM_BUSINESS_CONTEXT_ID,
             tags=["website", "estimate_request"],
+            lead_stage="new",
         )
     contact_id = contact.get("id")
     if not contact_id:

--- a/atlas_brain/mcp/crm_server.py
+++ b/atlas_brain/mcp/crm_server.py
@@ -31,6 +31,7 @@ import logging
 import sys
 import uuid as _uuid
 from contextlib import asynccontextmanager
+from datetime import datetime, timezone
 from typing import Any, Callable, Optional
 
 from mcp.server.fastmcp import FastMCP
@@ -96,6 +97,32 @@ def _default_context() -> "str | None":
     from ..config import settings
 
     return settings.mcp.crm_default_business_context or None
+
+
+def _pipeline_text(value: str, field: str, max_length: int) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{field} cannot be empty; use its clear flag")
+    if len(normalized) > max_length:
+        raise ValueError(f"{field} must be at most {max_length} characters")
+    return normalized
+
+
+def _pipeline_timestamp(value: str, field: str) -> datetime:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{field} cannot be empty; use clear_next_follow_up")
+    if len(normalized) > 64:
+        raise ValueError(f"{field} must be at most 64 characters")
+    if normalized.endswith("Z"):
+        normalized = f"{normalized[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise ValueError(f"{field} must be an ISO 8601 timestamp") from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"{field} must include a UTC offset")
+    return parsed.astimezone(timezone.utc)
 
 
 def _visible_under_default(contact: "dict | None") -> bool:
@@ -436,6 +463,11 @@ async def update_contact(
     notes: Optional[str] = None,
     status: Optional[str] = None,
     tags: Optional[list[str]] = None,
+    lead_stage: Optional[str] = None,
+    lead_owner: Optional[str] = None,
+    next_follow_up_at: Optional[str] = None,
+    clear_lead_owner: bool = False,
+    clear_next_follow_up: bool = False,
     business_context_id: Optional[str] = None,
 ) -> str:
     """
@@ -443,6 +475,9 @@ async def update_contact(
 
     Only supply fields you want to change.
     status: active | inactive | archived
+    lead_stage / lead_owner: pipeline values for lead contacts only.
+    next_follow_up_at: ISO 8601 timestamp with a UTC offset, for leads only.
+    clear_lead_owner / clear_next_follow_up: explicitly clear those fields.
     business_context_id: addresses which tenant page the contact is looked
     up on (explicit override of the deployment default); it is NOT an
     updatable field.
@@ -451,6 +486,19 @@ async def update_contact(
         return json.dumps({"success": False, "error": "Invalid contact_id (must be UUID)"})
 
     try:
+        if clear_lead_owner and lead_owner is not None:
+            return json.dumps({
+                "success": False,
+                "error": "lead_owner and clear_lead_owner are mutually exclusive",
+            })
+        if clear_next_follow_up and next_follow_up_at is not None:
+            return json.dumps({
+                "success": False,
+                "error": (
+                    "next_follow_up_at and clear_next_follow_up are mutually exclusive"
+                ),
+            })
+
         data = {
             k: v for k, v in {
                 "full_name": full_name,
@@ -465,21 +513,62 @@ async def update_contact(
                 "tags": tags,
             }.items() if v is not None
         }
+        pipeline_requested = any((
+            lead_stage is not None,
+            lead_owner is not None,
+            next_follow_up_at is not None,
+            clear_lead_owner,
+            clear_next_follow_up,
+        ))
+        if lead_stage is not None:
+            data["lead_stage"] = _pipeline_text(
+                lead_stage, "lead_stage", 64
+            )
+        if lead_owner is not None:
+            data["lead_owner"] = _pipeline_text(
+                lead_owner, "lead_owner", 128
+            )
+        elif clear_lead_owner:
+            data["lead_owner"] = None
+        if next_follow_up_at is not None:
+            data["next_follow_up_at"] = _pipeline_timestamp(
+                next_follow_up_at, "next_follow_up_at"
+            )
+        elif clear_next_follow_up:
+            data["next_follow_up_at"] = None
         if not data:
             return json.dumps({"success": False, "error": "No fields provided to update"})
 
         allowed, existing = await _guarded_contact(contact_id, business_context_id)
         if not allowed:
             return json.dumps({"success": False, "error": "Contact not found"})
+        if pipeline_requested and existing is None:
+            existing = await _provider().get_contact(contact_id)
+            if existing is None:
+                return json.dumps({"success": False, "error": "Contact not found"})
+        if pipeline_requested and existing.get("contact_type") != "lead":
+            return json.dumps({
+                "success": False,
+                "error": "Lead pipeline fields require a lead contact",
+            })
         # Claim-on-write: an update from a scoped session takes ownership of
         # the NULL-context legacy row, so corrected data stops being visible
         # to every tenant as unclaimed legacy.
         if not await _claim_if_legacy(contact_id, existing, business_context_id):
             return json.dumps({"success": False, "error": "Contact not found"})
-        updated = await _provider().update_contact(contact_id, data)
+        if pipeline_requested:
+            updated = await _provider().update_contact(
+                contact_id,
+                data,
+                require_contact_type="lead",
+            )
+        else:
+            updated = await _provider().update_contact(contact_id, data)
         if updated is None:
             return json.dumps({"success": False, "error": "Contact not found"})
         return json.dumps({"success": True, "contact": updated}, default=str)
+    except ValueError as exc:
+        return json.dumps({"success": False, "error": str(exc)})
     except Exception as exc:
         logger.exception("update_contact error")
         return json.dumps({"success": False, "error": "Internal error"})
@@ -527,6 +616,9 @@ async def list_contacts(
     business_context_id: Optional[str] = None,
     status: str = "active",
     contact_type: Optional[str] = None,
+    lead_stage: Optional[str] = None,
+    lead_owner: Optional[str] = None,
+    next_follow_up_before: Optional[str] = None,
     limit: int = 50,
     offset: int = 0,
 ) -> str:
@@ -535,42 +627,82 @@ async def list_contacts(
 
     status:       active (default) | inactive | archived
     contact_type: customer | lead | prospect | vendor
+    lead_stage / lead_owner: exact-match lead pipeline filters.
+    next_follow_up_before: include leads due at or before this ISO 8601
+        timestamp; a UTC offset is required.
     limit / offset: for pagination
 
-    With a deployment default tenant configured and no explicit
-    business_context_id, results merge the default tenant's page with the
-    NULL-context legacy page (offset applies to each page; the merged
-    result is truncated to limit).
+    With a deployment default tenant and no explicit business_context_id,
+    pipeline-filtered calls query the tenant-plus-legacy population in one SQL
+    statement so due ordering and pagination are global. Other list calls keep
+    the established two-page merge behavior.
     """
     try:
         provider = _provider()
         default = _default_context()
         capped = min(limit, 200)
+        pipeline_filtered = any((
+            lead_stage is not None,
+            lead_owner is not None,
+            next_follow_up_before is not None,
+        ))
+        if pipeline_filtered and contact_type not in (None, "lead"):
+            return json.dumps({
+                "error": "Lead pipeline filters require contact_type='lead'",
+                "contacts": [],
+                "count": 0,
+            })
+        effective_contact_type = "lead" if pipeline_filtered else contact_type
+        normalized_stage = (
+            _pipeline_text(lead_stage, "lead_stage", 64)
+            if lead_stage is not None
+            else None
+        )
+        normalized_owner = (
+            _pipeline_text(lead_owner, "lead_owner", 128)
+            if lead_owner is not None
+            else None
+        )
+        due_before = (
+            _pipeline_timestamp(
+                next_follow_up_before, "next_follow_up_before"
+            )
+            if next_follow_up_before is not None
+            else None
+        )
+        filters = {
+            "status": status,
+            "contact_type": effective_contact_type,
+            "lead_stage": normalized_stage,
+            "lead_owner": normalized_owner,
+            "next_follow_up_before": due_before,
+            "limit": capped,
+            "offset": offset,
+        }
         if business_context_id or not default:
             contacts = await provider.list_contacts(
                 business_context_id=business_context_id,
-                status=status,
-                contact_type=contact_type,
-                limit=capped,
-                offset=offset,
+                **filters,
+            )
+        elif pipeline_filtered:
+            contacts = await provider.list_contacts(
+                business_context_id=default,
+                include_unclaimed_legacy=True,
+                **filters,
             )
         else:
             tenant_rows = await provider.list_contacts(
                 business_context_id=default,
-                status=status,
-                contact_type=contact_type,
-                limit=capped,
-                offset=offset,
+                **filters,
             )
             legacy_rows = await provider.list_contacts(
                 business_context_id_is_null=True,
-                status=status,
-                contact_type=contact_type,
-                limit=capped,
-                offset=offset,
+                **filters,
             )
             contacts = (tenant_rows + legacy_rows)[:capped]
         return json.dumps({"contacts": contacts, "count": len(contacts)}, default=str)
+    except ValueError as exc:
+        return json.dumps({"error": str(exc), "contacts": [], "count": 0})
     except Exception as exc:
         logger.exception("list_contacts error")
         return json.dumps({"error": "Internal error", "contacts": [], "count": 0})

--- a/atlas_brain/services/crm_provider.py
+++ b/atlas_brain/services/crm_provider.py
@@ -119,6 +119,13 @@ class DatabaseCRMProvider:
         always gets the most complete version.  This is application-level dedup;
         migration 037 should add a DB-level partial unique index for extra safety.
         """
+        pipeline_fields = ("lead_stage", "lead_owner", "next_follow_up_at")
+        if (
+            any(data.get(field) is not None for field in pipeline_fields)
+            and data.get("contact_type", "customer") != "lead"
+        ):
+            raise ValueError("Lead pipeline fields require contact_type='lead'")
+
         # --- dedup check ---
         raw_email = data.get("email")
         email = raw_email.lower() if raw_email else None
@@ -216,9 +223,11 @@ class DatabaseCRMProvider:
                 id, full_name, first_name, last_name, email, phone,
                 address, city, state, zip, business_context_id,
                 contact_type, status, tags, notes, source, source_ref,
+                lead_stage, lead_owner, next_follow_up_at,
                 created_at, updated_at, metadata
             ) VALUES (
-                $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20::jsonb
+                $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,
+                $18,$19,$20,$21,$22,$23::jsonb
             ) RETURNING *
             """,
             contact_id,
@@ -238,8 +247,11 @@ class DatabaseCRMProvider:
             data.get("notes"),
             data.get("source", "manual"),
             data.get("source_ref"),
-            now,   # created_at ($18)
-            now,   # updated_at ($19) -- same value on insert
+            data.get("lead_stage"),
+            data.get("lead_owner"),
+            data.get("next_follow_up_at"),
+            now,   # created_at ($21)
+            now,   # updated_at ($22) -- same value on insert
             metadata_json,
         )
         result = dict(row) if row else {}
@@ -340,7 +352,11 @@ class DatabaseCRMProvider:
         return [dict(r) for r in rows]
 
     async def update_contact(
-        self, contact_id: str, data: dict[str, Any]
+        self,
+        contact_id: str,
+        data: dict[str, Any],
+        *,
+        require_contact_type: Optional[str] = None,
     ) -> Optional[dict[str, Any]]:
         from ..storage.database import get_db_pool
 
@@ -349,9 +365,19 @@ class DatabaseCRMProvider:
             "full_name", "first_name", "last_name", "email", "phone",
             "address", "city", "state", "zip", "contact_type", "status",
             "tags", "notes", "business_context_id", "source", "source_ref",
-            "metadata",
+            "metadata", "lead_stage", "lead_owner", "next_follow_up_at",
         }
         updates = {k: v for k, v in data.items() if k in allowed}
+        pipeline_requested = any(
+            key in updates
+            for key in ("lead_stage", "lead_owner", "next_follow_up_at")
+        )
+        if pipeline_requested:
+            if require_contact_type not in (None, "lead"):
+                raise ValueError(
+                    "Lead pipeline fields require contact_type='lead'"
+                )
+            require_contact_type = "lead"
         if "email" in updates and updates["email"]:
             updates["email"] = updates["email"].lower()
         if "metadata" in updates:
@@ -367,8 +393,13 @@ class DatabaseCRMProvider:
             set_parts.append(f"{key} = ${i}{cast}")
             params.append(val)
 
+        where = "id = $1"
+        if require_contact_type is not None:
+            params.append(require_contact_type)
+            where += f" AND contact_type = ${len(params)}"
+
         row = await pool.fetchrow(
-            f"UPDATE contacts SET {', '.join(set_parts)} WHERE id = $1 RETURNING *",
+            f"UPDATE contacts SET {', '.join(set_parts)} WHERE {where} RETURNING *",
             *params,
         )
         return dict(row) if row else None
@@ -413,8 +444,12 @@ class DatabaseCRMProvider:
         self,
         business_context_id: Optional[str] = None,
         business_context_id_is_null: bool = False,
+        include_unclaimed_legacy: bool = False,
         status: Optional[str] = "active",
         contact_type: Optional[str] = None,
+        lead_stage: Optional[str] = None,
+        lead_owner: Optional[str] = None,
+        next_follow_up_before: Optional[datetime] = None,
         limit: int = 50,
         offset: int = 0,
     ) -> list[dict[str, Any]]:
@@ -429,8 +464,21 @@ class DatabaseCRMProvider:
             conditions.append(f"status = ${idx}")
             params.append(status)
             idx += 1
+        if include_unclaimed_legacy and not business_context_id:
+            raise ValueError(
+                "include_unclaimed_legacy requires business_context_id"
+            )
+        if include_unclaimed_legacy and business_context_id_is_null:
+            raise ValueError(
+                "include_unclaimed_legacy conflicts with business_context_id_is_null"
+            )
         if business_context_id:
-            conditions.append(f"business_context_id = ${idx}")
+            operator = (
+                f"(business_context_id = ${idx} OR business_context_id IS NULL)"
+                if include_unclaimed_legacy
+                else f"business_context_id = ${idx}"
+            )
+            conditions.append(operator)
             params.append(business_context_id)
             idx += 1
         if business_context_id_is_null:
@@ -439,13 +487,30 @@ class DatabaseCRMProvider:
             conditions.append(f"contact_type = ${idx}")
             params.append(contact_type)
             idx += 1
+        if lead_stage:
+            conditions.append(f"lead_stage = ${idx}")
+            params.append(lead_stage)
+            idx += 1
+        if lead_owner:
+            conditions.append(f"lead_owner = ${idx}")
+            params.append(lead_owner)
+            idx += 1
+        if next_follow_up_before is not None:
+            conditions.append(f"next_follow_up_at <= ${idx}")
+            params.append(next_follow_up_before)
+            idx += 1
 
         where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
         params.extend([limit, max(0, offset)])
+        order_by = (
+            "next_follow_up_at ASC, full_name ASC"
+            if next_follow_up_before is not None
+            else "full_name ASC"
+        )
         rows = await pool.fetch(
             f"""
             SELECT * FROM contacts {where}
-            ORDER BY full_name ASC
+            ORDER BY {order_by}
             LIMIT ${idx} OFFSET ${idx + 1}
             """,
             *params,

--- a/atlas_brain/services/crm_provider.py
+++ b/atlas_brain/services/crm_provider.py
@@ -373,6 +373,13 @@ class DatabaseCRMProvider:
             for key in ("lead_stage", "lead_owner", "next_follow_up_at")
         )
         if pipeline_requested:
+            if (
+                "contact_type" in updates
+                and updates["contact_type"] != "lead"
+            ):
+                raise ValueError(
+                    "Lead pipeline fields require contact_type='lead'"
+                )
             if require_contact_type not in (None, "lead"):
                 raise ValueError(
                     "Lead pipeline fields require contact_type='lead'"

--- a/atlas_brain/storage/migrations/346_contact_lead_pipeline.sql
+++ b/atlas_brain/storage/migrations/346_contact_lead_pipeline.sql
@@ -1,0 +1,21 @@
+-- Optional lead-pipeline state on the canonical CRM contact.
+-- Existing contacts remain unchanged; new website leads initialize lead_stage
+-- through the intake path after this migration is deployed.
+
+ALTER TABLE contacts
+    ADD COLUMN IF NOT EXISTS lead_stage VARCHAR(64),
+    ADD COLUMN IF NOT EXISTS lead_owner VARCHAR(128),
+    ADD COLUMN IF NOT EXISTS next_follow_up_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_contacts_lead_follow_up
+    ON contacts (business_context_id, next_follow_up_at, updated_at)
+    WHERE contact_type = 'lead'
+      AND status = 'active'
+      AND next_follow_up_at IS NOT NULL;
+
+COMMENT ON COLUMN contacts.lead_stage IS
+    'Caller-defined pipeline stage for contact_type=lead';
+COMMENT ON COLUMN contacts.lead_owner IS
+    'Operator responsible for the lead; not a user-table foreign key';
+COMMENT ON COLUMN contacts.next_follow_up_at IS
+    'Next operator follow-up time for the lead';

--- a/plans/PR-EOM-Lead-Pipeline.md
+++ b/plans/PR-EOM-Lead-Pipeline.md
@@ -18,13 +18,19 @@ adjacent product behavior is included.
 - Root cause: lead lifecycle attributes are absent from the canonical contact
   persistence and CRM port. The intake path cannot initialize pipeline state,
   and the operator surface cannot persist or query actionable follow-ups.
+  Additionally, treating "the row was a lead" as the only pipeline-write
+  precondition permits one `UPDATE` to demote that row while setting lead-only
+  fields; SQL-shape assertions alone cannot prove the due query's observable
+  tenant, cutoff, ordering, and limit behavior.
 - Correct fix must touch/change: extend the existing contact record with
   backward-compatible lead stage, owner, and next-follow-up fields; carry those
   fields through the canonical CRM provider; expose tenant-scoped MCP operations
   that update a visible lead and query visible leads needing follow-up; and have
   the real EOM intake entrypoint assign the initial stage only when it creates a
-  new lead. Prove the migration, provider behavior, tenant boundary, idempotent
-  re-intake behavior, and real entrypoint-to-persisted-state path.
+  new lead. Reject a pipeline write that simultaneously changes
+  `contact_type` away from `lead`. Prove the migration, provider behavior,
+  tenant boundary, due-query filtering/order/limit against real rows,
+  idempotent re-intake behavior, and real entrypoint-to-persisted-state path.
 - Must not change: the existing definition of a lead
   (`contacts.contact_type = 'lead'`), contact visibility/legacy-claim semantics
   from #2157/#2165, existing customer or non-lead records, acknowledgement
@@ -102,17 +108,19 @@ initial stage on creation and leaves an existing row's pipeline state intact.
 - Existing `create_contact`/`update_contact` callers that omit the three new
   fields keep their prior SQL and merge behavior; the CRM MCP compatibility
   tests cover the unchanged generic paths.
+- A lead may still be deliberately demoted in an update that does not also
+  write pipeline fields; only the contradictory atomic combination is rejected.
 - The additive migration uses a normal partial index rather than a concurrent
   index because the live contacts table is small; rollback is the direct
   removal of the optional index/columns if deployment must be reversed.
 - A dedicated leads table is rejected because it would duplicate contact
   identity and tenant ownership for three contact-lifecycle attributes.
-- The storage maturity baseline accepts two `get_db_pool` test seams
-  (`INTERNAL_MOCK` 32 -> 34). One captures the provider's exact SQL/arguments;
-  the other routes the production provider through disposable real Postgres
-  for the entrypoint proof. Adding a production pool-injection surface solely
-  for these tests would widen the runtime contract without improving the
-  vertical behavior.
+- The storage maturity baseline accepts one `get_db_pool` test seam
+  (`INTERNAL_MOCK` 32 -> 33) that routes the production provider through
+  disposable real Postgres for the entrypoint and due-query proof. The former
+  SQL-capturing mock was removed in favor of observable rows. Adding a
+  production pool-injection surface solely for the remaining integration seam
+  would widen the runtime contract without improving the vertical behavior.
 
 ## Deferred
 
@@ -127,7 +135,7 @@ Parked hardening: none.
 ## Verification
 
 - `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas@127.0.0.1:55432/atlas_migration_tests /home/juan-canfield/Desktop/Atlas/.venv/bin/python -m pytest tests/test_crm_read_scoping.py tests/test_eom_lead_pipeline_integration.py tests/test_leads_intake.py tests/test_migrations_runner.py -q`
-  - passed: 107 (disposable Postgres 16 container)
+  - passed: 106 (disposable Postgres 16 container)
 - `/home/juan-canfield/Desktop/Atlas/.venv/bin/python -m pytest tests/test_mcp_servers.py -q -k 'CRM or crm'`
   - passed: 22; deselected: 58
 - /home/juan-canfield/Desktop/Atlas/.venv/bin/python scripts/audit_mcp_tool_names_match_docs.py
@@ -154,12 +162,12 @@ Parked hardening: none.
 | `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 74 |
 | `atlas_brain/api/leads.py` | 1 |
 | `atlas_brain/mcp/crm_server.py` | 166 |
-| `atlas_brain/services/crm_provider.py` | 81 |
+| `atlas_brain/services/crm_provider.py` | 88 |
 | `atlas_brain/storage/migrations/346_contact_lead_pipeline.sql` | 21 |
-| `plans/PR-EOM-Lead-Pipeline.md` | 165 |
+| `plans/PR-EOM-Lead-Pipeline.md` | 173 |
 | `tests/maturity_sweep/baseline_atlas_brain_storage.json` | 4 |
-| `tests/test_crm_read_scoping.py` | 154 |
-| `tests/test_eom_lead_pipeline_integration.py` | 114 |
+| `tests/test_crm_read_scoping.py` | 124 |
+| `tests/test_eom_lead_pipeline_integration.py` | 189 |
 | `tests/test_leads_intake.py` | 20 |
 | `tests/test_migrations_runner.py` | 17 |
-| **Total** | **817** |
+| **Total** | **877** |

--- a/plans/PR-EOM-Lead-Pipeline.md
+++ b/plans/PR-EOM-Lead-Pipeline.md
@@ -77,6 +77,7 @@ Slice phase: Vertical slice
 - `atlas_brain/services/crm_provider.py`
 - `atlas_brain/storage/migrations/346_contact_lead_pipeline.sql`
 - `plans/PR-EOM-Lead-Pipeline.md`
+- `tests/maturity_sweep/baseline_atlas_brain_storage.json`
 - `tests/test_crm_read_scoping.py`
 - `tests/test_eom_lead_pipeline_integration.py`
 - `tests/test_leads_intake.py`
@@ -106,6 +107,12 @@ initial stage on creation and leaves an existing row's pipeline state intact.
   removal of the optional index/columns if deployment must be reversed.
 - A dedicated leads table is rejected because it would duplicate contact
   identity and tenant ownership for three contact-lifecycle attributes.
+- The storage maturity baseline accepts two `get_db_pool` test seams
+  (`INTERNAL_MOCK` 32 -> 34). One captures the provider's exact SQL/arguments;
+  the other routes the production provider through disposable real Postgres
+  for the entrypoint proof. Adding a production pool-injection surface solely
+  for these tests would widen the runtime contract without improving the
+  vertical behavior.
 
 ## Deferred
 
@@ -135,6 +142,8 @@ Parked hardening: none.
   - passed.
 - Plan sync check
   - passed.
+- `/home/juan-canfield/Desktop/Atlas/.venv/bin/python scripts/maturity_sweep.py atlas_brain/storage --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_storage.json --min-score 8`
+  - passed: no brittleness above the recorded intentional baseline.
 - ATLAS_CURRENT_PR_BODY_FILE=/tmp/eom-lead-pipeline-pr-body.md ATLAS_SESSION_STATE_FILE=SESSION_STATE.codex-eom-lead-pipeline.local.md bash scripts/local_pr_review.sh
   - passed; the pre-existing plans-archive backlog was advisory only.
 
@@ -147,9 +156,10 @@ Parked hardening: none.
 | `atlas_brain/mcp/crm_server.py` | 166 |
 | `atlas_brain/services/crm_provider.py` | 81 |
 | `atlas_brain/storage/migrations/346_contact_lead_pipeline.sql` | 21 |
-| `plans/PR-EOM-Lead-Pipeline.md` | 155 |
+| `plans/PR-EOM-Lead-Pipeline.md` | 165 |
+| `tests/maturity_sweep/baseline_atlas_brain_storage.json` | 4 |
 | `tests/test_crm_read_scoping.py` | 154 |
 | `tests/test_eom_lead_pipeline_integration.py` | 114 |
 | `tests/test_leads_intake.py` | 20 |
 | `tests/test_migrations_runner.py` | 17 |
-| **Total** | **803** |
+| **Total** | **817** |

--- a/plans/PR-EOM-Lead-Pipeline.md
+++ b/plans/PR-EOM-Lead-Pipeline.md
@@ -1,0 +1,155 @@
+# PR-EOM-Lead-Pipeline
+
+## Why this slice exists
+
+Issue #2167 splits Phase 4a from the completed EOM operational-CRM audit
+(#2151). EOM leads are durable contacts, but the data model has no durable
+pipeline state, owner, or follow-up timestamp. An operator therefore cannot
+record lead progress or ask the CRM which EOM leads need attention.
+
+This vertical slice exceeds the 400-LOC target because the production behavior
+and its inseparable proof span the additive migration, canonical provider,
+existing MCP tools, intake entrypoint, boundary tests, real-Postgres
+reachability test, and the CI job that provisions Postgres for that test. No
+adjacent product behavior is included.
+
+### Problem-derived contract
+
+- Root cause: lead lifecycle attributes are absent from the canonical contact
+  persistence and CRM port. The intake path cannot initialize pipeline state,
+  and the operator surface cannot persist or query actionable follow-ups.
+- Correct fix must touch/change: extend the existing contact record with
+  backward-compatible lead stage, owner, and next-follow-up fields; carry those
+  fields through the canonical CRM provider; expose tenant-scoped MCP operations
+  that update a visible lead and query visible leads needing follow-up; and have
+  the real EOM intake entrypoint assign the initial stage only when it creates a
+  new lead. Prove the migration, provider behavior, tenant boundary, idempotent
+  re-intake behavior, and real entrypoint-to-persisted-state path.
+- Must not change: the existing definition of a lead
+  (`contacts.contact_type = 'lead'`), contact visibility/legacy-claim semantics
+  from #2157/#2165, existing customer or non-lead records, acknowledgement
+  delivery, website copy, complaint tracking, scheduling, pricing, API auth,
+  or tenant-addressability of email history.
+
+## Scope (this PR)
+
+Ownership lane: eom-crm/lead-funnel
+Slice phase: Vertical slice
+
+1. Add durable, optional pipeline fields to canonical contact records and make
+   them available through the CRM provider.
+2. Add a narrow MCP write/read pair for lead pipeline work, preserving the
+   default EOM-plus-unclaimed tenant visibility boundary.
+3. Stamp newly created EOM intake leads with the initial `new` stage without
+   resetting pipeline state when the same lead submits again.
+4. Add migration, provider, MCP, and real intake-entrypoint behavioral proof.
+
+### Review Contract
+
+- Acceptance criteria:
+  - Existing contacts remain valid after migration with nullable pipeline
+    fields, and returned contact objects include those fields.
+  - A caller can update stage, owner, and next follow-up for a visible lead
+    without converting or mutating a non-lead contact.
+  - A caller can query due leads by an inclusive follow-up cutoff; the tenant
+    predicate is applied in SQL before ordering and limiting.
+  - Default-scoped MCP calls see only `effingham_maids` plus claimable legacy
+    rows, while explicit context remains supported and foreign rows fail closed.
+  - A newly created EOM intake lead is persisted with stage `new`; a repeated
+    intake does not reset an existing lead's pipeline fields.
+  - Existing CRM callers and contact responses remain backward compatible.
+- Reachability proof: call the real lead-intake FastAPI entrypoint and assert
+  the canonical provider persists a new lead with `lead_stage = 'new'`; invoke
+  the registered MCP tool functions and assert observable provider/SQL results.
+- Affected surfaces: Postgres contact migration, CRM provider port and database
+  adapter, CRM MCP server, EOM lead-intake API, focused tests, and the focused
+  Postgres-backed CI workflow.
+- Risk areas: online migration compatibility, tenant isolation, SQL filtering
+  before `LIMIT`, mutation of non-leads, repeated-intake state reset, timestamp
+  timezone handling, and public/MCP backward compatibility.
+- Reviewer rules triggered: R1, R2, R3, R4, R5, R7, R8, R10, R12, R14.
+
+### Files touched
+
+- `.github/workflows/atlas_eom_lead_pipeline_checks.yml`
+- `atlas_brain/api/leads.py`
+- `atlas_brain/mcp/crm_server.py`
+- `atlas_brain/services/crm_provider.py`
+- `atlas_brain/storage/migrations/346_contact_lead_pipeline.sql`
+- `plans/PR-EOM-Lead-Pipeline.md`
+- `tests/test_crm_read_scoping.py`
+- `tests/test_eom_lead_pipeline_integration.py`
+- `tests/test_leads_intake.py`
+- `tests/test_migrations_runner.py`
+
+## Mechanism
+
+Use nullable columns on `contacts`, rather than a second lead table, because a
+lead is already represented by the canonical contact row and the three fields
+have the same lifecycle. The MCP layer performs transport-level text/timestamp
+normalization while the provider enforces lead-only persistence and builds the
+tenant-scoped due query. The existing `update_contact` and `list_contacts`
+tools are extended instead of adding a parallel surface. Intake supplies the
+initial stage on creation and leaves an existing row's pipeline state intact.
+
+## Intentional
+
+- Stage and owner remain caller-defined strings, matching the existing
+  unconstrained CRM vocabulary; this slice does not invent a larger stage
+  taxonomy or user-management model.
+- Existing rows stay nullable instead of receiving a speculative backfill.
+- Existing `create_contact`/`update_contact` callers that omit the three new
+  fields keep their prior SQL and merge behavior; the CRM MCP compatibility
+  tests cover the unchanged generic paths.
+- The additive migration uses a normal partial index rather than a concurrent
+  index because the live contacts table is small; rollback is the direct
+  removal of the optional index/columns if deployment must be reversed.
+- A dedicated leads table is rejected because it would duplicate contact
+  identity and tenant ownership for three contact-lifecycle attributes.
+
+## Deferred
+
+- Complaints tracking remains #2168.
+- Recurring schedules, cleaner assignment, and per-visit pricing remain #2169.
+- Contacts API auth/scoping remains #2170.
+- Tenant-addressable email history remains #2171.
+- Terms acceptance and card-on-file remain epic #2156.
+
+Parked hardening: none.
+
+## Verification
+
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas@127.0.0.1:55432/atlas_migration_tests /home/juan-canfield/Desktop/Atlas/.venv/bin/python -m pytest tests/test_crm_read_scoping.py tests/test_eom_lead_pipeline_integration.py tests/test_leads_intake.py tests/test_migrations_runner.py -q`
+  - passed: 107 (disposable Postgres 16 container)
+- `/home/juan-canfield/Desktop/Atlas/.venv/bin/python -m pytest tests/test_mcp_servers.py -q -k 'CRM or crm'`
+  - passed: 22; deselected: 58
+- /home/juan-canfield/Desktop/Atlas/.venv/bin/python scripts/audit_mcp_tool_names_match_docs.py
+  - passed: CRM inventory remains 10/10; all MCP inventories match.
+- /home/juan-canfield/Desktop/Atlas/.venv/bin/python scripts/audit_claude_md_claims.py
+  - passed: CRM count remains 10/10; all MCP count claims match.
+- bash scripts/check_ascii_python.sh
+  - passed.
+- `git diff --check`
+  - passed.
+- Workflow YAML parse and pinned Postgres-image assertion
+  - passed.
+- Plan sync check
+  - passed.
+- ATLAS_CURRENT_PR_BODY_FILE=/tmp/eom-lead-pipeline-pr-body.md ATLAS_SESSION_STATE_FILE=SESSION_STATE.codex-eom-lead-pipeline.local.md bash scripts/local_pr_review.sh
+  - passed; the pre-existing plans-archive backlog was advisory only.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 74 |
+| `atlas_brain/api/leads.py` | 1 |
+| `atlas_brain/mcp/crm_server.py` | 166 |
+| `atlas_brain/services/crm_provider.py` | 81 |
+| `atlas_brain/storage/migrations/346_contact_lead_pipeline.sql` | 21 |
+| `plans/PR-EOM-Lead-Pipeline.md` | 155 |
+| `tests/test_crm_read_scoping.py` | 154 |
+| `tests/test_eom_lead_pipeline_integration.py` | 114 |
+| `tests/test_leads_intake.py` | 20 |
+| `tests/test_migrations_runner.py` | 17 |
+| **Total** | **803** |

--- a/tests/maturity_sweep/baseline_atlas_brain_storage.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_storage.json
@@ -8,9 +8,9 @@
   "atlas_brain/storage/database.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
-      "INTERNAL_MOCK": 34
+      "INTERNAL_MOCK": 33
     },
-    "score": 140
+    "score": 136
   },
   "atlas_brain/storage/models.py": {
     "counts": {

--- a/tests/maturity_sweep/baseline_atlas_brain_storage.json
+++ b/tests/maturity_sweep/baseline_atlas_brain_storage.json
@@ -8,9 +8,9 @@
   "atlas_brain/storage/database.py": {
     "counts": {
       "HAPPY_PATH_TESTS": 1,
-      "INTERNAL_MOCK": 32
+      "INTERNAL_MOCK": 34
     },
-    "score": 132
+    "score": 140
   },
   "atlas_brain/storage/models.py": {
     "counts": {

--- a/tests/test_crm_read_scoping.py
+++ b/tests/test_crm_read_scoping.py
@@ -336,51 +336,21 @@ async def test_due_lead_list_uses_one_sql_scoped_population(
 
 
 @pytest.mark.asyncio
-async def test_provider_filters_due_leads_before_order_and_limit(monkeypatch):
-    from atlas_brain.services.crm_provider import DatabaseCRMProvider
-    import atlas_brain.storage.database as db_mod
-
-    pool = MagicMock()
-    pool.fetch = AsyncMock(return_value=[])
-    monkeypatch.setattr(db_mod, "get_db_pool", lambda: pool)
-    cutoff = datetime(2026, 7, 24, 22, tzinfo=timezone.utc)
-
-    await DatabaseCRMProvider().list_contacts(
-        business_context_id=EOM,
-        include_unclaimed_legacy=True,
-        contact_type="lead",
-        next_follow_up_before=cutoff,
-        limit=10,
-    )
-
-    sql = " ".join(pool.fetch.await_args.args[0].split())
-    assert "(business_context_id = $2 OR business_context_id IS NULL)" in sql
-    assert "contact_type = $3" in sql
-    assert "next_follow_up_at <= $4" in sql
-    assert sql.index("WHERE") < sql.index("ORDER BY") < sql.index("LIMIT")
-    assert pool.fetch.await_args.args[1:] == (
-        "active", EOM, "lead", cutoff, 10, 0
-    )
-
-    pool.fetchrow = AsyncMock(return_value=None)
-    await DatabaseCRMProvider().update_contact(
-        UUID, {"lead_stage": "qualified"}
-    )
-    update_sql = " ".join(pool.fetchrow.await_args.args[0].split())
-    assert "WHERE id = $1 AND contact_type = $4" in update_sql
-    assert pool.fetchrow.await_args.args[-1] == "lead"
-
-
-@pytest.mark.asyncio
 async def test_provider_rejects_pipeline_fields_on_new_non_lead():
     from atlas_brain.services.crm_provider import DatabaseCRMProvider
 
+    provider = DatabaseCRMProvider()
     with pytest.raises(ValueError, match="contact_type='lead'"):
-        await DatabaseCRMProvider().create_contact({
+        await provider.create_contact({
             "full_name": "Customer",
             "contact_type": "customer",
             "lead_stage": "new",
         })
+    with pytest.raises(ValueError, match="contact_type='lead'"):
+        await provider.update_contact(
+            UUID,
+            {"contact_type": "customer", "lead_stage": "qualified"},
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_crm_read_scoping.py
+++ b/tests/test_crm_read_scoping.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import ast
 import json
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -227,6 +228,159 @@ async def test_list_contacts_merges_null_page_under_default(default_ctx, monkeyp
     assert calls[0].kwargs["business_context_id"] == EOM
     assert calls[1].kwargs["business_context_id_is_null"] is True
     assert [c["id"] for c in out["contacts"]] == ["t1", "n1"]
+
+
+@pytest.mark.asyncio
+async def test_update_lead_pipeline_is_scoped_and_requires_lead(
+    default_ctx, monkeypatch
+):
+    provider = _provider_mock(
+        monkeypatch,
+        get={**SAME, "contact_type": "lead"},
+    )
+    out = json.loads(await crm_srv.update_contact(
+        UUID,
+        lead_stage=" qualified ",
+        lead_owner=" Juan ",
+        next_follow_up_at="2026-07-24T10:00:00-05:00",
+    ))
+
+    assert out["success"] is True
+    args, kwargs = provider.update_contact.await_args
+    assert args[0] == UUID
+    assert args[1] == {
+        "lead_stage": "qualified",
+        "lead_owner": "Juan",
+        "next_follow_up_at": datetime(2026, 7, 24, 15, tzinfo=timezone.utc),
+    }
+    assert kwargs == {"require_contact_type": "lead"}
+
+
+@pytest.mark.asyncio
+async def test_update_lead_pipeline_rejects_non_lead_and_foreign(
+    default_ctx, monkeypatch
+):
+    provider = _provider_mock(
+        monkeypatch,
+        get={**SAME, "contact_type": "customer"},
+    )
+    not_lead = json.loads(await crm_srv.update_contact(UUID, lead_stage="new"))
+    assert not_lead["success"] is False
+    assert "lead contact" in not_lead["error"]
+    provider.update_contact.assert_not_awaited()
+
+    provider.get_contact.return_value = {**FOREIGN, "contact_type": "lead"}
+    foreign = json.loads(await crm_srv.update_contact(UUID, lead_stage="new"))
+    assert foreign == {"success": False, "error": "Contact not found"}
+    provider.update_contact.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_update_lead_pipeline_clear_and_validation(default_ctx, monkeypatch):
+    provider = _provider_mock(
+        monkeypatch,
+        get={**SAME, "contact_type": "lead"},
+    )
+    cleared = json.loads(await crm_srv.update_contact(
+        UUID, clear_lead_owner=True, clear_next_follow_up=True
+    ))
+    assert cleared["success"] is True
+    assert provider.update_contact.await_args.args[1] == {
+        "lead_owner": None,
+        "next_follow_up_at": None,
+    }
+
+    provider.update_contact.reset_mock()
+    invalid = json.loads(await crm_srv.update_contact(
+        UUID, next_follow_up_at="2026-07-24T10:00:00"
+    ))
+    assert invalid["success"] is False
+    assert "UTC offset" in invalid["error"]
+    provider.update_contact.assert_not_awaited()
+
+
+def test_pipeline_input_boundaries():
+    assert crm_srv._pipeline_text("x" * 64, "lead_stage", 64) == "x" * 64
+    with pytest.raises(ValueError, match="at most 64"):
+        crm_srv._pipeline_text("x" * 65, "lead_stage", 64)
+    assert crm_srv._pipeline_timestamp(
+        "2026-07-24T22:00:00Z", "next_follow_up_at"
+    ) == datetime(2026, 7, 24, 22, tzinfo=timezone.utc)
+    with pytest.raises(ValueError, match="at most 64"):
+        crm_srv._pipeline_timestamp("2" * 65, "next_follow_up_at")
+
+
+@pytest.mark.asyncio
+async def test_due_lead_list_uses_one_sql_scoped_population(
+    default_ctx, monkeypatch
+):
+    provider = _provider_mock(monkeypatch)
+    provider.list_contacts.return_value = [{"id": "due-1"}]
+
+    out = json.loads(await crm_srv.list_contacts(
+        lead_stage="qualified",
+        next_follow_up_before="2026-07-24T17:00:00-05:00",
+        limit=10,
+    ))
+
+    assert [row["id"] for row in out["contacts"]] == ["due-1"]
+    provider.list_contacts.assert_awaited_once()
+    kwargs = provider.list_contacts.await_args.kwargs
+    assert kwargs["business_context_id"] == EOM
+    assert kwargs["include_unclaimed_legacy"] is True
+    assert kwargs["contact_type"] == "lead"
+    assert kwargs["lead_stage"] == "qualified"
+    assert kwargs["next_follow_up_before"] == datetime(
+        2026, 7, 24, 22, tzinfo=timezone.utc
+    )
+
+
+@pytest.mark.asyncio
+async def test_provider_filters_due_leads_before_order_and_limit(monkeypatch):
+    from atlas_brain.services.crm_provider import DatabaseCRMProvider
+    import atlas_brain.storage.database as db_mod
+
+    pool = MagicMock()
+    pool.fetch = AsyncMock(return_value=[])
+    monkeypatch.setattr(db_mod, "get_db_pool", lambda: pool)
+    cutoff = datetime(2026, 7, 24, 22, tzinfo=timezone.utc)
+
+    await DatabaseCRMProvider().list_contacts(
+        business_context_id=EOM,
+        include_unclaimed_legacy=True,
+        contact_type="lead",
+        next_follow_up_before=cutoff,
+        limit=10,
+    )
+
+    sql = " ".join(pool.fetch.await_args.args[0].split())
+    assert "(business_context_id = $2 OR business_context_id IS NULL)" in sql
+    assert "contact_type = $3" in sql
+    assert "next_follow_up_at <= $4" in sql
+    assert sql.index("WHERE") < sql.index("ORDER BY") < sql.index("LIMIT")
+    assert pool.fetch.await_args.args[1:] == (
+        "active", EOM, "lead", cutoff, 10, 0
+    )
+
+    pool.fetchrow = AsyncMock(return_value=None)
+    await DatabaseCRMProvider().update_contact(
+        UUID, {"lead_stage": "qualified"}
+    )
+    update_sql = " ".join(pool.fetchrow.await_args.args[0].split())
+    assert "WHERE id = $1 AND contact_type = $4" in update_sql
+    assert pool.fetchrow.await_args.args[-1] == "lead"
+
+
+@pytest.mark.asyncio
+async def test_provider_rejects_pipeline_fields_on_new_non_lead():
+    from atlas_brain.services.crm_provider import DatabaseCRMProvider
+
+    with pytest.raises(ValueError, match="contact_type='lead'"):
+        await DatabaseCRMProvider().create_contact({
+            "full_name": "Customer",
+            "contact_type": "customer",
+            "lead_stage": "new",
+        })
 
 
 @pytest.mark.asyncio

--- a/tests/test_eom_lead_pipeline_integration.py
+++ b/tests/test_eom_lead_pipeline_integration.py
@@ -1,0 +1,114 @@
+"""Real-Postgres reachability proof for the EOM lead pipeline slice."""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+asyncpg = pytest.importorskip("asyncpg")
+
+from atlas_brain.api import leads as leads_mod  # noqa: E402
+from atlas_brain.services.crm_provider import DatabaseCRMProvider  # noqa: E402
+
+
+ROOT = Path(__file__).resolve().parent.parent
+MIGRATIONS = ROOT / "atlas_brain" / "storage" / "migrations"
+DATABASE_URL_ENV = "ATLAS_MIGRATION_TEST_DATABASE_URL"
+
+
+@pytest.mark.asyncio
+async def test_intake_to_pipeline_roundtrip_preserves_managed_state(monkeypatch):
+    database_url = os.environ.get(DATABASE_URL_ENV)
+    if not database_url:
+        pytest.skip(f"{DATABASE_URL_ENV} is not configured")
+
+    schema = f"atlas_lead_pipeline_{uuid.uuid4().hex}"
+    conn = await asyncpg.connect(database_url)
+    try:
+        await conn.execute(f'CREATE SCHEMA "{schema}"')
+        await conn.execute(f'SET search_path TO "{schema}", public')
+        await conn.execute("CREATE TABLE appointments (id UUID PRIMARY KEY)")
+        for name in (
+            "035_contacts.sql",
+            "256_contact_interaction_dedupe.sql",
+            "346_contact_lead_pipeline.sql",
+        ):
+            await conn.execute((MIGRATIONS / name).read_text())
+
+        import atlas_brain.storage.database as db_mod
+
+        monkeypatch.setattr(db_mod, "get_db_pool", lambda: conn)
+        from atlas_brain.config import settings
+
+        monkeypatch.setattr(settings.email, "enabled", False)
+        provider = DatabaseCRMProvider()
+        app = FastAPI()
+        app.include_router(leads_mod.router, prefix="/api/v1")
+        app.dependency_overrides[leads_mod._crm_dependency] = lambda: provider
+        app.dependency_overrides[leads_mod._email_dependency] = (
+            lambda: MagicMock(send=AsyncMock())
+        )
+
+        async def zero_count(*_args):
+            return 0
+
+        app.dependency_overrides[leads_mod._daily_count_dependency] = (
+            lambda: zero_count
+        )
+        app.dependency_overrides[leads_mod._ack_volume_dependency] = (
+            lambda: zero_count
+        )
+
+        payload = {
+            "name": "Pipeline Proof",
+            "email": "pipeline-proof@example.com",
+        }
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            created = await client.post("/api/v1/leads/intake", json=payload)
+            assert created.status_code == 200
+
+            contact = await conn.fetchrow(
+                "SELECT * FROM contacts WHERE email = $1", payload["email"]
+            )
+            assert contact["lead_stage"] == "new"
+            assert contact["business_context_id"] == "effingham_maids"
+
+            follow_up = datetime(2026, 7, 25, 15, tzinfo=timezone.utc)
+            await provider.update_contact(
+                str(contact["id"]),
+                {
+                    "lead_stage": "qualified",
+                    "lead_owner": "Juan",
+                    "next_follow_up_at": follow_up,
+                },
+                require_contact_type="lead",
+            )
+            repeated = await client.post("/api/v1/leads/intake", json=payload)
+            assert repeated.status_code == 200
+
+        persisted = await conn.fetchrow(
+            """
+            SELECT lead_stage, lead_owner, next_follow_up_at
+            FROM contacts
+            WHERE id = $1
+            """,
+            contact["id"],
+        )
+        assert dict(persisted) == {
+            "lead_stage": "qualified",
+            "lead_owner": "Juan",
+            "next_follow_up_at": follow_up,
+        }
+    finally:
+        await conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        await conn.close()

--- a/tests/test_eom_lead_pipeline_integration.py
+++ b/tests/test_eom_lead_pipeline_integration.py
@@ -93,22 +93,97 @@ async def test_intake_to_pipeline_roundtrip_preserves_managed_state(monkeypatch)
                 },
                 require_contact_type="lead",
             )
+            with pytest.raises(ValueError, match="contact_type='lead'"):
+                await provider.update_contact(
+                    str(contact["id"]),
+                    {
+                        "contact_type": "customer",
+                        "lead_stage": "converted",
+                    },
+                )
             repeated = await client.post("/api/v1/leads/intake", json=payload)
             assert repeated.status_code == 200
 
         persisted = await conn.fetchrow(
             """
-            SELECT lead_stage, lead_owner, next_follow_up_at
+            SELECT contact_type, lead_stage, lead_owner, next_follow_up_at
             FROM contacts
             WHERE id = $1
             """,
             contact["id"],
         )
         assert dict(persisted) == {
+            "contact_type": "lead",
             "lead_stage": "qualified",
             "lead_owner": "Juan",
             "next_follow_up_at": follow_up,
         }
+
+        await conn.executemany(
+            """
+            INSERT INTO contacts (
+                full_name, business_context_id, contact_type, status,
+                lead_stage, next_follow_up_at
+            )
+            VALUES ($1, $2, $3, $4, $5, $6)
+            """,
+            [
+                (
+                    "Foreign Earlier",
+                    "churnsignals",
+                    "lead",
+                    "active",
+                    "qualified",
+                    datetime(2026, 7, 25, 12, tzinfo=timezone.utc),
+                ),
+                (
+                    "Non-lead Earlier",
+                    "effingham_maids",
+                    "customer",
+                    "active",
+                    "qualified",
+                    datetime(2026, 7, 25, 13, tzinfo=timezone.utc),
+                ),
+                (
+                    "Legacy Due",
+                    None,
+                    "lead",
+                    "active",
+                    "qualified",
+                    datetime(2026, 7, 25, 16, tzinfo=timezone.utc),
+                ),
+                (
+                    "Archived Earlier",
+                    "effingham_maids",
+                    "lead",
+                    "archived",
+                    "qualified",
+                    datetime(2026, 7, 25, 11, tzinfo=timezone.utc),
+                ),
+                (
+                    "Tenant Future",
+                    "effingham_maids",
+                    "lead",
+                    "active",
+                    "qualified",
+                    datetime(2026, 7, 25, 17, tzinfo=timezone.utc),
+                ),
+            ],
+        )
+        due = await provider.list_contacts(
+            business_context_id="effingham_maids",
+            include_unclaimed_legacy=True,
+            contact_type="lead",
+            lead_stage="qualified",
+            next_follow_up_before=datetime(
+                2026, 7, 25, 16, tzinfo=timezone.utc
+            ),
+            limit=2,
+        )
+        assert [row["full_name"] for row in due] == [
+            "Pipeline Proof",
+            "Legacy Due",
+        ]
     finally:
         await conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
         await conn.close()

--- a/tests/test_leads_intake.py
+++ b/tests/test_leads_intake.py
@@ -116,6 +116,7 @@ async def test_contact_stamped_with_eom_tenant_and_web_source():
     assert kwargs["source"] == "web"
     assert kwargs["source_ref"] == "website_estimate_form"
     assert kwargs["tags"] == ["website", "estimate_request"]
+    assert kwargs["lead_stage"] == "new"
     assert kwargs["email"] == "jane@example.com"
     assert kwargs["phone"] == "2175550100"  # digits-only normalization
 
@@ -455,6 +456,25 @@ async def test_existing_eom_contact_not_mutated_or_downgraded():
     # shared/mistyped email must not steal the match)
     first = crm.search_contacts.await_args_list[0]
     assert "phone" in first.kwargs
+
+
+@pytest.mark.asyncio
+async def test_repeat_intake_does_not_reset_existing_lead_pipeline():
+    existing = [{
+        "id": "lead-9",
+        "contact_type": "lead",
+        "business_context_id": EOM_BUSINESS_CONTEXT_ID,
+        "lead_stage": "qualified",
+        "lead_owner": "Juan",
+        "next_follow_up_at": "2026-07-24T15:00:00+00:00",
+    }]
+    crm, provider = _crm(existing=existing), _email_provider()
+
+    await _process_lead_intake(_payload(), crm=crm, email_provider=provider)
+
+    crm.find_or_create_contact.assert_not_awaited()
+    crm.update_contact.assert_not_called()
+    assert crm.log_interaction.call_args.kwargs["contact_id"] == "lead-9"
 
 
 @pytest.mark.asyncio

--- a/tests/test_migrations_runner.py
+++ b/tests/test_migrations_runner.py
@@ -120,3 +120,20 @@ def test_repo_migration_prefix_collisions_are_only_historical_exceptions():
             "298_b2b_watchlist_preview_alert_policy.sql",
         ],
     }
+
+
+def test_contact_lead_pipeline_migration_is_additive_and_indexed():
+    migration = (
+        Path(__file__).resolve().parent.parent
+        / "atlas_brain"
+        / "storage"
+        / "migrations"
+        / "346_contact_lead_pipeline.sql"
+    ).read_text()
+
+    assert "ADD COLUMN IF NOT EXISTS lead_stage VARCHAR(64)" in migration
+    assert "ADD COLUMN IF NOT EXISTS lead_owner VARCHAR(128)" in migration
+    assert "ADD COLUMN IF NOT EXISTS next_follow_up_at TIMESTAMPTZ" in migration
+    assert "idx_contacts_lead_follow_up" in migration
+    assert "WHERE contact_type = 'lead'" in migration
+    assert "DROP " not in migration.upper()


### PR DESCRIPTION
Plan: plans/PR-EOM-Lead-Pipeline.md
Slice phase: Vertical slice
Ownership lane: eom-crm/lead-funnel

Issue #2167 exists because EOM leads are canonical CRM contacts without durable pipeline state, ownership, or follow-up scheduling. This slice adds those optional fields to the existing contact model, carries them through the canonical provider and existing CRM MCP tools, and initializes only newly created website leads without changing repeat-intake state.

Diff-budget override: The 877-LOC slice is genuinely indivisible because its production migration, canonical provider behavior, existing MCP operator path, real intake entrypoint, tenant and boundary tests, disposable-Postgres reachability proof, and dedicated CI enrollment together prove the smallest usable end-to-end lead-pipeline flow.

## Intentional
- Stage and owner are caller-defined strings; this slice does not invent a stage taxonomy or user directory.
- Existing contacts remain nullable and are not speculatively backfilled.
- The existing `update_contact` and `list_contacts` tools are extended, so the CRM MCP inventory remains backward-compatible at 10 tools.
- The normal partial index is appropriate for the small live contacts table; rollback is removal of the optional index and columns.
- A pipeline update may deliberately demote a lead only when it does not also write lead-only pipeline fields; the contradictory atomic combination is rejected.
- The storage maturity baseline accepts one `get_db_pool` integration seam (`INTERNAL_MOCK` 32 -> 33) that routes the production provider through disposable real Postgres. The SQL-capturing mock was removed in favor of observable result rows.

## Deferred
- Complaints tracking: #2168.
- Recurring schedule, cleaner assignment, and per-visit pricing: #2169.
- Contacts API auth/scoping: #2170.
- Tenant-addressable email history: #2171.
- Terms acceptance and card-on-file: epic #2156.

## Parked hardening
- None.

## Cold diff reconstruction
- Gaps: None. Every changed production path and proof traces to the problem-derived contract; no forbidden adjacent lane or product-shape change remains.
- Changed: `atlas_brain/storage/migrations/346_contact_lead_pipeline.sql:5` adds three nullable contact columns, and `:10` adds the active-lead follow-up index.
- Changed: `atlas_brain/services/crm_provider.py:122` rejects pipeline data for newly inserted non-leads; `:194` deliberately keeps pipeline fields out of dedupe merges; `:220` persists the fields on a new contact; `:375` rejects an atomic pipeline-write plus non-lead type change before SQL; `:387` requires the existing row to be a lead; and `:482` builds stage/owner/due filters with the combined tenant-plus-legacy predicate before ordering and limiting.
- Changed: `atlas_brain/mcp/crm_server.py:102` validates field lengths and offset-aware timestamps; `:455` extends the existing update tool with guarded set/clear behavior and the established tenant claim path; `:614` extends the existing list tool with lead filters and one-query default-scope pagination.
- Changed: `atlas_brain/api/leads.py:256` supplies `lead_stage='new'` only inside the no-existing-contact branch.
- Changed: `tests/test_crm_read_scoping.py:233` proves visible-lead mutation, non-lead/foreign refusal, clearing, validation boundaries, combined MCP scoping, and contradictory provider-write rejection; `tests/test_leads_intake.py:106` proves initial-stage wiring and `:461` proves repeated intake does not reset managed state.
- Changed: `tests/test_eom_lead_pipeline_integration.py:26` applies the real migrations in disposable Postgres and proves HTTP intake -> canonical provider -> persisted `new` stage -> managed update -> contradictory demotion refusal -> repeated intake preserves the managed values; `:122` inserts tenant, legacy, foreign, non-lead, archived, and future rows, and `:173` asserts the ordered, limited due-list result.
- Changed: `.github/workflows/atlas_eom_lead_pipeline_checks.yml:32` provisions Postgres 16 and runs the full focused suite so the live persistence proof cannot silently skip in CI.
- Changed: `tests/maturity_sweep/baseline_atlas_brain_storage.json:11` records the one intentional `get_db_pool` integration seam and no other maturity change.
- Contract match: the migration/provider changes supply durable state; the existing MCP tools supply the tenant-scoped operator write/read path; the intake change initializes new leads; and the focused plus real-Postgres tests prove the acceptance criteria.
- Gaps: None. MCP tool names/counts remain unchanged, non-pipeline update/list branches remain intact, foreign rows still fail closed, and complaints/scheduling/pricing/auth/email-store work is untouched.

## Verification
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas:atlas@127.0.0.1:55432/atlas_migration_tests /home/juan-canfield/Desktop/Atlas/.venv/bin/python -m pytest tests/test_crm_read_scoping.py tests/test_eom_lead_pipeline_integration.py tests/test_leads_intake.py tests/test_migrations_runner.py -q` — 106 passed against disposable Postgres 16.
- `/home/juan-canfield/Desktop/Atlas/.venv/bin/python -m pytest tests/test_mcp_servers.py -q -k 'CRM or crm'` — 22 passed, 58 deselected.
- `/home/juan-canfield/Desktop/Atlas/.venv/bin/python scripts/maturity_sweep.py atlas_brain/storage --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_storage.json --min-score 8` — passed with no brittleness above the recorded intentional baseline.
- MCP name/count audits — all inventories matched; CRM remained 10/10.
- ASCII check, workflow YAML parse/pinned-image assertion, `git diff --check`, plan sync check, and local review — passed.

## Diff size
11 files, +850 / -27. The plan explains why the migration, vertical behavior, real-Postgres proof, CI enrollment, and one-line maturity ratchet are indivisible despite exceeding the 400-LOC target.
