### PR TITLE
[BLOCKED on #2202] docs(AGENTS,REVIEWER_RULES): require acceptance criteria to be dispositionable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,30 @@ contract surface, the Review Contract must also name the reachability proof:
 the real entrypoint exercised and the observable output/state/artifact/job/gate
 result that proves the surface is wired.
 
+**Every acceptance criterion must be dispositionable.** A reviewer has to be
+able to mark it met / not met / could-not-determine from evidence in the diff --
+that is what the reviewer's completion matrix (`docs/REVIEWER_RULES.md`, Review
+completion) checks against, so a criterion that cannot be dispositioned makes
+the whole review unfinishable no matter how bounded the rest of the pack is.
+
+A criterion states a **structural property** the code either has or lacks. It
+does not name an open category as its target: "no preflight-to-import TOCTOU",
+"all exit paths finalize truthfully", "handles every malformed input" are
+unbounded -- there is no evidence that discharges them, so the reviewer is
+correct to keep producing cases forever. Restate the same intent as a property:
+*"the receipt is constructed before any fallible work, and no path after
+finalization can change the process outcome"* is checkable by reading, and it
+covers the exit paths the open phrasing was reaching for.
+
+The same applies to **risk areas**: name the risk, then the property that closes
+it. A risk area listed without a closing property is an open-ended review
+mandate the builder wrote for themselves.
+
+Where the slice genuinely is open-input or open-execution work, the criterion
+points at the mechanism that closes it -- the evidence-gate of 3k.3 or the
+execution model of 3k.4 -- rather than at the category. Those sections are the
+"how"; this is the requirement that the contract use them.
+
 ### 1b. PR body
 
 For a non-empty human PR that intentionally carries no plan and changes only

--- a/docs/REVIEWER_RULES.md
+++ b/docs/REVIEWER_RULES.md
@@ -52,6 +52,16 @@ reviewer reviews against it. No contract, nothing to check against.
 The contract is optional for one-off scratch, mandatory for non-trivial PRs
 (same threshold as the plan doc itself, per `AGENTS.md`).
 
+**A criterion the reviewer cannot disposition is a defect in the contract, and
+the reviewer says so.** Review completion (below) checks each criterion met /
+not met / could-not-determine; a criterion that names an open category rather
+than a structural property -- "no TOCTOU", "all exit paths finalize truthfully",
+"handles every malformed input" -- can never be marked met, so it reopens the
+review indefinitely and defeats the stopping rule. The authoring requirement
+lives in `AGENTS.md` 1a. On review, flag it as **R1** against the plan and ask
+for the property restatement; do not silently work around it by hunting the
+category, which is the behavior that produced 13 rounds on #2195.
+
 ---
 
 ## The rules


### PR DESCRIPTION
Docs-only: true

Stacks on #2202 (base `claude/pr-reviewer-stopping-rule`). **This is the root the other two sit on** — merge #2202, then this.

## The defect

#2202 bounded the review *matrix*. But criterion 1 of that matrix is *"each acceptance criterion in the Review Contract"* — so **an open criterion reopens the review no matter how bounded the pack is.** The stopping rule is only ever as bounded as the contract it checks against.

#2195's contract is the worked case:

> Risk areas: false source attestation, **preflight-to-import TOCTOU**, ...
> - [ ] Normal, `SystemExit`, interrupt, and exceptional exits **finalize truthfully**

Neither can ever be marked *met* — there is no evidence that discharges "no TOCTOU" or "all exit paths." A reviewer checking that contract is **correct** to keep producing cases. The builder wrote himself an unbounded review mandate, and 13 rounds is what it cost.

## The change

Criteria and risk areas state a **structural property the code has or lacks**. Same intent, dispositionable:

> ~~"all exit paths finalize truthfully"~~ → *"the receipt is constructed before any fallible work, and no path after finalization can change the process outcome"*

Checkable by reading, and it covers the exit paths the open phrasing was reaching for. Where a slice genuinely is open-input or open-execution work, the criterion points at the closing mechanism — 3k.3's evidence-gate, 3k.4's execution model — rather than at the category.

Reviewer side: an undispositionable criterion is an **R1 finding against the plan**. Say so and ask for the property restatement; do not silently work around it by hunting the category.

## Intentional

- Points at 3k.3 / 3k.4 rather than restating them, so this cannot drift from them (the #2077 lesson recorded in 3k.1).
- Applies to risk areas as well as criteria — #2195's unbounded targets were in the risk-area list, not the criteria list.

## Deferred

- Mechanizing a "criterion is dispositionable" check. Judgment at plan review is the right start; if it earns automation it belongs in a `scripts/` checker with fixture tests, not prose (the #2197 lesson).

## Parked hardening

- None.

## Cold diff reconstruction

- Changed: `AGENTS.md:105` requires every acceptance criterion to be dispositionable, defines the structural-property form, extends it to risk areas, and routes open-category slices to 3k.3 / 3k.4.
- Changed: `docs/REVIEWER_RULES.md:52` makes an undispositionable criterion an R1 finding against the plan.
- Contract match: both changes trace to the single defect above.
- Gaps: none.

## Verification

- `scripts/audit_pr_plan_presence.py origin/main --pr-author canfieldjuan` → `classification: docs-only`, PASS.
- Path-trigger table still parses: 12 glob rows, 9 prose rows, unchanged.
- `git diff --check` clean; **0** non-ASCII characters added.

## AI reconciliation

No reviewer threads at open time; will reconcile any that arrive.

All fixed or waived: yes

## Diff size

2 files, +34 / -0
