### PR TITLE
[BLOCKED on #2202] docs(REVIEWER_RULES): let the misses-into-mechanism ratchet release

### DIFF
--- a/docs/REVIEWER_RULES.md
+++ b/docs/REVIEWER_RULES.md
@@ -354,3 +354,22 @@ recur: a new `scripts/audit_*.py`, a new rule ID here, a new path trigger above,
 a line in the recurring-lapse checklist, or a Review Contract template change.
 **No escaped defect is fixed only once.** This is the reviewer-side mirror of
 the builder's `HARDENING.md` + recurring-lapse flywheel.
+
+**The ratchet releases too.** As written this section only ever adds, and the
+reviewer's mandate grows with it -- every added rule is another category to hunt
+on every future PR, forever, which is a cost paid by every subsequent review.
+So each addition is reviewed for removal on the same terms it was added:
+
+- A rule, path trigger, or checklist line that **has not fired** in the last
+  ~50 merged PRs is either redundant with something else here or is addressing a
+  failure mode that has stopped happening. Remove it, or state why it stays.
+- One whose firings are **consistently waived** is mis-scoped, not load-bearing.
+  Re-scope it to what actually blocks, or remove it.
+- Removals are recorded the same way additions are, with the reasoning, so a
+  removal is a decision and not an erosion.
+
+Nothing here weakens the "no escaped defect is fixed only once" rule -- an
+escaped defect still converts into mechanism. This governs what happens to that
+mechanism afterwards, so the pack stays the size a reviewer can actually apply.
+A checklist nobody can finish is the failure mode Review completion exists to
+prevent, and an unbounded ratchet recreates it one rule at a time.


### PR DESCRIPTION
Docs-only: true

Stacks on #2202 (base `claude/pr-reviewer-stopping-rule`). Independent of #2204 and #2205 — touches a different region of the pack.

## The defect

`## Turning misses into mechanism` converts every escaped defect into a durable new rule, path trigger, or checklist line — and **only ever adds**. There is no removal path anywhere in the pack.

So the reviewer's mandate grows monotonically, and every added rule becomes another category hunted on every future PR, forever. That cost is paid by every subsequent review, not by the PR that caused the addition.

## The change

Additions are reviewed for removal on the same terms they were added:

- **Not fired** in the last ~50 merged PRs → redundant, or the failure mode stopped happening. Remove it, or state why it stays.
- **Firings consistently waived** → mis-scoped, not load-bearing. Re-scope to what actually blocks, or remove.
- **Removals recorded like additions**, with reasoning, so a removal is a decision rather than an erosion.

## Intentional

- **Does not weaken "no escaped defect is fixed only once."** Escaped defects still convert into mechanism. This governs what happens to that mechanism afterwards.
- **"Or state why it stays"** is the escape hatch that keeps this from failing on its second side: a load-bearing rule that rarely fires — a security trigger, say — survives on an argument rather than on a firing count. Without that clause this would delete exactly the rules that work by deterrence.
- A checklist nobody can finish is the failure mode #2202's Review completion exists to prevent; an unbounded ratchet recreates it one rule at a time.

## Deferred

- Mechanizing the ~50-PR non-firing check. By hand at pack-review time is the right start; if it earns automation it belongs with #2198's checker, not as procedure in prose (the #2197 lesson).

## Parked hardening

- None.

## Cold diff reconstruction

- Changed: `docs/REVIEWER_RULES.md:322` adds removal terms to the misses-into-mechanism ratchet, with the load-bearing-rule exception and an explicit statement that the no-escaped-defect rule is unchanged.
- Contract match: the single change traces to the monotonic-growth defect.
- Gaps: none.

## Verification

- `scripts/audit_pr_plan_presence.py origin/main --pr-author canfieldjuan` → `classification: docs-only`, PASS.
- Path-trigger table still parses: 12 glob rows, 9 prose rows, unchanged.
- `git diff --check` clean; **0** non-ASCII characters added.

## AI reconciliation

No reviewer threads at open time; will reconcile any that arrive.

All fixed or waived: yes

## Diff size

1 file, +19 / -0
