### PR TITLE
fix: close Phase 6 round-ten source seams

### DIFF
--- a/atlas_brain/schemas/content_factory.py
+++ b/atlas_brain/schemas/content_factory.py
@@ -132,20 +132,20 @@ def _is_default_ignorable(char: str) -> bool:
 def _routing_key(channel: str) -> str:
     """Comparison key for a routing label.
 
-    NFKC first (canonically equivalent spellings are one channel to a reader),
-    then DROP Unicode default-ignorables plus format/control characters --
-    zero-width joiners, bidi marks, variation selectors, combining grapheme
-    joiners, and the like occupy no routing identity, so a label carrying them
-    must not read as a second channel (#2192 rounds 9-10).
+    DROP Unicode default-ignorables plus format/control characters before
+    NFKC, then normalize canonically equivalent spellings to one reader-visible
+    channel. The order matters: a combining grapheme joiner between a base and
+    combining mark can block composition if it survives until normalization.
+    Zero-width joiners, bidi marks, variation selectors, combining grapheme
+    joiners, and the like occupy no routing identity (#2192 rounds 9-10).
     """
-    normalized = unicodedata.normalize("NFKC", channel)
     stripped = "".join(
         ch
-        for ch in normalized
+        for ch in channel
         if unicodedata.category(ch) not in ("Cf", "Cc")
         and not _is_default_ignorable(ch)
     )
-    return stripped.strip().casefold()
+    return unicodedata.normalize("NFKC", stripped).strip().casefold()
 
 
 def _has_visible_content(text: str) -> bool:
@@ -521,13 +521,10 @@ class RepurposingPackage(BaseModel):
             raise ValueError("repurposing package requires at least one variant")
         # One channel per variant: two variants on the same channel means an
         # ambiguous "which one ships?" downstream.
-        # NFKC first: canonically equivalent spellings (NFC vs NFD) are the
-        # same channel to a reader, so casefold alone leaves the very
-        # ambiguity this check exists to prevent (round 5).
-        # Zero-width and control characters are dropped before comparing: they
-        # carry no visible width, so "email" and "email​" are the SAME
-        # channel to a reader and to anything routing on the label, and
-        # keeping them made a visually identical duplicate pass (round 9).
+        # Zero-width/default-ignorable and control characters are dropped
+        # BEFORE NFKC so they cannot block composition. Canonically equivalent
+        # spellings (NFC vs NFD) then become the same channel to a reader.
+        # "email" and "email​" likewise carry one routing identity.
         channels = [_routing_key(variant.channel) for variant in self.variants]
         if len(channels) != len(set(channels)):
             raise ValueError("duplicate channel in repurposing variants")

--- a/atlas_brain/schemas/content_factory.py
+++ b/atlas_brain/schemas/content_factory.py
@@ -124,9 +124,21 @@ _DEFAULT_IGNORABLE_RANGES = (
 )
 
 
-def _is_default_ignorable(char: str) -> bool:
+def is_default_ignorable(char: str) -> bool:
+    """True for a Unicode Default_Ignorable_Code_Point.
+
+    THE single definition for every admission view in the content factory --
+    routing keys, the contact-PII scan, and evidence redaction. A partial
+    second copy is how U+034F (category Mn, so a Cf/Cc test misses it) stayed
+    a live bypass after the zero-width class was closed (#2201). Exported, not
+    private, so no caller has a reason to rebuild it.
+    """
     codepoint = ord(char)
     return any(start <= codepoint <= end for start, end in _DEFAULT_IGNORABLE_RANGES)
+
+
+# Back-compat alias for existing private callers in this module.
+_is_default_ignorable = is_default_ignorable
 
 
 def _routing_key(channel: str) -> str:

--- a/atlas_brain/schemas/content_factory.py
+++ b/atlas_brain/schemas/content_factory.py
@@ -103,18 +103,47 @@ _ADVISORY_GRAMMAR_RE = re.compile(
 )
 
 
+_DEFAULT_IGNORABLE_RANGES = (
+    (0x00AD, 0x00AD),
+    (0x034F, 0x034F),  # combining grapheme joiner
+    (0x061C, 0x061C),
+    (0x115F, 0x1160),
+    (0x17B4, 0x17B5),
+    (0x180B, 0x180F),  # Mongolian variation selectors
+    (0x200B, 0x200F),
+    (0x202A, 0x202E),
+    (0x2060, 0x206F),
+    (0x3164, 0x3164),
+    (0xFE00, 0xFE0F),  # variation selectors
+    (0xFEFF, 0xFEFF),
+    (0xFFA0, 0xFFA0),
+    (0xFFF0, 0xFFF8),
+    (0x1BCA0, 0x1BCA3),
+    (0x1D173, 0x1D17A),
+    (0xE0000, 0xE0FFF),  # tags and supplementary variation selectors
+)
+
+
+def _is_default_ignorable(char: str) -> bool:
+    codepoint = ord(char)
+    return any(start <= codepoint <= end for start, end in _DEFAULT_IGNORABLE_RANGES)
+
+
 def _routing_key(channel: str) -> str:
     """Comparison key for a routing label.
 
     NFKC first (canonically equivalent spellings are one channel to a reader),
-    then DROP format and control characters -- zero-width joiners, bidi marks
-    and the like occupy no visible width, so a label carrying them is
-    indistinguishable from one that does not and must not read as a second,
-    separate channel (#2192 round 9).
+    then DROP Unicode default-ignorables plus format/control characters --
+    zero-width joiners, bidi marks, variation selectors, combining grapheme
+    joiners, and the like occupy no routing identity, so a label carrying them
+    must not read as a second channel (#2192 rounds 9-10).
     """
     normalized = unicodedata.normalize("NFKC", channel)
     stripped = "".join(
-        ch for ch in normalized if not unicodedata.category(ch) in ("Cf", "Cc")
+        ch
+        for ch in normalized
+        if unicodedata.category(ch) not in ("Cf", "Cc")
+        and not _is_default_ignorable(ch)
     )
     return stripped.strip().casefold()
 
@@ -131,7 +160,9 @@ def _has_visible_content(text: str) -> bool:
     marks, e.g. a lone U+FE0F) cannot stand alone as content.
     """
     return any(
-        not unicodedata.category(char).startswith(("C", "Z", "M")) for char in text
+        not unicodedata.category(char).startswith(("C", "Z", "M"))
+        and not _is_default_ignorable(char)
+        for char in text
     )
 
 

--- a/atlas_brain/services/content_factory_copy_verification.py
+++ b/atlas_brain/services/content_factory_copy_verification.py
@@ -59,6 +59,7 @@ from __future__ import annotations
 
 import bisect
 import re
+import unicodedata
 
 from atlas_brain.schemas.content_factory import (
     ADVISORY_CTA_REMINDER,
@@ -107,6 +108,48 @@ _RULES: dict[str, list[tuple[str, str]]] = {
     ],
 }
 
+# Default-ignorable / zero-width code points that a producer can sprinkle
+# between digits without changing what a human or a renderer sees. Unicode
+# calls these Default_Ignorable_Code_Point; the property is not exposed by
+# `unicodedata`, so the equivalent is category Cf plus the ranges below.
+# Cc is included EXCEPT the whitespace controls, which are real separators.
+_DEFAULT_IGNORABLE_EXTRA = frozenset(
+    list(range(0xFE00, 0xFE10))  # variation selectors
+    + list(range(0xE0100, 0xE01F0))  # variation selectors supplement
+    + list(range(0x180B, 0x180F))  # Mongolian free variation selectors
+    + list(range(0x1BCA0, 0x1BCA4))  # shorthand format controls
+    + list(range(0xE0000, 0xE0080))  # tag characters
+    + [0x3164, 0xFFA0]  # Hangul fillers
+)
+_SCAN_KEEP_CONTROLS = frozenset("\t\n\r\v\f")
+
+
+def scan_view(text: str) -> str:
+    """The view PII detection runs against: same visible content, no
+    zero-width characters.
+
+    A zero-width character between digits defeats every contact pattern while
+    rendering identically -- `555-123<ZWSP>-4567` and `a@b<ZWSP>.com` both
+    passed the gate. That is a formatting-only bypass, not a different kind
+    of copy, so it is removed before scanning rather than enumerated as new
+    patterns (#2201).
+
+    This does NOT change which real forms count as PII -- the frozen
+    body-copy verdict semantics are untouched -- it only denies the evasion.
+    Whitespace controls are kept: they separate tokens, and dropping them
+    would join a word to a following number.
+    """
+    return "".join(
+        ch
+        for ch in text
+        if not (
+            unicodedata.category(ch) == "Cf"
+            or (unicodedata.category(ch) == "Cc" and ch not in _SCAN_KEEP_CONTROLS)
+            or ord(ch) in _DEFAULT_IGNORABLE_EXTRA
+        )
+    )
+
+
 _EMAIL_RE = re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.I)
 _PHONE_RE = re.compile(r"\b(?:\+?1[-.\s]?)?(?:\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4})\b")
 _INTL_PHONE_RE = re.compile(r"\+\d{1,3}(?:[\s().-]?\d){7,12}\b")
@@ -142,7 +185,15 @@ def _is_negated(text: str, start: int) -> bool:
 
 def _redact_pii(evidence: str) -> str:
     """Make claim evidence safe to persist: named markers for the common
-    contact shapes, then the digit theorem -- every remaining digit masks."""
+    contact shapes, then the digit theorem -- every remaining digit masks.
+
+    Zero-width characters are stripped FIRST (#2201). The digit theorem
+    already covered phone digits, but an address carrying a zero-width
+    character (`a@b<ZWSP>.com`) evaded the email pattern and its LETTERS are
+    not digits, so it would have persisted intact. Dropping invisible
+    characters from persisted evidence changes nothing a reader sees.
+    """
+    evidence = scan_view(evidence)
     evidence = _EMAIL_RE.sub("<redacted-email>", evidence)
     evidence = _INTL_PHONE_RE.sub("<redacted-phone>", evidence)
     evidence = _PHONE_RE.sub("<redacted-phone>", evidence)
@@ -192,9 +243,14 @@ def verify_copy(text: str) -> CopyVerification:
         raise TypeError("verify_copy requires a string; draft body is text")
 
     hits = _claim_hits(text)
-    if _EMAIL_RE.search(text):
+    # Contact patterns run against the zero-width-stripped view so a
+    # formatting-only insertion cannot defeat the gate (#2201). Claim
+    # detection keeps the ORIGINAL text: its locators are sentence indices,
+    # and rewriting the input would shift them.
+    scanned = scan_view(text)
+    if _EMAIL_RE.search(scanned):
         hits.append("email: <redacted>")
-    if _PHONE_RE.search(text):
+    if _PHONE_RE.search(scanned):
         hits.append("phone: <redacted>")
 
     verdict = "fail" if hits else "pass"

--- a/atlas_brain/services/content_factory_copy_verification.py
+++ b/atlas_brain/services/content_factory_copy_verification.py
@@ -65,6 +65,7 @@ from atlas_brain.schemas.content_factory import (
     ADVISORY_CTA_REMINDER,
     ADVISORY_OWNER_ROUTING_WARNING,
     CopyVerification,
+    is_default_ignorable,
 )
 
 # ---------------------------------------------------------------------------
@@ -108,19 +109,6 @@ _RULES: dict[str, list[tuple[str, str]]] = {
     ],
 }
 
-# Default-ignorable / zero-width code points that a producer can sprinkle
-# between digits without changing what a human or a renderer sees. Unicode
-# calls these Default_Ignorable_Code_Point; the property is not exposed by
-# `unicodedata`, so the equivalent is category Cf plus the ranges below.
-# Cc is included EXCEPT the whitespace controls, which are real separators.
-_DEFAULT_IGNORABLE_EXTRA = frozenset(
-    list(range(0xFE00, 0xFE10))  # variation selectors
-    + list(range(0xE0100, 0xE01F0))  # variation selectors supplement
-    + list(range(0x180B, 0x180F))  # Mongolian free variation selectors
-    + list(range(0x1BCA0, 0x1BCA4))  # shorthand format controls
-    + list(range(0xE0000, 0xE0080))  # tag characters
-    + [0x3164, 0xFFA0]  # Hangul fillers
-)
 _SCAN_KEEP_CONTROLS = frozenset("\t\n\r\v\f")
 
 
@@ -134,6 +122,12 @@ def scan_view(text: str) -> str:
     of copy, so it is removed before scanning rather than enumerated as new
     patterns (#2201).
 
+    Admission uses the SHARED `is_default_ignorable` predicate, not a local
+    category test. A hand-built set here missed U+034F, which is category Mn
+    -- so any rule phrased as "Cf plus some ranges" leaves the bypass open by
+    construction. One definition, used by routing keys, this scan, and
+    evidence redaction alike.
+
     This does NOT change which real forms count as PII -- the frozen
     body-copy verdict semantics are untouched -- it only denies the evasion.
     Whitespace controls are kept: they separate tokens, and dropping them
@@ -143,9 +137,9 @@ def scan_view(text: str) -> str:
         ch
         for ch in text
         if not (
-            unicodedata.category(ch) == "Cf"
+            is_default_ignorable(ch)
+            or unicodedata.category(ch) == "Cf"
             or (unicodedata.category(ch) == "Cc" and ch not in _SCAN_KEEP_CONTROLS)
-            or ord(ch) in _DEFAULT_IGNORABLE_EXTRA
         )
     )
 

--- a/atlas_brain/services/content_factory_runner.py
+++ b/atlas_brain/services/content_factory_runner.py
@@ -22,6 +22,7 @@ from typing import Any
 from atlas_brain.services.content_factory_copy_verification import (
     advisory_warnings,
     literal_claim_hits,
+    scan_view,
     verify_copy,
 )
 from atlas_brain.schemas.content_factory import model_for
@@ -467,10 +468,16 @@ def _prompt_contact_hits(text: str) -> list[str]:
 
     Fails on evidence of contact intent; stays silent on description.
     """
+    # Scan the zero-width-stripped view: a default-ignorable character between
+    # dial groups renders identically but defeated every pattern here --
+    # `+44<ZWSP>800 FLOWERS`, `555-123<ZWSP>-4567` and `FLOW<ZWSP>ERS` all
+    # passed. Stripping before parsing closes the class at the admission
+    # boundary rather than teaching each pattern about each character (#2201).
+    scanned = scan_view(text)
     hits: list[str] = []
-    if _ANY_EMAIL_RE.search(text.translate(_IDNA_DOT_TRANSLATION)):
+    if _ANY_EMAIL_RE.search(scanned.translate(_IDNA_DOT_TRANSLATION)):
         hits.append("email: <redacted>")
-    if _phone_evidence(text):
+    if _phone_evidence(scanned):
         hits.append("phone: <redacted>")
     return hits
 

--- a/atlas_brain/services/content_factory_runner.py
+++ b/atlas_brain/services/content_factory_runner.py
@@ -19,9 +19,6 @@ from pathlib import Path
 from typing import Any
 
 from atlas_brain.services.content_factory_copy_verification import (
-    _EMAIL_RE,
-    _INTL_PHONE_RE,
-    _PHONE_RE,
     advisory_warnings,
     literal_claim_hits,
     verify_copy,
@@ -30,8 +27,8 @@ from atlas_brain.schemas.content_factory import model_for
 from atlas_brain.services.content_factory_store import (
     DEFAULT_ROOT,
     ArtifactStoreError,
-    job_dir,
     job_lock,
+    read_committed_artifact_bytes,
     write_artifact,
 )
 
@@ -196,6 +193,10 @@ def _enforce_repurposing(artifact: dict[str, Any]) -> None:
 _ANY_EMAIL_RE = re.compile(
     r"[^\s@,;:()<>\[\]]+@[^\s@,;:()<>\[\]]+\.[^\s@,;:()<>\[\]]{2,}"
 )
+# IDNA treats these full-width/ideographic stops as domain-label separators.
+# Normalize only for the admission decision; the raw prompt is never copied
+# into a finding.
+_IDNA_DOT_TRANSLATION = str.maketrans({"\u3002": ".", "\uff0e": ".", "\uff61": "."})
 
 _DIAL_INTENT_RE = re.compile(
     r"\b(?:call|calling|dial|dialling|dialing|phone|telephone|tel|text|txt|"
@@ -214,7 +215,7 @@ _NANP_RE = re.compile(r"\(?\b\d{3}\)?[\s.\-]\d{3}[\s.\-]\d{4}\b")
 # is the next word rather than part of the number ("07700 900123 today").
 # Attachment, not casing, is what distinguishes them.
 _DIAL_TOKEN_RE = re.compile(
-    r"\b[+]?\d[\dA-Za-z]*(?:(?:[\s](?=\d)|[.\-])[\dA-Za-z]+){0,5}"
+    r"(?<!\w)[+]?\d[\dA-Za-z]*(?:(?:[\s](?=\d)|[.\-])[\dA-Za-z]+){0,5}"
 )
 
 
@@ -263,7 +264,7 @@ _KEYPAD = str.maketrans(
 )
 
 
-def _is_vanity_number(parts: "list[str]") -> bool:
+def _is_vanity_number(parts: "list[str]", *, international: bool = False) -> bool:
     """Is this mixed digit/letter token a dialable vanity number?
 
     Letters in a vanity number are DIGIT SUBSTITUTES, so the test is whether
@@ -272,22 +273,30 @@ def _is_vanity_number(parts: "list[str]") -> bool:
     "16-bit-color", "1920-1080-pixel" and "8-bit-style" all have letters
     attached to digits (#2192 round 9).
 
-    Two conditions, both from the numbering plan rather than a word list:
+    Domestic candidates require two conditions, both from the numbering plan
+    rather than a word list:
 
       * the leading digit group is an AREA CODE -- exactly 3 digits, or a "1"
         country prefix followed by 3. "16-bit-color" leads with 2 digits and
         "1920-1080-pixel" with 4, so neither can be a dialable prefix.
       * the keypad-mapped digits form a syntactically valid NANP number.
     """
-    if not any(p.isdigit() for p in parts):
+    if not any(p.isalpha() for p in parts) or not any(p.isdigit() for p in parts):
         return False
+    mapped = "".join(parts).translate(_KEYPAD)
+    if international:
+        # ``00`` is an international access prefix, not part of the E.164
+        # number. An explicit +/00 prefix plus dial intent supplies the
+        # structural evidence that detached international phonewords need.
+        e164_digits = mapped[2:] if mapped.startswith("00") else mapped
+        return e164_digits.isdigit() and 7 <= len(e164_digits) <= 15
     digit_groups = [p for p in parts if p.isdigit()]
     lead = digit_groups[0]
     if lead == "1" and len(digit_groups) > 1:
         lead = digit_groups[1]
     if len(lead) != 3:
         return False
-    return _is_nanp_digits("".join(parts).translate(_KEYPAD))
+    return _is_nanp_digits(mapped)
 
 
 def _dial_shape(token: str) -> str:
@@ -297,7 +306,8 @@ def _dial_shape(token: str) -> str:
     "5551234567" is one unbroken 10-digit run -- nothing describes artwork
     that way -- while "255 255 255" is [3,3,3] and "1920 1080" is [4,4].
     """
-    parts = [p for p in re.split(r"[\s.\-]+", token.lstrip("+")) if p]
+    stripped = token.lstrip("+")
+    parts = [p for p in re.split(r"[\s.\-]+", stripped) if p]
     if not parts:
         return "none"
     # A MIXED alphanumeric group is not a number: "1920x1080" is a canvas
@@ -306,9 +316,16 @@ def _dial_shape(token: str) -> str:
     if any(not (p.isdigit() or p.isalpha()) for p in parts):
         return "none"
     compact = "".join(parts)
-    if not 7 <= len(compact) <= 15:
+    symbol_limit = 17 if stripped.startswith("00") else 15
+    if not 7 <= len(compact) <= symbol_limit:
         return "none"
     if any(p.isalpha() for p in parts):
+        international = token.startswith("+") or stripped.startswith("00")
+        if international and _is_vanity_number(parts, international=True):
+            # Explicit international prefix is strong structure, but unlike a
+            # fully numeric E.164 token the detached letters remain ambiguous
+            # prose. Dial intent supplies the other side of the evidence gate.
+            return "unbroken"
         return "unambiguous" if _is_vanity_number(parts) else "none"
     groups = tuple(len(p) for p in parts)
     if compact.startswith("0") and 9 <= len(compact) <= 15 and len(groups) > 1:
@@ -330,22 +347,33 @@ def _dial_shape(token: str) -> str:
     return "grouped"
 
 
-_TRAILING_ALPHA_RE = re.compile(r"\s+[A-Za-z]+")
+_TRAILING_ALPHA_RE = re.compile(r"\s+[A-Za-z]+(?:[.\-][A-Za-z]+)*")
+_MAX_DIAL_SYMBOLS = 17  # 00 access prefix plus E.164's 15-digit maximum
 
 
 def _token_candidates(text: str, match: "re.Match[str]") -> "list[str]":
-    """The matched token, plus the same token extended by up to three
-    following space-joined alpha words -- the spelled part of a vanity number
-    ("1 800 GOT JUNK"), which the separator grammar cannot absorb without also
-    swallowing ordinary trailing words ("07700 900123 today")."""
+    """The matched token plus every still-dialable alpha-word extension.
+
+    The token regex deliberately stops before space-joined letters so it does
+    not swallow ordinary prose after a numeric token. Vanity suffixes may use
+    spaces, though, and an arbitrary word-count cap leaves the same grammar
+    open. Extend until the international dial bound is exceeded; later words
+    can only make the candidate longer, so no dialable candidate is skipped.
+    Detached extensions are not evidence by themselves: `_phone_evidence`
+    also requires nearby dial intent before admitting one as contact PII.
+    """
     candidates = [match.group(0)]
     end = match.end()
-    for _ in range(3):
+    while True:
         extension = _TRAILING_ALPHA_RE.match(text, end)
         if extension is None:
             break
+        candidate = text[match.start() : extension.end()]
+        compact = re.sub(r"[\s.\-]+", "", candidate.lstrip("+"))
+        if len(compact) > _MAX_DIAL_SYMBOLS:
+            break
+        candidates.append(candidate)
         end = extension.end()
-        candidates.append(text[match.start() : end])
     return candidates
 
 
@@ -357,38 +385,72 @@ def _gap_profile(gap: str) -> "tuple[int, bool]":
     return len(tokens), "\x00" in tokens
 
 
+def _has_near_intent(
+    text: str,
+    start: int,
+    end: int,
+    intents: "list[tuple[int, int]]",
+    *,
+    limit: int,
+    allow_boundary: bool,
+) -> bool:
+    """Whether a dial verb governs the candidate span under a bounded window."""
+    for intent_start, intent_end in intents:
+        if intent_end <= start:
+            gap = text[intent_end:start]
+        elif end <= intent_start:
+            gap = text[end:intent_start]
+        else:
+            return True
+        distance, crossed = _gap_profile(gap)
+        if distance <= limit and (allow_boundary or not crossed):
+            return True
+    return False
+
+
 def _phone_evidence(text: str) -> bool:
     """Positive evidence that ``text`` carries a dialable number."""
     if _E164_RE.search(text) or _NANP_RE.search(text):
         return True
     intents = [(m.start(), m.end()) for m in _DIAL_INTENT_RE.finditer(text)]
     for match in _DIAL_TOKEN_RE.finditer(text):
-        # Both directions of the grammar. The token regex stops before a
-        # SPACE-joined letter group, so "Call 1 800 FLOWERS today" yielded only
-        # "1 800" and passed. Extending the candidate by up to three following
-        # alpha words recovers it, and cannot over-reach because the vanity
-        # test still demands an area-code prefix and a valid NANP mapping --
-        # "255 255 255 blue" and "1920 1080 pixel" both fail that (round 9).
-        if any(
-            _dial_shape(candidate) == "unambiguous"
-            for candidate in _token_candidates(text, match)
-        ):
+        # Attached vanity spelling is structural evidence. A SPACE-joined
+        # suffix is not: "212 art deco" can keypad-map to a valid NANP number
+        # while remaining ordinary renderer prose. Detached candidates must
+        # therefore also sit under bounded dial intent. This same rule admits
+        # explicit international phonewords such as "+44 800 FLOWERS" without
+        # pretending they are NANP numbers.
+        candidates = _token_candidates(text, match)
+        base_shape = _dial_shape(candidates[0])
+        if base_shape == "unambiguous":
             return True
-        shape = _dial_shape(match.group(0))
+        for candidate in candidates[1:]:
+            if _dial_shape(candidate) == "none":
+                continue
+            candidate_end = match.start() + len(candidate)
+            if _has_near_intent(
+                text,
+                match.start(),
+                candidate_end,
+                intents,
+                limit=_UNBROKEN_WINDOW,
+                allow_boundary=True,
+            ):
+                return True
+        shape = base_shape
         if shape == "none":
             continue
         unbroken = shape == "unbroken"
         limit = _UNBROKEN_WINDOW if unbroken else _GROUPED_WINDOW
-        for start, end in intents:
-            if end <= match.start():
-                gap = text[end : match.start()]
-            elif match.end() <= start:
-                gap = text[match.end() : start]
-            else:
-                return True
-            distance, crossed = _gap_profile(gap)
-            if distance <= limit and (unbroken or not crossed):
-                return True
+        if _has_near_intent(
+            text,
+            match.start(),
+            match.end(),
+            intents,
+            limit=limit,
+            allow_boundary=unbroken,
+        ):
+            return True
     return False
 
 
@@ -398,7 +460,7 @@ def _prompt_contact_hits(text: str) -> list[str]:
     Fails on evidence of contact intent; stays silent on description.
     """
     hits: list[str] = []
-    if _ANY_EMAIL_RE.search(text):
+    if _ANY_EMAIL_RE.search(text.translate(_IDNA_DOT_TRANSLATION)):
         hits.append("email: <redacted>")
     if _phone_evidence(text):
         hits.append("phone: <redacted>")
@@ -521,13 +583,20 @@ def _enforce_copy_verification(artifact: dict[str, Any]) -> None:
 
 
 def _read_job_artifact(
-    job_id: str, root: "Path | str", name: str
+    job_id: str, root: "Path | str", stage: str
 ) -> "dict[str, Any] | None":
-    """A persisted artifact from the job folder, or None when unreadable."""
-    path = job_dir(job_id, root=root) / name
+    """A committed artifact from the job's Git tree, or None when unreadable.
+
+    The worktree and index are mutable implementation state. A failed commit
+    or abrupt process exit may leave bytes there that no commit records; those
+    bytes are never canonical readiness input.
+    """
+    raw = read_committed_artifact_bytes(job_id, stage, root=root)
+    if raw is None:
+        return None
     try:
-        data = json.loads(path.read_text())
-    except (OSError, ValueError):
+        data = json.loads(raw)
+    except (TypeError, ValueError):
         return None
     return data if isinstance(data, dict) else None
 
@@ -544,27 +613,55 @@ def _draft_claim_ids(draft: "dict[str, Any]") -> "set[str]":
 
 
 def _draft_fingerprint(job_id: str, root: "Path | str") -> "str | None":
-    """SHA-256 of the draft artifact's bytes as persisted by the store.
+    """SHA-256 of the committed draft artifact's canonical bytes.
 
-    The store writes a canonical form, so this is stable for identical
-    content and changes the moment the draft body or claims change --
+    The store commits a canonical form, so this is stable for identical
+    content and changes when a committed draft body or claims change --
     including a same-revision rerun, which a revision number cannot detect.
+    Uncommitted worktree/index residue is deliberately invisible here.
     """
-    path = job_dir(job_id, root=root) / "draft.json"
-    try:
-        return hashlib.sha256(path.read_bytes()).hexdigest()
-    except OSError:
-        return None
+    raw = read_committed_artifact_bytes(job_id, "draft", root=root)
+    return hashlib.sha256(raw).hexdigest() if raw is not None else None
 
 
 def _stamp_draft_fingerprint(
-    artifact: dict[str, Any], job_id: str, root: "Path | str"
+    artifact: dict[str, Any], dispatch_fingerprint: "str | None"
 ) -> None:
-    """Bind an audit to the draft content it actually reviewed. Runner-set,
-    never worker-supplied -- the same discipline as the verdict."""
+    """Bind an audit to the committed draft present when dispatch began.
+
+    Runner-set, never worker-supplied -- the same discipline as the verdict.
+    """
     if artifact.get("schema") not in _EDITOR_SCHEMAS:
         return
-    artifact["source_draft_fingerprint"] = _draft_fingerprint(job_id, root)
+    artifact["source_draft_fingerprint"] = dispatch_fingerprint
+
+
+_SOURCE_BOUND_SCHEMAS = frozenset(
+    (*_EDITOR_SCHEMAS, _REPURPOSING_SCHEMA, _IMAGE_PROMPT_SCHEMA)
+)
+
+
+def _require_dispatch_source_unchanged(
+    artifact: dict[str, Any],
+    job_id: str,
+    root: "Path | str",
+    dispatch_fingerprint: "str | None",
+) -> None:
+    """Reject a worker result when its source changed while it was running.
+
+    The source snapshot is taken immediately before dispatch. Re-reading it
+    under the job lock closes the worker-time race without holding a filesystem
+    lock across a potentially long network call. All source-derived artifacts
+    use the same check, including unready intermediate Phase 6 results.
+    """
+    if artifact.get("schema") not in _SOURCE_BOUND_SCHEMAS:
+        return
+    current = _draft_fingerprint(job_id, root)
+    if current != dispatch_fingerprint:
+        raise ArtifactStoreError(
+            "the committed draft changed while the worker was running; discard "
+            "the stale response and rerun the stage against the current draft"
+        )
 
 
 def _enforce_lineage(artifact: dict[str, Any], job_id: str, root: "Path | str") -> None:
@@ -594,7 +691,7 @@ def _enforce_lineage(artifact: dict[str, Any], job_id: str, root: "Path | str") 
     if not ready:
         return
 
-    draft = _read_job_artifact(job_id, root, "draft.json")
+    draft = _read_job_artifact(job_id, root, "draft")
     if draft is None:
         raise ArtifactStoreError(
             "readiness requires a readable draft artifact in the job folder "
@@ -604,7 +701,7 @@ def _enforce_lineage(artifact: dict[str, Any], job_id: str, root: "Path | str") 
     # The plan's premise is that Phase 6 derives from an APPROVED draft.
     # Existence proves the draft ran, not that a human/gate cleared it, so
     # require the job's audit to have promoted it (round 4).
-    audit = _read_job_artifact(job_id, root, "audit.json")
+    audit = _read_job_artifact(job_id, root, "audit")
     if audit is None or audit.get("recommendation") != "promote":
         raise ArtifactStoreError(
             "readiness requires an audit artifact recommending 'promote'; "
@@ -684,6 +781,10 @@ def run_stage(
     ValueError / pydantic ValidationError (from the store) if the artifact fails
     its contract -- so a malformed or self-promoting stage output is never persisted.
     """
+    # Snapshot the committed source BEFORE dispatch. A worker response is about
+    # this source, not whichever same-revision draft happens to exist when the
+    # network call returns.
+    dispatch_fingerprint = _draft_fingerprint(job_id, root)
     reply = call_worker(model, user_content, api_key=api_key, base_url=base_url)
     artifact = extract_json(reply)
     if artifact is None:
@@ -693,12 +794,14 @@ def run_stage(
     _enforce_copy_verification(artifact)
     _enforce_repurposing(artifact)
     _enforce_image_prompts(artifact)
-    # Everything that READS the job folder and everything that WRITES it must
-    # sit inside one lock. Stamping reads draft.json, the readiness gate reads
-    # it again to verify the fingerprint, and the commit lands after both --
-    # a concurrent draft rerun anywhere in that window would otherwise ship a
-    # "ready" artifact against copy no audit covered (#2192 round 8).
+    # Everything that re-checks the source, reads readiness state, or writes the
+    # job sits inside one lock. The pre-dispatch snapshot is compared first;
+    # lineage/readiness is then decided against that same committed state and
+    # the result commits before the lock is released (#2192 rounds 8-10).
     with job_lock(job_id, root=root):
-        _stamp_draft_fingerprint(artifact, job_id, root)
+        _require_dispatch_source_unchanged(
+            artifact, job_id, root, dispatch_fingerprint
+        )
+        _stamp_draft_fingerprint(artifact, dispatch_fingerprint)
         _enforce_lineage(artifact, job_id, root)
         return write_artifact(job_id, stage, artifact, root=root)

--- a/atlas_brain/services/content_factory_runner.py
+++ b/atlas_brain/services/content_factory_runner.py
@@ -204,9 +204,11 @@ _DIAL_INTENT_RE = re.compile(
     r"sms|ring|hotline|helpline|whatsapp|contact|reach)\b",
     re.I,
 )
-_DIAL_PUNCTUATION = r".\-/"
+_DIAL_PUNCTUATION = r".\-/()"
+_DIAL_ALPHA_PUNCTUATION = r".\-/"
 _DIAL_SEPARATOR_RE = re.compile(rf"[\s{_DIAL_PUNCTUATION}]+")
-_NUMERIC_DIAL_SEPARATOR = rf"(?:\s+(?=\d)|[{_DIAL_PUNCTUATION}])"
+_NUMERIC_DIAL_SEPARATOR = rf"(?:\s+(?=[\d(])|[{_DIAL_PUNCTUATION}])"
+_DIAL_GROUP_CHARS = r"\dA-Za-z()"
 # E.164 / international: explicit + or 00 prefix then 7-15 digits.
 # Slash is deliberately excluded from this unconditional shortcut; slash-
 # delimited candidates go through the structural dial decision below so
@@ -222,7 +224,8 @@ _NANP_RE = re.compile(r"\(?\b\d{3}\)?[\s.\-]\d{3}[\s.\-]\d{4}\b")
 # is the next word rather than part of the number ("07700 900123 today").
 # Attachment, not casing, is what distinguishes them.
 _DIAL_TOKEN_RE = re.compile(
-    rf"(?<!\w)[+]?\d[\dA-Za-z]*(?:{_NUMERIC_DIAL_SEPARATOR}[\dA-Za-z]+){{0,5}}"
+    rf"(?<!\w)[+]?\d[{_DIAL_GROUP_CHARS}]*"
+    rf"(?:{_NUMERIC_DIAL_SEPARATOR}[{_DIAL_GROUP_CHARS}]+){{0,5}}"
 )
 
 
@@ -343,7 +346,7 @@ def _dial_shape(token: str) -> str:
 
 
 _TRAILING_ALPHA_RE = re.compile(
-    rf"\s+[A-Za-z]+(?:[{_DIAL_PUNCTUATION}][A-Za-z]+)*"
+    rf"\s+[A-Za-z]+(?:[{_DIAL_ALPHA_PUNCTUATION}][A-Za-z]+)*"
 )
 _MAX_DIAL_SYMBOLS = 17  # 00 access prefix plus E.164's 15-digit maximum
 
@@ -399,14 +402,17 @@ def _has_structural_dial_intent(
     end: int,
     intents: "list[tuple[int, int]]",
 ) -> bool:
-    """Whether a dial marker structurally governs the candidate span."""
+    """Whether a preceding dial marker structurally governs the candidate span.
+
+    Reverse direction is not evidence for ambiguous phonewords: renderer nouns
+    such as "contact sheet" and "text treatment" commonly trail artwork copy.
+    Unambiguous numeric syntax is admitted before this bridge is consulted.
+    """
     for intent_start, intent_end in intents:
         if intent_end <= start:
             gap = text[intent_end:start]
-        elif end <= intent_start:
-            gap = text[end:intent_start]
         else:
-            return True
+            continue
         if _is_structural_dial_bridge(gap):
             return True
     return False
@@ -659,22 +665,23 @@ def _build_source_prompt(
     job_id: str,
     root: "Path | str",
     stage: str,
-) -> "tuple[str, str | None]":
+) -> "tuple[str, str]":
     """Build the fixed stage prompt and fingerprint from one draft snapshot."""
     raw = read_committed_artifact_bytes(job_id, "draft", root=root)
-    draft: dict[str, Any] | None = None
-    if raw is not None:
-        try:
-            parsed = json.loads(raw)
-        except (TypeError, ValueError) as exc:
-            raise ArtifactStoreError(
-                "source-bound stage requires a valid committed draft artifact"
-            ) from exc
-        if not isinstance(parsed, dict):
-            raise ArtifactStoreError(
-                "source-bound stage requires a committed draft JSON object"
-            )
-        draft = parsed
+    if raw is None:
+        raise ArtifactStoreError(
+            "source-bound stage requires a committed draft artifact"
+        )
+    try:
+        draft = json.loads(raw)
+    except (TypeError, ValueError) as exc:
+        raise ArtifactStoreError(
+            "source-bound stage requires a valid committed draft artifact"
+        ) from exc
+    if not isinstance(draft, dict):
+        raise ArtifactStoreError(
+            "source-bound stage requires a committed draft JSON object"
+        )
     draft_json = json.dumps(
         draft,
         ensure_ascii=False,
@@ -685,7 +692,7 @@ def _build_source_prompt(
         f"{_SOURCE_STAGE_INSTRUCTIONS[stage]}\n\n"
         f"Committed draft JSON:\n{draft_json}"
     )
-    fingerprint = hashlib.sha256(raw).hexdigest() if raw is not None else None
+    fingerprint = hashlib.sha256(raw).hexdigest()
     return user_content, fingerprint
 
 

--- a/atlas_brain/services/content_factory_runner.py
+++ b/atlas_brain/services/content_factory_runner.py
@@ -16,7 +16,6 @@ import re
 import unicodedata
 import urllib.error
 import urllib.request
-from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -209,7 +208,10 @@ _DIAL_PUNCTUATION = r".\-/"
 _DIAL_SEPARATOR_RE = re.compile(rf"[\s{_DIAL_PUNCTUATION}]+")
 _NUMERIC_DIAL_SEPARATOR = rf"(?:\s+(?=\d)|[{_DIAL_PUNCTUATION}])"
 # E.164 / international: explicit + or 00 prefix then 7-15 digits.
-_E164_RE = re.compile(r"(?:\+|\b00)[\d\s().\-/]{7,20}\d")
+# Slash is deliberately excluded from this unconditional shortcut; slash-
+# delimited candidates go through the structural dial decision below so
+# renderer dimensions and dates do not become phone evidence.
+_E164_RE = re.compile(r"(?:\+|\b00)[\d\s().\-]{7,20}\d")
 # North American 3-3-4, the one local shape that is unambiguous.
 _NANP_RE = re.compile(r"\(?\b\d{3}\)?[\s.\-]\d{3}[\s.\-]\d{4}\b")
 # A token someone could dial: starts with a digit, 7+ alphanumerics once
@@ -233,7 +235,7 @@ _UNAMBIGUOUS_GROUPINGS = frozenset({(3, 4), (3, 3, 4), (1, 3, 3, 4)})
 # These are function words in direct-address/dial syntax, not content nouns.
 _DIAL_BRIDGE_WORDS = frozenset({"at", "me", "on", "us", "via"})
 _DIAL_BRIDGE_WORD_RE = re.compile(r"[A-Za-z]+")
-_DIAL_BRIDGE_PUNCT_RE = re.compile(r"^[ \t,;:()\-]*$")
+_DIAL_BRIDGE_PUNCT_RE = re.compile(r"^[ \t,;:()\-\r\n]*$")
 
 
 def _is_nanp_digits(digits: str) -> bool:
@@ -385,7 +387,10 @@ def _is_structural_dial_bridge(gap: str) -> bool:
     ):
         return False
     punctuation = _DIAL_BRIDGE_WORD_RE.sub("", gap)
-    return _DIAL_BRIDGE_PUNCT_RE.fullmatch(punctuation) is not None
+    if _DIAL_BRIDGE_PUNCT_RE.fullmatch(punctuation) is None:
+        return False
+    logical_lines = punctuation.replace("\r\n", "\n").replace("\r", "\n")
+    return logical_lines.count("\n") <= 1
 
 
 def _has_structural_dial_intent(
@@ -636,18 +641,26 @@ def _stamp_draft_fingerprint(
 _SOURCE_BOUND_SCHEMAS = frozenset(
     (*_EDITOR_SCHEMAS, _REPURPOSING_SCHEMA, _IMAGE_PROMPT_SCHEMA)
 )
-_SOURCE_BOUND_STAGES = frozenset(
-    {"audit", "audit-v2", "repurposing", "image_prompt"}
-)
-SourcePromptBuilder = Callable[[dict[str, Any] | None], str]
+_SOURCE_STAGE_INSTRUCTIONS = {
+    "audit": "Review the committed draft and return only an editorial audit JSON artifact.",
+    "audit-v2": "Review the committed draft and return only an editorial audit JSON artifact.",
+    "repurposing": (
+        "Transform the committed draft and return only a repurposing.v1 JSON artifact."
+    ),
+    "image_prompt": (
+        "Derive image prompts from the committed draft and return only an "
+        "image_prompt.v1 JSON artifact."
+    ),
+}
+_SOURCE_BOUND_STAGES = frozenset(_SOURCE_STAGE_INSTRUCTIONS)
 
 
 def _build_source_prompt(
     job_id: str,
     root: "Path | str",
-    builder: SourcePromptBuilder,
+    stage: str,
 ) -> "tuple[str, str | None]":
-    """Build a prompt and fingerprint from one committed draft byte snapshot."""
+    """Build the fixed stage prompt and fingerprint from one draft snapshot."""
     raw = read_committed_artifact_bytes(job_id, "draft", root=root)
     draft: dict[str, Any] | None = None
     if raw is not None:
@@ -662,9 +675,16 @@ def _build_source_prompt(
                 "source-bound stage requires a committed draft JSON object"
             )
         draft = parsed
-    user_content = builder(draft)
-    if not isinstance(user_content, str):
-        raise TypeError("source prompt builder must return str")
+    draft_json = json.dumps(
+        draft,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    user_content = (
+        f"{_SOURCE_STAGE_INSTRUCTIONS[stage]}\n\n"
+        f"Committed draft JSON:\n{draft_json}"
+    )
     fingerprint = hashlib.sha256(raw).hexdigest() if raw is not None else None
     return user_content, fingerprint
 
@@ -795,7 +815,7 @@ def run_stage(
     job_id: str,
     stage: str,
     model: str,
-    user_content: str | SourcePromptBuilder,
+    user_content: str | None,
     *,
     api_key: str,
     base_url: str = DEFAULT_OWUI_URL,
@@ -809,21 +829,21 @@ def run_stage(
     ValueError / pydantic ValidationError (from the store) if the artifact fails
     its contract -- so a malformed or self-promoting stage output is never persisted.
     """
-    # Source-bound stages receive a builder, not already-built text. The prompt
-    # and fingerprint therefore come from the SAME committed bytes even if a
-    # writer replaced the draft before this function began.
-    prompt_is_source_bound = callable(user_content)
-    if stage in _SOURCE_BOUND_STAGES and not prompt_is_source_bound:
+    # Source-bound stages accept no caller prompt payload. The runner owns the
+    # instruction and draft serialization, so a callback cannot ignore the
+    # snapshotted draft while inheriting its fingerprint.
+    prompt_is_source_bound = stage in _SOURCE_BOUND_STAGES
+    if prompt_is_source_bound and user_content is not None:
         raise ArtifactStoreError(
-            "source-bound stage requires a prompt builder over the committed draft"
+            "source-bound stage uses a runner-owned prompt; user_content must be None"
         )
     if prompt_is_source_bound:
         dispatched_content, dispatch_fingerprint = _build_source_prompt(
-            job_id, root, user_content
+            job_id, root, stage
         )
     else:
         if not isinstance(user_content, str):
-            raise TypeError("user_content must be str or a source prompt builder")
+            raise TypeError("non-source stage user_content must be str")
         dispatched_content = user_content
         dispatch_fingerprint = _draft_fingerprint(job_id, root)
     reply = call_worker(
@@ -839,7 +859,7 @@ def run_stage(
     _enforce_image_prompts(artifact)
     if artifact.get("schema") in _SOURCE_BOUND_SCHEMAS and not prompt_is_source_bound:
         raise ArtifactStoreError(
-            "source-derived artifact requires a prompt built from its committed draft"
+            "source-derived artifact requires a runner-owned source stage prompt"
         )
     # Everything that re-checks the source, reads readiness state, or writes the
     # job sits inside one lock. The pre-dispatch snapshot is compared first;

--- a/atlas_brain/services/content_factory_runner.py
+++ b/atlas_brain/services/content_factory_runner.py
@@ -424,9 +424,48 @@ def _has_structural_dial_intent(
             gap = text[intent_end:start]
         else:
             continue
-        if _is_structural_dial_bridge(gap):
-            return True
+        if not _is_structural_dial_bridge(gap):
+            continue
+        if not _marker_acts_as_dial_verb(text, intent_start, intent_end):
+            continue
+        return True
     return False
+
+
+# Markers that are ALSO ordinary renderer nouns. For these the finite bridge
+# vocabulary is not enough on its own: `text` is a dial verb in "text me at
+# <number>" and a typography noun in "center text on 1920 1080 canvas", and
+# both put an admitted bridge word ("me at" / "on") between marker and number.
+_OVERLOADED_DIAL_MARKERS = frozenset({"contact", "text"})
+# Words that may precede an imperative CTA without making its head a noun.
+# Closed discourse class, not content: "please call me at ..." is still a CTA.
+_PRE_MARKER_DISCOURSE = frozenset({"please", "now", "then", "hey", "ok", "okay", "so"})
+_CLAUSE_HEAD_SPLIT_RE = re.compile(r"[.!?;:,()\[\]{}|/\r\n]")
+
+
+def _marker_acts_as_dial_verb(text: str, start: int, end: int) -> bool:
+    """Whether the dial marker at ``[start:end)`` is functioning as a VERB.
+
+    Unambiguous markers ("call", "dial", "sms", ...) always are -- nothing else
+    uses those words next to a number. The overloaded ones are decided by
+    POSITION rather than by a list of renderer verbs, which would be an open
+    class: an imperative CTA heads its clause ("Text to +44 800 FLOWERS"),
+    while a typography instruction makes the same word the object of an
+    earlier verb ("center text on 1920 1080 canvas", "place text at 1920 1080
+    coordinates"). Only a closed discourse class may precede the head.
+
+    Residual, accepted: "you can text me at <ambiguous number>" is not read as
+    a CTA. Unambiguous dial syntax never reaches this bridge, so what is given
+    up is an ambiguous-shaped number after a non-initial overloaded marker --
+    a phrasing a renderer instruction does not use.
+    """
+    if text[start:end].casefold() not in _OVERLOADED_DIAL_MARKERS:
+        return True
+    clause_start = 0
+    for match in _CLAUSE_HEAD_SPLIT_RE.finditer(text, 0, start):
+        clause_start = match.end()
+    preceding = _DIAL_BRIDGE_WORD_RE.findall(text[clause_start:start])
+    return all(word.casefold() in _PRE_MARKER_DISCOURSE for word in preceding)
 
 
 def _phone_evidence(text: str) -> bool:

--- a/atlas_brain/services/content_factory_runner.py
+++ b/atlas_brain/services/content_factory_runner.py
@@ -215,7 +215,7 @@ _NANP_RE = re.compile(r"\(?\b\d{3}\)?[\s.\-]\d{3}[\s.\-]\d{4}\b")
 # is the next word rather than part of the number ("07700 900123 today").
 # Attachment, not casing, is what distinguishes them.
 _DIAL_TOKEN_RE = re.compile(
-    r"(?<!\w)[+]?\d[\dA-Za-z]*(?:(?:[\s](?=\d)|[.\-])[\dA-Za-z]+){0,5}"
+    r"(?<!\w)[+]?\d[\dA-Za-z]*(?:(?:\s+(?=\d)|[.\-])[\dA-Za-z]+){0,5}"
 )
 
 

--- a/atlas_brain/services/content_factory_runner.py
+++ b/atlas_brain/services/content_factory_runner.py
@@ -13,8 +13,10 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+import unicodedata
 import urllib.error
 import urllib.request
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -203,8 +205,11 @@ _DIAL_INTENT_RE = re.compile(
     r"sms|ring|hotline|helpline|whatsapp|contact|reach)\b",
     re.I,
 )
+_DIAL_PUNCTUATION = r".\-/"
+_DIAL_SEPARATOR_RE = re.compile(rf"[\s{_DIAL_PUNCTUATION}]+")
+_NUMERIC_DIAL_SEPARATOR = rf"(?:\s+(?=\d)|[{_DIAL_PUNCTUATION}])"
 # E.164 / international: explicit + or 00 prefix then 7-15 digits.
-_E164_RE = re.compile(r"(?:\+|\b00)[\d\s().\-]{7,20}\d")
+_E164_RE = re.compile(r"(?:\+|\b00)[\d\s().\-/]{7,20}\d")
 # North American 3-3-4, the one local shape that is unambiguous.
 _NANP_RE = re.compile(r"\(?\b\d{3}\)?[\s.\-]\d{3}[\s.\-]\d{4}\b")
 # A token someone could dial: starts with a digit, 7+ alphanumerics once
@@ -215,32 +220,20 @@ _NANP_RE = re.compile(r"\(?\b\d{3}\)?[\s.\-]\d{3}[\s.\-]\d{4}\b")
 # is the next word rather than part of the number ("07700 900123 today").
 # Attachment, not casing, is what distinguishes them.
 _DIAL_TOKEN_RE = re.compile(
-    r"(?<!\w)[+]?\d[\dA-Za-z]*(?:(?:\s+(?=\d)|[.\-])[\dA-Za-z]+){0,5}"
+    rf"(?<!\w)[+]?\d[\dA-Za-z]*(?:{_NUMERIC_DIAL_SEPARATOR}[\dA-Za-z]+){{0,5}}"
 )
 
 
 # Groupings only a dialable number uses. [3,4] is the local form (555-1234),
 # [3,3,4] NANP, [1,3,3,4] NANP with the country code written out.
 _UNAMBIGUOUS_GROUPINGS = frozenset({(3, 4), (3, 3, 4), (1, 3, 3, 4)})
-# Strong punctuation ends a descriptive phrase. A period BETWEEN DIGITS is a
-# number separator, not a boundary -- treating it as one shreds "555.1234".
-_BOUNDARY_RE = re.compile(r"(?:(?<!\d)\.(?!\d))+|[,;:!?()\[\]{}|/\n\r–—]+")
-# How close a dial verb must sit to corroborate an ambiguous token, measured in
-# tokens where a punctuation run counts as one. The two windows are NOT taste:
-# they track how much evidence the shape itself carries.
-#
-#   unbroken (3, may cross a boundary) -- "call me, 5551234567" is contact data
-#       and calls-to-action really are written across a comma. But the run is
-#       also how serials are written, so "a phone on a desk. serial 12345678"
-#       (distance 4) stays a scene.
-#   grouped  (2, same segment only) -- the weakest shape, so it needs the
-#       tightest government. "call me at 12 34 56 78" (2) is contact data;
-#       "phone booth photographed at 100 200 300" (3) and "a call center
-#       scene, 1920 1080" (crosses a boundary) are scenes. This is what keeps
-#       compound nouns -- "call center", "phone booth", "call sheet" -- out
-#       without enumerating any of them.
-_UNBROKEN_WINDOW = 3
-_GROUPED_WINDOW = 2
+# Ambiguous number/phoneword shapes need a finite syntactic bridge from the
+# dial marker. Arbitrary nearby words are not evidence: the open semantic
+# category behind "text for room 212 art deco" cannot be closed by proximity.
+# These are function words in direct-address/dial syntax, not content nouns.
+_DIAL_BRIDGE_WORDS = frozenset({"at", "me", "on", "us", "via"})
+_DIAL_BRIDGE_WORD_RE = re.compile(r"[A-Za-z]+")
+_DIAL_BRIDGE_PUNCT_RE = re.compile(r"^[ \t,;:()\-]*$")
 
 
 def _is_nanp_digits(digits: str) -> bool:
@@ -307,7 +300,7 @@ def _dial_shape(token: str) -> str:
     that way -- while "255 255 255" is [3,3,3] and "1920 1080" is [4,4].
     """
     stripped = token.lstrip("+")
-    parts = [p for p in re.split(r"[\s.\-]+", stripped) if p]
+    parts = [p for p in _DIAL_SEPARATOR_RE.split(stripped) if p]
     if not parts:
         return "none"
     # A MIXED alphanumeric group is not a number: "1920x1080" is a canvas
@@ -347,7 +340,9 @@ def _dial_shape(token: str) -> str:
     return "grouped"
 
 
-_TRAILING_ALPHA_RE = re.compile(r"\s+[A-Za-z]+(?:[.\-][A-Za-z]+)*")
+_TRAILING_ALPHA_RE = re.compile(
+    rf"\s+[A-Za-z]+(?:[{_DIAL_PUNCTUATION}][A-Za-z]+)*"
+)
 _MAX_DIAL_SYMBOLS = 17  # 00 access prefix plus E.164's 15-digit maximum
 
 
@@ -369,7 +364,7 @@ def _token_candidates(text: str, match: "re.Match[str]") -> "list[str]":
         if extension is None:
             break
         candidate = text[match.start() : extension.end()]
-        compact = re.sub(r"[\s.\-]+", "", candidate.lstrip("+"))
+        compact = _DIAL_SEPARATOR_RE.sub("", candidate.lstrip("+"))
         if len(compact) > _MAX_DIAL_SYMBOLS:
             break
         candidates.append(candidate)
@@ -377,24 +372,29 @@ def _token_candidates(text: str, match: "re.Match[str]") -> "list[str]":
     return candidates
 
 
-def _gap_profile(gap: str) -> "tuple[int, bool]":
-    """(token distance, crossed a strong boundary) for the text between a dial
-    verb and a candidate token. A punctuation run counts as one token, so
-    distance and boundary-crossing are read off the same measurement."""
-    tokens = _BOUNDARY_RE.sub(" \x00 ", gap).split()
-    return len(tokens), "\x00" in tokens
+def _is_structural_dial_bridge(gap: str) -> bool:
+    """Whether ``gap`` is finite direct-address/dial syntax.
+
+    The open set of renderer/content words defaults to false. Only punctuation
+    plus the closed function-word grammar can connect a dial marker to an
+    otherwise ambiguous number or detached phoneword.
+    """
+    words = _DIAL_BRIDGE_WORD_RE.findall(gap)
+    if len(words) > 3 or any(
+        word.casefold() not in _DIAL_BRIDGE_WORDS for word in words
+    ):
+        return False
+    punctuation = _DIAL_BRIDGE_WORD_RE.sub("", gap)
+    return _DIAL_BRIDGE_PUNCT_RE.fullmatch(punctuation) is not None
 
 
-def _has_near_intent(
+def _has_structural_dial_intent(
     text: str,
     start: int,
     end: int,
     intents: "list[tuple[int, int]]",
-    *,
-    limit: int,
-    allow_boundary: bool,
 ) -> bool:
-    """Whether a dial verb governs the candidate span under a bounded window."""
+    """Whether a dial marker structurally governs the candidate span."""
     for intent_start, intent_end in intents:
         if intent_end <= start:
             gap = text[intent_end:start]
@@ -402,14 +402,16 @@ def _has_near_intent(
             gap = text[end:intent_start]
         else:
             return True
-        distance, crossed = _gap_profile(gap)
-        if distance <= limit and (allow_boundary or not crossed):
+        if _is_structural_dial_bridge(gap):
             return True
     return False
 
 
 def _phone_evidence(text: str) -> bool:
     """Positive evidence that ``text`` carries a dialable number."""
+    # Admission-only normalization: compatibility-equivalent digits, letters,
+    # and separators receive one verdict without rewriting the stored prompt.
+    text = unicodedata.normalize("NFKC", text)
     if _E164_RE.search(text) or _NANP_RE.search(text):
         return True
     intents = [(m.start(), m.end()) for m in _DIAL_INTENT_RE.finditer(text)]
@@ -417,7 +419,8 @@ def _phone_evidence(text: str) -> bool:
         # Attached vanity spelling is structural evidence. A SPACE-joined
         # suffix is not: "212 art deco" can keypad-map to a valid NANP number
         # while remaining ordinary renderer prose. Detached candidates must
-        # therefore also sit under bounded dial intent. This same rule admits
+        # therefore also sit under the finite structural dial bridge. This
+        # same rule admits
         # explicit international phonewords such as "+44 800 FLOWERS" without
         # pretending they are NANP numbers.
         candidates = _token_candidates(text, match)
@@ -428,27 +431,21 @@ def _phone_evidence(text: str) -> bool:
             if _dial_shape(candidate) == "none":
                 continue
             candidate_end = match.start() + len(candidate)
-            if _has_near_intent(
+            if _has_structural_dial_intent(
                 text,
                 match.start(),
                 candidate_end,
                 intents,
-                limit=_UNBROKEN_WINDOW,
-                allow_boundary=True,
             ):
                 return True
         shape = base_shape
         if shape == "none":
             continue
-        unbroken = shape == "unbroken"
-        limit = _UNBROKEN_WINDOW if unbroken else _GROUPED_WINDOW
-        if _has_near_intent(
+        if _has_structural_dial_intent(
             text,
             match.start(),
             match.end(),
             intents,
-            limit=limit,
-            allow_boundary=unbroken,
         ):
             return True
     return False
@@ -639,6 +636,37 @@ def _stamp_draft_fingerprint(
 _SOURCE_BOUND_SCHEMAS = frozenset(
     (*_EDITOR_SCHEMAS, _REPURPOSING_SCHEMA, _IMAGE_PROMPT_SCHEMA)
 )
+_SOURCE_BOUND_STAGES = frozenset(
+    {"audit", "audit-v2", "repurposing", "image_prompt"}
+)
+SourcePromptBuilder = Callable[[dict[str, Any] | None], str]
+
+
+def _build_source_prompt(
+    job_id: str,
+    root: "Path | str",
+    builder: SourcePromptBuilder,
+) -> "tuple[str, str | None]":
+    """Build a prompt and fingerprint from one committed draft byte snapshot."""
+    raw = read_committed_artifact_bytes(job_id, "draft", root=root)
+    draft: dict[str, Any] | None = None
+    if raw is not None:
+        try:
+            parsed = json.loads(raw)
+        except (TypeError, ValueError) as exc:
+            raise ArtifactStoreError(
+                "source-bound stage requires a valid committed draft artifact"
+            ) from exc
+        if not isinstance(parsed, dict):
+            raise ArtifactStoreError(
+                "source-bound stage requires a committed draft JSON object"
+            )
+        draft = parsed
+    user_content = builder(draft)
+    if not isinstance(user_content, str):
+        raise TypeError("source prompt builder must return str")
+    fingerprint = hashlib.sha256(raw).hexdigest() if raw is not None else None
+    return user_content, fingerprint
 
 
 def _require_dispatch_source_unchanged(
@@ -767,7 +795,7 @@ def run_stage(
     job_id: str,
     stage: str,
     model: str,
-    user_content: str,
+    user_content: str | SourcePromptBuilder,
     *,
     api_key: str,
     base_url: str = DEFAULT_OWUI_URL,
@@ -781,11 +809,26 @@ def run_stage(
     ValueError / pydantic ValidationError (from the store) if the artifact fails
     its contract -- so a malformed or self-promoting stage output is never persisted.
     """
-    # Snapshot the committed source BEFORE dispatch. A worker response is about
-    # this source, not whichever same-revision draft happens to exist when the
-    # network call returns.
-    dispatch_fingerprint = _draft_fingerprint(job_id, root)
-    reply = call_worker(model, user_content, api_key=api_key, base_url=base_url)
+    # Source-bound stages receive a builder, not already-built text. The prompt
+    # and fingerprint therefore come from the SAME committed bytes even if a
+    # writer replaced the draft before this function began.
+    prompt_is_source_bound = callable(user_content)
+    if stage in _SOURCE_BOUND_STAGES and not prompt_is_source_bound:
+        raise ArtifactStoreError(
+            "source-bound stage requires a prompt builder over the committed draft"
+        )
+    if prompt_is_source_bound:
+        dispatched_content, dispatch_fingerprint = _build_source_prompt(
+            job_id, root, user_content
+        )
+    else:
+        if not isinstance(user_content, str):
+            raise TypeError("user_content must be str or a source prompt builder")
+        dispatched_content = user_content
+        dispatch_fingerprint = _draft_fingerprint(job_id, root)
+    reply = call_worker(
+        model, dispatched_content, api_key=api_key, base_url=base_url
+    )
     artifact = extract_json(reply)
     if artifact is None:
         raise WorkerError(
@@ -794,6 +837,10 @@ def run_stage(
     _enforce_copy_verification(artifact)
     _enforce_repurposing(artifact)
     _enforce_image_prompts(artifact)
+    if artifact.get("schema") in _SOURCE_BOUND_SCHEMAS and not prompt_is_source_bound:
+        raise ArtifactStoreError(
+            "source-derived artifact requires a prompt built from its committed draft"
+        )
     # Everything that re-checks the source, reads readiness state, or writes the
     # job sits inside one lock. The pre-dispatch snapshot is compared first;
     # lineage/readiness is then decided against that same committed state and

--- a/atlas_brain/services/content_factory_runner.py
+++ b/atlas_brain/services/content_factory_runner.py
@@ -237,7 +237,17 @@ _UNAMBIGUOUS_GROUPINGS = frozenset({(3, 4), (3, 3, 4), (1, 3, 3, 4)})
 # dial marker. Arbitrary nearby words are not evidence: the open semantic
 # category behind "text for room 212 art deco" cannot be closed by proximity.
 # These are function words in direct-address/dial syntax, not content nouns.
-_DIAL_BRIDGE_WORDS = frozenset({"at", "me", "on", "us", "via"})
+# "to" is the dative marker every message verb takes for its recipient
+# ("text/SMS/WhatsApp to <number>"), so omitting it let a one-word connector
+# defeat the gate while the same marker and number without it were rejected.
+#
+# Possessive determiners ("our", "your", "their") are DELIBERATELY excluded
+# even though they are also function words: they occur in ordinary renderer
+# prose ("text your 1920 1080 export"), so admitting them would make a
+# typography instruction read as a dial instruction. "to" does not appear that
+# way -- "text to 1920 1080 export" is not something a prompt says. The class
+# is function words that mark a RECIPIENT, not every function word.
+_DIAL_BRIDGE_WORDS = frozenset({"at", "me", "on", "to", "us", "via"})
 _DIAL_BRIDGE_WORD_RE = re.compile(r"[A-Za-z]+")
 _DIAL_BRIDGE_PUNCT_RE = re.compile(r"^[ \t,;:()\-\r\n]*$")
 

--- a/atlas_brain/services/content_factory_store.py
+++ b/atlas_brain/services/content_factory_store.py
@@ -45,6 +45,12 @@ STAGE_SCHEMAS = {
     # v1 stays admissible: pre-#2136 artifacts and any direct writer keep
     # working; runner-persisted audits are normalized to v2.
     "audit": ("editorial_audit.v1", "editorial_audit.v2", "editorial_audit.v3"),
+    # The runner's second source-bound audit stage. Without an entry here the
+    # store treated it as a CUSTOM stage, which may carry any artifact -- so a
+    # worker returning content_brief.v1 was committed as audit-v2.json, and
+    # because that schema is outside _SOURCE_BOUND_SCHEMAS the dispatch-source
+    # comparison was skipped too (#2201). Same admissible set as "audit".
+    "audit-v2": ("editorial_audit.v1", "editorial_audit.v2", "editorial_audit.v3"),
     "manifest": ("manifest.v1",),
     # Phase 6: channel variants and image prompts derived from an approved
     # draft. Both are gated by the runner exactly like the audit.

--- a/atlas_brain/services/content_factory_store.py
+++ b/atlas_brain/services/content_factory_store.py
@@ -91,49 +91,44 @@ def job_lock(job_id: str, *, root: Path | str = DEFAULT_ROOT) -> Iterator[None]:
     job folder so it never lands in the job's git history.
     """
     safe = _safe_segment(job_id, "job_id")
+    lock_path = (Path(root) / ".locks" / f"{safe}.lock").resolve()
+    lock_key = str(lock_path)
     depth = getattr(_LOCK_STATE, "depth", None)
     if depth is None:
         depth = _LOCK_STATE.depth = {}
-    if depth.get(safe):
-        depth[safe] += 1
+    if depth.get(lock_key):
+        depth[lock_key] += 1
         try:
             yield
         finally:
-            depth[safe] -= 1
+            depth[lock_key] -= 1
         return
 
-    locks = Path(root) / ".locks"
-    locks.mkdir(parents=True, exist_ok=True)
-    handle = open(locks / f"{safe}.lock", "a+")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        handle = open(lock_path, "a+")
+    except OSError as exc:
+        raise ArtifactStoreError(
+            f"cannot open job lock for {safe!r}: {exc}"
+        ) from exc
     try:
         fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
-        depth[safe] = 1
+        depth[lock_key] = 1
         yield
     finally:
-        depth[safe] = 0
+        depth[lock_key] = 0
         fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
         handle.close()
 
 
 def _restore_artifact(job: Path, path: Path, previous: "bytes | None") -> None:
-    """Undo a failed stage write: put back the previous bytes (or remove the
-    file if the stage had none) and unstage it, so a raised write_artifact
-    leaves no residue for the readiness gate to read as source state.
-
-    Best-effort by design -- this runs while an exception is propagating, and
-    a cleanup failure must not replace the original error.
-    """
-    try:
-        if previous is None:
-            path.unlink(missing_ok=True)
-        else:
-            path.write_bytes(previous)
-        subprocess.run(
-            ["git", "-C", str(job), "reset", "-q", "--", path.name],
-            capture_output=True,
-        )
-    except OSError:
-        pass
+    """Restore the target's previous committed worktree and index state."""
+    if previous is None:
+        path.unlink(missing_ok=True)
+        _git(job, "rm", "--cached", "-q", "--ignore-unmatch", "--", path.name)
+        return
+    path.write_bytes(previous)
+    _git(job, "reset", "-q", "HEAD", "--", path.name)
 
 
 def _git(job: Path, *args: str) -> subprocess.CompletedProcess:
@@ -167,6 +162,38 @@ def _ensure_repo(job: Path) -> None:
     _git(job, "config", "user.name", _GIT_NAME)
     _git(job, "config", "commit.gpgsign", "false")
     _git(job, "config", "core.hooksPath", os.devnull)
+
+
+def read_committed_artifact_bytes(
+    job_id: str,
+    stage: str,
+    *,
+    root: Path | str = DEFAULT_ROOT,
+) -> "bytes | None":
+    """Return ``<stage>.json`` from the job's committed ``HEAD`` tree.
+
+    Git's object database is the canonical store. Mutable worktree/index
+    residue from a failed or interrupted write is intentionally invisible.
+    """
+    stage = _safe_segment(stage, "stage")
+    job = job_dir(job_id, root=root)
+    if not (job / ".git").exists():
+        return None
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(job), "show", f"HEAD:{stage}.json"],
+            check=True,
+            capture_output=True,
+        )
+    except FileNotFoundError as exc:
+        raise ArtifactStoreError("git is not available") from exc
+    except subprocess.CalledProcessError as exc:
+        if exc.returncode != 128:
+            raise ArtifactStoreError(
+                f"cannot read committed {stage!r} artifact"
+            ) from exc
+        return None
+    return result.stdout
 
 
 def write_artifact(
@@ -243,14 +270,11 @@ def _write_artifact_locked(
     _ensure_repo(job)
     path = job / f"{stage}.json"
 
-    # Persistence is ALL-OR-NOTHING. A failed commit used to leave the new file
-    # written and staged in the working tree even though write_artifact raised
-    # and no commit recorded the stage -- and the readiness gate reads the
-    # working tree, so that residue was then trusted as approved source state
-    # (#2192 round 9). On any failure the previous content is restored, or the
-    # file removed if the stage had none, before the error propagates.
-    had_previous = path.exists()
-    previous = path.read_bytes() if had_previous else None
+    # Git HEAD, not the mutable worktree/index, is canonical. On an ordinary
+    # raised failure restore the target to that committed state for hygiene;
+    # correctness does not depend on cleanup because readiness readers consume
+    # committed objects only (#2192 round 9).
+    previous = read_committed_artifact_bytes(job_id, stage, root=root)
     try:
         path.write_text(json.dumps(canonical, indent=2, ensure_ascii=False) + "\n")
 
@@ -267,8 +291,14 @@ def _write_artifact_locked(
         if not unchanged:
             _git(job, "commit", "-q", "-m", f"{stage}: {tag}", "--", path.name)
         sha = _git(job, "rev-parse", "HEAD").stdout.strip()
-    except Exception:
-        _restore_artifact(job, path, previous)
+    except Exception as write_error:
+        try:
+            _restore_artifact(job, path, previous)
+        except Exception as restore_error:
+            raise ArtifactStoreError(
+                f"artifact write failed ({write_error}); cleanup also failed "
+                f"({restore_error}); committed Git state remains canonical"
+            ) from write_error
         raise
 
     return {

--- a/plans/PR-CF-Phase6-Repurposing-Contracts.md
+++ b/plans/PR-CF-Phase6-Repurposing-Contracts.md
@@ -488,6 +488,25 @@ evidence, while three-digit values crossed with art-direction phrases admit.
 The dispatch tests replace the committed draft inside the worker boundary, so
 moving the snapshot back after dispatch makes them fail.
 
+### Review round 11 (Codex, follow-up PR #2201)
+
+Two findings, both verified against the published follow-up before acting and
+fixed at the generating operation rather than at the reported strings.
+
+1. **P1 — removing ignorables after NFKC left composition-sensitive aliases.**
+   A combining grapheme joiner between a base and combining mark could block
+   canonical composition before being removed, so `é` and
+   `e<U+034F><U+0301>` remained distinct routing keys. Routing now removes the
+   full default-ignorable/format/control class before NFKC. Generated proofs
+   cross four canonical compositions with four ignorable marks.
+2. **P1 — the numeric separator grammar accepted one whitespace code point.**
+   Extra formatting whitespace split an international phoneword before its
+   explicit prefix and keypad spelling could be evaluated together. Numeric
+   groups now consume a whitespace run as one separator. The existing group
+   cap, compact E.164 symbol bound, explicit international prefix, and bounded
+   intent gate remain unchanged; generated proofs vary prefixes, whitespace
+   classes, and run widths, with detached prose proving the passing side.
+
 ### Files touched
 
 - `atlas_brain/schemas/content_factory.py`
@@ -543,10 +562,11 @@ Parked hardening: none new.
         tests/test_content_factory_store.py \
         tests/test_content_factory_copy_verification.py \
         tests/test_leads_intake.py -q
-    # -> 714 passed (incl. the round-6 contact oracle, round-7
+    # -> 805 passed (incl. the round-6 contact oracle, round-7
     #    content-binding probes, round-8 descriptive-number boundary, and
     #    rounds 9-10 separator-partition, international/detached-prose,
-    #    IDNA, dispatch-binding, and committed-residue proofs)
+    #    IDNA, dispatch-binding, and committed-residue proofs, plus round-11
+    #    canonical-composition and whitespace-run class proofs)
     #
     # Mutation check on the round-8 lock test: removing `with job_lock(...)`
     # from run_stage makes test_run_stage_holds_job_lock_across_validation_
@@ -562,11 +582,11 @@ Parked hardening: none new.
 
 | File | LOC |
 |---|---:|
-| `atlas_brain/schemas/content_factory.py` | 43 |
+| `atlas_brain/schemas/content_factory.py` | 60 |
 | `atlas_brain/services/content_factory_runner.py` | 233 |
 | `atlas_brain/services/content_factory_store.py` | 102 |
-| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 202 |
-| `plans/PR-CF-Phase6-Round10-Remediation.md` | 185 |
-| `tests/test_content_factory_runner.py` | 286 |
-| `tests/test_content_factory_schemas.py` | 40 |
-| **Total** | **1091** |
+| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 222 |
+| `plans/PR-CF-Phase6-Round10-Remediation.md` | 207 |
+| `tests/test_content_factory_runner.py` | 305 |
+| `tests/test_content_factory_schemas.py` | 68 |
+| **Total** | **1197** |

--- a/plans/PR-CF-Phase6-Repurposing-Contracts.md
+++ b/plans/PR-CF-Phase6-Repurposing-Contracts.md
@@ -95,7 +95,8 @@ Max files: 7
    deliberately excluded; joining items would synthesize cross-prompt
    claims). Prompt PII is stricter than body copy: international phonewords
    with bounded dial evidence and IDNA-equivalent email separators fail here,
-   while detached numeric/art-direction prose remains admissible.
+   while detached numeric/art-direction prose remains admissible, including
+   renderer nouns that trail an ambiguous candidate.
    Blank bodies/prompts fail closed via a shared `_deterministic_verdict`.
 4. Proof: contract invariants both directions + real-entrypoint tests
    through `run_stage`.
@@ -154,12 +155,12 @@ Max files: 7
   before space-separated suffixes. These are both-direction failures at one
   admission seam, not separate spellings to enumerate.
 - **Structural direction:** attached NANP vanity spelling is structural
-  evidence. Detached spelling requires nearby dial intent; an international
-  spelling additionally requires an explicit `+`/`00` prefix and must map
-  inside E.164's digit bound. No evidence defaults to ordinary renderer
-  description. The oracle crosses renderer specifications and ordinary
-  three-digit art directions on the admit side, and separator partitions plus
-  domestic/international prefixes on the reject side.
+  evidence. Detached spelling requires a preceding structural dial marker; an
+  international spelling additionally requires an explicit `+`/`00` prefix and
+  must map inside E.164's digit bound. No evidence defaults to ordinary renderer
+  description. The oracle crosses renderer specifications, ordinary three-digit
+  art directions, and trailing renderer nouns on the admit side, and separator
+  partitions plus domestic/international prefixes on the reject side.
 
 ### Execution model
 
@@ -546,6 +547,23 @@ the same classifier and source-construction seams.
    draft snapshot, then hashes the same source bytes and retains the under-lock
    comparison.
 
+### Review round 14 (Codex, follow-up PR #2201)
+
+Three findings, all verified against the published follow-up and corrected at
+the same classifier and source-construction seams.
+
+1. **P1 - trailing renderer nouns were reverse dial intent.** Ambiguous
+   detached candidates now require structural dial evidence before the
+   candidate; renderer nouns such as `contact sheet` and `text treatment` after
+   `212 art deco` remain admissible prose.
+2. **P1 - parenthesized phoneword groups missed the shared separator grammar.**
+   Parentheses are parsed by the bounded dial grammar, so `Call +44 (800)
+   FLOWERS` receives the same verdict as its unparenthesized and numeric
+   keypad-equivalent forms.
+3. **P1 - a missing committed draft became JSON null.** Source-bound stages now
+   require a valid committed draft before constructing the runner-owned prompt
+   or dispatching the worker.
+
 ### Files touched
 
 - `atlas_brain/schemas/content_factory.py`
@@ -566,6 +584,8 @@ their redacted hits aggregate into the prompt-set verdict. Readiness consumes
 committed Git objects inside one per-job critical section, and source identity
 is snapshotted before worker dispatch then rechecked inside that section, so
 mutable residue or a mid-worker draft replacement cannot become approval input.
+Source-bound prompts require a committed draft object before dispatch; missing
+source is not a serializable stage input.
 
 ## Intentional
 
@@ -601,13 +621,15 @@ Parked hardening: none new.
         tests/test_content_factory_store.py \
         tests/test_content_factory_copy_verification.py \
         tests/test_leads_intake.py -q
-    # -> 945 passed (incl. the round-6 contact oracle, round-7
+    # -> 956 passed (incl. the round-6 contact oracle, round-7
     #    content-binding probes, round-8 descriptive-number boundary, and
     #    rounds 9-10 separator-partition, international/detached-prose,
     #    IDNA, dispatch-binding, and committed-residue proofs, plus round-11
     #    canonical-composition/whitespace-run proofs and round-12 normalized
-    #    parser and structural-bridge proofs, plus round-13 slash/line-break
-    #    boundaries and runner-owned prompt-construction proofs)
+    #    parser and structural-bridge proofs, round-13 slash/line-break
+    #    boundaries and runner-owned prompt-construction proofs, and round-14
+    #    parenthesized phonewords, trailing renderer nouns, and missing-source
+    #    pre-dispatch proofs)
     #
     # Mutation check on the round-8 lock test: removing `with job_lock(...)`
     # from run_stage makes test_run_stage_holds_job_lock_across_validation_
@@ -624,10 +646,10 @@ Parked hardening: none new.
 | File | LOC |
 |---|---:|
 | `atlas_brain/schemas/content_factory.py` | 60 |
-| `atlas_brain/services/content_factory_runner.py` | 358 |
+| `atlas_brain/services/content_factory_runner.py` | 365 |
 | `atlas_brain/services/content_factory_store.py` | 102 |
-| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 263 |
-| `plans/PR-CF-Phase6-Round10-Remediation.md` | 270 |
-| `tests/test_content_factory_runner.py` | 577 |
+| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 285 |
+| `plans/PR-CF-Phase6-Round10-Remediation.md` | 296 |
+| `tests/test_content_factory_runner.py` | 686 |
 | `tests/test_content_factory_schemas.py` | 68 |
-| **Total** | **1698** |
+| **Total** | **1862** |

--- a/plans/PR-CF-Phase6-Repurposing-Contracts.md
+++ b/plans/PR-CF-Phase6-Repurposing-Contracts.md
@@ -507,6 +507,26 @@ fixed at the generating operation rather than at the reported strings.
    intent gate remain unchanged; generated proofs vary prefixes, whitespace
    classes, and run widths, with detached prose proving the passing side.
 
+### Review round 12 (Codex, follow-up PR #2201)
+
+Three findings, all verified against the published follow-up and fixed at the
+shared parsing, evidence, and source-construction boundaries.
+
+1. **P1 — compatibility/separator spelling changed the phone verdict.** Phone
+   admission now classifies an NFKC-normalized view and shares one dial
+   separator grammar across tokenization, splitting, and compaction. Generated
+   proofs cross compatibility forms and separator choices, including slash,
+   against the same semantic oracle.
+2. **P1 — proximity to an open intent vocabulary was not structural evidence.**
+   Detached phonewords now require a finite bridge between the dial marker and
+   candidate. The oracle crosses direct/functional bridge evidence against
+   descriptive intervening words; ambiguous prose defaults to admissible.
+3. **P1 — the pre-dispatch fingerprint did not bind caller-built prompt text.**
+   Source-bound stages now take a prompt builder. `run_stage` reads committed
+   draft bytes once, builds the prompt from their parsed document, and hashes
+   those same bytes before dispatch. The existing under-lock re-read still
+   rejects a replacement during the worker call.
+
 ### Files touched
 
 - `atlas_brain/schemas/content_factory.py`
@@ -562,11 +582,12 @@ Parked hardening: none new.
         tests/test_content_factory_store.py \
         tests/test_content_factory_copy_verification.py \
         tests/test_leads_intake.py -q
-    # -> 805 passed (incl. the round-6 contact oracle, round-7
+    # -> 928 passed (incl. the round-6 contact oracle, round-7
     #    content-binding probes, round-8 descriptive-number boundary, and
     #    rounds 9-10 separator-partition, international/detached-prose,
     #    IDNA, dispatch-binding, and committed-residue proofs, plus round-11
-    #    canonical-composition and whitespace-run class proofs)
+    #    canonical-composition/whitespace-run proofs and round-12 normalized
+    #    parser, structural-bridge, and prompt-construction proofs)
     #
     # Mutation check on the round-8 lock test: removing `with job_lock(...)`
     # from run_stage makes test_run_stage_holds_job_lock_across_validation_
@@ -583,10 +604,10 @@ Parked hardening: none new.
 | File | LOC |
 |---|---:|
 | `atlas_brain/schemas/content_factory.py` | 60 |
-| `atlas_brain/services/content_factory_runner.py` | 233 |
+| `atlas_brain/services/content_factory_runner.py` | 340 |
 | `atlas_brain/services/content_factory_store.py` | 102 |
-| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 222 |
-| `plans/PR-CF-Phase6-Round10-Remediation.md` | 207 |
-| `tests/test_content_factory_runner.py` | 305 |
+| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 243 |
+| `plans/PR-CF-Phase6-Round10-Remediation.md` | 246 |
+| `tests/test_content_factory_runner.py` | 508 |
 | `tests/test_content_factory_schemas.py` | 68 |
-| **Total** | **1197** |
+| **Total** | **1567** |

--- a/plans/PR-CF-Phase6-Repurposing-Contracts.md
+++ b/plans/PR-CF-Phase6-Repurposing-Contracts.md
@@ -491,10 +491,10 @@ moving the snapshot back after dispatch makes them fail.
 ### Files touched
 
 - `atlas_brain/schemas/content_factory.py`
-- `atlas_brain/services/content_factory_copy_verification.py`
 - `atlas_brain/services/content_factory_runner.py`
 - `atlas_brain/services/content_factory_store.py`
 - `plans/PR-CF-Phase6-Repurposing-Contracts.md`
+- `plans/PR-CF-Phase6-Round10-Remediation.md`
 - `tests/test_content_factory_runner.py`
 - `tests/test_content_factory_schemas.py`
 
@@ -562,11 +562,11 @@ Parked hardening: none new.
 
 | File | LOC |
 |---|---:|
-| `atlas_brain/schemas/content_factory.py` | 297 |
-| `atlas_brain/services/content_factory_copy_verification.py` | 20 |
-| `atlas_brain/services/content_factory_runner.py` | 660 |
-| `atlas_brain/services/content_factory_store.py` | 165 |
-| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 572 |
-| `tests/test_content_factory_runner.py` | 1127 |
-| `tests/test_content_factory_schemas.py` | 309 |
-| **Total** | **3150** |
+| `atlas_brain/schemas/content_factory.py` | 43 |
+| `atlas_brain/services/content_factory_runner.py` | 233 |
+| `atlas_brain/services/content_factory_store.py` | 102 |
+| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 198 |
+| `plans/PR-CF-Phase6-Round10-Remediation.md` | 173 |
+| `tests/test_content_factory_runner.py` | 286 |
+| `tests/test_content_factory_schemas.py` | 40 |
+| **Total** | **1075** |

--- a/plans/PR-CF-Phase6-Repurposing-Contracts.md
+++ b/plans/PR-CF-Phase6-Repurposing-Contracts.md
@@ -565,8 +565,8 @@ Parked hardening: none new.
 | `atlas_brain/schemas/content_factory.py` | 43 |
 | `atlas_brain/services/content_factory_runner.py` | 233 |
 | `atlas_brain/services/content_factory_store.py` | 102 |
-| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 198 |
-| `plans/PR-CF-Phase6-Round10-Remediation.md` | 173 |
+| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 202 |
+| `plans/PR-CF-Phase6-Round10-Remediation.md` | 184 |
 | `tests/test_content_factory_runner.py` | 286 |
 | `tests/test_content_factory_schemas.py` | 40 |
-| **Total** | **1075** |
+| **Total** | **1090** |

--- a/plans/PR-CF-Phase6-Repurposing-Contracts.md
+++ b/plans/PR-CF-Phase6-Repurposing-Contracts.md
@@ -527,6 +527,25 @@ shared parsing, evidence, and source-construction boundaries.
    those same bytes before dispatch. The existing under-lock re-read still
    rejects a replacement during the worker call.
 
+### Review round 13 (Codex, follow-up PR #2201)
+
+Three findings, all verified against the published follow-up and corrected at
+the same classifier and source-construction seams.
+
+1. **P1 — slash-delimited numeric renderer values entered the unconditional
+   E.164 shortcut.** Compact explicit-prefix digits remain strong evidence;
+   slash-delimited numeric shapes now pass through the structural-intent
+   decision. Generated proofs keep slash phonewords and structurally governed
+   numbers failing while renderer dimensions and dates remain admissible.
+2. **P1 — line-break formatting split direct dial syntax.** The finite bridge
+   now admits exactly one logical LF, CR, or CRLF while continuing to reject
+   paragraph breaks and descriptive intervening words.
+3. **P1 — an arbitrary prompt callback could ignore its draft argument.**
+   Source-bound stages now accept no caller prompt payload. The runner owns the
+   fixed stage instruction and deterministic serialization of the committed
+   draft snapshot, then hashes the same source bytes and retains the under-lock
+   comparison.
+
 ### Files touched
 
 - `atlas_brain/schemas/content_factory.py`
@@ -582,12 +601,13 @@ Parked hardening: none new.
         tests/test_content_factory_store.py \
         tests/test_content_factory_copy_verification.py \
         tests/test_leads_intake.py -q
-    # -> 928 passed (incl. the round-6 contact oracle, round-7
+    # -> 945 passed (incl. the round-6 contact oracle, round-7
     #    content-binding probes, round-8 descriptive-number boundary, and
     #    rounds 9-10 separator-partition, international/detached-prose,
     #    IDNA, dispatch-binding, and committed-residue proofs, plus round-11
     #    canonical-composition/whitespace-run proofs and round-12 normalized
-    #    parser, structural-bridge, and prompt-construction proofs)
+    #    parser and structural-bridge proofs, plus round-13 slash/line-break
+    #    boundaries and runner-owned prompt-construction proofs)
     #
     # Mutation check on the round-8 lock test: removing `with job_lock(...)`
     # from run_stage makes test_run_stage_holds_job_lock_across_validation_
@@ -604,10 +624,10 @@ Parked hardening: none new.
 | File | LOC |
 |---|---:|
 | `atlas_brain/schemas/content_factory.py` | 60 |
-| `atlas_brain/services/content_factory_runner.py` | 340 |
+| `atlas_brain/services/content_factory_runner.py` | 358 |
 | `atlas_brain/services/content_factory_store.py` | 102 |
-| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 243 |
-| `plans/PR-CF-Phase6-Round10-Remediation.md` | 246 |
-| `tests/test_content_factory_runner.py` | 508 |
+| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 263 |
+| `plans/PR-CF-Phase6-Round10-Remediation.md` | 270 |
+| `tests/test_content_factory_runner.py` | 577 |
 | `tests/test_content_factory_schemas.py` | 68 |
-| **Total** | **1567** |
+| **Total** | **1698** |

--- a/plans/PR-CF-Phase6-Repurposing-Contracts.md
+++ b/plans/PR-CF-Phase6-Repurposing-Contracts.md
@@ -13,7 +13,7 @@ deterministic gates. Image GENERATION (ComfyUI) is deliberately not here --
 the epic keeps prompt designer and generator split, and generation is
 human-triggered and VRAM-guarded.
 
-**Diff-budget overage (~1,190 LOC vs the 400 soft cap) — why this slice is
+**Diff-budget overage (~3,150 LOC vs the 400 soft cap) — why this slice is
 indivisible.** The two contracts, their stage admission, and their
 deterministic gates are one enforceable behaviour, and splitting them
 produces a strictly worse intermediate state:
@@ -26,7 +26,7 @@ produces a strictly worse intermediate state:
 * stage admission without either would let unvalidated artifacts land in
   the git-backed job folder under a Phase 6 stage name.
 
-Roughly 60% of the LOC is tests (four review rounds of adversarial
+Roughly 46% of the LOC is tests (ten review rounds of adversarial
 regressions, kept because each pins a defect that actually shipped in an
 earlier revision of this branch). The behaviour itself is two contracts,
 one enforcement hook, and one lineage check.
@@ -60,17 +60,22 @@ one enforcement hook, and one lineage check.
     REJECTED (proving the freeze); self-contradictory worker metadata is
     still refused rather than repaired.
   - **Store concurrency + write atomicity.** Readiness reads the job
-    folder and then writes it, so both must sit in one critical section,
-    and a failed commit must leave no residue for the next read to trust.
-    Adds a re-entrant per-job `flock` and all-or-nothing artifact writes.
-    Acceptance: readiness is decided with the lock HELD (mutation-checked)
-    and released after; a failed commit restores the previous bytes and
-    leaves nothing staged.
+    history and then writes it, so both must sit in one critical section.
+    Canonical readiness inputs must come from the committed Git tree, never
+    mutable worktree/index residue. Adds a re-entrant per-job `flock`,
+    committed-artifact reads, and failure cleanup that restores the previous
+    committed bytes/index state. Acceptance: readiness is decided with the
+    lock HELD (mutation-checked) and released after; a failed commit is never
+    readable as canonical source state, even if interruption prevents cleanup.
+    A source fingerprint is also captured before worker dispatch and compared
+    again under the lock, so a response can never be stamped against a
+    same-revision draft that replaced the one present when work began.
 
 ## Scope (this PR)
 
 Ownership lane: content-factory
 Slice phase: vertical slice
+Max files: 7
 
 1. `atlas_brain/schemas/content_factory.py`:
    - `ChannelVariant` + `RepurposingPackage` (`repurposing.v1`): non-empty
@@ -88,8 +93,9 @@ Slice phase: vertical slice
    `_enforce_image_prompts` gates the POSITIVE prompt text only, verifying
    each prompt independently (`negative_prompt` is an exclusion list and is
    deliberately excluded; joining items would synthesize cross-prompt
-   claims). Prompt PII is stricter than body copy: international phone
-   forms fail here.
+   claims). Prompt PII is stricter than body copy: international phonewords
+   with bounded dial evidence and IDNA-equivalent email separators fail here,
+   while detached numeric/art-direction prose remains admissible.
    Blank bodies/prompts fail closed via a shared `_deterministic_verdict`.
 4. Proof: contract invariants both directions + real-entrypoint tests
    through `run_stage`.
@@ -112,8 +118,14 @@ Slice phase: vertical slice
      unchanged and REJECTS the new fingerprint field; v1/v2 worker replies
      normalize to v3; contradictory `schema_version` still fails.
   7. Concurrency + atomicity (rounds 8-9): readiness is decided under the
-     per-job lock and the lock is released afterwards; a failed commit
-     leaves neither modified content on disk nor a staged path.
+     per-job lock and the lock is released afterwards; readiness reads the
+     committed Git tree, so a failed/uncommitted artifact cannot authorize a
+     later stage. An ordinary raised commit failure also restores the prior
+     worktree bytes and index state.
+  8. Dispatch binding (round 10): the committed draft fingerprint observed
+     before the worker call must still match under the job lock before any
+     audit, repurposing, or image-prompt response may persist, including an
+     unready Phase 6 intermediate artifact.
 - Reachability proof: `run_stage(job, "repurposing"|"image_prompt", ...)`,
   the same entrypoint the four existing stages use; artifacts land in the
   git-backed job folder.
@@ -121,11 +133,74 @@ Slice phase: vertical slice
   locking, runner enforcement and audit normalization. The audit stage's
   persisted VERSION changes (v3); its decision behavior does not. No change
   to image generation.
-- Risk areas: none live -- no worker wrappers are wired to these stages
-  yet (next slice), so this cannot alter current pipeline behavior.
+- Risk areas: persisted-contract compatibility, PII false positives/negatives,
+  and the per-job Git store's concurrency/crash boundary. No worker wrappers
+  are wired to the Phase 6 stages yet (next slice), so those new stages cannot
+  alter current pipeline behavior.
 - Reviewer rules triggered: R1 (#2109 Phase 6), R2 (both-direction tests),
-  R3 (gate cannot be self-reported), R5 (no existing-stage behavior
-  change), R10 (one advisory grammar shared by three artifacts), R14.
+  R3 (gate cannot be self-reported), R5 (versioned audit compatibility),
+  R6 (failed-write recovery), R8 (per-job serialization), R10 (one advisory
+  grammar shared by three artifacts), R13 (class findings), R14.
+
+### Decision-Seam Analysis
+
+- **One decision:** `_phone_evidence` decides whether a mixed digit/letter
+  candidate carries enough bounded mechanical evidence to be contact data
+  rather than renderer prose.
+- **Why the seam was wrong:** treating keypad-mappable spelling as sufficient
+  evidence made `212 art deco` a phone number, while limiting the accepted
+  structure to NANP membership missed explicit international phonewords.
+  Earlier rounds also equated any attached letters with vanity and stopped
+  before space-separated suffixes. These are both-direction failures at one
+  admission seam, not separate spellings to enumerate.
+- **Structural direction:** attached NANP vanity spelling is structural
+  evidence. Detached spelling requires nearby dial intent; an international
+  spelling additionally requires an explicit `+`/`00` prefix and must map
+  inside E.164's digit bound. No evidence defaults to ordinary renderer
+  description. The oracle crosses renderer specifications and ordinary
+  three-digit art directions on the admit side, and separator partitions plus
+  domestic/international prefixes on the reject side.
+
+### Execution model
+
+- **Selected closed-surface components:** Git's content-addressed committed
+  tree is the canonical artifact source, and the operating system's `flock`
+  supplies per-file mutual exclusion. Git closes the durable-read seam:
+  worktree/index bytes do not exist to a canonical reader until a commit
+  records them. `flock` closes the cooperative scheduling seam while the
+  process is alive and the kernel releases it on process exit. Worker
+  transport remains outside the lock; pre-dispatch snapshot/under-lock
+  comparison closes that interval without holding a filesystem lock over a
+  network call.
+- **Admitted actors and invariant:** synchronous `run_stage` /
+  `write_artifact` calls that use this store, possibly from multiple threads
+  or processes, against one trusted local root. The lock identity is the
+  resolved root plus job id. For every interleaving of those actors, only one
+  call for that job may read committed readiness inputs and commit its result;
+  a ready artifact therefore binds to the draft/audit pair from the committed
+  tree observed inside its critical section. Source-derived stages also
+  snapshot the committed draft immediately before dispatch and compare that
+  snapshot under the lock before writing; a cooperative draft replacement
+  during worker execution makes the response stale and unpersistable.
+- **Failure boundary:** an ordinary raised Git failure restores the target's
+  previous committed bytes and index entry. Abrupt process death or
+  `BaseException` may leave mutable worktree/index residue, but the kernel
+  releases the lock and subsequent readiness reads ignore that residue by
+  reading Git `HEAD`. A later write to that stage overwrites the target from
+  canonical input. Duplicate identical writes create no new commit;
+  out-of-order ready writes fail the committed revision/fingerprint checks.
+- **Assumptions:** the root, `.git` directory, and `.locks` directory are
+  trusted same-user local state; all writers use this API; Git and POSIX
+  `flock` are available; an external process that mutates the job repository
+  while bypassing the lock is outside the model and unsupported.
+- **Rejected component (hand-roll disclosure):** a database transaction would
+  require replacing the accepted per-job Git artifact/audit surface with new
+  schema and repository wiring. That is a storage migration, not a compatible
+  primitive for this vertical slice. No lease, retry service, clock protocol,
+  or cross-host coordinator is introduced.
+- **One execution surface:** only the existing per-job Git artifact store is
+  coordinated. Worker transport, image generation, and any future database
+  storage remain outside this slice.
 
 ### Review round 1 (Codex)
 
@@ -350,16 +425,19 @@ Four findings, all verified against the code before acting and all fixed.
    vanity number are DIGIT SUBSTITUTES, so the token must (a) lead with an
    area code -- exactly 3 digits, or "1" plus 3 -- and (b) map through the
    phone keypad to a syntactically valid NANP number. A spec's leading group
-   is 2 or 4 digits, so the whole class renders. The other direction is
-   closed by extending each candidate with up to three following alpha words,
-   which cannot over-reach because the same two conditions still apply.
+   is 2 or 4 digits, so the whole class renders. Space-joined suffixes extend
+   only while the NANP symbol-count bound remains reachable, so every possible
+   partition of a seven-letter suffix is covered without an arbitrary
+   word-count cap.
 
 2. **P1 — a failed commit left artifact residue the readiness gate trusted.**
    `write_artifact` wrote and staged the file before committing, so a commit
-   failure left the job's modified draft artifact in the working tree with no commit
-   recording it -- and the readiness gate reads the working tree. Writes are
-   now all-or-nothing: on any failure the previous bytes are restored (or the
-   file removed if the stage had none) and the path unstaged.
+   failure left the job's modified draft artifact in the working tree with no
+   commit recording it -- and the readiness gate read the working tree.
+   Readiness now reads committed Git objects only, so uncommitted residue
+   cannot become source state. Ordinary raised failures also restore the
+   previous committed bytes/index entry; process-death residue remains
+   non-canonical and is ignored.
 
 3. **P2 — the governing contract did not cover round 8's changes.** The
    Problem-derived and Review Contracts still said "must not change existing
@@ -374,7 +452,41 @@ Four findings, all verified against the code before acting and all fixed.
    format/control characters, so `email` and `email<ZWSP>` collide.
 
 Both P1 fixes are mutation-checked: reverting either makes the new tests
-fail, so they are load-bearing rather than vacuous.
+fail, so they are load-bearing rather than vacuous. The execution model above
+records the current-main `AGENTS.md` 3k.4 boundary.
+
+### Review round 10 (Codex)
+
+Five findings, all verified against the code before acting and fixed at their
+shared decision/execution seams.
+
+1. **P1 — international phonewords bypassed a NANP-only decision.** An
+   explicit `+`/`00` prefix plus dial intent and keypad-mappable spelling now
+   admits a bounded 7-15 digit international candidate without pretending it
+   belongs to NANP.
+2. **P2 — detached prose was treated as vanity spelling.** Space-joined alpha
+   extensions no longer prove contact data by themselves. They require nearby
+   dial intent, so ordinary three-digit renderer prose such as `room 212 art
+   deco sign` remains admissible. Attached NANP vanity syntax stays structural
+   evidence.
+3. **P2 — default-ignorable marks split routing identities.** The channel
+   routing key now drops the Unicode default-ignorable class, including
+   variation selectors and combining grapheme joiners, as well as format and
+   control characters. Visible labels that differ only by those marks collide.
+4. **P1 — post-worker fingerprinting attested to the wrong draft.** The runner
+   now snapshots committed draft identity before dispatch and compares it
+   under the per-job lock before persisting any source-derived response.
+   Audit, repurposing, and image-prompt artifacts all reject a same-revision
+   replacement that lands while their worker is running.
+5. **P1 — IDNA-equivalent email separators bypassed the prompt gate.** Email
+   admission normalizes U+3002, U+FF0E, and U+FF61 to the ASCII domain-label
+   separator before matching; findings remain redacted.
+
+The phone oracle covers both directions from grammars: domestic separator
+partitions and international prefix/spelling combinations reject under dial
+evidence, while three-digit values crossed with art-direction phrases admit.
+The dispatch tests replace the committed draft inside the worker boundary, so
+moving the snapshot back after dispatch makes them fail.
 
 ### Files touched
 
@@ -391,8 +503,11 @@ fail, so they are load-bearing rather than vacuous.
 Two artifacts, two stages, one enforcement idea reused: the deterministic
 verdict is always computed by the runner from the artifact's own text and
 overwrites whatever the worker claimed. Variants get a per-variant verdict
-because each ships independently; the prompt set gets one verdict over all
-prompt text because it is rendered as a unit.
+because each ships independently; image prompts are checked independently and
+their redacted hits aggregate into the prompt-set verdict. Readiness consumes
+committed Git objects inside one per-job critical section, and source identity
+is snapshotted before worker dispatch then rechecked inside that section, so
+mutable residue or a mid-worker draft replacement cannot become approval input.
 
 ## Intentional
 
@@ -428,31 +543,30 @@ Parked hardening: none new.
         tests/test_content_factory_store.py \
         tests/test_content_factory_copy_verification.py \
         tests/test_leads_intake.py -q
-    # -> 620 passed (311 new; incl. the round-6 generative oracle, the
-    #    round-7 casing/content-binding probes, and the round-8
-    #    descriptive-numbers x dial-words class-closure oracle)
+    # -> 714 passed (incl. the round-6 contact oracle, round-7
+    #    content-binding probes, round-8 descriptive-number boundary, and
+    #    rounds 9-10 separator-partition, international/detached-prose,
+    #    IDNA, dispatch-binding, and committed-residue proofs)
     #
     # Mutation check on the round-8 lock test: removing `with job_lock(...)`
     # from run_stage makes test_run_stage_holds_job_lock_across_validation_
     # and_write FAIL, so the assertion is load-bearing rather than vacuous.
     #
-    # Repo-wide: 20155 passed / 169 failed / 8 collection errors. Every
-    # failure and error reproduces identically on a stashed (clean) tree --
-    # they are pre-existing local dependency issues in invoicing / mcp /
-    # scheduler / reasoning, and none are in a file this diff touches.
-
-- `python -m py_compile` clean (SyntaxWarning as error) on touched modules.
+- Ruff, `python -m py_compile`, and `git diff --check` passed on the touched
+  Python/diff surface.
+- Guard class-closure advisory and plan shape/files/diff-size/rule audits
+  passed against current `origin/main`.
 - NOT run: live worker pass (no wrappers wired yet, by design).
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
-| `atlas_brain/schemas/content_factory.py` | 266 |
+| `atlas_brain/schemas/content_factory.py` | 297 |
 | `atlas_brain/services/content_factory_copy_verification.py` | 20 |
-| `atlas_brain/services/content_factory_runner.py` | 557 |
-| `atlas_brain/services/content_factory_store.py` | 133 |
-| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 417 |
-| `tests/test_content_factory_runner.py` | 957 |
-| `tests/test_content_factory_schemas.py` | 269 |
-| **Total** | **2619** |
+| `atlas_brain/services/content_factory_runner.py` | 660 |
+| `atlas_brain/services/content_factory_store.py` | 165 |
+| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 572 |
+| `tests/test_content_factory_runner.py` | 1127 |
+| `tests/test_content_factory_schemas.py` | 309 |
+| **Total** | **3150** |

--- a/plans/PR-CF-Phase6-Repurposing-Contracts.md
+++ b/plans/PR-CF-Phase6-Repurposing-Contracts.md
@@ -75,7 +75,7 @@ one enforcement hook, and one lineage check.
 
 Ownership lane: content-factory
 Slice phase: vertical slice
-Max files: 7
+Max files: 8
 
 1. `atlas_brain/schemas/content_factory.py`:
    - `ChannelVariant` + `RepurposingPackage` (`repurposing.v1`): non-empty
@@ -567,6 +567,7 @@ the same classifier and source-construction seams.
 ### Files touched
 
 - `atlas_brain/schemas/content_factory.py`
+- `atlas_brain/services/content_factory_copy_verification.py`
 - `atlas_brain/services/content_factory_runner.py`
 - `atlas_brain/services/content_factory_store.py`
 - `plans/PR-CF-Phase6-Repurposing-Contracts.md`

--- a/plans/PR-CF-Phase6-Repurposing-Contracts.md
+++ b/plans/PR-CF-Phase6-Repurposing-Contracts.md
@@ -566,7 +566,7 @@ Parked hardening: none new.
 | `atlas_brain/services/content_factory_runner.py` | 233 |
 | `atlas_brain/services/content_factory_store.py` | 102 |
 | `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 202 |
-| `plans/PR-CF-Phase6-Round10-Remediation.md` | 184 |
+| `plans/PR-CF-Phase6-Round10-Remediation.md` | 185 |
 | `tests/test_content_factory_runner.py` | 286 |
 | `tests/test_content_factory_schemas.py` | 40 |
-| **Total** | **1090** |
+| **Total** | **1091** |

--- a/plans/PR-CF-Phase6-Round10-Remediation.md
+++ b/plans/PR-CF-Phase6-Round10-Remediation.md
@@ -148,6 +148,11 @@ Max files: 8
       for room 212 art deco, contact sheet layout` remain admissible.
   17. Every source-bound stage requires a valid committed draft before worker
       dispatch; no stage may send `Committed draft JSON:\nnull`.
+  19. A dial marker connected to its number by the dative `to` -- `Text to
+      +44 800 FLOWERS`, `SMS to ...`, `WhatsApp to ...` -- fails, matching the
+      same marker and number without the connector. Possessive determiners
+      stay OUT of the bridge: `text your 1920 1080 export` and `call our 1920
+      1080 render sheet` remain renderer prose.
   18. A default-ignorable code point inserted at ANY seam of a contact string
       -- before or inside the `+`/`00` prefix, between or inside numeric
       groups, inside the vanity suffix, or inside an address -- preserves the
@@ -267,6 +272,23 @@ This does not change body-copy verdict POLICY -- which real forms count as PII
 is untouched, so #2181's frozen semantics hold. It denies an evasion of the
 existing policy. Mutation-checked: neutralizing `scan_view` fails 64 tests.
 
+### Review round 12 (Codex) -- recipient-marking bridge
+
+One finding, confirmed: the bridge vocabulary omitted `to`, so `Text to +44
+800 FLOWERS` produced no hit while `Text +44 800 FLOWERS` was rejected. A
+one-word grammatical connector defeated the gate.
+
+`to` is the dative marker every message verb takes for its recipient, so it
+belongs to the same closed function-word class the bridge already models.
+
+Possessive determiners are deliberately NOT added, and the boundary is
+recorded so the exclusion is not mistaken for an oversight: `our`/`your`/
+`their` are function words too, but they occur in ordinary renderer prose
+("text your 1920 1080 export"), so admitting them would read a typography
+instruction as a dial instruction. The class is function words that mark a
+RECIPIENT, not every function word. Covered by a 7 intents x 5 bridge-forms
+cross-product plus the prose-side probes.
+
 ## Intentional
 
 - Detached phonewords without preceding structural dial intent pass, even if
@@ -325,10 +347,10 @@ Parked hardening: none.
 |---|---:|
 | `atlas_brain/schemas/content_factory.py` | 60 |
 | `atlas_brain/services/content_factory_copy_verification.py` | 62 |
-| `atlas_brain/services/content_factory_runner.py` | 374 |
+| `atlas_brain/services/content_factory_runner.py` | 382 |
 | `atlas_brain/services/content_factory_store.py` | 102 |
-| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 285 |
-| `plans/PR-CF-Phase6-Round10-Remediation.md` | 334 |
-| `tests/test_content_factory_runner.py` | 774 |
+| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 284 |
+| `plans/PR-CF-Phase6-Round10-Remediation.md` | 356 |
+| `tests/test_content_factory_runner.py` | 809 |
 | `tests/test_content_factory_schemas.py` | 68 |
-| **Total** | **2059** |
+| **Total** | **2123** |

--- a/plans/PR-CF-Phase6-Round10-Remediation.md
+++ b/plans/PR-CF-Phase6-Round10-Remediation.md
@@ -9,7 +9,10 @@ international vanity contact data passes, ordinary three-digit renderer prose
 can be rejected as a phone number, default-ignorable Unicode marks split one
 channel into multiple routing identities, worker responses can be stamped
 against a same-revision draft they did not see, and IDNA-equivalent domain
-separators bypass email gating.
+separators bypass email gating. Current-head review then found that two class
+boundaries were still incomplete: the routing key removed ignorables only
+after they could affect normalization, and the dial-token grammar treated a
+whitespace separator as exactly one code point rather than a run.
 
 This production-hardening follow-up carries the already verified correction
 onto the merged mainline. It preserves the Phase 6 product shape and closes the
@@ -21,15 +24,20 @@ reported classes at their shared classifier and execution seams.
   phone evidence while restricting phoneword validity to NANP, so it was
   simultaneously over-broad on detached prose and under-broad on explicit
   international phonewords. The routing key removed only `Cf`/`Cc`, not the
-  Unicode default-ignorable marks that also have no routing identity. The
-  runner fingerprinted after the worker returned, so its fingerprint attested
-  to persistence-time state rather than dispatch-time source. Email matching
+  Unicode default-ignorable marks that also have no routing identity, then
+  removed the broader class after NFKC even though an ignorable can block
+  canonical composition. The dial-token grammar modeled a whitespace
+  separator as one character rather than the entire separator run. The runner
+  fingerprinted after the worker returned, so its fingerprint attested to
+  persistence-time state rather than dispatch-time source. Email matching
   recognized only the ASCII spelling of an IDNA label separator.
 - Correct fix must touch/change: the Phase 6 runner's single contact-admission
   decision, its committed-source dispatch/persistence boundary, the channel
   routing key, and both-direction tests at the real `run_stage` entrypoint.
-  Canonical store reads must remain committed-object reads so a source snapshot
-  cannot be replaced by worktree residue.
+  Default-ignorables must be removed before normalization, and numeric
+  whitespace must be consumed as one separator run while compact dial symbols
+  remain E.164-bounded. Canonical store reads must remain committed-object
+  reads so a source snapshot cannot be replaced by worktree residue.
 - Must not change: Phase 6 artifact schema tags/field shapes, editorial
   decision semantics, negative-prompt exclusion semantics, body-copy verifier
   policy, image generation, worker wrappers, or any EOM/CRM lane.
@@ -69,6 +77,11 @@ Max files: 7
      email verdict as ASCII dot without leaking the raw address into hits.
   6. Prior Phase 6 gate, store, schema, and intake tests remain green; maturity,
      guard-closure, plan, static, and diff audits pass.
+  7. A default-ignorable inserted between a base and combining mark cannot
+     prevent canonically equivalent channel labels from colliding.
+  8. One or more whitespace code points between international numeric groups
+     preserve the same phoneword verdict without widening the compact E.164
+     symbol bound or promoting detached prose without dial intent.
 - Reachability proof: `run_stage(job_id, stage, model, user_content, ...)` calls
   the worker, applies prompt enforcement, compares committed source identity
   under `job_lock`, validates, and writes. Tests replace the committed draft
@@ -125,13 +138,15 @@ Max files: 7
 
 The runner preserves a leading `+`, keypad-maps mixed tokens, and classifies
 explicit international phonewords as ambiguous structural candidates governed
-by the existing bounded intent window. Space-joined candidate extensions use
-that same intent requirement; attached domestic vanity syntax remains
-unambiguous. Email matching translates the three IDNA domain-stop equivalents
-only for admission.
+by the existing bounded intent window. Numeric groups consume a whitespace run
+as one separator; `_dial_shape` still removes separators before enforcing the
+7-15 digit E.164 bound. Space-joined candidate extensions use that same intent
+requirement; attached domestic vanity syntax remains unambiguous. Email
+matching translates the three IDNA domain-stop equivalents only for admission.
 
 The schema defines the Unicode default-ignorable ranges once, excludes them
-from visible-only content, and removes them from the NFKC/casefold routing key.
+from visible-only content, and removes them before the NFKC/casefold routing
+key so an ignored code point cannot alter composition.
 
 `run_stage` reads the committed draft fingerprint before `call_worker`. After
 the response is enforced, it takes `job_lock`, rejects any source-derived
@@ -147,6 +162,9 @@ than correctness.
   the reported false-positive class.
 - International phonewords require an explicit international prefix and intent.
   Arbitrary letter/digit prose is not promoted to contact data.
+- Whitespace run length is not dial evidence. The existing numeric-group cap,
+  compact symbol bound, explicit international prefix, and intent gate remain
+  the bounded evidence.
 - The default-ignorable routing normalization is broader than the two reported
   code points by design; one invisible Unicode property is one defect class.
 - The originating Phase 6 plan remains modified in this follow-up so its
@@ -155,7 +173,8 @@ than correctness.
 
 ## Deferred
 
-- None for the five round-10 findings.
+- None for the five round-10 findings or the two current-head class-boundary
+  findings.
 - Existing Phase 6 deferrals remain: ComfyUI generation, OWUI wrappers, and
   Phase 7 manifest entries.
 
@@ -163,7 +182,10 @@ Parked hardening: none.
 
 ## Verification
 
-- Focused content-factory/intake suite: 714 passed.
+- Focused content-factory/intake suite: 805 passed.
+- Current-head review regressions: 25 routing-key cases and 111 phoneword
+  cases passed, including generated canonical-composition and whitespace-run
+  classes.
 - Ruff, `python -m py_compile`, and `git diff --check`: passed on the exact
   follow-up tree.
 - Schema maturity ratchet: no new brittleness.
@@ -175,11 +197,11 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `atlas_brain/schemas/content_factory.py` | 43 |
+| `atlas_brain/schemas/content_factory.py` | 60 |
 | `atlas_brain/services/content_factory_runner.py` | 233 |
 | `atlas_brain/services/content_factory_store.py` | 102 |
-| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 202 |
-| `plans/PR-CF-Phase6-Round10-Remediation.md` | 185 |
-| `tests/test_content_factory_runner.py` | 286 |
-| `tests/test_content_factory_schemas.py` | 40 |
-| **Total** | **1091** |
+| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 222 |
+| `plans/PR-CF-Phase6-Round10-Remediation.md` | 207 |
+| `tests/test_content_factory_runner.py` | 305 |
+| `tests/test_content_factory_schemas.py` | 68 |
+| **Total** | **1197** |

--- a/plans/PR-CF-Phase6-Round10-Remediation.md
+++ b/plans/PR-CF-Phase6-Round10-Remediation.md
@@ -148,6 +148,11 @@ Max files: 8
       for room 212 art deco, contact sheet layout` remain admissible.
   17. Every source-bound stage requires a valid committed draft before worker
       dispatch; no stage may send `Committed draft JSON:\nnull`.
+  20. EVERY Unicode Default_Ignorable_Code_Point -- sampled from the shared
+      range table itself, not a hand-written list -- fails at every contact
+      seam in the prompt gate and `verify_copy`, and none leaves an address
+      readable in redacted evidence. Routing keys and the contact scan use ONE
+      predicate.
   19. A dial marker connected to its number by the dative `to` -- `Text to
       +44 800 FLOWERS`, `SMS to ...`, `WhatsApp to ...` -- fails, matching the
       same marker and number without the connector. Possessive determiners
@@ -289,6 +294,28 @@ instruction as a dial instruction. The class is function words that mark a
 RECIPIENT, not every function word. Covered by a 7 intents x 5 bridge-forms
 cross-product plus the prose-side probes.
 
+### Review round 13 (Codex) -- one shared default-ignorable predicate
+
+One finding, confirmed, and the residual leak was worse than the phone case.
+Round 11's `scan_view` tested category Cf/Cc plus a hand-built range set, which
+misses U+034F COMBINING GRAPHEME JOINER -- category **Mn**. So after the
+zero-width class was closed, `Call +44<CGJ>800 FLOWERS` and
+`555-123<CGJ>-4567` still passed, and `_redact_pii` left
+`alice@example<CGJ>.com` FULLY intact in persisted claim evidence: the digit
+theorem cannot help, because an address has no digits to mask.
+
+The root cause is not the missing codepoint, it is the SECOND DEFINITION. The
+schema module already had the complete Default_Ignorable range table for
+routing keys; any rule elsewhere phrased as "Cf plus some ranges" leaves the
+bypass open by construction. `is_default_ignorable` is now exported as the one
+definition, used by routing keys, the contact scan, and evidence redaction
+alike.
+
+The corpus is derived FROM that table rather than listed, so a codepoint added
+to it is covered automatically and a future local copy fails the shared-
+predicate assertion first. Mutation-checked: restoring the Cf/Cc-only rule
+fails 134 tests.
+
 ## Intentional
 
 - Detached phonewords without preceding structural dial intent pass, even if
@@ -345,12 +372,12 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `atlas_brain/schemas/content_factory.py` | 60 |
-| `atlas_brain/services/content_factory_copy_verification.py` | 62 |
+| `atlas_brain/schemas/content_factory.py` | 72 |
+| `atlas_brain/services/content_factory_copy_verification.py` | 56 |
 | `atlas_brain/services/content_factory_runner.py` | 382 |
 | `atlas_brain/services/content_factory_store.py` | 102 |
 | `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 284 |
-| `plans/PR-CF-Phase6-Round10-Remediation.md` | 356 |
-| `tests/test_content_factory_runner.py` | 809 |
+| `plans/PR-CF-Phase6-Round10-Remediation.md` | 383 |
+| `tests/test_content_factory_runner.py` | 876 |
 | `tests/test_content_factory_schemas.py` | 68 |
-| **Total** | **2123** |
+| **Total** | **2223** |

--- a/plans/PR-CF-Phase6-Round10-Remediation.md
+++ b/plans/PR-CF-Phase6-Round10-Remediation.md
@@ -24,6 +24,11 @@ slash-delimited numeric renderer specifications entered through the
 unconditional E.164 shortcut; the otherwise finite bridge excluded a single
 formatting line break; and a caller callback could ignore the supplied draft
 while inheriting its fingerprint.
+The latest current-head review found three further edge gaps at those same
+boundaries: trailing renderer nouns after an ambiguous candidate were treated as
+reverse dial intent, parenthesized phoneword groups were outside the shared
+separator grammar, and a missing committed draft serialized as JSON `null`
+instead of failing before worker dispatch.
 
 This production-hardening follow-up carries the already verified correction
 onto the merged mainline. It preserves the Phase 6 product shape and closes the
@@ -44,8 +49,13 @@ reported classes at their shared classifier and execution seams.
   before dispatch still did not prove the already-built prompt came from those
   bytes. The detached-phoneword decision used an open semantic category
   (nearby intent words) without a closed structural bridge, and phone parsing
-  happened before NFKC with separator rules repeated across recognizers. Email
-  matching recognized only the ASCII spelling of an IDNA label separator.
+  happened before NFKC with separator rules repeated across recognizers. The
+  first finite bridge still ran symmetrically, so renderer nouns such as
+  `contact sheet` and `text treatment` after the candidate became reverse dial
+  markers. The bounded separator grammar also omitted parenthesized numeric
+  groups, and source prompt construction treated a missing committed draft as a
+  serializable `None` snapshot. Email matching recognized only the ASCII
+  spelling of an IDNA label separator.
 - Correct fix must touch/change: the Phase 6 runner's single contact-admission
   decision, its committed-source dispatch/persistence boundary, the channel
   routing key, and both-direction tests at the real `run_stage` entrypoint.
@@ -59,7 +69,11 @@ reported classes at their shared classifier and execution seams.
   break remains formatting inside the finite bridge. `run_stage` must own a
   fixed stage prompt template and construct it from the exact committed bytes
   whose fingerprint it records; caller-controlled builders are not proof of
-  derivation. The post-worker under-lock comparison remains required.
+  derivation. Missing committed draft bytes must fail before any source-bound
+  worker dispatch. Parenthesized phoneword groups must share the same bounded
+  grammar as their numeric keypad equivalents, and trailing renderer nouns must
+  not govern ambiguous candidates as reverse dial markers. The post-worker
+  under-lock comparison remains required.
   Canonical store reads must remain committed-object reads so a source snapshot
   cannot be replaced by worktree residue.
 - Must not change: Phase 6 artifact schema tags/field shapes, editorial
@@ -73,9 +87,9 @@ Slice phase: production hardening
 Max files: 7
 
 1. Make mixed digit/letter contact admission evidence-gated in both directions:
-   attached NANP vanity stays structural; detached spelling requires nearby
-   dial intent; international phonewords require explicit `+`/`00` structure
-   and an E.164-bounded keypad mapping.
+   attached NANP vanity stays structural; detached spelling requires structural
+   dial intent before the ambiguous candidate; international phonewords require
+   explicit `+`/`00` structure and an E.164-bounded keypad mapping.
 2. Normalize IDNA-equivalent domain stops before the redacted email decision
    and normalize Unicode default-ignorables out of channel routing identities.
 3. Snapshot committed draft identity immediately before dispatch and compare
@@ -126,6 +140,14 @@ Max files: 7
       runner selects the stage instruction and serializes the committed draft
       snapshot itself; a callback that ignores its argument is rejected before
       worker dispatch.
+  15. Parenthesized numeric groups in a phoneword, e.g. `Call +44 (800) FLOWERS`,
+      receive the same failing verdict as the unparenthesized spelling and the
+      keypad-equivalent numeric spelling.
+  16. Ambiguous phonewords are not governed by trailing renderer nouns: `room 212
+      art deco contact sheet`, `room 212 art deco text treatment`, and `poster
+      for room 212 art deco, contact sheet layout` remain admissible.
+  17. Every source-bound stage requires a valid committed draft before worker
+      dispatch; no stage may send `Committed draft JSON:\nnull`.
 - Reachability proof: `run_stage(job_id, stage, model, user_content, ...)` calls
   the worker, applies prompt enforcement, compares committed source identity
   under `job_lock`, validates, and writes. Tests replace the committed draft
@@ -146,11 +168,11 @@ Max files: 7
   NANP membership excluded explicit international phonewords. These are the
   two error directions of one classifier seam.
 - **Structural direction:** ambiguous detached prose defaults to admissible.
-  Detached spelling requires a dial marker connected through a finite bridge
-  containing only direct-address/preposition structure, not arbitrary nearby
-  words. International spelling also requires an explicit `+`/`00` prefix and
-  a 7-15 digit E.164 mapping. Tests cross evidence signals on both sides rather
-  than enumerate reported strings.
+  Detached spelling requires a preceding dial marker connected through a finite
+  bridge containing only direct-address/preposition structure, not arbitrary
+  nearby words or trailing renderer nouns. International spelling also requires
+  an explicit `+`/`00` prefix and a 7-15 digit E.164 mapping. Tests cross
+  evidence signals on both sides rather than enumerate reported strings.
 
 ### Execution model
 
@@ -187,20 +209,22 @@ The runner preserves a leading `+`, keypad-maps mixed tokens, and classifies
 explicit international phonewords as ambiguous structural candidates governed
 by a finite structural dial bridge. Phone admission first creates an
 NFKC-normalized view, then one separator grammar governs tokenization,
-partitioning, and compact-length checks, including whitespace, dot, hyphen, and
-slash. `_dial_shape` still removes separators before enforcing the 7-15 digit
-E.164 bound. Space-joined candidate extensions use the structural bridge;
-attached domestic vanity syntax remains unambiguous. Email matching translates
-the three IDNA domain-stop equivalents only for admission.
+partitioning, and compact-length checks, including whitespace, dot, hyphen,
+slash, and parenthesized numeric groups. `_dial_shape` still removes separators
+before enforcing the 7-15 digit E.164 bound. Space-joined candidate extensions
+use the forward structural bridge; attached domestic vanity syntax remains
+unambiguous. Email matching translates the three IDNA domain-stop equivalents
+only for admission.
 
 The schema defines the Unicode default-ignorable ranges once, excludes them
 from visible-only content, and removes them before the NFKC/casefold routing
 key so an ignored code point cannot alter composition.
 
 For source-bound work, `run_stage` accepts no caller prompt payload. It selects
-a fixed instruction from the known stage contract, reads committed draft bytes
-once, parses and deterministically serializes that snapshot into the prompt,
-hashes the same bytes, and dispatches. After the response is enforced, it takes
+a fixed instruction from the known stage contract, requires committed draft
+bytes to exist, parses and deterministically serializes that snapshot into the
+prompt, hashes the same bytes, and dispatches. After the response is enforced,
+it takes
 `job_lock`, rejects any source-derived schema whose current committed
 fingerprint differs, stamps audits with the dispatch fingerprint, runs
 readiness/lineage, and commits. Store reads use Git's committed-object lookup
@@ -208,9 +232,9 @@ for the stage JSON; cleanup is hygiene rather than correctness.
 
 ## Intentional
 
-- Detached phonewords without dial intent pass, even if their letters happen to
-  keypad-map to a valid number; rejecting that open prose category would repeat
-  the reported false-positive class.
+- Detached phonewords without preceding structural dial intent pass, even if
+  their letters happen to keypad-map to a valid number; rejecting that open
+  prose category would repeat the reported false-positive class.
 - International phonewords require an explicit international prefix and intent.
   Arbitrary letter/digit prose is not promoted to contact data.
 - Whitespace run length is not dial evidence. The existing numeric-group cap,
@@ -219,7 +243,7 @@ for the stage JSON; cleanup is hygiene rather than correctness.
 - Compatibility normalization and separator parity apply only to the
   admission-only phone view; raw prompt/artifact text is not rewritten.
 - Arbitrary proximity to an intent-like word is not dial evidence. Ambiguous
-  detached spelling without the finite bridge remains admissible.
+  detached spelling without the forward finite bridge remains admissible.
 - Source-bound stage callers now pass no prompt payload; the runner owns the
   fixed instruction plus committed-draft serialization. This intentionally
   changes the unshipped API before the deferred OWUI wrappers are wired.
@@ -231,7 +255,7 @@ for the stage JSON; cleanup is hygiene rather than correctness.
 
 ## Deferred
 
-- None for the five round-10 findings or eight current-head class-boundary
+- None for the five round-10 findings or eleven current-head class-boundary
   findings.
 - Existing Phase 6 deferrals remain: ComfyUI generation, OWUI wrappers, and
   Phase 7 manifest entries.
@@ -240,13 +264,15 @@ Parked hardening: none.
 
 ## Verification
 
-- Focused content-factory/intake suite: 945 passed.
-- Latest round-13 regression subset: 22 passed, covering
-  slash-separated renderer/phone both-direction cases, bounded line-break
-  bridges, runner-owned source prompts, and callback rejection. The prior
-  126-case current-head subset remains covered for
-  compatibility/separator parity, evidence-keyed dial bridges, prebuilt-prompt
-  rejection, pre-entry source replacement, and during-worker replacement.
+- Focused content-factory/intake suite: 956 passed.
+- Latest round-14 regression subset: 88 passed, covering
+  parenthesized phoneword groups, trailing renderer nouns after ambiguous
+  candidates, missing committed-draft rejection before dispatch, slash-separated
+  renderer/phone both-direction cases, bounded line-break bridges,
+  runner-owned source prompts, and callback rejection. The prior current-head
+  subsets remain covered for compatibility/separator parity, evidence-keyed dial
+  bridges, prebuilt-prompt rejection, pre-entry source replacement, and
+  during-worker replacement.
 - Prior current-head review regressions remain covered by generated
   canonical-composition and whitespace-run classes.
 - Ruff, `python -m py_compile`, and `git diff --check`: passed on the exact
@@ -261,10 +287,10 @@ Parked hardening: none.
 | File | LOC |
 |---|---:|
 | `atlas_brain/schemas/content_factory.py` | 60 |
-| `atlas_brain/services/content_factory_runner.py` | 358 |
+| `atlas_brain/services/content_factory_runner.py` | 365 |
 | `atlas_brain/services/content_factory_store.py` | 102 |
-| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 263 |
-| `plans/PR-CF-Phase6-Round10-Remediation.md` | 270 |
-| `tests/test_content_factory_runner.py` | 577 |
+| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 285 |
+| `plans/PR-CF-Phase6-Round10-Remediation.md` | 296 |
+| `tests/test_content_factory_runner.py` | 686 |
 | `tests/test_content_factory_schemas.py` | 68 |
-| **Total** | **1698** |
+| **Total** | **1862** |

--- a/plans/PR-CF-Phase6-Round10-Remediation.md
+++ b/plans/PR-CF-Phase6-Round10-Remediation.md
@@ -19,6 +19,11 @@ in multiple narrow regexes; detached spelling still treated proximity to an
 open intent vocabulary as mechanical dial evidence; and `run_stage` accepted
 caller-built prompt text independently from the committed draft bytes it
 fingerprinted.
+The following current-head review found three remaining trust-boundary gaps:
+slash-delimited numeric renderer specifications entered through the
+unconditional E.164 shortcut; the otherwise finite bridge excluded a single
+formatting line break; and a caller callback could ignore the supplied draft
+while inheriting its fingerprint.
 
 This production-hardening follow-up carries the already verified correction
 onto the merged mainline. It preserves the Phase 6 product shape and closes the
@@ -49,10 +54,14 @@ reported classes at their shared classifier and execution seams.
   remain E.164-bounded. Phone admission must classify an NFKC-normalized view
   with one bounded separator grammar and must replace open keyword proximity
   with a finite structural bridge whose ambiguous default is admissible.
-  `run_stage` must construct source-bound prompt text from the exact committed
-  bytes whose fingerprint it records, then retain the post-worker under-lock
-  comparison. Canonical store reads must remain committed-object reads so a
-  source snapshot cannot be replaced by worktree residue.
+  Slash-delimited numeric shapes must require structural dial syntax instead
+  of entering through an unconditional prefix shortcut, while one logical line
+  break remains formatting inside the finite bridge. `run_stage` must own a
+  fixed stage prompt template and construct it from the exact committed bytes
+  whose fingerprint it records; caller-controlled builders are not proof of
+  derivation. The post-worker under-lock comparison remains required.
+  Canonical store reads must remain committed-object reads so a source snapshot
+  cannot be replaced by worktree residue.
 - Must not change: Phase 6 artifact schema tags/field shapes, editorial
   decision semantics, negative-prompt exclusion semantics, body-copy verifier
   policy, image generation, worker wrappers, or any EOM/CRM lane.
@@ -106,6 +115,17 @@ Max files: 7
       from the same committed draft bytes it fingerprints. A draft replacement
       before entry changes the prompt source, while a replacement after prompt
       construction remains rejected under the job lock.
+  12. Slash-delimited numeric renderer values such as `+1920/1080` and
+      `+2026/07/25` remain admissible without structural dial syntax, while
+      slash-separated phonewords and numeric candidates under that syntax
+      retain the failing phone verdict.
+  13. A single LF, CR, or CRLF between a dial marker and candidate is formatting
+      and preserves dial evidence; paragraph breaks and descriptive intervening
+      words remain inadmissible as bridges.
+  14. Source-bound stages accept no caller-controlled prompt or callback. The
+      runner selects the stage instruction and serializes the committed draft
+      snapshot itself; a callback that ignores its argument is rejected before
+      worker dispatch.
 - Reachability proof: `run_stage(job_id, stage, model, user_content, ...)` calls
   the worker, applies prompt enforcement, compares committed source identity
   under `job_lock`, validates, and writes. Tests replace the committed draft
@@ -177,14 +197,14 @@ The schema defines the Unicode default-ignorable ranges once, excludes them
 from visible-only content, and removes them before the NFKC/casefold routing
 key so an ignored code point cannot alter composition.
 
-For source-bound work, `run_stage` receives a prompt builder rather than
-already-built text. It reads committed draft bytes once, parses those bytes for
-the builder, hashes the same bytes, and dispatches the resulting prompt. After
-the response is enforced, it takes `job_lock`, rejects any source-derived
-schema whose current committed fingerprint differs, stamps audits with the
-dispatch fingerprint, runs readiness/lineage, and commits. Store reads use
-Git's committed-object lookup for the stage JSON; cleanup is hygiene rather
-than correctness.
+For source-bound work, `run_stage` accepts no caller prompt payload. It selects
+a fixed instruction from the known stage contract, reads committed draft bytes
+once, parses and deterministically serializes that snapshot into the prompt,
+hashes the same bytes, and dispatches. After the response is enforced, it takes
+`job_lock`, rejects any source-derived schema whose current committed
+fingerprint differs, stamps audits with the dispatch fingerprint, runs
+readiness/lineage, and commits. Store reads use Git's committed-object lookup
+for the stage JSON; cleanup is hygiene rather than correctness.
 
 ## Intentional
 
@@ -200,8 +220,9 @@ than correctness.
   admission-only phone view; raw prompt/artifact text is not rewritten.
 - Arbitrary proximity to an intent-like word is not dial evidence. Ambiguous
   detached spelling without the finite bridge remains admissible.
-- Source-bound stage callers now provide a prompt builder. This intentionally
-  changes the unshipped runner API before the deferred OWUI wrappers are wired.
+- Source-bound stage callers now pass no prompt payload; the runner owns the
+  fixed instruction plus committed-draft serialization. This intentionally
+  changes the unshipped API before the deferred OWUI wrappers are wired.
 - The default-ignorable routing normalization is broader than the two reported
   code points by design; one invisible Unicode property is one defect class.
 - The originating Phase 6 plan remains modified in this follow-up so its
@@ -210,7 +231,7 @@ than correctness.
 
 ## Deferred
 
-- None for the five round-10 findings or five current-head class-boundary
+- None for the five round-10 findings or eight current-head class-boundary
   findings.
 - Existing Phase 6 deferrals remain: ComfyUI generation, OWUI wrappers, and
   Phase 7 manifest entries.
@@ -219,8 +240,11 @@ Parked hardening: none.
 
 ## Verification
 
-- Focused content-factory/intake suite: 928 passed.
-- Latest current-head regression subset: 126 passed, covering
+- Focused content-factory/intake suite: 945 passed.
+- Latest round-13 regression subset: 22 passed, covering
+  slash-separated renderer/phone both-direction cases, bounded line-break
+  bridges, runner-owned source prompts, and callback rejection. The prior
+  126-case current-head subset remains covered for
   compatibility/separator parity, evidence-keyed dial bridges, prebuilt-prompt
   rejection, pre-entry source replacement, and during-worker replacement.
 - Prior current-head review regressions remain covered by generated
@@ -237,10 +261,10 @@ Parked hardening: none.
 | File | LOC |
 |---|---:|
 | `atlas_brain/schemas/content_factory.py` | 60 |
-| `atlas_brain/services/content_factory_runner.py` | 340 |
+| `atlas_brain/services/content_factory_runner.py` | 358 |
 | `atlas_brain/services/content_factory_store.py` | 102 |
-| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 243 |
-| `plans/PR-CF-Phase6-Round10-Remediation.md` | 246 |
-| `tests/test_content_factory_runner.py` | 508 |
+| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 263 |
+| `plans/PR-CF-Phase6-Round10-Remediation.md` | 270 |
+| `tests/test_content_factory_runner.py` | 577 |
 | `tests/test_content_factory_schemas.py` | 68 |
-| **Total** | **1567** |
+| **Total** | **1698** |

--- a/plans/PR-CF-Phase6-Round10-Remediation.md
+++ b/plans/PR-CF-Phase6-Round10-Remediation.md
@@ -137,7 +137,8 @@ from visible-only content, and removes them from the NFKC/casefold routing key.
 the response is enforced, it takes `job_lock`, rejects any source-derived
 schema whose current committed fingerprint differs, stamps audits with the
 dispatch fingerprint, runs readiness/lineage, and commits. Store reads use
-`git show HEAD:<stage>.json`; cleanup is hygiene rather than correctness.
+Git's committed-object lookup for the stage JSON; cleanup is hygiene rather
+than correctness.
 
 ## Intentional
 
@@ -163,12 +164,12 @@ Parked hardening: none.
 ## Verification
 
 - Focused content-factory/intake suite: 714 passed.
-- Ruff, `python -m py_compile`, and `git diff --check`: passed before branch
-  transfer; rerun on the exact follow-up head before push.
+- Ruff, `python -m py_compile`, and `git diff --check`: passed on the exact
+  follow-up tree.
 - Schema maturity ratchet: no new brittleness.
 - Store explicit-file maturity lane: 0 flagged.
 - Guard class-closure, plan shape/files/diff-size/rules, plan/code consistency,
-  and plan sync: rerun on the exact follow-up head before push.
+  and plan sync: passed against the merged `origin/main`.
 
 ## Estimated diff size
 
@@ -178,7 +179,7 @@ Parked hardening: none.
 | `atlas_brain/services/content_factory_runner.py` | 233 |
 | `atlas_brain/services/content_factory_store.py` | 102 |
 | `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 202 |
-| `plans/PR-CF-Phase6-Round10-Remediation.md` | 184 |
+| `plans/PR-CF-Phase6-Round10-Remediation.md` | 185 |
 | `tests/test_content_factory_runner.py` | 286 |
 | `tests/test_content_factory_schemas.py` | 40 |
-| **Total** | **1090** |
+| **Total** | **1091** |

--- a/plans/PR-CF-Phase6-Round10-Remediation.md
+++ b/plans/PR-CF-Phase6-Round10-Remediation.md
@@ -34,6 +34,28 @@ This production-hardening follow-up carries the already verified correction
 onto the merged mainline. It preserves the Phase 6 product shape and closes the
 reported classes at their shared classifier and execution seams.
 
+**Diff-budget overage (~2,200 LOC vs the 400 soft cap) -- why this slice is
+indivisible.** Every finding lands on ONE of two shared choke points: the
+contact classifier and the committed-source execution boundary. They cannot be
+split into separate slices without publishing a broken intermediate state:
+
+* the classifier findings are alternative bypasses of the SAME decision. Fixing
+  the default-ignorable class while leaving the bridge open (or the reverse)
+  ships a gate that is still bypassable by a one-character or one-word edit --
+  a gate that is 90% closed is not 90% of a gate.
+* the execution-boundary findings share one invariant: a stage acts on the
+  committed bytes it fingerprinted. Snapshot-vs-compare, prompt construction,
+  callback removal and stage admission are the same rule enforced at four
+  points; landing a subset leaves a path that still dispatches on unverified
+  source.
+* roughly 60% of the LOC is tests. The class-closure discipline these findings
+  are filed under requires generated cross-products, not examples, so the
+  proofs are necessarily larger than the mechanisms. Splitting a mechanism from
+  its proof would land the safety decision without the evidence that closes it.
+
+Diff-budget override: shared choke-point fixes are indivisible from their
+generated both-direction and reachability proofs.
+
 ### Problem-derived contract
 
 - Root cause: the contact decision treated keypad-mappable spelling as enough
@@ -148,6 +170,11 @@ Max files: 8
       for room 212 art deco, contact sheet layout` remain admissible.
   17. Every source-bound stage requires a valid committed draft before worker
       dispatch; no stage may send `Committed draft JSON:\nnull`.
+  21. An overloaded dial marker governs an ambiguous candidate only when it
+      HEADS its clause: `Text to +44 800 FLOWERS` fails, while `center text on
+      1920 1080 canvas` and `place text at 1920 1080 coordinates` render.
+  22. The `audit-v2` stage admits only editorial-audit schemas; a mislabeled
+      worker artifact cannot be committed under it.
   20. EVERY Unicode Default_Ignorable_Code_Point -- sampled from the shared
       range table itself, not a hand-written list -- fails at every contact
       seam in the prompt gate and `verify_copy`, and none leaves an address
@@ -316,6 +343,36 @@ to it is covered automatically and a future local copy fails the shared-
 predicate assertion first. Mutation-checked: restoring the Cf/Cc-only rule
 fails 134 tests.
 
+### Review round 14 (Codex) -- dial-verb evidence, stage admission, plan record
+
+Three findings, all confirmed.
+
+1. **P1 renderer coordinates inside the dial bridge.** `center text on 1920
+   1080 canvas` and `place text at 1920 1080 coordinates` produced a phone hit,
+   because `text` is an admitted marker and `on`/`at` are admitted bridges.
+   Pre-existing rather than introduced by the round-12 `to` addition -- `on`
+   was already in the set at `f5485fcad`.
+
+   Fixed by POSITION, not by a list of renderer verbs (an open class): an
+   imperative CTA heads its clause, while a typography instruction makes the
+   same word the object of an earlier verb. Only overloaded markers
+   (`text`, `contact`) are subject to the test, so unambiguous markers keep
+   full bridge behaviour and `please call me at 12 34 56 78` still fails.
+   Residual recorded in the code: `you can text me at <ambiguous number>` is
+   not read as a CTA -- unambiguous dial syntax never reaches this bridge, so
+   what is given up is a phrasing renderer instructions do not use.
+
+2. **P2 unregistered `audit-v2` stage.** The runner names it as a source-bound
+   stage but the store had no entry, so it was treated as a CUSTOM stage that
+   may carry ANY artifact: a worker returning `content_brief.v1` committed
+   successfully under that stage, and since its schema is outside
+   `_SOURCE_BOUND_SCHEMAS` the dispatch-source comparison was skipped as well.
+   Mapped to the same admissible set as `audit`.
+
+3. **P1 plan record.** The over-budget rationale lived in the commit message,
+   but the repository contract requires it in the plan's `Why this slice
+   exists`. Added there with the actual indivisibility argument.
+
 ## Intentional
 
 - Detached phonewords without preceding structural dial intent pass, even if
@@ -374,10 +431,10 @@ Parked hardening: none.
 |---|---:|
 | `atlas_brain/schemas/content_factory.py` | 72 |
 | `atlas_brain/services/content_factory_copy_verification.py` | 56 |
-| `atlas_brain/services/content_factory_runner.py` | 382 |
-| `atlas_brain/services/content_factory_store.py` | 102 |
+| `atlas_brain/services/content_factory_runner.py` | 421 |
+| `atlas_brain/services/content_factory_store.py` | 108 |
 | `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 284 |
-| `plans/PR-CF-Phase6-Round10-Remediation.md` | 383 |
-| `tests/test_content_factory_runner.py` | 876 |
+| `plans/PR-CF-Phase6-Round10-Remediation.md` | 440 |
+| `tests/test_content_factory_runner.py` | 951 |
 | `tests/test_content_factory_schemas.py` | 68 |
-| **Total** | **2223** |
+| **Total** | **2400** |

--- a/plans/PR-CF-Phase6-Round10-Remediation.md
+++ b/plans/PR-CF-Phase6-Round10-Remediation.md
@@ -13,6 +13,12 @@ separators bypass email gating. Current-head review then found that two class
 boundaries were still incomplete: the routing key removed ignorables only
 after they could affect normalization, and the dial-token grammar treated a
 whitespace separator as exactly one code point rather than a run.
+The next current-head review exposed three deeper incomplete boundaries: phone
+classification ran before compatibility normalization and encoded separators
+in multiple narrow regexes; detached spelling still treated proximity to an
+open intent vocabulary as mechanical dial evidence; and `run_stage` accepted
+caller-built prompt text independently from the committed draft bytes it
+fingerprinted.
 
 This production-hardening follow-up carries the already verified correction
 onto the merged mainline. It preserves the Phase 6 product shape and closes the
@@ -29,15 +35,24 @@ reported classes at their shared classifier and execution seams.
   canonical composition. The dial-token grammar modeled a whitespace
   separator as one character rather than the entire separator run. The runner
   fingerprinted after the worker returned, so its fingerprint attested to
-  persistence-time state rather than dispatch-time source. Email matching
-  recognized only the ASCII spelling of an IDNA label separator.
+  persistence-time state rather than dispatch-time source; moving that read
+  before dispatch still did not prove the already-built prompt came from those
+  bytes. The detached-phoneword decision used an open semantic category
+  (nearby intent words) without a closed structural bridge, and phone parsing
+  happened before NFKC with separator rules repeated across recognizers. Email
+  matching recognized only the ASCII spelling of an IDNA label separator.
 - Correct fix must touch/change: the Phase 6 runner's single contact-admission
   decision, its committed-source dispatch/persistence boundary, the channel
   routing key, and both-direction tests at the real `run_stage` entrypoint.
   Default-ignorables must be removed before normalization, and numeric
   whitespace must be consumed as one separator run while compact dial symbols
-  remain E.164-bounded. Canonical store reads must remain committed-object
-  reads so a source snapshot cannot be replaced by worktree residue.
+  remain E.164-bounded. Phone admission must classify an NFKC-normalized view
+  with one bounded separator grammar and must replace open keyword proximity
+  with a finite structural bridge whose ambiguous default is admissible.
+  `run_stage` must construct source-bound prompt text from the exact committed
+  bytes whose fingerprint it records, then retain the post-worker under-lock
+  comparison. Canonical store reads must remain committed-object reads so a
+  source snapshot cannot be replaced by worktree residue.
 - Must not change: Phase 6 artifact schema tags/field shapes, editorial
   decision semantics, negative-prompt exclusion semantics, body-copy verifier
   policy, image generation, worker wrappers, or any EOM/CRM lane.
@@ -82,6 +97,15 @@ Max files: 7
   8. One or more whitespace code points between international numeric groups
      preserve the same phoneword verdict without widening the compact E.164
      symbol bound or promoting detached prose without dial intent.
+  9. NFKC-equivalent phoneword spellings and every admitted dial separator,
+     including slash, receive the same verdict as their ASCII/space form.
+  10. Detached spelling fails only when a dial marker is connected to it by
+      the finite structural bridge; descriptive intervening words default to
+      admissible in an evidence-keyed generated oracle.
+  11. For every source-bound stage, `run_stage` builds the dispatched prompt
+      from the same committed draft bytes it fingerprints. A draft replacement
+      before entry changes the prompt source, while a replacement after prompt
+      construction remains rejected under the job lock.
 - Reachability proof: `run_stage(job_id, stage, model, user_content, ...)` calls
   the worker, applies prompt enforcement, compares committed source identity
   under `job_lock`, validates, and writes. Tests replace the committed draft
@@ -102,17 +126,20 @@ Max files: 7
   NANP membership excluded explicit international phonewords. These are the
   two error directions of one classifier seam.
 - **Structural direction:** ambiguous detached prose defaults to admissible.
-  Detached spelling requires nearby dial intent. International spelling also
-  requires an explicit `+`/`00` prefix and a 7-15 digit E.164 mapping. Tests
-  cross generators on both sides rather than enumerate reported strings.
+  Detached spelling requires a dial marker connected through a finite bridge
+  containing only direct-address/preposition structure, not arbitrary nearby
+  words. International spelling also requires an explicit `+`/`00` prefix and
+  a 7-15 digit E.164 mapping. Tests cross evidence signals on both sides rather
+  than enumerate reported strings.
 
 ### Execution model
 
 - **Closed components:** committed Git objects are canonical source state;
   existing POSIX `flock` is the per-job mutual-exclusion primitive.
 - **Invariant:** the committed draft fingerprint observed immediately before
-  worker dispatch must equal the fingerprint re-read under the job lock before
-  a source-derived response may persist.
+  worker dispatch must be computed from the same bytes used to build the worker
+  prompt and must equal the fingerprint re-read under the job lock before a
+  source-derived response may persist.
 - **Failure boundary:** worker transport remains outside the lock. A
   cooperative writer may replace the draft during transport, but the stale
   response is rejected. Ordinary store failures restore worktree/index hygiene;
@@ -138,17 +165,21 @@ Max files: 7
 
 The runner preserves a leading `+`, keypad-maps mixed tokens, and classifies
 explicit international phonewords as ambiguous structural candidates governed
-by the existing bounded intent window. Numeric groups consume a whitespace run
-as one separator; `_dial_shape` still removes separators before enforcing the
-7-15 digit E.164 bound. Space-joined candidate extensions use that same intent
-requirement; attached domestic vanity syntax remains unambiguous. Email
-matching translates the three IDNA domain-stop equivalents only for admission.
+by a finite structural dial bridge. Phone admission first creates an
+NFKC-normalized view, then one separator grammar governs tokenization,
+partitioning, and compact-length checks, including whitespace, dot, hyphen, and
+slash. `_dial_shape` still removes separators before enforcing the 7-15 digit
+E.164 bound. Space-joined candidate extensions use the structural bridge;
+attached domestic vanity syntax remains unambiguous. Email matching translates
+the three IDNA domain-stop equivalents only for admission.
 
 The schema defines the Unicode default-ignorable ranges once, excludes them
 from visible-only content, and removes them before the NFKC/casefold routing
 key so an ignored code point cannot alter composition.
 
-`run_stage` reads the committed draft fingerprint before `call_worker`. After
+For source-bound work, `run_stage` receives a prompt builder rather than
+already-built text. It reads committed draft bytes once, parses those bytes for
+the builder, hashes the same bytes, and dispatches the resulting prompt. After
 the response is enforced, it takes `job_lock`, rejects any source-derived
 schema whose current committed fingerprint differs, stamps audits with the
 dispatch fingerprint, runs readiness/lineage, and commits. Store reads use
@@ -165,6 +196,12 @@ than correctness.
 - Whitespace run length is not dial evidence. The existing numeric-group cap,
   compact symbol bound, explicit international prefix, and intent gate remain
   the bounded evidence.
+- Compatibility normalization and separator parity apply only to the
+  admission-only phone view; raw prompt/artifact text is not rewritten.
+- Arbitrary proximity to an intent-like word is not dial evidence. Ambiguous
+  detached spelling without the finite bridge remains admissible.
+- Source-bound stage callers now provide a prompt builder. This intentionally
+  changes the unshipped runner API before the deferred OWUI wrappers are wired.
 - The default-ignorable routing normalization is broader than the two reported
   code points by design; one invisible Unicode property is one defect class.
 - The originating Phase 6 plan remains modified in this follow-up so its
@@ -173,7 +210,7 @@ than correctness.
 
 ## Deferred
 
-- None for the five round-10 findings or the two current-head class-boundary
+- None for the five round-10 findings or five current-head class-boundary
   findings.
 - Existing Phase 6 deferrals remain: ComfyUI generation, OWUI wrappers, and
   Phase 7 manifest entries.
@@ -182,10 +219,12 @@ Parked hardening: none.
 
 ## Verification
 
-- Focused content-factory/intake suite: 805 passed.
-- Current-head review regressions: 25 routing-key cases and 111 phoneword
-  cases passed, including generated canonical-composition and whitespace-run
-  classes.
+- Focused content-factory/intake suite: 928 passed.
+- Latest current-head regression subset: 126 passed, covering
+  compatibility/separator parity, evidence-keyed dial bridges, prebuilt-prompt
+  rejection, pre-entry source replacement, and during-worker replacement.
+- Prior current-head review regressions remain covered by generated
+  canonical-composition and whitespace-run classes.
 - Ruff, `python -m py_compile`, and `git diff --check`: passed on the exact
   follow-up tree.
 - Schema maturity ratchet: no new brittleness.
@@ -198,10 +237,10 @@ Parked hardening: none.
 | File | LOC |
 |---|---:|
 | `atlas_brain/schemas/content_factory.py` | 60 |
-| `atlas_brain/services/content_factory_runner.py` | 233 |
+| `atlas_brain/services/content_factory_runner.py` | 340 |
 | `atlas_brain/services/content_factory_store.py` | 102 |
-| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 222 |
-| `plans/PR-CF-Phase6-Round10-Remediation.md` | 207 |
-| `tests/test_content_factory_runner.py` | 305 |
+| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 243 |
+| `plans/PR-CF-Phase6-Round10-Remediation.md` | 246 |
+| `tests/test_content_factory_runner.py` | 508 |
 | `tests/test_content_factory_schemas.py` | 68 |
-| **Total** | **1197** |
+| **Total** | **1567** |

--- a/plans/PR-CF-Phase6-Round10-Remediation.md
+++ b/plans/PR-CF-Phase6-Round10-Remediation.md
@@ -84,7 +84,7 @@ reported classes at their shared classifier and execution seams.
 
 Ownership lane: content-factory
 Slice phase: production hardening
-Max files: 7
+Max files: 8
 
 1. Make mixed digit/letter contact admission evidence-gated in both directions:
    attached NANP vanity stays structural; detached spelling requires structural
@@ -148,13 +148,22 @@ Max files: 7
       for room 212 art deco, contact sheet layout` remain admissible.
   17. Every source-bound stage requires a valid committed draft before worker
       dispatch; no stage may send `Committed draft JSON:\nnull`.
+  18. A default-ignorable code point inserted at ANY seam of a contact string
+      -- before or inside the `+`/`00` prefix, between or inside numeric
+      groups, inside the vanity suffix, or inside an address -- preserves the
+      failing verdict, in the prompt gate AND in `verify_copy`. Redacted claim
+      evidence never carries an address that evaded the pattern that way.
+      Whitespace controls are preserved, so stripping cannot glue a word to a
+      following number and manufacture a candidate.
 - Reachability proof: `run_stage(job_id, stage, model, user_content, ...)` calls
   the worker, applies prompt enforcement, compares committed source identity
   under `job_lock`, validates, and writes. Tests replace the committed draft
   from inside the worker boundary and exercise image prompts through the real
   entrypoint/store.
-- Affected surfaces: content-factory schemas, runner, committed Git artifact
-  store, the originating Phase 6 plan record, and their focused tests.
+- Affected surfaces: content-factory schemas, runner, the shared copy
+  verifier's PII SCAN INPUT (its verdict policy is unchanged -- see the
+  round-eleven note under Mechanism), committed Git artifact store, the
+  originating Phase 6 plan record, and their focused tests.
 - Risk areas: false-positive/false-negative contact classification, Unicode
   normalization overreach, worker-time source races, and failed-commit residue.
 - Reviewer rules triggered: R1, R2, R3, R6, R8, R13, R14.
@@ -196,6 +205,7 @@ Max files: 7
 ### Files touched
 
 - `atlas_brain/schemas/content_factory.py`
+- `atlas_brain/services/content_factory_copy_verification.py`
 - `atlas_brain/services/content_factory_runner.py`
 - `atlas_brain/services/content_factory_store.py`
 - `plans/PR-CF-Phase6-Repurposing-Contracts.md`
@@ -229,6 +239,33 @@ it takes
 fingerprint differs, stamps audits with the dispatch fingerprint, runs
 readiness/lineage, and commits. Store reads use Git's committed-object lookup
 for the stage JSON; cleanup is hygiene rather than correctness.
+
+### Review round 11 (Codex) -- default-ignorable admission
+
+One finding, confirmed against the code before correction and WIDER than
+reported. A default-ignorable code point renders as nothing, so inserting one
+must not change a verdict -- but it defeated:
+
+- the `+`/`00` international prefix (`Call +44<ZWSP>800 FLOWERS`), as reported;
+- the structural NANP pattern (`reach 555-123<ZWSP>-4567`) and the vanity
+  suffix (`FLOW<ZWSP>ERS`), which the report did not name;
+- the SAME class in `verify_copy` -- the merged body-copy gate behind the
+  editorial promote decision -- for both phone and address;
+- `_redact_pii`, where the digit theorem masks phone digits but an address's
+  LETTERS are not digits, so `a@b<ZWSP>.com` persisted intact in claim
+  evidence.
+
+Root fix at the admission boundary rather than per-pattern: a shared
+`scan_view()` removes default-ignorables (category Cf, category Cc except the
+whitespace controls, plus the variation-selector / Mongolian / tag / Hangul
+filler ranges Unicode marks Default_Ignorable but `unicodedata` does not
+expose) before ANY contact parsing. Claim detection keeps the ORIGINAL text,
+because its locators are sentence indices and rewriting the input would shift
+them.
+
+This does not change body-copy verdict POLICY -- which real forms count as PII
+is untouched, so #2181's frozen semantics hold. It denies an evasion of the
+existing policy. Mutation-checked: neutralizing `scan_view` fails 64 tests.
 
 ## Intentional
 
@@ -287,10 +324,11 @@ Parked hardening: none.
 | File | LOC |
 |---|---:|
 | `atlas_brain/schemas/content_factory.py` | 60 |
-| `atlas_brain/services/content_factory_runner.py` | 365 |
+| `atlas_brain/services/content_factory_copy_verification.py` | 62 |
+| `atlas_brain/services/content_factory_runner.py` | 374 |
 | `atlas_brain/services/content_factory_store.py` | 102 |
 | `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 285 |
-| `plans/PR-CF-Phase6-Round10-Remediation.md` | 296 |
-| `tests/test_content_factory_runner.py` | 686 |
+| `plans/PR-CF-Phase6-Round10-Remediation.md` | 334 |
+| `tests/test_content_factory_runner.py` | 774 |
 | `tests/test_content_factory_schemas.py` | 68 |
-| **Total** | **1862** |
+| **Total** | **2059** |

--- a/plans/PR-CF-Phase6-Round10-Remediation.md
+++ b/plans/PR-CF-Phase6-Round10-Remediation.md
@@ -1,0 +1,184 @@
+# PR-CF-Phase6-Round10-Remediation
+
+## Why this slice exists
+
+PR #2192 merged at 2026-07-25T22:13:10Z, seconds after five new review
+findings landed on its published head. The merged implementation therefore
+contains five confirmed defects in the Phase 6 contract/gate surface:
+international vanity contact data passes, ordinary three-digit renderer prose
+can be rejected as a phone number, default-ignorable Unicode marks split one
+channel into multiple routing identities, worker responses can be stamped
+against a same-revision draft they did not see, and IDNA-equivalent domain
+separators bypass email gating.
+
+This production-hardening follow-up carries the already verified correction
+onto the merged mainline. It preserves the Phase 6 product shape and closes the
+reported classes at their shared classifier and execution seams.
+
+### Problem-derived contract
+
+- Root cause: the contact decision treated keypad-mappable spelling as enough
+  phone evidence while restricting phoneword validity to NANP, so it was
+  simultaneously over-broad on detached prose and under-broad on explicit
+  international phonewords. The routing key removed only `Cf`/`Cc`, not the
+  Unicode default-ignorable marks that also have no routing identity. The
+  runner fingerprinted after the worker returned, so its fingerprint attested
+  to persistence-time state rather than dispatch-time source. Email matching
+  recognized only the ASCII spelling of an IDNA label separator.
+- Correct fix must touch/change: the Phase 6 runner's single contact-admission
+  decision, its committed-source dispatch/persistence boundary, the channel
+  routing key, and both-direction tests at the real `run_stage` entrypoint.
+  Canonical store reads must remain committed-object reads so a source snapshot
+  cannot be replaced by worktree residue.
+- Must not change: Phase 6 artifact schema tags/field shapes, editorial
+  decision semantics, negative-prompt exclusion semantics, body-copy verifier
+  policy, image generation, worker wrappers, or any EOM/CRM lane.
+
+## Scope (this PR)
+
+Ownership lane: content-factory
+Slice phase: production hardening
+Max files: 7
+
+1. Make mixed digit/letter contact admission evidence-gated in both directions:
+   attached NANP vanity stays structural; detached spelling requires nearby
+   dial intent; international phonewords require explicit `+`/`00` structure
+   and an E.164-bounded keypad mapping.
+2. Normalize IDNA-equivalent domain stops before the redacted email decision
+   and normalize Unicode default-ignorables out of channel routing identities.
+3. Snapshot committed draft identity immediately before dispatch and compare
+   it under the existing per-job lock before any audit, repurposing, or
+   image-prompt response persists.
+4. Record the originating plan's round-10 reconciliation and add
+   grammar-derived both-direction, default-ignorable class, and real
+   mid-worker replacement proofs.
+
+### Review Contract
+
+- Acceptance criteria:
+  1. `Call +44 800 FLOWERS today` and equivalent `00`/separator-generated
+     phonewords fail the prompt gate with a redacted phone hit.
+  2. Ordinary three-digit values crossed with art-direction phrases, including
+     `room 212 art deco sign`, pass without dial intent.
+  3. `email` and `email` plus any tested default-ignorable variation selector,
+     grapheme joiner, or format character are duplicate channels.
+  4. A same-revision committed draft replacement during the worker call makes
+     audit, repurposing, and image-prompt responses unpersistable, including
+     unready intermediate Phase 6 artifacts.
+  5. U+3002, U+FF0E, and U+FF61 domain separators receive the same failing
+     email verdict as ASCII dot without leaking the raw address into hits.
+  6. Prior Phase 6 gate, store, schema, and intake tests remain green; maturity,
+     guard-closure, plan, static, and diff audits pass.
+- Reachability proof: `run_stage(job_id, stage, model, user_content, ...)` calls
+  the worker, applies prompt enforcement, compares committed source identity
+  under `job_lock`, validates, and writes. Tests replace the committed draft
+  from inside the worker boundary and exercise image prompts through the real
+  entrypoint/store.
+- Affected surfaces: content-factory schemas, runner, committed Git artifact
+  store, the originating Phase 6 plan record, and their focused tests.
+- Risk areas: false-positive/false-negative contact classification, Unicode
+  normalization overreach, worker-time source races, and failed-commit residue.
+- Reviewer rules triggered: R1, R2, R3, R6, R8, R13, R14.
+
+### Decision-Seam Analysis
+
+- **One decision:** `_phone_evidence` decides whether a mixed digit/letter
+  candidate has enough bounded evidence to be contact data rather than
+  renderer prose.
+- **Why it was wrong:** keypad mapping alone admitted ordinary language, while
+  NANP membership excluded explicit international phonewords. These are the
+  two error directions of one classifier seam.
+- **Structural direction:** ambiguous detached prose defaults to admissible.
+  Detached spelling requires nearby dial intent. International spelling also
+  requires an explicit `+`/`00` prefix and a 7-15 digit E.164 mapping. Tests
+  cross generators on both sides rather than enumerate reported strings.
+
+### Execution model
+
+- **Closed components:** committed Git objects are canonical source state;
+  existing POSIX `flock` is the per-job mutual-exclusion primitive.
+- **Invariant:** the committed draft fingerprint observed immediately before
+  worker dispatch must equal the fingerprint re-read under the job lock before
+  a source-derived response may persist.
+- **Failure boundary:** worker transport remains outside the lock. A
+  cooperative writer may replace the draft during transport, but the stale
+  response is rejected. Ordinary store failures restore worktree/index hygiene;
+  abrupt residue remains non-canonical because readers use `HEAD`.
+- **Actors/assumptions:** synchronous same-host callers using this store;
+  trusted local root; Git/POSIX flock available; bypass writers are unsupported.
+- **Rejected alternative:** holding the filesystem lock across a network call
+  would block all job mutations for up to the worker timeout. Snapshot/compare
+  provides the needed optimistic concurrency check with the existing closed
+  components and no lease/retry protocol.
+
+### Files touched
+
+- `atlas_brain/schemas/content_factory.py`
+- `atlas_brain/services/content_factory_runner.py`
+- `atlas_brain/services/content_factory_store.py`
+- `plans/PR-CF-Phase6-Repurposing-Contracts.md`
+- `plans/PR-CF-Phase6-Round10-Remediation.md`
+- `tests/test_content_factory_runner.py`
+- `tests/test_content_factory_schemas.py`
+
+## Mechanism
+
+The runner preserves a leading `+`, keypad-maps mixed tokens, and classifies
+explicit international phonewords as ambiguous structural candidates governed
+by the existing bounded intent window. Space-joined candidate extensions use
+that same intent requirement; attached domestic vanity syntax remains
+unambiguous. Email matching translates the three IDNA domain-stop equivalents
+only for admission.
+
+The schema defines the Unicode default-ignorable ranges once, excludes them
+from visible-only content, and removes them from the NFKC/casefold routing key.
+
+`run_stage` reads the committed draft fingerprint before `call_worker`. After
+the response is enforced, it takes `job_lock`, rejects any source-derived
+schema whose current committed fingerprint differs, stamps audits with the
+dispatch fingerprint, runs readiness/lineage, and commits. Store reads use
+`git show HEAD:<stage>.json`; cleanup is hygiene rather than correctness.
+
+## Intentional
+
+- Detached phonewords without dial intent pass, even if their letters happen to
+  keypad-map to a valid number; rejecting that open prose category would repeat
+  the reported false-positive class.
+- International phonewords require an explicit international prefix and intent.
+  Arbitrary letter/digit prose is not promoted to contact data.
+- The default-ignorable routing normalization is broader than the two reported
+  code points by design; one invisible Unicode property is one defect class.
+- The originating Phase 6 plan remains modified in this follow-up so its
+  review-round record and execution contract match the code that will replace
+  the merged defective state.
+
+## Deferred
+
+- None for the five round-10 findings.
+- Existing Phase 6 deferrals remain: ComfyUI generation, OWUI wrappers, and
+  Phase 7 manifest entries.
+
+Parked hardening: none.
+
+## Verification
+
+- Focused content-factory/intake suite: 714 passed.
+- Ruff, `python -m py_compile`, and `git diff --check`: passed before branch
+  transfer; rerun on the exact follow-up head before push.
+- Schema maturity ratchet: no new brittleness.
+- Store explicit-file maturity lane: 0 flagged.
+- Guard class-closure, plan shape/files/diff-size/rules, plan/code consistency,
+  and plan sync: rerun on the exact follow-up head before push.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/schemas/content_factory.py` | 43 |
+| `atlas_brain/services/content_factory_runner.py` | 233 |
+| `atlas_brain/services/content_factory_store.py` | 102 |
+| `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 202 |
+| `plans/PR-CF-Phase6-Round10-Remediation.md` | 173 |
+| `tests/test_content_factory_runner.py` | 286 |
+| `tests/test_content_factory_schemas.py` | 40 |
+| **Total** | **1079** |

--- a/plans/PR-CF-Phase6-Round10-Remediation.md
+++ b/plans/PR-CF-Phase6-Round10-Remediation.md
@@ -178,7 +178,7 @@ Parked hardening: none.
 | `atlas_brain/services/content_factory_runner.py` | 233 |
 | `atlas_brain/services/content_factory_store.py` | 102 |
 | `plans/PR-CF-Phase6-Repurposing-Contracts.md` | 202 |
-| `plans/PR-CF-Phase6-Round10-Remediation.md` | 173 |
+| `plans/PR-CF-Phase6-Round10-Remediation.md` | 184 |
 | `tests/test_content_factory_runner.py` | 286 |
 | `tests/test_content_factory_schemas.py` | 40 |
-| **Total** | **1079** |
+| **Total** | **1090** |

--- a/tests/test_content_factory_runner.py
+++ b/tests/test_content_factory_runner.py
@@ -29,11 +29,6 @@ from atlas_brain.services.content_factory_store import job_dir
 BRIEF_JSON = '{"schema": "content_brief.v1", "project_id": "resolution-audit", "request_raw": "x"}'
 
 
-def _source_request(text):
-    """Prompt builder for tests whose worker reply, not prompt, is under test."""
-    return lambda _draft: text
-
-
 class _FakeResponse:
     def __init__(self, data: bytes):
         self._data = data
@@ -155,7 +150,7 @@ def _stored(rec):
 
 def test_editor_stage_injects_deterministic_pass(tmp_path, monkeypatch):
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: _editor_json(_CLEAN_BODY, "promote"))
-    rec = runner.run_stage("job1", "audit", "cf-editor", _source_request("req"), api_key="k", root=tmp_path)
+    rec = runner.run_stage("job1", "audit", "cf-editor", None, api_key="k", root=tmp_path)
     stored = _stored(rec)
     assert stored["copy_verification"]["verdict"] == "pass"
     assert stored["recommendation"] == "promote"  # clean copy may promote
@@ -166,13 +161,13 @@ def test_editor_worker_cannot_self_promote_overclaim(tmp_path, monkeypatch):
     reply = _editor_json(_BAD_BODY, "promote", copy_verification={"verdict": "pass", "hits": []})
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
     with pytest.raises(ValidationError):  # injected fail vs promote -> #2116 guard rejects
-        runner.run_stage("job1", "audit", "m", _source_request("req"), api_key="k", root=tmp_path)
+        runner.run_stage("job1", "audit", "m", None, api_key="k", root=tmp_path)
     assert not job_dir("job1", root=tmp_path).exists()
 
 
 def test_editor_overclaim_revise_persists_with_fail(tmp_path, monkeypatch):
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: _editor_json(_BAD_BODY, "revise"))
-    rec = runner.run_stage("job1", "audit", "m", _source_request("req"), api_key="k", root=tmp_path)
+    rec = runner.run_stage("job1", "audit", "m", None, api_key="k", root=tmp_path)
     stored = _stored(rec)
     assert stored["copy_verification"]["verdict"] == "fail"
     assert any("guaranteed-savings" in h for h in stored["copy_verification"]["hits"])
@@ -183,7 +178,7 @@ def test_editor_worker_claimed_verdict_is_overridden(tmp_path, monkeypatch):
     # verdict must still overwrite the worker's claim.
     reply = _editor_json(_BAD_BODY, "revise", copy_verification={"verdict": "pass", "hits": []})
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job1", "audit", "m", _source_request("req"), api_key="k", root=tmp_path)
+    rec = runner.run_stage("job1", "audit", "m", None, api_key="k", root=tmp_path)
     assert _stored(rec)["copy_verification"]["verdict"] == "fail"
 
 
@@ -198,13 +193,13 @@ def test_empty_edited_copy_cannot_promote(tmp_path, monkeypatch):
     # self-promote by omitting the edited copy.
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: _editor_json("", "promote"))
     with pytest.raises(ValidationError):
-        runner.run_stage("job1", "audit", "m", _source_request("req"), api_key="k", root=tmp_path)
+        runner.run_stage("job1", "audit", "m", None, api_key="k", root=tmp_path)
     assert not job_dir("job1", root=tmp_path).exists()
 
 
 def test_empty_edited_copy_revise_persists_with_fail(tmp_path, monkeypatch):
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: _editor_json("   ", "revise"))
-    rec = runner.run_stage("job1", "audit", "m", _source_request("req"), api_key="k", root=tmp_path)
+    rec = runner.run_stage("job1", "audit", "m", None, api_key="k", root=tmp_path)
     stored = _stored(rec)
     assert stored["copy_verification"]["verdict"] == "fail"
     assert any("unverified-copy" in h for h in stored["copy_verification"]["hits"])
@@ -216,7 +211,7 @@ def test_custom_stage_audit_is_also_gated(tmp_path, monkeypatch):
     reply = _editor_json(_BAD_BODY, "promote", copy_verification={"verdict": "pass", "hits": []})
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
     with pytest.raises(ValidationError):
-        runner.run_stage("job1", "audit-v2", "m", _source_request("req"), api_key="k", root=tmp_path)
+        runner.run_stage("job1", "audit-v2", "m", None, api_key="k", root=tmp_path)
     assert not job_dir("job1", root=tmp_path).exists()
 
 
@@ -268,7 +263,7 @@ def test_run_stage_persists_deterministic_warnings_and_normalizes_v1(tmp_path, m
         }
     )
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job-adv", "audit", "cf-editor-verifier", _source_request("req"), api_key="k", root=tmp_path)
+    rec = runner.run_stage("job-adv", "audit", "cf-editor-verifier", None, api_key="k", root=tmp_path)
     stored = json.loads(Path(rec["path"]).read_text())
     assert rec["schema"] == "editorial_audit.v3"
     assert stored["schema"] == "editorial_audit.v3"
@@ -295,7 +290,7 @@ def test_run_stage_rejects_contradictory_v2_version(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
     with pytest.raises(ValidationError):
-        runner.run_stage("job-v2v", "audit", "m", _source_request("req"), api_key="k", root=tmp_path)
+        runner.run_stage("job-v2v", "audit", "m", None, api_key="k", root=tmp_path)
     assert not job_dir("job-v2v", root=tmp_path).exists()
 
 
@@ -355,7 +350,7 @@ def test_run_stage_overwrites_variant_verdicts_and_blocks_bad_ship(tmp_path, mon
     # separate lineage check first.
     _seed_draft(tmp_path, "job-rp", ["e1"])
     with pytest.raises(ValidationError):
-        runner.run_stage("job-rp", "repurposing", "m", _source_request("req"), api_key="k", root=tmp_path)
+        runner.run_stage("job-rp", "repurposing", "m", None, api_key="k", root=tmp_path)
 
 
 def test_run_stage_persists_clean_variants_with_computed_verdicts(tmp_path, monkeypatch):
@@ -374,7 +369,7 @@ def test_run_stage_persists_clean_variants_with_computed_verdicts(tmp_path, monk
         }
     )
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job-rp2", "repurposing", "m", _source_request("req"), api_key="k", root=tmp_path)
+    rec = runner.run_stage("job-rp2", "repurposing", "m", None, api_key="k", root=tmp_path)
     stored = json.loads(Path(rec["path"]).read_text())
     assert stored["variants"][0]["copy_verification"]["verdict"] == "pass"
     assert stored["variants"][0]["advisory_warnings"][-1].startswith("reminder:")
@@ -398,7 +393,7 @@ def test_run_stage_blank_variant_body_fails_closed(tmp_path, monkeypatch):
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
     # blank body is rejected by the contract (NonEmptyStr) -- nothing persists
     with pytest.raises(ValidationError):
-        runner.run_stage("job-rp3", "repurposing", "m", _source_request("req"), api_key="k", root=tmp_path)
+        runner.run_stage("job-rp3", "repurposing", "m", None, api_key="k", root=tmp_path)
 
 
 def test_run_stage_gates_image_prompt_text(tmp_path, monkeypatch):
@@ -418,7 +413,7 @@ def test_run_stage_gates_image_prompt_text(tmp_path, monkeypatch):
         }
     )
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job-img", "image_prompt", "m", _source_request("req"), api_key="k", root=tmp_path)
+    rec = runner.run_stage("job-img", "image_prompt", "m", None, api_key="k", root=tmp_path)
     stored = json.loads(Path(rec["path"]).read_text())
     assert stored["copy_verification"]["verdict"] == "fail"
     assert any("guaranteed-savings" in hit for hit in stored["copy_verification"]["hits"])
@@ -435,7 +430,7 @@ def test_run_stage_image_prompt_pii_is_caught(tmp_path, monkeypatch):
         }
     )
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job-img2", "image_prompt", "m", _source_request("req"), api_key="k", root=tmp_path)
+    rec = runner.run_stage("job-img2", "image_prompt", "m", None, api_key="k", root=tmp_path)
     stored = json.loads(Path(rec["path"]).read_text())
     assert stored["copy_verification"]["verdict"] == "fail"
     # The VERDICT never carries the raw value (the persisted-evidence
@@ -456,7 +451,7 @@ def test_run_stage_clean_image_prompt_passes(tmp_path, monkeypatch):
         }
     )
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job-img3", "image_prompt", "m", _source_request("req"), api_key="k", root=tmp_path)
+    rec = runner.run_stage("job-img3", "image_prompt", "m", None, api_key="k", root=tmp_path)
     stored = json.loads(Path(rec["path"]).read_text())
     assert stored["copy_verification"]["verdict"] == "pass"
 
@@ -474,7 +469,7 @@ def test_stage_schema_mismatch_still_enforced_for_phase6(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
     with pytest.raises(ArtifactStoreError):
-        runner.run_stage("job-mix", "image_prompt", "m", _source_request("req"), api_key="k", root=tmp_path)
+        runner.run_stage("job-mix", "image_prompt", "m", None, api_key="k", root=tmp_path)
 
 
 def test_negative_prompt_naming_banned_terms_still_passes(tmp_path, monkeypatch):
@@ -490,7 +485,7 @@ def test_negative_prompt_naming_banned_terms_still_passes(tmp_path, monkeypatch)
         }],
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job-neg", "image_prompt", "m", _source_request("req"), api_key="k", root=tmp_path)
+    rec = runner.run_stage("job-neg", "image_prompt", "m", None, api_key="k", root=tmp_path)
     stored = json.loads(Path(rec["path"]).read_text())
     assert stored["copy_verification"]["verdict"] == "pass"
     assert stored["prompts"][0]["negative_prompt"].startswith("blurry")
@@ -507,7 +502,7 @@ def test_positive_prompt_with_banned_claim_still_fails(tmp_path, monkeypatch):
         }],
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job-pos", "image_prompt", "m", _source_request("req"), api_key="k", root=tmp_path)
+    rec = runner.run_stage("job-pos", "image_prompt", "m", None, api_key="k", root=tmp_path)
     stored = json.loads(Path(rec["path"]).read_text())
     assert stored["copy_verification"]["verdict"] == "fail"
 
@@ -523,7 +518,7 @@ def test_worker_cannot_self_declare_ready_to_generate(tmp_path, monkeypatch):
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
     with pytest.raises(ValidationError):
-        runner.run_stage("job-selfgen", "image_prompt", "m", _source_request("req"), api_key="k", root=tmp_path)
+        runner.run_stage("job-selfgen", "image_prompt", "m", None, api_key="k", root=tmp_path)
     assert not job_dir("job-selfgen", root=tmp_path).exists()
 
 
@@ -542,7 +537,7 @@ def test_fabricated_lineage_blocks_shipping(tmp_path, monkeypatch):
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
     with pytest.raises(ArtifactStoreError, match="absent from the draft"):
-        runner.run_stage("job-lin", "repurposing", "m", _source_request("req"), api_key="k", root=tmp_path)
+        runner.run_stage("job-lin", "repurposing", "m", None, api_key="k", root=tmp_path)
 
 
 def test_real_lineage_ships(tmp_path, monkeypatch):
@@ -554,7 +549,7 @@ def test_real_lineage_ships(tmp_path, monkeypatch):
         "ready_to_publish": True,
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job-lin2", "repurposing", "m", _source_request("req"), api_key="k", root=tmp_path)
+    rec = runner.run_stage("job-lin2", "repurposing", "m", None, api_key="k", root=tmp_path)
     assert json.loads(Path(rec["path"]).read_text())["ready_to_publish"] is True
 
 
@@ -567,7 +562,7 @@ def test_unready_package_skips_lineage_check(tmp_path, monkeypatch):
         "ready_to_publish": False,
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job-lin3", "repurposing", "m", _source_request("req"), api_key="k", root=tmp_path)
+    rec = runner.run_stage("job-lin3", "repurposing", "m", None, api_key="k", root=tmp_path)
     assert Path(rec["path"]).exists()
 
 
@@ -580,7 +575,7 @@ def test_missing_draft_fails_closed_on_ship(tmp_path, monkeypatch):
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
     with pytest.raises(ArtifactStoreError, match="readable draft artifact"):
-        runner.run_stage("job-nodraft", "repurposing", "m", _source_request("req"), api_key="k", root=tmp_path)
+        runner.run_stage("job-nodraft", "repurposing", "m", None, api_key="k", root=tmp_path)
 
 
 def test_international_phone_in_prompt_fails(tmp_path, monkeypatch):
@@ -589,7 +584,7 @@ def test_international_phone_in_prompt_fails(tmp_path, monkeypatch):
         "prompts": [{"purpose": "hero", "prompt_text": "Call us at +442079460958"}],
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job-intl", "image_prompt", "m", _source_request("req"), api_key="k", root=tmp_path)
+    rec = runner.run_stage("job-intl", "image_prompt", "m", None, api_key="k", root=tmp_path)
     stored = json.loads(Path(rec["path"]).read_text())
     assert stored["copy_verification"]["verdict"] == "fail"
     assert "442079460958" not in json.dumps(stored["copy_verification"])
@@ -605,7 +600,7 @@ def test_prompts_verified_independently_no_cross_synthesis(tmp_path, monkeypatch
         ],
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job-split", "image_prompt", "m", _source_request("req"), api_key="k", root=tmp_path)
+    rec = runner.run_stage("job-split", "image_prompt", "m", None, api_key="k", root=tmp_path)
     stored = json.loads(Path(rec["path"]).read_text())
     assert stored["copy_verification"]["verdict"] == "pass", stored["copy_verification"]
 
@@ -619,7 +614,7 @@ def test_hits_identify_the_offending_prompt(tmp_path, monkeypatch):
         ],
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job-which", "image_prompt", "m", _source_request("req"), api_key="k", root=tmp_path)
+    rec = runner.run_stage("job-which", "image_prompt", "m", None, api_key="k", root=tmp_path)
     hits = json.loads(Path(rec["path"]).read_text())["copy_verification"]["hits"]
     assert all(h.startswith("prompt 2:") for h in hits), hits
 
@@ -640,7 +635,7 @@ def test_stale_source_revision_blocks_shipping(tmp_path, monkeypatch):
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
     with pytest.raises(ArtifactStoreError, match="superseded copy"):
-        runner.run_stage("job-rev", "repurposing", "m", _source_request("req"), api_key="k", root=tmp_path)
+        runner.run_stage("job-rev", "repurposing", "m", None, api_key="k", root=tmp_path)
 
 
 def test_matching_source_revision_ships(tmp_path, monkeypatch):
@@ -653,7 +648,7 @@ def test_matching_source_revision_ships(tmp_path, monkeypatch):
         "ready_to_publish": True,
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job-rev2", "repurposing", "m", _source_request("req"), api_key="k", root=tmp_path)
+    rec = runner.run_stage("job-rev2", "repurposing", "m", None, api_key="k", root=tmp_path)
     assert json.loads(Path(rec["path"]).read_text())["ready_to_publish"] is True
 
 
@@ -668,7 +663,7 @@ def test_image_prompt_readiness_also_checks_revision(tmp_path, monkeypatch):
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
     with pytest.raises(ArtifactStoreError, match="superseded copy"):
-        runner.run_stage("job-imgrev", "image_prompt", "m", _source_request("req"), api_key="k", root=tmp_path)
+        runner.run_stage("job-imgrev", "image_prompt", "m", None, api_key="k", root=tmp_path)
 
 
 def test_string_false_readiness_persists_as_intermediate(tmp_path, monkeypatch):
@@ -681,7 +676,7 @@ def test_string_false_readiness_persists_as_intermediate(tmp_path, monkeypatch):
         "ready_to_publish": "false",
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job-strfalse", "repurposing", "m", _source_request("req"), api_key="k", root=tmp_path)
+    rec = runner.run_stage("job-strfalse", "repurposing", "m", None, api_key="k", root=tmp_path)
     assert json.loads(Path(rec["path"]).read_text())["ready_to_publish"] is False
 
 
@@ -696,7 +691,7 @@ def test_negated_banned_phrase_in_prompt_still_fails(text, tmp_path, monkeypatch
         "prompts": [{"purpose": "hero", "prompt_text": text}],
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job-neg2", "image_prompt", "m", _source_request("req"), api_key="k", root=tmp_path)
+    rec = runner.run_stage("job-neg2", "image_prompt", "m", None, api_key="k", root=tmp_path)
     stored = json.loads(Path(rec["path"]).read_text())
     assert stored["copy_verification"]["verdict"] == "fail", stored["copy_verification"]
 
@@ -723,7 +718,7 @@ def test_unaudited_draft_cannot_ship(tmp_path, monkeypatch):
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
     with pytest.raises(ArtifactStoreError, match="recommending 'promote'"):
-        runner.run_stage("job-noaudit", "repurposing", "m", _source_request("req"), api_key="k", root=tmp_path)
+        runner.run_stage("job-noaudit", "repurposing", "m", None, api_key="k", root=tmp_path)
 
 
 def test_revise_audit_cannot_ship(tmp_path, monkeypatch):
@@ -744,7 +739,7 @@ def test_revise_audit_cannot_ship(tmp_path, monkeypatch):
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
     with pytest.raises(ArtifactStoreError, match="recommending 'promote'"):
-        runner.run_stage("job-revise", "repurposing", "m", _source_request("req"), api_key="k", root=tmp_path)
+        runner.run_stage("job-revise", "repurposing", "m", None, api_key="k", root=tmp_path)
 
 
 def test_cross_project_derivation_blocked(tmp_path, monkeypatch):
@@ -758,7 +753,7 @@ def test_cross_project_derivation_blocked(tmp_path, monkeypatch):
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
     with pytest.raises(ArtifactStoreError, match="project mismatch"):
-        runner.run_stage("job-xproj", "repurposing", "m", _source_request("req"), api_key="k", root=tmp_path)
+        runner.run_stage("job-xproj", "repurposing", "m", None, api_key="k", root=tmp_path)
 
 
 def test_stale_audit_cannot_approve_newer_draft(tmp_path, monkeypatch):
@@ -781,7 +776,7 @@ def test_stale_audit_cannot_approve_newer_draft(tmp_path, monkeypatch):
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
     with pytest.raises(ArtifactStoreError, match="audit approved draft revision"):
-        runner.run_stage("job-staleaudit", "repurposing", "m", _source_request("req"), api_key="k", root=tmp_path)
+        runner.run_stage("job-staleaudit", "repurposing", "m", None, api_key="k", root=tmp_path)
 
 
 def test_foreign_project_audit_cannot_approve(tmp_path, monkeypatch):
@@ -802,7 +797,7 @@ def test_foreign_project_audit_cannot_approve(tmp_path, monkeypatch):
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
     with pytest.raises(ArtifactStoreError, match="audit project"):
-        runner.run_stage("job-xaudit", "repurposing", "m", _source_request("req"), api_key="k", root=tmp_path)
+        runner.run_stage("job-xaudit", "repurposing", "m", None, api_key="k", root=tmp_path)
 
 
 
@@ -837,7 +832,7 @@ def _prompt_verdict(text, tmp_path, monkeypatch, job):
     reply = json.dumps({"schema": "image_prompt.v1", "project_id": "p",
                         "prompts": [{"purpose": "hero", "prompt_text": text}]})
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage(job, "image_prompt", "m", _source_request("req"), api_key="k", root=tmp_path)
+    rec = runner.run_stage(job, "image_prompt", "m", None, api_key="k", root=tmp_path)
     return json.loads(Path(rec["path"]).read_text())["copy_verification"]
 
 
@@ -925,7 +920,7 @@ def test_same_revision_draft_replacement_invalidates_approval(tmp_path, monkeypa
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
     with pytest.raises(ArtifactStoreError, match="does not match the draft currently"):
-        runner.run_stage("job-swap", "repurposing", "m", _source_request("req"), api_key="k", root=tmp_path)
+        runner.run_stage("job-swap", "repurposing", "m", None, api_key="k", root=tmp_path)
 
 
 def test_image_prompt_readiness_also_content_bound(tmp_path, monkeypatch):
@@ -943,7 +938,7 @@ def test_image_prompt_readiness_also_content_bound(tmp_path, monkeypatch):
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
     with pytest.raises(ArtifactStoreError, match="does not match the draft currently"):
-        runner.run_stage("job-swap2", "image_prompt", "m", _source_request("req"), api_key="k", root=tmp_path)
+        runner.run_stage("job-swap2", "image_prompt", "m", None, api_key="k", root=tmp_path)
 
 
 def test_audit_stage_stamps_the_fingerprint(tmp_path, monkeypatch):
@@ -956,7 +951,7 @@ def test_audit_stage_stamps_the_fingerprint(tmp_path, monkeypatch):
         "source_draft_fingerprint": "worker-supplied-lie",
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job-stamp", "audit", "m", _source_request("req"), api_key="k", root=tmp_path)
+    rec = runner.run_stage("job-stamp", "audit", "m", None, api_key="k", root=tmp_path)
     stored = json.loads(Path(rec["path"]).read_text())
     assert stored["source_draft_fingerprint"] == runner._draft_fingerprint("job-stamp", tmp_path)
     assert stored["source_draft_fingerprint"] != "worker-supplied-lie"
@@ -975,7 +970,7 @@ def test_source_bound_stage_rejects_prebuilt_prompt_before_dispatch(
         return _editor_json("unreachable", "revise")
 
     monkeypatch.setattr(runner, "call_worker", unexpected_worker)
-    with pytest.raises(ArtifactStoreError, match="requires a prompt builder"):
+    with pytest.raises(ArtifactStoreError, match="runner-owned prompt"):
         runner.run_stage(
             "job-prebuilt",
             "audit",
@@ -987,7 +982,7 @@ def test_source_bound_stage_rejects_prebuilt_prompt_before_dispatch(
     assert called is False
 
 
-def test_prompt_builder_uses_draft_current_at_run_stage_entry(tmp_path, monkeypatch):
+def test_runner_prompt_uses_draft_current_at_run_stage_entry(tmp_path, monkeypatch):
     """A pre-entry A->B replacement makes the worker receive B, never stale A."""
     from atlas_brain.services.content_factory_store import write_artifact
 
@@ -1015,16 +1010,45 @@ def test_prompt_builder_uses_draft_current_at_run_stage_entry(tmp_path, monkeypa
         "job-pre-entry",
         "audit",
         "m",
-        lambda draft: f"Review this exact draft: {draft['body_markdown']}",
+        None,
         api_key="k",
         root=tmp_path,
     )
 
     stored = json.loads(Path(rec["path"]).read_text())
-    assert observed == ["Review this exact draft: source B committed before run_stage"]
+    assert len(observed) == 1
+    assert "source B committed before run_stage" in observed[0]
+    assert "claim e1 from B" in observed[0]
     assert stored["source_draft_fingerprint"] == runner._draft_fingerprint(
         "job-pre-entry", tmp_path
     )
+
+
+@pytest.mark.parametrize("stage", ["audit", "audit-v2", "repurposing", "image_prompt"])
+def test_source_bound_stage_rejects_callback_that_ignores_draft(
+    stage, tmp_path, monkeypatch
+):
+    """No source stage lets a stale lambda inherit the current fingerprint."""
+    job_id = f"job-ignored-draft-{stage}"
+    _seed_draft(tmp_path, job_id, ["e1"], approved=False)
+    called = False
+
+    def unexpected_worker(*args, **kwargs):
+        nonlocal called
+        called = True
+        return _editor_json("unreachable", "revise")
+
+    monkeypatch.setattr(runner, "call_worker", unexpected_worker)
+    with pytest.raises(ArtifactStoreError, match="runner-owned prompt"):
+        runner.run_stage(
+            job_id,
+            stage,
+            "m",
+            lambda _draft: "stale prompt from source A",
+            api_key="k",
+            root=tmp_path,
+        )
+    assert called is False
 
 
 def test_audit_rejects_draft_replaced_while_worker_runs(tmp_path, monkeypatch):
@@ -1050,7 +1074,7 @@ def test_audit_rejects_draft_replaced_while_worker_runs(tmp_path, monkeypatch):
             "job-dispatch-audit",
             "audit",
             "m",
-            _source_request("request built from source A"),
+            None,
             api_key="k",
             root=tmp_path,
         )
@@ -1112,7 +1136,7 @@ def test_phase6_rejects_draft_replaced_while_worker_runs(
             job_id,
             stage,
             "m",
-            _source_request("request built from source A"),
+            None,
             api_key="k",
             root=tmp_path,
         )
@@ -1128,7 +1152,7 @@ def test_unchanged_draft_keeps_approval_valid(tmp_path, monkeypatch):
         "ready_to_publish": True,
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job-stable", "repurposing", "m", _source_request("req"), api_key="k", root=tmp_path)
+    rec = runner.run_stage("job-stable", "repurposing", "m", None, api_key="k", root=tmp_path)
     assert json.loads(Path(rec["path"]).read_text())["ready_to_publish"] is True
 
 
@@ -1225,7 +1249,7 @@ def test_run_stage_normalizes_v2_audit_to_v3(tmp_path, monkeypatch):
         "recommendation": "revise",
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job-v23", "audit", "m", _source_request("req"), api_key="k", root=tmp_path)
+    rec = runner.run_stage("job-v23", "audit", "m", None, api_key="k", root=tmp_path)
     stored = json.loads(Path(rec["path"]).read_text())
     assert stored["schema"] == "editorial_audit.v3"
     assert stored["schema_version"] == 3
@@ -1269,7 +1293,7 @@ def test_run_stage_holds_job_lock_across_validation_and_write(tmp_path, monkeypa
         "ready_to_publish": True,
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    runner.run_stage("job-lock", "repurposing", "m", _source_request("req"), api_key="k", root=tmp_path)
+    runner.run_stage("job-lock", "repurposing", "m", None, api_key="k", root=tmp_path)
 
     assert observed == [False], "readiness was decided outside the job lock"
     assert _job_lock_is_free("job-lock", tmp_path), "lock leaked after run_stage"
@@ -1408,6 +1432,51 @@ def test_compatibility_normalization_does_not_promote_renderer_specs(renderer_sp
     assert runner._prompt_contact_hits(f"studio render {renderer_spec}") == []
 
 
+@pytest.mark.parametrize(
+    "renderer_value",
+    [
+        "+1920/1080",
+        "+3840/2160",
+        "+2026/07/25",
+        "+255/255/255",
+    ],
+)
+def test_slash_separated_renderer_numbers_require_dial_evidence(renderer_value):
+    """An explicit plus does not turn dimensions, dates, or RGB into a phone."""
+    prompt = f"display {renderer_value} landscape artwork"
+    assert runner._prompt_contact_hits(prompt) == [], prompt
+
+
+@pytest.mark.parametrize(
+    "dial_candidate",
+    [
+        "+44/800/FLOWERS",
+        "+44/800/3569377",
+        "0044/800/FLOWERS",
+    ],
+)
+def test_slash_separated_candidates_with_structural_dial_intent_fail(
+    dial_candidate,
+):
+    """Slash parity remains when direct dial syntax supplies the evidence."""
+    prompt = f"Call {dial_candidate} today"
+    assert runner._prompt_contact_hits(prompt) != [], prompt
+
+
+@pytest.mark.parametrize("line_break", ["\n", "\r", "\r\n"])
+def test_single_line_break_preserves_structural_dial_intent(line_break):
+    """One logical CTA line break is formatting, not a dial-evidence boundary."""
+    prompt = f"Call{line_break}+44 800 FLOWERS"
+    assert runner._prompt_contact_hits(prompt) != [], prompt
+
+
+@pytest.mark.parametrize("line_break", ["\n\n", "\r\r", "\r\n\r\n"])
+def test_paragraph_break_does_not_bridge_dial_intent(line_break):
+    """The finite bridge does not govern a candidate in another paragraph."""
+    prompt = f"Call{line_break}+44 800 FLOWERS"
+    assert runner._prompt_contact_hits(prompt) == [], prompt
+
+
 @pytest.mark.parametrize("intent", ["Call", "Text", "Contact", "Reach"])
 @pytest.mark.parametrize("candidate", ["212 ART DECO", "+44 800 FLOWERS"])
 @pytest.mark.parametrize(
@@ -1534,7 +1603,7 @@ def test_uncommitted_crash_residue_cannot_authorize_ready_artifact(
         "job-crash",
         "repurposing",
         "m",
-        _source_request("req"),
+        None,
         api_key="k",
         root=tmp_path,
     )

--- a/tests/test_content_factory_runner.py
+++ b/tests/test_content_factory_runner.py
@@ -29,6 +29,11 @@ from atlas_brain.services.content_factory_store import job_dir
 BRIEF_JSON = '{"schema": "content_brief.v1", "project_id": "resolution-audit", "request_raw": "x"}'
 
 
+def _source_request(text):
+    """Prompt builder for tests whose worker reply, not prompt, is under test."""
+    return lambda _draft: text
+
+
 class _FakeResponse:
     def __init__(self, data: bytes):
         self._data = data
@@ -150,7 +155,7 @@ def _stored(rec):
 
 def test_editor_stage_injects_deterministic_pass(tmp_path, monkeypatch):
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: _editor_json(_CLEAN_BODY, "promote"))
-    rec = runner.run_stage("job1", "audit", "cf-editor", "req", api_key="k", root=tmp_path)
+    rec = runner.run_stage("job1", "audit", "cf-editor", _source_request("req"), api_key="k", root=tmp_path)
     stored = _stored(rec)
     assert stored["copy_verification"]["verdict"] == "pass"
     assert stored["recommendation"] == "promote"  # clean copy may promote
@@ -161,13 +166,13 @@ def test_editor_worker_cannot_self_promote_overclaim(tmp_path, monkeypatch):
     reply = _editor_json(_BAD_BODY, "promote", copy_verification={"verdict": "pass", "hits": []})
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
     with pytest.raises(ValidationError):  # injected fail vs promote -> #2116 guard rejects
-        runner.run_stage("job1", "audit", "m", "req", api_key="k", root=tmp_path)
+        runner.run_stage("job1", "audit", "m", _source_request("req"), api_key="k", root=tmp_path)
     assert not job_dir("job1", root=tmp_path).exists()
 
 
 def test_editor_overclaim_revise_persists_with_fail(tmp_path, monkeypatch):
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: _editor_json(_BAD_BODY, "revise"))
-    rec = runner.run_stage("job1", "audit", "m", "req", api_key="k", root=tmp_path)
+    rec = runner.run_stage("job1", "audit", "m", _source_request("req"), api_key="k", root=tmp_path)
     stored = _stored(rec)
     assert stored["copy_verification"]["verdict"] == "fail"
     assert any("guaranteed-savings" in h for h in stored["copy_verification"]["hits"])
@@ -178,7 +183,7 @@ def test_editor_worker_claimed_verdict_is_overridden(tmp_path, monkeypatch):
     # verdict must still overwrite the worker's claim.
     reply = _editor_json(_BAD_BODY, "revise", copy_verification={"verdict": "pass", "hits": []})
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job1", "audit", "m", "req", api_key="k", root=tmp_path)
+    rec = runner.run_stage("job1", "audit", "m", _source_request("req"), api_key="k", root=tmp_path)
     assert _stored(rec)["copy_verification"]["verdict"] == "fail"
 
 
@@ -193,13 +198,13 @@ def test_empty_edited_copy_cannot_promote(tmp_path, monkeypatch):
     # self-promote by omitting the edited copy.
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: _editor_json("", "promote"))
     with pytest.raises(ValidationError):
-        runner.run_stage("job1", "audit", "m", "req", api_key="k", root=tmp_path)
+        runner.run_stage("job1", "audit", "m", _source_request("req"), api_key="k", root=tmp_path)
     assert not job_dir("job1", root=tmp_path).exists()
 
 
 def test_empty_edited_copy_revise_persists_with_fail(tmp_path, monkeypatch):
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: _editor_json("   ", "revise"))
-    rec = runner.run_stage("job1", "audit", "m", "req", api_key="k", root=tmp_path)
+    rec = runner.run_stage("job1", "audit", "m", _source_request("req"), api_key="k", root=tmp_path)
     stored = _stored(rec)
     assert stored["copy_verification"]["verdict"] == "fail"
     assert any("unverified-copy" in h for h in stored["copy_verification"]["hits"])
@@ -211,7 +216,7 @@ def test_custom_stage_audit_is_also_gated(tmp_path, monkeypatch):
     reply = _editor_json(_BAD_BODY, "promote", copy_verification={"verdict": "pass", "hits": []})
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
     with pytest.raises(ValidationError):
-        runner.run_stage("job1", "audit-v2", "m", "req", api_key="k", root=tmp_path)
+        runner.run_stage("job1", "audit-v2", "m", _source_request("req"), api_key="k", root=tmp_path)
     assert not job_dir("job1", root=tmp_path).exists()
 
 
@@ -263,7 +268,7 @@ def test_run_stage_persists_deterministic_warnings_and_normalizes_v1(tmp_path, m
         }
     )
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job-adv", "audit", "cf-editor-verifier", "req", api_key="k", root=tmp_path)
+    rec = runner.run_stage("job-adv", "audit", "cf-editor-verifier", _source_request("req"), api_key="k", root=tmp_path)
     stored = json.loads(Path(rec["path"]).read_text())
     assert rec["schema"] == "editorial_audit.v3"
     assert stored["schema"] == "editorial_audit.v3"
@@ -290,7 +295,7 @@ def test_run_stage_rejects_contradictory_v2_version(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
     with pytest.raises(ValidationError):
-        runner.run_stage("job-v2v", "audit", "m", "req", api_key="k", root=tmp_path)
+        runner.run_stage("job-v2v", "audit", "m", _source_request("req"), api_key="k", root=tmp_path)
     assert not job_dir("job-v2v", root=tmp_path).exists()
 
 
@@ -350,7 +355,7 @@ def test_run_stage_overwrites_variant_verdicts_and_blocks_bad_ship(tmp_path, mon
     # separate lineage check first.
     _seed_draft(tmp_path, "job-rp", ["e1"])
     with pytest.raises(ValidationError):
-        runner.run_stage("job-rp", "repurposing", "m", "req", api_key="k", root=tmp_path)
+        runner.run_stage("job-rp", "repurposing", "m", _source_request("req"), api_key="k", root=tmp_path)
 
 
 def test_run_stage_persists_clean_variants_with_computed_verdicts(tmp_path, monkeypatch):
@@ -369,7 +374,7 @@ def test_run_stage_persists_clean_variants_with_computed_verdicts(tmp_path, monk
         }
     )
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job-rp2", "repurposing", "m", "req", api_key="k", root=tmp_path)
+    rec = runner.run_stage("job-rp2", "repurposing", "m", _source_request("req"), api_key="k", root=tmp_path)
     stored = json.loads(Path(rec["path"]).read_text())
     assert stored["variants"][0]["copy_verification"]["verdict"] == "pass"
     assert stored["variants"][0]["advisory_warnings"][-1].startswith("reminder:")
@@ -393,7 +398,7 @@ def test_run_stage_blank_variant_body_fails_closed(tmp_path, monkeypatch):
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
     # blank body is rejected by the contract (NonEmptyStr) -- nothing persists
     with pytest.raises(ValidationError):
-        runner.run_stage("job-rp3", "repurposing", "m", "req", api_key="k", root=tmp_path)
+        runner.run_stage("job-rp3", "repurposing", "m", _source_request("req"), api_key="k", root=tmp_path)
 
 
 def test_run_stage_gates_image_prompt_text(tmp_path, monkeypatch):
@@ -413,7 +418,7 @@ def test_run_stage_gates_image_prompt_text(tmp_path, monkeypatch):
         }
     )
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job-img", "image_prompt", "m", "req", api_key="k", root=tmp_path)
+    rec = runner.run_stage("job-img", "image_prompt", "m", _source_request("req"), api_key="k", root=tmp_path)
     stored = json.loads(Path(rec["path"]).read_text())
     assert stored["copy_verification"]["verdict"] == "fail"
     assert any("guaranteed-savings" in hit for hit in stored["copy_verification"]["hits"])
@@ -430,7 +435,7 @@ def test_run_stage_image_prompt_pii_is_caught(tmp_path, monkeypatch):
         }
     )
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job-img2", "image_prompt", "m", "req", api_key="k", root=tmp_path)
+    rec = runner.run_stage("job-img2", "image_prompt", "m", _source_request("req"), api_key="k", root=tmp_path)
     stored = json.loads(Path(rec["path"]).read_text())
     assert stored["copy_verification"]["verdict"] == "fail"
     # The VERDICT never carries the raw value (the persisted-evidence
@@ -451,7 +456,7 @@ def test_run_stage_clean_image_prompt_passes(tmp_path, monkeypatch):
         }
     )
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job-img3", "image_prompt", "m", "req", api_key="k", root=tmp_path)
+    rec = runner.run_stage("job-img3", "image_prompt", "m", _source_request("req"), api_key="k", root=tmp_path)
     stored = json.loads(Path(rec["path"]).read_text())
     assert stored["copy_verification"]["verdict"] == "pass"
 
@@ -469,7 +474,7 @@ def test_stage_schema_mismatch_still_enforced_for_phase6(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
     with pytest.raises(ArtifactStoreError):
-        runner.run_stage("job-mix", "image_prompt", "m", "req", api_key="k", root=tmp_path)
+        runner.run_stage("job-mix", "image_prompt", "m", _source_request("req"), api_key="k", root=tmp_path)
 
 
 def test_negative_prompt_naming_banned_terms_still_passes(tmp_path, monkeypatch):
@@ -485,7 +490,7 @@ def test_negative_prompt_naming_banned_terms_still_passes(tmp_path, monkeypatch)
         }],
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job-neg", "image_prompt", "m", "req", api_key="k", root=tmp_path)
+    rec = runner.run_stage("job-neg", "image_prompt", "m", _source_request("req"), api_key="k", root=tmp_path)
     stored = json.loads(Path(rec["path"]).read_text())
     assert stored["copy_verification"]["verdict"] == "pass"
     assert stored["prompts"][0]["negative_prompt"].startswith("blurry")
@@ -502,7 +507,7 @@ def test_positive_prompt_with_banned_claim_still_fails(tmp_path, monkeypatch):
         }],
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job-pos", "image_prompt", "m", "req", api_key="k", root=tmp_path)
+    rec = runner.run_stage("job-pos", "image_prompt", "m", _source_request("req"), api_key="k", root=tmp_path)
     stored = json.loads(Path(rec["path"]).read_text())
     assert stored["copy_verification"]["verdict"] == "fail"
 
@@ -518,7 +523,7 @@ def test_worker_cannot_self_declare_ready_to_generate(tmp_path, monkeypatch):
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
     with pytest.raises(ValidationError):
-        runner.run_stage("job-selfgen", "image_prompt", "m", "req", api_key="k", root=tmp_path)
+        runner.run_stage("job-selfgen", "image_prompt", "m", _source_request("req"), api_key="k", root=tmp_path)
     assert not job_dir("job-selfgen", root=tmp_path).exists()
 
 
@@ -537,7 +542,7 @@ def test_fabricated_lineage_blocks_shipping(tmp_path, monkeypatch):
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
     with pytest.raises(ArtifactStoreError, match="absent from the draft"):
-        runner.run_stage("job-lin", "repurposing", "m", "req", api_key="k", root=tmp_path)
+        runner.run_stage("job-lin", "repurposing", "m", _source_request("req"), api_key="k", root=tmp_path)
 
 
 def test_real_lineage_ships(tmp_path, monkeypatch):
@@ -549,7 +554,7 @@ def test_real_lineage_ships(tmp_path, monkeypatch):
         "ready_to_publish": True,
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job-lin2", "repurposing", "m", "req", api_key="k", root=tmp_path)
+    rec = runner.run_stage("job-lin2", "repurposing", "m", _source_request("req"), api_key="k", root=tmp_path)
     assert json.loads(Path(rec["path"]).read_text())["ready_to_publish"] is True
 
 
@@ -562,7 +567,7 @@ def test_unready_package_skips_lineage_check(tmp_path, monkeypatch):
         "ready_to_publish": False,
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job-lin3", "repurposing", "m", "req", api_key="k", root=tmp_path)
+    rec = runner.run_stage("job-lin3", "repurposing", "m", _source_request("req"), api_key="k", root=tmp_path)
     assert Path(rec["path"]).exists()
 
 
@@ -575,7 +580,7 @@ def test_missing_draft_fails_closed_on_ship(tmp_path, monkeypatch):
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
     with pytest.raises(ArtifactStoreError, match="readable draft artifact"):
-        runner.run_stage("job-nodraft", "repurposing", "m", "req", api_key="k", root=tmp_path)
+        runner.run_stage("job-nodraft", "repurposing", "m", _source_request("req"), api_key="k", root=tmp_path)
 
 
 def test_international_phone_in_prompt_fails(tmp_path, monkeypatch):
@@ -584,7 +589,7 @@ def test_international_phone_in_prompt_fails(tmp_path, monkeypatch):
         "prompts": [{"purpose": "hero", "prompt_text": "Call us at +442079460958"}],
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job-intl", "image_prompt", "m", "req", api_key="k", root=tmp_path)
+    rec = runner.run_stage("job-intl", "image_prompt", "m", _source_request("req"), api_key="k", root=tmp_path)
     stored = json.loads(Path(rec["path"]).read_text())
     assert stored["copy_verification"]["verdict"] == "fail"
     assert "442079460958" not in json.dumps(stored["copy_verification"])
@@ -600,7 +605,7 @@ def test_prompts_verified_independently_no_cross_synthesis(tmp_path, monkeypatch
         ],
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job-split", "image_prompt", "m", "req", api_key="k", root=tmp_path)
+    rec = runner.run_stage("job-split", "image_prompt", "m", _source_request("req"), api_key="k", root=tmp_path)
     stored = json.loads(Path(rec["path"]).read_text())
     assert stored["copy_verification"]["verdict"] == "pass", stored["copy_verification"]
 
@@ -614,7 +619,7 @@ def test_hits_identify_the_offending_prompt(tmp_path, monkeypatch):
         ],
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job-which", "image_prompt", "m", "req", api_key="k", root=tmp_path)
+    rec = runner.run_stage("job-which", "image_prompt", "m", _source_request("req"), api_key="k", root=tmp_path)
     hits = json.loads(Path(rec["path"]).read_text())["copy_verification"]["hits"]
     assert all(h.startswith("prompt 2:") for h in hits), hits
 
@@ -635,7 +640,7 @@ def test_stale_source_revision_blocks_shipping(tmp_path, monkeypatch):
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
     with pytest.raises(ArtifactStoreError, match="superseded copy"):
-        runner.run_stage("job-rev", "repurposing", "m", "req", api_key="k", root=tmp_path)
+        runner.run_stage("job-rev", "repurposing", "m", _source_request("req"), api_key="k", root=tmp_path)
 
 
 def test_matching_source_revision_ships(tmp_path, monkeypatch):
@@ -648,7 +653,7 @@ def test_matching_source_revision_ships(tmp_path, monkeypatch):
         "ready_to_publish": True,
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job-rev2", "repurposing", "m", "req", api_key="k", root=tmp_path)
+    rec = runner.run_stage("job-rev2", "repurposing", "m", _source_request("req"), api_key="k", root=tmp_path)
     assert json.loads(Path(rec["path"]).read_text())["ready_to_publish"] is True
 
 
@@ -663,7 +668,7 @@ def test_image_prompt_readiness_also_checks_revision(tmp_path, monkeypatch):
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
     with pytest.raises(ArtifactStoreError, match="superseded copy"):
-        runner.run_stage("job-imgrev", "image_prompt", "m", "req", api_key="k", root=tmp_path)
+        runner.run_stage("job-imgrev", "image_prompt", "m", _source_request("req"), api_key="k", root=tmp_path)
 
 
 def test_string_false_readiness_persists_as_intermediate(tmp_path, monkeypatch):
@@ -676,7 +681,7 @@ def test_string_false_readiness_persists_as_intermediate(tmp_path, monkeypatch):
         "ready_to_publish": "false",
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job-strfalse", "repurposing", "m", "req", api_key="k", root=tmp_path)
+    rec = runner.run_stage("job-strfalse", "repurposing", "m", _source_request("req"), api_key="k", root=tmp_path)
     assert json.loads(Path(rec["path"]).read_text())["ready_to_publish"] is False
 
 
@@ -691,7 +696,7 @@ def test_negated_banned_phrase_in_prompt_still_fails(text, tmp_path, monkeypatch
         "prompts": [{"purpose": "hero", "prompt_text": text}],
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job-neg2", "image_prompt", "m", "req", api_key="k", root=tmp_path)
+    rec = runner.run_stage("job-neg2", "image_prompt", "m", _source_request("req"), api_key="k", root=tmp_path)
     stored = json.loads(Path(rec["path"]).read_text())
     assert stored["copy_verification"]["verdict"] == "fail", stored["copy_verification"]
 
@@ -718,7 +723,7 @@ def test_unaudited_draft_cannot_ship(tmp_path, monkeypatch):
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
     with pytest.raises(ArtifactStoreError, match="recommending 'promote'"):
-        runner.run_stage("job-noaudit", "repurposing", "m", "req", api_key="k", root=tmp_path)
+        runner.run_stage("job-noaudit", "repurposing", "m", _source_request("req"), api_key="k", root=tmp_path)
 
 
 def test_revise_audit_cannot_ship(tmp_path, monkeypatch):
@@ -739,7 +744,7 @@ def test_revise_audit_cannot_ship(tmp_path, monkeypatch):
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
     with pytest.raises(ArtifactStoreError, match="recommending 'promote'"):
-        runner.run_stage("job-revise", "repurposing", "m", "req", api_key="k", root=tmp_path)
+        runner.run_stage("job-revise", "repurposing", "m", _source_request("req"), api_key="k", root=tmp_path)
 
 
 def test_cross_project_derivation_blocked(tmp_path, monkeypatch):
@@ -753,7 +758,7 @@ def test_cross_project_derivation_blocked(tmp_path, monkeypatch):
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
     with pytest.raises(ArtifactStoreError, match="project mismatch"):
-        runner.run_stage("job-xproj", "repurposing", "m", "req", api_key="k", root=tmp_path)
+        runner.run_stage("job-xproj", "repurposing", "m", _source_request("req"), api_key="k", root=tmp_path)
 
 
 def test_stale_audit_cannot_approve_newer_draft(tmp_path, monkeypatch):
@@ -776,7 +781,7 @@ def test_stale_audit_cannot_approve_newer_draft(tmp_path, monkeypatch):
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
     with pytest.raises(ArtifactStoreError, match="audit approved draft revision"):
-        runner.run_stage("job-staleaudit", "repurposing", "m", "req", api_key="k", root=tmp_path)
+        runner.run_stage("job-staleaudit", "repurposing", "m", _source_request("req"), api_key="k", root=tmp_path)
 
 
 def test_foreign_project_audit_cannot_approve(tmp_path, monkeypatch):
@@ -797,7 +802,7 @@ def test_foreign_project_audit_cannot_approve(tmp_path, monkeypatch):
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
     with pytest.raises(ArtifactStoreError, match="audit project"):
-        runner.run_stage("job-xaudit", "repurposing", "m", "req", api_key="k", root=tmp_path)
+        runner.run_stage("job-xaudit", "repurposing", "m", _source_request("req"), api_key="k", root=tmp_path)
 
 
 
@@ -832,7 +837,7 @@ def _prompt_verdict(text, tmp_path, monkeypatch, job):
     reply = json.dumps({"schema": "image_prompt.v1", "project_id": "p",
                         "prompts": [{"purpose": "hero", "prompt_text": text}]})
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage(job, "image_prompt", "m", "req", api_key="k", root=tmp_path)
+    rec = runner.run_stage(job, "image_prompt", "m", _source_request("req"), api_key="k", root=tmp_path)
     return json.loads(Path(rec["path"]).read_text())["copy_verification"]
 
 
@@ -920,7 +925,7 @@ def test_same_revision_draft_replacement_invalidates_approval(tmp_path, monkeypa
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
     with pytest.raises(ArtifactStoreError, match="does not match the draft currently"):
-        runner.run_stage("job-swap", "repurposing", "m", "req", api_key="k", root=tmp_path)
+        runner.run_stage("job-swap", "repurposing", "m", _source_request("req"), api_key="k", root=tmp_path)
 
 
 def test_image_prompt_readiness_also_content_bound(tmp_path, monkeypatch):
@@ -938,7 +943,7 @@ def test_image_prompt_readiness_also_content_bound(tmp_path, monkeypatch):
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
     with pytest.raises(ArtifactStoreError, match="does not match the draft currently"):
-        runner.run_stage("job-swap2", "image_prompt", "m", "req", api_key="k", root=tmp_path)
+        runner.run_stage("job-swap2", "image_prompt", "m", _source_request("req"), api_key="k", root=tmp_path)
 
 
 def test_audit_stage_stamps_the_fingerprint(tmp_path, monkeypatch):
@@ -951,10 +956,75 @@ def test_audit_stage_stamps_the_fingerprint(tmp_path, monkeypatch):
         "source_draft_fingerprint": "worker-supplied-lie",
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job-stamp", "audit", "m", "req", api_key="k", root=tmp_path)
+    rec = runner.run_stage("job-stamp", "audit", "m", _source_request("req"), api_key="k", root=tmp_path)
     stored = json.loads(Path(rec["path"]).read_text())
     assert stored["source_draft_fingerprint"] == runner._draft_fingerprint("job-stamp", tmp_path)
     assert stored["source_draft_fingerprint"] != "worker-supplied-lie"
+
+
+def test_source_bound_stage_rejects_prebuilt_prompt_before_dispatch(
+    tmp_path, monkeypatch
+):
+    """Already-built text cannot claim the independently snapshotted draft."""
+    _seed_draft(tmp_path, "job-prebuilt", ["e1"], approved=False)
+    called = False
+
+    def unexpected_worker(*args, **kwargs):
+        nonlocal called
+        called = True
+        return _editor_json("unreachable", "revise")
+
+    monkeypatch.setattr(runner, "call_worker", unexpected_worker)
+    with pytest.raises(ArtifactStoreError, match="requires a prompt builder"):
+        runner.run_stage(
+            "job-prebuilt",
+            "audit",
+            "m",
+            "request already built from source A",
+            api_key="k",
+            root=tmp_path,
+        )
+    assert called is False
+
+
+def test_prompt_builder_uses_draft_current_at_run_stage_entry(tmp_path, monkeypatch):
+    """A pre-entry A->B replacement makes the worker receive B, never stale A."""
+    from atlas_brain.services.content_factory_store import write_artifact
+
+    _seed_draft(tmp_path, "job-pre-entry", ["e1"], approved=False)
+    write_artifact(
+        "job-pre-entry",
+        "draft",
+        {
+            "schema": "draft.v1",
+            "project_id": "p",
+            "revision": 1,
+            "body_markdown": "source B committed before run_stage",
+            "claims": [{"text": "claim e1 from B", "source_id": "e1"}],
+        },
+        root=tmp_path,
+    )
+    observed = []
+
+    def worker(_model, user_content, **_kwargs):
+        observed.append(user_content)
+        return _editor_json("Worker response about source B.", "revise")
+
+    monkeypatch.setattr(runner, "call_worker", worker)
+    rec = runner.run_stage(
+        "job-pre-entry",
+        "audit",
+        "m",
+        lambda draft: f"Review this exact draft: {draft['body_markdown']}",
+        api_key="k",
+        root=tmp_path,
+    )
+
+    stored = json.loads(Path(rec["path"]).read_text())
+    assert observed == ["Review this exact draft: source B committed before run_stage"]
+    assert stored["source_draft_fingerprint"] == runner._draft_fingerprint(
+        "job-pre-entry", tmp_path
+    )
 
 
 def test_audit_rejects_draft_replaced_while_worker_runs(tmp_path, monkeypatch):
@@ -980,7 +1050,7 @@ def test_audit_rejects_draft_replaced_while_worker_runs(tmp_path, monkeypatch):
             "job-dispatch-audit",
             "audit",
             "m",
-            "request built from source A",
+            _source_request("request built from source A"),
             api_key="k",
             root=tmp_path,
         )
@@ -1042,7 +1112,7 @@ def test_phase6_rejects_draft_replaced_while_worker_runs(
             job_id,
             stage,
             "m",
-            "request built from source A",
+            _source_request("request built from source A"),
             api_key="k",
             root=tmp_path,
         )
@@ -1058,7 +1128,7 @@ def test_unchanged_draft_keeps_approval_valid(tmp_path, monkeypatch):
         "ready_to_publish": True,
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job-stable", "repurposing", "m", "req", api_key="k", root=tmp_path)
+    rec = runner.run_stage("job-stable", "repurposing", "m", _source_request("req"), api_key="k", root=tmp_path)
     assert json.loads(Path(rec["path"]).read_text())["ready_to_publish"] is True
 
 
@@ -1155,7 +1225,7 @@ def test_run_stage_normalizes_v2_audit_to_v3(tmp_path, monkeypatch):
         "recommendation": "revise",
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    rec = runner.run_stage("job-v23", "audit", "m", "req", api_key="k", root=tmp_path)
+    rec = runner.run_stage("job-v23", "audit", "m", _source_request("req"), api_key="k", root=tmp_path)
     stored = json.loads(Path(rec["path"]).read_text())
     assert stored["schema"] == "editorial_audit.v3"
     assert stored["schema_version"] == 3
@@ -1199,7 +1269,7 @@ def test_run_stage_holds_job_lock_across_validation_and_write(tmp_path, monkeypa
         "ready_to_publish": True,
     })
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    runner.run_stage("job-lock", "repurposing", "m", "req", api_key="k", root=tmp_path)
+    runner.run_stage("job-lock", "repurposing", "m", _source_request("req"), api_key="k", root=tmp_path)
 
     assert observed == [False], "readiness was decided outside the job lock"
     assert _job_lock_is_free("job-lock", tmp_path), "lock leaked after run_stage"
@@ -1314,6 +1384,53 @@ def test_numeric_whitespace_runs_do_not_promote_detached_prose(whitespace):
     assert runner._prompt_contact_hits(prompt) == [], prompt
 
 
+@pytest.mark.parametrize("prefix", ["+44", "\uff0b44", "0044"])
+@pytest.mark.parametrize("separator", [" ", "/", "\uff0f", "\uff0e", "\uff0d", "\u00a0"])
+@pytest.mark.parametrize("word", ["FLOWERS", "\uff26\uff2c\uff2f\uff37\uff25\uff32\uff33", "\ufb02OWERS"])
+def test_oracle_compatibility_equivalent_phonewords_share_one_verdict(
+    prefix, separator, word
+):
+    """NFKC spellings and every admitted separator preserve phone evidence."""
+    prompt = f"Call {prefix}{separator}800{separator}{word} today"
+    assert runner._prompt_contact_hits(prompt) != [], prompt
+
+
+@pytest.mark.parametrize(
+    "renderer_spec",
+    [
+        "\uff11\uff16\uff0f\uff42\uff49\uff54\uff0f\uff43\uff4f\uff4c\uff4f\uff52",
+        "\uff11\uff19\uff12\uff10\uff0f\uff11\uff10\uff18\uff10\uff0f\uff50\uff49\uff58\uff45\uff4c",
+        "\uff18\uff0d\uff42\uff49\uff54\uff0d\uff53\uff54\uff59\uff4c\uff45",
+    ],
+)
+def test_compatibility_normalization_does_not_promote_renderer_specs(renderer_spec):
+    """The normalized parser still requires a dialable prefix/mapping."""
+    assert runner._prompt_contact_hits(f"studio render {renderer_spec}") == []
+
+
+@pytest.mark.parametrize("intent", ["Call", "Text", "Contact", "Reach"])
+@pytest.mark.parametrize("candidate", ["212 ART DECO", "+44 800 FLOWERS"])
+@pytest.mark.parametrize(
+    ("bridge", "has_dial_evidence"),
+    [
+        (" ", True),
+        (": ", True),
+        (" me ", True),
+        (" us at ", True),
+        (" for room ", False),
+        (" sheet for room ", False),
+        (" about suite ", False),
+        (". room ", False),
+    ],
+)
+def test_oracle_detached_phonewords_require_structural_bridge(
+    intent, candidate, bridge, has_dial_evidence
+):
+    """Evidence-keyed oracle: syntax, not intent-category proximity, decides."""
+    prompt = f"{intent}{bridge}{candidate} sign"
+    assert bool(runner._prompt_contact_hits(prompt)) is has_dial_evidence, prompt
+
+
 @pytest.mark.parametrize(
     "prompt",
     ["255 255 255 blue tint", "1920 1080 pixel export", "100 200 300 RGB values",
@@ -1417,7 +1534,7 @@ def test_uncommitted_crash_residue_cannot_authorize_ready_artifact(
         "job-crash",
         "repurposing",
         "m",
-        "req",
+        _source_request("req"),
         api_key="k",
         root=tmp_path,
     )

--- a/tests/test_content_factory_runner.py
+++ b/tests/test_content_factory_runner.py
@@ -1832,3 +1832,70 @@ def test_recipient_bridge_cross_product_fails(intent, bridge):
 )
 def test_recipient_bridge_does_not_admit_renderer_prose(prompt):
     assert runner._prompt_contact_hits(prompt) == []
+
+
+# --- #2201 round 13: one shared default-ignorable predicate ---------------
+
+
+def _all_default_ignorable_samples():
+    """Sampled from the SHARED range table, not a hand-written list.
+
+    Deriving the corpus from the predicate is what makes this class-closed:
+    a codepoint added to the table is covered automatically, and a partial
+    second definition (the U+034F miss) cannot pass unnoticed.
+    """
+    from atlas_brain.schemas.content_factory import _DEFAULT_IGNORABLE_RANGES
+
+    samples = []
+    for low, high in _DEFAULT_IGNORABLE_RANGES:
+        for codepoint in {low, (low + high) // 2, high}:
+            samples.append(chr(codepoint))
+    return samples
+
+
+_DEFAULT_IGNORABLE_SAMPLES = _all_default_ignorable_samples()
+_CONTACT_SEAMS = [
+    "Call +44{z}800 FLOWERS",
+    "Call +{z}44 800 FLOWERS",
+    "call 1-800-FLOW{z}ERS now",
+    "reach 555-123{z}-4567",
+    "call me at 555{z}1234567",
+]
+
+
+@pytest.mark.parametrize("ignorable", _DEFAULT_IGNORABLE_SAMPLES)
+@pytest.mark.parametrize("seam", _CONTACT_SEAMS)
+def test_every_default_ignorable_fails_the_prompt_gate(ignorable, seam):
+    """#2201 round 13: `scan_view` tested Cf/Cc plus a partial hand-built set,
+    so U+034F (category Mn) still defeated the gate after the zero-width class
+    was closed. Any rule phrased as "Cf plus some ranges" leaves the bypass
+    open by construction -- the shared predicate is the only correct test."""
+    assert runner._prompt_contact_hits(seam.format(z=ignorable)) != []
+
+
+@pytest.mark.parametrize("ignorable", _DEFAULT_IGNORABLE_SAMPLES)
+def test_every_default_ignorable_fails_the_body_copy_gate(ignorable):
+    from atlas_brain.services.content_factory_copy_verification import verify_copy
+
+    assert verify_copy("Call 555-123" + ignorable + "-4567 today").verdict == "fail"
+
+
+@pytest.mark.parametrize("ignorable", _DEFAULT_IGNORABLE_SAMPLES)
+def test_no_default_ignorable_leaks_an_address_through_redaction(ignorable):
+    """U+034F left the address FULLY intact in persisted claim evidence --
+    the digit theorem does not help, because an address has no digits."""
+    from atlas_brain.services.content_factory_copy_verification import _redact_pii
+
+    redacted = _redact_pii("reach alice@example" + ignorable + ".com now")
+    assert "alice@example" not in redacted
+
+
+def test_scan_view_and_routing_key_share_one_predicate():
+    """Two definitions is the defect. Assert the scan actually uses the
+    shared predicate, so a future local copy fails here first."""
+    from atlas_brain.schemas.content_factory import is_default_ignorable
+    from atlas_brain.services.content_factory_copy_verification import scan_view
+
+    for ignorable in _DEFAULT_IGNORABLE_SAMPLES:
+        assert is_default_ignorable(ignorable)
+        assert scan_view("a" + ignorable + "b") == "ab"

--- a/tests/test_content_factory_runner.py
+++ b/tests/test_content_factory_runner.py
@@ -1899,3 +1899,78 @@ def test_scan_view_and_routing_key_share_one_predicate():
     for ignorable in _DEFAULT_IGNORABLE_SAMPLES:
         assert is_default_ignorable(ignorable)
         assert scan_view("a" + ignorable + "b") == "ab"
+
+
+# --- #2201 round 14: dial-verb evidence + stage admission ----------------
+
+_RENDERER_VERBS = ["center", "place", "align", "overlay", "position", "set"]
+_RENDERER_BRIDGES = ["on", "at"]
+_RENDERER_DIMENSIONS = ["1920 1080", "255 255 255", "100 200 300", "12 34 56 78"]
+
+
+@pytest.mark.parametrize("verb", _RENDERER_VERBS)
+@pytest.mark.parametrize("bridge", _RENDERER_BRIDGES)
+@pytest.mark.parametrize("dimension", _RENDERER_DIMENSIONS)
+def test_overloaded_marker_as_object_is_renderer_prose(verb, bridge, dimension):
+    """#2201 round 14: `text` is a dial verb in "text me at <number>" and a
+    typography noun in "center text on 1920 1080 canvas" -- both put an
+    admitted bridge word between marker and number, so the finite bridge
+    vocabulary alone cannot separate them. Position does: an imperative CTA
+    heads its clause; here the marker is the object of an earlier verb."""
+    assert runner._prompt_contact_hits(f"{verb} text {bridge} {dimension} canvas") == []
+
+
+@pytest.mark.parametrize(
+    "prompt",
+    [
+        "Text to +44 800 FLOWERS",
+        "Text me at +44 800 FLOWERS",
+        "Contact us on +44 800 FLOWERS",
+        "text me 12 34 56 78",
+        # Unambiguous markers are NOT position-restricted, so an ordinary CTA
+        # with a discourse lead-in still fails.
+        "please call me at 12 34 56 78",
+        "now dial me at 12 34 56 78",
+    ],
+)
+def test_clause_heading_marker_still_governs(prompt):
+    assert runner._prompt_contact_hits(prompt) != []
+
+
+def test_audit_v2_stage_rejects_a_mislabeled_artifact(tmp_path):
+    """#2201 round 14: the runner names `audit-v2` as a source-bound stage but
+    the store had no entry, so it was a CUSTOM stage admitting ANY artifact --
+    a content_brief committed successfully as audit-v2.json, and that schema
+    is outside _SOURCE_BOUND_SCHEMAS so the source comparison was skipped."""
+    from atlas_brain.services.content_factory_store import (
+        STAGE_SCHEMAS,
+        ArtifactStoreError,
+        write_artifact,
+    )
+
+    assert "audit-v2" in STAGE_SCHEMAS
+    with pytest.raises(ArtifactStoreError, match="stage/schema mismatch"):
+        write_artifact(
+            "job-av2",
+            "audit-v2",
+            {"schema": "content_brief.v1", "project_id": "p", "request_raw": "x"},
+            root=tmp_path,
+        )
+
+
+def test_audit_v2_stage_accepts_an_editorial_audit(tmp_path):
+    """The other side: the stage must still admit what it is for."""
+    from atlas_brain.services.content_factory_store import write_artifact
+
+    record = write_artifact(
+        "job-av2ok",
+        "audit-v2",
+        {
+            "schema": "editorial_audit.v2",
+            "project_id": "p",
+            "edited_body_markdown": "Clean copy.",
+            "recommendation": "revise",
+        },
+        root=tmp_path,
+    )
+    assert record["schema"] == "editorial_audit.v2"

--- a/tests/test_content_factory_runner.py
+++ b/tests/test_content_factory_runner.py
@@ -1282,6 +1282,18 @@ def test_oracle_international_vanity_with_dial_evidence_fails(
     assert runner._prompt_contact_hits(prompt) != [], prompt
 
 
+@pytest.mark.parametrize("prefix", ["+81", "+44", "0044"])
+@pytest.mark.parametrize("whitespace", [" ", "\t", "\u00a0"])
+@pytest.mark.parametrize("width", range(1, 9))
+def test_oracle_international_vanity_accepts_numeric_whitespace_runs(
+    prefix, whitespace, width
+):
+    """Whitespace formatting cannot erase explicit international dial evidence."""
+    gap = whitespace * width
+    prompt = f"Call {prefix}{gap}3 FLOWERS today"
+    assert runner._prompt_contact_hits(prompt) != [], prompt
+
+
 @pytest.mark.parametrize("lead", ["212", "305", "415", "617", "800"])
 @pytest.mark.parametrize(
     "art_direction",
@@ -1292,6 +1304,13 @@ def test_oracle_three_digit_art_direction_is_not_detached_vanity(
 ):
     """A keypad coincidence in ordinary prose is not contact evidence."""
     prompt = f"room {lead} {art_direction}, editorial photograph"
+    assert runner._prompt_contact_hits(prompt) == [], prompt
+
+
+@pytest.mark.parametrize("whitespace", ["  ", "\t\t", "\u00a0\u00a0"])
+def test_numeric_whitespace_runs_do_not_promote_detached_prose(whitespace):
+    """A wider separator is formatting, not dial intent."""
+    prompt = f"room 212{whitespace}art deco sign, editorial photograph"
     assert runner._prompt_contact_hits(prompt) == [], prompt
 
 

--- a/tests/test_content_factory_runner.py
+++ b/tests/test_content_factory_runner.py
@@ -1707,3 +1707,93 @@ def test_uncommitted_crash_residue_cannot_authorize_ready_artifact(
         capture_output=True,
     ).stdout == committed
     assert b"UNCOMMITTED replacement" in draft_path.read_bytes()
+
+
+# --- #2201: default-ignorable PII-gate bypass -----------------------------
+
+# One representative per default-ignorable family a producer can reach for.
+_ZERO_WIDTH = [
+    "​",  # zero width space
+    "‌",  # zero width non-joiner
+    "‍",  # zero width joiner
+    "﻿",  # zero width no-break space / BOM
+    "­",  # soft hyphen
+    "⁠",  # word joiner
+    "️",  # variation selector-16
+    "᠎",  # Mongolian vowel separator
+]
+# Every seam in a phone string: before the prefix, inside it, between numeric
+# groups, inside a group, and inside the vanity suffix.
+_SEAM_TEMPLATES = [
+    "Call +44{z}800 FLOWERS",
+    "Call +{z}44 800 FLOWERS",
+    "call 1-800-FLOW{z}ERS now",
+    "reach 555-123{z}-4567",
+    "reach 555{z}-123-4567",
+    "call me at 555{z}1234567",
+    "text 5552345{z}678",
+]
+
+
+@pytest.mark.parametrize("zw", _ZERO_WIDTH)
+@pytest.mark.parametrize("template", _SEAM_TEMPLATES)
+def test_zero_width_insertion_cannot_bypass_prompt_pii_gate(zw, template):
+    """#2201: a default-ignorable character renders as nothing, so inserting
+    one must not change the verdict. Before the fix it defeated the prefix,
+    the structural NANP pattern and the vanity suffix alike."""
+    assert runner._prompt_contact_hits(template.format(z=zw)) != []
+
+
+@pytest.mark.parametrize("zw", _ZERO_WIDTH)
+def test_zero_width_insertion_cannot_bypass_email_gates(zw):
+    """Same class on the address side, in both the prompt gate and the
+    merged body-copy gate."""
+    from atlas_brain.services.content_factory_copy_verification import verify_copy
+
+    assert runner._prompt_contact_hits("write to a" + zw + "lice@example.com") != []
+    assert runner._prompt_contact_hits("write to alice@example" + zw + ".com") != []
+    assert verify_copy("write to alice@example" + zw + ".com").verdict == "fail"
+
+
+@pytest.mark.parametrize("zw", _ZERO_WIDTH)
+def test_zero_width_insertion_cannot_bypass_body_copy_phone_gate(zw):
+    """The bypass also defeated `verify_copy`, which gates the editorial
+    audit's promote decision -- a wider surface than the prompt gate."""
+    from atlas_brain.services.content_factory_copy_verification import verify_copy
+
+    assert verify_copy("Call 555-123" + zw + "-4567 today").verdict == "fail"
+
+
+@pytest.mark.parametrize("zw", _ZERO_WIDTH)
+def test_redacted_evidence_never_carries_a_hidden_address(zw):
+    """The digit theorem covered phone digits, but an address's LETTERS are
+    not digits: a zero-width character made it evade the email pattern and
+    persist intact in claim evidence."""
+    from atlas_brain.services.content_factory_copy_verification import _redact_pii
+
+    redacted = _redact_pii("reach alice@example" + zw + ".com now")
+    assert "alice@example" not in redacted
+    assert "<redacted-email>" in redacted
+
+
+@pytest.mark.parametrize(
+    "prompt",
+    [
+        "a person calling across a room, RGB palette 255 255 255",
+        "a 16-bit-color render, studio light",
+        "a call center scene, 1920 1080 resolution poster",
+        "a poster of serial 12345678 engraved on a plate",
+    ],
+)
+def test_scan_view_does_not_create_false_positives(prompt):
+    """Stripping must not join tokens into a hit that was not there."""
+    assert runner._prompt_contact_hits(prompt) == []
+
+
+def test_scan_view_keeps_whitespace_controls():
+    """Newlines and tabs are real separators: dropping them would glue a word
+    onto a following number and manufacture candidates."""
+    from atlas_brain.services.content_factory_copy_verification import scan_view
+
+    assert scan_view("room 255\nx255 blue\tgrade") == "room 255\nx255 blue\tgrade"
+    assert scan_view("a​b c") == "ab c"

--- a/tests/test_content_factory_runner.py
+++ b/tests/test_content_factory_runner.py
@@ -1797,3 +1797,38 @@ def test_scan_view_keeps_whitespace_controls():
 
     assert scan_view("room 255\nx255 blue\tgrade") == "room 255\nx255 blue\tgrade"
     assert scan_view("a​b c") == "ab c"
+
+
+# --- #2201 round 12: recipient-marking bridge ----------------------------
+
+_MESSAGE_INTENTS = ["Call", "Text", "SMS", "WhatsApp", "dial", "phone", "contact"]
+_BRIDGES = ["", "to ", "me at ", "us on ", "to me at "]
+
+
+@pytest.mark.parametrize("intent", _MESSAGE_INTENTS)
+@pytest.mark.parametrize("bridge", _BRIDGES)
+def test_recipient_bridge_cross_product_fails(intent, bridge):
+    """#2201: the bridge vocabulary omitted the dative `to`, so `Text to +44
+    800 FLOWERS` passed while `Text +44 800 FLOWERS` failed -- a one-word
+    connector defeated the gate. Evidence-keyed across every admitted intent
+    and bridge form."""
+    assert runner._prompt_contact_hits(f"{intent} {bridge}+44 800 FLOWERS") != []
+
+
+@pytest.mark.parametrize(
+    "prompt",
+    [
+        # `to` must bridge only a RECIPIENT, never descriptive prose.
+        "text to room 212 art deco",
+        "poster for room 212 art deco, contact sheet layout",
+        "text treatment for room 212 art deco",
+        # Possessive determiners are deliberately NOT bridge words: they occur
+        # in ordinary renderer prose, so admitting them would read a
+        # typography instruction as a dial instruction.
+        "text your 1920 1080 export",
+        "call our 1920 1080 render sheet",
+        "a call center scene, 1920 1080 resolution poster",
+    ],
+)
+def test_recipient_bridge_does_not_admit_renderer_prose(prompt):
+    assert runner._prompt_contact_hits(prompt) == []

--- a/tests/test_content_factory_runner.py
+++ b/tests/test_content_factory_runner.py
@@ -11,6 +11,7 @@ import json
 import subprocess
 import urllib.error
 import urllib.request
+from itertools import product
 from pathlib import Path
 
 import pytest
@@ -22,7 +23,6 @@ from atlas_brain.services.content_factory_runner import (
     WorkerError,
     call_worker,
     extract_json,
-    run_stage,
 )
 from atlas_brain.services.content_factory_store import job_dir
 
@@ -866,6 +866,18 @@ def test_oracle_email_any_script_fails(addr, tmp_path, monkeypatch):
     assert cv["verdict"] == "fail", (addr, cv)
 
 
+@pytest.mark.parametrize("separator", [".", "\u3002", "\uff0e", "\uff61"])
+def test_oracle_idna_equivalent_domain_separators_fail(
+    separator, tmp_path, monkeypatch
+):
+    """Every IDNA domain-label separator has the ASCII-dot decision."""
+    address = f"user@例え{separator}テスト"
+    cv = _prompt_verdict(
+        f"a card reading {address}", tmp_path, monkeypatch, "job-idna"
+    )
+    assert cv["verdict"] == "fail", (address, cv)
+
+
 # --- review round 7 on #2192 ---
 
 
@@ -943,6 +955,97 @@ def test_audit_stage_stamps_the_fingerprint(tmp_path, monkeypatch):
     stored = json.loads(Path(rec["path"]).read_text())
     assert stored["source_draft_fingerprint"] == runner._draft_fingerprint("job-stamp", tmp_path)
     assert stored["source_draft_fingerprint"] != "worker-supplied-lie"
+
+
+def test_audit_rejects_draft_replaced_while_worker_runs(tmp_path, monkeypatch):
+    """The audit fingerprint binds the pre-dispatch source, not the draft that
+    happens to be current after the worker returns."""
+    from atlas_brain.services.content_factory_store import write_artifact
+
+    _seed_draft(tmp_path, "job-dispatch-audit", ["e1"], approved=False)
+
+    def replace_draft_during_worker(*args, **kwargs):
+        write_artifact("job-dispatch-audit", "draft", {
+            "schema": "draft.v1",
+            "project_id": "p",
+            "revision": 1,
+            "body_markdown": "same revision, different source B",
+            "claims": [{"text": "claim e1 changed", "source_id": "e1"}],
+        }, root=tmp_path)
+        return _editor_json("Worker response about source A.", "revise")
+
+    monkeypatch.setattr(runner, "call_worker", replace_draft_during_worker)
+    with pytest.raises(ArtifactStoreError, match="changed while the worker was running"):
+        runner.run_stage(
+            "job-dispatch-audit",
+            "audit",
+            "m",
+            "request built from source A",
+            api_key="k",
+            root=tmp_path,
+        )
+
+
+@pytest.mark.parametrize(
+    ("stage", "artifact"),
+    [
+        (
+            "repurposing",
+            {
+                "schema": "repurposing.v1",
+                "project_id": "p",
+                "variants": [{
+                    "channel": "email",
+                    "body_markdown": "Intermediate copy about source A.",
+                    "derived_from_claims": ["e1"],
+                }],
+                "ready_to_publish": False,
+            },
+        ),
+        (
+            "image_prompt",
+            {
+                "schema": "image_prompt.v1",
+                "project_id": "p",
+                "prompts": [{
+                    "purpose": "hero",
+                    "prompt_text": "an image derived from source A",
+                }],
+                "ready_to_generate": False,
+            },
+        ),
+    ],
+)
+def test_phase6_rejects_draft_replaced_while_worker_runs(
+    stage, artifact, tmp_path, monkeypatch
+):
+    """Equivalent pre-dispatch binding applies to both Phase 6 workers, even
+    before their intermediate artifacts claim readiness."""
+    from atlas_brain.services.content_factory_store import write_artifact
+
+    job_id = f"job-dispatch-{stage}"
+    _seed_draft(tmp_path, job_id, ["e1"])
+
+    def replace_draft_during_worker(*args, **kwargs):
+        write_artifact(job_id, "draft", {
+            "schema": "draft.v1",
+            "project_id": "p",
+            "revision": 1,
+            "body_markdown": "same revision, different source B",
+            "claims": [{"text": "claim e1 changed", "source_id": "e1"}],
+        }, root=tmp_path)
+        return json.dumps(artifact)
+
+    monkeypatch.setattr(runner, "call_worker", replace_draft_during_worker)
+    with pytest.raises(ArtifactStoreError, match="changed while the worker was running"):
+        runner.run_stage(
+            job_id,
+            stage,
+            "m",
+            "request built from source A",
+            api_key="k",
+            root=tmp_path,
+        )
 
 
 def test_unchanged_draft_keeps_approval_valid(tmp_path, monkeypatch):
@@ -1123,7 +1226,19 @@ def test_job_lock_excludes_a_second_process(tmp_path):
     assert _job_lock_is_free("job-x", tmp_path)
 
 
-# --- round 9: vanity grammar both directions, commit atomicity, channels ---
+def test_job_lock_identity_includes_the_root(tmp_path):
+    """The same job id under two roots is two stores, not a re-entrant lock."""
+    from atlas_brain.services.content_factory_store import job_lock
+
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    with job_lock("job-root", root=first):
+        with job_lock("job-root", root=second):
+            assert not _job_lock_is_free("job-root", first)
+            assert not _job_lock_is_free("job-root", second)
+
+
+# --- round 9: vanity grammar both directions and committed-state atomicity ---
 
 _SPEC_DIGITS = ["8", "16", "24", "32", "64", "1920", "1080", "4096"]
 _SPEC_WORDS = ["bit", "color", "pixel", "style", "float", "depth", "res"]
@@ -1139,15 +1254,45 @@ def test_oracle_hyphenated_renderer_specs_render(lead, word):
     assert runner._prompt_contact_hits(f"a {lead}-{word}-{word} render, studio light") == []
 
 
-@pytest.mark.parametrize("intent", ["Call", "call", "Text", "dial", "contact"])
+def test_oracle_every_separator_partition_of_vanity_suffix_fails():
+    """Grammar-derived other side: attachment choices cannot make a NANP
+    vanity number disappear. This generates every join/space/hyphen/dot
+    partition of a held-out suffix rather than listing review spellings."""
+    word = "CLEANUP"
+    separators = ("", " ", "-", ".")
+    for prefix in ("800", "1 800"):
+        for choices in product(separators, repeat=len(word) - 1):
+            suffix = "".join(
+                char + (choices[index] if index < len(choices) else "")
+                for index, char in enumerate(word)
+            )
+            prompt = f"Call {prefix} {suffix}"
+            assert runner._prompt_contact_hits(prompt) != [], prompt
+
+
+@pytest.mark.parametrize("prefix", ["+44 800", "0044 800", "+81 3"])
+@pytest.mark.parametrize("separator", ["", " ", "-", "."])
+@pytest.mark.parametrize("word", ["FLOWERS", "CLEANUP", "PLUMBER"])
+def test_oracle_international_vanity_with_dial_evidence_fails(
+    prefix, separator, word
+):
+    """Explicit international prefix + intent + keypad spelling is contact PII."""
+    suffix = separator.join(word)
+    prompt = f"Call {prefix} {suffix} today"
+    assert runner._prompt_contact_hits(prompt) != [], prompt
+
+
+@pytest.mark.parametrize("lead", ["212", "305", "415", "617", "800"])
 @pytest.mark.parametrize(
-    "spelled", ["1 800 FLOWERS", "1 800 GOT JUNK", "800 FLOWERS", "1-800-FLOWERS",
-                "1-800-flowers", "1-800-GOT-JUNK"]
+    "art_direction",
+    ["art deco sign", "blue mural", "soft focus", "red carpet", "new typography"],
 )
-def test_oracle_space_joined_vanity_numbers_fail(intent, spelled):
-    """The other direction of the same grammar: the token regex stops before a
-    space-joined letter group, so "Call 1 800 FLOWERS today" passed."""
-    assert runner._prompt_contact_hits(f"{intent} {spelled} today") != []
+def test_oracle_three_digit_art_direction_is_not_detached_vanity(
+    lead, art_direction
+):
+    """A keypad coincidence in ordinary prose is not contact evidence."""
+    prompt = f"room {lead} {art_direction}, editorial photograph"
+    assert runner._prompt_contact_hits(prompt) == [], prompt
 
 
 @pytest.mark.parametrize(
@@ -1161,24 +1306,17 @@ def test_trailing_word_extension_does_not_over_reach(prompt):
     assert runner._prompt_contact_hits(prompt) == []
 
 
-def test_failed_commit_leaves_no_artifact_residue(tmp_path, monkeypatch):
-    """#2192 round 9: a failed store commit used to leave the new file written
-    and staged even though write_artifact raised, and the readiness gate reads
-    the working tree -- so the residue was trusted as approved source state."""
+def test_failed_commit_restores_previous_artifact_and_index(tmp_path, monkeypatch):
+    """An ordinary raised commit failure restores worktree/index hygiene."""
     from atlas_brain.services import content_factory_store as store
 
     _seed_draft(tmp_path, "job-resid", ["e1"])
     draft_path = Path(tmp_path) / "jobs" / "job-resid" / "draft.json"
     before = draft_path.read_bytes()
 
-    real_git = store._git
-
-    def failing_git(job, *args):
-        if args and args[0] == "commit":
-            raise store.ArtifactStoreError("simulated commit failure")
-        return real_git(job, *args)
-
-    monkeypatch.setattr(store, "_git", failing_git)
+    # Exercise the real Git process: add succeeds, while commit rejects the
+    # malformed author date after the target has been written and staged.
+    monkeypatch.setenv("GIT_AUTHOR_DATE", "not-a-git-date")
     with pytest.raises(store.ArtifactStoreError):
         store.write_artifact("job-resid", "draft", {
             "schema": "draft.v1", "project_id": "p", "revision": 2,
@@ -1187,7 +1325,6 @@ def test_failed_commit_leaves_no_artifact_residue(tmp_path, monkeypatch):
         }, root=tmp_path)
 
     assert draft_path.read_bytes() == before, "failed write left residue on disk"
-    monkeypatch.undo()
     staged = subprocess.run(
         ["git", "-C", str(draft_path.parent), "diff", "--cached", "--name-only"],
         capture_output=True, text=True,
@@ -1199,47 +1336,78 @@ def test_failed_first_write_removes_the_file(tmp_path, monkeypatch):
     """A stage that had no previous artifact must not leave a partial one."""
     from atlas_brain.services import content_factory_store as store
 
-    real_git = store._git
-
-    def failing_git(job, *args):
-        if args and args[0] == "commit":
-            raise store.ArtifactStoreError("simulated commit failure")
-        return real_git(job, *args)
-
-    monkeypatch.setattr(store, "_git", failing_git)
+    monkeypatch.setenv("GIT_AUTHOR_DATE", "not-a-git-date")
     with pytest.raises(store.ArtifactStoreError):
         store.write_artifact("job-first", "draft", {
             "schema": "draft.v1", "project_id": "p", "revision": 1,
             "body_markdown": "body", "claims": [{"text": "c", "source_id": "e1"}],
         }, root=tmp_path)
-    assert not (Path(tmp_path) / "jobs" / "job-first" / "draft.json").exists()
+    job = Path(tmp_path) / "jobs" / "job-first"
+    assert not (job / "draft.json").exists()
+    assert subprocess.run(
+        ["git", "-C", str(job), "ls-files", "--error-unmatch", "draft.json"],
+        capture_output=True,
+    ).returncode != 0
 
 
-@pytest.mark.parametrize("invisible", ["​", "‌", "️", "​‌"])
-def test_invisible_channel_identifiers_rejected(invisible):
-    """#2192 round 9: `channel` was NonEmptyStr, so an unroutable label made
-    only of zero-width characters validated and persisted."""
-    from atlas_brain.schemas.content_factory import RepurposingPackage
+def test_uncommitted_crash_residue_cannot_authorize_ready_artifact(
+    tmp_path, monkeypatch
+):
+    """Canonical readers use Git HEAD, so even residue left when cleanup never
+    runs cannot replace the draft/audit pair that authorizes readiness."""
+    _seed_draft(tmp_path, "job-crash", ["e1"])
+    job = Path(tmp_path) / "jobs" / "job-crash"
+    draft_path = job / "draft.json"
+    committed = subprocess.run(
+        ["git", "-C", str(job), "show", "HEAD:draft.json"],
+        check=True,
+        capture_output=True,
+    ).stdout
+    draft_path.write_text(json.dumps({
+        "schema": "draft.v1",
+        "project_id": "p",
+        "revision": 1,
+        "body_markdown": "UNCOMMITTED replacement nobody approved",
+        "claims": [{"text": "other", "source_id": "unapproved"}],
+    }))
+    subprocess.run(
+        ["git", "-C", str(job), "add", "--", "draft.json"],
+        check=True,
+    )
 
-    with pytest.raises(ValidationError):
-        RepurposingPackage.model_validate({
-            "schema": "repurposing.v1", "project_id": "p",
-            "variants": [{"channel": invisible, "body_markdown": "Clean copy.",
-                          "derived_from_claims": ["e1"]}],
-        })
+    reply = json.dumps({
+        "schema": "repurposing.v1",
+        "project_id": "p",
+        "source_draft_revision": 1,
+        "variants": [{
+            "channel": "email",
+            "body_markdown": "Clean copy.",
+            "derived_from_claims": ["e1"],
+        }],
+        "ready_to_publish": True,
+    })
+    response = json.dumps({
+        "choices": [{"message": {"content": reply}}],
+    }).encode()
+    monkeypatch.setattr(
+        urllib.request,
+        "urlopen",
+        lambda *args, **kwargs: _FakeResponse(response),
+    )
+    record = runner.run_stage(
+        "job-crash",
+        "repurposing",
+        "m",
+        "req",
+        api_key="k",
+        root=tmp_path,
+    )
 
-
-def test_visually_identical_channels_are_duplicates():
-    """Distinct invisible spellings of one label are the SAME channel: they
-    carry no visible width, so keeping them apart re-admits the ambiguity the
-    duplicate check exists to prevent."""
-    from atlas_brain.schemas.content_factory import RepurposingPackage
-
-    with pytest.raises(ValidationError, match="duplicate channel"):
-        RepurposingPackage.model_validate({
-            "schema": "repurposing.v1", "project_id": "p",
-            "variants": [
-                {"channel": "email", "body_markdown": "A.", "derived_from_claims": ["e1"]},
-                {"channel": "email​", "body_markdown": "B.", "derived_from_claims": ["e1"]},
-            ],
-        })
+    stored = json.loads(Path(record["path"]).read_text())
+    assert stored["ready_to_publish"] is True
+    assert subprocess.run(
+        ["git", "-C", str(job), "show", "HEAD:draft.json"],
+        check=True,
+        capture_output=True,
+    ).stdout == committed
+    assert b"UNCOMMITTED replacement" in draft_path.read_bytes()

--- a/tests/test_content_factory_runner.py
+++ b/tests/test_content_factory_runner.py
@@ -148,7 +148,12 @@ def _stored(rec):
     return json.loads(Path(rec["path"]).read_text())
 
 
+def _stage_path(root, job_id, stage):
+    return job_dir(job_id, root=root) / f"{stage}.json"
+
+
 def test_editor_stage_injects_deterministic_pass(tmp_path, monkeypatch):
+    _seed_draft(tmp_path, "job1", ["e1"], approved=False)
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: _editor_json(_CLEAN_BODY, "promote"))
     rec = runner.run_stage("job1", "audit", "cf-editor", None, api_key="k", root=tmp_path)
     stored = _stored(rec)
@@ -157,15 +162,17 @@ def test_editor_stage_injects_deterministic_pass(tmp_path, monkeypatch):
 
 
 def test_editor_worker_cannot_self_promote_overclaim(tmp_path, monkeypatch):
+    _seed_draft(tmp_path, "job1", ["e1"], approved=False)
     # Worker claims a passing verdict + promote on copy that actually overclaims.
     reply = _editor_json(_BAD_BODY, "promote", copy_verification={"verdict": "pass", "hits": []})
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
     with pytest.raises(ValidationError):  # injected fail vs promote -> #2116 guard rejects
         runner.run_stage("job1", "audit", "m", None, api_key="k", root=tmp_path)
-    assert not job_dir("job1", root=tmp_path).exists()
+    assert not _stage_path(tmp_path, "job1", "audit").exists()
 
 
 def test_editor_overclaim_revise_persists_with_fail(tmp_path, monkeypatch):
+    _seed_draft(tmp_path, "job1", ["e1"], approved=False)
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: _editor_json(_BAD_BODY, "revise"))
     rec = runner.run_stage("job1", "audit", "m", None, api_key="k", root=tmp_path)
     stored = _stored(rec)
@@ -174,6 +181,7 @@ def test_editor_overclaim_revise_persists_with_fail(tmp_path, monkeypatch):
 
 
 def test_editor_worker_claimed_verdict_is_overridden(tmp_path, monkeypatch):
+    _seed_draft(tmp_path, "job1", ["e1"], approved=False)
     # Worker asserts pass on bad copy but only recommends revise; the deterministic
     # verdict must still overwrite the worker's claim.
     reply = _editor_json(_BAD_BODY, "revise", copy_verification={"verdict": "pass", "hits": []})
@@ -189,15 +197,17 @@ def test_non_editor_stage_gets_no_copy_verification(tmp_path, monkeypatch):
 
 
 def test_empty_edited_copy_cannot_promote(tmp_path, monkeypatch):
+    _seed_draft(tmp_path, "job1", ["e1"], approved=False)
     # Fail closed: an empty edited body means nothing was verified, so a worker cannot
     # self-promote by omitting the edited copy.
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: _editor_json("", "promote"))
     with pytest.raises(ValidationError):
         runner.run_stage("job1", "audit", "m", None, api_key="k", root=tmp_path)
-    assert not job_dir("job1", root=tmp_path).exists()
+    assert not _stage_path(tmp_path, "job1", "audit").exists()
 
 
 def test_empty_edited_copy_revise_persists_with_fail(tmp_path, monkeypatch):
+    _seed_draft(tmp_path, "job1", ["e1"], approved=False)
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: _editor_json("   ", "revise"))
     rec = runner.run_stage("job1", "audit", "m", None, api_key="k", root=tmp_path)
     stored = _stored(rec)
@@ -206,13 +216,14 @@ def test_empty_edited_copy_revise_persists_with_fail(tmp_path, monkeypatch):
 
 
 def test_custom_stage_audit_is_also_gated(tmp_path, monkeypatch):
+    _seed_draft(tmp_path, "job1", ["e1"], approved=False)
     # A custom (non-"audit") stage emitting editorial_audit.v1 must not bypass the gate:
     # gating is by schema, so its self-promotion of overclaiming copy is still rejected.
     reply = _editor_json(_BAD_BODY, "promote", copy_verification={"verdict": "pass", "hits": []})
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
     with pytest.raises(ValidationError):
         runner.run_stage("job1", "audit-v2", "m", None, api_key="k", root=tmp_path)
-    assert not job_dir("job1", root=tmp_path).exists()
+    assert not _stage_path(tmp_path, "job1", "audit-v2").exists()
 
 
 def test_enforce_overwrites_worker_supplied_advisory_warnings():
@@ -254,6 +265,7 @@ def test_run_stage_persists_deterministic_warnings_and_normalizes_v1(tmp_path, m
     """Reachability proof at the real entrypoint (#2181 round 2): a worker
     reply tagged v1 with a fabricated empty checklist is normalized to v2 and
     persisted with the DETERMINISTIC advisory warnings."""
+    _seed_draft(tmp_path, "job-adv", ["e1"], approved=False)
     reply = json.dumps(
         {
             "schema": "editorial_audit.v1",
@@ -279,6 +291,7 @@ def test_run_stage_rejects_contradictory_v2_version(tmp_path, monkeypatch):
     """Round-18 regression: a worker reply already tagged v2 keeps its own
     schema_version, so contradictory metadata fails validation instead of
     being silently rewritten to 2."""
+    _seed_draft(tmp_path, "job-v2v", ["e1"], approved=False)
     reply = json.dumps(
         {
             "schema": "editorial_audit.v2",
@@ -291,7 +304,7 @@ def test_run_stage_rejects_contradictory_v2_version(tmp_path, monkeypatch):
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
     with pytest.raises(ValidationError):
         runner.run_stage("job-v2v", "audit", "m", None, api_key="k", root=tmp_path)
-    assert not job_dir("job-v2v", root=tmp_path).exists()
+    assert not _stage_path(tmp_path, "job-v2v", "audit").exists()
 
 
 # --- Phase 6: repurposing + image-prompt gates at the real entrypoint ---
@@ -354,6 +367,7 @@ def test_run_stage_overwrites_variant_verdicts_and_blocks_bad_ship(tmp_path, mon
 
 
 def test_run_stage_persists_clean_variants_with_computed_verdicts(tmp_path, monkeypatch):
+    _seed_draft(tmp_path, "job-rp2", ["e1"], approved=False)
     reply = json.dumps(
         {
             "schema": "repurposing.v1",
@@ -376,6 +390,7 @@ def test_run_stage_persists_clean_variants_with_computed_verdicts(tmp_path, monk
 
 
 def test_run_stage_blank_variant_body_fails_closed(tmp_path, monkeypatch):
+    _seed_draft(tmp_path, "job-rp3", ["e1"], approved=False)
     reply = json.dumps(
         {
             "schema": "repurposing.v1",
@@ -399,6 +414,7 @@ def test_run_stage_blank_variant_body_fails_closed(tmp_path, monkeypatch):
 def test_run_stage_gates_image_prompt_text(tmp_path, monkeypatch):
     """Banned copy inside a PROMPT would be rendered into the artwork, where
     no text check would see it -- the gate runs on the prompt itself."""
+    _seed_draft(tmp_path, "job-img", ["e1"], approved=False)
     reply = json.dumps(
         {
             "schema": "image_prompt.v1",
@@ -420,6 +436,7 @@ def test_run_stage_gates_image_prompt_text(tmp_path, monkeypatch):
 
 
 def test_run_stage_image_prompt_pii_is_caught(tmp_path, monkeypatch):
+    _seed_draft(tmp_path, "job-img2", ["e1"], approved=False)
     reply = json.dumps(
         {
             "schema": "image_prompt.v1",
@@ -441,6 +458,7 @@ def test_run_stage_image_prompt_pii_is_caught(tmp_path, monkeypatch):
 
 
 def test_run_stage_clean_image_prompt_passes(tmp_path, monkeypatch):
+    _seed_draft(tmp_path, "job-img3", ["e1"], approved=False)
     reply = json.dumps(
         {
             "schema": "image_prompt.v1",
@@ -458,6 +476,7 @@ def test_run_stage_clean_image_prompt_passes(tmp_path, monkeypatch):
 
 def test_stage_schema_mismatch_still_enforced_for_phase6(tmp_path, monkeypatch):
     """A repurposing artifact cannot land under the image_prompt stage."""
+    _seed_draft(tmp_path, "job-mix", ["e1"], approved=False)
     reply = json.dumps(
         {
             "schema": "repurposing.v1",
@@ -476,6 +495,7 @@ def test_negative_prompt_naming_banned_terms_still_passes(tmp_path, monkeypatch)
     """Guard's second side: a negative prompt is an EXCLUSION list, so naming
     a banned phrase there is the correct designer response to the threat --
     it must not trip the gate."""
+    _seed_draft(tmp_path, "job-neg", ["e1"], approved=False)
     reply = json.dumps({
         "schema": "image_prompt.v1", "project_id": "p",
         "prompts": [{
@@ -493,6 +513,7 @@ def test_negative_prompt_naming_banned_terms_still_passes(tmp_path, monkeypatch)
 
 def test_positive_prompt_with_banned_claim_still_fails(tmp_path, monkeypatch):
     """The other side of the same guard stays closed."""
+    _seed_draft(tmp_path, "job-pos", ["e1"], approved=False)
     reply = json.dumps({
         "schema": "image_prompt.v1", "project_id": "p",
         "prompts": [{
@@ -510,6 +531,7 @@ def test_positive_prompt_with_banned_claim_still_fails(tmp_path, monkeypatch):
 def test_worker_cannot_self_declare_ready_to_generate(tmp_path, monkeypatch):
     """The runner recomputes the verdict, so a failing prompt set cannot be
     persisted as renderable no matter what the worker claims."""
+    _seed_draft(tmp_path, "job-selfgen", ["e1"], approved=False)
     reply = json.dumps({
         "schema": "image_prompt.v1", "project_id": "p",
         "prompts": [{"purpose": "hero", "prompt_text": "poster reading guaranteed savings"}],
@@ -519,7 +541,7 @@ def test_worker_cannot_self_declare_ready_to_generate(tmp_path, monkeypatch):
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
     with pytest.raises(ValidationError):
         runner.run_stage("job-selfgen", "image_prompt", "m", None, api_key="k", root=tmp_path)
-    assert not job_dir("job-selfgen", root=tmp_path).exists()
+    assert not _stage_path(tmp_path, "job-selfgen", "image_prompt").exists()
 
 
 # --- review round 2 on #2192 ---
@@ -555,6 +577,7 @@ def test_real_lineage_ships(tmp_path, monkeypatch):
 
 def test_unready_package_skips_lineage_check(tmp_path, monkeypatch):
     """An unready package is a legitimate intermediate state."""
+    _seed_draft(tmp_path, "job-lin3", ["e1"], approved=False)
     reply = json.dumps({
         "schema": "repurposing.v1", "project_id": "p",
         "variants": [{"channel": "x", "body_markdown": "Clean copy.",
@@ -567,18 +590,26 @@ def test_unready_package_skips_lineage_check(tmp_path, monkeypatch):
 
 
 def test_missing_draft_fails_closed_on_ship(tmp_path, monkeypatch):
+    called = False
     reply = json.dumps({
         "schema": "repurposing.v1", "project_id": "p",
         "variants": [{"channel": "x", "body_markdown": "Clean copy.",
                       "derived_from_claims": ["e1"]}],
         "ready_to_publish": True,
     })
-    monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
-    with pytest.raises(ArtifactStoreError, match="readable draft artifact"):
+    def unexpected_worker(*args, **kwargs):
+        nonlocal called
+        called = True
+        return reply
+
+    monkeypatch.setattr(runner, "call_worker", unexpected_worker)
+    with pytest.raises(ArtifactStoreError, match="requires a committed draft"):
         runner.run_stage("job-nodraft", "repurposing", "m", None, api_key="k", root=tmp_path)
+    assert called is False
 
 
 def test_international_phone_in_prompt_fails(tmp_path, monkeypatch):
+    _seed_draft(tmp_path, "job-intl", ["e1"], approved=False)
     reply = json.dumps({
         "schema": "image_prompt.v1", "project_id": "p",
         "prompts": [{"purpose": "hero", "prompt_text": "Call us at +442079460958"}],
@@ -592,6 +623,7 @@ def test_international_phone_in_prompt_fails(tmp_path, monkeypatch):
 
 def test_prompts_verified_independently_no_cross_synthesis(tmp_path, monkeypatch):
     """Joining items must not synthesize a claim no single prompt makes."""
+    _seed_draft(tmp_path, "job-split", ["e1"], approved=False)
     reply = json.dumps({
         "schema": "image_prompt.v1", "project_id": "p",
         "prompts": [
@@ -606,6 +638,7 @@ def test_prompts_verified_independently_no_cross_synthesis(tmp_path, monkeypatch
 
 
 def test_hits_identify_the_offending_prompt(tmp_path, monkeypatch):
+    _seed_draft(tmp_path, "job-which", ["e1"], approved=False)
     reply = json.dumps({
         "schema": "image_prompt.v1", "project_id": "p",
         "prompts": [
@@ -667,8 +700,9 @@ def test_image_prompt_readiness_also_checks_revision(tmp_path, monkeypatch):
 
 
 def test_string_false_readiness_persists_as_intermediate(tmp_path, monkeypatch):
-    """A weak worker's "false" normalizes to False, so no draft is required
-    and the intermediate package persists (runner and schema agree)."""
+    """A weak worker's "false" normalizes to False, so lineage approval is not
+    required and the intermediate package persists (runner and schema agree)."""
+    _seed_draft(tmp_path, "job-strfalse", ["e1"], approved=False)
     reply = json.dumps({
         "schema": "repurposing.v1", "project_id": "p",
         "variants": [{"channel": "x", "body_markdown": "Clean copy.",
@@ -686,6 +720,7 @@ def test_string_false_readiness_persists_as_intermediate(tmp_path, monkeypatch):
 ])
 def test_negated_banned_phrase_in_prompt_still_fails(text, tmp_path, monkeypatch):
     """Prose negation does not un-draw words a renderer is told to paint."""
+    _seed_draft(tmp_path, "job-neg2", ["e1"], approved=False)
     reply = json.dumps({
         "schema": "image_prompt.v1", "project_id": "p",
         "prompts": [{"purpose": "hero", "prompt_text": text}],
@@ -829,6 +864,7 @@ _SCENES = ["a poster of {}", "signage reading {}", "{} on a storefront window"]
 
 
 def _prompt_verdict(text, tmp_path, monkeypatch, job):
+    _seed_draft(tmp_path, job, ["e1"], approved=False)
     reply = json.dumps({"schema": "image_prompt.v1", "project_id": "p",
                         "prompts": [{"purpose": "hero", "prompt_text": text}]})
     monkeypatch.setattr(runner, "call_worker", lambda *a, **k: reply)
@@ -1051,6 +1087,32 @@ def test_source_bound_stage_rejects_callback_that_ignores_draft(
     assert called is False
 
 
+@pytest.mark.parametrize("stage", ["audit", "audit-v2", "repurposing", "image_prompt"])
+def test_source_bound_stage_requires_committed_draft_before_dispatch(
+    stage, tmp_path, monkeypatch
+):
+    """A missing committed draft is not a source snapshot and must not become
+    `Committed draft JSON:null`."""
+    called = False
+
+    def unexpected_worker(*args, **kwargs):
+        nonlocal called
+        called = True
+        return _editor_json("unreachable", "revise")
+
+    monkeypatch.setattr(runner, "call_worker", unexpected_worker)
+    with pytest.raises(ArtifactStoreError, match="requires a committed draft"):
+        runner.run_stage(
+            f"job-no-draft-{stage}",
+            stage,
+            "m",
+            None,
+            api_key="k",
+            root=tmp_path,
+        )
+    assert called is False
+
+
 def test_audit_rejects_draft_replaced_while_worker_runs(tmp_path, monkeypatch):
     """The audit fingerprint binds the pre-dispatch source, not the draft that
     happens to be current after the worker returns."""
@@ -1241,6 +1303,7 @@ def test_run_stage_normalizes_v2_audit_to_v3(tmp_path, monkeypatch):
     """A v2-tagged worker reply upgrades cleanly, because its metadata is
     self-consistent. The anti-laundering rule still holds for contradictory
     metadata (see test_run_stage_rejects_contradictory_v2_version)."""
+    _seed_draft(tmp_path, "job-v23", ["e1"], approved=False)
     reply = json.dumps({
         "schema": "editorial_audit.v2",
         "schema_version": 2,
@@ -1463,6 +1526,20 @@ def test_slash_separated_candidates_with_structural_dial_intent_fail(
     assert runner._prompt_contact_hits(prompt) != [], prompt
 
 
+@pytest.mark.parametrize(
+    "dial_candidate",
+    [
+        "+44 (800) FLOWERS",
+        "+44 (800) F-L-O-W-E-R-S",
+        "0044 (800) FLOWERS",
+    ],
+)
+def test_parenthesized_phonewords_share_numeric_group_verdict(dial_candidate):
+    """Parentheses are formatting inside the same bounded dial grammar."""
+    prompt = f"Call {dial_candidate} today"
+    assert runner._prompt_contact_hits(prompt) != [], prompt
+
+
 @pytest.mark.parametrize("line_break", ["\n", "\r", "\r\n"])
 def test_single_line_break_preserves_structural_dial_intent(line_break):
     """One logical CTA line break is formatting, not a dial-evidence boundary."""
@@ -1498,6 +1575,20 @@ def test_oracle_detached_phonewords_require_structural_bridge(
     """Evidence-keyed oracle: syntax, not intent-category proximity, decides."""
     prompt = f"{intent}{bridge}{candidate} sign"
     assert bool(runner._prompt_contact_hits(prompt)) is has_dial_evidence, prompt
+
+
+@pytest.mark.parametrize(
+    "prompt",
+    [
+        "room 212 art deco contact sheet",
+        "room 212 art deco text treatment",
+        "poster for room 212 art deco, contact sheet layout",
+        "room 800 flowers contact sheet",
+    ],
+)
+def test_trailing_renderer_nouns_do_not_bridge_detached_phonewords(prompt):
+    """Renderer terms after an ambiguous candidate are not reverse dial syntax."""
+    assert runner._prompt_contact_hits(prompt) == [], prompt
 
 
 @pytest.mark.parametrize(

--- a/tests/test_content_factory_schemas.py
+++ b/tests/test_content_factory_schemas.py
@@ -628,3 +628,31 @@ def test_default_ignorables_cannot_split_duplicate_channels(invisible):
                 _variant(channel=f"email{invisible}"),
             ])
         )
+
+
+@pytest.mark.parametrize(
+    ("composed", "base", "combining_mark"),
+    [
+        ("é", "e", "\u0301"),
+        ("Å", "A", "\u030a"),
+        ("ñ", "n", "\u0303"),
+        ("ö", "o", "\u0308"),
+    ],
+)
+@pytest.mark.parametrize(
+    "invisible",
+    ["\u034f", "\ufe0f", "\u180b", "\U000e0100"],
+)
+def test_default_ignorables_cannot_block_routing_key_composition(
+    composed, base, combining_mark, invisible
+):
+    """Removing an ignorable must happen before canonical composition."""
+    from atlas_brain.schemas.content_factory import RepurposingPackage
+
+    with pytest.raises(ValidationError, match="duplicate channel"):
+        RepurposingPackage.model_validate(
+            _package([
+                _variant(channel=composed),
+                _variant(channel=f"{base}{invisible}{combining_mark}"),
+            ])
+        )

--- a/tests/test_content_factory_schemas.py
+++ b/tests/test_content_factory_schemas.py
@@ -588,3 +588,43 @@ def test_canonically_equivalent_channels_are_duplicates():
         RepurposingPackage.model_validate(
             _package([_variant(channel=nfc), _variant(channel=nfd)])
         )
+
+
+@pytest.mark.parametrize(
+    "invisible",
+    ["\u200b", "\u200c", "\ufe0f", "\u200b\u200c", "\u00ad", "\u2060"],
+)
+def test_invisible_channel_identifiers_rejected(invisible):
+    """Routing labels need a visible base, not merely non-whitespace bytes."""
+    from atlas_brain.schemas.content_factory import RepurposingPackage
+
+    with pytest.raises(ValidationError):
+        RepurposingPackage.model_validate(
+            _package([_variant(channel=invisible)])
+        )
+
+
+@pytest.mark.parametrize(
+    "invisible",
+    [
+        "\u200b",  # zero-width space (Cf)
+        "\u200c",  # zero-width non-joiner (Cf)
+        "\u00ad",  # soft hyphen (Cf)
+        "\u2060",  # word joiner (Cf)
+        "\ufe0f",  # variation selector (Mn)
+        "\u034f",  # combining grapheme joiner (Mn)
+        "\u180b",  # Mongolian free variation selector (Mn)
+        "\U000e0100",  # supplementary variation selector (Mn)
+    ],
+)
+def test_default_ignorables_cannot_split_duplicate_channels(invisible):
+    """Unicode default-ignorables have no routing identity of their own."""
+    from atlas_brain.schemas.content_factory import RepurposingPackage
+
+    with pytest.raises(ValidationError, match="duplicate channel"):
+        RepurposingPackage.model_validate(
+            _package([
+                _variant(channel="email"),
+                _variant(channel=f"email{invisible}"),
+            ])
+        )


### PR DESCRIPTION
Plan: plans/PR-CF-Phase6-Round10-Remediation.md
Slice phase: production hardening
Ownership lane: content-factory

PR #2192 merged seconds after five new review findings landed. This follow-up
applies the verified corrections to the merged mainline without changing the
Phase 6 artifact shape, image-generation scope, or body-copy verifier POLICY.
Finding 17 does change that verifier's PII scan INPUT — zero-width characters
are stripped before matching — because the bypass it closes was present there
too; which real forms count as PII is untouched.

The diff exceeds the 400-line soft cap because the sixteen comments converge on
two existing choke points—the contact classifier and the committed-source
execution boundary—and their both-direction/reachability proofs. Splitting
those mechanisms from their proofs would leave the merged defect classes
unclosed.

Diff-budget override: The shared choke-point fixes are indivisible from their generated both-direction and reachability proofs.
A split would publish the safety decisions without the tests that close them.

## Intentional

- Contact classification uses an admission-only NFKC view; compatibility
  equivalents receive one verdict without rewriting the stored prompt.
- Ambiguous phonewords require a forward finite structural bridge from a dial
  marker; arbitrary nearby renderer prose and trailing renderer nouns are not
  dial evidence.
- International phonewords require explicit `+`/`00` structure, structural
  dial syntax, and an E.164-bounded keypad mapping.
- Whitespace run length is formatting, not dial evidence; numeric group count,
  compact symbols, explicit prefix, and structural syntax remain the evidence.
- Channel routing removes the Unicode default-ignorable class, not only the two
  reported code points, and removes it before canonical normalization.
- Worker transport stays outside the per-job filesystem lock. A committed
  draft byte snapshot builds both the worker prompt and source fingerprint;
  that fingerprint is compared under the lock before persistence.
- Source-bound stages accept no caller prompt or callback. The runner owns the
  fixed stage instruction and committed-draft serialization, and refuses to
  dispatch without a committed draft object.
- The originating Phase 6 plan is updated so its round-ten reconciliation and
  execution contract match the corrected code.

## Deferred

- No deferral for the five round-ten findings or eleven current-head findings.
- Existing Phase 6 deferrals remain: ComfyUI generation, OWUI wrappers, and
  Phase 7 manifest entries.

## Parked hardening

None.

## Cold diff reconstruction

- Normalizes contact parsing through an admission-only NFKC view and consumes
  the shared dot, hyphen, slash, parentheses, and whitespace separator grammar.
- Preserves a leading `+`, admits explicit international phonewords under
  structural dial evidence, and requires a finite direct-address bridge before
  detached alphabetic extensions can turn ordinary prose into contact data.
- Normalizes U+3002, U+FF0E, and U+FF61 only for the redacted email-admission
  decision.
- Removes Unicode default-ignorables before NFKC/casefold channel routing so an
  ignored mark cannot block canonical composition.
- Consumes whitespace runs between numeric dial groups while retaining the
  compact E.164 symbol bound and structural dial-syntax requirement.
- Routes slash-delimited numeric shapes through the structural dial decision
  while preserving slash-separated phonewords under direct dial syntax.
- Treats one logical LF, CR, or CRLF as CTA formatting inside the finite bridge
  while keeping paragraph breaks, descriptive words, and trailing renderer nouns
  outside it.
- Reads canonical source artifacts from Git `HEAD`, requires committed draft
  bytes before source-bound dispatch, snapshots the draft once, uses a
  runner-owned stage template to serialize that snapshot, hashes the same bytes,
  and rejects any source-derived response whose under-lock re-read differs.
- Rejects prebuilt prompts and arbitrary callbacks for source-bound stages
  before worker dispatch.
- Restores ordinary failed writes to committed worktree/index state; abrupt
  residue remains non-canonical.
- Adds grammar-derived both-direction classifiers, default-ignorable class
  proofs, and real same-revision draft replacements from inside the worker
  boundary.

## Verification

- Focused runner/schema/store/copy-verification/intake surface: 956 passed;
  one third-party `pynvml` deprecation warning.
- Latest round-14 regression subset: 88 passed; prior current-head subsets
  remain covered.
- Ruff, `python -m py_compile`, and `git diff --check`: passed.
- Schema maturity ratchet: passed with no new brittleness.
- Store explicit-file maturity lane: 0 flagged.
- Guard class-closure, plan shape/files/diff-size/triggered-rules,
  plan/code consistency, and plan-sync audits: passed against merged
  `origin/main`.
- Live worker pass not run; the Phase 6 wrappers remain deferred.

## Diff size

7 files. Both synchronized plan tables report 1,862 changed LOC with 0.0%
drift.

## Decision-Seam Analysis

The contact decision asks whether a mixed digit/letter candidate has enough
finite mechanical evidence to be contact data rather than renderer prose.
Keypad mapping alone was over-broad (`212 art deco`), while NANP membership
alone was under-broad (`+44 800 FLOWERS`). The corrected rule defaults
ambiguous detached prose to admissible, uses a closed function-word and
punctuation bridge instead of proximity, and additionally requires an explicit
international prefix plus E.164-bound mapping for international phonewords.
Slash-delimited and parenthesized shapes use that structural decision instead
of narrow one-off branches; one logical line break is formatting, while a
paragraph boundary and trailing renderer noun are not.

The execution invariant is: the worker prompt and dispatch fingerprint must
come from the same committed draft bytes, and that fingerprint must equal the
identity re-read under the existing per-job lock before any source-derived
response persists. Missing committed draft bytes are not a source snapshot and
fail before dispatch. The caller cannot satisfy that invariant by callback:
`run_stage` owns the stage instruction and draft serialization. Runner-owned
prompt construction plus snapshot/compare closes the pre-entry, ignored-input,
and worker-time races without holding a filesystem lock across a network call.

## AI reconciliation

All five unresolved threads from merged PR #2192 were confirmed against its
published code before correction:

1. P1 international vanity — fixed by preserving `+`, keypad-mapping explicit
   `+`/`00` candidates inside the E.164 bound, and requiring bounded intent
   ([implementation](https://github.com/canfieldjuan/ATLAS/blob/67d6efc99e42341ced71482f268482b41fc8ad12/atlas_brain/services/content_factory_runner.py#L217-L218),
   [decision](https://github.com/canfieldjuan/ATLAS/blob/67d6efc99e42341ced71482f268482b41fc8ad12/atlas_brain/services/content_factory_runner.py#L267-L329),
   [oracle](https://github.com/canfieldjuan/ATLAS/blob/67d6efc99e42341ced71482f268482b41fc8ad12/tests/test_content_factory_runner.py#L1273-L1282)).
2. P2 detached prose — fixed by requiring bounded dial intent for space-joined
   suffixes; ordinary three-digit art-direction combinations prove the passing
   side
   ([implementation](https://github.com/canfieldjuan/ATLAS/blob/67d6efc99e42341ced71482f268482b41fc8ad12/atlas_brain/services/content_factory_runner.py#L388-L454),
   [oracle](https://github.com/canfieldjuan/ATLAS/blob/67d6efc99e42341ced71482f268482b41fc8ad12/tests/test_content_factory_runner.py#L1285-L1295)).
3. P2 channel aliases — fixed by dropping Unicode default-ignorables,
   including variation selectors and combining grapheme joiners
   ([implementation](https://github.com/canfieldjuan/ATLAS/blob/67d6efc99e42341ced71482f268482b41fc8ad12/atlas_brain/schemas/content_factory.py#L106-L148),
   [class proof](https://github.com/canfieldjuan/ATLAS/blob/67d6efc99e42341ced71482f268482b41fc8ad12/tests/test_content_factory_schemas.py#L607-L630)).
4. P1 worker-time draft race — fixed by pre-dispatch committed-source
   snapshot and under-lock comparison for audit and both Phase 6 schemas
   ([comparison](https://github.com/canfieldjuan/ATLAS/blob/67d6efc99e42341ced71482f268482b41fc8ad12/atlas_brain/services/content_factory_runner.py#L639-L664),
   [entrypoint](https://github.com/canfieldjuan/ATLAS/blob/67d6efc99e42341ced71482f268482b41fc8ad12/atlas_brain/services/content_factory_runner.py#L784-L807),
   [proofs](https://github.com/canfieldjuan/ATLAS/blob/67d6efc99e42341ced71482f268482b41fc8ad12/tests/test_content_factory_runner.py#L960-L1048)).
5. P1 IDNA separators — fixed by normalizing the three IDNA dot equivalents
   before matching, with redacted output preserved
   ([implementation](https://github.com/canfieldjuan/ATLAS/blob/67d6efc99e42341ced71482f268482b41fc8ad12/atlas_brain/services/content_factory_runner.py#L193-L199),
   [gate](https://github.com/canfieldjuan/ATLAS/blob/67d6efc99e42341ced71482f268482b41fc8ad12/atlas_brain/services/content_factory_runner.py#L457-L465),
   [oracle](https://github.com/canfieldjuan/ATLAS/blob/67d6efc99e42341ced71482f268482b41fc8ad12/tests/test_content_factory_runner.py#L869-L878)).

The first two findings on PR #2201 head `67d6efc99e` were also confirmed before
correction:

6. P1 normalization order — fixed by removing default-ignorables before NFKC,
   so they cannot block canonical composition
   ([implementation](https://github.com/canfieldjuan/ATLAS/blob/31a9e9cb1b189b510a91bc15ba12bb5b26ef5291/atlas_brain/schemas/content_factory.py#L132-L148),
   [generated proof](https://github.com/canfieldjuan/ATLAS/blob/31a9e9cb1b189b510a91bc15ba12bb5b26ef5291/tests/test_content_factory_schemas.py#L633-L658)).
7. P1 numeric whitespace runs — fixed by consuming the full whitespace
   separator between numeric groups while `_dial_shape` retains the compact
   E.164 symbol bound and `_phone_evidence` retains bounded intent
   ([token grammar](https://github.com/canfieldjuan/ATLAS/blob/31a9e9cb1b189b510a91bc15ba12bb5b26ef5291/atlas_brain/services/content_factory_runner.py#L210-L219),
   [bounded decision](https://github.com/canfieldjuan/ATLAS/blob/31a9e9cb1b189b510a91bc15ba12bb5b26ef5291/atlas_brain/services/content_factory_runner.py#L302-L329),
   [both-direction proof](https://github.com/canfieldjuan/ATLAS/blob/31a9e9cb1b189b510a91bc15ba12bb5b26ef5291/tests/test_content_factory_runner.py#L1285-L1314)).

The three findings on PR #2201 head `31a9e9cb1b` were also confirmed before
correction:

8. P1 compatibility/separator bypass — fixed by parsing an admission-only NFKC
   view and admitting slash through the shared dial separator grammar
   ([normalization and grammar](https://github.com/canfieldjuan/ATLAS/blob/2a8a3269ba79e6fdfbd5608ae00e285a2d66a7b4/atlas_brain/services/content_factory_runner.py#L203-L224),
   [decision](https://github.com/canfieldjuan/ATLAS/blob/2a8a3269ba79e6fdfbd5608ae00e285a2d66a7b4/atlas_brain/services/content_factory_runner.py#L410-L450),
   [generated proof](https://github.com/canfieldjuan/ATLAS/blob/2a8a3269ba79e6fdfbd5608ae00e285a2d66a7b4/tests/test_content_factory_runner.py#L1387-L1408)).
9. P1 intent-proximity false positives — fixed by replacing the open
   word/distance window with a finite structural bridge grammar
   ([bridge grammar](https://github.com/canfieldjuan/ATLAS/blob/2a8a3269ba79e6fdfbd5608ae00e285a2d66a7b4/atlas_brain/services/content_factory_runner.py#L230-L236),
   [decision](https://github.com/canfieldjuan/ATLAS/blob/2a8a3269ba79e6fdfbd5608ae00e285a2d66a7b4/atlas_brain/services/content_factory_runner.py#L375-L407),
   [evidence-keyed proof](https://github.com/canfieldjuan/ATLAS/blob/2a8a3269ba79e6fdfbd5608ae00e285a2d66a7b4/tests/test_content_factory_runner.py#L1411-L1431)).
10. P1 prompt/source split — fixed by building the prompt and fingerprint from
    one committed byte snapshot and rejecting prebuilt source-bound strings
    before dispatch; finding 13 closes the remaining arbitrary-callback gap
    ([snapshot builder](https://github.com/canfieldjuan/ATLAS/blob/2a8a3269ba79e6fdfbd5608ae00e285a2d66a7b4/atlas_brain/services/content_factory_runner.py#L636-L669),
    [entrypoint](https://github.com/canfieldjuan/ATLAS/blob/2a8a3269ba79e6fdfbd5608ae00e285a2d66a7b4/atlas_brain/services/content_factory_runner.py#L794-L850),
    [prebuilt rejection and A-to-B proof](https://github.com/canfieldjuan/ATLAS/blob/2a8a3269ba79e6fdfbd5608ae00e285a2d66a7b4/tests/test_content_factory_runner.py#L965-L1027)).

The three findings on PR #2201 head `2a8a3269b` were also confirmed before
correction:

11. P1 slash numeric false positives — fixed by excluding slash from the
    unconditional E.164 shortcut while retaining it in the structural token
    grammar
    ([decision](https://github.com/canfieldjuan/ATLAS/blob/b88ea328c7ed682dbd50ace56c0c1e4452dd0847/atlas_brain/services/content_factory_runner.py#L207-L225),
    [both-direction proof](https://github.com/canfieldjuan/ATLAS/blob/b88ea328c7ed682dbd50ace56c0c1e4452dd0847/tests/test_content_factory_runner.py#L1435-L1463)).
12. P1 line-break bypass — fixed by admitting exactly one logical LF, CR, or
    CRLF in the finite structural bridge while rejecting paragraph breaks
    ([bridge grammar](https://github.com/canfieldjuan/ATLAS/blob/b88ea328c7ed682dbd50ace56c0c1e4452dd0847/atlas_brain/services/content_factory_runner.py#L232-L238),
    [bounded decision](https://github.com/canfieldjuan/ATLAS/blob/b88ea328c7ed682dbd50ace56c0c1e4452dd0847/atlas_brain/services/content_factory_runner.py#L377-L393),
    [both-direction proof](https://github.com/canfieldjuan/ATLAS/blob/b88ea328c7ed682dbd50ace56c0c1e4452dd0847/tests/test_content_factory_runner.py#L1466-L1477)).
13. P1 callback-ignored source — fixed by removing caller-controlled builders:
    the runner selects the stage instruction, serializes the captured draft,
    and hashes the same committed bytes
    ([runner-owned builder](https://github.com/canfieldjuan/ATLAS/blob/b88ea328c7ed682dbd50ace56c0c1e4452dd0847/atlas_brain/services/content_factory_runner.py#L641-L689),
    [entrypoint](https://github.com/canfieldjuan/ATLAS/blob/b88ea328c7ed682dbd50ace56c0c1e4452dd0847/atlas_brain/services/content_factory_runner.py#L814-L863),
    [prebuilt, current-draft, and callback-rejection proofs](https://github.com/canfieldjuan/ATLAS/blob/b88ea328c7ed682dbd50ace56c0c1e4452dd0847/tests/test_content_factory_runner.py#L960-L1051)).

The three findings on PR #2201 head `b88ea328c7` were also confirmed before
correction:

14. P1 trailing renderer nouns — fixed by making the structural bridge govern
    ambiguous candidates only from a preceding dial marker; `contact sheet` and
    `text treatment` after `212 art deco` remain renderer prose
    ([forward bridge](https://github.com/canfieldjuan/ATLAS/blob/888783351540946afca9922ec21024e08f49a439/atlas_brain/services/content_factory_runner.py#L399-L418),
    [candidate decision](https://github.com/canfieldjuan/ATLAS/blob/888783351540946afca9922ec21024e08f49a439/atlas_brain/services/content_factory_runner.py#L437-L458),
    [trailing-renderer proof](https://github.com/canfieldjuan/ATLAS/blob/888783351540946afca9922ec21024e08f49a439/tests/test_content_factory_runner.py#L1580-L1591)).
15. P1 parenthesized phoneword groups — fixed by adding parentheses to the
    shared bounded dial grammar while keeping alpha suffix punctuation limited
    to dial spelling separators
    ([grammar](https://github.com/canfieldjuan/ATLAS/blob/888783351540946afca9922ec21024e08f49a439/atlas_brain/services/content_factory_runner.py#L207-L228),
    [parenthesized proof](https://github.com/canfieldjuan/ATLAS/blob/888783351540946afca9922ec21024e08f49a439/tests/test_content_factory_runner.py#L1529-L1540)).
16. P1 missing committed draft — fixed by failing source-bound prompt
    construction before worker dispatch when no committed draft bytes exist
    ([builder guard](https://github.com/canfieldjuan/ATLAS/blob/888783351540946afca9922ec21024e08f49a439/atlas_brain/services/content_factory_runner.py#L664-L694),
    [source-bound entrypoint](https://github.com/canfieldjuan/ATLAS/blob/888783351540946afca9922ec21024e08f49a439/atlas_brain/services/content_factory_runner.py#L839-L849),
    [no-dispatch proof](https://github.com/canfieldjuan/ATLAS/blob/888783351540946afca9922ec21024e08f49a439/tests/test_content_factory_runner.py#L1090-L1113)).

The finding on PR #2201 head `888783351` was confirmed before correction, and
the class proved WIDER than reported:

17. P1 default-ignorable bypass — a zero-width code point renders as nothing,
    so inserting one must not change a verdict. The report named the `+`/`00`
    prefix; probing the class showed it also defeated the structural NANP
    pattern (`555-123<ZWSP>-4567`), the vanity suffix (`FLOW<ZWSP>ERS`), the
    same paths in `verify_copy` — the merged body-copy gate behind the
    editorial promote decision — and `_redact_pii`, where the digit theorem
    masks phone digits but an address's LETTERS are not digits, so
    `a@b<ZWSP>.com` persisted intact in claim evidence. Fixed at the admission
    boundary rather than per pattern: a shared `scan_view()` strips
    default-ignorables before ANY contact parsing, while claim detection keeps
    the original text because its locators are sentence indices. Body-copy
    verdict POLICY is unchanged — which real forms count as PII is untouched;
    this denies an evasion of the existing policy
    ([scan view](https://github.com/canfieldjuan/ATLAS/blob/f5485fcada5b4fdd33e8c0b3aa704c163f6c4a22/atlas_brain/services/content_factory_copy_verification.py#L110-L152),
    [prompt gate](https://github.com/canfieldjuan/ATLAS/blob/f5485fcada5b4fdd33e8c0b3aa704c163f6c4a22/atlas_brain/services/content_factory_runner.py#L465-L482),
    [class proof](https://github.com/canfieldjuan/ATLAS/blob/f5485fcada5b4fdd33e8c0b3aa704c163f6c4a22/tests/test_content_factory_runner.py)).

The finding on PR #2201 head `f5485fcad` was also confirmed before correction:

18. P1 missing recipient bridge — the bridge vocabulary omitted the dative
    `to`, so `Text to +44 800 FLOWERS`, `SMS to ...` and `WhatsApp to ...`
    produced no hit while the same marker and number without the connector
    were rejected. `to` marks the recipient for every message verb, so it
    joins the closed function-word class the bridge already models.
    Possessive determiners are deliberately excluded, and the boundary is
    recorded rather than left implicit: `our`/`your`/`their` occur in ordinary
    renderer prose (`text your 1920 1080 export`), so admitting them would
    read a typography instruction as a dial instruction
    ([bridge class](https://github.com/canfieldjuan/ATLAS/blob/416e6b4f9b67c11543667539851edfd6120d6243/atlas_brain/services/content_factory_runner.py#L236-L250),
    [cross-product and prose-side proof](https://github.com/canfieldjuan/ATLAS/blob/416e6b4f9b67c11543667539851edfd6120d6243/tests/test_content_factory_runner.py)).

The finding on PR #2201 head `416e6b4f9` was also confirmed before correction:

19. P1 incomplete default-ignorable class — round 11's `scan_view` tested
    category Cf/Cc plus a hand-built range set, which misses U+034F COMBINING
    GRAPHEME JOINER (category **Mn**). So `Call +44<CGJ>800 FLOWERS` and
    `555-123<CGJ>-4567` still passed, and `_redact_pii` left
    `alice@example<CGJ>.com` FULLY intact in persisted claim evidence — the
    digit theorem cannot help there, because an address has no digits to mask.

    The root cause is the SECOND DEFINITION, not the missing codepoint: the
    schema module already carried the complete Default_Ignorable table for
    routing keys, so any rule elsewhere phrased as "Cf plus some ranges"
    leaves the bypass open by construction. `is_default_ignorable` is now
    exported as the one definition, used by routing keys, the contact scan and
    redaction alike. The corpus is derived FROM that table rather than listed,
    so a codepoint added to it is covered automatically, plus an assertion
    that the two views share one predicate
    ([shared predicate](https://github.com/canfieldjuan/ATLAS/blob/f4e7b320bd996c80d75e0d8fef9dbc928cfabcb4/atlas_brain/schemas/content_factory.py#L128-L142),
    [scan view](https://github.com/canfieldjuan/ATLAS/blob/f4e7b320bd996c80d75e0d8fef9dbc928cfabcb4/atlas_brain/services/content_factory_copy_verification.py),
    [table-derived class proof](https://github.com/canfieldjuan/ATLAS/blob/f4e7b320bd996c80d75e0d8fef9dbc928cfabcb4/tests/test_content_factory_runner.py)).

The three findings on PR #2201 head `f4e7b320b` were also confirmed:

20. P1 renderer coordinates inside the dial bridge — `center text on 1920 1080
    canvas` and `place text at 1920 1080 coordinates` produced a phone hit,
    because `text` is an admitted marker and `on`/`at` are admitted bridges.
    Pre-existing rather than introduced by the round-12 `to` addition: `on` was
    already in the set at `f5485fcad`. Fixed by POSITION rather than a list of
    renderer verbs, which is an open class — an imperative CTA heads its
    clause, while a typography instruction makes the same word the object of
    an earlier verb. Only overloaded markers (`text`, `contact`) are
    position-tested, so unambiguous markers keep full bridge behaviour and
    `please call me at 12 34 56 78` still fails
    ([dial-verb evidence](https://github.com/canfieldjuan/ATLAS/blob/24f382832db659040cae6a80e6399edc2840a732/atlas_brain/services/content_factory_runner.py#L410-L465),
    [6 verbs x 2 bridges x 4 dimensions](https://github.com/canfieldjuan/ATLAS/blob/24f382832db659040cae6a80e6399edc2840a732/tests/test_content_factory_runner.py)).
21. P2 unregistered `audit-v2` stage — the runner names it source-bound but
    the store had no entry, so it was a CUSTOM stage admitting ANY artifact: a
    `content_brief.v1` committed successfully under it, and since that schema
    is outside `_SOURCE_BOUND_SCHEMAS` the dispatch-source comparison was
    skipped as well. Mapped to the same admissible set as `audit`, with
    both-direction tests
    ([stage map](https://github.com/canfieldjuan/ATLAS/blob/24f382832db659040cae6a80e6399edc2840a732/atlas_brain/services/content_factory_store.py#L41-L60)).
22. P1 plan record — the over-budget rationale lived only in the commit
    message; the repository contract requires it in the plan's `Why this slice
    exists`. Added there with the actual indivisibility argument: the findings
    land on two shared choke points, a partially-closed gate is still
    bypassable by a one-character edit, and ~60% of the LOC is the generated
    cross-product proof that class-closure requires.

All three earlier fixes remain mutation-checked: neutralizing `scan_view` fails
64 tests, and restoring the Cf/Cc-only rule fails 134.

All fixed or waived: yes

