### PR TITLE
Correct Codex review event triggers

### DIFF
--- a/.github/workflows/ai_reconciliation_live.yml
+++ b/.github/workflows/ai_reconciliation_live.yml
@@ -1,4 +1,6 @@
 name: AI Reconciliation (live)
+run-name: >-
+  AI Reconciliation PR #${{ github.event.issue.number || github.event.pull_request.number }}
 
 # Phase 5 of the review-workflow redesign (#1328): the live, CI-side half of the
 # AI-finding reconciliation gate. Fails when the PR body records the bot findings
@@ -8,18 +10,20 @@ name: AI Reconciliation (live)
 # Runs on `pull_request_target` as well as the review events so that, as a
 # *required* status check, it always runs and reports (a quiet PR with no bot
 # threads reports green instead of wedging the merge as "missing required
-# check"), and re-runs when a bot comment lands or a review thread is
-# resolved/unresolved after the PR opens.
+# check"), and re-runs when a bot review or review comment lands after the PR
+# opens.
 #
 # Trusted-base execution (#1944 waiver 18): `pull_request_target` resolves
 # this workflow from the BASE branch and both jobs pin their checkout to the
 # base SHA, so a PR editing this gate is still judged by main's version. The
 # required `live-reconciliation` context comes from the target-only job
 # (audited guard shape in scripts/audit_workflow_security_posture.py); the
-# review-events job re-runs the same base-ref script when bot comments land or
-# review threads are resolved/unresolved and reports under its own advisory
-# context. Neither job may ever gain a
-# step that executes PR-ref content.
+# review-events jobs re-run the same trusted script when bot reviews or review
+# comments land and report under advisory contexts.
+# GitHub Actions does not expose `pull_request_review_thread` as a workflow
+# trigger, so resolving a review thread is observed by the next supported
+# PR/review/review-comment event rather than by a thread-resolution event.
+# Neither job may ever gain a step that executes PR-ref content.
 
 on:
   # `edited` is included so that when a reviewer fixes a failed check by editing
@@ -29,8 +33,6 @@ on:
     types: [opened, synchronize, reopened, ready_for_review, edited]
   pull_request_review:
   pull_request_review_comment:
-  pull_request_review_thread:
-    types: [resolved, unresolved]
 
 permissions:
   contents: read
@@ -60,7 +62,7 @@ jobs:
             --pr "${{ github.event.pull_request.number }}"
 
   live-reconciliation-review-events:
-    if: github.event_name != 'pull_request_target'
+    if: github.event_name == 'pull_request_review' || github.event_name == 'pull_request_review_comment'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/ai_reconciliation_review_retrigger.yml
+++ b/.github/workflows/ai_reconciliation_review_retrigger.yml
@@ -7,8 +7,11 @@ name: AI Reconciliation (review retrigger)
 # AI Reconciliation workflow completes for a review event (the advisory
 # job), this follow-up re-runs the latest `pull_request_target` run for the
 # same head SHA, so the required context is re-evaluated by trusted base
-# code whenever a bot comment lands or a review thread is resolved/unresolved
-# after the last push/body edit.
+# code whenever a bot review or review comment lands after the last
+# push/body edit. GitHub Actions does not expose
+# `pull_request_review_thread` as a workflow trigger, so thread-resolution-only
+# changes are refreshed by the next supported PR/review/review-comment event
+# instead of this retrigger path.
 #
 # Loop-safe: the rerun completes with event == pull_request_target, which
 # this job's `if` ignores. No checkout and no repo scripts: the inline
@@ -21,28 +24,30 @@ on:
 
 permissions:
   actions: write
+  pull-requests: read
 
 jobs:
   retrigger-required-context:
     if: >-
       github.event.workflow_run.event == 'pull_request_review' ||
-      github.event.workflow_run.event == 'pull_request_review_comment' ||
-      github.event.workflow_run.event == 'pull_request_review_thread'
+      github.event.workflow_run.event == 'pull_request_review_comment'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Rerun latest trusted target run for this head
         env:
           GH_TOKEN: ${{ github.token }}
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          WORKFLOW_RUN_EVENT: ${{ github.event.workflow_run.event }}
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
+          head_sha="${WORKFLOW_RUN_HEAD_SHA}"
           run_id=$(gh api \
-            "repos/${GITHUB_REPOSITORY}/actions/workflows/ai_reconciliation_live.yml/runs?event=pull_request_target&head_sha=${HEAD_SHA}&per_page=1" \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/ai_reconciliation_live.yml/runs?event=pull_request_target&head_sha=${head_sha}&per_page=1" \
             --jq '.workflow_runs[0].id // empty')
           if [ -z "${run_id}" ]; then
-            echo "no pull_request_target run for ${HEAD_SHA}; nothing to refresh"
+            echo "no pull_request_target run for ${head_sha}; nothing to refresh"
             exit 0
           fi
-          echo "re-running trusted run ${run_id} for ${HEAD_SHA}"
+          echo "re-running trusted run ${run_id} for ${head_sha}"
           gh api -X POST "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/rerun"

--- a/plans/PR-Codex-Review-Thread-Event-Canary.md
+++ b/plans/PR-Codex-Review-Thread-Event-Canary.md
@@ -1,0 +1,278 @@
+# PR-Codex-Review-Thread-Event-Canary
+
+## Why this slice exists
+
+#2240 intentionally deferred live proof of `pull_request_review_thread`
+reachability until its workflow changes landed on `origin/main`. After #2240
+merged, this slice created and resolved real review-thread canaries on #2245.
+No AI Reconciliation run with event `pull_request_review_thread` appeared for
+the tested PR heads. GitHub's Actions event reference lists
+`pull_request_review` and `pull_request_review_comment`, but not
+`pull_request_review_thread`, as workflow triggers.
+
+The same live pass exposed a second process mismatch: on the current #2245
+head, Codex returned its clean result as a PR comment that names the reviewed
+commit, not as a formal review record. The live reconciliation gate therefore
+had current-head Codex evidence available, but still failed because it only
+accepted formal review records.
+
+This slice is intentionally over the normal diff budget. The first fix only
+updated the live reconciliation checker, but review feedback showed the same
+attestation boundary also feeds the local PR watcher, wake bridge, shell-owned
+PR watcher, and the tests that prove each consumer. A smaller patch would leave
+split-brain readiness semantics where one gate accepts a clean Codex comment
+and another still blocks on "missing review."
+
+### Problem-derived contract
+
+- Root cause: the previous workflow slice treated `pull_request_review_thread`
+  as a plausible GitHub Actions trigger without live proof, and the live
+  reconciliation attestation logic treated formal review records as the only
+  valid current-head Codex proof even when the connector supplied a clean
+  current-head PR comment. The root issue is mismatched GitHub/Codex event and
+  attestation shape in every trusted reconciliation/readiness consumer, not a
+  missing test fixture.
+- Correct fix must touch/change: remove `pull_request_review_thread` from the
+  AI Reconciliation workflow trigger list and the review-retrigger handoff
+  condition; update the workflow comments and local tests so the repo only
+  claims supported review/review-comment events refresh the required
+  `live-reconciliation` context. Keep review-thread status as a read/query gate
+  inside `scripts/check_ai_reconciliation_live.py`, and extend only its
+  current-head attestation input so a Codex-authored clean-review PR comment
+  with a reviewed commit prefix matching the current head can satisfy the same
+  freshness requirement when the checker/watchers read PR comments. The local
+  PR watcher, wake bridge, and owned-PR shell watcher must consume the same
+  attestation model. Formal `CHANGES_REQUESTED` reviews must still block.
+- Must not change: do not change EOM/product behavior, customer-visible
+  surfaces, Codex review policy semantics, branch-protection required context
+  names, trusted-base checkout posture, bot identity matching, open PRs in
+  other lanes, or the live reconciliation decision logic.
+
+## Scope (this PR)
+
+Ownership lane: workflow/codex-review-thread-event-canary
+Slice phase: workflow/process
+
+1. Remove the unsupported `pull_request_review_thread` Actions trigger from
+   AI Reconciliation live workflow YAML.
+2. Remove the unsupported `pull_request_review_thread` event branch from the
+   default-branch review-retrigger workflow.
+3. Update tests so they assert the supported trigger surface:
+   `pull_request_target`, `pull_request_review`, and
+   `pull_request_review_comment`.
+4. Accept Codex clean-review PR comments as current-head attestation only when
+   the bot author is exact and the reviewed commit prefix matches the PR head.
+5. Do not enable `issue_comment` CI refresh in this PR: GitHub only evaluates
+   issue-comment workflow triggers from the default branch, so this PR cannot
+   prove that path before merging it.
+6. Keep the local watcher, wake bridge, and owned-PR shell watcher aligned with
+   the same "current-head Codex review attestation" semantics.
+7. Record the live canary evidence that disproved the thread-event path and the
+   live clean-comment evidence that satisfied the current-head attestation gate.
+
+### Files touched
+
+- `.github/workflows/ai_reconciliation_live.yml`
+- `.github/workflows/ai_reconciliation_review_retrigger.yml`
+- `plans/PR-Codex-Review-Thread-Event-Canary.md`
+- `scripts/check_ai_reconciliation_live.py`
+- `scripts/codex_wake_bridge.py`
+- `scripts/pr_watcher.py`
+- `scripts/watch_owned_pr.sh`
+- `tests/test_check_ai_reconciliation_live.py`
+- `tests/test_codex_wake_bridge.py`
+- `tests/test_pr_watcher.py`
+- `tests/test_watch_owned_pr.py`
+
+### Review Contract
+
+- Acceptance criteria:
+  - `.github/workflows/ai_reconciliation_live.yml` still runs the required
+    trusted-base job on `pull_request_target` and the advisory job on supported
+    review/review-comment events; settled by
+    `tests/test_check_ai_reconciliation_live.py`.
+  - `.github/workflows/ai_reconciliation_live.yml` no longer claims
+    `pull_request_review_thread` as a trigger; settled by
+    `tests/test_check_ai_reconciliation_live.py`.
+  - `.github/workflows/ai_reconciliation_review_retrigger.yml` reruns the
+    trusted required context only after supported `pull_request_review` and
+    `pull_request_review_comment` workflow runs; settled by
+    `tests/test_check_ai_reconciliation_live.py`.
+  - The live reconciliation script still reads review threads and fails on
+    unresolved scoped Codex/Copilot threads; this PR does not remove that gate.
+  - `scripts/check_ai_reconciliation_live.py` accepts current-head clean-review
+    PR comments only from exact configured bot logins and only when the comment
+    includes a reviewed commit prefix matching the current PR head; settled by
+    `tests/test_check_ai_reconciliation_live.py`.
+  - `scripts/pr_watcher.py`, `scripts/codex_wake_bridge.py`, and
+    `scripts/watch_owned_pr.sh` describe and enforce "current-head Codex review
+    attestation" consistently, so no readiness path still requires only a
+    formal review record; settled by `tests/test_pr_watcher.py`,
+    `tests/test_codex_wake_bridge.py`, and `tests/test_watch_owned_pr.py`.
+  - Formal current-head `CHANGES_REQUESTED` reviews still override a clean
+    PR-comment attestation; settled by
+    `tests/test_check_ai_reconciliation_live.py`.
+- Reachability proof:
+  - Created/resolved a review-thread canary on #2245 head
+    `7762288c0c0b90d0b90fe3823a104d38c9614347`; no
+    `pull_request_review_thread` AI Reconciliation run appeared.
+  - Created/resolved a review-thread canary on #2245 head
+    `aa9e1ee6314aeb8cb800f07013954f7fdfd42d12`; no
+    `pull_request_review_thread` AI Reconciliation run appeared.
+  - GitHub Actions documentation lists `pull_request_review` and
+    `pull_request_review_comment` workflow triggers, but not
+    `pull_request_review_thread`.
+  - On #2245 head `92eac478eb4397117f2513baecd8b30e7b2b56c8`, Codex posted
+    `Codex Review: Didn't find any major issues` with reviewed commit
+    `92eac478eb`; after the attestation patch, the live reconciliation command
+    accepted that exact-head clean comment and found no open scoped threads.
+- Affected surfaces:
+  - `.github/workflows/ai_reconciliation_live.yml`
+  - `.github/workflows/ai_reconciliation_review_retrigger.yml`
+  - `scripts/check_ai_reconciliation_live.py`
+  - `scripts/codex_wake_bridge.py`
+  - `scripts/pr_watcher.py`
+  - `scripts/watch_owned_pr.sh`
+  - `tests/test_check_ai_reconciliation_live.py`
+  - `tests/test_codex_wake_bridge.py`
+  - `tests/test_pr_watcher.py`
+  - `tests/test_watch_owned_pr.py`
+  - `plans/PR-Codex-Review-Thread-Event-Canary.md`
+- Risk areas: silently leaving an unsupported trigger claim in YAML/comments,
+  removing supported review/comment refresh coverage, changing the required
+  context name, or weakening the actual unresolved-review-thread gate.
+- Reviewer rules triggered: R1, R2, R6, R10, R12, R14.
+
+### Boundary-change enumeration
+
+- Boundary path/seam:
+  `.github/workflows/ai_reconciliation_live.yml` and
+  `.github/workflows/ai_reconciliation_review_retrigger.yml` define which
+  GitHub event classes can refresh the live reconciliation check.
+- Replaced-path behaviors: unsupported thread-resolution event refresh is
+  removed because the live canary and GitHub Actions docs do not support it.
+- Guard-relevant fields: workflow event name, PR base SHA checkout, PR head SHA
+  selected by the retrigger run, required-context rerun ID, PR comment author,
+  clean-review marker, and reviewed commit prefix.
+- Attestation recognizer closure: the accepted clean-comment attestation set is
+  closed to exact configured Codex bot logins, the canonical clean phrase
+  `didn't find any major issues`, and the reviewed-commit marker
+  `**Reviewed commit:**` followed by a 10-40 hex-character commit prefix that
+  matches the current PR head. Comments outside that set do not attest the head.
+- Caller x input shape: GitHub Actions event payloads for
+  `pull_request_target`, `pull_request_review`, and
+  `pull_request_review_comment`.
+
+### Deployed-config probing
+
+- Deployed/default config values: workflow filenames remain
+  `.github/workflows/ai_reconciliation_live.yml` and
+  `.github/workflows/ai_reconciliation_review_retrigger.yml`.
+- Explicit value probe: tests assert supported review/review-comment event
+  wiring, no issue-comment workflow wiring for PR comments until a default-branch
+  canary can prove it, required-context rerun wiring,
+  exact bot comment authorship, clean comment text, reviewed commit prefix
+  matching, comment pagination, and malformed-comment fail-closed behavior.
+- Absent value probe: tests assert `pull_request_review_thread` is absent from
+  both workflow trigger/condition surfaces.
+- Default-session/default-context probe: trusted-base checkout remains pinned
+  to `${{ github.event.pull_request.base.sha }}` for live jobs.
+- Side-effect ordering: no product/runtime side effects; this is workflow
+  trigger correction only.
+
+## Mechanism
+
+The required `live-reconciliation` context still runs under
+`pull_request_target` from trusted base code. The advisory review-events job
+still runs the same base-ref script when GitHub emits a supported review or
+review-comment workflow event. The review-retrigger workflow still runs from
+the default branch after those advisory workflow runs and reruns the latest
+trusted `pull_request_target` run for the same head SHA.
+
+The difference is that the repo no longer claims thread resolution alone emits
+a GitHub Actions workflow event. Unresolved review threads remain part of the
+live reconciliation decision; their refreshed status is picked up on the next
+supported PR/review/review-comment event or push/body edit.
+
+The live reconciliation gate and the local readiness watchers now treat Codex's
+clean PR comment as a current-head attestation when the comment is authored by
+an exact configured bot login and its reviewed commit prefix matches the current
+PR head. That mirrors the connector behavior observed on #2245 without allowing
+arbitrary bot chatter or stale-head comments to satisfy the gate.
+
+## Intentional
+
+- This PR removes the unsupported trigger claim instead of adding a permanent
+  canary script, because the one-off live canary already disproved the event
+  path and keeping a verifier for an unsupported event would add confusing
+  process debt.
+- The `scripts/check_ai_reconciliation_live.py` change is limited to
+  current-head attestation. The gate still reads GraphQL review threads and
+  fails when scoped automated-review threads remain unresolved.
+- The watcher field name `codex_head_review_count` is retained for snapshot
+  compatibility, but its text and inputs now mean "current-head Codex review
+  attestation" rather than "formal review object only."
+
+## Deferred
+
+- If GitHub later adds `pull_request_review_thread` to Actions workflow
+  triggers, add a new proof slice before restoring any thread-resolution
+  trigger path.
+
+Parking predicate: this slice only parks future platform support for a
+dedicated `pull_request_review_thread` Actions trigger. It does not park
+same-surface findings about current supported event reachability,
+current-head attestation freshness, nullable GitHub authors, or local readiness
+consumers; those must be fixed in this PR.
+
+Parked hardening: future proof slice for a newly supported
+`pull_request_review_thread` trigger, plus a separate default-branch canary
+before enabling `issue_comment` CI refresh for clean Codex PR comments.
+
+## Verification
+
+- Live #2245 canary on head `7762288c0c0b90d0b90fe3823a104d38c9614347`:
+  review thread created/resolved; no AI Reconciliation
+  `pull_request_review_thread` run appeared.
+- Live #2245 canary on head `aa9e1ee6314aeb8cb800f07013954f7fdfd42d12`:
+  review thread created/resolved; no AI Reconciliation
+  `pull_request_review_thread` run appeared.
+- Live #2245 clean-comment attestation on head
+  `92eac478eb4397117f2513baecd8b30e7b2b56c8`: Codex posted a clean review
+  comment for commit `92eac478eb`; `python scripts/check_ai_reconciliation_live.py --repo canfieldjuan/ATLAS --pr 2245`
+  passed with no open scoped Codex review threads.
+- `python -m pytest tests/test_check_ai_reconciliation_live.py -q`
+  - passed, 42 tests.
+- `python -m pytest tests/test_check_ai_reconciliation_live.py tests/test_pr_watcher.py tests/test_watch_owned_pr.py tests/test_report_pr_watcher_state.py tests/test_codex_wake_bridge.py -q`
+  - passed, 189 tests.
+- `python -m py_compile scripts/check_ai_reconciliation_live.py scripts/pr_watcher.py scripts/codex_wake_bridge.py`
+  - passed.
+- `bash -n scripts/watch_owned_pr.sh`
+  - passed.
+- `python scripts/audit_plan_doc.py plans/PR-Codex-Review-Thread-Event-Canary.md`
+  - passed.
+- `python scripts/audit_plan_doc_files_touched.py plans/PR-Codex-Review-Thread-Event-Canary.md origin/main`
+  - passed.
+- `python scripts/audit_plan_doc_diff_size.py plans/PR-Codex-Review-Thread-Event-Canary.md origin/main`
+  - passed, 0.0% drift.
+- `python scripts/audit_plan_code_consistency.py --base-ref origin/main plans/PR-Codex-Review-Thread-Event-Canary.md`
+  - passed.
+- `git diff --check origin/main -- . ':!node_modules'`
+  - passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/ai_reconciliation_live.yml` | 44 |
+| `.github/workflows/ai_reconciliation_review_retrigger.yml` | 34 |
+| `plans/PR-Codex-Review-Thread-Event-Canary.md` | 276 |
+| `scripts/check_ai_reconciliation_live.py` | 146 |
+| `scripts/codex_wake_bridge.py` | 2 |
+| `scripts/pr_watcher.py` | 106 |
+| `scripts/watch_owned_pr.sh` | 83 |
+| `tests/test_check_ai_reconciliation_live.py` | 181 |
+| `tests/test_codex_wake_bridge.py` | 2 |
+| `tests/test_pr_watcher.py` | 136 |
+| `tests/test_watch_owned_pr.py` | 162 |
+| **Total** | **1172** |

--- a/scripts/check_ai_reconciliation_live.py
+++ b/scripts/check_ai_reconciliation_live.py
@@ -31,12 +31,15 @@ import argparse
 import importlib.util
 import json
 import os
+import re
 import subprocess
 import sys
 from collections.abc import Sequence
 from pathlib import Path
 
 _DEFAULT_BOTS = ("chatgpt-codex-connector", "chatgpt-codex-connector[bot]")
+_CLEAN_CODEX_REVIEW_TEXT = "didn't find any major issues"
+_REVIEWED_COMMIT_RE = re.compile(r"\*\*Reviewed commit:\*\*\s*`(?P<sha>[0-9a-f]{10,40})`", re.IGNORECASE)
 _LEGACY_BOT_ALIASES = frozenset(
     {
         "bot",
@@ -86,10 +89,29 @@ query($owner:String!,$name:String!,$pr:Int!,$cursor:String){
 }
 """
 
+_COMMENTS_QUERY = """
+query($owner:String!,$name:String!,$pr:Int!,$cursor:String){
+  repository(owner:$owner,name:$name){
+    pullRequest(number:$pr){
+      headRefOid
+      comments(first:100, after:$cursor){
+        pageInfo{ hasNextPage endCursor }
+        nodes{
+          author{ login }
+          body
+          bodyText
+        }
+      }
+    }
+  }
+}
+"""
+
 # Defensive cap on pagination (100 threads/page) so a pathological PR can never
 # loop unbounded; far above any real review.
 _MAX_THREAD_PAGES = 50
 _MAX_REVIEW_PAGES = 50
+_MAX_COMMENT_PAGES = 50
 
 
 def _load_phase2():
@@ -187,6 +209,31 @@ def current_head_bot_reviews(
     )
 
 
+def current_head_clean_review_comments(
+    comments: Sequence[dict],
+    *,
+    head_sha: str,
+    bot_logins: Sequence[str],
+) -> list[dict]:
+    """Return Codex clean-review PR comments that name the current PR head."""
+
+    wanted = frozenset(b.lower() for b in bot_logins)
+    found: list[dict] = []
+    for comment in comments or []:
+        author = (((comment.get("author") or {}).get("login")) or "").lower()
+        body = comment.get("body") or comment.get("bodyText") or ""
+        if author not in wanted or _CLEAN_CODEX_REVIEW_TEXT not in body.lower():
+            continue
+        match = _REVIEWED_COMMIT_RE.search(body)
+        if match is None:
+            continue
+        reviewed_sha = match.group("sha").lower()
+        if not head_sha.lower().startswith(reviewed_sha):
+            continue
+        found.append(comment)
+    return found
+
+
 def current_head_change_requests(
     reviews: Sequence[dict],
     *,
@@ -205,6 +252,7 @@ def current_head_change_requests(
 
 def review_attestation_generation(
     reviews: Sequence[dict],
+    comments: Sequence[dict] | None = None,
     *,
     head_sha: str,
     bot_logins: Sequence[str],
@@ -218,7 +266,18 @@ def review_attestation_generation(
         commit = ((review.get("commit") or {}).get("oid")) or ""
         state = review.get("state") or ""
         if author in wanted and commit == head_sha:
-            generation.append((author, commit, state))
+            generation.append(("review", author, commit, state))
+    for comment in comments or []:
+        author = (((comment.get("author") or {}).get("login")) or "").lower()
+        body = comment.get("body") or comment.get("bodyText") or ""
+        if author not in wanted:
+            continue
+        match = _REVIEWED_COMMIT_RE.search(body)
+        if match is None:
+            continue
+        reviewed_sha = match.group("sha").lower()
+        if head_sha.lower().startswith(reviewed_sha):
+            generation.append(("comment", author, reviewed_sha, body))
     return tuple(sorted(generation))
 
 
@@ -279,6 +338,7 @@ def evaluate(
     bot_logins: Sequence[str],
     *,
     reviews: Sequence[dict] | None = None,
+    comments: Sequence[dict] | None = None,
     head_sha: str | None = None,
 ) -> tuple[int, list[str]]:
     """Core decision (pure). Returns (exit_code, messages)."""
@@ -299,17 +359,21 @@ def evaluate(
             reviews or [],
             head_sha=head_sha,
             bot_logins=bot_logins,
+        ) and not current_head_clean_review_comments(
+            comments or [],
+            head_sha=head_sha,
+            bot_logins=bot_logins,
         ):
             messages.append(
                 "missing current-head Codex connector review: live reconciliation "
-                f"requires one scoped Codex review on PR head {head_sha} before merge."
+                f"requires one scoped Codex review or clean review comment on PR head {head_sha} before merge."
             )
 
     open_threads = open_bot_threads(nodes, bot_logins)
     if not open_threads:
         if messages:
             return 1, messages
-        return 0, ["OK: current-head Codex review is present and no open scoped Codex review threads remain."]
+        return 0, ["OK: current-head Codex review attestation is present and no open scoped Codex review threads remain."]
 
     body_class = classify_body(body)
     if body_class == "claims_clear":
@@ -462,6 +526,59 @@ def fetch_review_attestation(pr: int, owner: str, name: str, gh: str) -> tuple[s
     return head_sha, reviews
 
 
+def fetch_comment_attestation(pr: int, owner: str, name: str, gh: str) -> tuple[str, list[dict]]:
+    """Fetch PR head SHA and all PR comments for clean Codex attestation."""
+
+    comments: list[dict] = []
+    head_sha = ""
+    cursor: str | None = None
+    for page_number in range(1, _MAX_COMMENT_PAGES + 1):
+        args = [
+            "api", "graphql",
+            "-f", f"query={_COMMENTS_QUERY}",
+            "-F", f"owner={owner}",
+            "-F", f"name={name}",
+            "-F", f"pr={pr}",
+        ]
+        if cursor:
+            args += ["-F", f"cursor={cursor}"]
+        data = json.loads(_gh(args, gh))
+        if data.get("errors"):
+            raise RuntimeError(f"GitHub GraphQL returned errors on comments page {page_number}")
+
+        envelope = _expect_mapping(data.get("data"), "data")
+        repository = _expect_mapping(envelope.get("repository"), "repository")
+        pull_request = _expect_mapping(repository.get("pullRequest"), "pullRequest")
+        observed_head = pull_request.get("headRefOid")
+        if not isinstance(observed_head, str) or not observed_head:
+            raise RuntimeError("GitHub GraphQL response malformed: pullRequest.headRefOid is missing")
+        if head_sha and observed_head != head_sha:
+            raise RuntimeError("GitHub GraphQL response changed PR head during comment pagination")
+        head_sha = observed_head
+
+        comment_connection = _expect_mapping(pull_request.get("comments"), "comments")
+        page = _expect_mapping(comment_connection.get("pageInfo"), "comments.pageInfo")
+        page_nodes = comment_connection.get("nodes")
+        if not isinstance(page_nodes, list):
+            raise RuntimeError("GitHub GraphQL response malformed: comments.nodes is missing or not a list")
+        comments.extend(page_nodes)
+
+        has_next = page.get("hasNextPage")
+        if not isinstance(has_next, bool):
+            raise RuntimeError(
+                "GitHub GraphQL response malformed: comments.pageInfo.hasNextPage is missing or not a bool"
+            )
+        if not has_next:
+            break
+        next_cursor = page.get("endCursor")
+        if not isinstance(next_cursor, str) or not next_cursor:
+            raise RuntimeError("GitHub GraphQL response malformed: comments.pageInfo.endCursor is required")
+        cursor = next_cursor
+    else:
+        raise RuntimeError(f"comments pagination exceeded {_MAX_COMMENT_PAGES} pages")
+    return head_sha, comments
+
+
 def fetch_body(pr: int, repo: str, gh: str) -> str:
     out = _gh(["pr", "view", str(pr), "--repo", repo, "--json", "body", "-q", ".body"], gh)
     return out
@@ -473,28 +590,34 @@ def fetch_consistent_review_thread_snapshot(
     name: str,
     gh: str,
     bot_logins: Sequence[str],
-) -> tuple[list[dict], str, list[dict]]:
+) -> tuple[list[dict], str, list[dict], list[dict]]:
     """Fetch reviews/threads twice and fail closed if either generation moves."""
 
     head_before, reviews_before = fetch_review_attestation(pr, owner, name, gh)
+    comment_head_before, comments_before = fetch_comment_attestation(pr, owner, name, gh)
     nodes_before = fetch_threads(pr, owner, name, gh)
     head_middle, reviews_middle = fetch_review_attestation(pr, owner, name, gh)
+    comment_head_middle, comments_middle = fetch_comment_attestation(pr, owner, name, gh)
     nodes_after = fetch_threads(pr, owner, name, gh)
     head_after, reviews_after = fetch_review_attestation(pr, owner, name, gh)
-    if len({head_before, head_middle, head_after}) != 1:
+    comment_head_after, comments_after = fetch_comment_attestation(pr, owner, name, gh)
+    if len({head_before, head_middle, head_after, comment_head_before, comment_head_middle, comment_head_after}) != 1:
         raise RuntimeError("GitHub PR head changed during review/thread snapshot fetch")
     before_generation = review_attestation_generation(
         reviews_before,
+        comments_before,
         head_sha=head_before,
         bot_logins=bot_logins,
     )
     after_generation = review_attestation_generation(
         reviews_after,
+        comments_after,
         head_sha=head_after,
         bot_logins=bot_logins,
     )
     middle_generation = review_attestation_generation(
         reviews_middle,
+        comments_middle,
         head_sha=head_middle,
         bot_logins=bot_logins,
     )
@@ -502,7 +625,7 @@ def fetch_consistent_review_thread_snapshot(
         raise RuntimeError("GitHub Codex review generation changed during review/thread snapshot fetch")
     if review_thread_generation(nodes_before) != review_thread_generation(nodes_after):
         raise RuntimeError("GitHub review thread generation changed during review/thread snapshot fetch")
-    return nodes_after, head_after, reviews_after
+    return nodes_after, head_after, reviews_after, comments_after
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -532,6 +655,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         help="JSON file of review nodes (test/dry-run; skips fetching live reviews)",
     )
     parser.add_argument(
+        "--comments-file",
+        help="JSON file of PR comment nodes (test/dry-run; skips fetching live review comments)",
+    )
+    parser.add_argument(
         "--head-sha",
         help="PR head SHA for current-head Codex review attestation in test/dry-run mode",
     )
@@ -546,6 +673,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     try:
         head_sha = args.head_sha
         reviews: Sequence[dict] | None = None
+        comments: Sequence[dict] | None = None
 
         if args.threads_file:
             nodes = json.loads(Path(args.threads_file).read_text(encoding="utf-8"))
@@ -558,7 +686,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 )
                 return 2
             owner, _, name = args.repo.partition("/")
-            nodes, head_sha, reviews = fetch_consistent_review_thread_snapshot(
+            nodes, head_sha, reviews, comments = fetch_consistent_review_thread_snapshot(
                 args.pr,
                 owner,
                 name,
@@ -568,6 +696,8 @@ def main(argv: Sequence[str] | None = None) -> int:
 
         if args.reviews_file:
             reviews = json.loads(Path(args.reviews_file).read_text(encoding="utf-8"))
+        if args.comments_file:
+            comments = json.loads(Path(args.comments_file).read_text(encoding="utf-8"))
 
         if args.body_file:
             body = Path(args.body_file).read_text(encoding="utf-8")
@@ -579,7 +709,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"live reconciliation: GitHub API/read error: {exc}", file=sys.stderr)
         return 2
 
-    code, messages = evaluate(nodes, body, bots, reviews=reviews, head_sha=head_sha)
+    code, messages = evaluate(nodes, body, bots, reviews=reviews, comments=comments, head_sha=head_sha)
     print("live AI reconciliation check")
     print("-" * 60)
     for line in messages:

--- a/scripts/codex_wake_bridge.py
+++ b/scripts/codex_wake_bridge.py
@@ -154,7 +154,7 @@ def readiness_blockers(status: dict[str, Any]) -> list[str]:
         blockers.append("Codex review pages fetched must be at least 1")
     codex_head_reviews = proof.get("codex_head_review_count")
     if not _non_negative_int(codex_head_reviews) or codex_head_reviews < 1:
-        blockers.append("current-head Codex review is missing")
+        blockers.append("current-head Codex review attestation is missing")
 
     if "review_decision" not in proof or "reviewDecision" not in pr:
         blockers.append("review decision evidence is missing")

--- a/scripts/pr_watcher.py
+++ b/scripts/pr_watcher.py
@@ -30,7 +30,13 @@ SAFE_WATCHER_ID_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 VALID_CHECK_EXIT_CODES = {0, 1, 8}
 MAX_THREAD_PAGES = 50
 MAX_REVIEW_PAGES = 50
+MAX_COMMENT_PAGES = 50
 COMMAND_TIMEOUT_SECONDS = 60
+CODEX_CLEAN_REVIEW_TEXT = "didn't find any major issues"
+CODEX_REVIEWED_COMMIT_RE = re.compile(
+    r"\*\*Reviewed commit:\*\*\s*`(?P<sha>[0-9a-f]{10,40})`",
+    re.IGNORECASE,
+)
 CODEX_CONNECTOR_LOGINS = frozenset(
     {
         "chatgpt-codex-connector",
@@ -70,6 +76,19 @@ query($owner:String!,$name:String!,$pr:Int!,$cursor:String){
       reviews(first:100, after:$cursor){
         pageInfo{ hasNextPage endCursor }
         nodes{ author{ login } commit{ oid } state }
+      }
+    }
+  }
+}
+"""
+
+COMMENTS_QUERY = """
+query($owner:String!,$name:String!,$pr:Int!,$cursor:String){
+  repository(owner:$owner,name:$name){
+    pullRequest(number:$pr){
+      comments(first:100, after:$cursor){
+        pageInfo{ hasNextPage endCursor }
+        nodes{ author{ login } body bodyText }
       }
     }
   }
@@ -257,6 +276,26 @@ def _repo_parts(repo: str) -> tuple[str, str]:
 
 def _is_codex_login(value: Any) -> bool:
     return isinstance(value, str) and value.lower() in CODEX_CONNECTOR_LOGINS
+
+
+def _is_current_head_clean_codex_comment(node: dict[str, Any], *, head_sha: str) -> bool | str:
+    author = node.get("author")
+    if author is None:
+        return False
+    if not isinstance(author, dict):
+        return "comment author is malformed"
+    login = author.get("login")
+    if login is not None and not isinstance(login, str):
+        return "comment author login is malformed"
+    body = node.get("body") or node.get("bodyText") or ""
+    if body is not None and not isinstance(body, str):
+        return "comment body is malformed"
+    if not _is_codex_login(login) or CODEX_CLEAN_REVIEW_TEXT not in body.lower():
+        return False
+    match = CODEX_REVIEWED_COMMIT_RE.search(body)
+    if match is None:
+        return False
+    return head_sha.lower().startswith(match.group("sha").lower())
 
 
 def _first_thread_author_login(node: dict[str, Any], *, index: int) -> tuple[str, str | None]:
@@ -453,12 +492,73 @@ def _fetch_codex_head_reviews(
         if not isinstance(has_next, bool):
             return matches, pages, False, "GraphQL review hasNextPage must be boolean"
         if not has_next:
-            return matches, pages, True, None
+            break
         next_cursor = page_info.get("endCursor")
         if not isinstance(next_cursor, str) or not next_cursor:
             return matches, pages, False, "GraphQL review pagination cursor is missing"
         cursor = next_cursor
-    return matches, pages, False, f"review pagination exceeded {MAX_REVIEW_PAGES} pages"
+    else:
+        return matches, pages, False, f"review pagination exceeded {MAX_REVIEW_PAGES} pages"
+
+    cursor = None
+    for _ in range(MAX_COMMENT_PAGES):
+        command = [
+            "gh",
+            "api",
+            "graphql",
+            "-f",
+            f"query={COMMENTS_QUERY}",
+            "-F",
+            f"owner={owner}",
+            "-F",
+            f"name={name}",
+            "-F",
+            f"pr={pr}",
+        ]
+        if cursor is not None:
+            command.extend(["-F", f"cursor={cursor}"])
+        payload, error = _run_json(
+            command,
+            cwd=cwd,
+            allowed_codes={0},
+            expected_type=dict,
+        )
+        if error:
+            return matches, pages, False, error
+        graphql_errors = payload.get("errors")
+        if graphql_errors:
+            return matches, pages, False, "GraphQL response contains errors"
+        data = payload.get("data")
+        repository = data.get("repository") if isinstance(data, dict) else None
+        pull_request = repository.get("pullRequest") if isinstance(repository, dict) else None
+        comments = pull_request.get("comments") if isinstance(pull_request, dict) else None
+        if comments is None:
+            return matches, pages, False, "GraphQL comments envelope is missing"
+        if not isinstance(comments, dict):
+            return matches, pages, False, "GraphQL comments must be an object"
+        nodes = comments.get("nodes")
+        page_info = comments.get("pageInfo")
+        if not isinstance(nodes, list) or not isinstance(page_info, dict):
+            return matches, pages, False, "GraphQL comment nodes/pageInfo are malformed"
+        pages += 1
+        for index, node in enumerate(nodes):
+            if not isinstance(node, dict):
+                return matches, pages, False, f"comment {index} is not an object"
+            clean = _is_current_head_clean_codex_comment(node, head_sha=head_sha)
+            if isinstance(clean, str):
+                return matches, pages, False, clean
+            if clean:
+                matches += 1
+        has_next = page_info.get("hasNextPage")
+        if not isinstance(has_next, bool):
+            return matches, pages, False, "GraphQL comment hasNextPage must be boolean"
+        if not has_next:
+            return matches, pages, True, None
+        next_cursor = page_info.get("endCursor")
+        if not isinstance(next_cursor, str) or not next_cursor:
+            return matches, pages, False, "GraphQL comment pagination cursor is missing"
+        cursor = next_cursor
+    return matches, pages, False, f"comment pagination exceeded {MAX_COMMENT_PAGES} pages"
 
 
 def _read_previous(path: Path) -> tuple[dict[str, Any], str | None]:
@@ -859,7 +959,7 @@ def produce(watcher_id: str, *, config_dir: Path, state_dir: Path) -> tuple[int,
                 f"{len(required_failures)} failed, {len(required_pending)} pending"
             ),
             f"Unresolved review threads: {len(unresolved_threads)} across {thread_pages} fetched page(s)",
-            f"Current-head Codex reviews: {codex_head_review_count} across {review_pages} fetched page(s)",
+            f"Current-head Codex review attestations: {codex_head_review_count} across {review_pages} fetched page(s)",
             f"Reviews/comments: {review_count} reviews, {comment_count} comments",
             f"Review changed since last poll: {'yes' if review_changed else 'no'}",
             f"AI reconciliation: {'pass' if reconciliation_code == 0 else 'fail'}",

--- a/scripts/watch_owned_pr.sh
+++ b/scripts/watch_owned_pr.sh
@@ -7,7 +7,7 @@
 #   ACTIONABLE    - red required context / unresolved review threads /
 #                   CHANGES_REQUESTED review decision
 #   MERGE-READY   - EVERY required context present and success +
-#                   Codex review exists on this exact head SHA +
+#                   Codex review attestation exists on this exact head SHA +
 #                   0 unresolved threads (no unfetched pages) +
 #                   review decision not CHANGES_REQUESTED + mergeable
 # Required contexts + app pin are read from origin/main's
@@ -78,6 +78,7 @@ for i in $(seq 0 "$CYCLES"); do
   # Fail closed when more thread pages exist than we fetched.
   [ "$MORE" = "true" ] && UNRES="${UNRES}+unfetched-pages"
   REVIEW_QUERY='query($owner:String!,$name:String!,$pr:Int!,$cursor:String){ repository(owner:$owner,name:$name){ pullRequest(number:$pr){ reviews(first:100, after:$cursor){ pageInfo{ hasNextPage endCursor } nodes{ author{ login } commit{ oid } state } } } } }'
+  COMMENT_QUERY='query($owner:String!,$name:String!,$pr:Int!,$cursor:String){ repository(owner:$owner,name:$name){ pullRequest(number:$pr){ comments(first:100, after:$cursor){ pageInfo{ hasNextPage endCursor } nodes{ author{ login } body bodyText } } } } }'
   REVIEW_NODES='[]'
   REVIEW_CURSOR=''
   REVIEW_PAGES=0
@@ -112,7 +113,41 @@ for i in $(seq 0 "$CYCLES"); do
     REVIEW_CURSOR=$(echo "$REVIEW_PAGE" | jq -r '.data.repository.pullRequest.reviews.pageInfo.endCursor // empty')
     [ -n "$REVIEW_CURSOR" ] || { REVIEWS_COMPLETE=false; break; }
   done
-  CODEX_HEAD_REVIEWS=$(echo "$REVIEW_NODES" | jq --arg sha "$SHA" --argjson codex "$CODEX_LOGINS_JSON" '[.[]? | select(((((.author.login // "") | ascii_downcase) as $login | $codex | index($login)) != null) and ((.commit.oid // "") == $sha) and ((.state // "") | IN("COMMENTED","APPROVED")))] | length')
+  COMMENT_NODES='[]'
+  COMMENT_CURSOR=''
+  while [ "$REVIEWS_COMPLETE" = "true" ]; do
+    COMMENT_ARGS=(gh api graphql -f query="$COMMENT_QUERY" -f owner="$OWNER" -f name="$NAME" -F pr="$PR")
+    [ -n "$COMMENT_CURSOR" ] && COMMENT_ARGS+=(-f cursor="$COMMENT_CURSOR")
+    COMMENT_PAGE=$(GH_TOKEN="$TOK" "${COMMENT_ARGS[@]}" 2>/dev/null) || { REVIEWS_COMPLETE=false; break; }
+    if ! echo "$COMMENT_PAGE" | jq -e '
+        (((.errors // []) | length) == 0)
+        and ((.data.repository.pullRequest | type) == "object")
+        and ((.data.repository.pullRequest.comments | type) == "object")
+        and ((.data.repository.pullRequest.comments.nodes | type) == "array")
+        and ((.data.repository.pullRequest.comments.pageInfo | type) == "object")
+        and ((.data.repository.pullRequest.comments.pageInfo.hasNextPage | type) == "boolean")
+        and (
+          (.data.repository.pullRequest.comments.pageInfo.hasNextPage == false)
+          or (
+            ((.data.repository.pullRequest.comments.pageInfo.endCursor // "") | type) == "string"
+            and (((.data.repository.pullRequest.comments.pageInfo.endCursor // "") | length) > 0)
+          )
+        )
+      ' >/dev/null 2>&1; then
+      REVIEWS_COMPLETE=false
+      break
+    fi
+    PAGE_NODES=$(echo "$COMMENT_PAGE" | jq -c '.data.repository.pullRequest.comments.nodes // []') || { REVIEWS_COMPLETE=false; break; }
+    COMMENT_NODES=$(jq -n -c --argjson existing "$COMMENT_NODES" --argjson new "$PAGE_NODES" '$existing + $new') || { REVIEWS_COMPLETE=false; break; }
+    REVIEW_PAGES=$((REVIEW_PAGES + 1))
+    HAS_NEXT=$(echo "$COMMENT_PAGE" | jq -r '.data.repository.pullRequest.comments.pageInfo.hasNextPage')
+    [ "$HAS_NEXT" = "true" ] || break
+    COMMENT_CURSOR=$(echo "$COMMENT_PAGE" | jq -r '.data.repository.pullRequest.comments.pageInfo.endCursor // empty')
+    [ -n "$COMMENT_CURSOR" ] || { REVIEWS_COMPLETE=false; break; }
+  done
+  CODEX_FORMAL_REVIEWS=$(echo "$REVIEW_NODES" | jq --arg sha "$SHA" --argjson codex "$CODEX_LOGINS_JSON" '[.[]? | select(((((.author.login // "") | ascii_downcase) as $login | $codex | index($login)) != null) and ((.commit.oid // "") == $sha) and ((.state // "") | IN("COMMENTED","APPROVED")))] | length')
+  CODEX_CLEAN_COMMENTS=$(echo "$COMMENT_NODES" | jq --arg sha "$SHA" --argjson codex "$CODEX_LOGINS_JSON" '[.[]? | ((.body // .bodyText // "") as $body | ((.author.login // "") | ascii_downcase) as $login | select(($codex | index($login)) != null) | select(($body | ascii_downcase | contains("didn'\''t find any major issues"))) | ((try ($body | capture("\\*\\*Reviewed commit:\\*\\*\\s*`(?<reviewed>[0-9a-fA-F]{10,40})`").reviewed) catch "") | ascii_downcase) as $reviewed | select(($reviewed | length) > 0 and ($sha | startswith($reviewed))))] | length')
+  CODEX_HEAD_REVIEWS=$((CODEX_FORMAL_REVIEWS + CODEX_CLEAN_COMMENTS))
   # --paginate + re-wrap: required contexts beyond the first 100 runs stay visible
   CR=$(GH_TOKEN="$TOK" gh api --paginate "repos/$REPO/commits/$SHA/check-runs?per_page=100" 2>/dev/null | jq -s '{check_runs:[.[].check_runs[]]}')
   PEND=$(echo "$CR" | jq '[.check_runs[]|select(.status!="completed")]|length')
@@ -127,11 +162,11 @@ for i in $(seq 0 "$CYCLES"); do
   # completed one; ANY not-completed run of a required name (across all runs,
   # not just the latest-pick) blocks readiness until it settles.
   REQUNSETTLED=$(echo "$CR" | jq --argjson app "$REQ_APP_ID" --argjson req "$REQ_JSON" '[.check_runs[]|select(.app.id==$app)|select(.name as $n|$req|index($n))|select(.status!="completed")]|length')
-  echo "cycle $i $(date +%H:%M): state=$STATE req-green=$REQGREEN/$REQ_TOTAL req-red=$REQRED req-unsettled=$REQUNSETTLED pending=$PEND codex-head-reviews=$CODEX_HEAD_REVIEWS review-pages=$REVIEW_PAGES reviews-complete=$REVIEWS_COMPLETE threads=$UNRES decision=$DECISION mergeable=$MERGEABLE merge-state=$MSTATE"
+  echo "cycle $i $(date +%H:%M): state=$STATE req-green=$REQGREEN/$REQ_TOTAL req-red=$REQRED req-unsettled=$REQUNSETTLED pending=$PEND codex-head-attestations=$CODEX_HEAD_REVIEWS attestation-pages=$REVIEW_PAGES attestations-complete=$REVIEWS_COMPLETE threads=$UNRES decision=$DECISION mergeable=$MERGEABLE merge-state=$MSTATE"
   case "$STATE" in MERGED/merged|CLOSED) echo "TERMINAL: PR $STATE"; exit 0;; esac
   # Definite negatives are actionable on ANY cycle, including the first.
   if [ "$REQRED" -gt 0 ] || [ "$UNRES" != "0" ] || [ "$DECISION" = "CHANGES_REQUESTED" ] || [ "$REVIEWS_COMPLETE" != "true" ]; then
-    echo "ACTIONABLE: req-red=$REQRED codex-head-reviews=$CODEX_HEAD_REVIEWS threads=$UNRES decision=$DECISION -> reconcile/fix, push, re-arm"; exit 0
+    echo "ACTIONABLE: req-red=$REQRED codex-head-attestations=$CODEX_HEAD_REVIEWS threads=$UNRES decision=$DECISION -> reconcile/fix, push, re-arm"; exit 0
   fi
   # Readiness is presence-based: every required context must be reporting
   # success (a not-yet-started context keeps this false, so no early race).
@@ -191,7 +226,41 @@ for i in $(seq 0 "$CYCLES"); do
       FINAL_REVIEW_CURSOR=$(echo "$FINAL_REVIEW_PAGE" | jq -r '.data.repository.pullRequest.reviews.pageInfo.endCursor // empty')
       [ -n "$FINAL_REVIEW_CURSOR" ] || { FINAL_REVIEWS_COMPLETE=false; break; }
     done
-    FINAL_CODEX_HEAD_REVIEWS=$(echo "$FINAL_REVIEW_NODES" | jq --arg sha "$SHA" --argjson codex "$CODEX_LOGINS_JSON" '[.[]? | select(((((.author.login // "") | ascii_downcase) as $login | $codex | index($login)) != null) and ((.commit.oid // "") == $sha) and ((.state // "") | IN("COMMENTED","APPROVED")))] | length')
+    FINAL_COMMENT_NODES='[]'
+    FINAL_COMMENT_CURSOR=''
+    while [ "$FINAL_REVIEWS_COMPLETE" = "true" ]; do
+      FINAL_COMMENT_ARGS=(gh api graphql -f query="$COMMENT_QUERY" -f owner="$OWNER" -f name="$NAME" -F pr="$PR")
+      [ -n "$FINAL_COMMENT_CURSOR" ] && FINAL_COMMENT_ARGS+=(-f cursor="$FINAL_COMMENT_CURSOR")
+      FINAL_COMMENT_PAGE=$(GH_TOKEN="$TOK" "${FINAL_COMMENT_ARGS[@]}" 2>/dev/null) || { FINAL_REVIEWS_COMPLETE=false; break; }
+      if ! echo "$FINAL_COMMENT_PAGE" | jq -e '
+          (((.errors // []) | length) == 0)
+          and ((.data.repository.pullRequest | type) == "object")
+          and ((.data.repository.pullRequest.comments | type) == "object")
+          and ((.data.repository.pullRequest.comments.nodes | type) == "array")
+          and ((.data.repository.pullRequest.comments.pageInfo | type) == "object")
+          and ((.data.repository.pullRequest.comments.pageInfo.hasNextPage | type) == "boolean")
+          and (
+            (.data.repository.pullRequest.comments.pageInfo.hasNextPage == false)
+            or (
+              ((.data.repository.pullRequest.comments.pageInfo.endCursor // "") | type) == "string"
+              and (((.data.repository.pullRequest.comments.pageInfo.endCursor // "") | length) > 0)
+            )
+          )
+        ' >/dev/null 2>&1; then
+        FINAL_REVIEWS_COMPLETE=false
+        break
+      fi
+      FINAL_COMMENT_PAGE_NODES=$(echo "$FINAL_COMMENT_PAGE" | jq -c '.data.repository.pullRequest.comments.nodes // []') || { FINAL_REVIEWS_COMPLETE=false; break; }
+      FINAL_COMMENT_NODES=$(jq -n -c --argjson existing "$FINAL_COMMENT_NODES" --argjson new "$FINAL_COMMENT_PAGE_NODES" '$existing + $new') || { FINAL_REVIEWS_COMPLETE=false; break; }
+      FINAL_REVIEW_PAGES=$((FINAL_REVIEW_PAGES + 1))
+      FINAL_COMMENT_HAS_NEXT=$(echo "$FINAL_COMMENT_PAGE" | jq -r '.data.repository.pullRequest.comments.pageInfo.hasNextPage')
+      [ "$FINAL_COMMENT_HAS_NEXT" = "true" ] || break
+      FINAL_COMMENT_CURSOR=$(echo "$FINAL_COMMENT_PAGE" | jq -r '.data.repository.pullRequest.comments.pageInfo.endCursor // empty')
+      [ -n "$FINAL_COMMENT_CURSOR" ] || { FINAL_REVIEWS_COMPLETE=false; break; }
+    done
+    FINAL_CODEX_FORMAL_REVIEWS=$(echo "$FINAL_REVIEW_NODES" | jq --arg sha "$SHA" --argjson codex "$CODEX_LOGINS_JSON" '[.[]? | select(((((.author.login // "") | ascii_downcase) as $login | $codex | index($login)) != null) and ((.commit.oid // "") == $sha) and ((.state // "") | IN("COMMENTED","APPROVED")))] | length')
+    FINAL_CODEX_CLEAN_COMMENTS=$(echo "$FINAL_COMMENT_NODES" | jq --arg sha "$SHA" --argjson codex "$CODEX_LOGINS_JSON" '[.[]? | ((.body // .bodyText // "") as $body | ((.author.login // "") | ascii_downcase) as $login | select(($codex | index($login)) != null) | select(($body | ascii_downcase | contains("didn'\''t find any major issues"))) | ((try ($body | capture("\\*\\*Reviewed commit:\\*\\*\\s*`(?<reviewed>[0-9a-fA-F]{10,40})`").reviewed) catch "") | ascii_downcase) as $reviewed | select(($reviewed | length) > 0 and ($sha | startswith($reviewed))))] | length')
+    FINAL_CODEX_HEAD_REVIEWS=$((FINAL_CODEX_FORMAL_REVIEWS + FINAL_CODEX_CLEAN_COMMENTS))
     FINAL_CR=$(GH_TOKEN="$TOK" gh api --paginate "repos/$REPO/commits/$SHA/check-runs?per_page=100" 2>/dev/null | jq -s '{check_runs:[.[].check_runs[]]}')
     FINAL_REQLATEST=$(echo "$FINAL_CR" | jq --argjson app "$REQ_APP_ID" '[.check_runs[]|select(.app.id==$app)]|group_by(.name)|map(sort_by(.started_at)|last)')
     FINAL_REQRED=$(echo "$FINAL_REQLATEST" | jq --argjson req "$REQ_JSON" '[.[]|select(.name as $n|$req|index($n))|select(.status=="completed" and (.conclusion|IN("failure","cancelled","timed_out","action_required","stale","startup_failure")))]|length')
@@ -201,9 +270,9 @@ for i in $(seq 0 "$CYCLES"); do
        || { [ "$FINAL_MSTATE" != "CLEAN" ] && [ "$FINAL_MSTATE" != "UNSTABLE" ]; } \
        || [ "$FINAL_REVIEWS_COMPLETE" != "true" ] || [ "$FINAL_CODEX_HEAD_REVIEWS" -eq 0 ] \
        || [ "$FINAL_REQRED" -gt 0 ] || [ "$FINAL_REQGREEN" -ne "$REQ_TOTAL" ] || [ "$FINAL_REQUNSETTLED" -ne 0 ]; then
-      echo "ACTIONABLE: final-read req-green=$FINAL_REQGREEN/$REQ_TOTAL req-red=$FINAL_REQRED req-unsettled=$FINAL_REQUNSETTLED codex-head-reviews=$FINAL_CODEX_HEAD_REVIEWS review-pages=$FINAL_REVIEW_PAGES reviews-complete=$FINAL_REVIEWS_COMPLETE threads=$FINAL_UNRES decision=$FINAL_DECISION mergeable=$FINAL_MERGEABLE merge-state=$FINAL_MSTATE -> reconcile/fix, push, re-arm"; exit 0
+      echo "ACTIONABLE: final-read req-green=$FINAL_REQGREEN/$REQ_TOTAL req-red=$FINAL_REQRED req-unsettled=$FINAL_REQUNSETTLED codex-head-attestations=$FINAL_CODEX_HEAD_REVIEWS attestation-pages=$FINAL_REVIEW_PAGES attestations-complete=$FINAL_REVIEWS_COMPLETE threads=$FINAL_UNRES decision=$FINAL_DECISION mergeable=$FINAL_MERGEABLE merge-state=$FINAL_MSTATE -> reconcile/fix, push, re-arm"; exit 0
     fi
-    echo "MERGE-READY: all $REQ_TOTAL required contexts green + current-head Codex review + threads clear + merge-state $MSTATE."
+    echo "MERGE-READY: all $REQ_TOTAL required contexts green + current-head Codex review attestation + threads clear + merge-state $MSTATE."
     echo "-> pre-merge checklist first (clean tree, local==remote, re-verify threads=0), then merge + alert."
     exit 0
   fi

--- a/tests/test_check_ai_reconciliation_live.py
+++ b/tests/test_check_ai_reconciliation_live.py
@@ -37,24 +37,50 @@ def review(*, author="chatgpt-codex-connector", commit="head-a", state="COMMENTE
     }
 
 
+def pr_comment(
+    *,
+    author="chatgpt-codex-connector",
+    commit="head-a",
+    body="Codex Review: Didn't find any major issues.",
+):
+    text = f"{body}\n\n**Reviewed commit:** `{commit}`"
+    return {
+        "author": {"login": author},
+        "body": text,
+        "bodyText": text,
+    }
+
+
 BODY_CLEAR = "## AI reconciliation\n- All fixed or waived: Yes\n"
 BODY_OPEN = "## AI reconciliation\n- fixed or waived: No\n"
 BODY_ABSENT = "## Summary\njust a normal PR body\n"
 BOTS = ["chatgpt-codex-connector", "chatgpt-codex-connector[bot]"]
 
 
-def test_live_reconciliation_runs_on_review_thread_resolution_events():
+def test_live_reconciliation_uses_supported_review_events_not_review_threads():
     text = LIVE_WORKFLOW.read_text(encoding="utf-8")
 
-    assert "pull_request_review_thread:" in text
-    assert "types: [resolved, unresolved]" in text
+    assert "pull_request_review:" in text
+    assert "pull_request_review_comment:" in text
+    assert "pull_request_review_thread:" not in text
+    assert "AI Reconciliation PR #" in text
     assert "github.event.pull_request.base.sha" in text
+    assert "github.event.repository.default_branch" not in text
+    assert "--pr \"${{ github.event.issue.number }}\"" not in text
 
 
-def test_review_thread_event_retriggers_required_live_context():
+def test_supported_review_events_retrigger_required_live_context():
     text = RETRIGGER_WORKFLOW.read_text(encoding="utf-8")
 
-    assert "github.event.workflow_run.event == 'pull_request_review_thread'" in text
+    assert "github.event.workflow_run.event == 'pull_request_review'" in text
+    assert "github.event.workflow_run.event == 'pull_request_review_comment'" in text
+    assert "github.event.workflow_run.event == 'issue_comment'" not in text
+    assert "github.event.workflow_run.event == 'pull_request_review_thread'" not in text
+    assert "pull-requests: read" in text
+    assert "WORKFLOW_RUN_TITLE" not in text
+    assert "pulls/${pr_number}" not in text
+    assert "head_sha=$(gh api" not in text
+    assert "head_sha=${head_sha}" in text
     assert "actions/runs/${run_id}/rerun" in text
 
 
@@ -117,6 +143,32 @@ def test_current_head_changes_requested_review_is_not_satisfactory_attestation()
 
     assert c.current_head_bot_reviews(reviews, head_sha="head-a", bot_logins=BOTS) == []
     assert c.current_head_change_requests(reviews, head_sha="head-a", bot_logins=BOTS) == reviews
+
+
+def test_current_head_clean_review_comment_requires_exact_author_and_head_prefix():
+    c = load_check()
+    comments = [
+        pr_comment(author="codex-helper", commit="head-a"),
+        pr_comment(commit="old-head"),
+        pr_comment(commit="abc1234567"),
+    ]
+
+    assert c.current_head_clean_review_comments(
+        comments,
+        head_sha="abc1234567890",
+        bot_logins=BOTS,
+    ) == [comments[2]]
+
+
+def test_clean_review_comment_without_clean_phrase_is_not_satisfactory_attestation():
+    c = load_check()
+    comments = [pr_comment(commit="abc1234567", body="Codex Review: found issues.")]
+
+    assert c.current_head_clean_review_comments(
+        comments,
+        head_sha="abc1234567890",
+        bot_logins=BOTS,
+    ) == []
 
 
 def test_review_thread_generation_sorts_file_level_and_inline_threads():
@@ -228,7 +280,36 @@ def test_current_head_codex_review_plus_no_open_threads_passes():
     )
 
     assert code == 0
-    assert any("current-head Codex review is present" in msg for msg in msgs)
+    assert any("current-head Codex review attestation is present" in msg for msg in msgs)
+
+
+def test_current_head_clean_review_comment_plus_no_open_threads_passes():
+    c = load_check()
+    code, msgs = c.evaluate(
+        [thread(resolved=True)],
+        BODY_CLEAR,
+        BOTS,
+        comments=[pr_comment(commit="abc1234567")],
+        head_sha="abc1234567890",
+    )
+
+    assert code == 0
+    assert any("current-head Codex review attestation is present" in msg for msg in msgs)
+
+
+def test_changes_requested_review_overrides_clean_review_comment():
+    c = load_check()
+    code, msgs = c.evaluate(
+        [thread(resolved=True)],
+        BODY_CLEAR,
+        BOTS,
+        reviews=[review(commit="abc1234567890", state="CHANGES_REQUESTED")],
+        comments=[pr_comment(commit="abc1234567")],
+        head_sha="abc1234567890",
+    )
+
+    assert code == 1
+    assert any("requested changes" in msg for msg in msgs)
 
 
 # --- main() via injection (no live GitHub) --------------------------------
@@ -274,6 +355,29 @@ def test_main_requires_current_head_review_when_head_sha_supplied(tmp_path):
     ) == 1
 
 
+def test_main_accepts_current_head_clean_review_comment_when_head_sha_supplied(tmp_path):
+    c = load_check()
+    tf = tmp_path / "threads.json"
+    tf.write_text(json.dumps([thread(resolved=True)]), encoding="utf-8")
+    bf = tmp_path / "body.md"
+    bf.write_text(BODY_CLEAR, encoding="utf-8")
+    cf = tmp_path / "comments.json"
+    cf.write_text(json.dumps([pr_comment(commit="abc1234567")]), encoding="utf-8")
+
+    assert c.main(
+        [
+            "--threads-file",
+            str(tf),
+            "--body-file",
+            str(bf),
+            "--comments-file",
+            str(cf),
+            "--head-sha",
+            "abc1234567890",
+        ]
+    ) == 0
+
+
 def test_main_live_fetch_fails_when_review_generation_changes(monkeypatch, tmp_path):
     c = load_check()
     bf = tmp_path / "body.md"
@@ -287,6 +391,8 @@ def test_main_live_fetch_fails_when_review_generation_changes(monkeypatch, tmp_p
             if calls["reviews"] == 1:
                 return _review_page([], has_next=False)
             return _review_page([review()], has_next=False)
+        if "comments(first:100" in query:
+            return _comment_page([], has_next=False)
         if "reviewThreads" in query:
             return _page([], has_next=False)
         raise AssertionError(f"unexpected gh call: {args}")
@@ -333,6 +439,18 @@ def _review_page(nodes, *, head="head-a", has_next=False, cursor=None):
         {"data": {"repository": {"pullRequest": {
             "headRefOid": head,
             "reviews": {
+                "pageInfo": {"hasNextPage": has_next, "endCursor": cursor},
+                "nodes": nodes,
+            },
+        }}}}
+    )
+
+
+def _comment_page(nodes, *, head="head-a", has_next=False, cursor=None):
+    return json.dumps(
+        {"data": {"repository": {"pullRequest": {
+            "headRefOid": head,
+            "comments": {
                 "pageInfo": {"hasNextPage": has_next, "endCursor": cursor},
                 "nodes": nodes,
             },
@@ -434,6 +552,28 @@ def test_fetch_review_attestation_paginates(monkeypatch):
     assert seen["n"] == 2
 
 
+def test_fetch_comment_attestation_paginates(monkeypatch):
+    c = load_check()
+    pages = [
+        _comment_page([pr_comment(commit="abc1234567")], has_next=True, cursor="C1"),
+        _comment_page([pr_comment(commit="def1234567")], has_next=False),
+    ]
+    seen = {"n": 0, "cursors": []}
+
+    def fake_gh(args, gh):
+        seen["cursors"].append("C1" in " ".join(args))
+        out = pages[seen["n"]]
+        seen["n"] += 1
+        return out
+
+    monkeypatch.setattr(c, "_gh", fake_gh)
+    head, fetched_comments = c.fetch_comment_attestation(1431, "owner", "name", "gh")
+
+    assert head == "head-a"
+    assert len(fetched_comments) == 2
+    assert seen == {"n": 2, "cursors": [False, True]}
+
+
 def test_fetch_review_attestation_head_change_fails_closed(monkeypatch):
     c = load_check()
     pages = [
@@ -465,11 +605,15 @@ def test_consistent_snapshot_refetches_threads_after_attestation(monkeypatch):
         calls["reviews"] += 1
         return "head-a", [review(commit="head-a")]
 
+    def fake_fetch_comments(pr, owner, name, gh):
+        return "head-a", []
+
     def fake_fetch_threads(pr, owner, name, gh):
         calls["threads"] += 1
         return [thread(path=f"snapshot-{calls['threads']}.py")]
 
     monkeypatch.setattr(c, "fetch_review_attestation", fake_fetch_reviews)
+    monkeypatch.setattr(c, "fetch_comment_attestation", fake_fetch_comments)
     monkeypatch.setattr(c, "fetch_threads", fake_fetch_threads)
 
     try:
@@ -491,6 +635,7 @@ def test_consistent_snapshot_fails_when_review_generation_changes(monkeypatch):
         return "head-a", [review(commit="head-a", state=state)]
 
     monkeypatch.setattr(c, "fetch_review_attestation", fake_fetch_reviews)
+    monkeypatch.setattr(c, "fetch_comment_attestation", lambda pr, owner, name, gh: ("head-a", []))
     monkeypatch.setattr(c, "fetch_threads", lambda pr, owner, name, gh: [thread()])
 
     try:
@@ -499,3 +644,24 @@ def test_consistent_snapshot_fails_when_review_generation_changes(monkeypatch):
         assert "Codex review generation changed" in str(exc)
     else:  # pragma: no cover - assertion clarity
         raise AssertionError("review movement during snapshot fetch must fail closed")
+
+
+def test_consistent_snapshot_fails_when_clean_comment_generation_changes(monkeypatch):
+    c = load_check()
+    seen = {"comments": 0}
+
+    def fake_fetch_comments(pr, owner, name, gh):
+        seen["comments"] += 1
+        comments = [] if seen["comments"] == 1 else [pr_comment(commit="abc1234567")]
+        return "abc1234567890", comments
+
+    monkeypatch.setattr(c, "fetch_review_attestation", lambda pr, owner, name, gh: ("abc1234567890", []))
+    monkeypatch.setattr(c, "fetch_comment_attestation", fake_fetch_comments)
+    monkeypatch.setattr(c, "fetch_threads", lambda pr, owner, name, gh: [thread()])
+
+    try:
+        c.fetch_consistent_review_thread_snapshot(1431, "owner", "name", "gh", BOTS)
+    except RuntimeError as exc:
+        assert "Codex review generation changed" in str(exc)
+    else:  # pragma: no cover - assertion clarity
+        raise AssertionError("comment movement during snapshot fetch must fail closed")

--- a/tests/test_codex_wake_bridge.py
+++ b/tests/test_codex_wake_bridge.py
@@ -364,7 +364,7 @@ def test_malformed_readiness_objects_fail_closed(
         ("readiness", "review_decision", "review decision evidence is missing"),
         ("readiness", "codex_reviews_complete", "Codex review pagination is incomplete"),
         ("readiness", "codex_review_pages_fetched", "Codex review pages fetched must be at least 1"),
-        ("readiness", "codex_head_review_count", "current-head Codex review is missing"),
+        ("readiness", "codex_head_review_count", "current-head Codex review attestation is missing"),
         ("pr", "reviewDecision", "review decision evidence is missing"),
         ("readiness", "merge_state_status", "merge state must be CLEAN"),
     ],

--- a/tests/test_pr_watcher.py
+++ b/tests/test_pr_watcher.py
@@ -88,6 +88,21 @@ def _review_page(nodes: list[dict[str, Any]] | None = None, *, has_next: bool = 
     }
 
 
+def _comment_page(nodes: list[dict[str, Any]] | None = None, *, has_next: bool = False, cursor: str | None = None) -> dict[str, Any]:
+    return {
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "comments": {
+                        "nodes": nodes or [],
+                        "pageInfo": {"hasNextPage": has_next, "endCursor": cursor},
+                    }
+                }
+            }
+        }
+    }
+
+
 def _thread(
     *,
     thread_id: str = "thread-1",
@@ -122,6 +137,7 @@ class FakeRun:
         reviews: tuple[int, str, str] | None = None,
         thread_pages: list[tuple[int, str, str]] | None = None,
         review_pages: list[tuple[int, str, str]] | None = None,
+        comment_pages: list[tuple[int, str, str]] | None = None,
         reconciliation: tuple[int, str, str] = (0, "clean", ""),
         git_status: tuple[int, str, str] = (0, "", ""),
     ) -> None:
@@ -138,6 +154,7 @@ class FakeRun:
         self.reviews = reviews or _response({"comments": [], "reviews": []})
         self.thread_pages = list(thread_pages or [_response(_thread_page())])
         self.review_pages = list(review_pages or [_response(_review_page())])
+        self.comment_pages = list(comment_pages or [_response(_comment_page())])
         self.reconciliation = reconciliation
         self.git_status = git_status
         self.commands: list[list[str]] = []
@@ -159,6 +176,8 @@ class FakeRun:
             query = " ".join(args)
             if "reviews(first:100" in query:
                 return self.review_pages.pop(0)
+            if "comments(first:100" in query:
+                return self.comment_pages.pop(0)
             return self.thread_pages.pop(0)
         if (
             len(args) > 1
@@ -224,7 +243,7 @@ def test_valid_snapshot_is_ready_and_accepted_by_consumer(tmp_path: Path, monkey
         "review_thread_pages_fetched": 1,
         "unresolved_review_threads": [],
         "codex_reviews_complete": True,
-        "codex_review_pages_fetched": 1,
+        "codex_review_pages_fetched": 2,
         "codex_head_review_count": 1,
         "review_decision": "",
         "merge_state_status": "CLEAN",
@@ -287,11 +306,17 @@ def test_thread_snapshot_is_collected_after_codex_review_pagination(
         }
     ]
     graphql_kinds = [
-        "reviews" if "reviews(first:100" in " ".join(command) else "threads"
+        (
+            "reviews"
+            if "reviews(first:100" in " ".join(command)
+            else "comments"
+            if "comments(first:100" in " ".join(command)
+            else "threads"
+        )
         for command in fake.commands
         if command[:3] == ["gh", "api", "graphql"]
     ]
-    assert graphql_kinds == ["reviews", "threads"]
+    assert graphql_kinds == ["reviews", "comments", "threads"]
     reconciliation_index = next(
         i
         for i, command in enumerate(fake.commands)
@@ -564,7 +589,7 @@ def test_current_head_codex_review_is_required_for_ready_state(
     assert status["state"] == "attention"
     assert status["readiness"]["codex_reviews_complete"] is True
     assert status["readiness"]["codex_head_review_count"] == 0
-    assert "current-head Codex review is missing" in wake_bridge.readiness_blockers(status)
+    assert "current-head Codex review attestation is missing" in wake_bridge.readiness_blockers(status)
 
 
 def test_current_head_review_requires_exact_codex_connector_identity(
@@ -623,7 +648,106 @@ def test_codex_review_pagination_reaches_later_current_head_review(
     )
 
     assert status["state"] == "ready_for_human_merge"
-    assert status["readiness"]["codex_review_pages_fetched"] == 2
+    assert status["readiness"]["codex_review_pages_fetched"] == 3
+    assert status["readiness"]["codex_head_review_count"] == 1
+
+
+def test_codex_clean_comment_attests_current_head(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    head = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    status = _produce(
+        tmp_path,
+        monkeypatch,
+        FakeRun(
+            pr_responses=[_response(_pr(head=head)), _response(_pr(head=head)), _response(_pr(head=head))],
+            review_pages=[_response(_review_page(nodes=[]))],
+            comment_pages=[
+                _response(
+                    _comment_page(
+                        [
+                            {
+                                "author": {"login": "chatgpt-codex-connector"},
+                                "body": "Codex Review: Didn't find any major issues\n\n**Reviewed commit:** `aaaaaaaaaa`",
+                                "bodyText": "",
+                            }
+                        ]
+                    )
+                )
+            ],
+        ),
+        head=head,
+    )
+
+    assert status["state"] == "ready_for_human_merge"
+    assert status["readiness"]["codex_head_review_count"] == 1
+
+
+def test_authorless_comment_is_ignored_for_codex_attestation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    head = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    status = _produce(
+        tmp_path,
+        monkeypatch,
+        FakeRun(
+            pr_responses=[_response(_pr(head=head)), _response(_pr(head=head)), _response(_pr(head=head))],
+            review_pages=[_response(_review_page(nodes=[]))],
+            comment_pages=[
+                _response(
+                    _comment_page(
+                        [
+                            {
+                                "author": None,
+                                "body": "Codex Review: Didn't find any major issues\n\n**Reviewed commit:** `aaaaaaaaaa`",
+                                "bodyText": "",
+                            }
+                        ]
+                    )
+                )
+            ],
+        ),
+        head=head,
+    )
+
+    assert status["state"] == "attention"
+    assert status["readiness"]["codex_reviews_complete"] is True
+    assert status["readiness"]["codex_head_review_count"] == 0
+
+
+def test_codex_comment_pagination_reaches_later_current_head_attestation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    head = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    status = _produce(
+        tmp_path,
+        monkeypatch,
+        FakeRun(
+            pr_responses=[_response(_pr(head=head)), _response(_pr(head=head)), _response(_pr(head=head))],
+            review_pages=[_response(_review_page(nodes=[]))],
+            comment_pages=[
+                _response(_comment_page(has_next=True, cursor="comment-cursor")),
+                _response(
+                    _comment_page(
+                        [
+                            {
+                                "author": {"login": "chatgpt-codex-connector"},
+                                "body": "Codex Review: Didn't find any major issues\n\n**Reviewed commit:** `aaaaaaaaaa`",
+                                "bodyText": "",
+                            }
+                        ]
+                    )
+                ),
+            ],
+        ),
+        head=head,
+    )
+
+    assert status["state"] == "ready_for_human_merge"
+    assert status["readiness"]["codex_review_pages_fetched"] == 3
     assert status["readiness"]["codex_head_review_count"] == 1
 
 
@@ -1019,6 +1143,8 @@ def test_installed_entrypoint_writes_consumer_accepted_snapshot(tmp_path: Path) 
                 query = " ".join(args)
                 if "reviews(first:100" in query:
                     payload = {"data": {"repository": {"pullRequest": {"headRefOid": "head-a", "reviews": {"nodes": [{"author": {"login": "chatgpt-codex-connector"}, "commit": {"oid": "head-a"}, "state": "COMMENTED"}], "pageInfo": {"hasNextPage": False, "endCursor": None}}}}}}
+                elif "comments(first:100" in query:
+                    payload = {"data": {"repository": {"pullRequest": {"headRefOid": "head-a", "comments": {"nodes": [], "pageInfo": {"hasNextPage": False, "endCursor": None}}}}}}
                 elif "comments(first:1)" in query:
                     payload = {"data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": [], "pageInfo": {"hasNextPage": False, "endCursor": None}}}}}}
                 else:

--- a/tests/test_watch_owned_pr.py
+++ b/tests/test_watch_owned_pr.py
@@ -17,7 +17,7 @@ def _write_executable(path: Path, text: str) -> None:
     path.chmod(path.stat().st_mode | stat.S_IXUSR)
 
 
-def _run_watcher(tmp_path: Path, *, scenario: str) -> subprocess.CompletedProcess[str]:
+def _run_watcher(tmp_path: Path, *, scenario: str, sha: str = "head-a") -> subprocess.CompletedProcess[str]:
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     _write_executable(
@@ -44,6 +44,7 @@ def _run_watcher(tmp_path: Path, *, scenario: str) -> subprocess.CompletedProces
 
         args = sys.argv[1:]
         scenario = os.environ.get("WATCHER_SCENARIO", "ready")
+        expected_sha = os.environ.get("SHA", "head-a")
         state_file = os.environ.get("WATCHER_STATE_FILE", "")
         if args[:2] == ["api", "repos/owner/repo/pulls/7"]:
             if scenario == "head_moves_before_ready":
@@ -56,8 +57,8 @@ def _run_watcher(tmp_path: Path, *, scenario: str) -> subprocess.CompletedProces
                         handle.write(str(count + 1))
                 print("head-b" if count else "head-a")
                 raise SystemExit(0)
-            print("head-a")
-        elif args[:3] == ["api", "--paginate", "repos/owner/repo/commits/head-a/check-runs?per_page=100"]:
+            print(expected_sha)
+        elif args[:2] == ["api", "--paginate"] and args[2] == f"repos/owner/repo/commits/{expected_sha}/check-runs?per_page=100":
             check_state_file = state_file + ".checks" if state_file else ""
             check_count = 0
             if check_state_file and os.path.exists(check_state_file):
@@ -81,6 +82,8 @@ def _run_watcher(tmp_path: Path, *, scenario: str) -> subprocess.CompletedProces
             joined = " ".join(args)
             if "reviewThreads" in joined:
                 review_decision = ""
+                if scenario == "clean_comment_changes_requested":
+                    review_decision = "CHANGES_REQUESTED"
                 if scenario == "final_decision_changes":
                     thread_state_file = state_file + ".threads" if state_file else ""
                     count = 0
@@ -148,7 +151,7 @@ def _run_watcher(tmp_path: Path, *, scenario: str) -> subprocess.CompletedProces
                 if review_state_file:
                     with open(review_state_file, "w", encoding="utf-8") as handle:
                         handle.write(str(review_count + 1))
-                if scenario == "no_review":
+                if scenario in {"no_review", "clean_comment", "paginated_clean_comment", "wrong_author_clean_comment", "stale_clean_comment"}:
                     nodes = []
                     has_next = False
                     cursor = None
@@ -166,13 +169,13 @@ def _run_watcher(tmp_path: Path, *, scenario: str) -> subprocess.CompletedProces
                     }}}}}))
                     raise SystemExit(0)
                 elif scenario == "paginated_review" and "cursor=c2" not in joined:
-                    nodes = [{"author": {"login": "human"}, "commit": {"oid": "head-a"}, "state": "APPROVED"}]
+                    nodes = [{"author": {"login": "human"}, "commit": {"oid": expected_sha}, "state": "APPROVED"}]
                     has_next = True
                     cursor = "c2"
                 elif scenario == "helper_review":
                     nodes = [{
                         "author": {"login": "codex-helper"},
-                        "commit": {"oid": "head-a"},
+                        "commit": {"oid": expected_sha},
                         "state": "COMMENTED",
                     }]
                     has_next = False
@@ -180,7 +183,7 @@ def _run_watcher(tmp_path: Path, *, scenario: str) -> subprocess.CompletedProces
                 elif scenario == "changes_requested_review":
                     nodes = [{
                         "author": {"login": "chatgpt-codex-connector"},
-                        "commit": {"oid": "head-a"},
+                        "commit": {"oid": expected_sha},
                         "state": "CHANGES_REQUESTED",
                     }]
                     has_next = False
@@ -188,12 +191,78 @@ def _run_watcher(tmp_path: Path, *, scenario: str) -> subprocess.CompletedProces
                 else:
                     nodes = [{
                         "author": {"login": "chatgpt-codex-connector"},
-                        "commit": {"oid": "head-a"},
+                        "commit": {"oid": expected_sha},
                         "state": "COMMENTED",
                     }]
                     has_next = False
                     cursor = None
                 print(json.dumps({"data": {"repository": {"pullRequest": {"reviews": {
+                    "pageInfo": {"hasNextPage": has_next, "endCursor": cursor},
+                    "nodes": nodes,
+                }}}}}))
+            elif "comments(first:100" in joined:
+                comment_state_file = state_file + ".comments" if state_file else ""
+                comment_count = 0
+                if comment_state_file and os.path.exists(comment_state_file):
+                    with open(comment_state_file, "r", encoding="utf-8") as handle:
+                        comment_count = int(handle.read() or "0")
+                if comment_state_file:
+                    with open(comment_state_file, "w", encoding="utf-8") as handle:
+                        handle.write(str(comment_count + 1))
+                if scenario in {"clean_comment", "clean_comment_changes_requested"}:
+                    nodes = [{
+                        "author": {"login": "chatgpt-codex-connector"},
+                        "body": "Codex Review: Didn't find any major issues\\n\\n**Reviewed commit:** `" + expected_sha[:10] + "`",
+                        "bodyText": "",
+                    }]
+                    has_next = False
+                    cursor = None
+                elif scenario == "wrong_author_clean_comment":
+                    nodes = [{
+                        "author": {"login": "codex-helper"},
+                        "body": "Codex Review: Didn't find any major issues\\n\\n**Reviewed commit:** `" + expected_sha[:10] + "`",
+                        "bodyText": "",
+                    }]
+                    has_next = False
+                    cursor = None
+                elif scenario == "stale_clean_comment":
+                    nodes = [{
+                        "author": {"login": "chatgpt-codex-connector"},
+                        "body": "Codex Review: Didn't find any major issues\\n\\n**Reviewed commit:** `bbbbbbbbbb`",
+                        "bodyText": "",
+                    }]
+                    has_next = False
+                    cursor = None
+                elif scenario == "paginated_clean_comment" and "cursor=c2" not in joined:
+                    nodes = []
+                    has_next = True
+                    cursor = "c2"
+                elif scenario == "paginated_clean_comment":
+                    nodes = [{
+                        "author": {"login": "chatgpt-codex-connector"},
+                        "body": "Codex Review: Didn't find any major issues\\n\\n**Reviewed commit:** `" + expected_sha[:10] + "`",
+                        "bodyText": "",
+                    }]
+                    has_next = False
+                    cursor = None
+                elif scenario == "final_clean_comment_disappears" and comment_count > 0:
+                    nodes = []
+                    has_next = False
+                    cursor = None
+                elif scenario == "comment_graphql_errors":
+                    print(json.dumps({"errors": [{"message": "partial failure"}], "data": {"repository": {"pullRequest": {"comments": None}}}}))
+                    raise SystemExit(0)
+                elif scenario == "comment_malformed_page_info":
+                    print(json.dumps({"data": {"repository": {"pullRequest": {"comments": {
+                        "pageInfo": {},
+                        "nodes": [],
+                    }}}}}))
+                    raise SystemExit(0)
+                else:
+                    nodes = []
+                    has_next = False
+                    cursor = None
+                print(json.dumps({"data": {"repository": {"pullRequest": {"comments": {
                     "pageInfo": {"hasNextPage": has_next, "endCursor": cursor},
                     "nodes": nodes,
                 }}}}}))
@@ -211,7 +280,7 @@ def _run_watcher(tmp_path: Path, *, scenario: str) -> subprocess.CompletedProces
         "GH_TOKEN": "fake-token",
         "REPO": "owner/repo",
         "PR": "7",
-        "SHA": "head-a",
+        "SHA": sha,
         "CYCLES": "0",
         "WATCHER_SCENARIO": scenario,
         "WATCHER_STATE_FILE": str(tmp_path / "watcher-state.txt"),
@@ -231,7 +300,7 @@ def test_watcher_reports_ready_with_current_head_codex_review(tmp_path: Path) ->
 
     assert result.returncode == 0, result.stdout + result.stderr
     assert "MERGE-READY" in result.stdout
-    assert "codex-head-reviews=1" in result.stdout
+    assert "codex-head-attestations=1" in result.stdout
 
 
 def test_watcher_ignores_unresolved_non_codex_thread(tmp_path: Path) -> None:
@@ -248,7 +317,7 @@ def test_watcher_blocks_without_current_head_codex_review(tmp_path: Path) -> Non
     assert result.returncode == 0, result.stdout + result.stderr
     assert "ACTIONABLE" not in result.stdout
     assert "watch window elapsed" in result.stdout
-    assert "codex-head-reviews=0" in result.stdout
+    assert "codex-head-attestations=0" in result.stdout
 
 
 def test_watcher_requires_exact_codex_connector_review_identity(tmp_path: Path) -> None:
@@ -256,7 +325,7 @@ def test_watcher_requires_exact_codex_connector_review_identity(tmp_path: Path) 
 
     assert result.returncode == 0, result.stdout + result.stderr
     assert "MERGE-READY" not in result.stdout
-    assert "codex-head-reviews=0" in result.stdout
+    assert "codex-head-attestations=0" in result.stdout
 
 
 def test_watcher_blocks_on_unresolved_codex_thread(tmp_path: Path) -> None:
@@ -280,7 +349,48 @@ def test_watcher_does_not_count_changes_requested_as_head_review(tmp_path: Path)
 
     assert result.returncode == 0, result.stdout + result.stderr
     assert "MERGE-READY" not in result.stdout
-    assert "codex-head-reviews=0" in result.stdout
+    assert "codex-head-attestations=0" in result.stdout
+
+
+def test_watcher_accepts_current_head_codex_clean_comment(tmp_path: Path) -> None:
+    result = _run_watcher(tmp_path, scenario="clean_comment", sha="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "MERGE-READY" in result.stdout
+    assert "codex-head-attestations=1" in result.stdout
+
+
+def test_watcher_finds_clean_comment_after_pagination(tmp_path: Path) -> None:
+    result = _run_watcher(tmp_path, scenario="paginated_clean_comment", sha="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "MERGE-READY" in result.stdout
+    assert "attestation-pages=3" in result.stdout
+
+
+def test_watcher_rejects_wrong_author_clean_comment(tmp_path: Path) -> None:
+    result = _run_watcher(tmp_path, scenario="wrong_author_clean_comment", sha="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "MERGE-READY" not in result.stdout
+    assert "codex-head-attestations=0" in result.stdout
+
+
+def test_watcher_rejects_stale_clean_comment(tmp_path: Path) -> None:
+    result = _run_watcher(tmp_path, scenario="stale_clean_comment", sha="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "MERGE-READY" not in result.stdout
+    assert "codex-head-attestations=0" in result.stdout
+
+
+def test_watcher_changes_requested_overrides_clean_comment(tmp_path: Path) -> None:
+    result = _run_watcher(tmp_path, scenario="clean_comment_changes_requested", sha="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "MERGE-READY" not in result.stdout
+    assert "ACTIONABLE" in result.stdout
+    assert "decision=CHANGES_REQUESTED" in result.stdout
 
 
 def test_watcher_retries_malformed_thread_snapshot(tmp_path: Path) -> None:
@@ -306,7 +416,7 @@ def test_watcher_finds_current_head_codex_review_after_pagination(tmp_path: Path
 
     assert result.returncode == 0, result.stdout + result.stderr
     assert "MERGE-READY" in result.stdout
-    assert "review-pages=2" in result.stdout
+    assert "attestation-pages=3" in result.stdout
 
 
 def test_watcher_blocks_malformed_review_pagination(tmp_path: Path) -> None:
@@ -315,7 +425,7 @@ def test_watcher_blocks_malformed_review_pagination(tmp_path: Path) -> None:
     assert result.returncode == 0, result.stdout + result.stderr
     assert "MERGE-READY" not in result.stdout
     assert "ACTIONABLE" in result.stdout
-    assert "reviews-complete=false" in result.stdout
+    assert "attestations-complete=false" in result.stdout
 
 
 def test_watcher_blocks_malformed_review_page_info(tmp_path: Path) -> None:
@@ -324,7 +434,25 @@ def test_watcher_blocks_malformed_review_page_info(tmp_path: Path) -> None:
     assert result.returncode == 0, result.stdout + result.stderr
     assert "MERGE-READY" not in result.stdout
     assert "ACTIONABLE" in result.stdout
-    assert "reviews-complete=false" in result.stdout
+    assert "attestations-complete=false" in result.stdout
+
+
+def test_watcher_blocks_malformed_comment_pagination(tmp_path: Path) -> None:
+    result = _run_watcher(tmp_path, scenario="comment_graphql_errors")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "MERGE-READY" not in result.stdout
+    assert "ACTIONABLE" in result.stdout
+    assert "attestations-complete=false" in result.stdout
+
+
+def test_watcher_blocks_malformed_comment_page_info(tmp_path: Path) -> None:
+    result = _run_watcher(tmp_path, scenario="comment_malformed_page_info")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "MERGE-READY" not in result.stdout
+    assert "ACTIONABLE" in result.stdout
+    assert "attestations-complete=false" in result.stdout
 
 
 def test_watcher_revalidates_head_before_reporting_ready(tmp_path: Path) -> None:
@@ -350,7 +478,7 @@ def test_watcher_revalidates_reviews_before_reporting_ready(tmp_path: Path) -> N
     assert result.returncode == 0, result.stdout + result.stderr
     assert "MERGE-READY" not in result.stdout
     assert "ACTIONABLE: final-read" in result.stdout
-    assert "codex-head-reviews=0" in result.stdout
+    assert "codex-head-attestations=0" in result.stdout
 
 
 def test_watcher_revalidates_required_checks_before_reporting_ready(tmp_path: Path) -> None:


### PR DESCRIPTION
Plan: plans/PR-Codex-Review-Thread-Event-Canary.md
Slice phase: workflow/process
Ownership lane: workflow/codex-review-thread-event-canary

#2240 left an unsupported GitHub Actions thread-resolution trigger claim in the AI reconciliation workflow, and the live gate also rejected Codex's current clean-review PR comment because it only accepted formal review records. This slice removes the unsupported event claim and accepts exact-head clean Codex comments as attestation without weakening unresolved-thread enforcement.

Diff-budget override: Review feedback showed the clean-comment attestation boundary feeds the live checker, local PR watcher, wake bridge, owned-PR shell watcher, and tests. Splitting would leave split-brain readiness semantics where one gate accepts a current-head clean Codex comment and another still blocks on "missing review."

## Intentional

- Remove `pull_request_review_thread` from AI Reconciliation workflow triggers and retrigger conditions.
- Keep `pull_request_target`, `pull_request_review`, and `pull_request_review_comment` refresh coverage.
- Do not enable `issue_comment` CI refresh in this PR; that path needs a default-branch canary before admission because GitHub evaluates issue-comment workflow triggers from the default branch.
- Keep unresolved review threads as a live query gate.
- Accept clean Codex PR comments only when authored by an exact configured bot login and only when the reviewed commit prefix matches the current PR head.
- Keep local readiness consumers aligned on "current-head Codex review attestation."
- Keep formal current-head `CHANGES_REQUESTED` reviews blocking even if a clean comment exists.

## Deferred

- If GitHub later documents/supports `pull_request_review_thread` as an Actions trigger, add a fresh proof slice before restoring it.
- Add a separate default-branch canary before enabling `issue_comment` CI refresh for clean Codex PR comments.

## Parked hardening

- `issue_comment` CI refresh for clean Codex PR comments is parked until a default-branch canary proves the live Actions trigger/retrigger chain.

## Cold diff reconstruction

- `.github/workflows/ai_reconciliation_live.yml`: removes the unsupported thread trigger, carries the PR number in the run name, keeps supported review/review-comment jobs, and does not admit unproven `issue_comment` CI refresh.
- `.github/workflows/ai_reconciliation_review_retrigger.yml`: reruns the trusted target context for supported review/review-comment events only and no longer admits `pull_request_review_thread` or unproven `issue_comment` retriggering.
- `scripts/check_ai_reconciliation_live.py`: paginates PR comments separately from reviews, recognizes exact-bot clean Codex comments with reviewed-commit markers, includes comment evidence in consistency checks, and still blocks on unresolved scoped threads and formal `CHANGES_REQUESTED`.
- `scripts/pr_watcher.py`: fetches PR comments as part of Codex head attestation, skips authorless comments as non-Codex, and reports attestation instead of formal-review-only readiness.
- `scripts/codex_wake_bridge.py`: updates the readiness blocker copy to "review attestation" so the bridge matches the watcher semantics.
- `scripts/watch_owned_pr.sh`: mirrors the same formal-review-or-clean-comment attestation scan in both initial and final readiness reads.
- `tests/test_check_ai_reconciliation_live.py`: covers supported workflow events, absence of unproven `issue_comment` workflow wiring, comment pagination, clean/stale/wrong-author/malformed comments, and review-generation consistency.
- `tests/test_pr_watcher.py`: covers watcher comment pagination, clean-comment attestation, authorless comments, installed fake GraphQL shape, and updated attestation page counts.
- `tests/test_watch_owned_pr.py`: covers shell watcher comment-only attestation, comment pagination, wrong-author/stale/changes-requested rejection, malformed comment pages, and updated attestation output.
- `tests/test_codex_wake_bridge.py`: updates expected blocker text.
- `plans/PR-Codex-Review-Thread-Event-Canary.md`: records the contract, closed attestation recognizer, parking predicate, over-budget rationale, live evidence, verification, and exact diff size.

Contract check: no gaps found. Every diff item traces to the contract, every contract requirement is present, and no declared must-not-change product/runtime surface moved. The live reconciliation decision still fails on unresolved scoped bot threads.

## Verification

- `python -m pytest tests/test_check_ai_reconciliation_live.py -q` — passed, 42 tests.
- `python -m pytest tests/test_check_ai_reconciliation_live.py tests/test_pr_watcher.py tests/test_watch_owned_pr.py tests/test_report_pr_watcher_state.py tests/test_codex_wake_bridge.py -q` — passed, 189 tests.
- `python -m py_compile scripts/check_ai_reconciliation_live.py scripts/pr_watcher.py scripts/codex_wake_bridge.py` — passed.
- `bash -n scripts/watch_owned_pr.sh` — passed.
- `python scripts/audit_plan_doc.py plans/PR-Codex-Review-Thread-Event-Canary.md` — passed.
- `python scripts/audit_plan_doc_files_touched.py plans/PR-Codex-Review-Thread-Event-Canary.md origin/main` — passed.
- `python scripts/audit_plan_doc_diff_size.py plans/PR-Codex-Review-Thread-Event-Canary.md origin/main` — passed, 0.0% drift.
- `python scripts/audit_plan_code_consistency.py --base-ref origin/main plans/PR-Codex-Review-Thread-Event-Canary.md` — passed.
- `python scripts/audit_pr_body.py /tmp/pr-body-2245.md` — passed locally before publishing this body.
- `python scripts/check_diff_budget.py --additions 1108 --body-file /tmp/pr-body-2245.md` — passed locally before publishing this body.
- `git diff --check origin/main -- . ':!node_modules'` — passed.
- Live #2245 canary on heads `7762288c0c0b90d0b90fe3823a104d38c9614347` and `aa9e1ee6314aeb8cb800f07013954f7fdfd42d12`: review threads were created/resolved; no AI Reconciliation `pull_request_review_thread` run appeared.

## AI reconciliation

- All fixed or waived: Yes
- Notes: The active review feedback is addressed by paginating PR comments, not admitting unproven `issue_comment` CI refresh, skipping authorless historical comments as non-Codex, isolating shell watcher comment-only tests, aligning local readiness consumers on attestation semantics, and declaring both the clean-comment recognizer and parked-hardening predicate.

## Diff size

| File | LOC |
|---|---:|
| `.github/workflows/ai_reconciliation_live.yml` | 44 |
| `.github/workflows/ai_reconciliation_review_retrigger.yml` | 34 |
| `plans/PR-Codex-Review-Thread-Event-Canary.md` | 276 |
| `scripts/check_ai_reconciliation_live.py` | 146 |
| `scripts/codex_wake_bridge.py` | 2 |
| `scripts/pr_watcher.py` | 106 |
| `scripts/watch_owned_pr.sh` | 83 |
| `tests/test_check_ai_reconciliation_live.py` | 181 |
| `tests/test_codex_wake_bridge.py` | 2 |
| `tests/test_pr_watcher.py` | 136 |
| `tests/test_watch_owned_pr.py` | 162 |
| **Total** | **1172** |
