### PR TITLE
test: assert the job-lock unwind, not just the nested acquisition

### DIFF
--- a/HARDENING.md
+++ b/HARDENING.md
@@ -30,6 +30,27 @@ register under `docs/technical-debt/`.
 
 ## Parked Items
 
+## 2026-07-26
+
+### job_lock depth map never deletes released entries
+- File/location: `atlas_brain/services/content_factory_store.py` (`job_lock`,
+  the re-entrancy depth branch and its `finally`).
+- Description: releasing sets `depth[lock_key] = 0` instead of deleting the
+  key, so the per-thread depth map retains one entry per distinct (job id,
+  root) pair for the life of the thread. The zero value is correct for the
+  re-entrancy check; only the key lingers.
+- Why it matters: unbounded growth in a long-lived worker that processes many
+  distinct jobs. No correctness impact -- a stale zero entry is
+  indistinguishable from an absent one at every read site -- and no
+  demonstrated failure path, which is why it is parked rather than fixed in a
+  test-only slice.
+- Effort: S
+- Category: tech-debt
+- Owner/session: content-factory/store-locking
+- Found during: review of #2213; carried out of the #2214 plan's Deferred so it
+  survives that plan's archival on merge.
+
+
 ## 2026-07-15
 
 ### ASR Torch/Torchaudio compatibility baseline

--- a/plans/PR-Job-Lock-Unwind-Assertion.md
+++ b/plans/PR-Job-Lock-Unwind-Assertion.md
@@ -41,18 +41,40 @@ Slice phase: Robust testing
   3. The assertions detect a real defect: injecting a leak into `job_lock`'s
      `finally` fails this test, while the pre-change version of the same test
      passes with that leak present.
-  4. No other test changes behavior -- settled by the full content-factory
-     suite at 1184 passed.
+  4. No other test changes behavior -- settled by the content-factory suite
+     (runner + store + schemas + copy-verification) at 1354 passed on this
+     branch, matching `main`, since this slice adds assertions to an existing
+     test rather than new tests.
 - Reachability proof: the test drives the real `job_lock` context manager and
   probes exclusion through `_job_lock_is_free`, which opens a second file
   description and attempts a non-blocking `flock`, so it observes the OS lock.
 - Affected surfaces: one test function. No runtime code changes.
+- Execution model (R8). The invariant proved is: on leaving a `job_lock` scope,
+  exactly the lock identity that scope acquired is released, and no other. The
+  admitted model and what settles it:
+  - **Normal exit** -- the assertions added here, at both nesting levels.
+  - **Exception / early return** -- `job_lock` is a `@contextmanager` whose
+    release lives in a `finally`, so the generator is closed and the release
+    runs on any non-fatal unwind. `with` guarantees this; it is not sampled
+    separately because the same `finally` is the only release path, and a
+    probe would assert Python's context-manager contract rather than this
+    module's behaviour.
+  - **Re-entrant exit** -- the depth branch returns before touching `flock`, so
+    an inner same-identity release cannot free the outer OS lock. Covered by
+    the existing re-entrancy test.
+  - **Cross-process** -- `flock` is released by the kernel on fd close or
+    process death, so a crashed holder cannot wedge the lock permanently. Out
+    of scope for this slice: no test drives a second process.
+  - **Assumption, stated:** the probe reads the OS lock through a SECOND file
+    description, because `flock` is per-open-file-description; an in-process
+    flag would not observe a leak.
 - Risk areas: none -- test-only, and the injection probe bounds whether the new
   assertions are meaningful rather than decorative.
-- Reviewer rules triggered: R2, R10, R14.
+- Reviewer rules triggered: R2, R8, R10, R14.
 
 ### Files touched
 
+- `HARDENING.md`
 - `plans/PR-Job-Lock-Unwind-Assertion.md`
 - `tests/test_content_factory_runner.py`
 
@@ -74,9 +96,15 @@ as redundant with the two above them.
 
 ## Deferred
 
-- The two NITs recorded on #2213: `depth[lock_key] = 0` never deletes its entry,
-  and the depth key resolves the root while the lock path does not. Neither has
-  a demonstrated failure path.
+- One NIT from #2213 survives review: `depth[lock_key] = 0` never deletes its
+  entry, so the per-thread depth map grows one key per distinct (job, root).
+  No demonstrated failure path, so it is parked in `HARDENING.md` rather than
+  left only in this plan -- an in-flight plan is archived on merge, which would
+  drop the item out of the active queue.
+- The second #2213 NIT is WITHDRAWN as stale, not deferred: it claimed the
+  depth key and the lock path disagree about resolution, but the key is derived
+  FROM the resolved path, so they cannot differ. Recording the withdrawal
+  rather than deleting it silently, so the plan is not misleading history.
 
 Parked hardening: none.
 
@@ -102,6 +130,7 @@ so the added assertions catch something the previous ones could not.
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Job-Lock-Unwind-Assertion.md` | 107 |
+| `HARDENING.md` | 21 |
+| `plans/PR-Job-Lock-Unwind-Assertion.md` | 135 |
 | `tests/test_content_factory_runner.py` | 9 |
-| **Total** | **116** |
+| **Total** | **165** |

--- a/plans/PR-Job-Lock-Unwind-Assertion.md
+++ b/plans/PR-Job-Lock-Unwind-Assertion.md
@@ -106,7 +106,10 @@ as redundant with the two above them.
   FROM the resolved path, so they cannot differ. Recording the withdrawal
   rather than deleting it silently, so the plan is not misleading history.
 
-Parked hardening: none.
+Parked hardening: `job_lock` depth map never deletes released entries
+(`HARDENING.md`, 2026-07-26) -- the per-thread map retains one key per distinct
+(job, root). Parked, not fixed: no demonstrated failure path, and this is a
+test-only slice.
 
 ## Verification
 
@@ -115,8 +118,10 @@ Parked hardening: none.
 
     python -m pytest tests/test_content_factory_runner.py \
         tests/test_content_factory_schemas.py \
-        tests/test_content_factory_store.py -q
-    # -> 1184 passed
+        tests/test_content_factory_store.py \
+        tests/test_content_factory_copy_verification.py -q
+    # -> 1354 passed (the same four suites acceptance criterion 4 names;
+    #    the three-suite subset above it reports 1184, and both were run)
 
 Detection proven by injection, per AGENTS.md 3i. Replacing the release in
 `job_lock`'s `finally` with a leak:
@@ -131,6 +136,6 @@ so the added assertions catch something the previous ones could not.
 | File | LOC |
 |---|---:|
 | `HARDENING.md` | 21 |
-| `plans/PR-Job-Lock-Unwind-Assertion.md` | 135 |
+| `plans/PR-Job-Lock-Unwind-Assertion.md` | 141 |
 | `tests/test_content_factory_runner.py` | 9 |
-| **Total** | **165** |
+| **Total** | **171** |

--- a/plans/PR-Job-Lock-Unwind-Assertion.md
+++ b/plans/PR-Job-Lock-Unwind-Assertion.md
@@ -1,0 +1,107 @@
+# PR-Job-Lock-Unwind-Assertion
+
+## Why this slice exists
+
+`test_job_lock_identity_includes_the_root` proves the store's per-job lock is
+held for two roots while nested, but stops there. It never observes the unwind,
+so a `job_lock` that acquires correctly and then **never releases** passes it:
+inside the block a leaked lock and a healthy one are indistinguishable.
+
+This was found while reviewing #2208 and confirmed by injection rather than by
+reading: replacing the release in `job_lock`'s `finally` with a leak makes the
+pre-change test pass and the post-change test fail.
+
+### Problem-derived contract
+
+- Root cause: the test asserts an acquisition invariant and no release
+  invariant, so the release path has no coverage at all.
+- Correct fix must: observe the state *after* leaving the inner scope -- inner
+  root free, outer root still held -- and after leaving the outer scope, using
+  the same second-file-description probe the rest of the file uses so it reads
+  the OS lock rather than an in-process flag.
+- Must not change: `job_lock` itself, the existing acquisition assertions, or
+  any other test.
+
+## Scope (this PR)
+
+Ownership lane: content-factory/store-locking
+Slice phase: Robust testing
+
+1. `tests/test_content_factory_runner.py`: extend
+   `test_job_lock_identity_includes_the_root` with the unwind assertions.
+
+### Review Contract
+
+- Acceptance criteria:
+  1. Leaving the inner `job_lock` scope frees the inner root's OS lock and
+     leaves the outer root's held -- settled by the two assertions added after
+     the inner `with` block.
+  2. Leaving the outer scope frees the outer root's lock -- settled by the
+     assertion after the outer block.
+  3. The assertions detect a real defect: injecting a leak into `job_lock`'s
+     `finally` fails this test, while the pre-change version of the same test
+     passes with that leak present.
+  4. No other test changes behavior -- settled by the full content-factory
+     suite at 1184 passed.
+- Reachability proof: the test drives the real `job_lock` context manager and
+  probes exclusion through `_job_lock_is_free`, which opens a second file
+  description and attempts a non-blocking `flock`, so it observes the OS lock.
+- Affected surfaces: one test function. No runtime code changes.
+- Risk areas: none -- test-only, and the injection probe bounds whether the new
+  assertions are meaningful rather than decorative.
+- Reviewer rules triggered: R2, R10, R14.
+
+### Files touched
+
+- `plans/PR-Job-Lock-Unwind-Assertion.md`
+- `tests/test_content_factory_runner.py`
+
+## Mechanism
+
+Three assertions on the existing test. After the inner `with` exits,
+`_job_lock_is_free(second)` must be true and `_job_lock_is_free(first)` false;
+after the outer `with` exits, `first` must be free. The comment records why
+held-while-nested alone is insufficient, so the assertions are not deleted later
+as redundant with the two above them.
+
+## Intentional
+
+- **Extends the existing test rather than adding a new one.** The defect class
+  is identical; a second test function would duplicate coverage and the file
+  already carries four `job_lock` tests.
+- **Test-only.** `job_lock` is correct as it stands on `main` after #2201; this
+  closes a coverage gap, it does not change behavior.
+
+## Deferred
+
+- The two NITs recorded on #2213: `depth[lock_key] = 0` never deletes its entry,
+  and the depth key resolves the root while the lock path does not. Neither has
+  a demonstrated failure path.
+
+Parked hardening: none.
+
+## Verification
+
+    python -m pytest tests/test_content_factory_runner.py -k job_lock -q
+    # -> 4 passed
+
+    python -m pytest tests/test_content_factory_runner.py \
+        tests/test_content_factory_schemas.py \
+        tests/test_content_factory_store.py -q
+    # -> 1184 passed
+
+Detection proven by injection, per AGENTS.md 3i. Replacing the release in
+`job_lock`'s `finally` with a leak:
+
+    post-change test:  FAILED test_job_lock_identity_includes_the_root
+    pre-change test:   1 passed          <- blind to the leak
+
+so the added assertions catch something the previous ones could not.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Job-Lock-Unwind-Assertion.md` | 107 |
+| `tests/test_content_factory_runner.py` | 9 |
+| **Total** | **116** |

--- a/tests/test_content_factory_runner.py
+++ b/tests/test_content_factory_runner.py
@@ -1394,6 +1394,15 @@ def test_job_lock_identity_includes_the_root(tmp_path):
             assert not _job_lock_is_free("job-root", first)
             assert not _job_lock_is_free("job-root", second)
 
+        # Unwind. Asserting only "both held while nested" cannot distinguish a
+        # correct release from one that never happened -- a leaked inner lock
+        # looks identical inside the block. Leaving the inner scope must free
+        # the inner root and leave the outer one held.
+        assert _job_lock_is_free("job-root", second)
+        assert not _job_lock_is_free("job-root", first)
+
+    assert _job_lock_is_free("job-root", first)
+
 
 # --- round 9: vanity grammar both directions and committed-state atomicity ---
 


### PR DESCRIPTION
Plan: plans/PR-Job-Lock-Unwind-Assertion.md
Slice phase: Robust testing
Ownership lane: content-factory/store-locking

`test_job_lock_identity_includes_the_root` proves the store's per-job lock is held for two roots while nested, then stops. It never observes the unwind — so a `job_lock` that acquires correctly and **never releases** passes it. Inside the block, a leaked lock and a healthy one are indistinguishable.

Found while reviewing #2208, and confirmed by injection rather than by reading.

## Intentional

- **Extends the existing test rather than adding a new one.** Same defect class; a second function would duplicate coverage, and the file already carries four `job_lock` tests. This is also why #2213 was closed — it proposed a near-duplicate test instead of this.
- **Test-only.** `job_lock` is correct on `main` after #2201 (`lock_key = str(lock_path)`). This closes a coverage gap; it changes no behavior.
- The comment above the new assertions records *why* held-while-nested is insufficient, so they are not later deleted as redundant with the two lines above them.

## Deferred

- The two NITs recorded on #2213: `depth[lock_key] = 0` never deletes its entry (unbounded thread-local growth), and the depth key resolves the root while the lock path does not. Neither has a demonstrated failure path, so both stay recorded rather than bundled.

## Parked hardening

- None.

## Cold diff reconstruction

- Changed: `tests/test_content_factory_runner.py` — `test_job_lock_identity_includes_the_root` gains three assertions: after the inner `with`, the inner root's lock is free and the outer's is still held; after the outer `with`, the outer's is free.
- Added: `plans/PR-Job-Lock-Unwind-Assertion.md`.
- Contract match: the single change traces to the missing release invariant. No runtime code touched.
- Gaps: none.

## Review outcome

Three review rounds, all on the plan record rather than the test:

- **R8 execution model** — the Review Contract sampled normal-scope exits only.
  It now states the invariant (leaving a scope releases exactly the identity
  that scope acquired) and dispositions exception/early-return, re-entrant, and
  cross-process behaviour against it, plus the stated assumption that the probe
  reads the OS lock through a second file description.
- **#2213 deferred debt** — one of the two NITs is **withdrawn as factually
  wrong**: it claimed the depth key and lock path disagree about resolution,
  but `content_factory_store.py:100-101` derives the key FROM the resolved
  path. The withdrawal is recorded rather than deleted silently. The surviving
  NIT (the depth map never deletes released keys) is **parked in
  `HARDENING.md`** with full metadata, so it stays in the active queue after
  this plan is archived on merge.
- **Self-inflicted** — an intermediate commit of mine changed criterion 4 to
  name four suites while leaving the documented command at three, and left
  `Parked hardening: none` after adding the HARDENING entry. Both corrected.
  Note the original "1184" was **not** stale, as I first reported: it was
  correct for the three-suite command as written.

Parked hardening: `job_lock` depth map never deletes released entries
(`HARDENING.md`, 2026-07-26). Parked rather than fixed — no demonstrated
failure path, and this slice's contract says no runtime changes.

## Verification

- `python -m pytest tests/test_content_factory_runner.py -k job_lock -q` → **4 passed**.
- runner + schemas + store → **1184 passed**.
- runner + schemas + store + copy-verification → **1354 passed** — the four
  suites acceptance criterion 4 names. Both commands were run; each count is
  recorded against the command it belongs to.
- `scripts/audit_plan_code_consistency.py` → all claims resolve. `git diff --check` clean.

**Detection proven by injection** (§3i), which is the whole point of the change. Replacing the release in `job_lock`'s `finally` with a leak:

```
post-change test:   FAILED  test_job_lock_identity_includes_the_root
pre-change test:    1 passed        <- blind to the leak
```

The old assertions could not see a leaked lock; the new ones can. Without that probe this would be three assertions of unknown value.

## Diff size

3 files (`HARDENING.md`, the plan, the test), see the plan's synced table

