### PR TITLE
EOM Render receivables: enable digest-only service auth

### DIFF
--- a/atlas_brain/eom_api/auth.py
+++ b/atlas_brain/eom_api/auth.py
@@ -11,12 +11,7 @@ from typing import Protocol
 
 from fastapi import Depends, Header, HTTPException
 
-from .config import (
-    EOMInvoicingConfig,
-    RAW_RECEIVABLES_SERVICE_TOKEN_ENV,
-    invoicing_settings,
-    raw_receivables_service_token_configured,
-)
+from .config import EOMInvoicingConfig, invoicing_settings
 
 _GENERATED_TOKEN_PREFIX = "eomrx_v1_"
 _GENERATED_TOKEN_RANDOM_LENGTH = 43
@@ -123,13 +118,6 @@ def validate_receivables_api_config(
     resolved = config or invoicing_settings
     if not resolved.receivables_api_enabled:
         return
-    if raw_receivables_service_token_configured():
-        raise RuntimeError(
-            "Raw EOM receivables bearer token material must not be configured "
-            f"in {RAW_RECEIVABLES_SERVICE_TOKEN_ENV}; provision only "
-            "ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN_SHA256 on the Atlas API "
-            "service and keep the raw token on the caller side."
-        )
     raw_token = getattr(resolved, "receivables_service_token", "")
     if raw_token is not None and str(raw_token).strip():
         raise RuntimeError(

--- a/atlas_brain/eom_api/auth.py
+++ b/atlas_brain/eom_api/auth.py
@@ -56,6 +56,7 @@ def _token_sha256(token: str) -> str:
 _PLACEHOLDER_TOKEN_DIGESTS = {
     _token_sha256(token) for token in _PLACEHOLDER_TOKENS
 }
+_PLACEHOLDER_TOKEN_DIGESTS.add("0" * 64)
 
 
 def _validate_generated_token(token: str) -> None:
@@ -113,18 +114,20 @@ def _validate_generated_token_digest(token_digest: str) -> None:
 def validate_receivables_api_config(
     config: ReceivablesApiAuthConfig | EOMInvoicingConfig | None = None,
 ) -> None:
-    """Fail startup unless enabled auth comes from a trusted in-process source."""
+    """Fail startup unless enabled auth has digest-only generated-token config."""
     resolved = config or invoicing_settings
     if not resolved.receivables_api_enabled:
         return
-    if not isinstance(resolved, TrustedReceivablesApiConfig):
+    raw_token = getattr(resolved, "receivables_service_token", "")
+    if raw_token is not None and str(raw_token).strip():
         raise RuntimeError(
-            "The EOM receivables API cannot be enabled from operator-supplied "
-            "configuration in this Render profile slice; keep "
-            "ATLAS_INVOICING_RECEIVABLES_API_ENABLED=false until the Slice C "
-            "provisioning trust anchor lands."
+            "Raw EOM receivables bearer token material must not be configured "
+            "on the Atlas API service; provision only "
+            "ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN_SHA256 here and keep "
+            "the raw token on the caller side."
         )
-    token_digest = resolved.receivables_service_token_sha256.strip()
+    token_digest = getattr(resolved, "receivables_service_token_sha256", "")
+    token_digest = token_digest.strip() if isinstance(token_digest, str) else ""
     _validate_generated_token_digest(token_digest)
 
 

--- a/atlas_brain/eom_api/auth.py
+++ b/atlas_brain/eom_api/auth.py
@@ -15,7 +15,7 @@ from .config import (
     EOMInvoicingConfig,
     RAW_RECEIVABLES_SERVICE_TOKEN_ENV,
     invoicing_settings,
-    raw_receivables_service_token_env_value,
+    raw_receivables_service_token_configured,
 )
 
 _GENERATED_TOKEN_PREFIX = "eomrx_v1_"
@@ -71,9 +71,9 @@ def _validate_generated_token(token: str) -> None:
             "use atlas_brain.eom_api.auth.generate_receivables_service_token()"
         )
     random_part = token.removeprefix(_GENERATED_TOKEN_PREFIX)
-    if len(random_part) < _GENERATED_TOKEN_RANDOM_LENGTH:
+    if len(random_part) != _GENERATED_TOKEN_RANDOM_LENGTH:
         raise RuntimeError(
-            "Receivables service token random payload is too short; generate a "
+            "Receivables service token random payload has the wrong length; generate a "
             "new token with atlas_brain.eom_api.auth.generate_receivables_service_token()"
         )
     if fullmatch(_TOKEN_RANDOM_PATTERN, random_part) is None:
@@ -123,7 +123,7 @@ def validate_receivables_api_config(
     resolved = config or invoicing_settings
     if not resolved.receivables_api_enabled:
         return
-    if raw_receivables_service_token_env_value():
+    if raw_receivables_service_token_configured():
         raise RuntimeError(
             "Raw EOM receivables bearer token material must not be configured "
             f"in {RAW_RECEIVABLES_SERVICE_TOKEN_ENV}; provision only "

--- a/atlas_brain/eom_api/auth.py
+++ b/atlas_brain/eom_api/auth.py
@@ -11,7 +11,12 @@ from typing import Protocol
 
 from fastapi import Depends, Header, HTTPException
 
-from .config import EOMInvoicingConfig, invoicing_settings
+from .config import (
+    EOMInvoicingConfig,
+    RAW_RECEIVABLES_SERVICE_TOKEN_ENV,
+    invoicing_settings,
+    raw_receivables_service_token_env_value,
+)
 
 _GENERATED_TOKEN_PREFIX = "eomrx_v1_"
 _GENERATED_TOKEN_RANDOM_LENGTH = 43
@@ -118,6 +123,13 @@ def validate_receivables_api_config(
     resolved = config or invoicing_settings
     if not resolved.receivables_api_enabled:
         return
+    if raw_receivables_service_token_env_value():
+        raise RuntimeError(
+            "Raw EOM receivables bearer token material must not be configured "
+            f"in {RAW_RECEIVABLES_SERVICE_TOKEN_ENV}; provision only "
+            "ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN_SHA256 on the Atlas API "
+            "service and keep the raw token on the caller side."
+        )
     raw_token = getattr(resolved, "receivables_service_token", "")
     if raw_token is not None and str(raw_token).strip():
         raise RuntimeError(
@@ -157,8 +169,13 @@ async def require_receivables_api(
     scheme, separator, provided = authorization.partition(" ")
     if separator != " " or scheme.lower() != "bearer" or not provided.strip():
         raise HTTPException(status_code=401, detail="Bearer token required")
+    provided_token = provided.strip()
     try:
-        provided_digest = _token_sha256(provided.strip())
+        _validate_generated_token(provided_token)
+    except RuntimeError as exc:
+        raise HTTPException(status_code=401, detail="Invalid bearer token") from exc
+    try:
+        provided_digest = _token_sha256(provided_token)
     except UnicodeEncodeError as exc:
         raise HTTPException(status_code=401, detail="Invalid bearer token") from exc
     expected_digest = config.receivables_service_token_sha256.strip()

--- a/atlas_brain/eom_api/config.py
+++ b/atlas_brain/eom_api/config.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
+from pathlib import Path
 
+from dotenv import dotenv_values
 from pydantic import Field
 from pydantic import model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -13,12 +15,29 @@ ENV_FILES = (".env", ".env.local")
 RAW_RECEIVABLES_SERVICE_TOKEN_ENV = "ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN"
 
 
-def raw_receivables_service_token_env_value(
+def _has_raw_receivables_service_token(value: object) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def raw_receivables_service_token_configured(
     environ: Mapping[str, str] | None = None,
-) -> str:
-    """Return raw receivables token material from process env, if configured."""
-    value = (environ or os.environ).get(RAW_RECEIVABLES_SERVICE_TOKEN_ENV, "")
-    return value.strip()
+    env_files: Iterable[str | Path] = ENV_FILES,
+) -> bool:
+    """Return true when any admitted settings source carries raw token material."""
+    if _has_raw_receivables_service_token(
+        (environ or os.environ).get(RAW_RECEIVABLES_SERVICE_TOKEN_ENV, "")
+    ):
+        return True
+    for env_file in env_files:
+        try:
+            values = dotenv_values(env_file)
+        except OSError:
+            continue
+        if _has_raw_receivables_service_token(
+            values.get(RAW_RECEIVABLES_SERVICE_TOKEN_ENV)
+        ):
+            return True
+    return False
 
 
 class EOMRuntimeConfig(BaseSettings):
@@ -74,7 +93,7 @@ class EOMInvoicingConfig(BaseSettings):
     def reject_raw_receivables_service_token_env(self) -> "EOMInvoicingConfig":
         if (
             self.receivables_api_enabled
-            and raw_receivables_service_token_env_value()
+            and raw_receivables_service_token_configured()
         ):
             raise ValueError(
                 "Raw EOM receivables bearer token material must not be configured "

--- a/atlas_brain/eom_api/config.py
+++ b/atlas_brain/eom_api/config.py
@@ -2,10 +2,23 @@
 
 from __future__ import annotations
 
+import os
+from collections.abc import Mapping
+
 from pydantic import Field
+from pydantic import model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 ENV_FILES = (".env", ".env.local")
+RAW_RECEIVABLES_SERVICE_TOKEN_ENV = "ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN"
+
+
+def raw_receivables_service_token_env_value(
+    environ: Mapping[str, str] | None = None,
+) -> str:
+    """Return raw receivables token material from process env, if configured."""
+    value = (environ or os.environ).get(RAW_RECEIVABLES_SERVICE_TOKEN_ENV, "")
+    return value.strip()
 
 
 class EOMRuntimeConfig(BaseSettings):
@@ -56,6 +69,20 @@ class EOMInvoicingConfig(BaseSettings):
             "the raw token must live only on the caller side"
         ),
     )
+
+    @model_validator(mode="after")
+    def reject_raw_receivables_service_token_env(self) -> "EOMInvoicingConfig":
+        if (
+            self.receivables_api_enabled
+            and raw_receivables_service_token_env_value()
+        ):
+            raise ValueError(
+                "Raw EOM receivables bearer token material must not be configured "
+                f"in {RAW_RECEIVABLES_SERVICE_TOKEN_ENV}; provision only "
+                "ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN_SHA256 on the Atlas "
+                "API service and keep the raw token on the caller side."
+            )
+        return self
 
 
 eom_settings = EOMRuntimeConfig()

--- a/atlas_brain/eom_api/config.py
+++ b/atlas_brain/eom_api/config.py
@@ -13,10 +13,21 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 ENV_FILES = (".env", ".env.local")
 RAW_RECEIVABLES_SERVICE_TOKEN_ENV = "ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN"
+_RAW_RECEIVABLES_SERVICE_TOKEN_ENV_KEY = RAW_RECEIVABLES_SERVICE_TOKEN_ENV.casefold()
 
 
 def _has_raw_receivables_service_token(value: object) -> bool:
     return isinstance(value, str) and bool(value.strip())
+
+
+def _mapping_contains_raw_receivables_service_token(
+    values: Mapping[str, object],
+) -> bool:
+    return any(
+        key.casefold() == _RAW_RECEIVABLES_SERVICE_TOKEN_ENV_KEY
+        and _has_raw_receivables_service_token(value)
+        for key, value in values.items()
+    )
 
 
 def raw_receivables_service_token_configured(
@@ -24,18 +35,14 @@ def raw_receivables_service_token_configured(
     env_files: Iterable[str | Path] = ENV_FILES,
 ) -> bool:
     """Return true when any admitted settings source carries raw token material."""
-    if _has_raw_receivables_service_token(
-        (environ or os.environ).get(RAW_RECEIVABLES_SERVICE_TOKEN_ENV, "")
-    ):
+    if _mapping_contains_raw_receivables_service_token(environ or os.environ):
         return True
     for env_file in env_files:
         try:
             values = dotenv_values(env_file)
         except OSError:
             continue
-        if _has_raw_receivables_service_token(
-            values.get(RAW_RECEIVABLES_SERVICE_TOKEN_ENV)
-        ):
+        if _mapping_contains_raw_receivables_service_token(values):
             return True
     return False
 
@@ -91,10 +98,7 @@ class EOMInvoicingConfig(BaseSettings):
 
     @model_validator(mode="after")
     def reject_raw_receivables_service_token_env(self) -> "EOMInvoicingConfig":
-        if (
-            self.receivables_api_enabled
-            and raw_receivables_service_token_configured()
-        ):
+        if raw_receivables_service_token_configured():
             raise ValueError(
                 "Raw EOM receivables bearer token material must not be configured "
                 f"in {RAW_RECEIVABLES_SERVICE_TOKEN_ENV}; provision only "

--- a/atlas_brain/eom_api/config.py
+++ b/atlas_brain/eom_api/config.py
@@ -49,6 +49,13 @@ class EOMInvoicingConfig(BaseSettings):
         default=False,
         description="Enable the authenticated EOM receivables service API",
     )
+    receivables_service_token_sha256: str = Field(
+        default="",
+        description=(
+            "SHA-256 digest of the generated EOM receivables bearer token; "
+            "the raw token must live only on the caller side"
+        ),
+    )
 
 
 eom_settings = EOMRuntimeConfig()

--- a/plans/PR-EOM-Render-Receivables-Auth.md
+++ b/plans/PR-EOM-Render-Receivables-Auth.md
@@ -1,0 +1,147 @@
+# PR-EOM-Render-Receivables-Auth
+
+## Why this slice exists
+
+The operator asked to continue the EOM Render hosting arc after #2220 merged.
+#2217 created the slim EOM API profile, and #2220 wired the candidate Render
+Postgres connection string. The remaining blocker before the already-Render-
+hosted EOM time tracker can call Atlas is service-to-service auth: the API
+still refuses to start when `ATLAS_INVOICING_RECEIVABLES_API_ENABLED=true`.
+
+This slice narrows the old "Slice C" into the Atlas-side trust anchor first:
+allow the slim API to start only with a digest-only generated bearer-token
+configuration, keep raw bearer material out of the Atlas API service, and prove
+the real EOM route accepts/rejects callers through that runtime config.
+
+### Problem-derived contract
+
+- Root cause: The slim EOM API currently has a generated-token/digest helper,
+  but the runtime settings object exposes only the enable flag and startup
+  validation rejects every operator-supplied enabled config. As a result the
+  Render candidate cannot enable the receivables API without either failing
+  startup or falling back to a raw-token-in-API-service pattern.
+- Correct fix must touch/change: Add a typed digest-only runtime setting for
+  the EOM receivables service token; update startup/request validation to
+  accept enabled runtime config only when a generated-token SHA-256 digest is
+  present and no raw bearer token is present; update the Render candidate to
+  prompt for that digest and enable the receivables API; and add route/startup
+  tests that prove valid runtime digest config authorizes the real EOM route
+  while missing, malformed, placeholder, and raw-token-bearing configs fail
+  closed.
+- Must not change: Do not store raw bearer tokens on the Atlas API service,
+  modify the full Atlas app, enable migrations, change database schema, touch
+  the EOM time tracker repository/deployment, change customer/onboarding or
+  Stripe behavior, or touch unrelated open PR lanes.
+
+## Scope (this PR)
+
+Ownership lane: eom/render-receivables-auth
+Slice phase: vertical slice
+
+1. Allow the slim EOM API profile to run the receivables routes with a
+   digest-only service-token runtime config.
+2. Update the reviewable Render candidate so the API is enabled only with a
+   prompted SHA-256 digest secret and no raw token value.
+3. Prove the real EOM app route accepts the generated token and rejects bad or
+   missing auth through the runtime config object.
+
+### Review Contract
+
+- Acceptance criteria:
+  - `tests/test_eom_render_profile.py::test_eom_render_blueprint_maps_database_and_receivables_auth`
+    proves `render.eom.yaml` enables the receivables API, prompts for
+    `ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN_SHA256` with `sync: false`,
+    keeps migrations disabled, preserves the Render Postgres connection-string
+    mapping, and does not define any raw receivables token env var.
+  - `tests/test_eom_render_profile.py::test_eom_receivables_runtime_config_accepts_generated_digest_only`
+    proves `EOMInvoicingConfig` can enable the API with only a generated token
+    digest, and that the config model exposes no raw-token field.
+  - `tests/test_eom_render_profile.py::test_eom_receivables_startup_rejects_unsafe_enabled_runtime_config`
+    proves enabled config fails closed for missing digest, malformed digest,
+    placeholder-derived digest, and any object carrying raw bearer-token
+    material.
+  - `tests/test_eom_render_profile.py::test_eom_receivables_ready_route_is_fail_closed`
+    proves the route boundary returns 401 for missing/invalid bearer tokens,
+    401 for malformed non-ASCII bearer bytes, 200 for the configured generated
+    bearer token, and 503 when the API is disabled.
+  - `tests/test_eom_render_profile.py::test_eom_profile_reaches_receivables_ready_through_real_app`
+    proves the real `atlas_brain.main_eom:app` route transport reaches
+    `/api/v1/receivables/ready` using the runtime digest config, not the
+    in-process trusted test config.
+- Reachability proof: `tests/test_eom_render_profile.py::test_eom_profile_reaches_receivables_ready_through_real_app`
+  drives the real EOM FastAPI app and asserts the observable
+  `{"status": "ready"}` HTTP JSON result with runtime digest auth enabled and
+  DB access disabled/mocked at the service seam.
+- Affected surfaces: EOM invoicing config, EOM receivables auth validation,
+  candidate Render Blueprint, and focused EOM Render-profile tests.
+- Risk areas: raw secret placement, auth fail-open behavior, startup failure
+  behavior, Render env drift, accidental migration/API coupling, and EOM route
+  reachability.
+- Reviewer rules triggered: R1, R2, R3, R5, R6, R10, R11, R12, R14.
+
+### Files touched
+
+- `atlas_brain/eom_api/auth.py`
+- `atlas_brain/eom_api/config.py`
+- `plans/PR-EOM-Render-Receivables-Auth.md`
+- `render.eom.yaml`
+- `tests/test_eom_render_profile.py`
+
+## Mechanism
+
+`EOMInvoicingConfig` gains a digest-only
+`receivables_service_token_sha256` setting loaded through the existing
+`ATLAS_INVOICING_` prefix. `validate_receivables_api_config()` still returns
+early when the API is disabled. When enabled, it rejects any config object that
+carries raw bearer-token material, then validates the digest shape and rejects
+placeholder-derived digests. `require_receivables_api()` continues to hash the
+presented bearer token and compare digests with `hmac.compare_digest()`.
+
+`render.eom.yaml` turns on `ATLAS_INVOICING_RECEIVABLES_API_ENABLED` and adds
+`ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN_SHA256` as `sync: false`, so Render
+prompts the operator for the digest without hardcoding it in the candidate
+Blueprint. The raw generated token remains caller-side material for the later
+EOM time tracker slice.
+
+## Intentional
+
+- This PR does not put the raw bearer token in `render.eom.yaml` or
+  `EOMInvoicingConfig`; only the SHA-256 digest belongs on the Atlas API side.
+- This PR keeps the candidate file named `render.eom.yaml`, not render dot yaml,
+  so it remains reviewable infrastructure shape instead of auto-applied live
+  Render configuration.
+- This PR enables only the auth gate for the receivables API candidate; database
+  migrations remain disabled.
+- The in-process trusted config helper remains available for narrow tests, but
+  the real app reachability proof uses `EOMInvoicingConfig`.
+
+## Deferred
+
+- Next slice: wire the EOM time tracker caller to the Atlas private service URL,
+  store the raw generated bearer token only on that caller side, and prove
+  private-service `/api/v1/receivables/ready` connectivity.
+- Later slices: decide EOM migration ownership/order for production schema,
+  connect EOM funnel/customer lifecycle events, and plan deprecation of duplicate
+  or old onboarding/receivables code once the new path proves itself.
+
+Parked hardening: none.
+
+## Verification
+
+- Passed locally:
+  - Command: python -m pytest tests/test_eom_render_profile.py
+  - Command: python -m py_compile atlas_brain/eom_api/auth.py atlas_brain/eom_api/config.py atlas_brain/main_eom.py tests/test_eom_render_profile.py
+  - Command: git diff --check
+  - Command: python scripts/sync_pr_plan.py plans/PR-EOM-Render-Receivables-Auth.md
+  - Command: python scripts/audit_plan_code_consistency.py plans/PR-EOM-Render-Receivables-Auth.md
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/eom_api/auth.py` | 17 |
+| `atlas_brain/eom_api/config.py` | 7 |
+| `plans/PR-EOM-Render-Receivables-Auth.md` | 147 |
+| `render.eom.yaml` | 4 |
+| `tests/test_eom_render_profile.py` | 107 |
+| **Total** | **282** |

--- a/plans/PR-EOM-Render-Receivables-Auth.md
+++ b/plans/PR-EOM-Render-Receivables-Auth.md
@@ -9,25 +9,30 @@ hosted EOM time tracker can call Atlas is service-to-service auth: the API
 still refuses to start when `ATLAS_INVOICING_RECEIVABLES_API_ENABLED=true`.
 
 This slice narrows the old "Slice C" into the Atlas-side trust anchor first:
-allow the slim API to start only with a digest-only generated bearer-token
-configuration, keep raw bearer material out of the Atlas API service, and prove
-the real EOM route accepts/rejects callers through that runtime config.
+allow the slim API to start only with digest-only bearer-token configuration,
+keep raw bearer material out of the Atlas API service, and prove the real EOM
+route accepts generated-token callers while rejecting non-generated bearers.
 
 ### Problem-derived contract
 
 - Root cause: The slim EOM API currently has a generated-token/digest helper,
   but the runtime settings object exposes only the enable flag and startup
-  validation rejects every operator-supplied enabled config. As a result the
-  Render candidate cannot enable the receivables API without either failing
-  startup or falling back to a raw-token-in-API-service pattern.
+  validation rejects every operator-supplied enabled config. The first fix
+  added a digest setting, but review showed two remaining bugs: the settings
+  model ignores the forbidden raw-token env var before validation can see it,
+  and digest shape alone cannot prove that the bearer preimage came from the
+  generated-token helper. As a result the Render candidate cannot safely enable
+  the receivables API without fail-closed checks on both config projection and
+  request admission.
 - Correct fix must touch/change: Add a typed digest-only runtime setting for
-  the EOM receivables service token; update startup/request validation to
-  accept enabled runtime config only when a generated-token SHA-256 digest is
-  present and no raw bearer token is present; update the Render candidate to
-  prompt for that digest and enable the receivables API; and add route/startup
-  tests that prove valid runtime digest config authorizes the real EOM route
-  while missing, malformed, placeholder, and raw-token-bearing configs fail
-  closed.
+  the EOM receivables service token; reject the legacy/raw bearer-token env var
+  before model projection can hide it; update request validation to require the
+  presented bearer token to match the generated `eomrx_v1_...` format before
+  hashing and comparing it; update the Render candidate to prompt for the
+  digest and enable the receivables API; and add route/startup tests that prove
+  valid runtime digest config authorizes the real EOM route while missing,
+  malformed, placeholder, raw-token-bearing, and non-generated matching-digest
+  paths fail closed.
 - Must not change: Do not store raw bearer tokens on the Atlas API service,
   modify the full Atlas app, enable migrations, change database schema, touch
   the EOM time tracker repository/deployment, change customer/onboarding or
@@ -56,14 +61,19 @@ Slice phase: vertical slice
   - `tests/test_eom_render_profile.py::test_eom_receivables_runtime_config_accepts_generated_digest_only`
     proves `EOMInvoicingConfig` can enable the API with only a generated token
     digest, and that the config model exposes no raw-token field.
+  - `tests/test_eom_render_profile.py::test_eom_receivables_runtime_config_rejects_raw_token_env_before_projection`
+    proves a real environment-projected `EOMInvoicingConfig` rejects
+    `ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN` even when a valid digest is
+    also configured.
   - `tests/test_eom_render_profile.py::test_eom_receivables_startup_rejects_unsafe_enabled_runtime_config`
     proves enabled config fails closed for missing digest, malformed digest,
     placeholder-derived digest, and any object carrying raw bearer-token
     material.
   - `tests/test_eom_render_profile.py::test_eom_receivables_ready_route_is_fail_closed`
     proves the route boundary returns 401 for missing/invalid bearer tokens,
-    401 for malformed non-ASCII bearer bytes, 200 for the configured generated
-    bearer token, and 503 when the API is disabled.
+    401 for malformed non-ASCII bearer bytes, 401 for a non-generated bearer
+    whose digest matches config, 200 for the configured generated bearer token,
+    and 503 when the API is disabled.
   - `tests/test_eom_render_profile.py::test_eom_profile_reaches_receivables_ready_through_real_app`
     proves the real `atlas_brain.main_eom:app` route transport reaches
     `/api/v1/receivables/ready` using the runtime digest config, not the
@@ -91,11 +101,15 @@ Slice phase: vertical slice
 
 `EOMInvoicingConfig` gains a digest-only
 `receivables_service_token_sha256` setting loaded through the existing
-`ATLAS_INVOICING_` prefix. `validate_receivables_api_config()` still returns
-early when the API is disabled. When enabled, it rejects any config object that
-carries raw bearer-token material, then validates the digest shape and rejects
-placeholder-derived digests. `require_receivables_api()` continues to hash the
-presented bearer token and compare digests with `hmac.compare_digest()`.
+`ATLAS_INVOICING_` prefix. Its settings model rejects the legacy/raw
+`ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN` env var when the API is enabled, so
+`extra="ignore"` cannot hide forbidden bearer material before validation.
+`validate_receivables_api_config()` still returns early when the API is
+disabled. When enabled, it repeats the raw-env guard, rejects any config object
+that carries raw bearer-token material, then validates the digest shape and
+rejects placeholder-derived digests. `require_receivables_api()` validates the
+presented bearer token against the generated-token format before hashing it and
+comparing digests with `hmac.compare_digest()`.
 
 `render.eom.yaml` turns on `ATLAS_INVOICING_RECEIVABLES_API_ENABLED` and adds
 `ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN_SHA256` as `sync: false`, so Render
@@ -139,9 +153,9 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `atlas_brain/eom_api/auth.py` | 17 |
-| `atlas_brain/eom_api/config.py` | 7 |
-| `plans/PR-EOM-Render-Receivables-Auth.md` | 147 |
+| `atlas_brain/eom_api/auth.py` | 38 |
+| `atlas_brain/eom_api/config.py` | 34 |
+| `plans/PR-EOM-Render-Receivables-Auth.md` | 161 |
 | `render.eom.yaml` | 4 |
-| `tests/test_eom_render_profile.py` | 107 |
-| **Total** | **282** |
+| `tests/test_eom_render_profile.py` | 149 |
+| **Total** | **386** |

--- a/plans/PR-EOM-Render-Receivables-Auth.md
+++ b/plans/PR-EOM-Render-Receivables-Auth.md
@@ -106,9 +106,11 @@ Slice phase: vertical slice
     path.
   - `tests/test_eom_render_profile.py::test_eom_receivables_bearer_admission_matches_generated_token_grammar`
     proves the free-form `Authorization` bearer token admission matches an
-    independent prefix × payload-length × payload-character grammar oracle, with
-    matching digests supplied for every generated ASCII token candidate so bad
-    grammar cannot be hidden as a digest mismatch.
+    independent prefix × payload grammar oracle across homogeneous payloads,
+    mixed allowed payloads, and invalid characters inserted at first, middle,
+    and last payload positions, with matching digests supplied for every
+    generated ASCII token candidate so bad grammar cannot be hidden as a digest
+    mismatch.
   - `tests/test_eom_render_profile.py::test_eom_receivables_ready_route_is_fail_closed`
     proves `require_receivables_api()` has one bearer-admission choke point:
     `_validate_generated_token()` must accept only the bounded
@@ -132,7 +134,7 @@ Slice phase: vertical slice
 - Risk areas: raw secret placement, auth fail-open behavior, startup failure
   behavior, Render env drift, accidental migration/API coupling, and EOM route
   reachability.
-- Reviewer rules triggered: R1, R2, R3, R5, R6, R10, R11, R12, R14.
+- Reviewer rules triggered: R1, R2, R3, R5, R6, R8, R10, R11, R12, R13, R14.
 
 ### Files touched
 
@@ -202,7 +204,7 @@ Parked hardening: none.
 |---|---:|
 | `atlas_brain/eom_api/auth.py` | 28 |
 | `atlas_brain/eom_api/config.py` | 57 |
-| `plans/PR-EOM-Render-Receivables-Auth.md` | 208 |
+| `plans/PR-EOM-Render-Receivables-Auth.md` | 210 |
 | `render.eom.yaml` | 2 |
-| `tests/test_eom_render_profile.py` | 510 |
-| **Total** | **805** |
+| `tests/test_eom_render_profile.py` | 578 |
+| **Total** | **875** |

--- a/plans/PR-EOM-Render-Receivables-Auth.md
+++ b/plans/PR-EOM-Render-Receivables-Auth.md
@@ -21,18 +21,21 @@ route accepts generated-token callers while rejecting non-generated bearers.
   added a digest setting, but review showed two remaining bugs: the settings
   model ignores the forbidden raw-token env var before validation can see it,
   and digest shape alone cannot prove that the bearer preimage came from the
-  generated-token helper. As a result the Render candidate cannot safely enable
-  the receivables API without fail-closed checks on both config projection and
-  request admission.
+  generated-token helper. Follow-up review found the raw-token guard still
+  missed env-file settings sources, and request validation still admitted
+  generated-prefix bearers with the wrong payload length. As a result the Render
+  candidate cannot safely enable the receivables API without fail-closed checks
+  on both settings-source admission and request admission.
 - Correct fix must touch/change: Add a typed digest-only runtime setting for
-  the EOM receivables service token; reject the legacy/raw bearer-token env var
-  before model projection can hide it; update request validation to require the
-  presented bearer token to match the generated `eomrx_v1_...` format before
-  hashing and comparing it; update the Render candidate to prompt for the
-  digest and enable the receivables API; and add route/startup tests that prove
-  valid runtime digest config authorizes the real EOM route while missing,
-  malformed, placeholder, raw-token-bearing, and non-generated matching-digest
-  paths fail closed.
+  the EOM receivables service token; reject the legacy/raw bearer-token key
+  across process env and env-file settings sources before model projection can
+  hide it; update request validation to require the presented bearer token to
+  match the exact generated `eomrx_v1_...` payload length before hashing and
+  comparing it; update the Render candidate to prompt for the digest and enable
+  the receivables API; and add route/startup tests that prove valid runtime
+  digest config authorizes the real EOM route while missing, malformed,
+  placeholder, raw-token-bearing, non-generated matching-digest, and max+1
+  generated-format paths fail closed.
 - Must not change: Do not store raw bearer tokens on the Atlas API service,
   modify the full Atlas app, enable migrations, change database schema, touch
   the EOM time tracker repository/deployment, change customer/onboarding or
@@ -65,6 +68,9 @@ Slice phase: vertical slice
     proves a real environment-projected `EOMInvoicingConfig` rejects
     `ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN` even when a valid digest is
     also configured.
+  - `tests/test_eom_render_profile.py::test_eom_profile_rejects_raw_receivables_token_from_dotenv_before_projection`
+    proves the real EOM entrypoint rejects a forbidden raw token supplied from
+    an admitted dotenv settings source before `extra="ignore"` can hide it.
   - `tests/test_eom_render_profile.py::test_eom_receivables_startup_rejects_unsafe_enabled_runtime_config`
     proves enabled config fails closed for missing digest, malformed digest,
     placeholder-derived digest, and any object carrying raw bearer-token
@@ -72,8 +78,9 @@ Slice phase: vertical slice
   - `tests/test_eom_render_profile.py::test_eom_receivables_ready_route_is_fail_closed`
     proves the route boundary returns 401 for missing/invalid bearer tokens,
     401 for malformed non-ASCII bearer bytes, 401 for a non-generated bearer
-    whose digest matches config, 200 for the configured generated bearer token,
-    and 503 when the API is disabled.
+    whose digest matches config, 401 for a generated-prefix bearer with a max+1
+    payload whose digest matches config, 200 for the configured generated bearer
+    token, and 503 when the API is disabled.
   - `tests/test_eom_render_profile.py::test_eom_profile_reaches_receivables_ready_through_real_app`
     proves the real `atlas_brain.main_eom:app` route transport reaches
     `/api/v1/receivables/ready` using the runtime digest config, not the
@@ -102,14 +109,15 @@ Slice phase: vertical slice
 `EOMInvoicingConfig` gains a digest-only
 `receivables_service_token_sha256` setting loaded through the existing
 `ATLAS_INVOICING_` prefix. Its settings model rejects the legacy/raw
-`ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN` env var when the API is enabled, so
-`extra="ignore"` cannot hide forbidden bearer material before validation.
-`validate_receivables_api_config()` still returns early when the API is
-disabled. When enabled, it repeats the raw-env guard, rejects any config object
-that carries raw bearer-token material, then validates the digest shape and
-rejects placeholder-derived digests. `require_receivables_api()` validates the
-presented bearer token against the generated-token format before hashing it and
-comparing digests with `hmac.compare_digest()`.
+`ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN` key from process env and admitted
+dotenv settings sources when the API is enabled, so `extra="ignore"` cannot hide
+forbidden bearer material before validation. `validate_receivables_api_config()`
+still returns early when the API is disabled. When enabled, it repeats the raw
+settings-source guard, rejects any config object that carries raw bearer-token
+material, then validates the digest shape and rejects placeholder-derived
+digests. `require_receivables_api()` validates the presented bearer token
+against the exact generated-token prefix and payload length before hashing it
+and comparing digests with `hmac.compare_digest()`.
 
 `render.eom.yaml` turns on `ATLAS_INVOICING_RECEIVABLES_API_ENABLED` and adds
 `ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN_SHA256` as `sync: false`, so Render
@@ -153,9 +161,9 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `atlas_brain/eom_api/auth.py` | 38 |
-| `atlas_brain/eom_api/config.py` | 34 |
-| `plans/PR-EOM-Render-Receivables-Auth.md` | 161 |
+| `atlas_brain/eom_api/auth.py` | 42 |
+| `atlas_brain/eom_api/config.py` | 53 |
+| `plans/PR-EOM-Render-Receivables-Auth.md` | 169 |
 | `render.eom.yaml` | 4 |
-| `tests/test_eom_render_profile.py` | 149 |
-| **Total** | **386** |
+| `tests/test_eom_render_profile.py` | 210 |
+| **Total** | **478** |

--- a/plans/PR-EOM-Render-Receivables-Auth.md
+++ b/plans/PR-EOM-Render-Receivables-Auth.md
@@ -33,13 +33,17 @@ that is knowingly unsafe.
   and digest shape alone cannot prove that the bearer preimage came from the
   generated-token helper. Follow-up review found the raw-token guard still
   missed env-file settings sources, and request validation still admitted
-  generated-prefix bearers with the wrong payload length. As a result the Render
-  candidate cannot safely enable the receivables API without fail-closed checks
-  on both settings-source admission and request admission.
+  generated-prefix bearers with the wrong payload length. Latest review also
+  showed that the raw-token settings-source guard was case-sensitive and gated
+  by the API enable flag, leaving lowercase aliases and disabled raw-token config
+  admitted before projection. As a result the Render candidate cannot safely
+  carry the receivables API settings without fail-closed checks on both
+  settings-source admission and request admission.
 - Correct fix must touch/change: Add a typed digest-only runtime setting for
   the EOM receivables service token; reject the legacy/raw bearer-token key
-  across process env and env-file settings sources before model projection can
-  hide it; update request validation to require the presented bearer token to
+  across process env and env-file settings sources case-insensitively and
+  regardless of enable state before model projection can hide it; update request
+  validation to require the presented bearer token to
   match the exact generated `eomrx_v1_...` payload length before hashing and
   comparing it; update the Render candidate to prompt for the digest while
   keeping the receivables API disabled until schema provisioning is wired; and
@@ -76,12 +80,14 @@ Slice phase: vertical slice
     proves `EOMInvoicingConfig` can enable the API with only a generated token
     digest, and that the config model exposes no raw-token field.
   - `tests/test_eom_render_profile.py::test_eom_receivables_runtime_config_rejects_raw_token_env_before_projection`
-    proves a real environment-projected `EOMInvoicingConfig` rejects
-    `ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN` even when a valid digest is
+    proves a real environment-projected `EOMInvoicingConfig` rejects uppercase
+    and lowercase `ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN` aliases whether
+    the receivables API flag is enabled or disabled, even when a valid digest is
     also configured.
   - `tests/test_eom_render_profile.py::test_eom_profile_rejects_raw_receivables_token_from_dotenv_before_projection`
-    proves the real EOM entrypoint rejects a forbidden raw token supplied from
-    an admitted dotenv settings source before `extra="ignore"` can hide it.
+    proves the real EOM entrypoint rejects uppercase and lowercase forbidden raw
+    token aliases supplied from admitted dotenv settings sources whether the API
+    flag is enabled or disabled, before `extra="ignore"` can hide them.
   - `tests/test_eom_render_profile.py::test_eom_receivables_startup_rejects_unsafe_enabled_runtime_config`
     proves enabled config fails closed for missing digest, malformed digest,
     placeholder-derived digest, and any object carrying raw bearer-token
@@ -127,8 +133,9 @@ Slice phase: vertical slice
 `receivables_service_token_sha256` setting loaded through the existing
 `ATLAS_INVOICING_` prefix. Its settings model rejects the legacy/raw
 `ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN` key from process env and admitted
-dotenv settings sources when the API is enabled, so `extra="ignore"` cannot hide
-forbidden bearer material before validation. `validate_receivables_api_config()`
+dotenv settings sources with case-insensitive key matching and regardless of
+the API enable flag, so `extra="ignore"` cannot hide forbidden bearer material
+before validation. `validate_receivables_api_config()`
 still returns early when the API is disabled. When enabled, it rejects any config
 object that carries raw bearer-token material, then validates the digest shape
 and rejects placeholder-derived digests. `require_receivables_api()` validates the presented bearer token
@@ -167,7 +174,7 @@ Parked hardening: none.
 ## Verification
 
 - Passed locally:
-  - Command: python -m pytest tests/test_eom_render_profile.py -- 23 passed, 1 warning
+  - Command: python -m pytest tests/test_eom_render_profile.py -- 29 passed, 1 warning
   - Command: python -m py_compile atlas_brain/eom_api/auth.py atlas_brain/eom_api/config.py atlas_brain/main_eom.py tests/test_eom_render_profile.py -- passed
   - Command: git diff --check -- passed
   - Command: python scripts/sync_pr_plan.py plans/PR-EOM-Render-Receivables-Auth.md -- passed
@@ -178,8 +185,8 @@ Parked hardening: none.
 | File | LOC |
 |---|---:|
 | `atlas_brain/eom_api/auth.py` | 28 |
-| `atlas_brain/eom_api/config.py` | 53 |
-| `plans/PR-EOM-Render-Receivables-Auth.md` | 185 |
+| `atlas_brain/eom_api/config.py` | 57 |
+| `plans/PR-EOM-Render-Receivables-Auth.md` | 192 |
 | `render.eom.yaml` | 2 |
-| `tests/test_eom_render_profile.py` | 238 |
-| **Total** | **506** |
+| `tests/test_eom_render_profile.py` | 262 |
+| **Total** | **541** |

--- a/plans/PR-EOM-Render-Receivables-Auth.md
+++ b/plans/PR-EOM-Render-Receivables-Auth.md
@@ -5,13 +5,23 @@
 The operator asked to continue the EOM Render hosting arc after #2220 merged.
 #2217 created the slim EOM API profile, and #2220 wired the candidate Render
 Postgres connection string. The remaining blocker before the already-Render-
-hosted EOM time tracker can call Atlas is service-to-service auth: the API
-still refuses to start when `ATLAS_INVOICING_RECEIVABLES_API_ENABLED=true`.
+hosted EOM time tracker can call Atlas is service-to-service auth: the slim API
+needs a digest-only trust anchor that can be enabled safely after the receivables
+database schema is provisioned.
 
 This slice narrows the old "Slice C" into the Atlas-side trust anchor first:
 allow the slim API to start only with digest-only bearer-token configuration,
 keep raw bearer material out of the Atlas API service, and prove the real EOM
-route accepts generated-token callers while rejecting non-generated bearers.
+route accepts generated-token callers while rejecting non-generated bearers. The
+candidate Blueprint deliberately keeps the API disabled because the fresh Render
+database still has migrations disabled and this slice does not provision the
+receivables tables.
+
+Diff-budget rationale: this PR exceeds the 400-added-line soft cap because the
+reviewer-blocker repairs are indivisible from this trust-anchor slice. The
+production code, Render candidate posture, plan contract, and held-out
+regressions must move together to avoid either a red PR or a deployable candidate
+that is knowingly unsafe.
 
 ### Problem-derived contract
 
@@ -31,11 +41,11 @@ route accepts generated-token callers while rejecting non-generated bearers.
   across process env and env-file settings sources before model projection can
   hide it; update request validation to require the presented bearer token to
   match the exact generated `eomrx_v1_...` payload length before hashing and
-  comparing it; update the Render candidate to prompt for the digest and enable
-  the receivables API; and add route/startup tests that prove valid runtime
-  digest config authorizes the real EOM route while missing, malformed,
-  placeholder, raw-token-bearing, non-generated matching-digest, and max+1
-  generated-format paths fail closed.
+  comparing it; update the Render candidate to prompt for the digest while
+  keeping the receivables API disabled until schema provisioning is wired; and
+  add route/startup tests that prove valid runtime digest config authorizes the
+  real EOM route while missing, malformed, placeholder, raw-token-bearing,
+  non-generated matching-digest, and max+1 generated-format paths fail closed.
 - Must not change: Do not store raw bearer tokens on the Atlas API service,
   modify the full Atlas app, enable migrations, change database schema, touch
   the EOM time tracker repository/deployment, change customer/onboarding or
@@ -48,8 +58,9 @@ Slice phase: vertical slice
 
 1. Allow the slim EOM API profile to run the receivables routes with a
    digest-only service-token runtime config.
-2. Update the reviewable Render candidate so the API is enabled only with a
-   prompted SHA-256 digest secret and no raw token value.
+2. Update the reviewable Render candidate so the SHA-256 digest secret is
+   prompted but the API remains disabled until the receivables schema is
+   provisioned.
 3. Prove the real EOM app route accepts the generated token and rejects bad or
    missing auth through the runtime config object.
 
@@ -57,7 +68,7 @@ Slice phase: vertical slice
 
 - Acceptance criteria:
   - `tests/test_eom_render_profile.py::test_eom_render_blueprint_maps_database_and_receivables_auth`
-    proves `render.eom.yaml` enables the receivables API, prompts for
+    proves `render.eom.yaml` keeps the receivables API disabled, prompts for
     `ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN_SHA256` with `sync: false`,
     keeps migrations disabled, preserves the Render Postgres connection-string
     mapping, and does not define any raw receivables token env var.
@@ -75,12 +86,18 @@ Slice phase: vertical slice
     proves enabled config fails closed for missing digest, malformed digest,
     placeholder-derived digest, and any object carrying raw bearer-token
     material.
+  - `tests/test_eom_render_profile.py::test_eom_receivables_request_auth_does_not_rescan_settings_sources`
+    proves request-time bearer validation uses the in-memory runtime config and
+    does not synchronously re-read dotenv settings sources on the async request
+    path.
   - `tests/test_eom_render_profile.py::test_eom_receivables_ready_route_is_fail_closed`
-    proves the route boundary returns 401 for missing/invalid bearer tokens,
-    401 for malformed non-ASCII bearer bytes, 401 for a non-generated bearer
-    whose digest matches config, 401 for a generated-prefix bearer with a max+1
-    payload whose digest matches config, 200 for the configured generated bearer
-    token, and 503 when the API is disabled.
+    proves `require_receivables_api()` has one bearer-admission choke point:
+    `_validate_generated_token()` must accept only the bounded
+    `eomrx_v1_` prefix, exact payload length, and allowed-character recognizer
+    before digest comparison. Every missing, unrecognized, malformed,
+    non-ASCII, non-generated matching-digest, and max+1 generated-prefix bearer
+    defaults to 401; the configured generated bearer returns 200; and disabled
+    runtime config returns 503.
   - `tests/test_eom_render_profile.py::test_eom_profile_reaches_receivables_ready_through_real_app`
     proves the real `atlas_brain.main_eom:app` route transport reaches
     `/api/v1/receivables/ready` using the runtime digest config, not the
@@ -112,17 +129,16 @@ Slice phase: vertical slice
 `ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN` key from process env and admitted
 dotenv settings sources when the API is enabled, so `extra="ignore"` cannot hide
 forbidden bearer material before validation. `validate_receivables_api_config()`
-still returns early when the API is disabled. When enabled, it repeats the raw
-settings-source guard, rejects any config object that carries raw bearer-token
-material, then validates the digest shape and rejects placeholder-derived
-digests. `require_receivables_api()` validates the presented bearer token
+still returns early when the API is disabled. When enabled, it rejects any config
+object that carries raw bearer-token material, then validates the digest shape
+and rejects placeholder-derived digests. `require_receivables_api()` validates the presented bearer token
 against the exact generated-token prefix and payload length before hashing it
 and comparing digests with `hmac.compare_digest()`.
 
-`render.eom.yaml` turns on `ATLAS_INVOICING_RECEIVABLES_API_ENABLED` and adds
-`ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN_SHA256` as `sync: false`, so Render
-prompts the operator for the digest without hardcoding it in the candidate
-Blueprint. The raw generated token remains caller-side material for the later
+`render.eom.yaml` keeps `ATLAS_INVOICING_RECEIVABLES_API_ENABLED=false` and adds
+`ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN_SHA256` as `sync: false`, so the
+candidate can collect the digest without exposing the API before schema
+provisioning. The raw generated token remains caller-side material for the later
 EOM time tracker slice.
 
 ## Intentional
@@ -132,8 +148,8 @@ EOM time tracker slice.
 - This PR keeps the candidate file named `render.eom.yaml`, not render dot yaml,
   so it remains reviewable infrastructure shape instead of auto-applied live
   Render configuration.
-- This PR enables only the auth gate for the receivables API candidate; database
-  migrations remain disabled.
+- This PR keeps the receivables API disabled in the Render candidate because
+  database migrations remain disabled.
 - The in-process trusted config helper remains available for narrow tests, but
   the real app reachability proof uses `EOMInvoicingConfig`.
 
@@ -151,19 +167,19 @@ Parked hardening: none.
 ## Verification
 
 - Passed locally:
-  - Command: python -m pytest tests/test_eom_render_profile.py
-  - Command: python -m py_compile atlas_brain/eom_api/auth.py atlas_brain/eom_api/config.py atlas_brain/main_eom.py tests/test_eom_render_profile.py
-  - Command: git diff --check
-  - Command: python scripts/sync_pr_plan.py plans/PR-EOM-Render-Receivables-Auth.md
-  - Command: python scripts/audit_plan_code_consistency.py plans/PR-EOM-Render-Receivables-Auth.md
+  - Command: python -m pytest tests/test_eom_render_profile.py -- 23 passed, 1 warning
+  - Command: python -m py_compile atlas_brain/eom_api/auth.py atlas_brain/eom_api/config.py atlas_brain/main_eom.py tests/test_eom_render_profile.py -- passed
+  - Command: git diff --check -- passed
+  - Command: python scripts/sync_pr_plan.py plans/PR-EOM-Render-Receivables-Auth.md -- passed
+  - Command: python scripts/audit_plan_code_consistency.py plans/PR-EOM-Render-Receivables-Auth.md -- passed
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
-| `atlas_brain/eom_api/auth.py` | 42 |
+| `atlas_brain/eom_api/auth.py` | 28 |
 | `atlas_brain/eom_api/config.py` | 53 |
-| `plans/PR-EOM-Render-Receivables-Auth.md` | 169 |
-| `render.eom.yaml` | 4 |
-| `tests/test_eom_render_profile.py` | 210 |
-| **Total** | **478** |
+| `plans/PR-EOM-Render-Receivables-Auth.md` | 185 |
+| `render.eom.yaml` | 2 |
+| `tests/test_eom_render_profile.py` | 238 |
+| **Total** | **506** |

--- a/plans/PR-EOM-Render-Receivables-Auth.md
+++ b/plans/PR-EOM-Render-Receivables-Auth.md
@@ -36,8 +36,11 @@ that is knowingly unsafe.
   generated-prefix bearers with the wrong payload length. Latest review also
   showed that the raw-token settings-source guard was case-sensitive and gated
   by the API enable flag, leaving lowercase aliases and disabled raw-token config
-  admitted before projection. As a result the Render candidate cannot safely
-  carry the receivables API settings without fail-closed checks on both
+  admitted before projection. The newest review showed the evidence still proved
+  sampled strings rather than the raw-key and bearer grammars, and the real-app
+  reachability proof bypassed env projection by overriding the auth dependency.
+  As a result the Render candidate cannot safely carry the receivables API
+  settings without fail-closed checks and class-level evidence for both
   settings-source admission and request admission.
 - Correct fix must touch/change: Add a typed digest-only runtime setting for
   the EOM receivables service token; reject the legacy/raw bearer-token key
@@ -48,8 +51,9 @@ that is knowingly unsafe.
   comparing it; update the Render candidate to prompt for the digest while
   keeping the receivables API disabled until schema provisioning is wired; and
   add route/startup tests that prove valid runtime digest config authorizes the
-  real EOM route while missing, malformed, placeholder, raw-token-bearing,
-  non-generated matching-digest, and max+1 generated-format paths fail closed.
+  real EOM route through actual environment projection while missing, malformed,
+  placeholder, raw-token-bearing, non-generated matching-digest, max+1
+  generated-format, and grammar-generated invalid paths fail closed.
 - Must not change: Do not store raw bearer tokens on the Atlas API service,
   modify the full Atlas app, enable migrations, change database schema, touch
   the EOM time tracker repository/deployment, change customer/onboarding or
@@ -79,6 +83,10 @@ Slice phase: vertical slice
   - `tests/test_eom_render_profile.py::test_eom_receivables_runtime_config_accepts_generated_digest_only`
     proves `EOMInvoicingConfig` can enable the API with only a generated token
     digest, and that the config model exposes no raw-token field.
+  - `tests/test_eom_render_profile.py::test_eom_receivables_raw_token_source_admission_matches_casefold_oracle`
+    proves raw-token settings-source admission matches an independent
+    casefolding oracle across process-env and dotenv sources, canonical/mixed
+    case raw-token aliases, unrelated keys, and blank/nonblank values.
   - `tests/test_eom_render_profile.py::test_eom_receivables_runtime_config_rejects_raw_token_env_before_projection`
     proves a real environment-projected `EOMInvoicingConfig` rejects uppercase
     and lowercase `ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN` aliases whether
@@ -96,6 +104,11 @@ Slice phase: vertical slice
     proves request-time bearer validation uses the in-memory runtime config and
     does not synchronously re-read dotenv settings sources on the async request
     path.
+  - `tests/test_eom_render_profile.py::test_eom_receivables_bearer_admission_matches_generated_token_grammar`
+    proves the free-form `Authorization` bearer token admission matches an
+    independent prefix × payload-length × payload-character grammar oracle, with
+    matching digests supplied for every generated ASCII token candidate so bad
+    grammar cannot be hidden as a digest mismatch.
   - `tests/test_eom_render_profile.py::test_eom_receivables_ready_route_is_fail_closed`
     proves `require_receivables_api()` has one bearer-admission choke point:
     `_validate_generated_token()` must accept only the bounded
@@ -105,13 +118,15 @@ Slice phase: vertical slice
     defaults to 401; the configured generated bearer returns 200; and disabled
     runtime config returns 503.
   - `tests/test_eom_render_profile.py::test_eom_profile_reaches_receivables_ready_through_real_app`
-    proves the real `atlas_brain.main_eom:app` route transport reaches
-    `/api/v1/receivables/ready` using the runtime digest config, not the
-    in-process trusted test config.
+    proves a fresh process imports the real `atlas_brain.main_eom:app`, projects
+    `ATLAS_INVOICING_*` env vars into the runtime singleton, uses no auth
+    dependency override, and reaches `/api/v1/receivables/ready` with only the
+    database/service seam mocked.
 - Reachability proof: `tests/test_eom_render_profile.py::test_eom_profile_reaches_receivables_ready_through_real_app`
-  drives the real EOM FastAPI app and asserts the observable
-  `{"status": "ready"}` HTTP JSON result with runtime digest auth enabled and
-  DB access disabled/mocked at the service seam.
+  launches a fresh Python process, drives the real EOM FastAPI app, and asserts
+  the observable `{"status": "ready"}` HTTP JSON result with runtime digest auth
+  enabled from `ATLAS_INVOICING_*`, no auth dependency override, and DB/service
+  access mocked only at the service seam.
 - Affected surfaces: EOM invoicing config, EOM receivables auth validation,
   candidate Render Blueprint, and focused EOM Render-profile tests.
 - Risk areas: raw secret placement, auth fail-open behavior, startup failure
@@ -158,7 +173,8 @@ EOM time tracker slice.
 - This PR keeps the receivables API disabled in the Render candidate because
   database migrations remain disabled.
 - The in-process trusted config helper remains available for narrow tests, but
-  the real app reachability proof uses `EOMInvoicingConfig`.
+  the real app reachability proof uses the `EOMInvoicingConfig` singleton
+  projected from actual environment variables.
 
 ## Deferred
 
@@ -174,7 +190,7 @@ Parked hardening: none.
 ## Verification
 
 - Passed locally:
-  - Command: python -m pytest tests/test_eom_render_profile.py -- 29 passed, 1 warning
+  - Command: python -m pytest tests/test_eom_render_profile.py -- 31 passed, 1 warning
   - Command: python -m py_compile atlas_brain/eom_api/auth.py atlas_brain/eom_api/config.py atlas_brain/main_eom.py tests/test_eom_render_profile.py -- passed
   - Command: git diff --check -- passed
   - Command: python scripts/sync_pr_plan.py plans/PR-EOM-Render-Receivables-Auth.md -- passed
@@ -186,7 +202,7 @@ Parked hardening: none.
 |---|---:|
 | `atlas_brain/eom_api/auth.py` | 28 |
 | `atlas_brain/eom_api/config.py` | 57 |
-| `plans/PR-EOM-Render-Receivables-Auth.md` | 192 |
+| `plans/PR-EOM-Render-Receivables-Auth.md` | 208 |
 | `render.eom.yaml` | 2 |
-| `tests/test_eom_render_profile.py` | 262 |
-| **Total** | **541** |
+| `tests/test_eom_render_profile.py` | 510 |
+| **Total** | **805** |

--- a/render.eom.yaml
+++ b/render.eom.yaml
@@ -23,6 +23,8 @@ services:
           name: atlas-eom-postgres
           property: connectionString
       - key: ATLAS_INVOICING_RECEIVABLES_API_ENABLED
-        value: "false"
+        value: "true"
+      - key: ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN_SHA256
+        sync: false
       - key: ATLAS_EOM_RUN_MIGRATIONS
         value: "false"

--- a/render.eom.yaml
+++ b/render.eom.yaml
@@ -23,7 +23,7 @@ services:
           name: atlas-eom-postgres
           property: connectionString
       - key: ATLAS_INVOICING_RECEIVABLES_API_ENABLED
-        value: "true"
+        value: "false"
       - key: ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN_SHA256
         sync: false
       - key: ATLAS_EOM_RUN_MIGRATIONS

--- a/tests/test_eom_render_profile.py
+++ b/tests/test_eom_render_profile.py
@@ -212,7 +212,7 @@ def test_eom_env_loader_preserves_process_env_and_local_precedence(
     assert os.environ[process_interpolated_key] == "process-secret"
 
 
-def test_eom_render_blueprint_maps_database_connection_string():
+def test_eom_render_blueprint_maps_database_and_receivables_auth():
     blueprint = yaml.safe_load(Path("render.eom.yaml").read_text(encoding="utf-8"))
 
     assert blueprint["databases"] == [
@@ -245,12 +245,21 @@ def test_eom_render_blueprint_maps_database_connection_string():
     }
     assert env_vars["ATLAS_INVOICING_RECEIVABLES_API_ENABLED"] == {
         "key": "ATLAS_INVOICING_RECEIVABLES_API_ENABLED",
-        "value": "false",
+        "value": "true",
+    }
+    assert env_vars["ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN_SHA256"] == {
+        "key": "ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN_SHA256",
+        "sync": False,
     }
     assert env_vars["ATLAS_EOM_RUN_MIGRATIONS"] == {
         "key": "ATLAS_EOM_RUN_MIGRATIONS",
         "value": "false",
     }
+    assert [
+        key
+        for key in env_vars
+        if key.startswith("ATLAS_INVOICING_") and "TOKEN" in key
+    ] == ["ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN_SHA256"]
     for split_key in (
         "ATLAS_DB_HOST",
         "ATLAS_DB_PORT",
@@ -379,21 +388,66 @@ def test_database_pool_uses_configured_connection_kwargs(monkeypatch):
     assert calls["closed"] == {}
 
 
-def test_eom_receivables_startup_rejects_operator_enabled_config():
+def test_eom_receivables_runtime_config_accepts_generated_digest_only():
     from atlas_brain.eom_api import auth
     from atlas_brain.eom_api.config import EOMInvoicingConfig
 
-    for config in (
-        SimpleNamespace(
-            receivables_api_enabled=True,
-            receivables_service_token="eomrx_abcdefghijklmnopqrstuvwxyzabcdefghijklmnopq",
-            receivables_service_token_sha256=auth._token_sha256("password123"),
+    generated = auth.generate_receivables_service_token()
+    config = EOMInvoicingConfig(
+        receivables_api_enabled=True,
+        receivables_service_token_sha256=generated.sha256,
+    )
+
+    auth.validate_receivables_api_config(config)
+    assert (
+        auth.receivables_service_token_sha256(generated.token)
+        == config.receivables_service_token_sha256
+    )
+    assert "receivables_service_token" not in EOMInvoicingConfig.model_fields
+
+
+def test_eom_receivables_startup_rejects_unsafe_enabled_runtime_config():
+    from atlas_brain.eom_api import auth
+    from atlas_brain.eom_api.config import EOMInvoicingConfig
+
+    generated = auth.generate_receivables_service_token()
+    cases = (
+        (
+            SimpleNamespace(
+                receivables_api_enabled=True,
+                receivables_service_token=generated.token,
+                receivables_service_token_sha256=generated.sha256,
+            ),
+            "Raw EOM receivables bearer token",
         ),
-        EOMInvoicingConfig(
-            receivables_api_enabled=True,
+        (
+            EOMInvoicingConfig(receivables_api_enabled=True),
+            "digest is required",
         ),
-    ):
-        with pytest.raises(RuntimeError, match="cannot be enabled"):
+        (
+            EOMInvoicingConfig(
+                receivables_api_enabled=True,
+                receivables_service_token_sha256="0" * 63,
+            ),
+            "lowercase SHA-256",
+        ),
+        (
+            EOMInvoicingConfig(
+                receivables_api_enabled=True,
+                receivables_service_token_sha256="0" * 64,
+            ),
+            "placeholder",
+        ),
+        (
+            EOMInvoicingConfig(
+                receivables_api_enabled=True,
+                receivables_service_token_sha256=auth._token_sha256("change-me"),
+            ),
+            "placeholder",
+        ),
+    )
+    for config, message in cases:
+        with pytest.raises(RuntimeError, match=message):
             auth.validate_receivables_api_config(config)
 
 
@@ -403,6 +457,7 @@ def test_eom_receivables_trusted_config_rejects_bad_token_digests():
     for token_digest, message in (
         ("", "digest is required"),
         ("0" * 63, "lowercase SHA-256"),
+        ("0" * 64, "placeholder"),
         ("F" * 64, "lowercase SHA-256"),
         ("z" * 64, "lowercase SHA-256"),
         (auth._token_sha256("change-me"), "placeholder"),
@@ -454,6 +509,7 @@ def test_all_eom_receivables_routes_require_service_auth():
 def test_eom_receivables_ready_route_is_fail_closed(monkeypatch):
     from atlas_brain.eom_api import auth
     from atlas_brain.eom_api import receivables
+    from atlas_brain.eom_api.config import EOMInvoicingConfig
 
     class _ReadyService:
         async def is_ready(self):
@@ -462,7 +518,10 @@ def test_eom_receivables_ready_route_is_fail_closed(monkeypatch):
     app = FastAPI()
     app.include_router(receivables.router)
     generated = auth.generate_receivables_service_token()
-    config = auth.trusted_receivables_api_config(generated)
+    config = EOMInvoicingConfig(
+        receivables_api_enabled=True,
+        receivables_service_token_sha256=generated.sha256,
+    )
     valid_token = generated.token
     app.dependency_overrides[auth.get_receivables_api_config] = lambda: config
     monkeypatch.setattr(
@@ -572,13 +631,16 @@ def test_eom_lifespan_initializes_database_without_running_migrations(monkeypatc
 def test_eom_profile_ping_is_database_independent(monkeypatch):
     from atlas_brain import main_eom
     from atlas_brain.main_eom import app
-    from atlas_brain.eom_api.config import invoicing_settings
 
     monkeypatch.setattr(main_eom, "db_settings", SimpleNamespace(enabled=False))
-    monkeypatch.setattr(invoicing_settings, "receivables_api_enabled", False)
+    original_enabled = main_eom.invoicing_settings.receivables_api_enabled
+    main_eom.invoicing_settings.receivables_api_enabled = False
 
-    with TestClient(app) as client:
-        response = client.get("/api/v1/ping")
+    try:
+        with TestClient(app) as client:
+            response = client.get("/api/v1/ping")
+    finally:
+        main_eom.invoicing_settings.receivables_api_enabled = original_enabled
 
     assert response.status_code == 200
     assert response.json() == {"status": "ok", "profile": "eom"}
@@ -589,14 +651,15 @@ def test_eom_profile_reaches_receivables_ready_through_real_app(monkeypatch):
     from atlas_brain import main_eom
     from atlas_brain.main_eom import app
     from atlas_brain.eom_api import receivables
-    from atlas_brain.eom_api.config import invoicing_settings
+    from atlas_brain.eom_api.config import EOMInvoicingConfig
 
     class _ReadyService:
         async def is_ready(self):
             return True
 
     monkeypatch.setattr(main_eom, "db_settings", SimpleNamespace(enabled=False))
-    monkeypatch.setattr(invoicing_settings, "receivables_api_enabled", False)
+    original_enabled = main_eom.invoicing_settings.receivables_api_enabled
+    main_eom.invoicing_settings.receivables_api_enabled = False
     generated = auth.generate_receivables_service_token()
     valid_token = generated.token
     monkeypatch.setattr(
@@ -605,7 +668,10 @@ def test_eom_profile_reaches_receivables_ready_through_real_app(monkeypatch):
         lambda: _ReadyService(),
     )
     app.dependency_overrides[auth.get_receivables_api_config] = (
-        lambda: auth.trusted_receivables_api_config(generated)
+        lambda: EOMInvoicingConfig(
+            receivables_api_enabled=True,
+            receivables_service_token_sha256=generated.sha256,
+        )
     )
 
     try:
@@ -615,6 +681,7 @@ def test_eom_profile_reaches_receivables_ready_through_real_app(monkeypatch):
                 headers={"Authorization": f"Bearer {valid_token}"},
             )
     finally:
+        main_eom.invoicing_settings.receivables_api_enabled = original_enabled
         app.dependency_overrides.pop(auth.get_receivables_api_config, None)
 
     assert response.status_code == 200

--- a/tests/test_eom_render_profile.py
+++ b/tests/test_eom_render_profile.py
@@ -17,7 +17,7 @@ from fastapi.testclient import TestClient
 def _isolated_eom_subprocess_env() -> dict[str, str]:
     env = os.environ.copy()
     for key in list(env):
-        if key.startswith("ATLAS_INVOICING_"):
+        if key.upper().startswith("ATLAS_INVOICING_"):
             env.pop(key, None)
     env["ATLAS_DB_ENABLED"] = "false"
     return env
@@ -406,8 +406,19 @@ def test_eom_receivables_runtime_config_accepts_generated_digest_only():
     assert "receivables_service_token" not in EOMInvoicingConfig.model_fields
 
 
+@pytest.mark.parametrize(
+    ("raw_token_key", "api_enabled"),
+    (
+        ("ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN", "true"),
+        ("atlas_invoicing_receivables_service_token", "true"),
+        ("ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN", "false"),
+        ("atlas_invoicing_receivables_service_token", "false"),
+    ),
+)
 def test_eom_receivables_runtime_config_rejects_raw_token_env_before_projection(
     monkeypatch,
+    raw_token_key,
+    api_enabled,
 ):
     from pydantic import ValidationError
 
@@ -418,12 +429,12 @@ def test_eom_receivables_runtime_config_rejects_raw_token_env_before_projection(
     )
 
     generated = auth.generate_receivables_service_token()
-    monkeypatch.setenv("ATLAS_INVOICING_RECEIVABLES_API_ENABLED", "true")
+    monkeypatch.setenv("ATLAS_INVOICING_RECEIVABLES_API_ENABLED", api_enabled)
     monkeypatch.setenv(
         "ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN_SHA256",
         generated.sha256,
     )
-    monkeypatch.setenv(RAW_RECEIVABLES_SERVICE_TOKEN_ENV, generated.token)
+    monkeypatch.setenv(raw_token_key, generated.token)
 
     with pytest.raises(
         ValidationError,
@@ -433,8 +444,19 @@ def test_eom_receivables_runtime_config_rejects_raw_token_env_before_projection(
     assert "receivables_service_token" not in EOMInvoicingConfig.model_fields
 
 
+@pytest.mark.parametrize(
+    ("raw_token_key", "api_enabled"),
+    (
+        ("ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN", "true"),
+        ("atlas_invoicing_receivables_service_token", "true"),
+        ("ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN", "false"),
+        ("atlas_invoicing_receivables_service_token", "false"),
+    ),
+)
 def test_eom_profile_rejects_raw_receivables_token_from_dotenv_before_projection(
     tmp_path,
+    raw_token_key,
+    api_enabled,
 ):
     from atlas_brain.eom_api import auth
     from atlas_brain.eom_api.config import RAW_RECEIVABLES_SERVICE_TOKEN_ENV
@@ -443,9 +465,9 @@ def test_eom_profile_rejects_raw_receivables_token_from_dotenv_before_projection
     (tmp_path / ".env").write_text(
         "\n".join(
             [
-                "ATLAS_INVOICING_RECEIVABLES_API_ENABLED=true",
+                f"ATLAS_INVOICING_RECEIVABLES_API_ENABLED={api_enabled}",
                 f"ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN_SHA256={generated.sha256}",
-                f"{RAW_RECEIVABLES_SERVICE_TOKEN_ENV}={generated.token}",
+                f"{raw_token_key}={generated.token}",
             ]
         ),
         encoding="utf-8",

--- a/tests/test_eom_render_profile.py
+++ b/tests/test_eom_render_profile.py
@@ -433,6 +433,46 @@ def test_eom_receivables_runtime_config_rejects_raw_token_env_before_projection(
     assert "receivables_service_token" not in EOMInvoicingConfig.model_fields
 
 
+def test_eom_profile_rejects_raw_receivables_token_from_dotenv_before_projection(
+    tmp_path,
+):
+    from atlas_brain.eom_api import auth
+    from atlas_brain.eom_api.config import RAW_RECEIVABLES_SERVICE_TOKEN_ENV
+
+    generated = auth.generate_receivables_service_token()
+    (tmp_path / ".env").write_text(
+        "\n".join(
+            [
+                "ATLAS_INVOICING_RECEIVABLES_API_ENABLED=true",
+                f"ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN_SHA256={generated.sha256}",
+                f"{RAW_RECEIVABLES_SERVICE_TOKEN_ENV}={generated.token}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    env = _isolated_eom_subprocess_env()
+    repo_root = Path(__file__).resolve().parents[1]
+    existing_pythonpath = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = (
+        str(repo_root)
+        if not existing_pythonpath
+        else f"{repo_root}{os.pathsep}{existing_pythonpath}"
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", "import atlas_brain.main_eom"],
+        check=False,
+        capture_output=True,
+        cwd=tmp_path,
+        env=env,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "Raw EOM receivables bearer token material" in result.stderr
+    assert RAW_RECEIVABLES_SERVICE_TOKEN_ENV in result.stderr
+
+
 def test_eom_receivables_startup_rejects_unsafe_enabled_runtime_config():
     from atlas_brain.eom_api import auth
     from atlas_brain.eom_api.config import EOMInvoicingConfig
@@ -506,9 +546,10 @@ def test_eom_receivables_token_digest_helper_rejects_legacy_or_short_tokens():
         "a" * 24,
         "eomrx_abcdefghijklmnopqrstuvwxyzabcdefghijklmnopq",
         "eomrx_v1_" + ("a" * 42),
+        "eomrx_v1_" + ("a" * 44),
         "eomrx_v1_" + ("*" * 43),
     ):
-        with pytest.raises(RuntimeError, match="generated|too short|invalid"):
+        with pytest.raises(RuntimeError, match="generated|wrong length|invalid"):
             auth.receivables_service_token_sha256(token)
 
 
@@ -584,6 +625,24 @@ def test_eom_receivables_ready_route_is_fail_closed(monkeypatch):
         client.get(
             "/receivables/ready",
             headers={"Authorization": f"Bearer {nongenerated_token}"},
+        ).status_code
+        == 401
+    )
+    too_long_generated_format_token = "eomrx_v1_" + ("a" * 44)
+    app.dependency_overrides[auth.get_receivables_api_config] = (
+        lambda: EOMInvoicingConfig(
+            receivables_api_enabled=True,
+            receivables_service_token_sha256=auth._token_sha256(
+                too_long_generated_format_token
+            ),
+        )
+    )
+    assert (
+        client.get(
+            "/receivables/ready",
+            headers={
+                "Authorization": f"Bearer {too_long_generated_format_token}"
+            },
         ).status_code
         == 401
     )

--- a/tests/test_eom_render_profile.py
+++ b/tests/test_eom_render_profile.py
@@ -1,10 +1,13 @@
 import asyncio
+import hashlib
 import json
 import os
+import string
 import subprocess
 import sys
 import threading
 from concurrent.futures import ThreadPoolExecutor
+from itertools import product
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -12,6 +15,56 @@ import pytest
 import yaml
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+
+_RAW_RECEIVABLES_SERVICE_TOKEN_ENV = "ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN"
+_GENERATED_RECEIVABLES_TOKEN_PREFIX = "eomrx_v1_"
+_GENERATED_RECEIVABLES_TOKEN_PAYLOAD_LENGTH = 43
+_GENERATED_RECEIVABLES_TOKEN_PAYLOAD_CHARS = (
+    string.ascii_letters + string.digits + "_-"
+)
+
+
+def _alternating_case(value: str, *, starts_upper: bool) -> str:
+    uppercase = starts_upper
+    chars: list[str] = []
+    for char in value:
+        if char.isalpha():
+            chars.append(char.upper() if uppercase else char.lower())
+            uppercase = not uppercase
+        else:
+            chars.append(char)
+    return "".join(chars)
+
+
+_RAW_RECEIVABLES_SERVICE_TOKEN_KEY_CASES = tuple(
+    dict.fromkeys(
+        (
+            _RAW_RECEIVABLES_SERVICE_TOKEN_ENV,
+            _RAW_RECEIVABLES_SERVICE_TOKEN_ENV.lower(),
+            _alternating_case(
+                _RAW_RECEIVABLES_SERVICE_TOKEN_ENV,
+                starts_upper=True,
+            ),
+            _alternating_case(
+                _RAW_RECEIVABLES_SERVICE_TOKEN_ENV,
+                starts_upper=False,
+            ),
+        )
+    )
+)
+
+
+def _generated_receivables_token_oracle(token: str) -> bool:
+    if not token.startswith(_GENERATED_RECEIVABLES_TOKEN_PREFIX):
+        return False
+    payload = token.removeprefix(_GENERATED_RECEIVABLES_TOKEN_PREFIX)
+    return len(payload) == _GENERATED_RECEIVABLES_TOKEN_PAYLOAD_LENGTH and all(
+        char in _GENERATED_RECEIVABLES_TOKEN_PAYLOAD_CHARS for char in payload
+    )
+
+
+def _sha256_ascii(value: str) -> str:
+    return hashlib.sha256(value.encode("ascii")).hexdigest()
 
 
 def _isolated_eom_subprocess_env() -> dict[str, str]:
@@ -406,13 +459,51 @@ def test_eom_receivables_runtime_config_accepts_generated_digest_only():
     assert "receivables_service_token" not in EOMInvoicingConfig.model_fields
 
 
+def test_eom_receivables_raw_token_source_admission_matches_casefold_oracle(
+    tmp_path,
+):
+    from atlas_brain.eom_api import config as eom_config
+
+    raw_values = ("", "   ", "caller-side-raw-token")
+    unrelated_keys = (
+        "ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN_SHA256",
+        "ATLAS_EOM_RECEIVABLES_SERVICE_TOKEN",
+    )
+
+    case_index = 0
+    for source, key, value in product(
+        ("process-env", "dotenv"),
+        (*_RAW_RECEIVABLES_SERVICE_TOKEN_KEY_CASES, *unrelated_keys),
+        raw_values,
+    ):
+        expected = (
+            key.casefold() == _RAW_RECEIVABLES_SERVICE_TOKEN_ENV.casefold()
+            and bool(value.strip())
+        )
+        if source == "process-env":
+            observed = eom_config.raw_receivables_service_token_configured(
+                environ={key: value},
+                env_files=(),
+            )
+        else:
+            case_index += 1
+            env_file = tmp_path / f"raw-token-source-{case_index}.env"
+            env_file.write_text(f"{key}={value}\n", encoding="utf-8")
+            observed = eom_config.raw_receivables_service_token_configured(
+                environ={},
+                env_files=(env_file,),
+            )
+
+        assert observed is expected, (source, key, repr(value))
+
+
 @pytest.mark.parametrize(
     ("raw_token_key", "api_enabled"),
     (
         ("ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN", "true"),
         ("atlas_invoicing_receivables_service_token", "true"),
         ("ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN", "false"),
-        ("atlas_invoicing_receivables_service_token", "false"),
+        (_RAW_RECEIVABLES_SERVICE_TOKEN_KEY_CASES[-1], "false"),
     ),
 )
 def test_eom_receivables_runtime_config_rejects_raw_token_env_before_projection(
@@ -450,7 +541,7 @@ def test_eom_receivables_runtime_config_rejects_raw_token_env_before_projection(
         ("ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN", "true"),
         ("atlas_invoicing_receivables_service_token", "true"),
         ("ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN", "false"),
-        ("atlas_invoicing_receivables_service_token", "false"),
+        (_RAW_RECEIVABLES_SERVICE_TOKEN_KEY_CASES[-1], "false"),
     ),
 )
 def test_eom_profile_rejects_raw_receivables_token_from_dotenv_before_projection(
@@ -612,6 +703,81 @@ def test_eom_receivables_request_auth_does_not_rescan_settings_sources(
             f"Bearer {generated.token}",
             config=runtime_config,
         )
+    )
+
+
+def test_eom_receivables_bearer_admission_matches_generated_token_grammar(
+    monkeypatch,
+):
+    from atlas_brain.eom_api import auth
+    from atlas_brain.eom_api import receivables
+
+    class _ReadyService:
+        async def is_ready(self):
+            return True
+
+    app = FastAPI()
+    app.include_router(receivables.router)
+    runtime_config = {
+        "value": auth.TrustedReceivablesApiConfig(
+            receivables_api_enabled=True,
+            receivables_service_token_sha256=_sha256_ascii(
+                f"{_GENERATED_RECEIVABLES_TOKEN_PREFIX}"
+                f"{'a' * _GENERATED_RECEIVABLES_TOKEN_PAYLOAD_LENGTH}"
+            ),
+        )
+    }
+    app.dependency_overrides[auth.get_receivables_api_config] = (
+        lambda: runtime_config["value"]
+    )
+    monkeypatch.setattr(
+        receivables,
+        "get_receivables_service",
+        lambda: _ReadyService(),
+    )
+
+    token_prefixes = (
+        _GENERATED_RECEIVABLES_TOKEN_PREFIX,
+        _GENERATED_RECEIVABLES_TOKEN_PREFIX.upper(),
+        "eomrx_v1x",
+        "eomrx_v2_",
+        "",
+    )
+    payload_lengths = (0, 1, 42, 43, 44)
+    payload_chars = ("A", "z", "0", "_", "-", "*", ".", "=")
+    accepted_cases = 0
+
+    with TestClient(app) as client:
+        for token_prefix, payload_length, payload_char in product(
+            token_prefixes,
+            payload_lengths,
+            payload_chars,
+        ):
+            token = f"{token_prefix}{payload_char * payload_length}"
+            should_accept = _generated_receivables_token_oracle(token)
+            runtime_config["value"] = auth.TrustedReceivablesApiConfig(
+                receivables_api_enabled=True,
+                receivables_service_token_sha256=_sha256_ascii(token),
+            )
+
+            response = client.get(
+                "/receivables/ready",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+
+            assert response.status_code == (200 if should_accept else 401), (
+                token_prefix,
+                payload_length,
+                payload_char,
+            )
+            accepted_cases += int(should_accept)
+
+    assert accepted_cases == len(
+        [
+            char
+            for char in payload_chars
+            if char in _GENERATED_RECEIVABLES_TOKEN_PAYLOAD_CHARS
+        ]
     )
 
 
@@ -799,43 +965,75 @@ def test_eom_profile_ping_is_database_independent(monkeypatch):
     assert response.json() == {"status": "ok", "profile": "eom"}
 
 
-def test_eom_profile_reaches_receivables_ready_through_real_app(monkeypatch):
+def test_eom_profile_reaches_receivables_ready_through_real_app(tmp_path):
     from atlas_brain.eom_api import auth
-    from atlas_brain import main_eom
-    from atlas_brain.main_eom import app
-    from atlas_brain.eom_api import receivables
-    from atlas_brain.eom_api.config import EOMInvoicingConfig
 
-    class _ReadyService:
-        async def is_ready(self):
-            return True
-
-    monkeypatch.setattr(main_eom, "db_settings", SimpleNamespace(enabled=False))
-    original_enabled = main_eom.invoicing_settings.receivables_api_enabled
-    main_eom.invoicing_settings.receivables_api_enabled = False
     generated = auth.generate_receivables_service_token()
-    valid_token = generated.token
-    monkeypatch.setattr(
-        receivables,
-        "get_receivables_service",
-        lambda: _ReadyService(),
-    )
-    app.dependency_overrides[auth.get_receivables_api_config] = (
-        lambda: EOMInvoicingConfig(
-            receivables_api_enabled=True,
-            receivables_service_token_sha256=generated.sha256,
-        )
+    probe = """
+import json
+import os
+
+from fastapi.testclient import TestClient
+
+from atlas_brain import main_eom
+from atlas_brain.eom_api import receivables
+
+
+class _ReadyService:
+    async def is_ready(self):
+        return True
+
+
+receivables.get_receivables_service = lambda: _ReadyService()
+if main_eom.app.dependency_overrides:
+    raise AssertionError("auth dependency must not be overridden")
+
+with TestClient(main_eom.app) as client:
+    response = client.get(
+        "/api/v1/receivables/ready",
+        headers={
+            "Authorization": f"Bearer {os.environ['EOM_TEST_CALLER_TOKEN']}"
+        },
     )
 
-    try:
-        with TestClient(app) as client:
-            response = client.get(
-                "/api/v1/receivables/ready",
-                headers={"Authorization": f"Bearer {valid_token}"},
-            )
-    finally:
-        main_eom.invoicing_settings.receivables_api_enabled = original_enabled
-        app.dependency_overrides.pop(auth.get_receivables_api_config, None)
+print(json.dumps({
+    "status_code": response.status_code,
+    "body": response.json(),
+    "env_projected_enabled": main_eom.invoicing_settings.receivables_api_enabled,
+    "env_projected_digest": (
+        main_eom.invoicing_settings.receivables_service_token_sha256
+        == os.environ["ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN_SHA256"]
+    ),
+    "dependency_overrides": len(main_eom.app.dependency_overrides),
+}))
+"""
+    env = _isolated_eom_subprocess_env()
+    repo_root = Path(__file__).resolve().parents[1]
+    existing_pythonpath = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = (
+        str(repo_root)
+        if not existing_pythonpath
+        else f"{repo_root}{os.pathsep}{existing_pythonpath}"
+    )
+    env["ATLAS_INVOICING_RECEIVABLES_API_ENABLED"] = "true"
+    env["ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN_SHA256"] = generated.sha256
+    env["EOM_TEST_CALLER_TOKEN"] = generated.token
 
-    assert response.status_code == 200
-    assert response.json() == {"status": "ready"}
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        check=False,
+        capture_output=True,
+        cwd=tmp_path,
+        env=env,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    observed = json.loads(result.stdout.strip().splitlines()[-1])
+    assert observed == {
+        "status_code": 200,
+        "body": {"status": "ready"},
+        "env_projected_enabled": True,
+        "env_projected_digest": True,
+        "dependency_overrides": 0,
+    }

--- a/tests/test_eom_render_profile.py
+++ b/tests/test_eom_render_profile.py
@@ -245,7 +245,7 @@ def test_eom_render_blueprint_maps_database_and_receivables_auth():
     }
     assert env_vars["ATLAS_INVOICING_RECEIVABLES_API_ENABLED"] == {
         "key": "ATLAS_INVOICING_RECEIVABLES_API_ENABLED",
-        "value": "true",
+        "value": "false",
     }
     assert env_vars["ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN_SHA256"] == {
         "key": "ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN_SHA256",
@@ -561,6 +561,36 @@ def test_eom_receivables_startup_accepts_generated_service_token():
 
     auth.validate_receivables_api_config(config)
     assert auth.receivables_service_token_sha256(generated.token) == generated.sha256
+
+
+def test_eom_receivables_request_auth_does_not_rescan_settings_sources(
+    monkeypatch,
+):
+    from atlas_brain.eom_api import auth
+    from atlas_brain.eom_api import config as eom_config
+    from atlas_brain.eom_api.config import EOMInvoicingConfig
+
+    generated = auth.generate_receivables_service_token()
+    runtime_config = EOMInvoicingConfig(
+        receivables_api_enabled=True,
+        receivables_service_token_sha256=generated.sha256,
+    )
+
+    def fail_settings_rescan(*args, **kwargs):
+        raise AssertionError("request auth must not rescan dotenv settings sources")
+
+    monkeypatch.setattr(
+        eom_config,
+        "raw_receivables_service_token_configured",
+        fail_settings_rescan,
+    )
+
+    asyncio.run(
+        auth.require_receivables_api(
+            f"Bearer {generated.token}",
+            config=runtime_config,
+        )
+    )
 
 
 def test_all_eom_receivables_routes_require_service_auth():

--- a/tests/test_eom_render_profile.py
+++ b/tests/test_eom_render_profile.py
@@ -63,6 +63,26 @@ def _generated_receivables_token_oracle(token: str) -> bool:
     )
 
 
+def _mixed_generated_payload(length: int) -> str:
+    return "".join(
+        _GENERATED_RECEIVABLES_TOKEN_PAYLOAD_CHARS[
+            (index * 7 + 3) % len(_GENERATED_RECEIVABLES_TOKEN_PAYLOAD_CHARS)
+        ]
+        for index in range(length)
+    )
+
+
+def _generated_payload_with_replacement(
+    *,
+    length: int,
+    replacement: str,
+    position: int,
+) -> str:
+    payload = list(_mixed_generated_payload(length))
+    payload[position] = replacement
+    return "".join(payload)
+
+
 def _sha256_ascii(value: str) -> str:
     return hashlib.sha256(value.encode("ascii")).hexdigest()
 
@@ -745,15 +765,46 @@ def test_eom_receivables_bearer_admission_matches_generated_token_grammar(
     )
     payload_lengths = (0, 1, 42, 43, 44)
     payload_chars = ("A", "z", "0", "_", "-", "*", ".", "=")
+    invalid_payload_positions = (
+        0,
+        _GENERATED_RECEIVABLES_TOKEN_PAYLOAD_LENGTH // 2,
+        _GENERATED_RECEIVABLES_TOKEN_PAYLOAD_LENGTH - 1,
+    )
+    homogeneous_payloads = tuple(
+        payload_char * payload_length
+        for payload_length, payload_char in product(payload_lengths, payload_chars)
+    )
+    mixed_allowed_payloads = tuple(
+        _mixed_generated_payload(payload_length) for payload_length in payload_lengths
+    )
+    mixed_invalid_payloads = tuple(
+        _generated_payload_with_replacement(
+            length=_GENERATED_RECEIVABLES_TOKEN_PAYLOAD_LENGTH,
+            replacement=invalid_char,
+            position=position,
+        )
+        for invalid_char, position in product(
+            ("*", ".", "="),
+            invalid_payload_positions,
+        )
+    )
+    payloads = tuple(
+        dict.fromkeys(
+            (
+                *homogeneous_payloads,
+                *mixed_allowed_payloads,
+                *mixed_invalid_payloads,
+            )
+        )
+    )
     accepted_cases = 0
 
     with TestClient(app) as client:
-        for token_prefix, payload_length, payload_char in product(
+        for token_prefix, payload in product(
             token_prefixes,
-            payload_lengths,
-            payload_chars,
+            payloads,
         ):
-            token = f"{token_prefix}{payload_char * payload_length}"
+            token = f"{token_prefix}{payload}"
             should_accept = _generated_receivables_token_oracle(token)
             runtime_config["value"] = auth.TrustedReceivablesApiConfig(
                 receivables_api_enabled=True,
@@ -767,17 +818,34 @@ def test_eom_receivables_bearer_admission_matches_generated_token_grammar(
 
             assert response.status_code == (200 if should_accept else 401), (
                 token_prefix,
-                payload_length,
-                payload_char,
+                len(payload),
+                payload,
             )
             accepted_cases += int(should_accept)
 
-    assert accepted_cases == len(
-        [
-            char
-            for char in payload_chars
-            if char in _GENERATED_RECEIVABLES_TOKEN_PAYLOAD_CHARS
-        ]
+    expected_accepted_cases = sum(
+        1
+        for token_prefix, payload in product(token_prefixes, payloads)
+        if _generated_receivables_token_oracle(f"{token_prefix}{payload}")
+    )
+    assert accepted_cases == expected_accepted_cases
+    assert any(
+        _generated_receivables_token_oracle(
+            f"{_GENERATED_RECEIVABLES_TOKEN_PREFIX}{payload}"
+        )
+        and len(set(payload)) > 1
+        for payload in payloads
+    )
+    assert any(
+        len(payload) == _GENERATED_RECEIVABLES_TOKEN_PAYLOAD_LENGTH
+        and any(
+            char not in _GENERATED_RECEIVABLES_TOKEN_PAYLOAD_CHARS
+            for char in payload
+        )
+        and not _generated_receivables_token_oracle(
+            f"{_GENERATED_RECEIVABLES_TOKEN_PREFIX}{payload}"
+        )
+        for payload in payloads
     )
 
 

--- a/tests/test_eom_render_profile.py
+++ b/tests/test_eom_render_profile.py
@@ -406,6 +406,33 @@ def test_eom_receivables_runtime_config_accepts_generated_digest_only():
     assert "receivables_service_token" not in EOMInvoicingConfig.model_fields
 
 
+def test_eom_receivables_runtime_config_rejects_raw_token_env_before_projection(
+    monkeypatch,
+):
+    from pydantic import ValidationError
+
+    from atlas_brain.eom_api import auth
+    from atlas_brain.eom_api.config import (
+        EOMInvoicingConfig,
+        RAW_RECEIVABLES_SERVICE_TOKEN_ENV,
+    )
+
+    generated = auth.generate_receivables_service_token()
+    monkeypatch.setenv("ATLAS_INVOICING_RECEIVABLES_API_ENABLED", "true")
+    monkeypatch.setenv(
+        "ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN_SHA256",
+        generated.sha256,
+    )
+    monkeypatch.setenv(RAW_RECEIVABLES_SERVICE_TOKEN_ENV, generated.token)
+
+    with pytest.raises(
+        ValidationError,
+        match="Raw EOM receivables bearer token",
+    ):
+        EOMInvoicingConfig()
+    assert "receivables_service_token" not in EOMInvoicingConfig.model_fields
+
+
 def test_eom_receivables_startup_rejects_unsafe_enabled_runtime_config():
     from atlas_brain.eom_api import auth
     from atlas_brain.eom_api.config import EOMInvoicingConfig
@@ -546,6 +573,21 @@ def test_eom_receivables_ready_route_is_fail_closed(monkeypatch):
         ).status_code
         == 401
     )
+    nongenerated_token = "operator-supplied-low-entropy-secret"
+    app.dependency_overrides[auth.get_receivables_api_config] = (
+        lambda: EOMInvoicingConfig(
+            receivables_api_enabled=True,
+            receivables_service_token_sha256=auth._token_sha256(nongenerated_token),
+        )
+    )
+    assert (
+        client.get(
+            "/receivables/ready",
+            headers={"Authorization": f"Bearer {nongenerated_token}"},
+        ).status_code
+        == 401
+    )
+    app.dependency_overrides[auth.get_receivables_api_config] = lambda: config
     assert (
         client.get(
             "/receivables/ready",


### PR DESCRIPTION
Plan: plans/PR-EOM-Render-Receivables-Auth.md
Slice phase: vertical slice
Ownership lane: eom/render-receivables-auth

Prepare the slim EOM Render API candidate for digest-only receivables service
auth, while keeping raw bearer-token material off the Atlas API service. This is
the Atlas-side trust anchor before the EOM time tracker caller wiring and schema
provisioning slices.

## Intentional

- Add only a SHA-256 digest setting to the Atlas EOM invoicing runtime config;
  the raw generated bearer token remains caller-side material.
- Keep the candidate `render.eom.yaml` receivables API disabled while prompting
  for the digest secret shape and keeping migrations disabled.
- Prove startup/request auth through `EOMInvoicingConfig` and the real EOM app
  route, not just the in-process trusted test helper.
- Address the review blockers by rejecting the raw-token env var before model
  projection can ignore it and by rejecting non-generated bearer formats before
  digest comparison.
- Address the follow-up blockers by checking dotenv settings sources for the
  raw-token key and requiring the exact generated-token payload length.
- Address the latest blockers by removing dotenv parsing from the request path,
  keeping the Render candidate API disabled until schema provisioning, and
  recording plan pass counts plus the required over-budget rationale.
- Address the newest blocker by rejecting raw-token env/dotenv aliases
  case-insensitively and regardless of the receivables API enable flag.
- Address the latest blockers by replacing sampled auth evidence with
  grammar/product tests for bearer admission and raw-token key admission,
  covering mixed allowed bearer payloads plus invalid characters at varied
  payload positions, and by proving real-app reachability in a fresh process
  through actual `ATLAS_INVOICING_*` env projection without overriding the auth
  dependency.

## Deferred

- Wire the EOM time tracker caller to the Atlas private service URL and store
  the raw generated bearer token only on that caller side.
- Decide migration ownership/order for the EOM production schema.
- Connect the customer/funnel lifecycle and plan deprecation of duplicate or
  old onboarding/receivables code after the new path proves itself.

## Parked hardening

None.

## Cold diff reconstruction

- `atlas_brain/eom_api/config.py` adds
  `receivables_service_token_sha256` under the existing `ATLAS_INVOICING_`
  settings prefix, does not add a raw-token field, and rejects
  `ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN` aliases from process env and
  admitted dotenv settings sources case-insensitively and regardless of the API
  enable flag.
- `atlas_brain/eom_api/auth.py` treats the all-zero digest as a placeholder,
  lets disabled config return early, rejects raw bearer material from the
  config-object path, validates the digest value, and requires the request
  bearer to pass `_validate_generated_token()` before digest comparison.
- `render.eom.yaml` keeps `ATLAS_INVOICING_RECEIVABLES_API_ENABLED` as
  `"false"`, adds `ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN_SHA256` with
  `sync: false`, preserves the Render Postgres `fromDatabase.connectionString`
  mapping, and leaves `ATLAS_EOM_RUN_MIGRATIONS` as `"false"`.
- `tests/test_eom_render_profile.py` proves the blueprint env shape, digest-only
  runtime config acceptance, case-insensitive raw-env projection rejection,
  case-insensitive raw-dotenv entrypoint rejection, source/casing/value raw-key
  oracle coverage, raw/missing/malformed/placeholder rejection, request-path
  in-memory validation, bearer grammar oracle coverage for homogeneous, mixed,
  and invalid-position payloads, non-generated and max+1 matching-digest
  rejection, fail-closed route behavior, and fresh-process real EOM app route
  reachability through actual env projection.

## Verification

- PASS: python -m pytest tests/test_eom_render_profile.py -- 31 passed, 1 warning
- PASS: python -m py_compile atlas_brain/eom_api/auth.py atlas_brain/eom_api/config.py atlas_brain/main_eom.py tests/test_eom_render_profile.py
- PASS: git diff --check
- PASS: python scripts/sync_pr_plan.py plans/PR-EOM-Render-Receivables-Auth.md
- PASS: python scripts/audit_plan_code_consistency.py plans/PR-EOM-Render-Receivables-Auth.md

## Diff size

| File | LOC |
|---|---:|
| `atlas_brain/eom_api/auth.py` | 28 |
| `atlas_brain/eom_api/config.py` | 57 |
| `plans/PR-EOM-Render-Receivables-Auth.md` | 210 |
| `render.eom.yaml` | 2 |
| `tests/test_eom_render_profile.py` | 578 |
| **Total** | **875** |

Diff-budget override: reviewer-blocker repair adds held-out raw-dotenv and exact-token-length regressions to the same service-auth boundary; splitting would leave #2228 knowingly unsafe and red.

Added lines: 819, over the 400-line budget with the override above.
