### PR TITLE
docs(REVIEWER_RULES): BLOCKER requires a concrete failure path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,7 +248,7 @@ levels:
 | Level | Meaning | Builder action |
 |---|---|---|
 | **BLOCKER** | Correctness, security, contract break, or CI red. Must fix before merge. | Fix or push back with rationale. |
-| **MAJOR** | Architectural / scope / pattern concern. Strong recommendation but not auto-block. | Fix in this PR if the fix is small; otherwise discuss before deferring.; or a proven defect whose blast radius does not warrant blocking. |
+| **MAJOR** | Architectural / scope / pattern concern, **or a proven defect whose blast radius does not warrant blocking**. Strong recommendation but not auto-block. | Fix in this PR if the fix is small; otherwise discuss before deferring. |
 | **NIT** | Style, naming, comment polish. Skip-worthy. | Apply if 1-line; skip otherwise. The reviewer should mark NITs as skip-worthy explicitly. |
 | **LGTM** | All gates green, R14 verified, no remaining concerns. | Merge. |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1472,7 +1472,8 @@ repository. A separate builder session opens PRs; you audit them
 and post one consolidated review per push with a verdict at:
 
 - BLOCKER: correctness, security, contract break, or CI red.
-- MAJOR: architectural / scope / pattern concern.
+- MAJOR: architectural / scope / pattern concern, or a proven defect
+  whose blast radius does not warrant blocking.
 - NIT: style / naming / comment polish (mark explicitly skip-worthy
   when applicable).
 - LGTM: all gates green, no remaining concerns.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,7 +248,7 @@ levels:
 | Level | Meaning | Builder action |
 |---|---|---|
 | **BLOCKER** | Correctness, security, contract break, or CI red. Must fix before merge. | Fix or push back with rationale. |
-| **MAJOR** | Architectural / scope / pattern concern. Strong recommendation but not auto-block. | Fix in this PR if the fix is small; otherwise discuss before deferring. |
+| **MAJOR** | Architectural / scope / pattern concern. Strong recommendation but not auto-block. | Fix in this PR if the fix is small; otherwise discuss before deferring.; or a proven defect whose blast radius does not warrant blocking. |
 | **NIT** | Style, naming, comment polish. Skip-worthy. | Apply if 1-line; skip otherwise. The reviewer should mark NITs as skip-worthy explicitly. |
 | **LGTM** | All gates green, R14 verified, no remaining concerns. | Merge. |
 

--- a/docs/REVIEWER_RULES.md
+++ b/docs/REVIEWER_RULES.md
@@ -20,7 +20,7 @@ This pack sits **under** the existing verdict ladder, it does not replace it:
 | Verdict | Meaning |
 |---|---|
 | **BLOCKER** | A rule below is failed in a way that breaks correctness, security, a contract, or CI. Must fix before merge. |
-| **MAJOR** | A rule is at risk: architectural / scope / pattern concern. Fix if small; else discuss. |
+| **MAJOR** | A rule is at risk: architectural / scope / pattern concern; **or** a proven defect whose blast radius does not warrant blocking. Fix if small; else discuss. |
 | **NIT** | Style / naming / polish. Apply only if 1-line; reviewer marks skip-worthy. |
 | **LGTM** | Every rule R1-R14 is Pass or a reasoned N-A (no Not-Verified outstanding), R14 is satisfied, and all AI findings are fixed-or-waived. |
 
@@ -35,22 +35,28 @@ not drop it, and the level can be raised later once the path is shown.
 
 Three carve-outs, because a missing-evidence finding is not a speculative one:
 
-- **Absent mandatory proof is itself the failure.** Where this pack already
-  makes missing evidence blocking -- the guard boundary-probe on security,
-  billing, data-deletion, customer-visible-output or CI/release surfaces, and a
-  Not-Verified entry under Review completion -- the absence IS the blocker and
-  no exploit path is owed. A guard with only happy-path tests blocks on those
-  surfaces whether or not anyone has found the bypass yet.
+- **Absent mandatory proof is itself the failure path.** Wherever a rule's own
+  **Block if** clause names missing evidence as the defect, the absence IS the
+  blocker and no input sequence is owed. That is general, not a short list: R2's
+  untested new logic and missing regression test, R5's changed contract without
+  contract tests, R4's absent rollback plan, the guard boundary-probe on
+  security / billing / data-deletion / customer-output / CI-release surfaces,
+  and a Not-Verified entry under Review completion all qualify. A guard with
+  only happy-path tests blocks on those surfaces whether or not anyone has yet
+  found the bypass -- "no one has exploited it" is not evidence it is safe.
 - **Established, not necessarily published.** For an exploitable
   authentication, payment, data-access, credential, or report-access flaw,
   `SECURITY.md` routes details privately and forbids putting them in a public
   thread. The public finding states the rule, the surface, and the impact, and
   points at the private report; the failure path is recorded there. Routing it
   privately does not downgrade it.
-- **A failure path is necessary, not sufficient.** Severity is blast radius. A
-  proven but immaterial correctness defect is MAJOR or NIT on the strength of
-  its impact -- proving a path does not oblige BLOCKER, and the ladder's
-  "breaks correctness" line reads as material breakage, not any defect.
+- **A failure path is necessary, not sufficient.** Severity is blast radius, so
+  a proven but immaterial defect is MAJOR or NIT on the strength of its impact.
+  The ladder above is amended to say so: BLOCKER's "breaks correctness" reads as
+  *material* breakage, and MAJOR now explicitly admits a proven low-impact
+  defect rather than being reserved for architectural concerns. Without that
+  amendment the two would contradict and every proven defect would land at
+  BLOCKER by elimination.
 
 **The escape valve from "do not manufacture NITs" is not filing the finding, not
 promoting it.** That instruction bars padding a review with polish; it is not a

--- a/docs/REVIEWER_RULES.md
+++ b/docs/REVIEWER_RULES.md
@@ -41,15 +41,19 @@ Three carve-outs, because a missing-evidence finding is not a speculative one:
   untested new logic and missing regression test, R5's changed contract without
   contract tests, R4's absent rollback plan, the guard boundary-probe on
   security / billing / data-deletion / customer-output / CI-release surfaces,
-  and a Not-Verified entry under Review completion all qualify. A guard with
-  only happy-path tests blocks on those surfaces whether or not anyone has yet
-  found the bypass -- "no one has exploited it" is not evidence it is safe.
-- **Established, not necessarily published.** For an exploitable
-  authentication, payment, data-access, credential, or report-access flaw,
-  `SECURITY.md` routes details privately and forbids putting them in a public
-  thread. The public finding states the rule, the surface, and the impact, and
-  points at the private report; the failure path is recorded there. Routing it
-  privately does not downgrade it.
+  a Not-Verified rule, **and a `could-not-determine` acceptance criterion** all
+  qualify. A guard with only happy-path tests blocks on those surfaces whether
+  or not anyone has yet found the bypass -- "no one has exploited it" is not
+  evidence it is safe. The unifying test is simple: if what is missing is the
+  *evidence*, the absence is the failure path; only a speculative claim about
+  code you have read needs an input sequence.
+- **Established, not necessarily published.** For **any category
+  `SECURITY.md` routes privately** -- it names exploitable vulnerabilities,
+  exposed credentials, authentication bypasses, payment or billing issues, data
+  deletion gaps, and report-access bugs, and that policy governs, not this list
+  -- the public finding states the rule, the surface, and the impact and points
+  at the private report; the failure path is recorded there. Routing it
+  privately never downgrades it.
 - **A failure path is necessary, not sufficient.** Severity is blast radius, so
   a proven but immaterial defect is MAJOR or NIT on the strength of its impact.
   The ladder above is amended to say so: BLOCKER's "breaks correctness" reads as
@@ -61,8 +65,10 @@ Three carve-outs, because a missing-evidence finding is not a speculative one:
 **The escape valve from "do not manufacture NITs" is not filing the finding, not
 promoting it.** That instruction bars padding a review with polish; it is not a
 reason to enter a marginal finding at BLOCKER so it clears the bar. If a finding
-is real but minor, MAJOR and NIT exist for it; if it is not worth reporting,
-report nothing and mark the rule dispositioned.
+is real but minor, MAJOR and NIT exist for it -- **use them**. A defect you have
+identified is never silently dispositioned: the matrix offers Pass, Fail,
+Not-Verified and reasoned N-A, and none of those honestly represents "I found
+something and said nothing". Report nothing only when you found nothing.
 
 **Why:** across #2195 and #2184 all **68** filed findings are P1/P2 and none is
 lower. Real severity is not distributed that way, and a ladder where everything

--- a/docs/REVIEWER_RULES.md
+++ b/docs/REVIEWER_RULES.md
@@ -29,12 +29,28 @@ A finding is written as `Rxx (LEVEL) file:line - issue - required fix`.
 independent verification is worse than no comment.
 
 **BLOCKER requires a concrete failure path**: the specific input, sequence, or
-state that produces the harm, stated in the finding. "This could break" is not
-one. Without a failure path the finding is MAJOR at most -- downgrade it, do not
-drop it, and the level can be raised later once the path is shown. This does not
-touch the unresolved-entry rule in Review completion: a Not-Verified rule is a
-BLOCKER because the evidence is missing, which is a different thing from a
-speculative defect.
+state that produces the harm, established by the reviewer. "This could break" is
+not one. Without a failure path the finding is MAJOR at most -- downgrade it, do
+not drop it, and the level can be raised later once the path is shown.
+
+Three carve-outs, because a missing-evidence finding is not a speculative one:
+
+- **Absent mandatory proof is itself the failure.** Where this pack already
+  makes missing evidence blocking -- the guard boundary-probe on security,
+  billing, data-deletion, customer-visible-output or CI/release surfaces, and a
+  Not-Verified entry under Review completion -- the absence IS the blocker and
+  no exploit path is owed. A guard with only happy-path tests blocks on those
+  surfaces whether or not anyone has found the bypass yet.
+- **Established, not necessarily published.** For an exploitable
+  authentication, payment, data-access, credential, or report-access flaw,
+  `SECURITY.md` routes details privately and forbids putting them in a public
+  thread. The public finding states the rule, the surface, and the impact, and
+  points at the private report; the failure path is recorded there. Routing it
+  privately does not downgrade it.
+- **A failure path is necessary, not sufficient.** Severity is blast radius. A
+  proven but immaterial correctness defect is MAJOR or NIT on the strength of
+  its impact -- proving a path does not oblige BLOCKER, and the ladder's
+  "breaks correctness" line reads as material breakage, not any defect.
 
 **The escape valve from "do not manufacture NITs" is not filing the finding, not
 promoting it.** That instruction bars padding a review with polish; it is not a

--- a/docs/REVIEWER_RULES.md
+++ b/docs/REVIEWER_RULES.md
@@ -28,6 +28,26 @@ A finding is written as `Rxx (LEVEL) file:line - issue - required fix`.
 **Blockers must cite `file:line`.** A bare "LGTM" with no rule matrix and no
 independent verification is worse than no comment.
 
+**BLOCKER requires a concrete failure path**: the specific input, sequence, or
+state that produces the harm, stated in the finding. "This could break" is not
+one. Without a failure path the finding is MAJOR at most -- downgrade it, do not
+drop it, and the level can be raised later once the path is shown. This does not
+touch the unresolved-entry rule in Review completion: a Not-Verified rule is a
+BLOCKER because the evidence is missing, which is a different thing from a
+speculative defect.
+
+**The escape valve from "do not manufacture NITs" is not filing the finding, not
+promoting it.** That instruction bars padding a review with polish; it is not a
+reason to enter a marginal finding at BLOCKER so it clears the bar. If a finding
+is real but minor, MAJOR and NIT exist for it; if it is not worth reporting,
+report nothing and mark the rule dispositioned.
+
+**Why:** across #2195 and #2184 all **68** filed findings are P1/P2 and none is
+lower. Real severity is not distributed that way, and a ladder where everything
+is a blocker carries no information -- the reviewer cannot lead with blockers
+(above) when every finding is one, and the builder cannot tell an exploitable
+gap from an ordering nit.
+
 R14 is universal: it applies to every review verdict, even when no changed path
 specifically triggers it. A reviewer who has not inspected the checked-out PR
 head and relevant codebase evidence cannot issue LGTM.

--- a/docs/ai_dev_operating_model.md
+++ b/docs/ai_dev_operating_model.md
@@ -41,7 +41,7 @@ is worse than no comment."
 | Verdict | Meaning | Builder action |
 |---|---|---|
 | **BLOCKER** | Correctness, security, contract break, or CI red | Fix before merge |
-| **MAJOR** | Architectural / scope / pattern concern | Fix if small; else discuss |
+| **MAJOR** | Architectural / scope / pattern concern, or a proven defect whose blast radius does not warrant blocking | Fix if small; else discuss |
 | **NIT** | Style / naming / polish | Apply only if 1-line; reviewer marks skip-worthy |
 | **LGTM** | All gates green | Merge |
 


### PR DESCRIPTION
Docs-only: true

Supersedes #2205, auto-closed when its base branch was deleted after #2202 merged. Rebuilt on merged main `aaa03367f`.

## The evidence

Across #2195 and #2184, **all 68 filed findings are P1/P2 and none is lower.**

Real severity is not distributed that way. A ladder where everything is a blocker carries no information: the pack says *"lead with blockers"*, which is meaningless when every finding is one, and the builder cannot tell an exploitable gap from an ordering nit — #2195's round 13 presented a `refs/replace` attestation bypass and a cleanup-ordering issue at the same level.

## The change

**BLOCKER requires a concrete failure path** — the specific input, sequence, or state that produces the harm. *"This could break"* is not one. Without it the finding is MAJOR at most: **downgrade, do not drop**, raisable once the path is shown.

Also closes a perverse reading of *"do not manufacture NITs"*: that bars padding a review with polish, it is **not** license to enter a marginal finding at BLOCKER so it clears the bar.

## Intentional

- **Explicitly distinguished from merged #2202's unresolved-entry rule.** A `Not-Verified` rule is a BLOCKER because *evidence is missing*; that is a different thing from a speculative defect with no failure path. Without saying so, this PR would read as contradicting the rule that just landed.
- **Downgrade, never drop.** A findings cap would suppress real defects; this changes the level only.
- **Raisable later**, so the rule cannot be used to bury a real issue.
- **The MAJOR row IS reworded**, in all four places it is defined: the pack's ladder, the governing `AGENTS.md` ladder, the `AGENTS.md` reviewer-bootstrap list, and `docs/ai_dev_operating_model.md`. An earlier draft claimed the ladder was untouched, which the diff contradicted — a proven low-impact defect needs somewhere to land, and with MAJOR reserved for architectural concerns it would reach BLOCKER by elimination. The other three verdicts are unchanged, and no verdict is renumbered.

## Deferred

- Any automated severity audit; the failure-path requirement is checkable by reading the finding.

## Parked hardening

- None.

## Cold diff reconstruction

- Changed: `docs/REVIEWER_RULES.md` — BLOCKER now requires a concrete failure path, with three carve-outs (absent mandatory proof stated generally rather than enumerated; private routing deferring to `SECURITY.md`'s categories; failure path necessary-not-sufficient), the MAJOR ladder row widened, and the never-silently-disposition clause.
- Changed: `AGENTS.md` — the **governing** verdict ladder's MAJOR *Meaning* cell and the reviewer bootstrap's MAJOR line carry the same clause. The pack sits under this ladder, so a subordinate-only change would have had the two disagreeing.
- Changed: `docs/ai_dev_operating_model.md` — the third mirror of the same table.
- Contract match: every change traces to the severity-inflation evidence (68/68 P1-P2) and to keeping the four verdict definitions consistent across every reviewer entrypoint.
- Gaps: none.

## Verification

- `audit_pr_plan_presence.py origin/main --pr-author canfieldjuan` → `classification: docs-only`, PASS.
- Path-trigger table parses unchanged: 12 glob / 9 prose.
- `git diff --check` clean; **0** non-ASCII added.
- The 68/68 count is reproducible from the two PRs cited.

## AI reconciliation

3 findings, all **fixed**; none waived. All three said the failure-path rule swallowed cases where it should not apply.

- **Absent mandatory proof** (R2, BLOCKER) - a guard on a security/billing/release surface with only happy-path tests has no exploit path to state yet, so the rule forced a downgrade against the pack's own boundary-probe requirement. Carve-out: where missing evidence is already blocking, the absence *is* the blocker and no path is owed.
- **Exploit repro in public threads** (R3, BLOCKER) - `SECURITY.md:5-11,40-41` routes exploitable auth/payment/data-access flaws privately and forbids public detail. Now: the path must be **established, not published** - the public finding names rule, surface and impact and points at the private report. Routing privately never downgrades it.
- **No home for a proven-but-minor defect** (R10, MAJOR) - the ladder sends correctness failures to BLOCKER and reserves MAJOR for architectural concerns. Now stated: a failure path is **necessary, not sufficient** - severity is blast radius, and "breaks correctness" reads as material breakage.

All fixed or waived: yes

## Diff size

3 files, +53 / -4

Docs-only, so there is no plan table to defer to; this number is checked against
`git diff --numstat origin/main...HEAD` on each push rather than carried
forward, after it went stale once on this PR and three times on #2209.