### PR TITLE
EOM CRM: bind scoped inbox reads to tenant mailboxes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -378,6 +378,10 @@ ATLAS_EMAIL_IMAP_USERNAME=
 ATLAS_EMAIL_IMAP_PASSWORD=         # For Gmail: 16-char app password (myaccount.google.com/apppasswords)
 ATLAS_EMAIL_IMAP_SSL=true
 ATLAS_EMAIL_IMAP_MAILBOX=INBOX
+
+# Scoped CRM inbox reads require an explicit JSON binding per business context.
+# This slice supports explicit IMAP credentials only.
+ATLAS_EMAIL_INBOX_CONTEXT_BINDINGS='{"effingham_maids":{"provider":"imap","imap_host":"imap.gmail.com","imap_username":"office@example.com","imap_password":"app-password"}}'
 ```
 
 ## NocoDB CRM Setup
@@ -428,6 +432,13 @@ Tools: `search_contacts`, `get_contact`, `create_contact`, `update_contact`,
 `get_customer_context`,
 `open_customer_service_ticket`, `list_customer_service_tickets`,
 `update_customer_service_ticket`, `close_customer_service_ticket`
+
+Scoped get_customer_context inbox history is fail-closed. Configure
+ATLAS_EMAIL_INBOX_CONTEXT_BINDINGS as a JSON object keyed by the exact CRM
+business_context_id; an unmapped context omits inbox_emails without opening
+the global IMAP/Gmail account. This slice accepts provider "imap" with the
+imap_* fields shown above. Scoped Gmail OAuth requires a separate
+database-backed credential-state slice.
 
 ### Email MCP Server (9 tools)
 ```bash

--- a/atlas_brain/config.py
+++ b/atlas_brain/config.py
@@ -5,9 +5,18 @@ Configuration is loaded from environment variables with sensible defaults.
 """
 
 from pathlib import Path
-from typing import Any, Optional
+from typing import Annotated, Any, Literal, Optional
 
-from pydantic import AliasChoices, BaseModel, Field, field_validator, model_validator
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    Field,
+    SecretStr,
+    TypeAdapter,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from .config_defaults import (
@@ -18,6 +27,8 @@ from .config_defaults import (
 
 ENV_FILES = (".env", ".env.local")
 DEFAULT_OPENROUTER_CLAUDE_SONNET_MODEL = "anthropic/claude-sonnet-4-5"
+_IMAP_PORT_ADAPTER = TypeAdapter(Annotated[int, Field(ge=1, le=65535)])
+_IMAP_SSL_ADAPTER = TypeAdapter(bool)
 
 
 class LLMGatewayConfig(BaseSettings):
@@ -804,10 +815,103 @@ class AlertsConfig(BaseSettings):
     ntfy_topic: str = Field(default="atlas-alerts", description="ntfy topic for alerts")
 
 
+class InboxMailboxBinding(BaseModel):
+    """One CRM business context's authorized IMAP inbox."""
+
+    model_config = {"extra": "forbid", "hide_input_in_errors": True}
+
+    provider: Literal["imap"]
+    imap_host: str = ""
+    imap_port: int = Field(default=993, ge=1, le=65535)
+    imap_username: str = ""
+    imap_password: SecretStr = SecretStr("")
+    imap_ssl: bool = True
+    imap_mailbox: str = "INBOX"
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_and_preflight_credentials(cls, value: Any) -> Any:
+        """Normalize while keeping raw credentials out of validation errors."""
+        if not isinstance(value, dict):
+            return {"provider": "__invalid_binding_mapping__"}
+        data = dict(value)
+        provider = data.get("provider")
+        sentinels = {
+            "__invalid_context_mapping__",
+            "__invalid_context_type__",
+            "__invalid_context_blank__",
+            "__invalid_binding_fields__",
+            "__invalid_secret_type__",
+            "__invalid_binding_mapping__",
+            "__invalid_provider__",
+            "__invalid_field_type__",
+            "__invalid_field_value__",
+            "__invalid_imap_missing__",
+        }
+        if set(data) == {"provider"} and provider in sentinels:
+            return data
+        if provider != "imap":
+            return {"provider": "__invalid_provider__"}
+        allowed = {
+            "provider", "imap_host", "imap_port", "imap_username",
+            "imap_password", "imap_ssl", "imap_mailbox",
+        }
+        if set(data) - allowed:
+            return {"provider": "__invalid_binding_fields__"}
+        password = data.get("imap_password")
+        if isinstance(password, SecretStr):
+            password = password.get_secret_value()
+        required = (data.get("imap_host"), data.get("imap_username"), password)
+        if not all(isinstance(item, str) and item.strip() for item in required):
+            return {"provider": "__invalid_imap_missing__"}
+        data["imap_host"] = data["imap_host"].strip()
+        data["imap_username"] = data["imap_username"].strip()
+        try:
+            data["imap_port"] = _IMAP_PORT_ADAPTER.validate_python(
+                data.get("imap_port", 993)
+            )
+            data["imap_ssl"] = _IMAP_SSL_ADAPTER.validate_python(
+                data.get("imap_ssl", True)
+            )
+        except ValidationError:
+            return {"provider": "__invalid_field_type__"}
+        mailbox = data.get("imap_mailbox")
+        if mailbox is not None:
+            if not isinstance(mailbox, str):
+                return {"provider": "__invalid_field_type__"}
+            data["imap_mailbox"] = mailbox.strip()
+        return data
+
+    @field_validator("provider", mode="before")
+    @classmethod
+    def _reject_invalid_provider_binding(cls, value: Any) -> Any:
+        errors = {
+            "__invalid_imap_missing__":
+                "IMAP inbox bindings require host, username, and password",
+            "__invalid_context_mapping__": "Inbox context bindings must be a mapping",
+            "__invalid_context_type__": "Inbox binding contexts must be strings",
+            "__invalid_context_blank__": "Inbox binding context must not be blank",
+            "__invalid_binding_fields__": "Inbox binding has unsupported fields",
+            "__invalid_secret_type__": "Inbox credentials must be strings",
+            "__invalid_binding_mapping__": "Inbox bindings must be mappings",
+            "__invalid_provider__": "Inbox mailbox provider must be imap",
+            "__invalid_field_type__": "Inbox binding field types are invalid",
+            "__invalid_field_value__": "Inbox binding field values are invalid",
+        }
+        if value in errors:
+            raise ValueError(errors[value])
+        return value
+
+
 class EmailConfig(BaseSettings):
     """Email tool configuration (Resend API + Gmail + IMAP)."""
 
-    model_config = SettingsConfigDict(env_prefix="ATLAS_EMAIL_", env_file=ENV_FILES, extra="ignore")
+    model_config = SettingsConfigDict(
+        env_prefix="ATLAS_EMAIL_",
+        env_file=ENV_FILES,
+        extra="ignore",
+        hide_input_in_errors=True,
+    )
 
     enabled: bool = Field(default=False, description="Enable email tool")
     gmail_send_enabled: bool = Field(
@@ -840,6 +944,48 @@ class EmailConfig(BaseSettings):
     imap_password: str = Field(default="", description="IMAP password or app-specific password")
     imap_ssl: bool = Field(default=True, description="Use SSL/TLS for IMAP connection")
     imap_mailbox: str = Field(default="INBOX", description="Default IMAP mailbox to read from")
+    inbox_context_bindings: dict[str, InboxMailboxBinding] = Field(
+        default_factory=dict,
+        description=(
+            "Explicit CRM business_context_id to inbox credential bindings. "
+            "Scoped CRM reads refuse contexts absent from this map."
+        ),
+    )
+
+    @field_validator("inbox_context_bindings", mode="before")
+    @classmethod
+    def _normalize_inbox_context_bindings(cls, value: Any) -> Any:
+        def invalid(context: str, code: str) -> dict[str, dict[str, str]]:
+            return {context: {"provider": code}}
+
+        if value is None:
+            return {}
+        if not isinstance(value, dict):
+            return invalid(
+                "__invalid_context_mapping__",
+                "__invalid_context_mapping__",
+            )
+        normalized: dict[str, Any] = {}
+        for raw_context, binding in value.items():
+            if not isinstance(raw_context, str):
+                return invalid(
+                    "__invalid_context_type__",
+                    "__invalid_context_type__",
+                )
+            if not raw_context.strip():
+                return invalid(
+                    "__invalid_context_blank__",
+                    "__invalid_context_blank__",
+                )
+            if isinstance(binding, BaseModel):
+                binding = binding.model_dump()
+            if not isinstance(binding, dict):
+                return invalid(
+                    "__invalid_binding_mapping__",
+                    "__invalid_binding_mapping__",
+                )
+            normalized[raw_context] = binding
+        return normalized
 
 
 class EmailDraftConfig(BaseSettings):

--- a/atlas_brain/mcp/crm_server.py
+++ b/atlas_brain/mcp/crm_server.py
@@ -1268,7 +1268,10 @@ async def get_customer_context(
         )
 
     try:
-        from ..services.customer_context import get_customer_context_service
+        from ..services.customer_context import (
+            CustomerContextService,
+            get_customer_context_service,
+        )
 
         kwargs = {
             "max_interactions": min(max_interactions, 50),
@@ -1350,8 +1353,34 @@ async def get_customer_context(
             )
             if not _row_visible(latest_contact, business_context_id):
                 return json.dumps({"found": False, "context": None})
+            queried_inbox_address = getattr(
+                ctx,
+                "inbox_email_query_address",
+                None,
+            )
+            latest_inbox_address = CustomerContextService._normalize_ascii_mailbox(
+                latest_contact.get("email")
+            )
+            if ctx.inbox_emails and (
+                not isinstance(queried_inbox_address, str)
+                or latest_inbox_address is None
+                or not CustomerContextService._same_ascii_mailbox(
+                    queried_inbox_address,
+                    latest_inbox_address,
+                )
+            ):
+                logger.warning(
+                    "CustomerContext inbox results discarded after contact "
+                    "email changed during aggregation for %s",
+                    ctx.contact["id"],
+                )
+                ctx.inbox_emails = []
             ctx.contact = latest_contact
 
+        inbox_email_source_omitted = bool(
+            effective
+            and getattr(ctx, "inbox_email_source_omitted", True)
+        )
         result: dict = {
             "found": True,
             "contact": ctx.contact,
@@ -1361,15 +1390,20 @@ async def get_customer_context(
             "call_transcripts": _calls_in_scope(
                 ctx.call_transcripts, business_context_id),
             "sent_emails": ctx.sent_emails,
-            "inbox_emails": [] if effective else ctx.inbox_emails,
+            "inbox_emails": (
+                [] if inbox_email_source_omitted else ctx.inbox_emails
+            ),
             # B2B churn enrichment is keyed by email domain against a global
             # table with no tenant column -- omitted under a scope like the
             # email history (the B2B MCP server is the scoped surface for it).
             "b2b_churn_signals": [] if effective else ctx.b2b_churn_signals,
         }
         if effective:
-            result["emails_omitted_under_scope"] = True
-            result["email_sources_omitted_under_scope"] = ["inbox_emails"]
+            omitted_email_sources = (
+                ["inbox_emails"] if inbox_email_source_omitted else []
+            )
+            result["emails_omitted_under_scope"] = bool(omitted_email_sources)
+            result["email_sources_omitted_under_scope"] = omitted_email_sources
             result["b2b_enrichment_omitted_under_scope"] = True
 
         return json.dumps(result, default=str)

--- a/atlas_brain/services/customer_context.py
+++ b/atlas_brain/services/customer_context.py
@@ -14,7 +14,10 @@ Usage:
 
 import asyncio
 import logging
+import re
 from dataclasses import dataclass, field
+from email import policy
+from email.parser import Parser
 from typing import Any, Optional
 
 logger = logging.getLogger("atlas.services.customer_context")
@@ -24,6 +27,7 @@ _FREE_EMAIL_DOMAINS = frozenset({
     "icloud.com", "mail.com", "protonmail.com", "zoho.com", "yandex.com",
     "gmx.com", "live.com",
 })
+_SCOPED_INBOX_CANDIDATE_LIMIT = 50
 
 
 @dataclass
@@ -36,6 +40,8 @@ class CustomerContext:
     call_transcripts: list[dict[str, Any]] = field(default_factory=list)
     sent_emails: list[dict[str, Any]] = field(default_factory=list)
     inbox_emails: list[dict[str, Any]] = field(default_factory=list)
+    inbox_email_source_omitted: bool = False
+    inbox_email_query_address: str | None = None
     sms_messages: list[dict[str, Any]] = field(default_factory=list)
     invoices: list[dict[str, Any]] = field(default_factory=list)
     b2b_churn_signals: list[dict[str, Any]] = field(default_factory=list)
@@ -134,6 +140,12 @@ class CustomerContextService:
         (appointments strictly; call transcripts tenant-plus-NULL) inside
         their SQL, before per-source limits apply.
         """
+        inbox_max_emails = (
+            max(0, min(max_emails, 50))
+            if business_context_id is not None
+            else max_emails
+        )
+
         from .crm_provider import get_crm_provider
         from ..storage.repositories.call_transcript import get_call_transcript_repo
         from ..storage.repositories.sms_message import get_sms_message_repo
@@ -143,6 +155,36 @@ class CustomerContextService:
         call_repo = get_call_transcript_repo()
         sms_repo = get_sms_message_repo()
         inv_repo = get_invoice_repo()
+
+        inbox_email_source_omitted = False
+        inbox_email_query_address = None
+        inbox_provider = None
+        if business_context_id is not None:
+            from .email_provider import (
+                UnmappedInboxContextError,
+                get_scoped_inbox_provider,
+            )
+
+            try:
+                inbox_provider = get_scoped_inbox_provider(
+                    business_context_id
+                )
+            except UnmappedInboxContextError:
+                logger.info(
+                    "CustomerContext inbox omitted: no mailbox binding for %s",
+                    business_context_id,
+                )
+                inbox_email_source_omitted = True
+            except Exception as exc:
+                logger.warning(
+                    "CustomerContext inbox provider setup failed for %s: %s",
+                    business_context_id,
+                    exc,
+                )
+            else:
+                inbox_email_query_address = self._normalize_ascii_mailbox(
+                    contact.get("email")
+                )
 
         async def _safe(coro, label: str, default=None):
             try:
@@ -181,14 +223,23 @@ class CustomerContextService:
             ),
             "sent_emails",
         )
-        inbox_coro = (
-            asyncio.sleep(0, result=[])
-            if business_context_id is not None
-            else _safe(
-                self._get_inbox_emails(contact, max_emails),
+        if business_context_id is not None:
+            if inbox_provider is None:
+                inbox_coro = asyncio.sleep(0, result=[])
+            else:
+                inbox_coro = _safe(
+                    self._get_inbox_emails(
+                        contact,
+                        inbox_max_emails,
+                        provider=inbox_provider,
+                    ),
+                    "inbox_emails",
+                )
+        else:
+            inbox_coro = _safe(
+                self._get_inbox_emails(contact, inbox_max_emails),
                 "inbox_emails",
             )
-        )
         sms_coro = _safe(
             sms_repo.get_by_contact_id(contact_id, limit=max_sms),
             "sms_messages",
@@ -218,6 +269,8 @@ class CustomerContextService:
             call_transcripts=calls,
             sent_emails=emails,
             inbox_emails=inbox,
+            inbox_email_source_omitted=inbox_email_source_omitted,
+            inbox_email_query_address=inbox_email_query_address,
             sms_messages=sms,
             invoices=invoices,
             b2b_churn_signals=b2b,
@@ -290,31 +343,151 @@ class CustomerContextService:
         return [self._email_to_dict(e) for e in results]
 
     async def _get_inbox_emails(
-        self, contact: dict, limit: int,
+        self,
+        contact: dict,
+        limit: int,
+        provider: Any | None = None,
     ) -> list[dict]:
         """
         Find recent inbound emails from this contact via IMAP/Gmail.
 
         Searches for messages where the sender matches the contact's email address.
-        Uses CompositeEmailProvider (IMAP preferred; Gmail API fallback).
+        Scoped callers supply their authorized reader. Unscoped callers use
+        CompositeEmailProvider (IMAP preferred; Gmail API fallback).
         Fail-open: returns [] if email address is missing or provider unavailable.
         """
-        email_addr = contact.get("email")
-        if not email_addr:
+        raw_email = contact.get("email")
+        if not raw_email:
             return []
 
-        try:
-            from .email_provider import get_email_provider
+        scoped_reader = provider is not None
+        if not scoped_reader:
+            try:
+                from .email_provider import get_email_provider
 
-            provider = get_email_provider()
-            messages = await provider.list_messages(
-                query=f"from:{email_addr}",
-                max_results=limit,
+                provider = get_email_provider()
+                return await provider.list_messages(
+                    query=f"from:{raw_email}",
+                    max_results=limit,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "_get_inbox_emails failed for %s: %s",
+                    raw_email,
+                    exc,
+                )
+                return []
+
+        email_addr = self._normalize_ascii_mailbox(raw_email)
+        if email_addr is None:
+            logger.warning(
+                "_get_inbox_emails refused invalid address for contact %s",
+                contact.get("id", "unknown"),
             )
-            return messages
+            return []
+        safe_limit = max(0, min(limit, 50))
+        if safe_limit == 0:
+            return []
+        try:
+            messages = await provider.list_messages(
+                query=f'from:"{email_addr}"',
+                max_results=_SCOPED_INBOX_CANDIDATE_LIMIT,
+            )
+
+            admitted: list[dict[str, Any]] = []
+            for message in messages[:_SCOPED_INBOX_CANDIDATE_LIMIT]:
+                if not isinstance(message, dict):
+                    continue
+                try:
+                    sender = self._strict_sender_mailbox(message)
+                except Exception as exc:
+                    logger.warning(
+                        "_get_inbox_emails refused malformed sender "
+                        "candidate: %s",
+                        exc,
+                    )
+                    continue
+                if not self._same_ascii_mailbox(sender, email_addr):
+                    continue
+                public_message = dict(message)
+                public_message.pop("_atlas_from_header_values", None)
+                admitted.append(public_message)
+                if len(admitted) >= safe_limit:
+                    break
+            return admitted
         except Exception as exc:
             logger.warning("_get_inbox_emails failed for %s: %s", email_addr, exc)
             return []
+
+    @staticmethod
+    def _normalize_ascii_mailbox(value: Any) -> str | None:
+        if not isinstance(value, str):
+            return None
+        try:
+            from email_validator import EmailNotValidError, validate_email
+
+            validated = validate_email(
+                value.strip(),
+                check_deliverability=False,
+                allow_smtputf8=False,
+            )
+            return validated.ascii_email
+        except EmailNotValidError:
+            return None
+
+    @staticmethod
+    def _same_ascii_mailbox(left: Any, right: Any) -> bool:
+        """Compare normalized mailboxes with a case-sensitive local part."""
+        if not isinstance(left, str) or not isinstance(right, str):
+            return False
+        try:
+            left_local, left_domain = left.rsplit("@", 1)
+            right_local, right_domain = right.rsplit("@", 1)
+        except ValueError:
+            return False
+        return (
+            left_local == right_local
+            and left_domain.casefold() == right_domain.casefold()
+        )
+
+    @classmethod
+    def _strict_sender_mailbox(cls, message: dict[str, Any]) -> str | None:
+        """Return one exact sender, rejecting ambiguous header provenance."""
+        values = message.get("_atlas_from_header_values")
+        if (
+            not isinstance(values, list)
+            or len(values) != 1
+            or not isinstance(values[0], str)
+        ):
+            return None
+        return cls._parse_single_author(values[0])
+
+    @classmethod
+    def _parse_single_author(cls, value: Any) -> str | None:
+        """Parse one structurally valid, non-group RFC From mailbox."""
+        if not isinstance(value, str) or not value.strip():
+            return None
+        unfolded = re.sub(r"\r?\n(?=[ \t])", "", value)
+        if "\r" in unfolded or "\n" in unfolded:
+            return None
+        try:
+            parsed_message = Parser(policy=policy.default).parsestr(
+                f"From: {unfolded}\n\n"
+            )
+            header = parsed_message["From"]
+            if (
+                header is None
+                or parsed_message.defects
+                or header.defects
+                or len(header.addresses) != 1
+                or len(header.groups) != 1
+                or header.groups[0].display_name is not None
+            ):
+                return None
+            addr_spec = header.addresses[0].addr_spec
+        except (AttributeError, IndexError, TypeError, ValueError):
+            return None
+        return cls._normalize_ascii_mailbox(addr_spec)
 
     @staticmethod
     def _email_to_dict(email) -> dict:

--- a/atlas_brain/services/email_provider.py
+++ b/atlas_brain/services/email_provider.py
@@ -36,7 +36,10 @@ import logging
 import re
 import threading
 from email.header import decode_header as _decode_header
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:
+    from ..config import InboxMailboxBinding
 
 logger = logging.getLogger("atlas.services.email_provider")
 
@@ -125,10 +128,15 @@ def _imap_search_criteria(query: str) -> str:
     return " ".join(criteria) if criteria else "ALL"
 
 
-def _parse_envelope(uid: str, raw_headers: bytes) -> dict[str, Any]:
+def _parse_envelope(
+    uid: str,
+    raw_headers: bytes,
+    *,
+    preserve_sender_evidence: bool = False,
+) -> dict[str, Any]:
     """Parse raw RFC 822 headers into a metadata dict."""
     msg = _email_stdlib.message_from_bytes(raw_headers)
-    return {
+    envelope = {
         "id": uid,
         "subject": _decode_mime_words(msg.get("Subject", "")),
         "from": _decode_mime_words(msg.get("From", "")),
@@ -142,6 +150,9 @@ def _parse_envelope(uid: str, raw_headers: bytes) -> dict[str, Any]:
         "reply_to": _decode_mime_words(msg.get("Reply-To", "")),
         "has_unsubscribe": msg.get("List-Unsubscribe") is not None,
     }
+    if preserve_sender_evidence:
+        envelope["_atlas_from_header_values"] = msg.get_all("From", [])
+    return envelope
 
 
 def _extract_body(msg: _email_stdlib.message.Message) -> str:
@@ -185,7 +196,7 @@ class IMAPEmailProvider:
         ATLAS_EMAIL_IMAP_MAILBOX   INBOX
     """
 
-    def __init__(self) -> None:
+    def __init__(self, binding: "InboxMailboxBinding | None" = None) -> None:
         self._host: str = ""
         self._port: int = 993
         self._username: str = ""
@@ -193,8 +204,17 @@ class IMAPEmailProvider:
         self._ssl: bool = True
         self._mailbox: str = "INBOX"
         self._loaded = False
+        self._preserve_sender_evidence = binding is not None
         self._cached_conn: imaplib.IMAP4 | None = None
         self._lock = threading.RLock()  # reentrant: _get_thread_sync calls _get_message_sync
+        if binding is not None:
+            self._host = binding.imap_host
+            self._port = binding.imap_port
+            self._username = binding.imap_username
+            self._password = binding.imap_password.get_secret_value()
+            self._ssl = binding.imap_ssl
+            self._mailbox = binding.imap_mailbox or "INBOX"
+            self._loaded = True
 
     def _load_config(self) -> None:
         if self._loaded:
@@ -348,7 +368,15 @@ class IMAPEmailProvider:
                         descriptor = item[0].decode() if isinstance(item[0], bytes) else str(item[0])
                         uid_match = re.search(r"UID (\d+)", descriptor)
                         uid = uid_match.group(1) if uid_match else str(i)
-                        messages.append(_parse_envelope(uid, header_bytes))
+                        messages.append(
+                            _parse_envelope(
+                                uid,
+                                header_bytes,
+                                preserve_sender_evidence=(
+                                    self._preserve_sender_evidence
+                                ),
+                            )
+                        )
                     i += 1
                 return messages
             except Exception:
@@ -751,3 +779,32 @@ def get_email_provider() -> CompositeEmailProvider:
     if _email_provider is None:
         _email_provider = CompositeEmailProvider()
     return _email_provider
+
+
+class UnmappedInboxContextError(LookupError):
+    """Raised before mailbox I/O when a CRM context has no inbox binding."""
+
+
+def get_scoped_inbox_provider(
+    business_context_id: str,
+) -> IMAPEmailProvider:
+    """Return the single inbox reader explicitly bound to a CRM context.
+
+    Scoped readers never use ``CompositeEmailProvider`` because its IMAP error
+    fallback could cross the authorization boundary into the global Gmail
+    account.
+    """
+    from ..config import settings
+
+    context = business_context_id
+    if not isinstance(context, str) or not context.strip():
+        raise UnmappedInboxContextError(
+            f"No inbox mailbox is bound to business context {context!r}"
+        )
+    binding = settings.email.inbox_context_bindings.get(context)
+    if binding is None:
+        raise UnmappedInboxContextError(
+            f"No inbox mailbox is bound to business context {context!r}"
+        )
+
+    return IMAPEmailProvider(binding)

--- a/plans/PR-EOM-Mailbox-Context-Binding.md
+++ b/plans/PR-EOM-Mailbox-Context-Binding.md
@@ -1,0 +1,209 @@
+# PR Plan: EOM Mailbox Context Binding
+
+## Why this slice exists
+
+Issue #2177 requires scoped CRM customer context to read inbox history only
+from a mailbox explicitly authorized for that exact `business_context_id`.
+Today the unscoped email provider is a global IMAP/Gmail composite, so using it
+under a tenant scope could expose another operator mailbox.
+
+The original implementation widened this privacy slice into a bespoke durable
+Gmail refresh-token protocol. Review rounds then clustered on that subsystem:
+cross-process leases, file-system race resistance, cancellation draining,
+generation ancestry, and cache synchronization. Those concerns are real, but
+they are not required to prove the authorization boundary. This revision
+removes scoped Gmail from this PR and ships the smallest complete proof with
+explicit IMAP bindings.
+
+The slice remains above the 400-LOC soft cap because the authorization
+boundary is indivisible across typed configuration, provider construction,
+aggregation, MCP serialization, and a real-entrypoint regression. Most of the
+churn is the focused behavioral proof; splitting those tests from the runtime
+change would leave the privacy boundary unproven at merge.
+
+### Problem-derived contract
+
+Root cause: scoped CRM aggregation has no exact tenant-to-mailbox authorization
+mapping and otherwise reaches the global email reader.
+
+A correct fix must:
+
+1. Define a validated IMAP credential binding keyed by the exact, nonblank CRM
+   business-context ID.
+2. Refuse an unmapped context before any mailbox connection or query.
+3. Construct only the bound IMAP reader; never fall back to global IMAP or
+   Gmail for a scoped request.
+4. Admit only messages with one structurally valid `From` author that exactly
+   matches the contact address. Legal RFC folding must be unfolded, while bare
+   CR/LF injection, groups, duplicate fields, and multiple authors fail closed.
+   The final result cap must not truncate IMAP candidates before admission.
+5. Lift the scoped inbox omission flag only for a mapped source, and discard
+   results if the contact ownership or queried address changes during I/O.
+6. Preserve unscoped email behavior and every unrelated CRM source limit.
+
+This fixes the authorization root directly. It must not add scoped Gmail token
+rotation, durable token files, cross-process locking, a scoped provider cache,
+new outbound behavior, or a database-secret schema by implication.
+
+## Scope (this PR)
+
+Ownership lane: eom-crm/email-tenancy
+
+Slice phase: Production hardening
+
+1. Add exact-key, IMAP-only typed inbox bindings with redacted secrets.
+2. Build a fresh bound IMAP reader per scoped resolution; no authorization
+   cache or invalidation protocol.
+3. Route scoped customer-context inbox reads through that reader and preserve
+   fail-closed omission semantics.
+4. Enforce exact raw-sender admission with legal header unfolding.
+5. Prove the real CRM MCP entrypoint reads only the bound mailbox and refuses
+   unmapped contexts.
+6. Remove every scoped Gmail/token-store change from this PR.
+
+### Files touched
+
+- `CLAUDE.md`
+- `atlas_brain/config.py`
+- `atlas_brain/mcp/crm_server.py`
+- `atlas_brain/services/customer_context.py`
+- `atlas_brain/services/email_provider.py`
+- `plans/PR-EOM-Mailbox-Context-Binding.md`
+- `tests/test_eom_mailbox_context_binding.py`
+
+### Review Contract
+
+Acceptance criteria:
+
+- Exact, whitespace-distinct context IDs cannot alias one binding.
+- Invalid or unsupported bindings fail validation without exposing credential
+  values in string or structured errors.
+- An unmapped scoped request performs zero IMAP/Gmail operations and reports
+  `inbox_emails` as omitted.
+- A mapped scoped request constructs only its bound IMAP reader and never uses
+  the global composite fallback.
+- Legal `CRLF + WSP` and `LF + WSP` folding is admitted after unfolding; bare
+  CR/LF, duplicate fields, groups, and multiple authors remain rejected.
+- A collision or malformed candidate cannot hide a later exact sender, and a
+  malformed candidate cannot discard the rest of the batch.
+- Mailbox domains compare case-insensitively while local parts remain
+  case-sensitive in both sender admission and the post-I/O address guard.
+- Rebinding takes effect on the next request because no scoped provider is
+  cached.
+- Unscoped inbox behavior and non-mailbox aggregation limits are unchanged.
+- The real `get_customer_context` MCP entrypoint returns an admitted bound
+  message and clears the omission flag; the same entrypoint refuses an
+  unmapped context before mailbox I/O.
+
+Affected surfaces:
+
+- Email configuration validation.
+- Scoped IMAP provider construction and raw sender evidence.
+- Customer-context aggregation and CRM MCP serialization.
+
+Risk areas:
+
+- Tenant authorization and secret redaction (R3).
+- Legacy compatibility and exact sender parsing (R5).
+- Source-local errors and observable omission state (R6).
+- Bounded mailbox work and no stale authorization cache (R7/R8).
+- Configuration and deployment documentation (R11/R12).
+- Parser guard class closure and cold reconstruction (R13/R14).
+
+Triggered reviewer rules: R1, R2, R3, R5, R6, R7, R8, R10, R11, R12,
+R13, R14.
+
+Reachability proof: call the real CRM MCP `get_customer_context` function with
+a tenant-owned contact and an injected bound IMAP adapter; assert the serialized
+inbox result and omission fields. Repeat with an unmapped context and assert
+zero mailbox access.
+
+## Mechanism
+
+`EmailConfig.inbox_context_bindings` maps exact context strings to an
+`InboxMailboxBinding` containing only IMAP connection fields. The scoped
+binding preflights every allowed scalar into a typed value or a secret-free
+sentinel before Pydantic can render structured errors. The scoped factory
+validates the context, looks up the current binding on every call, and returns
+`IMAPEmailProvider(binding)`. Construction is in-memory and performs no mailbox
+I/O, so no cache or global construction lock is needed.
+
+The customer-context service resolves the binding before scheduling inbox work.
+IMAP operations already run in worker threads. A scoped read requests at most
+50 candidates, isolates parsing per message, and stops when the caller's result
+cap is filled. Scoped results carry private raw `From` evidence; admission
+unfolds only legal continuation sequences, rejects any remaining CR/LF, parses
+one non-group author, and compares the normalized domain case-insensitively
+without folding local-part case.
+
+## Intentional
+
+- Scoped Gmail is unsupported in this slice and fails typed validation.
+- A fresh scoped IMAP provider is cheap and makes binding changes effective on
+  the next request without cache invalidation.
+- Network/provider failures remain source-local and return an empty mapped
+  inbox; absence of a binding is separately reported as omission.
+- Unscoped email tooling retains its existing global composite behavior.
+- Sender admission remains fail-closed after legal folding is normalized.
+- Candidate discovery is capped at 50 independently of the final result cap,
+  so rejected near matches cannot starve exact senders within that bound.
+- The MCP reachability proof leaves unrelated repository factories real and
+  exercises their existing unavailable-store isolation through `_safe`; it
+  mocks only the CRM fixture and external IMAP edge.
+
+## Deferred
+
+- #2196 is the scoped Gmail follow-up with database-backed token state and its
+  own migration, repository contract, concurrency semantics, and integration
+  proof.
+- The existing `BusinessContextRepository` is not directly suitable for OAuth
+  secrets: it uses broad `SELECT *`, has no token column or encryption
+  boundary, and its `upsert` rewrites the full business-context row. The
+  follow-up must design a narrow credential store rather than placing secrets
+  in the existing row by convention.
+- Production IMAP credential provisioning remains an operator deployment
+  action; no secrets are committed.
+- Parked hardening: none.
+
+## Verification
+
+- pytest -q tests/test_eom_mailbox_context_binding.py -- 37 passed.
+- pytest -q tests/test_eom*.py tests/test_crm_read_scoping.py
+  tests/test_customer_context.py -- 158 passed, 5 skipped.
+- pytest -q tests/test_auth_api_keys.py tests/test_byok_keys.py
+  tests/test_eom_mailbox_context_binding.py -- 108 passed; proves a config
+  module reload does not reject a previously constructed typed binding.
+- `pytest -q tests/test_mcp_servers.py::TestCompositeEmailProvider
+  tests/test_mcp_servers.py::TestCompositeProviderIMAPPreference` -- 5 passed;
+  the unscoped IMAP-to-Gmail composite behavior is unchanged.
+- The broad `tests/test_mcp_servers.py` run reports 74 passed and 6 failures
+  already present in the current `origin/main` source/test pairing: two
+  redacted-error expectation failures, two stale IMAP executor-call
+  expectations, and two calendar mock-shape failures. None touches this
+  scoped factory or its focused proof.
+- `python scripts/check_guard_class_closure.py --base origin/main --strict` --
+  passed.
+- Changed-module compilation, `git diff --check`, and
+  bash scripts/check_ascii_python.sh -- passed.
+- Full unit ratchet -- 163 failing/errored nodes against a baseline of 182,
+  with 20 stale baseline entries and one intermittent unbaselined
+  `tests/test_nemotron_stt.py::test_nemotron_stt`; the exact node passed on
+  immediate isolated replay.
+- Storage maturity ratchet -- passed after removing four first-party
+  repository mocks from the MCP reachability proof; no baseline debt added.
+- Independent exact-snapshot re-review -- LGTM; held-out probes cover the
+  candidate-50 boundary, candidate-51 exclusion, early result-cap stop,
+  arbitrary parser exceptions, and domain/local-part case semantics.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `CLAUDE.md` | 11 |
+| `atlas_brain/config.py` | 154 |
+| `atlas_brain/mcp/crm_server.py` | 42 |
+| `atlas_brain/services/customer_context.py` | 205 |
+| `atlas_brain/services/email_provider.py` | 67 |
+| `plans/PR-EOM-Mailbox-Context-Binding.md` | 209 |
+| `tests/test_eom_mailbox_context_binding.py` | 513 |
+| **Total** | **1201** |

--- a/tests/test_eom_mailbox_context_binding.py
+++ b/tests/test_eom_mailbox_context_binding.py
@@ -1,0 +1,513 @@
+"""Behavioral proofs for scoped CRM IMAP authorization."""
+
+import json
+from decimal import Decimal
+from fractions import Fraction
+from unittest.mock import AsyncMock
+
+import pytest
+from pydantic import ValidationError
+
+from atlas_brain.config import EmailConfig, InboxMailboxBinding
+from atlas_brain.services import customer_context as context_mod
+from atlas_brain.services import email_provider as email_provider_mod
+
+
+TENANT = "effingham_maids"
+OTHER_TENANT = "churnsignals"
+TENANT_CONTACT_ID = "11111111-1111-4111-8111-111111111111"
+OTHER_CONTACT_ID = "22222222-2222-4222-8222-222222222222"
+
+
+def _binding(**overrides):
+    values = {
+        "provider": "imap",
+        "imap_host": "imap.eom.example",
+        "imap_port": 993,
+        "imap_username": "office@eom.example",
+        "imap_password": "eom-app-password",
+        "imap_ssl": True,
+        "imap_mailbox": "INBOX",
+    }
+    values.update(overrides)
+    return InboxMailboxBinding(**values)
+
+
+def test_config_preserves_exact_context_keys_and_rejects_scoped_gmail(
+    monkeypatch,
+):
+    exact = f" {TENANT} "
+    monkeypatch.setenv(
+        "ATLAS_EMAIL_INBOX_CONTEXT_BINDINGS",
+        json.dumps(
+            {
+                TENANT: _binding().model_dump(mode="json"),
+                exact: _binding(
+                    imap_username="spaced@eom.example"
+                ).model_dump(mode="json"),
+            }
+        ),
+    )
+
+    config = EmailConfig()
+
+    assert set(config.inbox_context_bindings) == {TENANT, exact}
+    assert (
+        config.inbox_context_bindings[exact].imap_username
+        == "spaced@eom.example"
+    )
+    typed = _binding()
+    assert EmailConfig(
+        inbox_context_bindings={TENANT: typed}
+    ).inbox_context_bindings[TENANT] == typed
+    with pytest.raises(ValidationError, match="provider must be imap"):
+        InboxMailboxBinding(
+            provider="gmail",
+            gmail_client_id="client",
+            gmail_client_secret="secret",
+            gmail_refresh_token="refresh",
+        )
+
+
+@pytest.mark.parametrize(
+    "bindings",
+    [
+        "not-a-map",
+        {1: {"provider": "imap"}},
+        {" ": {"provider": "imap"}},
+        {TENANT: "not-a-binding"},
+        {TENANT: {"provider": "imap", "unknown": "nested-secret"}},
+        {
+            TENANT: {
+                "provider": "gmail",
+                "gmail_refresh_token": "nested-secret",
+            }
+        },
+        {
+            TENANT: {
+                "provider": "imap",
+                "imap_username": "office@example.com",
+                "imap_password": "nested-secret",
+            }
+        },
+        {
+            TENANT: {
+                **_binding().model_dump(mode="json"),
+                "imap_port": "nested-secret",
+            }
+        },
+        {
+            TENANT: {
+                **_binding().model_dump(mode="json"),
+                "imap_ssl": "nested-secret",
+            }
+        },
+    ],
+)
+def test_invalid_binding_grammar_redacts_nested_values(bindings):
+    with pytest.raises(ValidationError) as captured:
+        EmailConfig(inbox_context_bindings=bindings)
+
+    rendered = str(captured.value)
+    structured = json.dumps(captured.value.errors(), default=str)
+    assert "nested-secret" not in rendered
+    assert "nested-secret" not in structured
+    assert "nested-secret" not in captured.value.json()
+
+
+@pytest.mark.parametrize(
+    "port",
+    [True, "993.0", b"993", Decimal("993"), Fraction(993, 1)],
+)
+def test_binding_preflight_preserves_port_coercion(port):
+    binding = _binding().model_dump()
+    binding["imap_port"] = port
+    config = EmailConfig(
+        inbox_context_bindings={TENANT: binding}
+    )
+
+    expected = 1 if port is True else 993
+    assert config.inbox_context_bindings[TENANT].imap_port == expected
+
+
+@pytest.mark.parametrize(
+    ("use_ssl", "expected"),
+    [
+        (0.0, False),
+        (1.0, True),
+        (Decimal(0), False),
+        (Decimal(1), True),
+        (Fraction(0, 1), False),
+        (Fraction(1, 1), True),
+    ],
+)
+def test_binding_preflight_preserves_ssl_coercion(use_ssl, expected):
+    binding = _binding().model_dump()
+    binding["imap_ssl"] = use_ssl
+    config = EmailConfig(
+        inbox_context_bindings={TENANT: binding}
+    )
+
+    assert config.inbox_context_bindings[TENANT].imap_ssl is expected
+
+
+def test_scoped_provider_rebinds_without_authorization_cache(monkeypatch):
+    import atlas_brain.config as config_mod
+
+    monkeypatch.setattr(
+        config_mod.settings.email,
+        "inbox_context_bindings",
+        {TENANT: _binding(imap_username="mailbox-a@example.com")},
+    )
+    first = email_provider_mod.get_scoped_inbox_provider(TENANT)
+
+    monkeypatch.setattr(
+        config_mod.settings.email,
+        "inbox_context_bindings",
+        {TENANT: _binding(imap_username="mailbox-b@example.com")},
+    )
+    second = email_provider_mod.get_scoped_inbox_provider(TENANT)
+
+    assert first is not second
+    assert first._username == "mailbox-a@example.com"
+    assert second._username == "mailbox-b@example.com"
+    with pytest.raises(email_provider_mod.UnmappedInboxContextError):
+        email_provider_mod.get_scoped_inbox_provider(OTHER_TENANT)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (
+            '"Bergmann, Katharina (Facilities Operations)"\r\n'
+            " <katharina.bergmann@example.com>",
+            "katharina.bergmann@example.com",
+        ),
+        (
+            '"Bergmann, Katharina"\r\n\t'
+            "<katharina.bergmann@example.com>",
+            "katharina.bergmann@example.com",
+        ),
+        (
+            '"Bergmann, Katharina"\n '
+            "<katharina.bergmann@example.com>",
+            "katharina.bergmann@example.com",
+        ),
+        ("Alice <alice@example.com>\r\nBcc: victim@example.com", None),
+        ("Alice <alice@example.com>\nBcc: victim@example.com", None),
+        (
+            "Alice <alice@example.com>,\r\n Bob <bob@example.com>",
+            None,
+        ),
+        ("Friends: Alice <alice@example.com>;", None),
+        ("=?utf-8?q?alice=40example.com?=", None),
+    ],
+)
+def test_sender_admission_unfolds_only_legal_continuations(value, expected):
+    assert context_mod.CustomerContextService._parse_single_author(value) == expected
+
+
+def test_real_imap_envelope_preserves_folded_and_duplicate_sender_evidence():
+    folded = (
+        b'From: "Bergmann, Katharina (Facilities Operations)"\r\n'
+        b" <katharina.bergmann@example.com>\r\n"
+        b"Subject: Facilities\r\n\r\n"
+    )
+    envelope = email_provider_mod._parse_envelope(
+        "1",
+        folded,
+        preserve_sender_evidence=True,
+    )
+    assert context_mod.CustomerContextService._strict_sender_mailbox(
+        envelope
+    ) == "katharina.bergmann@example.com"
+
+    duplicate = email_provider_mod._parse_envelope(
+        "2",
+        (
+            b"From: alice@example.com\r\n"
+            b"From: attacker@example.com\r\n\r\n"
+        ),
+        preserve_sender_evidence=True,
+    )
+    assert (
+        context_mod.CustomerContextService._strict_sender_mailbox(duplicate)
+        is None
+    )
+    assert context_mod.CustomerContextService._strict_sender_mailbox(
+        {"from": "alice@example.com"}
+    ) is None
+
+
+@pytest.mark.asyncio
+async def test_unscoped_inbox_preserves_legacy_provider_contract(monkeypatch):
+    class _LegacyProvider:
+        def __init__(self):
+            self.calls = []
+
+        async def list_messages(self, query, max_results):
+            self.calls.append((query, max_results))
+            return [{"id": "legacy", "from": "decoded-only"}]
+
+    provider = _LegacyProvider()
+    monkeypatch.setattr(email_provider_mod, "_email_provider", provider)
+
+    result = await context_mod.CustomerContextService()._get_inbox_emails(
+        {"email": "josé@example.com"},
+        -7,
+    )
+
+    assert result == [{"id": "legacy", "from": "decoded-only"}]
+    assert provider.calls == [("from:josé@example.com", -7)]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "rejected",
+    [
+        {
+            "id": "collision",
+            "_atlas_from_header_values": [
+                '"customer@example.com" <notcustomer@example.com>'
+            ],
+        },
+        {
+            "id": "malformed",
+            "_atlas_from_header_values": [
+                "Undisclosed:; customer@example.com"
+            ],
+        },
+    ],
+)
+async def test_scoped_inbox_scans_past_rejected_candidates(rejected):
+    class _Candidates:
+        def __init__(self):
+            self.calls = []
+
+        async def list_messages(self, query, max_results):
+            self.calls.append((query, max_results))
+            return [
+                rejected,
+                {
+                    "id": "exact",
+                    "_atlas_from_header_values": [
+                        "Customer <customer@example.com>"
+                    ],
+                },
+            ]
+
+    provider = _Candidates()
+
+    result = await context_mod.CustomerContextService()._get_inbox_emails(
+        {"email": "customer@example.com"},
+        1,
+        provider=provider,
+    )
+
+    assert result == [{"id": "exact"}]
+    assert provider.calls == [('from:"customer@example.com"', 50)]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("sender", "expected"),
+    [
+        ("Alice@example.com", []),
+        ("alice@EXAMPLE.COM", [{"id": "domain-case"}]),
+    ],
+)
+async def test_scoped_inbox_preserves_local_part_case(sender, expected):
+    class _Candidate:
+        async def list_messages(self, **_kwargs):
+            return [
+                {
+                    "id": "domain-case",
+                    "_atlas_from_header_values": [sender],
+                }
+            ]
+
+    result = await context_mod.CustomerContextService()._get_inbox_emails(
+        {"email": "alice@example.com"},
+        1,
+        provider=_Candidate(),
+    )
+
+    assert result == expected
+
+
+class _CRMProvider:
+    def __init__(self):
+        self.contacts = {
+            TENANT_CONTACT_ID: {
+                "id": TENANT_CONTACT_ID,
+                "email": "customer@example.com",
+                "full_name": "Customer",
+                "business_context_id": TENANT,
+            },
+            OTHER_CONTACT_ID: {
+                "id": OTHER_CONTACT_ID,
+                "email": "other@example.com",
+                "full_name": "Other",
+                "business_context_id": OTHER_TENANT,
+            },
+        }
+
+    async def get_contact(self, contact_id):
+        contact = self.contacts.get(str(contact_id))
+        return dict(contact) if contact else None
+
+    async def get_interactions(
+        self, _contact_id, *, limit, business_context_id
+    ):
+        return []
+
+    async def get_contact_appointments(
+        self, _contact_id, *, business_context_id
+    ):
+        return []
+
+
+class _FakeIMAP:
+    connections = []
+    on_search = None
+
+    def __init__(self, host, port, timeout):
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+        self.uid_calls = []
+        self.__class__.connections.append(self)
+
+    def login(self, username, password):
+        self.login_args = (username, password)
+        return "OK", []
+
+    def noop(self):
+        return "OK", []
+
+    def select(self, mailbox, readonly=True):
+        self.selected = (mailbox, readonly)
+        return "OK", []
+
+    def uid(self, command, *args):
+        self.uid_calls.append((command, args))
+        if command == "search":
+            if self.__class__.on_search is not None:
+                self.__class__.on_search()
+            return "OK", [b"41 42"]
+        if command == "fetch":
+            collision = (
+                b'From: "customer@example.com" <notcustomer@example.com>\r\n'
+                b"Subject: Collision\r\n\r\n"
+            )
+            folded = (
+                b'From: "Bergmann, Katharina (Facilities Operations)"\r\n'
+                b" <customer@example.com>\r\n"
+                b"Subject: Bound reply\r\n\r\n"
+            )
+            headers = {"42": collision, "41": folded}
+            response = []
+            for index, uid in enumerate(str(args[0]).split(","), start=1):
+                response.extend(
+                    [
+                        (
+                            f"{index} (UID {uid} RFC822.HEADER {{140}}".encode(),
+                            headers[uid],
+                        ),
+                        b")",
+                    ]
+                )
+            return "OK", response
+        raise AssertionError(f"unexpected IMAP command: {command}")
+
+    def logout(self):
+        return "BYE", []
+
+
+@pytest.mark.asyncio
+async def test_real_crm_mcp_uses_only_bound_imap_and_refuses_unmapped(
+    monkeypatch,
+):
+    import atlas_brain.config as config_mod
+    import atlas_brain.mcp.crm_server as crm_server
+    import atlas_brain.services.crm_provider as crm_provider_mod
+
+    provider = _CRMProvider()
+    monkeypatch.setattr(
+        crm_provider_mod,
+        "get_crm_provider",
+        lambda: provider,
+    )
+    monkeypatch.setattr(email_provider_mod.imaplib, "IMAP4_SSL", _FakeIMAP)
+    global_provider = AsyncMock()
+    monkeypatch.setattr(
+        email_provider_mod,
+        "get_email_provider",
+        global_provider,
+    )
+    monkeypatch.setattr(
+        config_mod.settings.email,
+        "inbox_context_bindings",
+        {TENANT: _binding()},
+    )
+    _FakeIMAP.connections.clear()
+    crm_server.set_provider_override(lambda: provider)
+    previous_service = context_mod._customer_context_service
+    context_mod._customer_context_service = None
+
+    try:
+        scoped = json.loads(
+            await crm_server.get_customer_context(
+                contact_id=TENANT_CONTACT_ID,
+                business_context_id=TENANT,
+                max_emails=1,
+            )
+        )
+        assert [row["id"] for row in scoped["inbox_emails"]] == ["41"]
+        assert scoped["email_sources_omitted_under_scope"] == []
+        assert scoped["emails_omitted_under_scope"] is False
+        assert len(_FakeIMAP.connections) == 1
+        connection = _FakeIMAP.connections[0]
+        assert (connection.host, connection.port) == (
+            "imap.eom.example",
+            993,
+        )
+        assert connection.login_args == (
+            "office@eom.example",
+            "eom-app-password",
+        )
+        assert connection.uid_calls[0] == (
+            "search",
+            (None, 'FROM "customer@example.com"'),
+        )
+
+        _FakeIMAP.on_search = lambda: provider.contacts[
+            TENANT_CONTACT_ID
+        ].update(email="Customer@example.com")
+        raced = json.loads(
+            await crm_server.get_customer_context(
+                contact_id=TENANT_CONTACT_ID,
+                business_context_id=TENANT,
+                max_emails=5,
+            )
+        )
+        assert raced["inbox_emails"] == []
+        assert raced["emails_omitted_under_scope"] is False
+
+        unmapped = json.loads(
+            await crm_server.get_customer_context(
+                contact_id=OTHER_CONTACT_ID,
+                business_context_id=OTHER_TENANT,
+                max_emails=5,
+            )
+        )
+        assert unmapped["inbox_emails"] == []
+        assert unmapped["email_sources_omitted_under_scope"] == [
+            "inbox_emails"
+        ]
+        assert len(_FakeIMAP.connections) == 2
+        global_provider.assert_not_called()
+    finally:
+        _FakeIMAP.on_search = None
+        crm_server.set_provider_override(None)
+        context_mod._customer_context_service = previous_service


### PR DESCRIPTION
Plan: plans/PR-EOM-Mailbox-Context-Binding.md
Slice phase: Production hardening
Ownership lane: eom-crm/email-tenancy

Issue #2177 closes the scoped-inbox privacy gap with an explicit,
exact-context IMAP binding. This revision removes scoped Gmail and the
hand-rolled token-file concurrency subsystem; Gmail tenancy is split to #2196
for a dedicated database credential repository.

## Intentional

- Scoped readers construct only the currently bound IMAP provider and never
  inherit the unscoped composite's global Gmail fallback.
- The factory does not cache authorization state, so a rebind is effective on
  the next request.
- Raw `From` evidence is private to scoped IMAP list results. Legal folded
  headers are unfolded before strict one-author admission; bare CR/LF,
  duplicate fields, groups, multiple authors, and decoded-only evidence fail
  closed.
- Scoped reads inspect at most 50 candidates independently of the caller's
  result cap, isolate malformed candidates, and preserve mailbox local-part
  case while comparing domains case-insensitively.
- Unscoped provider selection, query text, limits, and result forwarding are
  unchanged.
- A mapped provider failure is source-local and returns an empty inbox; an
  absent binding is separately reported as an authorization omission.
- The MCP reachability proof leaves unrelated repository factories real and
  exercises their existing unavailable-store isolation; it controls only the
  CRM fixture and external IMAP edge.

## Deferred

- #2196 owns scoped Gmail with a narrow database credential repository,
  migration, compare-and-set rotation semantics, and integration proof.
- The existing `BusinessContextRepository` is not reused directly because it
  exposes broad rows, has no credential column/encryption boundary, and
  rewrites the full business-context row.
- Production IMAP credential provisioning remains an operator deployment
  action; no secrets are committed.

## Parked hardening

- None.

## Cold diff reconstruction

- Changed: `atlas_brain/config.py:30` defines the original bounded-int and bool
  Pydantic schemas for preflight; `atlas_brain/config.py:818` adds the
  IMAP-only binding model; `atlas_brain/config.py:869` normalizes every allowed
  scalar or replaces failures with a secret-free sentinel; and
  `atlas_brain/config.py:947` maps exact nonblank context keys without aliasing
  whitespace-distinct tenants.
- Changed: `atlas_brain/services/email_provider.py:131` optionally preserves
  all raw `From` fields for scoped list admission; `atlas_brain/services/email_provider.py:199`
  initializes an IMAP reader from one binding; `atlas_brain/services/email_provider.py:788`
  refuses unmapped contexts and returns a fresh bound reader with no global
  composite, cache, Gmail, or token-file path.
- Changed: `atlas_brain/services/customer_context.py:159` resolves the binding
  before scheduling mailbox work and records unmapped omission;
  `atlas_brain/services/customer_context.py:226` selects the bound reader only
  for scoped requests; `atlas_brain/services/customer_context.py:363`
  preserves the legacy unscoped path; `atlas_brain/services/customer_context.py:388`
  separates the bounded candidate scan from the result cap and isolates
  per-candidate failures; `atlas_brain/services/customer_context.py:438`
  preserves local-part case while normalizing domain case; and
  `atlas_brain/services/customer_context.py:465` admits one structurally valid
  raw sender after legal unfolding.
- Changed: `atlas_brain/mcp/crm_server.py:1350` rechecks ownership and queried
  email after aggregation, discarding stale-address inbox results;
  `atlas_brain/mcp/crm_server.py:1380` exposes inbox data only when its scoped
  source is mapped.
- Changed: `CLAUDE.md:382` documents the IMAP-only context-binding deployment
  shape.
- Changed: `tests/test_eom_mailbox_context_binding.py:36` proves exact binding,
  structured redaction, original scalar-coercion compatibility, no-cache
  rebinding, folded-header admission, candidate starvation, parser isolation,
  local/domain case semantics, injection/ambiguity refusal, unscoped
  compatibility, and the real CRM MCP-to-bound-IMAP flow at
  `tests/test_eom_mailbox_context_binding.py:427`, including a newer collision,
  address-case change, and unmapped no-I/O case.
- Contract match: every runtime change traces to exact mailbox authorization,
  safe sender admission, omission state, or the post-I/O ownership/address
  guard.
- Gaps: none. Scoped Gmail/token rotation, outbound mail, sent history, B2B
  enrichment, and unrelated CRM limits do not change.

## Verification

- `pytest -q tests/test_eom_mailbox_context_binding.py` -- 37 passed.
- `pytest -q tests/test_eom*.py tests/test_crm_read_scoping.py tests/test_customer_context.py`
  -- 158 passed, 5 skipped.
- `pytest -q tests/test_auth_api_keys.py tests/test_byok_keys.py tests/test_eom_mailbox_context_binding.py`
  -- 108 passed.
- `pytest -q tests/test_mcp_servers.py::TestCompositeEmailProvider tests/test_mcp_servers.py::TestCompositeProviderIMAPPreference`
  -- 5 passed.
- `python scripts/check_guard_class_closure.py --base origin/main --strict`,
  changed-module compilation, `git diff --check`, and ASCII checks -- passed.
- Full unit ratchet -- 163 failing/errored nodes against a baseline of 182,
  with 20 stale baseline entries and one intermittent Nemotron STT failure;
  `tests/test_nemotron_stt.py::test_nemotron_stt` passed on immediate isolated
  replay.
- Storage maturity ratchet -- passed after removing four first-party
  repository mocks; no baseline debt added.
- Independent exact-snapshot re-review -- LGTM; held-out candidate-boundary,
  parser-exception, early-stop, and mailbox-case probes passed.
- Broad `tests/test_mcp_servers.py` baseline -- 74 passed, 6 unrelated
  origin/main source/test drift failures (redaction expectations, IMAP
  executor-call expectations, and calendar mock shape).

## Diff size

7 files, +1172 / -29.

Diff-budget override: the authorization boundary is indivisible across typed
configuration, provider construction, aggregation, MCP serialization, and the
real-entrypoint privacy regression; most churn is the focused behavioral proof,
which cannot be split from the runtime change without merging an unproven
cross-mailbox guard.
