### PR TITLE
docs(REVIEWER_RULES): let the misses-into-mechanism ratchet release

### DIFF
--- a/docs/REVIEWER_RULES.md
+++ b/docs/REVIEWER_RULES.md
@@ -402,16 +402,34 @@ the builder's `HARDENING.md` + recurring-lapse flywheel.
 **The ratchet releases too.** As written this section only ever adds, and the
 reviewer's mandate grows with it -- every added rule is another category to
 disposition on every future PR, forever, which is a cost paid by every
-subsequent review. So each addition is reviewed for removal on the same terms it
-was added:
+subsequent review.
 
-- A rule, path trigger, or checklist line that **has not fired** in the last
-  ~50 merged PRs is either redundant with something else here or is addressing a
-  failure mode that has stopped happening. Remove it, or state why it stays.
-- One whose firings are **consistently waived** is mis-scoped, not load-bearing.
-  Re-scope it to what actually blocks, or remove it.
-- Removals are recorded the same way additions are, with the reasoning, so a
-  removal is a decision and not an erosion.
+**When retirement is considered:** on each addition. Adding a durable mechanism
+is the trigger to examine one existing candidate for removal, so the ratchet
+self-balances and there is no separate cadence, owner, or audit to maintain. All
+**five** mechanism kinds this section creates are in scope -- `scripts/audit_*`
+checks, rule IDs, path triggers, recurring-lapse lines, and Review Contract
+template additions -- not only the ones that are cheapest to delete.
+
+Retirement terms:
+
+- **Silence is not evidence of absence.** A mechanism that has not fired may be
+  the reason the failure stopped. So not-firing is a prompt to examine, never a
+  licence to delete: a mechanism that is the sole protection for a defect logged
+  in `REVIEW_MISSES.md` may be removed **only** by naming what now covers that
+  defect -- a broader rule, a type, a test, a structural change that makes it
+  unrepresentable. No replacement named, no removal; state why it stays.
+- **Consistently waived** is the stronger signal, because it means the mechanism
+  fires and reviewers keep judging it wrong. Re-scope it to what actually
+  blocks, or remove it.
+- **Removals are atomic across mirrors.** A rule ID, checklist line, or template
+  entry is referenced from more than one place -- `AGENTS.md` review guidelines,
+  the §2a verification template, the 4d audit checklist, and the completion
+  matrix all enumerate rules. A removal updates every mirror in the same change,
+  or it leaves the matrix demanding a verdict on a rule that no longer exists.
+- **Removals are recorded** in `REVIEW_MISSES.md` beside the defect that
+  prompted the addition, with the replacement coverage named, so a removal is a
+  decision with a paper trail and not an erosion.
 
 Nothing here weakens the "no escaped defect is fixed only once" rule -- an
 escaped defect still converts into mechanism. This governs what happens to that

--- a/docs/REVIEWER_RULES.md
+++ b/docs/REVIEWER_RULES.md
@@ -407,7 +407,13 @@ subsequent review.
 **When retirement is considered:** on each addition. Adding a durable mechanism
 is the trigger to examine one existing candidate for removal, so the ratchet
 self-balances and there is no separate cadence, owner, or audit to maintain.
-**Record which candidate you examined** in `REVIEW_MISSES.md` with the outcome,
+**Record which candidate you examined** in `REVIEW_MISSES.md` with the outcome.
+The ledger's columns record the original miss, not the retirement pass, so this
+needs its own row shape -- add a **Retirement reviews** table beside the ledger
+with `Date | Mechanism | Last fired | Outcome (kept / removed) | Replacement
+coverage`. Without a durable `Date` and `Mechanism` per pass, the
+least-recently-examined ordering below cannot be computed from repository state
+and the rotation degrades to whatever the current reviewer remembers.
 and take the least-recently-examined mechanism -- when every mechanism has been
 examined once the rotation simply starts again, so a retained one is re-checked
 against fresh evidence rather than becoming permanently ineligible. Keying

--- a/docs/REVIEWER_RULES.md
+++ b/docs/REVIEWER_RULES.md
@@ -408,9 +408,14 @@ subsequent review.
 is the trigger to examine one existing candidate for removal, so the ratchet
 self-balances and there is no separate cadence, owner, or audit to maintain.
 **Record which candidate you examined** in `REVIEW_MISSES.md` with the outcome,
-and take the next one that has not been examined since its last firing -- an
-unrecorded pick lets every addition re-examine the same load-bearing mechanism,
-re-state why it stays, and retire nothing while the pack keeps growing. All
+and take the least-recently-examined mechanism -- when every mechanism has been
+examined once the rotation simply starts again, so a retained one is re-checked
+against fresh evidence rather than becoming permanently ineligible. Keying
+eligibility off "has not fired since it was examined" would exempt exactly the
+quiet mechanisms this section is about, and after one full pass only newly added
+ones would ever be inspected. An unrecorded pick has the opposite failure: every
+addition re-examines the same load-bearing mechanism, re-states why it stays,
+and retires nothing while the pack keeps growing. All
 **five** mechanism kinds this section creates are in scope -- `scripts/audit_*`
 checks, rule IDs, path triggers, recurring-lapse lines, and Review Contract
 template additions -- not only the ones that are cheapest to delete.

--- a/docs/REVIEWER_RULES.md
+++ b/docs/REVIEWER_RULES.md
@@ -406,7 +406,11 @@ subsequent review.
 
 **When retirement is considered:** on each addition. Adding a durable mechanism
 is the trigger to examine one existing candidate for removal, so the ratchet
-self-balances and there is no separate cadence, owner, or audit to maintain. All
+self-balances and there is no separate cadence, owner, or audit to maintain.
+**Record which candidate you examined** in `REVIEW_MISSES.md` with the outcome,
+and take the next one that has not been examined since its last firing -- an
+unrecorded pick lets every addition re-examine the same load-bearing mechanism,
+re-state why it stays, and retire nothing while the pack keeps growing. All
 **five** mechanism kinds this section creates are in scope -- `scripts/audit_*`
 checks, rule IDs, path triggers, recurring-lapse lines, and Review Contract
 template additions -- not only the ones that are cheapest to delete.

--- a/docs/REVIEWER_RULES.md
+++ b/docs/REVIEWER_RULES.md
@@ -417,8 +417,11 @@ Retirement terms:
   the reason the failure stopped. So not-firing is a prompt to examine, never a
   licence to delete: a mechanism that is the sole protection for a defect logged
   in `REVIEW_MISSES.md` may be removed **only** by naming what now covers that
-  defect -- a broader rule, a type, a test, a structural change that makes it
-  unrepresentable. No replacement named, no removal; state why it stays.
+  defect, and the replacement has to be able to **stop the escape** -- a broader
+  rule in this pack, a type or structural change that makes the defect
+  unrepresentable, or a test that runs in a **required** check. A test that no
+  required check executes cannot prevent anything, so it is not a replacement.
+  No enforcing replacement named, no removal; state why it stays.
 - **Consistently waived** is the stronger signal, because it means the mechanism
   fires and reviewers keep judging it wrong. Re-scope it to what actually
   blocks, or remove it.

--- a/docs/REVIEWER_RULES.md
+++ b/docs/REVIEWER_RULES.md
@@ -411,7 +411,12 @@ self-balances and there is no separate cadence, owner, or audit to maintain.
 The ledger's columns record the original miss, not the retirement pass, so this
 needs its own row shape -- add a **Retirement reviews** table beside the ledger
 with `Date | Mechanism | Last fired | Outcome (kept / removed) | Replacement
-coverage`. Without a durable `Date` and `Mechanism` per pass, the
+coverage`. **The replacement is itself recorded as a tracked mechanism** in that table: a
+required-check test, its CI enrollment, or a structural or type invariant
+becomes the sole protection for that defect the moment the old gate goes, so it
+inherits the same retirement lifecycle instead of sitting outside the five kinds
+and rotting unreviewed. Retiring a gate onto untracked coverage only moves the
+unreviewed mechanism. Without a durable `Date` and `Mechanism` per pass, the
 least-recently-examined ordering below cannot be computed from repository state
 and the rotation degrades to whatever the current reviewer remembers.
 and take the least-recently-examined mechanism -- when every mechanism has been

--- a/docs/REVIEWER_RULES.md
+++ b/docs/REVIEWER_RULES.md
@@ -398,3 +398,23 @@ recur: a new `scripts/audit_*.py`, a new rule ID here, a new path trigger above,
 a line in the recurring-lapse checklist, or a Review Contract template change.
 **No escaped defect is fixed only once.** This is the reviewer-side mirror of
 the builder's `HARDENING.md` + recurring-lapse flywheel.
+
+**The ratchet releases too.** As written this section only ever adds, and the
+reviewer's mandate grows with it -- every added rule is another category to
+disposition on every future PR, forever, which is a cost paid by every
+subsequent review. So each addition is reviewed for removal on the same terms it
+was added:
+
+- A rule, path trigger, or checklist line that **has not fired** in the last
+  ~50 merged PRs is either redundant with something else here or is addressing a
+  failure mode that has stopped happening. Remove it, or state why it stays.
+- One whose firings are **consistently waived** is mis-scoped, not load-bearing.
+  Re-scope it to what actually blocks, or remove it.
+- Removals are recorded the same way additions are, with the reasoning, so a
+  removal is a decision and not an erosion.
+
+Nothing here weakens the "no escaped defect is fixed only once" rule -- an
+escaped defect still converts into mechanism. This governs what happens to that
+mechanism afterwards, so the pack stays the size a reviewer can actually apply.
+A checklist nobody can finish is the failure mode Review completion exists to
+prevent, and an unbounded ratchet recreates it one rule at a time.


### PR DESCRIPTION
Docs-only: true

Supersedes #2206, auto-closed when its base branch was deleted after #2202 merged. Rebuilt on merged main `aaa03367f`.

## The defect

`## Turning misses into mechanism` converts every escaped defect into a durable new rule, path trigger, or checklist line — and **only ever adds**. There is no removal path anywhere in the pack.

This got sharper when #2202 landed. Before, an added rule only cost review effort when its path triggered. Now **every rule must be dispositioned on every PR**, so each addition is a permanent per-review cost — paid by every subsequent PR, not by the one that caused the addition.

## The change

Additions are reviewed for removal on the same terms they were added:

- **Not fired** in the last ~50 merged PRs → redundant, or the failure mode stopped happening. Remove it, or state why it stays.
- **Firings consistently waived** → mis-scoped, not load-bearing. Re-scope to what actually blocks, or remove.
- **Removals recorded like additions**, with reasoning, so a removal is a decision rather than an erosion.

## Intentional

- **Does not weaken "no escaped defect is fixed only once."** Escaped defects still convert into mechanism; this governs what happens to that mechanism afterwards.
- **"Or state why it stays"** keeps this from failing on its second side: a load-bearing rule that rarely fires — a security trigger, say — survives on an argument rather than a firing count. Without that clause this would delete exactly the rules that work by deterrence.
- A checklist nobody can finish is the failure mode #2202's Review completion exists to prevent; an unbounded ratchet recreates it one rule at a time.

## Deferred

- Mechanizing the ~50-PR non-firing check. By hand at pack-review time is the right start; if it earns automation it belongs with #2198's checker, not as procedure in prose (the #2197 lesson).

## Parked hardening

- None.

## Cold diff reconstruction

- Changed: `docs/REVIEWER_RULES.md:398` adds removal terms to the misses-into-mechanism ratchet, with the load-bearing-rule exception and an explicit statement that the no-escaped-defect rule is unchanged.
- Contract match: single change, single defect.
- Gaps: none.

## Verification

- `audit_pr_plan_presence.py origin/main --pr-author canfieldjuan` → `classification: docs-only`, PASS.
- Path-trigger table parses unchanged: 12 glob / 9 prose.
- `git diff --check` clean; **0** non-ASCII added.

## AI reconciliation

4 findings, all **fixed**; none waived.

- **Silence can mean the mechanism is working** (R1, BLOCKER) - not-firing for ~50 PRs may be *because* the gate deters the defect, so removal would let it recur silently. Now: not-firing is a prompt to examine, never a licence to delete. A mechanism that is the sole protection for a defect logged in `REVIEW_MISSES.md` may be removed **only** by naming what now covers it.
- **No trigger, so the review never happens** (R10, MAJOR) - there is no pack-review cadence or owner in the repo. Retirement now triggers **on each addition**: adding a mechanism is the prompt to examine one existing candidate, so the ratchet self-balances with no new cadence to maintain.
- **Only 3 of 5 mechanism kinds covered** (R1, MAJOR) - `scripts/audit_*` checks and Review Contract template additions were permanent by omission. All five kinds are now in scope.
- **Removals leave mirrors inconsistent** (R10, MAJOR) - a rule ID is enumerated in `AGENTS.md` review guidelines, the §2a template, the 4d checklist and the completion matrix; deleting one would leave the matrix demanding a verdict on a rule that no longer exists. Removals are now atomic across every mirror, and recorded in `REVIEW_MISSES.md` with the replacement coverage named.

All fixed or waived: yes

## Diff size

1 file, +20 / -0
