### PR TITLE
Make PR watcher use current-head check runs

### DIFF
--- a/plans/PR-Current-Head-Check-Readiness.md
+++ b/plans/PR-Current-Head-Check-Readiness.md
@@ -1,0 +1,129 @@
+# PR-Current-Head-Check-Readiness
+
+## Why this slice exists
+
+Recent PRs repeatedly showed stale red `live-reconciliation` / AI
+reconciliation rows beside newer green current-head rows, which made the
+watcher handoff report ambiguous readiness and forced patch-by-patch triage
+instead of root-cause convergence.
+
+### Problem-derived contract
+
+- Root cause: PR watcher readiness already fetches check-runs for the final PR
+  head, but non-managed `check_failures` / `check_pending` are still computed
+  from broad `gh pr checks` rows. When GitHub reports duplicate rows for the
+  same check name, an older failed row can keep the watcher red after the
+  latest final-head run is green.
+- Correct fix must touch/change: `scripts/pr_watcher.py` must derive active
+  non-managed check blockers from the latest GitHub Actions check-run on the
+  final PR head for each reported check name, while keeping shape/transport
+  errors fail-closed. `tests/test_pr_watcher.py` must prove older failed
+  duplicate rows do not mask the newer current-head green run and that a latest
+  optional failure still blocks readiness.
+- Must not change: Do not alter branch protection, required-check registry
+  semantics, review-thread reconciliation, Codex review policy, merge
+  authority, product behavior, or unrelated watcher/reporting lanes.
+
+## Scope (this PR)
+
+Ownership lane: dev-workflow/current-head-check-readiness
+Slice phase: Workflow/process
+
+1. Change PR watcher all-check readiness to collapse non-managed check state to
+   final-head latest check-runs by check name.
+2. Add regression coverage for stale duplicate check rows and active optional
+   failures.
+
+### Review Contract
+
+- Acceptance criteria:
+  - `scripts/pr_watcher.py` validates `gh pr checks` rows for shape but derives
+    active non-managed failures/pending from latest final-head check-runs.
+  - A duplicate optional check with an older failed run and newer successful
+    final-head run produces `state == "ready_for_human_merge"` and empty
+    `check_failures`.
+  - A duplicate optional check whose latest final-head run failed still
+    produces `state == "attention"` and the failed check name in
+    `check_failures`.
+  - Required/registry readiness remains governed by expected required/blocking
+    contexts and latest final-head GitHub Actions check-runs.
+- Reachability proof: `scripts/pr_watcher.py produce(...)` is exercised through
+  `tests/test_pr_watcher.py`; observable effect is the emitted watcher status
+  JSON state and `check_failures` / `readiness.required_*` fields.
+- Affected surfaces: `scripts/pr_watcher.py` watcher readiness producer and
+  `tests/test_pr_watcher.py` watcher fixtures.
+- Risk areas: stale duplicate rows, optional check regressions, malformed
+  check-row fail-closed behavior, required-check registry behavior.
+- Reviewer rules triggered: R1, R2, R6, R8, R10, R12, R14.
+
+### Boundary-change enumeration
+
+Required when this diff changes a guard, validator, normalizer, resolver,
+router/classifier, or admission boundary. Name each changed boundary path or
+seam in the enumeration; otherwise write "N/A - no boundary change."
+
+- Boundary path/seam: PR watcher check-state normalizer in
+  `scripts/pr_watcher.py`.
+- Replaced-path behaviors: Non-managed `gh pr checks` failure/pending rows are
+  no longer treated as active blockers when a newer final-head check-run for
+  the same name supersedes them.
+- Guard-relevant fields: `name`, `bucket`, `status`, `conclusion`,
+  `started_at`, and GitHub Actions `app.id`.
+- Caller x input shape: watcher config for one owned PR; GitHub CLI JSON for
+  PR checks and commit check-runs.
+
+### Deployed-config probing
+
+Required for guard, validator, resolver, admission-boundary, or env/config
+fallback changes; otherwise write "N/A - no guard/config boundary change."
+
+- Deployed/default config values: N/A - no config value change.
+- Explicit value probe: N/A - no config value change.
+- Absent value probe: N/A - no config value change.
+- Default-session/default-context probe: watcher default fake config is
+  exercised by `tests/test_pr_watcher.py`.
+- Side-effect ordering: watcher still reads PR/check/review state and writes a
+  status snapshot only; it does not merge or mutate PRs.
+
+### Files touched
+
+- `plans/PR-Current-Head-Check-Readiness.md`
+- `scripts/pr_watcher.py`
+- `tests/test_pr_watcher.py`
+
+## Mechanism
+
+The watcher keeps `gh pr checks` as the reported check-name inventory and shape
+validation source. After the final PR head is known, it fetches commit
+check-runs for that exact SHA, collapses GitHub Actions runs by check name using
+the latest `started_at`, and computes both required/blocking readiness and
+non-managed `check_failures` / `check_pending` from that collapsed current-head
+map.
+
+## Intentional
+
+- No branch protection or required-check registry changes; this is a readiness
+  observation fix only.
+- Non-GitHub Actions check-runs remain outside the provenance-backed readiness
+  source because the existing required-check guard already trusts GitHub Actions
+  app provenance for CI gates.
+
+## Deferred
+
+None.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_pr_watcher.py` - 75 passed.
+- `ATLAS_SESSION_STATE_FILE=SESSION_STATE.codex-current-head-check-readiness.local.md bash scripts/local_pr_review.sh --current-pr-body-file /tmp/atlas-pr-body-current-head-check-readiness.md` - passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Current-Head-Check-Readiness.md` | 129 |
+| `scripts/pr_watcher.py` | 28 |
+| `tests/test_pr_watcher.py` | 91 |
+| **Total** | **248** |

--- a/scripts/pr_watcher.py
+++ b/scripts/pr_watcher.py
@@ -436,6 +436,26 @@ def _check_summary(
     return failures, pending, None
 
 
+def _reported_check_names(
+    checks: list[Any],
+    *,
+    ignore_contexts: set[str] | frozenset[str] = frozenset(),
+) -> tuple[set[str], str | None]:
+    names: set[str] = set()
+    for index, item in enumerate(checks):
+        if not isinstance(item, dict):
+            return set(), f"check result {index} is not an object"
+        name = item.get("name")
+        bucket = item.get("bucket")
+        if not isinstance(name, str) or not name:
+            return set(), f"check result {index} has no name"
+        if not isinstance(bucket, str) or not bucket:
+            return set(), f"check {name!r} has no bucket"
+        if name not in ignore_contexts:
+            names.add(name)
+    return names, None
+
+
 def _latest_github_actions_check_runs(
     payload: dict[str, Any],
     *,
@@ -1036,9 +1056,8 @@ def produce(watcher_id: str, *, config_dir: Path, state_dir: Path) -> tuple[int,
     expected_required |= registry_policy.branch_required
     expected_blocking = expected_required | registry_policy.ci_blocking
     policy_managed_contexts = expected_blocking | registry_policy.non_blocking
-    failures, pending, all_shape_error = _check_summary(
+    reported_optional, all_shape_error = _reported_check_names(
         all_checks,
-        required=False,
         ignore_contexts=policy_managed_contexts,
     )
     _required_gh_failures, _required_gh_pending, required_shape_error = _check_summary(
@@ -1062,6 +1081,10 @@ def produce(watcher_id: str, *, config_dir: Path, state_dir: Path) -> tuple[int,
     )
     required_failures, required_pending, run_summary_error = _blocking_check_summary_from_runs(
         expected_blocking,
+        runs_by_name,
+    )
+    failures, pending, optional_run_summary_error = _blocking_check_summary_from_runs(
+        reported_optional,
         runs_by_name,
     )
     reported_required = {
@@ -1101,6 +1124,7 @@ def produce(watcher_id: str, *, config_dir: Path, state_dir: Path) -> tuple[int,
             required_shape_error,
             check_runs_shape_error,
             run_summary_error,
+            optional_run_summary_error,
             required_policy_shape_error,
             registry_required_error,
         )

--- a/tests/test_pr_watcher.py
+++ b/tests/test_pr_watcher.py
@@ -768,6 +768,89 @@ def test_optional_non_skipped_failure_still_blocks_green_state(
     assert status["readiness"]["required_checks_complete"] is True
 
 
+def test_stale_duplicate_optional_check_failure_is_ignored_when_latest_head_run_passes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    status = _produce(
+        tmp_path,
+        monkeypatch,
+        FakeRun(
+            all_checks=_response(
+                [
+                    _check("required-a"),
+                    _check("optional-a", "fail"),
+                    _check("optional-a"),
+                ]
+            ),
+            required_checks=_response([_check("required-a")]),
+            check_runs=_response(
+                {
+                    "check_runs": [
+                        _check_run("required-a"),
+                        _check_run(
+                            "optional-a",
+                            conclusion="failure",
+                            started_at="2026-07-27T00:00:00Z",
+                        ),
+                        _check_run(
+                            "optional-a",
+                            conclusion="success",
+                            started_at="2026-07-27T00:05:00Z",
+                        ),
+                    ]
+                }
+            ),
+        ),
+    )
+
+    assert status["state"] == "ready_for_human_merge"
+    assert status["check_failures"] == []
+    assert status["check_pending"] == []
+    assert status["readiness"]["required_checks_complete"] is True
+
+
+def test_latest_duplicate_optional_check_failure_still_blocks_readiness(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    status = _produce(
+        tmp_path,
+        monkeypatch,
+        FakeRun(
+            all_checks=_response(
+                [
+                    _check("required-a"),
+                    _check("optional-a"),
+                    _check("optional-a", "fail"),
+                ]
+            ),
+            required_checks=_response([_check("required-a")]),
+            check_runs=_response(
+                {
+                    "check_runs": [
+                        _check_run("required-a"),
+                        _check_run(
+                            "optional-a",
+                            conclusion="success",
+                            started_at="2026-07-27T00:00:00Z",
+                        ),
+                        _check_run(
+                            "optional-a",
+                            conclusion="failure",
+                            started_at="2026-07-27T00:05:00Z",
+                        ),
+                    ]
+                }
+            ),
+        ),
+    )
+
+    assert status["state"] == "attention"
+    assert status["check_failures"] == ["optional-a (failure)"]
+    assert status["readiness"]["required_checks_complete"] is True
+
+
 def test_optional_skipped_check_does_not_block_green_state(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -778,6 +861,14 @@ def test_optional_skipped_check_does_not_block_green_state(
         FakeRun(
             all_checks=_response([_check("required-a"), _check("optional-a", "skipping")]),
             required_checks=_response([_check("required-a")]),
+            check_runs=_response(
+                {
+                    "check_runs": [
+                        _check_run("required-a"),
+                        _check_run("optional-a", conclusion="skipped"),
+                    ]
+                }
+            ),
         ),
     )
 


### PR DESCRIPTION
Plan: plans/PR-Current-Head-Check-Readiness.md
Slice phase: Workflow/process
Ownership lane: dev-workflow/current-head-check-readiness

This slice fixes watcher readiness reporting when GitHub shows stale duplicate check rows beside newer final-head runs. The watcher now treats broad `gh pr checks` rows as check-name inventory/shape validation and uses latest GitHub Actions check-runs on the final PR head as the active verdict source for non-managed check failures and pending state.

## Intentional
- No branch protection, required-check registry, review-thread reconciliation, Codex review policy, or merge-authority changes.
- Non-GitHub Actions check-runs remain outside the provenance-backed readiness source because the existing required-check guard already trusts GitHub Actions app provenance for CI gates.

## AI reconciliation
- no-findings

## Deferred
- None.

## Parked hardening
- None.

## Cold diff reconstruction
- Changed: `scripts/pr_watcher.py:439` adds `_reported_check_names`, which validates `gh pr checks` row shape and collects non-managed check names without using stale row buckets as verdicts.
- Changed: `scripts/pr_watcher.py:1059` uses that inventory after excluding policy-managed contexts, while `scripts/pr_watcher.py:1067` fetches check-runs for the final PR head and `scripts/pr_watcher.py:1086` computes non-managed failures/pending from the collapsed latest-run map.
- Changed: `tests/test_pr_watcher.py:771` proves an older failed duplicate optional run is ignored when the newer final-head run succeeds.
- Changed: `tests/test_pr_watcher.py:813` proves the latest duplicate optional failure still blocks readiness.
- Changed: `tests/test_pr_watcher.py:854` keeps optional skipped readiness tied to an explicit current-head `skipped` check-run.
- Contract match: every code/test change traces to current-head/latest-run watcher readiness for stale duplicate check rows.
- Gaps: none.

## Verification
- `python -m pytest tests/test_pr_watcher.py` - 75 passed.
- `ATLAS_SESSION_STATE_FILE=SESSION_STATE.codex-current-head-check-readiness.local.md bash scripts/local_pr_review.sh --current-pr-body-file /tmp/atlas-pr-body-current-head-check-readiness.md` - passed.

## Mechanical verification
- Command: python -m pytest tests/test_pr_watcher.py - Result: 75 passed - Environment: local
- Command: ATLAS_SESSION_STATE_FILE=SESSION_STATE.codex-current-head-check-readiness.local.md bash scripts/local_pr_review.sh --current-pr-body-file /tmp/atlas-pr-body-current-head-check-readiness.md - Result: passed - Environment: local

## Diff size
3 files, +246 / -2
