### PR TITLE
Reconcile required status truth

### DIFF
--- a/.github/workflows/branch_protection_required_checks.yml
+++ b/.github/workflows/branch_protection_required_checks.yml
@@ -8,9 +8,15 @@ on:
     branches:
       - main
     paths:
+      - ".github/workflows/ai_reconciliation_live.yml"
       - ".github/workflows/branch_protection_required_checks.yml"
+      - ".github/workflows/diff_budget.yml"
       - ".github/workflows/gitleaks_baseline_growth_guard.yml"
+      - ".github/workflows/plan_admission.yml"
+      - ".github/workflows/pr_body_contract.yml"
+      - ".github/workflows/review_contract.yml"
       - ".github/workflows/security_guardrails.yml"
+      - ".github/workflows/session_lane.yml"
       - "docs/SECURITY_GUARDRAILS.md"
       - "scripts/check_required_status_checks.py"
       - "tests/test_security_guardrails_workflow.py"

--- a/docs/SECURITY_GUARDRAILS.md
+++ b/docs/SECURITY_GUARDRAILS.md
@@ -66,16 +66,21 @@ workflow suppresses the follow-up chain entirely (no event model exists
 that delivers trusted code on review events); the fallback is a scheduled
 trusted sweep, parked in plans/PR-Trusted-Base-Gate-Execution.md.
 
-Branch protection for `main` requires `live-reconciliation`, `diff-budget`
-(the AGENTS.md diff-budget gate), `Gitleaks PR secret scan`, and
-`Gitleaks baseline growth guard`. The
-`Branch Protection Required Checks` workflow audits that live repository
-setting on a weekly/manual cadence and on trusted `main` updates touching the
-branch-protection checker, the security workflows, or security guardrail docs
-when `ATLAS_BRANCH_PROTECTION_READ_TOKEN` is configured with GitHub
-Administration read permission. The audit requires those contexts to be pinned
-to the GitHub Actions app source in branch protection, not only present as
-legacy bare context names.
+Target branch protection for `main` is `live-reconciliation`, `diff-budget`,
+`plan-admission`, `session-lane`, `review-contract`,
+`pr-body-contract`, `Gitleaks PR secret scan`, and
+`Gitleaks baseline growth guard`, all pinned to the GitHub Actions app source
+instead of legacy bare context names. At the time of this slice, live GitHub
+settings still require only `live-reconciliation`, `Gitleaks PR secret scan`,
+and `Gitleaks baseline growth guard`; the REST PATCH that preserves those and
+adds `diff-budget`, `plan-admission`, `session-lane`, `review-contract`, and
+`pr-body-contract` remains a separate repository-settings step.
+
+The `Branch Protection Required Checks` workflow audits that live repository
+setting against the target set on a weekly/manual cadence and on trusted `main`
+updates touching the branch-protection checker, any target check producer
+workflow, or security guardrail docs when `ATLAS_BRANCH_PROTECTION_READ_TOKEN`
+is configured with GitHub Administration read permission.
 
 The workflow security posture auditor admits
 `.github/workflows/session_lane.yml` / `session-lane` only when it has the same

--- a/plans/PR-Required-Status-Truth-Reconciliation.md
+++ b/plans/PR-Required-Status-Truth-Reconciliation.md
@@ -1,0 +1,171 @@
+# PR-Required-Status-Truth-Reconciliation
+
+## Why this slice exists
+
+Issue #2035 tracks the CI/CD enforcement gap where the merge gate can appear
+stronger than the live branch-protection payload actually is. After #2253,
+local PR admission and Codex/live-reconciliation are tighter, but live
+branch protection still requires only `live-reconciliation` plus the two
+Gitleaks checks, while docs and the stale #2130 PR point at a broader required
+set. This workflow/process slice is admitted now because that mismatch is a
+merge-safety blocker: builders and reviewers cannot know which mechanical
+checks are actually merge-blocking unless the audit contract separates the
+target required set from the current live GitHub setting.
+
+### Problem-derived contract
+
+- Root cause: the required-status audit/docs conflate desired branch-protection
+  policy with current live repository configuration, and the target set is
+  missing current PR-shape gates (`plan-admission`, `session-lane`, and
+  `review-contract`) that now exist as trusted-base producers.
+- Correct fix must touch/change: update the required-status checker default
+  contract, branch-protection audit workflow trigger coverage, security docs,
+  and focused tests so the intended required set is explicit, source-pinned to
+  GitHub Actions, and distinguishable from the current live payload until the
+  external branch-protection PATCH lands.
+- Must not change: live GitHub branch protection, `claude-review`, product code,
+  EOM lanes, Dependabot PRs, #2130's branch, unit-gate enrollment, or any
+  workflow execution model beyond the branch-protection audit trigger inputs.
+
+## Scope (this PR)
+
+Ownership lane: workflow/required-status-truth
+Slice phase: Workflow/process
+
+1. Reconcile the required-status checker/docs with the current intended merge
+   gate set.
+2. Add focused regression coverage for the full target set and for the current
+   live payload failing until enrollment is patched.
+
+### Review Contract
+
+- Acceptance criteria:
+  1. `scripts/check_required_status_checks.py` default required contexts are the
+     intended target set: `live-reconciliation`, `diff-budget`,
+     `plan-admission`, `session-lane`, `review-contract`, `pr-body-contract`,
+     `Gitleaks PR secret scan`, and `Gitleaks baseline growth guard`.
+  2. The checker still fails when any target context is absent or not pinned to
+     GitHub Actions app id `15368`.
+  3. A fixture matching the current live branch-protection payload fails on the
+     missing target contexts, proving the audit exposes today's drift instead of
+     silently passing it.
+  4. `.github/workflows/branch_protection_required_checks.yml` reruns on edits
+     to every producer workflow named in the target set.
+  5. `docs/SECURITY_GUARDRAILS.md` names the target required set and clearly
+     states the live REST branch-protection PATCH remains separate until
+     enrollment is applied.
+- Reachability proof: `python -m pytest tests/test_security_guardrails_workflow.py
+  -q` exercises the checker entrypoint and workflow/docs assertions.
+- Affected surfaces: required-status checker, security guardrail docs,
+  branch-protection audit workflow trigger paths, focused workflow tests, plan.
+- Risk areas: false green branch-protection audit, docs claiming unpatched live
+  settings, missing producer trigger coverage, wrong-source required contexts,
+  and stale #2130 drift.
+- Reviewer rules triggered: R1, R2, R10, R11, R12, R13, R14.
+
+### Boundary-change enumeration
+
+Required when this diff changes a guard, validator, normalizer, resolver,
+router/classifier, or admission boundary. Name each changed boundary path or
+seam in the enumeration; otherwise write "N/A - no boundary change."
+
+- Boundary path/seam: branch-protection required-status audit.
+- Replaced-path behaviors: the target required-context set expands from four
+  contexts to eight and keeps source pinning as the pass condition.
+- Guard-relevant fields: `contexts[]`, `checks[].context`, `checks[].app_id`,
+  default required context order, workflow `paths`, and docs wording that
+  distinguishes target policy from live settings.
+- Caller x input shape: top-level required-status payload, nested
+  `required_status_checks` payload, contexts-only legacy payload, checks-only
+  app-pinned payload, wrong-app payload, and current-live-shaped payload.
+
+### Deployed-config probing
+
+Required for guard, validator, resolver, admission-boundary, or env/config
+fallback changes; otherwise write "N/A - no guard/config boundary change."
+
+- Deployed/default config values: live API currently returns only
+  `live-reconciliation`, `Gitleaks PR secret scan`, and `Gitleaks baseline
+  growth guard` as required.
+- Explicit value probe: tests include a full target payload with GitHub Actions
+  app id `15368` for every context and expect PASS.
+- Absent value probe: tests include missing-context and current-live-shaped
+  payloads and expect FAIL.
+- Default-session/default-context probe: checker defaults are used when no
+  `--required` override is passed.
+- Side-effect ordering: no live branch-protection mutation in this PR; REST
+  enrollment remains Deferred.
+
+### Files touched
+
+- `.github/workflows/branch_protection_required_checks.yml`
+- `docs/SECURITY_GUARDRAILS.md`
+- `plans/PR-Required-Status-Truth-Reconciliation.md`
+- `scripts/check_required_status_checks.py`
+- `tests/test_security_guardrails_workflow.py`
+
+## Mechanism
+
+The checker's default required-context list becomes the explicit target merge
+gate set. Focused tests exercise the full app-pinned target payload, legacy and
+wrong-source failures, missing-context failures, and the current live payload
+that should fail until the branch-protection setting is patched. The
+branch-protection audit workflow expands its `push.paths` coverage to include
+the trusted-base producer workflows for every target context. Docs name the
+target set and call out that the live REST PATCH is still a separate settings
+operation.
+
+## Intentional
+
+- No `claude-review` required check; Codex connector threads plus
+  `live-reconciliation` remain the reviewer gate.
+- No live branch-protection PATCH in this PR; repository settings mutation is an
+  external operation that must preserve the current checks.
+- No unit-gate enrollment in this slice; #2035 keeps that as a separate
+  operator-policy decision.
+- Supersedes the stale intent of #2130 from current `main` rather than editing
+  that old branch in place.
+
+## Deferred
+
+- Apply the minimal REST branch-protection PATCH after this audit contract lands:
+  preserve existing checks and add `diff-budget`, `plan-admission`,
+  `session-lane`, `review-contract`, and `pr-body-contract`, then re-fetch the
+  live payload and run the checker.
+- Close or supersede #2130 after this replacement PR is open.
+- #2035 G1.1 unit-gate enrollment remains an operator-policy follow-up.
+
+Default parking predicate: park only repository-settings mutations and
+operator-policy enrollments that cannot be represented as tracked code in this
+PR.
+
+Parked hardening: none.
+
+## Verification
+
+- PASS: `python -m pytest tests/test_security_guardrails_workflow.py -q` (16
+  passed).
+- EXPECTED FAIL: current-live-shaped payload probe against
+  `scripts/check_required_status_checks.py` exited `1` and reported missing
+  `diff-budget`, `plan-admission`, `session-lane`, `review-contract`, and
+  `pr-body-contract`.
+- PASS: full target payload probe against `scripts/check_required_status_checks.py`
+  reported all eight target contexts pinned to GitHub Actions app id `15368`.
+- PASS: `gh api repos/canfieldjuan/ATLAS/branches/main/protection/required_status_checks`
+  returned live required checks `live-reconciliation`,
+  `Gitleaks PR secret scan`, and `Gitleaks baseline growth guard`, matching the
+  documented unpatched state.
+- PASS: `ATLAS_SESSION_STATE_FILE=SESSION_STATE.codex-required-status-truth.local.md
+  ATLAS_CURRENT_PR_BODY_FILE=/tmp/atlas-pr-body-required-status-truth-reconciliation.md
+  bash scripts/local_pr_review.sh`.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/branch_protection_required_checks.yml` | 6 |
+| `docs/SECURITY_GUARDRAILS.md` | 25 |
+| `plans/PR-Required-Status-Truth-Reconciliation.md` | 171 |
+| `scripts/check_required_status_checks.py` | 4 |
+| `tests/test_security_guardrails_workflow.py` | 105 |
+| **Total** | **311** |

--- a/scripts/check_required_status_checks.py
+++ b/scripts/check_required_status_checks.py
@@ -13,6 +13,10 @@ GITHUB_ACTIONS_APP_ID = 15368
 DEFAULT_REQUIRED_CONTEXTS = (
     "live-reconciliation",
     "diff-budget",
+    "plan-admission",
+    "session-lane",
+    "review-contract",
+    "pr-body-contract",
     "Gitleaks PR secret scan",
     "Gitleaks baseline growth guard",
 )

--- a/tests/test_security_guardrails_workflow.py
+++ b/tests/test_security_guardrails_workflow.py
@@ -16,6 +16,28 @@ PRE_COMMIT_CONFIG = Path(__file__).resolve().parents[1] / ".pre-commit-config.ya
 SECURITY_GUARDRAILS_DOC = Path(__file__).resolve().parents[1] / "docs" / "SECURITY_GUARDRAILS.md"
 REQUIRED_STATUS_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "check_required_status_checks.py"
 
+REQUIRED_STATUS_CONTEXTS = (
+    "live-reconciliation",
+    "diff-budget",
+    "plan-admission",
+    "session-lane",
+    "review-contract",
+    "pr-body-contract",
+    "Gitleaks PR secret scan",
+    "Gitleaks baseline growth guard",
+)
+
+REQUIRED_STATUS_WORKFLOW_PATHS = (
+    ".github/workflows/ai_reconciliation_live.yml",
+    ".github/workflows/diff_budget.yml",
+    ".github/workflows/plan_admission.yml",
+    ".github/workflows/pr_body_contract.yml",
+    ".github/workflows/review_contract.yml",
+    ".github/workflows/session_lane.yml",
+    ".github/workflows/gitleaks_baseline_growth_guard.yml",
+    ".github/workflows/security_guardrails.yml",
+)
+
 
 def _workflow_text() -> str:
     return WORKFLOW.read_text(encoding="utf-8")
@@ -94,11 +116,13 @@ def test_security_guardrails_docs_explain_gitleaks_pre_commit_install() -> None:
 
 def test_security_guardrails_docs_name_required_gitleaks_checks() -> None:
     text = SECURITY_GUARDRAILS_DOC.read_text(encoding="utf-8")
+    normalized_text = " ".join(text.split())
 
-    assert "`Gitleaks PR secret scan`" in text
-    assert "`Gitleaks baseline growth guard`" in text
-    assert "`diff-budget`" in text
+    for context in REQUIRED_STATUS_CONTEXTS:
+        assert f"`{context}`" in text
     assert "`Branch Protection Required Checks` workflow" in text
+    assert "live GitHub settings still require only" in normalized_text
+    assert "REST PATCH" in text
 
 
 def test_branch_protection_workflow_audits_live_required_checks() -> None:
@@ -107,8 +131,8 @@ def test_branch_protection_workflow_audits_live_required_checks() -> None:
     assert "branches/main/protection/required_status_checks" in text
     assert "ATLAS_BRANCH_PROTECTION_READ_TOKEN" in text
     assert "BRANCH_PROTECTION_READ_TOKEN != ''" in text
-    assert ".github/workflows/gitleaks_baseline_growth_guard.yml" in text
-    assert ".github/workflows/security_guardrails.yml" in text
+    for workflow_path in REQUIRED_STATUS_WORKFLOW_PATHS:
+        assert workflow_path in text
     assert (
         "if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main'"
         in text
@@ -134,8 +158,15 @@ def test_branch_protection_workflow_ref_guard_precedes_admin_read_token() -> Non
 def test_required_status_check_audit_accepts_contexts_and_checks_shapes() -> None:
     checker = _load_required_status_script()
     payload = {
-        "contexts": ["live-reconciliation", "diff-budget"],
+        "contexts": [
+            "live-reconciliation",
+            "diff-budget",
+            "plan-admission",
+            "session-lane",
+            "pr-body-contract",
+        ],
         "checks": [
+            {"context": "review-contract"},
             {"context": "Gitleaks PR secret scan"},
             {"context": "Gitleaks baseline growth guard"},
         ],
@@ -147,17 +178,9 @@ def test_required_status_check_audit_accepts_contexts_and_checks_shapes() -> Non
 def test_required_status_check_audit_accepts_github_actions_source() -> None:
     checker = _load_required_status_script()
     payload = {
-        "contexts": [
-            "live-reconciliation",
-            "diff-budget",
-            "Gitleaks PR secret scan",
-            "Gitleaks baseline growth guard",
-        ],
         "checks": [
-            {"context": "live-reconciliation", "app_id": checker.GITHUB_ACTIONS_APP_ID},
-            {"context": "diff-budget", "app_id": checker.GITHUB_ACTIONS_APP_ID},
-            {"context": "Gitleaks PR secret scan", "app_id": checker.GITHUB_ACTIONS_APP_ID},
-            {"context": "Gitleaks baseline growth guard", "app_id": checker.GITHUB_ACTIONS_APP_ID},
+            {"context": context, "app_id": checker.GITHUB_ACTIONS_APP_ID}
+            for context in REQUIRED_STATUS_CONTEXTS
         ],
     }
 
@@ -167,22 +190,12 @@ def test_required_status_check_audit_accepts_github_actions_source() -> None:
 def test_required_status_check_audit_rejects_legacy_only_contexts() -> None:
     checker = _load_required_status_script()
     payload = {
-        "contexts": [
-            "live-reconciliation",
-            "diff-budget",
-            "Gitleaks PR secret scan",
-            "Gitleaks baseline growth guard",
-        ],
+        "contexts": list(REQUIRED_STATUS_CONTEXTS),
     }
 
     failures = checker.required_status_check_failures(payload)
 
-    assert [failure.context for failure in failures] == [
-        "live-reconciliation",
-        "diff-budget",
-        "Gitleaks PR secret scan",
-        "Gitleaks baseline growth guard",
-    ]
+    assert [failure.context for failure in failures] == list(REQUIRED_STATUS_CONTEXTS)
     assert all("expected app_id" in failure.reason for failure in failures)
 
 
@@ -190,8 +203,9 @@ def test_required_status_check_audit_rejects_wrong_check_source() -> None:
     checker = _load_required_status_script()
     payload = {
         "checks": [
-            {"context": "live-reconciliation", "app_id": checker.GITHUB_ACTIONS_APP_ID},
-            {"context": "diff-budget", "app_id": checker.GITHUB_ACTIONS_APP_ID},
+            {"context": context, "app_id": checker.GITHUB_ACTIONS_APP_ID}
+            for context in REQUIRED_STATUS_CONTEXTS[:-2]
+        ] + [
             {"context": "Gitleaks PR secret scan", "app_id": -1},
             {"context": "Gitleaks baseline growth guard", "app_id": None},
         ],
@@ -207,7 +221,7 @@ def test_required_status_check_audit_rejects_wrong_check_source() -> None:
     assert "found legacy/unpinned" in failures[1].reason
 
 
-def test_required_status_check_audit_fails_when_gitleaks_context_missing() -> None:
+def test_required_status_check_audit_fails_when_target_contexts_missing() -> None:
     checker = _load_required_status_script()
     payload = {
         "required_status_checks": {
@@ -217,6 +231,35 @@ def test_required_status_check_audit_fails_when_gitleaks_context_missing() -> No
 
     assert checker.missing_required_contexts(payload) == [
         "diff-budget",
+        "plan-admission",
+        "session-lane",
+        "review-contract",
+        "pr-body-contract",
         "Gitleaks PR secret scan",
         "Gitleaks baseline growth guard",
     ]
+
+
+def test_required_status_check_audit_fails_current_live_payload_until_enrolled() -> None:
+    checker = _load_required_status_script()
+    payload = {
+        "checks": [
+            {"context": "live-reconciliation", "app_id": checker.GITHUB_ACTIONS_APP_ID},
+            {"context": "Gitleaks PR secret scan", "app_id": checker.GITHUB_ACTIONS_APP_ID},
+            {
+                "context": "Gitleaks baseline growth guard",
+                "app_id": checker.GITHUB_ACTIONS_APP_ID,
+            },
+        ],
+    }
+
+    failures = checker.required_status_check_failures(payload)
+
+    assert [failure.context for failure in failures] == [
+        "diff-budget",
+        "plan-admission",
+        "session-lane",
+        "review-contract",
+        "pr-body-contract",
+    ]
+    assert all(failure.reason == "missing required check" for failure in failures)


### PR DESCRIPTION
Plan: plans/PR-Required-Status-Truth-Reconciliation.md
Slice phase: Workflow/process
Ownership lane: workflow/required-status-truth

Issue #2035 exposed that our merge policy can look stronger than the live branch-protection payload. This slice makes the required-status audit/docs name the intended target set, keeps it pinned to GitHub Actions app id `15368`, and adds a current-live payload fixture that fails until the separate repository-settings PATCH enrolls the missing checks.

## Intentional
- No `claude-review` required check; Codex connector threads plus `live-reconciliation` remain the reviewer gate.
- No live branch-protection PATCH in this PR; repository settings mutation is deferred so the audit contract can land cleanly first.
- No unit-gate enrollment in this slice; #2035 keeps that as a separate operator-policy decision.
- Supersedes the stale intent of #2130 from current `main` rather than editing that old branch in place.

## Deferred
- Apply the minimal REST branch-protection PATCH after this audit contract lands: preserve existing checks and add `diff-budget`, `plan-admission`, `session-lane`, `review-contract`, and `pr-body-contract`, then re-fetch the live payload and run the checker.
- Close or supersede #2130 after this replacement PR is open.
- #2035 G1.1 unit-gate enrollment remains an operator-policy follow-up.

## Parked hardening
- Default parking predicate: park only repository-settings mutations and operator-policy enrollments that cannot be represented as tracked code in this PR.
- None.

## Cold diff reconstruction
- Changed: `scripts/check_required_status_checks.py:13` expands the default required-context set from four checks to eight by adding `plan-admission`, `session-lane`, `review-contract`, and `pr-body-contract`.
- Changed: `.github/workflows/branch_protection_required_checks.yml:10` expands trusted `main` push-path coverage so edits to every target check producer rerun the live branch-protection audit.
- Changed: `docs/SECURITY_GUARDRAILS.md:69` rewrites the branch-protection paragraph as target policy plus current live reality, explicitly deferring the REST PATCH.
- Changed: `tests/test_security_guardrails_workflow.py:19` adds shared target-context and producer-workflow fixtures for the required-status assertions.
- Changed: `tests/test_security_guardrails_workflow.py:115` verifies the docs name every target context and do not claim live settings are already patched.
- Changed: `tests/test_security_guardrails_workflow.py:125` verifies branch-protection audit trigger coverage includes every target check producer workflow.
- Changed: `tests/test_security_guardrails_workflow.py:155` through `tests/test_security_guardrails_workflow.py:263` verifies accepted payload shapes, GitHub Actions source pinning, legacy/wrong-source rejection, missing target contexts, and the current-live payload failing on the five unenrolled contexts.
- Contract match: every code/doc/test/workflow change traces to the Problem-derived contract: make target status policy explicit, preserve GitHub Actions source pinning, distinguish the current live payload, and cover producer trigger drift.
- Gaps: none. The diff does not mutate live branch protection, does not add `claude-review`, does not touch product code, and does not edit #2130's branch.

## Verification
- PASS: `python -m pytest tests/test_security_guardrails_workflow.py -q` (16 passed).
- EXPECTED FAIL: current-live-shaped payload probe against `scripts/check_required_status_checks.py` exited `1` and reported missing `diff-budget`, `plan-admission`, `session-lane`, `review-contract`, and `pr-body-contract`.
- PASS: full target payload probe against `scripts/check_required_status_checks.py` reported all eight target contexts pinned to GitHub Actions app id `15368`.
- PASS: `gh api repos/canfieldjuan/ATLAS/branches/main/protection/required_status_checks` returned live required checks `live-reconciliation`, `Gitleaks PR secret scan`, and `Gitleaks baseline growth guard`, matching the documented unpatched state.
- PASS: `ATLAS_SESSION_STATE_FILE=SESSION_STATE.codex-required-status-truth.local.md ATLAS_CURRENT_PR_BODY_FILE=/tmp/atlas-pr-body-required-status-truth-reconciliation.md bash scripts/local_pr_review.sh`.

## Diff size
5 files, +109 / -55; plan included total 311 LOC.
