### PR TITLE
Add open PR final admission gate

### DIFF
--- a/plans/PR-Open-PR-Final-Admission-Gate.md
+++ b/plans/PR-Open-PR-Final-Admission-Gate.md
@@ -1,0 +1,131 @@
+# PR-Open-PR-Final-Admission-Gate
+
+## Why this slice exists
+
+PR #2251 turned one pre-open review gap into a proof-file/push-parser handshake.
+This replacement keeps the root fix in `open_pr.sh`: review before
+`gh pr create/edit`, then mutate only the published branch that was reviewed.
+This workflow/process slice is admitted now because it fixes a concrete
+merge-safety blocker: without the final admission gate, Atlas PRs can enter
+GitHub review and required checks with a head, body, or target that the local
+mechanical gate did not review.
+The slice is over the soft LOC budget because the reviewed snapshot, target
+binding, real-review tests, and plan/body contract must land together; splitting
+them would leave the mutating helper half-guarded.
+
+### Problem-derived contract
+
+- Root cause: `open_pr.sh` could mutate GitHub after only a body audit.
+- Correct fix must touch/change: `open_pr.sh` audits the body, rejects target
+  selectors, derives repo identity from normal GitHub `origin` URL forms,
+  verifies and pins head/body/PR identity before/after review, enforces a
+  single local writer around the reviewed mutation window, then calls
+  `gh pr create/edit` with explicit trusted `--repo` and `--base main`. Tests
+  cover each gate.
+- Must not change: `push_pr.sh`, pre-push hook dispatch, CI, product code, #2251
+  branch content, or other PR lanes.
+
+## Scope (this PR)
+
+Ownership lane: workflow/open-pr-final-admission
+Slice phase: Workflow/process
+
+1. Add the final admission checks to `scripts/open_pr.sh`.
+2. Add focused wrapper tests.
+
+### Review Contract
+
+- Acceptance criteria:
+  1. Missing, stale, or post-review-changed `origin/<branch>`/`HEAD` blocks fake `gh`.
+  2. Post-review body or full PR-identity drift blocks fake `gh`.
+  3. Fake and real `local_pr_review.sh` failures block create and edit mutation.
+  4. `--head`, `--repo`, non-main `--base`, and `GH_REPO` are rejected.
+  5. Create/edit still pass body over stdin and never pass the body path to `gh`.
+  6. Existing PR edits require matching `headRefName`, `headRefOid` equal to
+     the reviewed head, same `headRepository` by case-insensitive owner/repo
+     identity, `baseRefName=main`, and non-cross-repo identity.
+  7. `scripts/push_pr.sh` is unchanged.
+  8. Normal GitHub SSH/HTTPS origin forms, GitHub owner/repo casing differences,
+     and single-branch fetch refspecs are accepted without opening
+     target-selection holes.
+- Reachability proof: tests execute real `scripts/open_pr.sh` with fake `gh`;
+  two paths run real `scripts/local_pr_review.sh` and assert no mutation.
+- Affected surfaces: `scripts/open_pr.sh`, `tests/test_open_pr_wrapper.py`, plan.
+- Risk areas: skipped review, stale branch, target leakage, ambiguous PR
+  identity, docs-only handling, and #2251 proof-surface regrowth.
+- Reviewer rules triggered: R1, R2, R10, R12, R13, R14.
+
+### Boundary-change enumeration
+
+- Boundary path/seam: `scripts/open_pr.sh` mutation admission and PR lookup.
+- Replaced-path behaviors: create/edit now require publication, target rejection,
+  local review, exact pre/post-mutation snapshot recheck, single-local-writer
+  admission, and explicit repo/base.
+- Guard-relevant fields: branch, `HEAD`, `origin/<branch>`, `origin/main`, body
+  file/hash, create args, `GH_REPO`, origin repo URL, local review exit, PR
+  number, `headRefName`, `headRefOid`, `headRepository.nameWithOwner`,
+  `baseRefName`, `isCrossRepository`, local mutation lock.
+- Closure declaration: CLOSED. The target-selector denylist is exactly `GH_REPO`,
+  `--head`/`-H`, `--repo`/`-R`, and non-main `--base`/`-B`; membership comes
+  from `gh pr create` target-selection flags used by this wrapper. Inputs outside
+  this set are admitted only as non-target create args and still must pass body,
+  publication, review, and exact-identity gates.
+- Caller x input shape: create, edit, docs-only, stale/changing snapshot,
+  target/env override, bad PR identity, single-branch fetch refspec, normal
+  GitHub origin URL forms, and review failure.
+
+### Deployed-config probing
+
+- N/A local wrapper guard. Published fixture branch permits fake create/edit;
+  missing/stale branch, review failure, changed post-review snapshot, implicit
+  target config, or bad PR identity blocks it.
+
+### Files touched
+
+- `plans/PR-Open-PR-Final-Admission-Gate.md`
+- `scripts/open_pr.sh`
+- `tests/test_open_pr_wrapper.py`
+
+## Mechanism
+
+`open_pr.sh` rejects target overrides, derives the repo from raw `origin`, pins
+the reviewed head/body/PR snapshot, takes a local mutation lock, runs
+`local_pr_review.sh`, rechecks the same snapshot immediately before mutation,
+then mutates GitHub with explicit `--repo` and `--base main`. Because GitHub
+does not expose a PR body compare-and-swap operation, the enforced execution
+model is single local writer plus post-mutation verification: a competing writer
+that changes the branch or PR identity during the mutation window makes the
+wrapper fail after the mutation and requires human inspection before continuing.
+No proof file or `push_pr.sh` parser.
+
+## Intentional
+
+- Supersedes #2251; no proof-file handshake.
+- Cross-repo PRs, non-main bases, and explicit `--head` stay out of this helper.
+- The final GitHub mutation is not claimed to be atomic at the API layer; the
+  wrapper enforces single local writer and detects post-mutation drift because
+  `gh pr create/edit` has no reviewed-SHA compare-and-swap.
+
+## Deferred
+
+- Close #2251 as superseded after this replacement PR is published.
+- Ownership-wrapper and draft-consent guards remain separate slices.
+- Parking predicate: findings outside `open_pr.sh` final admission semantics,
+  wrapper tests, or this plan contract are parked unless they prove the helper
+  can still publish an unreviewed head/body/target or block a valid normal
+  Atlas push/open flow.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_open_pr_wrapper.py -q` - 25 passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Open-PR-Final-Admission-Gate.md` | 131 |
+| `scripts/open_pr.sh` | 285 |
+| `tests/test_open_pr_wrapper.py` | 470 |
+| **Total** | **886** |

--- a/scripts/open_pr.sh
+++ b/scripts/open_pr.sh
@@ -19,6 +19,12 @@ Examples:
 
 Use scripts/push_pr.sh before this wrapper to push the branch with the local
 review body env wired into the pre-push hook.
+
+This wrapper enforces a single local writer with an advisory git lock, then
+checks the reviewed head/body/PR snapshot immediately before and after the
+GitHub mutation. GitHub does not expose an atomic compare-and-swap for PR body
+edits, so competing writers must use this wrapper or be treated as a failed
+post-mutation verification.
 EOF
 }
 
@@ -44,6 +50,227 @@ refresh_base_ref() {
     fi
 }
 
+reject_target_overrides() {
+    if [ -n "${GH_REPO:-}" ]; then
+        echo "open_pr.sh: refusing GH_REPO target override: $GH_REPO" >&2
+        echo "Open PRs in the current repository only; unset GH_REPO and rerun this wrapper." >&2
+        exit 2
+    fi
+
+    local arg value
+    while [ "$#" -gt 0 ]; do
+        arg="$1"
+        shift
+        case "$arg" in
+            --head|-H|--repo|-R)
+                echo "open_pr.sh: refusing target-changing create arg: $arg" >&2
+                exit 2
+                ;;
+            --head=*|--repo=*|-H*|-R*)
+                echo "open_pr.sh: refusing target-changing create arg: $arg" >&2
+                exit 2
+                ;;
+            --base|-B)
+                if [ "$#" -eq 0 ]; then
+                    echo "open_pr.sh: $arg requires a value" >&2
+                    exit 2
+                fi
+                value="$1"
+                shift
+                if [ "$value" != "main" ]; then
+                    echo "open_pr.sh: refusing non-main base: $value" >&2
+                    echo "The local review gate is bound to origin/main." >&2
+                    exit 2
+                fi
+                ;;
+            --base=*)
+                value="${arg#--base=}"
+                if [ "$value" != "main" ]; then
+                    echo "open_pr.sh: refusing non-main base: $value" >&2
+                    echo "The local review gate is bound to origin/main." >&2
+                    exit 2
+                fi
+                ;;
+            -B*)
+                value="${arg#-B}"
+                if [ "$value" != "main" ]; then
+                    echo "open_pr.sh: refusing non-main base: $value" >&2
+                    echo "The local review gate is bound to origin/main." >&2
+                    exit 2
+                fi
+                ;;
+        esac
+    done
+}
+
+verify_published_head() {
+    local branch="$1" expected_sha="${2:-}" head_sha remote_sha
+    head_sha="$(git rev-parse HEAD)"
+    if ! git fetch --quiet origin "refs/heads/$branch"; then
+        echo "open_pr.sh: failed to refresh origin/$branch before PR mutation." >&2
+        echo "Run scripts/push_pr.sh before opening or updating the PR." >&2
+        exit 1
+    fi
+    if ! remote_sha="$(git rev-parse FETCH_HEAD 2>/dev/null)"; then
+        echo "open_pr.sh: current branch is not published at origin/$branch." >&2
+        echo "Run scripts/push_pr.sh before opening or updating the PR." >&2
+        exit 2
+    fi
+    if [ -n "$expected_sha" ] && [ "$head_sha" != "$expected_sha" ]; then
+        echo "open_pr.sh: current HEAD changed after review: reviewed $expected_sha, now $head_sha." >&2
+        echo "Rerun this wrapper so local review covers the exact mutation snapshot." >&2
+        exit 2
+    fi
+    if [ -n "$expected_sha" ] && [ "$remote_sha" != "$expected_sha" ]; then
+        echo "open_pr.sh: origin/$branch changed after review: reviewed $expected_sha, now $remote_sha." >&2
+        echo "Rerun this wrapper so local review covers the exact mutation snapshot." >&2
+        exit 2
+    fi
+    if [ -z "$expected_sha" ] && [ "$remote_sha" != "$head_sha" ]; then
+        echo "open_pr.sh: origin/$branch is $remote_sha, current HEAD is $head_sha." >&2
+        echo "Run scripts/push_pr.sh before opening or updating the PR." >&2
+        exit 2
+    fi
+    printf '%s\n' "$head_sha"
+}
+
+origin_repo_name() {
+    local url
+    url="$(git config --get remote.origin.url)"
+    python - "$url" <<'PY'
+import re
+import sys
+from urllib.parse import urlparse
+
+url = sys.argv[1]
+path = ""
+if url.startswith("git@github.com:"):
+    path = url.split(":", 1)[1]
+else:
+    parsed = urlparse(url)
+    host = (parsed.hostname or "").lower()
+    if host not in {"github.com", "www.github.com"}:
+        raise SystemExit(f"open_pr.sh: origin is not a GitHub remote: {url}")
+    path = parsed.path.lstrip("/")
+path = re.sub(r"\.git$", "", path)
+if not re.fullmatch(r"[^/]+/[^/]+", path):
+    raise SystemExit(f"open_pr.sh: could not derive owner/repo from origin: {url}")
+print(path)
+PY
+}
+
+body_hash() {
+    git hash-object "$body_file"
+}
+
+verify_body_hash() {
+    local expected="$1" current
+    current="$(body_hash)"
+    if [ "$current" != "$expected" ]; then
+        echo "open_pr.sh: PR body changed after review." >&2
+        echo "Rerun this wrapper so local review covers the exact body being published." >&2
+        exit 2
+    fi
+}
+
+run_final_local_review() {
+    echo "Running final local PR review before GitHub mutation..."
+    ATLAS_CURRENT_PR_BODY_FILE="$body_file" \
+        bash scripts/local_pr_review.sh --current-pr-body-file "$body_file"
+}
+
+acquire_mutation_lock() {
+    local lock_path
+    lock_path="$(git rev-parse --git-path open_pr_wrapper.lock)"
+    exec 9>"$lock_path"
+    if ! flock -n 9; then
+        echo "open_pr.sh: another open_pr.sh mutation is already running in this checkout." >&2
+        echo "Wait for that wrapper to finish, then rerun so review covers one writer's snapshot." >&2
+        exit 2
+    fi
+}
+
+existing_pr_number_for_branch() {
+    local branch="$1" current_repo="$2" pr_json
+    if ! pr_json="$(gh pr list --repo "$current_repo" --state open --head "$branch" --json number,headRefName,headRefOid,baseRefName,headRepository,isCrossRepository --limit 20)"; then
+        echo "open_pr.sh: failed to query existing PR for head branch $branch" >&2
+        exit 1
+    fi
+    python - "$branch" "$current_repo" "$pr_json" <<'PY'
+import json
+import sys
+
+branch = sys.argv[1]
+current_repo = sys.argv[2]
+
+def repo_key(value):
+    if not isinstance(value, str):
+        return None
+    parts = value.split("/")
+    if len(parts) != 2 or not all(parts):
+        return None
+    return tuple(part.lower() for part in parts)
+
+current_repo_key = repo_key(current_repo)
+items = [item for item in json.loads(sys.argv[3]) if item.get("headRefName") == branch]
+matches = [
+    item
+    for item in items
+    if item.get("baseRefName") == "main"
+    and repo_key(item.get("headRepository", {}).get("nameWithOwner")) == current_repo_key
+    and not item.get("isCrossRepository")
+]
+if items and len(matches) != len(items):
+    raise SystemExit(
+        f"open_pr.sh: found open PRs for head branch {branch} outside {current_repo}->main; use gh manually"
+    )
+if len(matches) > 1:
+    raise SystemExit(f"multiple open PRs found for head branch {branch}")
+if matches:
+    item = matches[0]
+    print(f"{item['number']}\t{item.get('headRefOid', '')}")
+PY
+}
+
+snapshot_head_oid() {
+    local snapshot="$1"
+    if [ "$snapshot" = "${snapshot#*$'\t'}" ]; then
+        printf '\n'
+    else
+        printf '%s\n' "${snapshot#*$'\t'}"
+    fi
+}
+
+verify_pr_snapshot_head() {
+    local snapshot="$1" expected="$2" actual
+    actual="$(snapshot_head_oid "$snapshot")"
+    if [ "$actual" != "$expected" ]; then
+        echo "open_pr.sh: existing PR head does not match reviewed head: reviewed $expected, PR reports ${actual:-<missing>}." >&2
+        echo "Wait for GitHub to reflect the pushed branch or rerun after refreshing the PR." >&2
+        exit 2
+    fi
+}
+
+normalize_create_args() {
+    trusted_create_args=()
+    local arg value
+    while [ "$#" -gt 0 ]; do
+        arg="$1"
+        shift
+        case "$arg" in
+            --base|-B)
+                value="${1:-}"
+                [ "$#" -gt 0 ] && shift
+                [ "$value" = "main" ] && continue
+                ;;
+            --base=main|-Bmain)
+                continue
+                ;;
+        esac
+        trusted_create_args+=("$arg")
+    done
+}
+
 refresh_base_ref
 
 body_audit_args=(--base-ref origin/main)
@@ -60,6 +287,7 @@ for arg in "$@"; do
             ;;
     esac
 done
+reject_target_overrides "$@"
 
 branch="$(git branch --show-current)"
 if [ -z "$branch" ]; then
@@ -67,7 +295,18 @@ if [ -z "$branch" ]; then
     exit 2
 fi
 
-if gh pr view "$branch" >/dev/null 2>&1; then
+acquire_mutation_lock
+
+trusted_repo="$(origin_repo_name)"
+reviewed_head="$(verify_published_head "$branch")"
+reviewed_body_hash="$(body_hash)"
+normalize_create_args "$@"
+
+existing_pr_snapshot="$(existing_pr_number_for_branch "$branch" "$trusted_repo")"
+existing_pr_number="${existing_pr_snapshot%%$'\t'*}"
+if [ -n "$existing_pr_number" ]; then
+    verify_pr_snapshot_head "$existing_pr_snapshot" "$reviewed_head"
+
     if [ "$#" -gt 0 ]; then
         echo "open_pr.sh: PR already exists for $branch; update body with no create args" >&2
         echo "Use gh pr edit manually for title/base/label changes." >&2
@@ -75,16 +314,52 @@ if gh pr view "$branch" >/dev/null 2>&1; then
     fi
 
     if [ "${ATLAS_OPEN_PR_DRY_RUN:-}" = "1" ]; then
-        echo "DRY RUN: gh pr edit $branch --body-file - < $body_file"
+        echo "DRY RUN: gh pr edit $existing_pr_number --body-file - < $body_file"
         exit 0
     fi
 
-    gh pr edit "$branch" --body-file - < "$body_file"
+    run_final_local_review
+    verify_body_hash "$reviewed_body_hash"
+    latest_existing_pr_snapshot="$(existing_pr_number_for_branch "$branch" "$trusted_repo")"
+    if [ "$latest_existing_pr_snapshot" != "$existing_pr_snapshot" ]; then
+        echo "open_pr.sh: existing PR identity changed after review; rerun this wrapper." >&2
+        exit 2
+    fi
+    verify_pr_snapshot_head "$latest_existing_pr_snapshot" "$reviewed_head"
+    verify_published_head "$branch" "$reviewed_head" >/dev/null
+    gh pr edit "$existing_pr_number" --repo "$trusted_repo" --body-file - < "$body_file"
+    verify_published_head "$branch" "$reviewed_head" >/dev/null
+    verify_body_hash "$reviewed_body_hash"
+    latest_existing_pr_snapshot="$(existing_pr_number_for_branch "$branch" "$trusted_repo")"
+    if [ "$latest_existing_pr_snapshot" != "$existing_pr_snapshot" ]; then
+        echo "open_pr.sh: existing PR identity changed during mutation; inspect before continuing." >&2
+        exit 2
+    fi
+    verify_pr_snapshot_head "$latest_existing_pr_snapshot" "$reviewed_head"
 else
     if [ "${ATLAS_OPEN_PR_DRY_RUN:-}" = "1" ]; then
-        echo "DRY RUN: gh pr create $* --body-file - < $body_file"
+        echo "DRY RUN: gh pr create ${trusted_create_args[*]} --repo $trusted_repo --base main --body-file - < $body_file"
         exit 0
     fi
 
-    gh pr create "$@" --body-file - < "$body_file"
+    run_final_local_review
+    verify_body_hash "$reviewed_body_hash"
+    if [ -n "$(existing_pr_number_for_branch "$branch" "$trusted_repo")" ]; then
+        echo "open_pr.sh: PR identity changed after review; rerun this wrapper." >&2
+        exit 2
+    fi
+    verify_published_head "$branch" "$reviewed_head" >/dev/null
+    gh pr create "${trusted_create_args[@]}" --repo "$trusted_repo" --base main --body-file - < "$body_file"
+    verify_published_head "$branch" "$reviewed_head" >/dev/null
+    verify_body_hash "$reviewed_body_hash"
+    created_pr_snapshot="$(existing_pr_number_for_branch "$branch" "$trusted_repo")"
+    if [ -z "$created_pr_snapshot" ]; then
+        echo "open_pr.sh: created PR was not discoverable with the reviewed identity; inspect before continuing." >&2
+        exit 2
+    fi
+    created_pr_head="${created_pr_snapshot#*$'\t'}"
+    if [ "$created_pr_head" != "$reviewed_head" ]; then
+        echo "open_pr.sh: created PR head changed during mutation; inspect before continuing." >&2
+        exit 2
+    fi
 fi

--- a/tests/test_open_pr_wrapper.py
+++ b/tests/test_open_pr_wrapper.py
@@ -1,133 +1,91 @@
 from __future__ import annotations
 
 import os
+import fcntl
 import subprocess
 from pathlib import Path
-from shutil import copy2
+from shutil import copy2, copytree, ignore_patterns
+
+import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = REPO_ROOT / "scripts" / "open_pr.sh"
 AUDIT_SCRIPT = REPO_ROOT / "scripts" / "audit_pr_body.py"
 CHANGE_POLICY_SCRIPT = REPO_ROOT / "scripts" / "_pr_change_policy.py"
+LOCAL_REVIEW_SCRIPT = REPO_ROOT / "scripts" / "local_pr_review.sh"
 
 
 def test_open_pr_create_passes_body_via_stdin_not_path(tmp_path: Path) -> None:
-    repo = _write_fixture_repo(tmp_path)
-    body = _write_body(repo)
-    env, log, stdin_capture = _fake_gh_env(tmp_path, view_exit=1)
+    repo, body, env, log, stdin_capture = _ready(tmp_path, view_exit=1)
 
-    result = subprocess.run(
-        [
-            "bash",
-            "scripts/open_pr.sh",
-            str(body),
-            "--title",
-            "Workflow wrapper",
-            "--base",
-            "main",
-        ],
-        cwd=repo,
-        env=env,
-        check=False,
-        capture_output=True,
-        text=True,
-    )
+    result = _run(repo, env, body, "--title", "Workflow wrapper", "--base", "main")
 
     assert result.returncode == 0
     assert log.read_text(encoding="utf-8").strip() == (
-        "pr create --title Workflow wrapper --base main --body-file -"
+        "pr create --title Workflow wrapper --repo canfieldjuan/ATLAS --base main --body-file -"
     )
+    assert (repo / "local-review.log").read_text(encoding="utf-8").strip() == f"local_pr_review {body}"
     assert str(body) not in log.read_text(encoding="utf-8")
     assert stdin_capture.read_text(encoding="utf-8") == body.read_text(encoding="utf-8")
 
 
 def test_open_pr_edit_passes_body_via_stdin_not_path(tmp_path: Path) -> None:
-    repo = _write_fixture_repo(tmp_path)
-    body = _write_body(repo)
-    env, log, stdin_capture = _fake_gh_env(tmp_path, view_exit=0)
+    repo, body, env, log, stdin_capture = _ready(tmp_path, view_exit=0)
 
-    result = subprocess.run(
-        ["bash", "scripts/open_pr.sh", str(body)],
-        cwd=repo,
-        env=env,
-        check=False,
-        capture_output=True,
-        text=True,
-    )
+    result = _run(repo, env, body)
 
     assert result.returncode == 0
-    assert log.read_text(encoding="utf-8").strip() == "pr edit main --body-file -"
+    assert log.read_text(encoding="utf-8").strip() == "pr edit 17 --repo canfieldjuan/ATLAS --body-file -"
     assert str(body) not in log.read_text(encoding="utf-8")
     assert stdin_capture.read_text(encoding="utf-8") == body.read_text(encoding="utf-8")
 
 
 def test_open_pr_existing_pr_rejects_create_only_args(tmp_path: Path) -> None:
-    repo = _write_fixture_repo(tmp_path)
-    body = _write_body(repo)
-    env, _, _ = _fake_gh_env(tmp_path, view_exit=0)
+    repo, body, env, _, _ = _ready(tmp_path, view_exit=0)
 
-    result = subprocess.run(
-        ["bash", "scripts/open_pr.sh", str(body), "--title", "New title"],
-        cwd=repo,
-        env=env,
-        check=False,
-        capture_output=True,
-        text=True,
-    )
+    result = _run(repo, env, body, "--title", "New title")
 
     assert result.returncode == 2
     assert "PR already exists" in result.stderr
 
 
-def test_open_pr_rejects_direct_body_args(tmp_path: Path) -> None:
-    repo = _write_fixture_repo(tmp_path)
-    body = _write_body(repo)
-    env, _, _ = _fake_gh_env(tmp_path, view_exit=1)
+@pytest.mark.parametrize(
+    ("args", "extra_env", "expected"),
+    [
+        (["--body-file", "body.md"], {}, "pass the PR body as BODY_FILE"),
+        (["--head", "other"], {}, "refusing target-changing create arg: --head"),
+        (["--repo", "other/repo"], {}, "refusing target-changing create arg: --repo"),
+        (["--base", "release"], {}, "refusing non-main base: release"),
+        (["-Brelease"], {}, "refusing non-main base: release"),
+        ([], {"GH_REPO": "other/repo"}, "refusing GH_REPO target override"),
+    ],
+)
+def test_open_pr_rejects_unsafe_inputs_before_gh(
+    tmp_path: Path,
+    args: list[str],
+    extra_env: dict[str, str],
+    expected: str,
+) -> None:
+    repo, body, env, log, stdin_capture = _ready(tmp_path, view_exit=1)
+    env.update(extra_env)
 
-    result = subprocess.run(
-        ["bash", "scripts/open_pr.sh", str(body), "--body-file", str(body)],
-        cwd=repo,
-        env=env,
-        check=False,
-        capture_output=True,
-        text=True,
-    )
-
-    assert result.returncode == 2
-    assert "pass the PR body as BODY_FILE" in result.stderr
-
-
-def test_open_pr_missing_body_file_fails_clearly(tmp_path: Path) -> None:
-    repo = _write_fixture_repo(tmp_path)
-    missing = repo / "missing.md"
-
-    result = subprocess.run(
-        ["bash", "scripts/open_pr.sh", str(missing)],
-        cwd=repo,
-        check=False,
-        capture_output=True,
-        text=True,
-    )
+    result = _run(repo, env, body, *args)
 
     assert result.returncode == 2
-    assert "PR body file not found" in result.stderr
-    assert str(missing) in result.stderr
+    assert expected in result.stderr
+    assert not log.exists()
+    assert not stdin_capture.exists()
 
 
-def test_open_pr_rejects_invalid_body_before_gh_create(tmp_path: Path) -> None:
+def test_open_pr_rejects_invalid_body_before_gh(tmp_path: Path) -> None:
     repo = _write_fixture_repo(tmp_path)
-    body = _write_invalid_body(repo)
+    _write_body(repo)
+    body = repo.parent / "body-invalid.md"
+    body.write_text(_valid_body().replace("## Cold diff reconstruction\n- Changed: scripts/example.sh:1 updates the wrapper.\n- Contract match: traces to the body contract.\n- Gaps: none.\n\n", ""), encoding="utf-8")
     env, log, stdin_capture = _fake_gh_env(tmp_path, view_exit=1)
 
-    result = subprocess.run(
-        ["bash", "scripts/open_pr.sh", str(body), "--title", "Workflow wrapper"],
-        cwd=repo,
-        env=env,
-        check=False,
-        capture_output=True,
-        text=True,
-    )
+    result = _run(repo, env, body, "--title", "Workflow wrapper")
 
     assert result.returncode == 1
     assert "missing required section: ## Cold diff reconstruction" in result.stdout
@@ -135,54 +93,204 @@ def test_open_pr_rejects_invalid_body_before_gh_create(tmp_path: Path) -> None:
     assert not stdin_capture.exists()
 
 
-def test_open_pr_rejects_invalid_body_before_gh_edit(tmp_path: Path) -> None:
-    repo = _write_fixture_repo(tmp_path)
-    body = _write_invalid_body(repo)
-    env, log, stdin_capture = _fake_gh_env(tmp_path, view_exit=0)
-
-    result = subprocess.run(
-        ["bash", "scripts/open_pr.sh", str(body)],
-        cwd=repo,
-        env=env,
-        check=False,
-        capture_output=True,
-        text=True,
-    )
-
-    assert result.returncode == 1
-    assert "missing required section: ## Cold diff reconstruction" in result.stdout
-    assert not log.exists()
-    assert not stdin_capture.exists()
-
-
-def test_open_pr_accepts_explicit_docs_only_body(tmp_path: Path) -> None:
+def test_open_pr_accepts_docs_only_body(tmp_path: Path) -> None:
     repo = _write_fixture_repo(tmp_path)
     body = _write_docs_only_body(repo)
     env, log, stdin_capture = _fake_gh_env(tmp_path, view_exit=1)
 
-    result = subprocess.run(
-        ["bash", "scripts/open_pr.sh", str(body), "--title", "Docs only"],
-        cwd=repo,
-        env=env,
-        check=False,
-        capture_output=True,
-        text=True,
-    )
+    result = _run(repo, env, body, "--title", "Docs only")
 
     assert result.returncode == 0, result.stdout + result.stderr
     assert "explicit Markdown-only body exemption" in result.stdout
-    assert log.read_text(encoding="utf-8").strip() == "pr create --title Docs only --body-file -"
+    assert log.read_text(encoding="utf-8").strip() == "pr create --title Docs only --repo canfieldjuan/ATLAS --base main --body-file -"
     assert stdin_capture.read_text(encoding="utf-8") == body.read_text(encoding="utf-8")
 
 
-def test_open_pr_refreshes_base_before_docs_only_audit(tmp_path: Path) -> None:
-    repo = _write_fixture_repo(tmp_path)
-    body = _write_docs_only_body(repo)
-    _git(repo, "update-ref", "-d", "refs/remotes/origin/main")
+def test_open_pr_accepts_normal_ssh_origin_url(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path, origin_url="ssh://git@github.com/canfieldjuan/ATLAS.git")
+    body = _write_body(repo)
     env, log, stdin_capture = _fake_gh_env(tmp_path, view_exit=1)
 
-    result = subprocess.run(
-        ["bash", "scripts/open_pr.sh", str(body), "--title", "Docs only"],
+    result = _run(repo, env, body, "--title", "Workflow wrapper")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert log.read_text(encoding="utf-8").strip() == (
+        "pr create --title Workflow wrapper --repo canfieldjuan/ATLAS --base main --body-file -"
+    )
+    assert stdin_capture.read_text(encoding="utf-8") == body.read_text(encoding="utf-8")
+
+
+def test_open_pr_accepts_case_insensitive_repo_identity_after_create(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path, origin_url="git@github.com:canfieldjuan/atlas.git")
+    body = _write_body(repo)
+    env, log, stdin_capture = _fake_gh_env(tmp_path, view_exit=1)
+
+    result = _run(repo, env, body, "--title", "Workflow wrapper")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert log.read_text(encoding="utf-8").strip() == (
+        "pr create --title Workflow wrapper --repo canfieldjuan/atlas --base main --body-file -"
+    )
+    assert stdin_capture.read_text(encoding="utf-8") == body.read_text(encoding="utf-8")
+
+
+def test_open_pr_rejects_unpublished_current_head_before_gh(tmp_path: Path) -> None:
+    repo, body, env, log, stdin_capture = _ready(tmp_path, view_exit=1)
+    _git(repo, "commit", "--allow-empty", "-qm", "unpushed")
+
+    result = _run(repo, env, body, "--title", "Workflow wrapper")
+
+    assert result.returncode == 2
+    assert "current HEAD is" in result.stderr
+    assert not log.exists()
+    assert not stdin_capture.exists()
+
+
+def test_open_pr_rejects_missing_remote_branch_before_gh(tmp_path: Path) -> None:
+    repo, body, env, log, stdin_capture = _ready(tmp_path, view_exit=1)
+    _git(repo, "push", "-q", "origin", "--delete", "claude/pr-test")
+
+    result = _run(repo, env, body, "--title", "Workflow wrapper")
+
+    assert result.returncode == 1
+    assert "failed to refresh origin/claude/pr-test" in result.stderr
+    assert not log.exists()
+    assert not stdin_capture.exists()
+
+
+def test_open_pr_rejects_parallel_local_writer_before_review(tmp_path: Path) -> None:
+    repo, body, env, log, stdin_capture = _ready(tmp_path, view_exit=1)
+    lock_path = repo / ".git" / "open_pr_wrapper.lock"
+
+    with lock_path.open("w", encoding="utf-8") as lock_file:
+        fcntl.flock(lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        result = _run(repo, env, body, "--title", "Workflow wrapper")
+
+    assert result.returncode == 2
+    assert "another open_pr.sh mutation is already running" in result.stderr
+    assert not log.exists()
+    assert not stdin_capture.exists()
+
+
+def test_open_pr_reads_fetched_head_without_tracking_ref(tmp_path: Path) -> None:
+    repo, body, env, log, stdin_capture = _ready(tmp_path, view_exit=1)
+    _git(repo, "config", "remote.origin.fetch", "+refs/heads/main:refs/remotes/origin/main")
+    _git(repo, "update-ref", "-d", "refs/remotes/origin/claude/pr-test")
+
+    result = _run(repo, env, body, "--title", "Workflow wrapper")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert log.read_text(encoding="utf-8").strip() == (
+        "pr create --title Workflow wrapper --repo canfieldjuan/ATLAS --base main --body-file -"
+    )
+    assert stdin_capture.read_text(encoding="utf-8") == body.read_text(encoding="utf-8")
+
+
+def test_open_pr_rejects_local_review_failure_before_gh(tmp_path: Path) -> None:
+    repo, body, env, log, stdin_capture = _ready(tmp_path, view_exit=1)
+    env["LOCAL_REVIEW_EXIT"] = "42"
+
+    result = _run(repo, env, body, "--title", "Workflow wrapper")
+
+    assert result.returncode == 42
+    assert "Running final local PR review before GitHub mutation" in result.stdout
+    assert not log.exists()
+    assert not stdin_capture.exists()
+
+
+@pytest.mark.parametrize(
+    ("env_flag", "expected"),
+    [
+        ("LOCAL_REVIEW_ADVANCE_REMOTE", "origin/claude/pr-test changed after review"),
+        ("LOCAL_REVIEW_ADVANCE_BOTH", "current HEAD changed after review"),
+        ("LOCAL_REVIEW_MUTATE_BODY", "PR body changed after review"),
+    ],
+)
+def test_open_pr_rejects_snapshot_changes_after_local_review(
+    tmp_path: Path,
+    env_flag: str,
+    expected: str,
+) -> None:
+    repo, body, env, log, stdin_capture = _ready(tmp_path, view_exit=1)
+    env[env_flag] = "1"
+
+    result = _run(repo, env, body, "--title", "Workflow wrapper")
+
+    assert result.returncode == 2
+    assert expected in result.stderr
+    assert not log.exists()
+    assert not stdin_capture.exists()
+
+
+@pytest.mark.parametrize(("view_exit", "args"), [(1, ["--title", "Workflow wrapper"]), (0, [])])
+def test_open_pr_real_local_review_failure_blocks_mutation_branches(
+    tmp_path: Path,
+    view_exit: int,
+    args: list[str],
+) -> None:
+    repo = _write_fixture_repo(tmp_path, real_local_review=True)
+    body = _write_body(repo)
+    env, log, stdin_capture = _fake_gh_env(tmp_path, view_exit=view_exit)
+
+    result = _run(repo, env, body, *args)
+
+    assert result.returncode != 0
+    assert "Running final local PR review before GitHub mutation" in result.stdout
+    assert "worktree has uncommitted changes" not in result.stderr
+    assert "==> Pre-push audit wrapper" in result.stdout
+    assert "==> Plan shape: plans/PR-Test.md" in result.stdout
+    assert "plans/PR-Test.md: missing Ownership lane" in result.stdout
+    assert "plans/PR-Test.md: missing Slice phase" in result.stdout
+    assert "No such file or directory" not in result.stderr
+    gh_log = log.read_text(encoding="utf-8") if log.exists() else ""
+    assert "pr create" not in gh_log
+    assert "pr edit" not in gh_log
+    captured_stdin = stdin_capture.read_text(encoding="utf-8") if stdin_capture.exists() else ""
+    assert captured_stdin == ""
+
+
+def test_open_pr_rejects_mismatched_existing_pr_identity_before_edit(tmp_path: Path) -> None:
+    repo, body, env, log, stdin_capture = _ready(tmp_path, view_exit=1)
+    env["GH_PR_LIST_JSON"] = (
+        '[{"number":17,"headRefName":"claude/pr-test","baseRefName":"release",'
+        '"headRepository":{"nameWithOwner":"canfieldjuan/ATLAS"},"isCrossRepository":false}]'
+    )
+
+    result = _run(repo, env, body)
+
+    assert result.returncode == 1
+    assert "outside canfieldjuan/ATLAS->main" in result.stderr
+    assert not log.exists()
+    assert not stdin_capture.exists()
+
+
+def test_open_pr_rejects_stale_existing_pr_head_before_edit(tmp_path: Path) -> None:
+    repo, body, env, log, stdin_capture = _ready(tmp_path, view_exit=0)
+    stale_head = subprocess.check_output(["git", "rev-parse", "HEAD^"], cwd=repo, text=True).strip()
+    env["GH_PR_LIST_JSON"] = (
+        f'[{{"number":17,"headRefName":"claude/pr-test","headRefOid":"{stale_head}",'
+        '"baseRefName":"main","headRepository":{"nameWithOwner":"canfieldjuan/ATLAS"},'
+        '"isCrossRepository":false}]'
+    )
+
+    result = _run(repo, env, body)
+
+    assert result.returncode == 2
+    assert "existing PR head does not match reviewed head" in result.stderr
+    assert not log.exists()
+    assert not stdin_capture.exists()
+
+
+def _ready(tmp_path: Path, *, view_exit: int) -> tuple[Path, Path, dict[str, str], Path, Path]:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    env, log, stdin_capture = _fake_gh_env(tmp_path, view_exit=view_exit)
+    return repo, body, env, log, stdin_capture
+
+
+def _run(repo: Path, env: dict[str, str], body: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", "scripts/open_pr.sh", str(body), *args],
         cwd=repo,
         env=env,
         check=False,
@@ -190,63 +298,74 @@ def test_open_pr_refreshes_base_before_docs_only_audit(tmp_path: Path) -> None:
         text=True,
     )
 
-    assert result.returncode == 0, result.stdout + result.stderr
-    assert "Refreshing origin/main before PR body audit" in result.stdout
-    assert log.read_text(encoding="utf-8").strip() == "pr create --title Docs only --body-file -"
-    assert stdin_capture.read_text(encoding="utf-8") == body.read_text(encoding="utf-8")
 
-
-def _write_fixture_repo(tmp_path: Path) -> Path:
+def _write_fixture_repo(
+    tmp_path: Path,
+    *,
+    real_local_review: bool = False,
+    origin_url: str = "git@github.com:canfieldjuan/ATLAS.git",
+) -> Path:
     repo = tmp_path / "repo"
     (repo / "scripts").mkdir(parents=True)
-    copy2(SCRIPT, repo / "scripts" / "open_pr.sh")
-    copy2(AUDIT_SCRIPT, repo / "scripts" / "audit_pr_body.py")
-    copy2(CHANGE_POLICY_SCRIPT, repo / "scripts" / "_pr_change_policy.py")
-    subprocess.run(
-        ["git", "init", "--initial-branch", "main"],
-        cwd=repo,
-        check=True,
-        capture_output=True,
-        text=True,
-    )
+    if real_local_review:
+        copytree(REPO_ROOT / "scripts", repo / "scripts", dirs_exist_ok=True, ignore=ignore_patterns("__pycache__"))
+        copytree(REPO_ROOT / "docs", repo / "docs", dirs_exist_ok=True, ignore=ignore_patterns("__pycache__"))
+        copytree(REPO_ROOT / ".github", repo / ".github", dirs_exist_ok=True, ignore=ignore_patterns("__pycache__"))
+        copytree(REPO_ROOT / "extracted", repo / "extracted", dirs_exist_ok=True, ignore=ignore_patterns("__pycache__"))
+        for package_root in REPO_ROOT.glob("extracted_*"):
+            if package_root.is_dir():
+                copytree(package_root, repo / package_root.name, dirs_exist_ok=True, ignore=ignore_patterns("__pycache__"))
+        copytree(REPO_ROOT / "atlas_brain", repo / "atlas_brain", dirs_exist_ok=True, ignore=ignore_patterns("__pycache__"))
+        copy2(REPO_ROOT / "AGENTS.md", repo / "AGENTS.md")
+        copy2(REPO_ROOT / "CLAUDE.md", repo / "CLAUDE.md")
+    else:
+        copy2(SCRIPT, repo / "scripts" / "open_pr.sh")
+        copy2(AUDIT_SCRIPT, repo / "scripts" / "audit_pr_body.py")
+        copy2(CHANGE_POLICY_SCRIPT, repo / "scripts" / "_pr_change_policy.py")
+        (repo / "scripts" / "local_pr_review.sh").write_text(
+            """#!/usr/bin/env bash
+set -euo pipefail
+printf 'local_pr_review %s\\n' "${ATLAS_CURRENT_PR_BODY_FILE:-}" >> local-review.log
+if [ "${LOCAL_REVIEW_ADVANCE_REMOTE:-}" = "1" ]; then
+    git --git-dir="$(git config --get atlas.testRemoteGitDir)" update-ref refs/heads/claude/pr-test "$(git rev-parse HEAD^)"
+fi
+if [ "${LOCAL_REVIEW_ADVANCE_BOTH:-}" = "1" ]; then
+    printf 'post-review\\n' >> scripts/example.py
+    git add scripts/example.py
+    git -c user.email=t@example.com -c user.name=t commit -qm post-review
+    git push -q origin HEAD:claude/pr-test
+fi
+if [ "${LOCAL_REVIEW_MUTATE_BODY:-}" = "1" ]; then
+    printf '\\npost-review body mutation\\n' >> "${ATLAS_CURRENT_PR_BODY_FILE}"
+fi
+exit "${LOCAL_REVIEW_EXIT:-0}"
+""",
+            encoding="utf-8",
+        )
+    (repo / "scripts" / "local_pr_review.sh").chmod(0o755)
+    subprocess.run(["git", "init", "--initial-branch", "main"], cwd=repo, check=True, capture_output=True, text=True)
     (repo / "README.md").write_text("base\n", encoding="utf-8")
     _git(repo, "add", ".")
     _git(repo, "commit", "-qm", "base")
     remote = tmp_path / "origin.git"
-    subprocess.run(
-        ["git", "init", "--bare", str(remote)],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    _git(repo, "remote", "add", "origin", str(remote))
+    subprocess.run(["git", "init", "--bare", str(remote)], check=True, capture_output=True, text=True)
+    _git(repo, "config", f"url.{remote}.insteadOf", origin_url)
+    _git(repo, "config", "atlas.testRemoteGitDir", str(remote))
+    _git(repo, "remote", "add", "origin", origin_url)
     _git(repo, "push", "-q", "-u", "origin", "main")
+    _git(repo, "switch", "-c", "claude/pr-test")
     return repo
 
 
 def _write_body(repo: Path) -> Path:
-    body = repo / "body.md"
-    _write_plan(repo)
+    (repo / "plans").mkdir(exist_ok=True)
+    (repo / "plans" / "PR-Test.md").write_text("# Test plan\n", encoding="utf-8")
     (repo / "scripts" / "example.py").write_text("print('changed')\n", encoding="utf-8")
     _git(repo, "add", "plans/PR-Test.md", "scripts/example.py")
     _git(repo, "commit", "-qm", "planned change")
+    _git(repo, "push", "-q", "-u", "origin", "HEAD")
+    body = repo.parent / "body.md"
     body.write_text(_valid_body(), encoding="utf-8")
-    return body
-
-
-def _write_invalid_body(repo: Path) -> Path:
-    _write_body(repo)
-    body = repo / "body-invalid.md"
-    body.write_text(
-        _valid_body().replace(
-            "## Cold diff reconstruction\n"
-            "- Changed: scripts/example.sh:1 updates the wrapper.\n"
-            "- Contract match: traces to the body contract.\n"
-            "- Gaps: none.\n\n",
-            "",
-        ),
-        encoding="utf-8",
-    )
     return body
 
 
@@ -256,15 +375,10 @@ def _write_docs_only_body(repo: Path) -> Path:
     doc.write_text("# docs only\n", encoding="utf-8")
     _git(repo, "add", "docs/example.md")
     _git(repo, "commit", "-qm", "docs only")
-    body = repo / "body-docs-only.md"
+    _git(repo, "push", "-q", "-u", "origin", "HEAD")
+    body = repo.parent / "body-docs-only.md"
     body.write_text("Docs-only: true\n\nCorrect a documentation typo.\n", encoding="utf-8")
     return body
-
-
-def _write_plan(repo: Path) -> None:
-    plan = repo / "plans" / "PR-Test.md"
-    plan.parent.mkdir(parents=True, exist_ok=True)
-    plan.write_text("# Test plan\n", encoding="utf-8")
 
 
 def _valid_body() -> str:
@@ -297,36 +411,50 @@ def _valid_body() -> str:
     ])
 
 
-def _fake_gh_env(
-    tmp_path: Path,
-    *,
-    view_exit: int,
-) -> tuple[dict[str, str], Path, Path]:
+def _fake_gh_env(tmp_path: Path, *, view_exit: int) -> tuple[dict[str, str], Path, Path]:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     log = tmp_path / "gh-argv.txt"
     stdin_capture = tmp_path / "gh-stdin.txt"
+    created_flag = tmp_path / "gh-created-pr"
     gh = bin_dir / "gh"
     gh.write_text(
         """#!/usr/bin/env bash
 set -euo pipefail
-if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
-    exit "${GH_VIEW_EXIT}"
+if [ "$1" = "repo" ] && [ "$2" = "view" ]; then
+    printf 'canfieldjuan/ATLAS\\n'
+    exit 0
+fi
+if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+    if [ -n "${GH_PR_LIST_JSON:-}" ]; then
+        printf '%s\\n' "${GH_PR_LIST_JSON}"
+        exit 0
+    fi
+    if [ "${GH_VIEW_EXIT}" = "0" ] || [ -f "${GH_CREATED_PR_FLAG}" ]; then
+        printf '[{"number":17,"headRefName":"claude/pr-test","headRefOid":"%s","baseRefName":"main","headRepository":{"nameWithOwner":"canfieldjuan/ATLAS"},"isCrossRepository":false}]\\n' "$(git rev-parse HEAD)"
+    else
+        printf '[]\\n'
+    fi
+    exit 0
 fi
 printf '%s\\n' "$*" > "${GH_ARGV_LOG}"
 cat > "${GH_STDIN_CAPTURE}"
+if [ "$1" = "pr" ] && [ "$2" = "create" ]; then
+    : > "${GH_CREATED_PR_FLAG}"
+fi
 """,
         encoding="utf-8",
     )
     gh.chmod(0o755)
-    env = {
+    return {
         **os.environ,
         "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
         "GH_VIEW_EXIT": str(view_exit),
         "GH_ARGV_LOG": str(log),
         "GH_STDIN_CAPTURE": str(stdin_capture),
-    }
-    return env, log, stdin_capture
+        "GH_CREATED_PR_FLAG": str(created_flag),
+        "PYTHONDONTWRITEBYTECODE": "1",
+    }, log, stdin_capture
 
 
 def _git(repo: Path, *args: str) -> None:


### PR DESCRIPTION
Plan: plans/PR-Open-PR-Final-Admission-Gate.md
Slice phase: Workflow/process
Ownership lane: workflow/open-pr-final-admission

PR #2251 grew into a proof-file handshake across `push_pr.sh` and `open_pr.sh`. This replacement keeps the root fix narrow: `open_pr.sh` runs the final local mechanical gate before mutating GitHub, binds the mutation to the reviewed snapshot, and leaves `push_pr.sh` unchanged. This workflow/process slice is admitted now because it fixes the concrete merge-safety blocker where a PR could enter GitHub review and required checks with a head, body, or target the local mechanical gate did not review.

## Intentional
- Supersedes #2251 instead of repairing its proof-file protocol in place.
- Leaves `push_pr.sh` and managed pre-push hook dispatch unchanged.
- Rejects cross-repo, non-main-base, and explicit-head user targets in this helper.
- The final GitHub mutation is not claimed as API-atomic; `gh pr create/edit` has no reviewed-SHA compare-and-swap, so the helper enforces a single local writer and fails on post-mutation drift.

## Deferred
- Ownership-wrapper and draft-consent guards remain separate slices.
- Parking predicate: findings outside `open_pr.sh` final admission semantics, wrapper tests, or this plan contract are parked unless they prove the helper can still publish an unreviewed head/body/target or block a valid normal Atlas push/open flow.

## Parked hardening
- None.

## Cold diff reconstruction
- Changed: `scripts/open_pr.sh:53` rejects `GH_REPO`, `--head`, `--repo`, and non-main `--base` target overrides before mutation.
- Changed: `scripts/open_pr.sh:106` fetches `refs/heads/<branch>` and reads `FETCH_HEAD`, so single-branch clones do not depend on `refs/remotes/origin/<branch>` while still requiring the reviewed SHA.
- Changed: `scripts/open_pr.sh:137` derives trusted `owner/repo` from raw `remote.origin.url`; `scripts/open_pr.sh:151` uses parsed hostname so normal GitHub SSH/HTTPS URL forms work without trusting `gh` default repo config.
- Changed: `scripts/open_pr.sh:162` and `scripts/open_pr.sh:166` hash the PR body and reject post-review body drift.
- Changed: `scripts/open_pr.sh:182` takes an advisory git lock so local wrapper runs enforce a single-writer mutation window.
- Changed: `scripts/open_pr.sh:193` resolves existing PRs with explicit `--repo`, same `headRefName`, case-insensitive same `headRepository.nameWithOwner`, `baseRefName=main`, and non-cross-repo identity.
- Changed: `scripts/open_pr.sh:235` parses the PR snapshot head OID; `scripts/open_pr.sh:308`, `scripts/open_pr.sh:328`, and `scripts/open_pr.sh:338` reject existing-PR edits when GitHub reports a PR head other than the reviewed SHA.
- Changed: `scripts/open_pr.sh:254` strips user `--base main` from create args so the wrapper can pass trusted `--repo <origin>` and `--base main` itself.
- Changed: `scripts/open_pr.sh:300` captures the reviewed repo/head/body/PR snapshot; `scripts/open_pr.sh:321` and `scripts/open_pr.sh:345` recheck that snapshot immediately before edit/create mutation; `scripts/open_pr.sh:331` and `scripts/open_pr.sh:353` verify the same identity after mutation.
- Changed: `plans/PR-Open-PR-Final-Admission-Gate.md:8`, `plans/PR-Open-PR-Final-Admission-Gate.md:91`, and `plans/PR-Open-PR-Final-Admission-Gate.md:113` declare the workflow/process admission rationale, over-budget rationale, non-atomic GitHub mutation execution model, and parking predicate.
- Changed: `tests/test_open_pr_wrapper.py:18` and `tests/test_open_pr_wrapper.py:32` prove create/edit still pass body over stdin while passing explicit trusted repo/base args to fake `gh`.
- Changed: `tests/test_open_pr_wrapper.py:52` proves unsafe target/body inputs exit before fake `gh`.
- Changed: `tests/test_open_pr_wrapper.py:109` proves `ssh://git@github.com/...` origins are accepted; `tests/test_open_pr_wrapper.py:123` proves GitHub repo casing differences still admit the same repo; `tests/test_open_pr_wrapper.py:161` proves an existing local mutation lock blocks before review; `tests/test_open_pr_wrapper.py:175` proves `FETCH_HEAD` branch verification works without a remote-tracking feature ref.
- Changed: `tests/test_open_pr_wrapper.py:201` proves missing/stale/post-review-changed branch, `HEAD`, or body snapshots exit before fake `gh`.
- Changed: `tests/test_open_pr_wrapper.py:225` copies the real scripts/docs/workflow/extracted/atlas_brain dependencies, runs real `scripts/local_pr_review.sh` on both mutation branches, and proves no fake create/edit mutation occurs when the real bundle fails on the fixture plan shape.
- Changed: `tests/test_open_pr_wrapper.py:252` proves mismatched existing-PR identity blocks edit before fake `gh`; `tests/test_open_pr_wrapper.py:267` proves a stable stale existing-PR head blocks before fake `gh`.

Contract match:
- The final admission gate traces to the requirement that the mutating wrapper run mechanical local review before GitHub mutation.
- Snapshot pinning traces to the requirement that the reviewed head/body/PR identity is still the exact mutation target.
- The local mutation lock plus post-mutation verification trace to the P1 requirement to state and enforce the non-atomic single-writer execution model available through `gh pr create/edit`.
- Origin-derived repo, trusted `--repo`, trusted `--base main`, target rejection, CLOSED selector declaration, and exact PR lookup trace to the requirement that `open_pr.sh` mutate the current branch/current repo/main-base PR only.
- Leaving `scripts/push_pr.sh` unchanged traces to the supersession requirement to avoid #2251's proof-file/push-parser surface.

Gaps:
- None.

## Verification
- `python -m pytest tests/test_open_pr_wrapper.py -q` - 25 passed.
- `bash -n scripts/open_pr.sh` - passed.
- `python scripts/audit_plan_doc.py plans/PR-Open-PR-Final-Admission-Gate.md` - passed.
- `python scripts/audit_plan_code_consistency.py --base-ref origin/main plans/PR-Open-PR-Final-Admission-Gate.md` - passed.
- `python scripts/sync_pr_plan.py plans/PR-Open-PR-Final-Admission-Gate.md origin/main --check` - passed.

## Diff size
3 files, +710 / -176
Diff-budget override: the slice is genuinely indivisible because the reviewed-snapshot binding, single-writer/post-mutation verification, explicit repo/base target binding, real-review tests, normal-origin/fetch handling, and plan/body contract must land together; splitting them would leave `open_pr.sh` half-guarded between pushes.
