### PR TITLE
[BLOCKED on #2202] docs(REVIEWER_RULES): BLOCKER requires a concrete failure path

### DIFF
--- a/docs/REVIEWER_RULES.md
+++ b/docs/REVIEWER_RULES.md
@@ -25,6 +25,23 @@ A finding is written as `Rxx (LEVEL) file:line - issue - required fix`.
 **Blockers must cite `file:line`.** A bare "LGTM" with no rule matrix and no
 independent verification is worse than no comment.
 
+**BLOCKER requires a concrete failure path**: the specific input, sequence, or
+state that produces the harm, stated in the finding. "This could break" is not
+one. Without a failure path the finding is MAJOR at most -- downgrade it, do not
+drop it, and the level can be raised later once the path is shown.
+
+**The escape valve from "do not manufacture NITs" is not filing the finding, not
+promoting it.** That instruction bars padding a review with polish; it is not a
+reason to enter a marginal finding at BLOCKER so it clears the bar. If a finding
+is real but minor, MAJOR and NIT exist for it; if it is not worth reporting,
+report nothing and mark the rule dispositioned.
+
+**Why:** across #2195 and #2184 all **68** filed findings are P1/P2 and none is
+lower. Real severity is not distributed that way, and a ladder where everything
+is a blocker carries no information -- the reviewer cannot lead with blockers
+(above) when every finding is one, and the builder cannot tell an exploitable
+gap from an ordering nit.
+
 R14 is universal: it applies to every review verdict, even when no changed path
 specifically triggers it. A reviewer who has not inspected the checked-out PR
 head and relevant codebase evidence cannot issue LGTM.


### PR DESCRIPTION
Docs-only: true

Stacks on #2202 (base `claude/pr-reviewer-stopping-rule`). Independent of #2204 and #2206 — touches a different region of the pack.

## The evidence

Across #2195 and #2184, **all 68 filed findings are P1/P2 and none is lower.**

Real severity is not distributed that way. A ladder where everything is a blocker carries no information: the pack tells reviewers to *"lead with blockers"*, which is meaningless when every finding is one, and the builder cannot tell an exploitable gap from an ordering nit — so #2195's round 13 presented a `refs/replace` attestation bypass and a cleanup-ordering issue at the same level.

## The change

**BLOCKER requires a concrete failure path** — the specific input, sequence, or state that produces the harm, stated in the finding. *"This could break"* is not one. Without a failure path the finding is MAJOR at most: **downgrade it, do not drop it**, and the level can be raised once the path is shown.

Also closes a perverse reading of *"do not manufacture NITs"*. That instruction bars padding a review with polish. It is **not** a reason to enter a marginal finding at BLOCKER so it clears the bar — the escape valve is not filing it.

## Intentional

- **Downgrade, never drop.** A cap on findings would suppress real defects; this changes the level only, so a genuine blocker found late is still filed and still blocks.
- **Raisable later.** A finding that starts as MAJOR becomes BLOCKER the moment someone shows the path, so the rule cannot be used to bury a real issue.
- Deliberately does not renumber or re-word the ladder table itself — the four verdicts are unchanged, only the bar for entering at the top one.

## Deferred

- Any automated severity audit. The failure-path requirement is checkable by reading the finding.

## Parked hardening

- None.

## Cold diff reconstruction

- Changed: `docs/REVIEWER_RULES.md:27` adds the BLOCKER failure-path requirement, the downgrade-not-drop rule, and the do-not-promote-marginal-findings clause, with the 68/68 measurement as the why.
- Contract match: the single change traces to the severity-inflation evidence.
- Gaps: none.

## Verification

- `scripts/audit_pr_plan_presence.py origin/main --pr-author canfieldjuan` → `classification: docs-only`, PASS.
- Path-trigger table still parses: 12 glob rows, 9 prose rows, unchanged.
- `git diff --check` clean; **0** non-ASCII characters added.
- The 68/68 P1-P2 count is reproducible from the two PRs cited.

## AI reconciliation

No reviewer threads at open time; will reconcile any that arrive.

All fixed or waived: yes

## Diff size

1 file, +17 / -0
