### PR TITLE
Make live reconciliation open-thread only

### DIFF
--- a/.github/workflows/ai_reconciliation_live.yml
+++ b/.github/workflows/ai_reconciliation_live.yml
@@ -59,8 +59,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           python scripts/check_ai_reconciliation_live.py \
-            --pr "${{ github.event.pull_request.number }}" \
-            --wait-for-review-window
+            --pr "${{ github.event.pull_request.number }}"
 
   live-reconciliation-review-events:
     if: github.event_name == 'pull_request_review' || github.event_name == 'pull_request_review_comment'

--- a/.github/workflows/ai_reconciliation_review_retrigger.yml
+++ b/.github/workflows/ai_reconciliation_review_retrigger.yml
@@ -32,7 +32,7 @@ jobs:
       github.event.workflow_run.event == 'pull_request_review' ||
       github.event.workflow_run.event == 'pull_request_review_comment'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     steps:
       - name: Rerun latest trusted target run for this head
         env:
@@ -42,12 +42,38 @@ jobs:
         run: |
           set -euo pipefail
           head_sha="${WORKFLOW_RUN_HEAD_SHA}"
-          run_id=$(gh api \
-            "repos/${GITHUB_REPOSITORY}/actions/workflows/ai_reconciliation_live.yml/runs?event=pull_request_target&head_sha=${head_sha}&per_page=1" \
-            --jq '.workflow_runs[0].id // empty')
+          target_runs_path="repos/${GITHUB_REPOSITORY}/actions/workflows/ai_reconciliation_live.yml/runs?event=pull_request_target&head_sha=${head_sha}&per_page=1"
+          run_id=""
+          status=""
+          for attempt in $(seq 1 72); do
+            run_id=$(gh api "${target_runs_path}" --jq '.workflow_runs[0].id // empty')
+            if [ -z "${run_id}" ]; then
+              echo "target run for ${head_sha} is not visible yet; retry ${attempt}/72"
+              sleep 10
+              continue
+            fi
+            status=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}" --jq '.status // empty')
+            if [ "${status}" = "completed" ]; then
+              break
+            fi
+            echo "target run ${run_id} is ${status:-unknown}; retry ${attempt}/72"
+            sleep 10
+          done
           if [ -z "${run_id}" ]; then
             echo "no pull_request_target run for ${head_sha}; nothing to refresh"
             exit 0
           fi
+          if [ "${status}" != "completed" ]; then
+            echo "target run ${run_id} did not complete before retrigger timeout"
+            exit 1
+          fi
           echo "re-running trusted run ${run_id} for ${head_sha}"
-          gh api -X POST "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/rerun"
+          for attempt in $(seq 1 6); do
+            if gh api -X POST "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/rerun"; then
+              exit 0
+            fi
+            echo "rerun request for ${run_id} was rejected; retry ${attempt}/6"
+            sleep 10
+          done
+          echo "could not rerun trusted run ${run_id}"
+          exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1341,8 +1341,7 @@ Before LGTM or merge readiness:
 - [ ] R14 is satisfied: verdict claims are backed by checked-out code,
       caller/test/artifact spot-checks, CI, or explicit not-verified notes.
 - [ ] Codex threads are resolved or waived with a reason in the PR body, and
-      `live-reconciliation` is green for the current PR head after a Codex
-      connector review on that exact head SHA.
+      `live-reconciliation` is green for the current PR head.
 - [ ] No drift from the plan's stated scope.
 
 ---

--- a/docs/OVERNIGHT_ARC_WORKFLOW.md
+++ b/docs/OVERNIGHT_ARC_WORKFLOW.md
@@ -79,13 +79,11 @@ overnight deltas:
   reviewer boundary probe BEFORE pushing -- both error directions (fail-open
   AND over-reject), boundary values, at least one negative test. Cheaper than
   a review round.
-- **Merge:** required checks green + a current-head review by the exact Codex
-  connector identity (`chatgpt-codex-connector` or
-  `chatgpt-codex-connector[bot]`) + 0 unresolved Codex connector threads + no
-  CHANGES_REQUESTED + clean tree + local==remote -> merge, teardown, next
-  slice. Log for the report; do not ping the operator per merge. Exception:
-  documentation-only PRs hold for bot review before merging (doc PRs that
-  merged on green before the bot pass have burned us).
+- **Merge:** required checks green + 0 unresolved Codex connector threads +
+  clean tree + local==remote -> merge, teardown, next slice. Documentation-only
+  PRs use the same open-thread gate: do not hold them for Codex review presence
+  when `live-reconciliation` is green for the current head. Log for the report;
+  do not ping the operator per merge.
 - **Compaction recovery:** the `CLAUDE.md` compact instructions preserve the
   overnight baton. First acts after any compaction: re-read this doc, verify
   the baton against `git`/`gh` reality, re-arm the watcher.
@@ -132,21 +130,16 @@ there is something to act on:
 - `MERGED/CLOSED` -- terminal; stop watching.
 - `HEAD-MOVED` -- the branch advanced past the armed SHA; reconcile, re-arm
   on the new head.
-- `ACTIONABLE` -- a red required context, unresolved review threads (counts
-  fail closed when more thread pages exist than fetched), or a
-  CHANGES_REQUESTED review decision.
+- `ACTIONABLE` -- a red required context or unresolved review threads (counts
+  fail closed when more thread pages exist than fetched).
   Definite negatives exit on any cycle, including the first.
 - `MERGE-READY` -- readiness is presence-based and fail-closed: EVERY
   required branch-protection context (read at runtime from
   `ci/gates.yml` through the required-status checker/watcher path, so the gate
   cannot drift from the canonical list) must be present and reporting success,
-  plus
-  a current-head review by the exact Codex connector identity, 0 unresolved
-  Codex connector threads, no CHANGES_REQUESTED, and mergeable. A context that
-  has not started yet keeps readiness false; a missing current-head Codex
-  connector review keeps the watcher polling instead of reporting builder
-  action. Run the pre-merge checklist (clean tree, local==remote, threads still
-  0 and current-head connector review still present), merge, alert.
+  plus 0 unresolved Codex connector threads and mergeable. A context that has
+  not started yet keeps readiness false. Run the pre-merge checklist (clean
+  tree, local==remote, threads still 0), merge, alert.
 
 The watcher itself never merges and never holds merge authority (AGENTS
 3c.1.1); it only reports states.

--- a/docs/long_running_session_watcher_handoff.md
+++ b/docs/long_running_session_watcher_handoff.md
@@ -143,9 +143,8 @@ Wake-source rules:
   `scheduled-ready` only when the snapshot carries a version-1 readiness proof
   for the same open, non-draft head: at least one required check, all required
   checks complete/green, complete review-thread pagination, zero unresolved
-  non-outdated Codex connector threads, complete Codex review pagination with
-  at least one current-head Codex connector review, no changes-requested
-  decision, and a clean merge state. Missing or contradictory proof becomes
+  non-outdated Codex connector threads, and a clean merge state. Missing or
+  contradictory proof becomes
   `attention` and lists its blockers. `scheduled-ready` is still only
   permission to run the AGENTS merge guards; the resumed builder also needs
   explicit standing merge authorization in this session's state file before
@@ -167,9 +166,6 @@ The version-1 snapshot proof is:
     "review_threads_complete": true,
     "review_thread_pages_fetched": 1,
     "unresolved_review_threads": [],
-    "codex_reviews_complete": true,
-    "codex_review_pages_fetched": 1,
-    "codex_head_review_count": 1,
     "review_decision": "<same as pr.reviewDecision>",
     "merge_state_status": "CLEAN"
   }
@@ -330,21 +326,18 @@ systemctl --user disable --now "atlas-pr-watch@${SESSION_ID}.timer"
 | `pending` | At least one check is still pending and no new review/comment activity was observed | Record the next poll; do not ask the operator to babysit CI |
 | `attention` | Red/canceled check, failed AI reconciliation, or status details such as `head_mismatch: true` | Inspect the owned PR, fix the root cause in-scope, push, update watcher config head SHA. If `head_mismatch` is true, follow the stop/fetch/inspect branch before any force-push or merge |
 | `review_changed` | New review/comment activity since last poll, including while checks are pending | Inspect comments before any merge decision |
-| `ready_for_human_merge` | The snapshot label and version-1 proof agree: same open/non-draft head, required checks complete/green, all thread pages fetched, zero unresolved non-outdated Codex connector threads, complete Codex review pagination, at least one current-head Codex connector review, no changes requested, clean merge state | Run `scripts/report_pr_watcher_state.py`; missing/contradictory proof is reported as attention. Otherwise report readiness or perform the active-builder guarded merge only when explicitly authorized and after fresh live guards |
+| `ready_for_human_merge` | The snapshot label and version-1 proof agree: same open/non-draft head, required checks complete/green, all thread pages fetched, zero unresolved non-outdated Codex connector threads, clean merge state | Run `scripts/report_pr_watcher_state.py`; missing/contradictory proof is reported as attention. Otherwise report readiness or perform the active-builder guarded merge only when explicitly authorized and after fresh live guards |
 
 The installed producer reads branch protection's required-context inventory,
 then replaces that expected set with `origin/main:ci/gates.yml` parsed through
-`origin/main:scripts/check_required_status_checks.py` when the trusted
-registry exists. It compares the expected set with `gh pr checks --required`,
-fetches every GraphQL
-`reviewThreads` page, fetches every current-head Codex connector review page,
-and reads PR metadata again after those calls. This prevents a required context
-that has not reported yet from disappearing from the observed set and prevents
-review pagination from proving readiness for a head that is no longer current.
-A changed head, empty/malformed required policy, unreported required context,
-incomplete pagination, unresolved non-outdated Codex connector thread, missing
-current-head Codex connector review, or GitHub read error cannot produce a
-ready proof. The JSON snapshot is replaced atomically so the bridge/reporter
+`origin/main:scripts/check_required_status_checks.py` when the trusted registry
+exists. It compares the expected set with `gh pr checks --required`, fetches
+every GraphQL `reviewThreads` page, and reads PR metadata again after those
+calls. This prevents a required context that has not reported yet from
+disappearing from the observed set. A changed head, empty/malformed required
+policy, unreported required context, incomplete thread pagination, unresolved
+non-outdated Codex connector thread, or GitHub read error cannot produce a ready
+proof. The JSON snapshot is replaced atomically so the bridge/reporter
 cannot consume a partial file.
 Live AI reconciliation runs from the exact checker and parser sources installed
 beside the watcher; it never executes the watched PR worktree's checker.

--- a/plans/PR-Live-Reconciliation-Thread-Gate.md
+++ b/plans/PR-Live-Reconciliation-Thread-Gate.md
@@ -1,0 +1,284 @@
+# PR-Live-Reconciliation-Thread-Gate
+
+## Why this slice exists
+
+PR #2256 proved the `live-reconciliation` check can remain red after the Codex
+connector has no unresolved review threads. The required target workflow still
+waited for current-head Codex activity, so clean/no-thread states could burn an
+extra review-window cycle and invite more review churn before the PR became
+mergeable. This workflow/process slice removes that timing race at the source.
+Codex review on #2258 also exposed stale current-head attestation language in
+`AGENTS.md` and watcher readiness surfaces; those have to move with the checker
+or the reviewer will keep enforcing the old contract from a different anchor.
+The diff is over the 400 LOC soft cap because the indivisible fix removes the
+obsolete wait/docs-only proof branch, aligns the watcher/wake-bridge readiness
+contract, closes the review-event retrigger race, renames the colliding plan
+basename, and updates the matching regression tests in the same slice.
+
+### Problem-derived contract
+
+- Root cause: `live-reconciliation` conflated two different concerns: whether
+  scoped Codex review threads are still open, and whether the connector has
+  posted current-head review activity inside a grace window. The second concern
+  is a timing/attestation proxy that can fail a PR with no actionable Codex
+  threads.
+- Correct fix must touch/change: the required
+  `.github/workflows/ai_reconciliation_live.yml` invocation, the
+  `.github/workflows/ai_reconciliation_review_retrigger.yml` follow-up,
+  `scripts/check_ai_reconciliation_live.py` decision path, `AGENTS.md`
+  readiness wording, watcher/wake-bridge readiness gates, unit-gate impacted
+  test ownership for the changed reconciliation workflows/scripts, and focused
+  tests so required and local watcher gates pass as soon as no unresolved scoped
+  Codex threads remain.
+- Must not change: branch-protection inventory, `claude-review` policy,
+  exact Codex bot-login filtering, review-thread pagination/stability checks,
+  open-thread failure behavior, PR body reconciliation wording, product code,
+  EOM/render lanes, or customer-visible behavior.
+
+## Scope (this PR)
+
+Ownership lane: workflow/live-reconciliation-open-threads-only
+Slice phase: Workflow/process
+
+1. Remove the required live workflow's `--wait-for-review-window` invocation.
+2. Make the checker treat "no unresolved scoped Codex threads" as the only
+   success condition, independent of current-head review state or PR update
+   age.
+3. Keep `--wait-for-review-window` and `--review-grace-seconds` accepted as
+   deprecated compatibility inputs, but make them no-ops.
+4. Update focused tests for no-wait, no-refetch, no-file-proof, and open-thread
+   failure behavior.
+5. Align `AGENTS.md`, the watcher, wake bridge, and overnight watcher script so
+   they no longer require current-head Codex review attestation or block on
+   `CHANGES_REQUESTED` when scoped Codex threads are clear.
+6. Rename the plan to an unused basename so merge teardown can archive it.
+7. Make the review-event retrigger wait for the current target run to complete
+   before rerunning it, with bounded retry when GitHub rejects an in-progress
+   rerun request.
+8. Keep Codex review-attestation fetch failures diagnostic-only in the wake
+   bridge when the required checks and review-thread proof are complete/clear.
+9. Map the changed AI-reconciliation workflows and checker/wake-bridge scripts
+   to their focused unit-test owners so `unit-gate` does not escalate to the
+   full repo suite and fail on unrelated baseline drift.
+
+### Review Contract
+
+- Acceptance criteria:
+  1. Required `pull_request_target` live reconciliation invokes
+     `scripts/check_ai_reconciliation_live.py --pr <number>` without
+     `--wait-for-review-window`.
+  2. `evaluate()` returns success immediately when `open_bot_threads()` finds no
+     unresolved scoped Codex threads, even when the current-head Codex review is
+     missing or `CHANGES_REQUESTED`.
+  3. Live `main()` accepts `--wait-for-review-window` and malformed
+     `ATLAS_CODEX_REVIEW_GRACE_SECONDS` without sleeping, fetching
+     `updatedAt`, or refetching a second review-thread snapshot.
+  4. Docs-only/no-thread PRs no longer fetch changed-file proof just to emit a
+     current-head attestation exemption.
+  5. Open scoped Codex threads still fail when the PR body claims clear,
+     acknowledges open findings, lacks a usable reconciliation record, or omits
+     the record.
+  6. Watcher readiness and scheduled wake-bridge readiness require complete
+     thread pagination and zero unresolved scoped Codex threads, but no longer
+     require current-head Codex review attestation.
+  7. `CHANGES_REQUESTED` review decision is recorded as metadata but does not
+     block readiness by itself when scoped Codex threads are clear.
+  8. Live snapshot consistency still fails closed on PR head movement or review
+     thread movement, but Codex review/comment generation movement no longer
+     fails the thread-only gate.
+  9. Overnight documentation-only PR readiness uses the same required-green plus
+     zero-unresolved-Codex-threads gate; it does not hold for bot review
+     presence when `live-reconciliation` is green for the current head.
+  10. The root plan basename is unique against `plans/archive/`.
+  11. Review-event retrigger waits for the trusted target run for the same head
+      SHA to complete before posting the rerun request, and retries transient
+      rerun rejection.
+  12. Scheduled wake bridge readiness is not blocked by optional Codex review
+      attestation errors when required checks are green and review threads are
+      complete/clear.
+  13. Unit-gate impacted-test selection for this branch returns the focused
+      reconciliation/watcher/security owner tests instead of `FULL`.
+- Reachability proof: real entrypoint is the GitHub Actions workflow command in
+  `.github/workflows/ai_reconciliation_live.yml`; observable effect is the
+  checker returning exit 0 for no-thread states and exit 1 for unresolved
+  scoped Codex threads in `tests/test_check_ai_reconciliation_live.py`, plus
+  watcher/wake-bridge tests returning ready when review attestation is missing
+  but scoped Codex threads are clear, and checker tests allow review/comment
+  generation movement while still failing closed on thread generation movement,
+  plus static workflow assertions that the review-event retrigger waits/retries
+  before rerunning the trusted target context. Unit-gate reachability proof is
+  `scripts/select_impacted_tests.py --base origin/main` returning focused owner
+  tests and `scripts/check_unit_gate.py --selected-files` reporting zero
+  regressions.
+- Affected surfaces: live AI reconciliation workflow, reconciliation checker
+  CLI, review-event retrigger workflow, AGENTS readiness wording, local
+  watcher/wake-bridge readiness, overnight watcher docs/script wording, and
+  focused checker/watcher tests.
+  Unit-gate impacted-test ownership for those workflow/script surfaces is also
+  affected.
+- Risk areas: required-check timing races, stale current-head review state,
+  accidental sleep/refetch in required CI, docs-only proof fetch churn, stale
+  overnight docs-only holds, and preserving unresolved-thread blocking.
+- Reviewer rules triggered: R1, R2, R6, R8, R10, R12, R14.
+
+### Boundary-change enumeration
+
+Required when this diff changes a guard, validator, normalizer, resolver,
+router/classifier, or admission boundary. Name each changed boundary path or
+seam in the enumeration; otherwise write "N/A - no boundary change."
+
+- Boundary path/seam: `scripts/check_ai_reconciliation_live.py::evaluate` and
+  `main()` gate the required `live-reconciliation` check;
+  `.github/workflows/ai_reconciliation_review_retrigger.yml` gates
+  review-event re-evaluation of that required context;
+  `scripts/pr_watcher.py::_classify` and
+  `scripts/codex_wake_bridge.py::readiness_blockers` gate local watcher
+  readiness; `scripts/select_impacted_tests.py::EXPLICIT_TEST_OWNERS` gates
+  scoped unit-test selection for runtime/config and path-loaded script changes.
+- Replaced-path behaviors: no-thread states no longer evaluate current-head
+  Codex review state, PR update age, review grace, docs-only file proof, or
+  `CHANGES_REQUESTED` review-decision metadata.
+- Guard-relevant fields: `reviewThreads.nodes[].isResolved`, first-thread
+  comment author login, PR body reconciliation marker, optional `--threads-file`
+  fixtures, and live PR thread snapshot.
+- Caller x input shape: GitHub Actions passes only `--pr`; tests exercise
+  file-backed fixtures and live-mode monkeypatched PR snapshots.
+
+### Deployed-config probing
+
+Required for guard, validator, resolver, admission-boundary, or env/config
+fallback changes; otherwise write "N/A - no guard/config boundary change."
+
+- Deployed/default config values: `ATLAS_CODEX_REVIEW_GRACE_SECONDS` remains
+  accepted for compatibility but no longer affects the gate.
+- Explicit value probe:
+  `test_main_ignores_malformed_review_window_config` proves malformed grace
+  config no longer fails no-thread reconciliation.
+- Absent value probe: `test_main_live_default_does_not_refetch_inside_review_window`
+  proves the default live path does not fetch PR `updatedAt`.
+- Default-session/default-context probe:
+  `test_missing_current_head_codex_review_passes_inside_fresh_update_window`
+  proves missing current-head activity inside the old window passes when
+  threads are clear.
+- Side-effect ordering:
+  `test_main_live_wait_flag_is_noop_inside_review_window` proves the deprecated
+  wait flag does not sleep or refetch.
+  `test_current_head_codex_review_is_not_required_for_ready_state` and
+  `test_post_review_metadata_records_review_decision_without_blocking_readiness`
+  prove watcher readiness no longer blocks on stale review metadata.
+
+### Files touched
+
+- `.github/workflows/ai_reconciliation_live.yml`
+- `.github/workflows/ai_reconciliation_review_retrigger.yml`
+- `AGENTS.md`
+- `docs/OVERNIGHT_ARC_WORKFLOW.md`
+- `docs/long_running_session_watcher_handoff.md`
+- `plans/PR-Live-Reconciliation-Thread-Gate.md`
+- `scripts/check_ai_reconciliation_live.py`
+- `scripts/codex_wake_bridge.py`
+- `scripts/pr_watcher.py`
+- `scripts/select_impacted_tests.py`
+- `scripts/watch_owned_pr.sh`
+- `tests/test_check_ai_reconciliation_live.py`
+- `tests/test_codex_wake_bridge.py`
+- `tests/test_pr_watcher.py`
+- `tests/test_select_impacted_tests.py`
+- `tests/test_watch_owned_pr.py`
+
+## Mechanism
+
+The workflow stops passing the wait flag to the required `pull_request_target`
+job. The checker keeps fetching a stable review-thread snapshot, then
+`evaluate()` makes one decisive split: no unresolved scoped Codex threads exits
+0; any unresolved scoped Codex thread exits 1 with the existing PR-body
+reconciliation diagnostics. The CLI still accepts the old wait/grace arguments
+so existing callers do not break, but no code path uses them to sleep, refetch,
+or require current-head Codex activity.
+
+Review/comment attestation fetches remain available as diagnostics, but snapshot
+stability checks no longer compare their generations; only PR head movement and
+review-thread movement can fail the thread-only snapshot.
+
+The watcher and wake bridge keep review-decision and current-head-review counts
+as diagnostics, but readiness depends on required checks, thread-pagination
+completion, zero unresolved scoped Codex threads, non-draft/open PR state, clean
+merge state, and local/head consistency. The shell watcher and docs use the same
+contract, including documentation-only PRs, so autonomous handoffs do not
+reintroduce the removed gate.
+
+The review-event retrigger remains default-branch trusted code, but now waits
+for the matching `pull_request_target` run to complete before requesting a
+rerun and retries rerun rejection. That closes the window where a review-event
+follow-up could finish before the required target run and leave the current head
+with a stale green required context after a new inline Codex thread.
+
+The unit-gate selector now treats the changed AI-reconciliation workflows and
+path-loaded checker/wake-bridge scripts as explicitly owned CI surfaces. That
+keeps this workflow/process slice on its focused reconciliation, watcher, and
+workflow-security tests instead of escalating to the full repo suite, where a
+separate baseline-shrink drift can block an unrelated runtime/config change.
+
+## Intentional
+
+- No branch-protection change in this slice. The required status remains
+  `live-reconciliation`; only its pass/fail predicate changes.
+- No replacement "final Codex approval" gate. The operator asked to use whether
+  Codex left unresolved comments as the merge signal, and the existing
+  `claude-review` discussion is a separate trust-boundary slice.
+- Deprecated CLI flags are kept as no-op compatibility inputs to avoid breaking
+  external/manual invocations while the workflow call is simplified.
+- Current-head Codex review counts remain in watcher output as diagnostics only.
+- Codex review-attestation API/pagination errors remain in watcher output as
+  diagnostics only; the bridge trusts the complete review-thread proof for
+  readiness.
+- Review/comment-generation movement is intentionally ignored by the live
+  checker because review presence is no longer part of the required predicate;
+  PR head and review-thread movement still fail closed.
+- The unit-gate selector fix does not restore or edit
+  `tests/unit_gate_baseline.txt`; it maps this slice's owned runtime/config
+  surfaces to focused tests so unrelated full-suite baseline drift is not
+  repaired inside this PR.
+
+## Deferred
+
+None.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_check_ai_reconciliation_live.py -q` -- 64 passed.
+- `python -m pytest tests/test_codex_wake_bridge.py -q` -- 46 passed.
+- `python -m pytest tests/test_watch_owned_pr.py -q` -- 23 passed.
+- `python -m pytest tests/test_watch_owned_pr.py tests/test_pr_watcher.py tests/test_codex_wake_bridge.py tests/test_check_ai_reconciliation_live.py -q` -- 209 passed.
+- `python -m pytest tests/test_select_impacted_tests.py -q` -- 48 passed.
+- `python scripts/select_impacted_tests.py --base origin/main` -- selected
+  `tests/test_audit_workflow_security_posture.py`,
+  `tests/test_check_ai_reconciliation_live.py`,
+  `tests/test_codex_wake_bridge.py`, `tests/test_pr_watcher.py`, and
+  `tests/test_watch_owned_pr.py` (not `FULL`).
+- `python scripts/check_unit_gate.py --baseline tests/unit_gate_baseline.txt --base-baseline /tmp/atlas-base-baseline-2258.txt --selected-files /tmp/atlas-selected-2258.txt --pytest-args $(tr '\n' ' ' < /tmp/atlas-selected-2258.txt) -m "not integration and not e2e" --continue-on-collection-errors -rfE --tb=no -q -p no:cacheprovider` -- 0 regressions.
+- `python -m pytest tests/test_check_ai_reconciliation_live.py tests/test_codex_wake_bridge.py tests/test_pr_watcher.py tests/test_watch_owned_pr.py tests/test_select_impacted_tests.py tests/test_audit_workflow_security_posture.py -q` -- 276 passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/ai_reconciliation_live.yml` | 3 |
+| `.github/workflows/ai_reconciliation_review_retrigger.yml` | 36 |
+| `AGENTS.md` | 3 |
+| `docs/OVERNIGHT_ARC_WORKFLOW.md` | 27 |
+| `docs/long_running_session_watcher_handoff.md` | 29 |
+| `plans/PR-Live-Reconciliation-Thread-Gate.md` | 284 |
+| `scripts/check_ai_reconciliation_live.py` | 329 |
+| `scripts/codex_wake_bridge.py` | 16 |
+| `scripts/pr_watcher.py` | 9 |
+| `scripts/select_impacted_tests.py` | 13 |
+| `scripts/watch_owned_pr.sh` | 16 |
+| `tests/test_check_ai_reconciliation_live.py` | 255 |
+| `tests/test_codex_wake_bridge.py` | 46 |
+| `tests/test_pr_watcher.py` | 40 |
+| `tests/test_select_impacted_tests.py` | 19 |
+| `tests/test_watch_owned_pr.py` | 64 |
+| **Total** | **1189** |

--- a/scripts/check_ai_reconciliation_live.py
+++ b/scripts/check_ai_reconciliation_live.py
@@ -30,14 +30,12 @@ from __future__ import annotations
 import argparse
 import importlib.util
 import json
-import math
 import os
 import re
 import subprocess
 import sys
-import time
 from collections.abc import Sequence
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from pathlib import Path, PurePosixPath
 
 _DEFAULT_BOTS = ("chatgpt-codex-connector", "chatgpt-codex-connector[bot]")
@@ -60,6 +58,7 @@ _THREADS_QUERY = """
 query($owner:String!,$name:String!,$pr:Int!,$cursor:String){
   repository(owner:$owner,name:$name){
     pullRequest(number:$pr){
+      headRefOid
       reviewThreads(first:100, after:$cursor){
         pageInfo{ hasNextPage endCursor }
         nodes{
@@ -369,81 +368,6 @@ def _parse_github_timestamp(raw: str) -> datetime:
     return datetime.fromisoformat(raw.replace("Z", "+00:00")).astimezone(UTC)
 
 
-def updated_within_review_grace(
-    updated_at: str | None,
-    *,
-    review_grace_seconds: int,
-    now: datetime | None = None,
-) -> bool:
-    """Return true while a fresh PR update is still inside the Codex review window."""
-
-    return review_grace_remaining_seconds(
-        updated_at,
-        review_grace_seconds=review_grace_seconds,
-        now=now,
-    ) > 0
-
-
-def review_grace_remaining_seconds(
-    updated_at: str | None,
-    *,
-    review_grace_seconds: int,
-    now: datetime | None = None,
-) -> float:
-    """Return seconds left in the fresh-head Codex review window."""
-
-    if review_grace_seconds <= 0 or not updated_at:
-        return 0.0
-    reference_time = now or datetime.now(UTC)
-    if reference_time.tzinfo is None:
-        reference_time = reference_time.replace(tzinfo=UTC)
-    updated_time = _parse_github_timestamp(updated_at)
-    expires_at = updated_time + timedelta(seconds=review_grace_seconds)
-    return max(0.0, (expires_at - reference_time.astimezone(UTC)).total_seconds())
-
-
-def missing_codex_activity_inside_review_grace(
-    nodes: Sequence[dict],
-    bot_logins: Sequence[str],
-    *,
-    reviews: Sequence[dict] | None,
-    comments: Sequence[dict] | None,
-    head_sha: str | None,
-    pr_updated_at: str | None,
-    review_grace_seconds: int,
-    now: datetime | None = None,
-) -> bool:
-    """Return true only for the quiet fresh-head race the required job must wait out."""
-
-    if head_sha is None or open_bot_threads(nodes, bot_logins):
-        return False
-    if current_head_change_requests(reviews or [], head_sha=head_sha, bot_logins=bot_logins):
-        return False
-    if current_head_bot_reviews(reviews or [], head_sha=head_sha, bot_logins=bot_logins):
-        return False
-    if current_head_clean_review_comments(comments or [], head_sha=head_sha, bot_logins=bot_logins):
-        return False
-    return updated_within_review_grace(
-        pr_updated_at,
-        review_grace_seconds=review_grace_seconds,
-        now=now,
-    )
-
-
-def parse_review_grace_seconds(raw: str | int | None) -> int:
-    """Parse the review-window duration from CLI/env without argparse tracebacks."""
-
-    if raw is None:
-        return _DEFAULT_CODEX_REVIEW_GRACE_SECONDS
-    try:
-        value = int(raw)
-    except (TypeError, ValueError) as exc:
-        raise ValueError("review grace seconds must be an integer") from exc
-    if value < 0:
-        raise ValueError("review grace seconds must be non-negative")
-    return value
-
-
 def review_attestation_generation(
     reviews: Sequence[dict],
     comments: Sequence[dict] | None = None,
@@ -542,47 +466,8 @@ def evaluate(
     """Core decision (pure). Returns (exit_code, messages)."""
     messages: list[str] = []
     open_threads = open_bot_threads(nodes, bot_logins)
-    if head_sha is not None:
-        change_requests = current_head_change_requests(
-            reviews or [],
-            head_sha=head_sha,
-            bot_logins=bot_logins,
-        )
-        if change_requests:
-            messages.append(
-                "current-head Codex connector review requested changes: live "
-                f"reconciliation cannot pass PR head {head_sha} until the "
-                "changes-requested review is superseded or resolved."
-            )
-        elif not open_threads and not current_head_bot_reviews(
-            reviews or [],
-            head_sha=head_sha,
-            bot_logins=bot_logins,
-        ) and not current_head_clean_review_comments(
-            comments or [],
-            head_sha=head_sha,
-            bot_logins=bot_logins,
-        ) and updated_within_review_grace(
-            pr_updated_at,
-            review_grace_seconds=review_grace_seconds,
-            now=now,
-        ):
-            messages.append(
-                "waiting for Codex connector review window: no scoped Codex "
-                f"activity is recorded on PR head {head_sha} yet, and the PR "
-                f"was updated less than {review_grace_seconds} seconds ago."
-            )
-        elif not open_threads and is_docs_only_body(body) and changed_files_are_docs_only(changed_files or []):
-            messages.append(
-                "OK: docs-only PR diff has no open scoped Codex review threads; "
-                "current-head Codex review attestation is not required."
-            )
 
     if not open_threads:
-        if messages:
-            if all(message.startswith("OK:") for message in messages):
-                return 0, messages
-            return 1, messages
         return 0, ["OK: no open scoped Codex review threads remain."]
 
     body_class = classify_body(body)
@@ -618,30 +503,6 @@ def evaluate(
     return 1, messages
 
 
-def docs_only_exemption_needs_file_proof(
-    nodes: Sequence[dict],
-    body: str,
-    bot_logins: Sequence[str],
-    *,
-    reviews: Sequence[dict] | None,
-    comments: Sequence[dict] | None,
-    head_sha: str | None,
-) -> bool:
-    """Return true only when file proof is needed to emit the docs-only watcher signal."""
-
-    if head_sha is None or not is_docs_only_body(body):
-        return False
-    if open_bot_threads(nodes, bot_logins):
-        return False
-    if current_head_change_requests(reviews or [], head_sha=head_sha, bot_logins=bot_logins):
-        return False
-    if current_head_bot_reviews(reviews or [], head_sha=head_sha, bot_logins=bot_logins):
-        return False
-    if current_head_clean_review_comments(comments or [], head_sha=head_sha, bot_logins=bot_logins):
-        return False
-    return True
-
-
 def _gh(args: Sequence[str], gh: str) -> str:
     proc = subprocess.run(
         [gh, *args], capture_output=True, text=True, check=False
@@ -670,12 +531,14 @@ def _expect_mapping(value: object, label: str) -> dict:
     return value
 
 
-def fetch_threads(pr: int, owner: str, name: str, gh: str) -> list[dict]:
-    """Fetch ALL review threads, paginating so a PR with >100 threads cannot
+def fetch_thread_snapshot(pr: int, owner: str, name: str, gh: str) -> tuple[str, list[dict]]:
+    """Fetch the PR head and ALL review threads from the thread query only.
 
-    hide an unresolved finding past the first page and pass as clear.
+    The required live gate is thread-only, so review/comment attestation API
+    failures must not block a clear thread snapshot.
     """
     nodes: list[dict] = []
+    head_sha = ""
     cursor: str | None = None
     for page_number in range(1, _MAX_THREAD_PAGES + 1):
         args = [
@@ -694,6 +557,12 @@ def fetch_threads(pr: int, owner: str, name: str, gh: str) -> list[dict]:
         envelope = _expect_mapping(data.get("data"), "data")
         repository = _expect_mapping(envelope.get("repository"), "repository")
         pull_request = _expect_mapping(repository.get("pullRequest"), "pullRequest")
+        observed_head = pull_request.get("headRefOid")
+        if not isinstance(observed_head, str) or not observed_head:
+            raise RuntimeError("GitHub GraphQL response malformed: pullRequest.headRefOid is missing")
+        if head_sha and observed_head != head_sha:
+            raise RuntimeError("GitHub GraphQL response changed PR head during reviewThreads pagination")
+        head_sha = observed_head
         threads = _expect_mapping(pull_request.get("reviewThreads"), "reviewThreads")
         page = _expect_mapping(threads.get("pageInfo"), "reviewThreads.pageInfo")
 
@@ -717,6 +586,15 @@ def fetch_threads(pr: int, owner: str, name: str, gh: str) -> list[dict]:
         cursor = next_cursor
     else:
         raise RuntimeError(f"reviewThreads pagination exceeded {_MAX_THREAD_PAGES} pages")
+    return head_sha, nodes
+
+
+def fetch_threads(pr: int, owner: str, name: str, gh: str) -> list[dict]:
+    """Fetch ALL review threads, paginating so a PR with >100 threads cannot
+
+    hide an unresolved finding past the first page and pass as clear.
+    """
+    _, nodes = fetch_thread_snapshot(pr, owner, name, gh)
     return nodes
 
 
@@ -874,11 +752,6 @@ def fetch_pr_ref_snapshot(pr: int, repo: str, gh: str) -> PrRefSnapshot:
     )
 
 
-def fetch_pr_refs(pr: int, repo: str, gh: str) -> tuple[str, str, int]:
-    snapshot = fetch_pr_ref_snapshot(pr, repo, gh)
-    return snapshot.base_sha, snapshot.head_sha, snapshot.changed_files
-
-
 def fetch_merge_base(repo: str, base_sha: str, head_sha: str, gh: str) -> str:
     out = _gh(["api", f"repos/{repo}/compare/{base_sha}...{head_sha}", "--jq", ".merge_base_commit.sha"], gh)
     merge_base = out.strip()
@@ -1027,20 +900,6 @@ def fetch_changed_files(pr: int, repo: str, gh: str, head_sha: str | None = None
     return proof.files
 
 
-def _assert_stable_changed_file_proof(
-    *,
-    proof: ChangedFileProof,
-    after_refs: tuple[str, str, int],
-) -> None:
-    after_base, after_head, after_count = after_refs
-    if proof.base_sha != after_base:
-        raise RuntimeError("GitHub PR base changed during body/file proof fetch")
-    if proof.head_sha != after_head:
-        raise RuntimeError("GitHub PR head changed during body/file proof fetch")
-    if proof.expected_count != after_count:
-        raise RuntimeError("GitHub PR changed-file count changed during body/file proof fetch")
-
-
 def fetch_consistent_review_thread_snapshot(
     pr: int,
     owner: str,
@@ -1048,41 +907,15 @@ def fetch_consistent_review_thread_snapshot(
     gh: str,
     bot_logins: Sequence[str],
 ) -> tuple[list[dict], str, list[dict], list[dict]]:
-    """Fetch reviews/threads twice and fail closed if either generation moves."""
+    """Fetch threads twice and fail closed only if head or thread state moves."""
 
-    head_before, reviews_before = fetch_review_attestation(pr, owner, name, gh)
-    comment_head_before, comments_before = fetch_comment_attestation(pr, owner, name, gh)
-    nodes_before = fetch_threads(pr, owner, name, gh)
-    head_middle, reviews_middle = fetch_review_attestation(pr, owner, name, gh)
-    comment_head_middle, comments_middle = fetch_comment_attestation(pr, owner, name, gh)
-    nodes_after = fetch_threads(pr, owner, name, gh)
-    head_after, reviews_after = fetch_review_attestation(pr, owner, name, gh)
-    comment_head_after, comments_after = fetch_comment_attestation(pr, owner, name, gh)
-    if len({head_before, head_middle, head_after, comment_head_before, comment_head_middle, comment_head_after}) != 1:
+    head_before, nodes_before = fetch_thread_snapshot(pr, owner, name, gh)
+    head_after, nodes_after = fetch_thread_snapshot(pr, owner, name, gh)
+    if head_before != head_after:
         raise RuntimeError("GitHub PR head changed during review/thread snapshot fetch")
-    before_generation = review_attestation_generation(
-        reviews_before,
-        comments_before,
-        head_sha=head_before,
-        bot_logins=bot_logins,
-    )
-    after_generation = review_attestation_generation(
-        reviews_after,
-        comments_after,
-        head_sha=head_after,
-        bot_logins=bot_logins,
-    )
-    middle_generation = review_attestation_generation(
-        reviews_middle,
-        comments_middle,
-        head_sha=head_middle,
-        bot_logins=bot_logins,
-    )
-    if before_generation != middle_generation or middle_generation != after_generation:
-        raise RuntimeError("GitHub Codex review generation changed during review/thread snapshot fetch")
     if review_thread_generation(nodes_before) != review_thread_generation(nodes_after):
         raise RuntimeError("GitHub review thread generation changed during review/thread snapshot fetch")
-    return nodes_after, head_after, reviews_after, comments_after
+    return nodes_after, head_after, [], []
 
 
 def _assert_stable_review_thread_state(
@@ -1095,20 +928,6 @@ def _assert_stable_review_thread_state(
     after_nodes, after_head, after_reviews, after_comments = after
     if before_head != after_head:
         raise RuntimeError("GitHub PR head changed during body/file proof fetch")
-    before_generation = review_attestation_generation(
-        before_reviews,
-        before_comments,
-        head_sha=before_head,
-        bot_logins=bot_logins,
-    )
-    after_generation = review_attestation_generation(
-        after_reviews,
-        after_comments,
-        head_sha=after_head,
-        bot_logins=bot_logins,
-    )
-    if before_generation != after_generation:
-        raise RuntimeError("GitHub Codex review generation changed during body/file proof fetch")
     if review_thread_generation(before_nodes) != review_thread_generation(after_nodes):
         raise RuntimeError("GitHub review thread generation changed during body/file proof fetch")
 
@@ -1153,23 +972,22 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     parser.add_argument(
         "--pr-updated-at",
-        help="GitHub PR updatedAt timestamp for fresh-head Codex review-window checks",
+        help="Deprecated compatibility input; live reconciliation no longer waits on PR updatedAt.",
     )
     parser.add_argument(
         "--review-grace-seconds",
         default=os.environ.get("ATLAS_CODEX_REVIEW_GRACE_SECONDS", str(_DEFAULT_CODEX_REVIEW_GRACE_SECONDS)),
-        help="seconds after a PR update to wait for Codex activity before allowing a quiet no-thread pass",
+        help="Deprecated compatibility input; ignored by the open-thread-only gate.",
     )
     parser.add_argument(
         "--wait-for-review-window",
         action="store_true",
-        help="wait/refetch once when a live PR is still inside the fresh-head review window",
+        help="Deprecated compatibility flag; accepted but ignored.",
     )
     args = parser.parse_args(argv)
 
     try:
         bots = parse_bot_logins(args.bots)
-        review_grace_seconds = parse_review_grace_seconds(args.review_grace_seconds)
     except ValueError as exc:
         print(f"live reconciliation: {exc}", file=sys.stderr)
         return 2
@@ -1179,7 +997,6 @@ def main(argv: Sequence[str] | None = None) -> int:
         reviews: Sequence[dict] | None = None
         comments: Sequence[dict] | None = None
         changed_files: Sequence[dict] | None = None
-        changed_file_proof: ChangedFileProof | None = None
         pr_updated_at = args.pr_updated_at
         if pr_updated_at is not None:
             _parse_github_timestamp(pr_updated_at)
@@ -1218,89 +1035,6 @@ def main(argv: Sequence[str] | None = None) -> int:
         else:
             body = ""
 
-        if pr_updated_at is None and args.pr is not None and args.repo and not args.threads_file:
-            pr_updated_at = fetch_pr_updated_at(args.pr, args.repo, args.gh)
-
-        if (
-            args.wait_for_review_window
-            and not args.threads_file
-            and args.pr is not None
-            and args.repo
-            and missing_codex_activity_inside_review_grace(
-                nodes,
-                bots,
-                reviews=reviews,
-                comments=comments,
-                head_sha=head_sha,
-                pr_updated_at=pr_updated_at,
-                review_grace_seconds=review_grace_seconds,
-            )
-        ):
-            remaining = review_grace_remaining_seconds(
-                pr_updated_at,
-                review_grace_seconds=review_grace_seconds,
-            )
-            wait_seconds = max(1, math.ceil(remaining))
-            print(
-                "live reconciliation: waiting "
-                f"{wait_seconds} second(s) for the Codex review window to close",
-                file=sys.stderr,
-            )
-            time.sleep(wait_seconds)
-            before_snapshot = fetch_consistent_review_thread_snapshot(
-                args.pr,
-                owner,
-                name,
-                args.gh,
-                bots,
-            )
-            nodes, head_sha, reviews, comments = before_snapshot
-            body = fetch_body(args.pr, args.repo, args.gh)
-            pr_updated_at = fetch_pr_updated_at(args.pr, args.repo, args.gh)
-            changed_files = None
-            changed_file_proof = None
-
-        needs_live_changed_file_proof = (
-            changed_files is None
-            and args.pr is not None
-            and args.repo
-            and docs_only_exemption_needs_file_proof(
-                nodes,
-                body,
-                bots,
-                reviews=reviews,
-                comments=comments,
-                head_sha=head_sha,
-            )
-        )
-        if needs_live_changed_file_proof:
-            changed_file_proof = fetch_changed_file_proof(args.pr, args.repo, args.gh, head_sha=head_sha)
-            changed_files = changed_file_proof.files
-        if needs_live_changed_file_proof and not args.threads_file and args.pr is not None and args.repo:
-            body_after = fetch_body(args.pr, args.repo, args.gh)
-            after_snapshot = fetch_consistent_review_thread_snapshot(
-                args.pr,
-                owner,
-                name,
-                args.gh,
-                bots,
-            )
-            body_final = fetch_body(args.pr, args.repo, args.gh)
-            after_refs = fetch_pr_refs(args.pr, args.repo, args.gh)
-            if body != body_after or body != body_final:
-                raise RuntimeError("GitHub PR body changed during body/file proof fetch")
-            if changed_file_proof is None:
-                raise RuntimeError("changed-file proof missing during body/file proof fetch")
-            _assert_stable_changed_file_proof(
-                proof=changed_file_proof,
-                after_refs=after_refs,
-            )
-            _assert_stable_review_thread_state(
-                before=before_snapshot,
-                after=after_snapshot,
-                bot_logins=bots,
-            )
-            nodes, head_sha, reviews, comments = after_snapshot
     except (OSError, ValueError, RuntimeError) as exc:
         print(f"live reconciliation: GitHub API/read error: {exc}", file=sys.stderr)
         return 2
@@ -1314,7 +1048,6 @@ def main(argv: Sequence[str] | None = None) -> int:
         changed_files=changed_files,
         head_sha=head_sha,
         pr_updated_at=pr_updated_at,
-        review_grace_seconds=review_grace_seconds,
     )
     print("live AI reconciliation check")
     print("-" * 60)

--- a/scripts/codex_wake_bridge.py
+++ b/scripts/codex_wake_bridge.py
@@ -84,7 +84,6 @@ def attention_blockers(status: dict[str, Any]) -> list[str]:
         "checks_error",
         "reviews_error",
         "review_threads_error",
-        "codex_reviews_error",
     ):
         if _truthy(status.get(key)):
             blockers.append(key)
@@ -147,19 +146,6 @@ def readiness_blockers(status: dict[str, Any]) -> list[str]:
     elif unresolved:
         blockers.append(f"unresolved review threads remain: {len(unresolved)}")
 
-    if proof.get("codex_reviews_complete") is not True:
-        blockers.append("Codex review pagination is incomplete")
-    codex_pages = proof.get("codex_review_pages_fetched")
-    if not _non_negative_int(codex_pages) or codex_pages < 1:
-        blockers.append("Codex review pages fetched must be at least 1")
-    codex_head_reviews = proof.get("codex_head_review_count")
-    docs_only_exemption = proof.get("docs_only_reconciliation_exemption") is True
-    if (
-        not _non_negative_int(codex_head_reviews)
-        or (codex_head_reviews < 1 and not docs_only_exemption)
-    ):
-        blockers.append("current-head Codex review attestation is missing")
-
     if "review_decision" not in proof or "reviewDecision" not in pr:
         blockers.append("review decision evidence is missing")
     else:
@@ -167,8 +153,6 @@ def readiness_blockers(status: dict[str, Any]) -> list[str]:
         pr_decision = str(pr.get("reviewDecision") or "").upper()
         if proof_decision != pr_decision:
             blockers.append("review decision does not match PR metadata")
-        if proof_decision == "CHANGES_REQUESTED":
-            blockers.append("review decision has changes requested")
 
     proof_merge = proof.get("merge_state_status")
     pr_merge = pr.get("mergeStateStatus")

--- a/scripts/pr_watcher.py
+++ b/scripts/pr_watcher.py
@@ -859,7 +859,6 @@ def _classify(
     unresolved_threads: list[dict[str, Any]],
     reviews_complete: bool,
     codex_head_review_count: int,
-    docs_only_reconciliation_exemption: bool,
     reconciliation_code: int,
     review_changed: bool,
 ) -> str:
@@ -876,12 +875,8 @@ def _classify(
     if (
         not threads_complete
         or unresolved_threads
-        or not reviews_complete
-        or (codex_head_review_count < 1 and not docs_only_reconciliation_exemption)
         or pr.get("isDraft") is not False
     ):
-        return "attention"
-    if str(pr.get("reviewDecision") or "").upper() == "CHANGES_REQUESTED":
         return "attention"
     if review_changed:
         return "review_changed"
@@ -1129,7 +1124,6 @@ def produce(watcher_id: str, *, config_dir: Path, state_dir: Path) -> tuple[int,
             checks_error,
             reviews_error,
             threads_error,
-            codex_reviews_error,
         )
         if item
     ]
@@ -1148,7 +1142,6 @@ def produce(watcher_id: str, *, config_dir: Path, state_dir: Path) -> tuple[int,
         unresolved_threads=unresolved_threads,
         reviews_complete=reviews_complete,
         codex_head_review_count=codex_head_review_count,
-        docs_only_reconciliation_exemption=docs_only_reconciliation_exemption,
         reconciliation_code=reconciliation_code,
         review_changed=review_changed,
     )
@@ -1250,7 +1243,7 @@ def produce(watcher_id: str, *, config_dir: Path, state_dir: Path) -> tuple[int,
                 f"{len(required_failures)} failed, {len(required_pending)} pending"
             ),
             f"Unresolved review threads: {len(unresolved_threads)} across {thread_pages} fetched page(s)",
-            f"Current-head Codex review attestations: {codex_head_review_count} across {review_pages} fetched page(s)",
+            f"Codex review diagnostics: {codex_head_review_count} current-head clean review(s) across {review_pages} fetched page(s)",
             f"Reviews/comments: {review_count} reviews, {comment_count} comments",
             f"Review changed since last poll: {'yes' if review_changed else 'no'}",
             f"AI reconciliation: {'pass' if reconciliation_code == 0 else 'fail'}",

--- a/scripts/select_impacted_tests.py
+++ b/scripts/select_impacted_tests.py
@@ -69,6 +69,13 @@ EXPLICIT_TEST_OWNERS: dict[str, tuple[str, ...]] = {
     ".github/workflows/branch_protection_required_checks.yml": (
         "tests/test_security_guardrails_workflow.py",
     ),
+    ".github/workflows/ai_reconciliation_live.yml": (
+        "tests/test_audit_workflow_security_posture.py",
+        "tests/test_check_ai_reconciliation_live.py",
+    ),
+    ".github/workflows/ai_reconciliation_review_retrigger.yml": (
+        "tests/test_check_ai_reconciliation_live.py",
+    ),
     ".github/workflows/unit_gate.yml": (
         "tests/test_check_unit_gate.py",
         "tests/test_select_impacted_tests.py",
@@ -79,6 +86,12 @@ EXPLICIT_TEST_OWNERS: dict[str, tuple[str, ...]] = {
     ),
     "scripts/check_required_status_checks.py": (
         "tests/test_security_guardrails_workflow.py",
+    ),
+    "scripts/check_ai_reconciliation_live.py": (
+        "tests/test_check_ai_reconciliation_live.py",
+    ),
+    "scripts/codex_wake_bridge.py": (
+        "tests/test_codex_wake_bridge.py",
     ),
     "scripts/check_unit_gate.py": (
         "tests/test_check_unit_gate.py",

--- a/scripts/watch_owned_pr.sh
+++ b/scripts/watch_owned_pr.sh
@@ -4,12 +4,9 @@
 # is something to act on:
 #   MERGED/CLOSED - PR reached terminal state (stop watching)
 #   HEAD-MOVED    - branch advanced past the SHA this watch was armed on
-#   ACTIONABLE    - red required context / unresolved review threads /
-#                   CHANGES_REQUESTED review decision
+#   ACTIONABLE    - red required context / unresolved Codex review threads
 #   MERGE-READY   - EVERY required context present and success +
-#                   Codex review attestation exists on this exact head SHA +
-#                   0 unresolved threads (no unfetched pages) +
-#                   review decision not CHANGES_REQUESTED + mergeable
+#                   0 unresolved Codex threads (no unfetched pages) + mergeable
 # Required contexts are read from origin/main's ci/gates.yml and the app pin is
 # read from origin/main's scripts/check_required_status_checks.py (trusted ref
 # -- the watched branch cannot weaken its own gate); MERGE-READY requires their
@@ -229,12 +226,12 @@ for i in $(seq 0 "$CYCLES"); do
   echo "cycle $i $(date +%H:%M): state=$STATE req-green=$REQGREEN/$REQ_TOTAL req-red=$REQRED req-unsettled=$REQUNSETTLED pending=$PEND codex-head-attestations=$CODEX_HEAD_REVIEWS attestation-pages=$REVIEW_PAGES attestations-complete=$REVIEWS_COMPLETE threads=$UNRES decision=$DECISION mergeable=$MERGEABLE merge-state=$MSTATE"
   case "$STATE" in MERGED/merged|CLOSED) echo "TERMINAL: PR $STATE"; exit 0;; esac
   # Definite negatives are actionable on ANY cycle, including the first.
-  if [ "$REQRED" -gt 0 ] || [ "$UNRES" != "0" ] || [ "$DECISION" = "CHANGES_REQUESTED" ] || [ "$REVIEWS_COMPLETE" != "true" ]; then
+  if [ "$REQRED" -gt 0 ] || [ "$UNRES" != "0" ]; then
     echo "ACTIONABLE: req-red=$REQRED codex-head-attestations=$CODEX_HEAD_REVIEWS threads=$UNRES decision=$DECISION -> reconcile/fix, push, re-arm"; exit 0
   fi
   # Readiness is presence-based: every required context must be reporting
   # success (a not-yet-started context keeps this false, so no early race).
-  if [ "$REQGREEN" -eq "$REQ_TOTAL" ] && [ "$REQUNSETTLED" -eq 0 ] && [ "$CODEX_HEAD_REVIEWS" -gt 0 ] && [ "$MERGEABLE" = "MERGEABLE" ] \
+  if [ "$REQGREEN" -eq "$REQ_TOTAL" ] && [ "$REQUNSETTLED" -eq 0 ] && [ "$MERGEABLE" = "MERGEABLE" ] \
      && { [ "$MSTATE" = "CLEAN" ] || [ "$MSTATE" = "UNSTABLE" ]; }; then
     CUR=$(GH_TOKEN="$TOK" gh api "repos/$REPO/pulls/$PR" --jq '.head.sha' 2>/dev/null) || { echo "cycle $i: API error before readiness, retrying"; continue; }
     if [ "$CUR" != "$SHA" ]; then echo "HEAD-MOVED: ${SHA:0:9} -> ${CUR:0:9} (new push; reconcile + re-arm on new head)"; exit 0; fi
@@ -330,13 +327,12 @@ for i in $(seq 0 "$CYCLES"); do
     FINAL_REQRED=$(echo "$FINAL_REQLATEST" | jq --argjson req "$REQ_JSON" '[.[]|select(.name as $n|$req|index($n))|select(.status=="completed" and (.conclusion|IN("failure","cancelled","timed_out","action_required","stale","startup_failure")))]|length')
     FINAL_REQGREEN=$(echo "$FINAL_REQLATEST" | jq --argjson req "$REQ_JSON" '[.[]|select(.name as $n|$req|index($n))|select(.status=="completed" and (.conclusion|IN("success","neutral","skipped")))]|length')
     FINAL_REQUNSETTLED=$(echo "$FINAL_CR" | jq --argjson app "$REQ_APP_ID" --argjson req "$REQ_JSON" '[.check_runs[]|select(.app.id==$app)|select(.name as $n|$req|index($n))|select(.status!="completed")]|length')
-    if [ "$FINAL_UNRES" != "0" ] || [ "$FINAL_DECISION" = "CHANGES_REQUESTED" ] || [ "$FINAL_MERGEABLE" != "MERGEABLE" ] \
+    if [ "$FINAL_UNRES" != "0" ] || [ "$FINAL_MERGEABLE" != "MERGEABLE" ] \
        || { [ "$FINAL_MSTATE" != "CLEAN" ] && [ "$FINAL_MSTATE" != "UNSTABLE" ]; } \
-       || [ "$FINAL_REVIEWS_COMPLETE" != "true" ] || [ "$FINAL_CODEX_HEAD_REVIEWS" -eq 0 ] \
        || [ "$FINAL_REQRED" -gt 0 ] || [ "$FINAL_REQGREEN" -ne "$REQ_TOTAL" ] || [ "$FINAL_REQUNSETTLED" -ne 0 ]; then
       echo "ACTIONABLE: final-read req-green=$FINAL_REQGREEN/$REQ_TOTAL req-red=$FINAL_REQRED req-unsettled=$FINAL_REQUNSETTLED codex-head-attestations=$FINAL_CODEX_HEAD_REVIEWS attestation-pages=$FINAL_REVIEW_PAGES attestations-complete=$FINAL_REVIEWS_COMPLETE threads=$FINAL_UNRES decision=$FINAL_DECISION mergeable=$FINAL_MERGEABLE merge-state=$FINAL_MSTATE -> reconcile/fix, push, re-arm"; exit 0
     fi
-    echo "MERGE-READY: all $REQ_TOTAL required contexts green + current-head Codex review attestation + threads clear + merge-state $MSTATE."
+    echo "MERGE-READY: all $REQ_TOTAL required contexts green + Codex threads clear + merge-state $MSTATE."
     echo "-> pre-merge checklist first (clean tree, local==remote, re-verify threads=0), then merge + alert."
     exit 0
   fi

--- a/tests/test_check_ai_reconciliation_live.py
+++ b/tests/test_check_ai_reconciliation_live.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from pathlib import Path
 
 SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "check_ai_reconciliation_live.py"
@@ -76,17 +76,6 @@ def changed_file(
     return item
 
 
-def changed_file_proof(c, files=None, *, base="base-a", head="head-a", merge_base=None, expected_count=None):
-    file_list = list(files if files is not None else [changed_file("docs/a.md")])
-    return c.ChangedFileProof(
-        base_sha=base,
-        head_sha=head,
-        merge_base_sha=merge_base or "a" * 40,
-        expected_count=len(file_list) if expected_count is None else expected_count,
-        files=file_list,
-    )
-
-
 BODY_CLEAR = "## AI reconciliation\n- All fixed or waived: Yes\n"
 BODY_OPEN = "## AI reconciliation\n- fixed or waived: No\n"
 BODY_ABSENT = "## Summary\njust a normal PR body\n"
@@ -119,6 +108,10 @@ def test_supported_review_events_retrigger_required_live_context():
     assert "head_sha=$(gh api" not in text
     assert "head_sha=${head_sha}" in text
     assert "actions/runs/${run_id}/rerun" in text
+    assert "timeout-minutes: 15" in text
+    assert "target run ${run_id} is ${status:-unknown}" in text
+    assert "actions/runs/${run_id}\" --jq '.status // empty'" in text
+    assert "rerun request for ${run_id} was rejected" in text
 
 
 # --- open_bot_threads filtering -------------------------------------------
@@ -341,7 +334,7 @@ def test_missing_current_head_codex_review_passes_when_threads_are_clear():
     assert any("no open scoped Codex review threads remain" in msg for msg in msgs)
 
 
-def test_missing_current_head_codex_review_waits_inside_fresh_update_window():
+def test_missing_current_head_codex_review_passes_inside_fresh_update_window():
     c = load_check()
     code, msgs = c.evaluate(
         [thread(resolved=True)],
@@ -354,8 +347,8 @@ def test_missing_current_head_codex_review_waits_inside_fresh_update_window():
         now=datetime(2026, 7, 30, 18, 2, tzinfo=UTC),
     )
 
-    assert code == 1
-    assert any("waiting for Codex connector review window" in msg for msg in msgs)
+    assert code == 0
+    assert any("no open scoped Codex review threads remain" in msg for msg in msgs)
 
 
 def test_missing_current_head_codex_review_passes_after_fresh_update_window():
@@ -388,10 +381,10 @@ def test_docs_only_no_open_threads_passes_without_current_head_review():
     )
 
     assert code == 0
-    assert any("docs-only PR diff has no open scoped Codex review threads" in msg for msg in msgs)
+    assert any("no open scoped Codex review threads remain" in msg for msg in msgs)
 
 
-def test_docs_only_current_head_change_request_still_fails_with_valid_file_proof():
+def test_docs_only_current_head_change_request_does_not_block_without_open_threads():
     c = load_check()
     code, msgs = c.evaluate(
         [thread(resolved=True)],
@@ -403,9 +396,8 @@ def test_docs_only_current_head_change_request_still_fails_with_valid_file_proof
         head_sha="head-a",
     )
 
-    assert code == 1
-    assert any("requested changes" in msg for msg in msgs)
-    assert not any("docs-only PR diff" in msg for msg in msgs)
+    assert code == 0
+    assert any("no open scoped Codex review threads remain" in msg for msg in msgs)
 
 
 def test_docs_only_non_markdown_diff_passes_when_threads_are_clear():
@@ -440,7 +432,7 @@ def test_docs_only_open_codex_thread_still_fails_without_ai_record():
     assert any("atlas_brain/x.py:12" in msg for msg in msgs)
 
 
-def test_current_head_changes_requested_review_fails_even_without_open_threads():
+def test_current_head_changes_requested_review_does_not_block_without_open_threads():
     c = load_check()
     code, msgs = c.evaluate(
         [thread(resolved=True)],
@@ -450,8 +442,8 @@ def test_current_head_changes_requested_review_fails_even_without_open_threads()
         head_sha="head-a",
     )
 
-    assert code == 1
-    assert any("requested changes" in msg for msg in msgs)
+    assert code == 0
+    assert any("no open scoped Codex review threads remain" in msg for msg in msgs)
 
 
 def test_current_head_codex_review_plus_no_open_threads_passes():
@@ -482,39 +474,7 @@ def test_current_head_clean_review_comment_plus_no_open_threads_passes():
     assert any("no open scoped Codex review threads remain" in msg for msg in msgs)
 
 
-def test_docs_only_exemption_skips_file_proof_when_current_head_review_already_present():
-    c = load_check()
-
-    assert (
-        c.docs_only_exemption_needs_file_proof(
-            [thread(resolved=True)],
-            BODY_DOCS_ONLY,
-            BOTS,
-            reviews=[review(commit="head-a")],
-            comments=[],
-            head_sha="head-a",
-        )
-        is False
-    )
-
-
-def test_docs_only_exemption_needs_file_proof_for_watcher_signal():
-    c = load_check()
-
-    assert (
-        c.docs_only_exemption_needs_file_proof(
-            [thread(resolved=True)],
-            BODY_DOCS_ONLY,
-            BOTS,
-            reviews=[],
-            comments=[],
-            head_sha="head-a",
-        )
-        is True
-    )
-
-
-def test_changes_requested_review_overrides_clean_review_comment():
+def test_changes_requested_review_does_not_override_clean_review_comment_without_open_threads():
     c = load_check()
     code, msgs = c.evaluate(
         [thread(resolved=True)],
@@ -525,8 +485,8 @@ def test_changes_requested_review_overrides_clean_review_comment():
         head_sha="abc1234567890",
     )
 
-    assert code == 1
-    assert any("requested changes" in msg for msg in msgs)
+    assert code == 0
+    assert any("no open scoped Codex review threads remain" in msg for msg in msgs)
 
 
 # --- main() via injection (no live GitHub) --------------------------------
@@ -618,7 +578,7 @@ def test_main_accepts_docs_only_without_current_head_review_when_threads_clear(t
     ) == 0
 
 
-def test_main_malformed_review_window_config_exit_2(monkeypatch, tmp_path):
+def test_main_ignores_malformed_review_window_config(monkeypatch, tmp_path):
     monkeypatch.setenv("ATLAS_CODEX_REVIEW_GRACE_SECONDS", "not-an-int")
     c = load_check()
     tf = tmp_path / "threads.json"
@@ -626,7 +586,7 @@ def test_main_malformed_review_window_config_exit_2(monkeypatch, tmp_path):
     bf = tmp_path / "body.md"
     bf.write_text(BODY_CLEAR, encoding="utf-8")
 
-    assert c.main(["--threads-file", str(tf), "--body-file", str(bf)]) == 2
+    assert c.main(["--threads-file", str(tf), "--body-file", str(bf)]) == 0
 
 
 def test_main_malformed_pr_updated_at_exit_2(tmp_path):
@@ -650,14 +610,12 @@ def test_main_malformed_pr_updated_at_exit_2(tmp_path):
     ) == 2
 
 
-def test_main_live_default_does_not_sleep_inside_review_window(monkeypatch, tmp_path):
+def test_main_live_default_does_not_refetch_inside_review_window(monkeypatch, tmp_path):
     c = load_check()
-    fresh_updated_at = (datetime.now(UTC) - timedelta(seconds=299)).isoformat().replace("+00:00", "Z")
     snapshots = [
         ([thread(resolved=True)], "head-a", [], []),
         ([thread(resolved=True)], "head-a", [], []),
     ]
-    sleeps = []
     bf = tmp_path / "body.md"
     bf.write_text(BODY_CLEAR, encoding="utf-8")
 
@@ -666,24 +624,18 @@ def test_main_live_default_does_not_sleep_inside_review_window(monkeypatch, tmp_
 
     monkeypatch.setattr(c, "fetch_consistent_review_thread_snapshot", fake_snapshot)
     monkeypatch.setattr(c, "fetch_body", lambda pr, repo, gh: BODY_CLEAR)
-    monkeypatch.setattr(c, "fetch_pr_updated_at", lambda pr, repo, gh: fresh_updated_at)
-    monkeypatch.setattr(c.time, "sleep", lambda seconds: sleeps.append(seconds))
+    monkeypatch.setattr(c, "fetch_pr_updated_at", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError()))
 
-    assert c.main(["--pr", "1431", "--repo", "owner/name", "--body-file", str(bf), "--gh", "gh"]) == 1
-    assert sleeps == []
+    assert c.main(["--pr", "1431", "--repo", "owner/name", "--body-file", str(bf), "--gh", "gh"]) == 0
     assert len(snapshots) == 1
 
 
-def test_main_live_waits_and_refetches_after_review_window(monkeypatch, tmp_path):
+def test_main_live_wait_flag_is_noop_inside_review_window(monkeypatch, tmp_path):
     c = load_check()
-    fresh_updated_at = (datetime.now(UTC) - timedelta(seconds=299)).isoformat().replace("+00:00", "Z")
-    stale_updated_at = (datetime.now(UTC) - timedelta(seconds=301)).isoformat().replace("+00:00", "Z")
     snapshots = [
         ([thread(resolved=True)], "head-a", [], []),
         ([thread(resolved=True)], "head-a", [], []),
     ]
-    updated_at_values = [fresh_updated_at, stale_updated_at]
-    sleeps = []
     bf = tmp_path / "body.md"
     bf.write_text(BODY_CLEAR, encoding="utf-8")
 
@@ -692,8 +644,7 @@ def test_main_live_waits_and_refetches_after_review_window(monkeypatch, tmp_path
 
     monkeypatch.setattr(c, "fetch_consistent_review_thread_snapshot", fake_snapshot)
     monkeypatch.setattr(c, "fetch_body", lambda pr, repo, gh: BODY_CLEAR)
-    monkeypatch.setattr(c, "fetch_pr_updated_at", lambda pr, repo, gh: updated_at_values.pop(0))
-    monkeypatch.setattr(c.time, "sleep", lambda seconds: sleeps.append(seconds))
+    monkeypatch.setattr(c, "fetch_pr_updated_at", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError()))
 
     assert c.main(
         [
@@ -708,26 +659,20 @@ def test_main_live_waits_and_refetches_after_review_window(monkeypatch, tmp_path
             "--wait-for-review-window",
         ]
     ) == 0
-    assert len(sleeps) == 1
-    assert not snapshots
-    assert not updated_at_values
+    assert len(snapshots) == 1
 
 
-def test_main_live_fetch_fails_when_review_generation_changes(monkeypatch, tmp_path):
+def test_main_live_fetch_does_not_call_review_or_comment_attestation(monkeypatch, tmp_path):
     c = load_check()
     bf = tmp_path / "body.md"
     bf.write_text(BODY_CLEAR, encoding="utf-8")
-    calls = {"reviews": 0}
 
     def fake_gh(args, gh):
         query = " ".join(args)
         if "reviews(first:100" in query:
-            calls["reviews"] += 1
-            if calls["reviews"] == 1:
-                return _review_page([], has_next=False)
-            return _review_page([review()], has_next=False)
+            raise AssertionError("thread-only live fetch must not call reviews")
         if "comments(first:100" in query:
-            return _comment_page([], has_next=False)
+            raise AssertionError("thread-only live fetch must not call comments")
         if "reviewThreads" in query:
             return _page([], has_next=False)
         if "/pulls/1431/files" in query:
@@ -736,11 +681,10 @@ def test_main_live_fetch_fails_when_review_generation_changes(monkeypatch, tmp_p
 
     monkeypatch.setattr(c, "_gh", fake_gh)
 
-    assert c.main(["--pr", "1431", "--repo", "owner/name", "--body-file", str(bf), "--gh", "gh"]) == 2
-    assert calls["reviews"] == 3
+    assert c.main(["--pr", "1431", "--repo", "owner/name", "--body-file", str(bf), "--gh", "gh"]) == 0
 
 
-def test_main_fetches_file_proof_for_docs_only_watcher_signal(monkeypatch, tmp_path):
+def test_main_does_not_fetch_file_proof_for_docs_only_no_thread_signal(monkeypatch, tmp_path):
     c = load_check()
     bf = tmp_path / "body.md"
     bf.write_text(BODY_DOCS_ONLY, encoding="utf-8")
@@ -750,9 +694,8 @@ def test_main_fetches_file_proof_for_docs_only_watcher_signal(monkeypatch, tmp_p
         "fetch_consistent_review_thread_snapshot",
         lambda pr, owner, name, gh, bot_logins: ([thread(resolved=True)], "head-a", [], []),
     )
-    monkeypatch.setattr(c, "fetch_changed_file_proof", lambda pr, repo, gh, head_sha=None: changed_file_proof(c))
-    monkeypatch.setattr(c, "fetch_pr_refs", lambda pr, repo, gh: ("base-a", "head-a", 1))
-    monkeypatch.setattr(c, "fetch_pr_updated_at", lambda pr, repo, gh: "2026-07-30T18:00:00Z")
+    monkeypatch.setattr(c, "fetch_changed_file_proof", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError()))
+    monkeypatch.setattr(c, "fetch_pr_updated_at", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError()))
     monkeypatch.setattr(c, "fetch_body", lambda pr, repo, gh: BODY_DOCS_ONLY)
 
     assert c.main(["--pr", "1431", "--repo", "owner/name", "--body-file", str(bf), "--gh", "gh"]) == 0
@@ -769,7 +712,7 @@ def test_main_does_not_fetch_file_proof_for_non_docs_body(monkeypatch, tmp_path)
         lambda pr, owner, name, gh, bot_logins: ([thread(resolved=True)], "head-a", [review(commit="head-a")], []),
     )
     monkeypatch.setattr(c, "fetch_changed_file_proof", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError()))
-    monkeypatch.setattr(c, "fetch_pr_updated_at", lambda pr, repo, gh: "2026-07-30T18:00:00Z")
+    monkeypatch.setattr(c, "fetch_pr_updated_at", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError()))
 
     assert c.main(["--pr", "1431", "--repo", "owner/name", "--body-file", str(bf), "--gh", "gh"]) == 0
 
@@ -1028,12 +971,15 @@ def test_main_legacy_bot_alias_exit_2(tmp_path):
 
 # --- pagination: a thread past the first page must not be missed -----------
 
-def _page(nodes, *, has_next, cursor=None):
+def _page(nodes, *, head="head-a", has_next, cursor=None):
     return json.dumps(
-        {"data": {"repository": {"pullRequest": {"reviewThreads": {
-            "pageInfo": {"hasNextPage": has_next, "endCursor": cursor},
-            "nodes": nodes,
-        }}}}}
+        {"data": {"repository": {"pullRequest": {
+            "headRefOid": head,
+            "reviewThreads": {
+                "pageInfo": {"hasNextPage": has_next, "endCursor": cursor},
+                "nodes": nodes,
+            },
+        }}}}
     )
 
 
@@ -1110,10 +1056,13 @@ def test_fetch_threads_malformed_page_info_fails_closed(monkeypatch):
         c,
         "_gh",
         lambda args, gh: json.dumps(
-            {"data": {"repository": {"pullRequest": {"reviewThreads": {
-                "pageInfo": {},
-                "nodes": [],
-            }}}}}
+            {"data": {"repository": {"pullRequest": {
+                "headRefOid": "head-a",
+                "reviewThreads": {
+                    "pageInfo": {},
+                    "nodes": [],
+                },
+            }}}}
         ),
     )
 
@@ -1136,6 +1085,29 @@ def test_fetch_threads_page_cap_exhaustion_fails_closed(monkeypatch):
         assert "pagination exceeded 1 pages" in str(exc)
     else:  # pragma: no cover - assertion clarity
         raise AssertionError("pagination cap exhaustion must fail closed")
+
+
+def test_fetch_thread_snapshot_head_change_fails_closed(monkeypatch):
+    c = load_check()
+    pages = [
+        _page([], head="head-a", has_next=True, cursor="C1"),
+        _page([], head="head-b", has_next=False),
+    ]
+    seen = {"n": 0}
+
+    def fake_gh(args, gh):
+        out = pages[seen["n"]]
+        seen["n"] += 1
+        return out
+
+    monkeypatch.setattr(c, "_gh", fake_gh)
+
+    try:
+        c.fetch_thread_snapshot(1431, "owner", "name", "gh")
+    except RuntimeError as exc:
+        assert "changed PR head" in str(exc)
+    else:  # pragma: no cover - assertion clarity
+        raise AssertionError("head changes during thread pagination must fail closed")
 
 
 def test_fetch_review_attestation_paginates(monkeypatch):
@@ -1204,24 +1176,15 @@ def test_fetch_review_attestation_head_change_fails_closed(monkeypatch):
         raise AssertionError("head changes during review pagination must fail closed")
 
 
-def test_consistent_snapshot_refetches_threads_after_attestation(monkeypatch):
+def test_consistent_snapshot_refetches_threads(monkeypatch):
     c = load_check()
-    calls = {"reviews": 0, "threads": 0}
+    calls = {"snapshots": 0}
 
-    def fake_fetch_reviews(pr, owner, name, gh):
-        calls["reviews"] += 1
-        return "head-a", [review(commit="head-a")]
+    def fake_fetch_thread_snapshot(pr, owner, name, gh):
+        calls["snapshots"] += 1
+        return "head-a", [thread(path=f"snapshot-{calls['snapshots']}.py")]
 
-    def fake_fetch_comments(pr, owner, name, gh):
-        return "head-a", []
-
-    def fake_fetch_threads(pr, owner, name, gh):
-        calls["threads"] += 1
-        return [thread(path=f"snapshot-{calls['threads']}.py")]
-
-    monkeypatch.setattr(c, "fetch_review_attestation", fake_fetch_reviews)
-    monkeypatch.setattr(c, "fetch_comment_attestation", fake_fetch_comments)
-    monkeypatch.setattr(c, "fetch_threads", fake_fetch_threads)
+    monkeypatch.setattr(c, "fetch_thread_snapshot", fake_fetch_thread_snapshot)
 
     try:
         c.fetch_consistent_review_thread_snapshot(1431, "owner", "name", "gh", BOTS)
@@ -1229,46 +1192,46 @@ def test_consistent_snapshot_refetches_threads_after_attestation(monkeypatch):
         assert "review thread generation changed" in str(exc)
     else:  # pragma: no cover - assertion clarity
         raise AssertionError("thread movement during snapshot fetch must fail closed")
-    assert calls == {"reviews": 3, "threads": 2}
+    assert calls == {"snapshots": 2}
 
 
-def test_consistent_snapshot_fails_when_review_generation_changes(monkeypatch):
+def test_consistent_snapshot_does_not_fetch_reviews(monkeypatch):
     c = load_check()
-    seen = {"reviews": 0}
 
-    def fake_fetch_reviews(pr, owner, name, gh):
-        seen["reviews"] += 1
-        state = "COMMENTED" if seen["reviews"] == 1 else "CHANGES_REQUESTED"
-        return "head-a", [review(commit="head-a", state=state)]
+    monkeypatch.setattr(c, "fetch_review_attestation", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError()))
+    monkeypatch.setattr(c, "fetch_comment_attestation", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError()))
+    monkeypatch.setattr(c, "fetch_thread_snapshot", lambda pr, owner, name, gh: ("head-a", [thread()]))
 
-    monkeypatch.setattr(c, "fetch_review_attestation", fake_fetch_reviews)
-    monkeypatch.setattr(c, "fetch_comment_attestation", lambda pr, owner, name, gh: ("head-a", []))
-    monkeypatch.setattr(c, "fetch_threads", lambda pr, owner, name, gh: [thread()])
+    nodes, head, reviews, comments = c.fetch_consistent_review_thread_snapshot(
+        1431,
+        "owner",
+        "name",
+        "gh",
+        BOTS,
+    )
 
-    try:
-        c.fetch_consistent_review_thread_snapshot(1431, "owner", "name", "gh", BOTS)
-    except RuntimeError as exc:
-        assert "Codex review generation changed" in str(exc)
-    else:  # pragma: no cover - assertion clarity
-        raise AssertionError("review movement during snapshot fetch must fail closed")
+    assert nodes == [thread()]
+    assert head == "head-a"
+    assert reviews == []
+    assert comments == []
 
 
-def test_consistent_snapshot_fails_when_clean_comment_generation_changes(monkeypatch):
+def test_consistent_snapshot_does_not_fetch_comments(monkeypatch):
     c = load_check()
-    seen = {"comments": 0}
 
-    def fake_fetch_comments(pr, owner, name, gh):
-        seen["comments"] += 1
-        comments = [] if seen["comments"] == 1 else [pr_comment(commit="abc1234567")]
-        return "abc1234567890", comments
+    monkeypatch.setattr(c, "fetch_review_attestation", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError()))
+    monkeypatch.setattr(c, "fetch_comment_attestation", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError()))
+    monkeypatch.setattr(c, "fetch_thread_snapshot", lambda pr, owner, name, gh: ("abc1234567890", [thread()]))
 
-    monkeypatch.setattr(c, "fetch_review_attestation", lambda pr, owner, name, gh: ("abc1234567890", []))
-    monkeypatch.setattr(c, "fetch_comment_attestation", fake_fetch_comments)
-    monkeypatch.setattr(c, "fetch_threads", lambda pr, owner, name, gh: [thread()])
+    nodes, head, reviews, comments = c.fetch_consistent_review_thread_snapshot(
+        1431,
+        "owner",
+        "name",
+        "gh",
+        BOTS,
+    )
 
-    try:
-        c.fetch_consistent_review_thread_snapshot(1431, "owner", "name", "gh", BOTS)
-    except RuntimeError as exc:
-        assert "Codex review generation changed" in str(exc)
-    else:  # pragma: no cover - assertion clarity
-        raise AssertionError("comment movement during snapshot fetch must fail closed")
+    assert nodes == [thread()]
+    assert head == "abc1234567890"
+    assert reviews == []
+    assert comments == []

--- a/tests/test_codex_wake_bridge.py
+++ b/tests/test_codex_wake_bridge.py
@@ -280,11 +280,6 @@ def test_github_read_errors_override_scheduled_ready(
             "unresolved review threads remain: 1",
         ),
         (
-            {"review_decision": "CHANGES_REQUESTED"},
-            {"reviewDecision": "CHANGES_REQUESTED"},
-            "has changes requested",
-        ),
-        (
             {"review_decision": "APPROVED"},
             {},
             "review decision does not match PR metadata",
@@ -363,9 +358,6 @@ def test_malformed_readiness_objects_fail_closed(
     [
         ("pr", "headRefOid", "PR head SHA is missing"),
         ("readiness", "review_decision", "review decision evidence is missing"),
-        ("readiness", "codex_reviews_complete", "Codex review pagination is incomplete"),
-        ("readiness", "codex_review_pages_fetched", "Codex review pages fetched must be at least 1"),
-        ("readiness", "codex_head_review_count", "current-head Codex review attestation is missing"),
         ("pr", "reviewDecision", "review decision evidence is missing"),
         ("readiness", "merge_state_status", "merge state must be CLEAN"),
     ],
@@ -383,15 +375,49 @@ def test_missing_readiness_evidence_fails_closed(
     assert expected in bridge.readiness_blockers(status)
 
 
-def test_docs_only_reconciliation_exemption_satisfies_codex_review_attestation(
+def test_codex_review_attestation_is_not_required_for_ready_state(
     tmp_path: Path,
 ) -> None:
     _config_dir, state_dir, watcher_id = _write_fixture(tmp_path)
     status = json.loads((state_dir / f"{watcher_id}.json").read_text(encoding="utf-8"))
     status["readiness"]["codex_head_review_count"] = 0
-    status["readiness"]["docs_only_reconciliation_exemption"] = True
+    status["readiness"]["docs_only_reconciliation_exemption"] = False
 
     assert bridge.readiness_blockers(status) == []
+
+
+def test_codex_review_attestation_error_is_diagnostic_for_ready_state(
+    tmp_path: Path,
+) -> None:
+    config_dir, state_dir, watcher_id = _write_fixture(
+        tmp_path,
+        extra_status={"codex_reviews_error": "review pagination exceeded 1 pages"},
+    )
+    status_path = state_dir / f"{watcher_id}.json"
+    status = json.loads(status_path.read_text(encoding="utf-8"))
+    status["readiness"]["codex_reviews_complete"] = False
+    status["readiness"]["codex_review_pages_fetched"] = 1
+    status["readiness"]["codex_head_review_count"] = 0
+    status_path.write_text(json.dumps(status), encoding="utf-8")
+
+    assert bridge.attention_blockers(status) == []
+    assert bridge.readiness_blockers(status) == []
+
+    code = bridge.main([
+        watcher_id,
+        "--source",
+        "scheduled",
+        "--config-dir",
+        str(config_dir),
+        "--state-dir",
+        str(state_dir),
+    ])
+
+    assert code == 0
+    payload, prompt = _read_handoff(state_dir, watcher_id)
+    assert payload["wake_kind"] == "scheduled-ready"
+    assert payload["actionable"] is True
+    assert "Scheduled green-confirmation wake" in prompt
 
 
 def test_malformed_status_fails_closed_to_attention_handoff(tmp_path: Path) -> None:

--- a/tests/test_pr_watcher.py
+++ b/tests/test_pr_watcher.py
@@ -361,7 +361,7 @@ def test_valid_snapshot_is_ready_and_accepted_by_consumer(tmp_path: Path, monkey
     assert watcher.TRUSTED_RECONCILIATION_CHECKER.parent.name == watcher.RECONCILIATION_LIB_DIR
 
 
-def test_post_review_metadata_controls_readiness_decision(
+def test_post_review_metadata_records_review_decision_without_blocking_readiness(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -375,10 +375,10 @@ def test_post_review_metadata_controls_readiness_decision(
 
     status = _produce(tmp_path, monkeypatch, fake)
 
-    assert status["state"] == "attention"
+    assert status["state"] == "ready_for_human_merge"
     assert status["pr"]["reviewDecision"] == "CHANGES_REQUESTED"
     assert status["readiness"]["review_decision"] == "CHANGES_REQUESTED"
-    assert "review decision has changes requested" in wake_bridge.readiness_blockers(status)
+    assert wake_bridge.readiness_blockers(status) == []
 
 
 def test_thread_snapshot_is_collected_after_codex_review_pagination(
@@ -814,7 +814,7 @@ def test_paginates_threads_and_keeps_outdated_unresolved_codex_threads(
     ]
 
 
-def test_changes_requested_codex_review_does_not_satisfy_head_review_count(
+def test_changes_requested_codex_review_does_not_block_ready_state_without_threads(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -838,7 +838,7 @@ def test_changes_requested_codex_review_does_not_satisfy_head_review_count(
         ),
     )
 
-    assert status["state"] == "attention"
+    assert status["state"] == "ready_for_human_merge"
     assert status["readiness"]["codex_head_review_count"] == 0
 
 
@@ -869,7 +869,7 @@ def test_unresolved_non_codex_thread_does_not_block_ready_state(
     assert status["readiness"]["unresolved_review_threads"] == []
 
 
-def test_current_head_codex_review_is_required_for_ready_state(
+def test_current_head_codex_review_is_not_required_for_ready_state(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -893,13 +893,13 @@ def test_current_head_codex_review_is_required_for_ready_state(
         ),
     )
 
-    assert status["state"] == "attention"
+    assert status["state"] == "ready_for_human_merge"
     assert status["readiness"]["codex_reviews_complete"] is True
     assert status["readiness"]["codex_head_review_count"] == 0
-    assert "current-head Codex review attestation is missing" in wake_bridge.readiness_blockers(status)
+    assert wake_bridge.readiness_blockers(status) == []
 
 
-def test_docs_only_reconciliation_exemption_can_satisfy_review_readiness(
+def test_docs_only_body_does_not_need_review_exemption_for_readiness(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -919,7 +919,7 @@ def test_docs_only_reconciliation_exemption_can_satisfy_review_readiness(
                 "\n".join(
                     [
                         "live AI reconciliation check",
-                        "OK: docs-only PR diff has no open scoped Codex review threads; current-head Codex review attestation is not required.",
+                        "OK: no open scoped Codex review threads remain.",
                     ]
                 ),
                 "",
@@ -929,7 +929,7 @@ def test_docs_only_reconciliation_exemption_can_satisfy_review_readiness(
 
     assert status["state"] == "ready_for_human_merge"
     assert status["readiness"]["codex_head_review_count"] == 0
-    assert status["readiness"]["docs_only_reconciliation_exemption"] is True
+    assert status["readiness"]["docs_only_reconciliation_exemption"] is False
     assert wake_bridge.readiness_blockers(status) == []
 
 
@@ -950,7 +950,7 @@ def test_docs_only_reconciliation_exemption_requires_final_body_marker(
             "\n".join(
                 [
                     "live AI reconciliation check",
-                    "OK: docs-only PR diff has no open scoped Codex review threads; current-head Codex review attestation is not required.",
+                    "OK: docs-only PR diff has no open scoped Codex review threads.",
                 ]
             ),
             "",
@@ -1007,7 +1007,7 @@ def test_docs_only_reconciliation_exemption_uses_post_reconciliation_checks(
                 "\n".join(
                     [
                         "live AI reconciliation check",
-                        "OK: docs-only PR diff has no open scoped Codex review threads; current-head Codex review attestation is not required.",
+                        "OK: docs-only PR diff has no open scoped Codex review threads.",
                     ]
                 ),
                 "",
@@ -1044,7 +1044,7 @@ def test_current_head_review_requires_exact_codex_connector_identity(
         ),
     )
 
-    assert status["state"] == "attention"
+    assert status["state"] == "ready_for_human_merge"
     assert status["readiness"]["codex_head_review_count"] == 0
 
 
@@ -1140,7 +1140,7 @@ def test_authorless_comment_is_ignored_for_codex_attestation(
         head=head,
     )
 
-    assert status["state"] == "attention"
+    assert status["state"] == "ready_for_human_merge"
     assert status["readiness"]["codex_reviews_complete"] is True
     assert status["readiness"]["codex_head_review_count"] == 0
 
@@ -1179,7 +1179,7 @@ def test_codex_comment_pagination_reaches_later_current_head_attestation(
     assert status["readiness"]["codex_head_review_count"] == 1
 
 
-def test_codex_review_pagination_failure_blocks_ready_state(
+def test_codex_review_pagination_failure_is_diagnostic_only(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1190,7 +1190,7 @@ def test_codex_review_pagination_failure_blocks_ready_state(
         FakeRun(review_pages=[_response(_review_page(has_next=True, cursor="again"))]),
     )
 
-    assert status["state"] == "attention"
+    assert status["state"] == "ready_for_human_merge"
     assert status["readiness"]["codex_reviews_complete"] is False
     assert "review pagination exceeded 1 pages" in status["codex_reviews_error"]
 
@@ -1417,7 +1417,7 @@ def test_malformed_review_thread_nodes_fail_closed(
     ("pr_value", "all_checks", "reconciliation", "git_status", "expected"),
     [
         (_pr(draft=True), None, (0, "clean", ""), (0, "", ""), "attention"),
-        (_pr(decision="CHANGES_REQUESTED"), None, (0, "clean", ""), (0, "", ""), "attention"),
+        (_pr(decision="CHANGES_REQUESTED"), None, (0, "clean", ""), (0, "", ""), "ready_for_human_merge"),
         (_pr(merge="DIRTY"), None, (0, "clean", ""), (0, "", ""), "attention"),
         (_pr(merge="UNSTABLE"), [_check("required-a", "pending")], (0, "clean", ""), (0, "", ""), "pending"),
         (_pr(state="MERGED"), None, (0, "clean", ""), (0, "", ""), "closed"),
@@ -1592,9 +1592,9 @@ def test_installed_entrypoint_writes_consumer_accepted_snapshot(tmp_path: Path) 
                 elif "comments(first:100" in query:
                     payload = {"data": {"repository": {"pullRequest": {"headRefOid": "head-a", "comments": {"nodes": [], "pageInfo": {"hasNextPage": False, "endCursor": None}}}}}}
                 elif "comments(first:1)" in query:
-                    payload = {"data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": [], "pageInfo": {"hasNextPage": False, "endCursor": None}}}}}}
+                    payload = {"data": {"repository": {"pullRequest": {"headRefOid": "head-a", "reviewThreads": {"nodes": [], "pageInfo": {"hasNextPage": False, "endCursor": None}}}}}}
                 else:
-                    payload = {"data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": [], "pageInfo": {"hasNextPage": False, "endCursor": None}}}}}}
+                    payload = {"data": {"repository": {"pullRequest": {"headRefOid": "head-a", "reviewThreads": {"nodes": [], "pageInfo": {"hasNextPage": False, "endCursor": None}}}}}}
                 print(json.dumps(payload))
             else:
                 print("unexpected gh args: " + repr(args), file=sys.stderr)

--- a/tests/test_select_impacted_tests.py
+++ b/tests/test_select_impacted_tests.py
@@ -142,6 +142,17 @@ def test_global_files_escalate_to_full(tmp_path, path):
         ["tests/test_security_guardrails_workflow.py"],
     ),
     (
+        ".github/workflows/ai_reconciliation_live.yml",
+        [
+            "tests/test_audit_workflow_security_posture.py",
+            "tests/test_check_ai_reconciliation_live.py",
+        ],
+    ),
+    (
+        ".github/workflows/ai_reconciliation_review_retrigger.yml",
+        ["tests/test_check_ai_reconciliation_live.py"],
+    ),
+    (
         ".github/workflows/unit_gate.yml",
         [
             "tests/test_check_unit_gate.py",
@@ -153,6 +164,14 @@ def test_global_files_escalate_to_full(tmp_path, path):
     (
         "scripts/check_required_status_checks.py",
         ["tests/test_security_guardrails_workflow.py"],
+    ),
+    (
+        "scripts/check_ai_reconciliation_live.py",
+        ["tests/test_check_ai_reconciliation_live.py"],
+    ),
+    (
+        "scripts/codex_wake_bridge.py",
+        ["tests/test_codex_wake_bridge.py"],
     ),
     (
         "scripts/check_unit_gate.py",

--- a/tests/test_watch_owned_pr.py
+++ b/tests/test_watch_owned_pr.py
@@ -398,20 +398,20 @@ def test_watcher_ignores_unresolved_non_codex_thread(tmp_path: Path) -> None:
     assert "threads=0" in result.stdout
 
 
-def test_watcher_blocks_without_current_head_codex_review(tmp_path: Path) -> None:
+def test_watcher_reports_ready_without_current_head_codex_review(tmp_path: Path) -> None:
     result = _run_watcher(tmp_path, scenario="no_review")
 
     assert result.returncode == 0, result.stdout + result.stderr
     assert "ACTIONABLE" not in result.stdout
-    assert "watch window elapsed" in result.stdout
+    assert "MERGE-READY" in result.stdout
     assert "codex-head-attestations=0" in result.stdout
 
 
-def test_watcher_requires_exact_codex_connector_review_identity(tmp_path: Path) -> None:
+def test_watcher_treats_wrong_review_identity_as_diagnostic_only(tmp_path: Path) -> None:
     result = _run_watcher(tmp_path, scenario="helper_review")
 
     assert result.returncode == 0, result.stdout + result.stderr
-    assert "MERGE-READY" not in result.stdout
+    assert "MERGE-READY" in result.stdout
     assert "codex-head-attestations=0" in result.stdout
 
 
@@ -431,11 +431,11 @@ def test_watcher_blocks_on_outdated_unresolved_codex_thread(tmp_path: Path) -> N
     assert "threads=1" in result.stdout
 
 
-def test_watcher_does_not_count_changes_requested_as_head_review(tmp_path: Path) -> None:
+def test_watcher_does_not_block_on_changes_requested_review_without_threads(tmp_path: Path) -> None:
     result = _run_watcher(tmp_path, scenario="changes_requested_review")
 
     assert result.returncode == 0, result.stdout + result.stderr
-    assert "MERGE-READY" not in result.stdout
+    assert "MERGE-READY" in result.stdout
     assert "codex-head-attestations=0" in result.stdout
 
 
@@ -455,28 +455,28 @@ def test_watcher_finds_clean_comment_after_pagination(tmp_path: Path) -> None:
     assert "attestation-pages=3" in result.stdout
 
 
-def test_watcher_rejects_wrong_author_clean_comment(tmp_path: Path) -> None:
+def test_watcher_treats_wrong_author_clean_comment_as_diagnostic_only(tmp_path: Path) -> None:
     result = _run_watcher(tmp_path, scenario="wrong_author_clean_comment", sha="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 
     assert result.returncode == 0, result.stdout + result.stderr
-    assert "MERGE-READY" not in result.stdout
+    assert "MERGE-READY" in result.stdout
     assert "codex-head-attestations=0" in result.stdout
 
 
-def test_watcher_rejects_stale_clean_comment(tmp_path: Path) -> None:
+def test_watcher_treats_stale_clean_comment_as_diagnostic_only(tmp_path: Path) -> None:
     result = _run_watcher(tmp_path, scenario="stale_clean_comment", sha="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 
     assert result.returncode == 0, result.stdout + result.stderr
-    assert "MERGE-READY" not in result.stdout
+    assert "MERGE-READY" in result.stdout
     assert "codex-head-attestations=0" in result.stdout
 
 
-def test_watcher_changes_requested_overrides_clean_comment(tmp_path: Path) -> None:
+def test_watcher_changes_requested_decision_is_diagnostic_when_threads_clear(tmp_path: Path) -> None:
     result = _run_watcher(tmp_path, scenario="clean_comment_changes_requested", sha="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 
     assert result.returncode == 0, result.stdout + result.stderr
-    assert "MERGE-READY" not in result.stdout
-    assert "ACTIONABLE" in result.stdout
+    assert "MERGE-READY" in result.stdout
+    assert "ACTIONABLE" not in result.stdout
     assert "decision=CHANGES_REQUESTED" in result.stdout
 
 
@@ -506,39 +506,39 @@ def test_watcher_finds_current_head_codex_review_after_pagination(tmp_path: Path
     assert "attestation-pages=3" in result.stdout
 
 
-def test_watcher_blocks_malformed_review_pagination(tmp_path: Path) -> None:
+def test_watcher_treats_malformed_review_pagination_as_diagnostic_only(tmp_path: Path) -> None:
     result = _run_watcher(tmp_path, scenario="review_graphql_errors")
 
     assert result.returncode == 0, result.stdout + result.stderr
-    assert "MERGE-READY" not in result.stdout
-    assert "ACTIONABLE" in result.stdout
+    assert "MERGE-READY" in result.stdout
+    assert "ACTIONABLE" not in result.stdout
     assert "attestations-complete=false" in result.stdout
 
 
-def test_watcher_blocks_malformed_review_page_info(tmp_path: Path) -> None:
+def test_watcher_treats_malformed_review_page_info_as_diagnostic_only(tmp_path: Path) -> None:
     result = _run_watcher(tmp_path, scenario="review_malformed_page_info")
 
     assert result.returncode == 0, result.stdout + result.stderr
-    assert "MERGE-READY" not in result.stdout
-    assert "ACTIONABLE" in result.stdout
+    assert "MERGE-READY" in result.stdout
+    assert "ACTIONABLE" not in result.stdout
     assert "attestations-complete=false" in result.stdout
 
 
-def test_watcher_blocks_malformed_comment_pagination(tmp_path: Path) -> None:
+def test_watcher_treats_malformed_comment_pagination_as_diagnostic_only(tmp_path: Path) -> None:
     result = _run_watcher(tmp_path, scenario="comment_graphql_errors")
 
     assert result.returncode == 0, result.stdout + result.stderr
-    assert "MERGE-READY" not in result.stdout
-    assert "ACTIONABLE" in result.stdout
+    assert "MERGE-READY" in result.stdout
+    assert "ACTIONABLE" not in result.stdout
     assert "attestations-complete=false" in result.stdout
 
 
-def test_watcher_blocks_malformed_comment_page_info(tmp_path: Path) -> None:
+def test_watcher_treats_malformed_comment_page_info_as_diagnostic_only(tmp_path: Path) -> None:
     result = _run_watcher(tmp_path, scenario="comment_malformed_page_info")
 
     assert result.returncode == 0, result.stdout + result.stderr
-    assert "MERGE-READY" not in result.stdout
-    assert "ACTIONABLE" in result.stdout
+    assert "MERGE-READY" in result.stdout
+    assert "ACTIONABLE" not in result.stdout
     assert "attestations-complete=false" in result.stdout
 
 
@@ -550,22 +550,20 @@ def test_watcher_revalidates_head_before_reporting_ready(tmp_path: Path) -> None
     assert "HEAD-MOVED: head-a -> head-b" in result.stdout
 
 
-def test_watcher_revalidates_decision_before_reporting_ready(tmp_path: Path) -> None:
+def test_watcher_does_not_block_final_decision_change_when_threads_clear(tmp_path: Path) -> None:
     result = _run_watcher(tmp_path, scenario="final_decision_changes")
 
     assert result.returncode == 0, result.stdout + result.stderr
-    assert "MERGE-READY" not in result.stdout
-    assert "ACTIONABLE: final-read" in result.stdout
-    assert "decision=CHANGES_REQUESTED" in result.stdout
+    assert "MERGE-READY" in result.stdout
+    assert "ACTIONABLE: final-read" not in result.stdout
 
 
-def test_watcher_revalidates_reviews_before_reporting_ready(tmp_path: Path) -> None:
+def test_watcher_does_not_block_final_review_disappearance(tmp_path: Path) -> None:
     result = _run_watcher(tmp_path, scenario="final_review_disappears")
 
     assert result.returncode == 0, result.stdout + result.stderr
-    assert "MERGE-READY" not in result.stdout
-    assert "ACTIONABLE: final-read" in result.stdout
-    assert "codex-head-attestations=0" in result.stdout
+    assert "MERGE-READY" in result.stdout
+    assert "ACTIONABLE: final-read" not in result.stdout
 
 
 def test_watcher_revalidates_required_checks_before_reporting_ready(tmp_path: Path) -> None:


### PR DESCRIPTION
Plan: plans/PR-Live-Reconciliation-Thread-Gate.md
Slice phase: Workflow/process
Ownership lane: workflow/live-reconciliation-open-threads-only

Remove the live-reconciliation timing race by making required and watcher readiness depend on unresolved scoped Codex review threads, not current-head Codex review activity or a grace-window wait, and keep the unit-gate selector scoped to this slice's owned reconciliation surfaces.

## Intentional
- No branch-protection change; the required status remains `live-reconciliation`.
- Deprecated CLI flags remain accepted as no-ops so manual callers do not break.
- No replacement final Codex approval gate; unresolved Codex comments are the machine signal in this slice.
- Current-head Codex review counts remain watcher diagnostics only.
- Codex review-attestation API/pagination errors remain watcher diagnostics only; bridge readiness trusts complete required-check and review-thread proof.
- Review/comment-generation movement is ignored by the live checker because review presence is no longer part of the required predicate; PR head and review-thread movement still fail closed.
- Unit-gate selector ownership is added for this slice's AI-reconciliation workflows and checker/wake-bridge scripts; `tests/unit_gate_baseline.txt` is intentionally not edited.
- Rebase conflict resolution keeps main's trusted `ci/gates.yml` required-context registry while preserving this PR's open-thread-only readiness predicate.

## Deferred
- None.

## Parked hardening
- None.

## Cold diff reconstruction
- Changed: `.github/workflows/ai_reconciliation_live.yml:61` now invokes `scripts/check_ai_reconciliation_live.py --pr <number>` without `--wait-for-review-window`.
- Changed: `.github/workflows/ai_reconciliation_review_retrigger.yml:35` through `.github/workflows/ai_reconciliation_review_retrigger.yml:79` extends the default-branch retrigger timeout, waits for the matching trusted target run to complete, and retries rerun rejection before failing.
- Changed: `scripts/check_ai_reconciliation_live.py:453` computes scoped open Codex threads, and `scripts/check_ai_reconciliation_live.py:470` exits success immediately when none remain.
- Changed: `scripts/check_ai_reconciliation_live.py:473` through `scripts/check_ai_reconciliation_live.py:502` preserve the existing failure messages for unresolved scoped Codex threads.
- Changed: `scripts/check_ai_reconciliation_live.py:534` through `scripts/check_ai_reconciliation_live.py:589` fetch PR head identity and all review threads from the reviewThreads query, failing closed if the head changes during thread pagination.
- Changed: `scripts/check_ai_reconciliation_live.py:903` through `scripts/check_ai_reconciliation_live.py:918` keep snapshot stability fail-closed for PR head/thread movement while removing Codex review/comment attestation fetches from the required thread-only snapshot.
- Changed: `AGENTS.md:1343` through `AGENTS.md:1344` now require resolved/waived Codex threads plus green current-head `live-reconciliation`, without current-head connector review attestation.
- Changed: `scripts/pr_watcher.py:846` through `scripts/pr_watcher.py:887` make watcher readiness depend on complete thread pagination and zero unresolved scoped Codex threads, not current-head review count or review decision.
- Changed: `scripts/codex_wake_bridge.py:74` through `scripts/codex_wake_bridge.py:90` no longer treats optional Codex review-attestation pagination/API errors as attention blockers.
- Changed: `scripts/codex_wake_bridge.py:98` through `scripts/codex_wake_bridge.py:160` keeps required-check, thread-proof, review-decision metadata, and merge-state proof blockers intact.
- Changed: `scripts/select_impacted_tests.py:72` through `scripts/select_impacted_tests.py:95` maps the AI-reconciliation workflows and checker/wake-bridge scripts to focused owner tests so unit-gate does not escalate this branch to `FULL`.
- Changed: `tests/test_select_impacted_tests.py:145` through `tests/test_select_impacted_tests.py:174` proves those explicit owner mappings select the expected test files.
- Changed: `scripts/watch_owned_pr.sh:7` through `scripts/watch_owned_pr.sh:14`, `docs/OVERNIGHT_ARC_WORKFLOW.md:82` through `docs/OVERNIGHT_ARC_WORKFLOW.md:85`, `docs/OVERNIGHT_ARC_WORKFLOW.md:136` through `docs/OVERNIGHT_ARC_WORKFLOW.md:142`, and `docs/long_running_session_watcher_handoff.md:329` through `docs/long_running_session_watcher_handoff.md:338` align long-running watcher wording with the open-thread-only gate while retaining main's `ci/gates.yml` trusted registry.
- Changed: `tests/test_check_ai_reconciliation_live.py:98` through `tests/test_check_ai_reconciliation_live.py:114` statically proves the review-event retrigger waits/retries before rerunning the trusted target context.
- Changed: `tests/test_check_ai_reconciliation_live.py:661`, `tests/test_check_ai_reconciliation_live.py:1086`, `tests/test_check_ai_reconciliation_live.py:1194`, and `tests/test_check_ai_reconciliation_live.py:1215` prove the required checker does not call review/comment attestation for the live thread snapshot and still fails closed on thread-query head movement.
- Changed: `tests/test_codex_wake_bridge.py:389` through `tests/test_codex_wake_bridge.py:420` proves Codex review-attestation errors are diagnostic-only for a scheduled-ready wake when required checks and review threads are clear.
- Changed: `tests/test_watch_owned_pr.py:401`, `tests/test_watch_owned_pr.py:434`, and `tests/test_watch_owned_pr.py:509` through `tests/test_watch_owned_pr.py:536` update the enrolled shell-watcher contract so review/comment attestation metadata is diagnostic-only while unresolved scoped Codex threads and required checks still block.
- Changed: `tests/test_pr_watcher.py:1530` keeps the installed watcher consumer snapshot fixture aligned with the thread query carrying `headRefOid`.
- Contract match: every code change traces to the Problem-derived contract: remove wait/current-head attestation gating, preserve unresolved-thread failures, keep compatibility arguments, align watcher readiness, close the review-event retrigger race, keep optional attestation diagnostics non-blocking, scope unit-gate selection to owned reconciliation surfaces, avoid branch-protection/product changes, and avoid plan archive collision.
- Gaps: none.

## AI reconciliation
- AI findings reviewed: Yes
- All fixed or waived: Yes
- Fixed: preserved the open-thread-only root rule by updating stale AGENTS/watcher readiness contracts instead of reintroducing the current-head wait gate.
- Fixed: removed watcher dependence on the docs-only attestation exemption by making no-thread readiness independent of current-head review metadata.
- Fixed: renamed the plan to `plans/PR-Live-Reconciliation-Thread-Gate.md` to avoid the existing archive basename.
- Fixed: removed the remaining review/comment-generation race failure from the required checker while preserving PR-head and review-thread stability failures.
- Fixed: reconciled the overnight docs-only runbook exception so docs-only PRs use the same required-green plus zero-unresolved-Codex-thread readiness contract.
- Fixed: removed review/comment attestation fetches from the required thread-only snapshot; the PR head now comes from the reviewThreads query and tests assert those attestation APIs are not called.
- Fixed: updated the enrolled shell-watcher tests for the new thread-only contract while retaining unresolved-thread and required-check failures.
- Fixed: closed the review-event retrigger race by waiting for the trusted target run to complete before rerunning it and retrying transient rerun rejection.
- Fixed: stopped treating optional Codex review-attestation errors as wake-bridge blockers when required checks and review-thread proof are complete/clear.
- Fixed: scoped unit-gate selection for the changed AI-reconciliation workflow/script surfaces to focused owner tests instead of `FULL`, avoiding unrelated reasoning baseline drift without editing `tests/unit_gate_baseline.txt`.

## Verification
- `python -m pytest tests/test_check_ai_reconciliation_live.py -q` -- 64 passed.
- `python -m pytest tests/test_codex_wake_bridge.py -q` -- 46 passed.
- `python -m pytest tests/test_watch_owned_pr.py -q` -- 23 passed.
- `python -m pytest tests/test_watch_owned_pr.py tests/test_pr_watcher.py tests/test_codex_wake_bridge.py tests/test_check_ai_reconciliation_live.py -q` -- 209 passed.
- `python -m pytest tests/test_select_impacted_tests.py -q` -- 48 passed.
- `python scripts/select_impacted_tests.py --base origin/main` -- selected `tests/test_audit_workflow_security_posture.py`, `tests/test_check_ai_reconciliation_live.py`, `tests/test_codex_wake_bridge.py`, `tests/test_pr_watcher.py`, and `tests/test_watch_owned_pr.py` instead of `FULL`.
- `python scripts/check_unit_gate.py --baseline tests/unit_gate_baseline.txt --base-baseline /tmp/atlas-base-baseline-2258.txt --selected-files /tmp/atlas-selected-2258.txt --pytest-args $(tr '\n' ' ' < /tmp/atlas-selected-2258.txt) -m "not integration and not e2e" --continue-on-collection-errors -rfE --tb=no -q -p no:cacheprovider` -- 0 regressions.
- `python -m pytest tests/test_check_ai_reconciliation_live.py tests/test_codex_wake_bridge.py tests/test_pr_watcher.py tests/test_watch_owned_pr.py tests/test_select_impacted_tests.py tests/test_audit_workflow_security_posture.py -q` -- 276 passed.
- CI log inspected: current-head unit-gate failed because `scripts/select_impacted_tests.py` escalated this branch to `FULL`, exposing three unrelated `tests/test_reasoning_graph_routing.py` failures removed from baseline by #2259.

## Diff size
16 files, +604 / -585
Diff-budget override: removing obsolete wait/docs-only proof and review-generation race logic, aligning AGENTS/watcher/overnight readiness contracts, preserving main's required-context registry, closing the review-event retrigger race, scoping unit-gate selection for this slice's owned runtime/config surfaces, renaming the colliding plan, and updating inseparable regression tests in the same policy slice.
