### PR TITLE
Make live reconciliation depend on open bot threads

### DIFF
--- a/.github/workflows/ai_reconciliation_live.yml
+++ b/.github/workflows/ai_reconciliation_live.yml
@@ -59,7 +59,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           python scripts/check_ai_reconciliation_live.py \
-            --pr "${{ github.event.pull_request.number }}"
+            --pr "${{ github.event.pull_request.number }}" \
+            --wait-for-review-window
 
   live-reconciliation-review-events:
     if: github.event_name == 'pull_request_review' || github.event_name == 'pull_request_review_comment'

--- a/.github/workflows/ai_reconciliation_live.yml
+++ b/.github/workflows/ai_reconciliation_live.yml
@@ -42,7 +42,7 @@ jobs:
   live-reconciliation:
     if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Checkout trusted base
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/plans/PR-Live-Reconciliation-Open-Threads-Only.md
+++ b/plans/PR-Live-Reconciliation-Open-Threads-Only.md
@@ -2,160 +2,140 @@
 
 ## Why this slice exists
 
-The operator reported that CI/CD is not converging because the live
-reconciliation gate can require a final Codex connector approval-style signal
-that sometimes never appears. The intended gate is simpler: if the Codex
-connector leaves unresolved scoped findings, live reconciliation goes red. A
-fresh PR head should not go green before the connector has had a chance to
-react, but after that bounded window, no scoped findings should be enough to
-merge without waiting for extra Codex consent.
+The operator reported that CI/CD is not converging because
+`live-reconciliation` can require a final Codex connector approval-style signal
+that sometimes never appears. The intended gate is simpler: unresolved scoped
+Codex findings make the check red; a quiet head should pass after a short window
+that gives the connector a chance to react.
+
+Diff budget overage is intentional: the reviewer-found root cause spans the
+required workflow context, checker CLI, checker tests, and watcher contract
+fixture. Splitting those would leave one of the red checks unfixed.
 
 ### Problem-derived contract
 
-- Root cause: `scripts/check_ai_reconciliation_live.py` mixes two different
-  responsibilities: enforcing real open Codex feedback and requiring a fresh
-  current-head clean review/attestation. The second requirement is not the
-  desired merge predicate and creates red CI when no open Codex findings exist.
-- Correct fix must touch/change: The live reconciliation evaluator must stop
-  failing solely because a current-head Codex review or clean-review comment is
-  absent; it must still fail for current-head `CHANGES_REQUESTED` reviews and
-  unresolved scoped bot threads. It must preserve the docs-only success signal
-  consumed by watcher readiness, and it must fail during a short fresh-head
-  window when no current-head Codex activity exists yet. The direct unit tests
-  must encode those pass and fail cases.
-- Must not change: Do not change branch protection, PR opening behavior, review
-  bot identities, watcher merge authority, comment-thread filtering, PR body
-  reconciliation parsing, product surfaces, or active PR #2251.
+- Root cause: `scripts/check_ai_reconciliation_live.py` mixes open-feedback
+  enforcement with a current-head clean-review attestation requirement.
+- Correct fix must touch/change: remove the missing-attestation failure, keep
+  current-head `CHANGES_REQUESTED` and unresolved scoped bot threads blocking,
+  keep the watcher-owned docs-only success signal, and keep fresh heads from
+  going green before the review window closes.
+- Must not change: branch protection, PR opening behavior, bot identities,
+  watcher merge authority, PR body reconciliation parsing, product surfaces, or
+  active PR #2251.
 
 ## Scope (this PR)
 
 Ownership lane: workflow/live-reconciliation-open-threads-only
 Slice phase: Workflow/process
 
-1. Change live reconciliation's quiet-path decision from "current-head Codex
-   attestation required" to "no open scoped Codex threads, no current-head
-   changes-requested review, and not inside the fresh-head Codex review window."
-2. Update the focused live reconciliation tests so the old missing-attestation
-   failure becomes a passing quiet-path case while existing open-thread and
-   changes-requested failures remain covered.
+1. Change the quiet-path predicate from "current-head Codex attestation exists"
+   to "no open scoped Codex threads, no current-head `CHANGES_REQUESTED`, and no
+   active fresh-head review window."
+2. In live CI mode, wait for the fresh-head window once and refetch before
+   returning a required-context result, so the check stays pending instead of
+   permanently red.
+3. Validate review-window inputs inside controlled error handling.
+4. Update focused checker and watcher contract tests for the changed policy.
 
 ### Review Contract
 
 - Acceptance criteria:
-  1. `evaluate()` returns success when all scoped bot review threads are closed
-     and there is no current-head Codex review/clean-comment attestation.
-  2. `evaluate()` still returns failure when a current-head Codex connector
-     review has state `CHANGES_REQUESTED`, even if threads are closed.
-  3. `evaluate()` still returns failure when unresolved scoped Codex review
-     threads exist, including when the PR body claims all findings are fixed.
-  4. `evaluate()` returns failure during the configured fresh-head review
-     window when no current-head Codex activity exists yet, then returns success
-     after that window if threads remain clear.
+  1. Clear scoped bot threads pass without a current-head Codex
+     review/clean-comment attestation after the review window.
+  2. Current-head Codex `CHANGES_REQUESTED` still fails.
+  3. Unresolved scoped Codex review threads still fail.
+  4. A quiet fresh head waits/refetches in live mode instead of leaving the
+     required context red indefinitely.
   5. Docs-only PRs with proven Markdown-only diffs still emit the watcher-owned
-     docs-only success text when threads are clear and no current-head Codex
-     review already satisfies watcher readiness.
-  6. The `main()` dry-run path with `--head-sha` and no review attestation
-     exits `0` when threads are clear.
-- Reachability proof: `python -m pytest tests/test_check_ai_reconciliation_live.py -q`
-  exercises the live reconciliation CLI/evaluator entrypoint with injected
-  review-thread, review, comment, body, and head-SHA data.
-- Affected surfaces: `scripts/check_ai_reconciliation_live.py`,
-  `tests/test_check_ai_reconciliation_live.py`, and this plan.
-- Risk areas: accidental weakening of open-thread failures, accidental
-  weakening of current-head changes-requested failures, stale docs-only-only
-  proof paths, and noisy success text that still implies Codex consent is
-  required.
-- Reviewer rules triggered: R1, R2, R6, R8, R10, R12, R13, R14.
+     docs-only success text.
+  6. Malformed `ATLAS_CODEX_REVIEW_GRACE_SECONDS` or `--pr-updated-at` exits `2`
+     with a diagnostic, not an argparse traceback.
+- Reachability proof: focused pytest covers the CLI/evaluator entrypoint with
+  injected thread, review, comment, body, head-SHA, and timing data.
+- Affected surfaces: `.github/workflows/ai_reconciliation_live.yml`,
+  `scripts/check_ai_reconciliation_live.py`,
+  `tests/test_check_ai_reconciliation_live.py`, `tests/test_pr_watcher.py`, and
+  this plan.
+- Risk areas: weakening open-thread failures, weakening current-head
+  changes-requested failures, stale docs-only watcher readiness, red required
+  contexts after the grace window, and malformed config handling.
+- Reviewer rules triggered: R1, R2, R6, R8, R10, R11, R12, R13, R14.
 
 ### Boundary-change enumeration
 
-Required when this diff changes a guard, validator, normalizer, resolver,
-router/classifier, or admission boundary. Name each changed boundary path or
-seam in the enumeration; otherwise write "N/A - no boundary change."
-
-- Boundary path/seam: `scripts/check_ai_reconciliation_live.py::evaluate`.
-- Replaced-path behaviors: The missing-current-head-attestation failure path is
-  replaced with a quiet success path when no scoped bot threads are open and no
-  current-head `CHANGES_REQUESTED` review exists, except during the configured
-  fresh-head Codex review window.
-- Guard-relevant fields: review-thread `isResolved`, first thread comment
-  author/path/line/body, review `author.login`, review `commit.oid`, review
-  `state`, PR body reconciliation section, and optional `head_sha`.
+- Boundary path/seam: `scripts/check_ai_reconciliation_live.py::evaluate` and
+  live-mode `main()` fetch/wait/refetch orchestration.
+- Replaced-path behaviors: missing-attestation failure becomes quiet success
+  after the review window; live mode waits/refetches once during the window.
+- Guard-relevant fields: review-thread resolution/author/path/line/body, review
+  author/commit/state, PR body, head SHA, PR `updatedAt`, and review-window
+  seconds.
 - Caller x input shape: CI invokes `main()` with live GitHub data; tests invoke
-  `evaluate()` and `main()` with injected JSON fixtures.
+  `evaluate()` and `main()` with injected fixtures.
 
 ### Deployed-config probing
 
-Required for guard, validator, resolver, admission-boundary, or env/config
-fallback changes; otherwise write "N/A - no guard/config boundary change."
-
-- Deployed/default config values: Default bot identities remain
-  `chatgpt-codex-connector,chatgpt-codex-connector[bot]`.
-- Explicit value probe: Focused tests pass explicit `BOTS` and current-head
-  review states into `evaluate()`.
-- Absent value probe: Focused tests cover no review/clean-comment attestation
-  with closed threads both inside and after the fresh-head review window.
-- Default-session/default-context probe: N/A - no session-state or environment
-  default changes.
-- Side-effect ordering: N/A - decision logic remains pure after fetches finish.
+- Deployed/default config values: default bots remain
+  `chatgpt-codex-connector,chatgpt-codex-connector[bot]`;
+  default review window remains 300 seconds.
+- Explicit value probe: tests pass review states, head SHA, `--pr-updated-at`,
+  and malformed review-window config.
+- Absent value probe: tests cover no current-head attestation with closed threads
+  inside and after the fresh-head window.
+- Default-session/default-context probe: N/A - no session-state default change.
+- Side-effect ordering: live mode waits/refetches before docs-only file proof and
+  final evaluation.
 
 ### Files touched
 
+- `.github/workflows/ai_reconciliation_live.yml`
 - `plans/PR-Live-Reconciliation-Open-Threads-Only.md`
 - `scripts/check_ai_reconciliation_live.py`
 - `tests/test_check_ai_reconciliation_live.py`
+- `tests/test_pr_watcher.py`
 
 ## Mechanism
 
-The evaluator still computes unresolved scoped bot review threads first. If a
-current-head Codex connector review requested changes, it records a failure
-message. If there are no open threads and no current-head Codex activity yet,
-the evaluator fails only while the PR's `updatedAt` timestamp is inside the
-configured review window. After the window, no open scoped threads returns
-success without requiring a clean Codex approval comment.
+The evaluator still checks unresolved scoped bot threads first. It still fails
+for current-head Codex `CHANGES_REQUESTED`. If there are no open threads and no
+current-head Codex activity yet, the fresh-head window blocks only until the
+configured duration expires.
 
-Docs-only PRs are not a policy bypass anymore, but their proven Markdown-only
-quiet path still emits the prior docs-only success text because
-`scripts/pr_watcher.py` consumes that string when calculating watcher readiness.
+The CLI validates timing inputs after parsing, inside the script's controlled
+error path. In live GitHub mode, when the quiet fresh-head race is present, the
+required job sleeps until the window closes, refetches threads/reviews/body, and
+then evaluates the refreshed state. The workflow timeout is raised to 10 minutes
+so the default 300-second wait can complete. Docs-only file proof remains only
+for the watcher-owned success signal.
 
 ## Intentional
 
-- No branch-protection edit in this PR. The required check can stay in place;
-  its internal pass/fail predicate changes to the desired one.
-- No watcher merge-policy edit in this PR. Watcher readiness still has separate
-  policy language around Codex attestations and should be handled as its own
-  bounded follow-up if the operator wants automated watcher merge readiness to
-  match this gate exactly.
-- No change to bot identity matching. The scope remains the exact Codex
-  connector logins configured for this check.
-- The fresh-head review window is a race guard, not Codex consent. It prevents
-  immediate green before the connector can react, then quiet no-thread heads
-  pass without a final LGTM signal.
+- No branch-protection edit; the existing required check stays in place.
+- No watcher merge-policy edit; only the watcher fixture is updated for the new
+  `updatedAt` read.
+- No bot identity change; the check still uses exact Codex connector logins.
+- The fresh-head window is a race guard, not Codex consent.
 
 ## Deferred
 
-- Align watcher/readiness wording and merge-ready predicates that still mention
-  Codex review attestations, if the operator wants the watcher layer to use the
-  same open-threads-only policy.
-- Update the mechanical-enforcement audit note that currently records the old
-  attestation requirement, after this policy lands.
+- Update the mechanical-enforcement audit note that records the old attestation
+  requirement after this policy lands.
 
 Parked hardening: none.
 
 ## Verification
 
-- `python -m pytest tests/test_check_ai_reconciliation_live.py -q` - 61 passed.
-- `python -m pytest tests/test_content_factory_copy_verification.py::test_scope_lookup_scales_with_negation_scopes_present -q --tb=short` - 1 passed locally after CI unit-gate reported this unrelated node as the only unbaselined failure.
-- `python scripts/audit_plan_doc.py plans/PR-Live-Reconciliation-Open-Threads-Only.md` - passed.
-- `python scripts/audit_plan_code_consistency.py --base-ref origin/main plans/PR-Live-Reconciliation-Open-Threads-Only.md` - passed.
-- `python scripts/sync_pr_plan.py plans/PR-Live-Reconciliation-Open-Threads-Only.md origin/main --check` - passed after syncing generated file/diff-size sections.
-- `ATLAS_SESSION_STATE_FILE=SESSION_STATE.codex-live-reconciliation-open-threads.local.md bash scripts/local_pr_review.sh --current-pr-body-file /tmp/atlas-pr-body-live-reconciliation-open-threads-only.md` - passed.
+- `python -m py_compile scripts/check_ai_reconciliation_live.py && python -m pytest tests/test_check_ai_reconciliation_live.py -q` - 64 passed.
+- `python -m pytest tests/test_pr_watcher.py::test_installed_entrypoint_writes_consumer_accepted_snapshot -q --tb=short` - 1 passed.
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Live-Reconciliation-Open-Threads-Only.md` | 161 |
-| `scripts/check_ai_reconciliation_live.py` | 78 |
-| `tests/test_check_ai_reconciliation_live.py` | 130 |
-| **Total** | **369** |
+| `.github/workflows/ai_reconciliation_live.yml` | 2 |
+| `plans/PR-Live-Reconciliation-Open-Threads-Only.md` | 141 |
+| `scripts/check_ai_reconciliation_live.py` | 178 |
+| `tests/test_check_ai_reconciliation_live.py` | 189 |
+| `tests/test_pr_watcher.py` | 2 |
+| **Total** | **512** |

--- a/plans/PR-Live-Reconciliation-Open-Threads-Only.md
+++ b/plans/PR-Live-Reconciliation-Open-Threads-Only.md
@@ -18,8 +18,10 @@ fixture. Splitting those would leave one of the red checks unfixed.
   enforcement with a current-head clean-review attestation requirement.
 - Correct fix must touch/change: remove the missing-attestation failure, keep
   current-head `CHANGES_REQUESTED` and unresolved scoped bot threads blocking,
-  keep the watcher-owned docs-only success signal, and keep fresh heads from
-  going green before the review window closes.
+  keep the watcher-owned docs-only success signal, keep fresh heads from going
+  green before the review window closes, and keep watcher/status-producer
+  invocations nonblocking by making the grace wait an explicit required-CI
+  opt-in.
 - Must not change: branch protection, PR opening behavior, bot identities,
   watcher merge authority, PR body reconciliation parsing, product surfaces, or
   active PR #2251.
@@ -32,9 +34,9 @@ Slice phase: Workflow/process
 1. Change the quiet-path predicate from "current-head Codex attestation exists"
    to "no open scoped Codex threads, no current-head `CHANGES_REQUESTED`, and no
    active fresh-head review window."
-2. In live CI mode, wait for the fresh-head window once and refetch before
-   returning a required-context result, so the check stays pending instead of
-   permanently red.
+2. In required live CI mode, opt into waiting for the fresh-head window once
+   and refetch before returning a required-context result, so the check stays
+   pending instead of permanently red.
 3. Validate review-window inputs inside controlled error handling.
 4. Update focused checker and watcher contract tests for the changed policy.
 
@@ -46,11 +48,14 @@ Slice phase: Workflow/process
   2. Current-head Codex `CHANGES_REQUESTED` still fails.
   3. Unresolved scoped Codex review threads still fail.
   4. A quiet fresh head waits/refetches in live mode instead of leaving the
-     required context red indefinitely.
+     required context red indefinitely when the required workflow opts into
+     `--wait-for-review-window`.
   5. Docs-only PRs with proven Markdown-only diffs still emit the watcher-owned
      docs-only success text.
   6. Malformed `ATLAS_CODEX_REVIEW_GRACE_SECONDS` or `--pr-updated-at` exits `2`
      with a diagnostic, not an argparse traceback.
+  7. Default live checker invocations return immediately inside the fresh-head
+     window, so watcher/status producers do not block on the grace sleep.
 - Reachability proof: focused pytest covers the CLI/evaluator entrypoint with
   injected thread, review, comment, body, head-SHA, and timing data.
 - Affected surfaces: `.github/workflows/ai_reconciliation_live.yml`,
@@ -67,7 +72,8 @@ Slice phase: Workflow/process
 - Boundary path/seam: `scripts/check_ai_reconciliation_live.py::evaluate` and
   live-mode `main()` fetch/wait/refetch orchestration.
 - Replaced-path behaviors: missing-attestation failure becomes quiet success
-  after the review window; live mode waits/refetches once during the window.
+  after the review window; required live mode waits/refetches once during the
+  window only when `--wait-for-review-window` is present.
 - Guard-relevant fields: review-thread resolution/author/path/line/body, review
   author/commit/state, PR body, head SHA, PR `updatedAt`, and review-window
   seconds.
@@ -84,8 +90,9 @@ Slice phase: Workflow/process
 - Absent value probe: tests cover no current-head attestation with closed threads
   inside and after the fresh-head window.
 - Default-session/default-context probe: N/A - no session-state default change.
-- Side-effect ordering: live mode waits/refetches before docs-only file proof and
-  final evaluation.
+- Side-effect ordering: opt-in required live mode waits/refetches before
+  docs-only file proof and final evaluation; default live mode evaluates
+  immediately.
 
 ### Files touched
 
@@ -103,17 +110,19 @@ current-head Codex activity yet, the fresh-head window blocks only until the
 configured duration expires.
 
 The CLI validates timing inputs after parsing, inside the script's controlled
-error path. In live GitHub mode, when the quiet fresh-head race is present, the
-required job sleeps until the window closes, refetches threads/reviews/body, and
-then evaluates the refreshed state. The workflow timeout is raised to 10 minutes
-so the default 300-second wait can complete. Docs-only file proof remains only
-for the watcher-owned success signal.
+error path. In live GitHub mode, the default remains nonblocking: a quiet
+fresh-head race returns the immediate pending/failure result without sleeping,
+which keeps watcher/status-producer invocations fast. The required workflow
+passes `--wait-for-review-window`, sleeps until the window closes, refetches
+threads/reviews/body, and then evaluates the refreshed state. The workflow
+timeout is raised to 10 minutes so the default 300-second wait can complete.
+Docs-only file proof remains only for the watcher-owned success signal.
 
 ## Intentional
 
 - No branch-protection edit; the existing required check stays in place.
 - No watcher merge-policy edit; only the watcher fixture is updated for the new
-  `updatedAt` read.
+  `updatedAt` read, and default checker invocations still exit fast.
 - No bot identity change; the check still uses exact Codex connector logins.
 - The fresh-head window is a race guard, not Codex consent.
 
@@ -126,16 +135,16 @@ Parked hardening: none.
 
 ## Verification
 
-- `python -m py_compile scripts/check_ai_reconciliation_live.py && python -m pytest tests/test_check_ai_reconciliation_live.py -q` - 64 passed.
+- `python -m py_compile scripts/check_ai_reconciliation_live.py && python -m pytest tests/test_check_ai_reconciliation_live.py -q` - 65 passed.
 - `python -m pytest tests/test_pr_watcher.py::test_installed_entrypoint_writes_consumer_accepted_snapshot -q --tb=short` - 1 passed.
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
-| `.github/workflows/ai_reconciliation_live.yml` | 2 |
-| `plans/PR-Live-Reconciliation-Open-Threads-Only.md` | 141 |
-| `scripts/check_ai_reconciliation_live.py` | 178 |
-| `tests/test_check_ai_reconciliation_live.py` | 189 |
+| `.github/workflows/ai_reconciliation_live.yml` | 5 |
+| `plans/PR-Live-Reconciliation-Open-Threads-Only.md` | 150 |
+| `scripts/check_ai_reconciliation_live.py` | 184 |
+| `tests/test_check_ai_reconciliation_live.py` | 225 |
 | `tests/test_pr_watcher.py` | 2 |
-| **Total** | **512** |
+| **Total** | **566** |

--- a/plans/PR-Live-Reconciliation-Open-Threads-Only.md
+++ b/plans/PR-Live-Reconciliation-Open-Threads-Only.md
@@ -1,0 +1,161 @@
+# PR-Live-Reconciliation-Open-Threads-Only
+
+## Why this slice exists
+
+The operator reported that CI/CD is not converging because the live
+reconciliation gate can require a final Codex connector approval-style signal
+that sometimes never appears. The intended gate is simpler: if the Codex
+connector leaves unresolved scoped findings, live reconciliation goes red. A
+fresh PR head should not go green before the connector has had a chance to
+react, but after that bounded window, no scoped findings should be enough to
+merge without waiting for extra Codex consent.
+
+### Problem-derived contract
+
+- Root cause: `scripts/check_ai_reconciliation_live.py` mixes two different
+  responsibilities: enforcing real open Codex feedback and requiring a fresh
+  current-head clean review/attestation. The second requirement is not the
+  desired merge predicate and creates red CI when no open Codex findings exist.
+- Correct fix must touch/change: The live reconciliation evaluator must stop
+  failing solely because a current-head Codex review or clean-review comment is
+  absent; it must still fail for current-head `CHANGES_REQUESTED` reviews and
+  unresolved scoped bot threads. It must preserve the docs-only success signal
+  consumed by watcher readiness, and it must fail during a short fresh-head
+  window when no current-head Codex activity exists yet. The direct unit tests
+  must encode those pass and fail cases.
+- Must not change: Do not change branch protection, PR opening behavior, review
+  bot identities, watcher merge authority, comment-thread filtering, PR body
+  reconciliation parsing, product surfaces, or active PR #2251.
+
+## Scope (this PR)
+
+Ownership lane: workflow/live-reconciliation-open-threads-only
+Slice phase: Workflow/process
+
+1. Change live reconciliation's quiet-path decision from "current-head Codex
+   attestation required" to "no open scoped Codex threads, no current-head
+   changes-requested review, and not inside the fresh-head Codex review window."
+2. Update the focused live reconciliation tests so the old missing-attestation
+   failure becomes a passing quiet-path case while existing open-thread and
+   changes-requested failures remain covered.
+
+### Review Contract
+
+- Acceptance criteria:
+  1. `evaluate()` returns success when all scoped bot review threads are closed
+     and there is no current-head Codex review/clean-comment attestation.
+  2. `evaluate()` still returns failure when a current-head Codex connector
+     review has state `CHANGES_REQUESTED`, even if threads are closed.
+  3. `evaluate()` still returns failure when unresolved scoped Codex review
+     threads exist, including when the PR body claims all findings are fixed.
+  4. `evaluate()` returns failure during the configured fresh-head review
+     window when no current-head Codex activity exists yet, then returns success
+     after that window if threads remain clear.
+  5. Docs-only PRs with proven Markdown-only diffs still emit the watcher-owned
+     docs-only success text when threads are clear and no current-head Codex
+     review already satisfies watcher readiness.
+  6. The `main()` dry-run path with `--head-sha` and no review attestation
+     exits `0` when threads are clear.
+- Reachability proof: `python -m pytest tests/test_check_ai_reconciliation_live.py -q`
+  exercises the live reconciliation CLI/evaluator entrypoint with injected
+  review-thread, review, comment, body, and head-SHA data.
+- Affected surfaces: `scripts/check_ai_reconciliation_live.py`,
+  `tests/test_check_ai_reconciliation_live.py`, and this plan.
+- Risk areas: accidental weakening of open-thread failures, accidental
+  weakening of current-head changes-requested failures, stale docs-only-only
+  proof paths, and noisy success text that still implies Codex consent is
+  required.
+- Reviewer rules triggered: R1, R2, R6, R8, R10, R12, R13, R14.
+
+### Boundary-change enumeration
+
+Required when this diff changes a guard, validator, normalizer, resolver,
+router/classifier, or admission boundary. Name each changed boundary path or
+seam in the enumeration; otherwise write "N/A - no boundary change."
+
+- Boundary path/seam: `scripts/check_ai_reconciliation_live.py::evaluate`.
+- Replaced-path behaviors: The missing-current-head-attestation failure path is
+  replaced with a quiet success path when no scoped bot threads are open and no
+  current-head `CHANGES_REQUESTED` review exists, except during the configured
+  fresh-head Codex review window.
+- Guard-relevant fields: review-thread `isResolved`, first thread comment
+  author/path/line/body, review `author.login`, review `commit.oid`, review
+  `state`, PR body reconciliation section, and optional `head_sha`.
+- Caller x input shape: CI invokes `main()` with live GitHub data; tests invoke
+  `evaluate()` and `main()` with injected JSON fixtures.
+
+### Deployed-config probing
+
+Required for guard, validator, resolver, admission-boundary, or env/config
+fallback changes; otherwise write "N/A - no guard/config boundary change."
+
+- Deployed/default config values: Default bot identities remain
+  `chatgpt-codex-connector,chatgpt-codex-connector[bot]`.
+- Explicit value probe: Focused tests pass explicit `BOTS` and current-head
+  review states into `evaluate()`.
+- Absent value probe: Focused tests cover no review/clean-comment attestation
+  with closed threads both inside and after the fresh-head review window.
+- Default-session/default-context probe: N/A - no session-state or environment
+  default changes.
+- Side-effect ordering: N/A - decision logic remains pure after fetches finish.
+
+### Files touched
+
+- `plans/PR-Live-Reconciliation-Open-Threads-Only.md`
+- `scripts/check_ai_reconciliation_live.py`
+- `tests/test_check_ai_reconciliation_live.py`
+
+## Mechanism
+
+The evaluator still computes unresolved scoped bot review threads first. If a
+current-head Codex connector review requested changes, it records a failure
+message. If there are no open threads and no current-head Codex activity yet,
+the evaluator fails only while the PR's `updatedAt` timestamp is inside the
+configured review window. After the window, no open scoped threads returns
+success without requiring a clean Codex approval comment.
+
+Docs-only PRs are not a policy bypass anymore, but their proven Markdown-only
+quiet path still emits the prior docs-only success text because
+`scripts/pr_watcher.py` consumes that string when calculating watcher readiness.
+
+## Intentional
+
+- No branch-protection edit in this PR. The required check can stay in place;
+  its internal pass/fail predicate changes to the desired one.
+- No watcher merge-policy edit in this PR. Watcher readiness still has separate
+  policy language around Codex attestations and should be handled as its own
+  bounded follow-up if the operator wants automated watcher merge readiness to
+  match this gate exactly.
+- No change to bot identity matching. The scope remains the exact Codex
+  connector logins configured for this check.
+- The fresh-head review window is a race guard, not Codex consent. It prevents
+  immediate green before the connector can react, then quiet no-thread heads
+  pass without a final LGTM signal.
+
+## Deferred
+
+- Align watcher/readiness wording and merge-ready predicates that still mention
+  Codex review attestations, if the operator wants the watcher layer to use the
+  same open-threads-only policy.
+- Update the mechanical-enforcement audit note that currently records the old
+  attestation requirement, after this policy lands.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_check_ai_reconciliation_live.py -q` - 61 passed.
+- `python -m pytest tests/test_content_factory_copy_verification.py::test_scope_lookup_scales_with_negation_scopes_present -q --tb=short` - 1 passed locally after CI unit-gate reported this unrelated node as the only unbaselined failure.
+- `python scripts/audit_plan_doc.py plans/PR-Live-Reconciliation-Open-Threads-Only.md` - passed.
+- `python scripts/audit_plan_code_consistency.py --base-ref origin/main plans/PR-Live-Reconciliation-Open-Threads-Only.md` - passed.
+- `python scripts/sync_pr_plan.py plans/PR-Live-Reconciliation-Open-Threads-Only.md origin/main --check` - passed after syncing generated file/diff-size sections.
+- `ATLAS_SESSION_STATE_FILE=SESSION_STATE.codex-live-reconciliation-open-threads.local.md bash scripts/local_pr_review.sh --current-pr-body-file /tmp/atlas-pr-body-live-reconciliation-open-threads-only.md` - passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Live-Reconciliation-Open-Threads-Only.md` | 161 |
+| `scripts/check_ai_reconciliation_live.py` | 78 |
+| `tests/test_check_ai_reconciliation_live.py` | 130 |
+| **Total** | **369** |

--- a/scripts/check_ai_reconciliation_live.py
+++ b/scripts/check_ai_reconciliation_live.py
@@ -1160,6 +1160,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         default=os.environ.get("ATLAS_CODEX_REVIEW_GRACE_SECONDS", str(_DEFAULT_CODEX_REVIEW_GRACE_SECONDS)),
         help="seconds after a PR update to wait for Codex activity before allowing a quiet no-thread pass",
     )
+    parser.add_argument(
+        "--wait-for-review-window",
+        action="store_true",
+        help="wait/refetch once when a live PR is still inside the fresh-head review window",
+    )
     args = parser.parse_args(argv)
 
     try:
@@ -1217,7 +1222,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             pr_updated_at = fetch_pr_updated_at(args.pr, args.repo, args.gh)
 
         if (
-            not args.threads_file
+            args.wait_for_review_window
+            and not args.threads_file
             and args.pr is not None
             and args.repo
             and missing_codex_activity_inside_review_grace(

--- a/scripts/check_ai_reconciliation_live.py
+++ b/scripts/check_ai_reconciliation_live.py
@@ -30,10 +30,12 @@ from __future__ import annotations
 import argparse
 import importlib.util
 import json
+import math
 import os
 import re
 import subprocess
 import sys
+import time
 from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
 from pathlib import Path, PurePosixPath
@@ -375,13 +377,71 @@ def updated_within_review_grace(
 ) -> bool:
     """Return true while a fresh PR update is still inside the Codex review window."""
 
+    return review_grace_remaining_seconds(
+        updated_at,
+        review_grace_seconds=review_grace_seconds,
+        now=now,
+    ) > 0
+
+
+def review_grace_remaining_seconds(
+    updated_at: str | None,
+    *,
+    review_grace_seconds: int,
+    now: datetime | None = None,
+) -> float:
+    """Return seconds left in the fresh-head Codex review window."""
+
     if review_grace_seconds <= 0 or not updated_at:
-        return False
+        return 0.0
     reference_time = now or datetime.now(UTC)
     if reference_time.tzinfo is None:
         reference_time = reference_time.replace(tzinfo=UTC)
     updated_time = _parse_github_timestamp(updated_at)
-    return reference_time.astimezone(UTC) - updated_time < timedelta(seconds=review_grace_seconds)
+    expires_at = updated_time + timedelta(seconds=review_grace_seconds)
+    return max(0.0, (expires_at - reference_time.astimezone(UTC)).total_seconds())
+
+
+def missing_codex_activity_inside_review_grace(
+    nodes: Sequence[dict],
+    bot_logins: Sequence[str],
+    *,
+    reviews: Sequence[dict] | None,
+    comments: Sequence[dict] | None,
+    head_sha: str | None,
+    pr_updated_at: str | None,
+    review_grace_seconds: int,
+    now: datetime | None = None,
+) -> bool:
+    """Return true only for the quiet fresh-head race the required job must wait out."""
+
+    if head_sha is None or open_bot_threads(nodes, bot_logins):
+        return False
+    if current_head_change_requests(reviews or [], head_sha=head_sha, bot_logins=bot_logins):
+        return False
+    if current_head_bot_reviews(reviews or [], head_sha=head_sha, bot_logins=bot_logins):
+        return False
+    if current_head_clean_review_comments(comments or [], head_sha=head_sha, bot_logins=bot_logins):
+        return False
+    return updated_within_review_grace(
+        pr_updated_at,
+        review_grace_seconds=review_grace_seconds,
+        now=now,
+    )
+
+
+def parse_review_grace_seconds(raw: str | int | None) -> int:
+    """Parse the review-window duration from CLI/env without argparse tracebacks."""
+
+    if raw is None:
+        return _DEFAULT_CODEX_REVIEW_GRACE_SECONDS
+    try:
+        value = int(raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("review grace seconds must be an integer") from exc
+    if value < 0:
+        raise ValueError("review grace seconds must be non-negative")
+    return value
 
 
 def review_attestation_generation(
@@ -1097,14 +1157,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     parser.add_argument(
         "--review-grace-seconds",
-        type=int,
-        default=int(os.environ.get("ATLAS_CODEX_REVIEW_GRACE_SECONDS", _DEFAULT_CODEX_REVIEW_GRACE_SECONDS)),
+        default=os.environ.get("ATLAS_CODEX_REVIEW_GRACE_SECONDS", str(_DEFAULT_CODEX_REVIEW_GRACE_SECONDS)),
         help="seconds after a PR update to wait for Codex activity before allowing a quiet no-thread pass",
     )
     args = parser.parse_args(argv)
 
     try:
         bots = parse_bot_logins(args.bots)
+        review_grace_seconds = parse_review_grace_seconds(args.review_grace_seconds)
     except ValueError as exc:
         print(f"live reconciliation: {exc}", file=sys.stderr)
         return 2
@@ -1116,6 +1176,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         changed_files: Sequence[dict] | None = None
         changed_file_proof: ChangedFileProof | None = None
         pr_updated_at = args.pr_updated_at
+        if pr_updated_at is not None:
+            _parse_github_timestamp(pr_updated_at)
 
         if args.threads_file:
             nodes = json.loads(Path(args.threads_file).read_text(encoding="utf-8"))
@@ -1153,6 +1215,44 @@ def main(argv: Sequence[str] | None = None) -> int:
 
         if pr_updated_at is None and args.pr is not None and args.repo and not args.threads_file:
             pr_updated_at = fetch_pr_updated_at(args.pr, args.repo, args.gh)
+
+        if (
+            not args.threads_file
+            and args.pr is not None
+            and args.repo
+            and missing_codex_activity_inside_review_grace(
+                nodes,
+                bots,
+                reviews=reviews,
+                comments=comments,
+                head_sha=head_sha,
+                pr_updated_at=pr_updated_at,
+                review_grace_seconds=review_grace_seconds,
+            )
+        ):
+            remaining = review_grace_remaining_seconds(
+                pr_updated_at,
+                review_grace_seconds=review_grace_seconds,
+            )
+            wait_seconds = max(1, math.ceil(remaining))
+            print(
+                "live reconciliation: waiting "
+                f"{wait_seconds} second(s) for the Codex review window to close",
+                file=sys.stderr,
+            )
+            time.sleep(wait_seconds)
+            before_snapshot = fetch_consistent_review_thread_snapshot(
+                args.pr,
+                owner,
+                name,
+                args.gh,
+                bots,
+            )
+            nodes, head_sha, reviews, comments = before_snapshot
+            body = fetch_body(args.pr, args.repo, args.gh)
+            pr_updated_at = fetch_pr_updated_at(args.pr, args.repo, args.gh)
+            changed_files = None
+            changed_file_proof = None
 
         needs_live_changed_file_proof = (
             changed_files is None
@@ -1208,7 +1308,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         changed_files=changed_files,
         head_sha=head_sha,
         pr_updated_at=pr_updated_at,
-        review_grace_seconds=args.review_grace_seconds,
+        review_grace_seconds=review_grace_seconds,
     )
     print("live AI reconciliation check")
     print("-" * 60)

--- a/scripts/check_ai_reconciliation_live.py
+++ b/scripts/check_ai_reconciliation_live.py
@@ -35,10 +35,12 @@ import re
 import subprocess
 import sys
 from collections.abc import Sequence
+from datetime import UTC, datetime, timedelta
 from pathlib import Path, PurePosixPath
 
 _DEFAULT_BOTS = ("chatgpt-codex-connector", "chatgpt-codex-connector[bot]")
 _CLEAN_CODEX_REVIEW_TEXT = "didn't find any major issues"
+_DEFAULT_CODEX_REVIEW_GRACE_SECONDS = 300
 _REVIEWED_COMMIT_RE = re.compile(r"\*\*Reviewed commit:\*\*\s*`(?P<sha>[0-9a-f]{10,40})`", re.IGNORECASE)
 _LEGACY_BOT_ALIASES = frozenset(
     {
@@ -359,6 +361,29 @@ def current_head_change_requests(
     )
 
 
+def _parse_github_timestamp(raw: str) -> datetime:
+    """Parse a GitHub API timestamp into an aware UTC datetime."""
+
+    return datetime.fromisoformat(raw.replace("Z", "+00:00")).astimezone(UTC)
+
+
+def updated_within_review_grace(
+    updated_at: str | None,
+    *,
+    review_grace_seconds: int,
+    now: datetime | None = None,
+) -> bool:
+    """Return true while a fresh PR update is still inside the Codex review window."""
+
+    if review_grace_seconds <= 0 or not updated_at:
+        return False
+    reference_time = now or datetime.now(UTC)
+    if reference_time.tzinfo is None:
+        reference_time = reference_time.replace(tzinfo=UTC)
+    updated_time = _parse_github_timestamp(updated_at)
+    return reference_time.astimezone(UTC) - updated_time < timedelta(seconds=review_grace_seconds)
+
+
 def review_attestation_generation(
     reviews: Sequence[dict],
     comments: Sequence[dict] | None = None,
@@ -450,6 +475,9 @@ def evaluate(
     comments: Sequence[dict] | None = None,
     changed_files: Sequence[dict] | None = None,
     head_sha: str | None = None,
+    pr_updated_at: str | None = None,
+    review_grace_seconds: int = 0,
+    now: datetime | None = None,
 ) -> tuple[int, list[str]]:
     """Core decision (pure). Returns (exit_code, messages)."""
     messages: list[str] = []
@@ -466,12 +494,7 @@ def evaluate(
                 f"reconciliation cannot pass PR head {head_sha} until the "
                 "changes-requested review is superseded or resolved."
             )
-        elif not open_threads and is_docs_only_body(body) and changed_files_are_docs_only(changed_files or []):
-            messages.append(
-                "OK: docs-only PR diff has no open scoped Codex review threads; "
-                "current-head Codex review attestation is not required."
-            )
-        elif not current_head_bot_reviews(
+        elif not open_threads and not current_head_bot_reviews(
             reviews or [],
             head_sha=head_sha,
             bot_logins=bot_logins,
@@ -479,10 +502,20 @@ def evaluate(
             comments or [],
             head_sha=head_sha,
             bot_logins=bot_logins,
+        ) and updated_within_review_grace(
+            pr_updated_at,
+            review_grace_seconds=review_grace_seconds,
+            now=now,
         ):
             messages.append(
-                "missing current-head Codex connector review: live reconciliation "
-                f"requires one scoped Codex review or clean review comment on PR head {head_sha} before merge."
+                "waiting for Codex connector review window: no scoped Codex "
+                f"activity is recorded on PR head {head_sha} yet, and the PR "
+                f"was updated less than {review_grace_seconds} seconds ago."
+            )
+        elif not open_threads and is_docs_only_body(body) and changed_files_are_docs_only(changed_files or []):
+            messages.append(
+                "OK: docs-only PR diff has no open scoped Codex review threads; "
+                "current-head Codex review attestation is not required."
             )
 
     if not open_threads:
@@ -490,7 +523,7 @@ def evaluate(
             if all(message.startswith("OK:") for message in messages):
                 return 0, messages
             return 1, messages
-        return 0, ["OK: current-head Codex review attestation is present and no open scoped Codex review threads remain."]
+        return 0, ["OK: no open scoped Codex review threads remain."]
 
     body_class = classify_body(body)
     if body_class == "claims_clear":
@@ -534,7 +567,7 @@ def docs_only_exemption_needs_file_proof(
     comments: Sequence[dict] | None,
     head_sha: str | None,
 ) -> bool:
-    """Return true only when file proof is needed to decide the docs-only bypass."""
+    """Return true only when file proof is needed to emit the docs-only watcher signal."""
 
     if head_sha is None or not is_docs_only_body(body):
         return False
@@ -736,6 +769,13 @@ def fetch_comment_attestation(pr: int, owner: str, name: str, gh: str) -> tuple[
 def fetch_body(pr: int, repo: str, gh: str) -> str:
     out = _gh(["pr", "view", str(pr), "--repo", repo, "--json", "body", "-q", ".body"], gh)
     return out
+
+
+def fetch_pr_updated_at(pr: int, repo: str, gh: str) -> str:
+    out = _gh(["pr", "view", str(pr), "--repo", repo, "--json", "updatedAt", "-q", ".updatedAt"], gh)
+    updated_at = out.strip()
+    _parse_github_timestamp(updated_at)
+    return updated_at
 
 
 def fetch_pr_ref_snapshot(pr: int, repo: str, gh: str) -> PrRefSnapshot:
@@ -1049,7 +1089,17 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     parser.add_argument(
         "--head-sha",
-        help="PR head SHA for current-head Codex review attestation in test/dry-run mode",
+        help="PR head SHA for current-head Codex review state in test/dry-run mode",
+    )
+    parser.add_argument(
+        "--pr-updated-at",
+        help="GitHub PR updatedAt timestamp for fresh-head Codex review-window checks",
+    )
+    parser.add_argument(
+        "--review-grace-seconds",
+        type=int,
+        default=int(os.environ.get("ATLAS_CODEX_REVIEW_GRACE_SECONDS", _DEFAULT_CODEX_REVIEW_GRACE_SECONDS)),
+        help="seconds after a PR update to wait for Codex activity before allowing a quiet no-thread pass",
     )
     args = parser.parse_args(argv)
 
@@ -1065,6 +1115,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         comments: Sequence[dict] | None = None
         changed_files: Sequence[dict] | None = None
         changed_file_proof: ChangedFileProof | None = None
+        pr_updated_at = args.pr_updated_at
 
         if args.threads_file:
             nodes = json.loads(Path(args.threads_file).read_text(encoding="utf-8"))
@@ -1099,6 +1150,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             body = fetch_body(args.pr, args.repo, args.gh)
         else:
             body = ""
+
+        if pr_updated_at is None and args.pr is not None and args.repo and not args.threads_file:
+            pr_updated_at = fetch_pr_updated_at(args.pr, args.repo, args.gh)
 
         needs_live_changed_file_proof = (
             changed_files is None
@@ -1153,6 +1207,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         comments=comments,
         changed_files=changed_files,
         head_sha=head_sha,
+        pr_updated_at=pr_updated_at,
+        review_grace_seconds=args.review_grace_seconds,
     )
     print("live AI reconciliation check")
     print("-" * 60)

--- a/tests/test_check_ai_reconciliation_live.py
+++ b/tests/test_check_ai_reconciliation_live.py
@@ -650,6 +650,30 @@ def test_main_malformed_pr_updated_at_exit_2(tmp_path):
     ) == 2
 
 
+def test_main_live_default_does_not_sleep_inside_review_window(monkeypatch, tmp_path):
+    c = load_check()
+    fresh_updated_at = (datetime.now(UTC) - timedelta(seconds=299)).isoformat().replace("+00:00", "Z")
+    snapshots = [
+        ([thread(resolved=True)], "head-a", [], []),
+        ([thread(resolved=True)], "head-a", [], []),
+    ]
+    sleeps = []
+    bf = tmp_path / "body.md"
+    bf.write_text(BODY_CLEAR, encoding="utf-8")
+
+    def fake_snapshot(pr, owner, name, gh, bot_logins):
+        return snapshots.pop(0)
+
+    monkeypatch.setattr(c, "fetch_consistent_review_thread_snapshot", fake_snapshot)
+    monkeypatch.setattr(c, "fetch_body", lambda pr, repo, gh: BODY_CLEAR)
+    monkeypatch.setattr(c, "fetch_pr_updated_at", lambda pr, repo, gh: fresh_updated_at)
+    monkeypatch.setattr(c.time, "sleep", lambda seconds: sleeps.append(seconds))
+
+    assert c.main(["--pr", "1431", "--repo", "owner/name", "--body-file", str(bf), "--gh", "gh"]) == 1
+    assert sleeps == []
+    assert len(snapshots) == 1
+
+
 def test_main_live_waits_and_refetches_after_review_window(monkeypatch, tmp_path):
     c = load_check()
     fresh_updated_at = (datetime.now(UTC) - timedelta(seconds=299)).isoformat().replace("+00:00", "Z")
@@ -671,7 +695,19 @@ def test_main_live_waits_and_refetches_after_review_window(monkeypatch, tmp_path
     monkeypatch.setattr(c, "fetch_pr_updated_at", lambda pr, repo, gh: updated_at_values.pop(0))
     monkeypatch.setattr(c.time, "sleep", lambda seconds: sleeps.append(seconds))
 
-    assert c.main(["--pr", "1431", "--repo", "owner/name", "--body-file", str(bf), "--gh", "gh"]) == 0
+    assert c.main(
+        [
+            "--pr",
+            "1431",
+            "--repo",
+            "owner/name",
+            "--body-file",
+            str(bf),
+            "--gh",
+            "gh",
+            "--wait-for-review-window",
+        ]
+    ) == 0
     assert len(sleeps) == 1
     assert not snapshots
     assert not updated_at_values

--- a/tests/test_check_ai_reconciliation_live.py
+++ b/tests/test_check_ai_reconciliation_live.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+from datetime import UTC, datetime
 from pathlib import Path
 
 SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "check_ai_reconciliation_live.py"
@@ -326,7 +327,7 @@ def test_no_open_threads_passes_even_with_clear_body():
     assert code == 0
 
 
-def test_missing_current_head_codex_review_fails_even_without_open_threads():
+def test_missing_current_head_codex_review_passes_when_threads_are_clear():
     c = load_check()
     code, msgs = c.evaluate(
         [thread(resolved=True)],
@@ -336,8 +337,42 @@ def test_missing_current_head_codex_review_fails_even_without_open_threads():
         head_sha="head-a",
     )
 
+    assert code == 0
+    assert any("no open scoped Codex review threads remain" in msg for msg in msgs)
+
+
+def test_missing_current_head_codex_review_waits_inside_fresh_update_window():
+    c = load_check()
+    code, msgs = c.evaluate(
+        [thread(resolved=True)],
+        BODY_CLEAR,
+        BOTS,
+        reviews=[review(commit="old-head")],
+        head_sha="head-a",
+        pr_updated_at="2026-07-30T18:00:00Z",
+        review_grace_seconds=300,
+        now=datetime(2026, 7, 30, 18, 2, tzinfo=UTC),
+    )
+
     assert code == 1
-    assert any("missing current-head Codex connector review" in msg for msg in msgs)
+    assert any("waiting for Codex connector review window" in msg for msg in msgs)
+
+
+def test_missing_current_head_codex_review_passes_after_fresh_update_window():
+    c = load_check()
+    code, msgs = c.evaluate(
+        [thread(resolved=True)],
+        BODY_CLEAR,
+        BOTS,
+        reviews=[review(commit="old-head")],
+        head_sha="head-a",
+        pr_updated_at="2026-07-30T18:00:00Z",
+        review_grace_seconds=300,
+        now=datetime(2026, 7, 30, 18, 6, tzinfo=UTC),
+    )
+
+    assert code == 0
+    assert any("no open scoped Codex review threads remain" in msg for msg in msgs)
 
 
 def test_docs_only_no_open_threads_passes_without_current_head_review():
@@ -373,7 +408,7 @@ def test_docs_only_current_head_change_request_still_fails_with_valid_file_proof
     assert not any("docs-only PR diff" in msg for msg in msgs)
 
 
-def test_docs_only_non_markdown_diff_still_requires_current_head_review():
+def test_docs_only_non_markdown_diff_passes_when_threads_are_clear():
     c = load_check()
     code, msgs = c.evaluate(
         [thread(resolved=True)],
@@ -385,8 +420,8 @@ def test_docs_only_non_markdown_diff_still_requires_current_head_review():
         head_sha="head-a",
     )
 
-    assert code == 1
-    assert any("missing current-head Codex connector review" in msg for msg in msgs)
+    assert code == 0
+    assert any("no open scoped Codex review threads remain" in msg for msg in msgs)
 
 
 def test_docs_only_open_codex_thread_still_fails_without_ai_record():
@@ -417,7 +452,6 @@ def test_current_head_changes_requested_review_fails_even_without_open_threads()
 
     assert code == 1
     assert any("requested changes" in msg for msg in msgs)
-    assert not any("missing current-head Codex connector review" in msg for msg in msgs)
 
 
 def test_current_head_codex_review_plus_no_open_threads_passes():
@@ -431,7 +465,7 @@ def test_current_head_codex_review_plus_no_open_threads_passes():
     )
 
     assert code == 0
-    assert any("current-head Codex review attestation is present" in msg for msg in msgs)
+    assert any("no open scoped Codex review threads remain" in msg for msg in msgs)
 
 
 def test_current_head_clean_review_comment_plus_no_open_threads_passes():
@@ -445,7 +479,7 @@ def test_current_head_clean_review_comment_plus_no_open_threads_passes():
     )
 
     assert code == 0
-    assert any("current-head Codex review attestation is present" in msg for msg in msgs)
+    assert any("no open scoped Codex review threads remain" in msg for msg in msgs)
 
 
 def test_docs_only_exemption_skips_file_proof_when_current_head_review_already_present():
@@ -464,7 +498,7 @@ def test_docs_only_exemption_skips_file_proof_when_current_head_review_already_p
     )
 
 
-def test_docs_only_exemption_needs_file_proof_only_for_missing_attestation_candidate():
+def test_docs_only_exemption_needs_file_proof_for_watcher_signal():
     c = load_check()
 
     assert (
@@ -515,7 +549,7 @@ def test_main_clean_exit_0(tmp_path):
     assert c.main(["--threads-file", str(tf), "--body-file", str(bf)]) == 0
 
 
-def test_main_requires_current_head_review_when_head_sha_supplied(tmp_path):
+def test_main_accepts_missing_current_head_review_when_threads_clear(tmp_path):
     c = load_check()
     tf = tmp_path / "threads.json"
     tf.write_text(json.dumps([thread(resolved=True)]), encoding="utf-8")
@@ -535,7 +569,7 @@ def test_main_requires_current_head_review_when_head_sha_supplied(tmp_path):
             "--head-sha",
             "head-a",
         ]
-    ) == 1
+    ) == 0
 
 
 def test_main_accepts_current_head_clean_review_comment_when_head_sha_supplied(tmp_path):
@@ -611,85 +645,22 @@ def test_main_live_fetch_fails_when_review_generation_changes(monkeypatch, tmp_p
     assert calls["reviews"] == 3
 
 
-def test_main_live_fetch_fails_when_review_generation_changes_after_file_proof(monkeypatch):
+def test_main_fetches_file_proof_for_docs_only_watcher_signal(monkeypatch, tmp_path):
     c = load_check()
-    calls = {"snapshots": 0}
+    bf = tmp_path / "body.md"
+    bf.write_text(BODY_DOCS_ONLY, encoding="utf-8")
 
-    def fake_snapshot(pr, owner, name, gh, bot_logins):
-        calls["snapshots"] += 1
-        if calls["snapshots"] == 1:
-            return [thread(resolved=True)], "head-a", [], []
-        return [thread(resolved=True)], "head-a", [review(commit="head-a", state="CHANGES_REQUESTED")], []
-
-    monkeypatch.setattr(c, "fetch_consistent_review_thread_snapshot", fake_snapshot)
-    monkeypatch.setattr(c, "fetch_body", lambda pr, repo, gh: BODY_DOCS_ONLY)
+    monkeypatch.setattr(
+        c,
+        "fetch_consistent_review_thread_snapshot",
+        lambda pr, owner, name, gh, bot_logins: ([thread(resolved=True)], "head-a", [], []),
+    )
     monkeypatch.setattr(c, "fetch_changed_file_proof", lambda pr, repo, gh, head_sha=None: changed_file_proof(c))
     monkeypatch.setattr(c, "fetch_pr_refs", lambda pr, repo, gh: ("base-a", "head-a", 1))
-
-    assert c.main(["--pr", "1431", "--repo", "owner/name", "--gh", "gh"]) == 2
-    assert calls["snapshots"] == 2
-
-
-def test_main_live_fetch_fails_when_body_changes_after_file_proof(monkeypatch):
-    c = load_check()
-    bodies = [BODY_DOCS_ONLY, BODY_DOCS_ONLY + "\nchanged\n", BODY_DOCS_ONLY + "\nchanged\n"]
-
-    monkeypatch.setattr(
-        c,
-        "fetch_consistent_review_thread_snapshot",
-        lambda pr, owner, name, gh, bot_logins: ([thread(resolved=True)], "head-a", [], []),
-    )
-    monkeypatch.setattr(c, "fetch_body", lambda pr, repo, gh: bodies.pop(0))
-    monkeypatch.setattr(c, "fetch_changed_file_proof", lambda pr, repo, gh, head_sha=None: changed_file_proof(c))
-    monkeypatch.setattr(c, "fetch_pr_refs", lambda pr, repo, gh: ("base-a", "head-a", 1))
-
-    assert c.main(["--pr", "1431", "--repo", "owner/name", "--gh", "gh"]) == 2
-
-
-def test_main_live_fetch_fails_when_body_changes_after_final_snapshot(monkeypatch):
-    c = load_check()
-    bodies = [BODY_DOCS_ONLY, BODY_DOCS_ONLY, BODY_DOCS_ONLY + "\nchanged\n"]
-
-    monkeypatch.setattr(
-        c,
-        "fetch_consistent_review_thread_snapshot",
-        lambda pr, owner, name, gh, bot_logins: ([thread(resolved=True)], "head-a", [], []),
-    )
-    monkeypatch.setattr(c, "fetch_body", lambda pr, repo, gh: bodies.pop(0))
-    monkeypatch.setattr(c, "fetch_changed_file_proof", lambda pr, repo, gh, head_sha=None: changed_file_proof(c))
-    monkeypatch.setattr(c, "fetch_pr_refs", lambda pr, repo, gh: ("base-a", "head-a", 1))
-
-    assert c.main(["--pr", "1431", "--repo", "owner/name", "--gh", "gh"]) == 2
-
-
-def test_main_live_fetch_fails_when_base_changes_after_file_proof(monkeypatch):
-    c = load_check()
-
-    monkeypatch.setattr(
-        c,
-        "fetch_consistent_review_thread_snapshot",
-        lambda pr, owner, name, gh, bot_logins: ([thread(resolved=True)], "head-a", [], []),
-    )
+    monkeypatch.setattr(c, "fetch_pr_updated_at", lambda pr, repo, gh: "2026-07-30T18:00:00Z")
     monkeypatch.setattr(c, "fetch_body", lambda pr, repo, gh: BODY_DOCS_ONLY)
-    monkeypatch.setattr(c, "fetch_changed_file_proof", lambda pr, repo, gh, head_sha=None: changed_file_proof(c))
-    monkeypatch.setattr(c, "fetch_pr_refs", lambda pr, repo, gh: ("base-b", "head-a", 1))
 
-    assert c.main(["--pr", "1431", "--repo", "owner/name", "--gh", "gh"]) == 2
-
-
-def test_main_live_fetch_fails_when_changed_file_count_changes_after_file_proof(monkeypatch):
-    c = load_check()
-
-    monkeypatch.setattr(
-        c,
-        "fetch_consistent_review_thread_snapshot",
-        lambda pr, owner, name, gh, bot_logins: ([thread(resolved=True)], "head-a", [], []),
-    )
-    monkeypatch.setattr(c, "fetch_body", lambda pr, repo, gh: BODY_DOCS_ONLY)
-    monkeypatch.setattr(c, "fetch_changed_file_proof", lambda pr, repo, gh, head_sha=None: changed_file_proof(c))
-    monkeypatch.setattr(c, "fetch_pr_refs", lambda pr, repo, gh: ("base-a", "head-a", 2))
-
-    assert c.main(["--pr", "1431", "--repo", "owner/name", "--gh", "gh"]) == 2
+    assert c.main(["--pr", "1431", "--repo", "owner/name", "--body-file", str(bf), "--gh", "gh"]) == 0
 
 
 def test_main_does_not_fetch_file_proof_for_non_docs_body(monkeypatch, tmp_path):
@@ -703,6 +674,7 @@ def test_main_does_not_fetch_file_proof_for_non_docs_body(monkeypatch, tmp_path)
         lambda pr, owner, name, gh, bot_logins: ([thread(resolved=True)], "head-a", [review(commit="head-a")], []),
     )
     monkeypatch.setattr(c, "fetch_changed_file_proof", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError()))
+    monkeypatch.setattr(c, "fetch_pr_updated_at", lambda pr, repo, gh: "2026-07-30T18:00:00Z")
 
     assert c.main(["--pr", "1431", "--repo", "owner/name", "--body-file", str(bf), "--gh", "gh"]) == 0
 

--- a/tests/test_check_ai_reconciliation_live.py
+++ b/tests/test_check_ai_reconciliation_live.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "check_ai_reconciliation_live.py"
@@ -616,6 +616,65 @@ def test_main_accepts_docs_only_without_current_head_review_when_threads_clear(t
             "head-a",
         ]
     ) == 0
+
+
+def test_main_malformed_review_window_config_exit_2(monkeypatch, tmp_path):
+    monkeypatch.setenv("ATLAS_CODEX_REVIEW_GRACE_SECONDS", "not-an-int")
+    c = load_check()
+    tf = tmp_path / "threads.json"
+    tf.write_text(json.dumps([thread(resolved=True)]), encoding="utf-8")
+    bf = tmp_path / "body.md"
+    bf.write_text(BODY_CLEAR, encoding="utf-8")
+
+    assert c.main(["--threads-file", str(tf), "--body-file", str(bf)]) == 2
+
+
+def test_main_malformed_pr_updated_at_exit_2(tmp_path):
+    c = load_check()
+    tf = tmp_path / "threads.json"
+    tf.write_text(json.dumps([thread(resolved=True)]), encoding="utf-8")
+    bf = tmp_path / "body.md"
+    bf.write_text(BODY_CLEAR, encoding="utf-8")
+
+    assert c.main(
+        [
+            "--threads-file",
+            str(tf),
+            "--body-file",
+            str(bf),
+            "--head-sha",
+            "head-a",
+            "--pr-updated-at",
+            "not-a-timestamp",
+        ]
+    ) == 2
+
+
+def test_main_live_waits_and_refetches_after_review_window(monkeypatch, tmp_path):
+    c = load_check()
+    fresh_updated_at = (datetime.now(UTC) - timedelta(seconds=299)).isoformat().replace("+00:00", "Z")
+    stale_updated_at = (datetime.now(UTC) - timedelta(seconds=301)).isoformat().replace("+00:00", "Z")
+    snapshots = [
+        ([thread(resolved=True)], "head-a", [], []),
+        ([thread(resolved=True)], "head-a", [], []),
+    ]
+    updated_at_values = [fresh_updated_at, stale_updated_at]
+    sleeps = []
+    bf = tmp_path / "body.md"
+    bf.write_text(BODY_CLEAR, encoding="utf-8")
+
+    def fake_snapshot(pr, owner, name, gh, bot_logins):
+        return snapshots.pop(0)
+
+    monkeypatch.setattr(c, "fetch_consistent_review_thread_snapshot", fake_snapshot)
+    monkeypatch.setattr(c, "fetch_body", lambda pr, repo, gh: BODY_CLEAR)
+    monkeypatch.setattr(c, "fetch_pr_updated_at", lambda pr, repo, gh: updated_at_values.pop(0))
+    monkeypatch.setattr(c.time, "sleep", lambda seconds: sleeps.append(seconds))
+
+    assert c.main(["--pr", "1431", "--repo", "owner/name", "--body-file", str(bf), "--gh", "gh"]) == 0
+    assert len(sleeps) == 1
+    assert not snapshots
+    assert not updated_at_values
 
 
 def test_main_live_fetch_fails_when_review_generation_changes(monkeypatch, tmp_path):

--- a/tests/test_pr_watcher.py
+++ b/tests/test_pr_watcher.py
@@ -1271,6 +1271,8 @@ def test_installed_entrypoint_writes_consumer_accepted_snapshot(tmp_path: Path) 
             }
             if args[:2] == ["pr", "checks"]:
                 print(json.dumps([{"name": "required-a", "bucket": "pass", "state": "SUCCESS"}]))
+            elif args[:2] == ["pr", "view"] and "--json" in args and "updatedAt" in args:
+                print("2026-07-30T18:00:00Z")
             elif args[:2] == ["pr", "view"] and "-q" in args:
                 print("")
             elif args[:2] == ["pr", "view"] and "--comments" in args:


### PR DESCRIPTION
Plan: plans/PR-Live-Reconciliation-Open-Threads-Only.md
Slice phase: Workflow/process
Ownership lane: workflow/live-reconciliation-open-threads-only

Live reconciliation should gate on actual Codex feedback, not on a final clean Codex consent signal that can fail to arrive. This slice changes the quiet path so closed/no scoped bot threads plus no current-head `CHANGES_REQUESTED` review passes after a short fresh-head review window, while open scoped bot threads still make the check red.

## Intentional
- No branch-protection edit; the existing required live reconciliation check keeps enforcing the policy.
- No watcher merge-policy edit; only the watcher fixture is updated for the new `updatedAt` read, and default checker invocations still exit fast.
- No bot identity change; exact Codex connector logins remain the scoped review source.
- The fresh-head review window is a race guard, not Codex consent.

## Deferred
- Update the mechanical-enforcement audit note that records the old attestation requirement after this policy lands.

## Parked hardening
- None.

## Cold diff reconstruction
Problem:
`scripts/check_ai_reconciliation_live.py` mixed two predicates: open Codex feedback and a current-head clean Codex attestation. The desired merge predicate is open feedback, not final consent.

Problem-derived contract:
- Correct fix must touch/change: remove the missing-attestation failure path; preserve current-head `CHANGES_REQUESTED` failure; preserve unresolved scoped bot-thread failures; preserve docs-only watcher signaling; prevent the immediate quiet-head merge window without leaving the required context red forever; keep watcher/status-producer invocations nonblocking by making the grace wait an explicit required-CI opt-in; test those outcomes.
- Must not change: branch protection, PR opening behavior, bot identity matching, watcher merge authority, PR body reconciliation parsing, product surfaces, or active PR #2251.

Diff:
- Changed: `scripts/check_ai_reconciliation_live.py:405` names the quiet fresh-head/no-Codex-activity race, and `scripts/check_ai_reconciliation_live.py:433` validates review-window seconds without argparse tracebacks.
- Changed: `scripts/check_ai_reconciliation_live.py:1163` adds `--wait-for-review-window`, and `scripts/check_ai_reconciliation_live.py:1222` gates the live grace sleep/refetch on that explicit required-CI opt-in.
- Changed: `scripts/check_ai_reconciliation_live.py:1222` now waits once in opt-in live GitHub mode, refetches threads/reviews/body at `scripts/check_ai_reconciliation_live.py:1249`, and evaluates refreshed state at `scripts/check_ai_reconciliation_live.py:1307`.
- Changed: `.github/workflows/ai_reconciliation_live.yml:45` raises the required job timeout to 10 minutes so the default 300-second wait can complete.
- Changed: `.github/workflows/ai_reconciliation_live.yml:62` passes `--wait-for-review-window` only in the required `pull_request_target` check, leaving review-event/watch-style invocations nonblocking.
- Changed: `tests/test_check_ai_reconciliation_live.py:330` proves missing current-head Codex review passes when threads are clear; `tests/test_check_ai_reconciliation_live.py:344` and `tests/test_check_ai_reconciliation_live.py:361` prove the grace-window pass/fail boundary.
- Changed: `tests/test_check_ai_reconciliation_live.py:621` and `tests/test_check_ai_reconciliation_live.py:632` prove malformed review-window inputs exit 2; `tests/test_check_ai_reconciliation_live.py:653` proves default live mode does not sleep inside the review window; `tests/test_check_ai_reconciliation_live.py:677` proves opt-in required live mode waits/refetches and then passes after the window.
- Changed: `tests/test_pr_watcher.py:1274` keeps the installed watcher fixture compatible with the checker’s new `updatedAt` read.

Contract match:
- Removing the missing-attestation failure traces to the requirement to stop blocking quiet PRs on absent final Codex consent.
- The wait/refetch traces to the requirement to avoid immediate green before Codex can react without making the required context permanently red.
- The explicit wait flag traces to the watcher fast-exit contract: required CI can wait, default live callers cannot be trapped in a five-minute sleep.
- Preserving docs-only text and watcher fixture coverage traces to the requirement not to break watcher readiness callers.
- Preserving `CHANGES_REQUESTED` and open-thread branches traces to the requirement that actual scoped Codex findings still block.

Gaps:
- None.

## AI reconciliation
- AI findings reviewed: Yes.
- All fixed or waived: Yes.
- Fixed: Preserved the watcher-owned docs-only success signal by fetching docs-only file proof only when it is needed for that signal.
- Fixed: Added a bounded fresh-head review window so the required live check cannot go green immediately before the connector has had a chance to react.
- Fixed: Changed live CI mode to wait/refetch once after the review window instead of leaving the required `live-reconciliation` context red indefinitely.
- Fixed: Moved review-window input validation into the controlled exit-2 path and covered malformed env/CLI values.
- Fixed: Restricted the grace sleep/refetch path to explicit required-CI opt-in so watcher/default checker invocations exit fast.

## Verification
- `python -m py_compile scripts/check_ai_reconciliation_live.py && python -m pytest tests/test_check_ai_reconciliation_live.py -q` - 65 passed.
- `python -m pytest tests/test_pr_watcher.py::test_installed_entrypoint_writes_consumer_accepted_snapshot -q --tb=short` - 1 passed.
- `python scripts/audit_plan_doc.py plans/PR-Live-Reconciliation-Open-Threads-Only.md` - passed.
- `python scripts/audit_plan_code_consistency.py --base-ref origin/main plans/PR-Live-Reconciliation-Open-Threads-Only.md` - passed.

## Diff size
5 files, +474 / -92. Over target intentionally because the root fix spans the required workflow context, checker CLI, checker tests, and watcher contract fixture.
Diff-budget override: The root fix is genuinely indivisible because the red checks come from one live-reconciliation race spanning the required workflow context, checker CLI behavior, checker tests, and watcher contract fixture.
