### PR TITLE
Add pre-open local review proof guard

### DIFF
--- a/plans/PR-Pre-Open-Local-Review-Guard.md
+++ b/plans/PR-Pre-Open-Local-Review-Guard.md
@@ -1,0 +1,325 @@
+# PR-Pre-Open-Local-Review-Guard
+
+## Why this slice exists
+
+The merged AGENTS mechanical enforcement audit found that the local review
+bundle is required before opening or updating a PR, but `open_pr.sh` only runs
+the PR body audit before `gh pr create/edit`. A builder can push directly and
+then open the PR, which lets GitHub see an immediately red branch even though the
+AGENTS workflow says `local_pr_review.sh` is the pre-open fast path. This
+workflow/process slice closes that helper gap without changing branch
+protection, CI required contexts, or product behavior. The diff is over the
+400-LOC soft cap because this is a guard/admission-boundary slice and the
+correct proof requires both positive and negative wrapper fixtures across
+create/edit/docs-only paths, stale `HEAD`, stale `origin/main`, stale body,
+dry-run/refspec rejection, remote-branch publication proof, and failed-push
+ordering. The Codex review on the first published head found that a zero-exit
+`git push --dry-run` or unrelated refspec could still write proof; this update
+closes that root cause instead of treating the example only. The follow-up
+Codex review found two same-class bypasses: proof was still not bound to the
+branch being opened, and Git's long-option abbreviation for `--no-verify` could
+disable the managed pre-push hook. The next Codex review found three more
+same-class bypasses: Git also abbreviates `--dry-run`, `open_pr.sh` could pass
+target-changing create args that were not covered by the proof, and both
+wrappers used a mutable body file after review. This update closes those guard
+classes too. The current-head Codex review then found the remaining shared seam:
+the wrappers still interpreted shell/Git state piecemeal. This update closes
+that seam by parsing the supported push option shapes, capturing proof inputs
+before review, verifying those inputs remain unchanged after push, and
+revalidating the published branch immediately before `gh`.
+The next current-head Codex review found three adjacent proof-boundary gaps
+inside that same seam: remote-head revalidation still happened before the
+`gh pr view` existence probe, environment-selected `GH_REPO` could retarget the
+GitHub CLI without passing through argv validation, and the push-arg parser did
+not consume operands for value-taking Git push options. This update closes those
+remaining parser/target/timing classes.
+The following current-head Codex review found that endpoint sampling still
+allowed an ABA checkout interleaving, the boundary enumeration did not
+disposition each wrapper input shape, and numeric branch names were ambiguous
+with GitHub PR-number selectors. This update runs review in an immutable
+captured-head worktree, expands the boundary enumeration by caller/input class,
+and resolves existing PRs by matched head ref before editing.
+The latest current-head Codex review found three remaining target-binding gaps:
+a positional non-`origin` push remote could still receive the push while proof
+checked `origin`, same-branch fork PRs could be mistaken for the existing
+current-repo PR, and the create path still let `gh pr create` infer the head
+branch from mutable checkout state. This update rejects non-`origin` positional
+remotes, verifies existing PR matches against current owner/repo identity, and
+passes the proven branch explicitly with `gh pr create --head`.
+
+### Problem-derived contract
+
+- Root cause: `push_pr.sh` is the only helper that guarantees the mechanical
+  local review bundle ran before publication, but `open_pr.sh` has no durable
+  local signal proving that the current `HEAD` and PR body are the same inputs
+  that passed that bundle.
+- Correct fix must touch/change: `push_pr.sh` must write a local, ignored proof
+  only after its guarded push succeeds and the current branch's remote-tracking
+  ref equals local `HEAD`; `push_pr.sh` must reject dry-run pushes and refspecs
+  that do not publish the current branch; `push_pr.sh` must reject
+  `--no-verify` and Git-abbreviated spellings that disable the pre-push hook;
+  `push_pr.sh` must also reject Git-abbreviated and bundled dry-run spellings,
+  reject only the Git spellings that bypass verification, preserve valid
+  non-bypass options such as `--no-verbose`, capture branch/head/base/body proof
+  inputs before review, run local review against that immutable captured Git
+  state, and verify those exact inputs remain unchanged after push; `open_pr.sh`
+  must verify the proof's branch, head, base, and body
+  snapshot before `gh pr create/edit`, must reject environment-selected target
+  overrides such as `GH_REPO`, must revalidate the remote branch SHA after the
+  PR existence probe and immediately before the mutating `gh` call, must pass
+  the captured branch explicitly to `gh pr create --head`, must verify existing
+  PR lookup results belong to the current repository before edit, must pass
+  the same immutable body snapshot to `gh`, and must reject target-changing
+  create args outside the proof's
+  current-branch/current-repo/`origin/main` contract; tests must cover missing,
+  stale-head, stale-base, stale-body, stale-branch-at-same-head, create, edit,
+  docs-only, dry-run and abbreviated/bundled dry-run, unrelated-refspec,
+  abbreviated-no-verify, `--no-verbose`, value-taking push options, stale-remote
+  before and after the PR existence probe, base movement during push, same-branch
+  fork PR lookup, explicit create-head binding, body
+  mutation during push/open, argv/environment target overrides, and failed-push
+  paths, plus ABA checkout interleavings and numeric branch names.
+- Must not change: no CI workflow, branch protection, PR body contract, plan
+  admission contract, product code, remote GitHub state semantics, or other open
+  PR lanes.
+
+## Scope (this PR)
+
+Ownership lane: workflow/pre-open-local-review-guard
+Slice phase: Workflow/process
+
+1. Add a local pre-open proof handshake between `push_pr.sh` and `open_pr.sh`.
+2. Block `open_pr.sh` before any `gh pr create/edit` when proof is missing or
+   stale for the current `HEAD`, `origin/main`, or body file.
+3. Keep the proof local to the worktree/Git directory so it is not committed and
+   not treated as a branch-protection or CI mechanism.
+
+### Review Contract
+
+- Acceptance criteria:
+  1. `scripts/push_pr.sh` records a proof after a successful guarded push that
+     includes the current `HEAD` SHA, `origin/main` SHA, and SHA-256 of the
+     reviewed PR body snapshot plus current branch name, but only after
+     `refs/remotes/origin/<current-branch>` equals local `HEAD`.
+  2. `scripts/open_pr.sh` checks the proof before create and edit, and exits
+     before invoking `gh` if the proof is missing, points at another branch,
+     another `HEAD`, another `origin/main`, or another reviewed body hash.
+  3. `tests/test_open_pr_wrapper.py` proves missing proof, stale `HEAD`, stale
+     `origin/main`, stale branch at the same `HEAD`, and stale body cases never
+     invoke fake `gh`, and proves matching proof still passes the body over
+     stdin for create, edit, and docs-only bodies. It also proves the wrapper
+     rejects target-changing `--head`/`--repo`/non-main `--base` args before
+     fake `gh`, rejects `GH_REPO` environment target overrides before fake
+     `gh`, revalidates the published branch after the PR-existence probe, and
+     that a body mutation during fake `gh` still sends the reviewed snapshot.
+    4. `tests/test_push_pr_wrapper.py` proves the push wrapper writes the proof
+       after successful current-branch publication and does not write it when the
+       push fails, the push is a Git dry-run, the refspec targets another branch,
+       Git receives a `--no-verify` spelling/abbreviation, Git receives a
+       dry-run abbreviation/bundled short dry-run, `origin/main` moves during the
+       push, or the remote-tracking branch does not equal local `HEAD`. It also
+       proves a body mutation during fake `git push` cannot change the reviewed
+       body hash recorded in proof, that `--no-verbose` remains allowed, that
+       value-taking push options consume their operands before remote/refspec
+       detection, that `--repo` target overrides are rejected, that staged,
+       unstaged, and untracked source worktree changes are rejected before
+       immutable review, that source dirtied during push is rejected before proof
+       write, and that an ABA checkout interleaving during review still reviews
+     the captured head, and that a non-`origin` positional push remote exits
+     before review, push, or proof.
+    5. Numeric branch names are resolved through an unambiguous head-branch PR
+       query before edit; `open_pr.sh` never passes a numeric branch name as the
+       positional PR selector to `gh pr view/edit`.
+    6. R8 execution model: selected component is Git's immutable object store plus
+       `git worktree add --detach <captured-head>` for review isolation, with the
+       source checkout used only as an admission surface. The admitted execution
+       model is one wrapper process for the proof file, arbitrary concurrent
+       source-checkout edits, arbitrary remote/base movement, and ordinary
+       `git push` success/failure. Property invariant: a proof is written only if
+       the source checkout is clean before immutable review and again after push,
+       the reviewed body snapshot hash is unchanged, the captured branch/`HEAD`
+       /`origin/main` values still match, and `origin/<captured-branch>` equals
+       captured `HEAD`; otherwise the helper fails closed before proof. Explicit
+       assumption: a process that can modify the Git object database or rewrite
+       the ignored proof file outside this wrapper is outside the local-helper
+       trust boundary.
+- Reachability proof: wrapper-level surface; exercised through the real
+  `scripts/open_pr.sh` and `scripts/push_pr.sh` entrypoints with fake `gh`/`git`
+  adapters and observable `gh` invocation/proof-file effects.
+- Affected surfaces: `scripts/open_pr.sh`, `scripts/push_pr.sh`,
+  `tests/test_open_pr_wrapper.py`, `tests/test_push_pr_wrapper.py`, and this
+  plan.
+- Risk areas: stale proof acceptance, skipped source worktree edits,
+  cross-worktree interleavings, bypassing body-stdin behavior, breaking docs-only
+  PR bodies, and accidentally turning the local helper proof into a CI or
+  branch-protection claim.
+- Reviewer rules triggered: R1, R2, R8, R10, R12, R14.
+
+### Boundary-change enumeration
+
+Required when this diff changes a guard, validator, normalizer, resolver,
+router/classifier, or admission boundary. Name each changed boundary path or
+seam in the enumeration; otherwise write "N/A - no boundary change."
+
+- Boundary path/seam: `scripts/push_pr.sh` local-review execution state.
+  - Caller x input: managed pre-push hook installed, no managed hook installed,
+    or `ATLAS_SKIP_LOCAL_PR_REVIEW=1`.
+    - Disposition: changed. All supported push paths run one wrapper-owned local
+      review in a temporary worktree pinned to the captured `HEAD`, but only
+      after the source checkout is clean; the final `git push` receives
+      `ATLAS_SKIP_LOCAL_PR_REVIEW=1` so the mutable checkout is not reviewed a
+      second time by the hook, then the source checkout is checked again before
+      proof write.
+    - Preserved: the PR body snapshot is still passed through
+      `ATLAS_CURRENT_PR_BODY_FILE`; invalid bodies still fail before push.
+    - Rejected: staged, unstaged, untracked, and dirty-during-push source edits do
+      not receive proof; ABA checkout interleavings no longer affect the reviewed
+      Git tree.
+- Boundary path/seam: `scripts/push_pr.sh` push-argument admission.
+  - Caller x input: default args, explicit `origin HEAD`, upstream `-u`,
+    force-with-lease, verbosity options, value-taking push options, dry-run
+    spellings, hook-bypass spellings, unrelated refspecs, and target overrides.
+  - Disposition: preserved for default/current-branch publication, `-u`,
+    `--force-with-lease`, `--no-verbose`, and value-taking options whose operands
+    are consumed before remote/refspec detection; rejected for non-`origin`
+    positional remotes, dry-run
+    abbreviations/bundles, `--no-veri*`, unrelated refspecs, missing explicit
+    refspecs, and `--repo` target overrides.
+  - Deferred/N-A: arbitrary non-origin target publication remains outside this
+    helper contract.
+- Boundary path/seam: `scripts/open_pr.sh` proof and target admission.
+  - Caller x input: create path, edit path, docs-only body, missing proof, stale
+    branch/head/base/body proof, stale published branch before/after PR lookup,
+    body mutation during `gh`, argv target selectors, and `GH_REPO`.
+  - Disposition: preserved for matching proof and stdin body delivery; rejected
+    for missing/stale proof, stale published branch, target-changing argv,
+    non-main base, `GH_REPO`, direct body args, and body mutation after review.
+  - Deferred/N-A: cross-repository PR creation and non-main base PRs require a
+    separately reviewed helper.
+- Boundary path/seam: `scripts/open_pr.sh` existing-PR resolution.
+  - Caller x input: nonnumeric branch names, numeric branch names, no existing
+    PR, same-branch fork PR records, one existing PR for the exact current-repo
+    head branch, multiple matching PR records.
+  - Disposition: changed. Existing PRs are resolved with
+    `gh pr list --head <branch> --json number,headRefName,headRepository,headRepositoryOwner,isCrossRepository`
+    and edited by returned PR number only after `headRefName`, owner, repository,
+    and non-cross-repository status match the current repo and proof branch.
+    Numeric branch names are never passed as ambiguous positional selectors.
+    Same-branch fork records are ignored. No match takes the create path; multiple
+    current-repo matches fail closed.
+
+### Deployed-config probing
+
+Required for guard, validator, resolver, admission-boundary, or env/config
+fallback changes; otherwise write "N/A - no guard/config boundary change."
+
+- Deployed/default config values: N/A - local wrapper guard only.
+- Explicit value probe: proof file with matching `HEAD`, `origin/main`, and body
+  hash plus a published matching remote branch allows fake `gh` invocation in
+  wrapper tests.
+- Absent value probe: missing proof exits before fake `gh` invocation in wrapper
+  tests.
+- Default-session/default-context probe: stale proof for another `HEAD`,
+  branch, `origin/main`, or body hash exits before fake `gh` invocation in
+  wrapper tests.
+- Side-effect ordering: `push_pr.sh` writes proof only after the fake successful
+  push and remote-tracking branch update; failed push, Git dry-run, unrelated
+  refspec, abbreviated/bundled dry-run, abbreviated `--no-verify`,
+  `origin/main` movement during push, and stale remote-tracking state leave no
+  proof in wrapper tests. Body mutations during fake push/create do not change
+  the reviewed snapshot hash or stdin payload. Target-changing `open_pr.sh`
+  create args, `GH_REPO`, stale published branch state before fake `gh`, and
+  stale published branch state after the PR-existence probe exit before fake
+  `gh`. Value-taking push options consume their operands before remote/refspec
+  detection, while `--repo` target overrides exit before fake `git push`.
+
+### Files touched
+
+- `plans/PR-Pre-Open-Local-Review-Guard.md`
+- `scripts/open_pr.sh`
+- `scripts/push_pr.sh`
+- `tests/test_open_pr_wrapper.py`
+- `tests/test_push_pr_wrapper.py`
+
+## Mechanism
+
+Both wrappers copy the PR body into a temporary snapshot before auditing,
+pushing, proving, or feeding `gh`, then delete that snapshot on exit.
+`push_pr.sh` parses the supported push argument shapes before review: it rejects
+dry-run options including bundled `-n`, abbreviated `--dr*` spellings, refspecs
+that do not publish the current branch, non-`origin` positional remotes, push
+target overrides such as `--repo`, and only the `--no-veri*` spellings that would
+bypass the managed pre-push hook; it also consumes operands for value-taking push
+options before identifying the remote and refspec. After refreshing
+`origin/main`, it captures the branch, `HEAD`, base SHA, and body snapshot hash
+before audit/local review, rejects staged/unstaged/untracked source checkout
+changes, then creates a temporary detached worktree at that captured `HEAD` and
+runs `local_pr_review.sh` there so the review cannot observe a later checkout
+transition in the mutable worktree. The detached review exports the captured
+branch as `GITHUB_HEAD_REF`, preserving the current-PR identity needed by the
+cross-session drift audit without reviewing the mutable branch checkout. The
+final push skips the managed hook because the immutable wrapper review has
+already run once. After push success, it checks the source checkout is still
+clean, then verifies those captured values remain unchanged and verifies
+`refs/remotes/origin/<current-branch>` equals local `HEAD`; only then does it
+write the captured values to the ignored proof file under the Git directory.
+
+`open_pr.sh` calculates the same values against its snapshot before any
+create/edit operation, rejects target-changing create args outside the
+current-branch/current-repo/main-base contract, rejects `GH_REPO` environment
+target overrides, refreshes the current remote branch before the existence probe
+and again immediately before the selected mutating `gh` call, resolves existing
+PRs with an unambiguous head-branch query that must match current repository
+owner/name before edit, passes the proven branch explicitly to `gh pr create
+--head`, requires that remote SHA to equal local `HEAD`, and feeds the same
+snapshot to `gh` over stdin. A stale proof therefore fails closed whenever the
+builder commits again, switches to another branch at the same commit,
+`origin/main` moves after proof capture, the reviewed branch is force-pushed or
+deleted before open, the builder edits/regenerates the PR body after pushing,
+the source checkout is dirty before review or before proof write, a body file
+mutates during the helper run, the create target changes away from the proof, or
+the push did not actually publish the current branch head.
+
+## Intentional
+
+- The proof is local and advisory-helper scoped. It is not a security boundary:
+  a user can still bypass helpers or edit local files. The goal is to keep the
+  endorsed Atlas helper path from opening immediate-red PRs by accident.
+- This slice does not enforce branch naming, draft consent, PR ownership, or
+  commit-message shape; those remain separate audit follow-ups.
+- The proof records the reviewed body snapshot hash, not the body path, so
+  regenerating the same body content does not create needless friction.
+
+## Deferred
+
+- `PR-PR-Mutation-Ownership-Wrapper`: wire session ownership checks into the
+  mutation helpers.
+- `PR-Open-Ready-Draft-Consent-Guard`: reject `--draft` without operator consent.
+- `PR-Branch-Naming-Gate`: enforce or downgrade the builder branch naming
+  convention.
+
+Parked hardening: none.
+
+## Verification
+
+- Completed before PR open:
+    - `python -m pytest tests/test_open_pr_wrapper.py tests/test_push_pr_wrapper.py -q`
+      - passed, 57 tests after the Codex review fixes.
+  - `python -m pytest tests/test_content_factory_copy_verification.py -q`
+      - passed, 324 tests while investigating the CI unit-gate regression.
+  - `python scripts/audit_plan_doc.py plans/PR-Pre-Open-Local-Review-Guard.md`
+  - `python scripts/audit_plan_code_consistency.py --base-ref origin/main plans/PR-Pre-Open-Local-Review-Guard.md`
+  - `python scripts/sync_pr_plan.py plans/PR-Pre-Open-Local-Review-Guard.md origin/main --check`
+  - `python scripts/audit_pr_body.py --repo-root . --base-ref origin/main /tmp/atlas-pr-body-pre-open-local-review-guard.md`
+  - `bash scripts/push_pr.sh /tmp/atlas-pr-body-pre-open-local-review-guard.md --force-with-lease origin HEAD`
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Pre-Open-Local-Review-Guard.md` | 325 |
+| `scripts/open_pr.sh` | 216 |
+| `scripts/push_pr.sh` | 276 |
+| `tests/test_open_pr_wrapper.py` | 460 |
+| `tests/test_push_pr_wrapper.py` | 922 |
+| **Total** | **2199** |

--- a/scripts/open_pr.sh
+++ b/scripts/open_pr.sh
@@ -36,6 +36,19 @@ if [ ! -f "$body_file" ]; then
     exit 2
 fi
 
+snapshot_body() {
+    local source="$1" snapshot
+    snapshot="$(mktemp "${TMPDIR:-/tmp}/atlas-pr-body.XXXXXX")"
+    cp "$source" "$snapshot"
+    printf '%s\n' "$snapshot"
+}
+
+cleanup_body_snapshot() {
+    if [ -n "${body_snapshot:-}" ]; then
+        rm -f "$body_snapshot"
+    fi
+}
+
 refresh_base_ref() {
     echo "Refreshing origin/main before PR body audit..."
     if ! git fetch --quiet origin main; then
@@ -44,13 +57,194 @@ refresh_base_ref() {
     fi
 }
 
+body_sha256() {
+    python - "$1" <<'PY'
+import hashlib
+import sys
+from pathlib import Path
+
+print(hashlib.sha256(Path(sys.argv[1]).read_bytes()).hexdigest())
+PY
+}
+
+proof_value() {
+    local key="$1" proof_file="$2"
+    awk -F= -v key="$key" '$1 == key {print substr($0, length(key) + 2); exit}' "$proof_file"
+}
+
+existing_pr_number_for_branch() {
+    local branch="$1" current_repo_json pr_json
+    if ! current_repo_json="$(gh repo view --json owner,name)"; then
+        echo "open_pr.sh: failed to query current GitHub repository" >&2
+        exit 1
+    fi
+    if ! pr_json="$(gh pr list --state open --head "$branch" --json number,headRefName,headRepository,headRepositoryOwner,isCrossRepository --limit 20)"; then
+        echo "open_pr.sh: failed to query existing PR for head branch $branch" >&2
+        exit 1
+    fi
+    python - "$branch" "$current_repo_json" "$pr_json" <<'PY'
+import json
+import sys
+
+branch = sys.argv[1]
+current_repo = json.loads(sys.argv[2])
+current_owner = (current_repo.get("owner") or {}).get("login")
+current_name = current_repo.get("name")
+matches = [
+    item for item in json.loads(sys.argv[3])
+    if item.get("headRefName") == branch
+    and not item.get("isCrossRepository", False)
+    and ((item.get("headRepositoryOwner") or {}).get("login") == current_owner)
+    and ((item.get("headRepository") or {}).get("name") == current_name)
+]
+if len(matches) > 1:
+    raise SystemExit(f"multiple open PRs found for head branch {branch}")
+if matches:
+    print(matches[0]["number"])
+PY
+}
+
+require_local_review_proof() {
+    local proof_path expected_branch expected_head expected_base expected_body actual_branch actual_head actual_base actual_body
+    proof_path="$(git rev-parse --git-path atlas-local-pr-review-proof)"
+    if [ ! -f "$proof_path" ]; then
+        echo "open_pr.sh: missing local review proof for this head/body." >&2
+        echo "Run scripts/push_pr.sh with this PR body before opening or updating the PR." >&2
+        exit 2
+    fi
+
+    expected_branch="$(proof_value branch "$proof_path")"
+    expected_head="$(proof_value head_sha "$proof_path")"
+    expected_base="$(proof_value base_sha "$proof_path")"
+    expected_body="$(proof_value body_sha256 "$proof_path")"
+    actual_branch="$(git branch --show-current)"
+    actual_head="$(git rev-parse HEAD)"
+    actual_base="$(git rev-parse origin/main)"
+    actual_body="$(body_sha256 "$body_snapshot")"
+
+    if [ "$expected_branch" != "$actual_branch" ]; then
+        echo "open_pr.sh: stale local review proof: expected branch $actual_branch, found ${expected_branch:-<missing>}." >&2
+        echo "Run scripts/push_pr.sh again from this branch before opening or updating the PR." >&2
+        exit 2
+    fi
+    if [ "$expected_head" != "$actual_head" ]; then
+        echo "open_pr.sh: stale local review proof: expected HEAD $actual_head, found ${expected_head:-<missing>}." >&2
+        echo "Run scripts/push_pr.sh again before opening or updating the PR." >&2
+        exit 2
+    fi
+    if [ "$expected_base" != "$actual_base" ]; then
+        echo "open_pr.sh: stale local review proof: expected origin/main $actual_base, found ${expected_base:-<missing>}." >&2
+        echo "Run scripts/push_pr.sh again before opening or updating the PR." >&2
+        exit 2
+    fi
+    if [ "$expected_body" != "$actual_body" ]; then
+        echo "open_pr.sh: stale local review proof: PR body changed after local review." >&2
+        echo "Run scripts/push_pr.sh again with this body before opening or updating the PR." >&2
+        exit 2
+    fi
+}
+
+verify_published_head() {
+    local actual_branch actual_head actual_remote
+    actual_branch="$(git branch --show-current)"
+    actual_head="$(git rev-parse HEAD)"
+    if ! git fetch --quiet origin "$actual_branch"; then
+        echo "open_pr.sh: failed to refresh origin/$actual_branch before PR mutation." >&2
+        echo "Run scripts/push_pr.sh again before opening or updating the PR." >&2
+        exit 1
+    fi
+    if ! actual_remote="$(git rev-parse "refs/remotes/origin/$actual_branch" 2>/dev/null)"; then
+        echo "open_pr.sh: reviewed branch is not published at origin/$actual_branch." >&2
+        echo "Run scripts/push_pr.sh again before opening or updating the PR." >&2
+        exit 2
+    fi
+    if [ "$actual_remote" != "$actual_head" ]; then
+        echo "open_pr.sh: stale local review proof: origin/$actual_branch is $actual_remote, current HEAD is $actual_head." >&2
+        echo "Run scripts/push_pr.sh again before opening or updating the PR." >&2
+        exit 2
+    fi
+}
+
+reject_environment_target_overrides() {
+    if [ -n "${GH_REPO:-}" ]; then
+        echo "open_pr.sh: refusing GH_REPO target override: $GH_REPO" >&2
+        echo "Open PRs in the current repository only; unset GH_REPO and rerun this wrapper." >&2
+        exit 2
+    fi
+}
+
+validate_create_target_args() {
+    local arg value
+    while [ "$#" -gt 0 ]; do
+        arg="$1"
+        shift
+        case "$arg" in
+            --head|-H|--repo|-R)
+                echo "open_pr.sh: refusing target-changing create arg: $arg" >&2
+                echo "Open PRs from the current branch in this repo only; use a separate reviewed helper for target overrides." >&2
+                exit 2
+                ;;
+            --head=*|--repo=*|-H*|-R*)
+                echo "open_pr.sh: refusing target-changing create arg: $arg" >&2
+                echo "Open PRs from the current branch in this repo only; use a separate reviewed helper for target overrides." >&2
+                exit 2
+                ;;
+            --base)
+                if [ "$#" -eq 0 ]; then
+                    echo "open_pr.sh: --base requires a value" >&2
+                    exit 2
+                fi
+                value="$1"
+                shift
+                if [ "$value" != "main" ]; then
+                    echo "open_pr.sh: refusing non-main base: $value" >&2
+                    echo "The local review proof is bound to origin/main; use a separate reviewed helper for target overrides." >&2
+                    exit 2
+                fi
+                ;;
+            --base=*)
+                value="${arg#--base=}"
+                if [ "$value" != "main" ]; then
+                    echo "open_pr.sh: refusing non-main base: $value" >&2
+                    echo "The local review proof is bound to origin/main; use a separate reviewed helper for target overrides." >&2
+                    exit 2
+                fi
+                ;;
+            -B)
+                if [ "$#" -eq 0 ]; then
+                    echo "open_pr.sh: -B requires a value" >&2
+                    exit 2
+                fi
+                value="$1"
+                shift
+                if [ "$value" != "main" ]; then
+                    echo "open_pr.sh: refusing non-main base: $value" >&2
+                    echo "The local review proof is bound to origin/main; use a separate reviewed helper for target overrides." >&2
+                    exit 2
+                fi
+                ;;
+            -B*)
+                value="${arg#-B}"
+                if [ "$value" != "main" ]; then
+                    echo "open_pr.sh: refusing non-main base: $value" >&2
+                    echo "The local review proof is bound to origin/main; use a separate reviewed helper for target overrides." >&2
+                    exit 2
+                fi
+                ;;
+        esac
+    done
+}
+
+body_snapshot="$(snapshot_body "$body_file")"
+trap cleanup_body_snapshot EXIT
+
 refresh_base_ref
 
 body_audit_args=(--base-ref origin/main)
 if [ -n "${ATLAS_CURRENT_PR_AUTHOR:-}" ]; then
     body_audit_args+=(--pr-author "$ATLAS_CURRENT_PR_AUTHOR")
 fi
-python scripts/audit_pr_body.py "${body_audit_args[@]}" "$body_file"
+python scripts/audit_pr_body.py "${body_audit_args[@]}" "$body_snapshot"
 
 for arg in "$@"; do
     case "$arg" in
@@ -60,6 +254,8 @@ for arg in "$@"; do
             ;;
     esac
 done
+validate_create_target_args "$@"
+reject_environment_target_overrides
 
 branch="$(git branch --show-current)"
 if [ -z "$branch" ]; then
@@ -67,7 +263,11 @@ if [ -z "$branch" ]; then
     exit 2
 fi
 
-if gh pr view "$branch" >/dev/null 2>&1; then
+require_local_review_proof
+verify_published_head
+
+existing_pr_number="$(existing_pr_number_for_branch "$branch")"
+if [ -n "$existing_pr_number" ]; then
     if [ "$#" -gt 0 ]; then
         echo "open_pr.sh: PR already exists for $branch; update body with no create args" >&2
         echo "Use gh pr edit manually for title/base/label changes." >&2
@@ -75,16 +275,20 @@ if gh pr view "$branch" >/dev/null 2>&1; then
     fi
 
     if [ "${ATLAS_OPEN_PR_DRY_RUN:-}" = "1" ]; then
-        echo "DRY RUN: gh pr edit $branch --body-file - < $body_file"
+        verify_published_head
+        echo "DRY RUN: gh pr edit $existing_pr_number --body-file - < $body_file"
         exit 0
     fi
 
-    gh pr edit "$branch" --body-file - < "$body_file"
+    verify_published_head
+    gh pr edit "$existing_pr_number" --body-file - < "$body_snapshot"
 else
     if [ "${ATLAS_OPEN_PR_DRY_RUN:-}" = "1" ]; then
-        echo "DRY RUN: gh pr create $* --body-file - < $body_file"
+        verify_published_head
+        echo "DRY RUN: gh pr create --head $branch $* --body-file - < $body_file"
         exit 0
     fi
 
-    gh pr create "$@" --body-file - < "$body_file"
+    verify_published_head
+    gh pr create --head "$branch" "$@" --body-file - < "$body_snapshot"
 fi

--- a/scripts/push_pr.sh
+++ b/scripts/push_pr.sh
@@ -4,15 +4,14 @@
 set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
+repo_root="$(pwd)"
 
 usage() {
     cat <<'EOF'
 Usage: bash scripts/push_pr.sh BODY_FILE [git-push-args...]
 
-Pushes with ATLAS_CURRENT_PR_BODY_FILE exported so the installed pre-push hook
-validates the same body. When the managed hook is installed, the hook is the
-single local-review runner. Without that hook, this wrapper runs local review
-before pushing.
+Runs local review once in a temporary worktree pinned to the captured HEAD,
+then pushes with ATLAS_CURRENT_PR_BODY_FILE exported for hook/body context.
 
 Examples:
   bash scripts/push_pr.sh tmp/pr-body-my-slice.md -u origin HEAD
@@ -20,10 +19,227 @@ Examples:
 EOF
 }
 
-has_managed_pre_push_hook() {
-    local hook_path
-    hook_path="$(git rev-parse --git-path hooks/pre-push)"
-    [ -x "$hook_path" ] && grep -q "ATLAS_LOCAL_PR_REVIEW_HOOK" "$hook_path"
+body_sha256() {
+    python - "$1" <<'PY'
+import hashlib
+import sys
+from pathlib import Path
+
+print(hashlib.sha256(Path(sys.argv[1]).read_bytes()).hexdigest())
+PY
+}
+
+snapshot_body() {
+    local source="$1" snapshot
+    snapshot="$(mktemp "${TMPDIR:-/tmp}/atlas-pr-body.XXXXXX")"
+    cp "$source" "$snapshot"
+    printf '%s\n' "$snapshot"
+}
+
+cleanup_body_snapshot() {
+    if [ -n "${body_snapshot:-}" ]; then
+        rm -f "$body_snapshot"
+    fi
+    cleanup_review_worktree
+}
+
+cleanup_review_worktree() {
+    if [ -n "${review_worktree:-}" ]; then
+        git worktree remove --force "$review_worktree" >/dev/null 2>&1 || true
+        if [ -n "${review_parent:-}" ]; then
+            rmdir "$review_parent" >/dev/null 2>&1 || true
+        fi
+        review_worktree=""
+        review_parent=""
+    fi
+}
+
+current_branch() {
+    local branch
+    branch="$(git branch --show-current)"
+    if [ -z "$branch" ]; then
+        echo "push_pr.sh: current checkout is detached; switch to a branch before pushing" >&2
+        exit 2
+    fi
+    printf '%s\n' "$branch"
+}
+
+capture_proof_inputs() {
+    proof_branch="$(current_branch)"
+    proof_head_sha="$(git rev-parse HEAD)"
+    proof_base_sha="$(git rev-parse origin/main)"
+    proof_body_hash="$(body_sha256 "$body_snapshot")"
+}
+
+reject_unproofable_push_args() {
+    local branch="$1"
+    local saw_remote=0
+    local saw_refspec=0
+    local arg
+    shift
+
+    while [ "$#" -gt 0 ]; do
+        arg="$1"
+        shift
+        case "$arg" in
+            --dr*)
+                echo "push_pr.sh: refusing git push dry-run; local review proof requires a real remote update" >&2
+                exit 2
+                ;;
+            --no-veri*)
+                echo "push_pr.sh: refusing to forward --no-verify or its Git-abbreviated spellings; local PR review must run once" >&2
+                exit 2
+                ;;
+            --repo|--repo=*)
+                echo "push_pr.sh: refusing git push target override: $arg" >&2
+                echo "Use the default origin remote so the local review proof can verify origin/$branch." >&2
+                exit 2
+                ;;
+            --receive-pack|--exec|--recurse-submodules|--push-option)
+                if [ "$#" -eq 0 ]; then
+                    echo "push_pr.sh: $arg requires a value" >&2
+                    exit 2
+                fi
+                shift
+                continue
+                ;;
+            --receive-pack=*|--exec=*|--recurse-submodules=*|--push-option=*)
+                continue
+                ;;
+            --*)
+                continue
+                ;;
+            -o)
+                if [ "$#" -eq 0 ]; then
+                    echo "push_pr.sh: -o requires a value" >&2
+                    exit 2
+                fi
+                shift
+                continue
+                ;;
+            -o?*)
+                continue
+                ;;
+            -*)
+                if [[ "${arg#-}" == *n* ]]; then
+                    echo "push_pr.sh: refusing git push dry-run; local review proof requires a real remote update" >&2
+                    exit 2
+                fi
+                continue
+                ;;
+        esac
+
+        if [ "$saw_remote" -eq 0 ]; then
+            if [ "$arg" != "origin" ]; then
+                echo "push_pr.sh: refusing git push remote $arg; local review proof must publish origin/$branch" >&2
+                echo "Use: bash scripts/push_pr.sh \"$body_file\" -u origin HEAD" >&2
+                exit 2
+            fi
+            saw_remote=1
+            continue
+        fi
+
+        saw_refspec=1
+        case "$arg" in
+            HEAD|"$branch"|HEAD:"$branch"|HEAD:refs/heads/"$branch"|"$branch":"$branch"|"$branch":refs/heads/"$branch")
+                ;;
+            *)
+                echo "push_pr.sh: refusing to write proof for refspec that does not publish the current branch HEAD: $arg" >&2
+                echo "Use: bash scripts/push_pr.sh \"$body_file\" -u origin HEAD" >&2
+                exit 2
+                ;;
+        esac
+    done
+
+    if [ "$saw_refspec" -eq 0 ]; then
+        echo "push_pr.sh: refusing ambiguous push args; pass an explicit current-branch refspec such as HEAD" >&2
+        exit 2
+    fi
+}
+
+verify_current_head_published() {
+    local branch="$1" head_sha remote_sha
+    head_sha="$(git rev-parse HEAD)"
+    if ! remote_sha="$(git rev-parse "refs/remotes/origin/$branch" 2>/dev/null)"; then
+        echo "push_pr.sh: pushed branch proof missing refs/remotes/origin/$branch" >&2
+        echo "Fetch or push the current branch with: bash scripts/push_pr.sh \"$body_file\" -u origin HEAD" >&2
+        exit 2
+    fi
+    if [ "$remote_sha" != "$head_sha" ]; then
+        echo "push_pr.sh: refusing local review proof; origin/$branch is $remote_sha, current HEAD is $head_sha" >&2
+        echo "Push the current branch HEAD before opening or updating the PR." >&2
+        exit 2
+    fi
+}
+
+verify_proof_inputs_unchanged() {
+    local branch head_sha base_sha body_hash
+    branch="$(current_branch)"
+    head_sha="$(git rev-parse HEAD)"
+    base_sha="$(git rev-parse origin/main)"
+    body_hash="$(body_sha256 "$body_snapshot")"
+    if [ "$branch" != "$proof_branch" ]; then
+        echo "push_pr.sh: refusing local review proof; branch changed from $proof_branch to $branch" >&2
+        exit 2
+    fi
+    if [ "$head_sha" != "$proof_head_sha" ]; then
+        echo "push_pr.sh: refusing local review proof; HEAD changed from $proof_head_sha to $head_sha" >&2
+        exit 2
+    fi
+    if [ "$base_sha" != "$proof_base_sha" ]; then
+        echo "push_pr.sh: refusing local review proof; origin/main changed from $proof_base_sha to $base_sha" >&2
+        echo "Rerun scripts/push_pr.sh so local review covers the current base." >&2
+        exit 2
+    fi
+    if [ "$body_hash" != "$proof_body_hash" ]; then
+        echo "push_pr.sh: refusing local review proof; reviewed body snapshot changed" >&2
+        exit 2
+    fi
+}
+
+verify_source_worktree_clean() {
+    local dirty
+    dirty="$(git status --porcelain)"
+    if [ -n "$dirty" ]; then
+        echo "push_pr.sh: source worktree has uncommitted changes; commit or stash before pushing" >&2
+        echo "$dirty" >&2
+        exit 1
+    fi
+}
+
+write_local_review_proof() {
+    local proof_path proof_dir
+    proof_path="$(git rev-parse --git-path atlas-local-pr-review-proof)"
+    proof_dir="$(dirname "$proof_path")"
+    mkdir -p "$proof_dir"
+    {
+        printf 'branch=%s\n' "$proof_branch"
+        printf 'head_sha=%s\n' "$proof_head_sha"
+        printf 'base_sha=%s\n' "$proof_base_sha"
+        printf 'body_sha256=%s\n' "$proof_body_hash"
+    } > "$proof_path"
+    echo "Wrote local review proof for $proof_head_sha: $proof_path"
+}
+
+run_immutable_local_review() {
+    local state_file="${ATLAS_SESSION_STATE_FILE:-}"
+    if [ -n "$state_file" ] && [ "${state_file#/}" = "$state_file" ]; then
+        state_file="$repo_root/$state_file"
+    fi
+    review_parent="$(mktemp -d "${TMPDIR:-/tmp}/atlas-pr-review-worktree.XXXXXX")"
+    review_worktree="$review_parent/worktree"
+    git worktree add --quiet --detach "$review_worktree" "$proof_head_sha"
+    echo "Running local PR review in immutable worktree for $proof_head_sha"
+    (
+        cd "$review_worktree"
+        if [ -n "$state_file" ]; then
+            export ATLAS_SESSION_STATE_FILE="$state_file"
+        fi
+        export GITHUB_HEAD_REF="$proof_branch"
+        ATLAS_CURRENT_PR_BODY_FILE="$body_snapshot" \
+            bash scripts/local_pr_review.sh --current-pr-body-file "$body_snapshot"
+    )
+    cleanup_review_worktree
 }
 
 refresh_base_ref() {
@@ -48,48 +264,38 @@ if [ ! -f "$body_file" ]; then
     exit 2
 fi
 
+body_snapshot="$(snapshot_body "$body_file")"
+trap cleanup_body_snapshot EXIT
+
 if [ "$#" -eq 0 ]; then
     set -- -u origin HEAD
 fi
 
-for arg in "$@"; do
-    if [ "$arg" = "--no-verify" ]; then
-        echo "push_pr.sh: refusing to forward --no-verify; local PR review must run once" >&2
-        exit 2
-    fi
-done
-
-run_wrapper_review=1
-if has_managed_pre_push_hook && [ "${ATLAS_SKIP_LOCAL_PR_REVIEW:-}" != "1" ]; then
-    run_wrapper_review=0
-fi
+branch="$(current_branch)"
+reject_unproofable_push_args "$branch" "$@"
 
 if [ "${ATLAS_PUSH_PR_DRY_RUN:-}" = "1" ]; then
     echo "DRY RUN: git fetch --quiet origin main"
-    if [ "$run_wrapper_review" -eq 1 ]; then
-        echo "DRY RUN: ATLAS_CURRENT_PR_BODY_FILE=$body_file bash scripts/local_pr_review.sh --current-pr-body-file $body_file"
-    else
-        echo "DRY RUN: managed pre-push hook will run local PR review once with body: $body_file"
-    fi
-    echo "DRY RUN: ATLAS_CURRENT_PR_BODY_FILE=$body_file git push $*"
+    echo "DRY RUN: ATLAS_CURRENT_PR_BODY_FILE=$body_file bash scripts/local_pr_review.sh --current-pr-body-file $body_file in immutable captured-head worktree"
+    echo "DRY RUN: ATLAS_SKIP_LOCAL_PR_REVIEW=1 ATLAS_CURRENT_PR_BODY_FILE=$body_file git push $*"
     exit 0
 fi
 
 refresh_base_ref
+capture_proof_inputs
 
 body_audit_args=(--base-ref origin/main)
 if [ -n "${ATLAS_CURRENT_PR_AUTHOR:-}" ]; then
     body_audit_args+=(--pr-author "$ATLAS_CURRENT_PR_AUTHOR")
 fi
-python scripts/audit_pr_body.py "${body_audit_args[@]}" "$body_file"
+python scripts/audit_pr_body.py "${body_audit_args[@]}" "$body_snapshot"
 
-if [ "$run_wrapper_review" -eq 1 ]; then
-    echo "Running local PR review with PR body: $body_file"
-    ATLAS_CURRENT_PR_BODY_FILE="$body_file" \
-        bash scripts/local_pr_review.sh --current-pr-body-file "$body_file"
-else
-    echo "Managed pre-push hook detected; local PR review will run once in the hook."
-fi
+verify_source_worktree_clean
+run_immutable_local_review
 
 echo "Pushing with PR body env available to pre-push hook: $body_file"
-ATLAS_CURRENT_PR_BODY_FILE="$body_file" git push "$@"
+ATLAS_SKIP_LOCAL_PR_REVIEW=1 ATLAS_CURRENT_PR_BODY_FILE="$body_snapshot" git push "$@"
+verify_source_worktree_clean
+verify_proof_inputs_unchanged
+verify_current_head_published "$branch"
+write_local_review_proof

--- a/tests/test_open_pr_wrapper.py
+++ b/tests/test_open_pr_wrapper.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import hashlib
 from pathlib import Path
 from shutil import copy2
 
@@ -15,6 +16,7 @@ CHANGE_POLICY_SCRIPT = REPO_ROOT / "scripts" / "_pr_change_policy.py"
 def test_open_pr_create_passes_body_via_stdin_not_path(tmp_path: Path) -> None:
     repo = _write_fixture_repo(tmp_path)
     body = _write_body(repo)
+    _write_review_proof(repo, body)
     env, log, stdin_capture = _fake_gh_env(tmp_path, view_exit=1)
 
     result = subprocess.run(
@@ -36,15 +38,44 @@ def test_open_pr_create_passes_body_via_stdin_not_path(tmp_path: Path) -> None:
 
     assert result.returncode == 0
     assert log.read_text(encoding="utf-8").strip() == (
-        "pr create --title Workflow wrapper --base main --body-file -"
+        "pr create --head claude/pr-test --title Workflow wrapper --base main --body-file -"
     )
     assert str(body) not in log.read_text(encoding="utf-8")
     assert stdin_capture.read_text(encoding="utf-8") == body.read_text(encoding="utf-8")
 
 
+def test_open_pr_uses_snapshot_when_body_mutates_during_gh_create(
+    tmp_path: Path,
+) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    reviewed_body = body.read_text(encoding="utf-8")
+    _write_review_proof(repo, body)
+    env, log, stdin_capture = _fake_gh_env(tmp_path, view_exit=1)
+    env["GH_MUTATE_BODY"] = str(body)
+
+    result = subprocess.run(
+        ["bash", "scripts/open_pr.sh", str(body), "--title", "Workflow wrapper"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert (
+        log.read_text(encoding="utf-8").strip()
+        == "pr create --head claude/pr-test --title Workflow wrapper --body-file -"
+    )
+    assert stdin_capture.read_text(encoding="utf-8") == reviewed_body
+    assert body.read_text(encoding="utf-8") != reviewed_body
+
+
 def test_open_pr_edit_passes_body_via_stdin_not_path(tmp_path: Path) -> None:
     repo = _write_fixture_repo(tmp_path)
     body = _write_body(repo)
+    _write_review_proof(repo, body)
     env, log, stdin_capture = _fake_gh_env(tmp_path, view_exit=0)
 
     result = subprocess.run(
@@ -57,7 +88,7 @@ def test_open_pr_edit_passes_body_via_stdin_not_path(tmp_path: Path) -> None:
     )
 
     assert result.returncode == 0
-    assert log.read_text(encoding="utf-8").strip() == "pr edit main --body-file -"
+    assert log.read_text(encoding="utf-8").strip() == "pr edit 123 --body-file -"
     assert str(body) not in log.read_text(encoding="utf-8")
     assert stdin_capture.read_text(encoding="utf-8") == body.read_text(encoding="utf-8")
 
@@ -65,6 +96,7 @@ def test_open_pr_edit_passes_body_via_stdin_not_path(tmp_path: Path) -> None:
 def test_open_pr_existing_pr_rejects_create_only_args(tmp_path: Path) -> None:
     repo = _write_fixture_repo(tmp_path)
     body = _write_body(repo)
+    _write_review_proof(repo, body)
     env, _, _ = _fake_gh_env(tmp_path, view_exit=0)
 
     result = subprocess.run(
@@ -78,6 +110,73 @@ def test_open_pr_existing_pr_rejects_create_only_args(tmp_path: Path) -> None:
 
     assert result.returncode == 2
     assert "PR already exists" in result.stderr
+
+
+def test_open_pr_numeric_branch_edits_matched_head_pr_not_numeric_selector(
+    tmp_path: Path,
+) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body_for_branch(repo, "123")
+    _write_review_proof(repo, body)
+    env, log, stdin_capture = _fake_gh_env(tmp_path, view_exit=0)
+    env["GH_PR_NUMBER"] = "456"
+
+    result = subprocess.run(
+        ["bash", "scripts/open_pr.sh", str(body)],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert log.read_text(encoding="utf-8").strip() == "pr edit 456 --body-file -"
+    assert stdin_capture.read_text(encoding="utf-8") == body.read_text(encoding="utf-8")
+
+
+def test_open_pr_ignores_same_branch_fork_pr_before_create(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    _write_review_proof(repo, body)
+    env, log, stdin_capture = _fake_gh_env(tmp_path, view_exit=0)
+    env["GH_PR_CROSS_REPOSITORY"] = "true"
+    env["GH_PR_HEAD_OWNER"] = "fork-owner"
+
+    result = subprocess.run(
+        ["bash", "scripts/open_pr.sh", str(body), "--title", "Workflow wrapper"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert (
+        log.read_text(encoding="utf-8").strip()
+        == "pr create --head claude/pr-test --title Workflow wrapper --body-file -"
+    )
+    assert stdin_capture.read_text(encoding="utf-8") == body.read_text(encoding="utf-8")
+
+
+def test_open_pr_create_binds_captured_head_branch(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    _write_review_proof(repo, body)
+    env, log, _ = _fake_gh_env(tmp_path, view_exit=1)
+
+    result = subprocess.run(
+        ["bash", "scripts/open_pr.sh", str(body), "--title", "Workflow wrapper"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert log.read_text(encoding="utf-8").startswith("pr create --head claude/pr-test ")
 
 
 def test_open_pr_rejects_direct_body_args(tmp_path: Path) -> None:
@@ -96,6 +195,93 @@ def test_open_pr_rejects_direct_body_args(tmp_path: Path) -> None:
 
     assert result.returncode == 2
     assert "pass the PR body as BODY_FILE" in result.stderr
+
+
+def test_open_pr_rejects_head_target_override_before_gh(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    _write_review_proof(repo, body)
+    env, log, stdin_capture = _fake_gh_env(tmp_path, view_exit=1)
+
+    result = subprocess.run(
+        ["bash", "scripts/open_pr.sh", str(body), "--head", "other-branch"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "refusing target-changing create arg: --head" in result.stderr
+    assert not log.exists()
+    assert not stdin_capture.exists()
+
+
+def test_open_pr_rejects_repo_target_override_before_gh(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    _write_review_proof(repo, body)
+    env, log, stdin_capture = _fake_gh_env(tmp_path, view_exit=1)
+
+    result = subprocess.run(
+        ["bash", "scripts/open_pr.sh", str(body), "--repo", "canfieldjuan/OTHER"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "refusing target-changing create arg: --repo" in result.stderr
+    assert not log.exists()
+    assert not stdin_capture.exists()
+
+
+def test_open_pr_rejects_gh_repo_environment_target_override_before_gh(
+    tmp_path: Path,
+) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    _write_review_proof(repo, body)
+    env, log, stdin_capture = _fake_gh_env(tmp_path, view_exit=1)
+    env["GH_REPO"] = "canfieldjuan/OTHER"
+
+    result = subprocess.run(
+        ["bash", "scripts/open_pr.sh", str(body), "--title", "Workflow wrapper"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "refusing GH_REPO target override" in result.stderr
+    assert not log.exists()
+    assert not stdin_capture.exists()
+
+
+def test_open_pr_rejects_non_main_base_before_gh(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    _write_review_proof(repo, body)
+    env, log, stdin_capture = _fake_gh_env(tmp_path, view_exit=1)
+
+    result = subprocess.run(
+        ["bash", "scripts/open_pr.sh", str(body), "--base", "release"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "refusing non-main base: release" in result.stderr
+    assert not log.exists()
+    assert not stdin_capture.exists()
 
 
 def test_open_pr_missing_body_file_fails_clearly(tmp_path: Path) -> None:
@@ -158,6 +344,7 @@ def test_open_pr_rejects_invalid_body_before_gh_edit(tmp_path: Path) -> None:
 def test_open_pr_accepts_explicit_docs_only_body(tmp_path: Path) -> None:
     repo = _write_fixture_repo(tmp_path)
     body = _write_docs_only_body(repo)
+    _write_review_proof(repo, body)
     env, log, stdin_capture = _fake_gh_env(tmp_path, view_exit=1)
 
     result = subprocess.run(
@@ -171,13 +358,17 @@ def test_open_pr_accepts_explicit_docs_only_body(tmp_path: Path) -> None:
 
     assert result.returncode == 0, result.stdout + result.stderr
     assert "explicit Markdown-only body exemption" in result.stdout
-    assert log.read_text(encoding="utf-8").strip() == "pr create --title Docs only --body-file -"
+    assert (
+        log.read_text(encoding="utf-8").strip()
+        == "pr create --head claude/pr-test --title Docs only --body-file -"
+    )
     assert stdin_capture.read_text(encoding="utf-8") == body.read_text(encoding="utf-8")
 
 
 def test_open_pr_refreshes_base_before_docs_only_audit(tmp_path: Path) -> None:
     repo = _write_fixture_repo(tmp_path)
     body = _write_docs_only_body(repo)
+    _write_review_proof(repo, body)
     _git(repo, "update-ref", "-d", "refs/remotes/origin/main")
     env, log, stdin_capture = _fake_gh_env(tmp_path, view_exit=1)
 
@@ -192,8 +383,173 @@ def test_open_pr_refreshes_base_before_docs_only_audit(tmp_path: Path) -> None:
 
     assert result.returncode == 0, result.stdout + result.stderr
     assert "Refreshing origin/main before PR body audit" in result.stdout
-    assert log.read_text(encoding="utf-8").strip() == "pr create --title Docs only --body-file -"
+    assert (
+        log.read_text(encoding="utf-8").strip()
+        == "pr create --head claude/pr-test --title Docs only --body-file -"
+    )
     assert stdin_capture.read_text(encoding="utf-8") == body.read_text(encoding="utf-8")
+
+
+def test_open_pr_requires_local_review_proof_before_gh(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    env, log, stdin_capture = _fake_gh_env(tmp_path, view_exit=1)
+
+    result = subprocess.run(
+        ["bash", "scripts/open_pr.sh", str(body), "--title", "Workflow wrapper"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "missing local review proof" in result.stderr
+    assert not log.exists()
+    assert not stdin_capture.exists()
+
+
+def test_open_pr_rejects_stale_head_proof_before_gh(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    _write_review_proof(repo, body)
+    (repo / "scripts" / "another.py").write_text("print('later')\n", encoding="utf-8")
+    _git(repo, "add", "scripts/another.py")
+    _git(repo, "commit", "-qm", "later change")
+    env, log, stdin_capture = _fake_gh_env(tmp_path, view_exit=1)
+
+    result = subprocess.run(
+        ["bash", "scripts/open_pr.sh", str(body), "--title", "Workflow wrapper"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "stale local review proof" in result.stderr
+    assert "Run scripts/push_pr.sh again" in result.stderr
+    assert not log.exists()
+    assert not stdin_capture.exists()
+
+
+def test_open_pr_rejects_stale_body_proof_before_gh(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    _write_review_proof(repo, body)
+    body.write_text(body.read_text(encoding="utf-8") + "\nRegenerated body.\n", encoding="utf-8")
+    env, log, stdin_capture = _fake_gh_env(tmp_path, view_exit=1)
+
+    result = subprocess.run(
+        ["bash", "scripts/open_pr.sh", str(body), "--title", "Workflow wrapper"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "PR body changed after local review" in result.stderr
+    assert not log.exists()
+    assert not stdin_capture.exists()
+
+
+def test_open_pr_rejects_stale_base_proof_before_gh(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    _write_review_proof(repo, body, base_sha="0" * 40)
+    env, log, stdin_capture = _fake_gh_env(tmp_path, view_exit=1)
+
+    result = subprocess.run(
+        ["bash", "scripts/open_pr.sh", str(body), "--title", "Workflow wrapper"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "expected origin/main" in result.stderr
+    assert not log.exists()
+    assert not stdin_capture.exists()
+
+
+def test_open_pr_rejects_same_head_different_branch_proof_before_gh(
+    tmp_path: Path,
+) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    _write_review_proof(repo, body)
+    _git(repo, "checkout", "-b", "claude/pr-other")
+    env, log, stdin_capture = _fake_gh_env(tmp_path, view_exit=1)
+
+    result = subprocess.run(
+        ["bash", "scripts/open_pr.sh", str(body), "--title", "Workflow wrapper"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "expected branch claude/pr-other" in result.stderr
+    assert "found claude/pr-test" in result.stderr
+    assert not log.exists()
+    assert not stdin_capture.exists()
+
+
+def test_open_pr_rejects_stale_remote_head_before_gh(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    _write_review_proof(repo, body)
+    _git(repo, "push", "-q", "--force", "origin", "HEAD^:refs/heads/claude/pr-test")
+    env, log, stdin_capture = _fake_gh_env(tmp_path, view_exit=1)
+
+    result = subprocess.run(
+        ["bash", "scripts/open_pr.sh", str(body), "--title", "Workflow wrapper"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "stale local review proof" in result.stderr
+    assert "origin/claude/pr-test" in result.stderr
+    assert not log.exists()
+    assert not stdin_capture.exists()
+
+
+def test_open_pr_rechecks_remote_head_after_pr_view_before_create(
+    tmp_path: Path,
+) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    _write_review_proof(repo, body)
+    env, log, stdin_capture = _fake_gh_env(tmp_path, view_exit=1)
+    env["GH_FORCE_PUSH_DURING_VIEW"] = "1"
+    env["GH_FAKE_REPO"] = str(repo)
+
+    result = subprocess.run(
+        ["bash", "scripts/open_pr.sh", str(body), "--title", "Workflow wrapper"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "stale local review proof" in result.stderr
+    assert "origin/claude/pr-test" in result.stderr
+    assert not log.exists()
+    assert not stdin_capture.exists()
 
 
 def _write_fixture_repo(tmp_path: Path) -> Path:
@@ -225,11 +581,17 @@ def _write_fixture_repo(tmp_path: Path) -> Path:
 
 
 def _write_body(repo: Path) -> Path:
+    return _write_body_for_branch(repo, "claude/pr-test")
+
+
+def _write_body_for_branch(repo: Path, branch: str) -> Path:
     body = repo / "body.md"
+    _checkout_pr_branch(repo, branch)
     _write_plan(repo)
     (repo / "scripts" / "example.py").write_text("print('changed')\n", encoding="utf-8")
     _git(repo, "add", "plans/PR-Test.md", "scripts/example.py")
     _git(repo, "commit", "-qm", "planned change")
+    _git(repo, "push", "-q", "-u", "origin", "HEAD")
     body.write_text(_valid_body(), encoding="utf-8")
     return body
 
@@ -251,11 +613,13 @@ def _write_invalid_body(repo: Path) -> Path:
 
 
 def _write_docs_only_body(repo: Path) -> Path:
+    _checkout_pr_branch(repo, "claude/pr-test")
     doc = repo / "docs" / "example.md"
     doc.parent.mkdir()
     doc.write_text("# docs only\n", encoding="utf-8")
     _git(repo, "add", "docs/example.md")
     _git(repo, "commit", "-qm", "docs only")
+    _git(repo, "push", "-q", "-u", "origin", "HEAD")
     body = repo / "body-docs-only.md"
     body.write_text("Docs-only: true\n\nCorrect a documentation typo.\n", encoding="utf-8")
     return body
@@ -265,6 +629,66 @@ def _write_plan(repo: Path) -> None:
     plan = repo / "plans" / "PR-Test.md"
     plan.parent.mkdir(parents=True, exist_ok=True)
     plan.write_text("# Test plan\n", encoding="utf-8")
+
+
+def _checkout_pr_branch(repo: Path, target: str) -> None:
+    branch = subprocess.run(
+        ["git", "branch", "--show-current"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    if branch != target:
+        _git(repo, "checkout", "-b", target)
+
+
+def _write_review_proof(repo: Path, body: Path, *, base_sha: str | None = None) -> Path:
+    proof = Path(
+        subprocess.run(
+            ["git", "rev-parse", "--git-path", "atlas-local-pr-review-proof"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    )
+    if not proof.is_absolute():
+        proof = repo / proof
+    proof.parent.mkdir(parents=True, exist_ok=True)
+    branch = subprocess.run(
+        ["git", "branch", "--show-current"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    if base_sha is None:
+        base_sha = subprocess.run(
+            ["git", "rev-parse", "origin/main"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    body_hash = hashlib.sha256(body.read_bytes()).hexdigest()
+    proof.write_text(
+        (
+            f"branch={branch}\n"
+            f"head_sha={head}\n"
+            f"base_sha={base_sha}\n"
+            f"body_sha256={body_hash}\n"
+        ),
+        encoding="utf-8",
+    )
+    return proof
 
 
 def _valid_body() -> str:
@@ -310,10 +734,34 @@ def _fake_gh_env(
     gh.write_text(
         """#!/usr/bin/env bash
 set -euo pipefail
-if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
-    exit "${GH_VIEW_EXIT}"
+if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+    head=""
+    while [ "$#" -gt 0 ]; do
+        if [ "${1:-}" = "--head" ]; then
+            head="${2:-}"
+            shift 2
+            continue
+        fi
+        shift
+    done
+    if [ "${GH_FORCE_PUSH_DURING_VIEW:-}" = "1" ]; then
+        git -C "${GH_FAKE_REPO}" push -q --force origin HEAD^:refs/heads/claude/pr-test
+    fi
+    if [ "${GH_VIEW_EXIT}" = "0" ]; then
+        printf '[{"number":%s,"headRefName":"%s","headRepository":{"name":"%s"},"headRepositoryOwner":{"login":"%s"},"isCrossRepository":%s}]\\n' "${GH_PR_NUMBER:-123}" "$head" "${GH_PR_HEAD_REPO:-ATLAS}" "${GH_PR_HEAD_OWNER:-canfieldjuan}" "${GH_PR_CROSS_REPOSITORY:-false}"
+    else
+        printf '[]\\n'
+    fi
+    exit 0
+fi
+if [ "$1" = "repo" ] && [ "$2" = "view" ]; then
+    printf '{"name":"ATLAS","owner":{"login":"canfieldjuan"}}\\n'
+    exit 0
 fi
 printf '%s\\n' "$*" > "${GH_ARGV_LOG}"
+if [ -n "${GH_MUTATE_BODY:-}" ]; then
+    printf '\\nmutated during gh\\n' >> "${GH_MUTATE_BODY}"
+fi
 cat > "${GH_STDIN_CAPTURE}"
 """,
         encoding="utf-8",

--- a/tests/test_push_pr_wrapper.py
+++ b/tests/test_push_pr_wrapper.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import hashlib
 from pathlib import Path
 from shutil import copy2, which
 
@@ -33,7 +34,7 @@ def test_push_pr_dry_run_without_managed_hook_runs_wrapper_review(tmp_path: Path
     assert "git push -u origin HEAD" in result.stdout
 
 
-def test_push_pr_dry_run_with_managed_hook_uses_hook_as_single_review_runner(
+def test_push_pr_dry_run_with_managed_hook_uses_immutable_wrapper_review(
     tmp_path: Path,
 ) -> None:
     repo = _write_fixture_repo(tmp_path)
@@ -52,9 +53,10 @@ def test_push_pr_dry_run_with_managed_hook_uses_hook_as_single_review_runner(
 
     assert result.returncode == 0
     assert "DRY RUN: git fetch --quiet origin main" in result.stdout
-    assert "managed pre-push hook will run local PR review once" in result.stdout
-    assert "bash scripts/local_pr_review.sh" not in result.stdout
+    assert "immutable captured-head worktree" in result.stdout
+    assert "managed pre-push hook will run local PR review once" not in result.stdout
     assert f"ATLAS_CURRENT_PR_BODY_FILE={body}" in result.stdout
+    assert "ATLAS_SKIP_LOCAL_PR_REVIEW=1" in result.stdout
     assert "git push -u origin HEAD" in result.stdout
 
 
@@ -104,7 +106,7 @@ def test_push_pr_dry_run_with_non_executable_managed_hook_keeps_wrapper_review(
     assert result.returncode == 0
     assert "DRY RUN: git fetch --quiet origin main" in result.stdout
     assert f"ATLAS_CURRENT_PR_BODY_FILE={body}" in result.stdout
-    assert f"--current-pr-body-file {body}" in result.stdout
+    assert "immutable captured-head worktree" in result.stdout
     assert "managed pre-push hook will run local PR review once" not in result.stdout
 
 
@@ -128,7 +130,7 @@ def test_push_pr_docs_only_dry_run_does_not_fetch_or_audit(tmp_path: Path) -> No
 def test_push_pr_refreshes_before_docs_only_body_audit(tmp_path: Path) -> None:
     repo = _write_fixture_repo(tmp_path)
     body = _write_docs_only_body(repo)
-    order_log = repo / "order.log"
+    order_log = _order_log(repo)
     _write_body_audit_recorder(repo)
     _write_local_review(repo)
     fake_bin = _write_fake_git(repo, order_log)
@@ -157,7 +159,7 @@ def test_push_pr_refreshes_before_docs_only_body_audit(tmp_path: Path) -> None:
 def test_push_pr_refreshes_base_before_wrapper_review_and_push(tmp_path: Path) -> None:
     repo = _write_fixture_repo(tmp_path)
     body = _write_body(repo)
-    order_log = repo / "order.log"
+    order_log = _order_log(repo)
     _write_local_review(repo)
     fake_bin = _write_fake_git(repo, order_log)
     env = {
@@ -179,18 +181,49 @@ def test_push_pr_refreshes_base_before_wrapper_review_and_push(tmp_path: Path) -
 
     assert result.returncode == 0, result.stderr
     lines = order_log.read_text(encoding="utf-8").splitlines()
-    assert lines.index("git fetch --quiet origin main") < lines.index(
-        f"local-review --current-pr-body-file {body}"
+    local_review_index = next(
+        index for index, line in enumerate(lines) if line.startswith("local-review ")
     )
-    assert lines.index(f"local-review --current-pr-body-file {body}") < lines.index(
-        "git push -u origin HEAD"
-    )
+    assert lines.index("git fetch --quiet origin main") < local_review_index
+    assert local_review_index < lines.index("git push -u origin HEAD")
 
 
-def test_push_pr_refreshes_base_before_managed_hook_push(tmp_path: Path) -> None:
+def test_push_pr_sets_github_head_ref_for_detached_immutable_review(
+    tmp_path: Path,
+) -> None:
     repo = _write_fixture_repo(tmp_path)
     body = _write_body(repo)
-    order_log = repo / "order.log"
+    order_log = _order_log(repo)
+    _write_local_review(repo)
+    fake_bin = _write_fake_git(repo, order_log)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "FAKE_GIT_TOPLEVEL": str(repo),
+        "FAKE_GIT_LOG": str(order_log),
+        "ORDER_LOG": str(order_log),
+    }
+
+    result = subprocess.run(
+        ["bash", "scripts/push_pr.sh", str(body), "-u", "origin", "HEAD"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    lines = order_log.read_text(encoding="utf-8").splitlines()
+    assert "github-head-ref claude/pr-test" in lines
+
+
+def test_push_pr_refreshes_base_before_immutable_review_and_managed_hook_push(
+    tmp_path: Path,
+) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    order_log = _order_log(repo)
     _write_local_review(repo)
     _write_managed_hook(repo)
     fake_bin = _write_fake_git(repo, order_log)
@@ -213,16 +246,524 @@ def test_push_pr_refreshes_base_before_managed_hook_push(tmp_path: Path) -> None
 
     assert result.returncode == 0, result.stderr
     lines = order_log.read_text(encoding="utf-8").splitlines()
+    local_review_index = next(
+        index for index, line in enumerate(lines) if line.startswith("local-review ")
+    )
     assert lines.index("git fetch --quiet origin main") < lines.index(
         "git push -u origin HEAD"
     )
+    assert lines.index("git fetch --quiet origin main") < local_review_index
+    assert local_review_index < lines.index("git push -u origin HEAD")
+
+
+def test_push_pr_writes_review_proof_after_successful_push(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    order_log = _order_log(repo)
+    _write_local_review(repo)
+    fake_bin = _write_fake_git(repo, order_log)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "FAKE_GIT_TOPLEVEL": str(repo),
+        "FAKE_GIT_LOG": str(order_log),
+        "ORDER_LOG": str(order_log),
+    }
+
+    result = subprocess.run(
+        ["bash", "scripts/push_pr.sh", str(body), "-u", "origin", "HEAD"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    proof = _proof_path(repo)
+    assert proof.is_file()
+    proof_text = proof.read_text(encoding="utf-8")
+    assert "branch=claude/pr-test" in proof_text
+    assert f"head_sha={_head(repo)}" in proof_text
+    assert f"base_sha={_base(repo)}" in proof_text
+    assert f"body_sha256={hashlib.sha256(body.read_bytes()).hexdigest()}" in proof_text
+    assert "Wrote local review proof" in result.stdout
+
+
+def test_push_pr_uses_reviewed_body_snapshot_when_body_mutates_during_push(
+    tmp_path: Path,
+) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    reviewed_body = body.read_bytes()
+    reviewed_hash = hashlib.sha256(reviewed_body).hexdigest()
+    order_log = _order_log(repo)
+    _write_local_review(repo)
+    fake_bin = _write_fake_git(repo, order_log)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "FAKE_GIT_TOPLEVEL": str(repo),
+        "FAKE_GIT_LOG": str(order_log),
+        "FAKE_GIT_MUTATE_BODY": str(body),
+        "ORDER_LOG": str(order_log),
+    }
+
+    result = subprocess.run(
+        ["bash", "scripts/push_pr.sh", str(body), "-u", "origin", "HEAD"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert body.read_bytes() != reviewed_body
+    proof_text = _proof_path(repo).read_text(encoding="utf-8")
+    assert f"body_sha256={reviewed_hash}" in proof_text
+    assert hashlib.sha256(body.read_bytes()).hexdigest() not in proof_text
+
+
+def test_push_pr_reviews_immutable_captured_head_despite_aba_checkout(
+    tmp_path: Path,
+) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    branch = subprocess.run(
+        ["git", "branch", "--show-current"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    (repo / "scripts" / "aba.py").write_text("print('aba')\n", encoding="utf-8")
+    _git(repo, "add", "scripts/aba.py")
+    _git(repo, "commit", "-qm", "aba other commit")
+    other_head = _head(repo)
+    _git(repo, "reset", "--hard", "HEAD^")
+    order_log = _order_log(repo)
+    _write_aba_local_review(repo)
+    reviewed_head = _head(repo)
+    fake_bin = _write_fake_git(repo, order_log)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "FAKE_GIT_TOPLEVEL": str(repo),
+        "FAKE_GIT_LOG": str(order_log),
+        "ABA_REPO": str(repo),
+        "ABA_BRANCH": branch,
+        "ABA_OTHER_SHA": other_head,
+        "ORDER_LOG": str(order_log),
+    }
+
+    result = subprocess.run(
+        ["bash", "scripts/push_pr.sh", str(body), "-u", "origin", "HEAD"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    lines = order_log.read_text(encoding="utf-8").splitlines()
+    assert f"local-review-head {reviewed_head}" in lines
+    assert f"local-review-original-after {reviewed_head}" in lines
+    assert f"head_sha={reviewed_head}" in _proof_path(repo).read_text(encoding="utf-8")
+
+
+def test_push_pr_rejects_staged_source_worktree_before_immutable_review(
+    tmp_path: Path,
+) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    order_log = _order_log(repo)
+    _write_local_review(repo)
+    fake_bin = _write_fake_git(repo, order_log)
+    (repo / "scripts" / "example.py").write_text("print('staged')\n", encoding="utf-8")
+    _git(repo, "add", "scripts/example.py")
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "FAKE_GIT_TOPLEVEL": str(repo),
+        "FAKE_GIT_LOG": str(order_log),
+        "ORDER_LOG": str(order_log),
+    }
+
+    result = subprocess.run(
+        ["bash", "scripts/push_pr.sh", str(body), "-u", "origin", "HEAD"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "source worktree has uncommitted changes" in result.stderr
+    assert "M  scripts/example.py" in result.stderr
+    lines = order_log.read_text(encoding="utf-8").splitlines()
     assert not any(line.startswith("local-review ") for line in lines)
+    assert "git push -u origin HEAD" not in lines
+    assert not _proof_path(repo).exists()
+
+
+def test_push_pr_rejects_unstaged_source_worktree_before_immutable_review(
+    tmp_path: Path,
+) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    order_log = _order_log(repo)
+    _write_local_review(repo)
+    fake_bin = _write_fake_git(repo, order_log)
+    (repo / "scripts" / "example.py").write_text("print('unstaged')\n", encoding="utf-8")
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "FAKE_GIT_TOPLEVEL": str(repo),
+        "FAKE_GIT_LOG": str(order_log),
+        "ORDER_LOG": str(order_log),
+    }
+
+    result = subprocess.run(
+        ["bash", "scripts/push_pr.sh", str(body), "-u", "origin", "HEAD"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "source worktree has uncommitted changes" in result.stderr
+    assert " M scripts/example.py" in result.stderr
+    lines = order_log.read_text(encoding="utf-8").splitlines()
+    assert not any(line.startswith("local-review ") for line in lines)
+    assert "git push -u origin HEAD" not in lines
+    assert not _proof_path(repo).exists()
+
+
+def test_push_pr_rejects_untracked_source_worktree_before_immutable_review(
+    tmp_path: Path,
+) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    order_log = _order_log(repo)
+    _write_local_review(repo)
+    fake_bin = _write_fake_git(repo, order_log)
+    (repo / "scratch.txt").write_text("not reviewed\n", encoding="utf-8")
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "FAKE_GIT_TOPLEVEL": str(repo),
+        "FAKE_GIT_LOG": str(order_log),
+        "ORDER_LOG": str(order_log),
+    }
+
+    result = subprocess.run(
+        ["bash", "scripts/push_pr.sh", str(body), "-u", "origin", "HEAD"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "source worktree has uncommitted changes" in result.stderr
+    assert "?? scratch.txt" in result.stderr
+    lines = order_log.read_text(encoding="utf-8").splitlines()
+    assert not any(line.startswith("local-review ") for line in lines)
+    assert "git push -u origin HEAD" not in lines
+    assert not _proof_path(repo).exists()
+
+
+def test_push_pr_rejects_source_worktree_dirtied_during_push_before_proof(
+    tmp_path: Path,
+) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    order_log = _order_log(repo)
+    _write_local_review(repo)
+    fake_bin = _write_fake_git(repo, order_log)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "FAKE_GIT_TOPLEVEL": str(repo),
+        "FAKE_GIT_LOG": str(order_log),
+        "FAKE_GIT_DIRTY_SOURCE_DURING_PUSH": "1",
+        "ORDER_LOG": str(order_log),
+    }
+
+    result = subprocess.run(
+        ["bash", "scripts/push_pr.sh", str(body), "-u", "origin", "HEAD"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "source worktree has uncommitted changes" in result.stderr
+    assert "?? pushed-dirty.txt" in result.stderr
+    lines = order_log.read_text(encoding="utf-8").splitlines()
+    assert any(line.startswith("local-review ") for line in lines)
+    assert "git push -u origin HEAD" in lines
+    assert not _proof_path(repo).exists()
+
+
+def test_push_pr_rejects_git_dry_run_before_review_or_push(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    order_log = _order_log(repo)
+    _write_local_review(repo)
+    fake_bin = _write_fake_git(repo, order_log)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "FAKE_GIT_TOPLEVEL": str(repo),
+        "FAKE_GIT_LOG": str(order_log),
+        "ORDER_LOG": str(order_log),
+    }
+
+    result = subprocess.run(
+        ["bash", "scripts/push_pr.sh", str(body), "--dry-run", "origin", "HEAD"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "refusing git push dry-run" in result.stderr
+    assert "git push" not in order_log.read_text(encoding="utf-8")
+    assert not _proof_path(repo).exists()
+
+
+def test_push_pr_rejects_abbreviated_dry_run_before_review_or_push(
+    tmp_path: Path,
+) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    order_log = _order_log(repo)
+    _write_local_review(repo)
+    fake_bin = _write_fake_git(repo, order_log)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "FAKE_GIT_TOPLEVEL": str(repo),
+        "FAKE_GIT_LOG": str(order_log),
+        "ORDER_LOG": str(order_log),
+    }
+
+    result = subprocess.run(
+        ["bash", "scripts/push_pr.sh", str(body), "--dry", "origin", "HEAD"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "refusing git push dry-run" in result.stderr
+    assert "git push" not in order_log.read_text(encoding="utf-8")
+    assert not _proof_path(repo).exists()
+
+
+def test_push_pr_rejects_bundled_short_dry_run_before_review_or_push(
+    tmp_path: Path,
+) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    order_log = _order_log(repo)
+    _write_local_review(repo)
+    fake_bin = _write_fake_git(repo, order_log)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "FAKE_GIT_TOPLEVEL": str(repo),
+        "FAKE_GIT_LOG": str(order_log),
+        "ORDER_LOG": str(order_log),
+    }
+
+    result = subprocess.run(
+        ["bash", "scripts/push_pr.sh", str(body), "-un", "origin", "HEAD"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "refusing git push dry-run" in result.stderr
+    assert "git push" not in order_log.read_text(encoding="utf-8")
+    assert not _proof_path(repo).exists()
+
+
+def test_push_pr_rejects_unrelated_refspec_before_review_or_push(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    order_log = _order_log(repo)
+    _write_local_review(repo)
+    fake_bin = _write_fake_git(repo, order_log)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "FAKE_GIT_TOPLEVEL": str(repo),
+        "FAKE_GIT_LOG": str(order_log),
+        "ORDER_LOG": str(order_log),
+    }
+
+    result = subprocess.run(
+        ["bash", "scripts/push_pr.sh", str(body), "origin", "HEAD:other-branch"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "does not publish the current branch HEAD" in result.stderr
+    assert "git push" not in order_log.read_text(encoding="utf-8")
+    assert not _proof_path(repo).exists()
+
+
+def test_push_pr_rejects_non_origin_positional_remote_before_review_or_push(
+    tmp_path: Path,
+) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    order_log = _order_log(repo)
+    _write_local_review(repo)
+    fake_bin = _write_fake_git(repo, order_log)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "FAKE_GIT_TOPLEVEL": str(repo),
+        "FAKE_GIT_LOG": str(order_log),
+        "ORDER_LOG": str(order_log),
+    }
+
+    result = subprocess.run(
+        ["bash", "scripts/push_pr.sh", str(body), "upstream", "HEAD"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "refusing git push remote upstream" in result.stderr
+    lines = order_log.read_text(encoding="utf-8").splitlines()
+    assert not any(line.startswith("local-review ") for line in lines)
+    assert "git push upstream HEAD" not in lines
+    assert not _proof_path(repo).exists()
+
+
+def test_push_pr_does_not_write_review_proof_when_remote_head_is_stale(
+    tmp_path: Path,
+) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    order_log = _order_log(repo)
+    _write_local_review(repo)
+    fake_bin = _write_fake_git(repo, order_log)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "FAKE_GIT_TOPLEVEL": str(repo),
+        "FAKE_GIT_LOG": str(order_log),
+        "FAKE_GIT_SKIP_REMOTE_UPDATE": "1",
+        "ORDER_LOG": str(order_log),
+    }
+
+    result = subprocess.run(
+        ["bash", "scripts/push_pr.sh", str(body), "-u", "origin", "HEAD"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "pushed branch proof missing refs/remotes/origin/claude/pr-test" in result.stderr
+    assert "git push -u origin HEAD" in order_log.read_text(encoding="utf-8")
+    assert not _proof_path(repo).exists()
+
+
+def test_push_pr_does_not_write_review_proof_when_base_moves_during_push(
+    tmp_path: Path,
+) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    order_log = _order_log(repo)
+    _write_local_review(repo)
+    fake_bin = _write_fake_git(repo, order_log)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "FAKE_GIT_TOPLEVEL": str(repo),
+        "FAKE_GIT_LOG": str(order_log),
+        "FAKE_GIT_ADVANCE_BASE_DURING_PUSH": "1",
+        "ORDER_LOG": str(order_log),
+    }
+
+    result = subprocess.run(
+        ["bash", "scripts/push_pr.sh", str(body), "-u", "origin", "HEAD"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "origin/main changed" in result.stderr
+    assert "git push -u origin HEAD" in order_log.read_text(encoding="utf-8")
+    assert not _proof_path(repo).exists()
+
+
+def test_push_pr_does_not_write_review_proof_when_push_fails(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    order_log = _order_log(repo)
+    _write_local_review(repo)
+    fake_bin = _write_fake_git(repo, order_log)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "FAKE_GIT_TOPLEVEL": str(repo),
+        "FAKE_GIT_LOG": str(order_log),
+        "FAKE_GIT_PUSH_FAIL": "1",
+        "ORDER_LOG": str(order_log),
+    }
+
+    result = subprocess.run(
+        ["bash", "scripts/push_pr.sh", str(body), "-u", "origin", "HEAD"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 42
+    assert "git push -u origin HEAD" in order_log.read_text(encoding="utf-8")
+    assert not _proof_path(repo).exists()
 
 
 def test_push_pr_fetch_failure_aborts_before_review_or_push(tmp_path: Path) -> None:
     repo = _write_fixture_repo(tmp_path)
     body = _write_body(repo)
-    order_log = repo / "order.log"
+    order_log = _order_log(repo)
     _write_local_review(repo)
     fake_bin = _write_fake_git(repo, order_log)
     env = {
@@ -267,6 +808,170 @@ def test_push_pr_rejects_no_verify(tmp_path: Path) -> None:
     assert "refusing to forward --no-verify" in result.stderr
 
 
+def test_push_pr_rejects_abbreviated_no_verify_before_managed_hook_push(
+    tmp_path: Path,
+) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    order_log = _order_log(repo)
+    _write_local_review(repo)
+    _write_managed_hook(repo)
+    fake_bin = _write_fake_git(repo, order_log)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "FAKE_GIT_TOPLEVEL": str(repo),
+        "FAKE_GIT_LOG": str(order_log),
+        "ORDER_LOG": str(order_log),
+    }
+
+    result = subprocess.run(
+        ["bash", "scripts/push_pr.sh", str(body), "--no-veri", "-u", "origin", "HEAD"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "Git-abbreviated spellings" in result.stderr
+    assert "git push" not in order_log.read_text(encoding="utf-8")
+    assert not _proof_path(repo).exists()
+
+
+def test_push_pr_allows_no_verbose_without_bypassing_review(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    order_log = _order_log(repo)
+    _write_local_review(repo)
+    fake_bin = _write_fake_git(repo, order_log)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "FAKE_GIT_TOPLEVEL": str(repo),
+        "FAKE_GIT_LOG": str(order_log),
+        "ORDER_LOG": str(order_log),
+    }
+
+    result = subprocess.run(
+        ["bash", "scripts/push_pr.sh", str(body), "--no-verbose", "-u", "origin", "HEAD"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "git push --no-verbose -u origin HEAD" in order_log.read_text(encoding="utf-8")
+    assert _proof_path(repo).is_file()
+
+
+def test_push_pr_consumes_long_option_operands_before_remote_and_refspec(
+    tmp_path: Path,
+) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    order_log = _order_log(repo)
+    _write_local_review(repo)
+    fake_bin = _write_fake_git(repo, order_log)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "FAKE_GIT_TOPLEVEL": str(repo),
+        "FAKE_GIT_LOG": str(order_log),
+        "ORDER_LOG": str(order_log),
+    }
+
+    result = subprocess.run(
+        [
+            "bash",
+            "scripts/push_pr.sh",
+            str(body),
+            "--receive-pack",
+            "git-receive-pack",
+            "--recurse-submodules",
+            "check",
+            "origin",
+            "HEAD",
+        ],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert (
+        "git push --receive-pack git-receive-pack --recurse-submodules check origin HEAD"
+        in order_log.read_text(encoding="utf-8")
+    )
+    assert _proof_path(repo).is_file()
+
+
+def test_push_pr_consumes_short_push_option_operand_before_remote_and_refspec(
+    tmp_path: Path,
+) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    order_log = _order_log(repo)
+    _write_local_review(repo)
+    fake_bin = _write_fake_git(repo, order_log)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "FAKE_GIT_TOPLEVEL": str(repo),
+        "FAKE_GIT_LOG": str(order_log),
+        "ORDER_LOG": str(order_log),
+    }
+
+    result = subprocess.run(
+        ["bash", "scripts/push_pr.sh", str(body), "-o", "ci.skip", "origin", "HEAD"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "git push -o ci.skip origin HEAD" in order_log.read_text(encoding="utf-8")
+    assert _proof_path(repo).is_file()
+
+
+def test_push_pr_rejects_repo_target_override_before_review_or_push(
+    tmp_path: Path,
+) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    order_log = _order_log(repo)
+    _write_local_review(repo)
+    fake_bin = _write_fake_git(repo, order_log)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "FAKE_GIT_TOPLEVEL": str(repo),
+        "FAKE_GIT_LOG": str(order_log),
+        "ORDER_LOG": str(order_log),
+    }
+
+    result = subprocess.run(
+        ["bash", "scripts/push_pr.sh", str(body), "--repo", "origin", "HEAD"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "refusing git push target override" in result.stderr
+    assert "git push" not in order_log.read_text(encoding="utf-8")
+    assert not _proof_path(repo).exists()
+
+
 def test_push_pr_missing_body_file_fails_clearly(tmp_path: Path) -> None:
     missing = tmp_path / "missing.md"
 
@@ -286,7 +991,7 @@ def test_push_pr_missing_body_file_fails_clearly(tmp_path: Path) -> None:
 def test_push_pr_rejects_invalid_body_before_fetch_review_or_push(tmp_path: Path) -> None:
     repo = _write_fixture_repo(tmp_path)
     body = _write_invalid_body(repo)
-    order_log = repo / "order.log"
+    order_log = _order_log(repo)
     _write_local_review(repo)
     fake_bin = _write_fake_git(repo, order_log)
     env = {
@@ -321,6 +1026,7 @@ def _write_fixture_repo(tmp_path: Path) -> Path:
     copy2(AUDIT_SCRIPT, repo / "scripts" / "audit_pr_body.py")
     copy2(CHANGE_POLICY_SCRIPT, repo / "scripts" / "_pr_change_policy.py")
     subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, text=True)
+    (repo / ".gitignore").write_text("__pycache__/\n", encoding="utf-8")
     (repo / "README.md").write_text("base\n", encoding="utf-8")
     _git(repo, "add", ".")
     _git(repo, "commit", "-qm", "base")
@@ -331,7 +1037,8 @@ def _write_fixture_repo(tmp_path: Path) -> Path:
 
 
 def _write_body(repo: Path) -> Path:
-    body = repo / "body.md"
+    body = repo.parent / "body.md"
+    _checkout_pr_branch(repo)
     _write_plan(repo)
     (repo / "scripts" / "example.py").write_text("print('changed')\n", encoding="utf-8")
     _git(repo, "add", "plans/PR-Test.md", "scripts/example.py")
@@ -342,7 +1049,7 @@ def _write_body(repo: Path) -> Path:
 
 def _write_invalid_body(repo: Path) -> Path:
     _write_body(repo)
-    body = repo / "body-invalid.md"
+    body = repo.parent / "body-invalid.md"
     body.write_text(
         _valid_body().replace(
             "## Cold diff reconstruction\n"
@@ -357,12 +1064,13 @@ def _write_invalid_body(repo: Path) -> Path:
 
 
 def _write_docs_only_body(repo: Path) -> Path:
+    _checkout_pr_branch(repo)
     doc = repo / "docs" / "example.md"
     doc.parent.mkdir()
     doc.write_text("# docs only\n", encoding="utf-8")
     _git(repo, "add", "docs/example.md")
     _git(repo, "commit", "-qm", "docs only")
-    body = repo / "body-docs-only.md"
+    body = repo.parent / "body-docs-only.md"
     body.write_text("Docs-only: true\n\nCorrect a documentation typo.\n", encoding="utf-8")
     return body
 
@@ -371,6 +1079,18 @@ def _write_plan(repo: Path) -> None:
     plan = repo / "plans" / "PR-Test.md"
     plan.parent.mkdir(parents=True, exist_ok=True)
     plan.write_text("# Test plan\n", encoding="utf-8")
+
+
+def _checkout_pr_branch(repo: Path) -> None:
+    branch = subprocess.run(
+        ["git", "branch", "--show-current"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    if branch != "claude/pr-test":
+        _git(repo, "checkout", "-b", "claude/pr-test")
 
 
 def _valid_body() -> str:
@@ -408,10 +1128,29 @@ def _write_local_review(repo: Path) -> None:
     review.write_text(
         "#!/usr/bin/env bash\n"
         "set -euo pipefail\n"
-        "printf 'local-review %s\\n' \"$*\" >> \"$ORDER_LOG\"\n",
+        "printf 'local-review %s\\n' \"$*\" >> \"$ORDER_LOG\"\n"
+        "printf 'github-head-ref %s\\n' \"${GITHUB_HEAD_REF:-}\" >> \"$ORDER_LOG\"\n",
         encoding="utf-8",
     )
     review.chmod(0o755)
+    _git(repo, "add", "scripts/local_pr_review.sh")
+    _git(repo, "commit", "--amend", "--no-edit", "-q")
+
+
+def _write_aba_local_review(repo: Path) -> None:
+    review = repo / "scripts" / "local_pr_review.sh"
+    review.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "printf 'local-review-head %s\\n' \"$(git rev-parse HEAD)\" >> \"$ORDER_LOG\"\n"
+        "git -C \"$ABA_REPO\" checkout -q \"$ABA_OTHER_SHA\"\n"
+        "git -C \"$ABA_REPO\" checkout -q \"$ABA_BRANCH\"\n"
+        "printf 'local-review-original-after %s\\n' \"$(git -C \"$ABA_REPO\" rev-parse HEAD)\" >> \"$ORDER_LOG\"\n",
+        encoding="utf-8",
+    )
+    review.chmod(0o755)
+    _git(repo, "add", "scripts/local_pr_review.sh")
+    _git(repo, "commit", "--amend", "--no-edit", "-q")
 
 
 def _write_body_audit_recorder(repo: Path) -> None:
@@ -422,6 +1161,8 @@ def _write_body_audit_recorder(repo: Path) -> None:
         "    handle.write('body-audit\\n')\n",
         encoding="utf-8",
     )
+    _git(repo, "add", "scripts/audit_pr_body.py")
+    _git(repo, "commit", "--amend", "--no-edit", "-q")
 
 
 def _write_managed_hook(repo: Path, *, executable: bool = True) -> None:
@@ -434,9 +1175,13 @@ def _write_managed_hook(repo: Path, *, executable: bool = True) -> None:
         hook.chmod(0o755)
 
 
+def _order_log(repo: Path) -> Path:
+    return repo.parent / "order.log"
+
+
 def _write_fake_git(repo: Path, order_log: Path) -> Path:
-    fake_bin = repo / "fake-bin"
-    fake_bin.mkdir()
+    fake_bin = repo.parent / "fake-bin"
+    fake_bin.mkdir(exist_ok=True)
     git = fake_bin / "git"
     real_git = which("git")
     assert real_git is not None
@@ -463,6 +1208,22 @@ def _write_fake_git(repo: Path, order_log: Path) -> Path:
         "    ;;\n"
         "  push)\n"
         "    printf 'git %s\\n' \"$*\" >> \"$FAKE_GIT_LOG\"\n"
+        "    if [ \"${FAKE_GIT_PUSH_FAIL:-}\" = \"1\" ]; then\n"
+        "      exit 42\n"
+        "    fi\n"
+        "    if [ -n \"${FAKE_GIT_MUTATE_BODY:-}\" ]; then\n"
+        "      printf '\\nmutated during push\\n' >> \"$FAKE_GIT_MUTATE_BODY\"\n"
+        "    fi\n"
+        "    if [ \"${FAKE_GIT_DIRTY_SOURCE_DURING_PUSH:-}\" = \"1\" ]; then\n"
+        "      printf 'not reviewed\\n' > \"$FAKE_GIT_TOPLEVEL/pushed-dirty.txt\"\n"
+        "    fi\n"
+        "    if [ \"${FAKE_GIT_SKIP_REMOTE_UPDATE:-}\" != \"1\" ]; then\n"
+        f"      branch=\"$({real_git!r} branch --show-current)\"\n"
+        f"      {real_git!r} update-ref \"refs/remotes/origin/$branch\" HEAD\n"
+        "    fi\n"
+        "    if [ \"${FAKE_GIT_ADVANCE_BASE_DURING_PUSH:-}\" = \"1\" ]; then\n"
+        f"      {real_git!r} update-ref refs/remotes/origin/main HEAD\n"
+        "    fi\n"
         "    exit 0\n"
         "    ;;\n"
         "esac\n"
@@ -472,6 +1233,39 @@ def _write_fake_git(repo: Path, order_log: Path) -> Path:
     git.chmod(0o755)
     order_log.write_text("", encoding="utf-8")
     return fake_bin
+
+
+def _proof_path(repo: Path) -> Path:
+    proof = Path(
+        subprocess.run(
+            ["git", "rev-parse", "--git-path", "atlas-local-pr-review-proof"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    )
+    return proof if proof.is_absolute() else repo / proof
+
+
+def _head(repo: Path) -> str:
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _base(repo: Path) -> str:
+    return subprocess.run(
+        ["git", "rev-parse", "origin/main"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
 
 
 def _git(repo: Path, *args: str) -> None:


### PR DESCRIPTION
Plan: plans/PR-Pre-Open-Local-Review-Guard.md
Slice phase: Workflow/process
Ownership lane: workflow/pre-open-local-review-guard

The AGENTS enforcement audit found that `open_pr.sh` could still create or update a PR without proof that the full local review bundle passed for the current head and PR body. This slice adds a local proof handshake from `push_pr.sh` to `open_pr.sh`, then tightens that proof after Codex found publication, branch, hook-bypass, target-binding, dry-run-abbreviation, mutable-body, option-parsing, proof-input timing, remote-head revalidation, PR-existence race, environment-target, value-taking-option parsing, ABA checkout, boundary-enumeration, numeric-branch lookup, R8 execution-model, source-worktree-dirty, positional-remote, fork-PR lookup, and create-head-binding gaps in the first guard shape.

Diff-budget override: This guard/admission-boundary slice is genuinely indivisible because the code change and regression fixtures must prove the full publication handshake across push proof creation, open proof consumption, missing/stale proof rejection, branch switching at the same head, dry-run/refspec rejection, abbreviated and bundled dry-run rejection, scoped no-verify rejection without blocking `--no-verbose`, immutable body snapshots, pre-review proof-input capture, source dirty-state rejection, immutable captured-head review, ABA checkout resistance, base-movement rejection, create-target rejection, environment-target rejection, value-taking push-option parsing, numeric branch lookup, exact current-repo PR lookup, explicit create-head binding, remote-head revalidation before and after the PR existence probe, non-`origin` positional remote rejection, and failed-push ordering in one reviewed contract.

## Intentional
- The proof is local helper state, not branch protection or a security boundary.
- The proof binds branch name, `HEAD`, refreshed `origin/main`, and reviewed PR body snapshot SHA-256, but not the body path, so regenerating identical body content does not add friction.
- `push_pr.sh` now refuses Git dry-runs, abbreviated/bundled dry-runs, unrelated refspecs, and `--no-verify` abbreviations before proof creation while allowing valid non-bypass options such as `--no-verbose`; this is intentionally conservative for the endorsed helper path.
- `push_pr.sh` now refuses push target overrides such as `--repo`, because the proof is verified against `origin/<current-branch>`.
- `push_pr.sh` now refuses positional push remotes other than `origin`, because the proof is intentionally bound to `origin/<current-branch>`.
- `push_pr.sh` now rejects dirty source worktrees before immutable review and before proof write, runs the single local review in a temporary worktree pinned to the captured `HEAD`, then skips the mutable-checkout managed hook during the final push.
- `open_pr.sh` now refuses target-changing create args and `GH_REPO` environment overrides outside the current-branch/current-repo/main-base proof contract; use a separately reviewed helper if Atlas later needs target overrides.
- `open_pr.sh` resolves existing PRs by exact `headRefName` match and edits by returned PR number, so numeric branch names are not used as ambiguous positional selectors.
- `open_pr.sh` ignores same-branch fork PR records, requires existing PR records to match the current repository owner/name before edit, and passes the proven branch explicitly to `gh pr create --head`.
- Draft consent, branch naming, ownership-helper wiring, and commit-message gates remain separate follow-up slices.

## AI reconciliation
- [chatgpt-codex-connector] R12 BLOCKER at `scripts/push_pr.sh:122`: fixed by rejecting `git push -n/--dry-run`, rejecting refspecs that do not publish the current branch, and verifying `refs/remotes/origin/<current-branch>` equals local `HEAD` before writing local review proof.
- [chatgpt-codex-connector] R1/R12 BLOCKER at `scripts/open_pr.sh:73`: fixed by recording `branch=<current-branch>` in the proof and rejecting `open_pr.sh` when the proof branch differs from the branch being opened.
- [chatgpt-codex-connector] R12/R13 BLOCKER at `scripts/push_pr.sh:192`: fixed by rejecting `--no-v*`, covering Git's accepted `--no-verify` abbreviations before a managed-hook push can bypass local review and still write proof.
- [chatgpt-codex-connector] R1/R13 BLOCKER at `scripts/push_pr.sh:58`: fixed by rejecting `--dr*`, covering Git's accepted `--dry-run` abbreviations before a zero-exit dry-run can write proof.
- [chatgpt-codex-connector] R1/R12 BLOCKER at `scripts/open_pr.sh:125`: fixed by rejecting `--head`/`-H`, `--repo`/`-R`, and non-main `--base`/`-B` create-target args before fake or real `gh`, keeping the proof bound to the current branch, current repo, and `origin/main` base.
- [chatgpt-codex-connector] R8/R12 BLOCKER at `scripts/push_pr.sh:112`: fixed by snapshotting the PR body once per wrapper invocation and using that immutable snapshot for audit, local review, push/open stdin, and proof hashing.
- [chatgpt-codex-connector] R1/R13 BLOCKER at `scripts/push_pr.sh:76`: fixed by parsing supported push option shapes, rejecting bundled short dry-run options such as `-un`, narrowing hook-bypass rejection to `--no-veri*`, and preserving valid `--no-verbose`.
- [chatgpt-codex-connector] R8/R12 BLOCKER at `scripts/open_pr.sh:91`: fixed by refreshing `origin/<current-branch>` immediately before `gh` and requiring the published branch SHA to equal local `HEAD`.
- [chatgpt-codex-connector] R8 BLOCKER at `scripts/push_pr.sh:125`: fixed by capturing branch, `HEAD`, `origin/main`, and body snapshot hash before body audit/local review, then verifying those exact inputs remain unchanged after push before writing proof.
- [chatgpt-codex-connector] R8/R12 BLOCKER at `scripts/open_pr.sh:221`: fixed by re-running the published-head verification after `gh pr view` selects the create/edit path and immediately before the mutating `gh pr create/edit` call.
- [chatgpt-codex-connector] R1/R13 BLOCKER at `scripts/open_pr.sh:143`: fixed by rejecting non-empty `GH_REPO` before any `gh` call, so environment-selected repositories cannot retarget the proof.
- [chatgpt-codex-connector] R5/R13 MAJOR at `scripts/push_pr.sh:94`: fixed by consuming operands for value-taking Git push options before detecting remote/refspec, while rejecting `--repo` target overrides that cannot be proven against `origin/<current-branch>`.
- [chatgpt-codex-connector] R8 BLOCKER at `scripts/push_pr.sh:167`: fixed by running local review in a temporary detached worktree at the captured `HEAD`, exporting the captured branch as `GITHUB_HEAD_REF` for current-PR drift detection, then skipping the mutable-checkout managed hook during the final push; covered by ABA checkout and detached-branch-identity regressions.
- [chatgpt-codex-connector] R1/R13 BLOCKER at `plans/PR-Pre-Open-Local-Review-Guard.md:132`: fixed by splitting boundary-change enumeration into push review execution, push argument admission, open proof/target admission, and existing-PR resolution caller/input disposition groups.
- [chatgpt-codex-connector] R1/R12 BLOCKER at `scripts/open_pr.sh:237`: fixed by replacing positional `gh pr view "$branch"` with `gh pr list --head "$branch" --json number,headRefName`, matching exact `headRefName`, and editing by returned PR number.
- [chatgpt-codex-connector] R8 BLOCKER at `plans/PR-Pre-Open-Local-Review-Guard.md:128`: fixed by adding R8 to the Review Contract and naming the open-execution model: Git immutable object store plus detached captured-head worktree, source checkout as admission surface, wrapper-only proof writer, admitted interleavings, invariant, and explicit trust-boundary assumptions.
- [chatgpt-codex-connector] R1/R12 BLOCKER at `scripts/push_pr.sh:216`: fixed by rejecting dirty source checkout state before immutable review and again after push before proof write; covered by staged, unstaged, untracked, and dirty-during-push regressions.
- [chatgpt-codex-connector] R1/R12 BLOCKER at `scripts/push_pr.sh:135`: fixed by requiring the first positional push remote to be exactly `origin` before local review, push, or proof; covered by a non-`origin` remote regression.
- [chatgpt-codex-connector] R1/R12 BLOCKER at `scripts/open_pr.sh:77`: fixed by querying `headRepository`, `headRepositoryOwner`, and `isCrossRepository`, requiring the existing PR record to match the current repository owner/name before edit, and ignoring same-branch fork PR records so the wrapper takes the create path instead.
- [chatgpt-codex-connector] R8/R12 BLOCKER at `scripts/open_pr.sh:283`: fixed by passing the proven branch explicitly to `gh pr create --head <branch>` after the final published-head check, so `gh` does not infer the head from mutable checkout state.

All findings fixed or waived: yes.

## Deferred
- `PR-PR-Mutation-Ownership-Wrapper`: wire session ownership checks into mutation helpers.
- `PR-Open-Ready-Draft-Consent-Guard`: reject `--draft` without operator consent.
- `PR-Branch-Naming-Gate`: enforce or downgrade the builder branch naming convention.

## Parked hardening
- None.

## Cold diff reconstruction
- Changed: `scripts/push_pr.sh:62` captures branch, `HEAD`, `origin/main`, and reviewed body hash before review; `scripts/push_pr.sh:136` verifies those inputs remain unchanged after push; `scripts/push_pr.sh:167` writes only those captured values to proof.
- Changed: `scripts/push_pr.sh:78` rejects abbreviated dry-run, `scripts/push_pr.sh:90` rejects bundled short `-n` dry-run, and `scripts/push_pr.sh:82` narrows hook-bypass rejection to `--no-veri*` so `--no-verbose` remains valid.
- Changed: `scripts/open_pr.sh:113` refreshes `origin/<current-branch>` immediately before `gh`, and `scripts/open_pr.sh:123` rejects proof when the published branch SHA differs from local `HEAD`.
- Changed: `scripts/open_pr.sh:136` rejects `GH_REPO`; `scripts/open_pr.sh:235`, `scripts/open_pr.sh:250`, and `scripts/open_pr.sh:259` revalidate the published branch before and after the PR-existence probe and immediately before mutation.
- Changed: `scripts/push_pr.sh:88` rejects `--repo` push target overrides; `scripts/push_pr.sh:93` and `scripts/push_pr.sh:107` consume value-taking push-option operands before remote/refspec detection.
- Changed: `scripts/push_pr.sh:195` rejects dirty source checkout state, `scripts/push_pr.sh:288` applies that check before immutable review, and `scripts/push_pr.sh:293` applies it again after push before proof write.
- Changed: `scripts/push_pr.sh:219` creates an immutable detached review worktree at captured `HEAD`, and `scripts/push_pr.sh:233` exports the captured branch as `GITHUB_HEAD_REF` so cross-session drift treats the owned PR as current; `scripts/push_pr.sh:292` skips the mutable-checkout managed hook during final push after that review has passed.
- Changed: `scripts/open_pr.sh:75` queries existing PRs by `--head <branch>` and exact `headRefName`; `scripts/open_pr.sh:259` selects create/edit from that unambiguous result; `scripts/open_pr.sh:274` edits by returned PR number.
- Changed: `scripts/push_pr.sh:132` rejects positional push remotes other than `origin` before review/push/proof; `tests/test_push_pr_wrapper.py:637` proves `upstream HEAD` exits before fake local review, fake push, or proof.
- Changed: `scripts/open_pr.sh:75` queries current repo identity and existing PR head-repository metadata; `tests/test_open_pr_wrapper.py:135` proves a same-branch fork PR is ignored and the create path is used.
- Changed: `scripts/open_pr.sh:286` passes the proven branch explicitly to `gh pr create --head`; `tests/test_open_pr_wrapper.py:160` proves create argv is bound to the captured branch.
- Changed: `plans/PR-Pre-Open-Local-Review-Guard.md` now enumerates each changed wrapper boundary and dispositions caller/input shapes as preserved, changed, rejected, deferred, or N/A; its Review Contract now triggers R8 and states the open-execution model/invariant for admitted interleavings.
- Changed: `tests/test_push_pr_wrapper.py:351` proves bundled `-un` exits before fake `git push`, `tests/test_push_pr_wrapper.py:443` proves `origin/main` movement during fake push leaves no proof, and `tests/test_push_pr_wrapper.py:584` proves non-bypass `--no-verbose` remains allowed.
- Changed: `tests/test_open_pr_wrapper.py:172` proves `GH_REPO` exits before fake `gh`, `tests/test_open_pr_wrapper.py:430` proves a force-pushed reviewed branch exits before fake `gh`, and `tests/test_open_pr_wrapper.py:453` proves a force-push during fake `gh pr view` is caught before fake `gh pr create`.
- Changed: `tests/test_push_pr_wrapper.py:612` and `tests/test_push_pr_wrapper.py:655` prove value-taking push options consume operands before remote/refspec detection, and `tests/test_push_pr_wrapper.py:685` proves `--repo` exits before fake `git push`.
- Changed: `tests/test_push_pr_wrapper.py:191` proves detached immutable review carries the captured branch identity, `tests/test_push_pr_wrapper.py:328` proves an ABA checkout during fake local review still reviews and proves the captured head, `tests/test_push_pr_wrapper.py:376`/`:412`/`:447` prove staged, unstaged, and untracked source edits fail before immutable review, `tests/test_push_pr_wrapper.py:482` proves dirty-during-push fails before proof write, and `tests/test_open_pr_wrapper.py:112` proves numeric branch `123` edits the matched head PR number instead of treating `123` as the PR selector.
- Contract match: the diff traces to the problem-derived need for `open_pr.sh` to prove the current branch, `HEAD`, `origin/main`, reviewed body, and published branch are the same inputs that passed the guarded push/local-review path, plus the Codex-reviewed requirements that the wrapper parse Git options by class, capture proof inputs before review, reject base movement after review, and revalidate remote branch state immediately before mutation.
- Gaps: none.

## Verification
- `python -m pytest tests/test_open_pr_wrapper.py tests/test_push_pr_wrapper.py -q` - passed, 57 tests.
- `python -m pytest tests/test_content_factory_copy_verification.py -q` - passed, 324 tests while investigating the CI unit-gate regression.
- `python scripts/audit_plan_doc.py plans/PR-Pre-Open-Local-Review-Guard.md` - passed.
- `python scripts/audit_plan_code_consistency.py --base-ref origin/main plans/PR-Pre-Open-Local-Review-Guard.md` - passed.
- `python scripts/sync_pr_plan.py plans/PR-Pre-Open-Local-Review-Guard.md origin/main --check` - passed.
- `python scripts/audit_pr_body.py --repo-root . --base-ref origin/main /tmp/atlas-pr-body-pre-open-local-review-guard.md` - passed.
- `python scripts/check_diff_budget.py --additions 1959 --body-file /tmp/atlas-pr-body-pre-open-local-review-guard.md` - passed.
- `python scripts/audit_ai_reconciliation.py --current-pr-body-file /tmp/atlas-pr-body-pre-open-local-review-guard.md` - passed.
- `bash scripts/push_pr.sh /tmp/atlas-pr-body-pre-open-local-review-guard.md --force-with-lease origin HEAD` - passed; this ran the immutable captured-head local review once with the final PR body and wrote the proof consumed by `open_pr.sh`.

## Diff size
5 files, +2088 / -111
