### PR TITLE
docs(AGENTS): gate open-execution work (3k.4); count 3k.2 by bot rounds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -995,11 +995,22 @@ case.
 **Counting the trigger under squash-amend.** Builder branches are amended into a
 single commit (§1c), so "3 consecutive pushes" is not observable from the commit
 graph -- a branch showing one commit may have absorbed a dozen review cycles.
-Count **bot review rounds** instead (distinct automated-review submissions on the
-PR), which is the same signal `live-reconciliation` already reads. Three
-consecutive rounds whose new same-class finding count is flat or rising trip this
-breaker regardless of how many commits the branch shows. One commit and twelve
-bot rounds is the case this rule exists for, not an exemption from it.
+Count **bot review rounds** instead: distinct automated-review submissions, which
+carry their own ids and timestamps on the reviews endpoint.
+
+    gh api repos/canfieldjuan/ATLAS/pulls/<n>/reviews --paginate \
+      --jq '[.[]|select(.user.login=="chatgpt-codex-connector[bot]")]|length'
+
+This is a **different source** from `live-reconciliation`, which must not be
+substituted for it: that check queries `reviewThreads` and discards resolved and
+outdated ones (`scripts/check_ai_reconciliation_live.py`), so it reports what is
+unresolved right now and carries no submission ids, timestamps, or round
+membership. It cannot supply a round count. Read rounds from the reviews endpoint
+above.
+
+Three consecutive rounds whose new same-class finding count is flat or rising
+trip this breaker regardless of how many commits the branch shows. One commit and
+twelve bot rounds is the case this rule exists for, not an exemption from it.
 
 When this trips, the next push may NOT add another example-scoped patch (another
 token, regex, vocabulary row, or oracle fixture). It must carry a **Decision-Seam
@@ -1097,6 +1108,14 @@ special case; the PR body accretes those special cases as intent.
    subsystem inside a PR whose stated purpose is something else (a privacy
    boundary, a feature, a migration). Split it: the feature ships against the
    closed-surface component; the subsystem ships alone if it is genuinely needed.
+
+Reviewer enforcement lives in the open-execution row of the path-trigger table in
+`docs/REVIEWER_RULES.md` (R8 + R2). Like the guard row it is deliberately
+prose-only -- no path glob identifies a durability protocol, since the same
+module paths carry ordinary code -- so `scripts/audit_review_rules_triggered.py`
+surfaces it as an explicit advisory finding per 3g rather than deriving it. A
+plan whose slice is open-execution work and whose Review Contract omits R8 fails
+that surfacing, and the three requirements above are what the reviewer checks.
 
 **Why:** #2184 (scoped mailbox binding) is the case. Its stated purpose was an
 authorization boundary -- bind each CRM business context to one mailbox. It also

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1091,14 +1091,20 @@ special case; the PR body accretes those special cases as intent.
    supplies primitives, not your application invariant: a read-modify-write under
    an insufficient isolation level still loses updates, and a lock service does
    not define your crash or cancellation behavior. So every open-execution plan
-   states what can interleave, what can be cancelled, where a crash can land,
-   and -- wherever the surface can retry or redeliver (retry state machine,
-   webhook, queued job) -- what a duplicate or out-of-order attempt does, which
-   is R8's invariant and is not implied by the other three. For a selected
-   component, state which of its guarantees close which part of that seam
-   (isolation level, lock semantics, durability on crash). The
-   invariants must hold for **every** interleaving the model admits; anything not
-   covered is stated as an explicit assumption, never just omitted. "Correct
+   states the model **its own surface** admits, and for a selected component
+   which of that component's guarantees close which part of the seam.
+
+   This section deliberately does **not** carry the list of failure modes to
+   cover. A fixed list is itself an enumeration, and the mode it omits is the one
+   that bites: interleaving, cancellation, crash, duplicate and out-of-order
+   delivery, and lease expiry with stale-holder fencing were each caught as a
+   real omission during this section's own review, one per round, and the next
+   one is on no list yet. Derive the modes from the surface instead. R8 in
+   `docs/REVIEWER_RULES.md` is the floor for anything that retries or redelivers;
+   a surface with leases, clocks, or partitions owes the modes those admit.
+
+   The invariants must hold for **every** interleaving the model admits; anything
+   not covered is stated as an explicit assumption, never just omitted. "Correct
    under a bounded set of interleavings" is the enumerative answer in formal
    dress -- the schedule left out of the set is the one that corrupts state. A
    plan that instead lists schedules to handle -- "drain cancellation here",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1092,8 +1092,11 @@ special case; the PR body accretes those special cases as intent.
    an insufficient isolation level still loses updates, and a lock service does
    not define your crash or cancellation behavior. So every open-execution plan
    states what can interleave, what can be cancelled, where a crash can land,
-   and -- for a selected component -- which of its guarantees close which part of
-   that seam (isolation level, lock semantics, durability on crash). The
+   and -- wherever the surface can retry or redeliver (retry state machine,
+   webhook, queued job) -- what a duplicate or out-of-order attempt does, which
+   is R8's invariant and is not implied by the other three. For a selected
+   component, state which of its guarantees close which part of that seam
+   (isolation level, lock semantics, durability on crash). The
    invariants must hold for **every** interleaving the model admits; anything not
    covered is stated as an explicit assumption, never just omitted. "Correct
    under a bounded set of interleavings" is the enumerative answer in formal

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1086,18 +1086,26 @@ special case; the PR body accretes those special cases as intent.
    written for this slice. Durable, concurrent, per-tenant state is a row, not a
    file. This is 3k.3's "pick the structural solution over the enumerative one"
    applied to execution.
-2. **Plan-stage gate if you hand-roll anyway.** Naming the closed-surface
-   component you rejected is required, not optional: state the component, why it
-   does not fit, and the **execution model** the design assumes -- what can
-   interleave, what can be cancelled, where a crash can land. The invariants must
-   then hold for **every** interleaving that model admits; anything not covered
-   is stated as an explicit assumption, never just omitted. "Correct under a
-   bounded set of interleavings" is the enumerative answer in formal dress -- the
-   schedule left out of the set is the one that corrupts state. A plan that
-   instead lists schedules to handle -- "drain cancellation here", "fsync there",
-   "reject FIFOs" -- is the same enumeration without even the model, and is
-   rejected at the plan stage before it is written.
-3. **One execution surface per slice.** Do not land a concurrency/durability
+2. **State the execution model, whichever option you took.** Selecting a
+   closed-surface component narrows the seam; it does not remove it. A component
+   supplies primitives, not your application invariant: a read-modify-write under
+   an insufficient isolation level still loses updates, and a lock service does
+   not define your crash or cancellation behavior. So every open-execution plan
+   states what can interleave, what can be cancelled, where a crash can land,
+   and -- for a selected component -- which of its guarantees close which part of
+   that seam (isolation level, lock semantics, durability on crash). The
+   invariants must hold for **every** interleaving the model admits; anything not
+   covered is stated as an explicit assumption, never just omitted. "Correct
+   under a bounded set of interleavings" is the enumerative answer in formal
+   dress -- the schedule left out of the set is the one that corrupts state. A
+   plan that instead lists schedules to handle -- "drain cancellation here",
+   "fsync there", "reject FIFOs" -- is the same enumeration without even the
+   model, and is rejected at the plan stage before it is written.
+3. **Name what you rejected -- only if you hand-rolled.** A slice that took the
+   closed-surface component has no rejected component to name and must not be
+   asked to invent one. A slice that hand-rolled states which component it
+   rejected and why it does not fit, on top of the model required by 2.
+4. **One execution surface per slice.** Do not land a concurrency/durability
    subsystem inside a PR whose stated purpose is something else (a privacy
    boundary, a feature, a migration). Split it: the feature ships against the
    closed-surface component; the subsystem ships alone if it is genuinely needed.
@@ -1108,9 +1116,8 @@ prose-only -- no path glob identifies a durability protocol, since the same
 module paths carry ordinary code -- so `scripts/audit_review_rules_triggered.py`
 surfaces it as an explicit advisory finding per 3g rather than deriving it. A
 plan whose slice is open-execution work and whose Review Contract omits R8 fails
-that surfacing. What the reviewer then checks is 1 and 3 for every such slice,
-and 2 **only** where the slice hand-rolled: a plan that took the closed-surface
-component has no rejected component to name, and must not be asked to invent one.
+that surfacing. The reviewer checks 1, 2, and 4 for every such slice, and 3 only
+where the slice hand-rolled.
 
 **Why:** #2184 (scoped mailbox binding) is the case. Its stated purpose was an
 authorization boundary -- bind each CRM business context to one mailbox. It also

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -995,11 +995,20 @@ case.
 **Counting the trigger under squash-amend.** Builder branches are amended into a
 single commit (§1c), so "3 consecutive pushes" is not observable from the commit
 graph -- a branch showing one commit may have absorbed a dozen review cycles.
-Count **bot review rounds** instead: distinct automated-review submissions, which
-carry their own ids and timestamps on the reviews endpoint.
+Count **bot review rounds** instead. Every review comment carries the id of the
+submission it belongs to, so group by it to get the per-round finding count and
+the files each round touched -- the two values this breaker actually compares:
 
-    gh api repos/canfieldjuan/ATLAS/pulls/<n>/reviews --paginate \
-      --jq '[.[]|select(.user.login=="chatgpt-codex-connector[bot]")]|length'
+    gh api repos/canfieldjuan/ATLAS/pulls/<n>/comments --paginate \
+      --jq 'group_by(.pull_request_review_id)[]
+            | {round: .[0].pull_request_review_id,
+               findings: length,
+               files: (map(.path) | unique)}'
+
+Read it as one row per round. A bare round count is not enough: the trigger is
+whether the *finding count per round* is flat or rising, and the repeated `files`
+entries are what identify the same file/decision the findings keep landing on --
+that is the seam 3k.2 asks you to name.
 
 This is a **different source** from `live-reconciliation`, which must not be
 substituted for it: that check queries `reviewThreads` and discards resolved and
@@ -1115,7 +1124,9 @@ prose-only -- no path glob identifies a durability protocol, since the same
 module paths carry ordinary code -- so `scripts/audit_review_rules_triggered.py`
 surfaces it as an explicit advisory finding per 3g rather than deriving it. A
 plan whose slice is open-execution work and whose Review Contract omits R8 fails
-that surfacing, and the three requirements above are what the reviewer checks.
+that surfacing. What the reviewer then checks is 1 and 3 for every such slice,
+and 2 **only** where the slice hand-rolled: a plan that took the closed-surface
+component has no rejected component to name, and must not be asked to invent one.
 
 **Why:** #2184 (scoped mailbox binding) is the case. Its stated purpose was an
 authorization boundary -- bind each CRM business context to one mailbox. It also

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -992,6 +992,15 @@ findings are formally-identical re-litigation of a green contract; here the
 findings are real, and each patch shifts the boundary and exposes the adjacent
 case.
 
+**Counting the trigger under squash-amend.** Builder branches are amended into a
+single commit (§1c), so "3 consecutive pushes" is not observable from the commit
+graph -- a branch showing one commit may have absorbed a dozen review cycles.
+Count **bot review rounds** instead (distinct automated-review submissions on the
+PR), which is the same signal `live-reconciliation` already reads. Three
+consecutive rounds whose new same-class finding count is flat or rising trip this
+breaker regardless of how many commits the branch shows. One commit and twelve
+bot rounds is the case this rule exists for, not an exemption from it.
+
 When this trips, the next push may NOT add another example-scoped patch (another
 token, regex, vocabulary row, or oracle fixture). It must carry a **Decision-Seam
 Analysis** in the plan / PR body:
@@ -1054,6 +1063,55 @@ collapses a class to one choke point. Gate the method at plan time (primary);
 slice for surface (secondary). The general form -- pick the structural solution
 over the enumerative one, which is also the smaller diff -- is why the
 evidence-gated rewrite shrank both the code and the thread count together.
+
+### 3k.4. Open-execution work: take the closed-surface component
+
+3k.1 and 3k.3 govern an open **input** space -- free text, producer-supplied
+structure. This section governs the other open space: **execution**. Here the
+unbounded axis is not the input but the schedule: thread and process
+interleavings, cancellation points, crash points, partial writes, descriptor and
+path races. A durability or concurrency protocol, a lock/lease, a cache with a
+coherence requirement, a rotation or retry state machine, and a crash-safe file
+replacement all live here. None of them is a guard, sanitizer, or classifier, so
+3k.1 and 3k.3 do not admit them by their own terms and an open-execution slice
+can reach review ungated. That is the gap this section closes.
+
+The failure signature is identical to the open-input one: each round reports a
+real, previously-unenumerated schedule; the only available fix is another
+special case; the PR body accretes those special cases as intent.
+
+1. **Prefer the component whose surface is already closed.** At the fork, take
+   the option whose failure cases someone else has already enumerated -- a
+   database transaction over a hand-rolled file lease, an existing lock service
+   over a bespoke `flock` protocol, an established library over a protocol
+   written for this slice. Durable, concurrent, per-tenant state is a row, not a
+   file. This is 3k.3's "pick the structural solution over the enumerative one"
+   applied to execution.
+2. **Plan-stage gate if you hand-roll anyway.** Naming the closed-surface
+   component you rejected is required, not optional: state the component, why it
+   does not fit, and the bounded set of interleavings the design is correct
+   under. A plan that instead lists schedules to handle -- "drain cancellation
+   here", "fsync there", "reject FIFOs" -- is the enumerative method and is
+   rejected at the plan stage, before the enumeration is written.
+3. **One execution surface per slice.** Do not land a concurrency/durability
+   subsystem inside a PR whose stated purpose is something else (a privacy
+   boundary, a feature, a migration). Split it: the feature ships against the
+   closed-surface component; the subsystem ships alone if it is genuinely needed.
+
+**Why:** #2184 (scoped mailbox binding) is the case. Its stated purpose was an
+authorization boundary -- bind each CRM business context to one mailbox. It also
+grew `ScopedGmailTokenStore`, a 15-method cross-process durability protocol
+(`flock` lease, double fsync, `fstat`-verified no-follow descriptors,
+FIFO/socket/symlink rejection, monotonic generation ancestry with cycle
+detection, repeated-cancellation draining at three call sites) -- while
+`atlas_brain/storage/repositories/business_context.py` already offered
+`get`/`upsert` on the row that state belongs in. Because none of it is a guard,
+3k.1/3k.3 never applied; it reached 12 bot rounds, and its *Intentional* section
+now records schedule patches as design intent ("the FIFO nonblocking regression
+starts its deadline only after the spawned reader has completed
+interpreter/import setup"). Review cost is not predicted by diff size --
+#2117 (+2813) took 3 rounds, #2181 (+2569) took 20 -- it is predicted by whether
+the slice hand-rolled an open surface.
 
 ### 3l. PR fix mode (constrain the fix loop)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -995,33 +995,10 @@ case.
 **Counting the trigger under squash-amend.** Builder branches are amended into a
 single commit (§1c), so "3 consecutive pushes" is not observable from the commit
 graph -- a branch showing one commit may have absorbed a dozen review cycles.
-Count **bot review rounds** instead. Each review comment carries the id of the
-submission it belongs to (`pull_request_review_id`), so rounds are recoverable
-from the review and review-comment endpoints even when the commit graph shows
-one commit. Read three values per round: the count of top-level bot findings,
-which files/decisions they land on, and whether those repeat from the prior
-round. A bare round count does not trip this breaker; a flat-or-rising
-**per-round finding count on a repeating decision** does.
-
-This section deliberately specifies **what to compare, not a command to run**.
-An operational one-liner in this document would be untested code in prose -- it
-cannot satisfy 3h (auditors ship with fixture tests) or 3i (checkers prove their
-failure detection), and each imprecision in it (page-boundary grouping, filtering
-replies and human comments, establishing that two findings are actually the same
-class) becomes its own review round with nothing to close it. If this comparison
-is worth mechanizing, it ships as a script under `scripts/` with those fixture
-tests, and this section points at it.
-
-This is a **different source** from `live-reconciliation`, which must not be
-substituted for it: that check queries `reviewThreads` and discards resolved and
-outdated ones (`scripts/check_ai_reconciliation_live.py`), so it reports what is
-unresolved right now and carries no submission ids, timestamps, or round
-membership. It cannot supply a round count. Read rounds from the reviews endpoint
-above.
-
-Three consecutive rounds whose new same-class finding count is flat or rising
-trip this breaker regardless of how many commits the branch shows. One commit and
-twelve bot rounds is the case this rule exists for, not an exemption from it.
+Read the trigger as **3 consecutive review iterations** (a push and the review
+round it draws), not 3 commits. How to count those iterations mechanically is
+deliberately not specified here: it belongs in a `scripts/` checker with the
+fixture tests 3h/3i require, not as untested procedure in prose (see #2198).
 
 When this trips, the next push may NOT add another example-scoped patch (another
 token, regex, vocabulary row, or oracle fixture). It must carry a **Decision-Seam
@@ -1111,10 +1088,15 @@ special case; the PR body accretes those special cases as intent.
    applied to execution.
 2. **Plan-stage gate if you hand-roll anyway.** Naming the closed-surface
    component you rejected is required, not optional: state the component, why it
-   does not fit, and the bounded set of interleavings the design is correct
-   under. A plan that instead lists schedules to handle -- "drain cancellation
-   here", "fsync there", "reject FIFOs" -- is the enumerative method and is
-   rejected at the plan stage, before the enumeration is written.
+   does not fit, and the **execution model** the design assumes -- what can
+   interleave, what can be cancelled, where a crash can land. The invariants must
+   then hold for **every** interleaving that model admits; anything not covered
+   is stated as an explicit assumption, never just omitted. "Correct under a
+   bounded set of interleavings" is the enumerative answer in formal dress -- the
+   schedule left out of the set is the one that corrupts state. A plan that
+   instead lists schedules to handle -- "drain cancellation here", "fsync there",
+   "reject FIFOs" -- is the same enumeration without even the model, and is
+   rejected at the plan stage before it is written.
 3. **One execution surface per slice.** Do not land a concurrency/durability
    subsystem inside a PR whose stated purpose is something else (a privacy
    boundary, a feature, a migration). Split it: the feature ships against the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -995,20 +995,22 @@ case.
 **Counting the trigger under squash-amend.** Builder branches are amended into a
 single commit (§1c), so "3 consecutive pushes" is not observable from the commit
 graph -- a branch showing one commit may have absorbed a dozen review cycles.
-Count **bot review rounds** instead. Every review comment carries the id of the
-submission it belongs to, so group by it to get the per-round finding count and
-the files each round touched -- the two values this breaker actually compares:
+Count **bot review rounds** instead. Each review comment carries the id of the
+submission it belongs to (`pull_request_review_id`), so rounds are recoverable
+from the review and review-comment endpoints even when the commit graph shows
+one commit. Read three values per round: the count of top-level bot findings,
+which files/decisions they land on, and whether those repeat from the prior
+round. A bare round count does not trip this breaker; a flat-or-rising
+**per-round finding count on a repeating decision** does.
 
-    gh api repos/canfieldjuan/ATLAS/pulls/<n>/comments --paginate \
-      --jq 'group_by(.pull_request_review_id)[]
-            | {round: .[0].pull_request_review_id,
-               findings: length,
-               files: (map(.path) | unique)}'
-
-Read it as one row per round. A bare round count is not enough: the trigger is
-whether the *finding count per round* is flat or rising, and the repeated `files`
-entries are what identify the same file/decision the findings keep landing on --
-that is the seam 3k.2 asks you to name.
+This section deliberately specifies **what to compare, not a command to run**.
+An operational one-liner in this document would be untested code in prose -- it
+cannot satisfy 3h (auditors ship with fixture tests) or 3i (checkers prove their
+failure detection), and each imprecision in it (page-boundary grouping, filtering
+replies and human comments, establishing that two findings are actually the same
+class) becomes its own review round with nothing to close it. If this comparison
+is worth mechanizing, it ships as a script under `scripts/` with those fixture
+tests, and this section points at it.
 
 This is a **different source** from `live-reconciliation`, which must not be
 substituted for it: that check queries `reviewThreads` and discards resolved and
@@ -1134,8 +1136,14 @@ grew `ScopedGmailTokenStore`, a 15-method cross-process durability protocol
 (`flock` lease, double fsync, `fstat`-verified no-follow descriptors,
 FIFO/socket/symlink rejection, monotonic generation ancestry with cycle
 detection, repeated-cancellation draining at three call sites) -- while
-`atlas_brain/storage/repositories/business_context.py` already offered
-`get`/`upsert` on the row that state belongs in. Because none of it is a guard,
+the project already runs Postgres with a repository layer, where this state is a
+row and the ordering it hand-rolls is a transaction. (That alternative needs new
+schema: `atlas_brain/storage/repositories/business_context.py` writes a fixed
+business-profile column list with no token or binding field, and its `get` and
+`upsert` are separate pool operations, not one compare-and-swap. "Add a column
+and a transaction" is still a far smaller and better-tested surface than a
+bespoke cross-process lease -- but it is a build, not a drop-in.) Because none of
+this is a guard,
 3k.1/3k.3 never applied; it reached 12 bot rounds, and its *Intentional* section
 now records schedule patches as design intent ("the FIFO nonblocking regression
 starts its deadline only after the spawned reader has completed

--- a/docs/REVIEWER_RULES.md
+++ b/docs/REVIEWER_RULES.md
@@ -247,6 +247,7 @@ these for the paths it touches:
 | `scripts/audit_*.py`, `scripts/check_*.py`, evaluators / gate predicates | R2 (failure-branch fixtures per `AGENTS.md` 3h/3i), R10 |
 | `extracted_*/` synced files | R1, R10 (manifest sync discipline) |
 | Guard, validator, cap, classifier, gate, sanitizer, denylist, parser admission rule, or safety checker changes | R2, R14 (boundary-probe before LGTM) |
+| Concurrency, durability, lock/lease, cache-coherence, rotation or retry state-machine, or crash-safe replacement changes | R8, R2 (`AGENTS.md` 3k.4: the plan names the closed-surface component it rejected and why, the bounded interleavings the design is correct under, and keeps one execution surface per slice) |
 | Review comments that name a defect class ("all X", "class of Y", "same failure mode") | R13 (held-out/propertied proof that the class, not only the example, is fixed) |
 | All reviewer verdicts | R14 (checked-out PR-head and codebase-backed verification) |
 

--- a/docs/REVIEWER_RULES.md
+++ b/docs/REVIEWER_RULES.md
@@ -247,7 +247,7 @@ these for the paths it touches:
 | `scripts/audit_*.py`, `scripts/check_*.py`, evaluators / gate predicates | R2 (failure-branch fixtures per `AGENTS.md` 3h/3i), R10 |
 | `extracted_*/` synced files | R1, R10 (manifest sync discipline) |
 | Guard, validator, cap, classifier, gate, sanitizer, denylist, parser admission rule, or safety checker changes | R2, R14 (boundary-probe before LGTM) |
-| Concurrency, durability, lock/lease, cache-coherence, rotation or retry state-machine, or crash-safe replacement changes | R8, R2 (`AGENTS.md` 3k.4: the plan names the **selected** component and keeps one execution surface per slice; **only if it hand-rolls** rather than using a closed-surface component, it also names the component it rejected, why, and the execution model it assumes, with the invariants holding for every interleaving that model admits and anything uncovered stated as an explicit assumption) |
+| Concurrency, durability, lock/lease, cache-coherence, rotation or retry state-machine, or crash-safe replacement changes | R8, R2 (`AGENTS.md` 3k.4: every such plan names the selected component and which of its guarantees close which part of the seam, states the execution model with the invariants holding for every interleaving it admits and anything uncovered as an explicit assumption, and keeps one execution surface per slice; **only if it hand-rolls** it also names the component it rejected and why) |
 | Review comments that name a defect class ("all X", "class of Y", "same failure mode") | R13 (held-out/propertied proof that the class, not only the example, is fixed) |
 | All reviewer verdicts | R14 (checked-out PR-head and codebase-backed verification) |
 

--- a/docs/REVIEWER_RULES.md
+++ b/docs/REVIEWER_RULES.md
@@ -247,7 +247,7 @@ these for the paths it touches:
 | `scripts/audit_*.py`, `scripts/check_*.py`, evaluators / gate predicates | R2 (failure-branch fixtures per `AGENTS.md` 3h/3i), R10 |
 | `extracted_*/` synced files | R1, R10 (manifest sync discipline) |
 | Guard, validator, cap, classifier, gate, sanitizer, denylist, parser admission rule, or safety checker changes | R2, R14 (boundary-probe before LGTM) |
-| Concurrency, durability, lock/lease, cache-coherence, rotation or retry state-machine, or crash-safe replacement changes | R8, R2 (`AGENTS.md` 3k.4: the plan names the closed-surface component it rejected and why, the bounded interleavings the design is correct under, and keeps one execution surface per slice) |
+| Concurrency, durability, lock/lease, cache-coherence, rotation or retry state-machine, or crash-safe replacement changes | R8, R2 (`AGENTS.md` 3k.4: the plan names the **selected** component and keeps one execution surface per slice; **only if it hand-rolls** rather than using a closed-surface component, it also names the component it rejected, why, and the bounded interleavings the design is correct under) |
 | Review comments that name a defect class ("all X", "class of Y", "same failure mode") | R13 (held-out/propertied proof that the class, not only the example, is fixed) |
 | All reviewer verdicts | R14 (checked-out PR-head and codebase-backed verification) |
 

--- a/docs/REVIEWER_RULES.md
+++ b/docs/REVIEWER_RULES.md
@@ -247,7 +247,7 @@ these for the paths it touches:
 | `scripts/audit_*.py`, `scripts/check_*.py`, evaluators / gate predicates | R2 (failure-branch fixtures per `AGENTS.md` 3h/3i), R10 |
 | `extracted_*/` synced files | R1, R10 (manifest sync discipline) |
 | Guard, validator, cap, classifier, gate, sanitizer, denylist, parser admission rule, or safety checker changes | R2, R14 (boundary-probe before LGTM) |
-| Concurrency, durability, lock/lease, cache-coherence, rotation or retry state-machine, or crash-safe replacement changes | R8, R2 (`AGENTS.md` 3k.4: the plan names the **selected** component and keeps one execution surface per slice; **only if it hand-rolls** rather than using a closed-surface component, it also names the component it rejected, why, and the bounded interleavings the design is correct under) |
+| Concurrency, durability, lock/lease, cache-coherence, rotation or retry state-machine, or crash-safe replacement changes | R8, R2 (`AGENTS.md` 3k.4: the plan names the **selected** component and keeps one execution surface per slice; **only if it hand-rolls** rather than using a closed-surface component, it also names the component it rejected, why, and the execution model it assumes, with the invariants holding for every interleaving that model admits and anything uncovered stated as an explicit assumption) |
 | Review comments that name a defect class ("all X", "class of Y", "same failure mode") | R13 (held-out/propertied proof that the class, not only the example, is fixed) |
 | All reviewer verdicts | R14 (checked-out PR-head and codebase-backed verification) |
 


### PR DESCRIPTION
Docs-only: true

Two gaps in AGENTS.md section 3k, both found while reviewing #2184 and #2192. Additive only — no existing rule is restated or weakened.

## Qualifying product need (§0 admission)

Per `AGENTS.md:59-64` a workflow/process slice must name the blocker, risk, or failed run. This one qualifies on two limbs:

- **Live privacy risk, unshipped.** Issue #2177 is the cross-mailbox privacy gap: scoped CRM inbox history is **disabled today** because a business context could otherwise read a mailbox it was never authorized for — real EOM tenant data.
- **A recent slice that failed on exactly this gap.** #2184 is that slice: 12 bot rounds, `live-reconciliation` red, 2 unresolved BLOCKERs, still open. Its diff shows why — `ScopedGmailTokenStore`, a 15-method cross-process durability protocol built inside a privacy PR, while `atlas_brain/storage/repositories/business_context.py` already offers `get`/`upsert` on the row that state belongs in. 3k.1/3k.3 could not gate it because it is not a guard, sanitizer, or classifier.

Vertical proof unblocked: scoped CRM inbox history for EOM tenants (#2177).

## 1. Open *execution* spaces are ungated (new 3k.4)

3k.1 and 3k.3 scope their plan-stage method gate to an open *input* space — "free text, nested/recursive structures, producer-supplied keys/values" — and enumerate what they govern: guard, validator, sanitizer, classifier, denylist, parser-admission rule, safety checker.

A durability or concurrency protocol is none of those, so it is admitted by neither rule. But its input space is open in the same way; the unbounded axis is the *schedule* rather than the data — interleavings, cancellation points, crash points, descriptor races. The failure signature is identical: each round reports a real, previously-unenumerated case, the only available fix is another special case, and the PR body accretes them as intent.

## 2. 3k.2's trigger was structurally unable to fire

The circuit-breaker trips on findings "flat or rising over 3 consecutive pushes". Builder branches are amended into a single commit per §1c, so push history is not in the commit graph — **#2184's branch shows one commit and twelve bot rounds.** This is a bug fix to an existing gate, not new process. Now counts distinct bot review submissions, read from the reviews endpoint.

## Why diff budget would not have caught either case

Review cost is not predicted by size: #2117 (+2813) took 3 bot rounds, #2181 (+2569) took 20. Normalized: 1.1 to 7.8 rounds per 1k added lines, and the high end is every PR that hand-rolled an open surface. §1d does not see this.

## Intentional

- The new REVIEWER_RULES trigger row is **prose-only, not a glob** — the same choice the guard row makes, for the same reason: no path pattern identifies a durability protocol, since the same modules carry ordinary code. Per §3g the audit surfaces prose rows as explicit advisory findings rather than skipping them.
- 3k.4 does not restate `docs/GUARD_CLASS_CLOSURE.md` or R8; it cross-references, so it cannot drift (the failure §3k.1 records from #2077).

## Deferred

- A frozen non-goals header for `plans/PR-*.md` (the compaction anchor: #2192's plan is 145 lines / 1 round, #2184's is 686 with a 96-line preamble / 12 rounds, and neither has a non-goals section). Separable change to the plan-doc contract; landing it here would be the scope drift this PR argues against.

## Parked hardening

- None.

## Cold diff reconstruction

- Changed: `AGENTS.md:995` makes a **definitional clarification only** to 3k.2: read its trigger as 3 consecutive *review iterations*, not 3 commits, because squash-amend (§1c) hides pushes from the commit graph. **No counting mechanism ships here** — the circuit-breaker remains a reviewer judgment call, exactly as it was before this PR, and mechanical evaluation is deferred to #2198.
- Changed: `AGENTS.md:1069` adds 3k.4, four items: (1) prefer the closed-surface component; (2) state the execution model — interleaving, cancellation, crash, and duplicate/out-of-order where the surface can retry — with invariants holding for every interleaving it admits; (3) name the rejected component only if hand-rolling; (4) one execution surface per slice. Plus the reviewer-enforcement cross-reference.
- Changed: `docs/REVIEWER_RULES.md:252` adds the open-execution path-trigger row (R8, R2).
- Contract match: every change traces to one of the two named gaps. No existing rule text is modified except the two anchor points the new text attaches to.
- Gaps: none.

## Verification

- `scripts/audit_pr_plan_presence.py origin/main --pr-author canfieldjuan` → `classification: docs-only`, `changed paths: 2`, PASS.
- New trigger row parsed by the real `audit_review_rules_triggered.py` parser → `PROSE, rules ['R2', 'R8']` (correct; a glob row would have been wrong). Table totals: 12 glob rows, 9 prose rows.
- `git diff --check` clean; no new non-ASCII beyond `§`, already used 7× in AGENTS.md on main. `check_ascii_python*.sh` covers Python paths only.
- R1's claim verified directly against `scripts/check_ai_reconciliation_live.py:41-54` and `:93-103` before accepting it.

## AI reconciliation

14 Codex findings across 7 rounds, all fixed; no waivers requested. Counts by round: 3, 2, 3, 2, 1, 2, 1.

Round 1 → `d6eae11ca`:
- R1 (round source) — my factual error; `live-reconciliation` reads open threads, not rounds. Corrected to the reviews endpoint + an explicit non-substitution note.
- R2 (gate not enrolled) — 3k.4 had no reviewer-side enforcement; added the REVIEWER_RULES trigger row + cross-reference.
- R3 (§0 admission) — qualifying need named above with citations.

Round 2 → `ac9fef78c`:
- R1 (per-round membership) — the replacement command reduced to `| length`, discarding the per-round counts the breaker compares. Now groups by `pull_request_review_id` and emits `{round, findings, files}`; verified against #2184.
- R2 (over-rejection) — the trigger row demanded hand-roll disclosures unconditionally, so a PR that correctly used a DB transaction had no truthful value to supply. Now conditional. This was a second-side over-rejection in my own guard — the same class I filed against #2192 and #2184 today.

Round 3 → `f973b9eb0`:
- R1 ×2 (pagination; class evidence) — both correct. **Closed by removing the command, not by patching it.** Rounds 1→2→3 gave 3→2→3 findings and rounds 2 and 3 both landed on the same decision — the jq one-liner embedded in 3k.2 — which is this section's own trigger. Per 3k.2 the next push may not be another example-scoped patch, so the seam is named instead: *an operational command inside a policy doc is untested code in prose*, unable to satisfy §3h/§3i, so each imprecision becomes a round with nothing to close it. The section now states what to compare and defers mechanization to a `scripts/` checker with fixture tests.
- R14 (DB alternative) — **correct, and the most consequential finding here.** `BusinessContextRepository.upsert` writes a fixed business-profile column list with no token or binding field, and `get`/`upsert` are separate pool operations, not a compare-and-swap. My "already offered `get`/`upsert`" was wrong. Corrected to state the DB path needs new schema and is a build, not a drop-in. The same correction is posted to my #2184 review, which repeated the error to the builder.

Round 4 → `8ae3db0c6`:
- R8 (bounded interleavings) — real hole in 3k.4 item 2: "correct under a bounded set of interleavings" let the author draw the boundary after deciding what the design handles, so the corrupting schedule is simply excluded. **Fixed**, not re-scoped: item 2 now requires a stated execution model, invariants holding for every interleaving it admits, and exclusions as explicit assumptions.
- R1 (submissions vs pushes) — correct false-trip: parallel bots or a rerun against one unchanged head counted as separate iterations. **Re-scoped out of this PR entirely** per 3k.2(c) — see below.

Round 5 → `293cf98dd`:
- R8 (selected component still needs a model) — round 2's over-rejection fix over-corrected into under-rejection: exempting selected-component slices from item 2 let "we used Postgres" skip the execution model, though a read-modify-write under a weak isolation level still loses updates. **Fixed** by attaching the exemption to the right clause: the execution model is now required of every slice (item 2, including which of a selected component's guarantees close which part of the seam); only naming a *rejected* component is hand-roll-conditional (item 3).

Round-over-round: 3 → 2 → 3 → 2 → 1. The last two rounds sharpened 3k.4 itself rather than the counting paragraph, which is convergence, not re-litigation.

Round 6 → pending push:
- R1 (reconstruction misaligned) — correct: `Cold diff reconstruction` still described the reviews-endpoint mechanism that round 4 re-scoped out, and §1c makes this body the canonical commit message. Rewritten to state a definitional clarification only, with mechanization explicitly deferred to #2198.
- R8 (duplicate/out-of-order) — correct gap: the mandatory model covered interleaving, cancellation, and crash but not duplicate or replayed delivery, which is R8's own invariant (`docs/REVIEWER_RULES.md:116-121`) and is not implied by the other three. Item 2 now requires it wherever the surface can retry or redeliver.

Round 7 → `class closure`:
- R8 (lease expiry / fencing) — correct, and the third round running to find a real failure mode missing from item 2's fixed list (round 5: selected-component guarantees; round 6: duplicate/out-of-order; round 7: lease expiry + fencing). Same shape three times is 3k.2's instance-patching signature applied to a list, and a fixed list of failure modes is the enumerative method this section rejects. **The list is removed.** Item 2 now requires the model the slice's own surface admits, derives modes from the surface, names R8 as the floor for retry/redelivery surfaces, and keeps the five modes found in review as evidence that fixed lists omit — not as the list.

**3k.2 applied to this PR, twice.**

All four rounds produced a defect in the same decision: how this PR specifies counting review iterations (round 1 wrong source → round 2 aggregate `| length` → round 3 pagination + class evidence → round 4 submissions-vs-pushes). At round 3 I named the seam as "a command in a policy doc" and removed the command; round 4 then found a defect in the remaining prose, which proves that diagnosis wrong. **The seam is specifying a counting procedure in a policy document at all**, where §3h/§3i cannot govern it — untested procedure has no failure detection, so defects surface by reading, one per round, with no closure condition.

Re-scoped: the counting mechanism is gone. 3k.2 keeps only the definitional fix the original defect needed — read the trigger as 3 consecutive **review iterations**, not 3 commits — and mechanization moves to **#2198**, a `scripts/` checker with the fixture tests §3i requires, carrying all four rounds' findings as its stated requirements.

This PR argues that hand-rolling an open surface produces unbounded review rounds, then did exactly that in its own counting paragraph. The rule was applied to its author before anyone else.

All fixed or waived: yes

## Diff size

2 files, +95 / -0 (AGENTS.md +94, docs/REVIEWER_RULES.md +1)
