### PR TITLE
Add EOM funnel env placeholders

### DIFF
--- a/atlas_brain/eom_api/config.py
+++ b/atlas_brain/eom_api/config.py
@@ -73,6 +73,13 @@ class EOMProfileConfig(BaseSettings):
         default=False,
         description="Run database migrations during the slim EOM profile startup",
     )
+    canonical_crm_database_confirmed: bool = Field(
+        default=False,
+        description=(
+            "Confirm the slim EOM profile is connected to the canonical Atlas CRM "
+            "database before it may serve funnel APIs"
+        ),
+    )
 
 
 class EOMInvoicingConfig(BaseSettings):
@@ -126,6 +133,13 @@ class EOMFunnelConfig(BaseSettings):
         description=(
             "SHA-256 digest of the generated bearer accepted from the EOM time "
             "tracker only; the raw bearer is never stored in Atlas"
+        ),
+    )
+    db_connection_string: str = Field(
+        default="",
+        description=(
+            "Canonical Atlas CRM PostgreSQL connection string used only by the "
+            "slim EOM funnel routes"
         ),
     )
 

--- a/plans/PR-EOM-Funnel-Env-Placeholders.md
+++ b/plans/PR-EOM-Funnel-Env-Placeholders.md
@@ -1,0 +1,84 @@
+# PR-EOM-Funnel-Env-Placeholders
+
+## Why this slice exists
+
+Effingham Office Maids issue #59 needs Atlas-side runtime slots before live
+funnel wiring can be configured. This slice deliberately stops at fail-closed
+configuration placeholders so follow-up routing, datastore, migration, and CI
+hardening work can converge independently.
+
+### Problem-derived contract
+
+- Root cause: the slim EOM Render blueprint and settings surface do not expose
+  the funnel enable flag, service-token digest, canonical CRM DSN, or canonical
+  confirmation bit needed for later live configuration.
+- Correct fix must touch/change: add those env placeholders to `render.eom.yaml`
+  and expose matching settings fields in `atlas_brain/eom_api/config.py`.
+- Must not change: route mounting, startup behavior, database pools, migrations,
+  auth validation, or LLM/runtime infrastructure.
+
+## Scope (this PR)
+
+Ownership lane: eom-funnel
+Slice phase: production hardening
+
+1. Add disabled-by-default funnel env placeholders to `render.eom.yaml`.
+2. Add matching settings fields to `atlas_brain/eom_api/config.py`.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] `render.eom.yaml` declares `ATLAS_EOM_FUNNEL_API_ENABLED` as `"false"`.
+  - [ ] `render.eom.yaml` declares `ATLAS_EOM_FUNNEL_SERVICE_TOKEN_SHA256` with
+    `sync: false`.
+  - [ ] `render.eom.yaml` declares `ATLAS_EOM_FUNNEL_DB_CONNECTION_STRING` with
+    `sync: false`.
+  - [ ] `render.eom.yaml` declares `ATLAS_EOM_CANONICAL_CRM_DATABASE_CONFIRMED`
+    as `"false"`.
+  - [ ] `atlas_brain/eom_api/config.py` exposes the same values through settings
+    fields without changing serving behavior.
+- Affected surfaces: EOM Render blueprint and slim EOM settings.
+- Risk areas: environment naming drift and accidental live enablement.
+- Reviewer rules triggered: R1, R11, R12.
+
+### Files touched
+
+- `atlas_brain/eom_api/config.py`
+- `plans/PR-EOM-Funnel-Env-Placeholders.md`
+- `render.eom.yaml`
+
+## Mechanism
+
+- The blueprint remains fail-closed because the funnel enable flag and canonical
+  confirmation bit default to false.
+- Atlas receives only the funnel service-token digest slot; the raw tracker
+  bearer remains outside Atlas.
+- The dedicated funnel DSN is only a settings placeholder in this slice.
+
+## Intentional
+
+- No route is mounted.
+- No database pool is created.
+- No migration set is changed.
+- No auth validator or startup preflight is changed.
+
+## Deferred
+
+- Slim router mount, datastore preflight, dedicated pool wiring, migration
+  354/356 privilege work, domain CI enrollment, and LLM/torch CI fixes move to
+  separate bounded PRs.
+
+Parked hardening: none.
+
+## Verification
+
+- Passed: `/tmp/atlas-eom-funnel-env-1785688582/.venv/bin/python -m py_compile atlas_brain/eom_api/config.py`.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/eom_api/config.py` | 14 |
+| `render.eom.yaml` | 8 |
+| `plans/PR-EOM-Funnel-Env-Placeholders.md` | 84 |
+| **Total** | **106** |

--- a/plans/PR-EOM-Funnel-Env-Placeholders.md
+++ b/plans/PR-EOM-Funnel-Env-Placeholders.md
@@ -24,6 +24,7 @@ Slice phase: production hardening
 
 1. Add disabled-by-default funnel env placeholders to `render.eom.yaml`.
 2. Add matching settings fields to `atlas_brain/eom_api/config.py`.
+3. Add focused tests for the new Render keys and settings env projections.
 
 ### Review Contract
 
@@ -39,13 +40,14 @@ Slice phase: production hardening
     fields without changing serving behavior.
 - Affected surfaces: EOM Render blueprint and slim EOM settings.
 - Risk areas: environment naming drift and accidental live enablement.
-- Reviewer rules triggered: R1, R11, R12.
+- Reviewer rules triggered: R1, R2, R11, R12.
 
 ### Files touched
 
 - `atlas_brain/eom_api/config.py`
 - `plans/PR-EOM-Funnel-Env-Placeholders.md`
 - `render.eom.yaml`
+- `tests/test_eom_render_profile.py`
 
 ## Mechanism
 
@@ -73,6 +75,7 @@ Parked hardening: none.
 ## Verification
 
 - Passed: `/tmp/atlas-eom-funnel-env-1785688582/.venv/bin/python -m py_compile atlas_brain/eom_api/config.py`.
+- Passed: `/tmp/atlas-eom-funnel-env-1785688582/.venv/bin/python -m pytest tests/test_eom_render_profile.py::test_eom_render_blueprint_maps_database_and_receivables_auth tests/test_eom_render_profile.py::test_eom_funnel_placeholders_load_from_env_and_default_fail_closed -q`.
 
 ## Estimated diff size
 
@@ -80,5 +83,6 @@ Parked hardening: none.
 |---|---:|
 | `atlas_brain/eom_api/config.py` | 14 |
 | `render.eom.yaml` | 8 |
-| `plans/PR-EOM-Funnel-Env-Placeholders.md` | 84 |
-| **Total** | **106** |
+| `tests/test_eom_render_profile.py` | 54 |
+| `plans/PR-EOM-Funnel-Env-Placeholders.md` | 88 |
+| **Total** | **164** |

--- a/render.eom.yaml
+++ b/render.eom.yaml
@@ -26,5 +26,13 @@ services:
         value: "false"
       - key: ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN_SHA256
         sync: false
+      - key: ATLAS_EOM_FUNNEL_API_ENABLED
+        value: "false"
+      - key: ATLAS_EOM_FUNNEL_SERVICE_TOKEN_SHA256
+        sync: false
+      - key: ATLAS_EOM_FUNNEL_DB_CONNECTION_STRING
+        sync: false
+      - key: ATLAS_EOM_CANONICAL_CRM_DATABASE_CONFIRMED
+        value: "false"
       - key: ATLAS_EOM_RUN_MIGRATIONS
         value: "true"

--- a/tests/test_eom_render_profile.py
+++ b/tests/test_eom_render_profile.py
@@ -372,6 +372,22 @@ def test_eom_render_blueprint_maps_database_and_receivables_auth():
         "key": "ATLAS_INVOICING_RECEIVABLES_SERVICE_TOKEN_SHA256",
         "sync": False,
     }
+    assert env_vars["ATLAS_EOM_FUNNEL_API_ENABLED"] == {
+        "key": "ATLAS_EOM_FUNNEL_API_ENABLED",
+        "value": "false",
+    }
+    assert env_vars["ATLAS_EOM_FUNNEL_SERVICE_TOKEN_SHA256"] == {
+        "key": "ATLAS_EOM_FUNNEL_SERVICE_TOKEN_SHA256",
+        "sync": False,
+    }
+    assert env_vars["ATLAS_EOM_FUNNEL_DB_CONNECTION_STRING"] == {
+        "key": "ATLAS_EOM_FUNNEL_DB_CONNECTION_STRING",
+        "sync": False,
+    }
+    assert env_vars["ATLAS_EOM_CANONICAL_CRM_DATABASE_CONFIRMED"] == {
+        "key": "ATLAS_EOM_CANONICAL_CRM_DATABASE_CONFIRMED",
+        "value": "false",
+    }
     assert env_vars["ATLAS_EOM_RUN_MIGRATIONS"] == {
         "key": "ATLAS_EOM_RUN_MIGRATIONS",
         "value": "true",
@@ -389,6 +405,44 @@ def test_eom_render_blueprint_maps_database_and_receivables_auth():
         "ATLAS_DB_PASSWORD",
     ):
         assert split_key not in env_vars
+
+
+def test_eom_funnel_placeholders_load_from_env_and_default_fail_closed(monkeypatch):
+    for key in (
+        "ATLAS_EOM_CANONICAL_CRM_DATABASE_CONFIRMED",
+        "ATLAS_EOM_FUNNEL_API_ENABLED",
+        "ATLAS_EOM_FUNNEL_SERVICE_TOKEN_SHA256",
+        "ATLAS_EOM_FUNNEL_DB_CONNECTION_STRING",
+        _RAW_RECEIVABLES_SERVICE_TOKEN_ENV,
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    from atlas_brain.eom_api.config import EOMFunnelConfig, EOMProfileConfig
+
+    profile_defaults = EOMProfileConfig()
+    funnel_defaults = EOMFunnelConfig()
+    assert profile_defaults.canonical_crm_database_confirmed is False
+    assert funnel_defaults.api_enabled is False
+    assert funnel_defaults.service_token_sha256 == ""
+    assert funnel_defaults.db_connection_string == ""
+
+    monkeypatch.setenv("ATLAS_EOM_CANONICAL_CRM_DATABASE_CONFIRMED", "true")
+    monkeypatch.setenv("ATLAS_EOM_FUNNEL_API_ENABLED", "true")
+    monkeypatch.setenv("ATLAS_EOM_FUNNEL_SERVICE_TOKEN_SHA256", "abc123")
+    monkeypatch.setenv(
+        "ATLAS_EOM_FUNNEL_DB_CONNECTION_STRING",
+        "postgresql://atlas-eom-funnel.example/db",
+    )
+
+    profile = EOMProfileConfig()
+    funnel = EOMFunnelConfig()
+    assert profile.canonical_crm_database_confirmed is True
+    assert funnel.api_enabled is True
+    assert funnel.service_token_sha256 == "abc123"
+    assert (
+        funnel.db_connection_string
+        == "postgresql://atlas-eom-funnel.example/db"
+    )
 
 
 def test_eom_startup_migrations_are_curated_for_receivables_readiness():


### PR DESCRIPTION
Plan: plans/PR-EOM-Funnel-Env-Placeholders.md
Slice phase: production hardening
Ownership lane: eom-funnel

Issue canfieldjuan/Effingham_Office_Maids_Website#59 needs the Atlas EOM Render profile to expose the funnel runtime knobs before live configuration can be wired. This replacement slice intentionally stops at the fail-closed env/config placeholders and does not mount routes, add pools, run migrations, or change serving behavior.

## Intentional
- `render.eom.yaml` declares `ATLAS_EOM_FUNNEL_API_ENABLED` with `value: "false"` so the blueprint remains disabled by default.
- `render.eom.yaml` declares `ATLAS_EOM_FUNNEL_SERVICE_TOKEN_SHA256` with `sync: false`; Atlas still does not declare a raw funnel bearer token.
- `render.eom.yaml` declares `ATLAS_EOM_FUNNEL_DB_CONNECTION_STRING` with `sync: false` and `ATLAS_EOM_CANONICAL_CRM_DATABASE_CONFIRMED` with `value: "false"` so later live enablement has explicit fail-closed slots.
- `atlas_brain/eom_api/config.py` exposes those new envs through existing settings classes only; no startup, routing, database, migration, or auth behavior is changed in this PR.
- `tests/test_eom_render_profile.py` asserts the new Render keys plus settings defaults/env projection for the new placeholders.

## Deferred
- Slim EOM router mount, datastore preflight, dedicated funnel DB pool wiring, migration 354/356 privilege work, domain CI enrollment, and LLM/torch CI fixes are intentionally deferred to smaller follow-up PRs.
- The contradictory least-privilege serving versus privileged migration design question stays out of this placeholder PR.

## Review scope boundary
- This PR is only the fail-closed Render env placeholders and matching settings fields. A finding is in scope only if it proves this placeholder diff itself breaks existing behavior, exposes a secret, changes startup/routing/database/auth semantics, or contradicts the stated disabled-by-default contract.
- Findings that require router mounting, datastore preflight, dedicated pool behavior, migrations, CI path-filter enrollment, LLM/torch fixes, or live enablement are deferred by design unless they cite a regression caused by these placeholders.
- Duplicate instances of the same underlying concern should be grouped under the class-level finding or waived as duplicates under the repository review rules.

## Parked hardening
None.

## Cold diff reconstruction
- Changed: `render.eom.yaml` adds disabled-by-default funnel enable, service-token digest, dedicated DSN, and canonical confirmation env placeholders.
- Changed: `atlas_brain/eom_api/config.py` adds matching settings fields.
- Changed: `tests/test_eom_render_profile.py` adds focused assertions for the new Render keys and settings defaults/env mappings.
- Preserved: no route mounting, startup behavior, database pool, migration, auth validation, or LLM/runtime infrastructure behavior changes.

## Verification
- Passed: `/tmp/atlas-eom-funnel-env-1785688582/.venv/bin/python -m py_compile atlas_brain/eom_api/config.py`
- Passed: `/tmp/atlas-eom-funnel-env-1785688582/.venv/bin/python -m pytest tests/test_eom_render_profile.py::test_eom_render_blueprint_maps_database_and_receivables_auth tests/test_eom_render_profile.py::test_eom_funnel_placeholders_load_from_env_and_default_fail_closed -q`

## AI reconciliation
- Codex findings reviewed: yes.
- Fixed: `atlas_brain/eom_api/config.py:76` R2 BLOCKER asking for focused settings-loading/default and blueprint assertions; added targeted coverage in `tests/test_eom_render_profile.py`.
- All findings fixed or waived: yes.
- Waivers: none.

## Diff size
4 files, 164 LOC; code/config change remains 2 files, 22 LOC.
