### PR TITLE
Guard PR edits with session ownership

### DIFF
--- a/plans/PR-Mutation-Ownership-Wrapper.md
+++ b/plans/PR-Mutation-Ownership-Wrapper.md
@@ -1,0 +1,152 @@
+# PR-Mutation-Ownership-Wrapper
+
+## Why this slice exists
+
+The mechanical-enforcement audit found that Atlas has a session PR ownership
+helper, but the prescribed PR mutation wrapper does not call it before editing
+an existing PR body. That leaves the "do not touch another session's PR" rule as
+a manual memory step at the exact point where the wrapper already has the PR
+number, branch, and head SHA needed to enforce it.
+
+Audit finding:
+
+- `docs/audits/agents-mechanical-enforcement-audit-2026-07-29.md` classified
+  "PR ownership before mutation is guarded" as `MANUAL_HELPER` because
+  `scripts/check_session_pr_ownership.py` existed but no invocation was found in
+  `scripts/open_pr.sh`, `scripts/push_pr.sh`, or `scripts/local_pr_review.sh`.
+
+### Problem-derived contract
+
+- Root cause: existing-PR body edits happen through `scripts/open_pr.sh` after
+  the wrapper discovers the target PR, but the discovered PR identity is not
+  checked against the session-scoped ownership file before `gh pr edit` mutates
+  GitHub.
+- Correct fix must touch/change: `scripts/open_pr.sh` must invoke
+  `scripts/check_session_pr_ownership.py` on the existing-PR edit path after
+  discovering the PR number/head and before final review or `gh pr edit`;
+  `tests/test_open_pr_wrapper.py` must prove an owned PR can proceed and an
+  unowned PR fails before GitHub mutation.
+- Must not change: do not change product code, branch protection, reviewer
+  policy, new-PR creation semantics, draft consent semantics, local review
+  contents, `push_pr.sh` behavior where no PR number is known, or any EOM /
+  Dependabot / non-owned PR lane.
+
+## Scope (this PR)
+
+Ownership lane: dev-workflow/pr-mutation-ownership
+Slice phase: Workflow/process
+
+1. Add a wrapper-level ownership guard for existing PR body edits in
+   `scripts/open_pr.sh`.
+2. Add fixture tests proving the guard runs before mutation and blocks `gh pr
+   edit` when session ownership fails.
+
+### Review Contract
+
+- Acceptance criteria:
+  1. Existing-PR body updates through `scripts/open_pr.sh` call
+     `scripts/check_session_pr_ownership.py --pr <number> --branch <branch>
+     --head-sha <reviewed-head>` before `gh pr edit`.
+  2. A failing ownership guard stops the wrapper before final local review,
+     `gh pr edit`, or body stdin capture; settled by
+     `tests/test_open_pr_wrapper.py::test_open_pr_existing_pr_ownership_guard_failure_blocks_before_edit`.
+  3. An owned existing PR still edits via stdin and preserves the existing body
+     publication contract; settled by
+     `tests/test_open_pr_wrapper.py::test_open_pr_edit_passes_body_via_stdin_not_path`.
+  4. New-PR creation remains on the existing create path because there is no PR
+     number to check before creation; the wrapper's existing branch/repo/base,
+     final-review, and post-create identity checks are unchanged.
+- Reachability proof: `bash scripts/open_pr.sh BODY_FILE` is exercised by
+  `tests/test_open_pr_wrapper.py`; the observable effect is the fake `gh pr
+  edit` log or the absence of that log when the guard fails.
+- Affected surfaces: `scripts/open_pr.sh`, `tests/test_open_pr_wrapper.py`, and
+  this plan.
+- Risk areas: shell argument ordering, PR edit admission boundary, session-state
+  path resolution, existing create/update behavior.
+- Reviewer rules triggered: R1, R2, R6, R10, R12, R14.
+
+### Boundary-change enumeration
+
+Required when this diff changes a guard, validator, normalizer, resolver,
+router/classifier, or admission boundary. Name each changed boundary path or
+seam in the enumeration; otherwise write "N/A - no boundary change."
+
+- Boundary path/seam: existing PR body mutation via `scripts/open_pr.sh`.
+- Replaced-path behaviors: existing-PR edits previously checked branch/repo/head
+  identity but did not check session ownership before `gh pr edit`.
+- Guard-relevant fields: PR number, current branch, reviewed head SHA, and
+  `ATLAS_SESSION_STATE_FILE` or the helper's default state-file fallback.
+- Caller x input shape: `bash scripts/open_pr.sh BODY_FILE` with an already-open
+  PR for the current branch and no create args.
+
+### Deployed-config probing
+
+Required for guard, validator, resolver, admission-boundary, or env/config
+fallback changes; otherwise write "N/A - no guard/config boundary change."
+
+- Deployed/default config values: no deployed config; local
+  `ATLAS_SESSION_STATE_FILE` may point at a session-specific state file and the
+  helper defaults to `SESSION_STATE.local.md`.
+- Explicit value probe: fixture sets `ATLAS_SESSION_STATE_FILE` to an owned PR
+  state file and verifies the edit proceeds.
+- Absent value probe: existing helper behavior remains unchanged; absence of a
+  readable state file fails the guard.
+- Default-session/default-context probe: wrapper invokes the existing helper so
+  default fallback semantics stay owned by `scripts/check_session_pr_ownership.py`.
+- Side-effect ordering: guard failure is tested to happen before final local
+  review, `gh pr edit`, or PR-body stdin capture.
+
+### Files touched
+
+- `plans/PR-Mutation-Ownership-Wrapper.md`
+- `scripts/open_pr.sh`
+- `tests/test_open_pr_wrapper.py`
+
+## Mechanism
+
+`scripts/open_pr.sh` already resolves the current branch, verifies the pushed
+head, discovers the existing PR snapshot, and confirms the PR head matches the
+reviewed head. This slice adds one helper call at that existing-PR boundary:
+
+```bash
+python scripts/check_session_pr_ownership.py \
+  --pr "$existing_pr_number" \
+  --branch "$branch" \
+  --head-sha "$reviewed_head"
+```
+
+The helper reads the current session-state file, rejects must-not-touch PRs,
+and rejects PRs absent from the owned/may-touch set. Because the call happens
+before the final local review and before `gh pr edit`, a wrong-lane PR cannot
+burn review or mutate GitHub through the wrapper.
+
+## Intentional
+
+- No `push_pr.sh` guard in this slice because that wrapper normally has branch
+  metadata but not a PR number/head snapshot; forcing PR lookup into push would
+  widen the mutation surface and duplicate `open_pr.sh` identity logic.
+- No new-PR creation guard in this slice because there is no PR number before
+  creation. Existing create-path checks for branch publication, repo/base
+  targeting, final local review, draft consent, and post-create identity remain
+  unchanged.
+
+## Deferred
+
+- New-PR pre-create ownership admission, if desired, should be a separate
+  helper mode with its own contract for "planned branch may open one PR."
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_open_pr_wrapper.py tests/test_check_session_pr_ownership.py`
+  - 63 passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Mutation-Ownership-Wrapper.md` | 152 |
+| `scripts/open_pr.sh` | 10 |
+| `tests/test_open_pr_wrapper.py` | 62 |
+| **Total** | **224** |

--- a/scripts/open_pr.sh
+++ b/scripts/open_pr.sh
@@ -353,6 +353,14 @@ verify_pr_snapshot_head() {
     fi
 }
 
+guard_existing_pr_ownership() {
+    local pr_number="$1" branch="$2" expected_head="$3"
+    "$python_bin" scripts/check_session_pr_ownership.py \
+        --pr "$pr_number" \
+        --branch "$branch" \
+        --head-sha "$expected_head"
+}
+
 normalize_create_args() {
     trusted_create_args=()
     local arg value
@@ -416,6 +424,8 @@ if [ -n "$existing_pr_number" ]; then
         echo "Use gh pr edit manually for title/base/label changes." >&2
         exit 2
     fi
+
+    guard_existing_pr_ownership "$existing_pr_number" "$branch" "$reviewed_head"
 
     if [ "${ATLAS_OPEN_PR_DRY_RUN:-}" = "1" ]; then
         echo "DRY RUN: gh pr edit $existing_pr_number --body-file - < $body_file"

--- a/tests/test_open_pr_wrapper.py
+++ b/tests/test_open_pr_wrapper.py
@@ -33,13 +33,30 @@ def test_open_pr_create_passes_body_via_stdin_not_path(tmp_path: Path) -> None:
 
 def test_open_pr_edit_passes_body_via_stdin_not_path(tmp_path: Path) -> None:
     repo, body, env, log, stdin_capture = _ready(tmp_path, view_exit=0)
+    guard_log = Path(env["OWNERSHIP_GUARD_LOG"])
 
     result = _run(repo, env, body)
 
     assert result.returncode == 0
     assert log.read_text(encoding="utf-8").strip() == "pr edit 17 --repo canfieldjuan/ATLAS --body-file -"
+    assert guard_log.read_text(encoding="utf-8").strip() == (
+        f"--pr 17 --branch claude/pr-test --head-sha {_git_output(repo, 'rev-parse', 'HEAD')}"
+    )
     assert str(body) not in log.read_text(encoding="utf-8")
     assert stdin_capture.read_text(encoding="utf-8") == body.read_text(encoding="utf-8")
+
+
+def test_open_pr_existing_pr_ownership_guard_failure_blocks_before_edit(tmp_path: Path) -> None:
+    repo, body, env, log, stdin_capture = _ready(tmp_path, view_exit=0)
+    env["OWNERSHIP_GUARD_EXIT"] = "23"
+
+    result = _run(repo, env, body)
+
+    assert result.returncode == 23
+    assert "fake ownership guard failed" in result.stderr
+    assert not log.exists()
+    assert not stdin_capture.exists()
+    assert not (repo / "local-review.log").exists()
 
 
 def test_open_pr_existing_pr_rejects_create_only_args(tmp_path: Path) -> None:
@@ -573,6 +590,25 @@ def _write_fixture_repo(
         copy2(AUDIT_SCRIPT, repo / "scripts" / "audit_pr_body.py")
         copy2(AI_RECONCILIATION_SCRIPT, repo / "scripts" / "audit_ai_reconciliation.py")
         copy2(CHANGE_POLICY_SCRIPT, repo / "scripts" / "_pr_change_policy.py")
+        (repo / "scripts" / "check_session_pr_ownership.py").write_text(
+            """#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+import sys
+
+log = os.environ.get("OWNERSHIP_GUARD_LOG")
+if log:
+    with open(log, "a", encoding="utf-8") as handle:
+        handle.write(" ".join(sys.argv[1:]) + "\\n")
+exit_code = int(os.environ.get("OWNERSHIP_GUARD_EXIT", "0"))
+if exit_code:
+    print("fake ownership guard failed", file=sys.stderr)
+raise SystemExit(exit_code)
+""",
+            encoding="utf-8",
+        )
+        (repo / "scripts" / "check_session_pr_ownership.py").chmod(0o755)
         (repo / "scripts" / "local_pr_review.sh").write_text(
             """#!/usr/bin/env bash
 set -euo pipefail
@@ -674,6 +710,26 @@ def _fake_gh_env(tmp_path: Path, *, view_exit: int) -> tuple[dict[str, str], Pat
     log = tmp_path / "gh-argv.txt"
     stdin_capture = tmp_path / "gh-stdin.txt"
     created_flag = tmp_path / "gh-created-pr"
+    ownership_guard_log = tmp_path / "ownership-guard-argv.txt"
+    state_file = tmp_path / "SESSION_STATE.codex-test.local.md"
+    state_file.write_text(
+        """# Atlas Builder Session State
+
+## Owned Active PR
+
+PR: none
+Branch: claude/pr-test
+Expected head SHA: none
+
+## PRs This Session May Touch
+
+- #17 Workflow wrapper -- fixture-owned PR.
+
+## PRs This Session Must Not Touch
+
+""",
+        encoding="utf-8",
+    )
     gh = bin_dir / "gh"
     gh.write_text(
         """#!/usr/bin/env bash
@@ -712,6 +768,8 @@ fi
         "GH_STDIN_CAPTURE": str(stdin_capture),
         "GH_CREATED_PR_FLAG": str(created_flag),
         "GH_PROMPT_STATE": str(tmp_path / "gh-prompt-state.txt"),
+        "OWNERSHIP_GUARD_LOG": str(ownership_guard_log),
+        "ATLAS_SESSION_STATE_FILE": str(state_file),
         "PYTHONDONTWRITEBYTECODE": "1",
     }, log, stdin_capture
 
@@ -724,3 +782,7 @@ def _git(repo: Path, *args: str) -> None:
         capture_output=True,
         text=True,
     )
+
+
+def _git_output(repo: Path, *args: str) -> str:
+    return subprocess.check_output(["git", *args], cwd=repo, text=True).strip()


### PR DESCRIPTION
Plan: plans/PR-Mutation-Ownership-Wrapper.md
Slice phase: Workflow/process
Ownership lane: dev-workflow/pr-mutation-ownership

The mechanical-enforcement audit found that PR ownership before mutation existed only as a manual helper: `open_pr.sh` could discover an existing PR number/head and still edit the PR body without first checking the session-state ownership map. This slice moves that guard into the existing-PR edit path so wrong-lane PR edits fail before review burn or GitHub mutation.

## Intentional
- Guard only the existing-PR edit path, where `open_pr.sh` already knows PR number, branch, and reviewed head SHA.
- Leave `push_pr.sh` unchanged because it normally has no PR number to validate.
- Leave new-PR creation semantics unchanged; pre-create ownership admission needs a separate "planned branch may open one PR" contract if we want that later.

## AI reconciliation
- no-findings

## Deferred
- New-PR pre-create ownership admission, if desired, should be a separate helper mode with its own contract.

## Parked hardening
- None.

## Cold diff reconstruction
- Changed: `scripts/open_pr.sh:356` adds `guard_existing_pr_ownership`, which invokes `scripts/check_session_pr_ownership.py --pr --branch --head-sha`.
- Changed: `scripts/open_pr.sh:428` calls that guard after existing PR identity/head verification and before dry-run, final local review, or `gh pr edit`.
- Changed: `tests/test_open_pr_wrapper.py:34` now proves a normal existing-PR edit records the guard arguments and still sends the body through stdin.
- Changed: `tests/test_open_pr_wrapper.py:49` proves guard failure exits before `gh pr edit`, stdin capture, or final local review.
- Changed: `tests/test_open_pr_wrapper.py:593` and `tests/test_open_pr_wrapper.py:713` add fixture support for the fake ownership guard and session-state file.
- Contract match: every non-plan change traces to the audit gap: enforce session ownership at the existing-PR mutation boundary without changing create/push/product behavior.
- Gaps: none.

## Verification
- `python -m pytest tests/test_open_pr_wrapper.py tests/test_check_session_pr_ownership.py` - 63 passed.

## Mechanical verification
- Command: `python -m pytest tests/test_open_pr_wrapper.py tests/test_check_session_pr_ownership.py` - Result: 63 passed - Environment: local

## Diff size
3 files, +224 / -0
