### PR TITLE
Prepare EOM receivables schema startup

### DIFF
--- a/.github/workflows/atlas_invoicing_checks.yml
+++ b/.github/workflows/atlas_invoicing_checks.yml
@@ -18,6 +18,7 @@ on:
       - "atlas_brain/api/invoicing/**"
       - "atlas_brain/config.py"
       - "atlas_brain/config_defaults.py"
+      - "atlas_brain/main_eom.py"
       - "atlas_brain/services/__init__.py"
       - "atlas_brain/services/receivables.py"
       - "atlas_brain/storage/migrations/344_receivables_payments.sql"
@@ -31,6 +32,8 @@ on:
       - "tests/test_invoicing_readonly_oauth.py"
       - "tests/test_invoicing_draft_writer_mcp.py"
       - "tests/test_invoicing_draft_writer_oauth.py"
+      - "tests/test_eom_render_profile.py"
+      - "render.eom.yaml"
   push:
     branches:
       - main
@@ -47,6 +50,7 @@ on:
       - "atlas_brain/api/invoicing/**"
       - "atlas_brain/config.py"
       - "atlas_brain/config_defaults.py"
+      - "atlas_brain/main_eom.py"
       - "atlas_brain/services/__init__.py"
       - "atlas_brain/services/receivables.py"
       - "atlas_brain/storage/migrations/344_receivables_payments.sql"
@@ -60,6 +64,8 @@ on:
       - "tests/test_invoicing_readonly_oauth.py"
       - "tests/test_invoicing_draft_writer_mcp.py"
       - "tests/test_invoicing_draft_writer_oauth.py"
+      - "tests/test_eom_render_profile.py"
+      - "render.eom.yaml"
 
 jobs:
   atlas-invoicing-checks:
@@ -106,6 +112,7 @@ jobs:
       - name: Run receivables ledger and repository tests
         run: |
           python -m pytest \
+            tests/test_eom_render_profile.py \
             tests/test_receivables.py \
             tests/test_invoice_repository.py \
             -q

--- a/atlas_brain/main_eom.py
+++ b/atlas_brain/main_eom.py
@@ -56,7 +56,9 @@ _env_root = Path(__file__).parent.parent
 _load_local_env_files(_env_root)
 
 import logging
+from collections.abc import Awaitable, Callable
 from contextlib import asynccontextmanager
+from typing import Any
 
 from fastapi import FastAPI
 
@@ -74,14 +76,44 @@ from .storage.database import close_database, get_db_pool, init_database
 configure_logging(level=eom_settings.log_level, log_format=eom_settings.log_format)
 logger = logging.getLogger("atlas.eom")
 
+MigrationRunner = Callable[..., Awaitable[None]]
+
+# Closure for the EOM startup migration set: CLOSED and ENUMERATED from the
+# current receivables readiness contract plus its SQL prerequisite chain.
+# Migrations outside this set are intentionally not run by the EOM profile; a
+# new receivables readiness table/index or SQL prerequisite must update this
+# tuple and the live readiness migration test in the same slice.
+EOM_RECEIVABLES_READINESS_MIGRATIONS: tuple[str, ...] = (
+    "012_appointments",
+    "035_contacts",
+    "045_invoices",
+    "344_receivables_payments",
+    "345_receivables_event_key_lookup",
+)
+
+
+async def _apply_eom_receivables_migrations(
+    pool: Any,
+    run_migrations_fn: MigrationRunner | None = None,
+) -> None:
+    if run_migrations_fn is None:
+        from .storage.migrations import run_migrations
+
+        runner = run_migrations
+    else:
+        runner = run_migrations_fn
+
+    await runner(pool, only=EOM_RECEIVABLES_READINESS_MIGRATIONS)
+
 
 async def _run_startup_migrations() -> None:
-    from .storage.migrations import run_migrations
-
     pool = get_db_pool()
     if pool.is_initialized:
-        await run_migrations(pool)
-        logger.info("Database migrations checked")
+        await _apply_eom_receivables_migrations(pool)
+        logger.info(
+            "EOM receivables readiness migrations checked: %s",
+            ", ".join(EOM_RECEIVABLES_READINESS_MIGRATIONS),
+        )
 
 
 @asynccontextmanager

--- a/plans/PR-EOM-Receivables-Schema-Readiness.md
+++ b/plans/PR-EOM-Receivables-Schema-Readiness.md
@@ -1,0 +1,223 @@
+# PR-EOM-Receivables-Schema-Readiness
+
+## Why this slice exists
+
+The EOM Render service is meant to host the slim Atlas receivables API against
+its own `atlas-eom-postgres` database, but the deployed profile currently leaves
+startup migrations disabled. Turning the existing switch on as-is would ask the
+EOM app to run Atlas's entire migration chain, even though the migration runner
+documents that the full chain is not fresh-applicable for standalone component
+databases.
+
+### Problem-derived contract
+
+- Root cause: The EOM profile has a migration switch, but its startup path calls
+  the default full-chain runner. A fresh EOM-only Render database needs the
+  tables required by receivables readiness without inheriting Atlas B2B/V2V
+  migrations or the known full-chain fresh-database failure mode.
+- Correct fix must touch/change: the EOM app startup migration seam, the EOM
+  Render blueprint's migration setting, and render-profile tests proving the
+  app applies an explicit EOM-safe migration set when configured. The
+  per-PR invoicing workflow must also enroll the changed EOM startup/config
+  paths and the render-profile tests that prove them.
+- Must not change: receivables auth, token format, API enablement, payment
+  posting/allocation semantics, customer-facing onboarding shape, main Atlas app
+  startup behavior, unrelated open PR lanes, or the existing packaged SQL
+  migrations unless a dependency proof requires a minimal schema-safety patch.
+
+## Scope (this PR)
+
+Ownership lane: eom-render/receivables-schema-readiness
+Slice phase: Vertical slice
+
+1. Make the EOM app's `ATLAS_EOM_RUN_MIGRATIONS=true` path apply an explicit
+   curated schema-readiness migration set instead of Atlas's whole migration
+   chain.
+2. Flip the EOM Render blueprint to run that curated set at startup while
+   keeping the receivables API disabled until the service-token digest is
+   provisioned separately.
+3. Add tests that lock the curated migration set, the startup call shape, the
+   Render blueprint values, and the real migration dependency proof needed for
+   `/receivables/ready`.
+4. Enroll the EOM startup/config paths and render-profile tests in per-PR
+   invoicing CI so this deployed startup seam cannot merge untested.
+
+### Review Contract
+
+- Acceptance criteria:
+  - `atlas_brain/main_eom.py` applies a private EOM migration helper from
+    startup; that helper calls `run_migrations(..., only=...)` and the `only`
+    value is a named, ordered EOM receivables readiness contract.
+  - `tests/test_eom_render_profile.py` proves the migration helper calls the
+    migration runner with exactly that curated set, and startup still skips
+    migrations when the DB pool is uninitialized.
+  - `tests/test_eom_render_profile.py` proves `render.eom.yaml` sets
+    `ATLAS_EOM_RUN_MIGRATIONS` to `true`, leaves
+    `ATLAS_INVOICING_RECEIVABLES_API_ENABLED` as `false`, and keeps
+    `ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN_SHA256` configured as a synced
+    secret rather than a raw/default token.
+  - A real SQL migration test proves the curated set creates every table,
+    column, index, and required foreign-key relationship on the tested pre-EOM
+    schema.
+  - Validation includes `tests/test_eom_render_profile.py`, the targeted
+    receivables migration test, `python -m py_compile` for touched Python, and
+    `git diff --check`.
+- Reachability proof: EOM Render profile starts `uvicorn atlas_brain.main_eom:app`;
+  the app lifespan reads `ATLAS_EOM_RUN_MIGRATIONS=true` and invokes the scoped
+  migration runner before the `/api/v1/receivables/ready` router is served.
+- Affected surfaces: `atlas_brain/main_eom.py`, `render.eom.yaml`,
+  `.github/workflows/atlas_invoicing_checks.yml`,
+  `tests/test_eom_render_profile.py`, and targeted receivables migration tests.
+- Risk areas: fresh-database migration dependencies, avoiding the full Atlas
+  migration chain, idempotent startup re-runs, auth/API enablement separation,
+  and Render deployed-config drift.
+- Reviewer rules triggered: R1, R2, R3, R4, R5, R6, R8, R10, R11, R12, R14.
+
+### Boundary-change enumeration
+
+Required when this diff changes a guard, validator, normalizer, resolver,
+router/classifier, or admission boundary. Name each changed boundary path or
+seam in the enumeration; otherwise write "N/A - no boundary change."
+
+- Boundary path/seam: EOM app lifespan migration seam guarded by
+  `EOMProfileConfig.run_migrations` / `ATLAS_EOM_RUN_MIGRATIONS`.
+- Replaced-path behaviors: true used to run the full Atlas migration chain;
+  true must now run only the named EOM receivables readiness migration set.
+  false must still skip migrations.
+- Guard-relevant fields: `ATLAS_EOM_RUN_MIGRATIONS`,
+  `ATLAS_DB_ENABLED`, `ATLAS_DB_CONNECTION_STRING`,
+  `ATLAS_INVOICING_RECEIVABLES_API_ENABLED`,
+  `ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN_SHA256`.
+- Caller x input shape: Render service process starts
+  `atlas_brain.main_eom:app` with the deployed `render.eom.yaml` env values.
+
+### Deployed-config probing
+
+Required for guard, validator, resolver, admission-boundary, or env/config
+fallback changes; otherwise write "N/A - no guard/config boundary change."
+
+- Deployed/default config values: `render.eom.yaml` must set
+  `ATLAS_EOM_RUN_MIGRATIONS=true`, keep `ATLAS_DB_ENABLED=true`, keep the DB
+  connection from `atlas-eom-postgres`, keep the receivables API disabled, and
+  require a synced digest secret for later API enablement.
+- Explicit value probe: test with `ATLAS_EOM_RUN_MIGRATIONS=true` must observe
+  the scoped migration runner call.
+- Absent value probe: default `EOMProfileConfig.run_migrations` remains false
+  outside the deployed blueprint.
+- Default-session/default-context probe: EOM profile startup with migrations
+  false still initializes and closes DB without invoking migrations.
+- Side-effect ordering: startup validates auth config, initializes the DB,
+  runs scoped migrations only when the pool is initialized and the flag is true,
+  and closes the DB on startup failure.
+
+### Rollback and backout
+
+- If EOM startup fails before any readiness migration is recorded, set
+  `ATLAS_EOM_RUN_MIGRATIONS=false` in Render or redeploy the previous blueprint
+  revision, then restart the service. The private receivables API remains
+  disabled in this slice, so this backout returns the service to schema-idle
+  startup without opening the API.
+- If startup fails after one or more curated migrations are recorded, first set
+  `ATLAS_EOM_RUN_MIGRATIONS=false` or revert the service version to stop repeat
+  startup attempts. Keep the additive schema and `schema_migrations` rows in
+  place unless a follow-up, database-specific rollback plan proves removal is
+  safe; these migrations create/add receivables readiness tables, columns,
+  indexes, and foreign keys, and the runner is idempotent on re-entry.
+- After disabling the flag, inspect the failed migration name in
+  `schema_migrations`/startup logs and either roll forward with a narrow SQL fix
+  or cut a dedicated database-repair slice. Do not enable
+  `ATLAS_INVOICING_RECEIVABLES_API_ENABLED` until the readiness check is green.
+
+### Closure declaration
+
+Set-valued dependency: `EOM_RECEIVABLES_READINESS_MIGRATIONS`, the migration
+inventory that the EOM startup path passes to `run_migrations(..., only=...)`.
+
+1. Membership is **CLOSED** for this slice. The set is finite: it contains the
+   packaged Atlas migrations needed for a standalone EOM database to satisfy the
+   current receivables readiness contract. Unlisted Atlas migrations are either
+   unrelated to the slim EOM receivables API or are out of scope because this
+   profile does not mount the full Atlas/B2B/V2V runtime.
+2. Membership is **ENUMERATED** in `atlas_brain/main_eom.py`, sourced from two
+   canonical surfaces: `ReceivablesService.is_ready()` via
+   `_RECEIVABLES_REQUIRED_COLUMNS` / `_RECEIVABLES_REQUIRED_INDEXES`, and the
+   SQL prerequisite chain in the packaged migrations. The chain is:
+   `345_receivables_event_key_lookup` depends on `payment_events` from
+   `344_receivables_payments`; `344_receivables_payments` alters
+   `invoice_payments` and references `contacts`; `045_invoices` creates
+   `invoice_payments` and references `contacts`; `035_contacts` alters
+   `appointments`; `012_appointments` creates `appointments`.
+3. Inputs outside the set are **not run** by the EOM profile. That is the safer
+   default because the full Atlas migration chain is documented as unsafe for a
+   fresh standalone component database and because unrelated Atlas/B2B/V2V
+   migrations would pollute the EOM database. If a future receivables readiness
+   table/index or SQL prerequisite falls outside the set, the readiness tests and
+   `/receivables/ready` fail closed until a follow-up slice expands this
+   declaration, the tuple, and the migration proof together.
+
+### Files touched
+
+- `.github/workflows/atlas_invoicing_checks.yml`
+- `atlas_brain/main_eom.py`
+- `plans/PR-EOM-Receivables-Schema-Readiness.md`
+- `render.eom.yaml`
+- `tests/test_eom_render_profile.py`
+- `tests/test_receivables.py`
+
+## Mechanism
+
+Define the EOM receivables readiness migration set at the EOM app boundary and
+pass it through a private EOM startup helper to the existing
+`run_migrations(..., only=...)` mechanism. That reuses the central migration
+runner's advisory-lock and ledger behavior while avoiding unrelated full-chain
+migrations. The Render profile can then enable `ATLAS_EOM_RUN_MIGRATIONS`
+without starting B2B/V2V schema work in the EOM database.
+
+## Intentional
+
+- Do not enable the private receivables API in this slice; token digest
+  provisioning and EOM time-tracker runtime cutover stay separate.
+- Do not run the whole Atlas migration chain from the EOM profile; the existing
+  migration runner documents that this is unsafe for fresh standalone databases.
+- Do not rewrite the SQL migration history; this slice uses the smallest
+  explicit dependency set needed for receivables readiness.
+
+## Deferred
+
+- Provision/rotate the EOM receivables service-token digest and enable the
+  private API after schema readiness is deployed.
+- Remove or deprecate any old EOM/Atlas receivables compatibility code once the
+  Render-backed path is carrying production traffic.
+
+## Parked hardening
+
+Parking predicate: defer only hardening unrelated to safely enabling this EOM
+startup migration boundary. Findings that affect migration membership,
+fresh-database schema integrity, required foreign keys/indexes, Render rollback,
+API-disabled separation, or per-PR CI enrollment are in scope for this slice.
+
+Parked hardening under that predicate: none.
+
+## Verification
+
+- Command: python -m py_compile atlas_brain/main_eom.py tests/test_eom_render_profile.py tests/test_receivables.py — passed locally.
+- Command: git diff --check — passed locally.
+- Command: python -m pytest tests/test_eom_render_profile.py -q — passed locally.
+- Command: python -m pytest tests/test_receivables.py -q — passed locally with live-Postgres tests skipped when `ATLAS_RECEIVABLES_TEST_DATABASE_URL` is unset.
+- CI command enrolled in `.github/workflows/atlas_invoicing_checks.yml` with `ATLAS_RECEIVABLES_TEST_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/atlas_receivables_test`: python -m pytest tests/test_eom_render_profile.py tests/test_receivables.py tests/test_invoice_repository.py -q.
+- Command: python scripts/maturity_sweep.py atlas_brain/storage --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_storage.json --min-score 8 --sensitive-glob '**/auth/**' --sensitive-glob '**/auth*' --sensitive-glob '**/webhook*' --sensitive-glob '**/webhooks/**' --sensitive-glob '**/*webhook*/**' --sensitive-glob '**/payment*' --sensitive-glob '**/invoicing/**' --sensitive-glob '**/*invoice*' --sensitive-glob '**/*deletion*' --sensitive-glob '**/delete*/**' --sensitive-glob 'atlas_brain/security/**' --sensitive-glob 'atlas_brain/storage/**' — ratchet gate passed locally.
+- Command: python scripts/audit_plan_doc.py plans/PR-EOM-Receivables-Schema-Readiness.md — passed locally.
+- Command: python scripts/check_deployed_config_probing.py --base origin/main — passed locally.
+- Command: bash scripts/local_pr_review.sh --allow-dirty --current-pr-body-file tmp/pr-body-eom-receivables-schema-readiness.md — passed locally.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_invoicing_checks.yml` | 7 |
+| `atlas_brain/main_eom.py` | 40 |
+| `plans/PR-EOM-Receivables-Schema-Readiness.md` | 223 |
+| `render.eom.yaml` | 2 |
+| `tests/test_eom_render_profile.py` | 57 |
+| `tests/test_receivables.py` | 203 |
+| **Total** | **532** |

--- a/render.eom.yaml
+++ b/render.eom.yaml
@@ -27,4 +27,4 @@ services:
       - key: ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN_SHA256
         sync: false
       - key: ATLAS_EOM_RUN_MIGRATIONS
-        value: "false"
+        value: "true"

--- a/tests/test_eom_render_profile.py
+++ b/tests/test_eom_render_profile.py
@@ -326,7 +326,7 @@ def test_eom_render_blueprint_maps_database_and_receivables_auth():
     }
     assert env_vars["ATLAS_EOM_RUN_MIGRATIONS"] == {
         "key": "ATLAS_EOM_RUN_MIGRATIONS",
-        "value": "false",
+        "value": "true",
     }
     assert [
         key
@@ -341,6 +341,61 @@ def test_eom_render_blueprint_maps_database_and_receivables_auth():
         "ATLAS_DB_PASSWORD",
     ):
         assert split_key not in env_vars
+
+
+def test_eom_startup_migrations_are_curated_for_receivables_readiness():
+    from atlas_brain import main_eom
+
+    assert main_eom.EOM_RECEIVABLES_READINESS_MIGRATIONS == (
+        "012_appointments",
+        "035_contacts",
+        "045_invoices",
+        "344_receivables_payments",
+        "345_receivables_event_key_lookup",
+    )
+    assert not any(
+        migration.startswith(("066_", "068_", "074_", "076_", "083_", "095_"))
+        for migration in main_eom.EOM_RECEIVABLES_READINESS_MIGRATIONS
+    )
+
+
+def test_eom_migration_helper_uses_curated_set():
+    from atlas_brain import main_eom
+
+    pool = SimpleNamespace(is_initialized=True)
+    calls = []
+
+    async def run_migrations(observed_pool, *, only=None):
+        calls.append((observed_pool, tuple(only or ())))
+
+    asyncio.run(
+        main_eom._apply_eom_receivables_migrations(
+            pool,
+            run_migrations_fn=run_migrations,
+        )
+    )
+
+    assert calls == [(pool, main_eom.EOM_RECEIVABLES_READINESS_MIGRATIONS)]
+
+
+def test_eom_startup_migration_runner_skips_uninitialized_pool(monkeypatch):
+    from atlas_brain import main_eom
+
+    async def fail_migrations(*_args, **_kwargs):
+        raise AssertionError("uninitialized EOM DB pool must not run migrations")
+
+    monkeypatch.setattr(
+        main_eom,
+        "get_db_pool",
+        lambda: SimpleNamespace(is_initialized=False),
+    )
+    monkeypatch.setattr(
+        main_eom,
+        "_apply_eom_receivables_migrations",
+        fail_migrations,
+    )
+
+    asyncio.run(main_eom._run_startup_migrations())
 
 
 def test_database_config_prefers_connection_string_for_asyncpg_kwargs():

--- a/tests/test_receivables.py
+++ b/tests/test_receivables.py
@@ -693,6 +693,21 @@ class _SingleConnectionPool:
             return await self.conn.fetchval(query, *args)
 
 
+class _MigrationConnectionPool:
+    is_initialized = True
+
+    def __init__(self, conn, schema: str) -> None:
+        self.conn = conn
+        self.schema = schema
+
+    async def acquire(self):
+        await self.conn.execute(f'SET search_path TO "{self.schema}"')
+        return self.conn
+
+    async def release(self, released) -> None:
+        assert released is self.conn
+
+
 async def _create_pre_receivables_schema(conn, schema: str) -> None:
     await conn.execute(f'CREATE SCHEMA "{schema}"')
     await conn.execute(f'SET search_path TO "{schema}"')
@@ -712,6 +727,194 @@ def _receivables_migration_sql() -> str:
             "345_receivables_event_key_lookup.sql",
         )
     )
+
+
+def _packaged_migration_sql(migration_stem: str) -> str:
+    return (
+        Path(__file__).parents[1]
+        / "atlas_brain/storage/migrations"
+        / f"{migration_stem}.sql"
+    ).read_text(encoding="utf-8")
+
+
+async def _schema_foreign_key_relationships(conn, schema: str) -> set[tuple]:
+    rows = await conn.fetch(
+        """
+        SELECT
+            source_table.relname AS source_table,
+            ARRAY_AGG(source_column.attname ORDER BY source_key.position)
+                AS source_columns,
+            target_table.relname AS target_table,
+            ARRAY_AGG(target_column.attname ORDER BY target_key.position)
+                AS target_columns,
+            constraint_state.confdeltype::text AS delete_action
+        FROM pg_constraint AS constraint_state
+        JOIN pg_class AS source_table
+          ON source_table.oid = constraint_state.conrelid
+        JOIN pg_namespace AS source_namespace
+          ON source_namespace.oid = source_table.relnamespace
+        JOIN pg_class AS target_table
+          ON target_table.oid = constraint_state.confrelid
+        JOIN UNNEST(constraint_state.conkey) WITH ORDINALITY
+            AS source_key(attnum, position)
+          ON TRUE
+        JOIN pg_attribute AS source_column
+          ON source_column.attrelid = source_table.oid
+         AND source_column.attnum = source_key.attnum
+        JOIN UNNEST(constraint_state.confkey) WITH ORDINALITY
+            AS target_key(attnum, position)
+          ON target_key.position = source_key.position
+        JOIN pg_attribute AS target_column
+          ON target_column.attrelid = target_table.oid
+         AND target_column.attnum = target_key.attnum
+        WHERE source_namespace.nspname = $1
+          AND constraint_state.contype = 'f'
+        GROUP BY
+            constraint_state.oid,
+            source_table.relname,
+            target_table.relname,
+            constraint_state.confdeltype
+        """,
+        schema,
+    )
+    return {
+        (
+            row["source_table"],
+            tuple(row["source_columns"]),
+            row["target_table"],
+            tuple(row["target_columns"]),
+            row["delete_action"],
+        )
+        for row in rows
+    }
+
+
+def test_eom_readiness_migration_set_is_closed_over_receivables_dependencies():
+    from atlas_brain import main_eom
+
+    positions = {
+        migration: index
+        for index, migration in enumerate(main_eom.EOM_RECEIVABLES_READINESS_MIGRATIONS)
+    }
+    combined_sql = "\n".join(
+        _packaged_migration_sql(migration)
+        for migration in main_eom.EOM_RECEIVABLES_READINESS_MIGRATIONS
+    )
+    created_tables = set(
+        re.findall(r"CREATE TABLE IF NOT EXISTS ([a-z_]+)", combined_sql)
+    )
+
+    assert set(_RECEIVABLES_REQUIRED_COLUMNS) <= created_tables
+    assert positions["012_appointments"] < positions["035_contacts"]
+    assert positions["035_contacts"] < positions["045_invoices"]
+    assert positions["045_invoices"] < positions["344_receivables_payments"]
+    assert (
+        positions["344_receivables_payments"]
+        < positions["345_receivables_event_key_lookup"]
+    )
+    assert "ALTER TABLE appointments" in _packaged_migration_sql("035_contacts")
+    assert "REFERENCES contacts(id)" in _packaged_migration_sql("045_invoices")
+    assert "ALTER TABLE invoice_payments" in _packaged_migration_sql(
+        "344_receivables_payments"
+    )
+    assert "ON payment_events(idempotency_key)" in _packaged_migration_sql(
+        "345_receivables_event_key_lookup"
+    )
+
+
+@pytest.mark.asyncio
+async def test_eom_receivables_readiness_migration_set_builds_ready_schema():
+    asyncpg = pytest.importorskip("asyncpg")
+    database_url = os.environ.get("ATLAS_RECEIVABLES_TEST_DATABASE_URL")
+    if not database_url:
+        pytest.skip("ATLAS_RECEIVABLES_TEST_DATABASE_URL not set")
+
+    from atlas_brain import main_eom
+    from atlas_brain.storage.migrations import run_migrations
+
+    schema = f"eom_receivables_readiness_{uuid4().hex}"
+    conn = await asyncpg.connect(database_url)
+    migrations_dir = Path(__file__).parents[1] / "atlas_brain/storage/migrations"
+    try:
+        await conn.execute(f'CREATE SCHEMA "{schema}"')
+        pool = _MigrationConnectionPool(conn, schema)
+
+        await run_migrations(
+            pool,
+            migrations_dir=migrations_dir,
+            only=main_eom.EOM_RECEIVABLES_READINESS_MIGRATIONS,
+        )
+
+        applied_names = {
+            row["name"]
+            for row in await conn.fetch(
+                """
+                SELECT name
+                FROM schema_migrations
+                ORDER BY name
+                """
+            )
+        }
+        assert applied_names == set(main_eom.EOM_RECEIVABLES_READINESS_MIGRATIONS)
+        assert not any(
+            name.startswith(("066_", "068_", "074_", "076_", "083_", "095_"))
+            for name in applied_names
+        )
+        service = ReceivablesService(_SingleConnectionPool(conn, schema))
+        assert await service.is_ready() is True
+        expected_foreign_keys = {
+            ("appointments", ("contact_id",), "contacts", ("id",), "n"),
+            ("contact_interactions", ("contact_id",), "contacts", ("id",), "c"),
+            ("invoices", ("contact_id",), "contacts", ("id",), "n"),
+            ("invoice_payments", ("invoice_id",), "invoices", ("id",), "c"),
+            ("customer_payments", ("contact_id",), "contacts", ("id",), "n"),
+            (
+                "invoice_payments",
+                ("payment_id",),
+                "customer_payments",
+                ("id",),
+                "r",
+            ),
+            (
+                "payment_deposit_items",
+                ("batch_id",),
+                "payment_deposit_batches",
+                ("id",),
+                "r",
+            ),
+            (
+                "payment_deposit_items",
+                ("payment_id",),
+                "customer_payments",
+                ("id",),
+                "r",
+            ),
+            ("payment_events", ("payment_id",), "customer_payments", ("id",), "r"),
+        }
+        assert expected_foreign_keys <= await _schema_foreign_key_relationships(
+            conn,
+            schema,
+        )
+
+        await run_migrations(
+            pool,
+            migrations_dir=migrations_dir,
+            only=main_eom.EOM_RECEIVABLES_READINESS_MIGRATIONS,
+        )
+        assert {
+            row["name"]
+            for row in await conn.fetch(
+                """
+                SELECT name
+                FROM schema_migrations
+                ORDER BY name
+                """
+            )
+        } == applied_names
+        assert await service.is_ready() is True
+    finally:
+        await conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        await conn.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-EOM-Receivables-Schema-Readiness.md
Slice phase: Vertical slice
Ownership lane: eom-render/receivables-schema-readiness

The EOM Render profile had a migration switch, but enabling it would have run the whole Atlas migration chain against the standalone EOM database. This slice makes that startup path use an explicit receivables-readiness migration set and flips the Render blueprint to run it while keeping the private receivables API disabled until the token digest is provisioned separately.

Diff-budget override: this slice is indivisible because the startup migration switch, Render flag, schema/FK readiness proof, per-PR CI enrollment, rollback plan, and reconciliation record all guard the same deployed EOM startup boundary.

## Intentional

- Do not enable the private receivables API in this slice; token digest provisioning and the EOM time-tracker runtime cutover stay separate.
- Do not run the whole Atlas migration chain from the EOM profile; the existing migration runner documents that the full chain is unsafe for fresh standalone databases.
- Do not rewrite historical SQL migrations; this slice names the smallest existing dependency set needed for receivables readiness.

## Deferred

- Provision/rotate the EOM receivables service-token digest and enable the private API after schema readiness is deployed.
- Deprecate old EOM/Atlas receivables compatibility code after the Render-backed path is carrying production traffic.

## Parked hardening

- Parking predicate: defer only hardening unrelated to safely enabling this EOM startup migration boundary. Findings that affect migration membership, fresh-database schema integrity, required foreign keys/indexes, Render rollback, API-disabled separation, or per-PR CI enrollment are in scope for this slice.
- None under that predicate.

## Cold diff reconstruction

- Gaps: none found.
- Changed: `atlas_brain/main_eom.py:81` declares the migration set closure beside the tuple: closed/enumerated from the current receivables readiness contract and SQL prerequisite chain, with migrations outside the set intentionally not run by the EOM profile.
- Changed: `atlas_brain/main_eom.py:86` adds `EOM_RECEIVABLES_READINESS_MIGRATIONS` with `012_appointments`, `035_contacts`, `045_invoices`, `344_receivables_payments`, and `345_receivables_event_key_lookup`.
- Changed: `atlas_brain/main_eom.py:95` adds a private EOM migration helper, and `atlas_brain/main_eom.py:106` calls the central runner with `only=EOM_RECEIVABLES_READINESS_MIGRATIONS` instead of the default full-chain runner.
- Changed: `atlas_brain/main_eom.py:109` keeps startup gated on the initialized DB pool, but `atlas_brain/main_eom.py:112` now delegates to the private EOM helper.
- Changed: `render.eom.yaml:29` keeps the EOM migration env key and `render.eom.yaml:30` changes its deployed value to `"true"`. The blueprint still keeps the receivables API disabled at `render.eom.yaml:25` and still requires a synced digest secret at `render.eom.yaml:27`.
- Changed: `.github/workflows/atlas_invoicing_checks.yml:21` and `.github/workflows/atlas_invoicing_checks.yml:35` enroll the EOM app startup file and render-profile test in the pull-request path filter; `.github/workflows/atlas_invoicing_checks.yml:53` and `.github/workflows/atlas_invoicing_checks.yml:67` mirror that enrollment for main pushes; `.github/workflows/atlas_invoicing_checks.yml:114` now runs `tests/test_eom_render_profile.py` in the invoicing CI test command.
- Changed: `tests/test_eom_render_profile.py:327` updates the Render blueprint assertion for `ATLAS_EOM_RUN_MIGRATIONS=true`; `tests/test_eom_render_profile.py:346` locks the curated migration set and excludes B2B/V2V-looking migration prefixes; `tests/test_eom_render_profile.py:362` proves the EOM helper passes that exact set to the migration runner; `tests/test_eom_render_profile.py:381` proves an uninitialized pool still skips migration work without mocking the storage package.
- Changed: `tests/test_receivables.py:696` adds a single-connection migration pool fixture for live DB migration-runner tests; `tests/test_receivables.py:740` adds a `pg_constraint` reader for live foreign-key relationships; `tests/test_receivables.py:792` adds a non-live closure test that derives required receivables tables from `_RECEIVABLES_REQUIRED_COLUMNS`, checks the packaged SQL creates them, and checks the SQL prerequisite order; `tests/test_receivables.py:825` adds a live-Postgres-gated test that runs the real migration runner with the EOM readiness set; `tests/test_receivables.py:858` asserts only that set was recorded, `tests/test_receivables.py:863` proves `ReceivablesService.is_ready()` becomes true, `tests/test_receivables.py:865` asserts the required FK relationships, and `tests/test_receivables.py:899` reruns the same set to prove idempotent startup behavior.
- Changed: `plans/PR-EOM-Receivables-Schema-Readiness.md:14` records the root cause, `plans/PR-EOM-Receivables-Schema-Readiness.md:30` scopes the behavior change, `plans/PR-EOM-Receivables-Schema-Readiness.md:47` records acceptance criteria, `plans/PR-EOM-Receivables-Schema-Readiness.md:82` enumerates the changed startup/config boundary, `plans/PR-EOM-Receivables-Schema-Readiness.md:113` records rollback/backout, `plans/PR-EOM-Receivables-Schema-Readiness.md:131` adds the formal closure declaration for `EOM_RECEIVABLES_READINESS_MIGRATIONS`, `plans/PR-EOM-Receivables-Schema-Readiness.md:194` states the hardening parking predicate, and `plans/PR-EOM-Receivables-Schema-Readiness.md:203` records exact verification commands.
- Contract match: the startup seam now touches only EOM migration selection, not receivables auth or payment semantics; the Render blueprint enables schema startup without enabling the API; tests cover config, helper call shape, skip behavior, real SQL readiness, and idempotent re-run.
- Missing contract items: none found.
- Forbidden/extra changes: none found. Workflow enrollment is included here because the changed EOM startup/config paths and render-profile tests must be exercised by per-PR CI before the Render migration switch can merge.

## AI reconciliation

- [chatgpt-codex-connector] Declare closure for the curated migration set: fixed by adding the formal closure declaration in the plan, documenting the closed/enumerated source beside `EOM_RECEIVABLES_READINESS_MIGRATIONS`, and adding a non-live SQL/readiness dependency-closure test.
- [chatgpt-codex-connector] Declare the hardening parking predicate: fixed by adding the predicate in the plan and PR body; no hardening is parked under that predicate.
- [chatgpt-codex-connector] Record reproducible verification commands: fixed by replacing descriptive plan verification bullets with exact commands and the CI command/environment for the live migration path.
- [chatgpt-codex-connector] Document rollback before enabling startup migrations: fixed by adding the rollback/backout procedure for disabling `ATLAS_EOM_RUN_MIGRATIONS`, preserving additive schema, and rolling forward with a database repair if a migration partially records.
- [chatgpt-codex-connector] Verify the required foreign keys in the live migration test: fixed by querying `pg_constraint` and asserting required contact, invoice allocation, customer payment, deposit item, and payment event relationships.
- [chatgpt-codex-connector] Enroll the EOM migration tests in per-PR CI: fixed by adding EOM startup/config/test paths to `atlas_invoicing_checks.yml` filters and running `tests/test_eom_render_profile.py` in the invoicing CI test command.
- All fixed or waived: Yes.

## Verification

- Command: python -m py_compile atlas_brain/main_eom.py tests/test_eom_render_profile.py tests/test_receivables.py - passed.
- Command: git diff --check - passed.
- Command: pytest tests/test_eom_render_profile.py -q - 34 passed.
- Command: pytest tests/test_receivables.py::test_eom_readiness_migration_set_is_closed_over_receivables_dependencies tests/test_receivables.py::test_eom_receivables_readiness_migration_set_builds_ready_schema tests/test_receivables.py::test_real_migration_backfills_and_adopts_late_rolling_writer_checks -q - 1 passed, 2 skipped locally because `ATLAS_RECEIVABLES_TEST_DATABASE_URL` is not configured.
- Command: pytest tests/test_receivables.py -q - 57 passed, 6 skipped locally because `ATLAS_RECEIVABLES_TEST_DATABASE_URL` is not configured; GitHub invoicing CI provides that env for the live migration tests.
- Command: pytest tests/test_eom_render_profile.py tests/test_receivables.py tests/test_invoice_repository.py -q - 91 passed, 7 skipped locally because `ATLAS_RECEIVABLES_TEST_DATABASE_URL` is not configured; GitHub invoicing CI provides that env for the live migration tests.
- Command: python scripts/maturity_sweep.py atlas_brain/storage --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_storage.json --min-score 8 ... - ratchet gate passed.
- Command: python scripts/audit_plan_doc.py plans/PR-EOM-Receivables-Schema-Readiness.md - passed.
- Command: python scripts/check_deployed_config_probing.py --base origin/main - passed.
- Command: bash scripts/local_pr_review.sh --allow-dirty --current-pr-body-file tmp/pr-body-eom-receivables-schema-readiness.md - passed.

## Diff size

6 files, +526 / -6.
