### PR TITLE
Widen guard closure to set-valued dependencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,10 @@ Contract` subsection): acceptance criteria the reviewer checks one-by-one,
 affected surfaces, risk areas, and the reviewer rule IDs the changed paths
 trigger. The builder codes against it; the reviewer reviews against it. See
 `docs/REVIEWER_RULES.md` for the rule pack and the path-to-rule trigger table.
+If the plan or docs-only PR body adds or edits a decision-driving member set, or
+enumerates the behaviors / callers / fields / input shapes a change must cover,
+it carries the closure declaration defined canonically in
+`docs/GUARD_CLASS_CLOSURE.md`.
 For any new runtime, workflow, UI, report, billing, delivery, or public
 contract surface, the Review Contract must also name the reachability proof:
 the real entrypoint exercised and the observable output/state/artifact/job/gate

--- a/docs/GUARD_CLASS_CLOSURE.md
+++ b/docs/GUARD_CLASS_CLOSURE.md
@@ -1,10 +1,11 @@
 # Guard Class-Closure Discipline
 
 The specific form of the root-cause gate (`AGENTS.md` section 3k) for guards over an
-**open input space**. It exists because "fix the reported input" is a symptom
-fix on these surfaces, and the symptom fix is invisible per-round: every listed
-input passes, so the diff looks correct, while the *class* the input belongs to
-stays open and the next input in that class is reported next round.
+**open input space**, and the closure-declaration bar for set-valued dependencies
+in decision paths. It exists because "fix the reported input" is a symptom fix on
+these surfaces, and the symptom fix is invisible per-round: every listed input
+passes, so the diff looks correct, while the *class* the input belongs to stays
+open and the next input in that class is reported next round.
 
 **This document is the single source** for the guard-closure bar (the three
 requirements below), the open-category evidence-gated exception, and the
@@ -18,12 +19,43 @@ this file.
 
 ## When this applies (trigger)
 
-Any change to a guard / validator / sanitizer / classifier / gate / denylist /
-parser-admission rule / privacy or safety checker whose input space is **open**:
-free text, nested or recursive structures, producer-supplied keys and values,
-user data, or anything where the set of possible inputs is not a small closed
-enum. If the input space is genuinely a closed enum (a fixed set of statuses,
-say), this does not apply -- enumerate it and move on.
+**A. Guards over an open input space.** Any change to a guard / validator /
+sanitizer / classifier / gate / denylist / parser-admission rule / privacy or
+safety checker whose input space is **open**: free text, nested or recursive
+structures, producer-supplied keys and values, user data, or anything where the
+set of possible inputs is not a small closed enum. If the input space is
+genuinely a closed enum (a fixed set of statuses, say), declare it **CLOSED**,
+cite the canonical enum, and move on.
+
+**B. Set-valued dependencies (any change, guard-shaped or not).** Any change that
+adds or edits a **set whose membership a decision depends on**: a literal
+collection used in a branch, a pattern family (regex alternation, prefix list),
+a list duplicating one that already exists elsewhere in the repo, or the bounded
+set of behaviors / callers / fields / input shapes a named source surface says a
+change must cover.
+
+Trigger B exists because the same failure arrives constantly in code that nobody
+reads as "a guard." A mirror script's test-file list, a detector's grep patterns,
+a refactor's replaced-path behaviors, and a browser snapshot predicate are all
+one behavior -- **the set was enumerated at authoring time instead of bound to a
+source of truth or given a stated default for its unlisted members** -- and each
+member discovered later is a real, correct review finding, so the loop cannot be
+blamed on the reviewer and does not converge until someone writes down what
+*generates* membership rather than what is currently in the set.
+
+Implicit inventories trigger when the plan or code enumerates the behaviors,
+callers, fields, or input shapes a change must cover. The closure declaration
+must bind that inventory to a reviewable surface -- old code path, workflow job,
+schema, canonical vocabulary, affected decision, or another named source -- so
+the reviewer is not asked to prove that no invisible set was missed. Missing
+source binding is itself the closure failure, not an exemption from this trigger.
+
+Trigger B requires the closure declaration below. It requires the three
+requirements only when the change is also a trigger-A guard.
+
+The mechanical tell is a new or edited literal collection of string literals, a
+`re.compile(...)` alternation, a copied list, or plan language that enumerates
+covered behaviors/callers/fields without saying what generates the set.
 
 ## The failure mode this prevents
 
@@ -43,7 +75,35 @@ slice per round. Two compounding symptoms:
    handling), and each new branch's *fall-through* is the next round's hole.
    Complexity and edge-count grow every round while the guarantee does not.
 
+## Closure declaration (mandatory before code)
+
+Every triggering PR declares each set-valued dependency exactly once before
+implementation: in the plan, or in the PR body for a Markdown-only change
+explicitly admitted by `AGENTS.md` section 1's `Docs-only: true` path. Use one of
+these dispositions:
+
+- **CLOSED** -- the set is genuinely finite and repo-owned. Cite the canonical
+  source of truth and explain why unlisted members are impossible or out of
+  scope. Do not duplicate the canonical list unless the duplicate is generated
+  from it.
+- **DERIVED** -- membership is computed from a source of truth at runtime or test
+  time, so it cannot drift. Cite the source and the derivation point (for
+  example: parse the workflow, inspect the settings schema, derive the old-code
+  inventory before refactor).
+- **DEFAULTED** -- the set is open or heuristic. State the default direction for
+  unlisted members, make incompleteness flow to the cheap/safe side, and name
+  why that side is cheaper or safer. Enumerating an open set with no declared
+  default is a defect even when every currently listed member passes.
+
+"Here are the members I noticed" is not a closure declaration. A plan that lists
+members without CLOSED / DERIVED / DEFAULTED is still open and should be treated
+as a round generator. A Markdown-only body has the same bar when it is the
+admission artifact.
+
 ## The three requirements (all mandatory before merge)
+
+These apply to trigger-A guards. A trigger-B change that is not also a trigger-A
+guard satisfies this document with the closure declaration above.
 
 ### 1. Fail-closed choke point (allowlist-shaped, one decision)
 
@@ -171,7 +231,14 @@ because the evidence signals are finite even when the category is not.
 
 ## Reviewer bar (enforced)
 
-For a triggering PR, the reviewer **blocks** until all three hold, and states
+For a trigger-B PR, the reviewer states before LGTM: each set-valued dependency
+the change adds or edits, the reviewable surface that bounds the inventory, and
+its declared disposition. An enumerated open set with no declared default is
+"needs the closure declaration," even when every listed member behaves correctly
+-- that is the round-generating state this document exists to stop, and it is
+invisible per-round by construction.
+
+For a trigger-A PR, the reviewer **blocks** until all three hold, and states
 before LGTM: the choke-point location, the class and invariant it enforces, and
 that the acceptance test is grammar-derived (not a fixture list). For an
 **open-category** guard (see the section above), the three requirements hold in
@@ -189,12 +256,22 @@ both error directions) and `AGENTS.md` section 3k (root cause, not symptom): her
 root cause is the open default, and closing it is the choke point.
 
 An **advisory CI lint** (`scripts/check_guard_class_closure.py`, workflow
-`Guard Class-Closure Lint`) surfaces a warning when a PR changes a Python guard-shaped
-file over open input without a co-changed property/generative test. It is
-heuristic and advisory-first (warns, never blocks); it does not replace the
+`Guard Class-Closure Lint`) surfaces a warning when a PR changes a Python
+guard-shaped file over open input without a co-changed property/generative test.
+It is heuristic and advisory-first (warns, never blocks); it does not replace the
 reviewer bar above, it makes the omission visible on every PR. Opt a
-false-positive path out in `scripts/guard_class_closure_config.json` (optional -- absent means no ignores; create it only when an opt-out is needed) or waive
+false-positive path out in `scripts/guard_class_closure_config.json` (optional --
+absent means no ignores; create it only when an opt-out is needed) or waive
 inline with a `guard-class-closure: waived` marker in the PR body.
+
+For the widened set-valued-dependency trigger, the advisory signal is the same
+shape and priority: a diff that adds a literal collection of strings, a regex
+alternation, or a copied list in a decision path should warn when the active
+admission artifact -- the plan, or the permitted PR body for a planless
+Markdown-only change -- lacks a Closure Declaration for that set. Keep this
+advisory-first (warn, exit 0) until operator promotion; the warning exists to put
+the set-disposition question back into a compacted builder context, not to block
+before the detector has earned trust.
 
 ## Relationship to the review-round cap
 

--- a/docs/REVIEWER_RULES.md
+++ b/docs/REVIEWER_RULES.md
@@ -269,6 +269,11 @@ fixture) while the thread history shows the class is open and not converging --
 that is the `AGENTS.md` 3k.2 convergence circuit-breaker, and the next push owes
 a Decision-Seam Analysis, not another example.
 
+**Set-valued dependencies.** When a diff adds or edits a member set that drives a
+decision, or enumerates the behaviors/callers/fields/input shapes a change must
+cover, require the closure declaration defined canonically in
+`docs/GUARD_CLASS_CLOSURE.md`. This is a pointer, not a restatement of that bar.
+
 ### R14 - Verify against the codebase, not the PR story
 Review verdicts must be based on the checked-out PR head and the current
 codebase, not the PR description, issue summary, builder claims, or prior

--- a/plans/PR-Set-Valued-Closure.md
+++ b/plans/PR-Set-Valued-Closure.md
@@ -1,0 +1,171 @@
+# PR-Set-Valued-Closure
+
+## Why this slice exists
+
+Juan identified the shared cause behind the 2026-07-26 review loops: builders
+enumerated the members visible at authoring time instead of binding the set to a
+source of truth or declaring the default for members not listed. The concrete
+instances were Website #70, ATLAS #2216, #2222, #2223, and #2225. The current
+code/doc state confirms `docs/GUARD_CLASS_CLOSURE.md` is the single source for
+this bar, but its trigger is scoped to guards over open input; it does not
+plainly catch copied workflow file lists, detector regex families, replaced-code
+inventories, or other set-valued dependencies in decision paths.
+
+This slice keeps the normative bar in one source because #2226 says the bar
+changes by editing `docs/GUARD_CLASS_CLOSURE.md`, not by creating another
+normative document. It also adds a reviewer-rule pointer, which that same source
+requires for every doc that names the bar. It moves ahead of #2221-#2224 because
+it attacks the round generator those PRs kept reproducing.
+
+### Problem-derived contract
+
+- Root cause: the guard-closure bar already rejects enumerate-instead-of-close,
+  but the trigger is too narrow; authors see "guard over open input" and miss
+  the same set failure in workflow mirrors, detectors, and refactor inventories.
+- Correct fix must touch/change: widen `docs/GUARD_CLASS_CLOSURE.md` so
+  set-valued dependencies in decision paths must declare CLOSED, DERIVED, or
+  DEFAULTED before code; point the reviewer entrypoint at that widened trigger;
+  and state the advisory trigger shape.
+- Must not change: product/runtime behavior, current advisory-check behavior,
+  required CI status, reviewer strength, review caps, or the open #2221-#2224
+  branches.
+
+## Scope (this PR)
+
+Ownership lane: dev-workflow/set-valued-closure
+Slice phase: Workflow/process
+
+1. Widen the guard-class-closure trigger to set-valued dependencies in decision
+   paths.
+2. Add the mandatory Closure Declaration dispositions: CLOSED, DERIVED, and
+   DEFAULTED.
+3. State the advisory-first mechanical trigger shape for future detector work.
+4. Add a pointer from the reviewer rules pack to the canonical set-valued
+   dependency declaration, without copying the bar.
+
+### Review Contract
+
+- Acceptance criteria:
+  - `docs/GUARD_CLASS_CLOSURE.md` still declares itself the single source for
+    the closure bar.
+  - Its trigger includes set-valued dependencies such as literal collections,
+    regex alternations, copied lists, and behavior/caller/field inventories.
+  - Builder-facing entrypoints point to the canonical trigger-B declaration, so
+    the rule reaches the author before review rather than only after a bot
+    finding.
+  - It requires every triggering set to declare exactly one of CLOSED, DERIVED,
+    or DEFAULTED before code, including docs-only PR bodies when the body is the
+    admission artifact.
+  - It preserves the existing three-requirement bar for trigger-A open-input
+    guards and does not impose guard-only requirements on non-guard set-valued
+    dependencies.
+  - Implicit behavior/caller/field/input-shape inventories are bound to a named
+    reviewable source surface.
+  - It preserves advisory-first language for mechanical surfacing and does not
+    claim the existing checker already enforces the widened trigger.
+- Reachability proof: documentation/process rule only; future builders and
+  reviewers read `docs/GUARD_CLASS_CLOSURE.md` through AGENTS and the reviewer
+  rules pointer.
+- Affected surfaces: `AGENTS.md`, `docs/GUARD_CLASS_CLOSURE.md`,
+  `docs/REVIEWER_RULES.md`, and this plan artifact.
+- Risk areas: overbroad trigger, accidental normative copy outside the source
+  doc, implying implemented CI behavior that does not exist yet.
+- Reviewer rules triggered: R1, R2, R10, R12, R13.
+
+#### Closure declarations for this PR
+
+- **CLOSED — closure-disposition vocabulary.** The set `{CLOSED, DERIVED,
+  DEFAULTED}` is finite and repo-owned by this canonical doc. Unlisted
+  dispositions are invalid because the rule requires exactly one of those three.
+- **DERIVED — trigger-A inventory.** The open-input guard surface is derived from
+  the pre-existing `docs/GUARD_CLASS_CLOSURE.md` trigger text and AGENTS 3k.1
+  pointer; this PR preserves that source rather than replacing it with a new
+  list.
+- **DERIVED — trigger-B inventory.** The non-guard set-valued dependency surface
+  is derived from #2226's stated pattern and its evidence ledger classes: literal
+  member collections, regex/pattern families, copied repo lists, and bounded
+  behavior/caller/field/input-shape inventories.
+- **DEFAULTED — deferred detector coverage.** The future mechanical detector is
+  explicitly advisory-first and defaults misses to review visibility rather than
+  blocking, because this PR records the law before the detector has earned trust.
+
+#### R13 same-class proof
+
+The rule was checked against held-out set-valued dependency shapes not required
+by the cited incidents. Each terminates by choosing a disposition instead of
+extending a hand list:
+
+- A release gate hand-copies environment names from deployment config -> CLOSED
+  only if it cites the canonical environment enum; otherwise DERIVED from config.
+- A report renderer branches on section keys -> DERIVED from the report schema,
+  or CLOSED only if the schema names the finite repo-owned section set.
+- A detector regex alternates over import idioms -> DERIVED from AST/schema
+  inspection where possible; otherwise DEFAULTED so unrecognized idioms warn to
+  the cheap side rather than claiming closure.
+- A workflow mirror lists job or test names -> DERIVED from workflow YAML, not a
+  copied list.
+- A route or tool admission table lists allowed operations -> CLOSED only when
+  the router/tool registry is the canonical source; otherwise DERIVED from that
+  registry.
+
+### Files touched
+
+- `AGENTS.md`
+- `docs/GUARD_CLASS_CLOSURE.md`
+- `docs/REVIEWER_RULES.md`
+- `plans/PR-Set-Valued-Closure.md`
+
+## Mechanism
+
+The canonical doc now separates trigger A (open-input guards, still owing the
+three guard requirements) from trigger B (set-valued dependencies, owing a
+closure declaration unless they are also trigger-A guards). Trigger B names
+examples that match the observed loops: literal collections, regex alternations,
+copied repo lists, and behavior/caller/field inventories whose missing source
+binding is a closure failure. The Closure Declaration section requires the author
+to classify each set as CLOSED, DERIVED, or DEFAULTED before code, with the PR
+body allowed as the artifact for Markdown-only docs-only changes. `AGENTS.md`
+and `docs/REVIEWER_RULES.md` only point builders/reviewers to the canonical bar
+so the new trigger is reachable. The advisory paragraph keeps the existing
+advisory-first posture and describes the widened mechanical tell without
+pretending the current Python guard checker already implements it.
+
+## Intentional
+
+- This PR edits `docs/REVIEWER_RULES.md` only to add a pointer. It does not copy
+  the CLOSED / DERIVED / DEFAULTED bar outside the canonical source.
+- This PR edits `AGENTS.md` only to add the builder-facing pointer needed for
+  trigger-B reachability. It does not copy the canonical bar.
+- This PR does not update `scripts/check_guard_class_closure.py`; #2226's first
+  convergence step is to widen the single source. A detector expansion can
+  follow from this source without another normative copy.
+- The rule allows CLOSED sets when there is a real canonical repo-owned list; it
+  rejects duplicated hand copies of that list.
+
+## Deferred
+
+- Expanding `scripts/check_guard_class_closure.py` to detect set-valued
+  dependencies mechanically is deferred to a follow-up implementation slice.
+- Reworking or superseding #2221-#2224 is deferred until this source-rule PR is
+  reviewed.
+
+Parked hardening: none.
+
+## Verification
+
+- git diff --check - OK.
+- python scripts/audit_plan_doc.py plans/PR-Set-Valued-Closure.md - OK.
+- python scripts/audit_plan_doc_files_touched.py plans/PR-Set-Valued-Closure.md origin/main - OK after commit.
+- python scripts/audit_plan_doc_diff_size.py plans/PR-Set-Valued-Closure.md origin/main - OK after commit.
+- python scripts/audit_plan_code_consistency.py plans/PR-Set-Valued-Closure.md - OK.
+- python scripts/audit_review_rules_triggered.py origin/main --plan plans/PR-Set-Valued-Closure.md - OK.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `AGENTS.md` | ~4 |
+| `docs/GUARD_CLASS_CLOSURE.md` | ~104 |
+| `docs/REVIEWER_RULES.md` | ~5 |
+| `plans/PR-Set-Valued-Closure.md` | ~170 |
+| **Total** | **~283** |


### PR DESCRIPTION
Plan: plans/PR-Set-Valued-Closure.md
Slice phase: Workflow/process
Ownership lane: dev-workflow/set-valued-closure

Widen `docs/GUARD_CLASS_CLOSURE.md` from only open-input guards to set-valued dependencies in decision paths, while keeping the normative bar in that canonical source. This codifies #2226's shared failure pattern: builders enumerate current members instead of binding the set to a source of truth or declaring what happens to unlisted members.

## Incident evidence
- Covers Website #70, ATLAS #2216, #2222, #2223, and #2225: each loop came from a literal/current-member enumeration rather than CLOSED / DERIVED / DEFAULTED closure.

## Intentional
- `docs/GUARD_CLASS_CLOSURE.md` remains the canonical source; `AGENTS.md` and `docs/REVIEWER_RULES.md` get pointer-only reachability edits so the widened trigger reaches builders and reviewers without copying the bar.
- Does not claim the current checker already enforces the widened trigger; detector expansion stays advisory-first follow-up.
- Preserves the existing open-input guard bar: trigger-A guards still owe the three guard requirements; non-guard set-valued dependencies owe the closure declaration.
- Missing source binding for an implicit inventory is itself a trigger-B closure failure, not an exemption.

## Deferred
- Expanding `scripts/check_guard_class_closure.py` to detect set-valued dependencies mechanically is deferred to a follow-up implementation slice.
- Reworking or superseding #2221-#2224 is deferred until this source-rule PR is reviewed.

## Parked hardening
- None.

## Cold diff reconstruction
- `AGENTS.md` now points builders to the canonical closure declaration when a plan or docs-only body adds/edits decision-driving member sets or enumerates behavior/caller/field/input-shape coverage.
- `docs/GUARD_CLASS_CLOSURE.md` now splits trigger A (open-input guards) from trigger B (set-valued dependencies), allows docs-only PR bodies to carry declarations, treats missing source binding as the closure failure, and makes deferred detector language inspect the active admission artifact.
- `docs/REVIEWER_RULES.md` now points reviewers to the canonical closure declaration when a diff adds/edits a decision-driving member set.
- `plans/PR-Set-Valued-Closure.md` records the contract, closure declarations for this PR's own sets, R13 same-class proof, scope, and verification.

## AI reconciliation
AI findings reviewed: Y. All fixed or waived: Yes. Waivers justified in PR body: N/A.
- Fixed `Treat unbound inventories as closure failures` by making missing source binding itself a trigger-B closure failure and adding the builder-facing AGENTS pointer.
- Fixed `Apply the closure declaration to this PR` by adding explicit CLOSED / DERIVED / DEFAULTED declarations for this PR's own disposition and trigger inventories.
- Fixed `Declare R13 for this class-level fix` by adding R13 to the Review Contract and recording five held-out same-class set-valued dependency probes.
- Fixed `Inspect the active admission artifact before warning` by changing detector guidance from `plan` to the active admission artifact: plan or permitted docs-only PR body.

## Verification
- `git diff --check` - OK.
- `python scripts/audit_plan_doc.py plans/PR-Set-Valued-Closure.md` - OK.
- `python scripts/audit_plan_doc_files_touched.py plans/PR-Set-Valued-Closure.md origin/main` - OK.
- `python scripts/audit_plan_doc_diff_size.py plans/PR-Set-Valued-Closure.md origin/main` - OK, estimate 283 / actual 287.
- `python scripts/audit_plan_code_consistency.py plans/PR-Set-Valued-Closure.md` - OK.
- `python scripts/audit_review_rules_triggered.py origin/main --plan plans/PR-Set-Valued-Closure.md` - OK.

## Diff size
- `AGENTS.md`: +4/-0.
- `docs/GUARD_CLASS_CLOSURE.md`: +107/-15.
- `docs/REVIEWER_RULES.md`: +5/-0.
- `plans/PR-Set-Valued-Closure.md`: +171/-0.
- Total: 287 changed lines, under the <400 LOC soft cap.

Closes #2226.
