### PR TITLE
ci: add httpx to the pre_push_audit tooling-test install

### DIFF
--- a/.github/workflows/pre_push_audit.yml
+++ b/.github/workflows/pre_push_audit.yml
@@ -79,7 +79,7 @@ jobs:
       # the PR checkout above is data and must not be executed.
       - name: PR-review tooling unit tests
         run: |
-          python -m pip install --quiet pytest pytest-asyncio pyyaml jsonschema
+          python -m pip install --quiet pytest pytest-asyncio pyyaml jsonschema httpx
           python -m pytest tests/test_local_pr_review.py tests/test_audit_ai_reconciliation.py tests/test_audit_review_rules_triggered.py tests/test_summarize_review_misses.py tests/test_check_ai_reconciliation_live.py tests/test_pre_push_audit_workflow.py tests/test_pr_body_contract_workflow.py tests/test_check_review_body_r14.py tests/test_push_pr_wrapper.py tests/test_open_pr_wrapper.py tests/test_audit_pr_body.py tests/test_audit_pr_plan_presence.py tests/test_plan_admission_workflow.py tests/test_audit_plan_doc.py tests/test_audit_pr_session_drift.py tests/test_session_lane_workflow.py tests/test_new_pr_plan.py tests/test_pre_push_audit.py tests/test_check_deflection_full_report_proof_bundle.py tests/test_check_gitleaks_baseline_rotation.py tests/test_security_guardrails_workflow.py tests/test_audit_workflow_security_posture.py tests/test_claude_workflow_security.py tests/test_deflection_report_ttl_workflow.py tests/test_fix_mode_hook.py tests/test_eval_local_mcp_models.py tests/test_check_diff_budget.py tests/test_codex_wake_bridge.py tests/test_audit_pr_watcher_safety.py tests/test_report_pr_watcher_state.py tests/test_set_claude_review_status.py -q
 
       - name: Workflow security posture audit
@@ -111,7 +111,7 @@ jobs:
 
       - name: PR-review tooling unit tests
         run: |
-          python -m pip install --quiet pytest pytest-asyncio pyyaml jsonschema
+          python -m pip install --quiet pytest pytest-asyncio pyyaml jsonschema httpx
           python -m pytest tests/test_local_pr_review.py tests/test_audit_ai_reconciliation.py tests/test_audit_review_rules_triggered.py tests/test_summarize_review_misses.py tests/test_check_ai_reconciliation_live.py tests/test_pre_push_audit_workflow.py tests/test_pr_body_contract_workflow.py tests/test_check_review_body_r14.py tests/test_push_pr_wrapper.py tests/test_open_pr_wrapper.py tests/test_audit_pr_body.py tests/test_audit_pr_plan_presence.py tests/test_plan_admission_workflow.py tests/test_audit_plan_doc.py tests/test_audit_pr_session_drift.py tests/test_session_lane_workflow.py tests/test_new_pr_plan.py tests/test_pre_push_audit.py tests/test_check_deflection_full_report_proof_bundle.py tests/test_check_gitleaks_baseline_rotation.py tests/test_security_guardrails_workflow.py tests/test_audit_workflow_security_posture.py tests/test_claude_workflow_security.py tests/test_deflection_report_ttl_workflow.py tests/test_fix_mode_hook.py tests/test_eval_local_mcp_models.py tests/test_check_diff_budget.py tests/test_codex_wake_bridge.py tests/test_audit_pr_watcher_safety.py tests/test_report_pr_watcher_state.py tests/test_set_claude_review_status.py -q
 
       - name: Workflow security posture audit

--- a/plans/PR-Pre-Push-Audit-Httpx.md
+++ b/plans/PR-Pre-Push-Audit-Httpx.md
@@ -1,0 +1,74 @@
+# PR-Pre-Push-Audit-Httpx
+
+## Why this slice exists
+
+The #2117 merge added `tests/test_eval_local_mcp_models.py` to the
+pre_push_audit tooling-test bundle; that suite imports the eval script
+whose live-runner path does a function-level `import httpx`
+(`scripts/eval_local_mcp_models.py:1453`). The workflow runs under
+`pull_request_target` (trusted-base execution, #1949), so #2117's own CI
+ran the pre-merge bundle and never exercised the new test — every PR
+since the merge now fails `pre-push-audit` with ModuleNotFoundError.
+Both requirements files already pin httpx==0.28.1; the workflow env is
+the only gap. Same class as #2117's in-PR jsonschema fix — which also
+only took effect post-merge for the same trusted-base reason.
+
+### Problem-derived contract
+
+- Root cause: workflow tooling-test env missing a dependency the merged
+  bundle needs; trusted-base execution hid it until after merge.
+- Correct fix must: add httpx to both tooling-test install lines.
+- Must not change: anything else.
+
+## Scope (this PR)
+
+Ownership lane: mcp/local-model-qualification
+Slice phase: workflow/process
+
+1. `.github/workflows/pre_push_audit.yml`: both tooling-test pip lines
+   gain `httpx`.
+
+### Review Contract
+
+- Acceptance criteria: the tooling-test bundle imports
+  `eval_local_mcp_models` end-to-end on a clean runner (post-merge, any
+  PR's `pre-push-audit` passes the import).
+- Reachability proof: `pre-push-audit` check on every PR after merge.
+- Affected surfaces: CI env only.
+- Risk areas: none (pinned dep already in requirements).
+- Reviewer rules triggered: R11, R12, R14.
+
+### Files touched
+
+- `.github/workflows/pre_push_audit.yml`
+- `plans/PR-Pre-Push-Audit-Httpx.md`
+
+## Mechanism
+
+One package name on two install lines.
+
+## Intentional
+
+- httpx unpinned on the install line, matching the bundle's existing
+  style (jsonschema etc.); the version contract lives in requirements.
+
+## Deferred
+
+- Nothing.
+
+Parked hardening: none new.
+
+## Verification
+
+- Local: `python -m pip install pytest pytest-asyncio pyyaml jsonschema
+  httpx` + the bundle's eval tests pass (103 in the harness suite).
+- The real proof is post-merge CI (trusted-base: this PR's own
+  pre-push-audit still runs the OLD line and still fails — expected).
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/pre_push_audit.yml` | 2 |
+| `plans/PR-Pre-Push-Audit-Httpx.md` | 60 |
+| **Total** | **~62** |


### PR DESCRIPTION
Plan: plans/PR-Pre-Push-Audit-Httpx.md
Slice phase: workflow/process
Ownership lane: mcp/local-model-qualification

Unbreaks `pre-push-audit` for every open PR: the #2117 merge added the
eval harness suite to the tooling-test bundle, whose live-runner path
imports httpx; the workflow runs under pull_request_target
(trusted-base), so the gap only surfaced post-merge. Both requirements
files already pin httpx==0.28.1.

## Intentional

- Both install lines updated; nothing else touched.
- This PR's own pre-push-audit still runs the OLD (base) line and still
  fails — expected under trusted-base; the fix takes effect on merge.

## Deferred

- Nothing.

## Parked hardening

None new.

## Cold diff reconstruction

One package name appended to two pip install lines + this plan.

## Verification

Local install of the bundle set + the 103-test harness suite passes.

## Diff size

2 files, ~62 LOC.

## AI reconciliation

No reviewer threads yet at open time; will reconcile any that arrive.

All fixed or waived: yes
