### PR TITLE
Resume unlinked EOM SMS retries

### DIFF
--- a/.github/workflows/atlas_eom_lead_pipeline_checks.yml
+++ b/.github/workflows/atlas_eom_lead_pipeline_checks.yml
@@ -31,6 +31,7 @@ on:
       - "atlas_brain/storage/models.py"
       - "atlas_brain/storage/repositories/email.py"
       - "atlas_brain/storage/repositories/call_transcript.py"
+      - "atlas_brain/storage/repositories/sms_message.py"
       - "atlas_brain/storage/repositories/scoped_mailbox_credential.py"
       - "atlas_brain/storage/migrations/012_appointments.sql"
       - "atlas_brain/storage/migrations/035_contacts.sql"
@@ -58,6 +59,7 @@ on:
       - "tests/test_eom_scoped_gmail_hardening.py"
       - "atlas_brain/storage/migrations/__init__.py"
       - "tests/test_eom_sent_email_tenant_scope.py"
+      - "tests/test_eom_sms_webhook_retry.py"
       - "tests/test_leads_intake.py"
       - "tests/test_migrations_runner.py"
   push:
@@ -89,6 +91,7 @@ on:
       - "atlas_brain/storage/models.py"
       - "atlas_brain/storage/repositories/email.py"
       - "atlas_brain/storage/repositories/call_transcript.py"
+      - "atlas_brain/storage/repositories/sms_message.py"
       - "atlas_brain/storage/repositories/scoped_mailbox_credential.py"
       - "atlas_brain/storage/migrations/012_appointments.sql"
       - "atlas_brain/storage/migrations/035_contacts.sql"
@@ -116,6 +119,7 @@ on:
       - "tests/test_eom_scoped_gmail_hardening.py"
       - "atlas_brain/storage/migrations/__init__.py"
       - "tests/test_eom_sent_email_tenant_scope.py"
+      - "tests/test_eom_sms_webhook_retry.py"
       - "tests/test_leads_intake.py"
       - "tests/test_migrations_runner.py"
 
@@ -138,6 +142,7 @@ jobs:
           --health-retries 5
     env:
       ATLAS_MIGRATION_TEST_DATABASE_URL: postgresql://atlas:atlas@localhost:5432/atlas_migration_tests
+      ATLAS_EOM_SMS_RETRY_POSTGRES_URL: postgresql://atlas:atlas@localhost:5432/atlas_migration_tests
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -169,6 +174,7 @@ jobs:
             tests/test_eom_scoped_gmail_credentials.py \
             tests/test_eom_scoped_gmail_hardening.py \
             tests/test_eom_sent_email_tenant_scope.py \
+            tests/test_eom_sms_webhook_retry.py \
             tests/test_leads_intake.py \
             tests/test_migrations_runner.py \
             -q

--- a/atlas_brain/api/comms/webhooks.py
+++ b/atlas_brain/api/comms/webhooks.py
@@ -12,6 +12,7 @@ import re
 import time
 from typing import Optional
 from urllib.parse import quote
+from uuid import uuid4
 
 from fastapi import APIRouter, Form, Query, Request, WebSocket, WebSocketDisconnect
 from fastapi.responses import Response, JSONResponse
@@ -34,11 +35,12 @@ def swml_response(sections: dict) -> JSONResponse:
     )
 
 
-def laml_response(content: str) -> Response:
+def laml_response(content: str, status_code: int = 200) -> Response:
     """Return a LaML/TwiML XML response (legacy)."""
     return Response(
         content=content,
         media_type="application/xml",
+        status_code=status_code,
     )
 
 
@@ -83,6 +85,102 @@ def _fallback_outbound_caller_id() -> str:
     except Exception as e:
         logger.warning("Failed to resolve outbound caller ID: %s", e)
     return ""
+
+
+def _persisted_sms_value(existing: dict, key: str, fallback):
+    value = existing[key] if key in existing else None
+    return fallback if value is None else value
+
+
+_RESUMABLE_INBOUND_SMS_STATUSES = frozenset({"received", "processing", "retry_pending"})
+SMS_INBOUND_BEFORE_ACK_TIMEOUT_SECONDS = 8.0
+
+
+def _sms_ack_remaining_seconds(started_at: float) -> float:
+    return max(0.001, SMS_INBOUND_BEFORE_ACK_TIMEOUT_SECONDS - (time.monotonic() - started_at))
+
+
+async def _await_sms_before_ack(awaitable, *, started_at: float):
+    return await asyncio.wait_for(awaitable, timeout=_sms_ack_remaining_seconds(started_at))
+
+
+def _sms_needs_contact_processing(existing: dict) -> bool:
+    return existing.get("status") in _RESUMABLE_INBOUND_SMS_STATUSES
+
+
+def _context_for_persisted_sms(existing: dict, *, fallback_to: str, context_router):
+    context_id = existing.get("business_context_id")
+    if context_id:
+        context = context_router.get_context(context_id)
+        if context is not None:
+            return context
+        raise ValueError(f"Persisted SMS business context no longer resolves: {context_id}")
+
+    to_number = _persisted_sms_value(existing, "to_number", fallback_to)
+    return context_router.get_context_for_number(to_number)
+
+
+async def _resume_duplicate_inbound_sms_before_ack(
+    existing: dict,
+    *,
+    fallback_from: str,
+    fallback_to: str,
+    fallback_body: str,
+    fallback_media_urls: list,
+    context,
+    provider_message_id: str,
+    sms_repo,
+    started_at: float | None = None,
+) -> str:
+    """Run duplicate SMS resume work before acknowledging the provider retry."""
+    if not _sms_needs_contact_processing(existing):
+        return "complete"
+
+    sms_id = existing.get("id")
+    if sms_id is None:
+        logger.warning(
+            "Duplicate inbound SMS webhook for %s has no row id; skipping resume",
+            provider_message_id,
+        )
+        return "complete"
+
+    return await _run_inbound_sms_processing_before_ack(
+        sms_id,
+        _persisted_sms_value(existing, "from_number", fallback_from),
+        _persisted_sms_value(existing, "to_number", fallback_to),
+        _persisted_sms_value(existing, "body", fallback_body),
+        context,
+        _persisted_sms_value(existing, "media_urls", fallback_media_urls),
+        provider_message_id=provider_message_id,
+        claim_processing=True,
+        retry_pending_recorder="caller",
+        started_at=started_at,
+    )
+
+
+async def _run_inbound_sms_processing_before_ack(*args, **kwargs) -> str:
+    """Run provider-facing SMS processing under the webhook response deadline."""
+    started_at = kwargs.pop("started_at", None)
+    timeout = (
+        _sms_ack_remaining_seconds(started_at)
+        if started_at is not None
+        else SMS_INBOUND_BEFORE_ACK_TIMEOUT_SECONDS
+    )
+    try:
+        return await asyncio.wait_for(
+            _process_inbound_sms(*args, **kwargs),
+            timeout=timeout,
+        )
+    except asyncio.TimeoutError:
+        logger.warning(
+            "Inbound SMS processing exceeded %.1fs provider ack budget",
+            SMS_INBOUND_BEFORE_ACK_TIMEOUT_SECONDS,
+        )
+        return "retry_pending"
+
+
+def _sms_processing_outcome_requires_provider_retry(outcome: str) -> bool:
+    return outcome in {"retry_pending", "already_processing", "lost_ownership"}
 
 
 # Track which calls already have recording started (avoid duplicates).
@@ -1458,20 +1556,75 @@ async def _run_recording_processing(
 async def _process_inbound_sms(
     sms_id, from_number: str, to_number: str, body: str, context, media_urls: list,
     provider_message_id: str | None = None,
-) -> None:
+    claim_processing: bool = True,
+    sms_repo=None,
+    intelligence_runner=None,
+    retry_pending_recorder: str = "repo",
+) -> str:
     """Background task: CRM link, intelligence pipeline, ntfy, auto-reply.
 
     Each step is fail-open -- partial results are better than no results.
     Matches the pattern of _run_recording_processing for calls.
     """
-    from ...storage.repositories.sms_message import get_sms_message_repo
+    if sms_repo is None:
+        from ...storage.repositories.sms_message import get_sms_message_repo
 
-    sms_repo = get_sms_message_repo()
+        sms_repo = get_sms_message_repo()
+
+    processing_owner_token = f"sms-contact:{uuid4().hex}" if sms_id else None
+
+    if claim_processing and sms_id:
+        try:
+            claim_row = await sms_repo.claim_contact_processing(
+                sms_id,
+                owner_token=processing_owner_token,
+            )
+        except Exception as e:
+            logger.error("Failed to claim inbound SMS %s for processing: %s", sms_id, e)
+            if retry_pending_recorder == "repo":
+                try:
+                    await sms_repo.mark_contact_processing_retry_pending(
+                        sms_id,
+                        f"SMS processing claim failed: {e}",
+                    )
+                except Exception as e2:
+                    logger.error(
+                        "Failed to mark SMS %s retry_pending after claim failure: %s",
+                        sms_id,
+                        e2,
+                    )
+            return "retry_pending"
+        if claim_row is None:
+            logger.warning("Inbound SMS %s vanished before contact processing claim", sms_id)
+            return "retry_pending"
+        if not claim_row.get("_claim_acquired"):
+            if not _sms_needs_contact_processing(claim_row):
+                logger.info("Inbound SMS %s already reached terminal status", sms_id)
+                return "complete"
+            logger.info("Inbound SMS %s is already being processed; skipping", sms_id)
+            return "already_processing"
+    else:
+        claim_row = None
+
+    existing_contact_id = None
+    if claim_row and claim_row.get("contact_id"):
+        existing_contact_id = str(claim_row["contact_id"])
 
     # Step 1: Run SMS intelligence pipeline (classify + CRM + action plan + ntfy)
     try:
-        from ...comms.sms_intelligence import process_inbound_sms as run_intelligence
-        await run_intelligence(
+        if intelligence_runner is None:
+            from ...comms.sms_intelligence import process_inbound_sms as run_intelligence
+        else:
+            run_intelligence = intelligence_runner
+        if sms_id and processing_owner_token:
+            owner_ok = await sms_repo.touch_contact_processing_owner(
+                sms_id,
+                processing_owner_token,
+            )
+            if not owner_ok:
+                logger.info("Inbound SMS %s lost processing ownership before intelligence", sms_id)
+                return "lost_ownership"
+        processing_outcome = await run_intelligence(
             sms_id=sms_id,
             from_number=from_number,
             to_number=to_number,
@@ -1480,51 +1633,148 @@ async def _process_inbound_sms(
             business_context=context,
             media_urls=media_urls,
             provider_message_id=provider_message_id,
+            processing_owner_token=processing_owner_token,
+            existing_contact_id=existing_contact_id,
         )
+        if processing_outcome == "terminal_no_contact":
+            if sms_id:
+                await sms_repo.mark_contact_processing_complete(
+                    sms_id,
+                    owner_token=processing_owner_token,
+                )
+            return "complete"
+        if processing_outcome == "retry_pending":
+            if sms_id:
+                await sms_repo.mark_contact_processing_retry_pending(
+                    sms_id,
+                    "SMS CRM handoff failed",
+                    owner_token=processing_owner_token,
+                )
+            return "retry_pending"
     except Exception as e:
         logger.error("SMS intelligence pipeline failed for %s: %s", sms_id, e)
 
         # Fallback: basic CRM + ntfy if intelligence pipeline is unavailable
         try:
+            if sms_id and processing_owner_token:
+                owner_ok = await sms_repo.touch_contact_processing_owner(
+                    sms_id,
+                    processing_owner_token,
+                )
+                if not owner_ok:
+                    logger.info("Inbound SMS %s lost processing ownership before fallback", sms_id)
+                    return "lost_ownership"
             await _sms_fallback_crm_and_notify(
                 sms_id, sms_repo, from_number, body, context,
                 provider_message_id=provider_message_id,
             )
         except Exception as e2:
             logger.error("SMS fallback CRM+ntfy also failed: %s", e2)
-
+            if sms_id:
+                try:
+                    await sms_repo.mark_contact_processing_retry_pending(
+                        sms_id,
+                        f"SMS processing failed: {e2}",
+                        owner_token=processing_owner_token,
+                    )
+                except Exception as e3:
+                    logger.error(
+                        "Failed to mark SMS %s retry_pending after processing failure: %s",
+                        sms_id,
+                        e3,
+                    )
+            return "retry_pending"
     # Step 2: Auto-reply via LLM if enabled
     if context.sms_auto_reply and context.sms_enabled and body.strip():
         try:
+            if sms_id and processing_owner_token:
+                owner_ok = await sms_repo.touch_contact_processing_owner(
+                    sms_id,
+                    processing_owner_token,
+                )
+                if not owner_ok:
+                    logger.info("Inbound SMS %s lost processing ownership before auto-reply", sms_id)
+                    return "lost_ownership"
             reply = await _generate_sms_reply(body, context)
             if reply:
-                provider = get_comms_service().provider
-                msg = await provider.send_sms(
-                    to_number=from_number,
-                    from_number=to_number,
-                    body=reply,
-                    context_id=context.id,
-                )
-                logger.info("SMS auto-reply sent to %s", from_number)
-
-                # Persist outbound auto-reply
-                try:
-                    from uuid import uuid4 as _uuid4
-                    await sms_repo.create(
-                        message_sid=getattr(msg, "provider_message_id", "") or f"auto_reply_{_uuid4().hex[:12]}",
-                        from_number=to_number,
-                        to_number=from_number,
-                        direction="outbound",
-                        body=reply,
-                        business_context_id=context.id,
-                        status="sent",
-                        source="auto_reply",
-                        source_ref=str(sms_id) if sms_id else None,
+                skip_auto_reply_send = False
+                if sms_id and processing_owner_token:
+                    owner_ok = await sms_repo.owns_contact_processing(
+                        sms_id,
+                        processing_owner_token,
                     )
-                except Exception as e:
-                    logger.warning("Failed to persist auto-reply SMS: %s", e)
+                    if not owner_ok:
+                        logger.info("Inbound SMS %s lost processing ownership before send", sms_id)
+                        return "lost_ownership"
+                    has_auto_reply = getattr(sms_repo, "has_auto_reply_for_inbound", None)
+                    reserve_auto_reply = getattr(sms_repo, "reserve_auto_reply_for_inbound", None)
+                    if callable(has_auto_reply) and await has_auto_reply(sms_id):
+                        logger.info("SMS auto-reply already reserved for inbound %s; skipping duplicate send", sms_id)
+                        skip_auto_reply_send = True
+                    if callable(reserve_auto_reply):
+                        if skip_auto_reply_send:
+                            auto_reply_row = None
+                        else:
+                            auto_reply_row = await reserve_auto_reply(
+                                inbound_sms_id=sms_id,
+                                from_number=to_number,
+                                to_number=from_number,
+                                body=reply,
+                                business_context_id=context.id,
+                            )
+                            if auto_reply_row is None:
+                                logger.info("SMS auto-reply reservation already exists for inbound %s", sms_id)
+                                skip_auto_reply_send = True
+                    else:
+                        auto_reply_row = None
+                else:
+                    auto_reply_row = None
+                    skip_auto_reply_send = False
+                if not skip_auto_reply_send:
+                    provider = get_comms_service().provider
+                    msg = await provider.send_sms(
+                        to_number=from_number,
+                        from_number=to_number,
+                        body=reply,
+                        context_id=context.id,
+                    )
+                    logger.info("SMS auto-reply sent to %s", from_number)
+
+                    # Persist outbound auto-reply
+                    try:
+                        marker = getattr(sms_repo, "mark_auto_reply_sent", None)
+                        if auto_reply_row is not None and callable(marker):
+                            await marker(
+                                auto_reply_row["id"],
+                                provider_message_id=getattr(msg, "provider_message_id", None),
+                            )
+                        else:
+                            from uuid import uuid4 as _uuid4
+                            await sms_repo.create(
+                                message_sid=getattr(msg, "provider_message_id", "") or f"auto_reply_{_uuid4().hex[:12]}",
+                                from_number=to_number,
+                                to_number=from_number,
+                                direction="outbound",
+                                body=reply,
+                                business_context_id=context.id,
+                                status="sent",
+                                source="auto_reply",
+                                source_ref=str(sms_id) if sms_id else None,
+                            )
+                    except Exception as e:
+                        logger.warning("Failed to persist auto-reply SMS: %s", e)
         except Exception as e:
             logger.warning("SMS auto-reply failed: %s", e)
+
+    if sms_id:
+        try:
+            await sms_repo.mark_contact_processing_complete(
+                sms_id,
+                owner_token=processing_owner_token,
+            )
+        except Exception as e:
+            logger.warning("Failed to mark SMS %s processing complete: %s", sms_id, e)
+    return "complete"
 
 
 async def _sms_fallback_crm_and_notify(
@@ -1584,18 +1834,22 @@ async def _sms_fallback_crm_and_notify(
             if sms_id:
                 await sms_repo.link_contact(sms_id, contact_id)
             if context.id != EOM_BUSINESS_CONTEXT_ID:
-                await crm.log_interaction(
-                    contact_id=contact_id,
-                    interaction_type="sms",
-                    summary=f"Inbound SMS: {body[:100]}",
-                    metadata=(
-                        {"crm_event_id": f"sms:{inbound_message_id}"}
-                        if inbound_message_id
-                        else None
-                    ),
-                )
+                try:
+                    await crm.log_interaction(
+                        contact_id=contact_id,
+                        interaction_type="sms",
+                        summary=f"Inbound SMS: {body[:100]}",
+                        metadata=(
+                            {"crm_event_id": f"sms:{inbound_message_id}"}
+                            if inbound_message_id
+                            else None
+                        ),
+                    )
+                except Exception as e:
+                    logger.warning("Fallback CRM interaction logging failed after contact link: %s", e)
     except Exception as e:
         logger.warning("Fallback CRM link failed: %s", e)
+        raise
 
     # ntfy notification
     try:
@@ -1688,10 +1942,11 @@ async def handle_inbound_sms(
     """
     Handle incoming SMS webhook.
 
-    Persists to DB immediately, then spawns a background task for
-    CRM linking, intelligence pipeline, ntfy, and auto-reply.
-    Webhook returns TwiML in <1s.
+    Persists to DB immediately, then runs contact/intelligence processing
+    before acknowledging so transient CRM handoff failures can return 503 and
+    rely on provider retry.
     """
+    ack_started_at = time.monotonic()
     logger.info("Inbound SMS from %s to %s: %s", From, To, Body[:50])
 
     # Get business context
@@ -1701,7 +1956,15 @@ async def handle_inbound_sms(
     # Collect media URLs if any
     media_urls = []
     num_media = int(NumMedia)
-    form_data = await request.form()
+    try:
+        form_data = await _await_sms_before_ack(request.form(), started_at=ack_started_at)
+    except asyncio.TimeoutError:
+        logger.warning("Inbound SMS media parsing exceeded provider ack budget")
+        return laml_response(
+            """<?xml version="1.0" encoding="UTF-8"?>
+<Response></Response>""",
+            status_code=503,
+        )
     for i in range(num_media):
         url = form_data.get(f"MediaUrl{i}")
         if url:
@@ -1709,59 +1972,187 @@ async def handle_inbound_sms(
 
     try:
         provider = get_comms_service().provider
-        message = await provider.handle_incoming_sms(
-            message_sid=MessageSid,
-            from_number=From,
-            to_number=To,
-            body=Body,
-            media_urls=media_urls,
+        message = await _await_sms_before_ack(
+            provider.handle_incoming_sms(
+                message_sid=MessageSid,
+                from_number=From,
+                to_number=To,
+                body=Body,
+                media_urls=media_urls,
+            ),
+            started_at=ack_started_at,
         )
         message.context_id = context.id
+    except asyncio.TimeoutError:
+        logger.warning("Inbound SMS provider callback exceeded provider ack budget")
+        return laml_response(
+            """<?xml version="1.0" encoding="UTF-8"?>
+<Response></Response>""",
+            status_code=503,
+        )
     except Exception as e:
         logger.error("Error handling inbound SMS: %s", e)
 
     # Persist inbound SMS to DB (dedup on message_sid unique constraint)
     sms_id = None
+    sms_repo = None
     try:
         from ...storage.repositories.sms_message import get_sms_message_repo
         sms_repo = get_sms_message_repo()
 
         # Check for duplicate (webhook retry)
-        existing = await sms_repo.get_by_message_sid(MessageSid)
+        existing = await _await_sms_before_ack(
+            sms_repo.get_by_message_sid(MessageSid),
+            started_at=ack_started_at,
+        )
         if existing:
-            logger.info("Duplicate inbound SMS webhook for %s, skipping", MessageSid)
+            if not _sms_needs_contact_processing(existing):
+                logger.info("Duplicate inbound SMS webhook for %s, skipping", MessageSid)
+                return laml_response("""<?xml version="1.0" encoding="UTF-8"?>
+<Response></Response>""")
+
+            resume_outcome = await _await_sms_before_ack(
+                _resume_duplicate_inbound_sms_before_ack(
+                    existing,
+                    fallback_from=From,
+                    fallback_to=To,
+                    fallback_body=Body,
+                    fallback_media_urls=media_urls,
+                    context=_context_for_persisted_sms(
+                        existing,
+                        fallback_to=To,
+                        context_router=context_router,
+                    ),
+                    provider_message_id=MessageSid,
+                    sms_repo=sms_repo,
+                    started_at=ack_started_at,
+                ),
+                started_at=ack_started_at,
+            )
+            if _sms_processing_outcome_requires_provider_retry(resume_outcome):
+                return laml_response(
+                    """<?xml version="1.0" encoding="UTF-8"?>
+<Response></Response>""",
+                    status_code=503,
+                )
+            if resume_outcome != "already_processing":
+                logger.info(
+                    "Duplicate inbound SMS webhook for %s has no contact link; resumed processing",
+                    MessageSid,
+                )
             return laml_response("""<?xml version="1.0" encoding="UTF-8"?>
 <Response></Response>""")
 
-        record = await sms_repo.create(
-            message_sid=MessageSid,
-            from_number=From,
-            to_number=To,
-            direction="inbound",
-            body=Body,
-            media_urls=media_urls,
-            business_context_id=context.id,
-            source="webhook",
+        record = await _await_sms_before_ack(
+            sms_repo.create(
+                message_sid=MessageSid,
+                from_number=From,
+                to_number=To,
+                direction="inbound",
+                body=Body,
+                media_urls=media_urls,
+                business_context_id=context.id,
+                source="webhook",
+            ),
+            started_at=ack_started_at,
         )
         sms_id = record["id"]
         logger.info("Inbound SMS persisted: id=%s sid=%s", sms_id, MessageSid)
-    except Exception as e:
-        logger.warning("Failed to persist inbound SMS %s: %s", MessageSid, e)
 
-    # Spawn background task for CRM + intelligence + ntfy + auto-reply
-    asyncio.create_task(
-        _process_inbound_sms(
-            sms_id,
-            From,
-            To,
-            Body,
-            context,
-            media_urls,
-            provider_message_id=MessageSid,
+    except asyncio.TimeoutError:
+        logger.warning("Inbound SMS persistence/duplicate handling exceeded provider ack budget")
+        return laml_response(
+            """<?xml version="1.0" encoding="UTF-8"?>
+<Response></Response>""",
+            status_code=503,
         )
-    )
+    except Exception as e:
+        logger.warning("Failed to persist/claim inbound SMS %s: %s", MessageSid, e)
+        if sms_repo is None:
+            return laml_response(
+                """<?xml version="1.0" encoding="UTF-8"?>
+<Response></Response>""",
+                status_code=503,
+            )
+        try:
+            existing = await _await_sms_before_ack(
+                sms_repo.get_by_message_sid(MessageSid),
+                started_at=ack_started_at,
+            )
+        except Exception as lookup_e:
+            logger.warning("Failed to recover existing SMS %s after persistence error: %s", MessageSid, lookup_e)
+            return laml_response(
+                """<?xml version="1.0" encoding="UTF-8"?>
+<Response></Response>""",
+                status_code=503,
+            )
+        if not existing:
+            return laml_response(
+                """<?xml version="1.0" encoding="UTF-8"?>
+<Response></Response>""",
+                status_code=503,
+            )
+        try:
+            recovered_context = _context_for_persisted_sms(
+                existing,
+                fallback_to=To,
+                context_router=context_router,
+            )
+            resume_outcome = await _await_sms_before_ack(
+                _resume_duplicate_inbound_sms_before_ack(
+                    existing,
+                    fallback_from=From,
+                    fallback_to=To,
+                    fallback_body=Body,
+                    fallback_media_urls=media_urls,
+                    context=recovered_context,
+                    provider_message_id=MessageSid,
+                    sms_repo=sms_repo,
+                    started_at=ack_started_at,
+                ),
+                started_at=ack_started_at,
+            )
+        except Exception as resume_e:
+            logger.warning("Failed to resume inbound SMS %s after persistence error: %s", MessageSid, resume_e)
+            return laml_response(
+                """<?xml version="1.0" encoding="UTF-8"?>
+<Response></Response>""",
+                status_code=503,
+            )
+        if _sms_processing_outcome_requires_provider_retry(resume_outcome):
+            return laml_response(
+                """<?xml version="1.0" encoding="UTF-8"?>
+<Response></Response>""",
+                status_code=503,
+            )
+        if resume_outcome != "complete":
+            return laml_response(
+                """<?xml version="1.0" encoding="UTF-8"?>
+<Response></Response>""",
+                status_code=503,
+            )
+        return laml_response("""<?xml version="1.0" encoding="UTF-8"?>
+<Response></Response>""")
 
-    # Return empty TwiML immediately
+    processing_outcome = await _run_inbound_sms_processing_before_ack(
+        sms_id,
+        From,
+        To,
+        Body,
+        context,
+        media_urls,
+        provider_message_id=MessageSid,
+        claim_processing=True,
+        retry_pending_recorder="caller",
+        started_at=ack_started_at,
+    )
+    if _sms_processing_outcome_requires_provider_retry(processing_outcome):
+        return laml_response(
+            """<?xml version="1.0" encoding="UTF-8"?>
+<Response></Response>""",
+            status_code=503,
+        )
+
     return laml_response("""<?xml version="1.0" encoding="UTF-8"?>
 <Response></Response>""")
 

--- a/atlas_brain/api/comms/webhooks.py
+++ b/atlas_brain/api/comms/webhooks.py
@@ -93,11 +93,28 @@ def _persisted_sms_value(existing: dict, key: str, fallback):
 
 
 _RESUMABLE_INBOUND_SMS_STATUSES = frozenset({"received", "processing", "retry_pending"})
-SMS_INBOUND_BEFORE_ACK_TIMEOUT_SECONDS = 8.0
+_DEFAULT_SMS_INBOUND_BEFORE_ACK_TIMEOUT_SECONDS = 45.0
+SMS_INBOUND_BEFORE_ACK_TIMEOUT_SECONDS = _DEFAULT_SMS_INBOUND_BEFORE_ACK_TIMEOUT_SECONDS
+
+
+def _sms_before_ack_timeout_seconds() -> float:
+    """Return an end-to-end SMS ack budget consistent with admitted component latency."""
+    if SMS_INBOUND_BEFORE_ACK_TIMEOUT_SECONDS != _DEFAULT_SMS_INBOUND_BEFORE_ACK_TIMEOUT_SECONDS:
+        return SMS_INBOUND_BEFORE_ACK_TIMEOUT_SECONDS
+    try:
+        from ...config import settings
+
+        sms_cfg = settings.sms_intelligence
+        return max(
+            _DEFAULT_SMS_INBOUND_BEFORE_ACK_TIMEOUT_SECONDS,
+            float(sms_cfg.llm_timeout) + float(sms_cfg.auto_reply_timeout) + 15.0,
+        )
+    except Exception:
+        return _DEFAULT_SMS_INBOUND_BEFORE_ACK_TIMEOUT_SECONDS
 
 
 def _sms_ack_remaining_seconds(started_at: float) -> float:
-    return max(0.001, SMS_INBOUND_BEFORE_ACK_TIMEOUT_SECONDS - (time.monotonic() - started_at))
+    return max(0.001, _sms_before_ack_timeout_seconds() - (time.monotonic() - started_at))
 
 
 async def _await_sms_before_ack(awaitable, *, started_at: float):
@@ -174,7 +191,7 @@ async def _run_inbound_sms_processing_before_ack(*args, **kwargs) -> str:
     except asyncio.TimeoutError:
         logger.warning(
             "Inbound SMS processing exceeded %.1fs provider ack budget",
-            SMS_INBOUND_BEFORE_ACK_TIMEOUT_SECONDS,
+            _sms_before_ack_timeout_seconds(),
         )
         return "retry_pending"
 
@@ -1607,8 +1624,11 @@ async def _process_inbound_sms(
         claim_row = None
 
     existing_contact_id = None
+    notification_already_sent = False
     if claim_row and claim_row.get("contact_id"):
         existing_contact_id = str(claim_row["contact_id"])
+    if claim_row and claim_row.get("notified"):
+        notification_already_sent = True
 
     # Step 1: Run SMS intelligence pipeline (classify + CRM + action plan + ntfy)
     try:
@@ -1635,13 +1655,21 @@ async def _process_inbound_sms(
             provider_message_id=provider_message_id,
             processing_owner_token=processing_owner_token,
             existing_contact_id=existing_contact_id,
+            notification_already_sent=notification_already_sent,
         )
         if processing_outcome == "terminal_no_contact":
             if sms_id:
-                await sms_repo.mark_contact_processing_complete(
-                    sms_id,
-                    owner_token=processing_owner_token,
-                )
+                try:
+                    complete = await sms_repo.mark_contact_processing_complete(
+                        sms_id,
+                        owner_token=processing_owner_token,
+                    )
+                except Exception as e:
+                    logger.warning("Failed to finalize terminal SMS %s processing: %s", sms_id, e)
+                    return "retry_pending"
+                if not complete:
+                    logger.info("Inbound SMS %s lost processing ownership before terminal finalization", sms_id)
+                    return "lost_ownership"
             return "complete"
         if processing_outcome == "retry_pending":
             if sms_id:
@@ -1667,6 +1695,7 @@ async def _process_inbound_sms(
             await _sms_fallback_crm_and_notify(
                 sms_id, sms_repo, from_number, body, context,
                 provider_message_id=provider_message_id,
+                notification_already_sent=notification_already_sent,
             )
         except Exception as e2:
             logger.error("SMS fallback CRM+ntfy also failed: %s", e2)
@@ -1698,6 +1727,7 @@ async def _process_inbound_sms(
             reply = await _generate_sms_reply(body, context)
             if reply:
                 skip_auto_reply_send = False
+                auto_reply_row = None
                 if sms_id and processing_owner_token:
                     owner_ok = await sms_repo.owns_contact_processing(
                         sms_id,
@@ -1706,15 +1736,19 @@ async def _process_inbound_sms(
                     if not owner_ok:
                         logger.info("Inbound SMS %s lost processing ownership before send", sms_id)
                         return "lost_ownership"
-                    has_auto_reply = getattr(sms_repo, "has_auto_reply_for_inbound", None)
                     reserve_auto_reply = getattr(sms_repo, "reserve_auto_reply_for_inbound", None)
-                    if callable(has_auto_reply) and await has_auto_reply(sms_id):
-                        logger.info("SMS auto-reply already reserved for inbound %s; skipping duplicate send", sms_id)
-                        skip_auto_reply_send = True
+                    get_auto_reply = getattr(sms_repo, "get_auto_reply_for_inbound", None)
+                    if callable(get_auto_reply):
+                        auto_reply_row = await get_auto_reply(sms_id)
+                        if auto_reply_row and auto_reply_row.get("status") == "sent":
+                            logger.info("SMS auto-reply already sent for inbound %s; skipping duplicate send", sms_id)
+                            skip_auto_reply_send = True
+                        elif auto_reply_row:
+                            logger.info("SMS auto-reply pending for inbound %s; retrying provider send", sms_id)
                     if callable(reserve_auto_reply):
                         if skip_auto_reply_send:
                             auto_reply_row = None
-                        else:
+                        elif auto_reply_row is None:
                             auto_reply_row = await reserve_auto_reply(
                                 inbound_sms_id=sms_id,
                                 from_number=to_number,
@@ -1723,8 +1757,16 @@ async def _process_inbound_sms(
                                 business_context_id=context.id,
                             )
                             if auto_reply_row is None:
-                                logger.info("SMS auto-reply reservation already exists for inbound %s", sms_id)
-                                skip_auto_reply_send = True
+                                if callable(get_auto_reply):
+                                    auto_reply_row = await get_auto_reply(sms_id)
+                                if auto_reply_row and auto_reply_row.get("status") == "sent":
+                                    logger.info("SMS auto-reply already sent for inbound %s; skipping duplicate send", sms_id)
+                                    skip_auto_reply_send = True
+                                elif auto_reply_row:
+                                    logger.info("SMS auto-reply pending for inbound %s after reservation race; retrying send", sms_id)
+                                else:
+                                    logger.warning("SMS auto-reply reservation vanished for inbound %s", sms_id)
+                                    return "retry_pending"
                     else:
                         auto_reply_row = None
                 else:
@@ -1744,10 +1786,16 @@ async def _process_inbound_sms(
                     try:
                         marker = getattr(sms_repo, "mark_auto_reply_sent", None)
                         if auto_reply_row is not None and callable(marker):
-                            await marker(
+                            marked = await marker(
                                 auto_reply_row["id"],
                                 provider_message_id=getattr(msg, "provider_message_id", None),
                             )
+                            if not marked:
+                                logger.warning(
+                                    "Failed to mark reserved SMS auto-reply %s sent",
+                                    auto_reply_row["id"],
+                                )
+                                return "retry_pending"
                         else:
                             from uuid import uuid4 as _uuid4
                             await sms_repo.create(
@@ -1763,17 +1811,23 @@ async def _process_inbound_sms(
                             )
                     except Exception as e:
                         logger.warning("Failed to persist auto-reply SMS: %s", e)
+                        return "retry_pending"
         except Exception as e:
             logger.warning("SMS auto-reply failed: %s", e)
+            return "retry_pending"
 
     if sms_id:
         try:
-            await sms_repo.mark_contact_processing_complete(
+            complete = await sms_repo.mark_contact_processing_complete(
                 sms_id,
                 owner_token=processing_owner_token,
             )
         except Exception as e:
             logger.warning("Failed to mark SMS %s processing complete: %s", sms_id, e)
+            return "retry_pending"
+        if not complete:
+            logger.info("Inbound SMS %s lost processing ownership before finalization", sms_id)
+            return "lost_ownership"
     return "complete"
 
 
@@ -1781,6 +1835,7 @@ async def _sms_fallback_crm_and_notify(
     sms_id, sms_repo, from_number: str, body: str, context,
     *,
     provider_message_id: str | None = None,
+    notification_already_sent: bool = False,
 ) -> None:
     """Fallback CRM link + ntfy when full intelligence pipeline is unavailable."""
     from ...services.crm_provider import get_crm_provider
@@ -1853,6 +1908,9 @@ async def _sms_fallback_crm_and_notify(
 
     # ntfy notification
     try:
+        if notification_already_sent:
+            logger.info("Fallback SMS notification already sent for %s; skipping", sms_id)
+            return
         if not settings.alerts.ntfy_enabled or not settings.alerts.ntfy_url:
             return
 

--- a/atlas_brain/api/comms/webhooks.py
+++ b/atlas_brain/api/comms/webhooks.py
@@ -105,9 +105,17 @@ def _sms_before_ack_timeout_seconds() -> float:
         from ...config import settings
 
         sms_cfg = settings.sms_intelligence
+        call_cfg = settings.call_intelligence
+        auto_reply_timeout = max(float(sms_cfg.auto_reply_timeout), 15.0)
+        notification_timeout = 10.0
+        crm_provider_margin = 15.0
         return max(
             _DEFAULT_SMS_INBOUND_BEFORE_ACK_TIMEOUT_SECONDS,
-            float(sms_cfg.llm_timeout) + float(sms_cfg.auto_reply_timeout) + 15.0,
+            float(sms_cfg.llm_timeout)
+            + float(call_cfg.llm_timeout)
+            + notification_timeout
+            + auto_reply_timeout
+            + crm_provider_margin,
         )
     except Exception:
         return _DEFAULT_SMS_INBOUND_BEFORE_ACK_TIMEOUT_SECONDS
@@ -1724,10 +1732,23 @@ async def _process_inbound_sms(
                 if not owner_ok:
                     logger.info("Inbound SMS %s lost processing ownership before auto-reply", sms_id)
                     return "lost_ownership"
-            reply = await _generate_sms_reply(body, context)
+            reply = None
+            if sms_id and processing_owner_token:
+                get_auto_reply = getattr(sms_repo, "get_auto_reply_for_inbound", None)
+                if callable(get_auto_reply):
+                    auto_reply_row = await get_auto_reply(sms_id)
+                else:
+                    auto_reply_row = None
+            else:
+                auto_reply_row = None
+
+            if auto_reply_row is None:
+                reply = await _generate_sms_reply(body, context)
+            else:
+                reply = auto_reply_row.get("body")
+
             if reply:
                 skip_auto_reply_send = False
-                auto_reply_row = None
                 if sms_id and processing_owner_token:
                     owner_ok = await sms_repo.owns_contact_processing(
                         sms_id,
@@ -1738,13 +1759,16 @@ async def _process_inbound_sms(
                         return "lost_ownership"
                     reserve_auto_reply = getattr(sms_repo, "reserve_auto_reply_for_inbound", None)
                     get_auto_reply = getattr(sms_repo, "get_auto_reply_for_inbound", None)
-                    if callable(get_auto_reply):
-                        auto_reply_row = await get_auto_reply(sms_id)
-                        if auto_reply_row and auto_reply_row.get("status") == "sent":
-                            logger.info("SMS auto-reply already sent for inbound %s; skipping duplicate send", sms_id)
-                            skip_auto_reply_send = True
-                        elif auto_reply_row:
-                            logger.info("SMS auto-reply pending for inbound %s; retrying provider send", sms_id)
+                    mark_auto_reply_sending = getattr(sms_repo, "mark_auto_reply_sending", None)
+                    if auto_reply_row and auto_reply_row.get("status") in {"sent", "sending"}:
+                        logger.info(
+                            "SMS auto-reply already %s for inbound %s; skipping duplicate send",
+                            auto_reply_row.get("status"),
+                            sms_id,
+                        )
+                        skip_auto_reply_send = True
+                    elif auto_reply_row:
+                        logger.info("SMS auto-reply pending for inbound %s; retrying persisted provider send", sms_id)
                     if callable(reserve_auto_reply):
                         if skip_auto_reply_send:
                             auto_reply_row = None
@@ -1759,11 +1783,18 @@ async def _process_inbound_sms(
                             if auto_reply_row is None:
                                 if callable(get_auto_reply):
                                     auto_reply_row = await get_auto_reply(sms_id)
-                                if auto_reply_row and auto_reply_row.get("status") == "sent":
-                                    logger.info("SMS auto-reply already sent for inbound %s; skipping duplicate send", sms_id)
+                                if auto_reply_row and auto_reply_row.get("status") in {"sent", "sending"}:
+                                    logger.info(
+                                        "SMS auto-reply already %s for inbound %s; skipping duplicate send",
+                                        auto_reply_row.get("status"),
+                                        sms_id,
+                                    )
                                     skip_auto_reply_send = True
                                 elif auto_reply_row:
-                                    logger.info("SMS auto-reply pending for inbound %s after reservation race; retrying send", sms_id)
+                                    logger.info(
+                                        "SMS auto-reply pending for inbound %s after reservation race; retrying persisted send",
+                                        sms_id,
+                                    )
                                 else:
                                     logger.warning("SMS auto-reply reservation vanished for inbound %s", sms_id)
                                     return "retry_pending"
@@ -1773,11 +1804,35 @@ async def _process_inbound_sms(
                     auto_reply_row = None
                     skip_auto_reply_send = False
                 if not skip_auto_reply_send:
+                    reply_body = auto_reply_row.get("body") if auto_reply_row is not None else reply
+                    if auto_reply_row is not None and callable(mark_auto_reply_sending):
+                        marked_sending = await mark_auto_reply_sending(auto_reply_row["id"])
+                        if not marked_sending:
+                            if callable(get_auto_reply):
+                                refreshed_row = await get_auto_reply(sms_id)
+                            else:
+                                refreshed_row = None
+                            if refreshed_row and refreshed_row.get("status") in {"sent", "sending"}:
+                                logger.info(
+                                    "SMS auto-reply became %s for inbound %s before provider send; skipping duplicate",
+                                    refreshed_row.get("status"),
+                                    sms_id,
+                                )
+                                skip_auto_reply_send = True
+                            else:
+                                logger.warning(
+                                    "Failed to mark reserved SMS auto-reply %s sending",
+                                    auto_reply_row["id"],
+                                )
+                                return "retry_pending"
+                    if skip_auto_reply_send:
+                        reply_body = None
+                if not skip_auto_reply_send:
                     provider = get_comms_service().provider
                     msg = await provider.send_sms(
                         to_number=from_number,
                         from_number=to_number,
-                        body=reply,
+                        body=reply_body,
                         context_id=context.id,
                     )
                     logger.info("SMS auto-reply sent to %s", from_number)
@@ -1803,7 +1858,7 @@ async def _process_inbound_sms(
                                 from_number=to_number,
                                 to_number=from_number,
                                 direction="outbound",
-                                body=reply,
+                                body=reply_body,
                                 business_context_id=context.id,
                                 status="sent",
                                 source="auto_reply",

--- a/atlas_brain/comms/sms_intelligence.py
+++ b/atlas_brain/comms/sms_intelligence.py
@@ -167,14 +167,11 @@ async def process_inbound_sms(
         if sms_id:
             try:
                 if processing_owner_token:
-                    updater = getattr(repo, "update_contact_processing_status", None)
-                    if callable(updater):
-                        await updater(
-                            sms_id,
-                            "ready",
-                            owner_token=processing_owner_token,
-                            clear_owner=True,
-                        )
+                    # The webhook owns the leased terminal transition. Clearing
+                    # the owner here would make its owner-fenced finalization
+                    # look like lost ownership and force a spurious provider
+                    # retry for successful opt-out/spam handling.
+                    pass
                 else:
                     await repo.update_status(sms_id, "ready")
             except Exception:

--- a/atlas_brain/comms/sms_intelligence.py
+++ b/atlas_brain/comms/sms_intelligence.py
@@ -26,6 +26,10 @@ from ..storage.repositories.sms_message import get_sms_message_repo
 logger = logging.getLogger("atlas.comms.sms_intelligence")
 
 
+class SMSCRMRetryableError(RuntimeError):
+    """CRM infrastructure failed after the SMS row was claimed."""
+
+
 # ---------------------------------------------------------------------------
 # SMS intent -> business intent normalization
 # ---------------------------------------------------------------------------
@@ -92,7 +96,10 @@ async def process_inbound_sms(
     business_context=None,
     media_urls: Optional[list] = None,
     provider_message_id: Optional[str] = None,
-) -> None:
+    processing_owner_token: Optional[str] = None,
+    stop_after_crm: bool = False,
+    existing_contact_id: Optional[str] = None,
+) -> str:
     """
     Process an inbound SMS through the intelligence pipeline.
 
@@ -102,11 +109,11 @@ async def process_inbound_sms(
 
     if not cfg.enabled:
         logger.info("SMS intelligence disabled, skipping")
-        return
+        return "skipped_intelligence"
 
     if not body.strip():
         logger.info("Empty SMS body, skipping intelligence pipeline")
-        return
+        return "skipped_intelligence"
 
     repo = get_sms_message_repo()
 
@@ -115,7 +122,12 @@ async def process_inbound_sms(
     extracted_data = {}
     raw_intent = None
     try:
-        if sms_id:
+        if sms_id and processing_owner_token:
+            touch = getattr(repo, "touch_contact_processing_owner", None)
+            if callable(touch) and not await touch(sms_id, processing_owner_token):
+                logger.info("SMS %s lost processing ownership before extraction", sms_id)
+                return "lost_ownership"
+        elif sms_id:
             await repo.update_status(sms_id, "processing")
 
         summary, extracted_data, raw_intent = await _extract_sms_data(body, business_context)
@@ -153,26 +165,44 @@ async def process_inbound_sms(
         logger.info("SMS intent=%s, skipping CRM/plan/notify", raw_intent)
         if sms_id:
             try:
-                await repo.update_status(sms_id, "ready")
+                if processing_owner_token:
+                    updater = getattr(repo, "update_contact_processing_status", None)
+                    if callable(updater):
+                        await updater(
+                            sms_id,
+                            "ready",
+                            owner_token=processing_owner_token,
+                            clear_owner=True,
+                        )
+                else:
+                    await repo.update_status(sms_id, "ready")
             except Exception:
                 pass
-        return
+        return "terminal_no_contact"
 
     # Step 2: CRM link
-    contact_id = None
+    contact_id = str(existing_contact_id) if existing_contact_id else None
     is_new_lead = False
-    try:
-        contact_id, is_new_lead = await _link_to_crm(
-            repo, sms_id, from_number, business_context_id,
-            extracted_data, summary or f"Inbound SMS: {body[:100]}",
-            provider_message_id=provider_message_id,
-        )
-        if contact_id:
-            logger.info("Step 2/4 OK: Linked SMS to contact %s (new=%s)", contact_id, is_new_lead)
-        else:
-            logger.info("Step 2/4 OK: No CRM link created (insufficient data)")
-    except Exception as e:
-        logger.error("Step 2/4 FAIL: CRM link: %s", e)
+    if contact_id:
+        logger.info("Step 2/4 OK: Resuming SMS with existing contact %s", contact_id)
+    else:
+        try:
+            contact_id, is_new_lead = await _link_to_crm(
+                repo, sms_id, from_number, business_context_id,
+                extracted_data, summary or f"Inbound SMS: {body[:100]}",
+                provider_message_id=provider_message_id,
+                processing_owner_token=processing_owner_token,
+            )
+            if contact_id:
+                logger.info("Step 2/4 OK: Linked SMS to contact %s (new=%s)", contact_id, is_new_lead)
+            else:
+                logger.info("Step 2/4 OK: No CRM link created (insufficient data)")
+        except Exception as e:
+            logger.error("Step 2/4 FAIL: CRM link: %s", e)
+            return "retry_pending"
+
+    if contact_id and stop_after_crm:
+        return "crm_linked"
 
     # Step 3: Action plan
     action_plan = []
@@ -198,6 +228,7 @@ async def process_inbound_sms(
             summary, extracted_data, action_plan,
             business_context,
             is_new_lead=is_new_lead,
+            processing_owner_token=processing_owner_token,
         )
         notified = True
         logger.info("Step 4/4 OK: Notification sent")
@@ -210,6 +241,7 @@ async def process_inbound_sms(
             await repo.update_status(sms_id, "ready")
         except Exception:
             pass
+    return "complete"
 
 
 async def _extract_sms_data(
@@ -386,6 +418,7 @@ async def _link_to_crm(
     summary: str,
     *,
     provider_message_id: Optional[str] = None,
+    processing_owner_token: Optional[str] = None,
 ) -> tuple[Optional[str], bool]:
     """Look up or create a CRM contact from SMS extraction data.
 
@@ -396,7 +429,7 @@ async def _link_to_crm(
 
     pool = get_db_pool()
     if not pool.is_initialized:
-        return None, False
+        raise SMSCRMRetryableError("CRM database pool unavailable")
 
     email_addr = extracted_data.get("customer_email")
     name = extracted_data.get("customer_name")
@@ -419,6 +452,16 @@ async def _link_to_crm(
 
     if not phone and not email_addr:
         return None, False
+
+    if sms_id and processing_owner_token:
+        owns = getattr(repo, "owns_contact_processing", None)
+        if callable(owns) and not await owns(sms_id, processing_owner_token):
+            logger.info("SMS %s lost processing ownership before CRM link", sms_id)
+            raise SMSCRMRetryableError("lost SMS processing ownership before CRM link")
+        touch = getattr(repo, "touch_contact_processing_owner", None)
+        if callable(touch) and not await touch(sms_id, processing_owner_token):
+            logger.info("SMS %s lost processing ownership before CRM link heartbeat", sms_id)
+            raise SMSCRMRetryableError("lost SMS processing ownership before CRM link")
 
     raw_intent = extracted_data.get("intent", "")
     business_intent = _SMS_INTENT_MAP.get(raw_intent)
@@ -453,27 +496,39 @@ async def _link_to_crm(
             source_ref=(str(sms_id) if sms_id else inbound_message_id),
         )
     if not contact.get("id"):
-        return None, False
+        raise SMSCRMRetryableError("CRM contact command returned no contact id")
 
     contact_id = str(contact["id"])
     is_new_lead = contact.get("_was_created", False)
 
     # Link the SMS to the contact
     if sms_id:
+        if processing_owner_token:
+            owns = getattr(repo, "owns_contact_processing", None)
+            if callable(owns) and not await owns(sms_id, processing_owner_token):
+                logger.info("SMS %s lost processing ownership after CRM contact write", sms_id)
+                raise SMSCRMRetryableError("lost SMS processing ownership after CRM contact write")
         await repo.link_contact(sms_id, contact_id)
 
     if context_id != EOM_BUSINESS_CONTEXT_ID:
-        await crm.log_interaction(
-            contact_id=contact_id,
-            interaction_type="sms",
-            summary=summary or f"Inbound SMS from {from_number}",
-            intent=business_intent,
-            metadata=(
-                {"crm_event_id": f"sms:{inbound_message_id}"}
-                if inbound_message_id
-                else None
-            ),
-        )
+        try:
+            await crm.log_interaction(
+                contact_id=contact_id,
+                interaction_type="sms",
+                summary=summary or f"Inbound SMS from {from_number}",
+                intent=business_intent,
+                metadata=(
+                    {"crm_event_id": f"sms:{inbound_message_id}"}
+                    if inbound_message_id
+                    else None
+                ),
+            )
+        except Exception as e:
+            logger.warning(
+                "SMS interaction logging failed after contact link for %s: %s",
+                contact_id,
+                e,
+            )
 
     return contact_id, is_new_lead
 
@@ -517,6 +572,7 @@ async def _notify_sms_summary(
     proposed_actions: list,
     business_context=None,
     is_new_lead: bool = False,
+    processing_owner_token: Optional[str] = None,
 ) -> None:
     """Send ntfy notification with SMS summary and intent-aware buttons."""
     cfg = settings.sms_intelligence
@@ -610,7 +666,16 @@ async def _notify_sms_summary(
 
         if sms_id:
             await repo.mark_notified(sms_id)
-            await repo.update_status(sms_id, "notified")
+            if processing_owner_token:
+                updater = getattr(repo, "update_contact_processing_status", None)
+                if callable(updater):
+                    await updater(
+                        sms_id,
+                        "processing",
+                        owner_token=processing_owner_token,
+                    )
+            else:
+                await repo.update_status(sms_id, "notified")
         logger.info("SMS notification sent for %s", from_number)
     except Exception as e:
         logger.warning("Failed to send SMS notification: %s", e)

--- a/atlas_brain/comms/sms_intelligence.py
+++ b/atlas_brain/comms/sms_intelligence.py
@@ -99,6 +99,7 @@ async def process_inbound_sms(
     processing_owner_token: Optional[str] = None,
     stop_after_crm: bool = False,
     existing_contact_id: Optional[str] = None,
+    notification_already_sent: bool = False,
 ) -> str:
     """
     Process an inbound SMS through the intelligence pipeline.
@@ -221,19 +222,22 @@ async def process_inbound_sms(
         logger.error("Step 3/4 FAIL: Action plan: %s", e)
 
     # Step 4: ntfy notification
-    notified = False
-    try:
-        await _notify_sms_summary(
-            repo, sms_id, from_number, body,
-            summary, extracted_data, action_plan,
-            business_context,
-            is_new_lead=is_new_lead,
-            processing_owner_token=processing_owner_token,
-        )
-        notified = True
-        logger.info("Step 4/4 OK: Notification sent")
-    except Exception as e:
-        logger.error("Step 4/4 FAIL: Notification: %s", e)
+    notified = bool(notification_already_sent)
+    if notification_already_sent:
+        logger.info("Step 4/4 SKIP: Notification already sent for SMS %s", sms_id)
+    else:
+        try:
+            await _notify_sms_summary(
+                repo, sms_id, from_number, body,
+                summary, extracted_data, action_plan,
+                business_context,
+                is_new_lead=is_new_lead,
+                processing_owner_token=processing_owner_token,
+            )
+            notified = True
+            logger.info("Step 4/4 OK: Notification sent")
+        except Exception as e:
+            logger.error("Step 4/4 FAIL: Notification: %s", e)
 
     # Mark ready only if notification didn't already set "notified"
     if sms_id and not notified:

--- a/atlas_brain/storage/repositories/sms_message.py
+++ b/atlas_brain/storage/repositories/sms_message.py
@@ -401,8 +401,11 @@ class SMSMessageRepository:
         sms_id: UUID,
         *,
         owner_token: Optional[str] = None,
-    ) -> None:
-        """Mark a still-processing SMS row complete without changing linked/notify state."""
+    ) -> bool:
+        """Mark a still-processing SMS row complete without changing linked/notify state.
+
+        Returns True only when the terminal transition was durably written.
+        """
         pool = get_db_pool()
         if not pool.is_initialized:
             raise DatabaseUnavailableError("mark SMS contact processing complete")
@@ -410,7 +413,7 @@ class SMSMessageRepository:
         try:
             now = datetime.now(timezone.utc)
             if owner_token is not None:
-                await pool.execute(
+                row = await pool.fetchrow(
                     """
                     UPDATE sms_messages
                     SET status = 'ready',
@@ -419,13 +422,14 @@ class SMSMessageRepository:
                     WHERE id = $1
                       AND status = 'processing'
                       AND error_message = $3
+                    RETURNING id
                     """,
                     sms_id,
                     now,
                     owner_token,
                 )
             else:
-                await pool.execute(
+                row = await pool.fetchrow(
                     """
                     UPDATE sms_messages
                     SET status = 'ready',
@@ -433,10 +437,12 @@ class SMSMessageRepository:
                         error_message = NULL
                     WHERE id = $1
                       AND status = 'processing'
+                    RETURNING id
                     """,
                     sms_id,
                     now,
                 )
+            return row is not None
         except DatabaseUnavailableError:
             raise
         except Exception as e:
@@ -460,6 +466,10 @@ class SMSMessageRepository:
 
     async def has_auto_reply_for_inbound(self, inbound_sms_id: UUID) -> bool:
         """Return True when an auto-reply send decision already exists."""
+        return await self.get_auto_reply_for_inbound(inbound_sms_id) is not None
+
+    async def get_auto_reply_for_inbound(self, inbound_sms_id: UUID) -> Optional[dict]:
+        """Return the durable auto-reply outbox row for an inbound SMS, if any."""
         pool = get_db_pool()
         if not pool.is_initialized:
             raise DatabaseUnavailableError("check SMS auto-reply outbox")
@@ -467,7 +477,7 @@ class SMSMessageRepository:
         try:
             row = await pool.fetchrow(
                 """
-                SELECT id
+                SELECT *
                 FROM sms_messages
                 WHERE direction = 'outbound'
                   AND source = 'auto_reply'
@@ -476,7 +486,7 @@ class SMSMessageRepository:
                 """,
                 str(inbound_sms_id),
             )
-            return row is not None
+            return self._row_to_dict(row) if row else None
         except DatabaseUnavailableError:
             raise
         except Exception as e:
@@ -531,14 +541,17 @@ class SMSMessageRepository:
         auto_reply_sms_id: UUID,
         *,
         provider_message_id: Optional[str] = None,
-    ) -> None:
-        """Mark a reserved auto-reply as sent after provider acceptance."""
+    ) -> bool:
+        """Mark a reserved auto-reply as sent after provider acceptance.
+
+        Returns True only when the pending outbox row was durably finalized.
+        """
         pool = get_db_pool()
         if not pool.is_initialized:
             raise DatabaseUnavailableError("mark SMS auto-reply sent")
 
         try:
-            await pool.execute(
+            row = await pool.fetchrow(
                 """
                 UPDATE sms_messages
                 SET status = 'sent',
@@ -547,11 +560,13 @@ class SMSMessageRepository:
                 WHERE id = $1
                   AND direction = 'outbound'
                   AND source = 'auto_reply'
+                RETURNING id
                 """,
                 auto_reply_sms_id,
                 provider_message_id,
                 datetime.now(timezone.utc),
             )
+            return row is not None
         except DatabaseUnavailableError:
             raise
         except Exception as e:

--- a/atlas_brain/storage/repositories/sms_message.py
+++ b/atlas_brain/storage/repositories/sms_message.py
@@ -6,7 +6,7 @@ Provides CRUD operations for SMS messages stored in PostgreSQL.
 
 import json
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 from uuid import UUID, uuid4
 
@@ -14,6 +14,8 @@ from ..database import get_db_pool
 from ..exceptions import DatabaseUnavailableError, DatabaseOperationError
 
 logger = logging.getLogger("atlas.storage.sms_message")
+
+SMS_CONTACT_PROCESSING_LEASE_SECONDS = 300
 
 
 class SMSMessageRepository:
@@ -103,6 +105,50 @@ class SMSMessageRepository:
         except Exception as e:
             raise DatabaseOperationError("update SMS status", e)
 
+    async def update_contact_processing_status(
+        self,
+        sms_id: UUID,
+        status: str,
+        *,
+        owner_token: str,
+        error_message: Optional[str] = None,
+        clear_owner: bool = False,
+    ) -> bool:
+        """Update a leased contact-processing row without losing ownership.
+
+        Returns True only when the caller still owns the processing lease.
+        Non-terminal progress/status writes keep ``error_message`` as the
+        owner token; terminal writes may clear it explicitly.
+        """
+        pool = get_db_pool()
+        if not pool.is_initialized:
+            raise DatabaseUnavailableError("update SMS contact processing status")
+
+        try:
+            row = await pool.fetchrow(
+                """
+                UPDATE sms_messages
+                SET status = $2,
+                    error_message = CASE WHEN $5 THEN NULL ELSE COALESCE($4, $3) END,
+                    processed_at = $6
+                WHERE id = $1
+                  AND status = 'processing'
+                  AND error_message = $3
+                RETURNING id
+                """,
+                sms_id,
+                status,
+                owner_token,
+                error_message,
+                clear_owner,
+                datetime.now(timezone.utc),
+            )
+            return row is not None
+        except DatabaseUnavailableError:
+            raise
+        except Exception as e:
+            raise DatabaseOperationError("update SMS contact processing status", e)
+
     async def update_delivery(self, sms_id: UUID, delivered_at: datetime) -> None:
         """Mark message as delivered with timestamp."""
         pool = get_db_pool()
@@ -174,6 +220,228 @@ class SMSMessageRepository:
         except Exception as e:
             raise DatabaseOperationError("link SMS contact", e)
 
+    async def claim_contact_processing(
+        self,
+        sms_id: UUID,
+        *,
+        owner_token: Optional[str] = None,
+    ) -> Optional[dict]:
+        """Atomically claim CRM/contact processing and return authoritative row state.
+
+        Returns the claimed row with ``_claim_acquired=True`` for the worker that
+        moves an incomplete or abandoned row into the processing state. If the
+        row exists but is not claimable, returns the current row with
+        ``_claim_acquired=False`` so callers can distinguish active leases from
+        already-terminal rows without racing a separate reload. Missing rows
+        return ``None``.
+        """
+        pool = get_db_pool()
+        if not pool.is_initialized:
+            raise DatabaseUnavailableError("claim SMS contact processing")
+
+        now = datetime.now(timezone.utc)
+        lease_cutoff = now - timedelta(seconds=SMS_CONTACT_PROCESSING_LEASE_SECONDS)
+        try:
+            row = await pool.fetchrow(
+                """
+                WITH attempted AS (
+                    UPDATE sms_messages
+                    SET status = 'processing',
+                        processed_at = $2,
+                        error_message = $4
+                    WHERE id = $1
+                      AND (
+                        status IN ('received', 'retry_pending')
+                        OR (status = 'processing' AND (processed_at IS NULL OR processed_at < $3))
+                      )
+                    RETURNING sms_messages.*, TRUE AS claim_acquired
+                ),
+                current_row AS (
+                    SELECT sms_messages.*, FALSE AS claim_acquired
+                    FROM sms_messages
+                    WHERE id = $1
+                      AND NOT EXISTS (SELECT 1 FROM attempted)
+                )
+                SELECT * FROM attempted
+                UNION ALL
+                SELECT * FROM current_row
+                LIMIT 1
+                """,
+                sms_id,
+                now,
+                lease_cutoff,
+                owner_token,
+            )
+            if row is None:
+                return None
+            result = self._row_to_dict(row)
+            result["_claim_acquired"] = bool(result.pop("claim_acquired", False))
+            return result
+        except DatabaseUnavailableError:
+            raise
+        except Exception as e:
+            raise DatabaseOperationError("claim SMS contact processing", e)
+
+    async def claim_contact_processing_bool(
+        self,
+        sms_id: UUID,
+        *,
+        owner_token: Optional[str] = None,
+    ) -> bool:
+        """Compatibility helper for callers that only need claim ownership."""
+        row = await self.claim_contact_processing(sms_id, owner_token=owner_token)
+        return bool(row and row.get("_claim_acquired"))
+
+    async def owns_contact_processing(self, sms_id: UUID, owner_token: str) -> bool:
+        """Return True when the current processing row is still owned by this token."""
+        pool = get_db_pool()
+        if not pool.is_initialized:
+            raise DatabaseUnavailableError("check SMS contact processing owner")
+
+        try:
+            row = await pool.fetchrow(
+                """
+                SELECT id
+                FROM sms_messages
+                WHERE id = $1
+                  AND status = 'processing'
+                  AND error_message = $2
+                """,
+                sms_id,
+                owner_token,
+            )
+            return row is not None
+        except DatabaseUnavailableError:
+            raise
+        except Exception as e:
+            raise DatabaseOperationError("check SMS contact processing owner", e)
+
+    async def touch_contact_processing_owner(
+        self,
+        sms_id: UUID,
+        owner_token: str,
+    ) -> bool:
+        """Heartbeat the processing lease only when this worker still owns it."""
+        pool = get_db_pool()
+        if not pool.is_initialized:
+            raise DatabaseUnavailableError("touch SMS contact processing owner")
+
+        try:
+            row = await pool.fetchrow(
+                """
+                UPDATE sms_messages
+                SET processed_at = $3
+                WHERE id = $1
+                  AND status = 'processing'
+                  AND error_message = $2
+                RETURNING id
+                """,
+                sms_id,
+                owner_token,
+                datetime.now(timezone.utc),
+            )
+            return row is not None
+        except DatabaseUnavailableError:
+            raise
+        except Exception as e:
+            raise DatabaseOperationError("touch SMS contact processing owner", e)
+
+    async def mark_contact_processing_retry_pending(
+        self,
+        sms_id: UUID,
+        error_message: Optional[str] = None,
+        *,
+        owner_token: Optional[str] = None,
+    ) -> None:
+        """Record that SMS contact processing should be retried by a future delivery."""
+        pool = get_db_pool()
+        if not pool.is_initialized:
+            raise DatabaseUnavailableError("mark SMS contact processing retry pending")
+
+        try:
+            now = datetime.now(timezone.utc)
+            if owner_token is not None:
+                await pool.execute(
+                    """
+                    UPDATE sms_messages
+                    SET status = 'retry_pending',
+                        error_message = $2,
+                        processed_at = $3
+                    WHERE id = $1
+                      AND status = 'processing'
+                      AND error_message = $4
+                    """,
+                    sms_id,
+                    error_message,
+                    now,
+                    owner_token,
+                )
+            else:
+                await pool.execute(
+                    """
+                    UPDATE sms_messages
+                    SET status = 'retry_pending',
+                        error_message = $2,
+                        processed_at = $3
+                    WHERE id = $1
+                      AND contact_id IS NULL
+                      AND status IN ('received', 'retry_pending')
+                    """,
+                    sms_id,
+                    error_message,
+                    now,
+                )
+        except DatabaseUnavailableError:
+            raise
+        except Exception as e:
+            raise DatabaseOperationError("mark SMS contact processing retry pending", e)
+
+    async def mark_contact_processing_complete(
+        self,
+        sms_id: UUID,
+        *,
+        owner_token: Optional[str] = None,
+    ) -> None:
+        """Mark a still-processing SMS row complete without changing linked/notify state."""
+        pool = get_db_pool()
+        if not pool.is_initialized:
+            raise DatabaseUnavailableError("mark SMS contact processing complete")
+
+        try:
+            now = datetime.now(timezone.utc)
+            if owner_token is not None:
+                await pool.execute(
+                    """
+                    UPDATE sms_messages
+                    SET status = 'ready',
+                        processed_at = $2,
+                        error_message = NULL
+                    WHERE id = $1
+                      AND status = 'processing'
+                      AND error_message = $3
+                    """,
+                    sms_id,
+                    now,
+                    owner_token,
+                )
+            else:
+                await pool.execute(
+                    """
+                    UPDATE sms_messages
+                    SET status = 'ready',
+                        processed_at = $2,
+                        error_message = NULL
+                    WHERE id = $1
+                      AND status = 'processing'
+                    """,
+                    sms_id,
+                    now,
+                )
+        except DatabaseUnavailableError:
+            raise
+        except Exception as e:
+            raise DatabaseOperationError("mark SMS contact processing complete", e)
+
     async def mark_notified(self, sms_id: UUID) -> None:
         """Mark message as notified."""
         pool = get_db_pool()
@@ -189,6 +457,105 @@ class SMSMessageRepository:
             raise
         except Exception as e:
             raise DatabaseOperationError("mark SMS notified", e)
+
+    async def has_auto_reply_for_inbound(self, inbound_sms_id: UUID) -> bool:
+        """Return True when an auto-reply send decision already exists."""
+        pool = get_db_pool()
+        if not pool.is_initialized:
+            raise DatabaseUnavailableError("check SMS auto-reply outbox")
+
+        try:
+            row = await pool.fetchrow(
+                """
+                SELECT id
+                FROM sms_messages
+                WHERE direction = 'outbound'
+                  AND source = 'auto_reply'
+                  AND source_ref = $1
+                LIMIT 1
+                """,
+                str(inbound_sms_id),
+            )
+            return row is not None
+        except DatabaseUnavailableError:
+            raise
+        except Exception as e:
+            raise DatabaseOperationError("check SMS auto-reply outbox", e)
+
+    async def reserve_auto_reply_for_inbound(
+        self,
+        *,
+        inbound_sms_id: UUID,
+        from_number: str,
+        to_number: str,
+        body: str,
+        business_context_id: Optional[str],
+    ) -> Optional[dict]:
+        """Persist an outbound auto-reply send decision before provider contact."""
+        pool = get_db_pool()
+        if not pool.is_initialized:
+            raise DatabaseUnavailableError("reserve SMS auto-reply")
+
+        sms_id = uuid4()
+        now = datetime.now(timezone.utc)
+        message_sid = f"auto_reply_{inbound_sms_id}"
+        try:
+            row = await pool.fetchrow(
+                """
+                INSERT INTO sms_messages (
+                    id, message_sid, from_number, to_number, direction,
+                    body, media_urls, business_context_id, status,
+                    source, source_ref, created_at
+                )
+                VALUES ($1, $2, $3, $4, 'outbound', $5, '[]'::jsonb, $6, 'pending', 'auto_reply', $7, $8)
+                ON CONFLICT (message_sid) DO NOTHING
+                RETURNING *
+                """,
+                sms_id,
+                message_sid,
+                from_number,
+                to_number,
+                body,
+                business_context_id,
+                str(inbound_sms_id),
+                now,
+            )
+            return self._row_to_dict(row) if row else None
+        except DatabaseUnavailableError:
+            raise
+        except Exception as e:
+            raise DatabaseOperationError("reserve SMS auto-reply", e)
+
+    async def mark_auto_reply_sent(
+        self,
+        auto_reply_sms_id: UUID,
+        *,
+        provider_message_id: Optional[str] = None,
+    ) -> None:
+        """Mark a reserved auto-reply as sent after provider acceptance."""
+        pool = get_db_pool()
+        if not pool.is_initialized:
+            raise DatabaseUnavailableError("mark SMS auto-reply sent")
+
+        try:
+            await pool.execute(
+                """
+                UPDATE sms_messages
+                SET status = 'sent',
+                    error_message = $2,
+                    processed_at = $3
+                WHERE id = $1
+                  AND direction = 'outbound'
+                  AND source = 'auto_reply'
+                """,
+                auto_reply_sms_id,
+                provider_message_id,
+                datetime.now(timezone.utc),
+            )
+        except DatabaseUnavailableError:
+            raise
+        except Exception as e:
+            raise DatabaseOperationError("mark SMS auto-reply sent", e)
 
     async def get_by_message_sid(self, message_sid: str) -> Optional[dict]:
         """Get a message by provider message SID."""

--- a/atlas_brain/storage/repositories/sms_message.py
+++ b/atlas_brain/storage/repositories/sms_message.py
@@ -239,20 +239,24 @@ class SMSMessageRepository:
         if not pool.is_initialized:
             raise DatabaseUnavailableError("claim SMS contact processing")
 
-        now = datetime.now(timezone.utc)
-        lease_cutoff = now - timedelta(seconds=SMS_CONTACT_PROCESSING_LEASE_SECONDS)
         try:
             row = await pool.fetchrow(
                 """
                 WITH attempted AS (
                     UPDATE sms_messages
                     SET status = 'processing',
-                        processed_at = $2,
-                        error_message = $4
+                        processed_at = CURRENT_TIMESTAMP,
+                        error_message = $3
                     WHERE id = $1
                       AND (
                         status IN ('received', 'retry_pending')
-                        OR (status = 'processing' AND (processed_at IS NULL OR processed_at < $3))
+                        OR (
+                            status = 'processing'
+                            AND (
+                                processed_at IS NULL
+                                OR processed_at < CURRENT_TIMESTAMP - ($2 * INTERVAL '1 second')
+                            )
+                        )
                       )
                     RETURNING sms_messages.*, TRUE AS claim_acquired
                 ),
@@ -268,8 +272,7 @@ class SMSMessageRepository:
                 LIMIT 1
                 """,
                 sms_id,
-                now,
-                lease_cutoff,
+                SMS_CONTACT_PROCESSING_LEASE_SECONDS,
                 owner_token,
             )
             if row is None:
@@ -330,7 +333,7 @@ class SMSMessageRepository:
             row = await pool.fetchrow(
                 """
                 UPDATE sms_messages
-                SET processed_at = $3
+                SET processed_at = CURRENT_TIMESTAMP
                 WHERE id = $1
                   AND status = 'processing'
                   AND error_message = $2
@@ -338,7 +341,6 @@ class SMSMessageRepository:
                 """,
                 sms_id,
                 owner_token,
-                datetime.now(timezone.utc),
             )
             return row is not None
         except DatabaseUnavailableError:
@@ -359,21 +361,19 @@ class SMSMessageRepository:
             raise DatabaseUnavailableError("mark SMS contact processing retry pending")
 
         try:
-            now = datetime.now(timezone.utc)
             if owner_token is not None:
                 await pool.execute(
                     """
                     UPDATE sms_messages
                     SET status = 'retry_pending',
                         error_message = $2,
-                        processed_at = $3
+                        processed_at = CURRENT_TIMESTAMP
                     WHERE id = $1
                       AND status = 'processing'
-                      AND error_message = $4
+                      AND error_message = $3
                     """,
                     sms_id,
                     error_message,
-                    now,
                     owner_token,
                 )
             else:
@@ -382,14 +382,13 @@ class SMSMessageRepository:
                     UPDATE sms_messages
                     SET status = 'retry_pending',
                         error_message = $2,
-                        processed_at = $3
+                        processed_at = CURRENT_TIMESTAMP
                     WHERE id = $1
                       AND contact_id IS NULL
                       AND status IN ('received', 'retry_pending')
                     """,
                     sms_id,
                     error_message,
-                    now,
                 )
         except DatabaseUnavailableError:
             raise
@@ -411,21 +410,19 @@ class SMSMessageRepository:
             raise DatabaseUnavailableError("mark SMS contact processing complete")
 
         try:
-            now = datetime.now(timezone.utc)
             if owner_token is not None:
                 row = await pool.fetchrow(
                     """
                     UPDATE sms_messages
                     SET status = 'ready',
-                        processed_at = $2,
+                        processed_at = CURRENT_TIMESTAMP,
                         error_message = NULL
                     WHERE id = $1
                       AND status = 'processing'
-                      AND error_message = $3
+                      AND error_message = $2
                     RETURNING id
                     """,
                     sms_id,
-                    now,
                     owner_token,
                 )
             else:
@@ -433,14 +430,13 @@ class SMSMessageRepository:
                     """
                     UPDATE sms_messages
                     SET status = 'ready',
-                        processed_at = $2,
+                        processed_at = CURRENT_TIMESTAMP,
                         error_message = NULL
                     WHERE id = $1
                       AND status = 'processing'
                     RETURNING id
                     """,
                     sms_id,
-                    now,
                 )
             return row is not None
         except DatabaseUnavailableError:
@@ -555,22 +551,49 @@ class SMSMessageRepository:
                 """
                 UPDATE sms_messages
                 SET status = 'sent',
-                    error_message = $2,
-                    processed_at = $3
+                    message_sid = COALESCE(NULLIF($2, ''), message_sid),
+                    error_message = NULL,
+                    processed_at = CURRENT_TIMESTAMP
                 WHERE id = $1
                   AND direction = 'outbound'
                   AND source = 'auto_reply'
-                RETURNING id
+                  AND status IN ('sending', 'sent')
+                RETURNING *
                 """,
                 auto_reply_sms_id,
                 provider_message_id,
-                datetime.now(timezone.utc),
             )
             return row is not None
         except DatabaseUnavailableError:
             raise
         except Exception as e:
             raise DatabaseOperationError("mark SMS auto-reply sent", e)
+
+    async def mark_auto_reply_sending(self, auto_reply_sms_id: UUID) -> bool:
+        """Mark a pending auto-reply as provider-send attempted before contact."""
+        pool = get_db_pool()
+        if not pool.is_initialized:
+            raise DatabaseUnavailableError("mark SMS auto-reply sending")
+
+        try:
+            row = await pool.fetchrow(
+                """
+                UPDATE sms_messages
+                SET status = 'sending',
+                    processed_at = CURRENT_TIMESTAMP
+                WHERE id = $1
+                  AND direction = 'outbound'
+                  AND source = 'auto_reply'
+                  AND status = 'pending'
+                RETURNING id
+                """,
+                auto_reply_sms_id,
+            )
+            return row is not None
+        except DatabaseUnavailableError:
+            raise
+        except Exception as e:
+            raise DatabaseOperationError("mark SMS auto-reply sending", e)
 
     async def get_by_message_sid(self, message_sid: str) -> Optional[dict]:
         """Get a message by provider message SID."""

--- a/plans/PR-EOM-SMS-Retry-Resume.md
+++ b/plans/PR-EOM-SMS-Retry-Resume.md
@@ -12,7 +12,7 @@ The remaining live gap is inbound SMS retry ownership: an SMS row can be
 persisted while CRM/contact processing is incomplete, and a duplicate provider
 delivery must neither skip that work nor duplicate side effects.
 
-This is approximately 2767 LOC by the repo diff-size audit because the review repair has to
+This is approximately 3371 LOC by the repo diff-size audit because the review repair has to
 state and test the full SMS retry ownership model in one pass: claim
 eligibility, completed-unlinked rows, owner-token-fenced processing, persisted
 context rehydration, before-ack 503 retry surfacing, active-lease retry
@@ -22,10 +22,12 @@ they remain resumable until processing reaches a terminal state, but resume with
 the existing contact id so the CRM link/interaction side effect is not repeated.
 The current review round also folds in route-entry ack budgeting, authoritative
 claim row state, narrow inbound auto-reply outbox recovery, durable finalization,
-and real-Postgres proof for retry-pending/status fencing.
-It also includes one test-only unit-gate stabilization after CI proved an
-unrelated content-factory linearity guard was asserting runner speed instead of
-scaling behavior.
+and real-Postgres proof for retry-pending/status fencing. The latest review
+round states the whole ownership path explicitly: lease timestamps use the
+database clock, opt-out/spam terminal handling finalizes in one layer only,
+auto-replies move through `pending` -> `sending` -> `sent` with persisted
+payloads and provider SIDs, and the before-ack budget covers every admitted
+sequential LLM/notification/CRM/auto-reply stage.
 
 ### Problem-derived contract
 
@@ -51,16 +53,14 @@ scaling behavior.
   suppress later SMS handling.
 - Must not change: EOM lead lifecycle rules, CRM provider ownership rules,
   estimate booking, customer/site onboarding, payments, customer-visible
-  auto-reply copy, or the already-enrolled migration-352 workflow filters. The
-  unrelated content-factory test-only stabilization must not change product
-  verification semantics.
+  auto-reply copy, or the already-enrolled migration-352 workflow filters.
 
 ## Scope (this PR)
 
 Ownership lane: eom-crm/sms-ingress-retry
 Slice phase: production hardening
-Max files: 7
-Actual files: 7
+Max files: 6
+Actual files: 6
 
 1. Resume linked-but-incomplete duplicate SMS rows while preserving their
    existing contact link.
@@ -76,8 +76,9 @@ Actual files: 7
 6. Continue SMS action planning/notification/auto-reply after a contact is
    linked even if non-EOM interaction logging fails.
 7. Persist inbound auto-reply decisions before provider send, distinguish
-   pending from provider-accepted sends, retry pending sends, and skip only
-   already-sent replies.
+   pending from provider-attempted/provider-accepted sends, send pending rows
+   from the persisted body, store provider SIDs for delivery callbacks, and
+   skip duplicate sends for `sending`/`sent` replies.
 8. Enroll the live Postgres claim proof in the EOM workflow that already owns a
    Postgres service.
 9. Add focused tests for owner-token claim fencing, before-ack 503 behavior,
@@ -86,8 +87,6 @@ Actual files: 7
    timeout, slow-but-admitted processing, auto-reply idempotency/recovery,
    finalization failure retry, notification dedupe, and real-Postgres retry
    fencing.
-10. Stabilize the unrelated content-factory linearity guard by checking scaling
-   behavior rather than absolute wall-clock runner speed.
 
 ### Review Contract
 
@@ -126,21 +125,25 @@ Acceptance criteria:
 - Claimed processing receives authoritative row/contact state from the claim
   operation, not a second racing reload.
 - Auto-reply sends are recoverable for a given inbound SMS row: a retry that
-  sees a pending reservation retries the provider send, a retry that sees a sent
-  reservation skips duplicate provider contact, and provider/mark-sent failures
-  do not complete the inbound lease.
+  sees a pending reservation sends the persisted body, a retry that sees a
+  sending or sent reservation skips duplicate provider contact, provider
+  acceptance stores the provider SID for delivery callbacks, and provider/mark-
+  sent failures do not complete the inbound lease.
 - A retry whose inbound row already has `notified = TRUE` does not re-post the
   manager notification.
-- The before-ack budget is not shorter than the configured SMS LLM/auto-reply
-  latency this path admits.
+- Lease claim, heartbeat, retry-pending, and finalization timestamps use the
+  PostgreSQL clock instead of worker-local clocks.
+- `stop`/`spam` intelligence returns a terminal outcome without clearing an
+  active processing owner; the webhook performs the owner-fenced terminal write
+  exactly once.
+- The before-ack budget is not shorter than the configured SMS LLM, call-action
+  LLM, notification, hard-coded auto-reply, and CRM/provider latency this path
+  admits.
 - Final processing completion failures or owner-mismatch no-ops propagate a
   retry/lost-ownership outcome instead of acknowledging success.
 - The EOM workflow sets `ATLAS_EOM_SMS_RETRY_POSTGRES_URL` and includes
   `tests/test_eom_sms_webhook_retry.py`, so the live claim proof runs against
   the workflow Postgres service instead of skipping.
-- The unrelated content-factory linearity guard still fails on quadratic
-  behavior but no longer depends on a fixed 1-second CI runner budget.
-
 Affected surfaces: inbound SMS webhook duplicate handling, SMS intelligence CRM
 link handling, SMS message repository claim helpers, and focused tests.
 
@@ -185,15 +188,14 @@ and retry-fencing proof.
 - `atlas_brain/storage/repositories/sms_message.py`
 - `.github/workflows/atlas_eom_lead_pipeline_checks.yml`
 - `plans/PR-EOM-SMS-Retry-Resume.md`
-- `tests/test_content_factory_copy_verification.py`
 - `tests/test_eom_sms_webhook_retry.py`
 
 ## Mechanism
 
 - `SMSMessageRepository.claim_contact_processing` atomically marks a resumable
-  SMS row `processing`, stores an opaque owner token in `error_message`, returns
-  authoritative row state plus `_claim_acquired`, and allows stale `processing`
-  reclaim only by replacing that owner token.
+  SMS row `processing` with PostgreSQL's clock, stores an opaque owner token in
+  `error_message`, returns authoritative row state plus `_claim_acquired`, and
+  allows stale `processing` reclaim only by replacing that owner token.
 - `SMSMessageRepository.owns_contact_processing`,
   `touch_contact_processing_owner`, `update_contact_processing_status`,
   `mark_contact_processing_retry_pending`, and
@@ -201,16 +203,20 @@ and retry-fencing proof.
   and terminal updates by owner token.
 - `SMSMessageRepository.reserve_auto_reply_for_inbound` persists a deterministic
   outbound auto-reply reservation before provider contact,
-  `get_auto_reply_for_inbound` returns its pending/sent state, and
-  `mark_auto_reply_sent` records provider acceptance afterwards.
+  `get_auto_reply_for_inbound` returns its `pending`/`sending`/`sent` state,
+  `mark_auto_reply_sending` records the provider-attempt boundary before
+  contact, and `mark_auto_reply_sent` records provider acceptance afterwards
+  while moving the real provider SID into `message_sid` for delivery callbacks.
 - `_process_inbound_sms` claims before CRM/intelligence work, uses the claimed
   row to preserve an existing contact link, heartbeats/checks the owner token
   before side-effect boundaries, returns `retry_pending` to before-ack callers
   on claim/CRM failures, distinguishes skipped intelligence from terminal
   opt-out/spam, keeps the owner token alive across processing status/notification
-  writes, skips already-sent notifications on retry, retries pending auto-reply
-  sends, skips sent auto-replies, and only returns success after the terminal
-  row transition is durably written by the active owner.
+  writes, skips already-sent notifications on retry, sends persisted pending
+  auto-reply bodies, treats `sending` auto-replies as ambiguous provider
+  attempts that must not be duplicated, skips sent auto-replies, and only
+  returns success after the terminal row transition is durably written by the
+  active owner.
 - `handle_inbound_sms` persists the row before awaiting `_process_inbound_sms`;
   it starts the ack deadline at route entry and returns 503 for before-ack retry
   outcomes, active incomplete leases, and ack-budget timeouts so
@@ -231,8 +237,6 @@ and retry-fencing proof.
 - `.github/workflows/atlas_eom_lead_pipeline_checks.yml` runs
   `tests/test_eom_sms_webhook_retry.py` with the workflow Postgres database URL
   exported as `ATLAS_EOM_SMS_RETRY_POSTGRES_URL`.
-- The content-factory unit-gate guard uses a generous large-input CPU-time
-  ceiling instead of asserting a fixed wall-clock ceiling.
 
 ## Intentional
 
@@ -249,14 +253,15 @@ and retry-fencing proof.
   worker queue.
 - The workflow edit is limited to this SMS retry test enrollment. The migration
   352 path filters remain unchanged because they were already enrolled.
-- The content-factory test stabilization is test-only and does not change
-  content-factory product verification semantics.
 
 ## Deferred
 
 - A broader exactly-once SMS processing state machine with a dedicated owner
-  column and durable worker queue is deferred until inbound SMS volume or
-  duplicate side effects justify it.
+  column, provider idempotency keys, and a durable worker/reconciliation queue is
+  deferred until inbound SMS volume or duplicate side effects justify it. This
+  slice deliberately treats `sending` as provider-acceptance ambiguous and
+  favors no duplicate customer SMS over resending after an unprovable crash
+  boundary.
 - Reminder dedupe and a broader outbound-message worker are deferred;
   linked-but-incomplete retries resume through the existing contact id, and this
   slice only reserves the direct inbound auto-reply tied to the retried SMS row.
@@ -272,9 +277,9 @@ reminder/outbound orchestration only.
 
 - `python scripts/audit_plan_doc.py plans/PR-EOM-SMS-Retry-Resume.md` — PASS; required plan sections present.
 - `python -m py_compile atlas_brain/api/comms/webhooks.py atlas_brain/comms/sms_intelligence.py atlas_brain/storage/repositories/sms_message.py tests/test_eom_sms_webhook_retry.py` — PASS.
-- `pytest -q tests/test_eom_sms_webhook_retry.py` — 35 passed, 1 skipped, 1 warning locally; the skipped live Postgres proof is CI-enrolled through `ATLAS_EOM_SMS_RETRY_POSTGRES_URL`.
-- `python -m pytest -q tests/test_eom_lead_ingress.py::test_real_sms_link_uses_eom_lead_resolver tests/test_eom_lead_ingress.py::test_sms_link_uses_provider_identity_without_a_local_sms_row tests/test_eom_lead_ingress.py::test_sms_fallback_uses_eom_lead_resolver tests/test_content_factory_copy_verification.py::test_scope_lookup_scales_with_negation_scopes_present` — 4 passed.
-- `python -m pytest -q tests/test_content_factory_copy_verification.py` — 324 passed.
+- `pytest -q tests/test_eom_sms_webhook_retry.py` — 38 passed, 1 skipped, 1 warning locally; the skipped live Postgres proof is CI-enrolled through `ATLAS_EOM_SMS_RETRY_POSTGRES_URL`.
+- `python -m pytest -q tests/test_eom_sms_webhook_retry.py tests/test_eom_lead_ingress.py::test_real_sms_link_uses_eom_lead_resolver tests/test_eom_lead_ingress.py::test_sms_link_uses_provider_identity_without_a_local_sms_row tests/test_eom_lead_ingress.py::test_sms_fallback_uses_eom_lead_resolver` — 41 passed, 1 skipped, 1 warning.
+- `python -m pytest -q tests/test_eom_lead_ingress.py::test_real_sms_link_uses_eom_lead_resolver tests/test_eom_lead_ingress.py::test_sms_link_uses_provider_identity_without_a_local_sms_row tests/test_eom_lead_ingress.py::test_sms_fallback_uses_eom_lead_resolver` — 3 passed.
 - `python scripts/audit_plan_doc_files_touched.py plans/PR-EOM-SMS-Retry-Resume.md origin/main` — PASS; plan files match git diff.
 - `python scripts/audit_plan_doc_diff_size.py plans/PR-EOM-SMS-Retry-Resume.md origin/main` — PASS; diff-size drift remains inside the plan threshold.
 - `python scripts/audit_plan_code_consistency.py --base-ref origin/main plans/PR-EOM-SMS-Retry-Resume.md` — PASS; all path claims resolve.
@@ -289,10 +294,9 @@ reminder/outbound orchestration only.
 | File | LOC |
 |---|---:|
 | `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 6 |
-| `atlas_brain/api/comms/webhooks.py` | 539 |
-| `atlas_brain/comms/sms_intelligence.py` | 131 |
-| `atlas_brain/storage/repositories/sms_message.py` | 369 |
-| `plans/PR-EOM-SMS-Retry-Resume.md` | 283 |
-| `tests/test_content_factory_copy_verification.py` | 18 |
-| `tests/test_eom_sms_webhook_retry.py` | 1421 |
-| **Total** | **2767** |
+| `atlas_brain/api/comms/webhooks.py` | 654 |
+| `atlas_brain/comms/sms_intelligence.py` | 156 |
+| `atlas_brain/storage/repositories/sms_message.py` | 407 |
+| `plans/PR-EOM-SMS-Retry-Resume.md` | 318 |
+| `tests/test_eom_sms_webhook_retry.py` | 1830 |
+| **Total** | **3371** |

--- a/plans/PR-EOM-SMS-Retry-Resume.md
+++ b/plans/PR-EOM-SMS-Retry-Resume.md
@@ -1,0 +1,283 @@
+# PR-EOM-SMS-Retry-Resume
+
+## Why this slice exists
+
+Issue #2230 records two parked hardening items from the EOM funnel ingress
+work. Current code already contradicts the workflow-filter half: both the
+`pull_request` and `push` path filters in
+`.github/workflows/atlas_eom_lead_pipeline_checks.yml` include
+`atlas_brain/storage/migrations/352_eom_inbound_delivery_receipts.sql`.
+
+The remaining live gap is inbound SMS retry ownership: an SMS row can be
+persisted while CRM/contact processing is incomplete, and a duplicate provider
+delivery must neither skip that work nor duplicate side effects.
+
+This is 2767 LOC by the repo diff-size audit because the review repair has to
+state and test the full SMS retry ownership model in one pass: claim
+eligibility, completed-unlinked rows, owner-token-fenced processing, persisted
+context rehydration, before-ack 503 retry surfacing, active-lease retry
+surfacing, stale-worker recovery, CI-enrolled live Postgres evidence, and
+post-link continuation. Review repair also covers linked-but-incomplete rows:
+they remain resumable until processing reaches a terminal state, but resume with
+the existing contact id so the CRM link/interaction side effect is not repeated.
+The current review round also folds in route-entry ack budgeting, authoritative
+claim row state, narrow inbound auto-reply outbox reservation, and real-Postgres
+proof for retry-pending/status fencing.
+It also includes one test-only unit-gate stabilization after CI proved an
+unrelated content-factory linearity guard was asserting runner speed instead of
+scaling behavior.
+
+### Problem-derived contract
+
+- Root cause: `handle_inbound_sms` treated SMS persistence and CRM/contact
+  processing as separable background work while duplicate detection treated an
+  existing `MessageSid` as enough evidence that the work was complete. That can
+  lose CRM work. The previous lease repair then stored ownership in
+  `error_message` but let normal status writes clear it and acknowledged
+  provider retries while an incomplete row was still leased.
+- Correct fix must touch/change: SMS processing must atomically claim
+  incomplete rows before CRM/intelligence work and receive authoritative row
+  state from that claim, fence terminal updates and outbound sends with an owner
+  token, reserve an inbound auto-reply send decision before provider contact,
+  process first deliveries and resumable duplicates before provider
+  acknowledgement, and return 503 for claim/CRM handoff failures or active
+  incomplete leases so provider retry is the durable retry mechanism for this
+  slice. Provider-facing work must have a bounded ack budget that begins at
+  route entry. Retries must use persisted row values and persisted business
+  context; stale stored context IDs must fail closed. CRM infrastructure
+  failures must be distinguishable from legitimate insufficient identity, and
+  post-link interaction logging failures must not undo the contact link or
+  suppress later SMS handling.
+- Must not change: EOM lead lifecycle rules, CRM provider ownership rules,
+  estimate booking, customer/site onboarding, payments, customer-visible
+  auto-reply copy, or the already-enrolled migration-352 workflow filters. The
+  unrelated content-factory test-only stabilization must not change product
+  verification semantics.
+
+## Scope (this PR)
+
+Ownership lane: eom-crm/sms-ingress-retry
+Slice phase: production hardening
+Max files: 7
+Actual files: 7
+
+1. Resume linked-but-incomplete duplicate SMS rows while preserving their
+   existing contact link.
+2. Add owner-token fencing to SMS contact-processing claims and terminal
+   updates using existing SMS row fields.
+3. Resume only explicitly incomplete/recoverable rows: `received`,
+   `processing`, or `retry_pending`.
+4. Run first-delivery and duplicate-resume processing under a bounded
+   provider-ack deadline so claim/CRM failures, active incomplete leases, and
+   slow processing can return 503.
+5. Preserve persisted body/media/from/to/context values during retry
+   rehydration and fail closed for stored-but-unresolvable context IDs.
+6. Continue SMS action planning/notification/auto-reply after a contact is
+   linked even if non-EOM interaction logging fails.
+7. Reserve inbound auto-reply decisions before provider send so provider retry
+   cannot duplicate the auto-reply after a crash/cancellation.
+8. Enroll the live Postgres claim proof in the EOM workflow that already owns a
+   Postgres service.
+9. Add focused tests for owner-token claim fencing, before-ack 503 behavior,
+   active-lease 503 behavior, persisted context handling, completed-unlinked
+   skip, CRM infra retry propagation, post-link continuation, route-entry ack
+   timeout, auto-reply idempotency, and real-Postgres retry fencing.
+10. Stabilize the unrelated content-factory linearity guard by checking scaling
+   behavior rather than absolute wall-clock runner speed.
+
+### Review Contract
+
+Acceptance criteria:
+
+- A duplicate inbound SMS with `contact_id` set and incomplete/recoverable
+  status keeps running processing before acknowledgement, but passes the
+  persisted contact id forward instead of creating/linking CRM again.
+- A duplicate inbound SMS whose unlinked row is already complete returns empty
+  TwiML and does not run processing again.
+- A duplicate inbound SMS with no `contact_id` and incomplete/recoverable status
+  runs `_process_inbound_sms` before acknowledgement with persisted row values
+  and `claim_processing=True`.
+- A processor whose claim is already owned exits before intelligence or
+  auto-reply side effects.
+- A provider retry that observes an incomplete row still owned by another
+  worker receives 503 rather than consuming the retry with 200.
+- Stale processing rows can be reclaimed only by replacing the owner token; old
+  owners cannot complete or send after losing ownership, and normal status or
+  notification writes do not clear the active owner token before completion.
+- New inbound SMS rows persist before contact processing; claim/CRM handoff
+  failures and provider-ack timeouts return 503 before acknowledgement.
+- The provider-ack timeout covers media parsing, provider callback, duplicate
+  lookup, persistence, recovery lookup, duplicate resume, and processing.
+- Persisted empty body/media values are preserved during retry rehydration.
+- Persisted `business_context_id` is restored before phone-number routing is
+  used as a legacy fallback.
+- A stored but unresolvable `business_context_id` returns 503 and never falls
+  through to phone-number routing.
+- CRM handoff failures return 503 before acknowledgement instead of becoming
+  terminal completed-unlinked rows or unconsumed retry-pending rows.
+- CRM database/provider infrastructure failures propagate as retryable while
+  legitimately identityless SMS content can still finish without a contact.
+- Post-link interaction logging failures do not undo the contact link or stop
+  action planning, notification, and auto-reply processing.
+- Claimed processing receives authoritative row/contact state from the claim
+  operation, not a second racing reload.
+- Auto-reply sends are crash-idempotent for a given inbound SMS row: a retry
+  that sees an existing auto-reply reservation does not contact the provider
+  again, but still completes the inbound lease.
+- The EOM workflow sets `ATLAS_EOM_SMS_RETRY_POSTGRES_URL` and includes
+  `tests/test_eom_sms_webhook_retry.py`, so the live claim proof runs against
+  the workflow Postgres service instead of skipping.
+- The unrelated content-factory linearity guard still fails on quadratic
+  behavior but no longer depends on a fixed 1-second CI runner budget.
+
+Affected surfaces: inbound SMS webhook duplicate handling, SMS intelligence CRM
+link handling, SMS message repository claim helpers, and focused tests.
+
+Risk areas: duplicate auto-replies, duplicate CRM interactions, stale-worker
+completion overwrites, and retry payload drift replacing persisted SMS data.
+
+Triggered reviewer rules: R1/R2/R5/R6/R7/R8/R12 code-grounded issue-claim
+verification, webhook retry behavior, crash/race-safe processing, and focused
+test coverage.
+
+Execution model and invariant mapping: one SMS row is the lease record. A worker
+may start CRM/contact processing only by atomically changing an unlinked
+`received`, `retry_pending`, or stale `processing` row to `processing` with a
+fresh owner token. Non-terminal status/notification writes keep that token.
+Every terminal transition or outbound-send boundary checks the token; a stale
+owner whose token has been replaced cannot complete or send. If another
+delivery arrives while a non-stale owner holds the incomplete row, the handler
+returns 503 so the provider retry remains alive rather than being consumed.
+Slow provider-facing work is capped from route entry by
+`SMS_INBOUND_BEFORE_ACK_TIMEOUT_SECONDS`; timeout is retryable and the row stays
+reclaimable by lease expiry. CRM contact and interaction writes are keyed by the
+provider message identity (`source_ref` / `crm_event_id`) so retries use the
+same idempotency evidence rather than mutable retry payloads. Auto-replies use a
+deterministic outbound reservation keyed to the inbound SMS row before provider
+contact, so a later retry cannot send a duplicate reply after crash or
+cancellation.
+
+Reachability proof: focused unit tests call the duplicate-retry resume helper,
+the `/sms/inbound` handler, `SMSMessageRepository.claim_contact_processing`, and
+`_process_inbound_sms` with injected external-edge fakes, asserting claim,
+before-ack processing/503, active-lease 503, timeout 503, skip, persisted
+value/context, owner-token preservation/fencing, completion, post-link
+continuation, linked-row resume with an existing contact id, CRM infra retry
+propagation, route-entry timeout behavior, auto-reply reservation idempotency,
+and retry-pending behavior. The EOM workflow enrolls the live Postgres claim
+and retry-fencing proof.
+
+### Files touched
+
+- `atlas_brain/api/comms/webhooks.py`
+- `atlas_brain/comms/sms_intelligence.py`
+- `atlas_brain/storage/repositories/sms_message.py`
+- `.github/workflows/atlas_eom_lead_pipeline_checks.yml`
+- `plans/PR-EOM-SMS-Retry-Resume.md`
+- `tests/test_content_factory_copy_verification.py`
+- `tests/test_eom_sms_webhook_retry.py`
+
+## Mechanism
+
+- `SMSMessageRepository.claim_contact_processing` atomically marks a resumable
+  SMS row `processing`, stores an opaque owner token in `error_message`, returns
+  authoritative row state plus `_claim_acquired`, and allows stale `processing`
+  reclaim only by replacing that owner token.
+- `SMSMessageRepository.owns_contact_processing`,
+  `touch_contact_processing_owner`, `update_contact_processing_status`,
+  `mark_contact_processing_retry_pending`, and
+  `mark_contact_processing_complete` fence heartbeat, non-terminal progress,
+  and terminal updates by owner token.
+- `SMSMessageRepository.reserve_auto_reply_for_inbound` persists a deterministic
+  outbound auto-reply reservation before provider contact, and
+  `mark_auto_reply_sent` records provider acceptance afterwards.
+- `_process_inbound_sms` claims before CRM/intelligence work, uses the claimed
+  row to preserve an existing contact link, heartbeats/checks the owner token
+  before side-effect boundaries, returns `retry_pending` to before-ack callers
+  on claim/CRM failures, distinguishes skipped intelligence from terminal
+  opt-out/spam, keeps the owner token alive across processing status/notification
+  writes, and only completes a row when its owner token still matches.
+- `handle_inbound_sms` persists the row before awaiting `_process_inbound_sms`;
+  it starts the ack deadline at route entry and returns 503 for before-ack retry
+  outcomes, active incomplete leases, and ack-budget timeouts so
+  SignalWire/provider retry remains the durable retry mechanism for this slice.
+- The duplicate retry branch awaits `_process_inbound_sms` only when the row is
+  still incomplete or recoverable, including linked rows that have not reached a
+  terminal status; completed rows return empty TwiML without more work.
+- Retry rehydration falls back only for missing/`None` persisted values, so an
+  intentionally empty body or media list is not replaced by retry payload drift.
+- Retry context rehydration uses persisted `business_context_id` first, fails
+  closed when that stored ID no longer resolves, and uses phone-number routing
+  only for legacy rows without a stored context.
+- `sms_intelligence.process_inbound_sms` accepts an existing contact id for
+  resumed linked rows, returns an explicit retry outcome for pre-link CRM
+  infrastructure failures, returns a separate skipped-intelligence outcome for
+  disabled/empty-body cases, and logs post-link interaction logging failures
+  while the SMS flow continues.
+- `.github/workflows/atlas_eom_lead_pipeline_checks.yml` runs
+  `tests/test_eom_sms_webhook_retry.py` with the workflow Postgres database URL
+  exported as `ATLAS_EOM_SMS_RETRY_POSTGRES_URL`.
+- The content-factory unit-gate guard uses a generous large-input CPU-time
+  ceiling instead of asserting a fixed wall-clock ceiling.
+
+## Intentional
+
+- The fix uses existing `status`, `processed_at`, and `error_message` fields
+  instead of adding schema. `received`/`retry_pending` are immediately
+  resumable, stale `processing` is recoverable with owner-token fencing, and
+  `ready`/`notified` are complete even when no contact is linked.
+- Normal successful duplicate retry responses remain empty TwiML; claim/CRM
+  handoff failures, active incomplete leases, and provider-ack timeouts return
+  503 before acknowledgement so the provider has a reason to retry.
+- The inbound auto-reply reservation is intentionally narrow: it prevents
+  duplicate provider sends for the same inbound SMS row without changing
+  customer-visible auto-reply copy or introducing a broader worker queue.
+- The workflow edit is limited to this SMS retry test enrollment. The migration
+  352 path filters remain unchanged because they were already enrolled.
+- The content-factory test stabilization is test-only and does not change
+  content-factory product verification semantics.
+
+## Deferred
+
+- A broader exactly-once SMS processing state machine with a dedicated owner
+  column and durable worker queue is deferred until inbound SMS volume or
+  duplicate side effects justify it.
+- Reminder dedupe and a broader outbound-message worker are deferred;
+  linked-but-incomplete retries resume through the existing contact id, and this
+  slice only reserves the direct inbound auto-reply tied to the retried SMS row.
+
+Parking predicate: this slice parks only hardening that would require a new
+durable queue/schema-backed worker system or reminder/outbound orchestration
+outside the direct inbound SMS retry ownership path.
+
+Parked hardening under that predicate: broader durable-queue orchestration and
+reminder/outbound orchestration only.
+
+## Verification
+
+- `python scripts/audit_plan_doc.py plans/PR-EOM-SMS-Retry-Resume.md` — PASS; required plan sections present.
+- `python -m py_compile atlas_brain/api/comms/webhooks.py atlas_brain/comms/sms_intelligence.py atlas_brain/storage/repositories/sms_message.py tests/test_eom_sms_webhook_retry.py` — PASS.
+- `pytest -q tests/test_eom_sms_webhook_retry.py` — 30 passed, 1 skipped, 1 warning locally; the skipped live Postgres proof is CI-enrolled through `ATLAS_EOM_SMS_RETRY_POSTGRES_URL`.
+- `python -m pytest -q tests/test_eom_lead_ingress.py::test_real_sms_link_uses_eom_lead_resolver tests/test_eom_lead_ingress.py::test_sms_link_uses_provider_identity_without_a_local_sms_row tests/test_eom_lead_ingress.py::test_sms_fallback_uses_eom_lead_resolver tests/test_content_factory_copy_verification.py::test_scope_lookup_scales_with_negation_scopes_present` — 4 passed.
+- `python -m pytest -q tests/test_content_factory_copy_verification.py` — 324 passed.
+- `python scripts/audit_plan_doc_files_touched.py plans/PR-EOM-SMS-Retry-Resume.md origin/main` — PASS; plan files match git diff.
+- `python scripts/audit_plan_doc_diff_size.py plans/PR-EOM-SMS-Retry-Resume.md origin/main` — PASS; estimated and actual diff size are 2767 LOC.
+- `python scripts/audit_plan_code_consistency.py --base-ref origin/main plans/PR-EOM-SMS-Retry-Resume.md` — PASS; all path claims resolve.
+- `python scripts/audit_review_rules_triggered.py origin/main --plan plans/PR-EOM-SMS-Retry-Resume.md` — PASS; plan declares every rule the diff triggers.
+- `python scripts/audit_pr_body.py --repo-root . --base-ref origin/main /tmp/pr2246-body.md` — PASS.
+- `git diff --check origin/main -- . ':!node_modules'` — PASS.
+- `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_api.json --min-score 8 --sensitive-glob '**/billing/**' --sensitive-glob '**/billing*' --sensitive-glob '**/paid*' --sensitive-glob '**/auth/**' --sensitive-glob '**/auth*' --sensitive-glob '**/webhook*' --sensitive-glob '**/webhooks/**' --sensitive-glob '**/payment*' --sensitive-glob '**/invoicing/**' --sensitive-glob '**/*invoice*' --sensitive-glob '**/*deletion*'` — ratchet gate passed; no new brittleness above baseline.
+- `python scripts/maturity_sweep.py atlas_brain/storage --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_storage.json --min-score 8` — ratchet gate passed; no new brittleness above baseline.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 6 |
+| `atlas_brain/api/comms/webhooks.py` | 539 |
+| `atlas_brain/comms/sms_intelligence.py` | 131 |
+| `atlas_brain/storage/repositories/sms_message.py` | 369 |
+| `plans/PR-EOM-SMS-Retry-Resume.md` | 283 |
+| `tests/test_content_factory_copy_verification.py` | 18 |
+| `tests/test_eom_sms_webhook_retry.py` | 1421 |
+| **Total** | **2767** |

--- a/plans/PR-EOM-SMS-Retry-Resume.md
+++ b/plans/PR-EOM-SMS-Retry-Resume.md
@@ -12,7 +12,7 @@ The remaining live gap is inbound SMS retry ownership: an SMS row can be
 persisted while CRM/contact processing is incomplete, and a duplicate provider
 delivery must neither skip that work nor duplicate side effects.
 
-This is 2767 LOC by the repo diff-size audit because the review repair has to
+This is approximately 2767 LOC by the repo diff-size audit because the review repair has to
 state and test the full SMS retry ownership model in one pass: claim
 eligibility, completed-unlinked rows, owner-token-fenced processing, persisted
 context rehydration, before-ack 503 retry surfacing, active-lease retry
@@ -21,8 +21,8 @@ post-link continuation. Review repair also covers linked-but-incomplete rows:
 they remain resumable until processing reaches a terminal state, but resume with
 the existing contact id so the CRM link/interaction side effect is not repeated.
 The current review round also folds in route-entry ack budgeting, authoritative
-claim row state, narrow inbound auto-reply outbox reservation, and real-Postgres
-proof for retry-pending/status fencing.
+claim row state, narrow inbound auto-reply outbox recovery, durable finalization,
+and real-Postgres proof for retry-pending/status fencing.
 It also includes one test-only unit-gate stabilization after CI proved an
 unrelated content-factory linearity guard was asserting runner speed instead of
 scaling behavior.
@@ -38,8 +38,9 @@ scaling behavior.
 - Correct fix must touch/change: SMS processing must atomically claim
   incomplete rows before CRM/intelligence work and receive authoritative row
   state from that claim, fence terminal updates and outbound sends with an owner
-  token, reserve an inbound auto-reply send decision before provider contact,
-  process first deliveries and resumable duplicates before provider
+  token, persist a recoverable inbound auto-reply send decision before provider
+  contact, require durable terminal finalization, process first deliveries and
+  resumable duplicates before provider
   acknowledgement, and return 503 for claim/CRM handoff failures or active
   incomplete leases so provider retry is the durable retry mechanism for this
   slice. Provider-facing work must have a bounded ack budget that begins at
@@ -74,14 +75,17 @@ Actual files: 7
    rehydration and fail closed for stored-but-unresolvable context IDs.
 6. Continue SMS action planning/notification/auto-reply after a contact is
    linked even if non-EOM interaction logging fails.
-7. Reserve inbound auto-reply decisions before provider send so provider retry
-   cannot duplicate the auto-reply after a crash/cancellation.
+7. Persist inbound auto-reply decisions before provider send, distinguish
+   pending from provider-accepted sends, retry pending sends, and skip only
+   already-sent replies.
 8. Enroll the live Postgres claim proof in the EOM workflow that already owns a
    Postgres service.
 9. Add focused tests for owner-token claim fencing, before-ack 503 behavior,
    active-lease 503 behavior, persisted context handling, completed-unlinked
    skip, CRM infra retry propagation, post-link continuation, route-entry ack
-   timeout, auto-reply idempotency, and real-Postgres retry fencing.
+   timeout, slow-but-admitted processing, auto-reply idempotency/recovery,
+   finalization failure retry, notification dedupe, and real-Postgres retry
+   fencing.
 10. Stabilize the unrelated content-factory linearity guard by checking scaling
    behavior rather than absolute wall-clock runner speed.
 
@@ -121,9 +125,16 @@ Acceptance criteria:
   action planning, notification, and auto-reply processing.
 - Claimed processing receives authoritative row/contact state from the claim
   operation, not a second racing reload.
-- Auto-reply sends are crash-idempotent for a given inbound SMS row: a retry
-  that sees an existing auto-reply reservation does not contact the provider
-  again, but still completes the inbound lease.
+- Auto-reply sends are recoverable for a given inbound SMS row: a retry that
+  sees a pending reservation retries the provider send, a retry that sees a sent
+  reservation skips duplicate provider contact, and provider/mark-sent failures
+  do not complete the inbound lease.
+- A retry whose inbound row already has `notified = TRUE` does not re-post the
+  manager notification.
+- The before-ack budget is not shorter than the configured SMS LLM/auto-reply
+  latency this path admits.
+- Final processing completion failures or owner-mismatch no-ops propagate a
+  retry/lost-ownership outcome instead of acknowledging success.
 - The EOM workflow sets `ATLAS_EOM_SMS_RETRY_POSTGRES_URL` and includes
   `tests/test_eom_sms_webhook_retry.py`, so the live claim proof runs against
   the workflow Postgres service instead of skipping.
@@ -189,14 +200,17 @@ and retry-fencing proof.
   `mark_contact_processing_complete` fence heartbeat, non-terminal progress,
   and terminal updates by owner token.
 - `SMSMessageRepository.reserve_auto_reply_for_inbound` persists a deterministic
-  outbound auto-reply reservation before provider contact, and
+  outbound auto-reply reservation before provider contact,
+  `get_auto_reply_for_inbound` returns its pending/sent state, and
   `mark_auto_reply_sent` records provider acceptance afterwards.
 - `_process_inbound_sms` claims before CRM/intelligence work, uses the claimed
   row to preserve an existing contact link, heartbeats/checks the owner token
   before side-effect boundaries, returns `retry_pending` to before-ack callers
   on claim/CRM failures, distinguishes skipped intelligence from terminal
   opt-out/spam, keeps the owner token alive across processing status/notification
-  writes, and only completes a row when its owner token still matches.
+  writes, skips already-sent notifications on retry, retries pending auto-reply
+  sends, skips sent auto-replies, and only returns success after the terminal
+  row transition is durably written by the active owner.
 - `handle_inbound_sms` persists the row before awaiting `_process_inbound_sms`;
   it starts the ack deadline at route entry and returns 503 for before-ack retry
   outcomes, active incomplete leases, and ack-budget timeouts so
@@ -229,9 +243,10 @@ and retry-fencing proof.
 - Normal successful duplicate retry responses remain empty TwiML; claim/CRM
   handoff failures, active incomplete leases, and provider-ack timeouts return
   503 before acknowledgement so the provider has a reason to retry.
-- The inbound auto-reply reservation is intentionally narrow: it prevents
-  duplicate provider sends for the same inbound SMS row without changing
-  customer-visible auto-reply copy or introducing a broader worker queue.
+- The inbound auto-reply outbox is intentionally narrow: it recovers pending
+  direct auto-reply sends and skips already-sent replies for the same inbound SMS
+  row without changing customer-visible auto-reply copy or introducing a broader
+  worker queue.
 - The workflow edit is limited to this SMS retry test enrollment. The migration
   352 path filters remain unchanged because they were already enrolled.
 - The content-factory test stabilization is test-only and does not change
@@ -257,11 +272,11 @@ reminder/outbound orchestration only.
 
 - `python scripts/audit_plan_doc.py plans/PR-EOM-SMS-Retry-Resume.md` — PASS; required plan sections present.
 - `python -m py_compile atlas_brain/api/comms/webhooks.py atlas_brain/comms/sms_intelligence.py atlas_brain/storage/repositories/sms_message.py tests/test_eom_sms_webhook_retry.py` — PASS.
-- `pytest -q tests/test_eom_sms_webhook_retry.py` — 30 passed, 1 skipped, 1 warning locally; the skipped live Postgres proof is CI-enrolled through `ATLAS_EOM_SMS_RETRY_POSTGRES_URL`.
+- `pytest -q tests/test_eom_sms_webhook_retry.py` — 35 passed, 1 skipped, 1 warning locally; the skipped live Postgres proof is CI-enrolled through `ATLAS_EOM_SMS_RETRY_POSTGRES_URL`.
 - `python -m pytest -q tests/test_eom_lead_ingress.py::test_real_sms_link_uses_eom_lead_resolver tests/test_eom_lead_ingress.py::test_sms_link_uses_provider_identity_without_a_local_sms_row tests/test_eom_lead_ingress.py::test_sms_fallback_uses_eom_lead_resolver tests/test_content_factory_copy_verification.py::test_scope_lookup_scales_with_negation_scopes_present` — 4 passed.
 - `python -m pytest -q tests/test_content_factory_copy_verification.py` — 324 passed.
 - `python scripts/audit_plan_doc_files_touched.py plans/PR-EOM-SMS-Retry-Resume.md origin/main` — PASS; plan files match git diff.
-- `python scripts/audit_plan_doc_diff_size.py plans/PR-EOM-SMS-Retry-Resume.md origin/main` — PASS; estimated and actual diff size are 2767 LOC.
+- `python scripts/audit_plan_doc_diff_size.py plans/PR-EOM-SMS-Retry-Resume.md origin/main` — PASS; diff-size drift remains inside the plan threshold.
 - `python scripts/audit_plan_code_consistency.py --base-ref origin/main plans/PR-EOM-SMS-Retry-Resume.md` — PASS; all path claims resolve.
 - `python scripts/audit_review_rules_triggered.py origin/main --plan plans/PR-EOM-SMS-Retry-Resume.md` — PASS; plan declares every rule the diff triggers.
 - `python scripts/audit_pr_body.py --repo-root . --base-ref origin/main /tmp/pr2246-body.md` — PASS.

--- a/tests/test_eom_sms_webhook_retry.py
+++ b/tests/test_eom_sms_webhook_retry.py
@@ -1,0 +1,1423 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from atlas_brain.api.comms import webhooks
+from atlas_brain.comms import sms_intelligence
+from atlas_brain.services import crm_provider
+from atlas_brain.storage import database as storage_database
+from atlas_brain.storage.repositories import sms_message
+
+
+class _ClaimingSMSRepo:
+    def __init__(self, *, claim_result: bool, claim_exc: Exception | None = None):
+        self.claim_result = claim_result
+        self.claim_exc = claim_exc
+        self.claimed_ids = []
+        self.linked_contacts = []
+        self.retry_pending = []
+        self.completed = []
+        self.owner_tokens = {}
+        self.touched = []
+        self.owner_status_updates = []
+        self.rows = {}
+        self.auto_reply_reserved = set()
+        self.auto_reply_sent = []
+
+    async def claim_contact_processing(self, sms_id, *, owner_token=None):
+        self.claimed_ids.append(sms_id)
+        if self.claim_exc is not None:
+            raise self.claim_exc
+        if self.claim_result and owner_token is not None:
+            self.owner_tokens[sms_id] = owner_token
+            row = dict(self.rows.get(sms_id, {"id": sms_id, "contact_id": None}))
+            row.update(
+                {
+                    "status": "processing",
+                    "error_message": owner_token,
+                    "_claim_acquired": True,
+                }
+            )
+            self.rows[sms_id] = row
+            return row
+        row = dict(self.rows.get(sms_id, {"id": sms_id, "contact_id": None}))
+        row.setdefault("status", "processing")
+        row["_claim_acquired"] = False
+        return row
+
+    async def owns_contact_processing(self, sms_id, owner_token):
+        return self.owner_tokens.get(sms_id) == owner_token
+
+    async def touch_contact_processing_owner(self, sms_id, owner_token):
+        self.touched.append((sms_id, owner_token))
+        return self.owner_tokens.get(sms_id) == owner_token
+
+    async def link_contact(self, sms_id, contact_id):
+        self.linked_contacts.append((sms_id, contact_id))
+
+    async def mark_contact_processing_retry_pending(
+        self,
+        sms_id,
+        error_message=None,
+        *,
+        owner_token=None,
+    ):
+        self.retry_pending.append((sms_id, error_message, owner_token))
+
+    async def mark_contact_processing_complete(self, sms_id, *, owner_token=None):
+        self.completed.append((sms_id, owner_token))
+
+    async def get_by_id(self, sms_id):
+        return self.rows.get(sms_id)
+
+    async def has_auto_reply_for_inbound(self, inbound_sms_id):
+        return inbound_sms_id in self.auto_reply_reserved
+
+    async def reserve_auto_reply_for_inbound(
+        self,
+        *,
+        inbound_sms_id,
+        from_number,
+        to_number,
+        body,
+        business_context_id,
+    ):
+        if inbound_sms_id in self.auto_reply_reserved:
+            return None
+        self.auto_reply_reserved.add(inbound_sms_id)
+        return {
+            "id": uuid4(),
+            "message_sid": f"auto_reply_{inbound_sms_id}",
+            "from_number": from_number,
+            "to_number": to_number,
+            "body": body,
+            "business_context_id": business_context_id,
+            "source": "auto_reply",
+            "source_ref": str(inbound_sms_id),
+        }
+
+    async def mark_auto_reply_sent(self, auto_reply_sms_id, *, provider_message_id=None):
+        self.auto_reply_sent.append((auto_reply_sms_id, provider_message_id))
+
+    async def update_contact_processing_status(
+        self,
+        sms_id,
+        status,
+        *,
+        owner_token,
+        error_message=None,
+        clear_owner=False,
+    ):
+        self.owner_status_updates.append(
+            (sms_id, status, owner_token, error_message, clear_owner)
+        )
+        if self.owner_tokens.get(sms_id) != owner_token:
+            return False
+        if clear_owner:
+            self.owner_tokens.pop(sms_id, None)
+        return True
+
+
+class _FormRequest:
+    async def form(self):
+        return {}
+
+
+class _SlowFormRequest:
+    async def form(self):
+        await asyncio.sleep(1)
+        return {}
+
+
+class _Provider:
+    def __init__(self, *, send_delay: float = 0.0):
+        self.sent_sms = []
+        self.send_delay = send_delay
+
+    async def handle_incoming_sms(self, **kwargs):
+        return SimpleNamespace(context_id=None)
+
+    async def send_sms(self, **kwargs):
+        if self.send_delay:
+            await asyncio.sleep(self.send_delay)
+        self.sent_sms.append(kwargs)
+        return SimpleNamespace(provider_message_id=f"SM-out-{len(self.sent_sms)}")
+
+
+class _Router:
+    def __init__(self, context=None):
+        self.context = context or _sms_context()
+
+    def get_context_for_number(self, number):
+        return self.context
+
+    def get_context(self, context_id):
+        return self.context if context_id == self.context.id else None
+
+
+class _WebhookRepo(_ClaimingSMSRepo):
+    def __init__(self, *, existing=None):
+        super().__init__(claim_result=True)
+        self.existing = existing
+        self.created = []
+
+    async def get_by_message_sid(self, message_sid):
+        return self.existing
+
+    async def create(self, **kwargs):
+        row = {"id": uuid4(), **kwargs}
+        self.created.append(row)
+        return row
+
+
+def _sms_context() -> SimpleNamespace:
+    return SimpleNamespace(
+        id="effingham_maids",
+        sms_auto_reply=False,
+        sms_enabled=False,
+    )
+
+
+class _ClaimPool:
+    is_initialized = True
+
+    def __init__(self):
+        self.calls = []
+
+    async def fetchrow(self, sql, *args):
+        self.calls.append((sql, args))
+        return {
+            "id": args[0],
+            "claim_acquired": True,
+            "media_urls": [],
+            "extracted_data": {},
+        }
+
+
+class _RetryPendingPool:
+    is_initialized = True
+
+    def __init__(self):
+        self.calls = []
+
+    async def execute(self, sql, *args):
+        self.calls.append((sql, args))
+        return "UPDATE 1"
+
+
+class _LiveSMSPool:
+    is_initialized = True
+
+    def __init__(self, pool):
+        self.pool = pool
+
+    async def fetchrow(self, sql, *args):
+        return await self.pool.fetchrow(sql, *args)
+
+    async def execute(self, sql, *args):
+        return await self.pool.execute(sql, *args)
+
+
+class _AttrReplacements:
+    def __init__(self):
+        self._originals = []
+
+    def replace(self, obj, name, value):
+        self._originals.append((obj, name, getattr(obj, name)))
+        setattr(obj, name, value)
+
+    def restore(self):
+        while self._originals:
+            obj, name, value = self._originals.pop()
+            setattr(obj, name, value)
+
+
+@pytest.mark.asyncio
+async def test_real_repository_claim_uses_reclaimable_processing_predicate():
+    pool = _ClaimPool()
+    sms_id = uuid4()
+    replacements = _AttrReplacements()
+    replacements.replace(sms_message, "get_db_pool", lambda: pool)
+
+    try:
+        claimed = await sms_message.SMSMessageRepository().claim_contact_processing(sms_id)
+    finally:
+        replacements.restore()
+
+    assert claimed["_claim_acquired"] is True
+    sql, args = pool.calls[0]
+    assert "status IN ('received', 'retry_pending')" in sql
+    assert "status = 'processing'" in sql
+    assert "processed_at IS NULL OR processed_at < $3" in sql
+    assert "error_message = $4" in sql
+    assert "contact_id IS NULL" not in sql
+    assert args[0] == sms_id
+
+
+@pytest.mark.asyncio
+async def test_ownerless_retry_pending_cannot_preempt_live_processing_rows():
+    pool = _RetryPendingPool()
+    sms_id = uuid4()
+    replacements = _AttrReplacements()
+    replacements.replace(sms_message, "get_db_pool", lambda: pool)
+
+    try:
+        await sms_message.SMSMessageRepository().mark_contact_processing_retry_pending(
+            sms_id,
+            "handoff failed before claim",
+        )
+    finally:
+        replacements.restore()
+
+    sql, args = pool.calls[0]
+    assert "AND contact_id IS NULL" in sql
+    assert "status IN ('received', 'retry_pending')" in sql
+    assert "status = 'processing'" not in sql
+    assert args[0] == sms_id
+
+
+@pytest.mark.asyncio
+async def test_owned_retry_pending_can_release_linked_processing_rows():
+    pool = _RetryPendingPool()
+    sms_id = uuid4()
+    replacements = _AttrReplacements()
+    replacements.replace(sms_message, "get_db_pool", lambda: pool)
+
+    try:
+        await sms_message.SMSMessageRepository().mark_contact_processing_retry_pending(
+            sms_id,
+            "handoff failed after link",
+            owner_token="owner-token",
+        )
+    finally:
+        replacements.restore()
+
+    sql, args = pool.calls[0]
+    assert "AND status = 'processing'" in sql
+    assert "AND error_message = $4" in sql
+    assert "contact_id IS NULL" not in sql
+    assert args[0] == sms_id
+    assert args[3] == "owner-token"
+
+
+@pytest.mark.asyncio
+async def test_live_postgres_sms_claim_fences_one_winner_and_stale_reclaim():
+    database_url = os.getenv("ATLAS_EOM_SMS_RETRY_POSTGRES_URL")
+    if not database_url:
+        pytest.skip("Set ATLAS_EOM_SMS_RETRY_POSTGRES_URL to run live SMS claim proof")
+
+    asyncpg = pytest.importorskip("asyncpg")
+    pool = await asyncpg.create_pool(dsn=database_url, min_size=1, max_size=4)
+    repo = sms_message.SMSMessageRepository()
+    message_sid = f"SM-live-claim-{uuid4()}"
+    replacements = _AttrReplacements()
+    replacements.replace(sms_message, "get_db_pool", lambda: _LiveSMSPool(pool))
+
+    try:
+        await pool.execute(
+            """
+            CREATE TABLE IF NOT EXISTS sms_messages (
+                id UUID PRIMARY KEY,
+                message_sid VARCHAR(128) NOT NULL UNIQUE,
+                from_number VARCHAR(32) NOT NULL,
+                to_number VARCHAR(32) NOT NULL,
+                direction VARCHAR(10) NOT NULL DEFAULT 'inbound',
+                body TEXT NOT NULL DEFAULT '',
+                media_urls JSONB DEFAULT '[]'::jsonb,
+                business_context_id VARCHAR(64),
+                conversation_id UUID,
+                intent VARCHAR(32),
+                extracted_data JSONB DEFAULT '{}'::jsonb,
+                summary TEXT,
+                contact_id UUID,
+                status VARCHAR(32) NOT NULL DEFAULT 'received',
+                error_message TEXT,
+                notified BOOLEAN DEFAULT FALSE,
+                source VARCHAR(64),
+                source_ref VARCHAR(256),
+                created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                delivered_at TIMESTAMPTZ,
+                processed_at TIMESTAMPTZ
+            )
+            """
+        )
+        row = await repo.create(
+            message_sid=message_sid,
+            from_number="+12175550101",
+            to_number="+12175550102",
+            direction="inbound",
+            body="live claim proof",
+            media_urls=[],
+            business_context_id="effingham_maids",
+            source="test",
+        )
+        sms_id = row["id"]
+
+        first_claims = await asyncio.gather(
+            repo.claim_contact_processing(sms_id, owner_token="owner-a"),
+            repo.claim_contact_processing(sms_id, owner_token="owner-b"),
+        )
+        first_claim_flags = [bool(row and row.get("_claim_acquired")) for row in first_claims]
+        assert sorted(first_claim_flags) == [False, True]
+        winning_owner = "owner-a" if first_claim_flags[0] else "owner-b"
+        losing_owner = "owner-b" if first_claim_flags[0] else "owner-a"
+
+        live_row = await pool.fetchrow(
+            "SELECT status, contact_id, processed_at, error_message FROM sms_messages WHERE id = $1",
+            sms_id,
+        )
+        assert live_row["status"] == "processing"
+        assert live_row["contact_id"] is None
+        assert live_row["processed_at"] is not None
+        assert live_row["error_message"] == winning_owner
+        assert await repo.owns_contact_processing(sms_id, winning_owner) is True
+        assert await repo.owns_contact_processing(sms_id, losing_owner) is False
+        owner_c_row = await repo.claim_contact_processing(sms_id, owner_token="owner-c")
+        assert owner_c_row["_claim_acquired"] is False
+        assert owner_c_row["status"] == "processing"
+
+        reclaim_owner = "reclaim"
+        followup_owner = "followup"
+        stale_processed_at = datetime.now(timezone.utc) - timedelta(
+            seconds=sms_message.SMS_CONTACT_PROCESSING_LEASE_SECONDS + 5
+        )
+        await pool.execute(
+            "UPDATE sms_messages SET processed_at = $2 WHERE id = $1",
+            sms_id,
+            stale_processed_at,
+        )
+        reclaim_row = await repo.claim_contact_processing(sms_id, owner_token=reclaim_owner)
+        assert reclaim_row["_claim_acquired"] is True
+        assert await repo.owns_contact_processing(sms_id, winning_owner) is False
+        assert await repo.owns_contact_processing(sms_id, reclaim_owner) is True
+
+        await repo.mark_contact_processing_complete(sms_id, owner_token=winning_owner)
+        assert await repo.owns_contact_processing(sms_id, reclaim_owner) is True
+
+        await pool.execute(
+            "UPDATE sms_messages SET contact_id = $2 WHERE id = $1",
+            sms_id,
+            uuid4(),
+        )
+        await repo.mark_contact_processing_retry_pending(
+            sms_id,
+            "wrong owner must not release",
+            owner_token=winning_owner,
+        )
+        live_row = await pool.fetchrow(
+            "SELECT status, contact_id, error_message FROM sms_messages WHERE id = $1",
+            sms_id,
+        )
+        assert live_row["status"] == "processing"
+        assert live_row["contact_id"] is not None
+        assert live_row["error_message"] == reclaim_owner
+
+        await repo.mark_contact_processing_retry_pending(
+            sms_id,
+            "owned retry",
+            owner_token=reclaim_owner,
+        )
+        live_row = await pool.fetchrow(
+            "SELECT status, contact_id, error_message FROM sms_messages WHERE id = $1",
+            sms_id,
+        )
+        assert live_row["status"] == "retry_pending"
+        assert live_row["contact_id"] is not None
+        assert live_row["error_message"] == "owned retry"
+
+        assert await repo.claim_contact_processing(sms_id, owner_token=followup_owner)
+        await pool.execute(
+            "UPDATE sms_messages SET contact_id = NULL WHERE id = $1",
+            sms_id,
+        )
+        await repo.mark_contact_processing_retry_pending(
+            sms_id,
+            "ownerless must not preempt live processing",
+        )
+        live_row = await pool.fetchrow(
+            "SELECT status, contact_id, error_message FROM sms_messages WHERE id = $1",
+            sms_id,
+        )
+        assert live_row["status"] == "processing"
+        assert live_row["error_message"] == followup_owner
+
+        stale_update = await repo.update_contact_processing_status(
+            sms_id,
+            "notified",
+            owner_token=reclaim_owner,
+            error_message="stale owner",
+            clear_owner=True,
+        )
+        assert stale_update is False
+        live_row = await pool.fetchrow(
+            "SELECT status, error_message FROM sms_messages WHERE id = $1",
+            sms_id,
+        )
+        assert live_row["status"] == "processing"
+        assert live_row["error_message"] == followup_owner
+
+        owner_update = await repo.update_contact_processing_status(
+            sms_id,
+            "notified",
+            owner_token=followup_owner,
+            clear_owner=False,
+        )
+        assert owner_update is True
+        live_row = await pool.fetchrow(
+            "SELECT status, error_message FROM sms_messages WHERE id = $1",
+            sms_id,
+        )
+        assert live_row["status"] == "notified"
+        assert live_row["error_message"] == followup_owner
+
+        await pool.execute(
+            "UPDATE sms_messages SET status = 'processing' WHERE id = $1",
+            sms_id,
+        )
+        await repo.mark_contact_processing_complete(sms_id, owner_token=followup_owner)
+        owner_d_row = await repo.claim_contact_processing(sms_id, owner_token="owner-d")
+        assert owner_d_row["_claim_acquired"] is False
+        assert owner_d_row["status"] == "ready"
+    finally:
+        await pool.execute(
+            "DELETE FROM sms_messages WHERE message_sid = $1",
+            message_sid,
+        )
+        replacements.restore()
+        await pool.close()
+
+
+@pytest.mark.asyncio
+async def test_inbound_sms_handler_processes_new_row_before_ack():
+    repo = _WebhookRepo()
+    calls = []
+
+    replacements = _AttrReplacements()
+    replacements.replace(webhooks, "get_context_router", lambda: _Router())
+    replacements.replace(
+        webhooks,
+        "get_comms_service",
+        lambda: SimpleNamespace(provider=_Provider()),
+    )
+    replacements.replace(sms_message, "get_sms_message_repo", lambda: repo)
+
+    async def processor(*args, **kwargs):
+        calls.append((args, kwargs))
+
+    replacements.replace(webhooks, "_process_inbound_sms", processor)
+
+    try:
+        response = await webhooks.handle_inbound_sms(
+            _FormRequest(),
+            MessageSid="SM-new",
+            From="+12175550101",
+            To="+12175550102",
+            Body="hello",
+            NumMedia="0",
+        )
+    finally:
+        replacements.restore()
+
+    assert response.status_code == 200
+    assert repo.created[0]["message_sid"] == "SM-new"
+    assert repo.claimed_ids == []
+    assert calls[0][1]["claim_processing"] is True
+    assert calls[0][1]["retry_pending_recorder"] == "caller"
+
+
+@pytest.mark.asyncio
+async def test_inbound_sms_handler_returns_503_when_before_ack_processing_needs_retry():
+    repo = _WebhookRepo()
+
+    replacements = _AttrReplacements()
+    replacements.replace(webhooks, "get_context_router", lambda: _Router())
+    replacements.replace(
+        webhooks,
+        "get_comms_service",
+        lambda: SimpleNamespace(provider=_Provider()),
+    )
+    replacements.replace(sms_message, "get_sms_message_repo", lambda: repo)
+
+    async def processor(*args, **kwargs):
+        return "retry_pending"
+
+    replacements.replace(webhooks, "_process_inbound_sms", processor)
+
+    try:
+        response = await webhooks.handle_inbound_sms(
+            _FormRequest(),
+            MessageSid="SM-new-retry",
+            From="+12175550101",
+            To="+12175550102",
+            Body="hello",
+            NumMedia="0",
+        )
+    finally:
+        replacements.restore()
+
+    assert response.status_code == 503
+    assert repo.created[0]["message_sid"] == "SM-new-retry"
+
+
+@pytest.mark.asyncio
+async def test_inbound_sms_handler_returns_503_while_duplicate_processing_is_leased():
+    repo = _WebhookRepo(
+        existing={
+            "id": uuid4(),
+            "message_sid": "SM-active-lease",
+            "from_number": "+12175550101",
+            "to_number": "+12175550102",
+            "body": "hello",
+            "media_urls": [],
+            "contact_id": None,
+            "status": "processing",
+        }
+    )
+
+    replacements = _AttrReplacements()
+    replacements.replace(webhooks, "get_context_router", lambda: _Router())
+    replacements.replace(
+        webhooks,
+        "get_comms_service",
+        lambda: SimpleNamespace(provider=_Provider()),
+    )
+    replacements.replace(sms_message, "get_sms_message_repo", lambda: repo)
+
+    async def processor(*args, **kwargs):
+        return "already_processing"
+
+    replacements.replace(webhooks, "_process_inbound_sms", processor)
+
+    try:
+        response = await webhooks.handle_inbound_sms(
+            _FormRequest(),
+            MessageSid="SM-active-lease",
+            From="+12175550101",
+            To="+12175550102",
+            Body="hello",
+            NumMedia="0",
+        )
+    finally:
+        replacements.restore()
+
+    assert response.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_inbound_sms_handler_returns_503_when_processing_exceeds_ack_budget():
+    repo = _WebhookRepo()
+
+    replacements = _AttrReplacements()
+    replacements.replace(webhooks, "get_context_router", lambda: _Router())
+    replacements.replace(
+        webhooks,
+        "get_comms_service",
+        lambda: SimpleNamespace(provider=_Provider()),
+    )
+    replacements.replace(sms_message, "get_sms_message_repo", lambda: repo)
+    replacements.replace(webhooks, "SMS_INBOUND_BEFORE_ACK_TIMEOUT_SECONDS", 0.01)
+
+    async def processor(*args, **kwargs):
+        await asyncio.sleep(1)
+        return "complete"
+
+    replacements.replace(webhooks, "_process_inbound_sms", processor)
+
+    try:
+        response = await webhooks.handle_inbound_sms(
+            _FormRequest(),
+            MessageSid="SM-timeout",
+            From="+12175550101",
+            To="+12175550102",
+            Body="hello",
+            NumMedia="0",
+        )
+    finally:
+        replacements.restore()
+
+    assert response.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_inbound_sms_handler_applies_ack_budget_to_media_parsing():
+    replacements = _AttrReplacements()
+    replacements.replace(webhooks, "get_context_router", lambda: _Router())
+    replacements.replace(webhooks, "SMS_INBOUND_BEFORE_ACK_TIMEOUT_SECONDS", 0.01)
+
+    try:
+        response = await webhooks.handle_inbound_sms(
+            _SlowFormRequest(),
+            MessageSid="SM-form-timeout",
+            From="+12175550101",
+            To="+12175550102",
+            Body="hello",
+            NumMedia="1",
+        )
+    finally:
+        replacements.restore()
+
+    assert response.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_inbound_sms_duplicate_stale_persisted_context_returns_503():
+    repo = _WebhookRepo(
+        existing={
+            "id": uuid4(),
+            "message_sid": "SM-stale-context",
+            "from_number": "+12175550101",
+            "to_number": "+12175550102",
+            "body": "hello",
+            "media_urls": [],
+            "contact_id": None,
+            "status": "received",
+            "business_context_id": "deleted-context",
+        }
+    )
+
+    replacements = _AttrReplacements()
+    replacements.replace(webhooks, "get_context_router", lambda: _Router())
+    replacements.replace(
+        webhooks,
+        "get_comms_service",
+        lambda: SimpleNamespace(provider=_Provider()),
+    )
+    replacements.replace(sms_message, "get_sms_message_repo", lambda: repo)
+
+    try:
+        response = await webhooks.handle_inbound_sms(
+            _FormRequest(),
+            MessageSid="SM-stale-context",
+            From="+12175550101",
+            To="+12175550102",
+            Body="hello",
+            NumMedia="0",
+        )
+    finally:
+        replacements.restore()
+
+    assert response.status_code == 503
+    assert repo.claimed_ids == []
+
+
+@pytest.mark.asyncio
+async def test_unlinked_duplicate_sms_resumes_before_ack_with_persisted_values():
+    sms_id = uuid4()
+    existing = {
+        "id": sms_id,
+        "message_sid": "SM-retry",
+        "from_number": "+12175550101",
+        "to_number": "+12175550102",
+        "body": "",
+        "media_urls": [],
+        "contact_id": None,
+        "status": "received",
+    }
+    repo = _ClaimingSMSRepo(claim_result=True)
+    context = _sms_context()
+    calls = []
+
+    async def processor(*args, **kwargs):
+        calls.append((args, kwargs))
+        return "complete"
+
+    replacements = _AttrReplacements()
+    replacements.replace(webhooks, "_process_inbound_sms", processor)
+    try:
+        outcome = await webhooks._resume_duplicate_inbound_sms_before_ack(
+            existing,
+            fallback_from="+19999999999",
+            fallback_to="+18888888888",
+            fallback_body="provider retry body must not replace persisted empty body",
+            fallback_media_urls=["https://example.test/retry-media.jpg"],
+            context=context,
+            provider_message_id="SM-retry",
+            sms_repo=repo,
+        )
+    finally:
+        replacements.restore()
+
+    assert outcome == "complete"
+    assert calls == [
+        (
+            (
+                sms_id,
+                "+12175550101",
+                "+12175550102",
+                "",
+                context,
+                [],
+            ),
+            {
+                "provider_message_id": "SM-retry",
+                "claim_processing": True,
+                "retry_pending_recorder": "caller",
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_unlinked_duplicate_sms_runs_worker_claim_for_owned_rows_before_ack():
+    sms_id = uuid4()
+    repo = _ClaimingSMSRepo(claim_result=False)
+    calls = []
+
+    async def processor(*args, **kwargs):
+        calls.append((args, kwargs))
+        return "already_processing"
+
+    replacements = _AttrReplacements()
+    replacements.replace(webhooks, "_process_inbound_sms", processor)
+    try:
+        outcome = await webhooks._resume_duplicate_inbound_sms_before_ack(
+            {
+                "id": sms_id,
+                "from_number": "+12175550101",
+                "to_number": "+12175550102",
+                "body": "already processing",
+                "media_urls": [],
+                "contact_id": None,
+                "status": "retry_pending",
+            },
+            fallback_from="+19999999999",
+            fallback_to="+18888888888",
+            fallback_body="retry body",
+            fallback_media_urls=[],
+            context=_sms_context(),
+            provider_message_id="SM-racing-retry",
+            sms_repo=repo,
+        )
+    finally:
+        replacements.restore()
+
+    assert outcome == "already_processing"
+    assert calls[0][1]["claim_processing"] is True
+
+
+@pytest.mark.asyncio
+async def test_linked_received_duplicate_sms_resumes_until_terminal_completion():
+    repo = _ClaimingSMSRepo(claim_result=True)
+    calls = []
+
+    async def processor(*args, **kwargs):
+        calls.append((args, kwargs))
+        return "complete"
+
+    replacements = _AttrReplacements()
+    replacements.replace(webhooks, "_process_inbound_sms", processor)
+    try:
+        outcome = await webhooks._resume_duplicate_inbound_sms_before_ack(
+            {
+                "id": uuid4(),
+                "from_number": "+12175550101",
+                "to_number": "+12175550102",
+                "body": "already linked but not complete",
+                "media_urls": [],
+                "contact_id": uuid4(),
+                "status": "received",
+            },
+            fallback_from="+19999999999",
+            fallback_to="+18888888888",
+            fallback_body="retry body",
+            fallback_media_urls=[],
+            context=_sms_context(),
+            provider_message_id="SM-linked",
+            sms_repo=repo,
+        )
+    finally:
+        replacements.restore()
+
+    assert outcome == "complete"
+    assert calls[0][1]["claim_processing"] is True
+
+
+@pytest.mark.asyncio
+async def test_completed_unlinked_duplicate_sms_does_not_resume():
+    repo = _ClaimingSMSRepo(claim_result=True)
+
+    outcome = await webhooks._resume_duplicate_inbound_sms_before_ack(
+        {
+            "id": uuid4(),
+            "from_number": "+12175550101",
+            "to_number": "+12175550102",
+            "body": "stop",
+            "media_urls": [],
+            "contact_id": None,
+            "status": "ready",
+        },
+        fallback_from="+19999999999",
+        fallback_to="+18888888888",
+        fallback_body="retry body",
+        fallback_media_urls=[],
+        context=_sms_context(),
+        provider_message_id="SM-ready",
+        sms_repo=repo,
+    )
+
+    assert outcome == "complete"
+    assert repo.claimed_ids == []
+
+
+@pytest.mark.asyncio
+async def test_processing_duplicate_sms_is_resumable_before_ack():
+    calls = []
+
+    async def processor(*args, **kwargs):
+        calls.append((args, kwargs))
+        return "complete"
+
+    replacements = _AttrReplacements()
+    replacements.replace(webhooks, "_process_inbound_sms", processor)
+    try:
+        outcome = await webhooks._resume_duplicate_inbound_sms_before_ack(
+            {
+                "id": uuid4(),
+                "from_number": "+12175550101",
+                "to_number": "+12175550102",
+                "body": "worker may have died",
+                "media_urls": [],
+                "contact_id": None,
+                "status": "processing",
+            },
+            fallback_from="+19999999999",
+            fallback_to="+18888888888",
+            fallback_body="retry body",
+            fallback_media_urls=[],
+            context=_sms_context(),
+            provider_message_id="SM-processing",
+            sms_repo=_ClaimingSMSRepo(claim_result=True),
+        )
+    finally:
+        replacements.restore()
+
+    assert outcome == "complete"
+    assert calls[0][1]["claim_processing"] is True
+
+
+def test_duplicate_sms_context_uses_persisted_context_id_before_number_routing():
+    seen_numbers = []
+    seen_context_ids = []
+
+    class Router:
+        def get_context(self, context_id):
+            seen_context_ids.append(context_id)
+            return SimpleNamespace(id=f"context-id:{context_id}")
+
+        def get_context_for_number(self, number):
+            seen_numbers.append(number)
+            return SimpleNamespace(id=f"context:{number}")
+
+    context = webhooks._context_for_persisted_sms(
+        {"business_context_id": "effingham_maids", "to_number": "+12175550102"},
+        fallback_to="+18888888888",
+        context_router=Router(),
+    )
+
+    assert seen_context_ids == ["effingham_maids"]
+    assert seen_numbers == []
+    assert context.id == "context-id:effingham_maids"
+
+
+def test_duplicate_sms_context_falls_back_to_persisted_destination_for_legacy_rows():
+    seen_numbers = []
+
+    class Router:
+        def get_context(self, context_id):
+            return None
+
+        def get_context_for_number(self, number):
+            seen_numbers.append(number)
+            return SimpleNamespace(id=f"context:{number}")
+
+    context = webhooks._context_for_persisted_sms(
+        {"to_number": "+12175550102"},
+        fallback_to="+18888888888",
+        context_router=Router(),
+    )
+
+    assert seen_numbers == ["+12175550102"]
+    assert context.id == "context:+12175550102"
+
+
+def test_duplicate_sms_context_fails_closed_for_stale_persisted_context_id():
+    class Router:
+        def get_context(self, context_id):
+            return None
+
+        def get_context_for_number(self, number):  # pragma: no cover
+            raise AssertionError("number routing must not run for stored context ids")
+
+    with pytest.raises(ValueError, match="business context no longer resolves"):
+        webhooks._context_for_persisted_sms(
+            {"business_context_id": "deleted-context", "to_number": "+12175550102"},
+            fallback_to="+18888888888",
+            context_router=Router(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_process_inbound_sms_claims_before_running_intelligence():
+    sms_id = uuid4()
+    repo = _ClaimingSMSRepo(claim_result=True)
+    intelligence_calls = []
+
+    async def intelligence_runner(**kwargs):
+        intelligence_calls.append(kwargs)
+        await repo.link_contact(kwargs["sms_id"], "contact-1")
+
+    outcome = await webhooks._process_inbound_sms(
+        sms_id,
+        "+12175550101",
+        "+12175550102",
+        "hello",
+        _sms_context(),
+        [],
+        provider_message_id="SM-process",
+        sms_repo=repo,
+        intelligence_runner=intelligence_runner,
+    )
+
+    assert repo.claimed_ids == [sms_id]
+    assert repo.linked_contacts == [(sms_id, "contact-1")]
+    assert outcome == "complete"
+    assert repo.completed[0][0] == sms_id
+    assert repo.completed[0][1] == repo.owner_tokens[sms_id]
+    assert len(intelligence_calls) == 1
+    assert intelligence_calls[0]["provider_message_id"] == "SM-process"
+
+
+@pytest.mark.asyncio
+async def test_process_inbound_sms_resumes_linked_row_with_existing_contact_id():
+    sms_id = uuid4()
+    repo = _ClaimingSMSRepo(claim_result=True)
+    repo.rows[sms_id] = {
+        "id": sms_id,
+        "status": "processing",
+        "contact_id": uuid4(),
+    }
+    intelligence_calls = []
+
+    async def intelligence_runner(**kwargs):
+        intelligence_calls.append(kwargs)
+        return "complete"
+
+    outcome = await webhooks._process_inbound_sms(
+        sms_id,
+        "+12175550101",
+        "+12175550102",
+        "hello",
+        _sms_context(),
+        [],
+        provider_message_id="SM-linked-resume",
+        sms_repo=repo,
+        intelligence_runner=intelligence_runner,
+    )
+
+    assert outcome == "complete"
+    assert repo.claimed_ids == [sms_id]
+    assert intelligence_calls[0]["existing_contact_id"] == str(repo.rows[sms_id]["contact_id"])
+    assert repo.completed == [(sms_id, repo.owner_tokens[sms_id])]
+
+
+@pytest.mark.asyncio
+async def test_sms_intelligence_preserves_processing_owner_token_before_crm_link():
+    class Pool:
+        is_initialized = True
+
+    class CRM:
+        async def find_or_create_contact(self, **kwargs):
+            return {"id": "contact-1", "full_name": kwargs["full_name"]}
+
+        async def log_interaction(self, **kwargs):
+            return {"id": "interaction-1"}
+
+    sms_id = uuid4()
+    repo = _ClaimingSMSRepo(claim_result=True)
+    owner_token = "owner-token"
+    repo.owner_tokens[sms_id] = owner_token
+    replacements = _AttrReplacements()
+    replacements.replace(sms_intelligence, "get_sms_message_repo", lambda: repo)
+    replacements.replace(storage_database, "get_db_pool", lambda: Pool())
+    replacements.replace(crm_provider, "get_crm_provider", lambda: CRM())
+
+    async def extract(body, business_context):
+        return (
+            "Inbound SMS from customer",
+            {"customer_phone": "+12175550101", "customer_name": "Customer"},
+            "inquiry",
+        )
+
+    replacements.replace(sms_intelligence, "_extract_sms_data", extract)
+
+    try:
+        outcome = await sms_intelligence.process_inbound_sms(
+            sms_id=sms_id,
+            from_number="+12175550101",
+            to_number="+12175550102",
+            body="hello",
+            business_context_id="non_eom_context",
+            processing_owner_token=owner_token,
+            stop_after_crm=True,
+        )
+    finally:
+        replacements.restore()
+
+    assert outcome == "crm_linked"
+    assert repo.linked_contacts == [(sms_id, "contact-1")]
+    assert repo.owner_tokens[sms_id] == owner_token
+    assert repo.touched
+
+
+@pytest.mark.asyncio
+async def test_sms_intelligence_existing_contact_id_skips_crm_link():
+    class Pool:
+        is_initialized = True
+
+    class CRM:
+        async def find_or_create_contact(self, **kwargs):  # pragma: no cover
+            raise AssertionError("existing linked contacts must not be recreated")
+
+        async def log_interaction(self, **kwargs):  # pragma: no cover
+            raise AssertionError("existing linked contacts must not create another CRM interaction")
+
+    sms_id = uuid4()
+    repo = _ClaimingSMSRepo(claim_result=True)
+    replacements = _AttrReplacements()
+    replacements.replace(sms_intelligence, "get_sms_message_repo", lambda: repo)
+    replacements.replace(storage_database, "get_db_pool", lambda: Pool())
+    replacements.replace(crm_provider, "get_crm_provider", lambda: CRM())
+
+    async def extract(body, business_context):
+        return (
+            "Inbound SMS from customer",
+            {"customer_phone": "+12175550101", "customer_name": "Customer"},
+            "inquiry",
+        )
+
+    replacements.replace(sms_intelligence, "_extract_sms_data", extract)
+
+    try:
+        outcome = await sms_intelligence.process_inbound_sms(
+            sms_id=sms_id,
+            from_number="+12175550101",
+            to_number="+12175550102",
+            body="hello",
+            business_context_id="non_eom_context",
+            existing_contact_id="contact-1",
+            stop_after_crm=True,
+        )
+    finally:
+        replacements.restore()
+
+    assert outcome == "crm_linked"
+    assert repo.linked_contacts == []
+
+
+@pytest.mark.asyncio
+async def test_sms_crm_database_unavailable_is_retryable_not_complete():
+    class Pool:
+        is_initialized = False
+
+    repo = _ClaimingSMSRepo(claim_result=True)
+    sms_id = uuid4()
+    replacements = _AttrReplacements()
+    replacements.replace(sms_intelligence, "get_sms_message_repo", lambda: repo)
+    replacements.replace(storage_database, "get_db_pool", lambda: Pool())
+
+    async def extract(body, business_context):
+        return (
+            "Inbound SMS from customer",
+            {"customer_phone": "+12175550101", "customer_name": "Customer"},
+            "inquiry",
+        )
+
+    replacements.replace(sms_intelligence, "_extract_sms_data", extract)
+
+    try:
+        outcome = await sms_intelligence.process_inbound_sms(
+            sms_id=sms_id,
+            from_number="+12175550101",
+            to_number="+12175550102",
+            body="hello",
+            business_context_id="non_eom_context",
+        )
+    finally:
+        replacements.restore()
+
+    assert outcome == "retry_pending"
+
+
+@pytest.mark.asyncio
+async def test_process_inbound_sms_does_not_run_intelligence_when_claim_is_owned():
+    sms_id = uuid4()
+    repo = _ClaimingSMSRepo(claim_result=False)
+    intelligence_calls = []
+
+    async def intelligence_runner(**kwargs):
+        intelligence_calls.append(kwargs)
+
+    outcome = await webhooks._process_inbound_sms(
+        sms_id,
+        "+12175550101",
+        "+12175550102",
+        "hello",
+        _sms_context(),
+        [],
+        provider_message_id="SM-owned",
+        sms_repo=repo,
+        intelligence_runner=intelligence_runner,
+    )
+
+    assert repo.claimed_ids == [sms_id]
+    assert outcome == "already_processing"
+    assert intelligence_calls == []
+
+
+@pytest.mark.asyncio
+async def test_process_inbound_sms_marks_retry_pending_when_claim_raises():
+    sms_id = uuid4()
+    repo = _ClaimingSMSRepo(claim_result=False, claim_exc=RuntimeError("db unavailable"))
+    intelligence_calls = []
+
+    async def intelligence_runner(**kwargs):
+        intelligence_calls.append(kwargs)
+
+    outcome = await webhooks._process_inbound_sms(
+        sms_id,
+        "+12175550101",
+        "+12175550102",
+        "hello",
+        _sms_context(),
+        [],
+        provider_message_id="SM-claim-fails",
+        sms_repo=repo,
+        intelligence_runner=intelligence_runner,
+    )
+
+    assert repo.claimed_ids == [sms_id]
+    assert outcome == "retry_pending"
+    assert intelligence_calls == []
+    assert repo.retry_pending == [(sms_id, "SMS processing claim failed: db unavailable", None)]
+
+
+@pytest.mark.asyncio
+async def test_process_inbound_sms_marks_retry_pending_for_crm_handoff_failure():
+    sms_id = uuid4()
+    repo = _ClaimingSMSRepo(claim_result=True)
+
+    async def intelligence_runner(**kwargs):
+        return "retry_pending"
+
+    outcome = await webhooks._process_inbound_sms(
+        sms_id,
+        "+12175550101",
+        "+12175550102",
+        "hello",
+        _sms_context(),
+        [],
+        provider_message_id="SM-crm-fails",
+        sms_repo=repo,
+        intelligence_runner=intelligence_runner,
+    )
+
+    assert repo.claimed_ids == [sms_id]
+    assert outcome == "retry_pending"
+    assert repo.retry_pending == [
+        (sms_id, "SMS CRM handoff failed", repo.owner_tokens[sms_id])
+    ]
+    assert repo.completed == []
+
+
+@pytest.mark.asyncio
+async def test_process_inbound_sms_releases_owned_lease_when_caller_records_retry():
+    sms_id = uuid4()
+    repo = _ClaimingSMSRepo(claim_result=True)
+
+    async def intelligence_runner(**kwargs):
+        return "retry_pending"
+
+    outcome = await webhooks._process_inbound_sms(
+        sms_id,
+        "+12175550101",
+        "+12175550102",
+        "hello",
+        _sms_context(),
+        [],
+        provider_message_id="SM-crm-fails-before-ack",
+        sms_repo=repo,
+        intelligence_runner=intelligence_runner,
+        retry_pending_recorder="caller",
+    )
+
+    assert outcome == "retry_pending"
+    assert repo.retry_pending == [
+        (sms_id, "SMS CRM handoff failed", repo.owner_tokens[sms_id])
+    ]
+    assert repo.completed == []
+
+
+@pytest.mark.asyncio
+async def test_process_inbound_sms_treats_terminal_no_contact_as_success():
+    sms_id = uuid4()
+    repo = _ClaimingSMSRepo(claim_result=True)
+    context = SimpleNamespace(
+        id="effingham_maids",
+        sms_auto_reply=True,
+        sms_enabled=True,
+    )
+
+    async def intelligence_runner(**kwargs):
+        return "terminal_no_contact"
+
+    outcome = await webhooks._process_inbound_sms(
+        sms_id,
+        "+12175550101",
+        "+12175550102",
+        "STOP",
+        context,
+        [],
+        provider_message_id="SM-stop",
+        sms_repo=repo,
+        intelligence_runner=intelligence_runner,
+    )
+
+    assert outcome == "complete"
+    assert repo.retry_pending == []
+    assert repo.completed == [(sms_id, repo.owner_tokens[sms_id])]
+
+
+@pytest.mark.asyncio
+async def test_process_inbound_sms_skipped_intelligence_still_auto_replies_and_completes():
+    sms_id = uuid4()
+    repo = _ClaimingSMSRepo(claim_result=True)
+    context = SimpleNamespace(
+        id="effingham_maids",
+        sms_auto_reply=True,
+        sms_enabled=True,
+    )
+    provider = _Provider()
+    replacements = _AttrReplacements()
+    replacements.replace(
+        webhooks,
+        "get_comms_service",
+        lambda: SimpleNamespace(provider=provider),
+    )
+
+    async def generate_reply(body, ctx):
+        return "Thanks!"
+
+    replacements.replace(webhooks, "_generate_sms_reply", generate_reply)
+
+    async def intelligence_runner(**kwargs):
+        return "skipped_intelligence"
+
+    try:
+        outcome = await webhooks._process_inbound_sms(
+            sms_id,
+            "+12175550101",
+            "+12175550102",
+            "hello",
+            context,
+            [],
+            provider_message_id="SM-skip-intel",
+            sms_repo=repo,
+            intelligence_runner=intelligence_runner,
+        )
+    finally:
+        replacements.restore()
+
+    assert outcome == "complete"
+    assert len(provider.sent_sms) == 1
+    assert repo.auto_reply_reserved == {sms_id}
+    assert len(repo.auto_reply_sent) == 1
+    assert repo.completed == [(sms_id, repo.owner_tokens[sms_id])]
+
+
+@pytest.mark.asyncio
+async def test_process_inbound_sms_reserved_auto_reply_skips_duplicate_send_and_completes():
+    sms_id = uuid4()
+    repo = _ClaimingSMSRepo(claim_result=True)
+    repo.auto_reply_reserved.add(sms_id)
+    context = SimpleNamespace(
+        id="effingham_maids",
+        sms_auto_reply=True,
+        sms_enabled=True,
+    )
+    provider = _Provider()
+    replacements = _AttrReplacements()
+    replacements.replace(
+        webhooks,
+        "get_comms_service",
+        lambda: SimpleNamespace(provider=provider),
+    )
+
+    async def generate_reply(body, ctx):
+        return "Thanks!"
+
+    replacements.replace(webhooks, "_generate_sms_reply", generate_reply)
+
+    async def intelligence_runner(**kwargs):
+        return "complete"
+
+    try:
+        outcome = await webhooks._process_inbound_sms(
+            sms_id,
+            "+12175550101",
+            "+12175550102",
+            "hello",
+            context,
+            [],
+            provider_message_id="SM-auto-retry",
+            sms_repo=repo,
+            intelligence_runner=intelligence_runner,
+        )
+    finally:
+        replacements.restore()
+
+    assert outcome == "complete"
+    assert provider.sent_sms == []
+    assert repo.auto_reply_sent == []
+    assert repo.completed == [(sms_id, repo.owner_tokens[sms_id])]
+
+
+@pytest.mark.asyncio
+async def test_sms_crm_post_link_interaction_failure_does_not_retry_or_unlink():
+    class Pool:
+        is_initialized = True
+
+    class CRM:
+        async def find_or_create_contact(self, **kwargs):
+            return {"id": "contact-1", "full_name": kwargs["full_name"]}
+
+        async def log_interaction(self, **kwargs):
+            raise RuntimeError("interaction store unavailable")
+
+    repo = _ClaimingSMSRepo(claim_result=True)
+    sms_id = uuid4()
+    replacements = _AttrReplacements()
+    replacements.replace(storage_database, "get_db_pool", lambda: Pool())
+    replacements.replace(crm_provider, "get_crm_provider", lambda: CRM())
+
+    try:
+        contact_id, is_new = await sms_intelligence._link_to_crm(
+            repo,
+            sms_id,
+            "+12175550101",
+            "non_eom_context",
+            {"customer_phone": "+12175550101", "customer_name": "Customer"},
+            "Inbound SMS from customer",
+            provider_message_id="SM-post-link-log-fails",
+        )
+    finally:
+        replacements.restore()
+
+    assert contact_id == "contact-1"
+    assert is_new is False
+    assert repo.linked_contacts == [(sms_id, "contact-1")]

--- a/tests/test_eom_sms_webhook_retry.py
+++ b/tests/test_eom_sms_webhook_retry.py
@@ -28,6 +28,7 @@ class _ClaimingSMSRepo:
         self.owner_status_updates = []
         self.rows = {}
         self.auto_reply_rows = {}
+        self.auto_reply_sending = []
         self.auto_reply_sent = []
         self.complete_exc = None
         self.complete_result = True
@@ -114,15 +115,28 @@ class _ClaimingSMSRepo:
         self.auto_reply_rows[inbound_sms_id] = row
         return row
 
+    async def mark_auto_reply_sending(self, auto_reply_sms_id):
+        self.auto_reply_sending.append(auto_reply_sms_id)
+        for row in self.auto_reply_rows.values():
+            if row["id"] == auto_reply_sms_id and row["status"] == "pending":
+                row["status"] = "sending"
+                return True
+        return False
+
     async def mark_auto_reply_sent(self, auto_reply_sms_id, *, provider_message_id=None):
         if self.mark_auto_reply_sent_exc is not None:
             raise self.mark_auto_reply_sent_exc
         self.auto_reply_sent.append((auto_reply_sms_id, provider_message_id))
         for row in self.auto_reply_rows.values():
             if row["id"] == auto_reply_sms_id:
+                if row["status"] not in {"sending", "sent"}:
+                    return False
                 row["status"] = "sent"
-                row["error_message"] = provider_message_id
-        return self.mark_auto_reply_sent_result
+                if provider_message_id:
+                    row["message_sid"] = provider_message_id
+                row["error_message"] = None
+                return self.mark_auto_reply_sent_result
+        return False
 
     async def update_contact_processing_status(
         self,
@@ -276,10 +290,13 @@ async def test_real_repository_claim_uses_reclaimable_processing_predicate():
     sql, args = pool.calls[0]
     assert "status IN ('received', 'retry_pending')" in sql
     assert "status = 'processing'" in sql
-    assert "processed_at IS NULL OR processed_at < $3" in sql
-    assert "error_message = $4" in sql
+    assert "CURRENT_TIMESTAMP" in sql
+    assert "processed_at IS NULL" in sql
+    assert "CURRENT_TIMESTAMP - ($2 * INTERVAL '1 second')" in sql
+    assert "error_message = $3" in sql
     assert "contact_id IS NULL" not in sql
     assert args[0] == sms_id
+    assert args[1] == sms_message.SMS_CONTACT_PROCESSING_LEASE_SECONDS
 
 
 @pytest.mark.asyncio
@@ -322,10 +339,10 @@ async def test_owned_retry_pending_can_release_linked_processing_rows():
 
     sql, args = pool.calls[0]
     assert "AND status = 'processing'" in sql
-    assert "AND error_message = $4" in sql
+    assert "AND error_message = $3" in sql
     assert "contact_id IS NULL" not in sql
     assert args[0] == sms_id
-    assert args[3] == "owner-token"
+    assert args[2] == "owner-token"
 
 
 @pytest.mark.asyncio
@@ -506,10 +523,34 @@ async def test_live_postgres_sms_claim_fences_one_winner_and_stale_reclaim():
         owner_d_row = await repo.claim_contact_processing(sms_id, owner_token="owner-d")
         assert owner_d_row["_claim_acquired"] is False
         assert owner_d_row["status"] == "ready"
+
+        auto_reply = await repo.reserve_auto_reply_for_inbound(
+            inbound_sms_id=sms_id,
+            from_number="+12175550102",
+            to_number="+12175550101",
+            body="Persisted live reply",
+            business_context_id="effingham_maids",
+        )
+        assert auto_reply["status"] == "pending"
+        assert auto_reply["message_sid"] == f"auto_reply_{sms_id}"
+        assert await repo.mark_auto_reply_sending(auto_reply["id"]) is True
+        provider_sid = f"SM-live-auto-reply-{uuid4()}"
+        assert await repo.mark_auto_reply_sent(
+            auto_reply["id"],
+            provider_message_id=provider_sid,
+        ) is True
+        provider_row = await repo.get_by_message_sid(provider_sid)
+        assert provider_row is not None
+        assert provider_row["id"] == auto_reply["id"]
+        assert provider_row["source_ref"] == str(sms_id)
+        assert provider_row["body"] == "Persisted live reply"
+        assert provider_row["status"] == "sent"
+        assert provider_row["error_message"] is None
     finally:
         await pool.execute(
-            "DELETE FROM sms_messages WHERE message_sid = $1",
+            "DELETE FROM sms_messages WHERE message_sid = $1 OR source_ref = $2",
             message_sid,
+            str(sms_id) if "sms_id" in locals() else None,
         )
         replacements.restore()
         await pool.close()
@@ -720,6 +761,30 @@ async def test_inbound_sms_handler_applies_ack_budget_to_media_parsing():
         replacements.restore()
 
     assert response.status_code == 503
+
+
+def test_sms_before_ack_budget_covers_all_admitted_sequential_stages():
+    from atlas_brain.config import settings
+
+    replacements = _AttrReplacements()
+    replacements.replace(
+        webhooks,
+        "SMS_INBOUND_BEFORE_ACK_TIMEOUT_SECONDS",
+        webhooks._DEFAULT_SMS_INBOUND_BEFORE_ACK_TIMEOUT_SECONDS,
+    )
+    try:
+        budget = webhooks._sms_before_ack_timeout_seconds()
+    finally:
+        replacements.restore()
+
+    expected = (
+        float(settings.sms_intelligence.llm_timeout)
+        + float(settings.call_intelligence.llm_timeout)
+        + 10.0
+        + max(float(settings.sms_intelligence.auto_reply_timeout), 15.0)
+        + 15.0
+    )
+    assert budget >= expected
 
 
 @pytest.mark.asyncio
@@ -1133,6 +1198,45 @@ async def test_sms_intelligence_preserves_processing_owner_token_before_crm_link
 
 
 @pytest.mark.asyncio
+async def test_sms_intelligence_stop_intent_leaves_leased_terminal_transition_to_webhook():
+    class Pool:
+        is_initialized = True
+
+    sms_id = uuid4()
+    repo = _ClaimingSMSRepo(claim_result=True)
+    owner_token = "owner-token"
+    repo.owner_tokens[sms_id] = owner_token
+    replacements = _AttrReplacements()
+    replacements.replace(sms_intelligence, "get_sms_message_repo", lambda: repo)
+    replacements.replace(storage_database, "get_db_pool", lambda: Pool())
+
+    async def extract(body, business_context):
+        return (
+            "Customer asked to stop",
+            {"customer_phone": "+12175550101"},
+            "stop",
+        )
+
+    replacements.replace(sms_intelligence, "_extract_sms_data", extract)
+
+    try:
+        outcome = await sms_intelligence.process_inbound_sms(
+            sms_id=sms_id,
+            from_number="+12175550101",
+            to_number="+12175550102",
+            body="STOP",
+            business_context_id="non_eom_context",
+            processing_owner_token=owner_token,
+        )
+    finally:
+        replacements.restore()
+
+    assert outcome == "terminal_no_contact"
+    assert repo.owner_status_updates == []
+    assert repo.owner_tokens[sms_id] == owner_token
+
+
+@pytest.mark.asyncio
 async def test_sms_intelligence_existing_contact_id_skips_crm_link():
     class Pool:
         is_initialized = True
@@ -1398,7 +1502,7 @@ async def test_process_inbound_sms_skipped_intelligence_still_auto_replies_and_c
 
 
 @pytest.mark.asyncio
-async def test_process_inbound_sms_pending_auto_reply_retries_send_and_completes():
+async def test_process_inbound_sms_pending_auto_reply_sends_persisted_body_and_completes():
     sms_id = uuid4()
     repo = _ClaimingSMSRepo(claim_result=True)
     pending_row = {
@@ -1406,7 +1510,7 @@ async def test_process_inbound_sms_pending_auto_reply_retries_send_and_completes
         "message_sid": f"auto_reply_{sms_id}",
         "from_number": "+12175550102",
         "to_number": "+12175550101",
-        "body": "Thanks!",
+        "body": "Persisted thanks!",
         "business_context_id": "effingham_maids",
         "status": "pending",
         "source": "auto_reply",
@@ -1427,7 +1531,7 @@ async def test_process_inbound_sms_pending_auto_reply_retries_send_and_completes
     )
 
     async def generate_reply(body, ctx):
-        return "Thanks!"
+        return "Regenerated thanks!"
 
     replacements.replace(webhooks, "_generate_sms_reply", generate_reply)
 
@@ -1451,8 +1555,12 @@ async def test_process_inbound_sms_pending_auto_reply_retries_send_and_completes
 
     assert outcome == "complete"
     assert len(provider.sent_sms) == 1
+    assert provider.sent_sms[0]["body"] == "Persisted thanks!"
+    assert repo.auto_reply_sending == [pending_row["id"]]
     assert repo.auto_reply_sent == [(pending_row["id"], "SM-out-1")]
     assert repo.auto_reply_rows[sms_id]["status"] == "sent"
+    assert repo.auto_reply_rows[sms_id]["message_sid"] == "SM-out-1"
+    assert repo.auto_reply_rows[sms_id]["error_message"] is None
     assert repo.completed == [(sms_id, repo.owner_tokens[sms_id])]
 
 
@@ -1509,6 +1617,65 @@ async def test_process_inbound_sms_sent_auto_reply_skips_duplicate_send_and_comp
 
     assert outcome == "complete"
     assert provider.sent_sms == []
+    assert repo.auto_reply_sending == []
+    assert repo.auto_reply_sent == []
+    assert repo.completed == [(sms_id, repo.owner_tokens[sms_id])]
+
+
+@pytest.mark.asyncio
+async def test_process_inbound_sms_sending_auto_reply_skips_ambiguous_duplicate_and_completes():
+    sms_id = uuid4()
+    repo = _ClaimingSMSRepo(claim_result=True)
+    repo.auto_reply_rows[sms_id] = {
+        "id": uuid4(),
+        "message_sid": f"auto_reply_{sms_id}",
+        "from_number": "+12175550102",
+        "to_number": "+12175550101",
+        "body": "Thanks!",
+        "business_context_id": "effingham_maids",
+        "status": "sending",
+        "source": "auto_reply",
+        "source_ref": str(sms_id),
+    }
+    context = SimpleNamespace(
+        id="effingham_maids",
+        sms_auto_reply=True,
+        sms_enabled=True,
+    )
+    provider = _Provider()
+    replacements = _AttrReplacements()
+    replacements.replace(
+        webhooks,
+        "get_comms_service",
+        lambda: SimpleNamespace(provider=provider),
+    )
+
+    async def generate_reply(body, ctx):  # pragma: no cover
+        raise AssertionError("existing sending outbox rows must not regenerate replies")
+
+    replacements.replace(webhooks, "_generate_sms_reply", generate_reply)
+
+    async def intelligence_runner(**kwargs):
+        return "complete"
+
+    try:
+        outcome = await webhooks._process_inbound_sms(
+            sms_id,
+            "+12175550101",
+            "+12175550102",
+            "hello",
+            context,
+            [],
+            provider_message_id="SM-auto-retry-sending",
+            sms_repo=repo,
+            intelligence_runner=intelligence_runner,
+        )
+    finally:
+        replacements.restore()
+
+    assert outcome == "complete"
+    assert provider.sent_sms == []
+    assert repo.auto_reply_sending == []
     assert repo.auto_reply_sent == []
     assert repo.completed == [(sms_id, repo.owner_tokens[sms_id])]
 
@@ -1554,7 +1721,8 @@ async def test_process_inbound_sms_auto_reply_send_failure_retries_without_compl
         replacements.restore()
 
     assert outcome == "retry_pending"
-    assert repo.auto_reply_rows[sms_id]["status"] == "pending"
+    assert repo.auto_reply_rows[sms_id]["status"] == "sending"
+    assert repo.auto_reply_sending == [repo.auto_reply_rows[sms_id]["id"]]
     assert repo.completed == []
 
 

--- a/tests/test_eom_sms_webhook_retry.py
+++ b/tests/test_eom_sms_webhook_retry.py
@@ -27,8 +27,12 @@ class _ClaimingSMSRepo:
         self.touched = []
         self.owner_status_updates = []
         self.rows = {}
-        self.auto_reply_reserved = set()
+        self.auto_reply_rows = {}
         self.auto_reply_sent = []
+        self.complete_exc = None
+        self.complete_result = True
+        self.mark_auto_reply_sent_exc = None
+        self.mark_auto_reply_sent_result = True
 
     async def claim_contact_processing(self, sms_id, *, owner_token=None):
         self.claimed_ids.append(sms_id)
@@ -71,13 +75,19 @@ class _ClaimingSMSRepo:
         self.retry_pending.append((sms_id, error_message, owner_token))
 
     async def mark_contact_processing_complete(self, sms_id, *, owner_token=None):
+        if self.complete_exc is not None:
+            raise self.complete_exc
         self.completed.append((sms_id, owner_token))
+        return self.complete_result
 
     async def get_by_id(self, sms_id):
         return self.rows.get(sms_id)
 
     async def has_auto_reply_for_inbound(self, inbound_sms_id):
-        return inbound_sms_id in self.auto_reply_reserved
+        return inbound_sms_id in self.auto_reply_rows
+
+    async def get_auto_reply_for_inbound(self, inbound_sms_id):
+        return self.auto_reply_rows.get(inbound_sms_id)
 
     async def reserve_auto_reply_for_inbound(
         self,
@@ -88,22 +98,31 @@ class _ClaimingSMSRepo:
         body,
         business_context_id,
     ):
-        if inbound_sms_id in self.auto_reply_reserved:
+        if inbound_sms_id in self.auto_reply_rows:
             return None
-        self.auto_reply_reserved.add(inbound_sms_id)
-        return {
+        row = {
             "id": uuid4(),
             "message_sid": f"auto_reply_{inbound_sms_id}",
             "from_number": from_number,
             "to_number": to_number,
             "body": body,
             "business_context_id": business_context_id,
+            "status": "pending",
             "source": "auto_reply",
             "source_ref": str(inbound_sms_id),
         }
+        self.auto_reply_rows[inbound_sms_id] = row
+        return row
 
     async def mark_auto_reply_sent(self, auto_reply_sms_id, *, provider_message_id=None):
+        if self.mark_auto_reply_sent_exc is not None:
+            raise self.mark_auto_reply_sent_exc
         self.auto_reply_sent.append((auto_reply_sms_id, provider_message_id))
+        for row in self.auto_reply_rows.values():
+            if row["id"] == auto_reply_sms_id:
+                row["status"] = "sent"
+                row["error_message"] = provider_message_id
+        return self.mark_auto_reply_sent_result
 
     async def update_contact_processing_status(
         self,
@@ -136,9 +155,10 @@ class _SlowFormRequest:
 
 
 class _Provider:
-    def __init__(self, *, send_delay: float = 0.0):
+    def __init__(self, *, send_delay: float = 0.0, send_exc: Exception | None = None):
         self.sent_sms = []
         self.send_delay = send_delay
+        self.send_exc = send_exc
 
     async def handle_incoming_sms(self, **kwargs):
         return SimpleNamespace(context_id=None)
@@ -146,6 +166,8 @@ class _Provider:
     async def send_sms(self, **kwargs):
         if self.send_delay:
             await asyncio.sleep(self.send_delay)
+        if self.send_exc is not None:
+            raise self.send_exc
         self.sent_sms.append(kwargs)
         return SimpleNamespace(provider_message_id=f"SM-out-{len(self.sent_sms)}")
 
@@ -642,6 +664,41 @@ async def test_inbound_sms_handler_returns_503_when_processing_exceeds_ack_budge
         replacements.restore()
 
     assert response.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_inbound_sms_handler_allows_slow_but_configured_processing_before_ack():
+    repo = _WebhookRepo()
+
+    replacements = _AttrReplacements()
+    replacements.replace(webhooks, "get_context_router", lambda: _Router())
+    replacements.replace(
+        webhooks,
+        "get_comms_service",
+        lambda: SimpleNamespace(provider=_Provider()),
+    )
+    replacements.replace(sms_message, "get_sms_message_repo", lambda: repo)
+    replacements.replace(webhooks, "SMS_INBOUND_BEFORE_ACK_TIMEOUT_SECONDS", 0.25)
+
+    async def processor(*args, **kwargs):
+        await asyncio.sleep(0.05)
+        return "complete"
+
+    replacements.replace(webhooks, "_process_inbound_sms", processor)
+
+    try:
+        response = await webhooks.handle_inbound_sms(
+            _FormRequest(),
+            MessageSid="SM-slow-valid",
+            From="+12175550101",
+            To="+12175550102",
+            Body="hello",
+            NumMedia="0",
+        )
+    finally:
+        replacements.restore()
+
+    assert response.status_code == 200
 
 
 @pytest.mark.asyncio
@@ -1335,16 +1392,27 @@ async def test_process_inbound_sms_skipped_intelligence_still_auto_replies_and_c
 
     assert outcome == "complete"
     assert len(provider.sent_sms) == 1
-    assert repo.auto_reply_reserved == {sms_id}
+    assert repo.auto_reply_rows[sms_id]["status"] == "sent"
     assert len(repo.auto_reply_sent) == 1
     assert repo.completed == [(sms_id, repo.owner_tokens[sms_id])]
 
 
 @pytest.mark.asyncio
-async def test_process_inbound_sms_reserved_auto_reply_skips_duplicate_send_and_completes():
+async def test_process_inbound_sms_pending_auto_reply_retries_send_and_completes():
     sms_id = uuid4()
     repo = _ClaimingSMSRepo(claim_result=True)
-    repo.auto_reply_reserved.add(sms_id)
+    pending_row = {
+        "id": uuid4(),
+        "message_sid": f"auto_reply_{sms_id}",
+        "from_number": "+12175550102",
+        "to_number": "+12175550101",
+        "body": "Thanks!",
+        "business_context_id": "effingham_maids",
+        "status": "pending",
+        "source": "auto_reply",
+        "source_ref": str(sms_id),
+    }
+    repo.auto_reply_rows[sms_id] = pending_row
     context = SimpleNamespace(
         id="effingham_maids",
         sms_auto_reply=True,
@@ -1382,8 +1450,179 @@ async def test_process_inbound_sms_reserved_auto_reply_skips_duplicate_send_and_
         replacements.restore()
 
     assert outcome == "complete"
+    assert len(provider.sent_sms) == 1
+    assert repo.auto_reply_sent == [(pending_row["id"], "SM-out-1")]
+    assert repo.auto_reply_rows[sms_id]["status"] == "sent"
+    assert repo.completed == [(sms_id, repo.owner_tokens[sms_id])]
+
+
+@pytest.mark.asyncio
+async def test_process_inbound_sms_sent_auto_reply_skips_duplicate_send_and_completes():
+    sms_id = uuid4()
+    repo = _ClaimingSMSRepo(claim_result=True)
+    repo.auto_reply_rows[sms_id] = {
+        "id": uuid4(),
+        "message_sid": f"auto_reply_{sms_id}",
+        "from_number": "+12175550102",
+        "to_number": "+12175550101",
+        "body": "Thanks!",
+        "business_context_id": "effingham_maids",
+        "status": "sent",
+        "source": "auto_reply",
+        "source_ref": str(sms_id),
+    }
+    context = SimpleNamespace(
+        id="effingham_maids",
+        sms_auto_reply=True,
+        sms_enabled=True,
+    )
+    provider = _Provider()
+    replacements = _AttrReplacements()
+    replacements.replace(
+        webhooks,
+        "get_comms_service",
+        lambda: SimpleNamespace(provider=provider),
+    )
+
+    async def generate_reply(body, ctx):
+        return "Thanks!"
+
+    replacements.replace(webhooks, "_generate_sms_reply", generate_reply)
+
+    async def intelligence_runner(**kwargs):
+        return "complete"
+
+    try:
+        outcome = await webhooks._process_inbound_sms(
+            sms_id,
+            "+12175550101",
+            "+12175550102",
+            "hello",
+            context,
+            [],
+            provider_message_id="SM-auto-retry-sent",
+            sms_repo=repo,
+            intelligence_runner=intelligence_runner,
+        )
+    finally:
+        replacements.restore()
+
+    assert outcome == "complete"
     assert provider.sent_sms == []
     assert repo.auto_reply_sent == []
+    assert repo.completed == [(sms_id, repo.owner_tokens[sms_id])]
+
+
+@pytest.mark.asyncio
+async def test_process_inbound_sms_auto_reply_send_failure_retries_without_completion():
+    sms_id = uuid4()
+    repo = _ClaimingSMSRepo(claim_result=True)
+    context = SimpleNamespace(
+        id="effingham_maids",
+        sms_auto_reply=True,
+        sms_enabled=True,
+    )
+    provider = _Provider(send_exc=RuntimeError("provider down"))
+    replacements = _AttrReplacements()
+    replacements.replace(
+        webhooks,
+        "get_comms_service",
+        lambda: SimpleNamespace(provider=provider),
+    )
+
+    async def generate_reply(body, ctx):
+        return "Thanks!"
+
+    replacements.replace(webhooks, "_generate_sms_reply", generate_reply)
+
+    async def intelligence_runner(**kwargs):
+        return "complete"
+
+    try:
+        outcome = await webhooks._process_inbound_sms(
+            sms_id,
+            "+12175550101",
+            "+12175550102",
+            "hello",
+            context,
+            [],
+            provider_message_id="SM-auto-send-fail",
+            sms_repo=repo,
+            intelligence_runner=intelligence_runner,
+        )
+    finally:
+        replacements.restore()
+
+    assert outcome == "retry_pending"
+    assert repo.auto_reply_rows[sms_id]["status"] == "pending"
+    assert repo.completed == []
+
+
+@pytest.mark.asyncio
+async def test_process_inbound_sms_final_completion_failure_retries():
+    sms_id = uuid4()
+    repo = _ClaimingSMSRepo(claim_result=True)
+    repo.complete_exc = RuntimeError("db down")
+    context = SimpleNamespace(
+        id="effingham_maids",
+        sms_auto_reply=False,
+        sms_enabled=True,
+    )
+
+    async def intelligence_runner(**kwargs):
+        return "complete"
+
+    outcome = await webhooks._process_inbound_sms(
+        sms_id,
+        "+12175550101",
+        "+12175550102",
+        "hello",
+        context,
+        [],
+        provider_message_id="SM-complete-fail",
+        sms_repo=repo,
+        intelligence_runner=intelligence_runner,
+    )
+
+    assert outcome == "retry_pending"
+    assert repo.completed == []
+
+
+@pytest.mark.asyncio
+async def test_process_inbound_sms_existing_notified_row_skips_duplicate_notification():
+    sms_id = uuid4()
+    repo = _ClaimingSMSRepo(claim_result=True)
+    repo.rows[sms_id] = {
+        "id": sms_id,
+        "status": "received",
+        "contact_id": uuid4(),
+        "notified": True,
+    }
+    context = SimpleNamespace(
+        id="effingham_maids",
+        sms_auto_reply=False,
+        sms_enabled=True,
+    )
+    intelligence_calls = []
+
+    async def intelligence_runner(**kwargs):
+        intelligence_calls.append(kwargs)
+        return "complete"
+
+    outcome = await webhooks._process_inbound_sms(
+        sms_id,
+        "+12175550101",
+        "+12175550102",
+        "hello",
+        context,
+        [],
+        provider_message_id="SM-notified-retry",
+        sms_repo=repo,
+        intelligence_runner=intelligence_runner,
+    )
+
+    assert outcome == "complete"
+    assert intelligence_calls[0]["notification_already_sent"] is True
     assert repo.completed == [(sms_id, repo.owner_tokens[sms_id])]
 
 


### PR DESCRIPTION
Plan: plans/PR-EOM-SMS-Retry-Resume.md
Slice phase: production hardening
Ownership lane: eom-crm/sms-ingress-retry

Fixes the live half of #2230: duplicate inbound SMS retries now resume incomplete CRM/contact processing without treating an existing MessageSid as proof that the work finished. The migration-352 workflow-filter claim is stale on current main; the workflow already includes that migration in both PR and push filters. This PR edits the EOM workflow only to enroll the SMS retry Postgres proof.

## Intentional

- Linked-but-incomplete duplicate SMS rows resume before acknowledgement and carry the existing contact id forward instead of creating/linking CRM again.
- Completed rows (ready / notified) are treated as finished, so stop, spam, disabled, or empty-body outcomes do not re-run on provider retry.
- New inbound SMS rows are persisted before contact/intelligence processing.
- Contact processing now runs under a bounded provider-ack deadline that covers SMS extraction, call-action planning, notification, CRM/provider margin, and the actual auto-reply timeout.
- Processing claims carry an owner token; heartbeat, non-terminal status writes, retry-pending, completion, and outbound-send boundaries check/preserve that token so a stale owner cannot finish after a reclaim.
- Lease timestamps use PostgreSQL's clock, not worker-local clocks.
- Retry rehydration uses persisted body/media/from/to exactly and uses persisted business_context_id before phone-number routing; a stored but unresolvable context id fails closed with 503.
- Post-link interaction logging failures are logged but do not undo the linked contact or suppress action planning, notification, or auto-reply.
- Inbound auto-replies use a deterministic outbound row as a narrow outbox: pending rows send the persisted body, sending/sent rows skip duplicate provider contact, and provider acceptance stores the provider SID in message_sid so delivery callbacks can find the row.
- Stop/spam classification does not clear an active webhook owner; terminal finalization happens once in the webhook.
- No lead lifecycle, estimate-booking, customer/site, payment, auto-reply copy, or migration-352 workflow-filter behavior is changed.

## Deferred

- A broader exactly-once SMS processing state machine with a dedicated owner column, provider idempotency keys, and a durable worker/reconciliation queue is deferred until inbound SMS volume or duplicate side effects justify it. This slice treats sending as provider-acceptance ambiguous and favors no duplicate customer SMS over resending after an unprovable crash boundary.
- Reminder dedupe and a broader outbound-message worker are deferred; linked-but-incomplete retries resume through the existing contact id, and this slice only reserves the direct inbound auto-reply tied to the retried SMS row.

## Parked hardening

- Parking predicate: parked hardening is limited to changes that require a new durable queue/schema-backed worker system, provider idempotency/reconciliation, or reminder/outbound orchestration outside the direct inbound SMS retry ownership path.
- Parked under that predicate: broader durable-queue orchestration, provider exactly-once reconciliation, and reminder/outbound orchestration only.

## AI reconciliation

- AI findings reviewed: Yes
- All fixed or waived: Yes
- Fixed: R8 ownerless stale-lease reclaim by storing an owner token on processing claims and requiring that token for heartbeat, retry-pending, completion, and outbound-send boundaries.
- Fixed: R8 token-erasing status writes by preserving the owner token across contact-processing status/notification writes until terminal completion.
- Fixed: R6 unconsumed retry_pending by running first-delivery and duplicate-resume processing under a bounded acknowledgement budget and returning 503 for claim/CRM retry outcomes, active incomplete leases, and timeouts.
- Fixed: R6 post-link interaction failure suppression by treating non-EOM interaction logging failure as post-link non-terminal logging, allowing action planning, notification, and auto-reply to continue.
- Fixed: R6/R13 CRM infrastructure failure suppression by propagating database/provider failures as retryable instead of treating them as legitimate no-contact completion.
- Fixed: R7 before-ack latency risk by capping provider-facing processing with an end-to-end budget.
- Fixed: R1/R8 completed-unlinked retry loop by treating ready/notified unlinked rows as complete instead of resumable.
- Fixed: R1 linked-row lost-work risk by continuing linked-but-incomplete rows until terminal processing while preserving the existing contact id.
- Fixed: R3/R5 tenant drift by restoring persisted business_context_id, failing closed when a stored id no longer resolves, and falling back to number routing only for legacy rows without a stored context.
- Fixed: R2/R12 evidence gap by adding handler-level before-ack tests, direct repository predicate coverage, a CI-enrolled live Postgres owner-token single-winner/stale-lease proof, and post-link continuation coverage.
- Fixed: R1 parking-policy gap by defining the slice parking predicate before declaring parked hardening.
- Fixed: R1/R8 execution-model gap by recording the lease invariant and component-to-invariant mapping in the Review Contract.
- Fixed: R8 crash-idempotent auto-reply gap by reserving a deterministic outbound auto-reply row before provider contact, sending only persisted pending bodies, treating sending as provider-ambiguous, and skipping duplicate sends on retry.
- Fixed: R5 provider SID callback gap by moving the accepted provider SID into message_sid while keeping the inbound idempotency link in source_ref.
- Fixed: R1/R6 terminal stop/spam gap by leaving leased terminal finalization to the webhook owner instead of clearing ownership in SMS intelligence.
- Fixed: R1/R7 late deadline gap by starting the provider acknowledgement budget at route entry and applying it to every awaited operation before acknowledgement.
- Fixed: R7/R8 deadline mismatch by deriving the before-ack budget from admitted SMS LLM, call-action LLM, notification, actual auto-reply, and CRM/provider latency.
- Fixed: R6/R8 finalization gap by requiring terminal lease completion to update the owned row before returning success.
- Fixed: R6/R8 duplicate notification replay by passing persisted notified row state into SMS intelligence and skipping already-sent notifications on retry.
- Fixed: R8 database-clock lease gap by using CURRENT_TIMESTAMP for claim/heartbeat/retry/finalization timestamps and stale-lease comparison.

## Cold diff reconstruction

- Changed: atlas_brain/storage/repositories/sms_message.py makes contact-processing leases use PostgreSQL time, returns authoritative claim/current row state, fences owned transitions, adds pending -> sending -> sent auto-reply helpers, and stores provider-accepted SIDs in message_sid for callback lookup.
- Changed: atlas_brain/api/comms/webhooks.py expands the before-ack budget, preserves/reuses durable auto-reply body text, marks reserved replies sending before provider contact, skips sending/sent retries, preserves provider retry outcomes, and finalizes only after the owned row update succeeds.
- Changed: atlas_brain/comms/sms_intelligence.py leaves stop/spam owner-fenced finalization to the webhook when a processing owner token exists.
- Changed: .github/workflows/atlas_eom_lead_pipeline_checks.yml enrolls tests/test_eom_sms_webhook_retry.py and exports the workflow Postgres URL as ATLAS_EOM_SMS_RETRY_POSTGRES_URL.
- Changed: tests/test_eom_sms_webhook_retry.py proves before-ack processing/503 behavior, active-lease 503 behavior, route-entry timeout and slow-valid behavior, linked-incomplete resume with existing contact/notified state, completed-row skip, persisted context restoration/fail-closed behavior, owner-token repository fencing, CI-enrolled live Postgres claim/retry/status/provider-SID fencing, owner-token preservation, skipped-vs-terminal intelligence handling, pending/sending/sent auto-reply behavior, finalization failure retry, CRM infra retry propagation, post-link continuation, and claim/CRM-failure retry marking.
- Changed: plans/PR-EOM-SMS-Retry-Resume.md records the updated contract, scope, review reconciliation, and diff-size.
- Contract match: every SMS code/test/plan change traces to the SMS retry ownership contract.
- Gaps: none found.

## Verification

- python -m py_compile atlas_brain/api/comms/webhooks.py atlas_brain/comms/sms_intelligence.py atlas_brain/storage/repositories/sms_message.py tests/test_eom_sms_webhook_retry.py — PASS.
- python -m pytest -q tests/test_eom_sms_webhook_retry.py tests/test_eom_lead_ingress.py::test_real_sms_link_uses_eom_lead_resolver tests/test_eom_lead_ingress.py::test_sms_link_uses_provider_identity_without_a_local_sms_row tests/test_eom_lead_ingress.py::test_sms_fallback_uses_eom_lead_resolver — 41 passed, 1 skipped, 1 warning.
- python scripts/audit_plan_doc.py plans/PR-EOM-SMS-Retry-Resume.md — PASS.
- python scripts/audit_plan_doc_files_touched.py plans/PR-EOM-SMS-Retry-Resume.md origin/main — PASS.
- python scripts/audit_plan_doc_diff_size.py plans/PR-EOM-SMS-Retry-Resume.md origin/main — PASS; estimated diff size is 3371 LOC, actual diff size is 3371 LOC, drift is 0.0%.
- python scripts/audit_plan_code_consistency.py --base-ref origin/main plans/PR-EOM-SMS-Retry-Resume.md — PASS.
- python scripts/audit_review_rules_triggered.py origin/main --plan plans/PR-EOM-SMS-Retry-Resume.md — PASS.
- git diff --check origin/main -- . ':!node_modules' — PASS.
- python scripts/maturity_sweep.py atlas_brain/api ... — ratchet gate passed.
- python scripts/maturity_sweep.py atlas_brain/storage ... — ratchet gate passed.

## Diff size

- 6 declared files, 3371 LOC by plan diff-size audit; estimate is 3371 LOC with 0.0% drift.
- Diff-budget override: this production-hardening slice is genuinely indivisible because the current-head review findings all describe the same SMS retry ownership seam; splitting claim eligibility, authoritative row state, completed-unlinked detection, owner-token fencing, before-ack 503 behavior, persisted tenant restoration, post-link continuation, recoverable auto-reply side effects, notification dedupe, and durable finalization would leave known duplicate/lost-work interleavings enabled between PRs.
