### PR TITLE
Guard draft PR creation behind consent

### DIFF
--- a/plans/PR-Open-Ready-Draft-Consent-Guard.md
+++ b/plans/PR-Open-Ready-Draft-Consent-Guard.md
@@ -1,0 +1,118 @@
+# PR-Open-Ready-Draft-Consent-Guard
+
+## Why this slice exists
+
+The AGENTS mechanical-enforcement audit found that PRs are supposed to open
+ready for review by default, but `open_pr.sh` still forwards `--draft` without
+any explicit operator-consent signal. Draft PRs delay automated review and have
+already cost this lane manual attention.
+
+### Problem-derived contract
+
+- Root cause: The PR mutation wrapper rejects target-changing args, but it does
+  not classify draft mode as a consent-gated create option, so a builder can
+  accidentally open a draft PR even though AGENTS says ready-for-review is the
+  default.
+- Correct fix must touch/change: `scripts/open_pr.sh` must reject `--draft` /
+  `-d` unless an explicit operator-consent environment flag is present.
+  `tests/test_open_pr_wrapper.py` must prove reject-by-default happens before
+  any GitHub mutation and prove the explicit flag forwards draft mode when the
+  operator intentionally allows it.
+- Must not change: Do not alter PR body validation, target repo/base/head
+  safety, local review ordering, existing PR edit behavior, branch protection,
+  or any product/runtime code.
+
+## Scope (this PR)
+
+Ownership lane: dev-workflow/open-ready-draft-consent
+Slice phase: Workflow/process
+
+1. Add an explicit draft-consent gate to `open_pr.sh` create-argument parsing.
+2. Add wrapper tests for rejected draft creation by default and allowed draft
+   creation with the explicit consent flag.
+
+### Review Contract
+
+- Acceptance criteria:
+  - `scripts/open_pr.sh` rejects `--draft` and `-d` before GitHub mutation when
+    `ATLAS_OPEN_PR_DRAFT_CONSENT` is not set to `1`.
+  - `scripts/open_pr.sh` forwards `--draft` to `gh pr create` when
+    `ATLAS_OPEN_PR_DRAFT_CONSENT=1` is set.
+  - Existing safe ready-for-review create and edit flows continue to pass.
+- Reachability proof: `tests/test_open_pr_wrapper.py` invokes the real wrapper
+  script against a fake `gh`; observable effects are process exit code, stderr,
+  and captured `gh pr create` argv/stdin.
+- Affected surfaces: `scripts/open_pr.sh` create-argument boundary and
+  `tests/test_open_pr_wrapper.py` fixtures.
+- Risk areas: create-argument parsing, accidental draft mode, consent flag
+  misuse, existing PR edit/create wrapper regression.
+- Reviewer rules triggered: R1, R2, R6, R10, R12, R14.
+
+### Boundary-change enumeration
+
+Required when this diff changes a guard, validator, normalizer, resolver,
+router/classifier, or admission boundary. Name each changed boundary path or
+seam in the enumeration; otherwise write "N/A - no boundary change."
+
+- Boundary path/seam: `scripts/open_pr.sh` create-argument admission.
+- Replaced-path behaviors: `--draft` / `-d` no longer pass through by default.
+- Guard-relevant fields: wrapper argv and `ATLAS_OPEN_PR_DRAFT_CONSENT`.
+- Caller x input shape: local builder running `bash scripts/open_pr.sh
+  BODY_FILE [gh-pr-create-args...]`.
+
+### Deployed-config probing
+
+Required for guard, validator, resolver, admission-boundary, or env/config
+fallback changes; otherwise write "N/A - no guard/config boundary change."
+
+- Deployed/default config values: `ATLAS_OPEN_PR_DRAFT_CONSENT` defaults absent.
+- Explicit value probe: test sets `ATLAS_OPEN_PR_DRAFT_CONSENT=1` and proves
+  draft mode is forwarded.
+- Absent value probe: tests omit the flag for `--draft` and `-d` and prove the
+  wrapper exits before fake `gh` is invoked.
+- Default-session/default-context probe: existing ready create/edit wrapper
+  tests continue to run without the flag.
+- Side-effect ordering: draft rejection happens in argument admission before
+  base refresh, local review, or GitHub mutation.
+
+### Files touched
+
+- `plans/PR-Open-Ready-Draft-Consent-Guard.md`
+- `scripts/open_pr.sh`
+- `tests/test_open_pr_wrapper.py`
+
+## Mechanism
+
+`reject_target_overrides` treats `--draft` and `-d` as consent-gated create
+arguments. Without `ATLAS_OPEN_PR_DRAFT_CONSENT=1`, it prints a targeted error
+and exits before any GitHub call. With the flag set, the wrapper leaves the
+argument in place so the existing `gh pr create` call can intentionally create a
+draft PR.
+
+## Intentional
+
+- The consent signal is an environment flag, not a new persistent session-state
+  parser; it keeps this slice small and makes the exceptional draft request
+  explicit at the command boundary.
+- The wrapper still opens ready PRs by default; no extra flag is needed for the
+  normal path.
+
+## Deferred
+
+None.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_open_pr_wrapper.py` - 28 passed.
+- `ATLAS_SESSION_STATE_FILE=SESSION_STATE.codex-open-ready-draft-consent.local.md bash scripts/local_pr_review.sh --current-pr-body-file /tmp/atlas-pr-body-open-ready-draft-consent.md` - passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Open-Ready-Draft-Consent-Guard.md` | 118 |
+| `scripts/open_pr.sh` | 10 |
+| `tests/test_open_pr_wrapper.py` | 15 |
+| **Total** | **143** |

--- a/plans/PR-Open-Ready-Draft-Consent-Guard.md
+++ b/plans/PR-Open-Ready-Draft-Consent-Guard.md
@@ -13,11 +13,13 @@ already cost this lane manual attention.
   not classify draft mode as a consent-gated create option, so a builder can
   accidentally open a draft PR even though AGENTS says ready-for-review is the
   default.
-- Correct fix must touch/change: `scripts/open_pr.sh` must reject `--draft` /
-  `-d` unless an explicit operator-consent environment flag is present.
+- Correct fix must touch/change: `scripts/open_pr.sh` must reject every draft
+  flag spelling `gh pr create` accepts -- `--draft`, `--draft=<value>`, `-d`,
+  `-d=<value>`, and `-d`-leading short-flag clusters such as `-dw` -- unless an
+  explicit operator-consent environment flag is present.
   `tests/test_open_pr_wrapper.py` must prove reject-by-default happens before
-  any GitHub mutation and prove the explicit flag forwards draft mode when the
-  operator intentionally allows it.
+  any GitHub mutation for each spelling class and prove the explicit flag
+  forwards draft mode when the operator intentionally allows it.
 - Must not change: Do not alter PR body validation, target repo/base/head
   safety, local review ordering, existing PR edit behavior, branch protection,
   or any product/runtime code.
@@ -34,10 +36,11 @@ Slice phase: Workflow/process
 ### Review Contract
 
 - Acceptance criteria:
-  - `scripts/open_pr.sh` rejects `--draft` and `-d` before GitHub mutation when
-    `ATLAS_OPEN_PR_DRAFT_CONSENT` is not set to `1`.
-  - `scripts/open_pr.sh` forwards `--draft` to `gh pr create` when
-    `ATLAS_OPEN_PR_DRAFT_CONSENT=1` is set.
+  - `scripts/open_pr.sh` rejects `--draft`, `--draft=<value>`, `-d`,
+    `-d=<value>`, and `-d`-leading short-flag clusters before GitHub mutation
+    when `ATLAS_OPEN_PR_DRAFT_CONSENT` is not set to `1`.
+  - `scripts/open_pr.sh` forwards `--draft` and `--draft=true` to
+    `gh pr create` when `ATLAS_OPEN_PR_DRAFT_CONSENT=1` is set.
   - Existing safe ready-for-review create and edit flows continue to pass.
 - Reachability proof: `tests/test_open_pr_wrapper.py` invokes the real wrapper
   script against a fake `gh`; observable effects are process exit code, stderr,
@@ -55,7 +58,9 @@ router/classifier, or admission boundary. Name each changed boundary path or
 seam in the enumeration; otherwise write "N/A - no boundary change."
 
 - Boundary path/seam: `scripts/open_pr.sh` create-argument admission.
-- Replaced-path behaviors: `--draft` / `-d` no longer pass through by default.
+- Replaced-path behaviors: `--draft`, `--draft=<value>`, and every `-d`-leading
+  token (`-d`, `-d=<value>`, clusters like `-dw`) no longer pass through by
+  default.
 - Guard-relevant fields: wrapper argv and `ATLAS_OPEN_PR_DRAFT_CONSENT`.
 - Caller x input shape: local builder running `bash scripts/open_pr.sh
   BODY_FILE [gh-pr-create-args...]`.
@@ -83,11 +88,16 @@ fallback changes; otherwise write "N/A - no guard/config boundary change."
 
 ## Mechanism
 
-`reject_target_overrides` treats `--draft` and `-d` as consent-gated create
-arguments. Without `ATLAS_OPEN_PR_DRAFT_CONSENT=1`, it prints a targeted error
-and exits before any GitHub call. With the flag set, the wrapper leaves the
-argument in place so the existing `gh pr create` call can intentionally create a
-draft PR.
+`reject_target_overrides` treats every draft-flag spelling as a consent-gated
+create argument via the case pattern `--draft|--draft=*|-d*`. The `-d*` arm
+covers bare `-d`, boolean assignments (`-d=true`), and `-d`-leading short-flag
+clusters (`-dw`), because `gh`'s pflag parser accepts all of them as draft
+mode. The gate is value-blind on purpose: `--draft=false` is also held behind
+consent rather than parsing pflag's six truthy spellings, since ready-for-review
+is already the default and fail-closed is simpler. Without
+`ATLAS_OPEN_PR_DRAFT_CONSENT=1`, the wrapper prints a targeted error and exits
+before any GitHub call. With the flag set, it leaves the argument in place so
+the existing `gh pr create` call can intentionally create a draft PR.
 
 ## Intentional
 
@@ -105,14 +115,14 @@ Parked hardening: none.
 
 ## Verification
 
-- `python -m pytest tests/test_open_pr_wrapper.py` - 28 passed.
+- `python -m pytest tests/test_open_pr_wrapper.py` - 36 passed.
 - `ATLAS_SESSION_STATE_FILE=SESSION_STATE.codex-open-ready-draft-consent.local.md bash scripts/local_pr_review.sh --current-pr-body-file /tmp/atlas-pr-body-open-ready-draft-consent.md` - passed.
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Open-Ready-Draft-Consent-Guard.md` | 118 |
+| `plans/PR-Open-Ready-Draft-Consent-Guard.md` | 128 |
 | `scripts/open_pr.sh` | 10 |
-| `tests/test_open_pr_wrapper.py` | 15 |
-| **Total** | **143** |
+| `tests/test_open_pr_wrapper.py` | 35 |
+| **Total** | **173** |

--- a/plans/PR-Open-Ready-Draft-Consent-Guard.md
+++ b/plans/PR-Open-Ready-Draft-Consent-Guard.md
@@ -7,7 +7,7 @@ ready for review by default, but `open_pr.sh` still forwards `--draft` without
 any explicit operator-consent signal. Draft PRs delay automated review and have
 already cost this lane manual attention.
 
-Diff budget: the slice exceeds the 400 LOC soft cap (543 actual) because four
+Diff budget: the slice exceeds the 400 LOC soft cap (622 actual) because five
 Codex review rounds required class-closure work rather than spot fixes -- the
 pflag-faithful argv-grammar walk, the admission-before-side-effects ordering,
 a grammar-derived property suite with an independent oracle, and the plan's
@@ -61,6 +61,10 @@ Slice phase: Workflow/process
   - `scripts/open_pr.sh` exports `GH_PROMPT_DISABLED=1` so gh's interactive
     create survey (which offers "Submit as draft" with no argv token) is
     unreachable through the wrapper.
+  - `scripts/open_pr.sh` rejects the browser create route (`--web`,
+    `--web=<value>`, and clusters whose walk reaches a boolean `w`) even when
+    draft consent is set, because the web UI can submit a draft with no argv
+    token and escapes post-mutation verification.
   - The consent decision matches an independent pflag oracle across a
     generated product of boolean-shorthand positions x value-taking
     terminators x attached/separate/`=` values
@@ -184,15 +188,24 @@ default and fail-closed is simpler. Without `ATLAS_OPEN_PR_DRAFT_CONSENT=1`,
 call. With the flag set, the wrapper leaves the argument in place so the
 existing `gh pr create` call can intentionally create a draft PR.
 
-Two structural guarantees close the remaining entry points: the wrapper
+Three structural guarantees close the remaining entry points: the wrapper
 exports `GH_PROMPT_DISABLED=1`, so gh's interactive create survey -- whose
 "Submit as draft" action carries no argv token -- is unreachable and draft
-mode can only arrive through the gated argv path; and
+mode can only arrive through the gated argv path; `reject_web_create`
+refuses the browser route (`--web`, `--web=<value>`, and clusters whose walk
+reaches a boolean `w`) even under draft consent, because GitHub's create UI
+can submit a draft with no argv token and the web flow also escapes this
+wrapper's post-mutation head/body verification; and
 `test_open_pr_draft_admission_matches_gh_argv_grammar` proves grammar closure
 by generating the product of boolean-shorthand positions, value-taking
 terminators, and attached/separate/`=` value bindings, then asserting the
-wrapper's consent decision equals an independent Python oracle modeling gh's
-pflag walk for every generated sequence.
+wrapper's admission decision (consent-gate, web-reject, or pass) equals an
+independent Python oracle modeling gh's pflag walk for every generated
+sequence. Creating a new PR requires `--title` or a gh fill option by
+pre-existing necessity, not as a change here: the wrapper binds stdin to the
+body file, so gh has never been able to prompt for a title through it;
+`GH_PROMPT_DISABLED` makes that non-interactive contract explicit and the
+usage text now states it.
 
 ## Intentional
 
@@ -213,20 +226,27 @@ pflag walk for every generated sequence.
 - Non-leading cluster spellings of the pre-existing `-H`/`-R`/`-B`
   target-override gates (e.g. `-fHother`) predate this slice and belong to a
   separate target-override hardening follow-up; this slice's argv-grammar
-  walk gates draft mode only.
+  walk gates draft mode and the browser route only.
 
-Parked hardening: none.
+Parking predicate: this slice parks, by default, hardening of `gh pr create`
+surfaces other than ready-for-review admission through this wrapper --
+non-draft flag hygiene, target-override cluster spellings, and gh-version
+drift tooling. Findings inside the draft/web admission path itself are owned
+by this slice and were fixed in-review, not parked.
+
+Parked hardening: none against that predicate; the two deferrals above are
+named follow-ups, not silent parkings.
 
 ## Verification
 
-- `python -m pytest tests/test_open_pr_wrapper.py` - 47 passed.
+- `python -m pytest tests/test_open_pr_wrapper.py` - 52 passed.
 - `ATLAS_SESSION_STATE_FILE=SESSION_STATE.codex-open-ready-draft-consent.local.md bash scripts/local_pr_review.sh --current-pr-body-file /tmp/atlas-pr-body-open-ready-draft-consent.md` - passed.
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Open-Ready-Draft-Consent-Guard.md` | 232 |
-| `scripts/open_pr.sh` | 93 |
-| `tests/test_open_pr_wrapper.py` | 218 |
-| **Total** | **543** |
+| `plans/PR-Open-Ready-Draft-Consent-Guard.md` | 252 |
+| `scripts/open_pr.sh` | 119 |
+| `tests/test_open_pr_wrapper.py` | 251 |
+| **Total** | **622** |

--- a/plans/PR-Open-Ready-Draft-Consent-Guard.md
+++ b/plans/PR-Open-Ready-Draft-Consent-Guard.md
@@ -43,7 +43,12 @@ Slice phase: Workflow/process
     position (`-dw`, `-fd`, `-wd`, `-fwd`, `-fd=true`) before GitHub mutation
     when `ATLAS_OPEN_PR_DRAFT_CONSENT` is not set to `1`.
   - `scripts/open_pr.sh` does not gate value-taking shorthands whose attached
-    value contains `d` (`-tdraft-note` forwards without consent).
+    value contains `d` (`-tdraft-note` forwards without consent), nor
+    draft-shaped tokens consumed as a separate option value (`--title --draft`
+    and `-t -d` forward without consent, matching gh's grammar).
+  - `scripts/open_pr.sh` rejects an unauthorized draft invocation before any
+    side effect: with origin unreachable, `--draft` still fails on consent,
+    not on fetch.
   - `scripts/open_pr.sh` forwards `--draft` and `--draft=true` to
     `gh pr create` when `ATLAS_OPEN_PR_DRAFT_CONSENT=1` is set.
   - Existing safe ready-for-review create and edit flows continue to pass.
@@ -94,21 +99,30 @@ fallback changes; otherwise write "N/A - no guard/config boundary change."
 
 ## Mechanism
 
+Argument admission (`--body`-family rejection plus `reject_target_overrides`)
+runs before `refresh_base_ref` and the body audit, so a rejected invocation
+produces no side effect -- no fetch, no ref update, no GitHub call.
+
 `reject_target_overrides` treats every draft-flag spelling as a consent-gated
-create argument. Long forms match `--draft|--draft=*` directly. Every other
-one-dash token goes through `shorthand_cluster_sets_draft`, which mirrors
-`gh`'s pflag cluster walk: boolean shorthands keep scanning (so `-fd` and
-`-wd` enable draft just like `-dw`), a value-taking shorthand (`-a -B -b -F
--H -l -m -p -r -R -t -T`) consumes the rest of the token as its value (so
-`-tdraft-note` is a title, not a draft flag), and `=` binds the remainder to
-the shorthand before it. Unknown letters scan on as booleans, which fails
-closed. The gate is value-blind on purpose: `--draft=false` and `-d=false`
-are also held behind consent rather than parsing pflag's six truthy
-spellings, since ready-for-review is already the default and fail-closed is
-simpler. Without `ATLAS_OPEN_PR_DRAFT_CONSENT=1`, `require_draft_consent`
-prints a targeted error and exits before any GitHub call. With the flag set,
-the wrapper leaves the argument in place so the existing `gh pr create` call
-can intentionally create a draft PR.
+create argument by modeling gh's argv grammar. Long forms match
+`--draft|--draft=*` directly. Long value-taking options with a separate value
+token (`--assignee --label --milestone --project --reviewer --title
+--template --recover`, plus the existing `--base` handling) consume their
+next token, so `--title --draft` is a title value, not a draft flag. `--`
+ends option parsing. Every other one-dash token goes through
+`scan_shorthand_cluster`, which mirrors gh's pflag cluster walk: boolean
+shorthands keep scanning (so `-fd` and `-wd` enable draft just like `-dw`), a
+value-taking shorthand (`-a -B -b -F -H -l -m -p -r -R -t -T`) takes the
+attached remainder as its value (`-tdraft-note` is a title) or, when nothing
+is attached, consumes the next argv token (`-t -d` is a title value), and `=`
+binds the remainder to the shorthand before it. Unknown letters scan on as
+booleans, which fails closed. The gate is value-blind on purpose:
+`--draft=false` and `-d=false` are also held behind consent rather than
+parsing pflag's six truthy spellings, since ready-for-review is already the
+default and fail-closed is simpler. Without `ATLAS_OPEN_PR_DRAFT_CONSENT=1`,
+`require_draft_consent` prints a targeted error and exits before any GitHub
+call. With the flag set, the wrapper leaves the argument in place so the
+existing `gh pr create` call can intentionally create a draft PR.
 
 ## Intentional
 
@@ -126,14 +140,14 @@ Parked hardening: none.
 
 ## Verification
 
-- `python -m pytest tests/test_open_pr_wrapper.py` - 41 passed.
+- `python -m pytest tests/test_open_pr_wrapper.py` - 45 passed.
 - `ATLAS_SESSION_STATE_FILE=SESSION_STATE.codex-open-ready-draft-consent.local.md bash scripts/local_pr_review.sh --current-pr-body-file /tmp/atlas-pr-body-open-ready-draft-consent.md` - passed.
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Open-Ready-Draft-Consent-Guard.md` | 139 |
-| `scripts/open_pr.sh` | 48 |
-| `tests/test_open_pr_wrapper.py` | 53 |
-| **Total** | **240** |
+| `plans/PR-Open-Ready-Draft-Consent-Guard.md` | 153 |
+| `scripts/open_pr.sh` | 87 |
+| `tests/test_open_pr_wrapper.py` | 89 |
+| **Total** | **329** |

--- a/plans/PR-Open-Ready-Draft-Consent-Guard.md
+++ b/plans/PR-Open-Ready-Draft-Consent-Guard.md
@@ -7,6 +7,13 @@ ready for review by default, but `open_pr.sh` still forwards `--draft` without
 any explicit operator-consent signal. Draft PRs delay automated review and have
 already cost this lane manual attention.
 
+Diff budget: the slice exceeds the 400 LOC soft cap (543 actual) because four
+Codex review rounds required class-closure work rather than spot fixes -- the
+pflag-faithful argv-grammar walk, the admission-before-side-effects ordering,
+a grammar-derived property suite with an independent oracle, and the plan's
+closure/R11 declarations. The runtime product surface is one wrapper script;
+over half the diff is tests and plan contract.
+
 ### Problem-derived contract
 
 - Root cause: The PR mutation wrapper rejects target-changing args, but it does
@@ -51,10 +58,20 @@ Slice phase: Workflow/process
     not on fetch.
   - `scripts/open_pr.sh` forwards `--draft` and `--draft=true` to
     `gh pr create` when `ATLAS_OPEN_PR_DRAFT_CONSENT=1` is set.
+  - `scripts/open_pr.sh` exports `GH_PROMPT_DISABLED=1` so gh's interactive
+    create survey (which offers "Submit as draft" with no argv token) is
+    unreachable through the wrapper.
+  - The consent decision matches an independent pflag oracle across a
+    generated product of boolean-shorthand positions x value-taking
+    terminators x attached/separate/`=` values
+    (`test_open_pr_draft_admission_matches_gh_argv_grammar`).
   - Existing safe ready-for-review create and edit flows continue to pass.
 - Reachability proof: `tests/test_open_pr_wrapper.py` invokes the real wrapper
   script against a fake `gh`; observable effects are process exit code, stderr,
-  and captured `gh pr create` argv/stdin.
+  and captured `gh pr create` argv/stdin. Class closure of the argv grammar is
+  proven by a grammar-derived property test whose expected verdicts come from
+  an independent Python model of gh's pflag walk, not from the shell code
+  under test.
 - Affected surfaces: `scripts/open_pr.sh` create-argument boundary and
   `tests/test_open_pr_wrapper.py` fixtures.
 - Risk areas: create-argument parsing, accidental draft mode, consent flag
@@ -167,6 +184,16 @@ default and fail-closed is simpler. Without `ATLAS_OPEN_PR_DRAFT_CONSENT=1`,
 call. With the flag set, the wrapper leaves the argument in place so the
 existing `gh pr create` call can intentionally create a draft PR.
 
+Two structural guarantees close the remaining entry points: the wrapper
+exports `GH_PROMPT_DISABLED=1`, so gh's interactive create survey -- whose
+"Submit as draft" action carries no argv token -- is unreachable and draft
+mode can only arrive through the gated argv path; and
+`test_open_pr_draft_admission_matches_gh_argv_grammar` proves grammar closure
+by generating the product of boolean-shorthand positions, value-taking
+terminators, and attached/separate/`=` value bindings, then asserting the
+wrapper's consent decision equals an independent Python oracle modeling gh's
+pflag walk for every generated sequence.
+
 ## Intentional
 
 - The consent signal is an environment flag, not a new persistent session-state
@@ -192,14 +219,14 @@ Parked hardening: none.
 
 ## Verification
 
-- `python -m pytest tests/test_open_pr_wrapper.py` - 45 passed.
+- `python -m pytest tests/test_open_pr_wrapper.py` - 47 passed.
 - `ATLAS_SESSION_STATE_FILE=SESSION_STATE.codex-open-ready-draft-consent.local.md bash scripts/local_pr_review.sh --current-pr-body-file /tmp/atlas-pr-body-open-ready-draft-consent.md` - passed.
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Open-Ready-Draft-Consent-Guard.md` | 205 |
-| `scripts/open_pr.sh` | 87 |
-| `tests/test_open_pr_wrapper.py` | 89 |
-| **Total** | **381** |
+| `plans/PR-Open-Ready-Draft-Consent-Guard.md` | 232 |
+| `scripts/open_pr.sh` | 93 |
+| `tests/test_open_pr_wrapper.py` | 218 |
+| **Total** | **543** |

--- a/plans/PR-Open-Ready-Draft-Consent-Guard.md
+++ b/plans/PR-Open-Ready-Draft-Consent-Guard.md
@@ -15,8 +15,10 @@ already cost this lane manual attention.
   default.
 - Correct fix must touch/change: `scripts/open_pr.sh` must reject every draft
   flag spelling `gh pr create` accepts -- `--draft`, `--draft=<value>`, `-d`,
-  `-d=<value>`, and `-d`-leading short-flag clusters such as `-dw` -- unless an
-  explicit operator-consent environment flag is present.
+  `-d=<value>`, and shorthand clusters that enable draft in any position
+  (`-dw`, `-fd`, `-wd`, `-fd=true`) -- unless an explicit operator-consent
+  environment flag is present. Value-taking shorthands whose attached value
+  merely contains a `d` (for example `-tdraft-note`) must not be gated.
   `tests/test_open_pr_wrapper.py` must prove reject-by-default happens before
   any GitHub mutation for each spelling class and prove the explicit flag
   forwards draft mode when the operator intentionally allows it.
@@ -37,8 +39,11 @@ Slice phase: Workflow/process
 
 - Acceptance criteria:
   - `scripts/open_pr.sh` rejects `--draft`, `--draft=<value>`, `-d`,
-    `-d=<value>`, and `-d`-leading short-flag clusters before GitHub mutation
+    `-d=<value>`, and shorthand clusters containing `d` in any boolean
+    position (`-dw`, `-fd`, `-wd`, `-fwd`, `-fd=true`) before GitHub mutation
     when `ATLAS_OPEN_PR_DRAFT_CONSENT` is not set to `1`.
+  - `scripts/open_pr.sh` does not gate value-taking shorthands whose attached
+    value contains `d` (`-tdraft-note` forwards without consent).
   - `scripts/open_pr.sh` forwards `--draft` and `--draft=true` to
     `gh pr create` when `ATLAS_OPEN_PR_DRAFT_CONSENT=1` is set.
   - Existing safe ready-for-review create and edit flows continue to pass.
@@ -58,9 +63,10 @@ router/classifier, or admission boundary. Name each changed boundary path or
 seam in the enumeration; otherwise write "N/A - no boundary change."
 
 - Boundary path/seam: `scripts/open_pr.sh` create-argument admission.
-- Replaced-path behaviors: `--draft`, `--draft=<value>`, and every `-d`-leading
-  token (`-d`, `-d=<value>`, clusters like `-dw`) no longer pass through by
-  default.
+- Replaced-path behaviors: `--draft`, `--draft=<value>`, and every shorthand
+  cluster whose pflag walk reaches a boolean `d` (`-d`, `-d=<value>`, `-dw`,
+  `-fd`, `-wd`) no longer pass through by default; value-attached shorthands
+  like `-tdraft-note` still do.
 - Guard-relevant fields: wrapper argv and `ATLAS_OPEN_PR_DRAFT_CONSENT`.
 - Caller x input shape: local builder running `bash scripts/open_pr.sh
   BODY_FILE [gh-pr-create-args...]`.
@@ -89,15 +95,20 @@ fallback changes; otherwise write "N/A - no guard/config boundary change."
 ## Mechanism
 
 `reject_target_overrides` treats every draft-flag spelling as a consent-gated
-create argument via the case pattern `--draft|--draft=*|-d*`. The `-d*` arm
-covers bare `-d`, boolean assignments (`-d=true`), and `-d`-leading short-flag
-clusters (`-dw`), because `gh`'s pflag parser accepts all of them as draft
-mode. The gate is value-blind on purpose: `--draft=false` is also held behind
-consent rather than parsing pflag's six truthy spellings, since ready-for-review
-is already the default and fail-closed is simpler. Without
-`ATLAS_OPEN_PR_DRAFT_CONSENT=1`, the wrapper prints a targeted error and exits
-before any GitHub call. With the flag set, it leaves the argument in place so
-the existing `gh pr create` call can intentionally create a draft PR.
+create argument. Long forms match `--draft|--draft=*` directly. Every other
+one-dash token goes through `shorthand_cluster_sets_draft`, which mirrors
+`gh`'s pflag cluster walk: boolean shorthands keep scanning (so `-fd` and
+`-wd` enable draft just like `-dw`), a value-taking shorthand (`-a -B -b -F
+-H -l -m -p -r -R -t -T`) consumes the rest of the token as its value (so
+`-tdraft-note` is a title, not a draft flag), and `=` binds the remainder to
+the shorthand before it. Unknown letters scan on as booleans, which fails
+closed. The gate is value-blind on purpose: `--draft=false` and `-d=false`
+are also held behind consent rather than parsing pflag's six truthy
+spellings, since ready-for-review is already the default and fail-closed is
+simpler. Without `ATLAS_OPEN_PR_DRAFT_CONSENT=1`, `require_draft_consent`
+prints a targeted error and exits before any GitHub call. With the flag set,
+the wrapper leaves the argument in place so the existing `gh pr create` call
+can intentionally create a draft PR.
 
 ## Intentional
 
@@ -115,14 +126,14 @@ Parked hardening: none.
 
 ## Verification
 
-- `python -m pytest tests/test_open_pr_wrapper.py` - 36 passed.
+- `python -m pytest tests/test_open_pr_wrapper.py` - 41 passed.
 - `ATLAS_SESSION_STATE_FILE=SESSION_STATE.codex-open-ready-draft-consent.local.md bash scripts/local_pr_review.sh --current-pr-body-file /tmp/atlas-pr-body-open-ready-draft-consent.md` - passed.
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Open-Ready-Draft-Consent-Guard.md` | 128 |
-| `scripts/open_pr.sh` | 10 |
-| `tests/test_open_pr_wrapper.py` | 35 |
-| **Total** | **173** |
+| `plans/PR-Open-Ready-Draft-Consent-Guard.md` | 139 |
+| `scripts/open_pr.sh` | 48 |
+| `tests/test_open_pr_wrapper.py` | 53 |
+| **Total** | **240** |

--- a/plans/PR-Open-Ready-Draft-Consent-Guard.md
+++ b/plans/PR-Open-Ready-Draft-Consent-Guard.md
@@ -59,7 +59,14 @@ Slice phase: Workflow/process
   `tests/test_open_pr_wrapper.py` fixtures.
 - Risk areas: create-argument parsing, accidental draft mode, consent flag
   misuse, existing PR edit/create wrapper regression.
-- Reviewer rules triggered: R1, R2, R6, R10, R12, R14.
+- Reviewer rules triggered: R1, R2, R6, R10, R11, R12, R13, R14.
+- R11 configuration disposition: `ATLAS_OPEN_PR_DRAFT_CONSENT` is a
+  per-invocation operator consent flag for a local dev-workflow wrapper, not a
+  runtime `atlas_brain/config.py` setting. Default is unset, which refuses
+  drafts. It is documented in the wrapper's usage text (the only operator
+  surface for this script), and it must not be exported persistently in
+  `.env`, shell profiles, or CI -- persisting it would convert a one-time
+  exception into standing consent, defeating the gate.
 
 ### Boundary-change enumeration
 
@@ -72,6 +79,42 @@ seam in the enumeration; otherwise write "N/A - no boundary change."
   cluster whose pflag walk reaches a boolean `d` (`-d`, `-d=<value>`, `-dw`,
   `-fd`, `-wd`) no longer pass through by default; value-attached shorthands
   like `-tdraft-note` still do.
+
+### Closure declaration
+
+Set-valued dependencies in the admission decision, per
+`docs/GUARD_CLASS_CLOSURE.md` (each answers closed/open, sourcing, and the
+outside-set direction):
+
+- Draft-flag spelling set (`--draft`, `--draft=<value>`, shorthand `d`):
+  CLOSED with respect to the installed gh CLI (2.96.0), whose help documents
+  exactly `-d, --draft` as the draft flag. Sourcing is ENUMERATED from
+  `gh pr create --help` at authoring time; a bash wrapper has no runtime
+  derivation point against gh's flag table, so a future gh alias for draft
+  would not be auto-detected.
+- Value-taking option inventory (long options with a separate value token:
+  `--assignee --label --milestone --project --reviewer --title --template
+  --recover`, plus the dedicated admission arms for `--base --head --repo
+  --body --body-file`; shorthand letters: `a B b F H l m p r R t T`): CLOSED
+  with respect to gh 2.96.0. Sourcing is ENUMERATED from
+  `gh pr create --help` at authoring time; ENUMERATED is the honest answer
+  because the wrapper cannot recompute gh's flag table per run and therefore
+  cannot notice upstream drift.
+- Caller x input shape: CLOSED. The only caller is a local builder running
+  `bash scripts/open_pr.sh BODY_FILE [gh-pr-create-args...]`, and every
+  scanned token is forwarded to exactly one consumer, `gh pr create`.
+
+Outside-the-set direction (required even for CLOSED sets): every token the
+inventory does not recognize flows to the consent-gated side. An unknown long
+option is not treated as value-taking, so a `--draft`-shaped token after it is
+still gated; an unknown shorthand letter scans on as a boolean, so a `d` after
+it is still gated. Inventory incompleteness therefore produces over-rejection
+(a ready invocation asked for consent it did not need -- cheap, because the
+operator reruns with the flag or without the token) and never an unconsented
+draft PR, which is the failure this slice exists to prevent. The one residual
+drift direction -- a future gh release demoting a currently value-taking flag
+to boolean, re-opening a cross-token spelling -- is accepted under ENUMERATED
+sourcing and named in Deferred.
 - Guard-relevant fields: wrapper argv and `ATLAS_OPEN_PR_DRAFT_CONSENT`.
 - Caller x input shape: local builder running `bash scripts/open_pr.sh
   BODY_FILE [gh-pr-create-args...]`.
@@ -134,7 +177,16 @@ existing `gh pr create` call can intentionally create a draft PR.
 
 ## Deferred
 
-None.
+- gh CLI flag-table drift: the value-taking inventory is enumerated from
+  gh 2.96.0. A future gh release that changes an existing flag's arity
+  (value-taking to boolean) would re-open a cross-token spelling and requires
+  re-auditing the inventory; no runtime derivation point exists in a bash
+  wrapper. Unlisted-member drift in the other direction only over-rejects
+  (see Closure declaration).
+- Non-leading cluster spellings of the pre-existing `-H`/`-R`/`-B`
+  target-override gates (e.g. `-fHother`) predate this slice and belong to a
+  separate target-override hardening follow-up; this slice's argv-grammar
+  walk gates draft mode only.
 
 Parked hardening: none.
 
@@ -147,7 +199,7 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Open-Ready-Draft-Consent-Guard.md` | 153 |
+| `plans/PR-Open-Ready-Draft-Consent-Guard.md` | 205 |
 | `scripts/open_pr.sh` | 87 |
 | `tests/test_open_pr_wrapper.py` | 89 |
-| **Total** | **329** |
+| **Total** | **381** |

--- a/scripts/open_pr.sh
+++ b/scripts/open_pr.sh
@@ -54,6 +54,43 @@ refresh_base_ref() {
     fi
 }
 
+require_draft_consent() {
+    if [ "${ATLAS_OPEN_PR_DRAFT_CONSENT:-}" != "1" ]; then
+        echo "open_pr.sh: refusing draft PR without explicit operator consent: $1" >&2
+        echo "Set ATLAS_OPEN_PR_DRAFT_CONSENT=1 only when the operator asked for a draft." >&2
+        exit 2
+    fi
+}
+
+shorthand_cluster_sets_draft() {
+    # gh's pflag parser walks a one-dash cluster left to right: boolean
+    # shorthands keep scanning (so -fd and -wd both enable draft), a
+    # value-taking shorthand consumes the rest of the token as its value, and
+    # '=' binds the remainder to the shorthand before it. Value-taking
+    # shorthands for `gh pr create`: -a -B -b -F -H -l -m -p -r -R -t -T.
+    # Unknown letters are treated as booleans, which fail closed: scanning
+    # continues, so a 'd' after them still requires consent.
+    local cluster="${1#-}" ch
+    while [ -n "$cluster" ]; do
+        ch="${cluster:0:1}"
+        if [ "$ch" = "d" ]; then
+            return 0
+        fi
+        case "$ch" in
+            a|B|b|F|H|l|m|p|r|R|t|T)
+                return 1
+                ;;
+        esac
+        cluster="${cluster:1}"
+        case "$cluster" in
+            =*)
+                return 1
+                ;;
+        esac
+    done
+    return 1
+}
+
 reject_target_overrides() {
     if [ -n "${GH_REPO:-}" ]; then
         echo "open_pr.sh: refusing GH_REPO target override: $GH_REPO" >&2
@@ -74,12 +111,8 @@ reject_target_overrides() {
                 echo "open_pr.sh: refusing target-changing create arg: $arg" >&2
                 exit 2
                 ;;
-            --draft|--draft=*|-d*)
-                if [ "${ATLAS_OPEN_PR_DRAFT_CONSENT:-}" != "1" ]; then
-                    echo "open_pr.sh: refusing draft PR without explicit operator consent: $arg" >&2
-                    echo "Set ATLAS_OPEN_PR_DRAFT_CONSENT=1 only when the operator asked for a draft." >&2
-                    exit 2
-                fi
+            --draft|--draft=*)
+                require_draft_consent "$arg"
                 ;;
             --base|-B)
                 if [ "$#" -eq 0 ]; then
@@ -108,6 +141,11 @@ reject_target_overrides() {
                     echo "open_pr.sh: refusing non-main base: $value" >&2
                     echo "The local review gate is bound to origin/main." >&2
                     exit 2
+                fi
+                ;;
+            -[!-]*)
+                if shorthand_cluster_sets_draft "$arg"; then
+                    require_draft_consent "$arg"
                 fi
                 ;;
         esac

--- a/scripts/open_pr.sh
+++ b/scripts/open_pr.sh
@@ -62,33 +62,39 @@ require_draft_consent() {
     fi
 }
 
-shorthand_cluster_sets_draft() {
+scan_shorthand_cluster() {
     # gh's pflag parser walks a one-dash cluster left to right: boolean
     # shorthands keep scanning (so -fd and -wd both enable draft), a
-    # value-taking shorthand consumes the rest of the token as its value, and
-    # '=' binds the remainder to the shorthand before it. Value-taking
-    # shorthands for `gh pr create`: -a -B -b -F -H -l -m -p -r -R -t -T.
-    # Unknown letters are treated as booleans, which fail closed: scanning
-    # continues, so a 'd' after them still requires consent.
+    # value-taking shorthand takes the attached remainder as its value or,
+    # when nothing is attached, consumes the NEXT argv token, and '=' binds
+    # the remainder to the shorthand before it. Value-taking shorthands for
+    # `gh pr create`: -a -B -b -F -H -l -m -p -r -R -t -T. Unknown letters
+    # are treated as booleans, which fails closed: scanning continues, so a
+    # 'd' after them still requires consent.
+    cluster_sets_draft=0
+    cluster_consumes_next=0
     local cluster="${1#-}" ch
     while [ -n "$cluster" ]; do
         ch="${cluster:0:1}"
-        if [ "$ch" = "d" ]; then
-            return 0
-        fi
         case "$ch" in
+            d)
+                cluster_sets_draft=1
+                ;;
             a|B|b|F|H|l|m|p|r|R|t|T)
-                return 1
+                if [ -z "${cluster:1}" ]; then
+                    cluster_consumes_next=1
+                fi
+                return 0
                 ;;
         esac
         cluster="${cluster:1}"
         case "$cluster" in
             =*)
-                return 1
+                return 0
                 ;;
         esac
     done
-    return 1
+    return 0
 }
 
 reject_target_overrides() {
@@ -103,6 +109,11 @@ reject_target_overrides() {
         arg="$1"
         shift
         case "$arg" in
+            --)
+                # pflag stops option parsing here and `gh pr create` accepts
+                # no positional args, so nothing after -- can enable draft.
+                break
+                ;;
             --head|-H|--repo|-R)
                 echo "open_pr.sh: refusing target-changing create arg: $arg" >&2
                 exit 2
@@ -143,9 +154,19 @@ reject_target_overrides() {
                     exit 2
                 fi
                 ;;
+            --assignee|--label|--milestone|--project|--reviewer|--title|--template|--recover)
+                # Long value-taking option with a separate value token: gh
+                # consumes the next token as the value, so a following
+                # "--draft"-shaped token is data, not a draft flag.
+                [ "$#" -gt 0 ] && shift
+                ;;
             -[!-]*)
-                if shorthand_cluster_sets_draft "$arg"; then
+                scan_shorthand_cluster "$arg"
+                if [ "$cluster_sets_draft" = "1" ]; then
                     require_draft_consent "$arg"
+                fi
+                if [ "$cluster_consumes_next" = "1" ] && [ "$#" -gt 0 ]; then
+                    shift
                 fi
                 ;;
         esac
@@ -320,14 +341,8 @@ normalize_create_args() {
     done
 }
 
-refresh_base_ref
-
-body_audit_args=(--base-ref origin/main)
-if [ -n "${ATLAS_CURRENT_PR_AUTHOR:-}" ]; then
-    body_audit_args+=(--pr-author "$ATLAS_CURRENT_PR_AUTHOR")
-fi
-"$python_bin" scripts/audit_pr_body.py "${body_audit_args[@]}" "$body_file"
-
+# Argument admission runs before any side effect (base fetch, body audit,
+# GitHub calls): a rejected invocation must not touch the network or refs.
 for arg in "$@"; do
     case "$arg" in
         --body|--body-file|-b|-F)
@@ -337,6 +352,14 @@ for arg in "$@"; do
     esac
 done
 reject_target_overrides "$@"
+
+refresh_base_ref
+
+body_audit_args=(--base-ref origin/main)
+if [ -n "${ATLAS_CURRENT_PR_AUTHOR:-}" ]; then
+    body_audit_args+=(--pr-author "$ATLAS_CURRENT_PR_AUTHOR")
+fi
+"$python_bin" scripts/audit_pr_body.py "${body_audit_args[@]}" "$body_file"
 
 branch="$(git branch --show-current)"
 if [ -z "$branch" ]; then

--- a/scripts/open_pr.sh
+++ b/scripts/open_pr.sh
@@ -74,7 +74,7 @@ reject_target_overrides() {
                 echo "open_pr.sh: refusing target-changing create arg: $arg" >&2
                 exit 2
                 ;;
-            --draft|-d)
+            --draft|--draft=*|-d*)
                 if [ "${ATLAS_OPEN_PR_DRAFT_CONSENT:-}" != "1" ]; then
                     echo "open_pr.sh: refusing draft PR without explicit operator consent: $arg" >&2
                     echo "Set ATLAS_OPEN_PR_DRAFT_CONSENT=1 only when the operator asked for a draft." >&2

--- a/scripts/open_pr.sh
+++ b/scripts/open_pr.sh
@@ -27,6 +27,12 @@ Examples:
 Draft PRs require explicit operator consent:
   ATLAS_OPEN_PR_DRAFT_CONSENT=1 bash scripts/open_pr.sh tmp/pr-body-my-slice.md --draft
 
+Creating a new PR requires --title (or a gh --fill option): the body is fed
+through stdin, so gh can never prompt for a title through this wrapper.
+Updating an existing PR needs no extra args. Browser-based creation
+(--web / -w) is refused even with draft consent; it bypasses both draft
+consent and this wrapper's post-mutation verification.
+
 Use scripts/push_pr.sh before this wrapper to push the branch with the local
 review body env wired into the pre-push hook.
 
@@ -68,6 +74,16 @@ require_draft_consent() {
     fi
 }
 
+reject_web_create() {
+    # The browser create flow lets the builder pick "draft" in GitHub's UI
+    # with no draft token in argv, and it also escapes this wrapper's
+    # post-mutation head/body verification. It is rejected outright -- even
+    # with draft consent -- because no verified path exists through it.
+    echo "open_pr.sh: refusing browser-based create arg: $1" >&2
+    echo "The web flow bypasses draft consent and post-mutation verification; use this wrapper's flag-based create path." >&2
+    exit 2
+}
+
 scan_shorthand_cluster() {
     # gh's pflag parser walks a one-dash cluster left to right: boolean
     # shorthands keep scanning (so -fd and -wd both enable draft), a
@@ -78,6 +94,7 @@ scan_shorthand_cluster() {
     # are treated as booleans, which fails closed: scanning continues, so a
     # 'd' after them still requires consent.
     cluster_sets_draft=0
+    cluster_sets_web=0
     cluster_consumes_next=0
     local cluster="${1#-}" ch
     while [ -n "$cluster" ]; do
@@ -85,6 +102,9 @@ scan_shorthand_cluster() {
         case "$ch" in
             d)
                 cluster_sets_draft=1
+                ;;
+            w)
+                cluster_sets_web=1
                 ;;
             a|B|b|F|H|l|m|p|r|R|t|T)
                 if [ -z "${cluster:1}" ]; then
@@ -131,6 +151,9 @@ reject_target_overrides() {
             --draft|--draft=*)
                 require_draft_consent "$arg"
                 ;;
+            --web|--web=*)
+                reject_web_create "$arg"
+                ;;
             --base|-B)
                 if [ "$#" -eq 0 ]; then
                     echo "open_pr.sh: $arg requires a value" >&2
@@ -170,6 +193,9 @@ reject_target_overrides() {
                 scan_shorthand_cluster "$arg"
                 if [ "$cluster_sets_draft" = "1" ]; then
                     require_draft_consent "$arg"
+                fi
+                if [ "$cluster_sets_web" = "1" ]; then
+                    reject_web_create "$arg"
                 fi
                 if [ "$cluster_consumes_next" = "1" ] && [ "$#" -gt 0 ]; then
                     shift

--- a/scripts/open_pr.sh
+++ b/scripts/open_pr.sh
@@ -18,6 +18,9 @@ Examples:
   bash scripts/open_pr.sh tmp/pr-body-my-slice.md --title "My slice" --base main
   bash scripts/open_pr.sh tmp/pr-body-my-slice.md
 
+Draft PRs require explicit operator consent:
+  ATLAS_OPEN_PR_DRAFT_CONSENT=1 bash scripts/open_pr.sh tmp/pr-body-my-slice.md --draft
+
 Use scripts/push_pr.sh before this wrapper to push the branch with the local
 review body env wired into the pre-push hook.
 
@@ -70,6 +73,13 @@ reject_target_overrides() {
             --head=*|--repo=*|-H*|-R*)
                 echo "open_pr.sh: refusing target-changing create arg: $arg" >&2
                 exit 2
+                ;;
+            --draft|-d)
+                if [ "${ATLAS_OPEN_PR_DRAFT_CONSENT:-}" != "1" ]; then
+                    echo "open_pr.sh: refusing draft PR without explicit operator consent: $arg" >&2
+                    echo "Set ATLAS_OPEN_PR_DRAFT_CONSENT=1 only when the operator asked for a draft." >&2
+                    exit 2
+                fi
                 ;;
             --base|-B)
                 if [ "$#" -eq 0 ]; then

--- a/scripts/open_pr.sh
+++ b/scripts/open_pr.sh
@@ -6,6 +6,12 @@ set -euo pipefail
 cd "$(git rev-parse --show-toplevel)"
 python_bin="${PYTHON:-python3}"
 
+# gh's interactive create survey exposes a "Submit as draft" action that would
+# bypass argv admission entirely; disable prompting structurally so every gh
+# call in this wrapper is non-interactive and draft mode can only arrive as an
+# argv flag through the consent gate.
+export GH_PROMPT_DISABLED=1
+
 usage() {
     cat <<'EOF'
 Usage: bash scripts/open_pr.sh BODY_FILE [gh-pr-create-args...]

--- a/tests/test_open_pr_wrapper.py
+++ b/tests/test_open_pr_wrapper.py
@@ -66,6 +66,10 @@ def test_open_pr_existing_pr_rejects_create_only_args(tmp_path: Path) -> None:
         (["-d=true"], {}, "refusing draft PR without explicit operator consent"),
         (["-d=1"], {}, "refusing draft PR without explicit operator consent"),
         (["-dw"], {}, "refusing draft PR without explicit operator consent"),
+        (["-fd"], {}, "refusing draft PR without explicit operator consent"),
+        (["-wd"], {}, "refusing draft PR without explicit operator consent"),
+        (["-fd=true"], {}, "refusing draft PR without explicit operator consent"),
+        (["-fwd"], {}, "refusing draft PR without explicit operator consent"),
         (["--base", "release"], {}, "refusing non-main base: release"),
         (["-Brelease"], {}, "refusing non-main base: release"),
         ([], {"GH_REPO": "other/repo"}, "refusing GH_REPO target override"),
@@ -110,6 +114,20 @@ def test_open_pr_forwards_draft_assignment_when_operator_consent_flag_is_set(tmp
     assert result.returncode == 0, result.stdout + result.stderr
     assert log.read_text(encoding="utf-8").strip() == (
         "pr create --draft=true --title Draft wrapper --repo canfieldjuan/ATLAS --base main --body-file -"
+    )
+    assert stdin_capture.read_text(encoding="utf-8") == body.read_text(encoding="utf-8")
+
+
+def test_open_pr_allows_value_shorthand_containing_d_without_consent(tmp_path: Path) -> None:
+    # -t takes a value, so the attached text (even containing 'd') is a title,
+    # not a shorthand cluster that enables draft mode.
+    repo, body, env, log, stdin_capture = _ready(tmp_path, view_exit=1)
+
+    result = _run(repo, env, body, "-tdraft-note")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert log.read_text(encoding="utf-8").strip() == (
+        "pr create -tdraft-note --repo canfieldjuan/ATLAS --base main --body-file -"
     )
     assert stdin_capture.read_text(encoding="utf-8") == body.read_text(encoding="utf-8")
 

--- a/tests/test_open_pr_wrapper.py
+++ b/tests/test_open_pr_wrapper.py
@@ -70,6 +70,7 @@ def test_open_pr_existing_pr_rejects_create_only_args(tmp_path: Path) -> None:
         (["-wd"], {}, "refusing draft PR without explicit operator consent"),
         (["-fd=true"], {}, "refusing draft PR without explicit operator consent"),
         (["-fwd"], {}, "refusing draft PR without explicit operator consent"),
+        (["-dt", "some title"], {}, "refusing draft PR without explicit operator consent"),
         (["--base", "release"], {}, "refusing non-main base: release"),
         (["-Brelease"], {}, "refusing non-main base: release"),
         ([], {"GH_REPO": "other/repo"}, "refusing GH_REPO target override"),
@@ -130,6 +131,41 @@ def test_open_pr_allows_value_shorthand_containing_d_without_consent(tmp_path: P
         "pr create -tdraft-note --repo canfieldjuan/ATLAS --base main --body-file -"
     )
     assert stdin_capture.read_text(encoding="utf-8") == body.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("args", [["--title", "--draft"], ["-t", "-d"]])
+def test_open_pr_allows_draft_shaped_value_of_title_without_consent(
+    tmp_path: Path,
+    args: list[str],
+) -> None:
+    # gh consumes the token after --title/-t as the title value, so a
+    # "--draft"-shaped value does not enable draft mode and needs no consent.
+    repo, body, env, log, stdin_capture = _ready(tmp_path, view_exit=1)
+
+    result = _run(repo, env, body, *args)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert log.read_text(encoding="utf-8").strip() == (
+        f"pr create {' '.join(args)} --repo canfieldjuan/ATLAS --base main --body-file -"
+    )
+    assert stdin_capture.read_text(encoding="utf-8") == body.read_text(encoding="utf-8")
+
+
+def test_open_pr_rejects_draft_before_any_fetch_side_effect(tmp_path: Path) -> None:
+    # Argument admission must run before refresh_base_ref: with origin
+    # destroyed, an unauthorized --draft still fails on consent, not on fetch.
+    import shutil
+
+    repo, body, env, log, stdin_capture = _ready(tmp_path, view_exit=1)
+    shutil.rmtree(tmp_path / "origin.git")
+
+    result = _run(repo, env, body, "--draft")
+
+    assert result.returncode == 2
+    assert "refusing draft PR without explicit operator consent" in result.stderr
+    assert "failed to refresh origin/main" not in result.stderr
+    assert not log.exists()
+    assert not stdin_capture.exists()
 
 
 def test_open_pr_rejects_invalid_body_before_gh(tmp_path: Path) -> None:

--- a/tests/test_open_pr_wrapper.py
+++ b/tests/test_open_pr_wrapper.py
@@ -151,6 +151,133 @@ def test_open_pr_allows_draft_shaped_value_of_title_without_consent(
     assert stdin_capture.read_text(encoding="utf-8") == body.read_text(encoding="utf-8")
 
 
+def test_open_pr_disables_gh_prompts_so_interactive_draft_is_unreachable(tmp_path: Path) -> None:
+    # gh's interactive create survey offers a "Submit as draft" action that
+    # never appears in argv; the wrapper must export GH_PROMPT_DISABLED=1 so
+    # every gh call is non-interactive and draft mode can only arrive as an
+    # argv flag through the consent gate.
+    repo, body, env, log, stdin_capture = _ready(tmp_path, view_exit=1)
+    env.pop("GH_PROMPT_DISABLED", None)
+
+    result = _run(repo, env, body, "--title", "Prompt gate")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    prompt_state = Path(env["GH_PROMPT_STATE"])
+    assert prompt_state.read_text(encoding="utf-8").strip() == "GH_PROMPT_DISABLED=1"
+
+
+def _pflag_draft_present(args: list[str]) -> bool:
+    """Independent consent oracle: walk argv as gh's pflag parser would.
+
+    Reports whether any draft-flag occurrence is present in the sequence
+    (value-blind, matching the wrapper's declared contract), modeling long
+    options with separate or '='-attached values, '--' end-of-options, and
+    shorthand clusters where booleans keep scanning and a value-taking
+    shorthand consumes the attached remainder or the next token.
+    """
+    val_short = set("aBbFHlmprRtT")
+    long_val = {
+        "--assignee", "--base", "--body", "--body-file", "--head", "--label",
+        "--milestone", "--project", "--recover", "--repo", "--reviewer",
+        "--template", "--title",
+    }
+    draft = False
+    i = 0
+    while i < len(args):
+        tok = args[i]
+        i += 1
+        if tok == "--":
+            break
+        if tok.startswith("--"):
+            name = tok.split("=", 1)[0]
+            if name == "--draft":
+                draft = True
+            elif name in long_val and "=" not in tok:
+                i += 1
+        elif tok.startswith("-") and len(tok) > 1:
+            cluster = tok[1:]
+            while cluster:
+                ch = cluster[0]
+                if ch in val_short:
+                    if len(cluster) == 1:
+                        i += 1
+                    break
+                if ch == "d":
+                    draft = True
+                cluster = cluster[1:]
+                if cluster.startswith("="):
+                    break
+    return draft
+
+
+def _generate_argv_grammar_cases() -> list[list[str]]:
+    # Product of boolean-shorthand positions x value-taking terminators x
+    # attached/separate/'=' values, restricted to letters the wrapper does not
+    # reject for target/body reasons (booleans f, w, e; value-taking t, l).
+    cases: list[tuple[str, ...]] = []
+    for pre in ("", "f", "w", "fw", "e"):
+        for core in ("", "d"):
+            base = pre + core
+            if base:
+                cases.append((f"-{base}",))
+                cases.append((f"-{base}=true",))
+                cases.append((f"-{base}=false",))
+            for val in ("t", "l"):
+                cases.append((f"-{base}{val}attached-value",))
+                cases.append((f"-{base}{val}", "separate-value"))
+                cases.append((f"-{base}{val}", "-d"))
+    cases += [
+        ("--draft",), ("--draft=true",), ("--draft=false",),
+        ("--title", "--draft"), ("--title", "-d"), ("--title", "t", "--draft"),
+        ("--label", "--draft", "--draft"),
+        ("--fill", "--draft"), ("--web", "-d"),
+        ("--", "--draft"), ("--", "-d"),
+        ("-t", "-d"), ("-a", "-d"), ("-t", "-d", "--draft"),
+        ("--template", "--draft"), ("--reviewer", "-fd"),
+    ]
+    unique: list[list[str]] = []
+    seen: set[tuple[str, ...]] = set()
+    for case in cases:
+        if case not in seen and all(tok != "-" for tok in case):
+            seen.add(case)
+            unique.append(list(case))
+    return unique
+
+
+def test_open_pr_draft_admission_matches_gh_argv_grammar(tmp_path: Path) -> None:
+    # Grammar-derived closure proof: for every generated argv sequence the
+    # wrapper's consent decision must equal the independent pflag oracle.
+    # The fixture has no origin remote, so a sequence that passes admission
+    # deterministically fails later at the base refresh -- proving admission
+    # neither gated it nor needed the network.
+    repo = tmp_path / "grammar-repo"
+    (repo / "scripts").mkdir(parents=True)
+    copy2(SCRIPT, repo / "scripts" / "open_pr.sh")
+    subprocess.run(
+        ["git", "init", "--initial-branch", "main"],
+        cwd=repo, check=True, capture_output=True, text=True,
+    )
+    body = tmp_path / "grammar-body.md"
+    body.write_text(_valid_body(), encoding="utf-8")
+    env = {**os.environ, "PYTHONDONTWRITEBYTECODE": "1"}
+    env.pop("GH_REPO", None)
+    env.pop("ATLAS_OPEN_PR_DRAFT_CONSENT", None)
+
+    failures = []
+    for args in _generate_argv_grammar_cases():
+        expected_draft = _pflag_draft_present(args)
+        result = subprocess.run(
+            ["bash", str(repo / "scripts" / "open_pr.sh"), str(body), *args],
+            cwd=repo, env=env, capture_output=True, text=True,
+        )
+        gated = "refusing draft PR without explicit operator consent" in result.stderr
+        if gated != expected_draft:
+            failures.append((args, f"oracle draft={expected_draft}", result.returncode, result.stderr.strip()))
+        elif not expected_draft and "failed to refresh origin/main" not in result.stderr:
+            failures.append((args, "admission pass did not reach base refresh", result.returncode, result.stderr.strip()))
+    assert not failures, failures
+
+
 def test_open_pr_rejects_draft_before_any_fetch_side_effect(tmp_path: Path) -> None:
     # Argument admission must run before refresh_base_ref: with origin
     # destroyed, an unauthorized --draft still fails on consent, not on fetch.
@@ -535,6 +662,7 @@ if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
     exit 0
 fi
 printf '%s\\n' "$*" > "${GH_ARGV_LOG}"
+printf 'GH_PROMPT_DISABLED=%s\\n' "${GH_PROMPT_DISABLED:-}" > "${GH_PROMPT_STATE}"
 cat > "${GH_STDIN_CAPTURE}"
 if [ "$1" = "pr" ] && [ "$2" = "create" ]; then
     : > "${GH_CREATED_PR_FLAG}"
@@ -550,6 +678,7 @@ fi
         "GH_ARGV_LOG": str(log),
         "GH_STDIN_CAPTURE": str(stdin_capture),
         "GH_CREATED_PR_FLAG": str(created_flag),
+        "GH_PROMPT_STATE": str(tmp_path / "gh-prompt-state.txt"),
         "PYTHONDONTWRITEBYTECODE": "1",
     }, log, stdin_capture
 

--- a/tests/test_open_pr_wrapper.py
+++ b/tests/test_open_pr_wrapper.py
@@ -57,6 +57,8 @@ def test_open_pr_existing_pr_rejects_create_only_args(tmp_path: Path) -> None:
         (["--body-file", "body.md"], {}, "pass the PR body as BODY_FILE"),
         (["--head", "other"], {}, "refusing target-changing create arg: --head"),
         (["--repo", "other/repo"], {}, "refusing target-changing create arg: --repo"),
+        (["--draft"], {}, "refusing draft PR without explicit operator consent"),
+        (["-d"], {}, "refusing draft PR without explicit operator consent"),
         (["--base", "release"], {}, "refusing non-main base: release"),
         (["-Brelease"], {}, "refusing non-main base: release"),
         ([], {"GH_REPO": "other/repo"}, "refusing GH_REPO target override"),
@@ -77,6 +79,19 @@ def test_open_pr_rejects_unsafe_inputs_before_gh(
     assert expected in result.stderr
     assert not log.exists()
     assert not stdin_capture.exists()
+
+
+def test_open_pr_forwards_draft_when_operator_consent_flag_is_set(tmp_path: Path) -> None:
+    repo, body, env, log, stdin_capture = _ready(tmp_path, view_exit=1)
+    env["ATLAS_OPEN_PR_DRAFT_CONSENT"] = "1"
+
+    result = _run(repo, env, body, "--draft", "--title", "Draft wrapper")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert log.read_text(encoding="utf-8").strip() == (
+        "pr create --draft --title Draft wrapper --repo canfieldjuan/ATLAS --base main --body-file -"
+    )
+    assert stdin_capture.read_text(encoding="utf-8") == body.read_text(encoding="utf-8")
 
 
 def test_open_pr_rejects_invalid_body_before_gh(tmp_path: Path) -> None:

--- a/tests/test_open_pr_wrapper.py
+++ b/tests/test_open_pr_wrapper.py
@@ -71,6 +71,10 @@ def test_open_pr_existing_pr_rejects_create_only_args(tmp_path: Path) -> None:
         (["-fd=true"], {}, "refusing draft PR without explicit operator consent"),
         (["-fwd"], {}, "refusing draft PR without explicit operator consent"),
         (["-dt", "some title"], {}, "refusing draft PR without explicit operator consent"),
+        (["--web"], {}, "refusing browser-based create arg"),
+        (["--web=true"], {}, "refusing browser-based create arg"),
+        (["-w"], {}, "refusing browser-based create arg"),
+        (["-fw"], {}, "refusing browser-based create arg"),
         (["--base", "release"], {}, "refusing non-main base: release"),
         (["-Brelease"], {}, "refusing non-main base: release"),
         ([], {"GH_REPO": "other/repo"}, "refusing GH_REPO target override"),
@@ -166,14 +170,16 @@ def test_open_pr_disables_gh_prompts_so_interactive_draft_is_unreachable(tmp_pat
     assert prompt_state.read_text(encoding="utf-8").strip() == "GH_PROMPT_DISABLED=1"
 
 
-def _pflag_draft_present(args: list[str]) -> bool:
-    """Independent consent oracle: walk argv as gh's pflag parser would.
+def _wrapper_expected_outcome(args: list[str]) -> str:
+    """Independent admission oracle: walk argv as gh's pflag parser would.
 
-    Reports whether any draft-flag occurrence is present in the sequence
-    (value-blind, matching the wrapper's declared contract), modeling long
-    options with separate or '='-attached values, '--' end-of-options, and
-    shorthand clusters where booleans keep scanning and a value-taking
-    shorthand consumes the attached remainder or the next token.
+    Returns "draft" when the first offending token carries a draft flag
+    (value-blind, matching the wrapper's declared contract), "web" when it
+    carries the browser-create flag without a draft flag, and "pass"
+    otherwise -- modeling long options with separate or '='-attached values,
+    '--' end-of-options, and shorthand clusters where booleans keep scanning
+    and a value-taking shorthand consumes the attached remainder or the next
+    token. Within one token, draft rejection takes precedence over web.
     """
     val_short = set("aBbFHlmprRtT")
     long_val = {
@@ -181,17 +187,19 @@ def _pflag_draft_present(args: list[str]) -> bool:
         "--milestone", "--project", "--recover", "--repo", "--reviewer",
         "--template", "--title",
     }
-    draft = False
     i = 0
     while i < len(args):
         tok = args[i]
         i += 1
+        draft_tok = web_tok = False
         if tok == "--":
             break
         if tok.startswith("--"):
             name = tok.split("=", 1)[0]
             if name == "--draft":
-                draft = True
+                draft_tok = True
+            elif name == "--web":
+                web_tok = True
             elif name in long_val and "=" not in tok:
                 i += 1
         elif tok.startswith("-") and len(tok) > 1:
@@ -203,11 +211,17 @@ def _pflag_draft_present(args: list[str]) -> bool:
                         i += 1
                     break
                 if ch == "d":
-                    draft = True
+                    draft_tok = True
+                elif ch == "w":
+                    web_tok = True
                 cluster = cluster[1:]
                 if cluster.startswith("="):
                     break
-    return draft
+        if draft_tok:
+            return "draft"
+        if web_tok:
+            return "web"
+    return "pass"
 
 
 def _generate_argv_grammar_cases() -> list[list[str]]:
@@ -265,17 +279,36 @@ def test_open_pr_draft_admission_matches_gh_argv_grammar(tmp_path: Path) -> None
 
     failures = []
     for args in _generate_argv_grammar_cases():
-        expected_draft = _pflag_draft_present(args)
+        expected = _wrapper_expected_outcome(args)
         result = subprocess.run(
             ["bash", str(repo / "scripts" / "open_pr.sh"), str(body), *args],
             cwd=repo, env=env, capture_output=True, text=True,
         )
-        gated = "refusing draft PR without explicit operator consent" in result.stderr
-        if gated != expected_draft:
-            failures.append((args, f"oracle draft={expected_draft}", result.returncode, result.stderr.strip()))
-        elif not expected_draft and "failed to refresh origin/main" not in result.stderr:
+        if "refusing draft PR without explicit operator consent" in result.stderr:
+            observed = "draft"
+        elif "refusing browser-based create arg" in result.stderr:
+            observed = "web"
+        else:
+            observed = "pass"
+        if observed != expected:
+            failures.append((args, f"oracle={expected} observed={observed}", result.returncode, result.stderr.strip()))
+        elif expected == "pass" and "failed to refresh origin/main" not in result.stderr:
             failures.append((args, "admission pass did not reach base refresh", result.returncode, result.stderr.strip()))
     assert not failures, failures
+
+
+def test_open_pr_rejects_web_create_even_with_draft_consent(tmp_path: Path) -> None:
+    # Draft consent authorizes the flag-based draft path only; the browser
+    # flow escapes post-mutation verification and stays rejected.
+    repo, body, env, log, stdin_capture = _ready(tmp_path, view_exit=1)
+    env["ATLAS_OPEN_PR_DRAFT_CONSENT"] = "1"
+
+    result = _run(repo, env, body, "--draft", "--web")
+
+    assert result.returncode == 2
+    assert "refusing browser-based create arg" in result.stderr
+    assert not log.exists()
+    assert not stdin_capture.exists()
 
 
 def test_open_pr_rejects_draft_before_any_fetch_side_effect(tmp_path: Path) -> None:

--- a/tests/test_open_pr_wrapper.py
+++ b/tests/test_open_pr_wrapper.py
@@ -58,7 +58,14 @@ def test_open_pr_existing_pr_rejects_create_only_args(tmp_path: Path) -> None:
         (["--head", "other"], {}, "refusing target-changing create arg: --head"),
         (["--repo", "other/repo"], {}, "refusing target-changing create arg: --repo"),
         (["--draft"], {}, "refusing draft PR without explicit operator consent"),
+        (["--draft=true"], {}, "refusing draft PR without explicit operator consent"),
+        (["--draft=TRUE"], {}, "refusing draft PR without explicit operator consent"),
+        (["--draft=1"], {}, "refusing draft PR without explicit operator consent"),
+        (["--draft=false"], {}, "refusing draft PR without explicit operator consent"),
         (["-d"], {}, "refusing draft PR without explicit operator consent"),
+        (["-d=true"], {}, "refusing draft PR without explicit operator consent"),
+        (["-d=1"], {}, "refusing draft PR without explicit operator consent"),
+        (["-dw"], {}, "refusing draft PR without explicit operator consent"),
         (["--base", "release"], {}, "refusing non-main base: release"),
         (["-Brelease"], {}, "refusing non-main base: release"),
         ([], {"GH_REPO": "other/repo"}, "refusing GH_REPO target override"),
@@ -90,6 +97,19 @@ def test_open_pr_forwards_draft_when_operator_consent_flag_is_set(tmp_path: Path
     assert result.returncode == 0, result.stdout + result.stderr
     assert log.read_text(encoding="utf-8").strip() == (
         "pr create --draft --title Draft wrapper --repo canfieldjuan/ATLAS --base main --body-file -"
+    )
+    assert stdin_capture.read_text(encoding="utf-8") == body.read_text(encoding="utf-8")
+
+
+def test_open_pr_forwards_draft_assignment_when_operator_consent_flag_is_set(tmp_path: Path) -> None:
+    repo, body, env, log, stdin_capture = _ready(tmp_path, view_exit=1)
+    env["ATLAS_OPEN_PR_DRAFT_CONSENT"] = "1"
+
+    result = _run(repo, env, body, "--draft=true", "--title", "Draft wrapper")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert log.read_text(encoding="utf-8").strip() == (
+        "pr create --draft=true --title Draft wrapper --repo canfieldjuan/ATLAS --base main --body-file -"
     )
     assert stdin_capture.read_text(encoding="utf-8") == body.read_text(encoding="utf-8")
 


### PR DESCRIPTION
Plan: plans/PR-Open-Ready-Draft-Consent-Guard.md
Slice phase: Workflow/process
Ownership lane: dev-workflow/open-ready-draft-consent

Diff-budget override: five Codex review rounds required class-closure work rather than spot fixes (pflag-faithful argv-grammar walk, admission-before-side-effects ordering, browser-route rejection, a grammar-derived property suite with an independent oracle, and plan closure/R11/parking declarations); the runtime surface is one wrapper script and over half the added lines are tests and plan contract.

This slice converts the AGENTS ready-for-review default from prose into wrapper behavior: `open_pr.sh` now refuses draft PR creation unless the operator explicitly authorized draft mode through `ATLAS_OPEN_PR_DRAFT_CONSENT=1`.

## Intentional
- The consent signal is an explicit environment flag rather than a persistent session-state parser, keeping the exception visible at the command boundary.
- The normal path still opens ready-for-review PRs without any extra flag.
- The gate is value-blind: `--draft=false` is also held behind consent rather than parsing pflag's six truthy spellings — ready-for-review is already the default, so fail-closed is simpler and safer.
- The detector models gh's argv grammar rather than pattern-matching tokens independently: long value-taking options consume their separate value token, `--` ends option parsing, and shorthand clusters are walked pflag-style.
- Argument admission runs before any side effect: an unauthorized draft invocation is rejected before the base fetch, body audit, or any GitHub call.
- Three structural guarantees close the non-argv entry points: `GH_PROMPT_DISABLED=1` makes gh's interactive "Submit as draft" survey unreachable; the browser route (`--web`/`-w`) is rejected even with draft consent because GitHub's create UI can submit a draft with no argv token and escapes post-mutation verification; and a grammar-derived property test proves the admission decision (consent-gate / web-reject / pass) equals an independent pflag oracle across the generated argv product.
- Creating a new PR requires `--title` or a gh fill option by pre-existing necessity, not as a change here: the wrapper binds stdin to the body file, so gh has never been able to prompt for a title through it; the usage text now states this explicitly.
- The plan carries the closure declaration for the flag inventory (CLOSED w.r.t. gh 2.96.0, ENUMERATED from `gh pr create --help`, unrecognized tokens flow to the consent-gated side), the R11 disposition for `ATLAS_OPEN_PR_DRAFT_CONSENT`, and the slice's parking predicate.

## AI reconciliation
- Reject boolean-assignment draft flags (Codex P1 R1/R2): `--draft=true` and `-d=true` bypassed the bare-token consent gate -- fixed-in: 412039a scripts/open_pr.sh gates assignment forms, with rejection regressions in tests/test_open_pr_wrapper.py.
- Reject draft shorthand in every cluster position (Codex P1 R1/R2): `-fd` and `-wd` bypassed the `-d*` prefix match -- fixed-in: da7d78a scripts/open_pr.sh cluster walk, with rejection and pass-through regressions in tests/test_open_pr_wrapper.py.
- Run draft admission before refreshing the base (Codex P1 R6/R12): unauthorized `--draft` executed `git fetch origin main` before rejection -- fixed-in: 37dc00a scripts/open_pr.sh moves argument admission ahead of refresh_base_ref and the body audit, with an origin-destroyed ordering regression in tests/test_open_pr_wrapper.py.
- Consume separate option values before draft detection (Codex P2 R1/R2/R13): `--title --draft` and `-t -d` were wrongly refused although gh consumes the token as the title value -- fixed-in: 37dc00a scripts/open_pr.sh consumes separate values for value-taking options, with cross-token regressions in tests/test_open_pr_wrapper.py.
- Add the required closure declaration for the flag inventory (Codex P1 R13): the plan enumerated the admission-driving flag and input-shape sets without declaring closure, sourcing, or out-of-set disposition -- fixed-in: 85680c6 plans/PR-Open-Ready-Draft-Consent-Guard.md Closure declaration section per docs/GUARD_CLASS_CLOSURE.md.
- Include R11 in the review contract (Codex P1 R11): the Review Contract listed R12 but not R11 although the slice adds and reads `ATLAS_OPEN_PR_DRAFT_CONSENT` -- fixed-in: 85680c6 plans/PR-Open-Ready-Draft-Consent-Guard.md adds R11 (and R13) and dispositions the variable's default, documentation, and operational handling.
- Gate interactive draft submission (Codex P1 R1/R2): gh's interactive create survey offers "Submit as draft" with no argv token, bypassing argv admission -- fixed-in: 30d1817 scripts/open_pr.sh exports GH_PROMPT_DISABLED=1 so every gh call is structurally non-interactive, with a prompt-state regression in tests/test_open_pr_wrapper.py.
- Generate the argv grammar instead of enumerating examples (Codex P1 R2/R13): the suite only enumerated reported spellings, so class closure was asserted rather than proven -- fixed-in: 30d1817 tests/test_open_pr_wrapper.py `test_open_pr_draft_admission_matches_gh_argv_grammar` generates boolean-shorthand positions x value-taking terminators x attached/separate/`=` values and checks every sequence against an independent pflag oracle.
- Reject web creation without draft consent (Codex P1 R1/R2): `--web`/`-w` reached GitHub's create UI where a draft can be submitted with no argv token -- fixed-in: 0d7ff18 scripts/open_pr.sh `reject_web_create` refuses `--web`, `--web=*`, and `w`-bearing clusters even with draft consent, with rejection regressions and a per-token draft/web/pass oracle upgrade in tests/test_open_pr_wrapper.py.
- Declare the slice's parking predicate (Codex P1 R1/R14): the plan claimed `Parked hardening: none` without stating the predicate the claim is made against -- fixed-in: 0d7ff18 plans/PR-Open-Ready-Draft-Consent-Guard.md Deferred section states the parking predicate and re-states the none claim against it.
- Preserve no-title PR creation (Codex P1 R1/R5): not-applicable: the BODY-only create path has never been reachable through this wrapper because `--body-file - < BODY_FILE` binds stdin to the body file and gh only prompts when stdin is a TTY, so title-less creation failed with gh's non-interactive error before this slice exactly as it does after; `GH_PROMPT_DISABLED=1` made that pre-existing contract explicit rather than changing behavior, and 0d7ff18 documents the create-requires-title contract in the wrapper usage text (scripts/open_pr.sh) and the plan.

## Deferred
- gh CLI flag-table drift: the value-taking inventory is enumerated from gh 2.96.0; a future gh release that changes an existing flag's arity re-opens a cross-token spelling and requires re-auditing the inventory (no runtime derivation point exists in a bash wrapper).
- Non-leading cluster spellings of the pre-existing `-H`/`-R`/`-B` target-override gates (e.g. `-fHother`) predate this slice and are a separate target-override hardening follow-up; this slice's argv-grammar walk gates draft mode and the browser route only.

## Parked hardening
- Parking predicate: this slice parks, by default, hardening of `gh pr create` surfaces other than ready-for-review admission through this wrapper (non-draft flag hygiene, target-override cluster spellings, gh-version drift tooling). None parked against that predicate; the two deferrals above are named follow-ups.

## Cold diff reconstruction
- Changed: `scripts/open_pr.sh:8` exports `GH_PROMPT_DISABLED=1` so gh's interactive draft survey is unreachable; usage text documents draft consent, the web rejection, and the create-requires-title contract.
- Changed: `scripts/open_pr.sh:70` adds `require_draft_consent`, `reject_web_create`, and `scan_shorthand_cluster` (pflag-faithful cluster walk reporting draft, web, and next-token consumption).
- Changed: `scripts/open_pr.sh:135` models the create-arg grammar: `--` ends parsing, long value-taking options consume their separate value token, `--draft`/`--draft=*` and draft-bearing clusters require consent, `--web`/`--web=*` and `w`-bearing clusters are refused.
- Changed: `scripts/open_pr.sh:395` runs argument admission before `refresh_base_ref` and the body audit so rejected invocations produce no side effects.
- Changed: `tests/test_open_pr_wrapper.py:60` proves every draft and web spelling class fails before fake GitHub mutation by default.
- Changed: `tests/test_open_pr_wrapper.py:110` proves consent-set forwarding, cross-token pass-through, prompt-disable state at create time, web rejection under consent, ordering with origin destroyed, and per-token oracle agreement (draft / web / pass) across the generated argv product.
- Changed: `plans/PR-Open-Ready-Draft-Consent-Guard.md` records the mechanism, closure declaration, R11 disposition, parking predicate, structural guarantees, and over-budget justification.
- Contract match: every changed line traces to ready-for-review admission in `open_pr.sh`.
- Gaps: none.

## Verification
- `python -m pytest tests/test_open_pr_wrapper.py` - 52 passed.
- `bash scripts/check_ascii_python.sh` - passed.

## Mechanical verification
- Command: python -m pytest tests/test_open_pr_wrapper.py - Result: 52 passed - Environment: local
- Command: bash scripts/check_ascii_python.sh - Result: passed - Environment: local

## Diff size
3 files, +614 / -8 (over the 400 LOC soft cap; override reason above, justification in the plan's *Why this slice exists*)
