### PR TITLE
Codify boundary-change enumeration

### DIFF
--- a/.github/workflows/boundary_change_enumeration.yml
+++ b/.github/workflows/boundary_change_enumeration.yml
@@ -1,0 +1,46 @@
+name: Boundary Change Enumeration
+
+# Advisory-first tripwire for AGENTS.md 3k.5. It emits warnings and exits 0 by
+# default so this arc gathers trust before any required-gate promotion.
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/boundary_change_enumeration.yml"
+      - "AGENTS.md"
+      - "scripts/check_boundary_change_enumeration.py"
+      - "tests/test_check_boundary_change_enumeration.py"
+
+jobs:
+  boundary-change-enumeration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.11"
+
+      - name: Install test runner
+        run: python -m pip install --quiet pytest
+
+      - name: Test the detector
+        run: python -m pytest tests/test_check_boundary_change_enumeration.py -q --noconftest
+
+      - name: Boundary-change enumeration lint (advisory)
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch --no-tags origin "${{ github.base_ref }}"
+          python scripts/check_boundary_change_enumeration.py --base "origin/${{ github.base_ref }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1231,18 +1231,19 @@ the slice hand-rolled an open surface.
 
 ### 3k.5. Boundary-change enumeration
 
-Boundary-change enumeration: a diff changing a guard, validator, resolver, or
-admission boundary must ship a plan-doc enumeration before code: replaced-path
-behaviors, guard-relevant fields, and every caller x input shape, each
-dispositioned.
+Boundary-change enumeration: a diff changing a guard, validator, normalizer,
+resolver, router/classifier, or admission boundary must ship a plan-doc
+enumeration before code: replaced-path behaviors, guard-relevant fields, and
+every caller x input shape, each dispositioned.
 
 This applies when the diff changes the decision seam that admits, rejects,
 normalizes, resolves identity for, or routes an input. The plan's enumeration is
 the baton that survives compaction: list the old behavior being replaced, the
 fields that influence the guard or resolver verdict, and each caller/input shape
 that can reach each changed boundary; name each changed boundary path or seam and
-mark every row preserved, intentionally changed, rejected, deferred, or not
-applicable. Do this before implementation, not as a post-review inventory.
+give that exact boundary entry its own complete disposition group. Mark every row
+preserved, intentionally changed, rejected, deferred, or not applicable. Do this
+before implementation, not as a post-review inventory.
 
 This rule does not weaken 3k.3. For open-input recognizers, enumerate the
 boundary surface and dispositions, then close the recognizer with the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1229,6 +1229,26 @@ interpreter/import setup"). Review cost is not predicted by diff size --
 #2117 (+2813) took 3 rounds, #2181 (+2569) took 20 -- it is predicted by whether
 the slice hand-rolled an open surface.
 
+### 3k.5. Boundary-change enumeration
+
+Boundary-change enumeration: a diff changing a guard, validator, resolver, or
+admission boundary must ship a plan-doc enumeration before code: replaced-path
+behaviors, guard-relevant fields, and every caller x input shape, each
+dispositioned.
+
+This applies when the diff changes the decision seam that admits, rejects,
+normalizes, resolves identity for, or routes an input. The plan's enumeration is
+the baton that survives compaction: list the old behavior being replaced, the
+fields that influence the guard or resolver verdict, and each caller/input shape
+that can reach the boundary; mark every row preserved, intentionally changed,
+rejected, deferred, or not applicable. Do this before implementation, not as a
+post-review inventory.
+
+This rule does not weaken 3k.3. For open-input recognizers, enumerate the
+boundary surface and dispositions, then close the recognizer with the
+evidence-gated/defaulted mechanism 3k.3 requires rather than trying to enumerate
+the whole open category.
+
 ### 3l. PR fix mode (constrain the fix loop)
 
 A **fix loop** -- iterating on red CI or review comments on an already-open PR

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1240,9 +1240,9 @@ This applies when the diff changes the decision seam that admits, rejects,
 normalizes, resolves identity for, or routes an input. The plan's enumeration is
 the baton that survives compaction: list the old behavior being replaced, the
 fields that influence the guard or resolver verdict, and each caller/input shape
-that can reach the boundary; mark every row preserved, intentionally changed,
-rejected, deferred, or not applicable. Do this before implementation, not as a
-post-review inventory.
+that can reach each changed boundary; name each changed boundary path or seam and
+mark every row preserved, intentionally changed, rejected, deferred, or not
+applicable. Do this before implementation, not as a post-review inventory.
 
 This rule does not weaken 3k.3. For open-input recognizers, enumerate the
 boundary surface and dispositions, then close the recognizer with the

--- a/plans/PR-Boundary-Change-Enumeration.md
+++ b/plans/PR-Boundary-Change-Enumeration.md
@@ -1,0 +1,139 @@
+# PR-Boundary-Change-Enumeration
+
+## Why this slice exists
+
+Juan asked this codification session to turn observed builder failure patterns
+into repo-enforced rules that survive context compaction. The first priority is
+boundary-change enumeration: when a guard, validator, resolver, or admission
+boundary changes, the plan must enumerate replaced-path behaviors,
+guard-relevant fields, and every caller x input shape before code. The evidence
+claims in the handoff remain claims, but the current code confirms there is no
+existing AGENTS subsection or CI tripwire requiring this broader enumeration.
+The qualifying blocker is the observed boundary-ripple class from ATLAS #2216
+rounds 1-7 and Website #70 rounds 1-4: a builder can change a decision seam and
+only discover replaced-path/caller/input-shape fallout after repeated review
+rounds. This detector is open-input work over free-form diffs, so the closure
+mechanism is a bounded recognizer: code suffix filtering is the choke point,
+boundary-shaped paths or declarations warn by default, and tests cover each
+detection branch plus section-scoped plan parsing as bounded evidence rather
+than an exhaustive language parser. This slice is over the 400 LOC target
+because the single rule is required to ship as law, template, tripwire,
+scaffold regression, and both-direction detector tests together; splitting would
+leave either an unenforced rule or a checker without the required authoring
+prompt/evidence.
+
+### Problem-derived contract
+
+- Root cause: Atlas has guard class-closure and open-input method rules, but a
+  boundary rewrite can still reach code review without a plan-time inventory of
+  the behavior it replaces, the fields that affect its verdict, and the callers
+  that feed it.
+- Correct fix must touch/change: add the rule to `AGENTS.md`, add the prompt to
+  the plan scaffold, add an advisory CI tripwire whose warning quotes the rule,
+  and prove the tripwire fires and stays silent with unit fixtures plus the
+  generated scaffold fields.
+- Must not change: product/runtime behavior, reviewer strength, review-round
+  caps, required branch protection checks, existing open PR branches, or
+  EOM/timetracker working copies.
+
+## Scope (this PR)
+
+Ownership lane: dev-workflow/codification
+Slice phase: Workflow/process
+
+1. Add the boundary-change enumeration rule to Atlas builder law.
+2. Add the corresponding plan-template prompt and advisory detector.
+3. Add both-direction detector tests and generated-scaffold coverage.
+
+### Review Contract
+
+- Acceptance criteria:
+  - `AGENTS.md` contains the verbatim boundary-change rule and states that it
+    does not weaken the existing open-input evidence-gate.
+  - `scripts/new_pr_plan.sh` scaffolds a `### Boundary-change enumeration`
+    subsection with replaced-path behavior, guard-relevant field, and caller x
+    input-shape prompts.
+  - `.github/workflows/boundary_change_enumeration.yml` runs on
+    `pull_request`, has read-only permissions, and runs the detector advisory.
+  - `tests/test_check_boundary_change_enumeration.py` proves a violating
+    boundary-shaped diff warns and a compliant plan stays silent.
+  - `tests/test_new_pr_plan.py` proves the generated scaffold keeps the
+    boundary-change enumeration heading, applicability instruction, and rows.
+- Reachability proof: CI/workflow-only surface; the observable gate is the new
+  workflow invoking python scripts/check_boundary_change_enumeration.py.
+- Affected surfaces: builder workflow docs, plan scaffold, advisory CI,
+  detector tests, and scaffold regression.
+- Risk areas: false positives, silent false negatives, contradiction with
+  open-input 3k.3, accidental required/blocking gate.
+- Reviewer rules triggered: R1, R2, R10, R12.
+
+### Boundary-change enumeration
+
+N/A - this PR adds the boundary-change rule and detector, but it does not change
+an Atlas product guard, validator, resolver, or admission boundary.
+
+- Replaced-path behaviors: N/A.
+- Guard-relevant fields: N/A.
+- Caller x input shape: N/A.
+
+### Files touched
+
+- `AGENTS.md`
+- `scripts/new_pr_plan.sh`
+- `scripts/check_boundary_change_enumeration.py`
+- `tests/test_check_boundary_change_enumeration.py`
+- `tests/test_new_pr_plan.py`
+- `.github/workflows/boundary_change_enumeration.yml`
+- `plans/PR-Boundary-Change-Enumeration.md`
+
+## Mechanism
+
+`AGENTS.md` gains a short imperative §3k.5 rule. `new_pr_plan.sh` adds a
+matching optional subsection so the requirement appears while the plan is being
+written. `check_boundary_change_enumeration.py` scans changed Python,
+JavaScript, and TypeScript-family files for boundary-shaped path/function/class
+signals and warns unless the `### Boundary-change enumeration` section carries
+non-placeholder rows for replaced-path behaviors, guard-relevant fields, and
+caller x input shape. The self-bootstrap exemption is limited to this detector;
+other checker/admission files still scan. The workflow runs the detector on PRs
+and emits warnings only.
+
+## Intentional
+
+- The detector is heuristic and advisory-first; it exits 0 unless `--strict` is
+  supplied.
+- The detector requires section-scoped, non-placeholder rows rather than
+  attempting to verify the semantic quality of each enumeration row.
+- The rule explicitly preserves 3k.3 so open-input work still needs an
+  evidence-gated/defaulted mechanism.
+
+## Deferred
+
+- Promotion to a required check is deferred to a later operator decision after
+  advisory evidence exists.
+- Porting or enforcing this rule in EOM repos is deferred unless Juan asks for
+  separate law-only repo PRs.
+
+Parked hardening: none.
+
+## Verification
+
+- python -m pytest tests/test_check_boundary_change_enumeration.py -q --noconftest - 13 passed.
+- python -m pytest tests/test_new_pr_plan.py -q --noconftest - 16 passed.
+- python scripts/check_boundary_change_enumeration.py --base origin/main - OK.
+- python scripts/audit_plan_doc.py plans/PR-Boundary-Change-Enumeration.md - OK.
+- python scripts/audit_plan_doc_files_touched.py plans/PR-Boundary-Change-Enumeration.md origin/main - OK.
+- python scripts/audit_plan_doc_diff_size.py plans/PR-Boundary-Change-Enumeration.md origin/main - OK.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `AGENTS.md` | +20 |
+| `scripts/new_pr_plan.sh` | +9 |
+| `scripts/check_boundary_change_enumeration.py` | +200 |
+| `tests/test_check_boundary_change_enumeration.py` | +134 |
+| `tests/test_new_pr_plan.py` | +5 |
+| `.github/workflows/boundary_change_enumeration.yml` | +46 |
+| `plans/PR-Boundary-Change-Enumeration.md` | +118 |
+| **Total** | **~553** |

--- a/plans/PR-Boundary-Change-Enumeration.md
+++ b/plans/PR-Boundary-Change-Enumeration.md
@@ -4,11 +4,12 @@
 
 Juan asked this codification session to turn observed builder failure patterns
 into repo-enforced rules that survive context compaction. The first priority is
-boundary-change enumeration: when a guard, validator, resolver, or admission
-boundary changes, the plan must enumerate replaced-path behaviors,
-guard-relevant fields, and every caller x input shape before code. The evidence
-claims in the handoff remain claims, but the current code confirms there is no
-existing AGENTS subsection or CI tripwire requiring this broader enumeration.
+boundary-change enumeration: when a guard, validator, normalizer, resolver,
+router/classifier, or admission boundary changes, the plan must enumerate
+replaced-path behaviors, guard-relevant fields, and every caller x input shape
+before code. The evidence claims in the handoff remain claims, but the current
+code confirms there is no existing AGENTS subsection or CI tripwire requiring
+this broader enumeration.
 The qualifying blocker is the observed boundary-ripple class from ATLAS #2216
 rounds 1-7 and Website #70 rounds 1-4: a builder can change a decision seam and
 only discover replaced-path/caller/input-shape fallout after repeated review
@@ -70,11 +71,23 @@ Slice phase: Workflow/process
 ### Boundary-change enumeration
 
 N/A - this PR adds the boundary-change rule and detector, but it does not change
-an Atlas product guard, validator, resolver, or admission boundary.
+an Atlas product guard, validator, normalizer, resolver, router/classifier, or
+admission boundary.
 
 - Replaced-path behaviors: N/A.
 - Guard-relevant fields: N/A.
 - Caller x input shape: N/A.
+
+Set-valued dependency closure for this detector:
+
+| Dependency | Disposition | Closure source/default |
+|---|---|---|
+| `CODE_SUFFIXES` | CLOSED | Finite repo-owned executable/text code suffixes scanned by this advisory: py, js, jsx, ts, tsx, mjs, cjs, sh. Omitted suffixes are out of scope until added with a failing fixture. |
+| Test-file suffix exclusions | DERIVED | Derived from the admitted Python/JS-family suffixes plus repo test naming conventions: test-prefix files, tests directories, Python underscore-test modules, and dot-test/dot-spec files for admitted JS suffixes. Test-only files default to no boundary warning. |
+| Boundary path/name regex alternatives | DEFAULTED | Open recognizer over observed decision-seam vocabulary; omitted semantic names default to no advisory warning and must be added only with a held-out failing fixture. The cheap side is advisory silence, not runtime behavior or reviewer waiver. |
+| Required disposition markers | CLOSED | The rule requires exactly these plan rows: replaced-path behaviors, guard-relevant fields, and caller x input shape. |
+| Placeholder/unresolved marker vocabulary | CLOSED | Explicit unresolved marker strings are rejected by `PLACEHOLDER_VALUES` and `UNRESOLVED_VALUE_RE`; new placeholder words require a failing parser fixture before expansion. |
+| Boundary path/seam matching | DEFAULTED | Exact changed path, detected seam name, or qualified class-method seam only; unmatched names default to warning so same-stem, same bare method name, or unrelated boundary entries cannot cover a distinct changed seam. |
 
 ### Files touched
 
@@ -93,15 +106,20 @@ matching optional subsection so the requirement appears while the plan is being
 written. `check_boundary_change_enumeration.py` scans changed Python,
 JavaScript, TypeScript-family, and shell files for added or removed
 boundary-shaped path/function/method/class signals, including normalizing,
-routing, allowed/allow, and classify seams, and warns unless the
+routing, allowed/allow, classify, eligibility, and TypeScript return-annotated
+method seams, and warns unless the
 `### Boundary-change enumeration` section carries non-placeholder rows for
 replaced-path behaviors, guard-relevant fields, and caller x input shape. A
 reasoned section-level not-applicable statement covers bare `N/A` rows so the
 generated scaffold's own instruction is accepted. Otherwise each changed
-boundary path or seam must be named in the section, so one valid inventory cannot
-hide an unrelated second boundary. Every duplicate enumeration row must be
-independently dispositioned so a later TODO cannot hide behind an earlier valid
-row. The self-bootstrap exemption is limited to this detector; other
+boundary path or seam must be named as an exact boundary entry with its own
+complete disposition group, so one valid inventory cannot hide an unrelated
+second boundary, a same-name file elsewhere, or a second class method that
+shares the same bare method name. Changed plan files are read relative to the
+repository root so invoking the checker from a subdirectory cannot silently
+drop the plan evidence. Every duplicate enumeration row must be independently
+dispositioned so a later TODO/TBD/unknown/pending value cannot hide behind an
+earlier valid row. The self-bootstrap exemption is limited to this detector; other
 checker/admission files still scan. The workflow runs the detector on PRs and
 emits warnings only.
 
@@ -126,7 +144,7 @@ Parked hardening: none.
 
 ## Verification
 
-- python -m pytest tests/test_check_boundary_change_enumeration.py tests/test_new_pr_plan.py -q --noconftest - 42 passed.
+- python -m pytest tests/test_check_boundary_change_enumeration.py tests/test_new_pr_plan.py -q --noconftest - 57 passed.
 - python scripts/check_boundary_change_enumeration.py --base origin/main - OK.
 - python scripts/check_boundary_change_enumeration.py --base origin/main --strict - OK.
 - git diff --check - OK.
@@ -140,11 +158,11 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `AGENTS.md` | +20 |
+| `AGENTS.md` | +21 |
 | `scripts/new_pr_plan.sh` | +11 |
-| `scripts/check_boundary_change_enumeration.py` | +260 |
-| `tests/test_check_boundary_change_enumeration.py` | +263 |
-| `tests/test_new_pr_plan.py` | +7 |
+| `scripts/check_boundary_change_enumeration.py` | +418 |
+| `tests/test_check_boundary_change_enumeration.py` | +521 |
+| `tests/test_new_pr_plan.py` | +11 |
 | `.github/workflows/boundary_change_enumeration.yml` | +46 |
-| `plans/PR-Boundary-Change-Enumeration.md` | +150 |
-| **Total** | **~760** |
+| `plans/PR-Boundary-Change-Enumeration.md` | +170 |
+| **Total** | **~1200** |

--- a/plans/PR-Boundary-Change-Enumeration.md
+++ b/plans/PR-Boundary-Change-Enumeration.md
@@ -92,11 +92,13 @@ an Atlas product guard, validator, resolver, or admission boundary.
 matching optional subsection so the requirement appears while the plan is being
 written. `check_boundary_change_enumeration.py` scans changed Python,
 JavaScript, TypeScript-family, and shell files for added or removed
-boundary-shaped path/function/method/class signals and warns unless the `### Boundary-change
-enumeration` section carries non-placeholder rows for replaced-path behaviors,
-guard-relevant fields, and caller x input shape. The self-bootstrap exemption is
-limited to this detector; other checker/admission files still scan. The workflow
-runs the detector on PRs and emits warnings only.
+boundary-shaped path/function/method/class signals, including normalizing and
+routing seams, and warns unless the `### Boundary-change enumeration` section
+carries non-placeholder rows for replaced-path behaviors, guard-relevant fields,
+and caller x input shape. Every duplicate enumeration row must be independently
+dispositioned so a later TODO cannot hide behind an earlier valid row. The
+self-bootstrap exemption is limited to this detector; other checker/admission
+files still scan. The workflow runs the detector on PRs and emits warnings only.
 
 ## Intentional
 
@@ -118,9 +120,10 @@ Parked hardening: none.
 
 ## Verification
 
-- python -m pytest tests/test_check_boundary_change_enumeration.py -q --noconftest - 19 passed.
+- python -m pytest tests/test_check_boundary_change_enumeration.py -q --noconftest - 22 passed.
 - python -m pytest tests/test_new_pr_plan.py -q --noconftest - 16 passed.
 - python scripts/check_boundary_change_enumeration.py --base origin/main - OK.
+- python scripts/check_boundary_change_enumeration.py --base origin/main --strict - OK.
 - python scripts/audit_plan_doc.py plans/PR-Boundary-Change-Enumeration.md - OK.
 - python scripts/audit_plan_doc_files_touched.py plans/PR-Boundary-Change-Enumeration.md origin/main - OK.
 - python scripts/audit_plan_doc_diff_size.py plans/PR-Boundary-Change-Enumeration.md origin/main - OK.
@@ -136,4 +139,4 @@ Parked hardening: none.
 | `tests/test_new_pr_plan.py` | +5 |
 | `.github/workflows/boundary_change_enumeration.yml` | +46 |
 | `plans/PR-Boundary-Change-Enumeration.md` | +139 |
-| **Total** | **~604** |
+| **Total** | **~650** |

--- a/plans/PR-Boundary-Change-Enumeration.md
+++ b/plans/PR-Boundary-Change-Enumeration.md
@@ -91,12 +91,12 @@ an Atlas product guard, validator, resolver, or admission boundary.
 `AGENTS.md` gains a short imperative §3k.5 rule. `new_pr_plan.sh` adds a
 matching optional subsection so the requirement appears while the plan is being
 written. `check_boundary_change_enumeration.py` scans changed Python,
-JavaScript, and TypeScript-family files for boundary-shaped path/function/class
-signals and warns unless the `### Boundary-change enumeration` section carries
-non-placeholder rows for replaced-path behaviors, guard-relevant fields, and
-caller x input shape. The self-bootstrap exemption is limited to this detector;
-other checker/admission files still scan. The workflow runs the detector on PRs
-and emits warnings only.
+JavaScript, TypeScript-family, and shell files for added or removed
+boundary-shaped path/function/method/class signals and warns unless the `### Boundary-change
+enumeration` section carries non-placeholder rows for replaced-path behaviors,
+guard-relevant fields, and caller x input shape. The self-bootstrap exemption is
+limited to this detector; other checker/admission files still scan. The workflow
+runs the detector on PRs and emits warnings only.
 
 ## Intentional
 
@@ -118,7 +118,7 @@ Parked hardening: none.
 
 ## Verification
 
-- python -m pytest tests/test_check_boundary_change_enumeration.py -q --noconftest - 13 passed.
+- python -m pytest tests/test_check_boundary_change_enumeration.py -q --noconftest - 19 passed.
 - python -m pytest tests/test_new_pr_plan.py -q --noconftest - 16 passed.
 - python scripts/check_boundary_change_enumeration.py --base origin/main - OK.
 - python scripts/audit_plan_doc.py plans/PR-Boundary-Change-Enumeration.md - OK.
@@ -131,9 +131,9 @@ Parked hardening: none.
 |---|---:|
 | `AGENTS.md` | +20 |
 | `scripts/new_pr_plan.sh` | +9 |
-| `scripts/check_boundary_change_enumeration.py` | +200 |
-| `tests/test_check_boundary_change_enumeration.py` | +134 |
+| `scripts/check_boundary_change_enumeration.py` | +210 |
+| `tests/test_check_boundary_change_enumeration.py` | +175 |
 | `tests/test_new_pr_plan.py` | +5 |
 | `.github/workflows/boundary_change_enumeration.yml` | +46 |
-| `plans/PR-Boundary-Change-Enumeration.md` | +118 |
-| **Total** | **~553** |
+| `plans/PR-Boundary-Change-Enumeration.md` | +139 |
+| **Total** | **~604** |

--- a/plans/PR-Boundary-Change-Enumeration.md
+++ b/plans/PR-Boundary-Change-Enumeration.md
@@ -51,8 +51,8 @@ Slice phase: Workflow/process
   - `AGENTS.md` contains the verbatim boundary-change rule and states that it
     does not weaken the existing open-input evidence-gate.
   - `scripts/new_pr_plan.sh` scaffolds a `### Boundary-change enumeration`
-    subsection with replaced-path behavior, guard-relevant field, and caller x
-    input-shape prompts.
+    subsection with changed boundary path/seam, replaced-path behavior,
+    guard-relevant field, and caller x input-shape prompts.
   - `.github/workflows/boundary_change_enumeration.yml` runs on
     `pull_request`, has read-only permissions, and runs the detector advisory.
   - `tests/test_check_boundary_change_enumeration.py` proves a violating
@@ -65,7 +65,7 @@ Slice phase: Workflow/process
   detector tests, and scaffold regression.
 - Risk areas: false positives, silent false negatives, contradiction with
   open-input 3k.3, accidental required/blocking gate.
-- Reviewer rules triggered: R1, R2, R10, R12.
+- Reviewer rules triggered: R1, R2, R10, R12, R13.
 
 ### Boundary-change enumeration
 
@@ -92,20 +92,26 @@ an Atlas product guard, validator, resolver, or admission boundary.
 matching optional subsection so the requirement appears while the plan is being
 written. `check_boundary_change_enumeration.py` scans changed Python,
 JavaScript, TypeScript-family, and shell files for added or removed
-boundary-shaped path/function/method/class signals, including normalizing and
-routing seams, and warns unless the `### Boundary-change enumeration` section
-carries non-placeholder rows for replaced-path behaviors, guard-relevant fields,
-and caller x input shape. Every duplicate enumeration row must be independently
-dispositioned so a later TODO cannot hide behind an earlier valid row. The
-self-bootstrap exemption is limited to this detector; other checker/admission
-files still scan. The workflow runs the detector on PRs and emits warnings only.
+boundary-shaped path/function/method/class signals, including normalizing,
+routing, allowed/allow, and classify seams, and warns unless the
+`### Boundary-change enumeration` section carries non-placeholder rows for
+replaced-path behaviors, guard-relevant fields, and caller x input shape. A
+reasoned section-level not-applicable statement covers bare `N/A` rows so the
+generated scaffold's own instruction is accepted. Otherwise each changed
+boundary path or seam must be named in the section, so one valid inventory cannot
+hide an unrelated second boundary. Every duplicate enumeration row must be
+independently dispositioned so a later TODO cannot hide behind an earlier valid
+row. The self-bootstrap exemption is limited to this detector; other
+checker/admission files still scan. The workflow runs the detector on PRs and
+emits warnings only.
 
 ## Intentional
 
 - The detector is heuristic and advisory-first; it exits 0 unless `--strict` is
   supplied.
-- The detector requires section-scoped, non-placeholder rows rather than
-  attempting to verify the semantic quality of each enumeration row.
+- The detector requires section-scoped, non-placeholder rows and changed-boundary
+  path/seam association rather than attempting to verify the semantic quality of
+  each enumeration row.
 - The rule explicitly preserves 3k.3 so open-input work still needs an
   evidence-gated/defaulted mechanism.
 
@@ -120,23 +126,25 @@ Parked hardening: none.
 
 ## Verification
 
-- python -m pytest tests/test_check_boundary_change_enumeration.py -q --noconftest - 22 passed.
-- python -m pytest tests/test_new_pr_plan.py -q --noconftest - 16 passed.
+- python -m pytest tests/test_check_boundary_change_enumeration.py tests/test_new_pr_plan.py -q --noconftest - 42 passed.
 - python scripts/check_boundary_change_enumeration.py --base origin/main - OK.
 - python scripts/check_boundary_change_enumeration.py --base origin/main --strict - OK.
+- git diff --check - OK.
 - python scripts/audit_plan_doc.py plans/PR-Boundary-Change-Enumeration.md - OK.
 - python scripts/audit_plan_doc_files_touched.py plans/PR-Boundary-Change-Enumeration.md origin/main - OK.
 - python scripts/audit_plan_doc_diff_size.py plans/PR-Boundary-Change-Enumeration.md origin/main - OK.
+- python scripts/audit_plan_code_consistency.py plans/PR-Boundary-Change-Enumeration.md - OK.
+- python scripts/audit_review_rules_triggered.py origin/main --plan plans/PR-Boundary-Change-Enumeration.md - OK.
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
 | `AGENTS.md` | +20 |
-| `scripts/new_pr_plan.sh` | +9 |
-| `scripts/check_boundary_change_enumeration.py` | +210 |
-| `tests/test_check_boundary_change_enumeration.py` | +175 |
-| `tests/test_new_pr_plan.py` | +5 |
+| `scripts/new_pr_plan.sh` | +11 |
+| `scripts/check_boundary_change_enumeration.py` | +260 |
+| `tests/test_check_boundary_change_enumeration.py` | +263 |
+| `tests/test_new_pr_plan.py` | +7 |
 | `.github/workflows/boundary_change_enumeration.yml` | +46 |
-| `plans/PR-Boundary-Change-Enumeration.md` | +139 |
-| **Total** | **~650** |
+| `plans/PR-Boundary-Change-Enumeration.md` | +150 |
+| **Total** | **~760** |

--- a/scripts/check_boundary_change_enumeration.py
+++ b/scripts/check_boundary_change_enumeration.py
@@ -20,29 +20,32 @@ RULE = (
 CODE_SUFFIXES = {".py", ".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".sh"}
 BOUNDARY_PATH_PART_RE = re.compile(
     r"(^|[-_./])"
-    r"(guard|validat(?:e|or|ion)?|normaliz(?:e|er|ation|ing)?|resolver|resolution|admission|intake|"
-    r"route|router|routing|dedupe|scope|tenant|auth(?:entication|orization)?)"
+    r"(guard|gate|validat(?:e|or|ion)?|normaliz(?:e|er|ation|ing)?|resolver|resolution|admission|intake|"
+    r"route|router|routing|classif(?:y|ier|ication)?|dedupe|scope|tenant|auth(?:entication|orization)?)"
     r"($|[-_./])",
     re.IGNORECASE,
+)
+BOUNDARY_NAME_TOKEN = (
+    r"guard|gate|validat|normaliz|resolve|admit|reject|allow|allowed|route|classif|dedupe|scope|auth"
 )
 BOUNDARY_CODE_RE = re.compile(
     r"^(?:[+-]\s*|@@[^@\n]*@@\s*.*?)"
     r"(?:"
     r"(?:export\s+)?(?:async\s+)?function\s+"
-    r"[a-zA-Z0-9_$]*(?:guard|validat|normaliz|resolve|admit|reject|dedupe|scope|auth)"
+    r"[a-zA-Z0-9_$]*(?:" + BOUNDARY_NAME_TOKEN + r")"
     r"[a-zA-Z0-9_$]*\s*\("
     r"|(?:async\s+)?def\s+"
-    r"[a-zA-Z0-9_]*(?:guard|validat|normaliz|resolve|admit|reject|dedupe|scope|auth)"
+    r"[a-zA-Z0-9_]*(?:" + BOUNDARY_NAME_TOKEN + r")"
     r"[a-zA-Z0-9_]*\s*\("
     r"|(?:const|let|var)\s+"
-    r"[a-zA-Z0-9_$]*(?:Guard|Validat|Normaliz|Resolve|Admit|Reject|Dedupe|Scope|Auth)"
+    r"[a-zA-Z0-9_$]*(?:Guard|Gate|Validat|Normaliz|Resolve|Admit|Reject|Allow|Allowed|Route|Classif|Dedupe|Scope|Auth)"
     r"[a-zA-Z0-9_$]*\s*="
     r"|class\s+[a-zA-Z0-9_$]*(?:Guard|Validator|Resolver|Admission|Authenticator|"
     r"Authentication|Authorization|AuthGate|AuthProvider|AuthValidator|AuthResolver)"
     r"[a-zA-Z0-9_$]*"
-    r"|(?:async\s+)?[a-zA-Z0-9_$]*(?:guard|validat|normaliz|resolve|admit|reject|dedupe|scope|auth)"
+    r"|(?:async\s+)?[a-zA-Z0-9_$]*(?:" + BOUNDARY_NAME_TOKEN + r")"
     r"[a-zA-Z0-9_$]*\s*\([^)]*\)\s*\{"
-    r"|(?:function\s+)?[a-zA-Z0-9_]*(?:guard|validat|normaliz|resolve|admit|reject|dedupe|scope|auth)"
+    r"|(?:function\s+)?[a-zA-Z0-9_]*(?:" + BOUNDARY_NAME_TOKEN + r")"
     r"[a-zA-Z0-9_]*\s*\(\)\s*\{"
     r")",
     re.MULTILINE | re.IGNORECASE,
@@ -119,12 +122,24 @@ def _marker_values(section: str, marker: str) -> list[str]:
     return values
 
 
-def _is_dispositioned_value(value: str | None) -> bool:
+def _has_section_level_not_applicable(section: str) -> bool:
+    for line in section.splitlines():
+        stripped = line.strip().lower().rstrip(".")
+        if stripped.startswith(("-", "*")):
+            continue
+        if stripped.startswith(("n/a -", "na -", "not applicable -")):
+            return True
+    return False
+
+
+def _is_dispositioned_value(value: str | None, *, section_not_applicable: bool = False) -> bool:
     if value is None:
         return False
     normalized = value.strip().lower()
     if "todo" in normalized:
         return False
+    if section_not_applicable and normalized in {"n/a", "na", "not applicable"}:
+        return True
     if normalized.startswith(("n/a -", "na -", "not applicable -")):
         return True
     return normalized not in PLACEHOLDER_VALUES
@@ -134,22 +149,49 @@ def plan_has_boundary_enumeration(plan_text: str) -> bool:
     if "boundary-change enumeration" not in plan_text.lower():
         return False
     section = boundary_enumeration_section(plan_text)
+    section_not_applicable = _has_section_level_not_applicable(section)
     for marker in DISPOSITION_MARKERS:
         values = _marker_values(section, marker)
         if not values:
             return False
-        if not all(_is_dispositioned_value(value) for value in values):
+        if not all(
+            _is_dispositioned_value(value, section_not_applicable=section_not_applicable)
+            for value in values
+        ):
             return False
     return True
 
 
+def _path_mentions(path: str, section: str) -> bool:
+    section_lower = section.lower()
+    p = PurePosixPath(path)
+    candidates = {
+        path.lower(),
+        p.name.lower(),
+        p.stem.lower(),
+        p.stem.lower().replace("_", "-"),
+        p.stem.lower().replace("-", "_"),
+        p.stem.lower().replace("_", " "),
+        p.stem.lower().replace("-", " "),
+    }
+    return any(candidate and candidate in section_lower for candidate in candidates)
+
+
+def plan_covers_boundary_path(plan_text: str, path: str) -> bool:
+    if not plan_has_boundary_enumeration(plan_text):
+        return False
+    section = boundary_enumeration_section(plan_text)
+    if _has_section_level_not_applicable(section):
+        return True
+    return _path_mentions(path, section)
+
+
 def scan_diff(added_by_file: Mapping[str, str], plan_texts: Sequence[str]) -> list[Finding]:
-    has_plan_enumeration = any(plan_has_boundary_enumeration(text) for text in plan_texts)
     findings: list[Finding] = []
     for path, added in sorted(added_by_file.items()):
         if not file_is_boundary_shaped(path, added):
             continue
-        if has_plan_enumeration:
+        if any(plan_covers_boundary_path(text, path) for text in plan_texts):
             continue
         findings.append(Finding(path=path, reason=RULE))
     return findings

--- a/scripts/check_boundary_change_enumeration.py
+++ b/scripts/check_boundary_change_enumeration.py
@@ -21,7 +21,7 @@ CODE_SUFFIXES = {".py", ".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".sh"}
 BOUNDARY_PATH_PART_RE = re.compile(
     r"(^|[-_./])"
     r"(guard|validat(?:e|or|ion)?|normaliz(?:e|er|ation|ing)?|resolver|resolution|admission|intake|"
-    r"dedupe|scope|tenant|auth(?:entication|orization)?)"
+    r"route|router|routing|dedupe|scope|tenant|auth(?:entication|orization)?)"
     r"($|[-_./])",
     re.IGNORECASE,
 )
@@ -37,7 +37,8 @@ BOUNDARY_CODE_RE = re.compile(
     r"|(?:const|let|var)\s+"
     r"[a-zA-Z0-9_$]*(?:Guard|Validat|Normaliz|Resolve|Admit|Reject|Dedupe|Scope|Auth)"
     r"[a-zA-Z0-9_$]*\s*="
-    r"|class\s+[a-zA-Z0-9_$]*(?:Guard|Validator|Resolver|Admission|Auth)"
+    r"|class\s+[a-zA-Z0-9_$]*(?:Guard|Validator|Resolver|Admission|Authenticator|"
+    r"Authentication|Authorization|AuthGate|AuthProvider|AuthValidator|AuthResolver)"
     r"[a-zA-Z0-9_$]*"
     r"|(?:async\s+)?[a-zA-Z0-9_$]*(?:guard|validat|normaliz|resolve|admit|reject|dedupe|scope|auth)"
     r"[a-zA-Z0-9_$]*\s*\([^)]*\)\s*\{"
@@ -104,17 +105,18 @@ def boundary_enumeration_section(text: str) -> str:
     return "\n".join(lines)
 
 
-def _marker_value(section: str, marker: str) -> str | None:
+def _marker_values(section: str, marker: str) -> list[str]:
     marker_lower = marker.lower()
+    values: list[str] = []
     for line in section.splitlines():
         if ":" not in line:
             continue
         label, value = line.split(":", 1)
         label = label.strip().lstrip("-*0123456789. ").strip().lower()
-        if label != marker_lower:
+        if label != marker_lower and not label.startswith(f"{marker_lower} "):
             continue
-        return value.strip().rstrip(".").lower()
-    return None
+        values.append(value.strip().rstrip(".").lower())
+    return values
 
 
 def _is_dispositioned_value(value: str | None) -> bool:
@@ -132,7 +134,13 @@ def plan_has_boundary_enumeration(plan_text: str) -> bool:
     if "boundary-change enumeration" not in plan_text.lower():
         return False
     section = boundary_enumeration_section(plan_text)
-    return all(_is_dispositioned_value(_marker_value(section, marker)) for marker in DISPOSITION_MARKERS)
+    for marker in DISPOSITION_MARKERS:
+        values = _marker_values(section, marker)
+        if not values:
+            return False
+        if not all(_is_dispositioned_value(value) for value in values):
+            return False
+    return True
 
 
 def scan_diff(added_by_file: Mapping[str, str], plan_texts: Sequence[str]) -> list[Finding]:

--- a/scripts/check_boundary_change_enumeration.py
+++ b/scripts/check_boundary_change_enumeration.py
@@ -11,8 +11,9 @@ from typing import Mapping, Sequence
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 RULE = (
-    "Boundary-change enumeration: a diff changing a guard, validator, resolver, "
-    "or admission boundary must ship a plan-doc enumeration before code: "
+    "Boundary-change enumeration: a diff changing a guard, validator, normalizer, "
+    "resolver, router/classifier, or admission boundary must ship a plan-doc "
+    "enumeration before code: "
     "replaced-path behaviors, guard-relevant fields, and every caller x input "
     "shape, each dispositioned."
 )
@@ -21,13 +22,14 @@ CODE_SUFFIXES = {".py", ".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".sh"}
 BOUNDARY_PATH_PART_RE = re.compile(
     r"(^|[-_./])"
     r"(guard|gate|validat(?:e|or|ion)?|normaliz(?:e|er|ation|ing)?|resolver|resolution|admission|intake|"
-    r"route|router|routing|classif(?:y|ier|ication)?|dedupe|scope|tenant|auth(?:entication|orization)?)"
+    r"route|router|routing|classif(?:y|ier|ication)?|eligib(?:le|ility)?|dedupe|scope|tenant|auth(?:entication|orization)?)"
     r"($|[-_./])",
     re.IGNORECASE,
 )
 BOUNDARY_NAME_TOKEN = (
-    r"guard|gate|validat|normaliz|resolve|admit|reject|allow|allowed|route|classif|dedupe|scope|auth"
+    r"guard|gate|validat|normaliz|resolve|admit|reject|allow|allowed|route|classif|eligib|should_scrape|dedupe|scope|auth"
 )
+BOUNDARY_NAME_RE = re.compile(BOUNDARY_NAME_TOKEN, re.IGNORECASE)
 BOUNDARY_CODE_RE = re.compile(
     r"^(?:[+-]\s*|@@[^@\n]*@@\s*.*?)"
     r"(?:"
@@ -38,15 +40,29 @@ BOUNDARY_CODE_RE = re.compile(
     r"[a-zA-Z0-9_]*(?:" + BOUNDARY_NAME_TOKEN + r")"
     r"[a-zA-Z0-9_]*\s*\("
     r"|(?:const|let|var)\s+"
-    r"[a-zA-Z0-9_$]*(?:Guard|Gate|Validat|Normaliz|Resolve|Admit|Reject|Allow|Allowed|Route|Classif|Dedupe|Scope|Auth)"
-    r"[a-zA-Z0-9_$]*\s*="
+    r"[a-zA-Z0-9_$]*(?:Guard|Gate|Validat|Normaliz|Resolve|Admit|Reject|Allow|Allowed|Route|Classif|Eligib|Dedupe|Scope|Auth)"
+    r"[a-zA-Z0-9_$]*\s*=\s*(?:(?:async\s+)?(?:\([^)]*\)|[a-zA-Z_$][a-zA-Z0-9_$]*)\s*=>|function\b)"
     r"|class\s+[a-zA-Z0-9_$]*(?:Guard|Validator|Resolver|Admission|Authenticator|"
     r"Authentication|Authorization|AuthGate|AuthProvider|AuthValidator|AuthResolver)"
     r"[a-zA-Z0-9_$]*"
-    r"|(?:async\s+)?[a-zA-Z0-9_$]*(?:" + BOUNDARY_NAME_TOKEN + r")"
-    r"[a-zA-Z0-9_$]*\s*\([^)]*\)\s*\{"
+    r"|(?:(?:public|private|protected|static|override|readonly)\s+)*(?:async\s+)?"
+    r"[a-zA-Z0-9_$]*(?:" + BOUNDARY_NAME_TOKEN + r")"
+    r"[a-zA-Z0-9_$]*\s*\([^)]*\)\s*(?::\s*[^={;]+)?\{"
     r"|(?:function\s+)?[a-zA-Z0-9_]*(?:" + BOUNDARY_NAME_TOKEN + r")"
     r"[a-zA-Z0-9_]*\s*\(\)\s*\{"
+    r")",
+    re.MULTILINE | re.IGNORECASE,
+)
+BOUNDARY_SEAM_RE = re.compile(
+    r"^(?:[+-]\s*|@@[^@\n]*@@\s*.*?)\s*"
+    r"(?:"
+    r"(?:export\s+)?(?:async\s+)?function\s+(?P<js_func>[a-zA-Z_$][a-zA-Z0-9_$]*)\s*\("
+    r"|(?:async\s+)?def\s+(?P<py_func>[a-zA-Z_][a-zA-Z0-9_]*)\s*\("
+    r"|(?:const|let|var)\s+(?P<var>[a-zA-Z_$][a-zA-Z0-9_$]*)"
+    r"\s*=\s*(?:(?:async\s+)?(?:\([^)]*\)|[a-zA-Z_$][a-zA-Z0-9_$]*)\s*=>|function\b)"
+    r"|class\s+(?P<class_name>[a-zA-Z_$][a-zA-Z0-9_$]*)"
+    r"|(?:(?:public|private|protected|static|override|readonly)\s+)*(?:async\s+)?"
+    r"(?P<method>[a-zA-Z_$][a-zA-Z0-9_$]*)\s*\([^)]*\)\s*(?::\s*[^={;]+)?\{"
     r")",
     re.MULTILINE | re.IGNORECASE,
 )
@@ -58,6 +74,7 @@ REQUIRED_PLAN_MARKERS = (
 )
 DISPOSITION_MARKERS = REQUIRED_PLAN_MARKERS[1:]
 PLACEHOLDER_VALUES = {"", "n/a", "na", "todo", "todo/n/a", "none"}
+UNRESOLVED_VALUE_RE = re.compile(r"\b(?:tbd|unknown|pending|unresolved)\b", re.IGNORECASE)
 
 
 @dataclass(frozen=True)
@@ -66,13 +83,34 @@ class Finding:
     reason: str
 
 
+@dataclass(frozen=True)
+class BoundarySeam:
+    name: str
+    bare_name: str
+
+
 def _is_test_path(path: str) -> bool:
     p = PurePosixPath(path)
     return (
         p.name.startswith("test_")
         or "tests/" in path
-        or p.name.endswith(("_test.py", ".test.js", ".test.jsx", ".test.ts", ".test.tsx"))
-        or p.name.endswith((".spec.js", ".spec.jsx", ".spec.ts", ".spec.tsx"))
+        or p.name.endswith((
+            "_test.py",
+            ".test.js",
+            ".test.jsx",
+            ".test.ts",
+            ".test.tsx",
+            ".test.mjs",
+            ".test.cjs",
+        ))
+        or p.name.endswith((
+            ".spec.js",
+            ".spec.jsx",
+            ".spec.ts",
+            ".spec.tsx",
+            ".spec.mjs",
+            ".spec.cjs",
+        ))
     )
 
 
@@ -83,6 +121,41 @@ def _is_process_path(path: str) -> bool:
         or p.name in {"AGENTS.md", "new_pr_plan.sh"}
         or path == "scripts/check_boundary_change_enumeration.py"
     )
+
+
+def _diff_line_body(line: str) -> str:
+    if line.startswith(("+", "-")) and not line.startswith(("+++", "---")):
+        return line[1:].strip()
+    if line.startswith("@@"):
+        match = re.match(r"@@[^@\n]*@@\s*(.*)", line)
+        if match:
+            return match.group(1).strip()
+    return line.strip()
+
+
+def boundary_seams(added: str) -> list[BoundarySeam]:
+    seams: list[BoundarySeam] = []
+    current_class: str | None = None
+    occurrence_counts: dict[str, int] = {}
+    for line in added.splitlines():
+        body = _diff_line_body(line)
+        class_match = re.search(r"\bclass\s+([a-zA-Z_$][a-zA-Z0-9_$]*)", body)
+        if class_match:
+            current_class = class_match.group(1)
+        match = BOUNDARY_SEAM_RE.match(line)
+        if not match:
+            continue
+        name = next(value for value in match.groupdict().values() if value)
+        if not BOUNDARY_NAME_RE.search(name):
+            continue
+        if match.group("method") and current_class:
+            qualified_name = f"{current_class}.{name}"
+        else:
+            occurrence_counts[name] = occurrence_counts.get(name, 0) + 1
+            occurrence = occurrence_counts[name]
+            qualified_name = name if occurrence == 1 else f"{name}#{occurrence}"
+        seams.append(BoundarySeam(name=qualified_name, bare_name=name))
+    return seams
 
 
 def file_is_boundary_shaped(path: str, added: str) -> bool:
@@ -122,6 +195,42 @@ def _marker_values(section: str, marker: str) -> list[str]:
     return values
 
 
+def _normalized_marker_label(line: str) -> tuple[str, str] | None:
+    if ":" not in line:
+        return None
+    label, value = line.split(":", 1)
+    normalized_label = label.strip().lstrip("-*0123456789. ").strip().lower()
+    return normalized_label, value.strip()
+
+
+def _boundary_blocks(section: str) -> list[tuple[str, str]]:
+    """Return (boundary-name, block-text) for each exact boundary entry.
+
+    Each `Boundary path/seam:` row owns only the disposition rows that follow it
+    until the next boundary row. This keeps one complete inventory from hiding a
+    second changed boundary merely because both paths were mentioned somewhere
+    in the section.
+    """
+    blocks: list[tuple[str, list[str]]] = []
+    current_name: str | None = None
+    current_lines: list[str] = []
+    for line in section.splitlines():
+        parsed = _normalized_marker_label(line)
+        if parsed is not None:
+            label, value = parsed
+            if label in {"boundary path", "boundary path/seam", "boundary seam"}:
+                if current_name is not None:
+                    blocks.append((current_name, current_lines))
+                current_name = value.strip().rstrip(".")
+                current_lines = []
+                continue
+        if current_name is not None:
+            current_lines.append(line)
+    if current_name is not None:
+        blocks.append((current_name, current_lines))
+    return [(name, "\n".join(lines)) for name, lines in blocks]
+
+
 def _has_section_level_not_applicable(section: str) -> bool:
     for line in section.splitlines():
         stripped = line.strip().lower().rstrip(".")
@@ -137,6 +246,8 @@ def _is_dispositioned_value(value: str | None, *, section_not_applicable: bool =
         return False
     normalized = value.strip().lower()
     if "todo" in normalized:
+        return False
+    if UNRESOLVED_VALUE_RE.search(normalized):
         return False
     if section_not_applicable and normalized in {"n/a", "na", "not applicable"}:
         return True
@@ -162,28 +273,66 @@ def plan_has_boundary_enumeration(plan_text: str) -> bool:
     return True
 
 
-def _path_mentions(path: str, section: str) -> bool:
-    section_lower = section.lower()
-    p = PurePosixPath(path)
-    candidates = {
-        path.lower(),
-        p.name.lower(),
-        p.stem.lower(),
-        p.stem.lower().replace("_", "-"),
-        p.stem.lower().replace("-", "_"),
-        p.stem.lower().replace("_", " "),
-        p.stem.lower().replace("-", " "),
-    }
-    return any(candidate and candidate in section_lower for candidate in candidates)
+def _block_has_complete_dispositions(block: str, *, section_not_applicable: bool = False) -> bool:
+    for marker in DISPOSITION_MARKERS:
+        values = _marker_values(block, marker)
+        if not values:
+            return False
+        if not all(
+            _is_dispositioned_value(value, section_not_applicable=section_not_applicable)
+            for value in values
+        ):
+            return False
+    return True
 
 
-def plan_covers_boundary_path(plan_text: str, path: str) -> bool:
+def _boundary_name_matches_target(name: str, targets: set[str]) -> bool:
+    normalized = name.strip().rstrip(".").lower()
+    return normalized in {target.lower() for target in targets}
+
+
+def plan_covers_boundary_target(plan_text: str, targets: set[str]) -> bool:
     if not plan_has_boundary_enumeration(plan_text):
         return False
     section = boundary_enumeration_section(plan_text)
-    if _has_section_level_not_applicable(section):
-        return True
-    return _path_mentions(path, section)
+    section_not_applicable = _has_section_level_not_applicable(section)
+    return any(
+        _boundary_name_matches_target(name, targets)
+        and _block_has_complete_dispositions(
+            block,
+            section_not_applicable=section_not_applicable,
+        )
+        for name, block in _boundary_blocks(section)
+    )
+
+
+def boundary_coverage_targets(path: str, added: str) -> list[set[str]]:
+    seams = boundary_seams(added)
+    qualified_classes = {
+        seam.name.split(".", 1)[0]
+        for seam in seams
+        if "." in seam.name
+    }
+    seams = [
+        seam
+        for seam in seams
+        if not (seam.name == seam.bare_name and seam.name in qualified_classes)
+    ]
+    if len(seams) > 1:
+        bare_counts: dict[str, int] = {}
+        for seam in seams:
+            bare_counts[seam.bare_name] = bare_counts.get(seam.bare_name, 0) + 1
+        targets: list[set[str]] = []
+        for seam in seams:
+            target = {seam.name}
+            if bare_counts[seam.bare_name] == 1:
+                target.add(seam.bare_name)
+            targets.append(target)
+        return targets
+    if len(seams) == 1:
+        seam = seams[0]
+        return [{path, seam.name, seam.bare_name}]
+    return [{path}]
 
 
 def scan_diff(added_by_file: Mapping[str, str], plan_texts: Sequence[str]) -> list[Finding]:
@@ -191,9 +340,14 @@ def scan_diff(added_by_file: Mapping[str, str], plan_texts: Sequence[str]) -> li
     for path, added in sorted(added_by_file.items()):
         if not file_is_boundary_shaped(path, added):
             continue
-        if any(plan_covers_boundary_path(text, path) for text in plan_texts):
-            continue
-        findings.append(Finding(path=path, reason=RULE))
+        missing_target = False
+        for targets in boundary_coverage_targets(path, added):
+            if any(plan_covers_boundary_target(text, targets) for text in plan_texts):
+                continue
+            missing_target = True
+            break
+        if missing_target:
+            findings.append(Finding(path=path, reason=RULE))
     return findings
 
 
@@ -235,7 +389,11 @@ def changed_plan_texts(base: str) -> list[str]:
         ).splitlines()
         if n
     ]
-    return [Path(name).read_text(encoding="utf-8") for name in names if Path(name).exists()]
+    return [
+        (REPO_ROOT / name).read_text(encoding="utf-8")
+        for name in names
+        if (REPO_ROOT / name).exists()
+    ]
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/scripts/check_boundary_change_enumeration.py
+++ b/scripts/check_boundary_change_enumeration.py
@@ -17,10 +17,10 @@ RULE = (
     "shape, each dispositioned."
 )
 
-CODE_SUFFIXES = {".py", ".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs"}
+CODE_SUFFIXES = {".py", ".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".sh"}
 BOUNDARY_PATH_PART_RE = re.compile(
     r"(^|[-_./])"
-    r"(guard|validat(?:e|or|ion)?|resolver|resolution|admission|intake|claim|"
+    r"(guard|validat(?:e|or|ion)?|normaliz(?:e|er|ation|ing)?|resolver|resolution|admission|intake|"
     r"dedupe|scope|tenant|auth(?:entication|orization)?)"
     r"($|[-_./])",
     re.IGNORECASE,
@@ -29,18 +29,22 @@ BOUNDARY_CODE_RE = re.compile(
     r"^(?:[+-]\s*|@@[^@\n]*@@\s*.*?)"
     r"(?:"
     r"(?:export\s+)?(?:async\s+)?function\s+"
-    r"[a-zA-Z0-9_$]*(?:guard|validat|resolve|admit|reject|claim|dedupe|scope|auth)"
+    r"[a-zA-Z0-9_$]*(?:guard|validat|normaliz|resolve|admit|reject|dedupe|scope|auth)"
     r"[a-zA-Z0-9_$]*\s*\("
     r"|(?:async\s+)?def\s+"
-    r"[a-zA-Z0-9_]*(?:guard|validat|resolve|admit|reject|claim|dedupe|scope|auth)"
+    r"[a-zA-Z0-9_]*(?:guard|validat|normaliz|resolve|admit|reject|dedupe|scope|auth)"
     r"[a-zA-Z0-9_]*\s*\("
     r"|(?:const|let|var)\s+"
-    r"[a-zA-Z0-9_$]*(?:Guard|Validat|Resolve|Admit|Reject|Claim|Dedupe|Scope|Auth)"
+    r"[a-zA-Z0-9_$]*(?:Guard|Validat|Normaliz|Resolve|Admit|Reject|Dedupe|Scope|Auth)"
     r"[a-zA-Z0-9_$]*\s*="
     r"|class\s+[a-zA-Z0-9_$]*(?:Guard|Validator|Resolver|Admission|Auth)"
     r"[a-zA-Z0-9_$]*"
+    r"|(?:async\s+)?[a-zA-Z0-9_$]*(?:guard|validat|normaliz|resolve|admit|reject|dedupe|scope|auth)"
+    r"[a-zA-Z0-9_$]*\s*\([^)]*\)\s*\{"
+    r"|(?:function\s+)?[a-zA-Z0-9_]*(?:guard|validat|normaliz|resolve|admit|reject|dedupe|scope|auth)"
+    r"[a-zA-Z0-9_]*\s*\(\)\s*\{"
     r")",
-    re.MULTILINE,
+    re.MULTILINE | re.IGNORECASE,
 )
 REQUIRED_PLAN_MARKERS = (
     "boundary-change enumeration",
@@ -119,6 +123,8 @@ def _is_dispositioned_value(value: str | None) -> bool:
     normalized = value.strip().lower()
     if "todo" in normalized:
         return False
+    if normalized.startswith(("n/a -", "na -", "not applicable -")):
+        return True
     return normalized not in PLACEHOLDER_VALUES
 
 
@@ -150,11 +156,15 @@ def _git(args: Sequence[str]) -> str:
     return result.stdout
 
 
-def _added_lines(diff_hunk: str) -> str:
+def _changed_lines(diff_hunk: str) -> str:
     return "\n".join(
         line
         for line in diff_hunk.splitlines()
-        if (line.startswith("+") and not line.startswith("+++")) or line.startswith("@@")
+        if (
+            (line.startswith("+") and not line.startswith("+++"))
+            or (line.startswith("-") and not line.startswith("---"))
+            or line.startswith("@@")
+        )
     )
 
 
@@ -163,7 +173,7 @@ def changed_added_lines(base: str) -> dict[str, str]:
     out: dict[str, str] = {}
     for name in names:
         if PurePosixPath(name).suffix in CODE_SUFFIXES:
-            out[name] = _added_lines(_git(["diff", "--unified=0", f"{base}...HEAD", "--", name]))
+            out[name] = _changed_lines(_git(["diff", "--unified=0", f"{base}...HEAD", "--", name]))
     return out
 
 

--- a/scripts/check_boundary_change_enumeration.py
+++ b/scripts/check_boundary_change_enumeration.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Advisory lint for boundary-change enumeration plan coverage."""
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Mapping, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RULE = (
+    "Boundary-change enumeration: a diff changing a guard, validator, resolver, "
+    "or admission boundary must ship a plan-doc enumeration before code: "
+    "replaced-path behaviors, guard-relevant fields, and every caller x input "
+    "shape, each dispositioned."
+)
+
+CODE_SUFFIXES = {".py", ".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs"}
+BOUNDARY_PATH_PART_RE = re.compile(
+    r"(^|[-_./])"
+    r"(guard|validat(?:e|or|ion)?|resolver|resolution|admission|intake|claim|"
+    r"dedupe|scope|tenant|auth(?:entication|orization)?)"
+    r"($|[-_./])",
+    re.IGNORECASE,
+)
+BOUNDARY_CODE_RE = re.compile(
+    r"^(?:[+-]\s*|@@[^@\n]*@@\s*.*?)"
+    r"(?:"
+    r"(?:export\s+)?(?:async\s+)?function\s+"
+    r"[a-zA-Z0-9_$]*(?:guard|validat|resolve|admit|reject|claim|dedupe|scope|auth)"
+    r"[a-zA-Z0-9_$]*\s*\("
+    r"|(?:async\s+)?def\s+"
+    r"[a-zA-Z0-9_]*(?:guard|validat|resolve|admit|reject|claim|dedupe|scope|auth)"
+    r"[a-zA-Z0-9_]*\s*\("
+    r"|(?:const|let|var)\s+"
+    r"[a-zA-Z0-9_$]*(?:Guard|Validat|Resolve|Admit|Reject|Claim|Dedupe|Scope|Auth)"
+    r"[a-zA-Z0-9_$]*\s*="
+    r"|class\s+[a-zA-Z0-9_$]*(?:Guard|Validator|Resolver|Admission|Auth)"
+    r"[a-zA-Z0-9_$]*"
+    r")",
+    re.MULTILINE,
+)
+REQUIRED_PLAN_MARKERS = (
+    "boundary-change enumeration",
+    "replaced-path behaviors",
+    "guard-relevant fields",
+    "caller x input shape",
+)
+DISPOSITION_MARKERS = REQUIRED_PLAN_MARKERS[1:]
+PLACEHOLDER_VALUES = {"", "n/a", "na", "todo", "todo/n/a", "none"}
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: str
+    reason: str
+
+
+def _is_test_path(path: str) -> bool:
+    p = PurePosixPath(path)
+    return (
+        p.name.startswith("test_")
+        or "tests/" in path
+        or p.name.endswith(("_test.py", ".test.js", ".test.jsx", ".test.ts", ".test.tsx"))
+        or p.name.endswith((".spec.js", ".spec.jsx", ".spec.ts", ".spec.tsx"))
+    )
+
+
+def _is_process_path(path: str) -> bool:
+    p = PurePosixPath(path)
+    return (
+        path.startswith(("plans/", ".github/"))
+        or p.name in {"AGENTS.md", "new_pr_plan.sh"}
+        or path == "scripts/check_boundary_change_enumeration.py"
+    )
+
+
+def file_is_boundary_shaped(path: str, added: str) -> bool:
+    if PurePosixPath(path).suffix not in CODE_SUFFIXES or _is_test_path(path) or _is_process_path(path):
+        return False
+    return bool(BOUNDARY_PATH_PART_RE.search(path) or BOUNDARY_CODE_RE.search(added))
+
+
+def boundary_enumeration_section(text: str) -> str:
+    lines: list[str] = []
+    in_section = False
+    for line in text.splitlines():
+        if line.startswith("### "):
+            if line.strip().lower() == "### boundary-change enumeration":
+                in_section = True
+                continue
+            if in_section:
+                break
+        elif line.startswith("## ") and in_section:
+            break
+        if in_section:
+            lines.append(line)
+    return "\n".join(lines)
+
+
+def _marker_value(section: str, marker: str) -> str | None:
+    marker_lower = marker.lower()
+    for line in section.splitlines():
+        if ":" not in line:
+            continue
+        label, value = line.split(":", 1)
+        label = label.strip().lstrip("-*0123456789. ").strip().lower()
+        if label != marker_lower:
+            continue
+        return value.strip().rstrip(".").lower()
+    return None
+
+
+def _is_dispositioned_value(value: str | None) -> bool:
+    if value is None:
+        return False
+    normalized = value.strip().lower()
+    if "todo" in normalized:
+        return False
+    return normalized not in PLACEHOLDER_VALUES
+
+
+def plan_has_boundary_enumeration(plan_text: str) -> bool:
+    if "boundary-change enumeration" not in plan_text.lower():
+        return False
+    section = boundary_enumeration_section(plan_text)
+    return all(_is_dispositioned_value(_marker_value(section, marker)) for marker in DISPOSITION_MARKERS)
+
+
+def scan_diff(added_by_file: Mapping[str, str], plan_texts: Sequence[str]) -> list[Finding]:
+    has_plan_enumeration = any(plan_has_boundary_enumeration(text) for text in plan_texts)
+    findings: list[Finding] = []
+    for path, added in sorted(added_by_file.items()):
+        if not file_is_boundary_shaped(path, added):
+            continue
+        if has_plan_enumeration:
+            continue
+        findings.append(Finding(path=path, reason=RULE))
+    return findings
+
+
+def _git(args: Sequence[str]) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=REPO_ROOT, check=False, capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        raise SystemExit(f"git {' '.join(args)} failed: {result.stderr.strip()}")
+    return result.stdout
+
+
+def _added_lines(diff_hunk: str) -> str:
+    return "\n".join(
+        line
+        for line in diff_hunk.splitlines()
+        if (line.startswith("+") and not line.startswith("+++")) or line.startswith("@@")
+    )
+
+
+def changed_added_lines(base: str) -> dict[str, str]:
+    names = [n for n in _git(["diff", "--name-only", f"{base}...HEAD"]).splitlines() if n]
+    out: dict[str, str] = {}
+    for name in names:
+        if PurePosixPath(name).suffix in CODE_SUFFIXES:
+            out[name] = _added_lines(_git(["diff", "--unified=0", f"{base}...HEAD", "--", name]))
+    return out
+
+
+def changed_plan_texts(base: str) -> list[str]:
+    names = [
+        n
+        for n in _git(
+            ["diff", "--name-only", "--diff-filter=AMR", f"{base}...HEAD", "--", "plans/PR-*.md"]
+        ).splitlines()
+        if n
+    ]
+    return [Path(name).read_text(encoding="utf-8") for name in names if Path(name).exists()]
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", default="origin/main", help="diff base ref")
+    parser.add_argument("--strict", action="store_true", help="exit non-zero on findings")
+    args = parser.parse_args(argv)
+
+    findings = scan_diff(changed_added_lines(args.base), changed_plan_texts(args.base))
+    print("boundary-change enumeration lint (advisory)")
+    print("-" * 60)
+    if not findings:
+        print("OK: no boundary-shaped change without plan enumeration.")
+        return 0
+    for finding in findings:
+        print(f"::warning file={finding.path}::{finding.reason}")
+        print(f"  {finding.path}: {finding.reason}")
+    return 1 if args.strict else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/new_pr_plan.sh
+++ b/scripts/new_pr_plan.sh
@@ -182,8 +182,10 @@ Slice phase: $phase
 ### Boundary-change enumeration
 
 Required when this diff changes a guard, validator, resolver, or admission
-boundary; otherwise write "N/A - no boundary change."
+boundary. Name each changed boundary path or seam in the enumeration; otherwise
+write "N/A - no boundary change."
 
+- Boundary path/seam: TODO/N/A.
 - Replaced-path behaviors: TODO/N/A.
 - Guard-relevant fields: TODO/N/A.
 - Caller x input shape: TODO/N/A.

--- a/scripts/new_pr_plan.sh
+++ b/scripts/new_pr_plan.sh
@@ -181,9 +181,9 @@ Slice phase: $phase
 
 ### Boundary-change enumeration
 
-Required when this diff changes a guard, validator, resolver, or admission
-boundary. Name each changed boundary path or seam in the enumeration; otherwise
-write "N/A - no boundary change."
+Required when this diff changes a guard, validator, normalizer, resolver,
+router/classifier, or admission boundary. Name each changed boundary path or
+seam in the enumeration; otherwise write "N/A - no boundary change."
 
 - Boundary path/seam: TODO/N/A.
 - Replaced-path behaviors: TODO/N/A.

--- a/scripts/new_pr_plan.sh
+++ b/scripts/new_pr_plan.sh
@@ -179,6 +179,15 @@ Slice phase: $phase
   dispositioned by the review matrix.
 - Reviewer rules triggered: TODO: List the applicable R1-R14 rule IDs.
 
+### Boundary-change enumeration
+
+Required when this diff changes a guard, validator, resolver, or admission
+boundary; otherwise write "N/A - no boundary change."
+
+- Replaced-path behaviors: TODO/N/A.
+- Guard-relevant fields: TODO/N/A.
+- Caller x input shape: TODO/N/A.
+
 ### Files touched
 
 - TODO: run \`python scripts/sync_pr_plan.py $plan_rel\` after implementation.

--- a/tests/test_check_boundary_change_enumeration.py
+++ b/tests/test_check_boundary_change_enumeration.py
@@ -24,6 +24,14 @@ TS_BOUNDARY_CHANGE = (
     "+  return Boolean(input.accountId)\n"
     "+}\n"
 )
+TS_ALLOWED_BOUNDARY_CHANGE = (
+    "@@ -25,6 +25,7 @@ function isProductClaimAllowed(product, account) {\n"
+    "+  return Boolean(account?.id && product.claimable)\n"
+)
+PY_CLASSIFY_ROUTE_CHANGE = (
+    "@@ -199,6 +199,7 @@ def classify_and_route(state):\n"
+    "+    return 'booking' if state.get('intent') == 'book' else 'fallback'\n"
+)
 PATH_ONLY_BOUNDARY_CHANGE = "+VALUE = 1\n"
 CONST_BOUNDARY_CHANGE = "+const resolveClaimGate = (input) => Boolean(input.accountId)\n"
 CLASS_BOUNDARY_CHANGE = "+class TenantResolver {\n+  resolve(input) { return input.tenantId }\n+}\n"
@@ -37,6 +45,7 @@ AUTH_ERROR_CHANGE = "+class RedditAuthError(RuntimeError):\n+    pass\n"
 PLAN_WITH_ENUMERATION = """
 ### Boundary-change enumeration
 
+- Boundary path: atlas_brain/services/crm_provider.py.
 - Replaced-path behaviors: preserved existing email-first lookup.
 - Guard-relevant fields: email, phone, source_ref.
 - Caller x input shape: intake x email-only -> preserved.
@@ -61,6 +70,22 @@ def test_typescript_boundary_change_without_plan_enumeration_is_flagged() -> Non
     findings = mod.scan_diff({"atlas-churn-ui/src/components/ProductClaimGate.tsx": TS_BOUNDARY_CHANGE}, [])
     assert len(findings) == 1
     assert findings[0].path == "atlas-churn-ui/src/components/ProductClaimGate.tsx"
+
+
+def test_allowed_product_gate_without_plan_enumeration_is_flagged() -> None:
+    findings = mod.scan_diff(
+        {"atlas-churn-ui/src/components/ProductClaimGate.tsx": TS_ALLOWED_BOUNDARY_CHANGE},
+        [],
+    )
+    assert len(findings) == 1
+
+
+def test_classify_and_route_without_plan_enumeration_is_flagged() -> None:
+    findings = mod.scan_diff(
+        {"atlas_brain/agents/graphs/atlas.py": PY_CLASSIFY_ROUTE_CHANGE},
+        [],
+    )
+    assert len(findings) == 1
 
 
 def test_boundary_path_signal_without_plan_enumeration_is_flagged() -> None:
@@ -162,8 +187,28 @@ def test_reasoned_not_applicable_dispositions_are_clean() -> None:
 - Replaced-path behaviors: N/A - no boundary behavior is replaced.
 - Guard-relevant fields: not applicable - no guard verdict fields.
 - Caller x input shape: N/A - no caller can reach a boundary.
+    """
+    assert mod.plan_has_boundary_enumeration(not_applicable)
+
+
+def test_section_level_not_applicable_reason_covers_bare_na_rows() -> None:
+    not_applicable = """
+### Boundary-change enumeration
+
+N/A - no boundary change; detector path matched a process-only helper.
+
+- Replaced-path behaviors: N/A.
+- Guard-relevant fields: N/A.
+- Caller x input shape: N/A.
 """
     assert mod.plan_has_boundary_enumeration(not_applicable)
+    assert (
+        mod.scan_diff(
+            {"atlas_brain/services/admission_gate.py": PATH_ONLY_BOUNDARY_CHANGE},
+            [not_applicable],
+        )
+        == []
+    )
 
 
 def test_duplicate_enumeration_rows_must_all_be_dispositioned() -> None:
@@ -174,8 +219,27 @@ def test_duplicate_enumeration_rows_must_all_be_dispositioned() -> None:
 - Replaced-path behaviors: TODO disposition replacement fallback.
 - Guard-relevant fields: email, phone.
 - Caller x input shape: intake x email-only -> preserved.
-"""
+    """
     assert not mod.plan_has_boundary_enumeration(duplicate_todo)
+
+
+def test_each_changed_boundary_requires_its_own_path_enumeration() -> None:
+    crm_only_plan = """
+### Boundary-change enumeration
+
+- Boundary path: atlas_brain/services/crm_resolver.py.
+- Replaced-path behaviors: crm_resolver.py preserves existing CRM lookup.
+- Guard-relevant fields: crm_resolver.py email.
+- Caller x input shape: crm_resolver.py intake x email-only -> preserved.
+"""
+    findings = mod.scan_diff(
+        {
+            "atlas_brain/services/crm_resolver.py": BOUNDARY_CHANGE,
+            "atlas_brain/services/tenant_resolver.py": BOUNDARY_CHANGE,
+        },
+        [crm_only_plan],
+    )
+    assert [finding.path for finding in findings] == ["atlas_brain/services/tenant_resolver.py"]
 
 
 def test_cli_entrypoint_warns_advisory_and_fails_strict(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_check_boundary_change_enumeration.py
+++ b/tests/test_check_boundary_change_enumeration.py
@@ -30,8 +30,10 @@ CLASS_BOUNDARY_CHANGE = "+class TenantResolver {\n+  resolve(input) { return inp
 SHELL_BOUNDARY_CHANGE = "+validate_scope() {\n+  test -n \"$ATLAS_SCOPE\"\n+}\n"
 TS_METHOD_BOUNDARY_CHANGE = "+  validateFileType(buffer, expectedType) {\n+    return true\n+  }\n"
 TS_NORMALIZER_CHANGE = "+function normalizeLandingPageRepairAttemptValue(value) {\n+  return Number(value)\n+}\n"
+ROUTING_TABLE_CHANGE = "+ROUTE_TO_ACTION = {\n+    'book': 'schedule_visit',\n+}\n"
 REMOVED_BOUNDARY_CHANGE = "-def resolve_contact(row):\n-    return row.email\n"
 CLAIM_SERIALIZER_CHANGE = "+def _serialize_claim(row):\n+    return {'claim': row.claim}\n"
+AUTH_ERROR_CHANGE = "+class RedditAuthError(RuntimeError):\n+    pass\n"
 PLAN_WITH_ENUMERATION = """
 ### Boundary-change enumeration
 
@@ -91,6 +93,11 @@ def test_normalizing_decision_seam_without_plan_enumeration_is_flagged() -> None
     assert len(findings) == 1
 
 
+def test_routing_decision_seam_without_plan_enumeration_is_flagged() -> None:
+    findings = mod.scan_diff({"atlas_brain/services/intent_router.py": ROUTING_TABLE_CHANGE}, [])
+    assert len(findings) == 1
+
+
 def test_removed_boundary_declaration_without_plan_enumeration_is_flagged() -> None:
     findings = mod.scan_diff({"scripts/sync_eom_portal_customers.py": REMOVED_BOUNDARY_CHANGE}, [])
     assert len(findings) == 1
@@ -111,6 +118,11 @@ def test_non_boundary_change_is_clean() -> None:
 
 def test_claim_serializer_lexical_lookalike_is_clean() -> None:
     findings = mod.scan_diff({"atlas_brain/api/b2b_vendor_claims.py": CLAIM_SERIALIZER_CHANGE}, [])
+    assert findings == []
+
+
+def test_auth_exception_lexical_lookalike_is_clean() -> None:
+    findings = mod.scan_diff({"atlas_reddit/reddit_client.py": AUTH_ERROR_CHANGE}, [])
     assert findings == []
 
 
@@ -152,6 +164,18 @@ def test_reasoned_not_applicable_dispositions_are_clean() -> None:
 - Caller x input shape: N/A - no caller can reach a boundary.
 """
     assert mod.plan_has_boundary_enumeration(not_applicable)
+
+
+def test_duplicate_enumeration_rows_must_all_be_dispositioned() -> None:
+    duplicate_todo = """
+### Boundary-change enumeration
+
+- Replaced-path behaviors: preserved legacy lookup.
+- Replaced-path behaviors: TODO disposition replacement fallback.
+- Guard-relevant fields: email, phone.
+- Caller x input shape: intake x email-only -> preserved.
+"""
+    assert not mod.plan_has_boundary_enumeration(duplicate_todo)
 
 
 def test_cli_entrypoint_warns_advisory_and_fails_strict(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_check_boundary_change_enumeration.py
+++ b/tests/test_check_boundary_change_enumeration.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_SPEC = importlib.util.spec_from_file_location(
+    "check_boundary_change_enumeration",
+    Path(__file__).resolve().parent.parent / "scripts" / "check_boundary_change_enumeration.py",
+)
+mod = importlib.util.module_from_spec(_SPEC)
+assert _SPEC and _SPEC.loader
+sys.modules[_SPEC.name] = mod
+_SPEC.loader.exec_module(mod)
+
+BOUNDARY_CHANGE = (
+    "+def resolve_contact_identity(payload):\n"
+    "+    return payload.get('email') or payload.get('phone')\n"
+)
+TS_BOUNDARY_CHANGE = (
+    "+export function validateClaimGate(input) {\n"
+    "+  return Boolean(input.accountId)\n"
+    "+}\n"
+)
+PATH_ONLY_BOUNDARY_CHANGE = "+VALUE = 1\n"
+CONST_BOUNDARY_CHANGE = "+const resolveClaimGate = (input) => Boolean(input.accountId)\n"
+CLASS_BOUNDARY_CHANGE = "+class TenantResolver {\n+  resolve(input) { return input.tenantId }\n+}\n"
+PLAN_WITH_ENUMERATION = """
+### Boundary-change enumeration
+
+- Replaced-path behaviors: preserved existing email-first lookup.
+- Guard-relevant fields: email, phone, source_ref.
+- Caller x input shape: intake x email-only -> preserved.
+"""
+SCAFFOLD_PLACEHOLDER = """
+### Boundary-change enumeration
+
+- Replaced-path behaviors: TODO/N/A.
+- Guard-relevant fields: TODO/N/A.
+- Caller x input shape: TODO/N/A.
+"""
+
+
+def test_boundary_change_without_plan_enumeration_is_flagged() -> None:
+    findings = mod.scan_diff({"atlas_brain/services/crm_provider.py": BOUNDARY_CHANGE}, [])
+    assert len(findings) == 1
+    assert findings[0].path == "atlas_brain/services/crm_provider.py"
+    assert mod.RULE in findings[0].reason
+
+
+def test_typescript_boundary_change_without_plan_enumeration_is_flagged() -> None:
+    findings = mod.scan_diff({"atlas-churn-ui/src/components/ProductClaimGate.tsx": TS_BOUNDARY_CHANGE}, [])
+    assert len(findings) == 1
+    assert findings[0].path == "atlas-churn-ui/src/components/ProductClaimGate.tsx"
+
+
+def test_boundary_path_signal_without_plan_enumeration_is_flagged() -> None:
+    findings = mod.scan_diff({"atlas_brain/services/admission_gate.py": PATH_ONLY_BOUNDARY_CHANGE}, [])
+    assert len(findings) == 1
+
+
+def test_const_boundary_signal_without_plan_enumeration_is_flagged() -> None:
+    findings = mod.scan_diff({"atlas-churn-ui/src/components/ClaimPanel.tsx": CONST_BOUNDARY_CHANGE}, [])
+    assert len(findings) == 1
+
+
+def test_class_boundary_signal_without_plan_enumeration_is_flagged() -> None:
+    findings = mod.scan_diff({"portfolio-ui/src/auth.ts": CLASS_BOUNDARY_CHANGE}, [])
+    assert len(findings) == 1
+
+
+def test_boundary_change_with_plan_enumeration_is_clean() -> None:
+    findings = mod.scan_diff(
+        {"atlas_brain/services/crm_provider.py": BOUNDARY_CHANGE},
+        [PLAN_WITH_ENUMERATION],
+    )
+    assert findings == []
+
+
+def test_non_boundary_change_is_clean() -> None:
+    findings = mod.scan_diff({"atlas_brain/api/health.py": "+def ping():\n+    return {'ok': True}\n"}, [])
+    assert findings == []
+
+
+def test_process_detector_change_is_clean_with_na_plan() -> None:
+    findings = mod.scan_diff({"scripts/check_boundary_change_enumeration.py": BOUNDARY_CHANGE}, [])
+    assert findings == []
+
+
+def test_other_checker_boundary_change_is_not_exempt() -> None:
+    findings = mod.scan_diff({"scripts/check_guard_class_closure.py": BOUNDARY_CHANGE}, [])
+    assert len(findings) == 1
+
+
+def test_test_file_boundary_words_are_ignored() -> None:
+    findings = mod.scan_diff({"tests/test_contact_resolver.py": BOUNDARY_CHANGE}, [])
+    assert findings == []
+
+
+def test_plan_requires_all_enumeration_markers() -> None:
+    incomplete = "### Boundary-change enumeration\n- Replaced-path behaviors: preserved."
+    narrative = (
+        "## Why this slice exists\n"
+        "replaced-path behaviors documented; guard-relevant fields documented; "
+        "caller x input shape documented.\n"
+        + SCAFFOLD_PLACEHOLDER
+    )
+    assert not mod.plan_has_boundary_enumeration(incomplete)
+    assert not mod.plan_has_boundary_enumeration(SCAFFOLD_PLACEHOLDER)
+    assert not mod.plan_has_boundary_enumeration(narrative)
+    assert mod.plan_has_boundary_enumeration(PLAN_WITH_ENUMERATION)
+
+
+def test_cli_entrypoint_warns_advisory_and_fails_strict(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    monkeypatch.setattr(
+        mod,
+        "changed_added_lines",
+        lambda base: {"atlas_brain/services/crm_provider.py": BOUNDARY_CHANGE},
+    )
+    monkeypatch.setattr(mod, "changed_plan_texts", lambda base: [])
+
+    assert mod.main(["--base", "ignored"]) == 0
+    out = capsys.readouterr().out
+    assert "::warning file=atlas_brain/services/crm_provider.py::" in out
+    assert mod.RULE in out
+
+    assert mod.main(["--base", "ignored", "--strict"]) == 1
+
+
+def test_git_failure_raises_system_exit() -> None:
+    with pytest.raises(SystemExit, match="git .* failed"):
+        mod._git(["rev-parse", "--verify", "definitely-not-a-ref-xyz"])

--- a/tests/test_check_boundary_change_enumeration.py
+++ b/tests/test_check_boundary_change_enumeration.py
@@ -32,16 +32,56 @@ PY_CLASSIFY_ROUTE_CHANGE = (
     "@@ -199,6 +199,7 @@ def classify_and_route(state):\n"
     "+    return 'booking' if state.get('intent') == 'book' else 'fallback'\n"
 )
+PY_SHOULD_SCRAPE_CHANGE = (
+    "@@ -723,6 +723,7 @@ async def should_scrape_now(candidate):\n"
+    "+    return candidate.manual or candidate.window_open\n"
+)
+TWO_SEAMS_CHANGE = (
+    "+def resolve_contact_identity(payload):\n"
+    "+    return payload.get('email')\n"
+    "+def resolve_tenant_identity(payload):\n"
+    "+    return payload.get('tenant_id')\n"
+)
 PATH_ONLY_BOUNDARY_CHANGE = "+VALUE = 1\n"
 CONST_BOUNDARY_CHANGE = "+const resolveClaimGate = (input) => Boolean(input.accountId)\n"
 CLASS_BOUNDARY_CHANGE = "+class TenantResolver {\n+  resolve(input) { return input.tenantId }\n+}\n"
 SHELL_BOUNDARY_CHANGE = "+validate_scope() {\n+  test -n \"$ATLAS_SCOPE\"\n+}\n"
 TS_METHOD_BOUNDARY_CHANGE = "+  validateFileType(buffer, expectedType) {\n+    return true\n+  }\n"
+TS_PRIVATE_METHOD_BOUNDARY_CHANGE = (
+    "@@ -671,6 +671,7 @@ export class DocumentService {\n"
+    "+  private validateFile(file) {\n"
+    "+    return file.size < 1000\n"
+    "+  }\n"
+)
+TS_RETURN_ANNOTATED_METHOD_BOUNDARY_CHANGE = (
+    "@@ -671,6 +671,7 @@ export class DocumentService {\n"
+    "+  private validateFile(file): void {\n"
+    "+    return file.size < 1000\n"
+    "+  }\n"
+)
+TS_RETURN_ANNOTATED_FUNCTION_BOUNDARY_CHANGE = (
+    "+export function validateFileType(buffer, expectedType): boolean {\n"
+    "+  return Boolean(buffer && expectedType)\n"
+    "+}\n"
+)
+TWO_CLASS_SAME_SEAM_CHANGE = (
+    "+class CustomerValidator {\n"
+    "+  validate(input): boolean {\n"
+    "+    return Boolean(input.customerId)\n"
+    "+  }\n"
+    "+}\n"
+    "+class TenantValidator {\n"
+    "+  validate(input): boolean {\n"
+    "+    return Boolean(input.tenantId)\n"
+    "+  }\n"
+    "+}\n"
+)
 TS_NORMALIZER_CHANGE = "+function normalizeLandingPageRepairAttemptValue(value) {\n+  return Number(value)\n+}\n"
 ROUTING_TABLE_CHANGE = "+ROUTE_TO_ACTION = {\n+    'book': 'schedule_visit',\n+}\n"
 REMOVED_BOUNDARY_CHANGE = "-def resolve_contact(row):\n-    return row.email\n"
 CLAIM_SERIALIZER_CHANGE = "+def _serialize_claim(row):\n+    return {'claim': row.claim}\n"
 AUTH_ERROR_CHANGE = "+class RedditAuthError(RuntimeError):\n+    pass\n"
+SEO_RESOLVED_IMAGE_ASSIGNMENT = "+const resolvedImage = image ?? defaultImage\n"
 PLAN_WITH_ENUMERATION = """
 ### Boundary-change enumeration
 
@@ -88,6 +128,14 @@ def test_classify_and_route_without_plan_enumeration_is_flagged() -> None:
     assert len(findings) == 1
 
 
+def test_should_scrape_eligibility_without_plan_enumeration_is_flagged() -> None:
+    findings = mod.scan_diff(
+        {"atlas_brain/services/scraping/eligibility.py": PY_SHOULD_SCRAPE_CHANGE},
+        [],
+    )
+    assert len(findings) == 1
+
+
 def test_boundary_path_signal_without_plan_enumeration_is_flagged() -> None:
     findings = mod.scan_diff({"atlas_brain/services/admission_gate.py": PATH_ONLY_BOUNDARY_CHANGE}, [])
     assert len(findings) == 1
@@ -113,6 +161,28 @@ def test_parameterized_typescript_method_without_plan_enumeration_is_flagged() -
     assert len(findings) == 1
 
 
+def test_access_modified_typescript_method_without_plan_enumeration_is_flagged() -> None:
+    findings = mod.scan_diff(
+        {"lib/graphrag/service/document-service.ts": TS_PRIVATE_METHOD_BOUNDARY_CHANGE},
+        [],
+    )
+    assert len(findings) == 1
+
+
+def test_return_annotated_typescript_methods_without_plan_enumeration_are_flagged() -> None:
+    findings = mod.scan_diff(
+        {
+            "lib/graphrag/service/document-service.ts": TS_RETURN_ANNOTATED_METHOD_BOUNDARY_CHANGE,
+            "lib/graphrag/parsers/index.ts": TS_RETURN_ANNOTATED_FUNCTION_BOUNDARY_CHANGE,
+        },
+        [],
+    )
+    assert [finding.path for finding in findings] == [
+        "lib/graphrag/parsers/index.ts",
+        "lib/graphrag/service/document-service.ts",
+    ]
+
+
 def test_normalizing_decision_seam_without_plan_enumeration_is_flagged() -> None:
     findings = mod.scan_diff({"atlas-intel-ui/src/pages/ContentOpsNewRun.tsx": TS_NORMALIZER_CHANGE}, [])
     assert len(findings) == 1
@@ -136,6 +206,22 @@ def test_boundary_change_with_plan_enumeration_is_clean() -> None:
     assert findings == []
 
 
+def test_boundary_change_with_exact_seam_enumeration_is_clean() -> None:
+    seam_plan = """
+### Boundary-change enumeration
+
+- Boundary path/seam: resolve_contact_identity.
+- Replaced-path behaviors: preserved existing email-first lookup.
+- Guard-relevant fields: preserved email, phone, source_ref.
+- Caller x input shape: preserved intake x email-only.
+"""
+    findings = mod.scan_diff(
+        {"atlas_brain/services/crm_provider.py": BOUNDARY_CHANGE},
+        [seam_plan],
+    )
+    assert findings == []
+
+
 def test_non_boundary_change_is_clean() -> None:
     findings = mod.scan_diff({"atlas_brain/api/health.py": "+def ping():\n+    return {'ok': True}\n"}, [])
     assert findings == []
@@ -151,6 +237,14 @@ def test_auth_exception_lexical_lookalike_is_clean() -> None:
     assert findings == []
 
 
+def test_token_bearing_local_variable_assignment_is_clean() -> None:
+    findings = mod.scan_diff(
+        {"atlas-intel-ui/src/components/SeoHead.tsx": SEO_RESOLVED_IMAGE_ASSIGNMENT},
+        [],
+    )
+    assert findings == []
+
+
 def test_process_detector_change_is_clean_with_na_plan() -> None:
     findings = mod.scan_diff({"scripts/check_boundary_change_enumeration.py": BOUNDARY_CHANGE}, [])
     assert findings == []
@@ -163,6 +257,14 @@ def test_other_checker_boundary_change_is_not_exempt() -> None:
 
 def test_test_file_boundary_words_are_ignored() -> None:
     findings = mod.scan_diff({"tests/test_contact_resolver.py": BOUNDARY_CHANGE}, [])
+    assert findings == []
+
+
+def test_mjs_test_file_boundary_words_are_ignored() -> None:
+    findings = mod.scan_diff({
+        "atlas-intel-ui/scripts/content-ops-ingestion-routing.test.mjs": PATH_ONLY_BOUNDARY_CHANGE,
+        "atlas-intel-ui/scripts/content-ops-ingestion-routing.spec.cjs": PATH_ONLY_BOUNDARY_CHANGE,
+    }, [])
     assert findings == []
 
 
@@ -197,6 +299,7 @@ def test_section_level_not_applicable_reason_covers_bare_na_rows() -> None:
 
 N/A - no boundary change; detector path matched a process-only helper.
 
+- Boundary path/seam: atlas_brain/services/admission_gate.py.
 - Replaced-path behaviors: N/A.
 - Guard-relevant fields: N/A.
 - Caller x input shape: N/A.
@@ -211,6 +314,24 @@ N/A - no boundary change; detector path matched a process-only helper.
     )
 
 
+def test_section_level_not_applicable_does_not_cover_unlisted_boundary() -> None:
+    not_applicable = """
+### Boundary-change enumeration
+
+N/A - no boundary change; detector path matched a process-only helper.
+
+- Boundary path/seam: atlas_brain/services/other_gate.py.
+- Replaced-path behaviors: N/A.
+- Guard-relevant fields: N/A.
+- Caller x input shape: N/A.
+"""
+    findings = mod.scan_diff(
+        {"atlas_brain/services/admission_gate.py": PATH_ONLY_BOUNDARY_CHANGE},
+        [not_applicable],
+    )
+    assert [finding.path for finding in findings] == ["atlas_brain/services/admission_gate.py"]
+
+
 def test_duplicate_enumeration_rows_must_all_be_dispositioned() -> None:
     duplicate_todo = """
 ### Boundary-change enumeration
@@ -221,6 +342,18 @@ def test_duplicate_enumeration_rows_must_all_be_dispositioned() -> None:
 - Caller x input shape: intake x email-only -> preserved.
     """
     assert not mod.plan_has_boundary_enumeration(duplicate_todo)
+
+
+def test_unresolved_disposition_words_are_not_enumeration() -> None:
+    unresolved = """
+### Boundary-change enumeration
+
+- Boundary path: atlas_brain/services/crm_resolver.py.
+- Replaced-path behaviors: TBD after caller audit.
+- Guard-relevant fields: unknown.
+- Caller x input shape: pending review.
+"""
+    assert not mod.plan_has_boundary_enumeration(unresolved)
 
 
 def test_each_changed_boundary_requires_its_own_path_enumeration() -> None:
@@ -242,6 +375,114 @@ def test_each_changed_boundary_requires_its_own_path_enumeration() -> None:
     assert [finding.path for finding in findings] == ["atlas_brain/services/tenant_resolver.py"]
 
 
+def test_each_boundary_path_owns_its_own_disposition_group() -> None:
+    shared_dispositions_plan = """
+### Boundary-change enumeration
+
+- Boundary path: atlas_brain/services/crm_resolver.py.
+- Replaced-path behaviors: CRM preserves existing lookup.
+- Guard-relevant fields: CRM email.
+- Caller x input shape: CRM intake x email-only -> preserved.
+- Boundary path: atlas_brain/services/tenant_resolver.py.
+"""
+    findings = mod.scan_diff(
+        {
+            "atlas_brain/services/crm_resolver.py": BOUNDARY_CHANGE,
+            "atlas_brain/services/tenant_resolver.py": BOUNDARY_CHANGE,
+        },
+        [shared_dispositions_plan],
+    )
+    assert [finding.path for finding in findings] == ["atlas_brain/services/tenant_resolver.py"]
+
+
+def test_each_changed_seam_in_one_file_requires_coverage() -> None:
+    one_seam_plan = """
+### Boundary-change enumeration
+
+- Boundary path/seam: resolve_contact_identity.
+- Replaced-path behaviors: preserved contact lookup.
+- Guard-relevant fields: preserved email.
+- Caller x input shape: preserved intake contact payload.
+"""
+    findings = mod.scan_diff(
+        {"atlas_brain/services/crm_resolver.py": TWO_SEAMS_CHANGE},
+        [one_seam_plan],
+    )
+    assert [finding.path for finding in findings] == ["atlas_brain/services/crm_resolver.py"]
+
+
+def test_each_changed_seam_in_one_file_can_be_dispositioned() -> None:
+    two_seam_plan = """
+### Boundary-change enumeration
+
+- Boundary path/seam: resolve_contact_identity.
+- Replaced-path behaviors: preserved contact lookup.
+- Guard-relevant fields: preserved email.
+- Caller x input shape: preserved intake contact payload.
+- Boundary path/seam: resolve_tenant_identity.
+- Replaced-path behaviors: preserved tenant lookup.
+- Guard-relevant fields: preserved tenant_id.
+- Caller x input shape: preserved intake tenant payload.
+"""
+    findings = mod.scan_diff(
+        {"atlas_brain/services/crm_resolver.py": TWO_SEAMS_CHANGE},
+        [two_seam_plan],
+    )
+    assert findings == []
+
+
+def test_same_named_methods_in_distinct_classes_need_distinct_boundary_entries() -> None:
+    bare_validate_plan = """
+### Boundary-change enumeration
+
+- Boundary path/seam: validate.
+- Replaced-path behaviors: preserved validation behavior.
+- Guard-relevant fields: preserved id fields.
+- Caller x input shape: preserved callers.
+"""
+    findings = mod.scan_diff(
+        {"atlas-churn-ui/src/validators/customer.ts": TWO_CLASS_SAME_SEAM_CHANGE},
+        [bare_validate_plan],
+    )
+    assert [finding.path for finding in findings] == ["atlas-churn-ui/src/validators/customer.ts"]
+
+
+def test_same_named_methods_in_distinct_classes_can_be_dispositioned_by_qualified_entry() -> None:
+    qualified_plan = """
+### Boundary-change enumeration
+
+- Boundary path/seam: CustomerValidator.validate.
+- Replaced-path behaviors: preserved customer validation behavior.
+- Guard-relevant fields: preserved customerId.
+- Caller x input shape: preserved customer callers.
+- Boundary path/seam: TenantValidator.validate.
+- Replaced-path behaviors: preserved tenant validation behavior.
+- Guard-relevant fields: preserved tenantId.
+- Caller x input shape: preserved tenant callers.
+"""
+    findings = mod.scan_diff(
+        {"atlas-churn-ui/src/validators/customer.ts": TWO_CLASS_SAME_SEAM_CHANGE},
+        [qualified_plan],
+    )
+    assert findings == []
+
+
+def test_boundary_path_match_requires_exact_changed_path() -> None:
+    basename_only_plan = """
+### Boundary-change enumeration
+
+- Boundary path: index.ts.
+- Replaced-path behaviors: preserves existing lookup.
+- Guard-relevant fields: account id.
+- Caller x input shape: panel x account-only -> preserved.
+"""
+    findings = mod.scan_diff(
+        {"atlas-churn-ui/src/components/index.ts": TS_BOUNDARY_CHANGE},
+        [basename_only_plan],
+    )
+    assert [finding.path for finding in findings] == ["atlas-churn-ui/src/components/index.ts"]
+
+
 def test_cli_entrypoint_warns_advisory_and_fails_strict(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
     monkeypatch.setattr(
         mod,
@@ -261,3 +502,20 @@ def test_cli_entrypoint_warns_advisory_and_fails_strict(monkeypatch: pytest.Monk
 def test_git_failure_raises_system_exit() -> None:
     with pytest.raises(SystemExit, match="git .* failed"):
         mod._git(["rev-parse", "--verify", "definitely-not-a-ref-xyz"])
+
+
+def test_changed_plan_texts_reads_from_repo_root_when_called_from_subdir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan_path = tmp_path / "plans" / "PR-Cwd.md"
+    plan_path.parent.mkdir()
+    plan_path.write_text(PLAN_WITH_ENUMERATION, encoding="utf-8")
+    caller_cwd = tmp_path / "subdir"
+    caller_cwd.mkdir()
+
+    monkeypatch.setattr(mod, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(mod, "_git", lambda args: "plans/PR-Cwd.md\n")
+    monkeypatch.chdir(caller_cwd)
+
+    assert mod.changed_plan_texts("ignored") == [PLAN_WITH_ENUMERATION]

--- a/tests/test_check_boundary_change_enumeration.py
+++ b/tests/test_check_boundary_change_enumeration.py
@@ -27,6 +27,11 @@ TS_BOUNDARY_CHANGE = (
 PATH_ONLY_BOUNDARY_CHANGE = "+VALUE = 1\n"
 CONST_BOUNDARY_CHANGE = "+const resolveClaimGate = (input) => Boolean(input.accountId)\n"
 CLASS_BOUNDARY_CHANGE = "+class TenantResolver {\n+  resolve(input) { return input.tenantId }\n+}\n"
+SHELL_BOUNDARY_CHANGE = "+validate_scope() {\n+  test -n \"$ATLAS_SCOPE\"\n+}\n"
+TS_METHOD_BOUNDARY_CHANGE = "+  validateFileType(buffer, expectedType) {\n+    return true\n+  }\n"
+TS_NORMALIZER_CHANGE = "+function normalizeLandingPageRepairAttemptValue(value) {\n+  return Number(value)\n+}\n"
+REMOVED_BOUNDARY_CHANGE = "-def resolve_contact(row):\n-    return row.email\n"
+CLAIM_SERIALIZER_CHANGE = "+def _serialize_claim(row):\n+    return {'claim': row.claim}\n"
 PLAN_WITH_ENUMERATION = """
 ### Boundary-change enumeration
 
@@ -71,6 +76,26 @@ def test_class_boundary_signal_without_plan_enumeration_is_flagged() -> None:
     assert len(findings) == 1
 
 
+def test_shell_boundary_signal_without_plan_enumeration_is_flagged() -> None:
+    findings = mod.scan_diff({"scripts/validate_extracted_content_pipeline.sh": SHELL_BOUNDARY_CHANGE}, [])
+    assert len(findings) == 1
+
+
+def test_parameterized_typescript_method_without_plan_enumeration_is_flagged() -> None:
+    findings = mod.scan_diff({"lib/graphrag/parsers/index.ts": TS_METHOD_BOUNDARY_CHANGE}, [])
+    assert len(findings) == 1
+
+
+def test_normalizing_decision_seam_without_plan_enumeration_is_flagged() -> None:
+    findings = mod.scan_diff({"atlas-intel-ui/src/pages/ContentOpsNewRun.tsx": TS_NORMALIZER_CHANGE}, [])
+    assert len(findings) == 1
+
+
+def test_removed_boundary_declaration_without_plan_enumeration_is_flagged() -> None:
+    findings = mod.scan_diff({"scripts/sync_eom_portal_customers.py": REMOVED_BOUNDARY_CHANGE}, [])
+    assert len(findings) == 1
+
+
 def test_boundary_change_with_plan_enumeration_is_clean() -> None:
     findings = mod.scan_diff(
         {"atlas_brain/services/crm_provider.py": BOUNDARY_CHANGE},
@@ -81,6 +106,11 @@ def test_boundary_change_with_plan_enumeration_is_clean() -> None:
 
 def test_non_boundary_change_is_clean() -> None:
     findings = mod.scan_diff({"atlas_brain/api/health.py": "+def ping():\n+    return {'ok': True}\n"}, [])
+    assert findings == []
+
+
+def test_claim_serializer_lexical_lookalike_is_clean() -> None:
+    findings = mod.scan_diff({"atlas_brain/api/b2b_vendor_claims.py": CLAIM_SERIALIZER_CHANGE}, [])
     assert findings == []
 
 
@@ -111,6 +141,17 @@ def test_plan_requires_all_enumeration_markers() -> None:
     assert not mod.plan_has_boundary_enumeration(SCAFFOLD_PLACEHOLDER)
     assert not mod.plan_has_boundary_enumeration(narrative)
     assert mod.plan_has_boundary_enumeration(PLAN_WITH_ENUMERATION)
+
+
+def test_reasoned_not_applicable_dispositions_are_clean() -> None:
+    not_applicable = """
+### Boundary-change enumeration
+
+- Replaced-path behaviors: N/A - no boundary behavior is replaced.
+- Guard-relevant fields: not applicable - no guard verdict fields.
+- Caller x input shape: N/A - no caller can reach a boundary.
+"""
+    assert mod.plan_has_boundary_enumeration(not_applicable)
 
 
 def test_cli_entrypoint_warns_advisory_and_fails_strict(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_new_pr_plan.py
+++ b/tests/test_new_pr_plan.py
@@ -91,6 +91,11 @@ def test_new_pr_plan_creates_agents_plan_skeleton(tmp_path: Path) -> None:
     assert "3k.4 execution model and property-level invariant" in compact_text
     assert "sampled concurrent test alone is not enough" in compact_text
     assert "not\n  dispositioned by the review matrix" in text
+    assert "### Boundary-change enumeration" in text
+    assert "Required when this diff changes a guard, validator, resolver, or admission" in text
+    assert "- Replaced-path behaviors: TODO/N/A." in text
+    assert "- Guard-relevant fields: TODO/N/A." in text
+    assert "- Caller x input shape: TODO/N/A." in text
     assert "### Files touched" in text
     assert "| **Total** | **0** |" in text
 

--- a/tests/test_new_pr_plan.py
+++ b/tests/test_new_pr_plan.py
@@ -92,8 +92,12 @@ def test_new_pr_plan_creates_agents_plan_skeleton(tmp_path: Path) -> None:
     assert "sampled concurrent test alone is not enough" in compact_text
     assert "not\n  dispositioned by the review matrix" in text
     assert "### Boundary-change enumeration" in text
-    assert "Required when this diff changes a guard, validator, resolver, or admission" in text
-    assert "Name each changed boundary path or seam in the enumeration" in text
+    assert (
+        "Required when this diff changes a guard, validator, normalizer, resolver,"
+        in text
+    )
+    assert "router/classifier, or admission boundary" in text
+    assert "Name each changed boundary path or\nseam in the enumeration" in text
     assert "- Boundary path/seam: TODO/N/A." in text
     assert "- Replaced-path behaviors: TODO/N/A." in text
     assert "- Guard-relevant fields: TODO/N/A." in text

--- a/tests/test_new_pr_plan.py
+++ b/tests/test_new_pr_plan.py
@@ -93,6 +93,8 @@ def test_new_pr_plan_creates_agents_plan_skeleton(tmp_path: Path) -> None:
     assert "not\n  dispositioned by the review matrix" in text
     assert "### Boundary-change enumeration" in text
     assert "Required when this diff changes a guard, validator, resolver, or admission" in text
+    assert "Name each changed boundary path or seam in the enumeration" in text
+    assert "- Boundary path/seam: TODO/N/A." in text
     assert "- Replaced-path behaviors: TODO/N/A." in text
     assert "- Guard-relevant fields: TODO/N/A." in text
     assert "- Caller x input shape: TODO/N/A." in text


### PR DESCRIPTION
Plan: plans/PR-Boundary-Change-Enumeration.md
Slice phase: Workflow/process
Ownership lane: dev-workflow/codification

Adds the boundary-change enumeration rule as Atlas builder law, plan-template prompt, advisory CI tripwire, and both-direction tests. This targets guard/validator/normalizer/resolver/router-classifier/admission boundary diffs that need the exact changed boundary path/seam, replaced-path behaviors, guard-relevant fields, and caller x input-shape dispositions before code.

Diff-budget override: this single-rule slice is genuinely indivisible because the requested three-layer mechanism requires AGENTS law, plan scaffold, advisory workflow/checker, and both-direction plus CLI regression tests in the same PR; the post-review hardening adds section-scoped plan parsing, Python/JS/TS/shell boundary coverage, generated-scaffold coverage, placeholder rejection, removed-declaration detection, parameterized/access-modified/return-annotated method detection, normalizing/routing/eligibility/allowed/classify seam detection, exact seam-name and qualified class-method plan matching, JS-family test suffix exclusions, claim/auth/local-variable lexical near-miss coverage, exact per-boundary disposition ownership, duplicate-row validation, unresolved-marker rejection, set-valued dependency closure, repo-root plan reads, reasoned section-level not-applicable parsing, and a narrowed self-bootstrap exemption so the tripwire cannot silently pass its target class.

## Incident evidence
- Prevents the boundary ripple class observed in ATLAS #2216 rounds 1-7 and Website #70 rounds 1-4, where a mid-PR inventory of replaced-path behaviors/fields/callers was the convergence lever.

## Intentional
- Advisory-first only; the detector emits warnings and exits 0 unless --strict is supplied.
- The rule explicitly preserves existing AGENTS 3k.3 open-input evidence-gating.

## Deferred
- Promotion to required is deferred to a later operator decision.

## Parked hardening
- None.

## AI reconciliation
AI findings reviewed: Yes. All fixed or waived: Yes. Waivers justified in PR body: N/A.
- Fixed/confirmed `Recognize normalizing decision seams`: current head recognizes normalize/normalizing names and has a focused normalizer fixture.
- Fixed `Detect routing decision seams`: added route/router/routing path signals and a mapping-only router fixture.
- Fixed `Reject undispositioned duplicate enumeration rows`: validates every marker row, including duplicate rows, instead of accepting the first match.
- Fixed `Exclude non-boundary authentication classes`: narrows auth class matching to decision implementations and adds an AuthError near-miss fixture.
- Fixed `Detect keyword-free boundary decision seams`: added allowed/allow/classify/gate signals and held-out fixtures for `isProductClaimAllowed` and `classify_and_route` hunks.
- Fixed `Align not-applicable parsing with the scaffold`: accepts a reasoned section-level `N/A - ...` statement with bare `N/A` rows while still rejecting untouched `TODO/N/A` placeholders.
- Fixed `Require enumeration for every changed boundary`: plan coverage is per changed boundary path/seam, with a multi-boundary fixture proving one enumerated resolver cannot hide another.
- Fixed `Include normalization and routing in the scaffold`: AGENTS, failure text, and `new_pr_plan.sh` now name normalizer and router/classifier seams consistently.
- Fixed `Bind each disposition set to its exact boundary`: each `Boundary path/seam:` row owns only its following disposition group, and exact changed-path matching prevents same-stem bleed.
- Fixed `Reject every unresolved disposition marker`: `TBD`, `unknown`, `pending`, and `unresolved` values fail the enumeration parser.
- Fixed `Recognize access-modified TypeScript boundary methods`: method detection now accepts TypeScript access/static/override/readonly modifiers, with a `private validateFile` fixture.
- Fixed `Detect eligibility decision seams without vocabulary tokens`: added eligibility/`should_scrape_now` detection with a held-out scraping eligibility fixture.
- Fixed `Accept exact seam names in boundary entries`: detected declaration seam names now satisfy exact `Boundary path/seam:` entries as an alternative to the full changed path.
- Fixed `Exclude MJS and CJS test files from boundary scanning`: `.test.mjs` and `.spec.cjs` routing-path fixtures are ignored as tests, with the suffix set covering admitted JS-family test/spec forms.
- Fixed `Declare closure for the detector's decision sets`: the plan now dispositions code suffixes, test exclusions, regex vocabularies, markers, unresolved vocabulary, and path/seam matching as CLOSED/DERIVED/DEFAULTED.
- Fixed `Bind coverage to every changed boundary`: reasoned section-level `N/A` no longer covers changed boundaries globally; each detected changed boundary path/seam needs its own exact entry, and multi-seam fixtures prove one covered seam cannot hide another.
- Fixed `Restrict variable matches to boundary declarations`: JavaScript/TypeScript `const`/`let`/`var` detection is limited to callable boundary declarations so local variables such as `resolvedImage` do not trigger the tripwire.
- Fixed `Recognize return-annotated TypeScript boundary methods`: method detection now accepts normal `): boolean` / `): void` signatures, with fixtures based on `validateFileType(...): boolean` and `private validateFile(...): void` shapes.
- Fixed `Preserve distinct boundaries that share a seam name`: class-method seams are qualified, so `CustomerValidator.validate` and `TenantValidator.validate` each need their own complete disposition group instead of collapsing to one bare `validate` entry.
- Fixed `Read changed plans relative to the repository root`: changed plan existence/read checks now use `REPO_ROOT / name`, with a cwd-changing entrypoint test proving subdirectory invocation still loads the plan.

## Cold diff reconstruction
- Changed: AGENTS.md adds §3k.5 with the verbatim boundary-change rule and requires naming each changed boundary path/seam.
- Changed: scripts/new_pr_plan.sh scaffolds a Boundary-change enumeration subsection with changed-boundary path/seam plus the required disposition rows.
- Changed: scripts/check_boundary_change_enumeration.py and tests add the advisory detector, section-scoped parsing, added/removed Python/JS/TS/shell boundary coverage, parameterized/access-modified/return-annotated method coverage, routing/normalizing/allowed/classify/eligibility coverage, exact path/seam and qualified class-method target association, multi-seam and same-bare-method coverage, section-level N/A support without global hiding, duplicate-row validation, claim/auth and local-variable near-miss coverage, repo-root plan reads, placeholder rejection, narrowed self-bootstrap behavior, and CLI advisory/strict fixtures.
- Changed: tests/test_new_pr_plan.py proves the generated plan scaffold includes the required Boundary-change enumeration prompts.
- Changed: .github/workflows/boundary_change_enumeration.yml runs the advisory detector on pull_request.
- Gaps: None known.

## Verification
- python -m pytest tests/test_check_boundary_change_enumeration.py tests/test_new_pr_plan.py -q --noconftest — 57 passed.
- python scripts/check_boundary_change_enumeration.py --base origin/main — OK.
- python scripts/check_boundary_change_enumeration.py --base origin/main --strict — OK.
- git diff --check origin/main...HEAD — OK.
- python scripts/audit_plan_doc.py plans/PR-Boundary-Change-Enumeration.md — OK.
- python scripts/audit_plan_doc_files_touched.py plans/PR-Boundary-Change-Enumeration.md origin/main — OK.
- python scripts/audit_plan_doc_diff_size.py plans/PR-Boundary-Change-Enumeration.md origin/main — OK, estimate 1200, actual 1196, drift 0.3%.
- python scripts/audit_plan_code_consistency.py plans/PR-Boundary-Change-Enumeration.md — OK.
- python scripts/audit_review_rules_triggered.py origin/main --plan plans/PR-Boundary-Change-Enumeration.md — OK.
- pre-push audit wrapper — passed on push; only plans archive backlog warning was advisory.

## Diff size
7 files, +1196 / -0
