### PR TITLE
ci: run the unit gate on the tests a change can reach, not the whole suite

### DIFF
--- a/.github/workflows/unit_gate.yml
+++ b/.github/workflows/unit_gate.yml
@@ -62,8 +62,42 @@ jobs:
           git show "origin/${BASE_REF}:tests/unit_gate_baseline.txt" \
             > /tmp/base_baseline.txt 2>/dev/null || : > /tmp/base_baseline.txt
 
+      - name: Select impacted tests
+        env:
+          BASE_REF: ${{ github.base_ref || 'main' }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin "${BASE_REF}"
+          python scripts/select_impacted_tests.py \
+            --base "origin/${BASE_REF}" > /tmp/selected.txt
+          echo "--- selection ---"
+          cat /tmp/selected.txt
+
       - name: Unit gate (ratchet against baseline)
         run: |
-          python scripts/check_unit_gate.py \
-            --baseline tests/unit_gate_baseline.txt \
-            --base-baseline /tmp/base_baseline.txt
+          set -euo pipefail
+          if [ "$(cat /tmp/selected.txt)" = "FULL" ]; then
+            echo "running the FULL suite (selection escalated)"
+            python scripts/check_unit_gate.py \
+              --baseline tests/unit_gate_baseline.txt \
+              --base-baseline /tmp/base_baseline.txt
+          elif [ ! -s /tmp/selected.txt ]; then
+            # Every changed file mapped, none is reachable from any test.
+            # The growth guard still runs -- it is a text comparison and must
+            # not be skippable by touching only non-Python files.
+            echo "no test is reachable from the changed files; growth guard only"
+            python scripts/check_unit_gate.py \
+              --baseline tests/unit_gate_baseline.txt \
+              --base-baseline /tmp/base_baseline.txt \
+              --report-file /dev/null
+          else
+            echo "running $(wc -l < /tmp/selected.txt) impacted test file(s)"
+            python scripts/check_unit_gate.py \
+              --baseline tests/unit_gate_baseline.txt \
+              --base-baseline /tmp/base_baseline.txt \
+              --selected-files /tmp/selected.txt \
+              --pytest-args $(tr '\n' ' ' < /tmp/selected.txt) \
+                -m "not integration and not e2e" \
+                --continue-on-collection-errors -rfE --tb=no -q \
+                -p no:cacheprovider
+          fi

--- a/.github/workflows/unit_gate.yml
+++ b/.github/workflows/unit_gate.yml
@@ -89,7 +89,7 @@ jobs:
             python scripts/check_unit_gate.py \
               --baseline tests/unit_gate_baseline.txt \
               --base-baseline /tmp/base_baseline.txt \
-              --report-file /dev/null
+              --growth-only
           else
             echo "running $(wc -l < /tmp/selected.txt) impacted test file(s)"
             python scripts/check_unit_gate.py \

--- a/plans/PR-Unit-Gate-Impacted-Selection.md
+++ b/plans/PR-Unit-Gate-Impacted-Selection.md
@@ -1,0 +1,157 @@
+# PR-Unit-Gate-Impacted-Selection
+
+## Why this slice exists
+
+`unit-gate` runs the entire unit suite on every PR push. Measured on run
+30181595014: **447s of pytest inside a 9.4-minute median job**, install only 98s.
+Every push pays it, including pushes that cannot affect any test -- #2202 was two
+Markdown edits and spent 9.7 minutes executing 755 test files.
+
+The full-suite guarantee it provides ("a test file no workflow enrolls still
+runs", #2035 / G1.1, G2) is **already held daily** by
+`repo_wide_unit_backstop.yml` (06:00 UTC cron + `workflow_dispatch`). `unit-gate`
+re-pays for that same guarantee on every push of every PR.
+
+### Problem-derived contract
+
+- Root cause: the gate's test selection is constant (`tests/`) and independent of
+  the diff, so cost is a function of the repo's size rather than the change's
+  blast radius.
+- Correct fix must: pick tests from the change's transitive reverse-import
+  closure, not a one-hop name match; escalate to the full suite whenever the
+  input cannot be mapped; and restrict the ratchet baseline to the executed
+  files, because `compare()` demands the failing set *exactly* equal the
+  baseline -- unselected entries would otherwise read as newly-passing and fail
+  every scoped run.
+- Must not change: the ratchet's meaning within its scope (regressions AND stale
+  entries still gate), the growth guard (a text comparison that must run even on
+  a zero-test change), the baseline file, or the daily backstop.
+
+## Scope (this PR)
+
+Ownership lane: ci-gates
+Slice phase: vertical slice
+
+1. `scripts/select_impacted_tests.py` (new): AST import graph over the
+   first-party roots, transitive reverse reachability from the changed files to
+   test files, `FULL` escalation on any unmappable input.
+2. `scripts/check_unit_gate.py`: `--selected-files` restricts the baseline to the
+   executed files; a failing node outside the selection is a hard error, not a
+   regression verdict; `--selected-files` may not be combined with
+   `--update-baseline`.
+3. `.github/workflows/unit_gate.yml`: select, then run FULL / scoped /
+   growth-guard-only.
+4. `tests/test_select_impacted_tests.py` (new): 25 fixture tests, weighted to the
+   under-selection direction.
+
+### Review Contract
+
+- Acceptance criteria (structural properties, per `AGENTS.md` 1a):
+  1. A test reachable from a changed module through **any** number of
+     first-party import hops appears in the selection (not only direct
+     importers).
+  2. Every input the selector cannot map to a module produces `FULL`; there is
+     no code path from an unmappable input to a non-empty partial selection.
+  3. An empty selection is produced only when every changed path was mapped and
+     none is reachable from any test.
+  4. On a scoped run the baseline compared against contains exactly the entries
+     whose node id file is in the executed set.
+  5. Within the executed scope both ratchet directions still fail the gate: an
+     un-baselined failure, and a baseline entry that now passes.
+  6. The growth guard runs on every path through the workflow, including the
+     zero-test path.
+- Reachability proof: the workflow's `Select impacted tests` step writes
+  the selected-tests temp file, echoed in the job log; `check_unit_gate.py` prints
+  `[scoped: N test file(s); baseline M/188]` on a scoped run. Both are observable
+  in the Actions log of this PR.
+- Affected surfaces: CI only. No runtime, API, DB, or product surface.
+- Risk areas: under-selection (a real regression not executed pre-merge);
+  baseline mis-scoping; growth guard skipped on the zero-test path.
+- Reviewer rules triggered: R1, R2, R10, R12, R13, R14.
+
+### Files touched
+
+- `.github/workflows/unit_gate.yml`
+- `plans/PR-Unit-Gate-Impacted-Selection.md`
+- `scripts/check_unit_gate.py`
+- `scripts/select_impacted_tests.py`
+- `tests/test_select_impacted_tests.py`
+
+## Mechanism
+
+Build a module -> importers map by parsing every first-party Python module with `ast`
+(not regex: a regex cannot resolve `from . import x`). Walk it breadth-first from
+the changed modules; every `tests.*` node reached is selected. Relative imports
+resolve against the file's **repo-relative** package -- resolving against the
+absolute path silently prefixes every `from .x` with the checkout directory, so
+the edge never matches and the importer looks independent. That bug existed in
+the first draft of this script and was caught by
+`test_relative_import_is_followed`, which is why that test is in the suite.
+
+The gate side is one restriction: `restrict_baseline()` keeps baseline entries
+whose node-id file part is in the executed set. `node_file()` splits on the first
+`::` so a parametrized id containing `::` inside its brackets still maps to its
+file.
+
+## Intentional
+
+- **Escalate, never guess.** Unparseable module, unmappable path, empty diff, or
+  a git failure all yield `FULL`. The dangerous direction is running too few
+  tests and reporting green, so every uncertainty resolves toward running more.
+- **Failing node outside the selection is exit 2, not a regression.** If pytest
+  ran something the selector did not claim, the scope and the run disagree and
+  the verdict would be scored against evidence it was not built for.
+- **`--selected-files` + `--update-baseline` is refused.** A scoped run must
+  never rewrite the repo-wide baseline; it would delete the 90%+ of entries it
+  never executed.
+- **Growth guard still runs on the zero-test path** via `--report-file /dev/null`,
+  so a docs-only PR cannot add baseline entries.
+- **No `pytest-xdist`.** Parallelism is the other lever on the same 447s and is
+  probably worth more, but it is a separate change with its own risk (session
+  fixtures, ordering) and does not belong bundled here.
+
+## Deferred
+
+- `pytest-xdist` on the full-suite path and the daily backstop.
+- Enrolling `unit-gate` in branch protection. It is still advisory; that decision
+  should follow evidence from this change, not precede it.
+
+Parked hardening: none.
+
+## Verification
+
+    python -m pytest tests/test_select_impacted_tests.py -q
+    # -> 25 passed
+
+Selector exercised against this repo:
+
+| Changed input | Result |
+|---|---|
+| `AGENTS.md`, `docs/REVIEWER_RULES.md` | empty -> growth guard only |
+| `atlas_brain/services/customer_context.py` | 64 of 755 test files |
+| `tests/conftest.py` | `FULL` |
+
+Node counts for the `customer_context.py` selection, via `--collect-only`:
+**1,455 collected vs 20,320 full (7.2%)**; collection alone drops 22.6s -> 8.8s.
+
+Not run: a live scoped CI run. This PR's own diff touches
+`scripts/check_unit_gate.py` and `.github/workflows/unit_gate.yml`, both on the
+`GLOBAL_FILES` list, so it deliberately escalates itself to `FULL` -- the scoped
+path is proven by the fixture tests and the local selections above, and will be
+exercised by the first PR that does not touch the gate.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `scripts/select_impacted_tests.py` | 235 |
+| `tests/test_select_impacted_tests.py` | 205 |
+| `scripts/check_unit_gate.py` | 55 |
+| `.github/workflows/unit_gate.yml` | 33 |
+| `plans/PR-Unit-Gate-Impacted-Selection.md` | 150 |
+| **Total** | **~678** |
+
+Over the 400-LOC budget: the selector, its baseline restriction, and its fixture
+tests are one behavior. Landing the selector without the baseline restriction
+would fail every scoped run, and landing either without the tests would ship an
+under-selection risk with no failure detection (3i).

--- a/plans/PR-Unit-Gate-Impacted-Selection.md
+++ b/plans/PR-Unit-Gate-Impacted-Selection.md
@@ -144,14 +144,9 @@ exercised by the first PR that does not touch the gate.
 
 | File | LOC |
 |---|---:|
-| `scripts/select_impacted_tests.py` | 235 |
-| `tests/test_select_impacted_tests.py` | 205 |
-| `scripts/check_unit_gate.py` | 55 |
-| `.github/workflows/unit_gate.yml` | 33 |
-| `plans/PR-Unit-Gate-Impacted-Selection.md` | 150 |
-| **Total** | **~678** |
-
-Over the 400-LOC budget: the selector, its baseline restriction, and its fixture
-tests are one behavior. Landing the selector without the baseline restriction
-would fail every scoped run, and landing either without the tests would ship an
-under-selection risk with no failure detection (3i).
+| `.github/workflows/unit_gate.yml` | 40 |
+| `plans/PR-Unit-Gate-Impacted-Selection.md` | 157 |
+| `scripts/check_unit_gate.py` | 105 |
+| `scripts/select_impacted_tests.py` | 307 |
+| `tests/test_select_impacted_tests.py` | 338 |
+| **Total** | **947** |

--- a/plans/PR-Unit-Gate-Impacted-Selection.md
+++ b/plans/PR-Unit-Gate-Impacted-Selection.md
@@ -18,11 +18,13 @@ re-pays for that same guarantee on every push of every PR.
   the diff, so cost is a function of the repo's size rather than the change's
   blast radius.
 - Correct fix must: pick tests from the change's transitive reverse-import
-  closure, not a one-hop name match; escalate to the full suite whenever the
-  input cannot be mapped; and restrict the ratchet baseline to the executed
-  files, because `compare()` demands the failing set *exactly* equal the
-  baseline -- unselected entries would otherwise read as newly-passing and fail
-  every scoped run.
+  closure, not a one-hop name match; preserve executable package initializer
+  edges; escalate to the full suite whenever the input cannot be proven scoped
+  (deleted paths, unknown Python roots, runtime/config assets, path-loaded
+  scripts, or reachable `conftest.py` fixture fanout); and restrict the ratchet
+  baseline to the executed files, because `compare()` demands the failing set
+  *exactly* equal the baseline -- unselected entries would otherwise read as
+  newly-passing and fail every scoped run.
 - Must not change: the ratchet's meaning within its scope (regressions AND stale
   entries still gate), the growth guard (a text comparison that must run even on
   a zero-test change), the baseline file, or the daily backstop.
@@ -34,15 +36,18 @@ Slice phase: vertical slice
 
 1. `scripts/select_impacted_tests.py` (new): AST import graph over the
    first-party roots, transitive reverse reachability from the changed files to
-   test files, `FULL` escalation on any unmappable input.
+   test files, package-initializer dependency edges, and `FULL` escalation on
+   any input the selector cannot prove scoped.
 2. `scripts/check_unit_gate.py`: `--selected-files` restricts the baseline to the
    executed files; a failing node outside the selection is a hard error, not a
-   regression verdict; `--selected-files` may not be combined with
-   `--update-baseline`.
+   regression verdict; scoped marker-filtered no-test runs are allowed only with
+   an explicit selected-file scope; `--growth-only` enforces the baseline growth
+   guard without pretending `/dev/null` is a pytest report; `--selected-files`
+   may not be combined with `--update-baseline`.
 3. `.github/workflows/unit_gate.yml`: select, then run FULL / scoped /
    growth-guard-only.
-4. `tests/test_select_impacted_tests.py` (new): 25 fixture tests, weighted to the
-   under-selection direction.
+4. `tests/test_select_impacted_tests.py` (new): 30 fixture tests / 36 executed
+   cases, weighted to the under-selection direction.
 
 ### Review Contract
 
@@ -50,16 +55,23 @@ Slice phase: vertical slice
   1. A test reachable from a changed module through **any** number of
      first-party import hops appears in the selection (not only direct
      importers).
-  2. Every input the selector cannot map to a module produces `FULL`; there is
-     no code path from an unmappable input to a non-empty partial selection.
-  3. An empty selection is produced only when every changed path was mapped and
-     none is reachable from any test.
-  4. On a scoped run the baseline compared against contains exactly the entries
+  2. A change to a package `__init__.py` is selected when tests import a module
+     under that package, because importing the leaf executes the initializer.
+  3. Every input the selector cannot prove scoped produces `FULL`; there is no
+     code path from a deleted path, unknown Python root, runtime/config asset,
+     path-loaded script, or reachable `conftest.py` to a non-empty partial
+     selection.
+  4. An empty selection is produced only for explicitly test-free text changes
+     and only after the growth guard still runs.
+  5. On a scoped run the baseline compared against contains exactly the entries
      whose node id file is in the executed set.
-  5. Within the executed scope both ratchet directions still fail the gate: an
+  6. Within the executed scope both ratchet directions still fail the gate: an
      un-baselined failure, and a baseline entry that now passes.
-  6. The growth guard runs on every path through the workflow, including the
-     zero-test path.
+  7. A scoped run whose selected files are fully removed by the unit marker
+     filter does not fail as infrastructure merely because pytest returned
+     "no tests collected"; unscoped no-test collection still fails loudly.
+  8. The growth guard runs on every path through the workflow, including the
+     zero-test path, via `--growth-only` rather than a synthetic pytest report.
 - Reachability proof: the workflow's `Select impacted tests` step writes
   the selected-tests temp file, echoed in the job log; `check_unit_gate.py` prints
   `[scoped: N test file(s); baseline M/188]` on a scoped run. Both are observable
@@ -87,6 +99,16 @@ absolute path silently prefixes every `from .x` with the checkout directory, so
 the edge never matches and the importer looks independent. That bug existed in
 the first draft of this script and was caught by
 `test_relative_import_is_followed`, which is why that test is in the suite.
+Package imports keep all real ancestor module edges, not just the longest leaf
+edge, because Python executes package initializers while resolving submodules.
+
+Before graph traversal, the selector classifies changed paths. Only Python
+modules inside known graph roots and explicit test-free Markdown can stay
+scoped. Deleted paths, unknown Python roots, non-Markdown assets/config/workflow
+files, and scripts that tests may load by path all escalate to `FULL`. If graph
+traversal reaches `tests.conftest` (or a nested conftest), it also escalates to
+`FULL`, because fixture consumers are discovered by pytest collection rather
+than import edges.
 
 The gate side is one restriction: `restrict_baseline()` keeps baseline entries
 whose node-id file part is in the executed set. `node_file()` splits on the first
@@ -98,14 +120,18 @@ file.
 - **Escalate, never guess.** Unparseable module, unmappable path, empty diff, or
   a git failure all yield `FULL`. The dangerous direction is running too few
   tests and reporting green, so every uncertainty resolves toward running more.
+- **Scripts escalate.** Some tests load `scripts/*.py` through
+  `importlib.util.spec_from_file_location`, `runpy.run_path`, or subprocess path
+  strings. The selector does not claim a scoped proof for that surface.
 - **Failing node outside the selection is exit 2, not a regression.** If pytest
   ran something the selector did not claim, the scope and the run disagree and
   the verdict would be scored against evidence it was not built for.
 - **`--selected-files` + `--update-baseline` is refused.** A scoped run must
   never rewrite the repo-wide baseline; it would delete the 90%+ of entries it
   never executed.
-- **Growth guard still runs on the zero-test path** via `--report-file /dev/null`,
-  so a docs-only PR cannot add baseline entries.
+- **Growth guard still runs on the zero-test path** via `--growth-only`, so a
+  docs-only PR cannot add baseline entries and the normal ratchet comparison is
+  not polluted by a synthetic empty report.
 - **No `pytest-xdist`.** Parallelism is the other lever on the same 447s and is
   probably worth more, but it is a separate change with its own risk (session
   fixtures, ordering) and does not belong bundled here.
@@ -121,7 +147,15 @@ Parked hardening: none.
 ## Verification
 
     python -m pytest tests/test_select_impacted_tests.py -q
-    # -> 25 passed
+    # -> 36 passed
+
+    python scripts/select_impacted_tests.py --base origin/main
+    # -> FULL
+
+    python scripts/maturity_sweep.py scripts --tests-root tests \
+      --baseline tests/maturity_sweep/baseline_scripts.json --min-score 8 \
+      --sensitive-glob 'scripts/**'
+    # -> ratchet gate passed: no new brittleness above baseline
 
 Selector exercised against this repo:
 
@@ -130,6 +164,7 @@ Selector exercised against this repo:
 | `AGENTS.md`, `docs/REVIEWER_RULES.md` | empty -> growth guard only |
 | `atlas_brain/services/customer_context.py` | 64 of 755 test files |
 | `tests/conftest.py` | `FULL` |
+| this PR diff (`scripts/check_unit_gate.py`, `scripts/select_impacted_tests.py`, `.github/workflows/unit_gate.yml`) | `FULL` |
 
 Node counts for the `customer_context.py` selection, via `--collect-only`:
 **1,455 collected vs 20,320 full (7.2%)**; collection alone drops 22.6s -> 8.8s.
@@ -145,8 +180,8 @@ exercised by the first PR that does not touch the gate.
 | File | LOC |
 |---|---:|
 | `.github/workflows/unit_gate.yml` | 40 |
-| `plans/PR-Unit-Gate-Impacted-Selection.md` | 157 |
+| `plans/PR-Unit-Gate-Impacted-Selection.md` | 187 |
 | `scripts/check_unit_gate.py` | 105 |
 | `scripts/select_impacted_tests.py` | 307 |
 | `tests/test_select_impacted_tests.py` | 338 |
-| **Total** | **947** |
+| **Total** | **977** |

--- a/scripts/check_unit_gate.py
+++ b/scripts/check_unit_gate.py
@@ -27,6 +27,10 @@ Usage:
   # maintenance: overwrite the baseline with the current failing set:
   python scripts/check_unit_gate.py --baseline B --update-baseline
 
+  # no tests are reachable; still enforce the baseline-growth ratchet:
+  python scripts/check_unit_gate.py --baseline B --base-baseline base.txt \
+      --growth-only
+
 Exit codes: 0 = no regression; 1 = regression (failing node not in baseline);
 2 = infrastructure/usage/IO error; 3 = baseline grew (ratchet violation).
 """
@@ -53,6 +57,7 @@ _SUMMARY_RE = re.compile(r"^(?:FAILED|ERROR)\s+(?P<node>[^\s\[]+(?:\[[^\]]*\])?)
 # (expected -- the baseline exists). 2 interrupted / 3 internal / 4 usage /
 # 5 no-tests-collected all mean the suite did not run cleanly.
 _OK_PYTEST_EXIT = frozenset((0, 1))
+_NO_TESTS_COLLECTED = 5
 
 DEFAULT_PYTEST_ARGS = ["tests/", "-m", "not integration and not e2e",
                        "--continue-on-collection-errors", "-rfE", "--tb=no",
@@ -111,12 +116,20 @@ def restrict_baseline(baseline: set[str], selected_files: set[str]) -> set[str]:
     return {node for node in baseline if node_file(node) in selected_files}
 
 
-def ensure_pytest_ran(returncode: int) -> None:
+def ensure_pytest_ran(returncode: int, *, allow_no_tests: bool = False) -> None:
     """Raise when pytest did not finish as a normal pass/fail run.
 
     Without this, an infrastructure/usage error (e.g. a plugin crash, a bad
     arg, or no tests collected) produces no FAILED/ERROR summary lines, parses
-    to an empty failing set, and the gate would go GREEN having run nothing."""
+    to an empty failing set, and the gate would go GREEN having run nothing.
+
+    A scoped run is different: marker filtering can legitimately remove every
+    selected test (for example an e2e-only selected file under the unit marker
+    expression). In that case pytest returns 5, but the selector still produced
+    a real file scope and the ratchet comparison is restricted to that scope.
+    """
+    if allow_no_tests and returncode == _NO_TESTS_COLLECTED:
+        return
     if returncode not in _OK_PYTEST_EXIT:
         raise RuntimeError(
             f"pytest exited {returncode}, not a normal pass/fail run "
@@ -161,7 +174,7 @@ def _fail_growth(added: list[str]) -> int:
     return 3
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description="Repo-wide unit gate (ratchet baseline).")
     ap.add_argument("--baseline", required=True, type=Path)
     ap.add_argument("--base-baseline", type=Path,
@@ -171,6 +184,10 @@ def main() -> int:
                     help="Gate a pre-captured pytest summary instead of running pytest.")
     ap.add_argument("--update-baseline", action="store_true",
                     help="Overwrite the baseline with the current failing set and exit 0.")
+    ap.add_argument("--growth-only", action="store_true",
+                    help="Only enforce the baseline-growth guard. Use this when "
+                         "selection found no reachable unit tests; do not pass a "
+                         "pytest report or selected-file scope.")
     ap.add_argument("--selected-files", type=Path,
                     help="File listing the test paths this run executed (scoped "
                          "run). The baseline is restricted to entries in those "
@@ -178,11 +195,21 @@ def main() -> int:
                          "otherwise read as newly-passing.")
     ap.add_argument("--pytest-args", nargs=argparse.REMAINDER,
                     help="Override the default pytest args (everything after this flag).")
-    args = ap.parse_args()
+    args = ap.parse_args(argv)
 
     if args.selected_files is not None and args.update_baseline:
         print("--selected-files cannot be combined with --update-baseline: a "
               "scoped run must never rewrite the repo-wide baseline",
+              file=sys.stderr)
+        return 2
+    if args.growth_only and (
+        args.report_file is not None
+        or args.selected_files is not None
+        or args.update_baseline
+        or args.pytest_args
+    ):
+        print("--growth-only cannot be combined with pytest reports, scoped "
+              "selection, pytest args, or --update-baseline",
               file=sys.stderr)
         return 2
 
@@ -199,6 +226,25 @@ def main() -> int:
             if added:
                 return _fail_growth(added)
 
+    if args.growth_only:
+        print("unit gate: growth guard passed; no reachable unit tests selected")
+        return 0
+
+    selected: set[str] | None = None
+    if args.selected_files is not None:
+        if not args.selected_files.exists():
+            print(f"selected files not found: {args.selected_files}", file=sys.stderr)
+            return 2
+        selected = {
+            line.strip()
+            for line in args.selected_files.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        }
+        if not selected:
+            print("--selected-files is empty; use --growth-only for the "
+                  "zero-test path", file=sys.stderr)
+            return 2
+
     if args.report_file is not None:
         if not args.report_file.exists():
             print(f"report file not found: {args.report_file}", file=sys.stderr)
@@ -207,7 +253,7 @@ def main() -> int:
     else:
         output, returncode = run_pytest(args.pytest_args or DEFAULT_PYTEST_ARGS)
         try:
-            ensure_pytest_ran(returncode)
+            ensure_pytest_ran(returncode, allow_no_tests=selected is not None)
         except RuntimeError as exc:
             print(f"unit gate: {exc}", file=sys.stderr)
             return 2
@@ -221,12 +267,7 @@ def main() -> int:
 
     baseline = load_baseline(args.baseline)
     scope_note = ""
-    if args.selected_files is not None:
-        selected = {
-            line.strip()
-            for line in args.selected_files.read_text(encoding="utf-8").splitlines()
-            if line.strip()
-        }
+    if selected is not None:
         full_size = len(baseline)
         baseline = restrict_baseline(baseline, selected)
         # Any failing node from a file we did not select means pytest ran

--- a/scripts/check_unit_gate.py
+++ b/scripts/check_unit_gate.py
@@ -93,6 +93,24 @@ def added_baseline_entries(pr_baseline: set[str], base_baseline: set[str]) -> li
     return sorted(pr_baseline - base_baseline)
 
 
+def node_file(node_id: str) -> str:
+    """The test-file part of a pytest node id (``tests/t.py::k[x::y]`` -> ``tests/t.py``)."""
+    return node_id.split("::", 1)[0]
+
+
+def restrict_baseline(baseline: set[str], selected_files: set[str]) -> set[str]:
+    """Baseline entries belonging to ``selected_files``.
+
+    compare() demands the failing set EXACTLY equal the baseline: an entry that
+    no longer fails is reported as a stale ratchet entry and fails the gate. On
+    a scoped run the unselected baseline entries were never executed, so without
+    this they would every one look "newly passing" and every scoped run would
+    fail. Restricting the baseline to what actually ran keeps both directions of
+    the ratchet meaningful -- regressions AND stale entries -- within that scope.
+    """
+    return {node for node in baseline if node_file(node) in selected_files}
+
+
 def ensure_pytest_ran(returncode: int) -> None:
     """Raise when pytest did not finish as a normal pass/fail run.
 
@@ -153,9 +171,20 @@ def main() -> int:
                     help="Gate a pre-captured pytest summary instead of running pytest.")
     ap.add_argument("--update-baseline", action="store_true",
                     help="Overwrite the baseline with the current failing set and exit 0.")
+    ap.add_argument("--selected-files", type=Path,
+                    help="File listing the test paths this run executed (scoped "
+                         "run). The baseline is restricted to entries in those "
+                         "files, since unselected entries never ran and would "
+                         "otherwise read as newly-passing.")
     ap.add_argument("--pytest-args", nargs=argparse.REMAINDER,
                     help="Override the default pytest args (everything after this flag).")
     args = ap.parse_args()
+
+    if args.selected_files is not None and args.update_baseline:
+        print("--selected-files cannot be combined with --update-baseline: a "
+              "scoped run must never rewrite the repo-wide baseline",
+              file=sys.stderr)
+        return 2
 
     if not args.baseline.exists() and not args.update_baseline:
         print(f"baseline not found: {args.baseline}", file=sys.stderr)
@@ -191,11 +220,34 @@ def main() -> int:
         return 0
 
     baseline = load_baseline(args.baseline)
+    scope_note = ""
+    if args.selected_files is not None:
+        selected = {
+            line.strip()
+            for line in args.selected_files.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        }
+        full_size = len(baseline)
+        baseline = restrict_baseline(baseline, selected)
+        # Any failing node from a file we did not select means pytest ran
+        # something the selector did not claim. Comparing that against a
+        # baseline restricted to the selection would score it as a regression
+        # on evidence the run was never scoped to produce, so fail loudly
+        # rather than guess.
+        stray = sorted({node for node in failing if node_file(node) not in selected})
+        if stray:
+            print(f"unit gate: {len(stray)} failing node(s) outside the selected "
+                  f"files; scope is inconsistent with the run:", file=sys.stderr)
+            for node in stray[:20]:
+                print(f"  {node}", file=sys.stderr)
+            return 2
+        scope_note = (f" [scoped: {len(selected)} test file(s); "
+                      f"baseline {len(baseline)}/{full_size}]")
     regressions, fixed = compare(failing, baseline)
 
     print(f"unit gate: {len(failing)} failing/errored node(s); "
           f"baseline={len(baseline)}; regressions={len(regressions)}; "
-          f"newly-passing={len(fixed)}")
+          f"newly-passing={len(fixed)}{scope_note}")
     # The baseline must EXACTLY equal the current failing set: no un-baselined
     # failure (regression), AND no stale entry that now passes. A stale entry
     # is a live allow-list hole -- a later PR could reintroduce that failure and

--- a/scripts/select_impacted_tests.py
+++ b/scripts/select_impacted_tests.py
@@ -13,10 +13,11 @@ Soundness rests on three properties, in order of how much they matter:
    selects `test_a`. A one-hop "which test names this module" grep silently
    drops exactly the indirect dependencies a refactor breaks.
 2. **Unresolvable input means FULL, never empty.** A file this script cannot
-   map (a global config, an unparseable module, anything outside the known
-   first-party roots) escalates to the full suite. The failure direction is
-   "run too much", never "run too little" -- a selector that silently returns
-   nothing is worse than no selector, because it reports green.
+   prove scoped (a global config, an unparseable module, a deleted path, an
+   unknown Python root, a runtime asset, or a script that tests may load by
+   path) escalates to the full suite. The failure direction is "run too much",
+   never "run too little" -- a selector that silently returns nothing is worse
+   than no selector, because it reports green.
 3. **Empty is only for provably test-free changes.** An empty selection means
    every changed file was mapped and none of them is reachable from any test
    (documentation, plans). It is not the fallback for "I could not tell".
@@ -58,6 +59,7 @@ GLOBAL_FILES = {
 GLOBAL_PREFIXES = ("requirements",)
 
 FULL = "FULL"
+TEST_FREE_SUFFIXES = {".md"}
 
 
 def changed_files_from_git(base: str) -> list[str]:
@@ -91,6 +93,16 @@ def module_name_for(path: Path) -> str | None:
     if parts[-1] == "__init__":
         parts = parts[:-1]
     return ".".join(parts) if parts else None
+
+
+def is_provably_test_free_path(path: Path) -> bool:
+    """True for paths that can safely produce an empty unit-test selection."""
+    return path.suffix in TEST_FREE_SUFFIXES
+
+
+def is_conftest_module(name: str) -> bool:
+    """True for any ``tests/.../conftest.py`` module name."""
+    return name == "tests.conftest" or name.endswith(".conftest")
 
 
 def _imports_of(path: Path, rel: Path) -> set[str]:
@@ -156,19 +168,20 @@ def build_reverse_graph(repo: Path) -> tuple[dict[str, set[str]], set[str]]:
         for target in imported:
             # Attribute imports (pkg.mod.symbol) resolve to the longest prefix
             # that is a real module, so importing a symbol still records the
-            # edge to the module that defines it.
+            # edge to the module that defines it. Package initializers are also
+            # executable dependencies, so keep ancestor package edges too:
+            # importing atlas_brain.pkg.leaf runs atlas_brain/pkg/__init__.py.
             parts = target.split(".")
             for i in range(len(parts), 0, -1):
                 candidate = ".".join(parts[:i])
                 if candidate in modules:
                     reverse[candidate].add(name)
-                    break
     return reverse, unparseable
 
 
 def impacted_tests(
     changed: Iterable[str], reverse: dict[str, set[str]], repo: Path
-) -> set[str]:
+) -> set[str] | str:
     """Test files transitively reachable from the changed modules."""
     seen: set[str] = set()
     queue: deque[str] = deque()
@@ -182,6 +195,13 @@ def impacted_tests(
     tests: set[str] = set()
     while queue:
         current = queue.popleft()
+        if is_conftest_module(current):
+            print(
+                f"select_impacted_tests: {current} is reachable; "
+                "fixture consumers are collection-scoped, escalating to FULL",
+                file=sys.stderr,
+            )
+            return FULL
         if current.startswith("tests."):
             rel = Path(*current.split(".")).with_suffix(".py")
             if (repo / rel).exists():
@@ -202,6 +222,39 @@ def select(changed: list[str], repo: Path) -> list[str] | str:
     if any(is_global_change(p) for p in changed):
         return FULL
 
+    for path in changed:
+        p = Path(path)
+        if p.suffix != ".py" and is_provably_test_free_path(p):
+            continue
+        abs_path = repo / p
+        if not abs_path.exists():
+            print(
+                f"select_impacted_tests: {path} is absent in the PR head; "
+                "deleted/renamed dependencies require FULL",
+                file=sys.stderr,
+            )
+            return FULL
+        if p.suffix != ".py":
+            print(
+                f"select_impacted_tests: {path} is a non-Python runtime/config "
+                "surface; escalating to FULL",
+                file=sys.stderr,
+            )
+            return FULL
+        if p.parts and p.parts[0] == "scripts":
+            print(
+                f"select_impacted_tests: {path} may be loaded by filesystem "
+                "path; escalating to FULL",
+                file=sys.stderr,
+            )
+            return FULL
+        if module_name_for(p) is None:
+            print(
+                f"select_impacted_tests: cannot map {path}; escalating to FULL",
+                file=sys.stderr,
+            )
+            return FULL
+
     reverse, unparseable = build_reverse_graph(repo)
     if unparseable:
         print(
@@ -211,19 +264,10 @@ def select(changed: list[str], repo: Path) -> list[str] | str:
         )
         return FULL
 
-    # A changed .py under a first-party root that yields no module name means
-    # the roots and the tree disagree -- unknown edges again.
-    for path in changed:
-        p = Path(path)
-        if p.suffix == ".py" and p.parts and p.parts[0] in FIRST_PARTY_ROOTS:
-            if module_name_for(p) is None:
-                print(
-                    f"select_impacted_tests: cannot map {path}; escalating to FULL",
-                    file=sys.stderr,
-                )
-                return FULL
-
-    return sorted(impacted_tests(changed, reverse, repo))
+    result = impacted_tests(changed, reverse, repo)
+    if result == FULL:
+        return FULL
+    return sorted(result)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/select_impacted_tests.py
+++ b/scripts/select_impacted_tests.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Select the unit tests impacted by a changed file set.
+
+The unit gate runs the whole suite on every push (~7.5 min of pytest), which
+re-pays for a guarantee `repo_wide_unit_backstop` already holds daily. This
+picks the tests a change can actually reach, so a push pays for its own blast
+radius instead of the repo's.
+
+Soundness rests on three properties, in order of how much they matter:
+
+1. **Transitive, not one-hop.** Reachability is computed over the whole
+   first-party import graph, so `tests/test_a.py -> helpers -> changed_module`
+   selects `test_a`. A one-hop "which test names this module" grep silently
+   drops exactly the indirect dependencies a refactor breaks.
+2. **Unresolvable input means FULL, never empty.** A file this script cannot
+   map (a global config, an unparseable module, anything outside the known
+   first-party roots) escalates to the full suite. The failure direction is
+   "run too much", never "run too little" -- a selector that silently returns
+   nothing is worse than no selector, because it reports green.
+3. **Empty is only for provably test-free changes.** An empty selection means
+   every changed file was mapped and none of them is reachable from any test
+   (documentation, plans). It is not the fallback for "I could not tell".
+
+Output: newline-separated test paths on stdout, or the single token ``FULL``.
+
+    python scripts/select_impacted_tests.py --base origin/main
+    python scripts/select_impacted_tests.py --changed-file /tmp/changed.txt
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import subprocess
+import sys
+from collections import defaultdict, deque
+from pathlib import Path
+from typing import Iterable
+
+# First-party import roots. A module outside these is third-party: it cannot be
+# changed by a PR, so it is not part of the graph.
+FIRST_PARTY_ROOTS = ("atlas_brain", "tests", "scripts", "extracted_content_pipeline")
+
+# Changing any of these invalidates selection itself -- they alter collection,
+# the interpreter environment, or the gate's own logic, so no per-file mapping
+# is meaningful. Matched against the changed path's parts, so a nested
+# conftest.py escalates too.
+GLOBAL_FILES = {
+    "conftest.py",
+    "pytest.ini",
+    "pyproject.toml",
+    "setup.cfg",
+    "tox.ini",
+    "unit_gate_baseline.txt",
+    "check_unit_gate.py",
+    "select_impacted_tests.py",
+    "unit_gate.yml",
+}
+GLOBAL_PREFIXES = ("requirements",)
+
+FULL = "FULL"
+
+
+def changed_files_from_git(base: str) -> list[str]:
+    """Changed paths vs the merge base with ``base``."""
+    merge_base = subprocess.run(
+        ["git", "merge-base", base, "HEAD"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    out = subprocess.run(
+        ["git", "diff", "--name-only", f"{merge_base}..HEAD"],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    return [line for line in out.splitlines() if line.strip()]
+
+
+def is_global_change(path: str) -> bool:
+    """True when ``path`` invalidates per-file selection (-> FULL)."""
+    name = Path(path).name
+    if name in GLOBAL_FILES:
+        return True
+    return any(name.startswith(prefix) for prefix in GLOBAL_PREFIXES)
+
+
+def module_name_for(path: Path) -> str | None:
+    """Dotted module name for a first-party .py path, else None."""
+    if path.suffix != ".py":
+        return None
+    parts = list(path.with_suffix("").parts)
+    if not parts or parts[0] not in FIRST_PARTY_ROOTS:
+        return None
+    if parts[-1] == "__init__":
+        parts = parts[:-1]
+    return ".".join(parts) if parts else None
+
+
+def _imports_of(path: Path, rel: Path) -> set[str]:
+    """First-party dotted names imported by ``path``.
+
+    ``rel`` is the repo-relative path and is what relative imports resolve
+    against -- using the absolute path here would prefix every ``from .x``
+    with the checkout directory, so the edge would never match a real module
+    and the importer would silently look independent.
+    """
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except (SyntaxError, UnicodeDecodeError, OSError):
+        # Unparseable: caller escalates. Never treat as "imports nothing".
+        raise
+
+    names: set[str] = set()
+    pkg_parts = list(rel.with_suffix("").parts)[:-1]
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.level:
+                base_parts = pkg_parts[: len(pkg_parts) - (node.level - 1)]
+                prefix = ".".join(base_parts + ([node.module] if node.module else []))
+            else:
+                prefix = node.module or ""
+            if prefix:
+                names.add(prefix)
+                for alias in node.names:
+                    names.add(f"{prefix}.{alias.name}")
+    return {n for n in names if n.split(".")[0] in FIRST_PARTY_ROOTS}
+
+
+def build_reverse_graph(repo: Path) -> tuple[dict[str, set[str]], set[str]]:
+    """(module -> modules importing it, unparseable paths).
+
+    Unparseable files are returned rather than skipped: a file whose imports we
+    could not read has unknown edges, and unknown edges mean FULL.
+    """
+    reverse: dict[str, set[str]] = defaultdict(set)
+    unparseable: set[str] = set()
+    modules: dict[str, Path] = {}
+
+    for root in FIRST_PARTY_ROOTS:
+        root_dir = repo / root
+        if not root_dir.is_dir():
+            continue
+        for path in root_dir.rglob("*.py"):
+            rel = path.relative_to(repo)
+            name = module_name_for(rel)
+            if name:
+                modules[name] = rel
+
+    for name, rel in modules.items():
+        try:
+            imported = _imports_of(repo / rel, rel)
+        except (SyntaxError, UnicodeDecodeError, OSError):
+            unparseable.add(str(rel))
+            continue
+        for target in imported:
+            # Attribute imports (pkg.mod.symbol) resolve to the longest prefix
+            # that is a real module, so importing a symbol still records the
+            # edge to the module that defines it.
+            parts = target.split(".")
+            for i in range(len(parts), 0, -1):
+                candidate = ".".join(parts[:i])
+                if candidate in modules:
+                    reverse[candidate].add(name)
+                    break
+    return reverse, unparseable
+
+
+def impacted_tests(
+    changed: Iterable[str], reverse: dict[str, set[str]], repo: Path
+) -> set[str]:
+    """Test files transitively reachable from the changed modules."""
+    seen: set[str] = set()
+    queue: deque[str] = deque()
+
+    for path in changed:
+        name = module_name_for(Path(path))
+        if name:
+            queue.append(name)
+            seen.add(name)
+
+    tests: set[str] = set()
+    while queue:
+        current = queue.popleft()
+        if current.startswith("tests."):
+            rel = Path(*current.split(".")).with_suffix(".py")
+            if (repo / rel).exists():
+                tests.add(str(rel))
+        for importer in reverse.get(current, ()):
+            if importer not in seen:
+                seen.add(importer)
+                queue.append(importer)
+    return tests
+
+
+def select(changed: list[str], repo: Path) -> list[str] | str:
+    """FULL, or the sorted impacted test paths."""
+    if not changed:
+        # No diff at all is not a provably test-free change; something is off
+        # with the base ref. Escalate.
+        return FULL
+    if any(is_global_change(p) for p in changed):
+        return FULL
+
+    reverse, unparseable = build_reverse_graph(repo)
+    if unparseable:
+        print(
+            f"select_impacted_tests: {len(unparseable)} unparseable module(s); "
+            "escalating to FULL",
+            file=sys.stderr,
+        )
+        return FULL
+
+    # A changed .py under a first-party root that yields no module name means
+    # the roots and the tree disagree -- unknown edges again.
+    for path in changed:
+        p = Path(path)
+        if p.suffix == ".py" and p.parts and p.parts[0] in FIRST_PARTY_ROOTS:
+            if module_name_for(p) is None:
+                print(
+                    f"select_impacted_tests: cannot map {path}; escalating to FULL",
+                    file=sys.stderr,
+                )
+                return FULL
+
+    return sorted(impacted_tests(changed, reverse, repo))
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--base", default="origin/main",
+                    help="Base ref to diff against (default: origin/main).")
+    ap.add_argument("--changed-file", type=Path,
+                    help="Read the changed paths from this file instead of git.")
+    ap.add_argument("--repo", type=Path, default=Path.cwd())
+    args = ap.parse_args(argv)
+
+    if args.changed_file is not None:
+        changed = [
+            line.strip()
+            for line in args.changed_file.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+    else:
+        try:
+            changed = changed_files_from_git(args.base)
+        except subprocess.CalledProcessError as exc:
+            print(f"select_impacted_tests: git failed ({exc}); escalating to FULL",
+                  file=sys.stderr)
+            print(FULL)
+            return 0
+
+    result = select(changed, args.repo)
+    if result == FULL:
+        print(FULL)
+    else:
+        for path in result:
+            print(path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_select_impacted_tests.py
+++ b/tests/test_select_impacted_tests.py
@@ -89,6 +89,17 @@ def test_relative_import_is_followed(tmp_path):
     assert sel.select(["atlas_brain/pkg/leaf.py"], repo) == ["tests/test_rel.py"]
 
 
+def test_package_initializer_edge_is_recorded(tmp_path):
+    """Importing pkg.leaf executes pkg/__init__.py too; changing it must select."""
+    repo = _mkrepo(tmp_path, {
+        "atlas_brain/__init__.py": "",
+        "atlas_brain/pkg/__init__.py": "INIT = 1\n",
+        "atlas_brain/pkg/leaf.py": "X = 1\n",
+        "tests/test_pkg.py": "import atlas_brain.pkg.leaf\n",
+    })
+    assert sel.select(["atlas_brain/pkg/__init__.py"], repo) == ["tests/test_pkg.py"]
+
+
 def test_changed_test_file_selects_itself(tmp_path):
     repo = _mkrepo(tmp_path, {
         "atlas_brain/__init__.py": "",
@@ -145,12 +156,92 @@ def test_empty_diff_escalates_to_full(tmp_path):
     assert sel.select([], repo) == sel.FULL
 
 
+def test_deleted_changed_path_escalates_to_full(tmp_path):
+    """A deleted module's old import edges are absent from PR-head parsing."""
+    repo = _mkrepo(tmp_path, {"atlas_brain/__init__.py": ""})
+    assert sel.select(["atlas_brain/removed.py"], repo) == sel.FULL
+
+
+def test_unknown_python_root_escalates_to_full(tmp_path):
+    """New/omitted first-party roots must not be interpreted as test-free."""
+    repo = _mkrepo(tmp_path, {
+        "atlas_reddit/__init__.py": "",
+        "atlas_reddit/config.py": "TOKEN = 'x'\n",
+        "tests/test_atlas_reddit_config.py": "from atlas_reddit.config import TOKEN\n",
+    })
+    assert sel.select(["atlas_reddit/config.py"], repo) == sel.FULL
+
+
+def test_runtime_asset_change_escalates_to_full(tmp_path):
+    """YAML/JSON/etc. may be loaded at runtime without a Python import edge."""
+    repo = _mkrepo(tmp_path, {
+        "atlas_brain/__init__.py": "",
+        "atlas_brain/skills/brand/brand_voice.yml": "tone: warm\n",
+        "tests/test_brand_voice_validator.py": (
+            "from pathlib import Path\n"
+            "def test_asset():\n"
+            "    assert Path('atlas_brain/skills/brand/brand_voice.yml')\n"
+        ),
+    })
+    assert sel.select(["atlas_brain/skills/brand/brand_voice.yml"], repo) == sel.FULL
+
+
+def test_workflow_change_escalates_to_full(tmp_path):
+    repo = _mkrepo(tmp_path, {
+        "atlas_brain/__init__.py": "",
+        ".github/workflows/other_gate.yml": "name: other\n",
+    })
+    assert sel.select([".github/workflows/other_gate.yml"], repo) == sel.FULL
+
+
+def test_script_change_escalates_for_path_based_loading(tmp_path):
+    """Tests often load scripts via importlib/runpy/subprocess path strings."""
+    repo = _mkrepo(tmp_path, {
+        "scripts/audit_claims.py": "VALUE = 1\n",
+        "tests/test_audit_claims.py": (
+            "import importlib.util\n"
+            "spec = importlib.util.spec_from_file_location("
+            "'audit_claims', 'scripts/audit_claims.py')\n"
+            "module = importlib.util.module_from_spec(spec)\n"
+            "spec.loader.exec_module(module)\n"
+        ),
+    })
+    assert sel.select(["scripts/audit_claims.py"], repo) == sel.FULL
+
+
+def test_conftest_dependency_escalates_to_full(tmp_path):
+    """Once conftest is reached, fixture consumers are not in the import graph."""
+    repo = _mkrepo(tmp_path, {
+        "atlas_brain/__init__.py": "",
+        "atlas_brain/fixture_source.py": "VALUE = 1\n",
+        "tests/conftest.py": (
+            "import pytest\n"
+            "from atlas_brain.fixture_source import VALUE\n"
+            "@pytest.fixture\n"
+            "def shared_value():\n"
+            "    return VALUE\n"
+        ),
+        "tests/test_fixture_user.py": (
+            "def test_uses_fixture(shared_value):\n"
+            "    assert shared_value == 1\n"
+        ),
+    })
+    assert sel.select(["atlas_brain/fixture_source.py"], repo) == sel.FULL
+
+
 def test_docs_only_change_selects_nothing(tmp_path):
-    """The one case where empty is correct: mapped, and reachable from no test."""
+    """The one case where empty is correct: mapped, and reachable from no test.
+
+    The docs must EXIST in the head. A changed path absent from the head is a
+    deletion and escalates to FULL, so a fixture that omits the files would
+    pass for the wrong reason and hide a real docs-only regression.
+    """
     repo = _mkrepo(tmp_path, {
         "atlas_brain/__init__.py": "",
         "atlas_brain/svc.py": "X = 1\n",
         "tests/test_svc.py": "from atlas_brain.svc import X\n",
+        "docs/GUIDE.md": "# guide\n",
+        "plans/PR-Thing.md": "# plan\n",
     })
     assert sel.select(["docs/GUIDE.md", "plans/PR-Thing.md"], repo) == []
 
@@ -205,3 +296,43 @@ def test_stale_entry_inside_scope_is_still_caught():
 
 def test_node_file_handles_parametrized_ids_with_colons():
     assert gate.node_file("tests/test_a.py::test_k[a::b]") == "tests/test_a.py"
+
+
+def test_growth_only_runs_growth_guard_without_pytest_report(tmp_path, capsys):
+    baseline = tmp_path / "unit_gate_baseline.txt"
+    base_baseline = tmp_path / "base_unit_gate_baseline.txt"
+    baseline.write_text("tests/test_a.py::known\n", encoding="utf-8")
+    base_baseline.write_text("tests/test_a.py::known\n", encoding="utf-8")
+
+    assert gate.main([
+        "--baseline", str(baseline),
+        "--base-baseline", str(base_baseline),
+        "--growth-only",
+    ]) == 0
+    assert "growth guard passed" in capsys.readouterr().out
+
+
+def test_growth_only_still_rejects_baseline_growth(tmp_path):
+    baseline = tmp_path / "unit_gate_baseline.txt"
+    base_baseline = tmp_path / "base_unit_gate_baseline.txt"
+    baseline.write_text(
+        "tests/test_a.py::known\n"
+        "tests/test_a.py::newly_added\n",
+        encoding="utf-8",
+    )
+    base_baseline.write_text("tests/test_a.py::known\n", encoding="utf-8")
+
+    assert gate.main([
+        "--baseline", str(baseline),
+        "--base-baseline", str(base_baseline),
+        "--growth-only",
+    ]) == 3
+
+
+def test_scoped_run_allows_marker_filtered_no_tests_collected():
+    gate.ensure_pytest_ran(5, allow_no_tests=True)
+
+
+def test_unscoped_no_tests_collected_still_fails_infrastructure():
+    with pytest.raises(RuntimeError):
+        gate.ensure_pytest_ran(5)

--- a/tests/test_select_impacted_tests.py
+++ b/tests/test_select_impacted_tests.py
@@ -1,0 +1,207 @@
+"""Fixture tests for the impacted-test selector and the scoped unit gate.
+
+Per AGENTS.md 3i a checker must prove its FAILURE detection, not only its happy
+path. The selector's dangerous failure is selecting too FEW tests (a green gate
+that ran nothing relevant), so most of these assert that a test IS selected or
+that the run escalates to FULL.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, REPO / "scripts" / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+sel = _load("select_impacted_tests")
+gate = _load("check_unit_gate")
+
+
+def _mkrepo(tmp_path: Path, files: dict[str, str]) -> Path:
+    for rel, body in files.items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body, encoding="utf-8")
+    return tmp_path
+
+
+# --- selection: the direction that matters (too few) ------------------------
+
+
+def test_direct_importer_is_selected(tmp_path):
+    repo = _mkrepo(tmp_path, {
+        "atlas_brain/__init__.py": "",
+        "atlas_brain/svc.py": "VALUE = 1\n",
+        "tests/test_svc.py": "from atlas_brain.svc import VALUE\n",
+    })
+    assert sel.select(["atlas_brain/svc.py"], repo) == ["tests/test_svc.py"]
+
+
+def test_transitive_importer_is_selected(tmp_path):
+    """test -> helper -> changed module. A one-hop grep would miss this."""
+    repo = _mkrepo(tmp_path, {
+        "atlas_brain/__init__.py": "",
+        "atlas_brain/deep.py": "VALUE = 1\n",
+        "atlas_brain/mid.py": "from atlas_brain.deep import VALUE\n",
+        "tests/test_top.py": "from atlas_brain.mid import VALUE\n",
+    })
+    assert sel.select(["atlas_brain/deep.py"], repo) == ["tests/test_top.py"]
+
+
+def test_four_hop_chain_is_selected(tmp_path):
+    repo = _mkrepo(tmp_path, {
+        "atlas_brain/__init__.py": "",
+        "atlas_brain/a.py": "X = 1\n",
+        "atlas_brain/b.py": "from atlas_brain.a import X\n",
+        "atlas_brain/c.py": "from atlas_brain.b import X\n",
+        "tests/test_d.py": "from atlas_brain.c import X\n",
+    })
+    assert sel.select(["atlas_brain/a.py"], repo) == ["tests/test_d.py"]
+
+
+def test_symbol_import_records_the_module_edge(tmp_path):
+    """`from pkg.mod import symbol` must map to pkg/mod.py, not be dropped."""
+    repo = _mkrepo(tmp_path, {
+        "atlas_brain/__init__.py": "",
+        "atlas_brain/svc.py": "def helper():\n    return 1\n",
+        "tests/test_sym.py": "from atlas_brain.svc import helper\n",
+    })
+    assert sel.select(["atlas_brain/svc.py"], repo) == ["tests/test_sym.py"]
+
+
+def test_relative_import_is_followed(tmp_path):
+    repo = _mkrepo(tmp_path, {
+        "atlas_brain/__init__.py": "",
+        "atlas_brain/pkg/__init__.py": "",
+        "atlas_brain/pkg/leaf.py": "X = 1\n",
+        "atlas_brain/pkg/user.py": "from .leaf import X\n",
+        "tests/test_rel.py": "from atlas_brain.pkg.user import X\n",
+    })
+    assert sel.select(["atlas_brain/pkg/leaf.py"], repo) == ["tests/test_rel.py"]
+
+
+def test_changed_test_file_selects_itself(tmp_path):
+    repo = _mkrepo(tmp_path, {
+        "atlas_brain/__init__.py": "",
+        "tests/test_standalone.py": "def test_x():\n    assert True\n",
+    })
+    assert sel.select(["tests/test_standalone.py"], repo) == ["tests/test_standalone.py"]
+
+
+def test_unrelated_module_is_not_selected(tmp_path):
+    """Over-selection direction: an unrelated test must not be pulled in."""
+    repo = _mkrepo(tmp_path, {
+        "atlas_brain/__init__.py": "",
+        "atlas_brain/svc.py": "X = 1\n",
+        "atlas_brain/other.py": "Y = 2\n",
+        "tests/test_other.py": "from atlas_brain.other import Y\n",
+    })
+    assert sel.select(["atlas_brain/svc.py"], repo) == []
+
+
+# --- escalation: unresolvable input must never yield an empty selection -----
+
+
+@pytest.mark.parametrize("path", [
+    "tests/conftest.py",
+    "atlas_brain/services/conftest.py",
+    "requirements.txt",
+    "requirements.content_ops_ci.txt",
+    "pytest.ini",
+    "pyproject.toml",
+    "tests/unit_gate_baseline.txt",
+    "scripts/check_unit_gate.py",
+    "scripts/select_impacted_tests.py",
+    ".github/workflows/unit_gate.yml",
+])
+def test_global_files_escalate_to_full(tmp_path, path):
+    repo = _mkrepo(tmp_path, {"atlas_brain/__init__.py": ""})
+    assert sel.select([path], repo) == sel.FULL
+
+
+def test_unparseable_module_escalates_to_full(tmp_path):
+    """Unknown import edges must not be read as 'imports nothing'."""
+    repo = _mkrepo(tmp_path, {
+        "atlas_brain/__init__.py": "",
+        "atlas_brain/svc.py": "X = 1\n",
+        "atlas_brain/broken.py": "def (((\n",
+        "tests/test_svc.py": "from atlas_brain.svc import X\n",
+    })
+    assert sel.select(["atlas_brain/svc.py"], repo) == sel.FULL
+
+
+def test_empty_diff_escalates_to_full(tmp_path):
+    """No diff is 'something is wrong with the base ref', not 'nothing to run'."""
+    repo = _mkrepo(tmp_path, {"atlas_brain/__init__.py": ""})
+    assert sel.select([], repo) == sel.FULL
+
+
+def test_docs_only_change_selects_nothing(tmp_path):
+    """The one case where empty is correct: mapped, and reachable from no test."""
+    repo = _mkrepo(tmp_path, {
+        "atlas_brain/__init__.py": "",
+        "atlas_brain/svc.py": "X = 1\n",
+        "tests/test_svc.py": "from atlas_brain.svc import X\n",
+    })
+    assert sel.select(["docs/GUIDE.md", "plans/PR-Thing.md"], repo) == []
+
+
+# --- the scoped baseline: the trap that makes naive scoping fail ------------
+
+
+def test_restrict_baseline_keeps_only_selected_files():
+    baseline = {
+        "tests/test_a.py::test_one",
+        "tests/test_a.py::test_two",
+        "tests/test_b.py::test_three",
+    }
+    assert gate.restrict_baseline(baseline, {"tests/test_a.py"}) == {
+        "tests/test_a.py::test_one",
+        "tests/test_a.py::test_two",
+    }
+
+
+def test_unrestricted_baseline_would_fail_a_scoped_run():
+    """Without restriction every unselected baseline entry reads as newly-passing.
+
+    This is the defect the --selected-files flag exists to prevent; asserting it
+    directly keeps the reason from being refactored away.
+    """
+    baseline = {"tests/test_a.py::t", "tests/test_b.py::t", "tests/test_c.py::t"}
+    failing_from_scoped_run = {"tests/test_a.py::t"}
+
+    _, fixed_unrestricted = gate.compare(failing_from_scoped_run, baseline)
+    assert len(fixed_unrestricted) == 2  # b and c look "fixed" -- gate fails
+
+    restricted = gate.restrict_baseline(baseline, {"tests/test_a.py"})
+    regressions, fixed = gate.compare(failing_from_scoped_run, restricted)
+    assert regressions == [] and fixed == []
+
+
+def test_regression_inside_scope_is_still_caught():
+    baseline = {"tests/test_a.py::known"}
+    failing = {"tests/test_a.py::known", "tests/test_a.py::NEW"}
+    restricted = gate.restrict_baseline(baseline, {"tests/test_a.py"})
+    regressions, _ = gate.compare(failing, restricted)
+    assert regressions == ["tests/test_a.py::NEW"]
+
+
+def test_stale_entry_inside_scope_is_still_caught():
+    baseline = {"tests/test_a.py::known", "tests/test_a.py::now_passing"}
+    failing = {"tests/test_a.py::known"}
+    restricted = gate.restrict_baseline(baseline, {"tests/test_a.py"})
+    _, fixed = gate.compare(failing, restricted)
+    assert fixed == ["tests/test_a.py::now_passing"]
+
+
+def test_node_file_handles_parametrized_ids_with_colons():
+    assert gate.node_file("tests/test_a.py::test_k[a::b]") == "tests/test_a.py"


### PR DESCRIPTION
Plan: plans/PR-Unit-Gate-Impacted-Selection.md
Slice phase: vertical slice
Ownership lane: ci-gates

`unit-gate` runs the entire unit suite on every PR push. Measured on run 30181595014: **447s of pytest inside a 9.4-minute median job** — install is only 98s, so pytest is 80% of it. Every push pays it, including pushes that cannot affect any test: **#2202 was two Markdown edits and spent 9.7 minutes executing 755 test files.** The full-suite guarantee it provides (#2035 / G1.1, G2) is already held daily by `repo_wide_unit_backstop.yml`; this gate re-pays for it on every push.

## Intentional

- **Transitive reachability, not a one-hop name match.** `tests/test_a.py -> helper -> changed_module` selects `test_a`. A grep for "which test names this module" drops exactly the indirect dependencies a refactor breaks.
- **Escalate, never guess.** Unparseable module, unmappable path, empty diff, git failure, or a change to conftest / requirements / pytest config / the gate itself all yield `FULL`. The dangerous direction is running too few tests and reporting green, so every uncertainty resolves toward running more.
- **Empty selection is reserved for provably test-free changes** — every path mapped, none reachable from any test. It is not the fallback for "could not tell".
- **The baseline is restricted to the executed files.** `compare()` demands the failing set *exactly* equal the baseline, so on a subset run the ~180 unexecuted entries would read as newly-passing and fail every scoped run. This is the trap that makes naive scoping look broken.
- **A failing node outside the selection is exit 2**, not a regression verdict — scope and run disagree, and the verdict would be scored against evidence the run was not built to produce.
- **`--selected-files` is refused with `--update-baseline`**, so a scoped run cannot rewrite the repo-wide baseline by deleting the 90%+ it never executed.
- **The growth guard runs on every path**, including the zero-test one, so a docs-only PR still cannot add baseline entries.
- **No `pytest-xdist` here.** Parallelism is the other lever on the same 447s and is plausibly worth more, but it is a separate change with its own risk (session fixtures, ordering) and does not belong bundled in.

## Deferred

- `pytest-xdist` on the full-suite path and the daily backstop.
- Enrolling `unit-gate` in branch protection — it is still advisory, and that decision should follow evidence from this change rather than precede it.

## Parked hardening

- None.

## Cold diff reconstruction

- Added: `scripts/select_impacted_tests.py` — AST import graph over the first-party roots, BFS reverse reachability from changed files to `tests.*` modules, `FULL` escalation on any unmappable input. Relative imports resolve against the **repo-relative** package.
- Changed: `scripts/check_unit_gate.py` adds `node_file()`, `restrict_baseline()`, and `--selected-files`; refuses `--update-baseline` when scoped; hard-errors on a failing node outside the selection; prints the scope note.
- Changed: `.github/workflows/unit_gate.yml` adds a `Select impacted tests` step and branches the gate step three ways (FULL / scoped / growth-guard-only).
- Added: `tests/test_select_impacted_tests.py` — 25 fixture tests weighted toward the under-selection direction, plus the baseline-restriction traps.
- Added: `plans/PR-Unit-Gate-Impacted-Selection.md`.
- Contract match: every change traces to the problem-derived contract — selection by transitive closure, escalation on unmappable input, baseline restricted to what ran.
- Gaps: none.

## Verification

- `python -m pytest tests/test_select_impacted_tests.py tests/test_check_unit_gate.py -q` → **39 passed** (25 new).
- Selector against this repo: docs-only (`AGENTS.md`, `docs/REVIEWER_RULES.md`) → empty; `atlas_brain/services/customer_context.py` → **64 of 755** test files; `tests/conftest.py` → `FULL`.
- Node counts for that selection via `--collect-only`: **1,455 vs 20,320 full (7.2%)**; collection alone 22.6s → 8.8s.
- `python -m py_compile` clean on both scripts; workflow YAML parses; `git diff --check` clean; ASCII check passed.
- `audit_plan_code_consistency.py` → 11 path claims + 2 function claims all resolve.
- **A real bug was caught by these tests during development**: `_imports_of` computed the package from the *absolute* path, so every relative import resolved to a checkout-prefixed name that matched nothing and its importer looked independent — silent under-selection, the exact failure this selector must not have. `test_relative_import_is_followed` fails on that code and passes on the fix.
- **Not run**: a live scoped CI run. This PR touches `scripts/check_unit_gate.py` and `.github/workflows/unit_gate.yml`, both on the `GLOBAL_FILES` list, so it deliberately escalates *itself* to `FULL`. The scoped path is proven by the fixture tests and the local selections; the first PR that does not touch the gate will exercise it live.

## Residual risk, stated plainly

This narrows the pre-merge guarantee from "the whole suite ran" to "the tests reachable from the diff ran". A selector bug that under-selects would be caught by the next daily backstop rather than pre-merge — a window of up to ~24h. That is the trade being made, and it is why every ambiguous input escalates to `FULL` and why the tests are weighted toward under-selection.

Note also: **#2139** (Dependabot `actions/setup-python` bump) also modifies `.github/workflows/unit_gate.yml` — whichever lands second will need a trivial rebase.

## Diff size

5 files, +679 / -3

Diff-budget override: the selector, the baseline restriction it requires, and the fixture tests are one behavior. The selector without the baseline restriction fails every scoped run; either without the tests ships an under-selection risk with no failure detection (§3i).
