### PR TITLE
docs(AGENTS,REVIEWER_RULES): bound contracts at plan time; severity floor; ratchet release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,30 @@ contract surface, the Review Contract must also name the reachability proof:
 the real entrypoint exercised and the observable output/state/artifact/job/gate
 result that proves the surface is wired.
 
+**Every acceptance criterion must be dispositionable.** A reviewer has to be
+able to mark it met / not met / could-not-determine from evidence in the diff --
+that is what the reviewer's completion matrix (`docs/REVIEWER_RULES.md`, Review
+completion) checks against, so a criterion that cannot be dispositioned makes
+the whole review unfinishable no matter how bounded the rest of the pack is.
+
+A criterion states a **structural property** the code either has or lacks. It
+does not name an open category as its target: "no preflight-to-import TOCTOU",
+"all exit paths finalize truthfully", "handles every malformed input" are
+unbounded -- there is no evidence that discharges them, so the reviewer is
+correct to keep producing cases forever. Restate the same intent as a property:
+*"the receipt is constructed before any fallible work, and no path after
+finalization can change the process outcome"* is checkable by reading, and it
+covers the exit paths the open phrasing was reaching for.
+
+The same applies to **risk areas**: name the risk, then the property that closes
+it. A risk area listed without a closing property is an open-ended review
+mandate the builder wrote for themselves.
+
+Where the slice genuinely is open-input or open-execution work, the criterion
+points at the mechanism that closes it -- the evidence-gate of 3k.3 or the
+execution model of 3k.4 -- rather than at the category. Those sections are the
+"how"; this is the requirement that the contract use them.
+
 ### 1b. PR body
 
 For a non-empty human PR that intentionally carries no plan and changes only

--- a/docs/REVIEWER_RULES.md
+++ b/docs/REVIEWER_RULES.md
@@ -25,6 +25,23 @@ A finding is written as `Rxx (LEVEL) file:line - issue - required fix`.
 **Blockers must cite `file:line`.** A bare "LGTM" with no rule matrix and no
 independent verification is worse than no comment.
 
+**BLOCKER requires a concrete failure path**: the specific input, sequence, or
+state that produces the harm, stated in the finding. "This could break" is not
+one. Without a failure path the finding is MAJOR at most -- downgrade it, do not
+drop it, and the level can be raised later once the path is shown.
+
+**The escape valve from "do not manufacture NITs" is not filing the finding, not
+promoting it.** That instruction bars padding a review with polish; it is not a
+reason to enter a marginal finding at BLOCKER so it clears the bar. If a finding
+is real but minor, MAJOR and NIT exist for it; if it is not worth reporting,
+report nothing and mark the rule dispositioned.
+
+**Why:** across #2195 and #2184 all **68** filed findings are P1/P2 and none is
+lower. Real severity is not distributed that way, and a ladder where everything
+is a blocker carries no information -- the reviewer cannot lead with blockers
+(above) when every finding is one, and the builder cannot tell an exploitable
+gap from an ordering nit.
+
 R14 is universal: it applies to every review verdict, even when no changed path
 specifically triggers it. A reviewer who has not inspected the checked-out PR
 head and relevant codebase evidence cannot issue LGTM.
@@ -51,6 +68,16 @@ reviewer reviews against it. No contract, nothing to check against.
 
 The contract is optional for one-off scratch, mandatory for non-trivial PRs
 (same threshold as the plan doc itself, per `AGENTS.md`).
+
+**A criterion the reviewer cannot disposition is a defect in the contract, and
+the reviewer says so.** Review completion (below) checks each criterion met /
+not met / could-not-determine; a criterion that names an open category rather
+than a structural property -- "no TOCTOU", "all exit paths finalize truthfully",
+"handles every malformed input" -- can never be marked met, so it reopens the
+review indefinitely and defeats the stopping rule. The authoring requirement
+lives in `AGENTS.md` 1a. On review, flag it as **R1** against the plan and ask
+for the property restatement; do not silently work around it by hunting the
+category, which is the behavior that produced 13 rounds on #2195.
 
 ---
 
@@ -354,3 +381,22 @@ recur: a new `scripts/audit_*.py`, a new rule ID here, a new path trigger above,
 a line in the recurring-lapse checklist, or a Review Contract template change.
 **No escaped defect is fixed only once.** This is the reviewer-side mirror of
 the builder's `HARDENING.md` + recurring-lapse flywheel.
+
+**The ratchet releases too.** As written this section only ever adds, and the
+reviewer's mandate grows with it -- every added rule is another category to hunt
+on every future PR, forever, which is a cost paid by every subsequent review.
+So each addition is reviewed for removal on the same terms it was added:
+
+- A rule, path trigger, or checklist line that **has not fired** in the last
+  ~50 merged PRs is either redundant with something else here or is addressing a
+  failure mode that has stopped happening. Remove it, or state why it stays.
+- One whose firings are **consistently waived** is mis-scoped, not load-bearing.
+  Re-scope it to what actually blocks, or remove it.
+- Removals are recorded the same way additions are, with the reasoning, so a
+  removal is a decision and not an erosion.
+
+Nothing here weakens the "no escaped defect is fixed only once" rule -- an
+escaped defect still converts into mechanism. This governs what happens to that
+mechanism afterwards, so the pack stays the size a reviewer can actually apply.
+A checklist nobody can finish is the failure mode Review completion exists to
+prevent, and an unbounded ratchet recreates it one rule at a time.


### PR DESCRIPTION
Docs-only: true

The three levers #2202 deferred, from the same diagnosis. **Stacks on #2202** (base is `claude/pr-reviewer-stopping-rule`) — merge that first.

## 1. Contracts bounded at plan time — this is the root

#2202 bounded the review *matrix*. But criterion 1 of that matrix is *"each acceptance criterion in the Review Contract"* — so **an open criterion reopens the review no matter how bounded the pack is.** The stopping rule is only ever as bounded as the contract it checks against.

#2195's contract is the worked case. It names as targets:

> Risk areas: false source attestation, **preflight-to-import TOCTOU**, ...
> - [ ] Normal, `SystemExit`, interrupt, and exceptional exits **finalize truthfully**

Neither can ever be marked *met*. There is no evidence that discharges "no TOCTOU" or "all exit paths." A reviewer checking that contract is **correct** to keep producing cases — the builder wrote an unbounded review mandate for themselves, and 13 rounds is what it cost.

The change: criteria and risk areas state a **structural property the code has or lacks**. Same intent, dispositionable —

> ~~"all exit paths finalize truthfully"~~ → *"the receipt is constructed before any fallible work, and no path after finalization can change the process outcome"*

— which is checkable by reading, and covers the exit paths the open phrasing was reaching for. Where a slice genuinely is open-input or open-execution work, the criterion points at the closing mechanism (3k.3's evidence-gate, 3k.4's execution model) rather than at the category.

Reviewer side: an undispositionable criterion is an **R1 finding against the plan** — say so, ask for the property restatement. Do not silently work around it by hunting the category.

## 2. Severity floor

**BLOCKER now requires a concrete failure path** — the input, sequence, or state that produces the harm, stated in the finding. Without one it is MAJOR at most: downgrade, don't drop, and it can be raised once the path is shown.

This also closes a perverse reading of *"do not manufacture NITs"*. That instruction bars padding a review with polish. It is **not** a reason to enter a marginal finding at BLOCKER so it clears the bar — the escape valve is not filing it.

Evidence: across #2195 and #2184, **all 68 filed findings are P1/P2 and none is lower.** Real severity is not distributed that way. A ladder where everything is a blocker carries no information — the pack tells reviewers to "lead with blockers," which is meaningless when every finding is one, and the builder cannot tell an exploitable gap from an ordering nit.

## 3. Ratchet release

"Turning misses into mechanism" converts every escaped defect into a durable new rule, trigger, or checklist line — and **only ever adds**. The reviewer's mandate therefore grows monotonically, and every added rule is another category hunted on every future PR forever, a cost paid by every subsequent review.

Additions are now reviewed for removal on the same terms they were added: not fired in ~50 merged PRs, or firings consistently waived → remove or state why it stays, with removals recorded like additions so a removal is a decision rather than an erosion.

This does not weaken *"no escaped defect is fixed only once"* — escaped defects still convert into mechanism. It governs what happens to that mechanism afterwards. A checklist nobody can finish is the exact failure mode #2202's Review completion exists to prevent, and an unbounded ratchet recreates it one rule at a time.

## Intentional

- **One PR, three changes** — deliberate, and I'd argue it against my own advice elsewhere. All three are docs-only edits to the same two files, they share one thesis (the instruction set's economics produce over-reporting), and splitting them into three PRs triples the review load on the bot whose review load is the thing being fixed. The diff is +70 across two Markdown files with no runtime surface.
- **Severity findings are downgraded, never dropped.** A cap on findings would suppress real defects; this changes the level, not the reporting.
- **The removal clause is bounded by "or state why it stays"** so a load-bearing rule that rarely fires (a security trigger, say) survives on an argument rather than on a firing count.

## Deferred

- Mechanizing the ~50-PR non-firing check. Doing it by hand at pack-review time is fine to start; if it proves worth automating it belongs with #2198's checker, not in prose (the lesson from #2197's seven rounds).

## Parked hardening

- None.

## Cold diff reconstruction

- Changed: `AGENTS.md:105` requires every acceptance criterion to be dispositionable, states the structural-property form, extends it to risk areas, and points open-input/open-execution slices at 3k.3 / 3k.4.
- Changed: `docs/REVIEWER_RULES.md:52` makes an undispositionable criterion an R1 finding against the plan.
- Changed: `docs/REVIEWER_RULES.md:27` adds the BLOCKER failure-path requirement and the do-not-promote-marginal-findings clause.
- Changed: `docs/REVIEWER_RULES.md:322` adds the removal terms to the misses-into-mechanism ratchet.
- Contract match: 1 traces to the unbounded-contract defect, 2 to the severity-inflation evidence, 3 to the monotonic-growth defect. All three were named in #2202's Deferred section.
- Gaps: none.

## Verification

- `scripts/audit_pr_plan_presence.py origin/main --pr-author canfieldjuan` → `classification: docs-only`, PASS.
- Path-trigger table still parses: 12 glob rows, 9 prose rows, unchanged.
- `git diff --check` clean. **Zero** non-ASCII characters added to either file.
- Applied to itself: this PR's own claims are dispositionable — the 68/68 P1-P2 count and the #2195 contract quotes are checkable from the PRs cited.

## AI reconciliation

No reviewer threads at open time; will reconcile any that arrive.

All fixed or waived: yes

## Diff size

2 files, +70 / -0
