### PR TITLE
fix: bind advisory locators to the audited body; case-independent polarity (#2189)

### DIFF
--- a/atlas_brain/schemas/content_factory.py
+++ b/atlas_brain/schemas/content_factory.py
@@ -205,7 +205,12 @@ def sentence_count(text: str) -> int:
     """
     last = 0
     for index, (start, end) in enumerate(sentence_spans(text), start=1):
-        if text[start:end].strip():
+        # VISIBLE content, not merely non-whitespace. `str.strip()` leaves a
+        # zero-width character intact, so a body of only U+200B/U+FEFF/U+034F
+        # counted as one sentence and admitted `sentence 1` against a body that
+        # renders blank -- the same open-input hole #2201 closed elsewhere, and
+        # a contradiction of "a blank body admits no locator".
+        if _has_visible_content(text[start:end]):
             last = index
     return last
 
@@ -306,7 +311,10 @@ def _validate_advisory_warnings(warnings: "list[str]", body: str = "") -> None:
             raise ValueError(
                 f"advisory warning locator names sentence {locator}, but the "
                 f"audited body has {limit}; a locator must reference the body "
-                "it was computed from"
+                "it was computed from. Repair a pre-existing artifact by "
+                "supplying the edited_body_markdown it was audited against, "
+                "or by dropping the locator warning -- without a body it "
+                "names nothing"
             )
 
 

--- a/atlas_brain/schemas/content_factory.py
+++ b/atlas_brain/schemas/content_factory.py
@@ -99,7 +99,7 @@ _ADVISORY_STATIC_WARNINGS = frozenset(
 # locator this grammar rejects.
 _ADVISORY_GRAMMAR_RE = re.compile(
     r"^(?:unqualified-answer-claim|unqualified-ownership-claim): "
-    r"sentence [1-9]\d{0,9}$"
+    r"sentence (?P<sentence>[1-9]\d{0,9})$"
 )
 
 
@@ -139,6 +139,75 @@ def is_default_ignorable(char: str) -> bool:
 
 # Back-compat alias for existing private callers in this module.
 _is_default_ignorable = is_default_ignorable
+
+
+# --- shared sentence machinery ------------------------------------------
+#
+# Lives HERE, not in the copy-verification engine, because the CONTRACT needs
+# it: an advisory locator names a sentence of the audited body, so validating
+# that locator requires counting sentences exactly the way the producer does.
+# Two implementations would drift, and a locator bound that disagrees with the
+# producer is either a false rejection or an open door (#2189). Same
+# one-definition rule as `is_default_ignorable`.
+
+SENTENCE_BOUNDARY_RE = re.compile(r"[.!?]+\s+(?=[A-Z\"'(])|[.!?]+\s*\Z|\n\s*\n+")
+ABBREVIATIONS = frozenset(
+    {"dr", "mr", "mrs", "ms", "prof", "inc", "ltd", "co", "corp", "dept",
+     "vs", "etc", "jr", "sr", "st", "fig", "approx", "est"}
+)
+# Capitalized words that overwhelmingly START sentences: an abbreviation
+# period followed by one of these is a real terminator ("Acme Inc. We
+# draft ..."), while "Dr. Billing" (a name) stays internal.
+SENTENCE_STARTERS = frozenset(
+    {"we", "the", "our", "this", "these", "those", "it", "they", "a", "an",
+     "i", "he", "she", "you", "all", "each", "no", "if", "when", "after",
+     "before", "there", "here"}
+)
+LAST_WORD_RE = re.compile(r"([A-Za-z][\w'-]*)\s*$")
+
+
+def sentence_spans(text: str) -> "list[tuple[int, int]]":
+    """Sentence spans with abbreviation protection: a period run is not a
+    terminator when the word before it is a known abbreviation or a single
+    initial ("Dr. Billing", "J. Smith") -- locators must count sentences the
+    way the reviewing human does."""
+    spans: list[tuple[int, int]] = []
+    start = 0
+    for match in SENTENCE_BOUNDARY_RE.finditer(text):
+        marks = set(match.group(0).strip()) - set("\n \t")
+        if marks and marks <= {"."}:
+            before = LAST_WORD_RE.search(text[max(0, match.start() - 40) : match.start()])
+            if before is not None:
+                word = before.group(1).lower()
+                if word in ABBREVIATIONS or len(word) == 1:
+                    follower = re.match(r"\s*([A-Za-z][\w'\u2019-]*)", text[match.end() :])
+                    if follower is None or follower.group(1).lower() not in SENTENCE_STARTERS:
+                        continue
+        spans.append((start, match.start()))
+        start = match.end()
+    spans.append((start, len(text)))
+    return spans
+
+
+def sentence_count(text: str) -> int:
+    """The highest sentence number a locator may legitimately reference.
+
+    This is the 1-based index of the LAST span carrying content, not the span
+    count: a terminator at the end of the text yields a trailing empty span,
+    so `len()` would admit a locator naming a sentence that does not exist.
+
+    It is deliberately the last CONTENT index rather than the number of
+    content spans. An empty span can also fall in the MIDDLE (a blank line
+    between sentences), and the producer numbers locators by span position --
+    so counting only non-empty spans would under-count and false-reject a
+    legitimate locator. The last content index can never be smaller than any
+    locator the producer can emit.
+    """
+    last = 0
+    for index, (start, end) in enumerate(sentence_spans(text), start=1):
+        if text[start:end].strip():
+            last = index
+    return last
 
 
 def _routing_key(channel: str) -> str:
@@ -196,7 +265,7 @@ def _raise_invisible():
     )
 
 
-def _validate_advisory_warnings(warnings: "list[str]") -> None:
+def _validate_advisory_warnings(warnings: "list[str]", body: str = "") -> None:
     """Persistence choke point for ALL writers (runner or direct) on EVERY
     artifact that carries advisory warnings.
 
@@ -205,17 +274,40 @@ def _validate_advisory_warnings(warnings: "list[str]") -> None:
     validation, before the store persists anything. Kept as one function so
     the audit, the repurposing variants, and the image prompts cannot drift
     into three different grammars.
+
+    The locator is also BOUND TO ``body`` (#2189). Grammar alone validated the
+    digit SHAPE, so a direct writer could persist
+    ``unqualified-answer-claim: sentence 2125551234`` against a one-sentence
+    body -- a raw phone number wearing a locator's clothes, which contradicts
+    the contract that PII-shaped producer values are unrepresentable for every
+    writer. A locator may now only name a sentence the audited body actually
+    has, which caps it at the body's own length: a ten-digit locator would
+    need a ten-digit-sentence body, and each sentence needs at least two
+    characters.
+
+    ``body`` defaults to empty, which admits NO locator. That is the correct
+    default for an artifact with no single audited body (an image-prompt set
+    verifies each prompt independently), and it fails closed for any future
+    caller that forgets to pass one.
     """
+    limit = sentence_count(body)
     for warning in warnings:
         if warning in _ADVISORY_STATIC_WARNINGS:
             continue
-        if _ADVISORY_GRAMMAR_RE.fullmatch(warning):
-            continue
-        raise ValueError(
-            "advisory_warnings entries must be deterministic checklist "
-            "lines (bounded locator grammar); free-text evidence is not "
-            "representable"
-        )
+        match = _ADVISORY_GRAMMAR_RE.fullmatch(warning)
+        if match is None:
+            raise ValueError(
+                "advisory_warnings entries must be deterministic checklist "
+                "lines (bounded locator grammar); free-text evidence is not "
+                "representable"
+            )
+        locator = int(match.group("sentence"))
+        if locator > limit:
+            raise ValueError(
+                f"advisory warning locator names sentence {locator}, but the "
+                f"audited body has {limit}; a locator must reference the body "
+                "it was computed from"
+            )
 
 
 Confidence = Literal["high", "medium", "low"]
@@ -393,7 +485,7 @@ class EditorialAuditV2(BaseModel):
 
     @model_validator(mode="after")
     def _advisory_warnings_bounded(self) -> "EditorialAuditV2":
-        _validate_advisory_warnings(self.advisory_warnings)
+        _validate_advisory_warnings(self.advisory_warnings, self.edited_body_markdown)
         return self
 
     @model_validator(mode="after")
@@ -503,7 +595,7 @@ class ChannelVariant(BaseModel):
 
     @model_validator(mode="after")
     def _advisory_warnings_bounded(self) -> "ChannelVariant":
-        _validate_advisory_warnings(self.advisory_warnings)
+        _validate_advisory_warnings(self.advisory_warnings, self.body_markdown)
         return self
 
 

--- a/atlas_brain/services/content_factory_copy_verification.py
+++ b/atlas_brain/services/content_factory_copy_verification.py
@@ -62,10 +62,15 @@ import re
 import unicodedata
 
 from atlas_brain.schemas.content_factory import (
+    ABBREVIATIONS,
     ADVISORY_CTA_REMINDER,
     ADVISORY_OWNER_ROUTING_WARNING,
+    LAST_WORD_RE,
+    SENTENCE_BOUNDARY_RE,
+    SENTENCE_STARTERS,
     CopyVerification,
     is_default_ignorable,
+    sentence_spans,
 )
 
 # ---------------------------------------------------------------------------
@@ -108,6 +113,11 @@ _RULES: dict[str, list[tuple[str, str]]] = {
         ),
     ],
 }
+
+_LAST_WORD_RE = LAST_WORD_RE
+_ABBREVIATIONS = ABBREVIATIONS
+_SENTENCE_STARTERS = SENTENCE_STARTERS
+_SENTENCE_BOUNDARY_RE = SENTENCE_BOUNDARY_RE
 
 _SCAN_KEEP_CONTROLS = frozenset("\t\n\r\v\f")
 
@@ -260,10 +270,6 @@ _WORD_RE = re.compile(r"[A-Za-z][\w'\u2019-]*|\d[\w.-]*")
 # Sentence terminators: runs of .!? followed by whitespace + a capital/quote,
 # or end of text; a blank line is a structural break. Single newlines (soft
 # wraps) never split; digit-internal and abbreviation periods never split.
-_SENTENCE_BOUNDARY_RE = re.compile(
-    r"[.!?]+\s+(?=[A-Z\"'(])|[.!?]+\s*\Z|\n\s*\n+"
-)
-
 # Clause boundaries: the minimal proposition. Punctuation (incl. dashes,
 # slashes, parens), coordinators, and relativizer/adjunct openers.
 _CLAUSE_BOUNDARY_RE = re.compile(
@@ -357,49 +363,13 @@ _REPORT_ITEM_NOUNS = frozenset(
 _CTA_REMINDER = ADVISORY_CTA_REMINDER
 
 
-_ABBREVIATIONS = frozenset(
-    {"dr", "mr", "mrs", "ms", "prof", "inc", "ltd", "co", "corp", "dept",
-     "vs", "etc", "jr", "sr", "st", "fig", "approx", "est"}
-)
-# Capitalized words that overwhelmingly START sentences: an abbreviation
-# period followed by one of these is a real terminator ("Acme Inc. We
-# draft ..."), while "Dr. Billing" (a name) stays internal.
-_SENTENCE_STARTERS = frozenset(
-    {"we", "the", "our", "this", "these", "those", "it", "they", "a", "an",
-     "i", "he", "she", "you", "all", "each", "no", "if", "when", "after",
-     "before", "there", "here"}
-)
 _FOCUS_MODIFIERS = frozenset({"only", "even", "just", "especially", "particularly"})
-_LAST_WORD_RE = re.compile(r"([A-Za-z][\w'-]*)\s*$")
 
 
 def _sentence_structure(text: str) -> "tuple[list[int], list[tuple[int, int]]]":
-    """Sentence spans with abbreviation protection: a period run is not a
-    terminator when the word before it is a known abbreviation or a single
-    initial ("Dr. Billing", "J. Smith") -- locators must count sentences the
-    way the reviewing human does."""
-    spans: list[tuple[int, int]] = []
-    start = 0
-    for match in _SENTENCE_BOUNDARY_RE.finditer(text):
-        marks = set(match.group(0).strip()) - set("\n \t")
-        if marks and marks <= {"."}:
-            before = _LAST_WORD_RE.search(
-                text[max(0, match.start() - 40) : match.start()]
-            )
-            if before is not None:
-                word = before.group(1).lower()
-                if word in _ABBREVIATIONS or len(word) == 1:
-                    follower = re.match(
-                        r"\s*([A-Za-z][\w'\u2019-]*)", text[match.end() :]
-                    )
-                    if (
-                        follower is None
-                        or follower.group(1).lower() not in _SENTENCE_STARTERS
-                    ):
-                        continue
-        spans.append((start, match.start()))
-        start = match.end()
-    spans.append((start, len(text)))
+    """(starts, spans) over the SHARED sentence definition in the contracts
+    module, so the engine and the locator validator cannot disagree (#2189)."""
+    spans = sentence_spans(text)
     return [s for s, _e in spans], spans
 
 
@@ -575,9 +545,14 @@ def _unqualified_claims(
         # "if the tickets contain no proof" must not excuse the claim
         # (the standing honest-gap form "no proven answer" matches as a
         # whole phrase and is unaffected).
+        # Case-insensitive, like the qualifier detector itself. Without re.I
+        # this check saw "no proof" but not "NO proof", so ordinary generated
+        # casing was accepted as a qualification and suppressed the warning
+        # (#2189). Polarity is not a property of capitalization.
         if re.match(
             r"\s+(?:[\w'\u2019-]+\s+){0,2}(?:no|not|never|nothing|none|zero)\b",
             text[qualifier.end() :],
+            re.IGNORECASE,
         ):
             continue
         index, _span = _span_for(clause_bounds, max(qualifier.end() - 1, 0))

--- a/plans/PR-CF-Advisory-Locator-Binding.md
+++ b/plans/PR-CF-Advisory-Locator-Binding.md
@@ -1,0 +1,169 @@
+# PR-CF-Advisory-Locator-Binding
+
+## Why this slice exists
+
+Issue #2189 collects the five findings Codex filed on #2181 after merge. This
+slice takes the two that are pure correctness defects in the persistence choke
+point, and records the state of a third.
+
+The P1 is the important one. The advisory contract claims that PII-shaped
+producer values are **unrepresentable for every writer** -- that is one of the
+two evidence theorems in the copy-verification module docstring. It was not
+true. The locator grammar validated only the digit SHAPE, so a direct v2 writer
+could persist `unqualified-answer-claim: sentence 2125551234` against a
+one-sentence body: a raw phone number wearing a locator's clothes, landing in
+the git-backed audit the theorem says it cannot reach.
+
+Deliberately NOT in this slice: findings 2 and 3 from #2189 (product-term
+negation scope, quantified routing subjects). Both are precision refinements to
+the routing-coverage checker's linguistic scope -- a different mechanism from
+the persistence gate, with no PII consequence -- and folding them in would put
+two unrelated decision surfaces behind one review. #2189 stays open for them.
+
+### Problem-derived contract
+
+- Root cause (P1): the locator grammar is a SHAPE check with no referent. It
+  never binds the sentence number to the body the warning was computed from, so
+  any ten-digit value is admissible on any body.
+- Root cause (P2): the qualifier detector is case-insensitive but its
+  complement-polarity check is not, so `NO proof` reads as a qualification
+  while `no proof` does not. Polarity is not a property of capitalization.
+- Correct fix must: bind the locator to the audited body's actual sentence
+  range at the same choke point that already validates the grammar, for EVERY
+  writer and every artifact that carries warnings; and match complement
+  polarity case-insensitively.
+- The bound must count sentences EXACTLY as the producer does. A second
+  sentence definition would drift, and a bound that disagrees with the producer
+  is either a false rejection of real output or an open door.
+- Must not change: which forms count as PII, the blocking verdict semantics
+  frozen in #2181, the warning grammar itself, or the routing-coverage
+  linguistic scope (findings 2/3, deferred above).
+
+## Scope (this PR)
+
+Ownership lane: content-factory
+Slice phase: production hardening
+Max files: 4
+
+1. `atlas_brain/schemas/content_factory.py`:
+   - `sentence_spans` / `sentence_count` move here as the SINGLE sentence
+     definition, because the contract now needs it to validate its own locator.
+   - `_validate_advisory_warnings(warnings, body)` bounds each locator to
+     `sentence_count(body)`.
+2. `atlas_brain/services/content_factory_copy_verification.py`: imports the
+   shared sentence machinery instead of defining it; `re.IGNORECASE` on the
+   complement-polarity check.
+3. Proof: both-direction probes, a casing cross-product, and a shared-definition
+   assertion.
+
+### Review Contract
+
+- Acceptance criteria:
+  1. `unqualified-answer-claim: sentence 2125551234` is REJECTED against a
+     one-sentence body, for the audit and for a channel variant.
+  2. Boundary, both sides: a locator naming the body's last sentence is
+     admissible; one past it is not; `sentence 0` still fails the grammar.
+  3. A blank body admits no locator at all, and an artifact with no single
+     audited body (image-prompt set) admits none by default -- fail closed.
+  4. Static checklist lines carry no locator and stay admissible on any body,
+     including none.
+  5. Producer/contract lockstep, strengthened: every warning
+     `advisory_warnings(B)` emits validates on an artifact whose body is `B`,
+     across the standing generated corpus. This is what proves the bound cannot
+     false-reject real producer output.
+  6. The negated-complement check behaves identically across casings, for every
+     negation token, in both directions (a genuine qualifier still qualifies).
+  7. The contract's `sentence_spans` and the engine's `_sentence_structure`
+     return identical spans, so the two cannot drift.
+- Reachability proof: the bound sits in the model validator every writer passes
+  through -- `EditorialAuditV2`/`V3` and `ChannelVariant` -- so a direct writer
+  is gated identically to the runner.
+- Affected surfaces: the advisory persistence choke point, the sentence
+  primitives' home module, and the qualifier complement check. No change to the
+  blocking verdict, the PII patterns, or the routing-coverage scope.
+- Risk areas: a bound that under-counts would false-reject legitimate producer
+  output -- addressed by criterion 5 and by counting to the LAST content-bearing
+  span rather than the number of content spans.
+- Reviewer rules triggered: R2 (both-direction tests), R3 (gate cannot be
+  self-reported), R10 (one shared definition), R13 (class findings), R14.
+
+### Files touched
+
+- `atlas_brain/schemas/content_factory.py`
+- `atlas_brain/services/content_factory_copy_verification.py`
+- `plans/PR-CF-Advisory-Locator-Binding.md`
+- `tests/test_content_factory_copy_verification.py`
+
+## Mechanism
+
+`sentence_count` returns the 1-based index of the LAST span carrying content,
+not the number of content spans. Both details are load-bearing:
+
+- a terminator at end of text yields a trailing empty span, so `len(spans)`
+  would admit a locator naming a sentence that does not exist;
+- an empty span can also fall in the MIDDLE (a blank line), and the producer
+  numbers locators by span POSITION -- so counting only non-empty spans would
+  under-count and reject a legitimate locator.
+
+The last content index can never be smaller than any locator the producer can
+emit, which is exactly the property criterion 5 checks.
+
+## Intentional
+
+- **The sentence machinery moves to the contracts module rather than being
+  duplicated.** The contract needs it to validate its own locator. This follows
+  the `is_default_ignorable` precedent from #2201, where a partial second copy
+  of a shared predicate was itself the defect.
+- **The image-prompt set binds to an empty body**, so it admits no locator. It
+  verifies each prompt independently and has no single audited body; the runner
+  already forces its warnings to `[]`. The default is empty so a future caller
+  that forgets to pass a body fails closed rather than open.
+- **Test fixtures were corrected, not the guard.** `_audit()` computed
+  `copy_verification` from a text but never set `edited_body_markdown`, pairing
+  warnings from one text with an empty audited body -- the exact inconsistency
+  this slice makes unrepresentable. Six existing tests carried that pairing.
+- **One existing assertion was inverted deliberately.** The locator boundary
+  probe asserted that `sentence 1000000` is admissible against no body. That IS
+  the reported defect, so the probe now checks the real boundary instead.
+
+## Deferred
+
+- #2189 findings 2 and 3 (product-term negation scope, quantified routing
+  subject nouns): both reproduce on current main, both are routing-coverage
+  precision rather than persistence correctness. #2189 stays open.
+- #2189 finding 1 (v1 metadata laundering) needs NO code: it was already fixed
+  by the normalizer rewrite in #2192 round 8, which synthesizes `schema_version`
+  only when the supplied value is absent or agrees with the declared tag.
+  Verified on current main: `"bogus"` and `99` survive to be rejected by the
+  version validator; only `None` is synthesized.
+- Observed while probing, NOT a #2189 finding and not fixed here: qualifier
+  opener/complement pairing is asymmetric on main -- `If the tickets contain
+  proof` and `When evidence exists` qualify, while `When the tickets contain
+  proof` and `If evidence exists` do not. Worth its own investigation; this
+  slice asserts only the casing invariant.
+
+Parked hardening: none.
+
+## Verification
+
+    python -m pytest tests/test_content_factory_runner.py \
+        tests/test_content_factory_store.py \
+        tests/test_content_factory_schemas.py \
+        tests/test_content_factory_copy_verification.py -q
+    # -> 1377 passed
+
+Detection proven by injection, per AGENTS.md 3i. Neutralizing both fixes
+(dropping `re.IGNORECASE`, and making the locator bound unreachable):
+
+    mutated:   15 failed, 6 passed
+    restored:  21 passed
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/schemas/content_factory.py` | 114 |
+| `atlas_brain/services/content_factory_copy_verification.py` | 61 |
+| `plans/PR-CF-Advisory-Locator-Binding.md` | 169 |
+| `tests/test_content_factory_copy_verification.py` | 186 |
+| **Total** | **530** |

--- a/plans/PR-CF-Advisory-Locator-Binding.md
+++ b/plans/PR-CF-Advisory-Locator-Binding.md
@@ -20,6 +20,36 @@ the routing-coverage checker's linguistic scope -- a different mechanism from
 the persistence gate, with no PII consequence -- and folding them in would put
 two unrelated decision surfaces behind one review. #2189 stays open for them.
 
+**Diff-budget overage (463 added lines vs the 400 soft cap) -- why this slice
+is indivisible.** The mechanism is 121 lines; the rest is the required review
+artifact and its proofs:
+
+| | added |
+|---|---:|
+| production code (schemas 103 + engine 18) | 121 |
+| the plan document itself | 169 |
+| both-direction proofs and corrected fixtures | 173 |
+
+The two remaining split lines both produce a worse intermediate state:
+
+* **Move vs. bound.** The sentence definition moves into the contracts module
+  ONLY so the locator bound can count sentences exactly as the producer does.
+  Landing the move alone is a refactor with no consumer; landing the bound
+  alone means a second sentence definition -- the precise defect #2201 round 13
+  was filed for.
+* **P1 vs. P2.** Splitting the casing fix out yields a ~3-line change plus its
+  casing cross-product, in the same function family and the same test file, and
+  leaves the P1 slice above the cap regardless.
+
+Tests are not compressible here: the bound's real risk is FALSE REJECTION of
+legitimate producer output, and the only thing that rules that out is the
+generated lockstep corpus. Shipping the guard without it would land a
+persistence gate whose failure mode is silently discarding valid audits.
+
+Diff-budget override: the sentence definition move and the locator bound are one
+decision, and separating either from its generated proof would land a
+persistence gate without the evidence that it cannot false-reject real output.
+
 ### Problem-derived contract
 
 - Root cause (P1): the locator grammar is a SHAPE check with no referent. It
@@ -164,6 +194,6 @@ Detection proven by injection, per AGENTS.md 3i. Neutralizing both fixes
 |---|---:|
 | `atlas_brain/schemas/content_factory.py` | 114 |
 | `atlas_brain/services/content_factory_copy_verification.py` | 61 |
-| `plans/PR-CF-Advisory-Locator-Binding.md` | 169 |
+| `plans/PR-CF-Advisory-Locator-Binding.md` | 199 |
 | `tests/test_content_factory_copy_verification.py` | 186 |
-| **Total** | **530** |
+| **Total** | **560** |

--- a/plans/PR-CF-Advisory-Locator-Binding.md
+++ b/plans/PR-CF-Advisory-Locator-Binding.md
@@ -156,6 +156,41 @@ emit, which is exactly the property criterion 5 checks.
   probe asserted that `sentence 1000000` is admissible against no body. That IS
   the reported defect, so the probe now checks the real boundary instead.
 
+## Deliberate exception to the v2/v3 freeze
+
+This slice TIGHTENS validation on frozen contracts, which the freeze note
+forbids in general. Recorded here as a decision with its evidence rather than
+made silently.
+
+**Why a new schema version does not solve it.** Putting the bound on a v4 while
+leaving v2/v3 admissible leaves the P1 open for exactly the writer it was filed
+against: a direct v2 writer could still persist a phone number as a locator. A
+new version relocates the hole instead of closing it.
+
+**Why the freeze's stated harm does not occur here.** The freeze exists because
+adding a FIELD makes new artifacts unreadable to an old reader -- `extra=forbid`
+rejects the unknown key, so a rollback loses data (that is the #2192 round-8
+case). This change adds no field. Artifacts written after it remain readable
+byte-for-byte by pre-change code, so the rollback direction is unaffected. Only
+the reverse narrows: an artifact that was ALREADY semantically broken -- a
+locator naming a sentence of a body that does not exist -- stops validating.
+
+**What is actually invalidated.** A payload carrying a locator warning with a
+blank or absent `edited_body_markdown`. That is not incidental breakage; it is
+the P1 in its most extreme form, since a locator with no body is a raw producer
+value with no referent at all. The runner cannot produce it: it clears
+`advisory_warnings` whenever the edited body is blank.
+
+**Evidence.** The local git-backed job store (`~/content-factory/jobs`, 3 jobs
+/ 9 artifacts) contains zero editorial audits carrying a locator warning, so no
+persisted artifact is invalidated in practice. This bounds the local blast
+radius; it does not prove none exists anywhere.
+
+**Migration path**, as the review asked for, and now stated in the validation
+error itself so an operator hitting it gets the repair: supply the
+`edited_body_markdown` the artifact was audited against, or drop the locator
+warning -- without a body it names nothing.
+
 ## Deferred
 
 - #2189 findings 2 and 3 (product-term negation scope, quantified routing
@@ -192,8 +227,8 @@ Detection proven by injection, per AGENTS.md 3i. Neutralizing both fixes
 
 | File | LOC |
 |---|---:|
-| `atlas_brain/schemas/content_factory.py` | 114 |
+| `atlas_brain/schemas/content_factory.py` | 122 |
 | `atlas_brain/services/content_factory_copy_verification.py` | 61 |
-| `plans/PR-CF-Advisory-Locator-Binding.md` | 199 |
-| `tests/test_content_factory_copy_verification.py` | 186 |
-| **Total** | **560** |
+| `plans/PR-CF-Advisory-Locator-Binding.md` | 234 |
+| `tests/test_content_factory_copy_verification.py` | 239 |
+| **Total** | **656** |

--- a/tests/test_content_factory_copy_verification.py
+++ b/tests/test_content_factory_copy_verification.py
@@ -1503,3 +1503,56 @@ def test_sentence_definition_is_shared_not_duplicated():
         "",
     ]:
         assert _sentence_structure(text)[1] == sentence_spans(text), text
+
+
+# --- #2219 review: invisible-only bodies admit no locator ----------------
+
+_INVISIBLE_BODIES = [
+    "\u200b",          # zero width space
+    "\ufeff",          # BOM / zero width no-break space
+    "\u034f",          # combining grapheme joiner (category Mn)
+    "\u00ad",          # soft hyphen
+    "  \u200b  ",      # padded with ordinary whitespace
+    "\u200b\u200c\ufeff",
+]
+
+
+@pytest.mark.parametrize("body", _INVISIBLE_BODIES)
+def test_invisible_only_body_admits_no_locator(body):
+    """`str.strip()` leaves a zero-width character intact, so an
+    invisible-only body counted as one sentence and admitted `sentence 1`
+    even though it renders blank -- fail-open on exactly the input class
+    #2201 closed elsewhere."""
+    from atlas_brain.schemas.content_factory import EditorialAuditV2, sentence_count
+    from pydantic import ValidationError
+
+    assert sentence_count(body) == 0
+    with pytest.raises(ValidationError, match="locator names sentence"):
+        EditorialAuditV2.model_validate(
+            {
+                "schema": "editorial_audit.v2",
+                "project_id": "p",
+                "edited_body_markdown": body,
+                "advisory_warnings": ["unqualified-answer-claim: sentence 1"],
+            }
+        )
+
+
+def test_invisible_span_between_sentences_does_not_undercount():
+    """The other direction: an invisible span in the MIDDLE must not shrink
+    the bound, or a legitimate trailing locator would be rejected. This is
+    why the bound is the last content INDEX, not the count of content spans.
+    """
+    from atlas_brain.schemas.content_factory import EditorialAuditV2, sentence_count
+
+    body = "One.\n\n\u200b\n\nThree."
+    assert sentence_count(body) == 3
+    audit = EditorialAuditV2.model_validate(
+        {
+            "schema": "editorial_audit.v2",
+            "project_id": "p",
+            "edited_body_markdown": body,
+            "advisory_warnings": ["unqualified-answer-claim: sentence 3"],
+        }
+    )
+    assert audit.advisory_warnings

--- a/tests/test_content_factory_copy_verification.py
+++ b/tests/test_content_factory_copy_verification.py
@@ -163,10 +163,15 @@ def test_non_string_rejected():
 
 
 def _audit(text, recommendation):
+    # edited_body_markdown carries the SAME text the verdict and any advisory
+    # warnings were computed from. Omitting it let a fixture pair locators with
+    # an empty audited body -- the inconsistency #2189's locator binding
+    # exists to make unrepresentable.
     return {
         "schema": "editorial_audit.v2",
         "project_id": "resolution-audit",
         "recommendation": recommendation,
+        "edited_body_markdown": text,
         "copy_verification": verify_copy(text).model_dump(),
     }
 
@@ -505,6 +510,9 @@ def test_schema_accepts_deterministic_warning_grammar():
         {
             "schema": "editorial_audit.v2",
             "project_id": "p",
+            # A locator names a sentence of THIS body, so the body must have
+            # at least three (#2189).
+            "edited_body_markdown": "One. Two. Three.",
             "advisory_warnings": [
                 "unqualified-answer-claim: sentence 3",
                 ADVISORY_OWNER_ROUTING_WARNING,
@@ -521,15 +529,20 @@ def test_generated_warnings_always_satisfy_schema_grammar():
     from atlas_brain.schemas.content_factory import EditorialAuditV2
     from atlas_brain.services.content_factory_copy_verification import advisory_warnings
 
-    generated = advisory_warnings(
+    body = (
         "The Resolution Audit snapshot ranks repeated tickets. We draft the "
         "answer for every ticket. Billing owns refunds. Really?! Version 2.1 "
         "provides an answer at bob@example.com or 020/7946/0958."
     )
+    generated = advisory_warnings(body)
+    # The audit must carry the SAME body: a locator is only meaningful against
+    # the text it was computed from (#2189), so lockstep is now the stronger
+    # property "warnings from B validate on an audit whose body is B".
     audit = EditorialAuditV2.model_validate(
         {
             "schema": "editorial_audit.v2",
             "project_id": "p",
+            "edited_body_markdown": body,
             "advisory_warnings": generated,
         }
     )
@@ -577,12 +590,14 @@ def test_multiline_claim_keyword_stays_schema_valid():
     from atlas_brain.schemas.content_factory import EditorialAuditV2
     from atlas_brain.services.content_factory_copy_verification import advisory_warnings
 
-    generated = advisory_warnings("Billing\nreally owns refunds.")
+    body = "Billing\nreally owns refunds."
+    generated = advisory_warnings(body)
     assert any(w.startswith("unqualified-ownership-claim:") for w in generated)
     audit = EditorialAuditV2.model_validate(
         {
             "schema": "editorial_audit.v2",
             "project_id": "p",
+            "edited_body_markdown": body,
             "advisory_warnings": generated,
         }
     )
@@ -999,6 +1014,7 @@ def test_invariant_all_outputs_satisfy_schema_grammar():
             {
                 "schema": "editorial_audit.v2",
                 "project_id": "p",
+                "edited_body_markdown": text,
                 "advisory_warnings": generated,
             }
         )
@@ -1106,22 +1122,31 @@ def test_locator_grammar_boundary_probe():
     from atlas_brain.schemas.content_factory import EditorialAuditV2
     from pydantic import ValidationError
 
-    audit = EditorialAuditV2.model_validate(
-        {
-            "schema": "editorial_audit.v2",
-            "project_id": "p",
-            "advisory_warnings": ["unqualified-answer-claim: sentence 1000000"],
-        }
-    )
-    assert audit.advisory_warnings
-    with pytest.raises(ValidationError):
-        EditorialAuditV2.model_validate(
+    # #2189 changed this boundary deliberately. It used to assert that
+    # "sentence 1000000" was admissible against NO body -- grammar alone
+    # validated the digit shape, which is what let a raw phone number pass as
+    # a locator. The boundary is now the audited body's own length.
+    body = "One. Two. Three."
+
+    def _audit_with(locator):
+        return EditorialAuditV2.model_validate(
             {
                 "schema": "editorial_audit.v2",
                 "project_id": "p",
-                "advisory_warnings": ["unqualified-answer-claim: sentence 0"],
+                "edited_body_markdown": body,
+                "advisory_warnings": [f"unqualified-answer-claim: sentence {locator}"],
             }
         )
+
+    # In range: the last sentence the body actually has.
+    assert _audit_with(3).advisory_warnings
+
+    # Out of range on both sides -- one past the body, and the grammar's own
+    # zero floor.
+    with pytest.raises(ValidationError):
+        _audit_with(1000000)
+    with pytest.raises(ValidationError):
+        _audit_with(0)
 
 
 # --- round-15 review fixes ---
@@ -1343,3 +1368,138 @@ def test_repeated_ownership_clause_is_linear():
     started = time.monotonic()
     advisory_warnings(draft)
     assert time.monotonic() - started < 2.5
+
+
+# --- #2189: casing-independent polarity + body-bound locators -------------
+
+_QUALIFIER_NEGATIONS = ["no", "not", "never", "nothing", "none", "zero"]
+
+
+@pytest.mark.parametrize("negation", _QUALIFIER_NEGATIONS)
+@pytest.mark.parametrize("caser", [str.lower, str.upper, str.title])
+def test_negated_qualifier_complement_is_casing_independent(negation, caser):
+    """#2189: the qualifier detector was case-insensitive but its complement
+    polarity check was not, so `NO proof` read as a qualification and
+    suppressed the claim warning. Polarity is not a property of capitalization.
+    """
+    from atlas_brain.services.content_factory_copy_verification import advisory_warnings
+
+    text = f"If the tickets contain {caser(negation)} proof, we draft answers."
+    assert any(
+        w.startswith("unqualified-answer-claim:") for w in advisory_warnings(text)
+    ), text
+
+
+def test_qualified_claim_still_suppressed_across_casings():
+    """The other direction: a genuine qualifier must still qualify, in any
+    casing, or the fix would just make everything warn."""
+    from atlas_brain.services.content_factory_copy_verification import advisory_warnings
+
+    # Forms the engine genuinely qualifies today, exercised across casings.
+    # (The opener/complement pairing is asymmetric on current main -- see the
+    # plan's Deferred note -- so this asserts the CASING invariant, which is
+    # what #2189 is about, not the pairing.)
+    for text in [
+        "If the tickets contain proof, we draft answers.",
+        "IF THE TICKETS CONTAIN PROOF, we draft answers.",
+        "When evidence exists, we draft answers.",
+        "WHEN EVIDENCE EXISTS, we draft answers.",
+    ]:
+        assert not any(
+            w.startswith("unqualified-answer-claim:") for w in advisory_warnings(text)
+        ), text
+
+
+def test_locator_cannot_exceed_the_audited_body():
+    """#2189 P1: the grammar validated the digit SHAPE only, so a direct writer
+    could persist a raw phone number wearing a locator's clothes."""
+    from atlas_brain.schemas.content_factory import EditorialAuditV2
+    from pydantic import ValidationError
+
+    def _audit_with(body, locator):
+        return EditorialAuditV2.model_validate(
+            {
+                "schema": "editorial_audit.v2",
+                "project_id": "p",
+                "edited_body_markdown": body,
+                "advisory_warnings": [f"unqualified-answer-claim: sentence {locator}"],
+            }
+        )
+
+    # The reported case: a ten-digit locator against a one-sentence body.
+    with pytest.raises(ValidationError, match="locator names sentence"):
+        _audit_with("One sentence only.", 2125551234)
+
+    # Boundary, both sides: the body's last sentence is admissible, one past
+    # it is not.
+    assert _audit_with("One. Two. Three.", 3).advisory_warnings
+    with pytest.raises(ValidationError, match="locator names sentence"):
+        _audit_with("One. Two. Three.", 4)
+
+    # A blank body admits no locator at all -- there is nothing to name.
+    with pytest.raises(ValidationError, match="locator names sentence"):
+        _audit_with("", 1)
+
+
+def test_static_warnings_are_not_locator_bound():
+    """Static checklist lines carry no locator, so they stay admissible on a
+    body of any length -- including none."""
+    from atlas_brain.schemas.content_factory import (
+        ADVISORY_CTA_REMINDER,
+        ADVISORY_OWNER_ROUTING_WARNING,
+        EditorialAuditV2,
+    )
+
+    audit = EditorialAuditV2.model_validate(
+        {
+            "schema": "editorial_audit.v2",
+            "project_id": "p",
+            "edited_body_markdown": "",
+            "advisory_warnings": [ADVISORY_CTA_REMINDER, ADVISORY_OWNER_ROUTING_WARNING],
+        }
+    )
+    assert len(audit.advisory_warnings) == 2
+
+
+def test_variant_locators_bind_to_the_variant_body():
+    """Each artifact binds to ITS OWN audited text, not a shared one."""
+    from atlas_brain.schemas.content_factory import ChannelVariant
+    from pydantic import ValidationError
+
+    ok = ChannelVariant.model_validate(
+        {
+            "channel": "email",
+            "body_markdown": "One. Two.",
+            "derived_from_claims": ["e1"],
+            "advisory_warnings": ["unqualified-answer-claim: sentence 2"],
+        }
+    )
+    assert ok.advisory_warnings
+
+    with pytest.raises(ValidationError, match="locator names sentence"):
+        ChannelVariant.model_validate(
+            {
+                "channel": "email",
+                "body_markdown": "One. Two.",
+                "derived_from_claims": ["e1"],
+                "advisory_warnings": ["unqualified-answer-claim: sentence 2125551234"],
+            }
+        )
+
+
+def test_sentence_definition_is_shared_not_duplicated():
+    """The contract and the producer must count sentences identically, or the
+    bound either false-rejects or leaves a door open (#2189)."""
+    from atlas_brain.schemas.content_factory import sentence_spans
+    from atlas_brain.services.content_factory_copy_verification import (
+        _sentence_structure,
+    )
+
+    for text in [
+        "One. Two. Three.",
+        "Dr. Billing owns refunds. We draft answers.",
+        "Acme Inc. We draft answers.",
+        "Intro.\n\nWe draft answers. Really?!",
+        "",
+    ]:
+        assert _sentence_structure(text)[1] == sentence_spans(text), text


### PR DESCRIPTION
Plan: plans/PR-CF-Advisory-Locator-Binding.md
Slice phase: production hardening
Ownership lane: content-factory

Closes two of the five findings in #2189. #2189 stays open for the other two.

The advisory module's docstring states an evidence theorem: advisory warnings
never persist producer-supplied text at all, so names and numbers are
**unrepresentable for every writer**. That was not true. The locator grammar
validated only the digit SHAPE and never bound the sentence number to a body,
so a direct v2 writer could persist

```
unqualified-answer-claim: sentence 2125551234
```

against a one-sentence body — a raw phone number wearing a locator's clothes,
landing in the git-backed audit the theorem says it cannot reach.

**Diff-budget overage (463 added lines vs the 400 soft cap) -- why this slice
is indivisible.** The mechanism is 121 lines; the rest is the required review
artifact and its proofs:

| | added |
|---|---:|
| production code (schemas 103 + engine 18) | 121 |
| the plan document itself | 169 |
| both-direction proofs and corrected fixtures | 173 |

The two remaining split lines both produce a worse intermediate state:

* **Move vs. bound.** The sentence definition moves into the contracts module
  ONLY so the locator bound can count sentences exactly as the producer does.
  Landing the move alone is a refactor with no consumer; landing the bound
  alone means a second sentence definition -- the precise defect #2201 round 13
  was filed for.
* **P1 vs. P2.** Splitting the casing fix out yields a ~3-line change plus its
  casing cross-product, in the same function family and the same test file, and
  leaves the P1 slice above the cap regardless.

Tests are not compressible here: the bound's real risk is FALSE REJECTION of
legitimate producer output, and the only thing that rules that out is the
generated lockstep corpus. Shipping the guard without it would land a
persistence gate whose failure mode is silently discarding valid audits.

Diff-budget override: the sentence definition move and the locator bound are one
decision, and separating either from its generated proof would land a
persistence gate without the evidence that it cannot false-reject real output.

## What changed

- **Locator binding (P1).** `_validate_advisory_warnings` now bounds each
  locator to the audited body's sentence range, at the same choke point that
  already validates the grammar. Applies to `EditorialAuditV2`/`V3` and
  `ChannelVariant`, so a direct writer is gated identically to the runner.
- **Case-independent polarity (P2).** The qualifier detector is
  case-insensitive; its complement-polarity check was not, so `NO proof` read
  as a qualification while `no proof` did not. Polarity is not a property of
  capitalization.

## Intentional

- **The sentence machinery moved into the contracts module** rather than being
  duplicated. The contract needs it to validate its own locator, and the bound
  must count sentences exactly as the producer does — a bound that disagrees is
  either a false rejection of real output or an open door. Same one-definition
  rule as `is_default_ignorable` in #2201, where a partial second copy of a
  shared predicate was itself the defect.
- **`sentence_count` returns the 1-based index of the LAST content-bearing
  span**, not the number of content spans. `len(spans)` would admit a sentence
  that does not exist (a terminator at end of text leaves a trailing empty
  span); counting only non-empty spans would under-count when a blank line
  falls mid-body, and false-reject a legitimate locator.
- **An image-prompt set binds to an empty body**, so it admits no locator. It
  verifies each prompt independently and has no single audited body; the runner
  already forces its warnings to `[]`. The parameter defaults to empty so a
  future caller that forgets to pass a body fails closed.
- **Fixtures were corrected, not the guard.** `_audit()` computed
  `copy_verification` from a text but never set `edited_body_markdown`, pairing
  warnings from one text with an empty audited body — the exact inconsistency
  this slice makes unrepresentable. Six existing tests carried that pairing.
- **One assertion was inverted deliberately.** The locator boundary probe
  asserted `sentence 1000000` is admissible against no body. That IS the
  reported defect, so it now checks the real boundary.

## Deliberate exception to the v2/v3 freeze

This slice TIGHTENS validation on frozen contracts, which the freeze note
forbids in general. Recorded here as a decision with its evidence rather than
made silently.

**Why a new schema version does not solve it.** Putting the bound on a v4 while
leaving v2/v3 admissible leaves the P1 open for exactly the writer it was filed
against: a direct v2 writer could still persist a phone number as a locator. A
new version relocates the hole instead of closing it.

**Why the freeze's stated harm does not occur here.** The freeze exists because
adding a FIELD makes new artifacts unreadable to an old reader -- `extra=forbid`
rejects the unknown key, so a rollback loses data (that is the #2192 round-8
case). This change adds no field. Artifacts written after it remain readable
byte-for-byte by pre-change code, so the rollback direction is unaffected. Only
the reverse narrows: an artifact that was ALREADY semantically broken -- a
locator naming a sentence of a body that does not exist -- stops validating.

**What is actually invalidated.** A payload carrying a locator warning with a
blank or absent `edited_body_markdown`. That is not incidental breakage; it is
the P1 in its most extreme form, since a locator with no body is a raw producer
value with no referent at all. The runner cannot produce it: it clears
`advisory_warnings` whenever the edited body is blank.

**Evidence.** The local git-backed job store (`~/content-factory/jobs`, 3 jobs
/ 9 artifacts) contains zero editorial audits carrying a locator warning, so no
persisted artifact is invalidated in practice. This bounds the local blast
radius; it does not prove none exists anywhere.

**Migration path**, as the review asked for, and now stated in the validation
error itself so an operator hitting it gets the repair: supply the
`edited_body_markdown` the artifact was audited against, or drop the locator
warning -- without a body it names nothing.

## Deferred

- **#2189 findings 2 and 3** (product-term negation scope, quantified routing
  subject nouns) — both reproduce on current main, both are routing-coverage
  linguistic precision rather than persistence correctness, and no PII
  consequence. Folding them in would put two unrelated decision surfaces behind
  one review. #2189 stays open.
- **#2189 finding 1 needs no code.** Already fixed by the normalizer rewrite in
  #2192 round 8, which synthesizes `schema_version` only when the supplied
  value is absent or agrees with the declared tag. Verified on current main:
  `"bogus"` and `99` survive to be rejected by the version validator; only
  `None` is synthesized.
- **Observed while probing, not a #2189 finding and not fixed here:** qualifier
  opener/complement pairing is asymmetric on main — `If the tickets contain
  proof` and `When evidence exists` qualify, while `When the tickets contain
  proof` and `If evidence exists` do not. Worth its own investigation; this
  slice asserts only the casing invariant.

## Parked hardening

None. The one thing observed and not fixed (the asymmetric qualifier
opener/complement pairing) is recorded under Deferred as an investigation, not
parked as known debt: it has no established correct behaviour yet.

## Cold diff reconstruction

- `atlas_brain/schemas/content_factory.py`
  - adds `SENTENCE_BOUNDARY_RE`, `ABBREVIATIONS`, `SENTENCE_STARTERS`,
    `LAST_WORD_RE`, `sentence_spans`, `sentence_count` — the sentence
    definition moved from the engine, verbatim except for the public names.
    Traces to: the bound must count sentences exactly as the producer does.
    Verified by `test_sentence_definition_is_shared_not_duplicated`.
  - `_ADVISORY_GRAMMAR_RE` gains a named `sentence` group so the locator can be
    read back. Traces to: the bound needs the value, not just a match.
  - `_validate_advisory_warnings(warnings, body="")` bounds each locator to
    `sentence_count(body)`. Traces to: root cause P1. Verified by
    `test_locator_cannot_exceed_the_audited_body` (both sides + blank body) and
    `test_static_warnings_are_not_locator_bound`.
  - `EditorialAuditV2._advisory_warnings_bounded` and
    `ChannelVariant._advisory_warnings_bounded` pass their own audited text.
    Traces to: every writer, every artifact. Verified by
    `test_variant_locators_bind_to_the_variant_body`.
- `atlas_brain/services/content_factory_copy_verification.py`
  - imports the shared sentence machinery; local definitions deleted;
    `_sentence_structure` becomes a thin wrapper preserving its `(starts,
    spans)` shape for its one existing caller. Traces to: one definition.
  - `re.IGNORECASE` on the complement-polarity `re.match`. Traces to: root
    cause P2. Verified by `test_negated_qualifier_complement_is_casing_
    independent` (6 negations x 3 casings) and the both-direction
    `test_qualified_claim_still_suppressed_across_casings`.
- `tests/test_content_factory_copy_verification.py`
  - `_audit()` now sets `edited_body_markdown`; five other fixtures bind the
    body their warnings were computed from; the locator boundary probe checks
    the real boundary. Traces to: the fixtures encoded the inconsistency this
    slice removes.
  - new tests as listed above.
- `plans/PR-CF-Advisory-Locator-Binding.md` — the plan for this slice.

## Verification

```
python -m pytest tests/test_content_factory_runner.py \
    tests/test_content_factory_store.py \
    tests/test_content_factory_schemas.py \
    tests/test_content_factory_copy_verification.py -q
# -> 1377 passed
```

**Detection proven by injection** (§3i). Neutralizing both fixes — dropping
`re.IGNORECASE`, and making the locator bound unreachable:

```
mutated:   15 failed, 6 passed
restored:  21 passed
```

The strongest guard against false rejection is the standing lockstep invariant,
now strengthened: every warning `advisory_warnings(B)` emits validates on an
artifact whose body is `B`, across the generated corpus. That is what proves the
bound cannot reject real producer output.

## Diff size

4 files, see the plan's synced table.

## AI reconciliation

No automated-review threads on this branch yet. The two findings it closes were
filed on #2181 (round 19) and collected into #2189; each was reproduced against
current `main` before any code changed, and finding 1 was confirmed ALREADY
FIXED rather than assumed outstanding.

All fixed or waived: yes

