### PR TITLE
docs(AGENTS,REVIEWER_RULES): require acceptance criteria to name a claim, not a bare hazard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,63 @@ contract surface, the Review Contract must also name the reachability proof:
 the real entrypoint exercised and the observable output/state/artifact/job/gate
 result that proves the surface is wired.
 
+**An acceptance criterion names a claim about the code, or the evidence that
+settles it -- never a bare risk category.** The reviewer marks each criterion
+met / not met / could-not-determine, so a criterion has to point at something to
+look at: a `file:line`, a command and its output, a CI run/job, a generated
+artifact.
+
+Behavioral criteria are not merely allowed, they are **required** wherever this
+section asks for a reachability proof. "POST /api/v1/leads/intake returns 204 to
+a preflight" is a good criterion -- the command and its output settle it.
+
+A **bare risk category** is not a criterion. "No preflight-to-import TOCTOU",
+"no race conditions", "handles every malformed input" name a hazard with no
+referent -- there is nothing to look at. For a contract authored or materially
+revised after this rule lands, fail the contract authoring and ask for the code
+claim or settling evidence; do not hunt the category on the builder's behalf.
+
+Naming the evidence rescues it. *"No unmasked email addresses in the audit
+export -- settled by `tests/test_audit_export.py::test_masks_email_addresses`"*
+is a perfectly good criterion: it is risk-shaped, but it says where to look, and
+the reviewer marks it met or not from that evidence. The defect is the missing
+referent, not the word "no" and not the hazard framing.
+For concurrency or open-execution criteria, a sampled concurrent test is not
+settling evidence by itself: the criterion names the 3k.4 execution model and
+the property-level invariant that holds across every admitted interleaving, with
+tests used as evidence under that model.
+For open-input criteria, a sampled fixture list is not settling evidence by
+itself: the criterion names the 3k.3 evidence-gated mechanism -- the single
+choke-point decision, safe default for ambiguous/unrecognized/malformed input,
+and bounded recognizer evidence -- with tests used as evidence under that
+mechanism.
+For a hazard-labelled concern, name the code claim it translates into --
+*"the receipt is constructed before any fallible work"* -- and the reviewer has
+a place to look.
+
+This is deliberately the narrow rule. It does **not** require criteria to avoid
+universally-quantified claims: "no path after finalization changes the process
+outcome" quantifies over paths and is perfectly reviewable, because the paths
+are in the diff. The defect is naming a hazard with no referent, not breadth.
+
+**Risk areas are not criteria.** They name the hazards the reviewer probes and
+set probe depth; the completion matrix does not disposition them, so a risk area
+may name a category -- that is what the field is for. Where a slice is genuinely
+open-input or open-execution work, the *criterion* points at the mechanism that
+closes it (3k.3's evidence-gate, 3k.4's execution model) rather than at the
+hazard.
+
+**Legacy contracts.** This binds contracts authored or materially revised after
+it lands; a plan already open is not retroactively invalid, since root `plans/`
+holds other sessions' in-flight slices (3a.1). Do not retroactively
+re-disposition a legacy criterion merely because this new authoring rule would
+have asked for clearer wording. Review the legacy contract as authored: follow
+the evidence and diff it points to, disposition normally when that evidence
+settles it, and record `could-not-determine` only if the criterion still has no
+claim or evidence to settle after that review. What is grandfathered is the
+**authoring** finding -- on a pre-existing contract the reviewer records the
+phrasing as an advisory NIT rather than an R1 against the plan.
+
 ### 1b. PR body
 
 For a non-empty human PR that intentionally carries no plan and changes only

--- a/docs/REVIEWER_RULES.md
+++ b/docs/REVIEWER_RULES.md
@@ -42,10 +42,11 @@ reviewer reviews against it. No contract, nothing to check against.
 
 ```
 ### Review Contract
-- Acceptance criteria:
-  - [ ] Behavior A works
-  - [ ] Edge case B handled
-  - [ ] Existing behavior C unchanged
+- Acceptance criteria (each a code claim, or a hazard plus the evidence that
+  settles it; a BARE risk category with no referent is the defect -- AGENTS.md 1a):
+  - [ ] <entrypoint> returns <observable result> for <input>
+  - [ ] <named boundary input> is rejected with <observable result>
+  - [ ] <existing behavior C> unchanged: <command / CI job that shows it>
 - Reachability proof: real entrypoint + observable output/state, or N/A with reason
 - Affected surfaces: API / DB / auth / frontend / jobs / config / observability / third-party
 - Risk areas: data-loss / security / backcompat / performance / concurrency / migration
@@ -54,6 +55,45 @@ reviewer reviews against it. No contract, nothing to check against.
 
 The contract is optional for one-off scratch, mandatory for non-trivial PRs
 (same threshold as the plan doc itself, per `AGENTS.md`).
+
+**For contracts authored or materially revised after this rule lands, a
+criterion that names a *bare* risk category is a defect in the contract, and the
+reviewer says so.** "No TOCTOU", "no race conditions", "handles every malformed
+input" name a hazard with no referent, so there is nothing to look at.
+
+Naming the evidence rescues it: *"No unmasked email addresses in the audit
+export -- settled by `tests/test_audit_export.py::test_masks_email_addresses`"*
+is valid and the reviewer dispositions it from that evidence. The defect is the
+missing referent, never the hazard framing. For concurrency or open-execution
+criteria, a sampled concurrent test is not settling evidence by itself; require
+the 3k.4 execution model and the property-level invariant that holds across
+every admitted interleaving. For open-input criteria, a sampled fixture list is
+not settling evidence by itself; require the 3k.3 evidence-gated mechanism:
+single choke-point decision, safe default for ambiguous/unrecognized/malformed
+input, and bounded recognizer evidence.
+
+Legacy contracts are different. This rule does not automatically
+re-disposition legacy criteria and does not forbid investigating them. For a
+contract authored before this lands, review against the contract as authored:
+inspect the diff and evidence it points to, disposition normally when that
+evidence settles it, and record `could-not-determine` only if the criterion
+still has no claim or evidence to settle after that review. The legacy phrasing
+is an advisory NIT, not a blocking R1 authoring finding, unless the contract is
+materially revised.
+
+Two things follow, and they are separate:
+
+- **New or materially revised contracts fail authoring review on a bare hazard.**
+  Ask for the code claim the hazard translates into, or the evidence that settles
+  it. Do not silently work around a newly authored bare hazard by hunting the
+  category.
+- **Legacy contracts keep their existing matrix behavior.** Do not mark a legacy
+  criterion `could-not-determine` solely because this authoring rule now exists;
+  use `could-not-determine` only when the actual legacy review still cannot find
+  a claim or evidence to settle.
+
+Risk areas are exempt: they name hazards by design and the matrix does not
+disposition them (`AGENTS.md` 1a).
 
 ---
 

--- a/plans/PR-Contract-Dispositionable-Criteria.md
+++ b/plans/PR-Contract-Dispositionable-Criteria.md
@@ -1,0 +1,195 @@
+# PR-Contract-Dispositionable-Criteria
+
+## Why this slice exists
+
+#2202 bounded the reviewer's completion matrix. But item 1 of that matrix is
+"each acceptance criterion in the Review Contract", and current `main` still
+teaches builders to author criteria without a code claim or settling evidence:
+the canonical example says only "Behavior A works" / "Edge case B handled", and
+the mandatory scaffold says only "List the outcomes the reviewer checks one by
+one." A plan can satisfy the shape checks while giving the reviewer no concrete
+claim to disposition. The stopping rule is only ever as bounded as the contract
+it checks against.
+
+### Why this phase, and why it is admissible now
+
+`Workflow/process` is the phase by definition -- this changes review contracts
+and the plan-authoring tool, not product behavior (`AGENTS.md` phase table).
+
+Section 0 admits a workflow slice only when it unblocks the current vertical
+proof, fixes a real safety/security/privacy/money risk, or is justified by a
+recent product slice that failed because the infrastructure gap existed. This is
+merge-gate integrity hardening for the safety/security/concurrency review path:
+`docs/REVIEWER_RULES.md` and `scripts/new_pr_plan.sh` are the authoring surfaces
+for the gate contract, and on current `main` they permit newly authored
+acceptance criteria with no code claim or evidence target. That lets a future
+security/concurrency claim reach review in a state the reviewer can only block
+or over-broaden. This PR closes that authoring gap at the source.
+
+### Problem-derived contract
+
+- Root cause: nothing requires a Review Contract's acceptance criteria to name
+  something the reviewer can look at, so a criterion can name a bare hazard --
+  an unbounded review mandate the builder authored for themselves, which the
+  reviewer is right to honor.
+- Correct fix must: require each acceptance criterion to name a code claim or
+  the evidence that settles it; keep behavioral and risk-shaped-but-evidenced
+  criteria first-class (1a's reachability proof depends on the former); leave
+  risk areas alone, since they name hazards by design and the matrix does not
+  disposition them; route newly authored bare hazards back to contract authoring
+  instead of asking reviewers to hunt open-ended categories; require
+  open-input criteria to name the 3k.3 evidence-gated mechanism instead of
+  treating one sampled fixture list as settling evidence; require
+  concurrency/open-execution criteria to name the 3k.4 execution model and
+  property-level invariant instead of treating one sampled concurrent test as
+  settling evidence; and reach every surface a builder authors a contract from
+  -- the rule text, the canonical example, and the scaffold that generates plans.
+- Must not change: #2202's completion vocabulary (criteria are met / not met /
+  could-not-determine; rules are pass / fail / not-verified / n-a), the
+  complete-but-blocked state, `success` semantics, or legacy contracts'
+  existing disposition behavior.
+
+## Scope (this PR)
+
+Ownership lane: reviewer-contract/plan-authoring
+Slice phase: Workflow/process
+Max files: 5
+
+1. `AGENTS.md` 1a: an acceptance criterion names a code claim or the evidence
+   that settles it, never a bare risk category; behavioral criteria explicitly
+   required where a reachability proof is asked for; risk areas exempt; open
+   categories route to 3k.3 / 3k.4; newly authored bare hazards fail contract
+   authoring instead of sending reviewers to hunt the category.
+2. `docs/REVIEWER_RULES.md`: canonical Review Contract example shows settleable
+   criteria with its risk-area line unchanged; the reviewer-side note uses the
+   criteria vocabulary and states the complete-but-blocked outcome.
+3. `scripts/new_pr_plan.sh`: the generated scaffold prompts for the same.
+
+### Review Contract
+
+- Acceptance criteria:
+  1. Running `scripts/new_pr_plan.sh` emits an acceptance-criteria prompt that
+     requires a code claim or settling evidence and forbids a bare risk category --
+     shown by running it and reading the emitted block.
+  2. The canonical example in `docs/REVIEWER_RULES.md` contains no criterion
+     phrased as a bare risk category, and its risk-area line is unchanged from
+     main (risk areas are exempt).
+  3. `AGENTS.md` 1a states that a behavioral criterion settled by a command,
+     CI job, or generated artifact is admissible.
+  4. No text in this diff retroactively changes legacy matrix outcomes:
+     reviewers keep investigating legacy contracts against the contract as
+     authored, and only the authoring finding is grandfathered to an advisory
+     NIT for contracts authored before landing.
+  5. Concurrency/open-execution criteria are not declared settled by one sampled
+     concurrent test; the rule text, reviewer pack, and emitted scaffold require
+     the 3k.4 execution model and property-level invariant.
+  6. Open-input criteria are not declared settled by one sampled fixture list; the
+     rule text, reviewer pack, and emitted scaffold require the 3k.3
+     evidence-gated mechanism.
+  7. The scaffold regression tests assert persistent canonical surfaces
+     (`AGENTS.md`, `docs/REVIEWER_RULES.md`, and a freshly emitted plan), not
+     this in-flight plan path that teardown will archive after merge.
+  8. `scripts/audit_plan_code_consistency.py` resolves every path and function
+     claim in this plan.
+- Reachability proof: `scripts/new_pr_plan.sh` is the real entrypoint builders
+  invoke to author a plan; the emitted plan file is the observable
+  artifact, and its Review Contract block carries the new prompts.
+- Affected surfaces: the plan-authoring scaffold and the two documents that
+  define contract shape. No runtime, API, DB, or product surface.
+- Risk areas:
+  - Over-rejection of legitimate criteria (universally-quantified but reviewable
+    claims, behavioral criteria) -> closed by criterion 3 and by 1a stating
+    explicitly that breadth is not the defect, a missing referent is.
+  - Blocking other sessions' in-flight plans -> closed by criterion 4: risk
+    areas are exempt entirely, and legacy contracts keep their existing
+    disposition behavior, so a legacy plan is not newly invalid.
+  - A surface left un-propagated -> closed by criteria 1 and 2.
+  - A concurrency example overclaims from one sampled test -> closed by
+    criterion 5, which rejects the sampled-test-only form and requires the
+    3k.4 model/invariant surface instead.
+  - An open-input example overclaims from a sampled fixture list -> closed by
+    criterion 6, which rejects the fixture-list-only form and requires the 3k.3
+    evidence-gated mechanism instead.
+  - A regression test depends on the root in-flight plan file -> closed by
+    criterion 7, which generates a throwaway plan and asserts only persistent
+    canonical surfaces.
+- Reviewer rules triggered: R1, R2, R10, R13, R14. (R13: this slice answers
+  class-level findings -- 'update every contract-authoring surface' -- so the
+  fix must be class-wide, not the cited example. R2: it changes a generator,
+  so the generated text needs assertions.)
+
+### Files touched
+
+- `AGENTS.md`
+- `docs/REVIEWER_RULES.md`
+- `plans/PR-Contract-Dispositionable-Criteria.md`
+- `scripts/new_pr_plan.sh`
+- `tests/test_new_pr_plan.py`
+
+## Mechanism
+
+One authoring test replaces the previous framing for new and materially revised
+contracts: does the criterion name a code claim or the evidence that settles it?
+A `file:line`, a command and its output, or a CI job all qualify, which keeps
+behavioral criteria admissible. A bare hazard qualifies for none of them.
+
+The earlier draft used "structural property" as the test, which excluded exactly
+the runtime criteria 1a requires for a reachability proof. Boundedness is the
+property that was actually wanted; structure was a proxy that over-rejected.
+
+## Intentional
+
+- **Behavioral criteria are explicitly admissible.** The first draft of this PR
+  banned them by accident, which would have made 1a's reachability proof
+  unauthorable.
+- **Vocabulary follows #2202 exactly**: criteria are met / not met /
+  could-not-determine; `not-verified` is the rule vocabulary and is not used for
+  criteria here.
+- **Complete-but-blocked is preserved.** An unsettleable criterion does not make
+  a review incomplete; it makes it complete and not approved.
+- **Legacy disposition behavior is preserved.** A pre-existing contract is still
+  reviewed against the contract as authored; this PR grandfathers only the
+  authoring finding, not the reviewer's ability to investigate legacy evidence.
+- **The scaffold is in scope on purpose.** A rule the mandatory helper generates
+  violations of is a rule builders break by construction.
+
+## Deferred
+
+- Mechanizing a settleability check. Judgment at plan review is the right start;
+  if it earns automation it belongs in a `scripts/` checker with fixture tests
+  rather than as prose (the #2197 lesson).
+
+Parked hardening: none.
+
+## Verification
+
+    bash -n scripts/new_pr_plan.sh
+    # -> syntax OK; emitted Review Contract block read directly and confirmed
+    #    to carry both new prompts
+
+    python scripts/audit_plan_code_consistency.py \
+        plans/PR-Contract-Dispositionable-Criteria.md
+
+    python -m pytest tests/test_new_pr_plan.py -q
+    # -> 16 passed
+
+Failure detection proven per 3i, not assumed: with both new scaffold prompts
+reverted to their prior one-line forms, the suite FAILS at
+`tests/test_new_pr_plan.py:80`; restored, 16 pass. So an edit that deletes the
+settleability prompts cannot leave the suite green.
+
+- `git diff --check` clean; 0 non-ASCII characters added.
+- Path-trigger table parses unchanged (12 glob rows, 9 prose rows).
+- `bash scripts/pre_push_audit.sh --repo-root "$PWD" --script-root "$PWD" --pr-author canfieldjuan`
+  passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `AGENTS.md` | 57 |
+| `docs/REVIEWER_RULES.md` | 48 |
+| `plans/PR-Contract-Dispositionable-Criteria.md` | 195 |
+| `scripts/new_pr_plan.sh` | 15 |
+| `tests/test_new_pr_plan.py` | 67 |
+| **Total** | **382** |

--- a/scripts/new_pr_plan.sh
+++ b/scripts/new_pr_plan.sh
@@ -158,12 +158,25 @@ Slice phase: $phase
 
 ### Review Contract
 
-- Acceptance criteria: TODO: List the outcomes the reviewer checks one by one.
+- Acceptance criteria: TODO: List outcomes the reviewer checks one by one. Each
+  names a claim about the code, or the evidence that settles it (a file:line, a
+  command + output, a CI job). Do NOT name a BARE risk category ("no TOCTOU",
+  "no race conditions", "handles every malformed input") -- those name a hazard
+  with nothing to look at, and the reviewer will fail authoring
+  until the builder names the code claim or the evidence that settles it.
+  Naming the evidence rescues it: "no unmasked email addresses in the audit
+  export -- settled by tests/test_audit_export.py::test_masks_email_addresses"
+  is fine. For open-input criteria, reference the 3k.3 evidence-gated mechanism;
+  a sampled fixture list alone is not enough. For concurrency/open-execution
+  criteria, reference the 3k.4 execution model and property-level invariant; a
+  sampled concurrent test alone is not enough. See AGENTS.md 1a.
 - Reachability proof: TODO: Name the real entrypoint and observable effect, or
   N/A with a reason for a surface-free change.
 - Affected surfaces: TODO: Name the modules, workflows, contracts, and callers
   in scope.
 - Risk areas: TODO: Name the regression or boundary risks the reviewer probes.
+  Categories are fine here -- this field sets probe depth and is not
+  dispositioned by the review matrix.
 - Reviewer rules triggered: TODO: List the applicable R1-R14 rule IDs.
 
 ### Files touched

--- a/tests/test_new_pr_plan.py
+++ b/tests/test_new_pr_plan.py
@@ -10,6 +10,10 @@ SCRIPT = REPO_ROOT / "scripts" / "new_pr_plan.sh"
 AUDIT_PLAN_DOC = REPO_ROOT / "scripts" / "audit_plan_doc.py"
 
 
+def _compact_ws(text: str) -> str:
+    return " ".join(text.split())
+
+
 def _init_git_repo(path: Path, *, with_state: bool = True) -> None:
     subprocess.run(["git", "init", "-q"], cwd=path, check=True)
     if with_state:
@@ -59,6 +63,7 @@ def test_new_pr_plan_creates_agents_plan_skeleton(tmp_path: Path) -> None:
     assert "created plan scaffold: plans/PR-Dev-Workflow-Example.md" in result.stdout
     plan_path = tmp_path / "plans" / "PR-Dev-Workflow-Example.md"
     text = plan_path.read_text(encoding="utf-8")
+    compact_text = _compact_ws(text)
     assert text.startswith("# PR-Dev-Workflow-Example\n")
     assert "Ownership lane: dev-workflow/test" in text
     assert "Slice phase: Workflow/process" in text
@@ -72,6 +77,20 @@ def test_new_pr_plan_creates_agents_plan_skeleton(tmp_path: Path) -> None:
     assert "- Affected surfaces:" in text
     assert "- Risk areas:" in text
     assert "- Reviewer rules triggered:" in text
+    # The scaffold must keep PROMPTING for a settleable contract, not merely
+    # emit the headings: a newly authored acceptance criterion with no code
+    # claim or settling evidence is an authoring defect, while risk areas remain
+    # exempt because the review matrix does not disposition them.
+    # Asserting only the headings let those prompts be deleted while green.
+    assert "names a claim about the code, or the evidence that settles it" in text
+    assert "Do NOT name a BARE risk category" in text
+    assert "fail authoring until the builder names the code claim" in compact_text
+    assert "Naming the evidence rescues it" in compact_text
+    assert "3k.3 evidence-gated mechanism" in compact_text
+    assert "sampled fixture list alone is not enough" in compact_text
+    assert "3k.4 execution model and property-level invariant" in compact_text
+    assert "sampled concurrent test alone is not enough" in compact_text
+    assert "not\n  dispositioned by the review matrix" in text
     assert "### Files touched" in text
     assert "| **Total** | **0** |" in text
 
@@ -82,6 +101,54 @@ def test_new_pr_plan_creates_agents_plan_skeleton(tmp_path: Path) -> None:
         text=True,
     )
     assert audit.returncode == 0
+
+
+def test_contract_rule_preserves_legacy_disposition_behavior() -> None:
+    agents = (REPO_ROOT / "AGENTS.md").read_text(encoding="utf-8")
+    reviewer_rules = (REPO_ROOT / "docs" / "REVIEWER_RULES.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "Do not retroactively\nre-disposition a legacy criterion" in agents
+    assert "review against the contract as authored" in reviewer_rules
+    assert (
+        "Do not mark a legacy\n  criterion `could-not-determine` solely because"
+        in reviewer_rules
+    )
+
+
+def test_contract_rule_qualifies_risk_category_prohibitions(tmp_path: Path) -> None:
+    agents = (REPO_ROOT / "AGENTS.md").read_text(encoding="utf-8")
+    reviewer_rules = (REPO_ROOT / "docs" / "REVIEWER_RULES.md").read_text(
+        encoding="utf-8"
+    )
+    _init_git_repo(tmp_path)
+    result = _run_new_plan(
+        tmp_path,
+        "Qualifier-Regression",
+        "--lane",
+        "dev-workflow/test",
+    )
+    assert result.returncode == 0
+    scaffold = (tmp_path / "plans" / "PR-Qualifier-Regression.md").read_text(
+        encoding="utf-8"
+    )
+
+    for source in (agents, reviewer_rules, scaffold):
+        assert "never a risk category" not in source
+        assert "forbids a risk category" not in source
+        assert "criterion sits at could-not-determine" not in source
+        assert "test_concurrent_claim" not in source
+
+    assert "never a bare risk category" in agents
+    assert "BARE risk category with no referent" in reviewer_rules
+    assert "Do NOT name a BARE risk category" in scaffold
+    assert "3k.3 evidence-gated mechanism" in _compact_ws(agents)
+    assert "3k.3 evidence-gated mechanism" in _compact_ws(reviewer_rules)
+    assert "3k.3 evidence-gated mechanism" in _compact_ws(scaffold)
+    assert "3k.4 execution model" in _compact_ws(agents)
+    assert "3k.4 execution model" in _compact_ws(reviewer_rules)
+    assert "3k.4 execution model and property-level invariant" in _compact_ws(scaffold)
 
 
 def test_new_pr_plan_does_not_double_prefix_existing_pr_name(tmp_path: Path) -> None:


### PR DESCRIPTION
Plan: plans/PR-Contract-Dispositionable-Criteria.md
Slice phase: Workflow/process
Ownership lane: reviewer-contract/plan-authoring
Max files: 5

#2202 bounded the reviewer's completion matrix, but that matrix still checks "each acceptance criterion in the Review Contract." On current `main`, the canonical Review Contract example and mandatory plan scaffold still allow a newly authored criterion to name an outcome or hazard without a code claim or settling evidence. That lets a future safety/security/concurrency review reach the gate with nothing concrete to disposition, or appear settled by evidence too weak for the claim. This PR fixes the authoring surfaces so the contract is bounded before review begins.

Latest canonical commit: `decd0b78b`.

## Intentional

- **Narrow rule, not broad language policing.** A criterion must name a claim about the code or the evidence that settles it. A bare hazard label is defective; an evidenced risk-shaped criterion is valid.
- **New bare hazards return to authoring.** Reviewers are not directed to hunt open-ended categories on the builder's behalf.
- **Behavioral criteria remain first-class.** §1a still requires behavioral reachability criteria when a real entrypoint, command, CI job, or artifact proves the surface.
- **Open-input criteria need mechanism evidence.** A sampled fixture list alone does not settle open-input claims; the contract must name the §3k.3 evidence-gated mechanism.
- **Concurrency criteria need model evidence.** A sampled concurrent test alone does not settle open-execution claims; the contract must name the §3k.4 execution model and property-level invariant.
- **Risk areas are exempt.** They set probe depth and are not dispositioned by the completion matrix.
- **Legacy disposition behavior is preserved.** Contracts authored before this lands are reviewed as authored; only the authoring finding is grandfathered to an advisory NIT.
- **Scaffold and canonical pack are in scope.** If the required helper or example teaches the wrong contract shape, builders reproduce the defect by construction.
- **The final commit is canonical.** The PR branch is collapsed to one fresh commit so its justification, verification, AI reconciliation, and diff size describe the reviewed tree.

## Deferred

- Mechanizing a settleability check. Judgment at plan review is the right start; if it earns automation, it belongs in a `scripts/` checker with fixture tests rather than prose alone.

## Parked hardening

- None.

## Cold diff reconstruction

- Changed: `AGENTS.md` §1a now says an acceptance criterion names a code claim or the evidence that settles it, never a bare risk category; it explicitly admits behavioral criteria and evidenced risk-shaped criteria; it tells reviewers to fail newly authored bare hazards at contract authoring instead of hunting the category; it requires §3k.3 evidence-gated mechanism evidence for open-input criteria and §3k.4 model/property-level evidence for concurrency/open-execution criteria; it exempts risk areas; and it preserves legacy contract disposition behavior.
- Changed: `docs/REVIEWER_RULES.md` updates the canonical Review Contract example and reviewer-side guidance so only bare hazards are defective, evidenced risk criteria are valid, sampled fixture lists and sampled concurrent tests alone are not settling evidence, risk areas remain exempt, and old/new contract authoring consequences are separated from unchanged matrix outcomes.
- Changed: `scripts/new_pr_plan.sh` so newly generated plan scaffolds prompt builders for the same acceptance-criteria rule, fail-authoring consequence, evidenced-risk allowance, open-input evidence-gate prompt, concurrency/open-execution model prompt, and risk-area exemption.
- Changed: `tests/test_new_pr_plan.py` to assert the generated scaffold keeps the settleability prompt, fail-authoring consequence, bare-risk prohibition, evidenced-risk allowance, open-input evidence-gate prompt, concurrency-model prompt, risk-area exemption, legacy-disposition preservation, and class-wide bare-risk qualifier. The regression now generates a throwaway plan and reads persistent canonical surfaces instead of depending on this in-flight plan path.
- Added: `plans/PR-Contract-Dispositionable-Criteria.md`.
- Contract match: every change traces to the problem-derived contract: stop bare-hazard criteria at authoring time, keep behavioral/evidenced criteria valid, require model evidence for concurrency criteria, exempt risk areas, preserve legacy matrix behavior, and propagate to every contract-authoring surface.
- Gaps: none.

## Verification

- `bash -n scripts/new_pr_plan.sh` → passed.
- `python scripts/audit_plan_code_consistency.py plans/PR-Contract-Dispositionable-Criteria.md` → all 6 path claims resolve.
- `python -m pytest tests/test_new_pr_plan.py -q` → 16 passed.
- `python scripts/sync_pr_plan.py --check plans/PR-Contract-Dispositionable-Criteria.md` → plan already in sync.
- `python scripts/audit_plan_doc_diff_size.py plans/PR-Contract-Dispositionable-Criteria.md` → OK.
- `git diff --check` → clean.
- `python scripts/select_impacted_tests.py --base origin/main` → `FULL` because `scripts/new_pr_plan.sh` is a non-Python runtime/config surface.
- `bash scripts/pre_push_audit.sh --repo-root "$PWD" --script-root "$PWD" --pr-author canfieldjuan` → all checks passed.

## AI reconciliation

All fixed or waived: yes

- Behavioral criteria were over-rejected by the first framing → fixed by switching from "structural property" to "code claim or settling evidence."
- #2202 vocabulary was contradicted (`Not-Verified` / "unfinishable") → fixed to criteria vocabulary: `could-not-determine`, complete but blocking.
- Canonical reviewer pack and mandatory scaffold were left behind → fixed in `docs/REVIEWER_RULES.md`, `scripts/new_pr_plan.sh`, and `tests/test_new_pr_plan.py`.
- Slice phase was wrong for a surface-free process change → fixed to `Workflow/process` with §0 admission justification.
- Scaffold prompt change lacked regression coverage → fixed with assertions and failure detection.
- The rule would have invalidated other sessions' in-flight plans → fixed by exempting risk areas and preserving legacy contract disposition behavior.
- R13/R2 triggers and verification were missing → fixed in the plan.
- Evidenced risk-shaped criteria were rejected outside `AGENTS.md` → fixed across the reviewer pack, scaffold, and assertion.
- The plan cited #2195 examples that the narrowed rule no longer bans → fixed by removing #2195 as the admission proof and citing current `main` authoring surfaces instead.
- Broad "risk category" prohibitions could still reject evidenced risk-shaped criteria → fixed by qualifying every prohibition so only a bare risk category with no referent is rejected, with a regression assertion.
- New bare hazards were directed into permanent `could-not-determine` plus reviewer hunting → fixed so newly authored/materially revised bare hazards fail contract authoring and ask for the code claim or settling evidence.
- Open-input criteria could still be deemed settled from sampled fixtures → fixed so the rule text, reviewer pack, scaffold, and tests require the §3k.3 evidence-gated mechanism.
- The concurrency example implied one sampled concurrent test settled an open-execution claim → fixed by replacing the example and requiring §3k.4 model/property-level evidence.
- The regression test depended on the root in-flight plan path → fixed by generating a throwaway plan and asserting persistent canonical surfaces instead.
- The scaffold still used the obsolete `could-not-determine`/LGTM consequence for new bare hazards → fixed to the fail-and-return authoring procedure.
- Diff-size metadata drifted from the synced plan budget → fixed in the canonical commit message and this PR body: `+377 / -5`, synced plan budget `382`.
- The final commit metadata was stale → fixed by replacing the iteration stack with a single fresh commit describing this reviewed tree.

None waived.

## Diff size

5 files, +377 / -5. Synced plan budget: 382 total changed LOC.
