### PR TITLE
docs: qualify the hardening-parking bar and require a parking predicate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,7 @@ Required sections, in this order:
 | **Scope (this PR)** | The narrow surface this PR touches. Start with an `Ownership lane: <lane>` line, then a `Slice phase: <phase>` line, then a numbered list of intent and a "Files touched" subsection. |
 | **Mechanism** | Short prose (and code stub if helpful) explaining *how* the change works -- enough that the reviewer doesn't have to reverse-engineer it from the diff. |
 | **Intentional** | Things that look wrong but aren't -- explicit trade-offs and rejected alternatives ("no `warnings.warn` shim because ..."). Saves reviewer cycles. |
-| **Deferred** | Things explicitly punted to a follow-up slice. Each item should name the future PR or describe what would unlock it. Include "Parked hardening: none" or list the `HARDENING.md` entries added by this slice. |
+| **Deferred** | Things explicitly punted to a follow-up slice. Each item should name the future PR or describe what would unlock it. State the slice's **parking predicate** -- which class of finding it parks by default -- then "Parked hardening: none" as a claim against that predicate, or list the `HARDENING.md` entries added by this slice. Bar and rationale: `docs/CURRENT_PRODUCT_DISCIPLINE.md`. |
 | **Verification** | The specific commands the builder ran locally + their pass counts. Reviewer reproduces. |
 | **Estimated diff size** | LOC budget; flag if approaching 400 LOC. |
 

--- a/docs/CURRENT_PRODUCT_DISCIPLINE.md
+++ b/docs/CURRENT_PRODUCT_DISCIPLINE.md
@@ -57,10 +57,40 @@ Inline hardening is allowed only when it:
 - fixes a real safety/security/privacy/money risk, including standalone
   production-hardening slices where that risk is the reason for the slice;
 - prevents the slice's output from being false or misleading;
-- resolves a reviewer BLOCKER.
+- resolves a reviewer BLOCKER **that independently meets one of the three
+  above**.
 
 Everything else goes to `HARDENING.md` or a GitHub issue with owner/context,
 risk, effort, and the trigger that would promote it.
+
+**A severity badge is not a qualification.** Assess blast radius against the
+severity rubric yourself and state the concrete failure path, or downgrade. An
+automated reviewer that files every finding as P1/BLOCKER otherwise turns the
+fourth clause into "all hardening is inline," and the rule is swallowed by the
+one clause that delegates its own decision. Observed on #2216: nine review
+rounds of bot-badged P1s, each individually real, each qualifying under an
+unqualified fourth clause; the PR grew from +1213/-99 to +3409/-172 during
+review on a core that was proven by round four.
+
+**State the parking predicate at plan time.** Every plan says, before any
+finding arrives, which class of finding the slice parks by default -- for
+example "races narrower than a single request, and findings whose blast radius
+is one recoverable record, are parked." `Parked hardening: none` is then a claim
+earned against a stated predicate rather than a silent default.
+
+Without one, the set of findings the slice owns is an empty set with no default
+for members discovered later: every new finding is in scope by construction, and
+there is no state in which the slice is finishable. That is the scope-level form
+of the closure declaration in `docs/GUARD_CLASS_CLOSURE.md` -- same defect, one
+level up from code.
+
+**A hardening fix that introduces new mechanism is never inline.** If closing a
+parked-class finding needs a new table, migration, subsystem, or dependency, it
+is a separate slice by definition: the new mechanism carries its own surface,
+and that surface generates the next finding inside the same review loop. Park it
+and link the follow-up. (#2216 added a migration and a delivery-receipts
+subsystem at round 8 in response to a hardening finding; the next bot poll found
+a P1 inside the new mechanism.)
 
 ## Product Shape Consent Gate
 


### PR DESCRIPTION
Docs-only: true

Codifies the scope-level counterpart to #2227. Closes the last item from the #2216 arc.

## Why

The Hardening Parking Rule in `docs/CURRENT_PRODUCT_DISCIPLINE.md` already said what to park. It did not hold on #2216, and reading it against that PR shows why precisely: its fourth clause admitted inline hardening that "resolves a reviewer BLOCKER," which delegates the parking decision to the reviewer's own severity badge. With an automated reviewer that files essentially every finding as P1/BLOCKER, that one clause silently swallows the other three — everything qualifies as inline.

Measured on #2216: ten review rounds, the PR growing **+1213/-99 → +3409/-172** during review, entirely from hardening findings, on a core that was proven by round four. Every finding was real and every fix landed correct on the first pass, so nothing in the loop looked wrong from inside any single round. At round 8 a hardening finding was answered with a new migration and a delivery-receipts subsystem, and the next bot poll found a P1 inside that new mechanism.

Two structural gaps under that:

1. **No parking predicate existed before findings arrived.** `Parked hardening: none` was the silent default — an empty set with no stated default for members discovered later — so every new finding was in scope by construction and there was no state in which the slice was finishable. This is the scope-level form of the closure defect that #2227 just codified for code.
2. **Nothing forbade answering a parked-class finding with new mechanism**, which is how a hardening fix becomes a surface that generates the next hardening finding inside the same loop.

## What changed

Three edits, in the rule's canonical owner (`docs/CURRENT_PRODUCT_DISCIPLINE.md`):

1. **Fourth clause qualified** — a reviewer BLOCKER admits inline hardening only when the finding *independently* meets one of the first three. Added: a severity badge is not a qualification; assess blast radius against the rubric and state the concrete failure path, or downgrade.
2. **Parking predicate required at plan time** — every plan states which class of finding it parks by default, before any finding arrives, so `Parked hardening: none` becomes a claim earned against a stated predicate.
3. **New mechanism is never inline hardening** — if closing a parked-class finding needs a new table, migration, subsystem, or dependency, it is a separate slice by definition.

Plus one line in `AGENTS.md`: the Deferred-section template now requires the predicate and points at the rule.

## Intentional

- **The bar is stated once.** `docs/CURRENT_PRODUCT_DISCIPLINE.md` owns it; `AGENTS.md` gets a template requirement and a pointer, not a restatement. Same anti-drift discipline `docs/GUARD_CLASS_CLOSURE.md` enforces for its own bar.
- **Amended the existing rule rather than adding a parallel one.** The rule was not missing — one clause of it was unqualified. A second rule covering the same ground would drift against this one, which is the failure `GUARD_CLASS_CLOSURE.md` documents.
- **No blanket round cap.** The operator rejected capping review rounds (2026-07-25): on classifier/PII/gate surfaces the findings are real, so a cap ships defects. This changes which findings are *in scope for the slice*, not whether the PR may proceed — and each parked item still lands in `HARDENING.md` or an issue with failure path, blast radius, fix shape, and revisit trigger.
- **Evidence is named inline** (#2216's growth numbers, the round-8 subsystem) so the rule justifies itself to a reader who was not in that loop — matching how `GUARD_CLASS_CLOSURE.md` carries its S6A and S6C forensics.

## Deferred

- Mechanical enforcement (a plan-admission check that a parking predicate is present when the Deferred section says `none`). Law first, matching how 3k.1/3k.2 and #2227 shipped.

Parking predicate for this slice: findings whose remedy is a mechanical check rather than the rule text are parked by default. Parked hardening: none.

## Verification

- Two files changed, +32/-2, confirmed with `git diff --cached --stat`.
- Checked that `AGENTS.md` and `docs/CURRENT_PRODUCT_DISCIPLINE.md` are the only two places `Parked hardening` is defined rather than merely referenced; the remaining AGENTS.md mentions (lines 216, 234, 337, 753) are template/format references and needed no change.
- Markdown only — no code, no workflow, no dependency.