### PR TITLE
EOM portal: add guarded Atlas site economics reconciliation

### DIFF
--- a/plans/PR-EOM-Portal-Reconciliation.md
+++ b/plans/PR-EOM-Portal-Reconciliation.md
@@ -1,0 +1,144 @@
+# PR-EOM-Portal-Reconciliation
+
+## Why this slice exists
+
+Issue canfieldjuan/eom-timetracker#20 identifies Atlas as the source for
+customer service economics, while the EOM portal owns operational Sites. PR
+canfieldjuan/eom-timetracker#52 added guarded Customer and Site updates to the
+portal. This slice proves the first safe Atlas-to-portal write without
+inventing a second customer-matching system.
+
+Diff-budget override: the safety-critical operator command, its real-entrypoint
+external-seam tests, and the required contract plan are one indivisible proof;
+splitting them would publish either an unproved write path or tests with no
+reachable implementation.
+
+### Problem-derived contract
+
+- Root cause: Atlas currently imports portal customers into its CRM but has no
+  reverse path for service economics. A Contact can represent several portal
+  Sites while Atlas stores one Contact address and no durable Site identity,
+  so name, address, phone, email, or calendar matching cannot safely choose a
+  Site.
+- Correct fix must touch/change: add a private operator entrypoint that accepts
+  one exact Atlas service ID and one exact existing portal Site ID; tenant-scope
+  the Atlas read to `effingham_maids`; verify the linked Contact's stamped
+  portal Customer ID owns that Site; map only supported service rate labels;
+  emit a deterministic preview and plan hash; and require that exact hash plus
+  the current portal update token before applying only `rate` and `rateType`.
+  Apply must bind approval to the portal origin and hold shared locks on the
+  selected Atlas service and Contact until the one portal write finishes, so
+  neither authoritative source nor target can drift outside the approved plan.
+  Focused tests must prove the real CLI path, zero-write preview/no-op behavior,
+  fail-closed identity and mapping boundaries, hash drift protection, guarded
+  apply payload, and surfaced stale/HTTP failures without retry.
+- Must not change: existing portal-to-Atlas synchronization, CRM/storage
+  schemas, repositories, config, invoices, contacts, billing recipients,
+  addresses, calendar import, schedules, public APIs, MCP tools, or UI. The
+  command must not infer identity, create, merge, archive, reassign, clear,
+  retry, or update a portal Customer.
+
+## Scope (this PR)
+
+Ownership lane: eom/portal-reconciliation
+Slice phase: Vertical slice
+
+1. Reconcile one explicitly selected Atlas service's economics to one
+   explicitly selected existing EOM portal Site.
+2. Prove real command-entrypoint reachability, preview/hash/apply concurrency,
+   and all fail-closed identity boundaries.
+
+### Review Contract
+
+- Acceptance criteria:
+  - Preview prints a canonical plan and deterministic SHA-256 hash and never
+    PATCHes the portal.
+  - Apply requires the matching hash recomputed from fresh Atlas and portal
+    state, binds it to the portal origin, locks the Atlas source rows through
+    the write, and sends only `expectedUpdateToken`, `rate`, and `rateType`.
+  - Exact tenant, active service/contact, stamped Customer identity, Site
+    ownership, and supported rate-label checks all fail closed.
+  - An unchanged target is a no-op; stale or other HTTP failures are reported
+    nonzero and are not retried.
+- Reachability proof: invoke `scripts/reconcile_eom_portal_site.py` through its
+  CLI `main()` and observe preview JSON/hash or one guarded Site PATCH.
+- Affected surfaces: one private reconciliation script, its focused tests, and
+  required script maturity enrollment if the repository gate identifies it.
+- Risk areas: cross-tenant reads, targeting a Site owned by another Customer,
+  Atlas or portal drift after approval, cross-origin hash replay, accidental
+  broad payloads, secret leakage, retries after a concurrency conflict, and
+  unsupported rate-label coercion.
+- Reviewer rules triggered: R1, R2, R3, R6, R8, R10, R12, R14.
+
+### Files touched
+
+- `plans/PR-EOM-Portal-Reconciliation.md`
+- `scripts/reconcile_eom_portal_site.py`
+- `tests/test_reconcile_eom_portal_site.py`
+
+## Mechanism
+
+Reuse the existing typed portal configuration, login, and active-customer fetch
+helpers. Read the selected service and linked Contact in one explicitly
+tenant-scoped query. Locate the selected Site only inside the fetched active
+portal roster, verify its `customerId`, translate the three exact supported
+rate labels, and compare the desired values with the Site.
+
+The canonical preview contains the stable identities, portal origin and current
+token, current economics, and desired economics. Preview prints it with its
+SHA-256 hash. Apply performs the same fresh derivation while holding shared
+locks on the selected Atlas service and Contact, compares the supplied hash
+before mutation, then sends one guarded PATCH before releasing those locks.
+There is only one possible remote mutation, so a failed apply cannot leave a
+multi-entity partial write.
+
+## Intentional
+
+- Exact IDs are an intentional operator boundary until Atlas has a durable
+  service-to-Site binding.
+- Contact address, names, phones, emails, and calendar labels are deliberately
+  rejected as identity signals.
+- A separate reverse-direction command keeps the existing portal-to-Atlas sync
+  behavior unchanged while reusing its transport primitives.
+
+## Deferred
+
+- Durable service-to-Site binding/bootstrap for multi-site customers.
+- Review-only customer primary/billing candidate previews.
+- Address and calendar-resolution workflows after stable per-Site identity
+  exists.
+
+Parked hardening: none.
+
+## Verification
+
+- python -m pytest tests/test_sync_eom_portal_customers.py
+  tests/test_reconcile_eom_portal_site.py -q
+  - passed, 70 tests.
+- python -m ruff check scripts/reconcile_eom_portal_site.py
+  tests/test_reconcile_eom_portal_site.py
+  - passed.
+- python -m py_compile scripts/reconcile_eom_portal_site.py
+  tests/test_reconcile_eom_portal_site.py and
+  python scripts/reconcile_eom_portal_site.py --help - passed.
+- python scripts/maturity_sweep.py scripts --tests-root tests --baseline
+  tests/maturity_sweep/baseline_scripts.json --top 25
+  - passed with no new brittleness above baseline.
+- Independent correctness review - LGTM after source-lock, origin-binding, and
+  strict external-confirmation boundary probes were fixed.
+- Cold diff audit - no gaps: the scoped/locked source read is at
+  `scripts/reconcile_eom_portal_site.py:39`, identity and plan construction at
+  `scripts/reconcile_eom_portal_site.py:107`, the sole guarded PATCH at
+  `scripts/reconcile_eom_portal_site.py:186`, and real-entrypoint/boundary
+  proofs at `tests/test_reconcile_eom_portal_site.py:146` and
+  `tests/test_reconcile_eom_portal_site.py:189`. No existing runtime module or
+  excluded behavior changed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-EOM-Portal-Reconciliation.md` | 144 |
+| `scripts/reconcile_eom_portal_site.py` | 310 |
+| `tests/test_reconcile_eom_portal_site.py` | 344 |
+| **Total** | **798** |

--- a/plans/PR-EOM-Portal-Reconciliation.md
+++ b/plans/PR-EOM-Portal-Reconciliation.md
@@ -4,8 +4,9 @@
 
 Issue canfieldjuan/eom-timetracker#20 identifies Atlas as the source for
 customer service economics, while the EOM portal owns operational Sites. PR
-canfieldjuan/eom-timetracker#52 added guarded Customer and Site updates to the
-portal. This slice proves the first safe Atlas-to-portal write without
+canfieldjuan/eom-timetracker#52 added individually guarded Customer and Site
+updates; follow-up PR #55 adds the cross-aggregate Customer precondition this
+command requires. This slice proves the first safe Atlas-to-portal write without
 inventing a second customer-matching system.
 
 Diff-budget override: the safety-critical operator command, its real-entrypoint
@@ -19,24 +20,34 @@ reachable implementation.
   reverse path for service economics. A Contact can represent several portal
   Sites while Atlas stores one Contact address and no durable Site identity,
   so name, address, phone, email, or calendar matching cannot safely choose a
-  Site.
+  Site. The existing Site update token also cannot detect a concurrent change
+  to its owning Customer's Atlas identity, and a caller-selected portal origin
+  can redirect globally configured credentials unless it is configuration
+  bound before login.
 - Correct fix must touch/change: add a private operator entrypoint that accepts
   one exact Atlas service ID and one exact existing portal Site ID; tenant-scope
   the Atlas read to `effingham_maids`; verify the linked Contact's stamped
   portal Customer ID owns that Site; map only supported service rate labels;
   emit a deterministic preview and plan hash; and require that exact hash plus
-  the current portal update token before applying only `rate` and `rateType`.
-  Apply must bind approval to the portal origin and hold shared locks on the
-  selected Atlas service and Contact until the one portal write finishes, so
-  neither authoritative source nor target can drift outside the approved plan.
+  the current portal Site and Customer update tokens before applying only
+  `rate` and `rateType`. Before any credential lookup or network request, the
+  selected origin must exactly match the configured credential origin. Apply
+  must hold shared locks on the selected Atlas service and Contact until the
+  one portal write finishes, while the portal atomically validates both target
+  tokens, so neither authoritative source nor either identity aggregate can
+  drift outside the approved plan. The portal's additive dual-token write
+  boundary is delivered independently by canfieldjuan/eom-timetracker#55 and
+  must land before this command is used.
   Focused tests must prove the real CLI path, zero-write preview/no-op behavior,
   fail-closed identity and mapping boundaries, hash drift protection, guarded
   apply payload, and surfaced stale/HTTP failures without retry.
-- Must not change: existing portal-to-Atlas synchronization, CRM/storage
-  schemas, repositories, config, invoices, contacts, billing recipients,
-  addresses, calendar import, schedules, public APIs, MCP tools, or UI. The
-  command must not infer identity, create, merge, archive, reassign, clear,
-  retry, or update a portal Customer.
+- Must not change in this Atlas slice: existing portal-to-Atlas
+  synchronization, CRM/storage schemas, repositories, config, invoices,
+  contacts, billing recipients, addresses, calendar import, schedules, public
+  APIs, MCP tools, or UI. The command must not infer identity, create, merge,
+  archive, reassign, clear, retry, or update a portal Customer. The paired
+  portal prerequisite is limited to one optional backward-compatible request
+  precondition and does not change response shapes.
 
 ## Scope (this PR)
 
@@ -54,8 +65,11 @@ Slice phase: Vertical slice
   - Preview prints a canonical plan and deterministic SHA-256 hash and never
     PATCHes the portal.
   - Apply requires the matching hash recomputed from fresh Atlas and portal
-    state, binds it to the portal origin, locks the Atlas source rows through
-    the write, and sends only `expectedUpdateToken`, `rate`, and `rateType`.
+    state, binds it to the configured credential origin, locks the Atlas source
+    rows through the write, and sends only the Site/Customer update tokens,
+    `rate`, and `rateType`.
+  - A mismatched or malformed `--base-url` is rejected before credentials,
+    database initialization, or HTTP calls.
   - Exact tenant, active service/contact, stamped Customer identity, Site
     ownership, and supported rate-label checks all fail closed.
   - An unchanged target is a no-op; stale or other HTTP failures are reported
@@ -65,9 +79,9 @@ Slice phase: Vertical slice
 - Affected surfaces: one private reconciliation script, its focused tests, and
   required script maturity enrollment if the repository gate identifies it.
 - Risk areas: cross-tenant reads, targeting a Site owned by another Customer,
-  Atlas or portal drift after approval, cross-origin hash replay, accidental
-  broad payloads, secret leakage, retries after a concurrency conflict, and
-  unsupported rate-label coercion.
+  Atlas/Site/Customer drift after approval, credential disclosure or
+  cross-origin hash replay, accidental broad payloads, secret leakage, retries
+  after a concurrency conflict, and unsupported rate-label coercion.
 - Reviewer rules triggered: R1, R2, R3, R6, R8, R10, R12, R14.
 
 ### Files touched
@@ -79,16 +93,19 @@ Slice phase: Vertical slice
 ## Mechanism
 
 Reuse the existing typed portal configuration, login, and active-customer fetch
-helpers. Read the selected service and linked Contact in one explicitly
-tenant-scoped query. Locate the selected Site only inside the fetched active
-portal roster, verify its `customerId`, translate the three exact supported
-rate labels, and compare the desired values with the Site.
+helpers. Canonicalize the configured credential origin and reject any selected
+origin that differs before invoking those helpers. Read the selected service
+and linked Contact in one explicitly tenant-scoped query. Locate the selected
+Site only inside the fetched active portal roster, verify its `customerId`,
+capture both Customer and Site update tokens, translate the three exact
+supported rate labels, and compare the desired values with the Site.
 
 The canonical preview contains the stable identities, portal origin and current
 token, current economics, and desired economics. Preview prints it with its
 SHA-256 hash. Apply performs the same fresh derivation while holding shared
 locks on the selected Atlas service and Contact, compares the supplied hash
-before mutation, then sends one guarded PATCH before releasing those locks.
+before mutation, then sends one PATCH whose portal transaction atomically
+checks both Customer and Site tokens before releasing the Atlas locks.
 There is only one possible remote mutation, so a failed apply cannot leave a
 multi-entity partial write.
 
@@ -114,7 +131,7 @@ Parked hardening: none.
 
 - python -m pytest tests/test_sync_eom_portal_customers.py
   tests/test_reconcile_eom_portal_site.py -q
-  - passed, 70 tests.
+  - passed, 73 tests.
 - python -m ruff check scripts/reconcile_eom_portal_site.py
   tests/test_reconcile_eom_portal_site.py
   - passed.
@@ -125,20 +142,24 @@ Parked hardening: none.
   tests/maturity_sweep/baseline_scripts.json --top 25
   - passed with no new brittleness above baseline.
 - Independent correctness review - LGTM after source-lock, origin-binding, and
-  strict external-confirmation boundary probes were fixed.
+  strict external-confirmation boundary probes were fixed; the final review is
+  conditional only on portal prerequisite canfieldjuan/eom-timetracker#55
+  landing before this command is used.
 - Cold diff audit - no gaps: the scoped/locked source read is at
-  `scripts/reconcile_eom_portal_site.py:39`, identity and plan construction at
-  `scripts/reconcile_eom_portal_site.py:107`, the sole guarded PATCH at
-  `scripts/reconcile_eom_portal_site.py:186`, and real-entrypoint/boundary
-  proofs at `tests/test_reconcile_eom_portal_site.py:146` and
-  `tests/test_reconcile_eom_portal_site.py:189`. No existing runtime module or
-  excluded behavior changed.
+  `scripts/reconcile_eom_portal_site.py:67`, configured-origin enforcement is
+  at `scripts/reconcile_eom_portal_site.py:40` and
+  `scripts/reconcile_eom_portal_site.py:328`, identity and dual-token plan
+  construction is at `scripts/reconcile_eom_portal_site.py:135`, the sole
+  guarded PATCH is at `scripts/reconcile_eom_portal_site.py:221`, and
+  real-entrypoint/boundary proofs begin at
+  `tests/test_reconcile_eom_portal_site.py:151`. No existing Atlas runtime
+  module or excluded behavior changed.
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
-| `plans/PR-EOM-Portal-Reconciliation.md` | 144 |
-| `scripts/reconcile_eom_portal_site.py` | 310 |
-| `tests/test_reconcile_eom_portal_site.py` | 344 |
-| **Total** | **798** |
+| `plans/PR-EOM-Portal-Reconciliation.md` | 165 |
+| `scripts/reconcile_eom_portal_site.py` | 361 |
+| `tests/test_reconcile_eom_portal_site.py` | 378 |
+| **Total** | **904** |

--- a/scripts/reconcile_eom_portal_site.py
+++ b/scripts/reconcile_eom_portal_site.py
@@ -18,6 +18,7 @@ import sys
 import uuid
 from decimal import Decimal, InvalidOperation
 from typing import Any, Callable, Mapping, Sequence
+from urllib.parse import urlsplit
 
 from sync_eom_portal_customers import (
     DEFAULT_BASE_URL,
@@ -34,6 +35,33 @@ RATE_TYPES = {
     "Per Month": "monthly",
 }
 HASH_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _portal_origin(value: str) -> str:
+    try:
+        parsed = urlsplit(str(value).strip())
+        port = parsed.port
+    except ValueError:
+        raise argparse.ArgumentTypeError("portal origin is invalid") from None
+    host = parsed.hostname
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not host
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.path not in {"", "/"}
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise argparse.ArgumentTypeError(
+            "portal origin must be an HTTP(S) origin without credentials or a path"
+        )
+    if parsed.scheme == "http" and host not in {"localhost", "127.0.0.1", "::1"}:
+        raise argparse.ArgumentTypeError("non-loopback portal origins must use HTTPS")
+    host = f"[{host}]" if ":" in host else host.lower()
+    default_port = 443 if parsed.scheme == "https" else 80
+    port_suffix = f":{port}" if port is not None and port != default_port else ""
+    return f"{parsed.scheme}://{host}{port_suffix}"
 
 
 async def load_service(
@@ -160,6 +188,12 @@ def build_plan(
     token = site.get("updateToken")
     if not isinstance(token, str) or HASH_PATTERN.fullmatch(token) is None:
         raise SystemExit("Portal Site has no valid update token")
+    customer_token = customer.get("updateToken")
+    if (
+        not isinstance(customer_token, str)
+        or HASH_PATTERN.fullmatch(customer_token) is None
+    ):
+        raise SystemExit("Portal Customer has no valid update token")
 
     return {
         "action": "noop" if current == desired else "update",
@@ -172,6 +206,7 @@ def build_plan(
         "portal": {
             "baseUrl": base_url,
             "customerId": portal_customer_id,
+            "expectedCustomerUpdateToken": customer_token,
             "expectedUpdateToken": token,
             "siteId": site_id,
         },
@@ -193,6 +228,7 @@ def apply_plan(client: Any, token: str, plan: Mapping[str, Any]) -> None:
         f"{portal['baseUrl']}/api/admin/locations/{portal['siteId']}",
         headers={"Authorization": f"Bearer {token}"},
         json={
+            "expectedCustomerUpdateToken": portal["expectedCustomerUpdateToken"],
             "expectedUpdateToken": portal["expectedUpdateToken"],
             "rate": desired["rate"],
             "rateType": desired["rateType"],
@@ -283,13 +319,29 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--plan-hash")
     parser.add_argument(
         "--base-url",
-        default=settings_default("eom_portal_base_url") or DEFAULT_BASE_URL,
+        type=_portal_origin,
+        help="Portal origin; must match the configured credential origin",
     )
     return parser
 
 
-def main(argv: Sequence[str] | None = None, **run_kwargs: Any) -> int:
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    credential_origin: str | None = None,
+    **run_kwargs: Any,
+) -> int:
     parser = _parser()
+    configured = (
+        credential_origin
+        or settings_default("eom_portal_base_url")
+        or DEFAULT_BASE_URL
+    )
+    try:
+        configured = _portal_origin(configured)
+    except argparse.ArgumentTypeError as exc:
+        parser.error(f"configured portal credential origin: {exc}")
+    parser.set_defaults(base_url=configured)
     args = parser.parse_args(argv)
     if args.site_id <= 0:
         parser.error("--site-id must be greater than zero")
@@ -300,9 +352,8 @@ def main(argv: Sequence[str] | None = None, **run_kwargs: Any) -> int:
         parser.error("--apply requires the exact lowercase --plan-hash from preview")
     if not args.apply and args.plan_hash is not None:
         parser.error("--plan-hash is only valid with --apply")
-    args.base_url = args.base_url.rstrip("/")
-    if not args.base_url:
-        parser.error("--base-url must not be empty")
+    if args.base_url != configured:
+        parser.error("--base-url must match the configured portal credential origin")
     return asyncio.run(run(args, **run_kwargs))
 
 

--- a/scripts/reconcile_eom_portal_site.py
+++ b/scripts/reconcile_eom_portal_site.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Preview or apply one exact Atlas service -> EOM portal Site rate update.
+
+Identity is operator-selected and verified, never inferred. Preview is the
+default. Applying requires the SHA-256 hash printed by a fresh preview.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import hmac
+import json
+import os
+import re
+import sys
+import uuid
+from decimal import Decimal, InvalidOperation
+from typing import Any, Callable, Mapping, Sequence
+
+from sync_eom_portal_customers import (
+    DEFAULT_BASE_URL,
+    EOM_CONTEXT_ID,
+    fetch_portal_customers,
+    portal_login,
+    settings_default,
+)
+
+MAX_PORTAL_RATE = Decimal("999999.99")
+RATE_TYPES = {
+    "Per Visit": "per_visit",
+    "Per Hour": "hourly",
+    "Per Month": "monthly",
+}
+HASH_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+
+
+async def load_service(
+    pool: Any, service_id: uuid.UUID, *, lock: bool = False
+) -> dict[str, Any]:
+    query = """
+        SELECT s.id AS service_id, s.rate, s.rate_label,
+               c.id AS contact_id, c.metadata AS contact_metadata
+          FROM customer_services s
+          JOIN contacts c ON c.id = s.contact_id
+         WHERE s.id = $1
+           AND s.business_context_id = $2
+           AND c.business_context_id = $2
+           AND s.status = 'active'
+           AND c.status = 'active'
+           AND c.contact_type = 'customer'
+        """
+    if lock:
+        query += " FOR SHARE OF s, c"
+    row = await pool.fetchrow(query, service_id, EOM_CONTEXT_ID)
+    if row is None:
+        raise SystemExit("Active EOM service and customer Contact not found")
+    return dict(row)
+
+
+def _metadata(value: Any) -> dict[str, Any]:
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError:
+            value = None
+    if not isinstance(value, dict):
+        raise SystemExit("Atlas Contact metadata is not a JSON object")
+    return value
+
+
+def _money(value: Any, *, source: str) -> float:
+    try:
+        amount = Decimal(str(value))
+        normalized = amount.quantize(Decimal("0.01"))
+    except (InvalidOperation, TypeError, ValueError):
+        raise SystemExit(f"{source} rate is not a valid amount") from None
+    if not amount.is_finite() or amount != normalized:
+        raise SystemExit(f"{source} rate must have at most two decimal places")
+    if amount < 0 or amount > MAX_PORTAL_RATE:
+        raise SystemExit(f"{source} rate is outside the portal's allowed range")
+    return float(normalized)
+
+
+def _selected_site(
+    customers: Sequence[dict[str, Any]], site_id: int
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    matches: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    for customer in customers:
+        if not isinstance(customer, dict):
+            continue
+        for site in customer.get("sites") or []:
+            if (
+                customer.get("active") is True
+                and isinstance(site, dict)
+                and type(site.get("id")) is int
+                and site["id"] == site_id
+                and site.get("active") is True
+            ):
+                matches.append((customer, site))
+    if len(matches) != 1:
+        raise SystemExit("Exact active portal Site was not found uniquely")
+    return matches[0]
+
+
+def build_plan(
+    service: Mapping[str, Any],
+    customers: Sequence[dict[str, Any]],
+    site_id: int,
+    base_url: str,
+) -> dict[str, Any]:
+    metadata = _metadata(service.get("contact_metadata"))
+    portal_customer_id = metadata.get("portal_customer_id")
+    if type(portal_customer_id) is not int or portal_customer_id <= 0:
+        raise SystemExit("Atlas Contact has no valid stamped portal Customer ID")
+
+    customer, site = _selected_site(customers, site_id)
+    customer_id = customer.get("id")
+    if type(customer_id) is not int or customer_id != portal_customer_id:
+        raise SystemExit("Selected portal Site is owned by another Customer")
+    site_customer_id = site.get("customerId")
+    if type(site_customer_id) is not int or site_customer_id != portal_customer_id:
+        raise SystemExit("Selected portal Site has inconsistent Customer ownership")
+
+    try:
+        service_id = str(uuid.UUID(str(service.get("service_id"))))
+    except ValueError:
+        raise SystemExit("Atlas service ID is not a UUID") from None
+    contact_id = str(service.get("contact_id"))
+    try:
+        contact_id = str(uuid.UUID(contact_id))
+    except ValueError:
+        raise SystemExit("Atlas Contact ID is not a UUID") from None
+    portal_contact_id = customer.get("atlasContactId")
+    if portal_contact_id not in (None, ""):
+        try:
+            portal_contact_id = str(uuid.UUID(str(portal_contact_id)))
+        except ValueError:
+            raise SystemExit("Portal Customer atlasContactId is not a UUID") from None
+        if portal_contact_id != contact_id:
+            raise SystemExit("Portal Customer is linked to another Atlas Contact")
+
+    rate_label = service.get("rate_label")
+    if rate_label not in RATE_TYPES:
+        raise SystemExit(f"Unsupported Atlas rate label: {rate_label!r}")
+    desired = {
+        "rate": _money(service.get("rate"), source="Atlas"),
+        "rateType": RATE_TYPES[rate_label],
+    }
+    current_rate = site.get("rate")
+    current = {
+        "rate": (
+            None
+            if current_rate is None
+            else _money(current_rate, source="Portal")
+        ),
+        "rateType": site.get("rateType"),
+    }
+    token = site.get("updateToken")
+    if not isinstance(token, str) or HASH_PATTERN.fullmatch(token) is None:
+        raise SystemExit("Portal Site has no valid update token")
+
+    return {
+        "action": "noop" if current == desired else "update",
+        "atlas": {
+            "contactId": contact_id,
+            "serviceId": service_id,
+        },
+        "current": current,
+        "desired": desired,
+        "portal": {
+            "baseUrl": base_url,
+            "customerId": portal_customer_id,
+            "expectedUpdateToken": token,
+            "siteId": site_id,
+        },
+    }
+
+
+def plan_hash(plan: Mapping[str, Any]) -> str:
+    canonical = json.dumps(plan, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def apply_plan(client: Any, token: str, plan: Mapping[str, Any]) -> None:
+    if plan["action"] == "noop":
+        print("No portal update required.")
+        return
+    portal = plan["portal"]
+    desired = plan["desired"]
+    response = client.patch(
+        f"{portal['baseUrl']}/api/admin/locations/{portal['siteId']}",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "expectedUpdateToken": portal["expectedUpdateToken"],
+            "rate": desired["rate"],
+            "rateType": desired["rateType"],
+        },
+    )
+    if response.status_code != 200:
+        suffix = "; rerun preview" if response.status_code == 409 else ""
+        raise SystemExit(f"Portal Site update failed (HTTP {response.status_code}){suffix}")
+    try:
+        body = response.json() or {}
+    except ValueError:
+        body = {}
+    if not isinstance(body, dict):
+        raise SystemExit("Portal Site update returned an invalid confirmation")
+    location = body.get("location")
+    if (
+        body.get("success") is not True
+        or not isinstance(location, dict)
+        or type(location.get("id")) is not int
+        or location.get("id") != portal["siteId"]
+        or location.get("rateType") != desired["rateType"]
+        or _money(location.get("rate"), source="Portal confirmation")
+        != desired["rate"]
+    ):
+        raise SystemExit("Portal Site update returned an invalid confirmation")
+    print(f"Updated portal Site {portal['siteId']}.")
+
+
+def _finish(
+    args: argparse.Namespace,
+    client: Any,
+    token: str,
+    service: Mapping[str, Any],
+    customers: Sequence[dict[str, Any]],
+) -> int:
+    plan = build_plan(service, customers, args.site_id, args.base_url)
+    digest = plan_hash(plan)
+    print(json.dumps(plan, indent=2, sort_keys=True))
+    print(f"Plan hash: {digest}")
+    if not args.apply:
+        print("Preview only; no portal data changed.")
+        return 0
+    if not hmac.compare_digest(args.plan_hash, digest):
+        raise SystemExit("Plan hash mismatch; rerun preview before applying")
+    apply_plan(client, token, plan)
+    return 0
+
+
+async def run(
+    args: argparse.Namespace,
+    *,
+    pool: Any = None,
+    client_factory: Callable[[], Any] | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> int:
+    if pool is None:
+        from atlas_brain.storage.database import get_db_pool
+
+        pool = get_db_pool()
+    await pool.initialize()
+    if client_factory is None:
+        import httpx
+
+        def client_factory() -> Any:
+            return httpx.Client(timeout=30.0)
+
+    with client_factory() as client:
+        runtime_env = os.environ if environ is None else environ
+        token = portal_login(client, args.base_url, dict(runtime_env))
+        customers = fetch_portal_customers(client, args.base_url, token)
+        if args.apply:
+            async with pool.transaction() as connection:
+                service = await load_service(
+                    connection, args.service_id, lock=True
+                )
+                return _finish(args, client, token, service, customers)
+        service = await load_service(pool, args.service_id)
+        return _finish(args, client, token, service, customers)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Reconcile one exact Atlas service to one EOM portal Site"
+    )
+    parser.add_argument("--service-id", required=True, type=uuid.UUID)
+    parser.add_argument("--site-id", required=True, type=int)
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--plan-hash")
+    parser.add_argument(
+        "--base-url",
+        default=settings_default("eom_portal_base_url") or DEFAULT_BASE_URL,
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None, **run_kwargs: Any) -> int:
+    parser = _parser()
+    args = parser.parse_args(argv)
+    if args.site_id <= 0:
+        parser.error("--site-id must be greater than zero")
+    if args.apply and (
+        not isinstance(args.plan_hash, str)
+        or HASH_PATTERN.fullmatch(args.plan_hash) is None
+    ):
+        parser.error("--apply requires the exact lowercase --plan-hash from preview")
+    if not args.apply and args.plan_hash is not None:
+        parser.error("--plan-hash is only valid with --apply")
+    args.base_url = args.base_url.rstrip("/")
+    if not args.base_url:
+        parser.error("--base-url must not be empty")
+    return asyncio.run(run(args, **run_kwargs))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_reconcile_eom_portal_site.py
+++ b/tests/test_reconcile_eom_portal_site.py
@@ -20,6 +20,7 @@ import reconcile_eom_portal_site as reconcile  # noqa: E402
 SERVICE_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
 CONTACT_ID = uuid.UUID("22222222-2222-2222-2222-222222222222")
 TOKEN = "a" * 64
+CUSTOMER_TOKEN = "b" * 64
 ENV = {"ATLAS_TOOLS_EOM_PORTAL_TOKEN": "secret-token"}
 BASE_URL = "https://portal.test"
 
@@ -51,6 +52,7 @@ def _customers(**site_over):
             "id": 7,
             "active": True,
             "atlasContactId": str(CONTACT_ID),
+            "updateToken": CUSTOMER_TOKEN,
             "sites": [site],
         }
     ]
@@ -71,6 +73,7 @@ class Client:
         self.patch_status = patch_status
         self.payload = payload
         self.on_get = on_get
+        self.gets = []
         self.patches = []
 
     def __enter__(self):
@@ -81,6 +84,7 @@ class Client:
 
     def get(self, url, headers):
         assert headers == {"Authorization": "Bearer secret-token"}
+        self.gets.append((url, headers))
         if self.on_get:
             self.on_get()
         return Response(200, {"success": True, "customers": self.customers})
@@ -134,6 +138,7 @@ def _run(service, client, *extra, pool=None):
         pool=pool or Pool(service),
         client_factory=lambda: client,
         environ=ENV,
+        credential_origin=BASE_URL,
     )
 
 
@@ -196,6 +201,7 @@ def test_only_exact_supported_rate_labels_map(label, expected):
         ("inactive_site", "not found uniquely"),
         ("inactive_customer", "not found uniquely"),
         ("bad_token", "valid update token"),
+        ("bad_customer_token", "Customer has no valid update token"),
         ("unsupported_label", "Unsupported Atlas rate label"),
     ],
 )
@@ -216,6 +222,8 @@ def test_identity_and_mapping_boundaries_fail_closed(case, message):
         customers[0].pop("active")
     elif case == "bad_token":
         customers[0]["sites"][0]["updateToken"] = "stale"
+    elif case == "bad_customer_token":
+        customers[0]["updateToken"] = "stale"
     else:
         service["rate_label"] = "Monthly"
 
@@ -257,6 +265,7 @@ def test_apply_sends_only_guarded_site_economics(capsys):
             "https://portal.test/api/admin/locations/31",
             {"Authorization": "Bearer secret-token"},
             {
+                "expectedCustomerUpdateToken": CUSTOMER_TOKEN,
                 "expectedUpdateToken": TOKEN,
                 "rate": 247.5,
                 "rateType": "per_visit",
@@ -329,6 +338,30 @@ def test_plan_hash_is_bound_to_portal_origin():
     assert reconcile.plan_hash(_plan()) != reconcile.plan_hash(
         _plan(base_url="https://other-portal.test")
     )
+    changed_customer = _customers()
+    changed_customer[0]["updateToken"] = "c" * 64
+    assert reconcile.plan_hash(_plan()) != reconcile.plan_hash(
+        _plan(customers=changed_customer)
+    )
+
+
+@pytest.mark.parametrize(
+    "selected_origin",
+    ["https://evil.test", "http://evil.test/path"],
+)
+def test_origin_mismatch_is_rejected_before_credentials_or_io(selected_origin):
+    pool, client = Pool(_service()), Client(_customers())
+    with pytest.raises(SystemExit) as exc:
+        reconcile.main(
+            _main_args("--base-url", selected_origin),
+            pool=pool,
+            client_factory=lambda: client,
+            environ=ENV,
+            credential_origin=BASE_URL,
+        )
+    assert exc.value.code == 2
+    assert pool.initialized == 0
+    assert client.gets == client.patches == []
 
 
 def test_apply_without_hash_is_rejected_before_external_io():
@@ -339,6 +372,7 @@ def test_apply_without_hash_is_rejected_before_external_io():
             pool=pool,
             client_factory=lambda: client,
             environ=ENV,
+            credential_origin=BASE_URL,
         )
     assert exc.value.code == 2
     assert pool.initialized == 0 and client.patches == []

--- a/tests/test_reconcile_eom_portal_site.py
+++ b/tests/test_reconcile_eom_portal_site.py
@@ -1,0 +1,344 @@
+"""Contract tests for one-service Atlas -> EOM Site reconciliation."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import uuid
+from contextlib import asynccontextmanager
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+
+import reconcile_eom_portal_site as reconcile  # noqa: E402
+
+SERVICE_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
+CONTACT_ID = uuid.UUID("22222222-2222-2222-2222-222222222222")
+TOKEN = "a" * 64
+ENV = {"ATLAS_TOOLS_EOM_PORTAL_TOKEN": "secret-token"}
+BASE_URL = "https://portal.test"
+
+
+def _service(**over):
+    row = {
+        "service_id": SERVICE_ID,
+        "contact_id": CONTACT_ID,
+        "contact_metadata": json.dumps({"portal_customer_id": 7}),
+        "rate": "247.50",
+        "rate_label": "Per Visit",
+    }
+    row.update(over)
+    return row
+
+
+def _customers(**site_over):
+    site = {
+        "id": 31,
+        "customerId": 7,
+        "active": True,
+        "rate": 200.0,
+        "rateType": "per_visit",
+        "updateToken": TOKEN,
+    }
+    site.update(site_over)
+    return [
+        {
+            "id": 7,
+            "active": True,
+            "atlasContactId": str(CONTACT_ID),
+            "sites": [site],
+        }
+    ]
+
+
+class Response:
+    def __init__(self, status_code=200, payload=None):
+        self.status_code = status_code
+        self._payload = payload or {}
+
+    def json(self):
+        return self._payload
+
+
+class Client:
+    def __init__(self, customers, patch_status=200, payload=None, on_get=None):
+        self.customers = customers
+        self.patch_status = patch_status
+        self.payload = payload
+        self.on_get = on_get
+        self.patches = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return None
+
+    def get(self, url, headers):
+        assert headers == {"Authorization": "Bearer secret-token"}
+        if self.on_get:
+            self.on_get()
+        return Response(200, {"success": True, "customers": self.customers})
+
+    def patch(self, url, headers, json):
+        self.patches.append((url, headers, json))
+        payload = self.payload
+        if payload is None:
+            payload = {
+                "success": True,
+                "location": {"id": 31, "rate": 247.5, "rateType": "per_visit"},
+            }
+        return Response(self.patch_status, payload)
+
+
+class Pool:
+    def __init__(self, row):
+        self.row = row
+        self.initialized = 0
+        self.calls = []
+        self.transactions = 0
+
+    async def initialize(self):
+        self.initialized += 1
+
+    async def fetchrow(self, query, *args):
+        self.calls.append((query, args))
+        return self.row
+
+    @asynccontextmanager
+    async def transaction(self):
+        self.transactions += 1
+        yield self
+
+
+def _main_args(*extra):
+    return [
+        "--service-id",
+        str(SERVICE_ID),
+        "--site-id",
+        "31",
+        "--base-url",
+        "https://portal.test/",
+        *extra,
+    ]
+
+
+def _run(service, client, *extra, pool=None):
+    return reconcile.main(
+        _main_args(*extra),
+        pool=pool or Pool(service),
+        client_factory=lambda: client,
+        environ=ENV,
+    )
+
+
+def _plan(service=None, customers=None, base_url=BASE_URL):
+    return reconcile.build_plan(
+        service or _service(), customers or _customers(), 31, base_url
+    )
+
+
+def test_real_cli_preview_is_stable_and_write_free(capsys):
+    service, customers = _service(), _customers()
+    first_client, second_client = Client(customers), Client(deepcopy(customers))
+    first = _run(service, first_client)
+    first_output = capsys.readouterr().out
+    second = _run(deepcopy(service), second_client)
+    second_output = capsys.readouterr().out
+
+    assert first == second == 0
+    assert first_output == second_output
+    assert "Preview only; no portal data changed." in first_output
+    assert "secret-token" not in first_output
+    assert first_client.patches == second_client.patches == []
+
+
+def test_service_read_is_exact_and_tenant_scoped():
+    pool = Pool(_service())
+    row = asyncio.run(reconcile.load_service(pool, SERVICE_ID))
+    query, args = pool.calls[0]
+
+    assert row["service_id"] == SERVICE_ID
+    assert "s.id = $1" in query
+    assert "s.business_context_id = $2" in query
+    assert "c.business_context_id = $2" in query
+    assert "s.status = 'active'" in query and "c.status = 'active'" in query
+    assert args == (SERVICE_ID, "effingham_maids")
+    with pytest.raises(SystemExit, match="not found"):
+        asyncio.run(reconcile.load_service(Pool(None), SERVICE_ID))
+
+
+@pytest.mark.parametrize(
+    ("label", "expected"),
+    [
+        ("Per Visit", "per_visit"),
+        ("Per Hour", "hourly"),
+        ("Per Month", "monthly"),
+    ],
+)
+def test_only_exact_supported_rate_labels_map(label, expected):
+    plan = _plan(_service(rate_label=label))
+    assert plan["desired"] == {"rate": 247.5, "rateType": expected}
+
+
+@pytest.mark.parametrize(
+    ("case", "message"),
+    [
+        ("missing_stamp", "stamped portal Customer ID"),
+        ("wrong_owner", "owned by another Customer"),
+        ("inconsistent_site", "inconsistent Customer ownership"),
+        ("wrong_contact", "another Atlas Contact"),
+        ("inactive_site", "not found uniquely"),
+        ("inactive_customer", "not found uniquely"),
+        ("bad_token", "valid update token"),
+        ("unsupported_label", "Unsupported Atlas rate label"),
+    ],
+)
+def test_identity_and_mapping_boundaries_fail_closed(case, message):
+    service, customers = _service(), _customers()
+    if case == "missing_stamp":
+        service["contact_metadata"] = "{}"
+    elif case == "wrong_owner":
+        customers[0]["id"] = 8
+        customers[0]["sites"][0]["customerId"] = 8
+    elif case == "inconsistent_site":
+        customers[0]["sites"][0]["customerId"] = 8
+    elif case == "wrong_contact":
+        customers[0]["atlasContactId"] = str(SERVICE_ID)
+    elif case == "inactive_site":
+        customers[0]["sites"][0]["active"] = False
+    elif case == "inactive_customer":
+        customers[0].pop("active")
+    elif case == "bad_token":
+        customers[0]["sites"][0]["updateToken"] = "stale"
+    else:
+        service["rate_label"] = "Monthly"
+
+    client = Client(customers)
+    with pytest.raises(SystemExit, match=message):
+        _run(service, client)
+    assert client.patches == []
+
+
+def test_apply_requires_matching_fresh_hash_before_patch():
+    customers = _customers()
+    service, pool = _service(rate="247.50"), Pool(_service(rate="247.50"))
+    stale = reconcile.plan_hash(_plan(service, customers))
+
+    def change_source():
+        pool.row = _service(rate="300.00")
+
+    client = Client(customers, on_get=change_source)
+    with pytest.raises(SystemExit, match="Plan hash mismatch"):
+        _run(service, client, "--apply", "--plan-hash", stale, pool=pool)
+    assert client.patches == []
+    assert pool.transactions == 1
+    assert "FOR SHARE OF s, c" in pool.calls[0][0]
+
+
+def test_apply_sends_only_guarded_site_economics(capsys):
+    service, customers = _service(), _customers()
+    digest = reconcile.plan_hash(_plan(service, customers))
+    client = Client(customers)
+    pool = Pool(service)
+
+    result = _run(
+        service, client, "--apply", "--plan-hash", digest, pool=pool
+    )
+
+    assert result == 0
+    assert client.patches == [
+        (
+            "https://portal.test/api/admin/locations/31",
+            {"Authorization": "Bearer secret-token"},
+            {
+                "expectedUpdateToken": TOKEN,
+                "rate": 247.5,
+                "rateType": "per_visit",
+            },
+        )
+    ]
+    assert pool.transactions == 1
+    assert "FOR SHARE OF s, c" in pool.calls[0][0]
+    assert "Updated portal Site 31." in capsys.readouterr().out
+
+
+def test_unchanged_apply_is_noop():
+    service, customers = _service(), _customers(rate=247.5)
+    plan = _plan(service, customers)
+    client = Client(customers)
+
+    assert plan["action"] == "noop"
+    assert (
+        _run(service, client, "--apply", "--plan-hash", reconcile.plan_hash(plan))
+        == 0
+    )
+    assert client.patches == []
+
+
+@pytest.mark.parametrize("status", [409, 500])
+def test_http_failure_is_nonzero_and_never_retried(status):
+    service, customers = _service(), _customers()
+    plan = _plan(service, customers)
+    client = Client(customers, patch_status=status)
+
+    with pytest.raises(SystemExit, match=f"HTTP {status}"):
+        _run(service, client, "--apply", "--plan-hash", reconcile.plan_hash(plan))
+    assert len(client.patches) == 1
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"success": True, "location": {"id": True, "rate": 247.5, "rateType": "per_visit"}},
+        {"success": True, "location": {"id": 31, "rate": 1.0, "rateType": "per_visit"}},
+        {"success": False, "location": {"id": 31, "rate": 247.5, "rateType": "per_visit"}},
+        [{"unexpected": "shape"}],
+    ],
+)
+def test_invalid_success_confirmation_never_prints_success(payload, capsys):
+    service, customers = _service(), _customers()
+    plan = _plan(service, customers)
+    client = Client(customers, payload=payload)
+    with pytest.raises(SystemExit, match="invalid confirmation"):
+        _run(service, client, "--apply", "--plan-hash", reconcile.plan_hash(plan))
+    assert len(client.patches) == 1
+    assert "Updated portal Site" not in capsys.readouterr().out
+
+
+def test_confirmation_rejects_bool_collision_with_site_one():
+    plan = _plan()
+    plan["portal"]["siteId"] = 1
+    client = Client(
+        _customers(),
+        payload={
+            "success": True,
+            "location": {"id": True, "rate": 247.5, "rateType": "per_visit"},
+        },
+    )
+    with pytest.raises(SystemExit, match="invalid confirmation"):
+        reconcile.apply_plan(client, "secret-token", plan)
+
+
+def test_plan_hash_is_bound_to_portal_origin():
+    assert reconcile.plan_hash(_plan()) != reconcile.plan_hash(
+        _plan(base_url="https://other-portal.test")
+    )
+
+
+def test_apply_without_hash_is_rejected_before_external_io():
+    pool, client = Pool(_service()), Client(_customers())
+    with pytest.raises(SystemExit) as exc:
+        reconcile.main(
+            _main_args("--apply"),
+            pool=pool,
+            client_factory=lambda: client,
+            environ=ENV,
+        )
+    assert exc.value.code == 2
+    assert pool.initialized == 0 and client.patches == []


### PR DESCRIPTION
Plan: plans/PR-EOM-Portal-Reconciliation.md
Slice phase: Vertical slice
Ownership lane: eom/portal-reconciliation

Issue canfieldjuan/eom-timetracker#20 needs Atlas service economics to reach
operational portal Sites, but Atlas has no stable per-Site identity. This PR
adds the smallest safe reverse path: one exact service ID to one exact existing
Site ID, with preview/hash approval and source/target concurrency guards.
Portal PR canfieldjuan/eom-timetracker#55 is the independently deployable
prerequisite that atomically validates the owning Customer token.

Diff-budget override: the safety-critical operator command, its real-entrypoint
external-seam tests, and the required contract plan are one indivisible proof;
splitting them would publish either an unproved write path or tests with no
reachable implementation.

## Intentional

- Require exact operator-selected service and Site IDs until Atlas has a
  durable service-to-Site binding.
- Reject names, addresses, phones, emails, and calendar labels as identity
  signals.
- Keep the existing portal-to-Atlas sync unchanged and reuse only its typed
  configuration, login, and active-roster transport helpers.

## Deferred

- Durable service-to-Site binding/bootstrap for multi-site customers.
- Review-only customer primary/billing candidate previews.
- Address and calendar resolution after stable per-Site identity exists.

## Parked hardening

- None.

## Cold diff reconstruction

- Gaps: none.
- Changed: `scripts/reconcile_eom_portal_site.py:67` performs the exact,
  dual-tenant active service/Contact read and optionally takes shared row locks;
  `scripts/reconcile_eom_portal_site.py:40` canonicalizes the configured portal
  origin and `scripts/reconcile_eom_portal_site.py:328` rejects any selected
  mismatch before credentials or I/O; `scripts/reconcile_eom_portal_site.py:135`
  verifies stable identities and builds the dual-token, origin-bound plan;
  `scripts/reconcile_eom_portal_site.py:221` sends the sole Site PATCH with only
  both update tokens, rate, and rate type; `scripts/reconcile_eom_portal_site.py:280`
  holds the Atlas locks through apply.
- Changed: `tests/test_reconcile_eom_portal_site.py:151` proves the real CLI
  preview is deterministic and write-free; the remaining focused cases prove
  tenant/identity rejection, source drift, origin binding, exact payload,
  no-op behavior, no retry, and strict success confirmation.
- Changed: `plans/PR-EOM-Portal-Reconciliation.md:16` records the pre-code
  problem contract, explicit exclusions, mechanism, verification, and the
  over-budget rationale.
- Contract match: every runtime change traces to exact identity, preview/hash
  approval, source locking, portal concurrency, or fail-closed confirmation.
  The diff adds no existing runtime-module edits. Portal PR #55 supplies the
  contract's additive atomic Customer precondition and must land before use.
- Forbidden-touch check: CRM schemas/repositories/config, invoices, contacts,
  billing, addresses, calendars, schedules, public APIs, MCP, UI, and the
  existing portal-to-Atlas sync behavior are unchanged.

## Verification

- `python -m pytest tests/test_sync_eom_portal_customers.py tests/test_reconcile_eom_portal_site.py -q`
  - passed, 73 tests.
- Ruff, Python byte compilation, command `--help`, and whitespace checks passed.
- The scripts maturity ratchet passed with no new brittleness above baseline.
- Independent code/test judgment review returned LGTM after all boundary
  findings were fixed, conditional only on portal prerequisite #55 landing
  before this command is used.
- No live Atlas or portal records were mutated during verification.

## Diff size

3 files, +904 / -0.
