### PR TITLE
docs(REVIEWER_RULES,AGENTS): give the reviewer a stopping rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,8 +36,10 @@ R1–R14) and the PR's Review Contract. Review the same way the Reviewer session
   actually does from the code.
 - Every finding cites a rule ID (R1–R14) and `file:line`. Blockers must cite
   `file:line`. Classify each finding as **BLOCKER / MAJOR / NIT / LGTM** per the pack.
-- Check the PR's `### Review Contract`: does the diff meet its acceptance criteria,
-  and which rules do the changed paths trigger (the path-to-rule table in the pack)?
+- Check the PR's `### Review Contract`: does the diff meet its acceptance criteria?
+  Then disposition EVERY rule R1-R14 -- the path-to-rule table in the pack sets how
+  deeply each is probed, not which appear, so a rule the table does not trigger is
+  still recorded (Pass, or N-A with a reason).
 - Hunt the rule categories: requirements match (R1), test evidence (R2),
   security/authorization (R3), data & migration safety (R4), backward compatibility
   (R5), error handling & observability (R6), performance (R7), concurrency &
@@ -274,11 +276,14 @@ Intentional / Deferred / Verification -- matches AGENTS.md framework.
 Slice phase is named and matches the PR's scope. Parked hardening is
 named in Deferred or explicitly marked none.
 
-**Rule results (triggered rules plus R14, see docs/REVIEWER_RULES.md):**
-- R1 Requirements match: Pass/Fail/N-A
-- R2 Test evidence: Pass/Fail/N-A
-- R3 Security/auth ... R14 Codebase verification: Pass/Fail/N-A
-(List the rules the changed paths trigger, plus R14; cite file:line on any Fail.)
+**Rule results (EVERY rule R1-R14, see docs/REVIEWER_RULES.md):**
+- R1 Requirements match: Pass/Fail/Not-Verified/N-A
+- R2 Test evidence: Pass/Fail/Not-Verified/N-A
+- R3 Security/auth ... R14 Codebase verification: Pass/Fail/Not-Verified/N-A
+(List every rule R1-R14. The path-trigger table sets probe DEPTH, not which
+rules appear -- a rule the table does not trigger is still recorded, as Pass or
+as N-A with a reason. Cite file:line on any Fail. Not-Verified ends the search
+but blocks LGTM.)
 
 **boundary-probe:** <N-A, or what guard-shaped probe applied + result. Required
 before LGTM on guards, validators, caps, classifiers, gates, sanitizers,
@@ -1189,11 +1194,19 @@ the **allowed-files set**, and a **max-files budget**.
 
 ## 4. Reviewer workflow
 
-The reviewer's job is **not** "review the code" -- it is to **prove whether
-the PR satisfies its Review Contract and violates none of the rules in
-`docs/REVIEWER_RULES.md`.** Every finding cites a rule ID (R1-R14) and maps to
-a verdict level (BLOCKER / MAJOR / NIT). The rule matrix and AI reconciliation
-go in the §2a template.
+The reviewer's job is **not** "review the code" -- it is to **disposition the
+review matrix: every acceptance criterion in the PR's Review Contract, and every
+rule in `docs/REVIEWER_RULES.md`.** Every rule gets a verdict (pass / fail /
+not-verified / n-a-with-reason); the path-trigger table sets how deeply each is
+probed, not which appear. Every finding cites a rule ID (R1-R14) and maps to a
+verdict level (BLOCKER / MAJOR / NIT). The rule matrix and AI reconciliation go
+in the §2a template.
+
+A dispositioned matrix is a **complete** review -- that is the stopping
+condition, and "violates none of the rules" is not, being a universal negative
+no non-trivial diff can discharge. Complete is not approved: `not-verified` or
+`could-not-determine` entries end the search but block LGTM. See **Review
+completion** in the pack.
 
 ### 4a. Independent verification
 
@@ -1230,8 +1243,10 @@ reviewer should:
 4. Sweep for missed call sites with grep patterns more reliable than
    the PR's claim (multi-line constructions, kwargs split across
    lines, etc.).
-5. Walk the rules triggered by the changed paths (per the trigger table in
-   `docs/REVIEWER_RULES.md`) and record Pass/Fail/N-A for each.
+5. Walk EVERY rule R1-R14 and record Pass/Fail/Not-Verified/N-A for each. The
+   trigger table in `docs/REVIEWER_RULES.md` sets probe depth, not matrix
+   membership -- an untriggered rule is still recorded, and N-A carries a
+   reason. A Not-Verified entry ends the search but blocks LGTM.
 6. Apply R14: every claim used in the verdict must be backed by checked-out
    code, a caller/test/artifact spot-check, or a "not verified" note with the
    reason. **No LGTM from the PR story alone.**
@@ -1276,9 +1291,11 @@ Before LGTM, the reviewer confirms:
 - [ ] Plan doc has all 7 required sections, including the `### Review
       Contract` block in Scope (acceptance criteria, affected surfaces, risk
       areas, triggered rule IDs).
-- [ ] Every rule triggered by the changed paths (`docs/REVIEWER_RULES.md`)
-      is recorded Pass/Fail/N-A, and every Fail at BLOCKER level cites
-      file:line.
+- [ ] EVERY rule R1-R14 (`docs/REVIEWER_RULES.md`) is recorded
+      Pass/Fail/Not-Verified/N-A -- the path-trigger table sets probe depth,
+      not which rules appear, so an untriggered rule is still recorded (Pass,
+      or N-A with a reason). Every Fail at BLOCKER level cites file:line, and
+      no Not-Verified entry remains when issuing LGTM.
 - [ ] R14 is recorded Pass/Fail/N-A. The verdict names the reviewed head SHA,
       changed code inspected, caller/test/artifact spot-checks, and any claims
       not verified. No LGTM from PR/body/builder claims alone.
@@ -1469,8 +1486,11 @@ defines:
 - Anti-patterns that should never appear in a builder PR.
 
 Read `docs/REVIEWER_RULES.md` before your first review. Your job is
-not "review the code" -- it is to prove the PR satisfies its Review
-Contract and violates none of R1-R14. Cite a rule ID on every finding.
+not "review the code" -- it is to disposition the review matrix: every
+acceptance criterion in the Review Contract, and every rule R1-R14, each
+pass / fail / not-verified / n-a-with-reason. That matrix is your stopping
+condition; an unresolved entry ends the search but blocks LGTM. Cite a
+rule ID on every finding.
 
 Read AUDITOR_PROMPT.md for the cross-cutting audit checks
 (canonical / integration / scope / debt). Apply both lenses.
@@ -1495,8 +1515,10 @@ For each PR you review:
 4. Sweep for missed call sites with grep patterns more reliable
    than the PR's claim (multi-line constructions, kwargs split
    across lines).
-5. Record Pass/Fail/N-A for each rule the changed paths trigger and for R14
-   (`docs/REVIEWER_RULES.md`); cite file:line on any Fail.
+5. Record Pass/Fail/Not-Verified/N-A for EVERY rule R1-R14
+   (`docs/REVIEWER_RULES.md`) -- the trigger table sets probe depth, not which
+   rules appear; cite file:line on any Fail. Do not LGTM with a Not-Verified
+   entry outstanding.
 6. Reconcile AI findings: do not LGTM until every Codex/Copilot
    finding is fixed or explicitly waived with a reason in the PR body.
 7. Confirm CI is green (extracted-checks x2 + Vercel) before

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,9 +7,11 @@ work:
 2. **Reviewer session** — audits each PR independently and posts a
    verdict (BLOCKER / MAJOR / NIT / LGTM). After the verdict, record it as the
    machine-readable `claude-review` gate for the reviewed head SHA with
-   `scripts/set_claude_review_status.py` (LGTM/no-blocker -> `success`, an open
-   BLOCKER -> `failure`); see `docs/REVIEWER_MERGE_GATE.md` for the two-gate
-   merge condition and its trust boundary.
+   `scripts/set_claude_review_status.py` (LGTM -> `success`; an open BLOCKER
+   -> `failure`; a complete matrix still carrying a `not-verified` rule or a
+   `could-not-determine` criterion is filed as a BLOCKER and so also
+   -> `failure`, fail-closed); see `docs/REVIEWER_MERGE_GATE.md` for the
+   two-gate merge condition and its trust boundary.
 
 This file is the contract both sessions work from. The auditor
 (prompt at `AUDITOR_PROMPT.md`) handles cross-cutting integration /

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,11 +7,12 @@ work:
 2. **Reviewer session** — audits each PR independently and posts a
    verdict (BLOCKER / MAJOR / NIT / LGTM). After the verdict, record it as the
    machine-readable `claude-review` gate for the reviewed head SHA with
-   `scripts/set_claude_review_status.py` (LGTM -> `success`; an open BLOCKER
-   -> `failure`; a complete matrix still carrying a `not-verified` rule or a
-   `could-not-determine` criterion is filed as a BLOCKER and so also
-   -> `failure`, fail-closed); see `docs/REVIEWER_MERGE_GATE.md` for the
-   two-gate merge condition and its trust boundary.
+   `scripts/set_claude_review_status.py` (no open BLOCKER -> `success`, i.e. an
+   LGTM or only non-blocking MAJOR/NIT notes; an open BLOCKER -> `failure`).
+   Unresolved matrix entries are themselves filed as BLOCKERs, so a review with
+   open questions lands on `failure` without changing this mapping; see
+   `docs/REVIEWER_MERGE_GATE.md` for the two-gate merge condition and its trust
+   boundary.
 
 This file is the contract both sessions work from. The auditor
 (prompt at `AUDITOR_PROMPT.md`) handles cross-cutting integration /
@@ -49,7 +50,8 @@ R1–R14) and the PR's Review Contract. Review the same way the Reviewer session
   (R11), deployment safety & CI (R12). Fix the class, not the example (R13).
 - **Know when you are done** (Review completion, in the pack): a review is complete
   when its matrix is dispositioned -- each acceptance criterion met / not met /
-  could-not-determine, each triggered rule pass / fail / not-verified, and what you
+  could-not-determine, EVERY rule R1-R14 pass / fail / not-verified / n-a-with-reason
+  (the path table sets probe depth, not which rules appear), and what you
   did not verify listed with the reason. State that matrix. Completeness is never
   "no further case can be found"; on an open surface that point does not exist.
 - **Report the class, not the instance.** R13 obliges the builder to fix the class
@@ -57,8 +59,8 @@ R1–R14) and the PR's Review Contract. Review the same way the Reviewer session
   underlying decision are **one** finding naming that decision, with the instances
   as illustrations. If a finding of yours would open "fresh evidence beyond the
   earlier X finding", it belongs merged into X, not filed separately.
-- Lead with blockers. `LGTM` (all triggered rules pass, no open BLOCKER/MAJOR) is a
-  valid, complete result; do not manufacture NITs.
+- Lead with blockers. `LGTM` (every rule R1-R14 Pass or reasoned N-A, no open
+  BLOCKER/MAJOR) is a valid, complete result; do not manufacture NITs.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,16 @@ R1–R14) and the PR's Review Contract. Review the same way the Reviewer session
   (R5), error handling & observability (R6), performance (R7), concurrency &
   idempotency (R8), frontend (R9), maintainability (R10), dependencies & config
   (R11), deployment safety & CI (R12). Fix the class, not the example (R13).
+- **Know when you are done** (Review completion, in the pack): a review is complete
+  when its matrix is dispositioned -- each acceptance criterion met / not met /
+  could-not-determine, each triggered rule pass / fail / not-verified, and what you
+  did not verify listed with the reason. State that matrix. Completeness is never
+  "no further case can be found"; on an open surface that point does not exist.
+- **Report the class, not the instance.** R13 obliges the builder to fix the class
+  rather than the example; the same duty binds you. Findings that share one
+  underlying decision are **one** finding naming that decision, with the instances
+  as illustrations. If a finding of yours would open "fresh evidence beyond the
+  earlier X finding", it belongs merged into X, not filed separately.
 - Lead with blockers. `LGTM` (all triggered rules pass, no open BLOCKER/MAJOR) is a
   valid, complete result; do not manufacture NITs.
 

--- a/docs/REVIEWER_RULES.md
+++ b/docs/REVIEWER_RULES.md
@@ -22,7 +22,7 @@ This pack sits **under** the existing verdict ladder, it does not replace it:
 | **BLOCKER** | A rule below is failed in a way that breaks correctness, security, a contract, or CI. Must fix before merge. |
 | **MAJOR** | A rule is at risk: architectural / scope / pattern concern. Fix if small; else discuss. |
 | **NIT** | Style / naming / polish. Apply only if 1-line; reviewer marks skip-worthy. |
-| **LGTM** | All triggered rules pass, R14 is satisfied, and all AI findings are fixed-or-waived. |
+| **LGTM** | Every rule R1-R14 is Pass or a reasoned N-A (no Not-Verified outstanding), R14 is satisfied, and all AI findings are fixed-or-waived. |
 
 A finding is written as `Rxx (LEVEL) file:line - issue - required fix`.
 **Blockers must cite `file:line`.** A bare "LGTM" with no rule matrix and no
@@ -336,9 +336,13 @@ scoped, which is a finding in itself.
 fourth one -- it maps onto the existing `failure`. A `not-verified` rule or a
 `could-not-determine` criterion is filed as a BLOCKER (`Rxx (BLOCKER) - not
 verified: <what, and why not>`), so `scripts/set_claude_review_status.py` takes
-`failure` and `success` is unreachable while anything is unresolved. `pending`
-keeps its meaning -- a review still in progress -- and is not a parking space
-for a finished review with open questions.
+`failure` and `success` is unreachable while anything is unresolved. This does
+**not** narrow `success` to LGTM: it keeps its established meaning of "no open
+BLOCKER", so a complete review carrying only non-blocking MAJOR/NIT notes is
+still `success`, exactly as `docs/REVIEWER_MERGE_GATE.md` and
+`scripts/set_claude_review_status.py` already define it. `pending` keeps its
+meaning -- a review still in progress -- and is not a parking space for a
+finished review with open questions.
 
 This is deliberately fail-closed. Unverified evidence is exactly what a merge
 gate exists to stop, so the burden is on resolving the entry or waiving it as a

--- a/docs/REVIEWER_RULES.md
+++ b/docs/REVIEWER_RULES.md
@@ -291,7 +291,13 @@ A review is **complete** when its matrix is dispositioned, and the review states
 that matrix:
 
 1. **Each acceptance criterion** in the Review Contract: met / not met /
-   could-not-determine, with `file:line`.
+   could-not-determine, with checkable evidence -- `file:line` for a
+   code/content claim, or a named non-file artifact (command + output, CI
+   run/job, generated artifact, PR metadata) where the criterion is not about
+   source. Same evidence forms the binding reviewer workflow already accepts
+   (`AGENTS.md` 4a step 4); demanding `file:line` for a CI-status or
+   command-output criterion would either stall the matrix or buy a green tick
+   with an irrelevant citation.
 2. **Every rule, R1-R14**: pass / fail / not-verified / n-a-with-reason. The
    path-trigger table sets how deeply each is probed, **not which appear**. A
    behavior change under a path the table does not list still owes an R2
@@ -307,9 +313,8 @@ holding that standard reports forever.
 or `could-not-determine` entries is a complete review -- the reviewer may stop
 -- but it is **not** an LGTM. LGTM requires every rule to be `pass` or a
 reasoned `n-a` (see the ladder above); an unresolved entry is an open question,
-so the verdict is *needs verification*, and `scripts/set_claude_review_status.py`
-must not be given `success` for it. Conflating the two would let a review that
-verified almost nothing produce a green merge gate, which is the opposite of
+so the verdict is *needs verification*. Conflating the two would let a review
+that verified almost nothing produce a green merge gate, which is the opposite of
 what a stopping rule is for.
 
 **Discharge is per head SHA.** A rule marked *pass* is discharged for **that
@@ -325,6 +330,21 @@ why the earlier discharge was wrong: the condition that was never actually met,
 not one more instance of a decision already reported. A discharge repeatedly
 overturned on unchanged code is evidence the rule was never dischargeable as
 scoped, which is a finding in itself.
+
+**Recording the gate: an unresolved entry is a BLOCKER-level finding.** The
+`claude-review` status has three states and "complete but not approved" is not a
+fourth one -- it maps onto the existing `failure`. A `not-verified` rule or a
+`could-not-determine` criterion is filed as a BLOCKER (`Rxx (BLOCKER) - not
+verified: <what, and why not>`), so `scripts/set_claude_review_status.py` takes
+`failure` and `success` is unreachable while anything is unresolved. `pending`
+keeps its meaning -- a review still in progress -- and is not a parking space
+for a finished review with open questions.
+
+This is deliberately fail-closed. Unverified evidence is exactly what a merge
+gate exists to stop, so the burden is on resolving the entry or waiving it as a
+reasoned `n-a`, never on the gate to guess. The reviewer is still *done*: the
+matrix bounds the search, the verdict reports what it found, and neither forces
+the other.
 
 **Report the class, not the instance.** R13 obliges the *builder* to fix the
 class rather than the cited example. The same duty binds the *reviewer*: when

--- a/docs/REVIEWER_RULES.md
+++ b/docs/REVIEWER_RULES.md
@@ -1,10 +1,16 @@
 # Reviewer Rules Pack v1
 
-> The reviewer's job is **not** to "review the code." It is to **prove whether
-> the PR satisfies its Review Contract and violates none of the rules below.**
-> Every review finding cites a rule ID (R1-R14). This pack is the checklist the
-> reviewer runs; the recurring-lapse list in `docs/SESSION_BOOTSTRAP.md` is the
-> same checklist front-loaded into the builder so the repeats stop.
+> The reviewer's job is **not** to "review the code." It is to **disposition the
+> review matrix: every acceptance criterion in the PR's Review Contract, and
+> every rule below that the changed paths trigger.** Every review finding cites
+> a rule ID (R1-R14). This pack is the checklist the reviewer runs; the
+> recurring-lapse list in `docs/SESSION_BOOTSTRAP.md` is the same checklist
+> front-loaded into the builder so the repeats stop.
+>
+> The standard is *the matrix is dispositioned*, not *the code violates no rule*.
+> "Violates none of the rules" is a universal negative -- undischargeable on any
+> non-trivial diff, so it defines no point at which a review is done. See
+> **Review completion** below, which is what makes a review finishable.
 
 This pack sits **under** the existing verdict ladder, it does not replace it:
 
@@ -273,6 +279,55 @@ example. Before LGTM on an R13-triggering finding, verify one of:
 - a property/parametrized test generates diverse same-class cases;
 - unseen fixtures cover varied cases not listed in the original finding; or
 - the reviewer reran a held-out probe and the verdict records it.
+
+---
+
+## Review completion (the stopping rule)
+
+A review is **complete** when its matrix is dispositioned, and the review states
+that matrix:
+
+1. **Each acceptance criterion** in the Review Contract: met / not met /
+   could-not-determine, with `file:line`.
+2. **Each rule the changed paths trigger** (path table above): pass / fail /
+   not-verified.
+3. **What was not verified**, listed with the reason.
+
+That is the whole standard. A dispositioned matrix with items honestly marked
+not-verified is a complete review; an exhaustive hunt with no matrix is not.
+Completeness is never "no further case can be found" -- on an open surface no
+such point exists, so a reviewer holding that standard reports forever.
+
+**Discharge.** A triggered rule marked *pass* is discharged for the reviewed
+head. A later round may re-open it, but only by stating **why the earlier
+discharge was wrong** -- the condition that was never actually met -- not by
+presenting one more instance of a decision already reported. Re-opening is a
+real move and sometimes the right one; it just has to be argued, because a
+discharge that keeps being silently overturned is evidence the rule was never
+dischargeable as scoped, which is a finding in itself.
+
+**Report the class, not the instance.** R13 obliges the *builder* to fix the
+class rather than the cited example. The same duty binds the *reviewer*: when
+two or more findings share one underlying decision, file **one** finding that
+names the decision, carrying the instances as illustrations. A finding whose own
+text opens "fresh evidence beyond the earlier `<X>` finding" is by its own words
+another instance of a decision already reported -- merge it into that finding
+instead of filing it separately. Where the decision keeps producing instances,
+the `AGENTS.md` 3k.2 breaker applies to the reviewer too: file the seam once and
+say so, rather than the next adjacent case.
+
+Nothing here licenses withholding a real defect. It changes how defects are
+*reported* -- once, at the level the fix has to happen anyway -- not whether.
+
+**Why:** measured on two PRs. #2195 drew 35 findings over 13 rounds; **18 of the
+35 (51%) explicitly declared themselves adjacent to an earlier finding**, and 27
+collapse into three decisions (source attestation 12, receipt lifecycle 12,
+preflight ordering 3). #2184 drew 33 over 14 rounds, collapsing into four
+decisions plus four distinct findings. Reported class-first, the same defects
+surface in roughly three rounds instead of thirteen, with none lost. Round 6 of
+#2195 is the cost of the alternative: it reverses round 5 ("reject ignored
+bytecode" became "stop rejecting bytecode created by the CLI itself"), which is
+what instance-by-instance boundary-shifting produces.
 
 ---
 

--- a/docs/REVIEWER_RULES.md
+++ b/docs/REVIEWER_RULES.md
@@ -2,8 +2,11 @@
 
 > The reviewer's job is **not** to "review the code." It is to **disposition the
 > review matrix: every acceptance criterion in the PR's Review Contract, and
-> every rule below that the changed paths trigger.** Every review finding cites
-> a rule ID (R1-R14). This pack is the checklist the reviewer runs; the
+> every rule below.** Every rule is in the matrix -- the path-trigger table sets
+> how DEEPLY a rule is probed, never whether it appears -- so a rule reaches a
+> verdict of pass / fail / not-verified / n-a, and `n-a` carries a reason.
+> Every review finding cites a rule ID (R1-R14). This pack is the checklist the
+> reviewer runs; the
 > recurring-lapse list in `docs/SESSION_BOOTSTRAP.md` is the same checklist
 > front-loaded into the builder so the repeats stop.
 >
@@ -289,22 +292,39 @@ that matrix:
 
 1. **Each acceptance criterion** in the Review Contract: met / not met /
    could-not-determine, with `file:line`.
-2. **Each rule the changed paths trigger** (path table above): pass / fail /
-   not-verified.
+2. **Every rule, R1-R14**: pass / fail / not-verified / n-a-with-reason. The
+   path-trigger table sets how deeply each is probed, **not which appear**. A
+   behavior change under a path the table does not list still owes an R2
+   verdict; deriving matrix membership from the table would let exactly that
+   PR reach LGTM without anyone asking whether the new behavior has tests.
 3. **What was not verified**, listed with the reason.
 
-That is the whole standard. A dispositioned matrix with items honestly marked
-not-verified is a complete review; an exhaustive hunt with no matrix is not.
-Completeness is never "no further case can be found" -- on an open surface no
-such point exists, so a reviewer holding that standard reports forever.
+That is the whole standard for *stopping*. Completeness is never "no further
+case can be found" -- on an open surface no such point exists, so a reviewer
+holding that standard reports forever.
 
-**Discharge.** A triggered rule marked *pass* is discharged for the reviewed
-head. A later round may re-open it, but only by stating **why the earlier
-discharge was wrong** -- the condition that was never actually met -- not by
-presenting one more instance of a decision already reported. Re-opening is a
-real move and sometimes the right one; it just has to be argued, because a
-discharge that keeps being silently overturned is evidence the rule was never
-dischargeable as scoped, which is a finding in itself.
+**Complete is not the same as approved.** A matrix with honest `not-verified`
+or `could-not-determine` entries is a complete review -- the reviewer may stop
+-- but it is **not** an LGTM. LGTM requires every rule to be `pass` or a
+reasoned `n-a` (see the ladder above); an unresolved entry is an open question,
+so the verdict is *needs verification*, and `scripts/set_claude_review_status.py`
+must not be given `success` for it. Conflating the two would let a review that
+verified almost nothing produce a green merge gate, which is the opposite of
+what a stopping rule is for.
+
+**Discharge is per head SHA.** A rule marked *pass* is discharged for **that
+head only**. A new head is new code: every rule re-opens on it freely, with no
+argument owed, because a defect the builder just introduced was not missed
+earlier -- it did not exist earlier. Requiring the reviewer to disown a
+previously-correct pass before reporting it would suppress exactly the
+regressions a re-review is for.
+
+The argument requirement applies only to re-opening a rule **on the same head**
+-- the reviewer revisiting their own verdict on unchanged code. There, state
+why the earlier discharge was wrong: the condition that was never actually met,
+not one more instance of a decision already reported. A discharge repeatedly
+overturned on unchanged code is evidence the rule was never dischargeable as
+scoped, which is a finding in itself.
 
 **Report the class, not the instance.** R13 obliges the *builder* to fix the
 class rather than the cited example. The same duty binds the *reviewer*: when


### PR DESCRIPTION
Docs-only: true

Gives the reviewer a completion condition. It currently has none, and that is the mechanism behind #2195 (35 findings / 13 rounds) and #2184 (33 / 14).

## The defect

`docs/REVIEWER_RULES.md:3-4` defined the reviewer's job as:

> prove whether the PR satisfies its Review Contract **and violates none of the rules below**

The first half terminates — a Review Contract has a finite acceptance-criteria list. The second half is a **universal negative**, undischargeable on any non-trivial diff. Nothing else in the pack supplies a stopping point, so a reviewer holding that standard is correct to keep reporting indefinitely.

Second defect, and the one with the clearest fingerprint: **R13 obliges the builder to fix the class, not the example — the pack never obliged the reviewer to report the class, not the instance.** Meanwhile R13 blocks when the builder cannot show *"fresh same-class cases the reviewer did not provide"*, and the class-defect framing tells the reviewer to *"keep a held-out probe for re-review"*. That guidance produces exactly one adjacent case per round.

It shows up verbatim in the data: **18 of #2195's 35 findings (51%) open with "Fresh evidence beyond the earlier `<X>` finding is..."** The bot is announcing that it is filing an adjacent instance, because that is what it was told to do.

## Corrected after review — read this first

The first version of this PR was wrong in a way worth stating plainly: by deriving matrix membership from the path-trigger table and calling a `not-verified` matrix "complete", it opened a path to `claude-review=success` on a review that had verified almost nothing. A PR whose stated purpose is bounding reviewer effort must not buy that bound by lowering the approval bar. Four P1 BLOCKERs caught it; `443eb0944` fixes all four, and the net effect is now a **stricter** gate than main: every rule R1-R14 must be dispositioned, where before only path-triggered ones were.

## The change

**`Review completion`** — a review is complete when its matrix is dispositioned:
1. each acceptance criterion: met / not met / could-not-determine, with `file:line`
2. each triggered rule: pass / fail / not-verified
3. what was not verified, with the reason

A dispositioned matrix with honest not-verified entries is a **complete** review. Completeness is never "no further case can be found" — on an open surface that point does not exist.

**Discharge** — a rule marked pass is discharged for that head. Re-opening it is allowed but must argue *why the earlier discharge was wrong*, not present one more instance. A discharge that keeps being silently overturned is itself evidence the rule was never dischargeable as scoped, which is a finding worth making.

**Report the class, not the instance** — findings sharing one decision are one finding naming that decision, instances as illustrations.

Explicitly: **nothing here withholds a real defect.** It changes how defects are reported — once, at the level the fix has to happen anyway — not whether.

## Verification: replayed against the two PRs before landing

Grouped every filed finding by the decision it touches.

**#2195 — 35 findings / 13 rounds → 3 decisions + 7 distinct ≈ 10 findings:**

| Decision | Findings | Rounds spanned |
|---|---:|---|
| What set of bytes is the attested source | 12 | 3–13 |
| When is the receipt authoritative vs the process outcome | 12 | 1–13 |
| Preflight/isolation ordering before untrusted code runs | 3 | 9–11 |
| Genuinely distinct (contract criteria, tests, docs, umask) | 7 | — |

**#2184 — 33 findings / 14 rounds → 4 decisions + 4 distinct ≈ 8 findings:** sender admission predicate (9), scoped token durability protocol (12), secret redaction in config errors (5), limit/cap scoping (3), plus 4 distinct.

Same defects, reported class-first, in roughly three rounds instead of thirteen. Nothing dropped — every seam finding still names the underlying defect.

The cost of the current behavior is visible in the same data: **#2195 round 6 reverses round 5.** "Reject ignored bytecode" (r5) became "stop rejecting bytecode created by the CLI itself" (r6). That is instance-by-instance boundary-shifting, and it is what a class-level finding at r5 would have avoided.

## Intentional

- **Deliberately not a per-round finding budget.** A cap would suppress real defects; this changes reporting granularity instead, so a genuine BLOCKER found at round 9 is still filed at round 9.
- **Re-opening a discharged rule stays legal.** Making it illegal would be a guard that fails on its second side — the reviewer who was wrong at round 3 must be able to say so.
- Applies to human reviewer sessions and the Codex connector identically. `AGENTS.md` "Review guidelines" is the surface the connector reads (it cites `AGENTS.md#L39-L45` on every recent PR), so the two new bullets go there and point at the pack.

## Deferred

Three other levers from the same diagnosis, each separable and not in this PR:
- Bounding Review Contracts at plan time — #2195's contract names *"preflight-to-import TOCTOU"* and *"all exit paths finalize truthfully"* as targets, which are open categories. **This is the root**; the stopping rule is downstream of it.
- Severity discipline — all 68 findings across both PRs are P1/P2, none lower. "Do not manufacture NITs" pushes marginal findings up rather than dropping them.
- A removal clause for "Turning misses into mechanism", which currently only grows the pack.

## Parked hardening

- None.

## Cold diff reconstruction

- Changed: `docs/REVIEWER_RULES.md:3` replaces the undischargeable framing with the matrix standard and points at the new section.
- Changed: `docs/REVIEWER_RULES.md:279` adds `## Review completion (the stopping rule)`: the matrix, discharge/re-open, report-the-class, and the measured why.
- Changed: `AGENTS.md:46` adds two bullets to Review guidelines — know when you are done, and report the class not the instance — on the surface the connector actually reads.
- Contract match: every change traces to one of the two named defects (no completion condition; R13 asymmetry).
- Gaps: none.

## Verification

- Replay against #2195 and #2184 above — the primary evidence, done before landing per the operator's instruction.
- `scripts/audit_pr_plan_presence.py origin/main --pr-author canfieldjuan` → `classification: docs-only`, PASS.
- Trigger table still parses: 12 glob rows, 9 prose rows, unchanged.
- `git diff --check` clean. No non-ASCII added; `docs/REVIEWER_RULES.md` has zero em-dashes on main and this diff adds none.

## AI reconciliation

4 findings, all P1 BLOCKER, all **fixed** in `443eb0944`; none waived. The operator's independent spot-check at head `d3236f9` reached the same four.

- **Matrix membership derived from the path table** (R2) — a behavior change under an unlisted path could complete the matrix *and* satisfy LGTM with no R2 verdict recorded. Every rule R1-R14 is now in the matrix; the table sets probe depth, not membership.
- **Complete conflated with approved** (R12) — `set_claude_review_status.py:13-20` maps any completed review with no BLOCKER to `claude-review=success`, so a matrix of honest `not-verified` entries would have gone green. Completion is now the stopping condition only; LGTM still requires Pass or reasoned N-A.
- **Discharge re-opening required disowning the earlier pass** (R14) — on a new head that pass was *correct*, so the rule suppressed exactly the regressions a re-review exists to catch. Discharge is now per head SHA.
- **Stopping rule reached only the pack header** (R1) — `AGENTS.md:1192` (binding §4 workflow), `:1471` (reviewer bootstrap), the §2a template, the 4d checklist and three more entrypoints still carried the old standard. Fixed at all of them; repo swept, class closed.

**The first draft made the merge gate weaker**, which is the opposite of the intent. That is the finding that mattered.

**Round 2** — 2 findings, both created by round 1's fix, both fixed in `66d36ddf2`:

- **No status could encode "complete but needs verification"** (R12, BLOCKER) — I added the state and left the gate unable to record it: three states, `AGENTS.md:9-10` sending every no-blocker verdict to `success`, and `pending` defined as an *incomplete* review. Resolved without a fourth state: an unresolved entry is filed as a BLOCKER-level finding, so the mapping is `failure`, `success` is unreachable while anything is unresolved, and `pending` keeps meaning in-progress. Fail-closed, no code change.
- **`file:line` required on every acceptance criterion** (R14, MAJOR) — breaks for criteria about CI status, command output, or a generated artifact. Now accepts `file:line` **or** a named non-file artifact, matching what `AGENTS.md` 4a step 4 already permits.

**Round 3** — 2 findings, both my own incomplete work, both fixed in `601a11b94`:

- **Matrix membership still path-derived in three places** (R2, BLOCKER) — including a bullet I wrote in this PR: `AGENTS.md:52` ("each triggered rule"), `AGENTS.md:60` (LGTM = "all triggered rules pass"), and the `REVIEWER_RULES.md:25` ladder. All now read every rule R1-R14. **I claimed class closure on this class in round 1 and was wrong — twice.** Both sweeps grepped the phrasings I remembered writing rather than the concept, and "all triggered rules pass" is invisible to a grep for "rules the changed paths trigger".
- **`LGTM -> success` over-corrected** (R12, BLOCKER) — `success` was already defined consistently as "no open BLOCKER" in `REVIEWER_MERGE_GATE.md:28-29` and `set_claude_review_status.py:14-15`. Narrowing it from one entrypoint left a complete MAJOR-only verdict unmapped there and green under the other. Reverted; the fail-closed property survives because an unresolved entry is already filed as a BLOCKER. All four surfaces verified in agreement.

Round-over-round: **4 → 2 → 2**. Every finding traces to incompleteness in my own prior round, not to re-litigation of settled ground.

All fixed or waived: yes

## Diff size

2 files, +166 / -31
