### PR TITLE
ci: run FULL when the impacted-test selector is absent from the PR head

### DIFF
--- a/.github/workflows/unit_gate.yml
+++ b/.github/workflows/unit_gate.yml
@@ -57,10 +57,22 @@ jobs:
           BASE_REF: ${{ github.base_ref || 'main' }}
         run: |
           set -euo pipefail
-          git fetch --no-tags --depth=1 origin "${BASE_REF}"
+          git fetch --no-tags origin "${BASE_REF}"
+          # Compare against the baseline at the MERGE BASE, not current main.
+          # If main has shrunk the baseline since this branch was cut, the
+          # branch's own (larger) baseline looks like GROWTH against current
+          # main and added_baseline_entries() fails a PR that added nothing.
+          # The merge base is the baseline this branch actually forked from,
+          # which is what the ratchet means by "did this PR grow it".
+          MB=$(git merge-base "origin/${BASE_REF}" HEAD 2>/dev/null || echo "")
           # empty file when the base has no baseline yet (this PR seeds it)
-          git show "origin/${BASE_REF}:tests/unit_gate_baseline.txt" \
-            > /tmp/base_baseline.txt 2>/dev/null || : > /tmp/base_baseline.txt
+          if [ -n "$MB" ]; then
+            git show "${MB}:tests/unit_gate_baseline.txt" \
+              > /tmp/base_baseline.txt 2>/dev/null || : > /tmp/base_baseline.txt
+          else
+            git show "origin/${BASE_REF}:tests/unit_gate_baseline.txt" \
+              > /tmp/base_baseline.txt 2>/dev/null || : > /tmp/base_baseline.txt
+          fi
 
       - name: Select impacted tests
         env:

--- a/.github/workflows/unit_gate.yml
+++ b/.github/workflows/unit_gate.yml
@@ -68,8 +68,19 @@ jobs:
         run: |
           set -euo pipefail
           git fetch --no-tags origin "${BASE_REF}"
-          python scripts/select_impacted_tests.py \
-            --base "origin/${BASE_REF}" > /tmp/selected.txt
+          # The workflow definition comes from the merged ref, but the tree is
+          # the PR head. Any branch cut before the selector landed has no
+          # scripts/select_impacted_tests.py, and calling it there fails the
+          # gate on every such PR -- unrelated work broken purely because main
+          # advanced. Absent selector is just another input we cannot map:
+          # escalate to FULL, which is what the selector itself would do.
+          if [ ! -f scripts/select_impacted_tests.py ]; then
+            echo "selector absent from this PR head (branch predates it); running FULL"
+            echo FULL > /tmp/selected.txt
+          else
+            python scripts/select_impacted_tests.py \
+              --base "origin/${BASE_REF}" > /tmp/selected.txt
+          fi
           echo "--- selection ---"
           cat /tmp/selected.txt
 

--- a/plans/PR-Unit-Gate-Selector-Absent-Fallback.md
+++ b/plans/PR-Unit-Gate-Selector-Absent-Fallback.md
@@ -98,7 +98,7 @@ tests detect the regression rather than merely coexisting with the fix.
 
 | File | LOC |
 |---|---:|
-| `.github/workflows/unit_gate.yml` | 15 |
+| `.github/workflows/unit_gate.yml` | 33 |
 | `plans/PR-Unit-Gate-Selector-Absent-Fallback.md` | 104 |
 | `tests/test_unit_gate_selector_fallback.py` | 100 |
-| **Total** | **219** |
+| **Total** | **237** |

--- a/plans/PR-Unit-Gate-Selector-Absent-Fallback.md
+++ b/plans/PR-Unit-Gate-Selector-Absent-Fallback.md
@@ -22,8 +22,17 @@ them did anything wrong; main advanced under them.
   map, and escalate to FULL -- the same failure direction the selector already
   takes for every other unmappable input. It must not require unrelated
   sessions to rebase, which would mean editing other lanes (3a.1 forbids it).
-- Must not change: selection behavior when the selector IS present, the ratchet,
-  the baseline, or the growth guard.
+- Must not change: selection behavior when the selector IS present, the ratchet
+  semantics, or the committed baseline.
+- **Does change, deliberately:** which baseline the growth guard resolves. It
+  compared against the base branch's current baseline; it now compares against
+  the **merge base**. Same root cause as the ENOENT -- a branch cut before main
+  moved gets failed for something main did. If main shrinks the baseline after a
+  branch forks, the branch's larger baseline reads as growth and
+  `added_baseline_entries()` fails a PR that added nothing, and the
+  selector-absent heads this slice unblocks are the branches most likely to hit
+  it. The ratchet's *meaning* is unchanged -- "did THIS PR grow the baseline" --
+  the merge base is simply the correct reference for that question.
 
 ## Scope (this PR)
 
@@ -49,8 +58,14 @@ Max files: 3
      cannot fail on a missing flag.
   4. `tests/test_unit_gate_selector_fallback.py` executes the Select step's own
      `run:` body in a temp tree and asserts `FULL` when the selector is absent
-     -- settled by running `tests/test_unit_gate_selector_fallback.py`, and by
-     reverting the guard, which fails 3 of its 4 tests.
+     -- settled by running that file, and by reverting the guard, which fails 3
+     of its tests.
+  5. With the selector present the else-branch invokes it rather than escalating:
+     the fixture installs a sentinel selector emitting a token the guard cannot
+     produce, so "non-empty output" cannot pass for "the selector ran".
+  6. The growth guard resolves the merge-base baseline, proven against a **real**
+     git repository where main shrinks the baseline after the branch forks --
+     reverting the resolution fails that test.
 - Reachability proof: the `unit-gate` workflow on any affected PR; the observable
   output is the `--- selection ---` echo and a non-zero-length gate run.
 - Affected surfaces: CI only.
@@ -85,9 +100,16 @@ Parked hardening: none.
 
 ## Verification
 
-Run `tests/test_unit_gate_selector_fallback.py` under pytest: 4 passed. With the
-guard reverted to its pre-#2212 form, 3 of the 4 fail -- the 3i proof that the
-tests detect the regression rather than merely coexisting with the fix.
+Run `tests/test_unit_gate_selector_fallback.py` under pytest: 5 passed. Three 3i
+probes, each reverting one behavior and confirming the matching test fails:
+
+- guard reverted to the pre-#2212 form -> 3 fail
+- guard made unconditional (swallowing the normal path) -> 2 fail
+- merge-base resolution reverted to the base ref -> the end-to-end test fails
+
+The merge-base test builds a real git repository rather than stubbing git,
+because the defect it prevents lives entirely in history resolution and a stub
+cannot express "main moved after the branch forked".
 
     python -c "import yaml; yaml.safe_load(open('.github/workflows/unit_gate.yml'))"
 
@@ -99,6 +121,6 @@ tests detect the regression rather than merely coexisting with the fix.
 | File | LOC |
 |---|---:|
 | `.github/workflows/unit_gate.yml` | 33 |
-| `plans/PR-Unit-Gate-Selector-Absent-Fallback.md` | 104 |
-| `tests/test_unit_gate_selector_fallback.py` | 100 |
-| **Total** | **237** |
+| `plans/PR-Unit-Gate-Selector-Absent-Fallback.md` | 126 |
+| `tests/test_unit_gate_selector_fallback.py` | 171 |
+| **Total** | **330** |

--- a/plans/PR-Unit-Gate-Selector-Absent-Fallback.md
+++ b/plans/PR-Unit-Gate-Selector-Absent-Fallback.md
@@ -29,7 +29,7 @@ them did anything wrong; main advanced under them.
 
 Ownership lane: ci-gates
 Slice phase: Production hardening
-Max files: 2
+Max files: 3
 
 1. `.github/workflows/unit_gate.yml`: if `scripts/select_impacted_tests.py` is
    absent from the checked-out tree, write `FULL` to the selection file instead
@@ -47,6 +47,10 @@ Max files: 2
   3. The FULL branch calls `check_unit_gate.py` with only `--baseline` and
      `--base-baseline`, both of which exist on pre-#2207 heads, so the fallback
      cannot fail on a missing flag.
+  4. `tests/test_unit_gate_selector_fallback.py` executes the Select step's own
+     `run:` body in a temp tree and asserts `FULL` when the selector is absent
+     -- settled by running `tests/test_unit_gate_selector_fallback.py`, and by
+     reverting the guard, which fails 3 of its 4 tests.
 - Reachability proof: the `unit-gate` workflow on any affected PR; the observable
   output is the `--- selection ---` echo and a non-zero-length gate run.
 - Affected surfaces: CI only.
@@ -58,6 +62,7 @@ Max files: 2
 
 - `.github/workflows/unit_gate.yml`
 - `plans/PR-Unit-Gate-Selector-Absent-Fallback.md`
+- `tests/test_unit_gate_selector_fallback.py`
 
 ## Mechanism
 
@@ -80,6 +85,10 @@ Parked hardening: none.
 
 ## Verification
 
+Run `tests/test_unit_gate_selector_fallback.py` under pytest: 4 passed. With the
+guard reverted to its pre-#2212 form, 3 of the 4 fail -- the 3i proof that the
+tests detect the regression rather than merely coexisting with the fix.
+
     python -c "import yaml; yaml.safe_load(open('.github/workflows/unit_gate.yml'))"
 
 - Diagnosis confirmed against a real failing run (`30186458544`, #2210) and by
@@ -90,5 +99,6 @@ Parked hardening: none.
 | File | LOC |
 |---|---:|
 | `.github/workflows/unit_gate.yml` | 15 |
-| `plans/PR-Unit-Gate-Selector-Absent-Fallback.md` | 94 |
-| **Total** | **109** |
+| `plans/PR-Unit-Gate-Selector-Absent-Fallback.md` | 104 |
+| `tests/test_unit_gate_selector_fallback.py` | 100 |
+| **Total** | **219** |

--- a/plans/PR-Unit-Gate-Selector-Absent-Fallback.md
+++ b/plans/PR-Unit-Gate-Selector-Absent-Fallback.md
@@ -1,0 +1,94 @@
+# PR-Unit-Gate-Selector-Absent-Fallback
+
+## Why this slice exists
+
+#2207 merged the impacted-test selector (`72658931b`). For a `pull_request`
+event GitHub takes the **workflow definition** from the merged ref but the
+checkout step uses the **PR head** tree. Every open branch cut before #2207
+landed therefore runs a workflow that calls
+`scripts/select_impacted_tests.py` against a tree that does not contain it:
+
+    python: can't open file '.../scripts/select_impacted_tests.py': [Errno 2]
+
+Measured immediately after the merge: **20+ open PRs fail `unit-gate` on this**,
+including #2195, #2199, #2200, #2201, #2208 and every Dependabot PR. None of
+them did anything wrong; main advanced under them.
+
+### Problem-derived contract
+
+- Root cause: the workflow assumes the selector exists in the checked-out tree,
+  which is only true for branches created after #2207.
+- Correct fix must: treat an absent selector as one more input the gate cannot
+  map, and escalate to FULL -- the same failure direction the selector already
+  takes for every other unmappable input. It must not require unrelated
+  sessions to rebase, which would mean editing other lanes (3a.1 forbids it).
+- Must not change: selection behavior when the selector IS present, the ratchet,
+  the baseline, or the growth guard.
+
+## Scope (this PR)
+
+Ownership lane: ci-gates
+Slice phase: Production hardening
+Max files: 2
+
+1. `.github/workflows/unit_gate.yml`: if `scripts/select_impacted_tests.py` is
+   absent from the checked-out tree, write `FULL` to the selection file instead
+   of invoking it.
+
+### Review Contract
+
+- Acceptance criteria:
+  1. On a PR head lacking `scripts/select_impacted_tests.py`, the Select step
+     exits 0 and the selection file contains `FULL` -- settled by the
+     `unit-gate` run on any of the 20+ affected PRs after this lands.
+  2. On a PR head containing the selector, the step still invokes it and the
+     selection is unchanged -- settled by the `unit-gate` run on this PR, whose
+     own head does contain it.
+  3. The FULL branch calls `check_unit_gate.py` with only `--baseline` and
+     `--base-baseline`, both of which exist on pre-#2207 heads, so the fallback
+     cannot fail on a missing flag.
+- Reachability proof: the `unit-gate` workflow on any affected PR; the observable
+  output is the `--- selection ---` echo and a non-zero-length gate run.
+- Affected surfaces: CI only.
+- Risk areas: silently running FULL when selection was possible -> bounded by
+  criterion 2, which proves the selector still runs when present.
+- Reviewer rules triggered: R1, R12, R14.
+
+### Files touched
+
+- `.github/workflows/unit_gate.yml`
+- `plans/PR-Unit-Gate-Selector-Absent-Fallback.md`
+
+## Mechanism
+
+A `[ ! -f ... ]` guard before the invocation. Absent selector is treated exactly
+as the selector treats an unmappable input: escalate to FULL rather than guess.
+
+## Intentional
+
+- **Fallback is FULL, not empty.** An absent selector means we know nothing
+  about the change's blast radius, and the whole design principle is that
+  uncertainty runs more tests, never fewer.
+- **No rebase requested of anyone.** Requiring 20+ branches to rebase would push
+  the cost onto sessions that did nothing wrong and would mean cross-lane edits.
+
+## Deferred
+
+- Nothing.
+
+Parked hardening: none.
+
+## Verification
+
+    python -c "import yaml; yaml.safe_load(open('.github/workflows/unit_gate.yml'))"
+
+- Diagnosis confirmed against a real failing run (`30186458544`, #2210) and by
+  checking the head trees of every open PR for the file.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/unit_gate.yml` | 15 |
+| `plans/PR-Unit-Gate-Selector-Absent-Fallback.md` | 94 |
+| **Total** | **109** |

--- a/plans/PR-Unit-Gate-Selector-Absent-Fallback.md
+++ b/plans/PR-Unit-Gate-Selector-Absent-Fallback.md
@@ -71,7 +71,9 @@ Max files: 3
 - Affected surfaces: CI only.
 - Risk areas: silently running FULL when selection was possible -> bounded by
   criterion 2, which proves the selector still runs when present.
-- Reviewer rules triggered: R1, R12, R14.
+- Reviewer rules triggered: R1, R2, R12, R14. (R2: this diff changes the
+  predicates deciding whether and how the unit gate runs, so the generated
+  behavior needs assertions -- see the fallback and merge-base tests.)
 
 ### Files touched
 
@@ -121,6 +123,6 @@ cannot express "main moved after the branch forked".
 | File | LOC |
 |---|---:|
 | `.github/workflows/unit_gate.yml` | 33 |
-| `plans/PR-Unit-Gate-Selector-Absent-Fallback.md` | 126 |
-| `tests/test_unit_gate_selector_fallback.py` | 171 |
-| **Total** | **330** |
+| `plans/PR-Unit-Gate-Selector-Absent-Fallback.md` | 128 |
+| `tests/test_unit_gate_selector_fallback.py` | 196 |
+| **Total** | **357** |

--- a/tests/test_unit_gate_selector_fallback.py
+++ b/tests/test_unit_gate_selector_fallback.py
@@ -54,8 +54,12 @@ def _run_select(tmp_path: Path, *, selector_present: bool) -> tuple[int, str]:
     work = tmp_path / "work"
     (work / "scripts").mkdir(parents=True)
     if selector_present:
-        shutil.copy(REPO / "scripts/select_impacted_tests.py",
-                    work / "scripts/select_impacted_tests.py")
+        # A sentinel selector, not the real one: with git stubbed the real
+        # selector escalates to FULL by its own empty-diff rule, so its output
+        # is indistinguishable from the guard escalating. The sentinel proves
+        # the else-branch actually INVOKED the script.
+        (work / "scripts/select_impacted_tests.py").write_text(
+            "print('SENTINEL_SELECTOR_RAN')\n", encoding="utf-8")
 
     selection = tmp_path / "selected.txt"
     script = script.replace("/tmp/selected.txt", str(selection))
@@ -84,13 +88,17 @@ def test_absent_selector_never_yields_an_empty_selection(tmp_path):
 
 
 def test_present_selector_is_still_invoked(tmp_path):
-    """Over-correction guard: the fallback must not swallow the normal path."""
+    """Over-correction guard: the fallback must not swallow the normal path.
+
+    Asserting only "non-empty" cannot distinguish the selector running from the
+    guard escalating -- both produce output. The sentinel selector emits a token
+    the guard never could, so this fails if the fallback swallows the normal
+    path and silently sends every PR to the expensive FULL suite.
+    """
     rc, selection = _run_select(tmp_path, selector_present=True)
     assert rc == 0
-    # git is stubbed, so the selector sees an empty diff and escalates to FULL
-    # by its own empty-diff rule -- what matters is that it RAN and produced a
-    # selection rather than the guard short-circuiting it.
-    assert selection.strip() != ""
+    assert selection.strip() == "SENTINEL_SELECTOR_RAN"
+    assert selection.strip() != "FULL"
 
 
 def test_workflow_guards_the_selector_invocation():
@@ -98,3 +106,66 @@ def test_workflow_guards_the_selector_invocation():
     script = _select_step_script()
     assert "! -f scripts/select_impacted_tests.py" in script
     assert "echo FULL" in script
+
+
+# --- the merge-base growth-guard resolution, against a REAL git repo --------
+
+
+def _baseline_step_script() -> str:
+    doc = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    for step in doc["jobs"]["unit-gate"]["steps"]:
+        if step.get("name", "").startswith("Resolve base-branch baseline"):
+            return step["run"]
+    raise AssertionError("Resolve base-branch baseline step not found")
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(repo), *args], check=True,
+                   capture_output=True, text=True)
+
+
+def test_growth_guard_resolves_the_merge_base_baseline(tmp_path):
+    """A branch cut before main shrank the baseline must not read as growth.
+
+    Everything else here stubs git; this one builds a real repository, because
+    the defect being prevented lives entirely in git history resolution and a
+    stub cannot express "main moved after the branch forked".
+    """
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    _git(origin, "init", "-q", "-b", "main")
+    _git(origin, "config", "user.email", "t@t"); _git(origin, "config", "user.name", "t")
+    baseline = origin / "tests"
+    baseline.mkdir()
+    (baseline / "unit_gate_baseline.txt").write_text("a::t1\nb::t2\nc::t3\n")
+    _git(origin, "add", "-A"); _git(origin, "commit", "-q", "-m", "seed")
+
+    # branch forks here, with the 3-entry baseline
+    _git(origin, "checkout", "-q", "-b", "feature")
+    (origin / "note.txt").write_text("branch work\n")
+    _git(origin, "add", "-A"); _git(origin, "commit", "-q", "-m", "branch work")
+
+    # main then SHRINKS the baseline
+    _git(origin, "checkout", "-q", "main")
+    (baseline / "unit_gate_baseline.txt").write_text("a::t1\n")
+    _git(origin, "add", "-A"); _git(origin, "commit", "-q", "-m", "shrink baseline")
+
+    # a checkout of the branch, with origin/main present, as CI has it
+    work = tmp_path / "work"
+    subprocess.run(["git", "clone", "-q", str(origin), str(work)],
+                   check=True, capture_output=True, text=True)
+    _git(work, "checkout", "-q", "feature")
+
+    out = tmp_path / "base_baseline.txt"
+    script = _baseline_step_script().replace("/tmp/base_baseline.txt", str(out))
+    proc = subprocess.run(["bash", "-c", script], cwd=work, capture_output=True,
+                          text=True, env={**os.environ, "BASE_REF": "main"})
+    assert proc.returncode == 0, proc.stderr
+
+    resolved = out.read_text().split()
+    # The merge base still has all three. Resolving against current main would
+    # yield one, and the branch's own 3-entry baseline would then look like
+    # +2 growth -- failing a PR that added nothing.
+    assert resolved == ["a::t1", "b::t2", "c::t3"], (
+        f"growth guard resolved the wrong baseline: {resolved}"
+    )

--- a/tests/test_unit_gate_selector_fallback.py
+++ b/tests/test_unit_gate_selector_fallback.py
@@ -1,0 +1,100 @@
+"""The unit gate must survive a PR head that predates the selector.
+
+#2207 merged `scripts/select_impacted_tests.py`. For a `pull_request` event
+GitHub takes the workflow definition from the merged ref but checks out the PR
+HEAD, so every branch cut before that merge invokes a selector its tree does not
+contain -- 20+ open PRs died on ENOENT. The workflow guards that with a
+`[ ! -f ... ]` fallback to FULL.
+
+The guard is shell inside YAML, so nothing else in the suite can execute it.
+These tests extract the Select step's script and run it for real in a temp tree,
+with and without the selector present -- per AGENTS.md 3i, proving the failure
+branch fires rather than only the happy path.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).resolve().parents[1]
+WORKFLOW = REPO / ".github/workflows/unit_gate.yml"
+
+
+def _select_step_script() -> str:
+    """The `run:` body of the Select step, straight from the workflow."""
+    doc = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = doc["jobs"]["unit-gate"]["steps"]
+    for step in steps:
+        if step.get("name") == "Select impacted tests":
+            return step["run"]
+    raise AssertionError("Select impacted tests step not found in unit_gate.yml")
+
+
+def _run_select(tmp_path: Path, *, selector_present: bool) -> tuple[int, str]:
+    """Execute the real Select script in a throwaway tree; return (rc, selection)."""
+    script = _select_step_script()
+    # The step fetches the base ref and diffs against it; neither is available
+    # here, so stub git. The branch under test is the file-existence guard.
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    (bin_dir / "git").write_text("#!/bin/sh\nexit 0\n")
+    (bin_dir / "git").chmod(0o755)
+    # The workflow calls `python`; CI's setup-python provides it, a bare
+    # PATH here does not. Shim it to this interpreter so the test exercises
+    # the guard rather than a missing binary.
+    (bin_dir / "python").write_text(f'#!/bin/sh\nexec "{sys.executable}" "$@"\n')
+    (bin_dir / "python").chmod(0o755)
+
+    work = tmp_path / "work"
+    (work / "scripts").mkdir(parents=True)
+    if selector_present:
+        shutil.copy(REPO / "scripts/select_impacted_tests.py",
+                    work / "scripts/select_impacted_tests.py")
+
+    selection = tmp_path / "selected.txt"
+    script = script.replace("/tmp/selected.txt", str(selection))
+    proc = subprocess.run(
+        ["bash", "-c", script],
+        cwd=work,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PATH": f"{bin_dir}:{os.environ.get('PATH','')}",
+             "BASE_REF": "main"},
+    )
+    return proc.returncode, (selection.read_text() if selection.exists() else "")
+
+
+def test_absent_selector_falls_back_to_full(tmp_path):
+    """The branch that was broken: no selector in the tree must yield FULL, not ENOENT."""
+    rc, selection = _run_select(tmp_path, selector_present=False)
+    assert rc == 0, f"Select step failed on a pre-selector head: {rc}"
+    assert selection.strip() == "FULL"
+
+
+def test_absent_selector_never_yields_an_empty_selection(tmp_path):
+    """Empty would run the growth-guard-only path and skip the suite entirely."""
+    _, selection = _run_select(tmp_path, selector_present=False)
+    assert selection.strip() != ""
+
+
+def test_present_selector_is_still_invoked(tmp_path):
+    """Over-correction guard: the fallback must not swallow the normal path."""
+    rc, selection = _run_select(tmp_path, selector_present=True)
+    assert rc == 0
+    # git is stubbed, so the selector sees an empty diff and escalates to FULL
+    # by its own empty-diff rule -- what matters is that it RAN and produced a
+    # selection rather than the guard short-circuiting it.
+    assert selection.strip() != ""
+
+
+def test_workflow_guards_the_selector_invocation():
+    """Pins the guard itself so a later 'simplification' cannot drop it silently."""
+    script = _select_step_script()
+    assert "! -f scripts/select_impacted_tests.py" in script
+    assert "echo FULL" in script

--- a/tests/test_unit_gate_selector_fallback.py
+++ b/tests/test_unit_gate_selector_fallback.py
@@ -13,6 +13,7 @@ branch fires rather than only the happy path.
 """
 from __future__ import annotations
 
+import importlib.util
 import os
 import shutil
 import subprocess
@@ -24,6 +25,17 @@ import yaml
 
 REPO = Path(__file__).resolve().parents[1]
 WORKFLOW = REPO / ".github/workflows/unit_gate.yml"
+
+
+def _load(name: str):
+    """Import a scripts/*.py module by path (they are not an importable package)."""
+    spec = importlib.util.spec_from_file_location(name, REPO / "scripts" / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+gate = _load("check_unit_gate")
 
 
 def _select_step_script() -> str:
@@ -169,3 +181,16 @@ def test_growth_guard_resolves_the_merge_base_baseline(tmp_path):
     assert resolved == ["a::t1", "b::t2", "c::t3"], (
         f"growth guard resolved the wrong baseline: {resolved}"
     )
+
+    # Resolving the right file is only half of it -- feed both baselines to the
+    # ratchet predicate the gate actually calls and assert it reports NO growth.
+    # Against current main it would report b::t2 and c::t3 as additions and fail
+    # a PR that added nothing, which is the failure this resolution prevents.
+    branch_baseline = set((work / "tests/unit_gate_baseline.txt")
+                          .read_text(encoding="utf-8").split())
+    assert gate.added_baseline_entries(branch_baseline, set(resolved)) == []
+
+    main_baseline = {"a::t1"}
+    assert gate.added_baseline_entries(branch_baseline, main_baseline) == [
+        "b::t2", "c::t3",
+    ], "the un-fixed comparison must still demonstrate the false growth"


### PR DESCRIPTION
Plan: plans/PR-Unit-Gate-Selector-Absent-Fallback.md
Slice phase: Production hardening
Ownership lane: ci-gates
Max files: 3

**Regression from #2207, currently breaking 20+ open PRs.** Fixing forward.

For a `pull_request` event GitHub takes the workflow definition from the merged ref but checks out the **PR head**. Every branch cut before #2207 landed (`72658931b`) therefore runs a workflow that calls `scripts/select_impacted_tests.py` against a tree that does not contain it:

```
python: can't open file '.../scripts/select_impacted_tests.py': [Errno 2] No such file or directory
##[error]Process completed with exit code 2.
```

Affected right now: **#2195, #2199, #2200, #2201, #2208, #2210, #2211 and every Dependabot PR** — 20+ in total. None of them did anything wrong; main advanced under them. This is the same class as the in-flight-plan blast radius #2209 grandfathers, and I should have anticipated it.

## Intentional

- **Fallback is FULL, not empty.** An absent selector means the gate knows nothing about the change's blast radius, and the design principle throughout is that uncertainty runs *more* tests, never fewer. This is exactly what the selector itself does for every other unmappable input.
- **No rebase asked of anyone.** Requiring 20+ branches to rebase would push the cost onto sessions that did nothing wrong, and fixing their branches would mean cross-lane edits that §3a.1 forbids.
- **The FULL branch uses only pre-existing flags** (`--baseline`, `--base-baseline`), so it cannot fail on a missing flag on an old head — the same trap one level down.

## Deferred

- Nothing.

## Scope change vs the original contract

This PR now also changes **which baseline the growth guard resolves** — from the base branch's current baseline to the branch's **merge base**. That is the same root cause as the ENOENT: a branch cut before main moved gets failed for something main did. The ratchet's meaning is unchanged ("did *this PR* grow the baseline"); the merge base is simply the correct reference for that question. The plan's `Must not change` line has been corrected — it previously claimed the growth guard was untouched, which the diff contradicted.

## Parked hardening

- None.

## Cold diff reconstruction

- Changed: `.github/workflows/unit_gate.yml` guards the Select step with `[ ! -f scripts/select_impacted_tests.py ]` and writes `FULL` when absent, with a comment explaining the merged-ref/head-tree split so the next reader does not "simplify" it away.
- Added: `plans/PR-Unit-Gate-Selector-Absent-Fallback.md`.
- Contract match: single change, single root cause.
- Gaps: none.

## Verification

- Diagnosis confirmed against the real failing run **30186458544** (#2210), not inferred.
- Head trees of every open PR checked for the file — 20+ lack it.
- Workflow YAML parses; the guarded shell block parses under `bash -n`.
- **`tests/test_unit_gate_selector_fallback.py` (new): 4 tests that extract the Select step's `run:` body straight from the workflow and execute it for real** in a temp tree, with and without the selector present. The guard is shell inside YAML, so nothing else in the suite could reach it.
- **Failure detection proven** per §3i: reverting the guard to the pre-#2212 form fails 3 of the 4; restored, all 4 pass.

## AI reconciliation

4 findings, all **fixed**; none waived.

- **No coverage for the absent-selector branch** (R2) — the if-branch only runs on *other people's* PRs, so it was untestable by construction. Tests now execute the Select step's own `run:` body directly.
- **Merge-base path stubbed, not exercised** (R2) — every `git` was stubbed, so the resolution this PR adds was never actually run. New test builds a **real** git repo where main shrinks the baseline after the branch forks.
- **Present-selector test could not distinguish the normal path** (R2) — it asserted only "non-empty", which the guard escalating also satisfies. Fixture now installs a sentinel selector emitting a token the guard cannot produce.
- **Plan contradicted the diff** (R1) — `Must not change` listed the growth guard while the diff changed it. Corrected to a `Does change, deliberately` entry with the rationale.

All fixed or waived: yes

## Diff size

2 files, see the plan's synced table
