### PR TITLE
feat: Phase 6 contracts — repurposing variants + image prompts (#2109)

### DIFF
--- a/atlas_brain/schemas/content_factory.py
+++ b/atlas_brain/schemas/content_factory.py
@@ -95,6 +95,28 @@ _ADVISORY_GRAMMAR_RE = re.compile(
 )
 
 
+def _validate_advisory_warnings(warnings: "list[str]") -> None:
+    """Persistence choke point for ALL writers (runner or direct) on EVERY
+    artifact that carries advisory warnings.
+
+    A warning must be a known static line or match the deterministic locator
+    grammar -- free-text (and therefore PII-shaped) entries are rejected at
+    validation, before the store persists anything. Kept as one function so
+    the audit, the repurposing variants, and the image prompts cannot drift
+    into three different grammars.
+    """
+    for warning in warnings:
+        if warning in _ADVISORY_STATIC_WARNINGS:
+            continue
+        if _ADVISORY_GRAMMAR_RE.fullmatch(warning):
+            continue
+        raise ValueError(
+            "advisory_warnings entries must be deterministic checklist "
+            "lines (bounded locator grammar); free-text evidence is not "
+            "representable"
+        )
+
+
 Confidence = Literal["high", "medium", "low"]
 Recommendation = Literal["promote", "revise"]
 Verdict = Literal["pass", "fail"]
@@ -262,20 +284,7 @@ class EditorialAuditV2(BaseModel):
 
     @model_validator(mode="after")
     def _advisory_warnings_bounded(self) -> "EditorialAuditV2":
-        # Choke point for ALL writers (runner or direct): warnings must be a
-        # known static line or match the deterministic locator grammar --
-        # free-text (and so PII-shaped) entries are rejected at validation,
-        # before the store persists anything.
-        for warning in self.advisory_warnings:
-            if warning in _ADVISORY_STATIC_WARNINGS:
-                continue
-            if _ADVISORY_GRAMMAR_RE.fullmatch(warning):
-                continue
-            raise ValueError(
-                "advisory_warnings entries must be deterministic checklist "
-                "lines (bounded locator grammar); free-text evidence is not "
-                "representable"
-            )
+        _validate_advisory_warnings(self.advisory_warnings)
         return self
 
     @model_validator(mode="after")
@@ -331,6 +340,114 @@ class ArtifactManifest(BaseModel):
     created_at: Optional[str] = None
 
 
+class ChannelVariant(BaseModel):
+    """One channel-specific rewrite of an approved draft.
+
+    A variant is the copy that actually SHIPS, so it carries its own
+    deterministic verdict rather than inheriting the draft's: a rewrite can
+    introduce an overclaim the source never made.
+    """
+
+    model_config = _BASE_CONFIG
+
+    # Non-blank: a variant with no channel cannot be routed, and one with no
+    # body is not a variant.
+    channel: NonEmptyStr
+    body_markdown: NonEmptyStr
+    # Claim lineage back to the source draft's claims/evidence ids. A variant
+    # with no lineage is an orphan -- it asserts something the approved draft
+    # never established, which is exactly the "repurposer invents claims"
+    # failure this field exists to make visible.
+    derived_from_claims: list[NonEmptyStr] = Field(default_factory=list)
+    copy_verification: Optional[CopyVerification] = None
+    advisory_warnings: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _advisory_warnings_bounded(self) -> "ChannelVariant":
+        _validate_advisory_warnings(self.advisory_warnings)
+        return self
+
+
+class RepurposingPackage(BaseModel):
+    """repurposing.json -- channel variants derived from an approved draft.
+
+    ``ready_to_publish`` is the variant-level analogue of the editorial
+    audit's promote gate: the model cannot declare a package shippable while
+    any variant carries a failing deterministic verdict.
+    """
+
+    model_config = _BASE_CONFIG
+
+    artifact_schema: Literal["repurposing.v1"] = Field(alias="schema")
+    schema_version: Literal[1] = 1
+    project_id: str
+    source_draft_revision: int = 1
+    variants: list[ChannelVariant] = Field(default_factory=list)
+    ready_to_publish: bool = False
+    prompt_version: Optional[str] = None
+
+    @model_validator(mode="after")
+    def _package_invariants(self) -> "RepurposingPackage":
+        # An empty package is not a repurposing result; it is a no-op that
+        # would otherwise persist as if work had been done.
+        if not self.variants:
+            raise ValueError("repurposing package requires at least one variant")
+        # One channel per variant: two variants on the same channel means an
+        # ambiguous "which one ships?" downstream.
+        channels = [variant.channel.casefold() for variant in self.variants]
+        if len(channels) != len(set(channels)):
+            raise ValueError("duplicate channel in repurposing variants")
+        if self.ready_to_publish:
+            for variant in self.variants:
+                verdict = variant.copy_verification
+                if verdict is None or verdict.verdict != "pass":
+                    raise ValueError(
+                        "ready_to_publish requires every variant to carry "
+                        "copy_verification.verdict == 'pass'"
+                    )
+        return self
+
+
+class ImagePrompt(BaseModel):
+    """One text-to-image prompt. TEXT ONLY -- generation is a separate,
+    human-triggered, VRAM-guarded step (epic #2109 Phase 6 keeps the prompt
+    designer and the generator split)."""
+
+    model_config = _BASE_CONFIG
+
+    purpose: NonEmptyStr
+    prompt_text: NonEmptyStr
+    negative_prompt: str = ""
+    aspect_ratio: str = "1:1"
+
+
+class ImagePromptSet(BaseModel):
+    """image_prompt.json -- image prompts derived from an approved draft.
+
+    Prompt text is gated like body copy: a diffusion model will happily
+    render a banned claim or a contact string INTO the artwork, where no
+    downstream text check would ever see it.
+    """
+
+    model_config = _BASE_CONFIG
+
+    artifact_schema: Literal["image_prompt.v1"] = Field(alias="schema")
+    schema_version: Literal[1] = 1
+    project_id: str
+    source_draft_revision: int = 1
+    prompts: list[ImagePrompt] = Field(default_factory=list)
+    copy_verification: Optional[CopyVerification] = None
+    advisory_warnings: list[str] = Field(default_factory=list)
+    prompt_version: Optional[str] = None
+
+    @model_validator(mode="after")
+    def _prompt_set_invariants(self) -> "ImagePromptSet":
+        if not self.prompts:
+            raise ValueError("image prompt set requires at least one prompt")
+        _validate_advisory_warnings(self.advisory_warnings)
+        return self
+
+
 ARTIFACT_MODELS: dict[str, type[BaseModel]] = {
     "content_brief.v1": ContentBrief,
     "evidence_packet.v1": EvidencePacket,
@@ -338,6 +455,8 @@ ARTIFACT_MODELS: dict[str, type[BaseModel]] = {
     "editorial_audit.v1": EditorialAudit,
     "editorial_audit.v2": EditorialAuditV2,
     "manifest.v1": ArtifactManifest,
+    "repurposing.v1": RepurposingPackage,
+    "image_prompt.v1": ImagePromptSet,
 }
 
 

--- a/atlas_brain/schemas/content_factory.py
+++ b/atlas_brain/schemas/content_factory.py
@@ -47,9 +47,17 @@ docs/schemas/ (generated, not hand-written).
 from __future__ import annotations
 
 import re
+import unicodedata
 from typing import Annotated, Any, Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, StringConstraints, model_validator
+from pydantic import (
+    AfterValidator,
+    BaseModel,
+    ConfigDict,
+    Field,
+    StringConstraints,
+    model_validator,
+)
 
 
 # The canonical "schema" key is the SOLE admission rule for the version tag,
@@ -93,6 +101,39 @@ _ADVISORY_GRAMMAR_RE = re.compile(
     r"^(?:unqualified-answer-claim|unqualified-ownership-claim): "
     r"sentence [1-9]\d{0,9}$"
 )
+
+
+def _has_visible_content(text: str) -> bool:
+    """True when ``text`` contains at least one VISIBLE character.
+
+    ``str.strip()`` only removes ASCII/Unicode whitespace, so a
+    producer-supplied zero-width space, soft hyphen, or bidi control passes
+    a non-blank check while rendering as nothing. Phase 6 artifacts are
+    shippable copy and renderer instructions, so "looks empty" must be
+    treated as empty (#2192 round 4). Categories C* (control/format/
+    surrogate/private-use/unassigned) and Z* (separators) are invisible.
+    """
+    return any(
+        not unicodedata.category(char).startswith(("C", "Z")) for char in text
+    )
+
+
+VisibleStr = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, min_length=1),
+    AfterValidator(
+        lambda value: value
+        if _has_visible_content(value)
+        else _raise_invisible()
+    ),
+]
+
+
+def _raise_invisible():
+    raise ValueError(
+        "value must contain visible characters (invisible/format-only text "
+        "is not content)"
+    )
 
 
 def _validate_advisory_warnings(warnings: "list[str]") -> None:
@@ -353,7 +394,7 @@ class ChannelVariant(BaseModel):
     # Non-blank: a variant with no channel cannot be routed, and one with no
     # body is not a variant.
     channel: NonEmptyStr
-    body_markdown: NonEmptyStr
+    body_markdown: VisibleStr
     # Claim lineage back to the source draft's claims/evidence ids. REQUIRED
     # and non-empty: a variant with no lineage is an orphan -- it asserts
     # something the approved draft never established, which is exactly the
@@ -417,7 +458,7 @@ class ImagePrompt(BaseModel):
     model_config = _BASE_CONFIG
 
     purpose: NonEmptyStr
-    prompt_text: NonEmptyStr
+    prompt_text: VisibleStr
     negative_prompt: str = ""
     aspect_ratio: str = "1:1"
 

--- a/atlas_brain/schemas/content_factory.py
+++ b/atlas_brain/schemas/content_factory.py
@@ -321,6 +321,12 @@ class EditorialAuditV2(BaseModel):
     # warnings from the copy-verification module. Deliberately NOT referenced
     # by any validator -- warnings never gate the recommendation.
     advisory_warnings: list[str] = Field(default_factory=list)
+    # Content identity of the draft this audit approved, stamped by the
+    # runner (never by the worker). A revision number is producer-supplied
+    # and reusable -- rerunning the draft stage can replace the body while
+    # keeping revision 1 -- so approval binds to the bytes that were
+    # actually reviewed (#2192 round 7).
+    source_draft_fingerprint: Optional[str] = None
     recommendation: Recommendation = "revise"
     prompt_version: Optional[str] = None
 

--- a/atlas_brain/schemas/content_factory.py
+++ b/atlas_brain/schemas/content_factory.py
@@ -305,7 +305,15 @@ class EditorialAudit(BaseModel):
 
 
 class EditorialAuditV2(BaseModel):
-    """audit.json (v2) -- v1 plus the non-blocking advisory checklist."""
+    """audit.json (v2, FROZEN) -- v1 plus the non-blocking advisory checklist.
+
+    Frozen for the same reason as v1: v2 shipped in #2181, so artifacts
+    already on disk and any rolled-back reader must keep validating
+    byte-for-byte. ``extra="forbid"`` makes that symmetric -- a field added
+    here would make every newly written audit UNREADABLE to a v2 consumer,
+    not merely unknown to it. ``source_draft_fingerprint`` therefore lives
+    on ``EditorialAuditV3`` (#2192 round 8). Do not add fields here.
+    """
 
     model_config = _BASE_CONFIG
 
@@ -321,12 +329,6 @@ class EditorialAuditV2(BaseModel):
     # warnings from the copy-verification module. Deliberately NOT referenced
     # by any validator -- warnings never gate the recommendation.
     advisory_warnings: list[str] = Field(default_factory=list)
-    # Content identity of the draft this audit approved, stamped by the
-    # runner (never by the worker). A revision number is producer-supplied
-    # and reusable -- rerunning the draft stage can replace the body while
-    # keeping revision 1 -- so approval binds to the bytes that were
-    # actually reviewed (#2192 round 7).
-    source_draft_fingerprint: Optional[str] = None
     recommendation: Recommendation = "revise"
     prompt_version: Optional[str] = None
 
@@ -346,6 +348,32 @@ class EditorialAuditV2(BaseModel):
                     "recommendation 'promote' requires copy_verification.verdict == 'pass'"
                 )
         return self
+
+
+class EditorialAuditV3(EditorialAuditV2):
+    """audit.json (v3) -- v2 plus the runner-stamped draft content identity.
+
+    v2 cannot express WHICH draft an approval covers. ``draft_revision`` is a
+    producer-supplied label, and a same-revision rerun replaces the body
+    while the number stays 1, so a stale approval carried over to copy
+    nobody reviewed (#2192 round 7). v3 binds approval to content instead.
+
+    A NEW VERSION rather than a v2 field: v2 shipped in #2181 and forbids
+    extras, so adding the key there would make every newly written audit
+    unreadable to a v2 consumer or a rolled-back reader -- the exact
+    breakage v1's freeze note exists to prevent (#2192 round 8).
+
+    Inherits v2's validators by subclassing so the promote-gate and the
+    advisory-warning grammar cannot drift between the two versions.
+    """
+
+    artifact_schema: Literal["editorial_audit.v3"] = Field(alias="schema")
+    schema_version: Literal[3] = 3
+    # Stamped by the runner, never by the worker -- the same self-report
+    # discipline as copy_verification. Optional so a direct writer can still
+    # persist a v3 audit, but the runner's readiness gate REJECTS an
+    # unstamped audit rather than treating absence as approval.
+    source_draft_fingerprint: Optional[str] = None
 
 
 class StageEntry(BaseModel):
@@ -520,6 +548,7 @@ ARTIFACT_MODELS: dict[str, type[BaseModel]] = {
     "draft.v1": DraftArtifact,
     "editorial_audit.v1": EditorialAudit,
     "editorial_audit.v2": EditorialAuditV2,
+    "editorial_audit.v3": EditorialAuditV3,
     "manifest.v1": ArtifactManifest,
     "repurposing.v1": RepurposingPackage,
     "image_prompt.v1": ImagePromptSet,

--- a/atlas_brain/schemas/content_factory.py
+++ b/atlas_brain/schemas/content_factory.py
@@ -103,6 +103,22 @@ _ADVISORY_GRAMMAR_RE = re.compile(
 )
 
 
+def _routing_key(channel: str) -> str:
+    """Comparison key for a routing label.
+
+    NFKC first (canonically equivalent spellings are one channel to a reader),
+    then DROP format and control characters -- zero-width joiners, bidi marks
+    and the like occupy no visible width, so a label carrying them is
+    indistinguishable from one that does not and must not read as a second,
+    separate channel (#2192 round 9).
+    """
+    normalized = unicodedata.normalize("NFKC", channel)
+    stripped = "".join(
+        ch for ch in normalized if not unicodedata.category(ch) in ("Cf", "Cc")
+    )
+    return stripped.strip().casefold()
+
+
 def _has_visible_content(text: str) -> bool:
     """True when ``text`` contains at least one VISIBLE character.
 
@@ -426,9 +442,12 @@ class ChannelVariant(BaseModel):
 
     model_config = _BASE_CONFIG
 
-    # Non-blank: a variant with no channel cannot be routed, and one with no
-    # body is not a variant.
-    channel: NonEmptyStr
+    # A channel must be VISIBLE, not merely non-blank: a label made only of
+    # U+200B/U+200C/U+FE0F satisfies "non-empty" while being unroutable, and
+    # several distinct invisible labels also slip past the duplicate check as
+    # different strings. Same class as the body/prompt fix, applied to the
+    # routing identifier (#2192 round 9).
+    channel: VisibleStr
     body_markdown: VisibleStr
     # Claim lineage back to the source draft's claims/evidence ids. REQUIRED
     # and non-empty: a variant with no lineage is an orphan -- it asserts
@@ -474,10 +493,11 @@ class RepurposingPackage(BaseModel):
         # NFKC first: canonically equivalent spellings (NFC vs NFD) are the
         # same channel to a reader, so casefold alone leaves the very
         # ambiguity this check exists to prevent (round 5).
-        channels = [
-            unicodedata.normalize("NFKC", variant.channel.strip()).casefold()
-            for variant in self.variants
-        ]
+        # Zero-width and control characters are dropped before comparing: they
+        # carry no visible width, so "email" and "email​" are the SAME
+        # channel to a reader and to anything routing on the label, and
+        # keeping them made a visually identical duplicate pass (round 9).
+        channels = [_routing_key(variant.channel) for variant in self.variants]
         if len(channels) != len(set(channels)):
             raise ValueError("duplicate channel in repurposing variants")
         if self.ready_to_publish:

--- a/atlas_brain/schemas/content_factory.py
+++ b/atlas_brain/schemas/content_factory.py
@@ -354,11 +354,12 @@ class ChannelVariant(BaseModel):
     # body is not a variant.
     channel: NonEmptyStr
     body_markdown: NonEmptyStr
-    # Claim lineage back to the source draft's claims/evidence ids. A variant
-    # with no lineage is an orphan -- it asserts something the approved draft
-    # never established, which is exactly the "repurposer invents claims"
-    # failure this field exists to make visible.
-    derived_from_claims: list[NonEmptyStr] = Field(default_factory=list)
+    # Claim lineage back to the source draft's claims/evidence ids. REQUIRED
+    # and non-empty: a variant with no lineage is an orphan -- it asserts
+    # something the approved draft never established, which is exactly the
+    # "repurposer invents claims" failure this field exists to prevent. A
+    # default would make that orphan representable (review round 1).
+    derived_from_claims: list[NonEmptyStr] = Field(min_length=1)
     copy_verification: Optional[CopyVerification] = None
     advisory_warnings: list[str] = Field(default_factory=list)
 
@@ -438,12 +439,23 @@ class ImagePromptSet(BaseModel):
     prompts: list[ImagePrompt] = Field(default_factory=list)
     copy_verification: Optional[CopyVerification] = None
     advisory_warnings: list[str] = Field(default_factory=list)
+    # The generation gate, mirroring RepurposingPackage.ready_to_publish: a
+    # set may not be marked renderable while its deterministic verdict
+    # fails. Recording a verdict nobody gates on is verification, not a gate
+    # (review round 1).
+    ready_to_generate: bool = False
     prompt_version: Optional[str] = None
 
     @model_validator(mode="after")
     def _prompt_set_invariants(self) -> "ImagePromptSet":
         if not self.prompts:
             raise ValueError("image prompt set requires at least one prompt")
+        if self.ready_to_generate:
+            verdict = self.copy_verification
+            if verdict is None or verdict.verdict != "pass":
+                raise ValueError(
+                    "ready_to_generate requires copy_verification.verdict == 'pass'"
+                )
         _validate_advisory_warnings(self.advisory_warnings)
         return self
 

--- a/atlas_brain/schemas/content_factory.py
+++ b/atlas_brain/schemas/content_factory.py
@@ -111,10 +111,11 @@ def _has_visible_content(text: str) -> bool:
     a non-blank check while rendering as nothing. Phase 6 artifacts are
     shippable copy and renderer instructions, so "looks empty" must be
     treated as empty (#2192 round 4). Categories C* (control/format/
-    surrogate/private-use/unassigned) and Z* (separators) are invisible.
+    surrogate/private-use/unassigned), Z* (separators) and M* (combining
+    marks, e.g. a lone U+FE0F) cannot stand alone as content.
     """
     return any(
-        not unicodedata.category(char).startswith(("C", "Z")) for char in text
+        not unicodedata.category(char).startswith(("C", "Z", "M")) for char in text
     )
 
 
@@ -436,7 +437,13 @@ class RepurposingPackage(BaseModel):
             raise ValueError("repurposing package requires at least one variant")
         # One channel per variant: two variants on the same channel means an
         # ambiguous "which one ships?" downstream.
-        channels = [variant.channel.casefold() for variant in self.variants]
+        # NFKC first: canonically equivalent spellings (NFC vs NFD) are the
+        # same channel to a reader, so casefold alone leaves the very
+        # ambiguity this check exists to prevent (round 5).
+        channels = [
+            unicodedata.normalize("NFKC", variant.channel.strip()).casefold()
+            for variant in self.variants
+        ]
         if len(channels) != len(set(channels)):
             raise ValueError("duplicate channel in repurposing variants")
         if self.ready_to_publish:

--- a/atlas_brain/services/content_factory_copy_verification.py
+++ b/atlas_brain/services/content_factory_copy_verification.py
@@ -159,6 +159,26 @@ def _claim_hits(text: str) -> list[str]:
     return hits
 
 
+def literal_claim_hits(text: str) -> list[str]:
+    """Banned-claim matches with NO negation suppression.
+
+    Body copy earns negation handling: "we do not promise guaranteed
+    savings" is a denial and reads as one. A text-to-image PROMPT does not
+    -- it is an instruction to a renderer, and "poster reading do not
+    guarantee savings" still draws the forbidden words onto the poster. The
+    grammar around the phrase is invisible once it is pixels, so the phrase
+    itself is what matters (#2192 round 3).
+
+    Callers that want prose semantics keep using :func:`verify_copy`.
+    """
+    hits: list[str] = []
+    for category in ("outcomes", "automation", "replacing_agents"):
+        for code, pattern in _RULES[category]:
+            for match in re.finditer(pattern, text, re.I):
+                hits.append(f"{code}: {_redact_pii(match.group(0))}")
+    return hits
+
+
 def verify_copy(text: str) -> CopyVerification:
     """Deterministically verify draft copy, producing the ``CopyVerification``
     verdict the #2116 EditorialAudit contract requires for promotion.

--- a/atlas_brain/services/content_factory_runner.py
+++ b/atlas_brain/services/content_factory_runner.py
@@ -111,6 +111,10 @@ def call_worker(
     return content or ""
 
 
+# A phone number is 7+ digits however it is written. Prompt text is short
+# descriptive copy, so a long digit run is contact data rather than prose.
+_CONTACT_DIGIT_RUN_RE = re.compile(r"\d(?:[^\w\n]{0,3}\d){6,}")
+
 _REPURPOSING_SCHEMA = "repurposing.v1"
 _IMAGE_PROMPT_SCHEMA = "image_prompt.v1"
 
@@ -200,7 +204,11 @@ def _enforce_image_prompts(artifact: dict[str, Any]) -> None:
             hits.append(f"prompt {index}: {hit}")
         if _EMAIL_RE.search(text):
             hits.append(f"prompt {index}: email: <redacted>")
-        if _PHONE_RE.search(text) or _INTL_PHONE_RE.search(text):
+        if _CONTACT_DIGIT_RUN_RE.search(text):
+            # Class-level, not prefix-level: any run of 7+ digits under
+            # tolerant separators is contact-shaped, so "+44...", "0044...",
+            # "(555) 123-4567" and any future dialling convention are all
+            # covered without enumerating prefixes (round 4).
             hits.append(f"prompt {index}: phone: <redacted>")
 
     artifact["copy_verification"] = {
@@ -262,9 +270,11 @@ def _enforce_copy_verification(artifact: dict[str, Any]) -> None:
     artifact["advisory_warnings"] = advisory_warnings(edited)
 
 
-def _read_draft(job_id: str, root: "Path | str") -> "dict[str, Any] | None":
-    """The job's persisted draft artifact, or None when it cannot be read."""
-    path = job_dir(job_id, root=root) / "draft.json"
+def _read_job_artifact(
+    job_id: str, root: "Path | str", name: str
+) -> "dict[str, Any] | None":
+    """A persisted artifact from the job folder, or None when unreadable."""
+    path = job_dir(job_id, root=root) / name
     try:
         data = json.loads(path.read_text())
     except (OSError, ValueError):
@@ -310,12 +320,33 @@ def _enforce_lineage(artifact: dict[str, Any], job_id: str, root: "Path | str") 
     if not ready:
         return
 
-    draft = _read_draft(job_id, root)
+    draft = _read_job_artifact(job_id, root, "draft.json")
     if draft is None:
         raise ArtifactStoreError(
             "readiness requires a readable draft artifact in the job folder "
             "to verify claim lineage and source revision"
         )
+
+    # The plan's premise is that Phase 6 derives from an APPROVED draft.
+    # Existence proves the draft ran, not that a human/gate cleared it, so
+    # require the job's audit to have promoted it (round 4).
+    audit = _read_job_artifact(job_id, root, "audit.json")
+    if audit is None or audit.get("recommendation") != "promote":
+        raise ArtifactStoreError(
+            "readiness requires an audit artifact recommending 'promote'; "
+            "unaudited or revise-state copy cannot ship or render"
+        )
+
+    # Cross-project derivation: a matching revision and overlapping ids are
+    # not evidence when the draft belongs to a different project (round 4).
+    artifact_project = getattr(model, "project_id", None)
+    draft_project = draft.get("project_id")
+    if artifact_project != draft_project:
+        raise ArtifactStoreError(
+            f"project mismatch: artifact project_id {artifact_project!r} does "
+            f"not match the draft's {draft_project!r}"
+        )
+
     declared = getattr(model, "source_draft_revision", None)
     actual = draft.get("revision", 1)
     if declared is not None and declared != actual:

--- a/atlas_brain/services/content_factory_runner.py
+++ b/atlas_brain/services/content_factory_runner.py
@@ -18,10 +18,14 @@ from pathlib import Path
 from typing import Any
 
 from atlas_brain.services.content_factory_copy_verification import (
+    _EMAIL_RE,
     _INTL_PHONE_RE,
+    _PHONE_RE,
     advisory_warnings,
+    literal_claim_hits,
     verify_copy,
 )
+from atlas_brain.schemas.content_factory import model_for
 from atlas_brain.services.content_factory_store import (
     DEFAULT_ROOT,
     ArtifactStoreError,
@@ -190,9 +194,13 @@ def _enforce_image_prompts(artifact: dict[str, Any]) -> None:
     for index, text in enumerate(texts, start=1):
         if not text.strip():
             continue
-        for hit in verify_copy(text).hits:
+        # Literal matching: prose negation does not un-draw words a renderer
+        # is told to put on a poster (round 3).
+        for hit in literal_claim_hits(text):
             hits.append(f"prompt {index}: {hit}")
-        if _INTL_PHONE_RE.search(text):
+        if _EMAIL_RE.search(text):
+            hits.append(f"prompt {index}: email: <redacted>")
+        if _PHONE_RE.search(text) or _INTL_PHONE_RE.search(text):
             hits.append(f"prompt {index}: phone: <redacted>")
 
     artifact["copy_verification"] = {
@@ -254,16 +262,20 @@ def _enforce_copy_verification(artifact: dict[str, Any]) -> None:
     artifact["advisory_warnings"] = advisory_warnings(edited)
 
 
-def _draft_claim_ids(job_id: str, root: "Path | str") -> "set[str] | None":
-    """Claim source ids the job's approved draft established, or None when
-    the draft cannot be read (missing/unparseable)."""
+def _read_draft(job_id: str, root: "Path | str") -> "dict[str, Any] | None":
+    """The job's persisted draft artifact, or None when it cannot be read."""
     path = job_dir(job_id, root=root) / "draft.json"
     try:
         data = json.loads(path.read_text())
     except (OSError, ValueError):
         return None
+    return data if isinstance(data, dict) else None
+
+
+def _draft_claim_ids(draft: "dict[str, Any]") -> "set[str]":
+    """Claim source ids the approved draft established."""
     ids: set[str] = set()
-    for claim in data.get("claims") or []:
+    for claim in draft.get("claims") or []:
         if isinstance(claim, dict):
             source_id = str(claim.get("source_id") or "").strip()
             if source_id:
@@ -272,30 +284,51 @@ def _draft_claim_ids(job_id: str, root: "Path | str") -> "set[str] | None":
 
 
 def _enforce_lineage(artifact: dict[str, Any], job_id: str, root: "Path | str") -> None:
-    """A package may not be declared shippable while any variant cites a
-    claim the job's draft never established.
+    """Readiness flags require a verified tie to the job's approved draft.
 
-    Non-blank lineage is not the same as REAL lineage: a fabricated id is
-    still an orphan. Checked only when ``ready_to_publish`` is asserted --
-    an unready package is a legitimate intermediate state -- and fails
-    closed when the draft cannot be read, since traceability then cannot be
-    demonstrated (round 2).
+    Checked for both Phase 6 artifacts once they claim readiness:
+      * every cited claim id exists in that draft (a fabricated id is still
+        an orphan), and
+      * the declared ``source_draft_revision`` matches the draft actually on
+        disk -- otherwise a package can ship copy derived from superseded
+        text whenever the claim ids happen to overlap (round 3).
+
+    The artifact is validated FIRST so this branches on the same normalized
+    values the contract will accept: a weak worker's ``"false"`` string
+    coerces to False here exactly as it does in the model, instead of the
+    runner reading raw truthiness and disagreeing with admission (round 3).
+    Unready artifacts skip the check -- that is the legitimate intermediate
+    state -- and a missing/unreadable draft fails closed.
     """
-    if artifact.get("schema") != _REPURPOSING_SCHEMA:
+    schema = artifact.get("schema")
+    if schema not in (_REPURPOSING_SCHEMA, _IMAGE_PROMPT_SCHEMA):
         return
-    if not artifact.get("ready_to_publish"):
+    model = model_for(artifact).model_validate(artifact)
+    ready = getattr(model, "ready_to_publish", False) or getattr(
+        model, "ready_to_generate", False
+    )
+    if not ready:
         return
-    known = _draft_claim_ids(job_id, root)
-    if known is None:
+
+    draft = _read_draft(job_id, root)
+    if draft is None:
         raise ArtifactStoreError(
-            "ready_to_publish requires a readable draft.json in the job "
-            "folder to verify variant claim lineage"
+            "readiness requires a readable draft artifact in the job folder "
+            "to verify claim lineage and source revision"
         )
+    declared = getattr(model, "source_draft_revision", None)
+    actual = draft.get("revision", 1)
+    if declared is not None and declared != actual:
+        raise ArtifactStoreError(
+            f"source_draft_revision {declared} does not match the draft on "
+            f"disk (revision {actual}); the artifact derives from superseded copy"
+        )
+
+    known = _draft_claim_ids(draft)
     cited: set[str] = set()
-    for variant in artifact.get("variants") or []:
-        if isinstance(variant, dict):
-            for claim_id in variant.get("derived_from_claims") or []:
-                cited.add(str(claim_id).strip())
+    for variant in getattr(model, "variants", []) or []:
+        for claim_id in variant.derived_from_claims:
+            cited.add(claim_id.strip())
     unknown = sorted(cited - known)
     if unknown:
         raise ArtifactStoreError(

--- a/atlas_brain/services/content_factory_runner.py
+++ b/atlas_brain/services/content_factory_runner.py
@@ -101,6 +101,69 @@ def call_worker(
     return content or ""
 
 
+_REPURPOSING_SCHEMA = "repurposing.v1"
+_IMAGE_PROMPT_SCHEMA = "image_prompt.v1"
+
+
+def _deterministic_verdict(text: str, *, empty_reason: str) -> "tuple[dict, list[str]]":
+    """(verdict, warnings) computed from ``text``. Blank text fails closed:
+    with nothing verified, no artifact may carry a passing verdict."""
+    if not text.strip():
+        return (
+            {"verdict": "fail", "hits": [f"unverified-copy: {empty_reason}"]},
+            [],
+        )
+    return verify_copy(text).model_dump(), advisory_warnings(text)
+
+
+def _enforce_repurposing(artifact: dict[str, Any]) -> None:
+    """OVERWRITE each variant's verdict/checklist from its own body.
+
+    Variants are the copy that ships, so each is verified independently and
+    the worker's self-reported values are discarded -- the same discipline
+    that makes the editorial audit unable to self-promote. A variant whose
+    body is blank fails closed, which in turn makes a worker-asserted
+    ``ready_to_publish`` invalid at contract validation.
+    """
+    if artifact.get("schema") != _REPURPOSING_SCHEMA:
+        return
+    variants = artifact.get("variants")
+    if not isinstance(variants, list):
+        return
+    for variant in variants:
+        if not isinstance(variant, dict):
+            continue
+        verdict, warnings = _deterministic_verdict(
+            str(variant.get("body_markdown") or ""),
+            empty_reason="body_markdown is empty; nothing was verified",
+        )
+        variant["copy_verification"] = verdict
+        variant["advisory_warnings"] = warnings
+
+
+def _enforce_image_prompts(artifact: dict[str, Any]) -> None:
+    """Gate the PROMPT TEXT itself: a diffusion model will render a banned
+    claim or a contact string into the artwork, where no downstream text
+    check would ever see it. Verified over every prompt's text and negative
+    prompt together."""
+    if artifact.get("schema") != _IMAGE_PROMPT_SCHEMA:
+        return
+    prompts = artifact.get("prompts")
+    if not isinstance(prompts, list):
+        return
+    parts: list[str] = []
+    for prompt in prompts:
+        if isinstance(prompt, dict):
+            parts.append(str(prompt.get("prompt_text") or ""))
+            parts.append(str(prompt.get("negative_prompt") or ""))
+    combined = "\n".join(part for part in parts if part)
+    verdict, warnings = _deterministic_verdict(
+        combined, empty_reason="prompt text is empty; nothing was verified"
+    )
+    artifact["copy_verification"] = verdict
+    artifact["advisory_warnings"] = warnings
+
+
 def _enforce_copy_verification(artifact: dict[str, Any]) -> None:
     """For ANY editorial audit (gated by schema, not stage name -- see below), OVERWRITE
     copy_verification with the deterministic verdict computed from the edited copy,
@@ -174,4 +237,6 @@ def run_stage(
             f"stage {stage!r}: worker {model!r} returned no JSON artifact"
         )
     _enforce_copy_verification(artifact)
+    _enforce_repurposing(artifact)
+    _enforce_image_prompts(artifact)
     return write_artifact(job_id, stage, artifact, root=root)

--- a/atlas_brain/services/content_factory_runner.py
+++ b/atlas_brain/services/content_factory_runner.py
@@ -111,50 +111,6 @@ def call_worker(
     return content or ""
 
 
-# --- prompt contact-PII classifiers -------------------------------------
-#
-# These are deliberately NOT the body-copy patterns. A prompt is an
-# instruction about to be rendered into pixels, so the decision has to hold
-# in BOTH directions: contact data must fail, and ordinary numeric/textual
-# description (dates, times, counts, dimensions) must pass. Rounds 3-5 all
-# broke on one side or the other of exactly this, so the shape is now:
-# candidate -> reject known non-contact shapes -> require contact evidence.
-
-# Address-shaped token, script-independent: closes internationalized email
-# (unicode local parts, IDN domains) that an ASCII pattern misses.
-_ANY_EMAIL_RE = re.compile(r"[^\s@,;:()<>\[\]]+@[^\s@,;:()<>\[\]]+\.[^\s@,;:()<>\[\]]{2,}")
-
-# Digit sequences with phone-ish separators, then filtered below.
-_DIGIT_SEQ_RE = re.compile(r"[+\d][\d\s().\-\u2010-\u2015]{5,}\d")
-# Shapes that are NOT contact data however many digits they carry.
-_NON_CONTACT_SHAPES = (
-    re.compile(r"^\d{4}[-/.]\d{1,2}[-/.]\d{1,2}$"),      # 2026-07-25
-    re.compile(r"^\d{1,2}[-/.]\d{1,2}[-/.]\d{2,4}$"),     # 07/25/2026
-    re.compile(r"^\d{1,2}:\d{2}(?::\d{2})?$"),            # 9:45
-)
-# Vanity numbers carry letters, so digit counting alone never sees them.
-_VANITY_PHONE_RE = re.compile(r"\b1[\s.\-]?[89]\d{2}[\s.\-]?[A-Za-z][A-Za-z0-9]{5,}\b")
-
-
-def _prompt_contact_hits(text: str) -> list[str]:
-    """Contact-PII findings for renderer instructions, both directions."""
-    hits: list[str] = []
-    if _ANY_EMAIL_RE.search(text):
-        hits.append("email: <redacted>")
-    if _VANITY_PHONE_RE.search(text):
-        hits.append("phone: <redacted>")
-        return hits
-    for match in _DIGIT_SEQ_RE.finditer(text):
-        token = match.group(0).strip()
-        if any(shape.match(token) for shape in _NON_CONTACT_SHAPES):
-            continue
-        digits = re.sub(r"\D", "", token)
-        # E.164 allows up to 15; below 7 is not a dialable number.
-        if 7 <= len(digits) <= 15:
-            hits.append("phone: <redacted>")
-            break
-    return hits
-
 _REPURPOSING_SCHEMA = "repurposing.v1"
 _IMAGE_PROMPT_SCHEMA = "image_prompt.v1"
 
@@ -193,6 +149,75 @@ def _enforce_repurposing(artifact: dict[str, Any]) -> None:
         )
         variant["copy_verification"] = verdict
         variant["advisory_warnings"] = warnings
+
+
+# --- prompt contact-PII classifiers -------------------------------------
+#
+# EVIDENCE-GATED, not pattern-enumerated. Rounds 3-6 each broke because the
+# rule asked "do these digits look like a phone number?" -- a question with
+# no closed answer, since dates, RGB triples, dimensions and dialable
+# numbers share a digit grammar. The decision now asks for POSITIVE
+# EVIDENCE of contact intent, of which there are exactly two kinds:
+#
+#   1. structural  -- an unambiguous dialable form (E.164 "+"/"00" prefix,
+#                     or the NANP 3-3-4 shape). Nothing describes artwork
+#                     this way.
+#   2. lexical     -- a dial-intent verb ("call", "text", "reach"...) near
+#                     a dial-shaped token, which is what makes
+#                     "Call 1-800-GOT-JUNK" contact data even though its
+#                     digits alone are not.
+#
+# Absent both, digits are just description and the prompt passes. That is
+# what makes "RGB palette 255 255 255" and "calendar showing 2026-07-25"
+# safe without enumerating them.
+
+_ANY_EMAIL_RE = re.compile(
+    r"[^\s@,;:()<>\[\]]+@[^\s@,;:()<>\[\]]+\.[^\s@,;:()<>\[\]]{2,}"
+)
+
+_DIAL_INTENT_RE = re.compile(
+    r"\b(?:call|calling|dial|dialling|dialing|phone|telephone|tel|text|txt|"
+    r"sms|ring|hotline|helpline|whatsapp|contact|reach)\b",
+    re.I,
+)
+# E.164 / international: explicit + or 00 prefix then 7-15 digits.
+_E164_RE = re.compile(r"(?:\+|\b00)[\d\s().\-]{7,20}\d")
+# North American 3-3-4, the one local shape that is unambiguous.
+_NANP_RE = re.compile(r"\(?\b\d{3}\)?[\s.\-]\d{3}[\s.\-]\d{4}\b")
+# A token someone could dial: starts with a digit, 7+ alphanumerics once
+# separators are stripped (covers 1-800-GOT-JUNK and 07700 900123 alike).
+# Continuation groups must be digits or an uppercase run (vanity numbers
+# are conventionally capitalised), so a token cannot swallow the ordinary
+# lowercase word that follows it ("07700 900123 today").
+_DIAL_TOKEN_RE = re.compile(
+    r"\b[+]?\d[\dA-Z]*(?:[\s.\-](?:\d+|[A-Z]{2,})){0,5}"
+)
+
+
+def _looks_dialable(token: str) -> bool:
+    compact = re.sub(r"[^0-9A-Za-z]", "", token)
+    return 7 <= len(compact) <= 15 and any(ch.isdigit() for ch in compact)
+
+
+def _prompt_contact_hits(text: str) -> list[str]:
+    """Contact-PII findings for renderer instructions.
+
+    Fails on evidence of contact intent; stays silent on description.
+    """
+    hits: list[str] = []
+    if _ANY_EMAIL_RE.search(text):
+        hits.append("email: <redacted>")
+
+    if _E164_RE.search(text) or _NANP_RE.search(text):
+        hits.append("phone: <redacted>")
+        return hits
+
+    if _DIAL_INTENT_RE.search(text):
+        for match in _DIAL_TOKEN_RE.finditer(text):
+            if _looks_dialable(match.group(0)):
+                hits.append("phone: <redacted>")
+                break
+    return hits
 
 
 def _enforce_image_prompts(artifact: dict[str, Any]) -> None:

--- a/atlas_brain/services/content_factory_runner.py
+++ b/atlas_brain/services/content_factory_runner.py
@@ -10,6 +10,7 @@ addressed by model id.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 import urllib.error
@@ -186,11 +187,13 @@ _E164_RE = re.compile(r"(?:\+|\b00)[\d\s().\-]{7,20}\d")
 _NANP_RE = re.compile(r"\(?\b\d{3}\)?[\s.\-]\d{3}[\s.\-]\d{4}\b")
 # A token someone could dial: starts with a digit, 7+ alphanumerics once
 # separators are stripped (covers 1-800-GOT-JUNK and 07700 900123 alike).
-# Continuation groups must be digits or an uppercase run (vanity numbers
-# are conventionally capitalised), so a token cannot swallow the ordinary
-# lowercase word that follows it ("07700 900123 today").
+# Continuation groups are digits (any separator) or LETTERS ONLY when
+# hyphen/dot-joined. Vanity spelling is case-insensitive ("1-800-flowers"
+# is the same number as "1-800-FLOWERS"), but a space-joined lowercase word
+# is the next word rather than part of the number ("07700 900123 today").
+# Attachment, not casing, is what distinguishes them.
 _DIAL_TOKEN_RE = re.compile(
-    r"\b[+]?\d[\dA-Z]*(?:[\s.\-](?:\d+|[A-Z]{2,})){0,5}"
+    r"\b[+]?\d[\dA-Za-z]*(?:(?:[\s](?=\d)|[.\-])[\dA-Za-z]+){0,5}"
 )
 
 
@@ -352,6 +355,30 @@ def _draft_claim_ids(draft: "dict[str, Any]") -> "set[str]":
     return ids
 
 
+def _draft_fingerprint(job_id: str, root: "Path | str") -> "str | None":
+    """SHA-256 of the draft artifact's bytes as persisted by the store.
+
+    The store writes a canonical form, so this is stable for identical
+    content and changes the moment the draft body or claims change --
+    including a same-revision rerun, which a revision number cannot detect.
+    """
+    path = job_dir(job_id, root=root) / "draft.json"
+    try:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError:
+        return None
+
+
+def _stamp_draft_fingerprint(
+    artifact: dict[str, Any], job_id: str, root: "Path | str"
+) -> None:
+    """Bind an audit to the draft content it actually reviewed. Runner-set,
+    never worker-supplied -- the same discipline as the verdict."""
+    if artifact.get("schema") not in _EDITOR_SCHEMAS:
+        return
+    artifact["source_draft_fingerprint"] = _draft_fingerprint(job_id, root)
+
+
 def _enforce_lineage(artifact: dict[str, Any], job_id: str, root: "Path | str") -> None:
     """Readiness flags require a verified tie to the job's approved draft.
 
@@ -407,6 +434,17 @@ def _enforce_lineage(artifact: dict[str, Any], job_id: str, root: "Path | str") 
         raise ArtifactStoreError(
             f"audit approved draft revision {audit.get('draft_revision', 1)} "
             f"but the draft on disk is revision {draft.get('revision', 1)}"
+        )
+    # Content identity, not just the revision label: a same-revision rerun
+    # replaces the body while the number stays 1, and the old approval must
+    # not carry over to text nobody reviewed (round 7).
+    approved_fingerprint = audit.get("source_draft_fingerprint")
+    current_fingerprint = _draft_fingerprint(job_id, root)
+    if not approved_fingerprint or approved_fingerprint != current_fingerprint:
+        raise ArtifactStoreError(
+            "the approving audit does not match the draft currently on disk "
+            "(content changed since approval, or the audit predates "
+            "content binding); re-run the audit stage before shipping"
         )
 
     # Cross-project derivation: a matching revision and overlapping ids are
@@ -465,6 +503,7 @@ def run_stage(
             f"stage {stage!r}: worker {model!r} returned no JSON artifact"
         )
     _enforce_copy_verification(artifact)
+    _stamp_draft_fingerprint(artifact, job_id, root)
     _enforce_repurposing(artifact)
     _enforce_image_prompts(artifact)
     _enforce_lineage(artifact, job_id, root)

--- a/atlas_brain/services/content_factory_runner.py
+++ b/atlas_brain/services/content_factory_runner.py
@@ -257,6 +257,39 @@ def _is_nanp_digits(digits: str) -> bool:
     return digits[0] in "23456789" and digits[3] in "23456789"
 
 
+_KEYPAD = str.maketrans(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    "22233344455566677778889999" "22233344455566677778889999",
+)
+
+
+def _is_vanity_number(parts: "list[str]") -> bool:
+    """Is this mixed digit/letter token a dialable vanity number?
+
+    Letters in a vanity number are DIGIT SUBSTITUTES, so the test is whether
+    the keypad-mapped token is a real number -- not merely whether letters and
+    digits co-occur. That earlier rule rejected renderer specifications:
+    "16-bit-color", "1920-1080-pixel" and "8-bit-style" all have letters
+    attached to digits (#2192 round 9).
+
+    Two conditions, both from the numbering plan rather than a word list:
+
+      * the leading digit group is an AREA CODE -- exactly 3 digits, or a "1"
+        country prefix followed by 3. "16-bit-color" leads with 2 digits and
+        "1920-1080-pixel" with 4, so neither can be a dialable prefix.
+      * the keypad-mapped digits form a syntactically valid NANP number.
+    """
+    if not any(p.isdigit() for p in parts):
+        return False
+    digit_groups = [p for p in parts if p.isdigit()]
+    lead = digit_groups[0]
+    if lead == "1" and len(digit_groups) > 1:
+        lead = digit_groups[1]
+    if len(lead) != 3:
+        return False
+    return _is_nanp_digits("".join(parts).translate(_KEYPAD))
+
+
 def _dial_shape(token: str) -> str:
     """Classify a candidate token: 'unambiguous', 'ambiguous', or 'none'.
 
@@ -276,7 +309,7 @@ def _dial_shape(token: str) -> str:
     if not 7 <= len(compact) <= 15:
         return "none"
     if any(p.isalpha() for p in parts):
-        return "unambiguous" if any(p.isdigit() for p in parts) else "none"
+        return "unambiguous" if _is_vanity_number(parts) else "none"
     groups = tuple(len(p) for p in parts)
     if compact.startswith("0") and 9 <= len(compact) <= 15 and len(groups) > 1:
         return "unambiguous"  # national trunk prefix: 07700 900123
@@ -297,6 +330,25 @@ def _dial_shape(token: str) -> str:
     return "grouped"
 
 
+_TRAILING_ALPHA_RE = re.compile(r"\s+[A-Za-z]+")
+
+
+def _token_candidates(text: str, match: "re.Match[str]") -> "list[str]":
+    """The matched token, plus the same token extended by up to three
+    following space-joined alpha words -- the spelled part of a vanity number
+    ("1 800 GOT JUNK"), which the separator grammar cannot absorb without also
+    swallowing ordinary trailing words ("07700 900123 today")."""
+    candidates = [match.group(0)]
+    end = match.end()
+    for _ in range(3):
+        extension = _TRAILING_ALPHA_RE.match(text, end)
+        if extension is None:
+            break
+        end = extension.end()
+        candidates.append(text[match.start() : end])
+    return candidates
+
+
 def _gap_profile(gap: str) -> "tuple[int, bool]":
     """(token distance, crossed a strong boundary) for the text between a dial
     verb and a candidate token. A punctuation run counts as one token, so
@@ -311,9 +363,18 @@ def _phone_evidence(text: str) -> bool:
         return True
     intents = [(m.start(), m.end()) for m in _DIAL_INTENT_RE.finditer(text)]
     for match in _DIAL_TOKEN_RE.finditer(text):
-        shape = _dial_shape(match.group(0))
-        if shape == "unambiguous":
+        # Both directions of the grammar. The token regex stops before a
+        # SPACE-joined letter group, so "Call 1 800 FLOWERS today" yielded only
+        # "1 800" and passed. Extending the candidate by up to three following
+        # alpha words recovers it, and cannot over-reach because the vanity
+        # test still demands an area-code prefix and a valid NANP mapping --
+        # "255 255 255 blue" and "1920 1080 pixel" both fail that (round 9).
+        if any(
+            _dial_shape(candidate) == "unambiguous"
+            for candidate in _token_candidates(text, match)
+        ):
             return True
+        shape = _dial_shape(match.group(0))
         if shape == "none":
             continue
         unbroken = shape == "unbroken"

--- a/atlas_brain/services/content_factory_runner.py
+++ b/atlas_brain/services/content_factory_runner.py
@@ -111,9 +111,49 @@ def call_worker(
     return content or ""
 
 
-# A phone number is 7+ digits however it is written. Prompt text is short
-# descriptive copy, so a long digit run is contact data rather than prose.
-_CONTACT_DIGIT_RUN_RE = re.compile(r"\d(?:[^\w\n]{0,3}\d){6,}")
+# --- prompt contact-PII classifiers -------------------------------------
+#
+# These are deliberately NOT the body-copy patterns. A prompt is an
+# instruction about to be rendered into pixels, so the decision has to hold
+# in BOTH directions: contact data must fail, and ordinary numeric/textual
+# description (dates, times, counts, dimensions) must pass. Rounds 3-5 all
+# broke on one side or the other of exactly this, so the shape is now:
+# candidate -> reject known non-contact shapes -> require contact evidence.
+
+# Address-shaped token, script-independent: closes internationalized email
+# (unicode local parts, IDN domains) that an ASCII pattern misses.
+_ANY_EMAIL_RE = re.compile(r"[^\s@,;:()<>\[\]]+@[^\s@,;:()<>\[\]]+\.[^\s@,;:()<>\[\]]{2,}")
+
+# Digit sequences with phone-ish separators, then filtered below.
+_DIGIT_SEQ_RE = re.compile(r"[+\d][\d\s().\-\u2010-\u2015]{5,}\d")
+# Shapes that are NOT contact data however many digits they carry.
+_NON_CONTACT_SHAPES = (
+    re.compile(r"^\d{4}[-/.]\d{1,2}[-/.]\d{1,2}$"),      # 2026-07-25
+    re.compile(r"^\d{1,2}[-/.]\d{1,2}[-/.]\d{2,4}$"),     # 07/25/2026
+    re.compile(r"^\d{1,2}:\d{2}(?::\d{2})?$"),            # 9:45
+)
+# Vanity numbers carry letters, so digit counting alone never sees them.
+_VANITY_PHONE_RE = re.compile(r"\b1[\s.\-]?[89]\d{2}[\s.\-]?[A-Za-z][A-Za-z0-9]{5,}\b")
+
+
+def _prompt_contact_hits(text: str) -> list[str]:
+    """Contact-PII findings for renderer instructions, both directions."""
+    hits: list[str] = []
+    if _ANY_EMAIL_RE.search(text):
+        hits.append("email: <redacted>")
+    if _VANITY_PHONE_RE.search(text):
+        hits.append("phone: <redacted>")
+        return hits
+    for match in _DIGIT_SEQ_RE.finditer(text):
+        token = match.group(0).strip()
+        if any(shape.match(token) for shape in _NON_CONTACT_SHAPES):
+            continue
+        digits = re.sub(r"\D", "", token)
+        # E.164 allows up to 15; below 7 is not a dialable number.
+        if 7 <= len(digits) <= 15:
+            hits.append("phone: <redacted>")
+            break
+    return hits
 
 _REPURPOSING_SCHEMA = "repurposing.v1"
 _IMAGE_PROMPT_SCHEMA = "image_prompt.v1"
@@ -202,14 +242,8 @@ def _enforce_image_prompts(artifact: dict[str, Any]) -> None:
         # is told to put on a poster (round 3).
         for hit in literal_claim_hits(text):
             hits.append(f"prompt {index}: {hit}")
-        if _EMAIL_RE.search(text):
-            hits.append(f"prompt {index}: email: <redacted>")
-        if _CONTACT_DIGIT_RUN_RE.search(text):
-            # Class-level, not prefix-level: any run of 7+ digits under
-            # tolerant separators is contact-shaped, so "+44...", "0044...",
-            # "(555) 123-4567" and any future dialling convention are all
-            # covered without enumerating prefixes (round 4).
-            hits.append(f"prompt {index}: phone: <redacted>")
+        for contact_hit in _prompt_contact_hits(text):
+            hits.append(f"prompt {index}: {contact_hit}")
 
     artifact["copy_verification"] = {
         "verdict": "fail" if hits else "pass",
@@ -335,6 +369,19 @@ def _enforce_lineage(artifact: dict[str, Any], job_id: str, root: "Path | str") 
         raise ArtifactStoreError(
             "readiness requires an audit artifact recommending 'promote'; "
             "unaudited or revise-state copy cannot ship or render"
+        )
+    # The approval must be FOR this draft: a revision-1 audit does not
+    # authorize revision-2 copy, and another project's audit authorizes
+    # nothing here (round 5).
+    if audit.get("project_id") != draft.get("project_id"):
+        raise ArtifactStoreError(
+            f"audit project {audit.get('project_id')!r} does not match the "
+            f"draft's {draft.get('project_id')!r}"
+        )
+    if audit.get("draft_revision", 1) != draft.get("revision", 1):
+        raise ArtifactStoreError(
+            f"audit approved draft revision {audit.get('draft_revision', 1)} "
+            f"but the draft on disk is revision {draft.get('revision', 1)}"
         )
 
     # Cross-project derivation: a matching revision and overlapping ids are

--- a/atlas_brain/services/content_factory_runner.py
+++ b/atlas_brain/services/content_factory_runner.py
@@ -18,10 +18,16 @@ from pathlib import Path
 from typing import Any
 
 from atlas_brain.services.content_factory_copy_verification import (
+    _INTL_PHONE_RE,
     advisory_warnings,
     verify_copy,
 )
-from atlas_brain.services.content_factory_store import DEFAULT_ROOT, write_artifact
+from atlas_brain.services.content_factory_store import (
+    DEFAULT_ROOT,
+    ArtifactStoreError,
+    job_dir,
+    write_artifact,
+)
 
 DEFAULT_OWUI_URL = "http://127.0.0.1:8080"
 
@@ -142,31 +148,62 @@ def _enforce_repurposing(artifact: dict[str, Any]) -> None:
 
 
 def _enforce_image_prompts(artifact: dict[str, Any]) -> None:
-    """Gate the POSITIVE prompt text: a diffusion model renders it into the
-    artwork, where no downstream text check would ever see it.
+    """Gate the POSITIVE prompt text, one prompt at a time.
 
     ``negative_prompt`` is deliberately EXCLUDED from the verdict. A negative
     prompt is an exclusion list -- naming a banned phrase there is the
     designer telling the renderer NOT to draw it, which is the correct
     response to this module's own threat model. Folding it into the scan
-    made the safest possible prompt set the one that failed (review round 1:
-    the guard failed on its second side).
+    made the safest possible prompt set the one that failed (round 1: the
+    guard failed on its second side).
+
+    Each prompt is verified INDEPENDENTLY and the results aggregated, so
+    joining items can never synthesize a claim that no single rendered
+    prompt contains ("...guaranteed" + "savings..." across two prompts).
+
+    PII is stricter here than in body copy: a prompt is an instruction to a
+    renderer, and any contact string in it is about to be drawn into an
+    image where no text check can reach it. So international phone forms
+    fail here even though `verify_copy` leaves the shared body-copy verdict
+    semantics unchanged (that scope was frozen deliberately in #2181).
     """
     if artifact.get("schema") != _IMAGE_PROMPT_SCHEMA:
         return
     prompts = artifact.get("prompts")
     if not isinstance(prompts, list):
         return
-    parts: list[str] = []
-    for prompt in prompts:
-        if isinstance(prompt, dict):
-            parts.append(str(prompt.get("prompt_text") or ""))
-    combined = "\n".join(part for part in parts if part)
-    verdict, warnings = _deterministic_verdict(
-        combined, empty_reason="prompt text is empty; nothing was verified"
-    )
-    artifact["copy_verification"] = verdict
-    artifact["advisory_warnings"] = warnings
+
+    texts = [
+        str(prompt.get("prompt_text") or "")
+        for prompt in prompts
+        if isinstance(prompt, dict)
+    ]
+    if not any(text.strip() for text in texts):
+        artifact["copy_verification"] = {
+            "verdict": "fail",
+            "hits": ["unverified-copy: prompt text is empty; nothing was verified"],
+        }
+        artifact["advisory_warnings"] = []
+        return
+
+    hits: list[str] = []
+    for index, text in enumerate(texts, start=1):
+        if not text.strip():
+            continue
+        for hit in verify_copy(text).hits:
+            hits.append(f"prompt {index}: {hit}")
+        if _INTL_PHONE_RE.search(text):
+            hits.append(f"prompt {index}: phone: <redacted>")
+
+    artifact["copy_verification"] = {
+        "verdict": "fail" if hits else "pass",
+        "hits": hits,
+    }
+    # The advisory layer is tuned for marketing PROSE (answer/ownership
+    # claims, report shape). Its sentence locators are not meaningful across
+    # a set of independent prompts, so prompt sets carry no advisory
+    # warnings rather than ambiguous ones.
+    artifact["advisory_warnings"] = []
 
 
 def _enforce_copy_verification(artifact: dict[str, Any]) -> None:
@@ -217,6 +254,56 @@ def _enforce_copy_verification(artifact: dict[str, Any]) -> None:
     artifact["advisory_warnings"] = advisory_warnings(edited)
 
 
+def _draft_claim_ids(job_id: str, root: "Path | str") -> "set[str] | None":
+    """Claim source ids the job's approved draft established, or None when
+    the draft cannot be read (missing/unparseable)."""
+    path = job_dir(job_id, root=root) / "draft.json"
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, ValueError):
+        return None
+    ids: set[str] = set()
+    for claim in data.get("claims") or []:
+        if isinstance(claim, dict):
+            source_id = str(claim.get("source_id") or "").strip()
+            if source_id:
+                ids.add(source_id)
+    return ids
+
+
+def _enforce_lineage(artifact: dict[str, Any], job_id: str, root: "Path | str") -> None:
+    """A package may not be declared shippable while any variant cites a
+    claim the job's draft never established.
+
+    Non-blank lineage is not the same as REAL lineage: a fabricated id is
+    still an orphan. Checked only when ``ready_to_publish`` is asserted --
+    an unready package is a legitimate intermediate state -- and fails
+    closed when the draft cannot be read, since traceability then cannot be
+    demonstrated (round 2).
+    """
+    if artifact.get("schema") != _REPURPOSING_SCHEMA:
+        return
+    if not artifact.get("ready_to_publish"):
+        return
+    known = _draft_claim_ids(job_id, root)
+    if known is None:
+        raise ArtifactStoreError(
+            "ready_to_publish requires a readable draft.json in the job "
+            "folder to verify variant claim lineage"
+        )
+    cited: set[str] = set()
+    for variant in artifact.get("variants") or []:
+        if isinstance(variant, dict):
+            for claim_id in variant.get("derived_from_claims") or []:
+                cited.add(str(claim_id).strip())
+    unknown = sorted(cited - known)
+    if unknown:
+        raise ArtifactStoreError(
+            "variant lineage cites claims absent from the draft: "
+            + ", ".join(unknown)
+        )
+
+
 def run_stage(
     job_id: str,
     stage: str,
@@ -244,4 +331,5 @@ def run_stage(
     _enforce_copy_verification(artifact)
     _enforce_repurposing(artifact)
     _enforce_image_prompts(artifact)
+    _enforce_lineage(artifact, job_id, root)
     return write_artifact(job_id, stage, artifact, root=root)

--- a/atlas_brain/services/content_factory_runner.py
+++ b/atlas_brain/services/content_factory_runner.py
@@ -142,10 +142,16 @@ def _enforce_repurposing(artifact: dict[str, Any]) -> None:
 
 
 def _enforce_image_prompts(artifact: dict[str, Any]) -> None:
-    """Gate the PROMPT TEXT itself: a diffusion model will render a banned
-    claim or a contact string into the artwork, where no downstream text
-    check would ever see it. Verified over every prompt's text and negative
-    prompt together."""
+    """Gate the POSITIVE prompt text: a diffusion model renders it into the
+    artwork, where no downstream text check would ever see it.
+
+    ``negative_prompt`` is deliberately EXCLUDED from the verdict. A negative
+    prompt is an exclusion list -- naming a banned phrase there is the
+    designer telling the renderer NOT to draw it, which is the correct
+    response to this module's own threat model. Folding it into the scan
+    made the safest possible prompt set the one that failed (review round 1:
+    the guard failed on its second side).
+    """
     if artifact.get("schema") != _IMAGE_PROMPT_SCHEMA:
         return
     prompts = artifact.get("prompts")
@@ -155,7 +161,6 @@ def _enforce_image_prompts(artifact: dict[str, Any]) -> None:
     for prompt in prompts:
         if isinstance(prompt, dict):
             parts.append(str(prompt.get("prompt_text") or ""))
-            parts.append(str(prompt.get("negative_prompt") or ""))
     combined = "\n".join(part for part in parts if part)
     verdict, warnings = _deterministic_verdict(
         combined, empty_reason="prompt text is empty; nothing was verified"

--- a/atlas_brain/services/content_factory_runner.py
+++ b/atlas_brain/services/content_factory_runner.py
@@ -31,6 +31,7 @@ from atlas_brain.services.content_factory_store import (
     DEFAULT_ROOT,
     ArtifactStoreError,
     job_dir,
+    job_lock,
     write_artifact,
 )
 
@@ -38,9 +39,17 @@ DEFAULT_OWUI_URL = "http://127.0.0.1:8080"
 
 # The editor stage's artifact schemas. The promote decision is gated (via
 # #2116's EditorialAudit contract) on copy_verification.verdict == "pass".
-# Workers may still emit v1; the runner normalizes to v2 (which carries the
-# advisory checklist) before persisting.
-_EDITOR_SCHEMAS = ("editorial_audit.v1", "editorial_audit.v2")
+# Workers may still emit v1 or v2; the runner normalizes to the current version
+# (v3, which carries the advisory checklist AND the draft fingerprint) before
+# persisting. Older versions stay frozen and readable -- see the contracts.
+_EDITOR_SCHEMA_VERSIONS = {
+    "editorial_audit.v1": 1,
+    "editorial_audit.v2": 2,
+    "editorial_audit.v3": 3,
+}
+_EDITOR_SCHEMAS = tuple(_EDITOR_SCHEMA_VERSIONS)
+_CURRENT_EDITOR_SCHEMA = "editorial_audit.v3"
+_CURRENT_EDITOR_VERSION = _EDITOR_SCHEMA_VERSIONS[_CURRENT_EDITOR_SCHEMA]
 
 # A leading ```/```json fence and a trailing fence, so a fenced reply still
 # yields its JSON body.
@@ -157,20 +166,32 @@ def _enforce_repurposing(artifact: dict[str, Any]) -> None:
 # EVIDENCE-GATED, not pattern-enumerated. Rounds 3-6 each broke because the
 # rule asked "do these digits look like a phone number?" -- a question with
 # no closed answer, since dates, RGB triples, dimensions and dialable
-# numbers share a digit grammar. The decision now asks for POSITIVE
-# EVIDENCE of contact intent, of which there are exactly two kinds:
+# numbers share a digit grammar. The decision asks for POSITIVE EVIDENCE.
 #
-#   1. structural  -- an unambiguous dialable form (E.164 "+"/"00" prefix,
-#                     or the NANP 3-3-4 shape). Nothing describes artwork
-#                     this way.
-#   2. lexical     -- a dial-intent verb ("call", "text", "reach"...) near
-#                     a dial-shaped token, which is what makes
-#                     "Call 1-800-GOT-JUNK" contact data even though its
-#                     digits alone are not.
+# Round 8 replaced "dial verb anywhere + any 7-15 digit token anywhere" with
+# a SHAPE-FIRST tier split, because the old rule flagged "a person calling
+# across a room, RGB palette 255 255 255".
 #
-# Absent both, digits are just description and the prompt passes. That is
-# what makes "RGB palette 255 255 255" and "calendar showing 2026-07-25"
-# safe without enumerating them.
+# Scoping intent to a window -- the obvious repair -- does not work, and the
+# counter-example matters enough to record: in "a call center scene, 1920
+# 1080 resolution" the gap from "call" to "1920" is TWO WORDS, exactly the
+# gap in "call me, 5551234567". No window separates them. Shape does:
+#
+#   unambiguous -- fails with NO intent required: E.164, NANP 3-3-4, [3,4]
+#                  local, a national trunk prefix, or vanity spelling.
+#                  Nothing describes artwork in these shapes.
+#   unbroken    -- one 7-15 digit run. Phone-plausible, but serials and
+#                  seeds are written identically, so it needs a dial verb
+#                  within 3 tokens (which may cross a comma, because
+#                  "call me, 5551234567" really is written that way).
+#   grouped     -- a shape descriptive numbers also use ([3,3,3] RGB,
+#                  [4,4] resolution, [4,2,2] dates). Weakest evidence, so
+#                  it needs the tightest government: a dial verb within 2
+#                  tokens and no boundary crossed.
+#
+# Absent both, digits are just description and the prompt passes -- without
+# enumerating "RGB", "resolution" or any other descriptive vocabulary,
+# which is the string-closure trap AGENTS.md 3k.1 forbids.
 
 _ANY_EMAIL_RE = re.compile(
     r"[^\s@,;:()<>\[\]]+@[^\s@,;:()<>\[\]]+\.[^\s@,;:()<>\[\]]{2,}"
@@ -197,9 +218,117 @@ _DIAL_TOKEN_RE = re.compile(
 )
 
 
-def _looks_dialable(token: str) -> bool:
-    compact = re.sub(r"[^0-9A-Za-z]", "", token)
-    return 7 <= len(compact) <= 15 and any(ch.isdigit() for ch in compact)
+# Groupings only a dialable number uses. [3,4] is the local form (555-1234),
+# [3,3,4] NANP, [1,3,3,4] NANP with the country code written out.
+_UNAMBIGUOUS_GROUPINGS = frozenset({(3, 4), (3, 3, 4), (1, 3, 3, 4)})
+# Strong punctuation ends a descriptive phrase. A period BETWEEN DIGITS is a
+# number separator, not a boundary -- treating it as one shreds "555.1234".
+_BOUNDARY_RE = re.compile(r"(?:(?<!\d)\.(?!\d))+|[,;:!?()\[\]{}|/\n\r–—]+")
+# How close a dial verb must sit to corroborate an ambiguous token, measured in
+# tokens where a punctuation run counts as one. The two windows are NOT taste:
+# they track how much evidence the shape itself carries.
+#
+#   unbroken (3, may cross a boundary) -- "call me, 5551234567" is contact data
+#       and calls-to-action really are written across a comma. But the run is
+#       also how serials are written, so "a phone on a desk. serial 12345678"
+#       (distance 4) stays a scene.
+#   grouped  (2, same segment only) -- the weakest shape, so it needs the
+#       tightest government. "call me at 12 34 56 78" (2) is contact data;
+#       "phone booth photographed at 100 200 300" (3) and "a call center
+#       scene, 1920 1080" (crosses a boundary) are scenes. This is what keeps
+#       compound nouns -- "call center", "phone booth", "call sheet" -- out
+#       without enumerating any of them.
+_UNBROKEN_WINDOW = 3
+_GROUPED_WINDOW = 2
+
+
+def _is_nanp_digits(digits: str) -> bool:
+    """A syntactically valid North American number.
+
+    The NANP forbids 0 and 1 as the leading digit of BOTH the area code and
+    the exchange code. That is a spec constraint, not a vocabulary, and it is
+    what separates a dialable unbroken 10-digit run from a 10-digit serial or
+    seed -- which is the one case shape alone cannot otherwise decide.
+    """
+    if len(digits) == 11 and digits.startswith("1"):
+        digits = digits[1:]
+    if len(digits) != 10 or not digits.isdigit():
+        return False
+    return digits[0] in "23456789" and digits[3] in "23456789"
+
+
+def _dial_shape(token: str) -> str:
+    """Classify a candidate token: 'unambiguous', 'ambiguous', or 'none'.
+
+    The digit-GROUP PROFILE is the discriminator, not the compact length.
+    "5551234567" is one unbroken 10-digit run -- nothing describes artwork
+    that way -- while "255 255 255" is [3,3,3] and "1920 1080" is [4,4].
+    """
+    parts = [p for p in re.split(r"[\s.\-]+", token.lstrip("+")) if p]
+    if not parts:
+        return "none"
+    # A MIXED alphanumeric group is not a number: "1920x1080" is a canvas
+    # size. Vanity spelling puts its letters in their own hyphen/dot-joined
+    # group ("1-800-FLOWERS"), which is what makes it dialable.
+    if any(not (p.isdigit() or p.isalpha()) for p in parts):
+        return "none"
+    compact = "".join(parts)
+    if not 7 <= len(compact) <= 15:
+        return "none"
+    if any(p.isalpha() for p in parts):
+        return "unambiguous" if any(p.isdigit() for p in parts) else "none"
+    groups = tuple(len(p) for p in parts)
+    if compact.startswith("0") and 9 <= len(compact) <= 15 and len(groups) > 1:
+        return "unambiguous"  # national trunk prefix: 07700 900123
+    if groups in _UNAMBIGUOUS_GROUPINGS:
+        return "unambiguous"
+    if len(groups) == 1 and _is_nanp_digits(compact):
+        # An unbroken run that is a SYNTACTICALLY VALID North American number
+        # needs no corroboration: serials do not obey the NANP's constraints
+        # by accident often enough to matter, and "5552345678 on a poster" is
+        # about to be painted into artwork.
+        return "unambiguous"
+    if len(groups) == 1:
+        # One unbroken 7-15 digit run. Phone-plausible, but serials, seeds and
+        # order numbers are written the same way ("serial 12345678 engraved on
+        # a plate" must render), so this needs corroboration -- with the wider
+        # window, since it is the stronger of the two ambiguous shapes.
+        return "unbroken"
+    return "grouped"
+
+
+def _gap_profile(gap: str) -> "tuple[int, bool]":
+    """(token distance, crossed a strong boundary) for the text between a dial
+    verb and a candidate token. A punctuation run counts as one token, so
+    distance and boundary-crossing are read off the same measurement."""
+    tokens = _BOUNDARY_RE.sub(" \x00 ", gap).split()
+    return len(tokens), "\x00" in tokens
+
+
+def _phone_evidence(text: str) -> bool:
+    """Positive evidence that ``text`` carries a dialable number."""
+    if _E164_RE.search(text) or _NANP_RE.search(text):
+        return True
+    intents = [(m.start(), m.end()) for m in _DIAL_INTENT_RE.finditer(text)]
+    for match in _DIAL_TOKEN_RE.finditer(text):
+        shape = _dial_shape(match.group(0))
+        if shape == "unambiguous":
+            return True
+        if shape == "none":
+            continue
+        unbroken = shape == "unbroken"
+        limit = _UNBROKEN_WINDOW if unbroken else _GROUPED_WINDOW
+        for start, end in intents:
+            if end <= match.start():
+                gap = text[end : match.start()]
+            elif match.end() <= start:
+                gap = text[match.end() : start]
+            else:
+                return True
+            distance, crossed = _gap_profile(gap)
+            if distance <= limit and (unbroken or not crossed):
+                return True
+    return False
 
 
 def _prompt_contact_hits(text: str) -> list[str]:
@@ -210,16 +339,8 @@ def _prompt_contact_hits(text: str) -> list[str]:
     hits: list[str] = []
     if _ANY_EMAIL_RE.search(text):
         hits.append("email: <redacted>")
-
-    if _E164_RE.search(text) or _NANP_RE.search(text):
+    if _phone_evidence(text):
         hits.append("phone: <redacted>")
-        return hits
-
-    if _DIAL_INTENT_RE.search(text):
-        for match in _DIAL_TOKEN_RE.finditer(text):
-            if _looks_dialable(match.group(0)):
-                hits.append("phone: <redacted>")
-                break
     return hits
 
 
@@ -306,16 +427,22 @@ def _enforce_copy_verification(artifact: dict[str, Any]) -> None:
     """
     if artifact.get("schema") not in _EDITOR_SCHEMAS:
         return
-    # Normalize to v2: the runner-persisted audit always carries the advisory
-    # checklist field; v1 stays frozen for pre-existing artifacts and direct
-    # writers (rollback-safe -- see the contracts module). Only an original
-    # v1 reply gets its version synthesized -- a v2-tagged reply keeps its
-    # own schema_version so the Literal[2] validator rejects contradictory
-    # worker metadata instead of the runner laundering it.
-    if artifact.get("schema") == "editorial_audit.v1":
-        artifact["schema_version"] = 2
-    artifact["schema"] = "editorial_audit.v2"
-    artifact.setdefault("schema_version", 2)
+    # Normalize to the newest audit version: the runner-persisted audit always
+    # carries the advisory checklist AND the draft fingerprint. Older versions
+    # stay frozen for pre-existing artifacts and direct writers (rollback-safe
+    # -- see the contracts module).
+    #
+    # The anti-laundering rule generalizes across the chain: synthesize
+    # schema_version ONLY when the worker's metadata is self-consistent (its
+    # schema_version matches the version its own tag declares, or is absent).
+    # A reply tagged v2 while claiming schema_version 7 keeps the 7 so the
+    # Literal[3] validator rejects it, instead of the runner quietly repairing
+    # contradictory worker metadata into a valid artifact.
+    declared = _EDITOR_SCHEMA_VERSIONS.get(artifact.get("schema"))
+    supplied = artifact.get("schema_version")
+    if supplied is None or supplied == declared:
+        artifact["schema_version"] = _CURRENT_EDITOR_VERSION
+    artifact["schema"] = _CURRENT_EDITOR_SCHEMA
     edited = str(artifact.get("edited_body_markdown") or "")
     if not edited.strip():
         artifact["copy_verification"] = {
@@ -503,8 +630,14 @@ def run_stage(
             f"stage {stage!r}: worker {model!r} returned no JSON artifact"
         )
     _enforce_copy_verification(artifact)
-    _stamp_draft_fingerprint(artifact, job_id, root)
     _enforce_repurposing(artifact)
     _enforce_image_prompts(artifact)
-    _enforce_lineage(artifact, job_id, root)
-    return write_artifact(job_id, stage, artifact, root=root)
+    # Everything that READS the job folder and everything that WRITES it must
+    # sit inside one lock. Stamping reads draft.json, the readiness gate reads
+    # it again to verify the fingerprint, and the commit lands after both --
+    # a concurrent draft rerun anywhere in that window would otherwise ship a
+    # "ready" artifact against copy no audit covered (#2192 round 8).
+    with job_lock(job_id, root=root):
+        _stamp_draft_fingerprint(artifact, job_id, root)
+        _enforce_lineage(artifact, job_id, root)
+        return write_artifact(job_id, stage, artifact, root=root)

--- a/atlas_brain/services/content_factory_store.py
+++ b/atlas_brain/services/content_factory_store.py
@@ -115,6 +115,27 @@ def job_lock(job_id: str, *, root: Path | str = DEFAULT_ROOT) -> Iterator[None]:
         handle.close()
 
 
+def _restore_artifact(job: Path, path: Path, previous: "bytes | None") -> None:
+    """Undo a failed stage write: put back the previous bytes (or remove the
+    file if the stage had none) and unstage it, so a raised write_artifact
+    leaves no residue for the readiness gate to read as source state.
+
+    Best-effort by design -- this runs while an exception is propagating, and
+    a cleanup failure must not replace the original error.
+    """
+    try:
+        if previous is None:
+            path.unlink(missing_ok=True)
+        else:
+            path.write_bytes(previous)
+        subprocess.run(
+            ["git", "-C", str(job), "reset", "-q", "--", path.name],
+            capture_output=True,
+        )
+    except OSError:
+        pass
+
+
 def _git(job: Path, *args: str) -> subprocess.CompletedProcess:
     try:
         return subprocess.run(
@@ -221,21 +242,34 @@ def _write_artifact_locked(
     job.mkdir(parents=True, exist_ok=True)
     _ensure_repo(job)
     path = job / f"{stage}.json"
-    path.write_text(json.dumps(canonical, indent=2, ensure_ascii=False) + "\n")
 
-    # Scope the staged-change check and the commit to THIS file, so an unrelated
-    # pre-staged file in the job repo cannot ride into this stage's commit and an
-    # identical rewrite still makes no empty commit.
-    _git(job, "add", "--", path.name)
-    unchanged = (
-        subprocess.run(
-            ["git", "-C", str(job), "diff", "--cached", "--quiet", "--", path.name]
-        ).returncode
-        == 0
-    )
-    if not unchanged:
-        _git(job, "commit", "-q", "-m", f"{stage}: {tag}", "--", path.name)
-    sha = _git(job, "rev-parse", "HEAD").stdout.strip()
+    # Persistence is ALL-OR-NOTHING. A failed commit used to leave the new file
+    # written and staged in the working tree even though write_artifact raised
+    # and no commit recorded the stage -- and the readiness gate reads the
+    # working tree, so that residue was then trusted as approved source state
+    # (#2192 round 9). On any failure the previous content is restored, or the
+    # file removed if the stage had none, before the error propagates.
+    had_previous = path.exists()
+    previous = path.read_bytes() if had_previous else None
+    try:
+        path.write_text(json.dumps(canonical, indent=2, ensure_ascii=False) + "\n")
+
+        # Scope the staged-change check and the commit to THIS file, so an
+        # unrelated pre-staged file in the job repo cannot ride into this
+        # stage's commit and an identical rewrite still makes no empty commit.
+        _git(job, "add", "--", path.name)
+        unchanged = (
+            subprocess.run(
+                ["git", "-C", str(job), "diff", "--cached", "--quiet", "--", path.name]
+            ).returncode
+            == 0
+        )
+        if not unchanged:
+            _git(job, "commit", "-q", "-m", f"{stage}: {tag}", "--", path.name)
+        sha = _git(job, "rev-parse", "HEAD").stdout.strip()
+    except Exception:
+        _restore_artifact(job, path, previous)
+        raise
 
     return {
         "job_id": job_id,

--- a/atlas_brain/services/content_factory_store.py
+++ b/atlas_brain/services/content_factory_store.py
@@ -42,6 +42,10 @@ STAGE_SCHEMAS = {
     # working; runner-persisted audits are normalized to v2.
     "audit": ("editorial_audit.v1", "editorial_audit.v2"),
     "manifest": ("manifest.v1",),
+    # Phase 6: channel variants and image prompts derived from an approved
+    # draft. Both are gated by the runner exactly like the audit.
+    "repurposing": ("repurposing.v1",),
+    "image_prompt": ("image_prompt.v1",),
 }
 
 _GIT_NAME = "Content Factory"

--- a/atlas_brain/services/content_factory_store.py
+++ b/atlas_brain/services/content_factory_store.py
@@ -13,10 +13,14 @@ Each job folder is its own git repo, so every stage write is an auditable commit
 
 from __future__ import annotations
 
+import fcntl
 import json
 import os
 import re
 import subprocess
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
@@ -40,7 +44,7 @@ STAGE_SCHEMAS = {
     "draft": ("draft.v1",),
     # v1 stays admissible: pre-#2136 artifacts and any direct writer keep
     # working; runner-persisted audits are normalized to v2.
-    "audit": ("editorial_audit.v1", "editorial_audit.v2"),
+    "audit": ("editorial_audit.v1", "editorial_audit.v2", "editorial_audit.v3"),
     "manifest": ("manifest.v1",),
     # Phase 6: channel variants and image prompts derived from an approved
     # draft. Both are gated by the runner exactly like the audit.
@@ -65,6 +69,50 @@ def _safe_segment(value: str, kind: str) -> str:
 def job_dir(job_id: str, *, root: Path | str = DEFAULT_ROOT) -> Path:
     """Return the (guarded) folder that holds a job's artifacts."""
     return Path(root) / "jobs" / _safe_segment(job_id, "job_id")
+
+
+_LOCK_STATE = threading.local()
+
+
+@contextmanager
+def job_lock(job_id: str, *, root: Path | str = DEFAULT_ROOT) -> Iterator[None]:
+    """Exclusive per-job lock covering a read-validate-write sequence.
+
+    Readiness enforcement READS draft.json and audit.json, decides, and only
+    then persists. Without mutual exclusion another stage run can replace the
+    draft inside that window, so a Phase 6 artifact lands as ready beside copy
+    its approving audit never covered: the fingerprint was checked against
+    content that no longer exists at write time (#2192 round 8). Validating
+    before writing is not enough when the thing validated against can move.
+
+    Re-entrant within a thread, so ``run_stage`` holds it across enforcement
+    while ``write_artifact`` takes it again without deadlocking; ``flock``
+    extends the exclusion across processes. The lock file lives OUTSIDE the
+    job folder so it never lands in the job's git history.
+    """
+    safe = _safe_segment(job_id, "job_id")
+    depth = getattr(_LOCK_STATE, "depth", None)
+    if depth is None:
+        depth = _LOCK_STATE.depth = {}
+    if depth.get(safe):
+        depth[safe] += 1
+        try:
+            yield
+        finally:
+            depth[safe] -= 1
+        return
+
+    locks = Path(root) / ".locks"
+    locks.mkdir(parents=True, exist_ok=True)
+    handle = open(locks / f"{safe}.lock", "a+")
+    try:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        depth[safe] = 1
+        yield
+    finally:
+        depth[safe] = 0
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        handle.close()
 
 
 def _git(job: Path, *args: str) -> subprocess.CompletedProcess:
@@ -101,6 +149,23 @@ def _ensure_repo(job: Path) -> None:
 
 
 def write_artifact(
+    job_id: str,
+    stage: str,
+    artifact: dict[str, Any],
+    *,
+    root: Path | str = DEFAULT_ROOT,
+) -> dict[str, Any]:
+    """Persist a stage artifact under the job's exclusive lock.
+
+    See ``_write_artifact_locked`` for the validation and commit behavior. The
+    lock is re-entrant, so a caller that already holds it (``run_stage``, which
+    must cover its read-validate-write window) is not blocked by this one.
+    """
+    with job_lock(job_id, root=root):
+        return _write_artifact_locked(job_id, stage, artifact, root=root)
+
+
+def _write_artifact_locked(
     job_id: str,
     stage: str,
     artifact: dict[str, Any],

--- a/plans/PR-CF-Phase6-Repurposing-Contracts.md
+++ b/plans/PR-CF-Phase6-Repurposing-Contracts.md
@@ -13,6 +13,24 @@ deterministic gates. Image GENERATION (ComfyUI) is deliberately not here --
 the epic keeps prompt designer and generator split, and generation is
 human-triggered and VRAM-guarded.
 
+**Diff-budget overage (~1,190 LOC vs the 400 soft cap) — why this slice is
+indivisible.** The two contracts, their stage admission, and their
+deterministic gates are one enforceable behaviour, and splitting them
+produces a strictly worse intermediate state:
+
+* contracts without their gates would let a worker self-declare shippable
+  or renderable copy -- the exact failure the editorial gate exists to
+  prevent, shipped as a landed artifact surface;
+* gates without the readiness contracts would have nothing to refuse,
+  since the flags they guard would not exist;
+* stage admission without either would let unvalidated artifacts land in
+  the git-backed job folder under a Phase 6 stage name.
+
+Roughly 60% of the LOC is tests (four review rounds of adversarial
+regressions, kept because each pins a defect that actually shipped in an
+earlier revision of this branch). The behaviour itself is two contracts,
+one enforcement hook, and one lineage check.
+
 ### Problem-derived contract
 
 - Root cause: the pipeline stops at an approved audit. Nothing turns an
@@ -140,6 +158,29 @@ Three findings, all fixed:
    pydantic normalized it to False. The artifact is now validated first and
    the check branches on the normalized model value.
 
+### Review round 4 (Codex)
+
+Five findings, all fixed:
+
+1. **P1 — readiness did not require an APPROVED draft.** Reading the draft
+   proved it existed, not that anything cleared it. Readiness now requires
+   the job's audit artifact to recommend `promote`, so unaudited or
+   revise-state copy cannot ship or render.
+2. **P1 — cross-project derivation.** A ready artifact could claim a draft
+   from another project whenever revision and claim ids overlapped. The
+   artifact's `project_id` must now match the draft's.
+3. **P1 — the phone class was still open.** `0044 20 7946 0958` passed
+   because only US and leading-plus forms were recognised. Replaced with a
+   class-level rule: any run of 7+ digits under tolerant separators is
+   contact-shaped. Ordinary short numbers in descriptions still pass.
+4. **P1 — invisible-only text satisfied the non-blank invariant.** A
+   zero-width space passed `NonEmptyStr` and earned a passing verdict.
+   Added `VisibleStr` (rejects text whose characters are all Unicode C*/Z*
+   categories) on the two fields that become shippable/renderable.
+5. **MAJOR — the diff-budget justification was missing from the plan.**
+   Added to "Why this slice exists" above, per the repository rule that it
+   live in the plan rather than only in the commit message.
+
 ### Files touched
 
 - `atlas_brain/schemas/content_factory.py`
@@ -192,7 +233,7 @@ Parked hardening: none new.
         tests/test_content_factory_store.py \
         tests/test_content_factory_copy_verification.py \
         tests/test_leads_intake.py -q
-    # -> 351 passed (42 new: 18 contract invariants, 24 run_stage gates)
+    # -> 370 passed (61 new: 24 contract invariants, 37 run_stage gates)
 
 - `python -m py_compile` clean (SyntaxWarning as error) on touched modules.
 - NOT run: live worker pass (no wrappers wired yet, by design).
@@ -201,11 +242,11 @@ Parked hardening: none new.
 
 | File | LOC |
 |---|---:|
-| `atlas_brain/schemas/content_factory.py` | 159 |
+| `atlas_brain/schemas/content_factory.py` | 202 |
 | `atlas_brain/services/content_factory_copy_verification.py` | 20 |
-| `atlas_brain/services/content_factory_runner.py` | 193 |
+| `atlas_brain/services/content_factory_runner.py` | 224 |
 | `atlas_brain/services/content_factory_store.py` | 4 |
-| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 209 |
-| `tests/test_content_factory_runner.py` | 396 |
-| `tests/test_content_factory_schemas.py` | 206 |
-| **Total** | **1187** |
+| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 252 |
+| `tests/test_content_factory_runner.py` | 495 |
+| `tests/test_content_factory_schemas.py` | 238 |
+| **Total** | **1435** |

--- a/plans/PR-CF-Phase6-Repurposing-Contracts.md
+++ b/plans/PR-CF-Phase6-Repurposing-Contracts.md
@@ -121,9 +121,29 @@ Four findings, all fixed:
 4. **MAJOR — stale plan text.** The Scope section still described
    combined positive+negative gating; corrected above.
 
+### Review round 3 (Codex)
+
+Three findings, all fixed:
+
+1. **P1 — the declared source revision was never checked.** A package could
+   claim revision 1 against a revision-2 draft and ship whenever claim ids
+   overlapped. `_enforce_lineage` now compares `source_draft_revision` with
+   the draft on disk, for BOTH Phase 6 artifacts, before honouring either
+   readiness flag.
+2. **P1 — prose negation let banned words into renderer instructions.**
+   "poster reading do not guarantee savings" passed, because the body-copy
+   verifier treats that as a denial -- but the renderer still paints the
+   words. Prompts now use `literal_claim_hits` (no negation suppression);
+   body copy keeps prose semantics, so the #2181 contract is untouched.
+3. **MAJOR — runner and schema disagreed on readiness.** The runner read raw
+   dict truthiness, so a worker's `"false"` string looked ready while
+   pydantic normalized it to False. The artifact is now validated first and
+   the check branches on the normalized model value.
+
 ### Files touched
 
 - `atlas_brain/schemas/content_factory.py`
+- `atlas_brain/services/content_factory_copy_verification.py`
 - `atlas_brain/services/content_factory_runner.py`
 - `atlas_brain/services/content_factory_store.py`
 - `plans/PR-CF-Phase6-Repurposing-Contracts.md`
@@ -172,7 +192,7 @@ Parked hardening: none new.
         tests/test_content_factory_store.py \
         tests/test_content_factory_copy_verification.py \
         tests/test_leads_intake.py -q
-    # -> 344 passed (35 new: 18 contract invariants, 17 run_stage gates)
+    # -> 351 passed (42 new: 18 contract invariants, 24 run_stage gates)
 
 - `python -m py_compile` clean (SyntaxWarning as error) on touched modules.
 - NOT run: live worker pass (no wrappers wired yet, by design).
@@ -182,9 +202,10 @@ Parked hardening: none new.
 | File | LOC |
 |---|---:|
 | `atlas_brain/schemas/content_factory.py` | 159 |
-| `atlas_brain/services/content_factory_runner.py` | 160 |
+| `atlas_brain/services/content_factory_copy_verification.py` | 20 |
+| `atlas_brain/services/content_factory_runner.py` | 193 |
 | `atlas_brain/services/content_factory_store.py` | 4 |
-| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 190 |
-| `tests/test_content_factory_runner.py` | 310 |
+| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 209 |
+| `tests/test_content_factory_runner.py` | 396 |
 | `tests/test_content_factory_schemas.py` | 206 |
-| **Total** | **1029** |
+| **Total** | **1187** |

--- a/plans/PR-CF-Phase6-Repurposing-Contracts.md
+++ b/plans/PR-CF-Phase6-Repurposing-Contracts.md
@@ -211,6 +211,36 @@ pattern as #2181's advisory engine. The classifiers are now written as
 two-directional decisions with both error sides pinned by parametrized
 probes, which is the shape that finally held there.
 
+### Review round 6 (Codex) — classifier redesign
+
+One finding, and it named the real problem: the phone check was still a
+"reject known-bad, admit the rest" enumeration. Evidence: `1-800-GOT-JUNK`
+passed (hyphenated vanity spelling) while `RGB palette 255 255 255` was
+rejected as PII.
+
+**Redesigned as an EVIDENCE-GATED decision.** Rounds 3-6 each failed
+because the rule asked "do these digits look like a phone number?", which
+has no closed answer -- dates, RGB triples, dimensions and dialable numbers
+share a digit grammar. It now requires positive evidence of contact intent,
+of which there are exactly two kinds:
+
+* **structural** — an unambiguous dialable form (E.164 `+`/`00` prefix, or
+  the NANP 3-3-4 shape). Nothing describes artwork this way, so these fail
+  with no other context.
+* **lexical** — a dial-intent verb (call/text/dial/ring/reach...) near a
+  dialable token. This is what makes "Call 1-800-GOT-JUNK" contact data
+  when its digits alone are not.
+
+Absent both, digits are description and the prompt passes. Token
+continuation groups are restricted to digits or uppercase runs so a token
+cannot swallow the following lowercase word.
+
+**Generative oracle** replaces the hand-listed fixtures: 6 intents x 11
+dialable forms (66 cases) must fail; 11 descriptive strings x 3 scene
+templates (33 cases) must pass; structural forms must fail without any
+intent word; and 4 email forms across scripts must fail. The hand-listed
+phone tests from rounds 4-5 were removed as superseded.
+
 ### Files touched
 
 - `atlas_brain/schemas/content_factory.py`
@@ -263,7 +293,8 @@ Parked hardening: none new.
         tests/test_content_factory_store.py \
         tests/test_content_factory_copy_verification.py \
         tests/test_leads_intake.py -q
-    # -> 388 passed (79 new: 30 contract invariants, 49 run_stage gates)
+    # -> 475 passed (166 new; the growth is the round-6 generative
+    #    oracle: 66 must-fail x 33 must-pass contact cases)
 
 - `python -m py_compile` clean (SyntaxWarning as error) on touched modules.
 - NOT run: live worker pass (no wrappers wired yet, by design).
@@ -274,9 +305,9 @@ Parked hardening: none new.
 |---|---:|
 | `atlas_brain/schemas/content_factory.py` | 209 |
 | `atlas_brain/services/content_factory_copy_verification.py` | 20 |
-| `atlas_brain/services/content_factory_runner.py` | 271 |
+| `atlas_brain/services/content_factory_runner.py` | 296 |
 | `atlas_brain/services/content_factory_store.py` | 4 |
-| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 282 |
-| `tests/test_content_factory_runner.py` | 578 |
+| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 313 |
+| `tests/test_content_factory_runner.py` | 569 |
 | `tests/test_content_factory_schemas.py` | 269 |
-| **Total** | **1633** |
+| **Total** | **1680** |

--- a/plans/PR-CF-Phase6-Repurposing-Contracts.md
+++ b/plans/PR-CF-Phase6-Repurposing-Contracts.md
@@ -181,6 +181,36 @@ Five findings, all fixed:
    Added to "Why this slice exists" above, per the repository rule that it
    live in the plan rather than only in the commit message.
 
+### Review round 5 (Codex)
+
+Five findings, all fixed:
+
+1. **P1 — the approving audit was not checked against the draft it
+   approves.** A revision-1 audit authorized revision-2 copy (this repo's
+   own test fixture created exactly that mismatch). The audit's
+   `project_id` and `draft_revision` must now match the draft.
+2. **P1 — a lone combining mark passed the visible-content rule.** U+FE0F
+   is category Mn, so `VisibleStr` accepted it. M* now joins C*/Z* as
+   non-standalone; real copy carrying a mark (emoji + VS16) still passes.
+3. **P1 — the prompt phone check was wrong in BOTH directions.**
+   `1-800-FLOWERS` passed (letters, so digit counting never saw it) while
+   `calendar showing 2026-07-25` failed (a date is not a phone number).
+   Replaced digit-counting with candidate -> reject known non-contact
+   shapes (ISO/US dates, clock times) -> require dialable evidence (7-15
+   digits, E.164 bound) plus an explicit vanity-number rule.
+4. **P1 — internationalized email escaped the ASCII pattern.**
+   `josé@example.com` and `user@例え.テスト` passed. The prompt path now
+   uses a script-independent address shape.
+5. **MAJOR — canonically equivalent channels were not duplicates.** NFC
+   and NFD "cafe" both validated in one package; channels are NFKC-
+   normalized before casefolding.
+
+**Convergence note.** Phone detection has now been reworked in rounds 3, 4
+and 5, and visible-text in rounds 4 and 5 -- the same non-convergent
+pattern as #2181's advisory engine. The classifiers are now written as
+two-directional decisions with both error sides pinned by parametrized
+probes, which is the shape that finally held there.
+
 ### Files touched
 
 - `atlas_brain/schemas/content_factory.py`
@@ -233,7 +263,7 @@ Parked hardening: none new.
         tests/test_content_factory_store.py \
         tests/test_content_factory_copy_verification.py \
         tests/test_leads_intake.py -q
-    # -> 370 passed (61 new: 24 contract invariants, 37 run_stage gates)
+    # -> 388 passed (79 new: 30 contract invariants, 49 run_stage gates)
 
 - `python -m py_compile` clean (SyntaxWarning as error) on touched modules.
 - NOT run: live worker pass (no wrappers wired yet, by design).
@@ -242,11 +272,11 @@ Parked hardening: none new.
 
 | File | LOC |
 |---|---:|
-| `atlas_brain/schemas/content_factory.py` | 202 |
+| `atlas_brain/schemas/content_factory.py` | 209 |
 | `atlas_brain/services/content_factory_copy_verification.py` | 20 |
-| `atlas_brain/services/content_factory_runner.py` | 224 |
+| `atlas_brain/services/content_factory_runner.py` | 271 |
 | `atlas_brain/services/content_factory_store.py` | 4 |
-| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 252 |
-| `tests/test_content_factory_runner.py` | 495 |
-| `tests/test_content_factory_schemas.py` | 238 |
-| **Total** | **1435** |
+| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 282 |
+| `tests/test_content_factory_runner.py` | 578 |
+| `tests/test_content_factory_schemas.py` | 269 |
+| **Total** | **1633** |

--- a/plans/PR-CF-Phase6-Repurposing-Contracts.md
+++ b/plans/PR-CF-Phase6-Repurposing-Contracts.md
@@ -1,0 +1,145 @@
+# PR-CF-Phase6-Repurposing-Contracts
+
+## Why this slice exists
+
+Epic #2109 Phase 6 (repurposing + image workflow) is the first phase whose
+output is the operator's actual workload: channel variants and media assets
+from an approved draft. Phase 3 is now closed (3a shipped; 3b/RAG is
+won't-do), so Phase 6 is the next unstarted phase.
+
+Phase 6 has two halves. This slice is the ARTIFACT half: the contracts for
+`repurposing.v1` and `image_prompt.v1`, their stage wiring, and their
+deterministic gates. Image GENERATION (ComfyUI) is deliberately not here --
+the epic keeps prompt designer and generator split, and generation is
+human-triggered and VRAM-guarded.
+
+### Problem-derived contract
+
+- Root cause: the pipeline stops at an approved audit. Nothing turns an
+  approved draft into per-channel copy or image prompts, and nothing gates
+  those outputs -- yet variants are the copy that actually ships and prompt
+  text is rendered into artwork where no text check can see it.
+- Correct fix must: define both artifacts with invariants that make the
+  failure modes unrepresentable (orphan variants, duplicate channels,
+  self-declared shippability, empty packages); admit both at the store's
+  stage map; and run the SAME deterministic overwrite the editorial audit
+  uses so a worker cannot self-approve either one.
+- Must not change: existing contracts/stages, the editorial gate's
+  behavior, the advisory grammar (extracted to a shared validator, same
+  rules), or anything about image generation (separate slice).
+
+## Scope (this PR)
+
+Ownership lane: content-factory
+Slice phase: vertical slice
+
+1. `atlas_brain/schemas/content_factory.py`:
+   - `ChannelVariant` + `RepurposingPackage` (`repurposing.v1`): non-empty
+     variants, non-blank channel/body, claim lineage, one channel per
+     variant, and `ready_to_publish` gated on EVERY variant carrying a
+     passing verdict (the variant-level analogue of the promote gate).
+   - `ImagePrompt` + `ImagePromptSet` (`image_prompt.v1`): text prompts
+     only, at least one prompt, gated prompt text.
+   - `_validate_advisory_warnings` extracted so audit, variants, and image
+     prompts share ONE bounded grammar and cannot drift.
+2. `atlas_brain/services/content_factory_store.py`: `repurposing` and
+   `image_prompt` stages admit their matching schemas.
+3. `atlas_brain/services/content_factory_runner.py`: `_enforce_repurposing`
+   recomputes each variant's verdict + checklist from its OWN body;
+   `_enforce_image_prompts` gates the combined prompt/negative-prompt text.
+   Blank bodies/prompts fail closed via a shared `_deterministic_verdict`.
+4. Proof: contract invariants both directions + real-entrypoint tests
+   through `run_stage`.
+
+### Review Contract
+
+- Acceptance criteria:
+  1. A worker asserting `ready_to_publish` on an overclaiming variant is
+     rejected and NOTHING persists (runner recomputes, contract refuses).
+  2. Clean variants persist with runner-computed verdicts and checklists;
+     worker-supplied values are discarded.
+  3. Image prompt text containing a banned claim or PII yields verdict
+     `fail`; the verdict never carries the raw PII value.
+  4. Contract invariants hold both ways: empty package, duplicate channel,
+     blank body, and non-grammar advisory warnings are rejected; a
+     not-ready package MAY carry a failing variant (legitimate
+     intermediate state).
+  5. Stage/schema mismatch still enforced for the new stages.
+- Reachability proof: `run_stage(job, "repurposing"|"image_prompt", ...)`,
+  the same entrypoint the four existing stages use; artifacts land in the
+  git-backed job folder.
+- Affected surfaces: contracts, store stage map, runner enforcement. No
+  change to existing stages or to image generation.
+- Risk areas: none live -- no worker wrappers are wired to these stages
+  yet (next slice), so this cannot alter current pipeline behavior.
+- Reviewer rules triggered: R1 (#2109 Phase 6), R2 (both-direction tests),
+  R3 (gate cannot be self-reported), R5 (no existing-stage behavior
+  change), R10 (one advisory grammar shared by three artifacts), R14.
+
+### Files touched
+
+- `atlas_brain/schemas/content_factory.py`
+- `atlas_brain/services/content_factory_runner.py`
+- `atlas_brain/services/content_factory_store.py`
+- `plans/PR-CF-Phase6-Repurposing-Contracts.md`
+- `tests/test_content_factory_runner.py`
+- `tests/test_content_factory_schemas.py`
+
+## Mechanism
+
+Two artifacts, two stages, one enforcement idea reused: the deterministic
+verdict is always computed by the runner from the artifact's own text and
+overwrites whatever the worker claimed. Variants get a per-variant verdict
+because each ships independently; the prompt set gets one verdict over all
+prompt text because it is rendered as a unit.
+
+## Intentional
+
+- **Per-variant verdicts, not one package verdict** -- variants ship
+  separately, so a failing LinkedIn variant must not block a clean X
+  variant from being fixed independently.
+- **`ready_to_publish` is a package-level gate** requiring ALL variants to
+  pass: partial shipping is a human decision, not a model's.
+- **Image prompts are gated on text** because a diffusion model renders
+  banned copy INTO the image, past every downstream text check.
+- **The offending prompt/body still persists** on a failing artifact --
+  the verdict is redacted, but the payload must stay visible or a human
+  cannot fix it (same as an existing draft body).
+- **No generation, no worker wrappers here** -- generation is
+  human-triggered and VRAM-guarded, and on this box a 30B model (~20 GB)
+  plus ComfyUI FLUX (~12 GB) exceeds the 24 GB card, so the generator
+  slice must handle model eviction explicitly.
+
+## Deferred
+
+- Image generation via the ComfyUI MCP (human-triggered, VRAM-guarded,
+  must address LLM/FLUX co-residency on a 24 GB card).
+- OWUI worker wrappers for the two new stages (`cf-repurposer`,
+  `cf-image-prompt`) with §8 tool scoping.
+- Phase 7 manifest entries for the new stages.
+
+Parked hardening: none new.
+
+## Verification
+
+    python -m pytest tests/test_content_factory_schemas.py \
+        tests/test_content_factory_runner.py \
+        tests/test_content_factory_store.py \
+        tests/test_content_factory_copy_verification.py \
+        tests/test_leads_intake.py -q
+    # -> 326 passed (17 new: 10 contract invariants, 7 run_stage gates)
+
+- `python -m py_compile` clean (SyntaxWarning as error) on touched modules.
+- NOT run: live worker pass (no wrappers wired yet, by design).
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/schemas/content_factory.py` | 147 |
+| `atlas_brain/services/content_factory_runner.py` | 65 |
+| `atlas_brain/services/content_factory_store.py` | 4 |
+| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 144 |
+| `tests/test_content_factory_runner.py` | 148 |
+| `tests/test_content_factory_schemas.py` | 118 |
+| **Total** | **626** |

--- a/plans/PR-CF-Phase6-Repurposing-Contracts.md
+++ b/plans/PR-CF-Phase6-Repurposing-Contracts.md
@@ -76,6 +76,26 @@ Slice phase: vertical slice
   R3 (gate cannot be self-reported), R5 (no existing-stage behavior
   change), R10 (one advisory grammar shared by three artifacts), R14.
 
+### Review round 1 (Codex)
+
+Three findings, all fixed:
+
+1. **P1 — orphan variants were representable.** `derived_from_claims` had a
+   list default, so an omitted/empty lineage passed and a clean body could
+   be marked `ready_to_publish`. Now `min_length=1` (required, non-empty),
+   with negative coverage for omitted, empty, mixed, and blank-id lineage.
+2. **MAJOR — the image gate failed on its second side.** `negative_prompt`
+   was folded into the verified text, so naming a banned phrase in the
+   EXCLUSION list -- the correct designer response to this module's own
+   threat model -- tripped the gate. The verdict now covers `prompt_text`
+   only; the negative prompt cannot cause rendering, so it cannot cause a
+   failure. Both sides probed.
+3. **MAJOR — the prompt set recorded a verdict nothing gated on.** Added
+   `ready_to_generate`, the generation analogue of the package's
+   `ready_to_publish`: it cannot be true while the deterministic verdict
+   fails. A failing set still persists when not marked ready (legitimate
+   intermediate state).
+
 ### Files touched
 
 - `atlas_brain/schemas/content_factory.py`
@@ -127,7 +147,7 @@ Parked hardening: none new.
         tests/test_content_factory_store.py \
         tests/test_content_factory_copy_verification.py \
         tests/test_leads_intake.py -q
-    # -> 326 passed (17 new: 10 contract invariants, 7 run_stage gates)
+    # -> 337 passed (28 new: 18 contract invariants, 10 run_stage gates)
 
 - `python -m py_compile` clean (SyntaxWarning as error) on touched modules.
 - NOT run: live worker pass (no wrappers wired yet, by design).
@@ -136,10 +156,10 @@ Parked hardening: none new.
 
 | File | LOC |
 |---|---:|
-| `atlas_brain/schemas/content_factory.py` | 147 |
-| `atlas_brain/services/content_factory_runner.py` | 65 |
+| `atlas_brain/schemas/content_factory.py` | 159 |
+| `atlas_brain/services/content_factory_runner.py` | 70 |
 | `atlas_brain/services/content_factory_store.py` | 4 |
-| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 144 |
-| `tests/test_content_factory_runner.py` | 148 |
-| `tests/test_content_factory_schemas.py` | 118 |
-| **Total** | **626** |
+| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 165 |
+| `tests/test_content_factory_runner.py` | 198 |
+| `tests/test_content_factory_schemas.py` | 206 |
+| **Total** | **802** |

--- a/plans/PR-CF-Phase6-Repurposing-Contracts.md
+++ b/plans/PR-CF-Phase6-Repurposing-Contracts.md
@@ -42,9 +42,30 @@ one enforcement hook, and one lineage check.
   self-declared shippability, empty packages); admit both at the store's
   stage map; and run the SAME deterministic overwrite the editorial audit
   uses so a worker cannot self-approve either one.
-- Must not change: existing contracts/stages, the editorial gate's
-  behavior, the advisory grammar (extracted to a shared validator, same
-  rules), or anything about image generation (separate slice).
+- Must not change: the editorial gate's DECISION behavior, the advisory
+  grammar (extracted to a shared validator, same rules), or anything about
+  image generation (separate slice). Published contract SHAPES stay frozen
+  and readable -- `editorial_audit.v1` and `.v2` both keep validating
+  byte-for-byte.
+- Must ALSO change (admitted in review, round 8 -- the original "must not
+  change existing contracts/stages" was too narrow to hold, because
+  readiness cannot be enforced without touching both):
+  - **Audit version.** Binding approval to draft CONTENT requires a field
+    on the audit. v2 is published and forbids extras, so the field cannot
+    go there without making new audits unreadable to a v2 consumer or a
+    rolled-back reader. Adds `editorial_audit.v3` (subclassing v2 so the
+    promote gate and warning grammar cannot drift), re-freezes v2, and
+    upgrades v1/v2 -> v3 in the runner's normalizer. Acceptance: a v2
+    payload still validates; a v2 payload carrying the new field is
+    REJECTED (proving the freeze); self-contradictory worker metadata is
+    still refused rather than repaired.
+  - **Store concurrency + write atomicity.** Readiness reads the job
+    folder and then writes it, so both must sit in one critical section,
+    and a failed commit must leave no residue for the next read to trust.
+    Adds a re-entrant per-job `flock` and all-or-nothing artifact writes.
+    Acceptance: readiness is decided with the lock HELD (mutation-checked)
+    and released after; a failed commit restores the previous bytes and
+    leaves nothing staged.
 
 ## Scope (this PR)
 
@@ -87,11 +108,19 @@ Slice phase: vertical slice
      not-ready package MAY carry a failing variant (legitimate
      intermediate state).
   5. Stage/schema mismatch still enforced for the new stages.
+  6. Compatibility (round 8): `editorial_audit.v2` still validates
+     unchanged and REJECTS the new fingerprint field; v1/v2 worker replies
+     normalize to v3; contradictory `schema_version` still fails.
+  7. Concurrency + atomicity (rounds 8-9): readiness is decided under the
+     per-job lock and the lock is released afterwards; a failed commit
+     leaves neither modified content on disk nor a staged path.
 - Reachability proof: `run_stage(job, "repurposing"|"image_prompt", ...)`,
   the same entrypoint the four existing stages use; artifacts land in the
   git-backed job folder.
-- Affected surfaces: contracts, store stage map, runner enforcement. No
-  change to existing stages or to image generation.
+- Affected surfaces: contracts, store stage map, store write path and
+  locking, runner enforcement and audit normalization. The audit stage's
+  persisted VERSION changes (v3); its decision behavior does not. No change
+  to image generation.
 - Risk areas: none live -- no worker wrappers are wired to these stages
   yet (next slice), so this cannot alter current pipeline behavior.
 - Reviewer rules triggered: R1 (#2109 Phase 6), R2 (both-direction tests),
@@ -306,6 +335,47 @@ start with 0 or 1) recovers the part that can be decided.
 to what began as a contracts slice. Both are the hardened fix for defects
 this PR introduced, so they belong here rather than in a follow-up.
 
+### Review round 9 (Codex)
+
+Four findings, all verified against the code before acting and all fixed.
+
+1. **P1 — the vanity rule was too loose one way and too tight the other.**
+   Treating ANY attached letter group as vanity rejected renderer specs:
+   `16-bit-color`, `1920-1080-pixel`, `8-bit-style` and `32-bit-float` all
+   failed (the last two were not in the report; found by probing the class).
+   Meanwhile the separator grammar stops before a SPACE-joined letter group,
+   so `Call 1 800 FLOWERS today` passed with `ready_to_generate=true`.
+
+   Root fix, from the numbering plan rather than a word list: letters in a
+   vanity number are DIGIT SUBSTITUTES, so the token must (a) lead with an
+   area code -- exactly 3 digits, or "1" plus 3 -- and (b) map through the
+   phone keypad to a syntactically valid NANP number. A spec's leading group
+   is 2 or 4 digits, so the whole class renders. The other direction is
+   closed by extending each candidate with up to three following alpha words,
+   which cannot over-reach because the same two conditions still apply.
+
+2. **P1 — a failed commit left artifact residue the readiness gate trusted.**
+   `write_artifact` wrote and staged the file before committing, so a commit
+   failure left the job's modified draft artifact in the working tree with no commit
+   recording it -- and the readiness gate reads the working tree. Writes are
+   now all-or-nothing: on any failure the previous bytes are restored (or the
+   file removed if the stage had none) and the path unstaged.
+
+3. **P2 — the governing contract did not cover round 8's changes.** The
+   Problem-derived and Review Contracts still said "must not change existing
+   contracts/stages" while the diff upgraded audits to v3 and added store
+   locking. Both sections now carry those changes with their own acceptance
+   criteria, rather than leaving them justified only by narrative.
+
+4. **P2 — `channel` was non-blank but not VISIBLE.** A label made only of
+   U+200B/U+200C/U+FE0F validated and persisted unroutable, and distinct
+   invisible spellings evaded the duplicate check. `channel` is now
+   `VisibleStr`, and duplicate detection compares on a routing key that drops
+   format/control characters, so `email` and `email<ZWSP>` collide.
+
+Both P1 fixes are mutation-checked: reverting either makes the new tests
+fail, so they are load-bearing rather than vacuous.
+
 ### Files touched
 
 - `atlas_brain/schemas/content_factory.py`
@@ -358,7 +428,7 @@ Parked hardening: none new.
         tests/test_content_factory_store.py \
         tests/test_content_factory_copy_verification.py \
         tests/test_leads_intake.py -q
-    # -> 523 passed (214 new; incl. the round-6 generative oracle, the
+    # -> 620 passed (311 new; incl. the round-6 generative oracle, the
     #    round-7 casing/content-binding probes, and the round-8
     #    descriptive-numbers x dial-words class-closure oracle)
     #
@@ -378,11 +448,11 @@ Parked hardening: none new.
 
 | File | LOC |
 |---|---:|
-| `atlas_brain/schemas/content_factory.py` | 246 |
+| `atlas_brain/schemas/content_factory.py` | 266 |
 | `atlas_brain/services/content_factory_copy_verification.py` | 20 |
-| `atlas_brain/services/content_factory_runner.py` | 496 |
-| `atlas_brain/services/content_factory_store.py` | 71 |
-| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 388 |
-| `tests/test_content_factory_runner.py` | 834 |
+| `atlas_brain/services/content_factory_runner.py` | 557 |
+| `atlas_brain/services/content_factory_store.py` | 133 |
+| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 417 |
+| `tests/test_content_factory_runner.py` | 957 |
 | `tests/test_content_factory_schemas.py` | 269 |
-| **Total** | **2324** |
+| **Total** | **2619** |

--- a/plans/PR-CF-Phase6-Repurposing-Contracts.md
+++ b/plans/PR-CF-Phase6-Repurposing-Contracts.md
@@ -46,7 +46,11 @@ Slice phase: vertical slice
    `image_prompt` stages admit their matching schemas.
 3. `atlas_brain/services/content_factory_runner.py`: `_enforce_repurposing`
    recomputes each variant's verdict + checklist from its OWN body;
-   `_enforce_image_prompts` gates the combined prompt/negative-prompt text.
+   `_enforce_image_prompts` gates the POSITIVE prompt text only, verifying
+   each prompt independently (`negative_prompt` is an exclusion list and is
+   deliberately excluded; joining items would synthesize cross-prompt
+   claims). Prompt PII is stricter than body copy: international phone
+   forms fail here.
    Blank bodies/prompts fail closed via a shared `_deterministic_verdict`.
 4. Proof: contract invariants both directions + real-entrypoint tests
    through `run_stage`.
@@ -95,6 +99,27 @@ Three findings, all fixed:
    `ready_to_publish`: it cannot be true while the deterministic verdict
    fails. A failing set still persists when not marked ready (legitimate
    intermediate state).
+
+### Review round 2 (Codex)
+
+Four findings, all fixed:
+
+1. **P1 — lineage was non-blank, not REAL.** `derived_from_claims`
+   accepted a fabricated id. `_enforce_lineage` now validates every cited
+   id against the claim source ids in the job's draft artifact before a package may
+   be `ready_to_publish`, and fails closed when the draft cannot be read.
+   An unready package still skips the check (intermediate state).
+2. **P1 — international phone PII passed the prompt gate.** `verify_copy`
+   only fails on the US pattern (that scope was frozen deliberately in
+   #2181). Prompt text now gets a stricter check -- an instruction about
+   to be drawn into an image -- so `+44...` forms fail here without
+   changing shared body-copy semantics.
+3. **MAJOR — cross-item claim synthesis.** Prompts were joined before
+   scanning, so "...guaranteed" + "savings..." across two prompts
+   fabricated a hit. Each prompt is now verified independently and hits
+   are prefixed with the offending prompt index.
+4. **MAJOR — stale plan text.** The Scope section still described
+   combined positive+negative gating; corrected above.
 
 ### Files touched
 
@@ -147,7 +172,7 @@ Parked hardening: none new.
         tests/test_content_factory_store.py \
         tests/test_content_factory_copy_verification.py \
         tests/test_leads_intake.py -q
-    # -> 337 passed (28 new: 18 contract invariants, 10 run_stage gates)
+    # -> 344 passed (35 new: 18 contract invariants, 17 run_stage gates)
 
 - `python -m py_compile` clean (SyntaxWarning as error) on touched modules.
 - NOT run: live worker pass (no wrappers wired yet, by design).
@@ -157,9 +182,9 @@ Parked hardening: none new.
 | File | LOC |
 |---|---:|
 | `atlas_brain/schemas/content_factory.py` | 159 |
-| `atlas_brain/services/content_factory_runner.py` | 70 |
+| `atlas_brain/services/content_factory_runner.py` | 160 |
 | `atlas_brain/services/content_factory_store.py` | 4 |
-| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 165 |
-| `tests/test_content_factory_runner.py` | 198 |
+| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 190 |
+| `tests/test_content_factory_runner.py` | 310 |
 | `tests/test_content_factory_schemas.py` | 206 |
-| **Total** | **802** |
+| **Total** | **1029** |

--- a/plans/PR-CF-Phase6-Repurposing-Contracts.md
+++ b/plans/PR-CF-Phase6-Repurposing-Contracts.md
@@ -258,6 +258,54 @@ Two findings, both fixed:
    draft bytes) onto the audit and verifies it at readiness. Worker-supplied
    values are overwritten, same discipline as the verdict.
 
+### Review round 8 (Codex)
+
+Three findings, all fixed. All three are defects this PR introduced, not
+inherited: the read-validate-write sequence and the fingerprint field both
+arrived in round 7, and the prompt classifier is Phase 6's own.
+
+1. **P1 — the fingerprint check was not atomic with the write.** Round 7
+   verified the draft fingerprint and then persisted; a concurrent draft
+   rerun inside that window landed a `ready_to_publish` artifact beside copy
+   the audit never covered. Validating before writing proves nothing when the
+   thing validated against can move. `job_lock` (re-entrant per thread,
+   `flock` across processes, lock file outside the job's git folder) now
+   spans stamping, readiness and the commit.
+2. **P1 — the fingerprint field silently rebroke the published v2 contract.**
+   `editorial_audit.v2` shipped in #2181 and forbids extras, so adding a key
+   to it made every newly written audit UNREADABLE to a v2 consumer or a
+   rolled-back reader — the exact breakage v1's freeze note exists to
+   prevent. Introduced `editorial_audit.v3` (subclassing v2 so the promote
+   gate and warning grammar cannot drift), re-froze v2, and generalized the
+   runner's normalizer to upgrade v1/v2 -> v3 while still refusing to launder
+   self-contradictory worker metadata.
+3. **P2 — dial intent was searched globally.** `a person calling across a
+   room, RGB palette 255 255 255` was rejected as contact PII.
+
+   Codex proposed scoping intent to a bounded candidate context. That does
+   not work, and the counter-example is worth recording: in `a call center
+   scene, 1920 1080 resolution` the gap from "call" to "1920" is two words —
+   exactly the gap in `call me, 5551234567`. No window separates them.
+
+   Replaced with a SHAPE-FIRST tier split. Unambiguous shapes (E.164, NANP
+   3-3-4, [3,4] local, trunk prefix, vanity, and syntactically valid NANP
+   runs) fail with no intent required. `unbroken` runs need a dial verb
+   within 3 tokens, which may cross a comma. `grouped` shapes ([3,3,3] RGB,
+   [4,4] resolution, [4,2,2] dates) need one within 2 tokens with no boundary
+   crossed — which is what keeps compound nouns ("call center", "phone
+   booth", "call sheet") out without enumerating any of them.
+
+**Documented residual (deliberate, not missed):** an unbroken digit run that
+is not a valid NANP number is shape-identical to a serial, and an earlier
+round established that `serial 12345678 engraved on a plate` must render. So
+that form fails only once a dial verb governs it. Shape alone cannot decide
+between the two; NANP's own constraint (neither area nor exchange code may
+start with 0 or 1) recovers the part that can be decided.
+
+**Scope note:** this round added a locking primitive and a contract version
+to what began as a contracts slice. Both are the hardened fix for defects
+this PR introduced, so they belong here rather than in a follow-up.
+
 ### Files touched
 
 - `atlas_brain/schemas/content_factory.py`
@@ -310,8 +358,18 @@ Parked hardening: none new.
         tests/test_content_factory_store.py \
         tests/test_content_factory_copy_verification.py \
         tests/test_leads_intake.py -q
-    # -> 495 passed (186 new; incl. the round-6 generative oracle and
-    #    the round-7 casing/content-binding probes)
+    # -> 523 passed (214 new; incl. the round-6 generative oracle, the
+    #    round-7 casing/content-binding probes, and the round-8
+    #    descriptive-numbers x dial-words class-closure oracle)
+    #
+    # Mutation check on the round-8 lock test: removing `with job_lock(...)`
+    # from run_stage makes test_run_stage_holds_job_lock_across_validation_
+    # and_write FAIL, so the assertion is load-bearing rather than vacuous.
+    #
+    # Repo-wide: 20155 passed / 169 failed / 8 collection errors. Every
+    # failure and error reproduces identically on a stashed (clean) tree --
+    # they are pre-existing local dependency issues in invoicing / mcp /
+    # scheduler / reasoning, and none are in a file this diff touches.
 
 - `python -m py_compile` clean (SyntaxWarning as error) on touched modules.
 - NOT run: live worker pass (no wrappers wired yet, by design).
@@ -320,11 +378,11 @@ Parked hardening: none new.
 
 | File | LOC |
 |---|---:|
-| `atlas_brain/schemas/content_factory.py` | 215 |
+| `atlas_brain/schemas/content_factory.py` | 246 |
 | `atlas_brain/services/content_factory_copy_verification.py` | 20 |
-| `atlas_brain/services/content_factory_runner.py` | 335 |
-| `atlas_brain/services/content_factory_store.py` | 4 |
-| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 330 |
-| `tests/test_content_factory_runner.py` | 665 |
+| `atlas_brain/services/content_factory_runner.py` | 496 |
+| `atlas_brain/services/content_factory_store.py` | 71 |
+| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 388 |
+| `tests/test_content_factory_runner.py` | 834 |
 | `tests/test_content_factory_schemas.py` | 269 |
-| **Total** | **1838** |
+| **Total** | **2324** |

--- a/plans/PR-CF-Phase6-Repurposing-Contracts.md
+++ b/plans/PR-CF-Phase6-Repurposing-Contracts.md
@@ -241,6 +241,23 @@ templates (33 cases) must pass; structural forms must fail without any
 intent word; and 4 email forms across scripts must fail. The hand-listed
 phone tests from rounds 4-5 were removed as superseded.
 
+### Review round 7 (Codex)
+
+Two findings, both fixed:
+
+1. **P1 — vanity recognition was casing-dependent.** `1-800-flowers`
+   passed because continuation groups accepted uppercase only. The real
+   distinction is ATTACHMENT, not casing: hyphen/dot-joined letters belong
+   to the number (any case), a space-joined lowercase word is the next
+   word. Oracle extended across casing modifiers, plus the other side
+   (trailing words must not extend the token past the E.164 bound).
+2. **P1 — approval was bound to a mutable revision label.** Rerunning the
+   draft stage replaces the body while keeping revision 1, and the old
+   audit still counted as approval. Approval now binds to draft CONTENT:
+   the runner stamps `source_draft_fingerprint` (SHA-256 of the persisted
+   draft bytes) onto the audit and verifies it at readiness. Worker-supplied
+   values are overwritten, same discipline as the verdict.
+
 ### Files touched
 
 - `atlas_brain/schemas/content_factory.py`
@@ -293,8 +310,8 @@ Parked hardening: none new.
         tests/test_content_factory_store.py \
         tests/test_content_factory_copy_verification.py \
         tests/test_leads_intake.py -q
-    # -> 475 passed (166 new; the growth is the round-6 generative
-    #    oracle: 66 must-fail x 33 must-pass contact cases)
+    # -> 495 passed (186 new; incl. the round-6 generative oracle and
+    #    the round-7 casing/content-binding probes)
 
 - `python -m py_compile` clean (SyntaxWarning as error) on touched modules.
 - NOT run: live worker pass (no wrappers wired yet, by design).
@@ -303,11 +320,11 @@ Parked hardening: none new.
 
 | File | LOC |
 |---|---:|
-| `atlas_brain/schemas/content_factory.py` | 209 |
+| `atlas_brain/schemas/content_factory.py` | 215 |
 | `atlas_brain/services/content_factory_copy_verification.py` | 20 |
-| `atlas_brain/services/content_factory_runner.py` | 296 |
+| `atlas_brain/services/content_factory_runner.py` | 335 |
 | `atlas_brain/services/content_factory_store.py` | 4 |
-| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 313 |
-| `tests/test_content_factory_runner.py` | 569 |
+| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 330 |
+| `tests/test_content_factory_runner.py` | 665 |
 | `tests/test_content_factory_schemas.py` | 269 |
-| **Total** | **1680** |
+| **Total** | **1838** |

--- a/tests/test_content_factory_runner.py
+++ b/tests/test_content_factory_runner.py
@@ -438,3 +438,53 @@ def test_stage_schema_mismatch_still_enforced_for_phase6(tmp_path, monkeypatch):
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
     with pytest.raises(ArtifactStoreError):
         runner.run_stage("job-mix", "image_prompt", "m", "req", api_key="k", root=tmp_path)
+
+
+def test_negative_prompt_naming_banned_terms_still_passes(tmp_path, monkeypatch):
+    """Guard's second side: a negative prompt is an EXCLUSION list, so naming
+    a banned phrase there is the correct designer response to the threat --
+    it must not trip the gate."""
+    reply = json.dumps({
+        "schema": "image_prompt.v1", "project_id": "p",
+        "prompts": [{
+            "purpose": "hero",
+            "prompt_text": "a tidy office desk in soft morning light",
+            "negative_prompt": "blurry, watermark, text, guaranteed savings, phone number",
+        }],
+    })
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
+    rec = runner.run_stage("job-neg", "image_prompt", "m", "req", api_key="k", root=tmp_path)
+    stored = json.loads(Path(rec["path"]).read_text())
+    assert stored["copy_verification"]["verdict"] == "pass"
+    assert stored["prompts"][0]["negative_prompt"].startswith("blurry")
+
+
+def test_positive_prompt_with_banned_claim_still_fails(tmp_path, monkeypatch):
+    """The other side of the same guard stays closed."""
+    reply = json.dumps({
+        "schema": "image_prompt.v1", "project_id": "p",
+        "prompts": [{
+            "purpose": "hero",
+            "prompt_text": "poster reading guaranteed savings",
+            "negative_prompt": "blurry",
+        }],
+    })
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
+    rec = runner.run_stage("job-pos", "image_prompt", "m", "req", api_key="k", root=tmp_path)
+    stored = json.loads(Path(rec["path"]).read_text())
+    assert stored["copy_verification"]["verdict"] == "fail"
+
+
+def test_worker_cannot_self_declare_ready_to_generate(tmp_path, monkeypatch):
+    """The runner recomputes the verdict, so a failing prompt set cannot be
+    persisted as renderable no matter what the worker claims."""
+    reply = json.dumps({
+        "schema": "image_prompt.v1", "project_id": "p",
+        "prompts": [{"purpose": "hero", "prompt_text": "poster reading guaranteed savings"}],
+        "copy_verification": {"verdict": "pass", "hits": []},
+        "ready_to_generate": True,
+    })
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
+    with pytest.raises(ValidationError):
+        runner.run_stage("job-selfgen", "image_prompt", "m", "req", api_key="k", root=tmp_path)
+    assert not job_dir("job-selfgen", root=tmp_path).exists()

--- a/tests/test_content_factory_runner.py
+++ b/tests/test_content_factory_runner.py
@@ -264,8 +264,8 @@ def test_run_stage_persists_deterministic_warnings_and_normalizes_v1(tmp_path, m
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
     rec = runner.run_stage("job-adv", "audit", "cf-editor-verifier", "req", api_key="k", root=tmp_path)
     stored = json.loads(Path(rec["path"]).read_text())
-    assert rec["schema"] == "editorial_audit.v2"
-    assert stored["schema"] == "editorial_audit.v2"
+    assert rec["schema"] == "editorial_audit.v3"
+    assert stored["schema"] == "editorial_audit.v3"
     assert any(
         w.startswith("unqualified-answer-claim:")
         for w in stored["advisory_warnings"]
@@ -313,7 +313,8 @@ def _seed_draft(root, job_id, source_ids, revision=1, project="p", approved=True
         fingerprint = runner._draft_fingerprint(job_id, root)
         write_artifact(job_id, "audit", {
             "source_draft_fingerprint": fingerprint,
-            "schema": "editorial_audit.v2",
+            "schema": "editorial_audit.v3",
+            "schema_version": 3,
             "project_id": project,
             # Must approve THIS revision -- a stale audit authorizes nothing.
             "draft_revision": revision,
@@ -955,3 +956,167 @@ def test_unchanged_draft_keeps_approval_valid(tmp_path, monkeypatch):
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
     rec = runner.run_stage("job-stable", "repurposing", "m", "req", api_key="k", root=tmp_path)
     assert json.loads(Path(rec["path"]).read_text())["ready_to_publish"] is True
+
+
+# --- round 8: shape-first PII classification, v3 contract, job lock -------
+
+_DIAL_WORDS = ["call", "calling", "phone", "telephone", "text", "contact", "reach", "dial"]
+_DESCRIPTIVE_NUMERALS = ["255 255 255", "1920 1080", "2026-07-25", "100 200 300", "1920x1080"]
+
+
+@pytest.mark.parametrize("word", _DIAL_WORDS)
+@pytest.mark.parametrize("numeral", _DESCRIPTIVE_NUMERALS)
+def test_oracle_descriptive_numbers_survive_unrelated_dial_words(word, numeral):
+    """Class-closure (#2192 round 8): a descriptive number must still render
+    when an UNRELATED dial word appears in the same prompt. The old rule
+    searched for intent globally, so "a person calling across a room, RGB
+    palette 255 255 255" was rejected as contact PII."""
+    prompt = f"a {word} booth in the background, {numeral} colour grade, wide shot"
+    assert runner._prompt_contact_hits(prompt) == []
+
+
+@pytest.mark.parametrize(
+    "prompt",
+    [
+        "a call center scene, 1920 1080 resolution poster",
+        "a person calling across a room, RGB palette 255 255 255",
+        "phone booth photographed at 100 200 300 RGB",
+        "wide shot. call sheet on the table. 1920 1080 export",
+        "a telephone on a desk, shot at 24 70 mm",
+    ],
+)
+def test_compound_noun_scenes_render(prompt):
+    """The intent words here are noun modifiers, not dial verbs. Separating
+    them is why grouped shapes need same-segment government within 2 tokens
+    rather than a wider window."""
+    assert runner._prompt_contact_hits(prompt) == []
+
+
+@pytest.mark.parametrize(
+    "numeral",
+    ["+44 20 7946 0958", "555 234 5678", "555.1234", "1-800-FLOWERS",
+     "1-800-flowers", "07700 900123", "5552345678"],
+)
+@pytest.mark.parametrize(
+    "scene", ["a poster of {}", "signage reading {}", "{} on a storefront window"]
+)
+def test_dialable_shapes_fail_with_no_intent_word(numeral, scene):
+    """Unambiguous dial shapes carry their own evidence: no dial verb needed,
+    in any scene and any casing."""
+    assert runner._prompt_contact_hits(scene.format(numeral)) != []
+
+
+def test_unbroken_run_is_a_serial_until_intent_appears():
+    """Documented residual: an unbroken digit run that is NOT a valid NANP
+    number is shape-identical to a serial, so it renders on its own and only
+    fails once a dial verb governs it."""
+    assert runner._prompt_contact_hits("a plate engraved serial 12345678") == []
+    assert runner._prompt_contact_hits("a phone on a desk. serial 12345678 engraved") == []
+    assert runner._prompt_contact_hits("text me 12345678 today") != []
+
+
+def test_v2_audit_stays_frozen_and_readable():
+    """#2192 round 8: v2 shipped in #2181, so it must keep validating
+    byte-for-byte and must NOT learn the fingerprint field -- extra='forbid'
+    means a field added there makes new audits unreadable to a v2 consumer."""
+    from atlas_brain.schemas.content_factory import EditorialAuditV2, EditorialAuditV3
+
+    v2_payload = {
+        "schema": "editorial_audit.v2",
+        "project_id": "p",
+        "edited_body_markdown": "Clean copy.",
+        "recommendation": "revise",
+    }
+    EditorialAuditV2.model_validate(v2_payload)  # still readable
+
+    with pytest.raises(ValidationError, match="extra_forbidden|Extra inputs"):
+        EditorialAuditV2.model_validate({**v2_payload, "source_draft_fingerprint": "abc"})
+
+    v3 = EditorialAuditV3.model_validate(
+        {**v2_payload, "schema": "editorial_audit.v3", "schema_version": 3,
+         "source_draft_fingerprint": "abc"}
+    )
+    assert v3.source_draft_fingerprint == "abc"
+
+
+def test_run_stage_normalizes_v2_audit_to_v3(tmp_path, monkeypatch):
+    """A v2-tagged worker reply upgrades cleanly, because its metadata is
+    self-consistent. The anti-laundering rule still holds for contradictory
+    metadata (see test_run_stage_rejects_contradictory_v2_version)."""
+    reply = json.dumps({
+        "schema": "editorial_audit.v2",
+        "schema_version": 2,
+        "project_id": "p",
+        "edited_body_markdown": "Clean copy.",
+        "recommendation": "revise",
+    })
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
+    rec = runner.run_stage("job-v23", "audit", "m", "req", api_key="k", root=tmp_path)
+    stored = json.loads(Path(rec["path"]).read_text())
+    assert stored["schema"] == "editorial_audit.v3"
+    assert stored["schema_version"] == 3
+
+
+def _job_lock_is_free(job_id, root):
+    """Probe the lock from a SECOND file description: flock conflicts between
+    separate open() calls even inside one process, so a non-blocking attempt
+    reports truthfully whether the runner holds it."""
+    import fcntl
+
+    path = Path(root) / ".locks" / f"{job_id}.lock"
+    if not path.exists():
+        return True
+    with open(path, "a+") as handle:
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            return False
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        return True
+
+
+def test_run_stage_holds_job_lock_across_validation_and_write(tmp_path, monkeypatch):
+    """#2192 round 8 (TOCTOU): validating the draft fingerprint proves nothing
+    if the draft can be replaced before the artifact commits. The lock must be
+    HELD while readiness is being decided, and released afterwards."""
+    _seed_draft(tmp_path, "job-lock", ["e1"])
+    observed = []
+    real_enforce = runner._enforce_lineage
+
+    def probing_enforce(artifact, job_id, root):
+        observed.append(_job_lock_is_free(job_id, root))
+        return real_enforce(artifact, job_id, root)
+
+    monkeypatch.setattr(runner, "_enforce_lineage", probing_enforce)
+    reply = json.dumps({
+        "schema": "repurposing.v1", "project_id": "p", "source_draft_revision": 1,
+        "variants": [{"channel": "x", "body_markdown": "Clean copy.",
+                      "derived_from_claims": ["e1"]}],
+        "ready_to_publish": True,
+    })
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
+    runner.run_stage("job-lock", "repurposing", "m", "req", api_key="k", root=tmp_path)
+
+    assert observed == [False], "readiness was decided outside the job lock"
+    assert _job_lock_is_free("job-lock", tmp_path), "lock leaked after run_stage"
+
+
+def test_job_lock_is_reentrant_within_a_thread(tmp_path):
+    """run_stage holds the lock and then calls write_artifact, which takes it
+    again -- that must not deadlock."""
+    from atlas_brain.services.content_factory_store import job_lock
+
+    with job_lock("job-re", root=tmp_path):
+        with job_lock("job-re", root=tmp_path):
+            assert not _job_lock_is_free("job-re", tmp_path)
+    assert _job_lock_is_free("job-re", tmp_path)
+
+
+def test_job_lock_excludes_a_second_process(tmp_path):
+    """The exclusion is real, not just an in-process flag."""
+    from atlas_brain.services.content_factory_store import job_lock
+
+    assert _job_lock_is_free("job-x", tmp_path)
+    with job_lock("job-x", root=tmp_path):
+        assert not _job_lock_is_free("job-x", tmp_path)
+    assert _job_lock_is_free("job-x", tmp_path)

--- a/tests/test_content_factory_runner.py
+++ b/tests/test_content_factory_runner.py
@@ -309,7 +309,10 @@ def _seed_draft(root, job_id, source_ids, revision=1, project="p", approved=True
         "claims": [{"text": f"claim {sid}", "source_id": sid} for sid in source_ids],
     }, root=root)
     if approved:
+        # Mirror what run_stage does: bind the approval to the draft bytes.
+        fingerprint = runner._draft_fingerprint(job_id, root)
         write_artifact(job_id, "audit", {
+            "source_draft_fingerprint": fingerprint,
             "schema": "editorial_audit.v2",
             "project_id": project,
             # Must approve THIS revision -- a stale audit authorizes nothing.
@@ -859,3 +862,96 @@ def test_oracle_structural_forms_fail_without_intent(number, tmp_path, monkeypat
 def test_oracle_email_any_script_fails(addr, tmp_path, monkeypatch):
     cv = _prompt_verdict(f"a card reading {addr}", tmp_path, monkeypatch, "job-or4")
     assert cv["verdict"] == "fail", (addr, cv)
+
+
+# --- review round 7 on #2192 ---
+
+
+_CASINGS = ["1-800-flowers", "1-800-FLOWERS", "1-800-Flowers", "1-800-gOt-JuNk"]
+
+
+@pytest.mark.parametrize("number", _CASINGS)
+@pytest.mark.parametrize("intent", ["Call", "Dial", "Text"])
+def test_vanity_recognition_is_case_independent(number, intent, tmp_path, monkeypatch):
+    """Vanity spelling is case-insensitive; attachment (hyphen vs space) is
+    what separates the number from the next word."""
+    cv = _prompt_verdict(f"{intent} {number} today", tmp_path, monkeypatch, "job-case")
+    assert cv["verdict"] == "fail", (intent, number, cv)
+
+
+@pytest.mark.parametrize("trailing", ["today", "now", "for details", "to book"])
+def test_trailing_lowercase_word_not_absorbed(trailing, tmp_path, monkeypatch):
+    """The other side: a space-joined word must not extend the token past
+    the E.164 bound and thereby hide a real number."""
+    cv = _prompt_verdict(f"Ring 07700 900123 {trailing}", tmp_path, monkeypatch, "job-trail")
+    assert cv["verdict"] == "fail", (trailing, cv)
+
+
+def test_same_revision_draft_replacement_invalidates_approval(tmp_path, monkeypatch):
+    """A rerun of the draft stage keeps revision 1 but changes the body, so
+    the old approval must not carry to text nobody reviewed."""
+    from atlas_brain.services.content_factory_store import write_artifact
+
+    _seed_draft(tmp_path, "job-swap", ["e1"])          # draft + matching audit
+    write_artifact("job-swap", "draft", {              # rerun, same revision
+        "schema": "draft.v1", "project_id": "p", "revision": 1,
+        "body_markdown": "completely different body",
+        "claims": [{"text": "claim e2", "source_id": "e2"}],
+    }, root=tmp_path)
+    reply = json.dumps({
+        "schema": "repurposing.v1", "project_id": "p",
+        "variants": [{"channel": "x", "body_markdown": "Clean copy.",
+                      "derived_from_claims": ["e2"]}],
+        "ready_to_publish": True,
+    })
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
+    with pytest.raises(ArtifactStoreError, match="does not match the draft currently"):
+        runner.run_stage("job-swap", "repurposing", "m", "req", api_key="k", root=tmp_path)
+
+
+def test_image_prompt_readiness_also_content_bound(tmp_path, monkeypatch):
+    from atlas_brain.services.content_factory_store import write_artifact
+
+    _seed_draft(tmp_path, "job-swap2", ["e1"])
+    write_artifact("job-swap2", "draft", {
+        "schema": "draft.v1", "project_id": "p", "revision": 1,
+        "body_markdown": "replaced body", "claims": [{"text": "c", "source_id": "e1"}],
+    }, root=tmp_path)
+    reply = json.dumps({
+        "schema": "image_prompt.v1", "project_id": "p",
+        "prompts": [{"purpose": "hero", "prompt_text": "a tidy desk"}],
+        "ready_to_generate": True,
+    })
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
+    with pytest.raises(ArtifactStoreError, match="does not match the draft currently"):
+        runner.run_stage("job-swap2", "image_prompt", "m", "req", api_key="k", root=tmp_path)
+
+
+def test_audit_stage_stamps_the_fingerprint(tmp_path, monkeypatch):
+    """The binding is runner-set, not worker-supplied."""
+    _seed_draft(tmp_path, "job-stamp", ["e1"], approved=False)
+    reply = json.dumps({
+        "schema": "editorial_audit.v2", "project_id": "p",
+        "edited_body_markdown": "Clean edited copy.",
+        "recommendation": "revise",
+        "source_draft_fingerprint": "worker-supplied-lie",
+    })
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
+    rec = runner.run_stage("job-stamp", "audit", "m", "req", api_key="k", root=tmp_path)
+    stored = json.loads(Path(rec["path"]).read_text())
+    assert stored["source_draft_fingerprint"] == runner._draft_fingerprint("job-stamp", tmp_path)
+    assert stored["source_draft_fingerprint"] != "worker-supplied-lie"
+
+
+def test_unchanged_draft_keeps_approval_valid(tmp_path, monkeypatch):
+    """The other side: an untouched draft still ships."""
+    _seed_draft(tmp_path, "job-stable", ["e1"])
+    reply = json.dumps({
+        "schema": "repurposing.v1", "project_id": "p",
+        "variants": [{"channel": "x", "body_markdown": "Clean copy.",
+                      "derived_from_claims": ["e1"]}],
+        "ready_to_publish": True,
+    })
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
+    rec = runner.run_stage("job-stable", "repurposing", "m", "req", api_key="k", root=tmp_path)
+    assert json.loads(Path(rec["path"]).read_text())["ready_to_publish"] is True

--- a/tests/test_content_factory_runner.py
+++ b/tests/test_content_factory_runner.py
@@ -751,47 +751,6 @@ def test_cross_project_derivation_blocked(tmp_path, monkeypatch):
         runner.run_stage("job-xproj", "repurposing", "m", "req", api_key="k", root=tmp_path)
 
 
-@pytest.mark.parametrize("phone", [
-    "Call 0044 20 7946 0958",
-    "Call us at +442079460958",
-    "reach us: (555) 123-4567",
-    "dial 555.123.4567 today",
-    "ring 07700 900123 now",
-])
-def test_prompt_phone_class_is_closed(phone, tmp_path, monkeypatch):
-    """Class-level: any 7+ digit run under tolerant separators, no matter
-    the dialling convention."""
-    reply = json.dumps({
-        "schema": "image_prompt.v1", "project_id": "p",
-        "prompts": [{"purpose": "hero", "prompt_text": phone}],
-    })
-    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job-ph", "image_prompt", "m", "req", api_key="k", root=tmp_path)
-    stored = json.loads(Path(rec["path"]).read_text())
-    assert stored["copy_verification"]["verdict"] == "fail", (phone, stored["copy_verification"])
-    assert "phone: <redacted>" in " ".join(stored["copy_verification"]["hits"])
-
-
-@pytest.mark.parametrize("ok_text", [
-    "a tidy desk in soft morning light",
-    "a wall clock showing 9:45",
-    "a room with 3 windows and 2 chairs",
-])
-def test_ordinary_prompt_numbers_still_pass(ok_text, tmp_path, monkeypatch):
-    """The other side: short numbers in normal descriptions are not PII."""
-    reply = json.dumps({
-        "schema": "image_prompt.v1", "project_id": "p",
-        "prompts": [{"purpose": "hero", "prompt_text": ok_text}],
-    })
-    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job-ok", "image_prompt", "m", "req", api_key="k", root=tmp_path)
-    stored = json.loads(Path(rec["path"]).read_text())
-    assert stored["copy_verification"]["verdict"] == "pass", (ok_text, stored["copy_verification"])
-
-
-# --- review round 5 on #2192 ---
-
-
 def test_stale_audit_cannot_approve_newer_draft(tmp_path, monkeypatch):
     """A revision-1 approval does not authorize revision-2 copy."""
     from atlas_brain.services.content_factory_store import write_artifact
@@ -836,35 +795,67 @@ def test_foreign_project_audit_cannot_approve(tmp_path, monkeypatch):
         runner.run_stage("job-xaudit", "repurposing", "m", "req", api_key="k", root=tmp_path)
 
 
-@pytest.mark.parametrize("bad", [
-    "Call 1-800-FLOWERS",
-    "Call 0044 20 7946 0958",
-    "reach us: (555) 123-4567",
-    "ring 07700 900123 now",
-    "email josé@example.com",
-    "write to user@例え.テスト",
-])
-def test_prompt_contact_data_fails_both_scripts(bad, tmp_path, monkeypatch):
-    reply = json.dumps({"schema": "image_prompt.v1", "project_id": "p",
-                        "prompts": [{"purpose": "hero", "prompt_text": bad}]})
-    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job-c5", "image_prompt", "m", "req", api_key="k", root=tmp_path)
-    cv = json.loads(Path(rec["path"]).read_text())["copy_verification"]
-    assert cv["verdict"] == "fail", (bad, cv)
 
 
-@pytest.mark.parametrize("ok", [
-    "calendar showing 2026-07-25",
-    "a wall clock showing 9:45",
-    "invoice dated 07/25/2026",
-    "a room with 3 windows and 2 chairs",
-    "address plaque reading 12 Elm",
-])
-def test_ordinary_numeric_description_passes(ok, tmp_path, monkeypatch):
-    """The other direction: dated/counted artwork is not contact data."""
+# --- review round 6: generative oracle for the contact classifier ---------
+#
+# Built from grammars rather than a fixture list, so the decision is
+# exercised across the space instead of the examples that happened to be
+# reported. Both error directions are asserted.
+
+_INTENTS = ["Call", "Text", "Dial", "Reach us at", "Phone", "Ring"]
+_DIALABLE = [
+    "1-800-GOT-JUNK", "1-800-FLOWERS",          # vanity, letters
+    "+442079460958", "+44 20 7946 0958",        # E.164
+    "0044 20 7946 0958",                        # 00 prefix
+    "(555) 123-4567", "555-123-4567",           # NANP
+    "555.123.4567", "5551234567",               # separators / unbroken
+    "07700 900123", "07700900123",              # local, long
+]
+_DESCRIPTIVE = [
+    "RGB palette 255 255 255", "canvas 1920 1080 pixels",
+    "calendar showing 2026-07-25", "invoice dated 07/25/2026",
+    "a wall clock showing 9:45", "a room with 3 windows and 2 chairs",
+    "address plaque reading 12 Elm", "serial 12345678 engraved on a plate",
+    "ISO 4217 currency chart", "recipe calls for 2 cups and 3 eggs",
+    "a tidy desk in soft morning light",
+]
+_SCENES = ["a poster of {}", "signage reading {}", "{} on a storefront window"]
+
+
+def _prompt_verdict(text, tmp_path, monkeypatch, job):
     reply = json.dumps({"schema": "image_prompt.v1", "project_id": "p",
-                        "prompts": [{"purpose": "hero", "prompt_text": ok}]})
+                        "prompts": [{"purpose": "hero", "prompt_text": text}]})
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job-o5", "image_prompt", "m", "req", api_key="k", root=tmp_path)
-    cv = json.loads(Path(rec["path"]).read_text())["copy_verification"]
-    assert cv["verdict"] == "pass", (ok, cv)
+    rec = runner.run_stage(job, "image_prompt", "m", "req", api_key="k", root=tmp_path)
+    return json.loads(Path(rec["path"]).read_text())["copy_verification"]
+
+
+@pytest.mark.parametrize("number", _DIALABLE)
+@pytest.mark.parametrize("intent", _INTENTS)
+def test_oracle_dial_intent_plus_number_always_fails(number, intent, tmp_path, monkeypatch):
+    cv = _prompt_verdict(f"{intent} {number} today", tmp_path, monkeypatch, "job-or1")
+    assert cv["verdict"] == "fail", (intent, number, cv)
+
+
+@pytest.mark.parametrize("text", _DESCRIPTIVE)
+@pytest.mark.parametrize("scene", _SCENES)
+def test_oracle_descriptive_numbers_never_fail(text, scene, tmp_path, monkeypatch):
+    """No dial intent and no dialable structure -> digits are description."""
+    cv = _prompt_verdict(scene.format(text), tmp_path, monkeypatch, "job-or2")
+    assert cv["verdict"] == "pass", (scene, text, cv)
+
+
+@pytest.mark.parametrize("number", ["+442079460958", "(555) 123-4567", "555-123-4567"])
+def test_oracle_structural_forms_fail_without_intent(number, tmp_path, monkeypatch):
+    """E.164 and NANP are unambiguous: no intent word needed."""
+    cv = _prompt_verdict(f"a poster showing {number}", tmp_path, monkeypatch, "job-or3")
+    assert cv["verdict"] == "fail", (number, cv)
+
+
+@pytest.mark.parametrize("addr", [
+    "bob@example.com", "josé@example.com", "user@例え.テスト", "a.b+tag@sub.domain.co.uk",
+])
+def test_oracle_email_any_script_fails(addr, tmp_path, monkeypatch):
+    cv = _prompt_verdict(f"a card reading {addr}", tmp_path, monkeypatch, "job-or4")
+    assert cv["verdict"] == "fail", (addr, cv)

--- a/tests/test_content_factory_runner.py
+++ b/tests/test_content_factory_runner.py
@@ -296,13 +296,14 @@ def test_run_stage_rejects_contradictory_v2_version(tmp_path, monkeypatch):
 # --- Phase 6: repurposing + image-prompt gates at the real entrypoint ---
 
 
-def _seed_draft(root, job_id, source_ids):
+def _seed_draft(root, job_id, source_ids, revision=1):
     """Write a minimal valid draft.json so lineage checks have a source."""
     from atlas_brain.services.content_factory_store import write_artifact
 
     write_artifact(job_id, "draft", {
         "schema": "draft.v1",
         "project_id": "p",
+        "revision": revision,
         "body_markdown": "seed",
         "claims": [{"text": f"claim {sid}", "source_id": sid} for sid in source_ids],
     }, root=root)
@@ -557,7 +558,7 @@ def test_missing_draft_fails_closed_on_ship(tmp_path, monkeypatch):
         "ready_to_publish": True,
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    with pytest.raises(ArtifactStoreError, match="readable draft.json"):
+    with pytest.raises(ArtifactStoreError, match="readable draft artifact"):
         runner.run_stage("job-nodraft", "repurposing", "m", "req", api_key="k", root=tmp_path)
 
 
@@ -600,3 +601,88 @@ def test_hits_identify_the_offending_prompt(tmp_path, monkeypatch):
     rec = runner.run_stage("job-which", "image_prompt", "m", "req", api_key="k", root=tmp_path)
     hits = json.loads(Path(rec["path"]).read_text())["copy_verification"]["hits"]
     assert all(h.startswith("prompt 2:") for h in hits), hits
+
+
+# --- review round 3 on #2192 ---
+
+
+def test_stale_source_revision_blocks_shipping(tmp_path, monkeypatch):
+    """Overlapping claim ids must not let a package built on superseded
+    copy ship."""
+    _seed_draft(tmp_path, "job-rev", ["e1"], revision=2)
+    reply = json.dumps({
+        "schema": "repurposing.v1", "project_id": "p",
+        "source_draft_revision": 1,
+        "variants": [{"channel": "x", "body_markdown": "Clean copy.",
+                      "derived_from_claims": ["e1"]}],
+        "ready_to_publish": True,
+    })
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
+    with pytest.raises(ArtifactStoreError, match="superseded copy"):
+        runner.run_stage("job-rev", "repurposing", "m", "req", api_key="k", root=tmp_path)
+
+
+def test_matching_source_revision_ships(tmp_path, monkeypatch):
+    _seed_draft(tmp_path, "job-rev2", ["e1"], revision=2)
+    reply = json.dumps({
+        "schema": "repurposing.v1", "project_id": "p",
+        "source_draft_revision": 2,
+        "variants": [{"channel": "x", "body_markdown": "Clean copy.",
+                      "derived_from_claims": ["e1"]}],
+        "ready_to_publish": True,
+    })
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
+    rec = runner.run_stage("job-rev2", "repurposing", "m", "req", api_key="k", root=tmp_path)
+    assert json.loads(Path(rec["path"]).read_text())["ready_to_publish"] is True
+
+
+def test_image_prompt_readiness_also_checks_revision(tmp_path, monkeypatch):
+    """ImagePromptSet gets the same tie to the approved draft."""
+    _seed_draft(tmp_path, "job-imgrev", ["e1"], revision=3)
+    reply = json.dumps({
+        "schema": "image_prompt.v1", "project_id": "p",
+        "source_draft_revision": 1,
+        "prompts": [{"purpose": "hero", "prompt_text": "a tidy desk"}],
+        "ready_to_generate": True,
+    })
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
+    with pytest.raises(ArtifactStoreError, match="superseded copy"):
+        runner.run_stage("job-imgrev", "image_prompt", "m", "req", api_key="k", root=tmp_path)
+
+
+def test_string_false_readiness_persists_as_intermediate(tmp_path, monkeypatch):
+    """A weak worker's "false" normalizes to False, so no draft is required
+    and the intermediate package persists (runner and schema agree)."""
+    reply = json.dumps({
+        "schema": "repurposing.v1", "project_id": "p",
+        "variants": [{"channel": "x", "body_markdown": "Clean copy.",
+                      "derived_from_claims": ["not-yet-real"]}],
+        "ready_to_publish": "false",
+    })
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
+    rec = runner.run_stage("job-strfalse", "repurposing", "m", "req", api_key="k", root=tmp_path)
+    assert json.loads(Path(rec["path"]).read_text())["ready_to_publish"] is False
+
+
+@pytest.mark.parametrize("text", [
+    "poster reading do not guarantee savings",
+    "a sign that says we never guarantee savings",
+])
+def test_negated_banned_phrase_in_prompt_still_fails(text, tmp_path, monkeypatch):
+    """Prose negation does not un-draw words a renderer is told to paint."""
+    reply = json.dumps({
+        "schema": "image_prompt.v1", "project_id": "p",
+        "prompts": [{"purpose": "hero", "prompt_text": text}],
+    })
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
+    rec = runner.run_stage("job-neg2", "image_prompt", "m", "req", api_key="k", root=tmp_path)
+    stored = json.loads(Path(rec["path"]).read_text())
+    assert stored["copy_verification"]["verdict"] == "fail", stored["copy_verification"]
+
+
+def test_body_copy_keeps_prose_negation_semantics():
+    """The literal matcher is prompt-only; body copy still reads denials as
+    denials (the #2181 contract is untouched)."""
+    from atlas_brain.services.content_factory_copy_verification import verify_copy
+
+    assert verify_copy("We do not promise guaranteed savings.").verdict == "pass"

--- a/tests/test_content_factory_runner.py
+++ b/tests/test_content_factory_runner.py
@@ -296,6 +296,18 @@ def test_run_stage_rejects_contradictory_v2_version(tmp_path, monkeypatch):
 # --- Phase 6: repurposing + image-prompt gates at the real entrypoint ---
 
 
+def _seed_draft(root, job_id, source_ids):
+    """Write a minimal valid draft.json so lineage checks have a source."""
+    from atlas_brain.services.content_factory_store import write_artifact
+
+    write_artifact(job_id, "draft", {
+        "schema": "draft.v1",
+        "project_id": "p",
+        "body_markdown": "seed",
+        "claims": [{"text": f"claim {sid}", "source_id": sid} for sid in source_ids],
+    }, root=root)
+
+
 def test_run_stage_overwrites_variant_verdicts_and_blocks_bad_ship(tmp_path, monkeypatch):
     """A worker cannot ship an overclaiming variant: the runner recomputes
     each variant's verdict from its own body, so a self-asserted
@@ -316,9 +328,12 @@ def test_run_stage_overwrites_variant_verdicts_and_blocks_bad_ship(tmp_path, mon
         }
     )
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
+    # Seed a draft whose lineage covers the variant, so this test isolates
+    # the CONTRACT behaviour (self-promotion) rather than tripping the
+    # separate lineage check first.
+    _seed_draft(tmp_path, "job-rp", ["e1"])
     with pytest.raises(ValidationError):
         runner.run_stage("job-rp", "repurposing", "m", "req", api_key="k", root=tmp_path)
-    assert not job_dir("job-rp", root=tmp_path).exists()
 
 
 def test_run_stage_persists_clean_variants_with_computed_verdicts(tmp_path, monkeypatch):
@@ -405,7 +420,7 @@ def test_run_stage_image_prompt_pii_is_caught(tmp_path, monkeypatch):
     # theorem); the prompt text itself is the artifact's payload and stays
     # so a human can see what to fix -- same as a draft body.
     assert "bob@example.com" not in json.dumps(stored["copy_verification"])
-    assert stored["copy_verification"]["hits"] == ["email: <redacted>"]
+    assert stored["copy_verification"]["hits"] == ["prompt 1: email: <redacted>"]
 
 
 def test_run_stage_clean_image_prompt_passes(tmp_path, monkeypatch):
@@ -488,3 +503,100 @@ def test_worker_cannot_self_declare_ready_to_generate(tmp_path, monkeypatch):
     with pytest.raises(ValidationError):
         runner.run_stage("job-selfgen", "image_prompt", "m", "req", api_key="k", root=tmp_path)
     assert not job_dir("job-selfgen", root=tmp_path).exists()
+
+
+# --- review round 2 on #2192 ---
+
+
+def test_fabricated_lineage_blocks_shipping(tmp_path, monkeypatch):
+    """Non-blank lineage is not REAL lineage: an id the draft never
+    established is still an orphan."""
+    _seed_draft(tmp_path, "job-lin", ["e1"])
+    reply = json.dumps({
+        "schema": "repurposing.v1", "project_id": "p",
+        "variants": [{"channel": "x", "body_markdown": "Clean copy.",
+                      "derived_from_claims": ["completely-fabricated-id"]}],
+        "ready_to_publish": True,
+    })
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
+    with pytest.raises(ArtifactStoreError, match="absent from the draft"):
+        runner.run_stage("job-lin", "repurposing", "m", "req", api_key="k", root=tmp_path)
+
+
+def test_real_lineage_ships(tmp_path, monkeypatch):
+    _seed_draft(tmp_path, "job-lin2", ["e1", "e2"])
+    reply = json.dumps({
+        "schema": "repurposing.v1", "project_id": "p",
+        "variants": [{"channel": "x", "body_markdown": "Clean copy.",
+                      "derived_from_claims": ["e2"]}],
+        "ready_to_publish": True,
+    })
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
+    rec = runner.run_stage("job-lin2", "repurposing", "m", "req", api_key="k", root=tmp_path)
+    assert json.loads(Path(rec["path"]).read_text())["ready_to_publish"] is True
+
+
+def test_unready_package_skips_lineage_check(tmp_path, monkeypatch):
+    """An unready package is a legitimate intermediate state."""
+    reply = json.dumps({
+        "schema": "repurposing.v1", "project_id": "p",
+        "variants": [{"channel": "x", "body_markdown": "Clean copy.",
+                      "derived_from_claims": ["not-yet-real"]}],
+        "ready_to_publish": False,
+    })
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
+    rec = runner.run_stage("job-lin3", "repurposing", "m", "req", api_key="k", root=tmp_path)
+    assert Path(rec["path"]).exists()
+
+
+def test_missing_draft_fails_closed_on_ship(tmp_path, monkeypatch):
+    reply = json.dumps({
+        "schema": "repurposing.v1", "project_id": "p",
+        "variants": [{"channel": "x", "body_markdown": "Clean copy.",
+                      "derived_from_claims": ["e1"]}],
+        "ready_to_publish": True,
+    })
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
+    with pytest.raises(ArtifactStoreError, match="readable draft.json"):
+        runner.run_stage("job-nodraft", "repurposing", "m", "req", api_key="k", root=tmp_path)
+
+
+def test_international_phone_in_prompt_fails(tmp_path, monkeypatch):
+    reply = json.dumps({
+        "schema": "image_prompt.v1", "project_id": "p",
+        "prompts": [{"purpose": "hero", "prompt_text": "Call us at +442079460958"}],
+    })
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
+    rec = runner.run_stage("job-intl", "image_prompt", "m", "req", api_key="k", root=tmp_path)
+    stored = json.loads(Path(rec["path"]).read_text())
+    assert stored["copy_verification"]["verdict"] == "fail"
+    assert "442079460958" not in json.dumps(stored["copy_verification"])
+
+
+def test_prompts_verified_independently_no_cross_synthesis(tmp_path, monkeypatch):
+    """Joining items must not synthesize a claim no single prompt makes."""
+    reply = json.dumps({
+        "schema": "image_prompt.v1", "project_id": "p",
+        "prompts": [
+            {"purpose": "a", "prompt_text": "a warm kitchen, results guaranteed"},
+            {"purpose": "b", "prompt_text": "savings account paperwork on a desk"},
+        ],
+    })
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
+    rec = runner.run_stage("job-split", "image_prompt", "m", "req", api_key="k", root=tmp_path)
+    stored = json.loads(Path(rec["path"]).read_text())
+    assert stored["copy_verification"]["verdict"] == "pass", stored["copy_verification"]
+
+
+def test_hits_identify_the_offending_prompt(tmp_path, monkeypatch):
+    reply = json.dumps({
+        "schema": "image_prompt.v1", "project_id": "p",
+        "prompts": [
+            {"purpose": "a", "prompt_text": "a clean desk"},
+            {"purpose": "b", "prompt_text": "poster reading guaranteed savings"},
+        ],
+    })
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
+    rec = runner.run_stage("job-which", "image_prompt", "m", "req", api_key="k", root=tmp_path)
+    hits = json.loads(Path(rec["path"]).read_text())["copy_verification"]["hits"]
+    assert all(h.startswith("prompt 2:") for h in hits), hits

--- a/tests/test_content_factory_runner.py
+++ b/tests/test_content_factory_runner.py
@@ -16,6 +16,7 @@ import pytest
 from pydantic import ValidationError
 
 import atlas_brain.services.content_factory_runner as runner
+from atlas_brain.services.content_factory_store import ArtifactStoreError
 from atlas_brain.services.content_factory_runner import (
     WorkerError,
     call_worker,
@@ -290,3 +291,150 @@ def test_run_stage_rejects_contradictory_v2_version(tmp_path, monkeypatch):
     with pytest.raises(ValidationError):
         runner.run_stage("job-v2v", "audit", "m", "req", api_key="k", root=tmp_path)
     assert not job_dir("job-v2v", root=tmp_path).exists()
+
+
+# --- Phase 6: repurposing + image-prompt gates at the real entrypoint ---
+
+
+def test_run_stage_overwrites_variant_verdicts_and_blocks_bad_ship(tmp_path, monkeypatch):
+    """A worker cannot ship an overclaiming variant: the runner recomputes
+    each variant's verdict from its own body, so a self-asserted
+    ready_to_publish becomes invalid and nothing persists."""
+    reply = json.dumps(
+        {
+            "schema": "repurposing.v1",
+            "project_id": "p",
+            "variants": [
+                {
+                    "channel": "linkedin",
+                    "body_markdown": "We guarantee savings for every team.",
+                    "derived_from_claims": ["e1"],
+                    "copy_verification": {"verdict": "pass", "hits": []},
+                }
+            ],
+            "ready_to_publish": True,
+        }
+    )
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
+    with pytest.raises(ValidationError):
+        runner.run_stage("job-rp", "repurposing", "m", "req", api_key="k", root=tmp_path)
+    assert not job_dir("job-rp", root=tmp_path).exists()
+
+
+def test_run_stage_persists_clean_variants_with_computed_verdicts(tmp_path, monkeypatch):
+    reply = json.dumps(
+        {
+            "schema": "repurposing.v1",
+            "project_id": "p",
+            "variants": [
+                {
+                    "channel": "linkedin",
+                    "body_markdown": "Repeat tickets quietly consume agent hours.",
+                    "derived_from_claims": ["e1"],
+                }
+            ],
+            "ready_to_publish": False,
+        }
+    )
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
+    rec = runner.run_stage("job-rp2", "repurposing", "m", "req", api_key="k", root=tmp_path)
+    stored = json.loads(Path(rec["path"]).read_text())
+    assert stored["variants"][0]["copy_verification"]["verdict"] == "pass"
+    assert stored["variants"][0]["advisory_warnings"][-1].startswith("reminder:")
+
+
+def test_run_stage_blank_variant_body_fails_closed(tmp_path, monkeypatch):
+    reply = json.dumps(
+        {
+            "schema": "repurposing.v1",
+            "project_id": "p",
+            "variants": [
+                {
+                    "channel": "x",
+                    "body_markdown": "   ",
+                    "derived_from_claims": ["e1"],
+                    "copy_verification": {"verdict": "pass", "hits": []},
+                }
+            ],
+        }
+    )
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
+    # blank body is rejected by the contract (NonEmptyStr) -- nothing persists
+    with pytest.raises(ValidationError):
+        runner.run_stage("job-rp3", "repurposing", "m", "req", api_key="k", root=tmp_path)
+
+
+def test_run_stage_gates_image_prompt_text(tmp_path, monkeypatch):
+    """Banned copy inside a PROMPT would be rendered into the artwork, where
+    no text check would see it -- the gate runs on the prompt itself."""
+    reply = json.dumps(
+        {
+            "schema": "image_prompt.v1",
+            "project_id": "p",
+            "prompts": [
+                {
+                    "purpose": "hero",
+                    "prompt_text": "poster reading guaranteed savings for every team",
+                }
+            ],
+            "copy_verification": {"verdict": "pass", "hits": []},
+        }
+    )
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
+    rec = runner.run_stage("job-img", "image_prompt", "m", "req", api_key="k", root=tmp_path)
+    stored = json.loads(Path(rec["path"]).read_text())
+    assert stored["copy_verification"]["verdict"] == "fail"
+    assert any("guaranteed-savings" in hit for hit in stored["copy_verification"]["hits"])
+
+
+def test_run_stage_image_prompt_pii_is_caught(tmp_path, monkeypatch):
+    reply = json.dumps(
+        {
+            "schema": "image_prompt.v1",
+            "project_id": "p",
+            "prompts": [
+                {"purpose": "card", "prompt_text": "business card reading bob@example.com"}
+            ],
+        }
+    )
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
+    rec = runner.run_stage("job-img2", "image_prompt", "m", "req", api_key="k", root=tmp_path)
+    stored = json.loads(Path(rec["path"]).read_text())
+    assert stored["copy_verification"]["verdict"] == "fail"
+    # The VERDICT never carries the raw value (the persisted-evidence
+    # theorem); the prompt text itself is the artifact's payload and stays
+    # so a human can see what to fix -- same as a draft body.
+    assert "bob@example.com" not in json.dumps(stored["copy_verification"])
+    assert stored["copy_verification"]["hits"] == ["email: <redacted>"]
+
+
+def test_run_stage_clean_image_prompt_passes(tmp_path, monkeypatch):
+    reply = json.dumps(
+        {
+            "schema": "image_prompt.v1",
+            "project_id": "p",
+            "prompts": [
+                {"purpose": "hero", "prompt_text": "a tidy office desk in soft morning light"}
+            ],
+        }
+    )
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
+    rec = runner.run_stage("job-img3", "image_prompt", "m", "req", api_key="k", root=tmp_path)
+    stored = json.loads(Path(rec["path"]).read_text())
+    assert stored["copy_verification"]["verdict"] == "pass"
+
+
+def test_stage_schema_mismatch_still_enforced_for_phase6(tmp_path, monkeypatch):
+    """A repurposing artifact cannot land under the image_prompt stage."""
+    reply = json.dumps(
+        {
+            "schema": "repurposing.v1",
+            "project_id": "p",
+            "variants": [
+                {"channel": "x", "body_markdown": "clean", "derived_from_claims": ["e1"]}
+            ],
+        }
+    )
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
+    with pytest.raises(ArtifactStoreError):
+        runner.run_stage("job-mix", "image_prompt", "m", "req", api_key="k", root=tmp_path)

--- a/tests/test_content_factory_runner.py
+++ b/tests/test_content_factory_runner.py
@@ -296,17 +296,26 @@ def test_run_stage_rejects_contradictory_v2_version(tmp_path, monkeypatch):
 # --- Phase 6: repurposing + image-prompt gates at the real entrypoint ---
 
 
-def _seed_draft(root, job_id, source_ids, revision=1):
-    """Write a minimal valid draft.json so lineage checks have a source."""
+def _seed_draft(root, job_id, source_ids, revision=1, project="p", approved=True):
+    """Establish the approved source state Phase 6 readiness requires: a
+    draft with claim lineage plus an audit that promoted it."""
     from atlas_brain.services.content_factory_store import write_artifact
 
     write_artifact(job_id, "draft", {
         "schema": "draft.v1",
-        "project_id": "p",
+        "project_id": project,
         "revision": revision,
         "body_markdown": "seed",
         "claims": [{"text": f"claim {sid}", "source_id": sid} for sid in source_ids],
     }, root=root)
+    if approved:
+        write_artifact(job_id, "audit", {
+            "schema": "editorial_audit.v2",
+            "project_id": project,
+            "edited_body_markdown": "seed",
+            "copy_verification": {"verdict": "pass", "hits": []},
+            "recommendation": "promote",
+        }, root=root)
 
 
 def test_run_stage_overwrites_variant_verdicts_and_blocks_bad_ship(tmp_path, monkeypatch):
@@ -686,3 +695,93 @@ def test_body_copy_keeps_prose_negation_semantics():
     from atlas_brain.services.content_factory_copy_verification import verify_copy
 
     assert verify_copy("We do not promise guaranteed savings.").verdict == "pass"
+
+
+# --- review round 4 on #2192 ---
+
+
+def test_unaudited_draft_cannot_ship(tmp_path, monkeypatch):
+    """Existence of a draft proves it ran, not that anything approved it."""
+    _seed_draft(tmp_path, "job-noaudit", ["e1"], approved=False)
+    reply = json.dumps({
+        "schema": "repurposing.v1", "project_id": "p",
+        "variants": [{"channel": "x", "body_markdown": "Clean copy.",
+                      "derived_from_claims": ["e1"]}],
+        "ready_to_publish": True,
+    })
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
+    with pytest.raises(ArtifactStoreError, match="recommending 'promote'"):
+        runner.run_stage("job-noaudit", "repurposing", "m", "req", api_key="k", root=tmp_path)
+
+
+def test_revise_audit_cannot_ship(tmp_path, monkeypatch):
+    from atlas_brain.services.content_factory_store import write_artifact
+
+    _seed_draft(tmp_path, "job-revise", ["e1"], approved=False)
+    write_artifact("job-revise", "audit", {
+        "schema": "editorial_audit.v2", "project_id": "p",
+        "edited_body_markdown": "seed",
+        "copy_verification": {"verdict": "fail", "hits": ["guaranteed-savings: x"]},
+        "recommendation": "revise",
+    }, root=tmp_path)
+    reply = json.dumps({
+        "schema": "repurposing.v1", "project_id": "p",
+        "variants": [{"channel": "x", "body_markdown": "Clean copy.",
+                      "derived_from_claims": ["e1"]}],
+        "ready_to_publish": True,
+    })
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
+    with pytest.raises(ArtifactStoreError, match="recommending 'promote'"):
+        runner.run_stage("job-revise", "repurposing", "m", "req", api_key="k", root=tmp_path)
+
+
+def test_cross_project_derivation_blocked(tmp_path, monkeypatch):
+    """Matching revision + overlapping ids are not evidence across projects."""
+    _seed_draft(tmp_path, "job-xproj", ["e1"], project="source")
+    reply = json.dumps({
+        "schema": "repurposing.v1", "project_id": "other",
+        "variants": [{"channel": "x", "body_markdown": "Clean copy.",
+                      "derived_from_claims": ["e1"]}],
+        "ready_to_publish": True,
+    })
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
+    with pytest.raises(ArtifactStoreError, match="project mismatch"):
+        runner.run_stage("job-xproj", "repurposing", "m", "req", api_key="k", root=tmp_path)
+
+
+@pytest.mark.parametrize("phone", [
+    "Call 0044 20 7946 0958",
+    "Call us at +442079460958",
+    "reach us: (555) 123-4567",
+    "dial 555.123.4567 today",
+    "ring 07700 900123 now",
+])
+def test_prompt_phone_class_is_closed(phone, tmp_path, monkeypatch):
+    """Class-level: any 7+ digit run under tolerant separators, no matter
+    the dialling convention."""
+    reply = json.dumps({
+        "schema": "image_prompt.v1", "project_id": "p",
+        "prompts": [{"purpose": "hero", "prompt_text": phone}],
+    })
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
+    rec = runner.run_stage("job-ph", "image_prompt", "m", "req", api_key="k", root=tmp_path)
+    stored = json.loads(Path(rec["path"]).read_text())
+    assert stored["copy_verification"]["verdict"] == "fail", (phone, stored["copy_verification"])
+    assert "phone: <redacted>" in " ".join(stored["copy_verification"]["hits"])
+
+
+@pytest.mark.parametrize("ok_text", [
+    "a tidy desk in soft morning light",
+    "a wall clock showing 9:45",
+    "a room with 3 windows and 2 chairs",
+])
+def test_ordinary_prompt_numbers_still_pass(ok_text, tmp_path, monkeypatch):
+    """The other side: short numbers in normal descriptions are not PII."""
+    reply = json.dumps({
+        "schema": "image_prompt.v1", "project_id": "p",
+        "prompts": [{"purpose": "hero", "prompt_text": ok_text}],
+    })
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
+    rec = runner.run_stage("job-ok", "image_prompt", "m", "req", api_key="k", root=tmp_path)
+    stored = json.loads(Path(rec["path"]).read_text())
+    assert stored["copy_verification"]["verdict"] == "pass", (ok_text, stored["copy_verification"])

--- a/tests/test_content_factory_runner.py
+++ b/tests/test_content_factory_runner.py
@@ -312,6 +312,8 @@ def _seed_draft(root, job_id, source_ids, revision=1, project="p", approved=True
         write_artifact(job_id, "audit", {
             "schema": "editorial_audit.v2",
             "project_id": project,
+            # Must approve THIS revision -- a stale audit authorizes nothing.
+            "draft_revision": revision,
             "edited_body_markdown": "seed",
             "copy_verification": {"verdict": "pass", "hits": []},
             "recommendation": "promote",
@@ -785,3 +787,84 @@ def test_ordinary_prompt_numbers_still_pass(ok_text, tmp_path, monkeypatch):
     rec = runner.run_stage("job-ok", "image_prompt", "m", "req", api_key="k", root=tmp_path)
     stored = json.loads(Path(rec["path"]).read_text())
     assert stored["copy_verification"]["verdict"] == "pass", (ok_text, stored["copy_verification"])
+
+
+# --- review round 5 on #2192 ---
+
+
+def test_stale_audit_cannot_approve_newer_draft(tmp_path, monkeypatch):
+    """A revision-1 approval does not authorize revision-2 copy."""
+    from atlas_brain.services.content_factory_store import write_artifact
+
+    _seed_draft(tmp_path, "job-staleaudit", ["e1"], revision=2, approved=False)
+    write_artifact("job-staleaudit", "audit", {
+        "schema": "editorial_audit.v2", "project_id": "p",
+        "draft_revision": 1,
+        "edited_body_markdown": "seed",
+        "copy_verification": {"verdict": "pass", "hits": []},
+        "recommendation": "promote",
+    }, root=tmp_path)
+    reply = json.dumps({
+        "schema": "repurposing.v1", "project_id": "p", "source_draft_revision": 2,
+        "variants": [{"channel": "x", "body_markdown": "Clean copy.",
+                      "derived_from_claims": ["e1"]}],
+        "ready_to_publish": True,
+    })
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
+    with pytest.raises(ArtifactStoreError, match="audit approved draft revision"):
+        runner.run_stage("job-staleaudit", "repurposing", "m", "req", api_key="k", root=tmp_path)
+
+
+def test_foreign_project_audit_cannot_approve(tmp_path, monkeypatch):
+    from atlas_brain.services.content_factory_store import write_artifact
+
+    _seed_draft(tmp_path, "job-xaudit", ["e1"], approved=False)
+    write_artifact("job-xaudit", "audit", {
+        "schema": "editorial_audit.v2", "project_id": "elsewhere",
+        "edited_body_markdown": "seed",
+        "copy_verification": {"verdict": "pass", "hits": []},
+        "recommendation": "promote",
+    }, root=tmp_path)
+    reply = json.dumps({
+        "schema": "repurposing.v1", "project_id": "p",
+        "variants": [{"channel": "x", "body_markdown": "Clean copy.",
+                      "derived_from_claims": ["e1"]}],
+        "ready_to_publish": True,
+    })
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
+    with pytest.raises(ArtifactStoreError, match="audit project"):
+        runner.run_stage("job-xaudit", "repurposing", "m", "req", api_key="k", root=tmp_path)
+
+
+@pytest.mark.parametrize("bad", [
+    "Call 1-800-FLOWERS",
+    "Call 0044 20 7946 0958",
+    "reach us: (555) 123-4567",
+    "ring 07700 900123 now",
+    "email josé@example.com",
+    "write to user@例え.テスト",
+])
+def test_prompt_contact_data_fails_both_scripts(bad, tmp_path, monkeypatch):
+    reply = json.dumps({"schema": "image_prompt.v1", "project_id": "p",
+                        "prompts": [{"purpose": "hero", "prompt_text": bad}]})
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
+    rec = runner.run_stage("job-c5", "image_prompt", "m", "req", api_key="k", root=tmp_path)
+    cv = json.loads(Path(rec["path"]).read_text())["copy_verification"]
+    assert cv["verdict"] == "fail", (bad, cv)
+
+
+@pytest.mark.parametrize("ok", [
+    "calendar showing 2026-07-25",
+    "a wall clock showing 9:45",
+    "invoice dated 07/25/2026",
+    "a room with 3 windows and 2 chairs",
+    "address plaque reading 12 Elm",
+])
+def test_ordinary_numeric_description_passes(ok, tmp_path, monkeypatch):
+    """The other direction: dated/counted artwork is not contact data."""
+    reply = json.dumps({"schema": "image_prompt.v1", "project_id": "p",
+                        "prompts": [{"purpose": "hero", "prompt_text": ok}]})
+    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
+    rec = runner.run_stage("job-o5", "image_prompt", "m", "req", api_key="k", root=tmp_path)
+    cv = json.loads(Path(rec["path"]).read_text())["copy_verification"]
+    assert cv["verdict"] == "pass", (ok, cv)

--- a/tests/test_content_factory_runner.py
+++ b/tests/test_content_factory_runner.py
@@ -8,6 +8,7 @@ exercised for real against a temp filesystem.
 from __future__ import annotations
 
 import json
+import subprocess
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -1120,3 +1121,125 @@ def test_job_lock_excludes_a_second_process(tmp_path):
     with job_lock("job-x", root=tmp_path):
         assert not _job_lock_is_free("job-x", tmp_path)
     assert _job_lock_is_free("job-x", tmp_path)
+
+
+# --- round 9: vanity grammar both directions, commit atomicity, channels ---
+
+_SPEC_DIGITS = ["8", "16", "24", "32", "64", "1920", "1080", "4096"]
+_SPEC_WORDS = ["bit", "color", "pixel", "style", "float", "depth", "res"]
+
+
+@pytest.mark.parametrize("lead", _SPEC_DIGITS)
+@pytest.mark.parametrize("word", _SPEC_WORDS)
+def test_oracle_hyphenated_renderer_specs_render(lead, word):
+    """Grammar-derived (#2192 round 9): letters ATTACHED to digits do not make
+    a vanity number. A renderer spec's leading group is not an area code, and
+    its keypad mapping is not a valid NANP number, so the whole class renders
+    -- "16-bit-color" and "1920-1080-pixel" were rejected before."""
+    assert runner._prompt_contact_hits(f"a {lead}-{word}-{word} render, studio light") == []
+
+
+@pytest.mark.parametrize("intent", ["Call", "call", "Text", "dial", "contact"])
+@pytest.mark.parametrize(
+    "spelled", ["1 800 FLOWERS", "1 800 GOT JUNK", "800 FLOWERS", "1-800-FLOWERS",
+                "1-800-flowers", "1-800-GOT-JUNK"]
+)
+def test_oracle_space_joined_vanity_numbers_fail(intent, spelled):
+    """The other direction of the same grammar: the token regex stops before a
+    space-joined letter group, so "Call 1 800 FLOWERS today" passed."""
+    assert runner._prompt_contact_hits(f"{intent} {spelled} today") != []
+
+
+@pytest.mark.parametrize(
+    "prompt",
+    ["255 255 255 blue tint", "1920 1080 pixel export", "100 200 300 RGB values",
+     "a poster of serial 12345678 engraved on a plate"],
+)
+def test_trailing_word_extension_does_not_over_reach(prompt):
+    """Extending a candidate by trailing words must not manufacture a hit:
+    the vanity test still demands an area-code prefix and a valid mapping."""
+    assert runner._prompt_contact_hits(prompt) == []
+
+
+def test_failed_commit_leaves_no_artifact_residue(tmp_path, monkeypatch):
+    """#2192 round 9: a failed store commit used to leave the new file written
+    and staged even though write_artifact raised, and the readiness gate reads
+    the working tree -- so the residue was trusted as approved source state."""
+    from atlas_brain.services import content_factory_store as store
+
+    _seed_draft(tmp_path, "job-resid", ["e1"])
+    draft_path = Path(tmp_path) / "jobs" / "job-resid" / "draft.json"
+    before = draft_path.read_bytes()
+
+    real_git = store._git
+
+    def failing_git(job, *args):
+        if args and args[0] == "commit":
+            raise store.ArtifactStoreError("simulated commit failure")
+        return real_git(job, *args)
+
+    monkeypatch.setattr(store, "_git", failing_git)
+    with pytest.raises(store.ArtifactStoreError):
+        store.write_artifact("job-resid", "draft", {
+            "schema": "draft.v1", "project_id": "p", "revision": 2,
+            "body_markdown": "REPLACED body nobody approved",
+            "claims": [{"text": "claim e1", "source_id": "e1"}],
+        }, root=tmp_path)
+
+    assert draft_path.read_bytes() == before, "failed write left residue on disk"
+    monkeypatch.undo()
+    staged = subprocess.run(
+        ["git", "-C", str(draft_path.parent), "diff", "--cached", "--name-only"],
+        capture_output=True, text=True,
+    ).stdout
+    assert "draft.json" not in staged, "failed write left draft.json staged"
+
+
+def test_failed_first_write_removes_the_file(tmp_path, monkeypatch):
+    """A stage that had no previous artifact must not leave a partial one."""
+    from atlas_brain.services import content_factory_store as store
+
+    real_git = store._git
+
+    def failing_git(job, *args):
+        if args and args[0] == "commit":
+            raise store.ArtifactStoreError("simulated commit failure")
+        return real_git(job, *args)
+
+    monkeypatch.setattr(store, "_git", failing_git)
+    with pytest.raises(store.ArtifactStoreError):
+        store.write_artifact("job-first", "draft", {
+            "schema": "draft.v1", "project_id": "p", "revision": 1,
+            "body_markdown": "body", "claims": [{"text": "c", "source_id": "e1"}],
+        }, root=tmp_path)
+    assert not (Path(tmp_path) / "jobs" / "job-first" / "draft.json").exists()
+
+
+@pytest.mark.parametrize("invisible", ["​", "‌", "️", "​‌"])
+def test_invisible_channel_identifiers_rejected(invisible):
+    """#2192 round 9: `channel` was NonEmptyStr, so an unroutable label made
+    only of zero-width characters validated and persisted."""
+    from atlas_brain.schemas.content_factory import RepurposingPackage
+
+    with pytest.raises(ValidationError):
+        RepurposingPackage.model_validate({
+            "schema": "repurposing.v1", "project_id": "p",
+            "variants": [{"channel": invisible, "body_markdown": "Clean copy.",
+                          "derived_from_claims": ["e1"]}],
+        })
+
+
+def test_visually_identical_channels_are_duplicates():
+    """Distinct invisible spellings of one label are the SAME channel: they
+    carry no visible width, so keeping them apart re-admits the ambiguity the
+    duplicate check exists to prevent."""
+    from atlas_brain.schemas.content_factory import RepurposingPackage
+
+    with pytest.raises(ValidationError, match="duplicate channel"):
+        RepurposingPackage.model_validate({
+            "schema": "repurposing.v1", "project_id": "p",
+            "variants": [
+                {"channel": "email", "body_markdown": "A.", "derived_from_claims": ["e1"]},
+                {"channel": "email​", "body_markdown": "B.", "derived_from_claims": ["e1"]},
+            ],
+        })

--- a/tests/test_content_factory_schemas.py
+++ b/tests/test_content_factory_schemas.py
@@ -525,3 +525,35 @@ def test_failing_set_may_persist_when_not_ready():
         "copy_verification": {"verdict": "fail", "hits": ["guaranteed-savings: x"]},
     })
     assert ps.ready_to_generate is False
+
+
+@pytest.mark.parametrize("invisible", ["​", "­‌", "⁠", "   "])
+def test_invisible_only_variant_body_rejected(invisible):
+    """Zero-width and format-only text renders as nothing; it is not copy."""
+    from atlas_brain.schemas.content_factory import RepurposingPackage
+
+    with pytest.raises(ValidationError):
+        RepurposingPackage.model_validate(
+            _package([{**_variant(), "body_markdown": invisible}])
+        )
+
+
+@pytest.mark.parametrize("invisible", ["​", "­", "⁠"])
+def test_invisible_only_prompt_text_rejected(invisible):
+    from atlas_brain.schemas.content_factory import ImagePromptSet
+
+    with pytest.raises(ValidationError):
+        ImagePromptSet.model_validate({
+            "schema": "image_prompt.v1", "project_id": "p",
+            "prompts": [{"purpose": "hero", "prompt_text": invisible}],
+        })
+
+
+def test_visible_text_with_incidental_zero_width_accepted():
+    """The other side: real copy is not rejected for containing one."""
+    from atlas_brain.schemas.content_factory import RepurposingPackage
+
+    pkg = RepurposingPackage.model_validate(
+        _package([{**_variant(), "body_markdown": "real​copy here"}])
+    )
+    assert "copy" in pkg.variants[0].body_markdown

--- a/tests/test_content_factory_schemas.py
+++ b/tests/test_content_factory_schemas.py
@@ -437,3 +437,91 @@ def test_phase6_schemas_dispatch():
 
     assert model_for({"schema": "repurposing.v1"}) is RepurposingPackage
     assert model_for({"schema": "image_prompt.v1"}) is ImagePromptSet
+
+
+# --- review round 1 on #2192 ---
+
+
+def test_variant_without_lineage_is_rejected():
+    """Orphan variants must be unrepresentable, not merely discouraged."""
+    from atlas_brain.schemas.content_factory import RepurposingPackage
+
+    v = _variant()
+    del v["derived_from_claims"]
+    with pytest.raises(ValidationError):
+        RepurposingPackage.model_validate(_package([v]))
+
+
+def test_variant_with_empty_lineage_is_rejected():
+    from atlas_brain.schemas.content_factory import RepurposingPackage
+
+    with pytest.raises(ValidationError):
+        RepurposingPackage.model_validate(
+            _package([{**_variant(), "derived_from_claims": []}])
+        )
+
+
+def test_mixed_lineage_package_is_rejected():
+    """One traceable variant does not license an untraceable sibling."""
+    from atlas_brain.schemas.content_factory import RepurposingPackage
+
+    good = _variant(channel="linkedin")
+    bad = {**_variant(channel="x"), "derived_from_claims": []}
+    with pytest.raises(ValidationError):
+        RepurposingPackage.model_validate(_package([good, bad], ready=True))
+
+
+def test_blank_lineage_id_is_rejected():
+    from atlas_brain.schemas.content_factory import RepurposingPackage
+
+    with pytest.raises(ValidationError):
+        RepurposingPackage.model_validate(
+            _package([{**_variant(), "derived_from_claims": ["  "]}])
+        )
+
+
+def test_ready_to_generate_requires_passing_verdict():
+    from atlas_brain.schemas.content_factory import ImagePromptSet
+
+    with pytest.raises(ValidationError):
+        ImagePromptSet.model_validate({
+            "schema": "image_prompt.v1", "project_id": "p",
+            "prompts": [{"purpose": "hero", "prompt_text": "a desk"}],
+            "copy_verification": {"verdict": "fail", "hits": ["guaranteed-savings: x"]},
+            "ready_to_generate": True,
+        })
+
+
+def test_ready_to_generate_rejected_without_any_verdict():
+    from atlas_brain.schemas.content_factory import ImagePromptSet
+
+    with pytest.raises(ValidationError):
+        ImagePromptSet.model_validate({
+            "schema": "image_prompt.v1", "project_id": "p",
+            "prompts": [{"purpose": "hero", "prompt_text": "a desk"}],
+            "ready_to_generate": True,
+        })
+
+
+def test_ready_to_generate_accepted_when_passing():
+    from atlas_brain.schemas.content_factory import ImagePromptSet
+
+    ps = ImagePromptSet.model_validate({
+        "schema": "image_prompt.v1", "project_id": "p",
+        "prompts": [{"purpose": "hero", "prompt_text": "a desk"}],
+        "copy_verification": {"verdict": "pass", "hits": []},
+        "ready_to_generate": True,
+    })
+    assert ps.ready_to_generate is True
+
+
+def test_failing_set_may_persist_when_not_ready():
+    """A failing verdict is a legitimate intermediate state."""
+    from atlas_brain.schemas.content_factory import ImagePromptSet
+
+    ps = ImagePromptSet.model_validate({
+        "schema": "image_prompt.v1", "project_id": "p",
+        "prompts": [{"purpose": "hero", "prompt_text": "guaranteed savings poster"}],
+        "copy_verification": {"verdict": "fail", "hits": ["guaranteed-savings: x"]},
+    })
+    assert ps.ready_to_generate is False

--- a/tests/test_content_factory_schemas.py
+++ b/tests/test_content_factory_schemas.py
@@ -557,3 +557,34 @@ def test_visible_text_with_incidental_zero_width_accepted():
         _package([{**_variant(), "body_markdown": "real​copy here"}])
     )
     assert "copy" in pkg.variants[0].body_markdown
+
+
+@pytest.mark.parametrize("mark_only", ["️", "́", "︎"])
+def test_combining_mark_only_text_rejected(mark_only):
+    """A lone variation selector/combining mark renders nothing."""
+    from atlas_brain.schemas.content_factory import RepurposingPackage
+
+    with pytest.raises(ValidationError):
+        RepurposingPackage.model_validate(
+            _package([{**_variant(), "body_markdown": mark_only}])
+        )
+
+
+def test_emoji_with_variation_selector_accepted():
+    """The other side: real content carrying a mark is still content."""
+    from atlas_brain.schemas.content_factory import RepurposingPackage
+
+    pkg = RepurposingPackage.model_validate(
+        _package([{**_variant(), "body_markdown": "spotless results ❤️"}])
+    )
+    assert "spotless" in pkg.variants[0].body_markdown
+
+
+def test_canonically_equivalent_channels_are_duplicates():
+    from atlas_brain.schemas.content_factory import RepurposingPackage
+
+    nfc, nfd = "café", "café"
+    with pytest.raises(ValidationError):
+        RepurposingPackage.model_validate(
+            _package([_variant(channel=nfc), _variant(channel=nfd)])
+        )

--- a/tests/test_content_factory_schemas.py
+++ b/tests/test_content_factory_schemas.py
@@ -319,3 +319,121 @@ def test_model_for_dispatches_both_audit_versions():
 
     assert model_for({"schema": "editorial_audit.v1"}) is EditorialAudit
     assert model_for({"schema": "editorial_audit.v2"}) is EditorialAuditV2
+
+
+# --- Phase 6 contracts: repurposing variants + image prompts (#2109) ---
+
+
+def _variant(channel="linkedin", body="Clean copy about repeat tickets.", verdict="pass"):
+    return {
+        "channel": channel,
+        "body_markdown": body,
+        "derived_from_claims": ["e1"],
+        "copy_verification": {"verdict": verdict, "hits": []},
+    }
+
+
+def _package(variants, ready=False):
+    return {
+        "schema": "repurposing.v1",
+        "project_id": "resolution-audit",
+        "variants": variants,
+        "ready_to_publish": ready,
+    }
+
+
+def test_repurposing_requires_at_least_one_variant():
+    from atlas_brain.schemas.content_factory import RepurposingPackage
+
+    with pytest.raises(ValidationError):
+        RepurposingPackage.model_validate(_package([]))
+
+
+def test_repurposing_rejects_duplicate_channels():
+    from atlas_brain.schemas.content_factory import RepurposingPackage
+
+    with pytest.raises(ValidationError):
+        RepurposingPackage.model_validate(
+            _package([_variant(channel="linkedin"), _variant(channel="LinkedIn")])
+        )
+
+
+def test_repurposing_rejects_blank_variant_body():
+    from atlas_brain.schemas.content_factory import RepurposingPackage
+
+    with pytest.raises(ValidationError):
+        RepurposingPackage.model_validate(_package([_variant(body="   ")]))
+
+
+def test_ready_to_publish_requires_every_variant_passing():
+    from atlas_brain.schemas.content_factory import RepurposingPackage
+
+    with pytest.raises(ValidationError):
+        RepurposingPackage.model_validate(
+            _package(
+                [_variant(channel="linkedin"), _variant(channel="x", verdict="fail")],
+                ready=True,
+            )
+        )
+
+
+def test_ready_to_publish_accepted_when_all_pass():
+    from atlas_brain.schemas.content_factory import RepurposingPackage
+
+    pkg = RepurposingPackage.model_validate(
+        _package([_variant(channel="linkedin"), _variant(channel="x")], ready=True)
+    )
+    assert pkg.ready_to_publish is True
+
+
+def test_not_ready_package_may_carry_failing_variant():
+    """A failing variant is a legitimate intermediate state -- it just cannot
+    be declared shippable."""
+    from atlas_brain.schemas.content_factory import RepurposingPackage
+
+    pkg = RepurposingPackage.model_validate(
+        _package([_variant(verdict="fail")], ready=False)
+    )
+    assert pkg.variants[0].copy_verification.verdict == "fail"
+
+
+def test_variant_advisory_warnings_share_the_bounded_grammar():
+    from atlas_brain.schemas.content_factory import RepurposingPackage
+
+    variant = _variant()
+    variant["advisory_warnings"] = ["Contact bob@example.com"]
+    with pytest.raises(ValidationError):
+        RepurposingPackage.model_validate(_package([variant]))
+
+
+def test_image_prompt_set_requires_a_prompt():
+    from atlas_brain.schemas.content_factory import ImagePromptSet
+
+    with pytest.raises(ValidationError):
+        ImagePromptSet.model_validate(
+            {"schema": "image_prompt.v1", "project_id": "p", "prompts": []}
+        )
+
+
+def test_image_prompt_set_accepts_valid_prompt():
+    from atlas_brain.schemas.content_factory import ImagePromptSet
+
+    ps = ImagePromptSet.model_validate(
+        {
+            "schema": "image_prompt.v1",
+            "project_id": "p",
+            "prompts": [{"purpose": "hero", "prompt_text": "a clean desk, soft light"}],
+        }
+    )
+    assert ps.prompts[0].aspect_ratio == "1:1"
+
+
+def test_phase6_schemas_dispatch():
+    from atlas_brain.schemas.content_factory import (
+        ImagePromptSet,
+        RepurposingPackage,
+        model_for,
+    )
+
+    assert model_for({"schema": "repurposing.v1"}) is RepurposingPackage
+    assert model_for({"schema": "image_prompt.v1"}) is ImagePromptSet


### PR DESCRIPTION
Plan: plans/PR-CF-Phase6-Repurposing-Contracts.md
Slice phase: vertical slice
Ownership lane: content-factory

Diff-budget override: the two contracts, their stage admission, and their
deterministic gates are one reviewable behavior -- landing a contract whose
gate is not wired would let a worker self-approve shippable copy, which is
the exact failure the editorial gate exists to prevent.

Starts epic #2109 Phase 6 (repurposing + image workflow) now that Phase 3 is
closed (3a shipped; 3b/RAG won't-do). This is the ARTIFACT half: contracts,
stages, and gates. Image generation is deliberately a separate slice.

## Intentional

- Per-variant verdicts (variants ship independently); `ready_to_publish` is
  a package gate requiring EVERY variant to pass -- the variant-level
  analogue of the editorial promote gate.
- Image prompt TEXT is gated: a diffusion model renders banned copy into the
  artwork, past every downstream text check.
- The runner recomputes and OVERWRITES verdicts/checklists from the
  artifact's own text; worker-supplied values are discarded. Blank
  bodies/prompts fail closed.
- A failing artifact still persists its payload (verdict redacted) so a
  human can see what to fix -- same as an existing draft body.
- `_validate_advisory_warnings` extracted: audit, variants, and image
  prompts now share ONE bounded grammar and cannot drift into three.
- No worker wrappers wired to the new stages yet, so this cannot change
  current pipeline behavior.

## Deferred

- ComfyUI generation (human-triggered, VRAM-guarded; must handle LLM/FLUX
  co-residency -- ~20 GB + ~12 GB exceeds the 24 GB card).
- OWUI wrappers for the two stages with section-8 tool scoping.
- Phase 7 manifest entries for the new stages.

## Parked hardening

None new.

## Cold diff reconstruction

Adds ChannelVariant/RepurposingPackage and ImagePrompt/ImagePromptSet with
their invariants; registers both tags; extracts the shared advisory-grammar
validator; admits `repurposing` and `image_prompt` stages in the store;
adds `_enforce_repurposing` / `_enforce_image_prompts` (shared
`_deterministic_verdict`) to the runner; 17 tests covering contract
invariants both directions and the gates through `run_stage`.

## Verification

326 passed across the five content-factory/intake suites; py_compile clean
with SyntaxWarning promoted to error. Commands and counts in the plan.

## Diff size

7 files (see plan table).

## AI reconciliation

Codex round 9 — four threads, all fixed. Each was verified against the
code before acting; all four are confirmed.

27. P1: the vanity rule was too loose in one direction and too tight in the
    other. Treating any attached letter group as vanity rejected renderer
    specs — `16-bit-color`, `1920-1080-pixel`, and also `8-bit-style` and
    `32-bit-float`, which were not in the report and turned up by probing
    the class. Meanwhile the separator grammar stops before a space-joined
    letter group, so `Call 1 800 FLOWERS today` passed with
    `ready_to_generate=true`.

    Fixed from the numbering plan rather than a word list: letters in a
    vanity number are DIGIT SUBSTITUTES, so a token qualifies only if it
    leads with an area code (exactly 3 digits, or "1" plus 3) AND maps
    through the phone keypad to a valid NANP number. A spec's leading group
    is 2 or 4 digits, so that whole class renders. The other direction is
    closed by extending each candidate with up to three following alpha
    words — which cannot over-reach, because the same two conditions apply.

    Oracle derived from the grammar as requested: 8 spec digits x 7 spec
    words must render (56), 5 intents x 6 spelled forms must fail (30).
28. P1: a failed commit left artifact residue that the readiness gate
    trusted. `write_artifact` wrote and staged before committing, so a
    commit failure left a modified `draft.json` in the working tree with no
    commit recording it — and readiness reads the working tree. Writes are
    now all-or-nothing: the previous bytes are restored (or the file removed
    if the stage had none) and the path unstaged before the error
    propagates.
29. P2: the governing contract did not cover round 8's changes. The
    Problem-derived and Review Contracts still said "must not change
    existing contracts/stages" while the diff upgraded audits to v3 and
    added store locking. Both now carry those changes with their own
    acceptance criteria (compatibility, concurrency/atomicity) rather than
    being justified only by narrative.
30. P2: `channel` was non-blank but not visible. A label of only
    U+200B/U+200C/U+FE0F validated and persisted unroutable, and distinct
    invisible spellings evaded the duplicate check. `channel` is now
    `VisibleStr`, and duplicates compare on a routing key that drops
    format/control characters, so `email` and `email<ZWSP>` collide.

Both P1 fixes are mutation-checked: reverting either makes the new tests
fail, so the assertions are load-bearing.

Codex round 8 — three threads, all fixed. All three are defects THIS PR
introduced: the read-validate-write sequence and the fingerprint field both
arrived in round 7, and the prompt classifier is Phase 6's own.

24. P1: the fingerprint check was not atomic with the write. Round 7
    verified the draft fingerprint and then persisted; a concurrent draft
    rerun inside that window landed a `ready_to_publish` artifact beside
    copy the audit never covered. Validating before writing proves
    nothing when the thing validated against can move. `job_lock`
    (re-entrant per thread, `flock` across processes, lock file outside
    the job's git folder) now spans stamping, readiness and the commit.
    The probe is mutation-checked: deleting `with job_lock(...)` from
    `run_stage` makes the test fail, so it is not vacuous.
25. P1: adding `source_draft_fingerprint` to `editorial_audit.v2` rebroke
    a published contract. v2 shipped in #2181 and forbids extras, so the
    new key made every newly written audit UNREADABLE to a v2 consumer or
    a rolled-back reader — the exact breakage v1's freeze note exists to
    prevent. Added `editorial_audit.v3` (subclassing v2 so the promote
    gate and warning grammar cannot drift), re-froze v2 with the reason
    recorded, and generalized the normalizer to upgrade v1/v2 -> v3 while
    still refusing to launder self-contradictory worker metadata.
26. P2: dial intent was searched globally, so `a person calling across a
    room, RGB palette 255 255 255` was rejected.

    The suggested fix — scoping intent to a bounded candidate context —
    does not work, and the counter-example is worth stating: in `a call
    center scene, 1920 1080 resolution` the gap from "call" to "1920" is
    two words, exactly the gap in `call me, 5551234567`. No window
    separates them. Shape does.

    Replaced with a shape-first tier split. Unambiguous shapes (E.164,
    NANP 3-3-4, [3,4] local, trunk prefix, vanity, syntactically valid
    NANP runs) fail with no intent required. `unbroken` runs need a dial
    verb within 3 tokens, which may cross a comma. `grouped` shapes
    ([3,3,3] RGB, [4,4] resolution, [4,2,2] dates) need one within 2
    tokens with no boundary crossed — which is what keeps compound nouns
    ("call center", "phone booth", "call sheet") out without enumerating
    any of them.

    Oracle extended as requested: 8 dial words x 5 descriptive numerals
    must render (40), 7 dialable forms x 3 scenes must fail (21), plus
    the compound-noun corpus.

    Documented residual, deliberate: an unbroken run that is not a valid
    NANP number is shape-identical to a serial, and an earlier round
    established `serial 12345678 engraved on a plate` must render. That
    form fails only once a dial verb governs it. NANP's own constraint
    (neither area nor exchange code may begin with 0 or 1) recovers the
    part shape can decide.

Codex round 7 — two threads, both fixed:

22. P1: vanity recognition is now casing-independent. The distinction is
    ATTACHMENT, not case — hyphen/dot-joined letters are part of the
    number in any casing, a space-joined lowercase word is the next word.
    Oracle extended across casings (4 spellings x 3 intents) and the
    other side (4 trailing words must not hide a real number).
23. P1: approval no longer trusts a producer-supplied revision label. A
    same-revision draft rerun replaced the body while the old audit still
    counted. The runner now stamps `source_draft_fingerprint` (SHA-256 of
    the persisted draft bytes) on the audit and verifies it at readiness;
    worker-supplied values are overwritten. Probes: same-revision
    replacement invalidates approval for both artifacts, the runner
    overwrites a worker-supplied fingerprint, and an untouched draft
    still ships.

Codex round 6 — one thread, fixed by redesign rather than another pattern:

21. P1: the phone check was still reject-known-bad/admit-rest
    (`1-800-GOT-JUNK` passed; `RGB palette 255 255 255` was rejected).
    Replaced with an EVIDENCE-GATED decision — a prompt fails only on
    positive evidence of contact intent: an unambiguous structural form
    (E.164 `+`/`00`, NANP 3-3-4), or a dial-intent verb near a dialable
    token. Digits without either are description and pass. Token groups
    are constrained to digits/uppercase so a token cannot absorb the next
    lowercase word.

    Generative oracle added as requested: 6 intents x 11 dialable forms
    must fail (66), 11 descriptive strings x 3 scene templates must pass
    (33), structural forms fail without intent, and 4 email forms across
    scripts fail. Rounds 4-5 hand-listed phone fixtures removed as
    superseded.

Codex round 5 — five threads, all fixed:

16. P1: the approving audit must match the draft it approves — project
    and `draft_revision` are both compared now. (The repo's own fixture
    had this mismatch; fixed there too.)
17. P1: a lone U+FE0F is category Mn and passed the visible-content
    rule. M* joins C*/Z*; emoji-with-VS16 copy still passes.
18. P1: the phone check failed BOTH ways — `1-800-FLOWERS` passed,
    `calendar showing 2026-07-25` failed. Rewritten as candidate ->
    reject non-contact shapes (dates/times) -> require dialable evidence
    (7-15 digits) + explicit vanity rule. Both directions parametrized.
19. P1: internationalized email (`josé@…`, `user@例え.テスト`) escaped
    the ASCII pattern; the prompt path now uses a script-independent
    address shape.
20. MAJOR: NFC/NFD channel names were not detected as duplicates;
    channels are NFKC-normalized before casefolding.

Note on convergence: phone detection has been reworked in rounds 3, 4 and
5 and visible-text in 4 and 5. The classifiers are now written as
explicit two-directional decisions with both error sides pinned, rather
than another pattern iteration.

Codex round 4 — five threads, all fixed:

11. P1: readiness now requires the job's audit to recommend `promote` —
    a draft existing is not a draft being approved. Unaudited and
    revise-state copy are both blocked.
12. P1: the artifact's project_id must match the draft's, so a matching
    revision plus overlapping ids can no longer license cross-project
    derivation.
13. P1: the prompt phone check is class-level (any 7+ digit run under
    tolerant separators), so `0044 ...`, `+44...`, `(555) 123-4567` and
    future conventions all fail. Ordinary short numbers still pass —
    both sides parametrized.
14. P1: `VisibleStr` rejects invisible/format-only text (zero-width
    space, soft hyphen, word joiner) on the fields that become shippable
    or renderable; `strip()` alone treated them as content.
15. MAJOR: the diff-budget overage justification now lives in the plan's
    "Why this slice exists", as the rule requires.

Codex round 3 — three threads, all fixed:

8. P1: `source_draft_revision` is now validated against the draft on disk
   for BOTH artifacts before any readiness flag is honoured — overlapping
   claim ids can no longer let superseded copy ship or render.
9. P1: prompts use negation-free claim matching (`literal_claim_hits`).
   "poster reading do not guarantee savings" now fails: prose negation
   does not un-draw words a renderer is instructed to paint. Body copy
   keeps its prose semantics, so #2181's frozen contract is untouched
   (pinned by a test).
10. MAJOR: readiness is read from the VALIDATED model, not raw dict
    truthiness — a weak worker's `"false"` string normalizes to False in
    both places, so the runner and schema can no longer disagree.

Codex round 2 — four threads, all fixed:

4. P1: lineage is now verified, not just non-blank. `_enforce_lineage`
   checks every `derived_from_claims` id against the job's draft.json
   claim source ids before `ready_to_publish` is allowed, and fails closed
   if the draft is unreadable. Unready packages skip it.
5. P1: international phone PII now fails the PROMPT gate. `verify_copy`'s
   shared body-copy semantics stay frozen (#2181 decision); prompt text
   gets the stricter check because it is an instruction about to be
   rendered into an image where no text check can reach it.
6. MAJOR: prompts are verified INDEPENDENTLY — joining them could
   synthesize "guaranteed\nsavings" across two clean prompts. Hits are
   prefixed with the offending prompt index.
7. MAJOR: the plan's Scope section still described combined
   positive+negative gating; corrected to match the implementation.

Codex round 1 — three threads, all fixed:

1. P1: `derived_from_claims` is now required and non-empty
   (`min_length=1`) — orphan variants are unrepresentable, as the plan
   claimed. Negative coverage for omitted / empty / mixed / blank-id.
2. MAJOR, conceded as a design error: `negative_prompt` was folded into
   the verified text, so the SAFEST prompt set (one naming banned strings
   in its exclusion list) was the one that failed — the guard failing on
   its second side. The verdict now covers `prompt_text` only; a negative
   prompt cannot cause rendering, so it cannot cause a failure. Both
   sides probed at the real entrypoint.
3. MAJOR: `ImagePromptSet` recorded a verdict nothing gated on. Added
   `ready_to_generate` (the generation analogue of `ready_to_publish`),
   invalid while the verdict fails; a failing set still persists when not
   marked ready. Also proved the worker cannot self-declare it — the
   runner recomputes and validation rejects.

All fixed or waived: yes
