### PR TITLE
Enforce PR branch naming in wrappers

### DIFF
--- a/plans/PR-Branch-Naming-Gate.md
+++ b/plans/PR-Branch-Naming-Gate.md
@@ -8,12 +8,9 @@ rule before a PR branch is pushed or opened. That leaves branch/lane drift as a
 manual convention at the same point where `push_pr.sh` and `open_pr.sh` already
 have the PR body and current branch available.
 
-Audit finding:
-
-- `docs/audits/agents-mechanical-enforcement-audit-2026-07-29.md` classified
-  "Builder branch names use `claude/pr-<slice-name>`" as `PROSE_ONLY` because
-  `AGENTS.md` defines the convention but no branch-name gate was found in
-  `open_pr.sh`, `push_pr.sh`, or CI.
+Audit finding: `docs/audits/agents-mechanical-enforcement-audit-2026-07-29.md`
+classified "Builder branch names use `claude/pr-<slice-name>`" as `PROSE_ONLY`;
+no branch-name gate was found in `open_pr.sh`, `push_pr.sh`, or CI.
 
 ### Problem-derived contract
 
@@ -142,17 +139,19 @@ Parked hardening: none.
 ## Verification
 
 - `python -m pytest tests/test_check_pr_branch_name.py tests/test_push_pr_wrapper.py tests/test_open_pr_wrapper.py`
-  - 74 passed.
+  - 75 passed.
+- `python scripts/maturity_sweep.py scripts --tests-root tests --baseline tests/maturity_sweep/baseline_scripts.json --min-score 8 --sensitive-glob 'scripts/**'`
+  - Ratchet gate passed: no new brittleness above baseline.
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Branch-Naming-Gate.md` | 158 |
+| `plans/PR-Branch-Naming-Gate.md` | 157 |
 | `scripts/check_pr_branch_name.py` | 85 |
 | `scripts/open_pr.sh` | 17 |
 | `scripts/push_pr.sh` | 8 |
-| `tests/test_check_pr_branch_name.py` | 74 |
+| `tests/test_check_pr_branch_name.py` | 81 |
 | `tests/test_open_pr_wrapper.py` | 20 |
 | `tests/test_push_pr_wrapper.py` | 31 |
-| **Total** | **393** |
+| **Total** | **399** |

--- a/plans/PR-Branch-Naming-Gate.md
+++ b/plans/PR-Branch-Naming-Gate.md
@@ -12,15 +12,21 @@ Audit finding: `docs/audits/agents-mechanical-enforcement-audit-2026-07-29.md`
 classified "Builder branch names use `claude/pr-<slice-name>`" as `PROSE_ONLY`;
 no branch-name gate was found in `open_pr.sh`, `push_pr.sh`, or CI.
 
+Review-fix overage: Codex found two admission-boundary gaps in the first push
+(forwarded refspecs and Dependabot-generated bodies). They are indivisible from
+this gate because both are ways around or through the same wrapper boundary.
+
 ### Problem-derived contract
 
 - Root cause: PR publication wrappers accept any current branch name, so a
-  builder can push/open a human PR from `main`, `claude/<topic>`, or a
-  wrong-slice branch even when the PR body names a PR plan file.
+  builder can push/open a human PR from `main`, `claude/<topic>`, a wrong-slice
+  branch, or a mismatched forwarded refspec even when the PR body names a PR
+  plan file.
 - Correct fix must touch/change: add a branch-name checker that reads the PR body
   and current branch; call it from `scripts/push_pr.sh` and `scripts/open_pr.sh`
-  before fetch/review/GitHub mutation; add direct and wrapper tests for matching,
-  mismatched, and docs-only bodies.
+  before fetch/review/GitHub mutation; validate forwarded push refspecs;
+  preserve the Dependabot author exemption; add direct and wrapper tests for
+  matching, mismatched, docs-only, refspec, and Dependabot bodies.
 - Must not change: do not change product code, branch protection, PR body audit
   semantics, draft consent semantics, PR ownership semantics, docs-only body
   admission, Dependabot behavior, or any EOM / dependency / non-owned PR lane.
@@ -53,6 +59,14 @@ Slice phase: Workflow/process
   4. Docs-only bodies keep the narrower exemption but still require a
      `claude/pr-*` PR branch; settled by
      `tests/test_check_pr_branch_name.py::test_docs_only_body_requires_pr_prefix_only`.
+  5. Explicit push refspecs cannot send the reviewed branch to another PR branch;
+     settled by
+     `tests/test_push_pr_wrapper.py::test_push_pr_rejects_mismatched_refspec_before_fetch`.
+  6. Dependabot-generated bodies keep their existing author exemption in both
+     wrappers; settled by
+     `tests/test_push_pr_wrapper.py::test_push_pr_dependabot_author_keeps_generated_body_exemption`
+     and
+     `tests/test_open_pr_wrapper.py::test_open_pr_dependabot_author_keeps_generated_body_exemption`.
 - Reachability proof: the real entrypoints `bash scripts/push_pr.sh BODY_FILE`
   and `bash scripts/open_pr.sh BODY_FILE` are exercised by wrapper tests; the
   observable effect is early failure before fetch/GitHub logs on mismatched
@@ -74,7 +88,8 @@ seam in the enumeration; otherwise write "N/A - no boundary change."
 - Replaced-path behaviors: wrappers previously accepted any current branch and
   deferred failure to later GitHub/session behavior.
 - Guard-relevant fields: current branch name, first structural PR body marker
-  (`Plan:` or `Docs-only: true`), and plan filename slug.
+  (`Plan:` or `Docs-only: true`), plan filename slug, PR author, and forwarded
+  push refspecs.
 - Caller x input shape: wrapper invocations with a planned PR body, docs-only
   body, mismatched branch, non-PR branch, and detached branch.
 
@@ -120,6 +135,11 @@ by the wrapper:
 local review, push, or GitHub mutation. That makes the branch-name convention an
 admission gate rather than a review-memory rule.
 
+`push_pr.sh` passes forwarded git-push arguments to the checker so explicit
+branch/refspec destinations must still target the reviewed branch. Dependabot
+authors bypass the builder-only plan/body/branch contract, matching the existing
+generated-PR exemption used by the PR body audit.
+
 ## Intentional
 
 - Docs-only bodies require only `claude/pr-*` because there is intentionally no
@@ -129,6 +149,9 @@ admission gate rather than a review-memory rule.
   for plan-backed slices.
 - No CI-only branch-protection change in this slice; the wrappers are the point
   where the local branch exists and can be rejected cheapest.
+- The 618 LOC total is over the soft cap because the Codex review fixes require
+  checker, wrapper, direct, and wrapper-fixture coverage for the same admission
+  boundary; splitting would leave `live-reconciliation` red on this PR.
 
 ## Deferred
 
@@ -139,7 +162,7 @@ Parked hardening: none.
 ## Verification
 
 - `python -m pytest tests/test_check_pr_branch_name.py tests/test_push_pr_wrapper.py tests/test_open_pr_wrapper.py`
-  - 75 passed.
+  - 81 passed.
 - `python scripts/maturity_sweep.py scripts --tests-root tests --baseline tests/maturity_sweep/baseline_scripts.json --min-score 8 --sensitive-glob 'scripts/**'`
   - Ratchet gate passed: no new brittleness above baseline.
 
@@ -147,11 +170,11 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Branch-Naming-Gate.md` | 157 |
-| `scripts/check_pr_branch_name.py` | 85 |
-| `scripts/open_pr.sh` | 17 |
-| `scripts/push_pr.sh` | 8 |
-| `tests/test_check_pr_branch_name.py` | 81 |
-| `tests/test_open_pr_wrapper.py` | 20 |
-| `tests/test_push_pr_wrapper.py` | 31 |
-| **Total** | **399** |
+| `plans/PR-Branch-Naming-Gate.md` | 180 |
+| `scripts/check_pr_branch_name.py` | 147 |
+| `scripts/open_pr.sh` | 24 |
+| `scripts/push_pr.sh` | 18 |
+| `tests/test_check_pr_branch_name.py` | 111 |
+| `tests/test_open_pr_wrapper.py` | 49 |
+| `tests/test_push_pr_wrapper.py` | 89 |
+| **Total** | **618** |

--- a/plans/PR-Branch-Naming-Gate.md
+++ b/plans/PR-Branch-Naming-Gate.md
@@ -12,9 +12,10 @@ Audit finding: `docs/audits/agents-mechanical-enforcement-audit-2026-07-29.md`
 classified "Builder branch names use `claude/pr-<slice-name>`" as `PROSE_ONLY`;
 no branch-name gate was found in `open_pr.sh`, `push_pr.sh`, or CI.
 
-Review-fix overage: Codex found two admission-boundary gaps in the first push
-(forwarded refspecs and Dependabot-generated bodies). They are indivisible from
-this gate because both are ways around or through the same wrapper boundary.
+Review-fix overage: Codex found admission-boundary gaps in the first pushes
+(forwarded refspecs, unqualified/bulk refs, and Dependabot-generated bodies).
+They are indivisible from this gate because each is a way around or through the
+same wrapper boundary.
 
 ### Problem-derived contract
 
@@ -62,7 +63,13 @@ Slice phase: Workflow/process
   5. Explicit push refspecs cannot send the reviewed branch to another PR branch;
      settled by
      `tests/test_push_pr_wrapper.py::test_push_pr_rejects_mismatched_refspec_before_fetch`.
-  6. Dependabot-generated bodies keep their existing author exemption in both
+  6. Unqualified non-matching refs, repository-only pushes, and bulk push modes
+     fail before fetch; settled by
+     `tests/test_check_pr_branch_name.py::test_push_refspec_rejects_unqualified_other_branch`,
+     `tests/test_check_pr_branch_name.py::test_push_refspec_rejects_bulk_push_mode`,
+     and
+     `tests/test_push_pr_wrapper.py::test_push_pr_rejects_bulk_push_mode_before_fetch`.
+  7. Dependabot-generated bodies keep their existing author exemption in both
      wrappers; settled by
      `tests/test_push_pr_wrapper.py::test_push_pr_dependabot_author_keeps_generated_body_exemption`
      and
@@ -149,7 +156,7 @@ generated-PR exemption used by the PR body audit.
   for plan-backed slices.
 - No CI-only branch-protection change in this slice; the wrappers are the point
   where the local branch exists and can be rejected cheapest.
-- The 618 LOC total is over the soft cap because the Codex review fixes require
+- The 729 LOC total is over the soft cap because the Codex review fixes require
   checker, wrapper, direct, and wrapper-fixture coverage for the same admission
   boundary; splitting would leave `live-reconciliation` red on this PR.
 
@@ -162,7 +169,7 @@ Parked hardening: none.
 ## Verification
 
 - `python -m pytest tests/test_check_pr_branch_name.py tests/test_push_pr_wrapper.py tests/test_open_pr_wrapper.py`
-  - 81 passed.
+  - 86 passed.
 - `python scripts/maturity_sweep.py scripts --tests-root tests --baseline tests/maturity_sweep/baseline_scripts.json --min-score 8 --sensitive-glob 'scripts/**'`
   - Ratchet gate passed: no new brittleness above baseline.
 
@@ -170,11 +177,11 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Branch-Naming-Gate.md` | 180 |
-| `scripts/check_pr_branch_name.py` | 147 |
+| `plans/PR-Branch-Naming-Gate.md` | 187 |
+| `scripts/check_pr_branch_name.py` | 160 |
 | `scripts/open_pr.sh` | 24 |
 | `scripts/push_pr.sh` | 18 |
-| `tests/test_check_pr_branch_name.py` | 111 |
+| `tests/test_check_pr_branch_name.py` | 148 |
 | `tests/test_open_pr_wrapper.py` | 49 |
-| `tests/test_push_pr_wrapper.py` | 89 |
-| **Total** | **618** |
+| `tests/test_push_pr_wrapper.py` | 143 |
+| **Total** | **729** |

--- a/plans/PR-Branch-Naming-Gate.md
+++ b/plans/PR-Branch-Naming-Gate.md
@@ -13,7 +13,8 @@ classified "Builder branch names use `claude/pr-<slice-name>`" as `PROSE_ONLY`;
 no branch-name gate was found in `open_pr.sh`, `push_pr.sh`, or CI.
 
 Review-fix overage: Codex found admission-boundary gaps in the first pushes
-(forwarded refspecs, unqualified/bulk refs, and Dependabot-generated bodies).
+(forwarded refspecs, unqualified/bulk refs, tag-pushing modes, option-only
+pushes, clustered delete flags, and Dependabot-generated bodies).
 They are indivisible from this gate because each is a way around or through the
 same wrapper boundary.
 
@@ -25,9 +26,10 @@ same wrapper boundary.
   plan file.
 - Correct fix must touch/change: add a branch-name checker that reads the PR body
   and current branch; call it from `scripts/push_pr.sh` and `scripts/open_pr.sh`
-  before fetch/review/GitHub mutation; validate forwarded push refspecs;
-  preserve the Dependabot author exemption; add direct and wrapper tests for
-  matching, mismatched, docs-only, refspec, and Dependabot bodies.
+  before fetch/review/GitHub mutation; validate forwarded push refspecs; reject
+  tag-pushing modes, option-only forwarded pushes, and delete-mode short-option
+  clusters; preserve the Dependabot author exemption; add direct and wrapper
+  tests for matching, mismatched, docs-only, refspec, and Dependabot bodies.
 - Must not change: do not change product code, branch protection, PR body audit
   semantics, draft consent semantics, PR ownership semantics, docs-only body
   admission, Dependabot behavior, or any EOM / dependency / non-owned PR lane.
@@ -63,12 +65,18 @@ Slice phase: Workflow/process
   5. Explicit push refspecs cannot send the reviewed branch to another PR branch;
      settled by
      `tests/test_push_pr_wrapper.py::test_push_pr_rejects_mismatched_refspec_before_fetch`.
-  6. Unqualified non-matching refs, repository-only pushes, and bulk push modes
-     fail before fetch; settled by
+  6. Unqualified non-matching refs, repository-only pushes, option-only pushes,
+     tag-pushing modes, clustered delete flags, and bulk push modes fail before
+     fetch; settled by
      `tests/test_check_pr_branch_name.py::test_push_refspec_rejects_unqualified_other_branch`,
      `tests/test_check_pr_branch_name.py::test_push_refspec_rejects_bulk_push_mode`,
-     and
-     `tests/test_push_pr_wrapper.py::test_push_pr_rejects_bulk_push_mode_before_fetch`.
+     `tests/test_check_pr_branch_name.py::test_push_refspec_rejects_follow_tags`,
+     `tests/test_check_pr_branch_name.py::test_push_refspec_rejects_clustered_delete_flag`,
+     `tests/test_check_pr_branch_name.py::test_push_refspec_rejects_option_only_push`,
+     `tests/test_push_pr_wrapper.py::test_push_pr_rejects_bulk_push_mode_before_fetch`,
+     `tests/test_push_pr_wrapper.py::test_push_pr_rejects_follow_tags_before_fetch`,
+     `tests/test_push_pr_wrapper.py::test_push_pr_rejects_clustered_delete_flag_before_fetch`,
+     and `tests/test_push_pr_wrapper.py::test_push_pr_rejects_option_only_push_before_fetch`.
   7. Dependabot-generated bodies keep their existing author exemption in both
      wrappers; settled by
      `tests/test_push_pr_wrapper.py::test_push_pr_dependabot_author_keeps_generated_body_exemption`
@@ -96,7 +104,8 @@ seam in the enumeration; otherwise write "N/A - no boundary change."
   deferred failure to later GitHub/session behavior.
 - Guard-relevant fields: current branch name, first structural PR body marker
   (`Plan:` or `Docs-only: true`), plan filename slug, PR author, and forwarded
-  push refspecs.
+  push refspecs, tag-pushing modes, option-only pushes, and clustered delete
+  flags.
 - Caller x input shape: wrapper invocations with a planned PR body, docs-only
   body, mismatched branch, non-PR branch, and detached branch.
 
@@ -143,9 +152,14 @@ local review, push, or GitHub mutation. That makes the branch-name convention an
 admission gate rather than a review-memory rule.
 
 `push_pr.sh` passes forwarded git-push arguments to the checker so explicit
-branch/refspec destinations must still target the reviewed branch. Dependabot
-authors bypass the builder-only plan/body/branch contract, matching the existing
-generated-PR exemption used by the PR body audit.
+branch/refspec destinations must still target the reviewed branch. It also
+rejects push modes that publish additional refs (`--tags`, `--follow-tags`,
+`--all`, `--mirror`) or delete refs (`--delete`, `-d`, clustered `-d` forms
+such as `-fd`). Forwarded push invocations must include an explicit `HEAD` or
+current-branch refspec, so option-only pushes cannot rely on implicit Git
+configuration. Dependabot authors bypass the builder-only plan/body/branch
+contract, matching the existing generated-PR exemption used by the PR body
+audit.
 
 ## Intentional
 
@@ -156,7 +170,7 @@ generated-PR exemption used by the PR body audit.
   for plan-backed slices.
 - No CI-only branch-protection change in this slice; the wrappers are the point
   where the local branch exists and can be rejected cheapest.
-- The 729 LOC total is over the soft cap because the Codex review fixes require
+- The LOC total is over the soft cap because the Codex review fixes require
   checker, wrapper, direct, and wrapper-fixture coverage for the same admission
   boundary; splitting would leave `live-reconciliation` red on this PR.
 
@@ -169,7 +183,7 @@ Parked hardening: none.
 ## Verification
 
 - `python -m pytest tests/test_check_pr_branch_name.py tests/test_push_pr_wrapper.py tests/test_open_pr_wrapper.py`
-  - 86 passed.
+  - 92 passed.
 - `python scripts/maturity_sweep.py scripts --tests-root tests --baseline tests/maturity_sweep/baseline_scripts.json --min-score 8 --sensitive-glob 'scripts/**'`
   - Ratchet gate passed: no new brittleness above baseline.
 
@@ -177,11 +191,11 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Branch-Naming-Gate.md` | 187 |
-| `scripts/check_pr_branch_name.py` | 160 |
+| `plans/PR-Branch-Naming-Gate.md` | 201 |
+| `scripts/check_pr_branch_name.py` | 165 |
 | `scripts/open_pr.sh` | 24 |
 | `scripts/push_pr.sh` | 18 |
-| `tests/test_check_pr_branch_name.py` | 148 |
+| `tests/test_check_pr_branch_name.py` | 185 |
 | `tests/test_open_pr_wrapper.py` | 49 |
-| `tests/test_push_pr_wrapper.py` | 143 |
-| **Total** | **729** |
+| `tests/test_push_pr_wrapper.py` | 231 |
+| **Total** | **873** |

--- a/plans/PR-Branch-Naming-Gate.md
+++ b/plans/PR-Branch-Naming-Gate.md
@@ -1,0 +1,158 @@
+# PR-Branch-Naming-Gate
+
+## Why this slice exists
+
+The mechanical-enforcement audit found that Atlas documents builder PR branch
+names as `claude/pr-<slice-name>`, but no wrapper or CI artifact enforces that
+rule before a PR branch is pushed or opened. That leaves branch/lane drift as a
+manual convention at the same point where `push_pr.sh` and `open_pr.sh` already
+have the PR body and current branch available.
+
+Audit finding:
+
+- `docs/audits/agents-mechanical-enforcement-audit-2026-07-29.md` classified
+  "Builder branch names use `claude/pr-<slice-name>`" as `PROSE_ONLY` because
+  `AGENTS.md` defines the convention but no branch-name gate was found in
+  `open_pr.sh`, `push_pr.sh`, or CI.
+
+### Problem-derived contract
+
+- Root cause: PR publication wrappers accept any current branch name, so a
+  builder can push/open a human PR from `main`, `claude/<topic>`, or a
+  wrong-slice branch even when the PR body names a PR plan file.
+- Correct fix must touch/change: add a branch-name checker that reads the PR body
+  and current branch; call it from `scripts/push_pr.sh` and `scripts/open_pr.sh`
+  before fetch/review/GitHub mutation; add direct and wrapper tests for matching,
+  mismatched, and docs-only bodies.
+- Must not change: do not change product code, branch protection, PR body audit
+  semantics, draft consent semantics, PR ownership semantics, docs-only body
+  admission, Dependabot behavior, or any EOM / dependency / non-owned PR lane.
+
+## Scope (this PR)
+
+Ownership lane: dev-workflow/branch-naming
+Slice phase: Workflow/process
+
+1. Add `scripts/check_pr_branch_name.py` to validate PR branches against the PR
+   body contract.
+2. Call that checker from `scripts/push_pr.sh` and `scripts/open_pr.sh` before
+   network/ref/GitHub mutation side effects.
+3. Add direct checker tests plus wrapper tests proving bad branch names fail
+   before fetch or GitHub mutation.
+
+### Review Contract
+
+- Acceptance criteria:
+  1. A planned PR body for this slice only
+     admits branch `claude/pr-branch-naming-gate`; settled by
+     `tests/test_check_pr_branch_name.py::test_branch_name_accepts_matching_plan_branch`
+     and `tests/test_check_pr_branch_name.py::test_branch_name_rejects_plan_slug_mismatch`.
+  2. `scripts/push_pr.sh` runs the branch-name check before `git fetch`, body
+     audit, local review, or push; settled by
+     `tests/test_push_pr_wrapper.py::test_push_pr_rejects_branch_that_does_not_match_plan_before_fetch`.
+  3. `scripts/open_pr.sh` runs the branch-name check before origin refresh or
+     GitHub mutation; settled by
+     `tests/test_open_pr_wrapper.py::test_open_pr_rejects_branch_that_does_not_match_plan_before_fetch`.
+  4. Docs-only bodies keep the narrower exemption but still require a
+     `claude/pr-*` PR branch; settled by
+     `tests/test_check_pr_branch_name.py::test_docs_only_body_requires_pr_prefix_only`.
+- Reachability proof: the real entrypoints `bash scripts/push_pr.sh BODY_FILE`
+  and `bash scripts/open_pr.sh BODY_FILE` are exercised by wrapper tests; the
+  observable effect is early failure before fetch/GitHub logs on mismatched
+  branches.
+- Affected surfaces: `scripts/check_pr_branch_name.py`, `scripts/push_pr.sh`,
+  `scripts/open_pr.sh`, wrapper tests, and this plan.
+- Risk areas: shell side-effect ordering, docs-only exemption, plan-to-branch
+  slug normalization, wrapper fixture parity.
+- Reviewer rules triggered: R1, R2, R6, R10, R12, R14.
+
+### Boundary-change enumeration
+
+Required when this diff changes a guard, validator, normalizer, resolver,
+router/classifier, or admission boundary. Name each changed boundary path or
+seam in the enumeration; otherwise write "N/A - no boundary change."
+
+- Boundary path/seam: PR publication admission through `scripts/push_pr.sh` and
+  `scripts/open_pr.sh`.
+- Replaced-path behaviors: wrappers previously accepted any current branch and
+  deferred failure to later GitHub/session behavior.
+- Guard-relevant fields: current branch name, first structural PR body marker
+  (`Plan:` or `Docs-only: true`), and plan filename slug.
+- Caller x input shape: wrapper invocations with a planned PR body, docs-only
+  body, mismatched branch, non-PR branch, and detached branch.
+
+### Deployed-config probing
+
+Required for guard, validator, resolver, admission-boundary, or env/config
+fallback changes; otherwise write "N/A - no guard/config boundary change."
+
+- Deployed/default config values: no deployed config; branch names and PR body
+  files are local wrapper inputs.
+- Explicit value probe: planned PR body plus matching
+  `claude/pr-branch-naming-gate` branch passes direct checker tests.
+- Absent value probe: missing plan/docs-only marker and detached branch both
+  fail direct checker tests.
+- Default-session/default-context probe: docs-only body has no plan slug and is
+  probed separately as prefix-only admission.
+- Side-effect ordering: push and open wrapper tests prove branch mismatch fails
+  before fetch/review/GitHub mutation logs.
+
+### Files touched
+
+- `plans/PR-Branch-Naming-Gate.md`
+- `scripts/check_pr_branch_name.py`
+- `scripts/open_pr.sh`
+- `scripts/push_pr.sh`
+- `tests/test_check_pr_branch_name.py`
+- `tests/test_open_pr_wrapper.py`
+- `tests/test_push_pr_wrapper.py`
+
+## Mechanism
+
+`scripts/check_pr_branch_name.py` reads the PR body and current branch supplied
+by the wrapper:
+
+- A plan-backed PR body computes an expected lowercase slug branch:
+  `claude/pr-<slice-slug>`.
+- `Docs-only: true` has no plan slug, so it keeps the docs-only exemption while
+  still requiring the `claude/pr-*` PR-branch prefix.
+- missing structural markers, detached branches, non-PR branches, and plan/branch
+  mismatches fail with exit code 2.
+
+`push_pr.sh` and `open_pr.sh` invoke the checker before `git fetch`, body audit,
+local review, push, or GitHub mutation. That makes the branch-name convention an
+admission gate rather than a review-memory rule.
+
+## Intentional
+
+- Docs-only bodies require only `claude/pr-*` because there is intentionally no
+  plan filename to compare against.
+- The checker normalizes plan filenames by lowercasing and collapsing non
+  alphanumeric separators to `-`, matching the branch style Atlas already uses
+  for plan-backed slices.
+- No CI-only branch-protection change in this slice; the wrappers are the point
+  where the local branch exists and can be rejected cheapest.
+
+## Deferred
+
+- Commit-message contract enforcement remains a separate follow-up slice.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_check_pr_branch_name.py tests/test_push_pr_wrapper.py tests/test_open_pr_wrapper.py`
+  - 74 passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Branch-Naming-Gate.md` | 158 |
+| `scripts/check_pr_branch_name.py` | 85 |
+| `scripts/open_pr.sh` | 17 |
+| `scripts/push_pr.sh` | 8 |
+| `tests/test_check_pr_branch_name.py` | 74 |
+| `tests/test_open_pr_wrapper.py` | 20 |
+| `tests/test_push_pr_wrapper.py` | 31 |
+| **Total** | **393** |

--- a/scripts/check_pr_branch_name.py
+++ b/scripts/check_pr_branch_name.py
@@ -8,6 +8,8 @@ import re
 import sys
 from typing import Sequence
 
+from _pr_change_policy import is_dependabot_author
+
 
 PLAN_LINE_RE = re.compile(r"^Plan:\s+plans/PR-(?P<slice>[A-Za-z0-9._-]+)\.md\s*$")
 DOCS_ONLY_RE = re.compile(r"^Docs-only:\s*true\s*$", re.IGNORECASE)
@@ -36,8 +38,15 @@ def expected_branch_for_body(body: str) -> str | None:
     return ""
 
 
-def branch_name_errors(*, branch: str, body: str) -> list[str]:
+def branch_name_errors(
+    *,
+    branch: str,
+    body: str,
+    pr_author: str | None = None,
+) -> list[str]:
     errors: list[str] = []
+    if is_dependabot_author(pr_author):
+        return errors
     clean_branch = branch.strip()
     if not clean_branch:
         return ["current checkout is detached; switch to a PR branch first"]
@@ -55,11 +64,59 @@ def branch_name_errors(*, branch: str, body: str) -> list[str]:
     return errors
 
 
+def push_refspec_errors(
+    *,
+    branch: str,
+    body: str,
+    push_args: Sequence[str],
+    pr_author: str | None = None,
+) -> list[str]:
+    errors = branch_name_errors(branch=branch, body=body, pr_author=pr_author)
+    if errors or is_dependabot_author(pr_author):
+        return errors
+
+    clean_branch = branch.strip()
+    allowed_sources = {"HEAD", clean_branch, f"refs/heads/{clean_branch}"}
+    allowed_destinations = {clean_branch, f"refs/heads/{clean_branch}"}
+    for arg in push_args:
+        refspec = arg.lstrip("+")
+        if not _looks_branch_refspec(refspec):
+            continue
+        if ":" in refspec:
+            source, destination = refspec.split(":", 1)
+            if source not in allowed_sources:
+                errors.append(
+                    f"push refspec source {source!r} must be HEAD or {clean_branch!r}"
+                )
+            if destination not in allowed_destinations:
+                errors.append(
+                    f"push refspec destination {destination!r} must be {clean_branch!r}"
+                )
+        elif refspec not in allowed_sources:
+            errors.append(f"push refspec {refspec!r} must be HEAD or {clean_branch!r}")
+    return errors
+
+
+def _looks_branch_refspec(value: str) -> bool:
+    if not value or value.startswith("-"):
+        return False
+    return (
+        value == "HEAD"
+        or value.startswith("HEAD:")
+        or value.startswith("claude/")
+        or value.startswith("refs/heads/")
+        or ":claude/" in value
+        or ":refs/heads/" in value
+    )
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Validate the current PR branch name against the PR body."
     )
     parser.add_argument("--branch", required=True)
+    parser.add_argument("--pr-author", default="")
+    parser.add_argument("--push-arg", action="append", default=[])
     parser.add_argument("body_file", type=Path)
     return parser
 
@@ -71,7 +128,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     except OSError as exc:
         print(f"branch name check could not read PR body file: {exc}", file=sys.stderr)
         return 2
-    errors = branch_name_errors(branch=args.branch, body=body)
+    errors = push_refspec_errors(
+        branch=args.branch,
+        body=body,
+        push_args=args.push_arg,
+        pr_author=args.pr_author,
+    )
     if errors:
         print("PR branch name check failed:", file=sys.stderr)
         for error in errors:

--- a/scripts/check_pr_branch_name.py
+++ b/scripts/check_pr_branch_name.py
@@ -14,6 +14,10 @@ from _pr_change_policy import is_dependabot_author
 PLAN_LINE_RE = re.compile(r"^Plan:\s+plans/PR-(?P<slice>[A-Za-z0-9._-]+)\.md\s*$")
 DOCS_ONLY_RE = re.compile(r"^Docs-only:\s*true\s*$", re.IGNORECASE)
 PR_BRANCH_RE = re.compile(r"^claude/pr-[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$")
+BULK_PUSH_MODES = frozenset({"--all", "--mirror", "--tags", "--delete", "-d"})
+PUSH_OPTIONS_WITH_VALUES = frozenset(
+    {"--receive-pack", "--exec", "--push-option", "-o"}
+)
 
 
 def plan_slug(slice_name: str) -> str:
@@ -78,10 +82,30 @@ def push_refspec_errors(
     clean_branch = branch.strip()
     allowed_sources = {"HEAD", clean_branch, f"refs/heads/{clean_branch}"}
     allowed_destinations = {clean_branch, f"refs/heads/{clean_branch}"}
-    for arg in push_args:
-        refspec = arg.lstrip("+")
-        if not _looks_branch_refspec(refspec):
+    repository_seen = False
+    refspec_seen = False
+    index = 0
+    while index < len(push_args):
+        arg = push_args[index]
+        index += 1
+        if arg in BULK_PUSH_MODES or any(
+            arg.startswith(f"{mode}=") for mode in BULK_PUSH_MODES
+        ):
+            errors.append(f"push mode {arg!r} can push refs outside {clean_branch!r}")
             continue
+        if arg in PUSH_OPTIONS_WITH_VALUES:
+            index += 1
+            continue
+        if arg == "--":
+            continue
+        if arg.startswith("-"):
+            continue
+        if not repository_seen:
+            repository_seen = True
+            continue
+
+        refspec_seen = True
+        refspec = arg.lstrip("+")
         if ":" in refspec:
             source, destination = refspec.split(":", 1)
             if source not in allowed_sources:
@@ -94,20 +118,9 @@ def push_refspec_errors(
                 )
         elif refspec not in allowed_sources:
             errors.append(f"push refspec {refspec!r} must be HEAD or {clean_branch!r}")
+    if repository_seen and not refspec_seen:
+        errors.append(f"push must explicitly name HEAD or {clean_branch!r} as refspec")
     return errors
-
-
-def _looks_branch_refspec(value: str) -> bool:
-    if not value or value.startswith("-"):
-        return False
-    return (
-        value == "HEAD"
-        or value.startswith("HEAD:")
-        or value.startswith("claude/")
-        or value.startswith("refs/heads/")
-        or ":claude/" in value
-        or ":refs/heads/" in value
-    )
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/scripts/check_pr_branch_name.py
+++ b/scripts/check_pr_branch_name.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Validate Atlas builder PR branch names against the PR body contract."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import re
+import sys
+from typing import Sequence
+
+
+PLAN_LINE_RE = re.compile(r"^Plan:\s+plans/PR-(?P<slice>[A-Za-z0-9._-]+)\.md\s*$")
+DOCS_ONLY_RE = re.compile(r"^Docs-only:\s*true\s*$", re.IGNORECASE)
+PR_BRANCH_RE = re.compile(r"^claude/pr-[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$")
+
+
+def plan_slug(slice_name: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9]+", "-", slice_name).strip("-").lower()
+    return slug
+
+
+def expected_branch_for_body(body: str) -> str | None:
+    for raw_line in body.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if DOCS_ONLY_RE.fullmatch(line):
+            return None
+        match = PLAN_LINE_RE.fullmatch(line)
+        if match:
+            slug = plan_slug(match.group("slice"))
+            if slug:
+                return f"claude/pr-{slug}"
+            return ""
+        return ""
+    return ""
+
+
+def branch_name_errors(*, branch: str, body: str) -> list[str]:
+    errors: list[str] = []
+    clean_branch = branch.strip()
+    if not clean_branch:
+        return ["current checkout is detached; switch to a PR branch first"]
+    if not PR_BRANCH_RE.fullmatch(clean_branch):
+        errors.append(
+            f"branch must match claude/pr-<slice-name>, got {clean_branch!r}"
+        )
+    expected = expected_branch_for_body(body)
+    if expected == "":
+        errors.append("PR body must begin with Plan: plans/PR-<Slice>.md or Docs-only: true")
+    elif expected is not None and clean_branch != expected:
+        errors.append(
+            f"branch {clean_branch!r} does not match PR plan branch {expected!r}"
+        )
+    return errors
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate the current PR branch name against the PR body."
+    )
+    parser.add_argument("--branch", required=True)
+    parser.add_argument("body_file", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        body = args.body_file.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"branch name check could not read PR body file: {exc}", file=sys.stderr)
+        return 2
+    errors = branch_name_errors(branch=args.branch, body=body)
+    if errors:
+        print("PR branch name check failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 2
+    print(f"PR branch name check passed for {args.branch}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_pr_branch_name.py
+++ b/scripts/check_pr_branch_name.py
@@ -14,7 +14,9 @@ from _pr_change_policy import is_dependabot_author
 PLAN_LINE_RE = re.compile(r"^Plan:\s+plans/PR-(?P<slice>[A-Za-z0-9._-]+)\.md\s*$")
 DOCS_ONLY_RE = re.compile(r"^Docs-only:\s*true\s*$", re.IGNORECASE)
 PR_BRANCH_RE = re.compile(r"^claude/pr-[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$")
-BULK_PUSH_MODES = frozenset({"--all", "--mirror", "--tags", "--delete", "-d"})
+BULK_PUSH_MODES = frozenset(
+    {"--all", "--mirror", "--tags", "--follow-tags", "--delete", "-d"}
+)
 PUSH_OPTIONS_WITH_VALUES = frozenset(
     {"--receive-pack", "--exec", "--push-option", "-o"}
 )
@@ -93,6 +95,9 @@ def push_refspec_errors(
         ):
             errors.append(f"push mode {arg!r} can push refs outside {clean_branch!r}")
             continue
+        if arg.startswith("-") and not arg.startswith("--") and "d" in arg[1:]:
+            errors.append(f"push mode {arg!r} can push refs outside {clean_branch!r}")
+            continue
         if arg in PUSH_OPTIONS_WITH_VALUES:
             index += 1
             continue
@@ -118,7 +123,7 @@ def push_refspec_errors(
                 )
         elif refspec not in allowed_sources:
             errors.append(f"push refspec {refspec!r} must be HEAD or {clean_branch!r}")
-    if repository_seen and not refspec_seen:
+    if push_args and not refspec_seen:
         errors.append(f"push must explicitly name HEAD or {clean_branch!r} as refspec")
     return errors
 

--- a/scripts/open_pr.sh
+++ b/scripts/open_pr.sh
@@ -275,6 +275,10 @@ verify_body_hash() {
     fi
 }
 
+require_pr_branch_name() {
+    "$python_bin" scripts/check_pr_branch_name.py --branch "$branch" "$body_file"
+}
+
 run_final_local_review() {
     echo "Running final local PR review before GitHub mutation..."
     ATLAS_CURRENT_PR_BODY_FILE="$body_file" \
@@ -393,6 +397,13 @@ for arg in "$@"; do
 done
 reject_target_overrides "$@"
 
+branch="$(git branch --show-current)"
+if [ -z "$branch" ]; then
+    echo "open_pr.sh: current checkout is detached; switch to a branch first" >&2
+    exit 2
+fi
+require_pr_branch_name
+
 refresh_base_ref
 
 body_audit_args=(--base-ref origin/main)
@@ -400,12 +411,6 @@ if [ -n "${ATLAS_CURRENT_PR_AUTHOR:-}" ]; then
     body_audit_args+=(--pr-author "$ATLAS_CURRENT_PR_AUTHOR")
 fi
 "$python_bin" scripts/audit_pr_body.py "${body_audit_args[@]}" "$body_file"
-
-branch="$(git branch --show-current)"
-if [ -z "$branch" ]; then
-    echo "open_pr.sh: current checkout is detached; switch to a branch first" >&2
-    exit 2
-fi
 
 acquire_mutation_lock
 

--- a/scripts/open_pr.sh
+++ b/scripts/open_pr.sh
@@ -276,7 +276,14 @@ verify_body_hash() {
 }
 
 require_pr_branch_name() {
-    "$python_bin" scripts/check_pr_branch_name.py --branch "$branch" "$body_file"
+    local checker_args=()
+    if [ -n "${ATLAS_CURRENT_PR_AUTHOR:-}" ]; then
+        checker_args+=(--pr-author "$ATLAS_CURRENT_PR_AUTHOR")
+    fi
+    "$python_bin" scripts/check_pr_branch_name.py \
+        --branch "$branch" \
+        "${checker_args[@]}" \
+        "$body_file"
 }
 
 run_final_local_review() {

--- a/scripts/push_pr.sh
+++ b/scripts/push_pr.sh
@@ -37,8 +37,18 @@ refresh_base_ref() {
 
 require_pr_branch_name() {
     local branch
+    local checker_args=()
     branch="$(git branch --show-current)"
-    "$python_bin" scripts/check_pr_branch_name.py --branch "$branch" "$body_file"
+    if [ -n "${ATLAS_CURRENT_PR_AUTHOR:-}" ]; then
+        checker_args+=(--pr-author "$ATLAS_CURRENT_PR_AUTHOR")
+    fi
+    for arg in "$@"; do
+        checker_args+=(--push-arg="$arg")
+    done
+    "$python_bin" scripts/check_pr_branch_name.py \
+        --branch "$branch" \
+        "${checker_args[@]}" \
+        "$body_file"
 }
 
 if [ "$#" -lt 1 ] || [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
@@ -72,7 +82,7 @@ if has_managed_pre_push_hook && [ "${ATLAS_SKIP_LOCAL_PR_REVIEW:-}" != "1" ]; th
 fi
 
 if [ "${ATLAS_PUSH_PR_DRY_RUN:-}" = "1" ]; then
-    require_pr_branch_name
+    require_pr_branch_name "$@"
     echo "DRY RUN: git fetch --quiet origin main"
     if [ "$run_wrapper_review" -eq 1 ]; then
         echo "DRY RUN: ATLAS_CURRENT_PR_BODY_FILE=$body_file bash scripts/local_pr_review.sh --current-pr-body-file $body_file"
@@ -83,7 +93,7 @@ if [ "${ATLAS_PUSH_PR_DRY_RUN:-}" = "1" ]; then
     exit 0
 fi
 
-require_pr_branch_name
+require_pr_branch_name "$@"
 refresh_base_ref
 
 body_audit_args=(--base-ref origin/main)

--- a/scripts/push_pr.sh
+++ b/scripts/push_pr.sh
@@ -35,6 +35,12 @@ refresh_base_ref() {
     fi
 }
 
+require_pr_branch_name() {
+    local branch
+    branch="$(git branch --show-current)"
+    "$python_bin" scripts/check_pr_branch_name.py --branch "$branch" "$body_file"
+}
+
 if [ "$#" -lt 1 ] || [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
     usage
     exit 2
@@ -66,6 +72,7 @@ if has_managed_pre_push_hook && [ "${ATLAS_SKIP_LOCAL_PR_REVIEW:-}" != "1" ]; th
 fi
 
 if [ "${ATLAS_PUSH_PR_DRY_RUN:-}" = "1" ]; then
+    require_pr_branch_name
     echo "DRY RUN: git fetch --quiet origin main"
     if [ "$run_wrapper_review" -eq 1 ]; then
         echo "DRY RUN: ATLAS_CURRENT_PR_BODY_FILE=$body_file bash scripts/local_pr_review.sh --current-pr-body-file $body_file"
@@ -76,6 +83,7 @@ if [ "${ATLAS_PUSH_PR_DRY_RUN:-}" = "1" ]; then
     exit 0
 fi
 
+require_pr_branch_name
 refresh_base_ref
 
 body_audit_args=(--base-ref origin/main)

--- a/tests/test_check_pr_branch_name.py
+++ b/tests/test_check_pr_branch_name.py
@@ -9,6 +9,7 @@ import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts/check_pr_branch_name.py"
+sys.path.insert(0, str(ROOT / "scripts"))
 SPEC = importlib.util.spec_from_file_location("check_pr_branch_name", SCRIPT)
 assert SPEC is not None and SPEC.loader is not None
 checker = importlib.util.module_from_spec(SPEC)
@@ -79,3 +80,32 @@ def test_detached_branch_fails() -> None:
 def test_cli_parser_rejects_missing_required_arguments() -> None:
     with pytest.raises(SystemExit):
         checker.main([])
+
+
+def test_dependabot_author_bypasses_builder_branch_contract() -> None:
+    assert checker.branch_name_errors(
+        branch="dependabot/pip/security-update",
+        body="Generated dependency update body.\n",
+        pr_author="dependabot[bot]",
+    ) == []
+
+
+def test_push_refspec_rejects_mismatched_destination() -> None:
+    errors = checker.push_refspec_errors(
+        branch="claude/pr-branch-naming-gate",
+        body=_body(),
+        push_args=["-u", "origin", "HEAD:claude/pr-other"],
+    )
+
+    assert errors == [
+        "push refspec destination 'claude/pr-other' must be "
+        "'claude/pr-branch-naming-gate'"
+    ]
+
+
+def test_push_refspec_accepts_head_to_matching_destination() -> None:
+    assert checker.push_refspec_errors(
+        branch="claude/pr-branch-naming-gate",
+        body=_body(),
+        push_args=["-u", "origin", "HEAD:refs/heads/claude/pr-branch-naming-gate"],
+    ) == []

--- a/tests/test_check_pr_branch_name.py
+++ b/tests/test_check_pr_branch_name.py
@@ -4,6 +4,8 @@ import importlib.util
 from pathlib import Path
 import sys
 
+import pytest
+
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts/check_pr_branch_name.py"
@@ -72,3 +74,8 @@ def test_detached_branch_fails() -> None:
     assert checker.branch_name_errors(branch="", body=_body()) == [
         "current checkout is detached; switch to a PR branch first"
     ]
+
+
+def test_cli_parser_rejects_missing_required_arguments() -> None:
+    with pytest.raises(SystemExit):
+        checker.main([])

--- a/tests/test_check_pr_branch_name.py
+++ b/tests/test_check_pr_branch_name.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/check_pr_branch_name.py"
+SPEC = importlib.util.spec_from_file_location("check_pr_branch_name", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+checker = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = checker
+SPEC.loader.exec_module(checker)
+
+
+def _body(plan: str = "plans/PR-Branch-Naming-Gate.md") -> str:
+    return f"Plan: {plan}\n\n## Intentional\n- none\n"
+
+
+def test_plan_slug_normalizes_plan_name_to_branch_slug() -> None:
+    assert checker.plan_slug("EOM_First.Clean-Won") == "eom-first-clean-won"
+
+
+def test_branch_name_accepts_matching_plan_branch() -> None:
+    assert checker.branch_name_errors(
+        branch="claude/pr-branch-naming-gate",
+        body=_body(),
+    ) == []
+
+
+def test_branch_name_rejects_non_pr_prefix() -> None:
+    errors = checker.branch_name_errors(
+        branch="claude/branch-naming-gate",
+        body=_body(),
+    )
+
+    assert "branch must match claude/pr-<slice-name>" in errors[0]
+
+
+def test_branch_name_rejects_plan_slug_mismatch() -> None:
+    errors = checker.branch_name_errors(
+        branch="claude/pr-other",
+        body=_body(),
+    )
+
+    assert errors == [
+        "branch 'claude/pr-other' does not match PR plan branch "
+        "'claude/pr-branch-naming-gate'"
+    ]
+
+
+def test_docs_only_body_requires_pr_prefix_only() -> None:
+    assert checker.branch_name_errors(
+        branch="claude/pr-docs-typo",
+        body="Docs-only: true\n\nFix docs.\n",
+    ) == []
+
+
+def test_body_without_plan_or_docs_only_marker_fails() -> None:
+    errors = checker.branch_name_errors(
+        branch="claude/pr-branch-naming-gate",
+        body="No marker here\n",
+    )
+
+    assert errors == [
+        "PR body must begin with Plan: plans/PR-<Slice>.md or Docs-only: true"
+    ]
+
+
+def test_detached_branch_fails() -> None:
+    assert checker.branch_name_errors(branch="", body=_body()) == [
+        "current checkout is detached; switch to a PR branch first"
+    ]

--- a/tests/test_check_pr_branch_name.py
+++ b/tests/test_check_pr_branch_name.py
@@ -136,11 +136,48 @@ def test_push_refspec_rejects_bulk_push_mode() -> None:
     ]
 
 
+def test_push_refspec_rejects_follow_tags() -> None:
+    errors = checker.push_refspec_errors(
+        branch="claude/pr-branch-naming-gate",
+        body=_body(),
+        push_args=["--follow-tags", "origin", "HEAD"],
+    )
+
+    assert errors == [
+        "push mode '--follow-tags' can push refs outside "
+        "'claude/pr-branch-naming-gate'"
+    ]
+
+
+def test_push_refspec_rejects_clustered_delete_flag() -> None:
+    errors = checker.push_refspec_errors(
+        branch="claude/pr-branch-naming-gate",
+        body=_body(),
+        push_args=["-fd", "origin", "claude/pr-branch-naming-gate"],
+    )
+
+    assert errors == [
+        "push mode '-fd' can push refs outside 'claude/pr-branch-naming-gate'"
+    ]
+
+
 def test_push_refspec_rejects_repository_without_refspec() -> None:
     errors = checker.push_refspec_errors(
         branch="claude/pr-branch-naming-gate",
         body=_body(),
         push_args=["origin"],
+    )
+
+    assert errors == [
+        "push must explicitly name HEAD or 'claude/pr-branch-naming-gate' as refspec"
+    ]
+
+
+def test_push_refspec_rejects_option_only_push() -> None:
+    errors = checker.push_refspec_errors(
+        branch="claude/pr-branch-naming-gate",
+        body=_body(),
+        push_args=["--force"],
     )
 
     assert errors == [

--- a/tests/test_check_pr_branch_name.py
+++ b/tests/test_check_pr_branch_name.py
@@ -109,3 +109,40 @@ def test_push_refspec_accepts_head_to_matching_destination() -> None:
         body=_body(),
         push_args=["-u", "origin", "HEAD:refs/heads/claude/pr-branch-naming-gate"],
     ) == []
+
+
+def test_push_refspec_rejects_unqualified_other_branch() -> None:
+    errors = checker.push_refspec_errors(
+        branch="claude/pr-branch-naming-gate",
+        body=_body(),
+        push_args=["-u", "origin", "main"],
+    )
+
+    assert errors == [
+        "push refspec 'main' must be HEAD or 'claude/pr-branch-naming-gate'"
+    ]
+
+
+def test_push_refspec_rejects_bulk_push_mode() -> None:
+    errors = checker.push_refspec_errors(
+        branch="claude/pr-branch-naming-gate",
+        body=_body(),
+        push_args=["--all", "origin"],
+    )
+
+    assert errors == [
+        "push mode '--all' can push refs outside 'claude/pr-branch-naming-gate'",
+        "push must explicitly name HEAD or 'claude/pr-branch-naming-gate' as refspec",
+    ]
+
+
+def test_push_refspec_rejects_repository_without_refspec() -> None:
+    errors = checker.push_refspec_errors(
+        branch="claude/pr-branch-naming-gate",
+        body=_body(),
+        push_args=["origin"],
+    )
+
+    assert errors == [
+        "push must explicitly name HEAD or 'claude/pr-branch-naming-gate' as refspec"
+    ]

--- a/tests/test_open_pr_wrapper.py
+++ b/tests/test_open_pr_wrapper.py
@@ -15,6 +15,7 @@ AUDIT_SCRIPT = REPO_ROOT / "scripts" / "audit_pr_body.py"
 AI_RECONCILIATION_SCRIPT = REPO_ROOT / "scripts" / "audit_ai_reconciliation.py"
 CHANGE_POLICY_SCRIPT = REPO_ROOT / "scripts" / "_pr_change_policy.py"
 LOCAL_REVIEW_SCRIPT = REPO_ROOT / "scripts" / "local_pr_review.sh"
+BRANCH_NAME_SCRIPT = REPO_ROOT / "scripts" / "check_pr_branch_name.py"
 
 
 def test_open_pr_create_passes_body_via_stdin_not_path(tmp_path: Path) -> None:
@@ -66,6 +67,19 @@ def test_open_pr_existing_pr_rejects_create_only_args(tmp_path: Path) -> None:
 
     assert result.returncode == 2
     assert "PR already exists" in result.stderr
+
+
+def test_open_pr_rejects_branch_that_does_not_match_plan_before_fetch(tmp_path: Path) -> None:
+    repo, body, env, log, stdin_capture = _ready(tmp_path, view_exit=1)
+    _git(repo, "switch", "-c", "claude/pr-other")
+
+    result = _run(repo, env, body, "--title", "Workflow wrapper")
+
+    assert result.returncode == 2
+    assert "does not match PR plan branch" in result.stderr
+    assert "Refreshing origin/main" not in result.stdout
+    assert not log.exists()
+    assert not stdin_capture.exists()
 
 
 @pytest.mark.parametrize(
@@ -284,10 +298,15 @@ def test_open_pr_draft_admission_matches_gh_argv_grammar(tmp_path: Path) -> None
     repo = tmp_path / "grammar-repo"
     (repo / "scripts").mkdir(parents=True)
     copy2(SCRIPT, repo / "scripts" / "open_pr.sh")
+    copy2(BRANCH_NAME_SCRIPT, repo / "scripts" / "check_pr_branch_name.py")
     subprocess.run(
         ["git", "init", "--initial-branch", "main"],
         cwd=repo, check=True, capture_output=True, text=True,
     )
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "base")
+    _git(repo, "switch", "-c", "claude/pr-test")
     body = tmp_path / "grammar-body.md"
     body.write_text(_valid_body(), encoding="utf-8")
     env = {**os.environ, "PYTHONDONTWRITEBYTECODE": "1"}
@@ -590,6 +609,7 @@ def _write_fixture_repo(
         copy2(AUDIT_SCRIPT, repo / "scripts" / "audit_pr_body.py")
         copy2(AI_RECONCILIATION_SCRIPT, repo / "scripts" / "audit_ai_reconciliation.py")
         copy2(CHANGE_POLICY_SCRIPT, repo / "scripts" / "_pr_change_policy.py")
+        copy2(BRANCH_NAME_SCRIPT, repo / "scripts" / "check_pr_branch_name.py")
         (repo / "scripts" / "check_session_pr_ownership.py").write_text(
             """#!/usr/bin/env python3
 from __future__ import annotations

--- a/tests/test_open_pr_wrapper.py
+++ b/tests/test_open_pr_wrapper.py
@@ -82,6 +82,31 @@ def test_open_pr_rejects_branch_that_does_not_match_plan_before_fetch(tmp_path: 
     assert not stdin_capture.exists()
 
 
+def test_open_pr_dependabot_author_keeps_generated_body_exemption(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    _git(repo, "switch", "-c", "dependabot/pip/security-update")
+    (repo / "scripts" / "dependabot_example.py").write_text(
+        "print('dependency update')\n",
+        encoding="utf-8",
+    )
+    _git(repo, "add", "scripts/dependabot_example.py")
+    _git(repo, "commit", "-qm", "dependabot fixture")
+    _git(repo, "push", "-q", "-u", "origin", "HEAD")
+    body = repo.parent / "body-dependabot.md"
+    body.write_text("Generated dependency update body.\n", encoding="utf-8")
+    env, log, stdin_capture = _fake_gh_env(tmp_path, view_exit=1)
+    env["ATLAS_CURRENT_PR_AUTHOR"] = "dependabot[bot]"
+
+    result = _run(repo, env, body, "--title", "Dependabot fixture")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "pr body audit: PASS (Dependabot PR body exempt)" in result.stdout
+    assert log.read_text(encoding="utf-8").strip() == (
+        "pr create --title Dependabot fixture --repo canfieldjuan/ATLAS --base main --body-file -"
+    )
+    assert stdin_capture.read_text(encoding="utf-8") == body.read_text(encoding="utf-8")
+
+
 @pytest.mark.parametrize(
     ("args", "extra_env", "expected"),
     [
@@ -299,6 +324,7 @@ def test_open_pr_draft_admission_matches_gh_argv_grammar(tmp_path: Path) -> None
     (repo / "scripts").mkdir(parents=True)
     copy2(SCRIPT, repo / "scripts" / "open_pr.sh")
     copy2(BRANCH_NAME_SCRIPT, repo / "scripts" / "check_pr_branch_name.py")
+    copy2(CHANGE_POLICY_SCRIPT, repo / "scripts" / "_pr_change_policy.py")
     subprocess.run(
         ["git", "init", "--initial-branch", "main"],
         cwd=repo, check=True, capture_output=True, text=True,
@@ -763,8 +789,9 @@ if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
         printf '%s\\n' "${GH_PR_LIST_JSON}"
         exit 0
     fi
+    current_branch="$(git branch --show-current)"
     if [ "${GH_VIEW_EXIT}" = "0" ] || [ -f "${GH_CREATED_PR_FLAG}" ]; then
-        printf '[{"number":17,"headRefName":"claude/pr-test","headRefOid":"%s","baseRefName":"main","headRepository":{"nameWithOwner":"canfieldjuan/ATLAS"},"isCrossRepository":false}]\\n' "$(git rev-parse HEAD)"
+        printf '[{"number":17,"headRefName":"%s","headRefOid":"%s","baseRefName":"main","headRepository":{"nameWithOwner":"canfieldjuan/ATLAS"},"isCrossRepository":false}]\\n' "$current_branch" "$(git rev-parse HEAD)"
     else
         printf '[]\\n'
     fi

--- a/tests/test_push_pr_wrapper.py
+++ b/tests/test_push_pr_wrapper.py
@@ -11,6 +11,7 @@ SCRIPT = REPO_ROOT / "scripts" / "push_pr.sh"
 AUDIT_SCRIPT = REPO_ROOT / "scripts" / "audit_pr_body.py"
 AI_RECONCILIATION_SCRIPT = REPO_ROOT / "scripts" / "audit_ai_reconciliation.py"
 CHANGE_POLICY_SCRIPT = REPO_ROOT / "scripts" / "_pr_change_policy.py"
+BRANCH_NAME_SCRIPT = REPO_ROOT / "scripts" / "check_pr_branch_name.py"
 
 
 def test_push_pr_dry_run_without_managed_hook_runs_wrapper_review(tmp_path: Path) -> None:
@@ -124,6 +125,34 @@ def test_push_pr_docs_only_dry_run_does_not_fetch_or_audit(tmp_path: Path) -> No
 
     assert result.returncode == 0, result.stdout + result.stderr
     assert "DRY RUN: git fetch --quiet origin main" in result.stdout
+
+
+def test_push_pr_rejects_branch_that_does_not_match_plan_before_fetch(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    _git(repo, "switch", "-c", "claude/pr-other")
+    order_log = repo / "order.log"
+    fake_bin = _write_fake_git(repo, order_log)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "FAKE_GIT_TOPLEVEL": str(repo),
+        "FAKE_GIT_LOG": str(order_log),
+        "ORDER_LOG": str(order_log),
+    }
+
+    result = subprocess.run(
+        ["bash", "scripts/push_pr.sh", str(body), "-u", "origin", "HEAD"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "does not match PR plan branch" in result.stderr
+    assert "git fetch --quiet origin main" not in order_log.read_text(encoding="utf-8")
 
 
 def test_push_pr_refreshes_before_docs_only_body_audit(tmp_path: Path) -> None:
@@ -322,6 +351,7 @@ def _write_fixture_repo(tmp_path: Path) -> Path:
     copy2(AUDIT_SCRIPT, repo / "scripts" / "audit_pr_body.py")
     copy2(AI_RECONCILIATION_SCRIPT, repo / "scripts" / "audit_ai_reconciliation.py")
     copy2(CHANGE_POLICY_SCRIPT, repo / "scripts" / "_pr_change_policy.py")
+    copy2(BRANCH_NAME_SCRIPT, repo / "scripts" / "check_pr_branch_name.py")
     subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, text=True)
     (repo / "README.md").write_text("base\n", encoding="utf-8")
     _git(repo, "add", ".")
@@ -329,6 +359,7 @@ def _write_fixture_repo(tmp_path: Path) -> Path:
     _git(repo, "branch", "-M", "main")
     _git(repo, "remote", "add", "origin", str(repo))
     _git(repo, "update-ref", "refs/remotes/origin/main", "HEAD")
+    _git(repo, "switch", "-c", "claude/pr-test")
     return repo
 
 

--- a/tests/test_push_pr_wrapper.py
+++ b/tests/test_push_pr_wrapper.py
@@ -182,6 +182,60 @@ def test_push_pr_rejects_mismatched_refspec_before_fetch(tmp_path: Path) -> None
     assert "git fetch --quiet origin main" not in order_log.read_text(encoding="utf-8")
 
 
+def test_push_pr_rejects_unqualified_other_branch_before_fetch(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    order_log = repo / "order.log"
+    fake_bin = _write_fake_git(repo, order_log)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "FAKE_GIT_TOPLEVEL": str(repo),
+        "FAKE_GIT_LOG": str(order_log),
+        "ORDER_LOG": str(order_log),
+    }
+
+    result = subprocess.run(
+        ["bash", "scripts/push_pr.sh", str(body), "-u", "origin", "main"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "push refspec 'main' must be HEAD" in result.stderr
+    assert "git fetch --quiet origin main" not in order_log.read_text(encoding="utf-8")
+
+
+def test_push_pr_rejects_bulk_push_mode_before_fetch(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    order_log = repo / "order.log"
+    fake_bin = _write_fake_git(repo, order_log)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "FAKE_GIT_TOPLEVEL": str(repo),
+        "FAKE_GIT_LOG": str(order_log),
+        "ORDER_LOG": str(order_log),
+    }
+
+    result = subprocess.run(
+        ["bash", "scripts/push_pr.sh", str(body), "--all", "origin"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "push mode '--all'" in result.stderr
+    assert "git fetch --quiet origin main" not in order_log.read_text(encoding="utf-8")
+
+
 def test_push_pr_dependabot_author_keeps_generated_body_exemption(tmp_path: Path) -> None:
     repo = _write_fixture_repo(tmp_path)
     _git(repo, "switch", "-c", "dependabot/pip/security-update")

--- a/tests/test_push_pr_wrapper.py
+++ b/tests/test_push_pr_wrapper.py
@@ -155,6 +155,64 @@ def test_push_pr_rejects_branch_that_does_not_match_plan_before_fetch(tmp_path: 
     assert "git fetch --quiet origin main" not in order_log.read_text(encoding="utf-8")
 
 
+def test_push_pr_rejects_mismatched_refspec_before_fetch(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    order_log = repo / "order.log"
+    fake_bin = _write_fake_git(repo, order_log)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "FAKE_GIT_TOPLEVEL": str(repo),
+        "FAKE_GIT_LOG": str(order_log),
+        "ORDER_LOG": str(order_log),
+    }
+
+    result = subprocess.run(
+        ["bash", "scripts/push_pr.sh", str(body), "-u", "origin", "HEAD:claude/pr-other"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "push refspec destination 'claude/pr-other'" in result.stderr
+    assert "git fetch --quiet origin main" not in order_log.read_text(encoding="utf-8")
+
+
+def test_push_pr_dependabot_author_keeps_generated_body_exemption(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    _git(repo, "switch", "-c", "dependabot/pip/security-update")
+    body = repo / "body-dependabot.md"
+    body.write_text("Generated dependency update body.\n", encoding="utf-8")
+    order_log = repo / "order.log"
+    _write_local_review(repo)
+    fake_bin = _write_fake_git(repo, order_log)
+    env = {
+        **os.environ,
+        "ATLAS_CURRENT_PR_AUTHOR": "dependabot[bot]",
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "FAKE_GIT_TOPLEVEL": str(repo),
+        "FAKE_GIT_LOG": str(order_log),
+        "ORDER_LOG": str(order_log),
+    }
+
+    result = subprocess.run(
+        ["bash", "scripts/push_pr.sh", str(body), "-u", "origin", "HEAD"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "pr body audit: PASS (Dependabot PR body exempt)" in result.stdout
+    assert "git push -u origin HEAD" in order_log.read_text(encoding="utf-8")
+
+
 def test_push_pr_refreshes_before_docs_only_body_audit(tmp_path: Path) -> None:
     repo = _write_fixture_repo(tmp_path)
     body = _write_docs_only_body(repo)

--- a/tests/test_push_pr_wrapper.py
+++ b/tests/test_push_pr_wrapper.py
@@ -236,6 +236,94 @@ def test_push_pr_rejects_bulk_push_mode_before_fetch(tmp_path: Path) -> None:
     assert "git fetch --quiet origin main" not in order_log.read_text(encoding="utf-8")
 
 
+def test_push_pr_rejects_follow_tags_before_fetch(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    order_log = repo / "order.log"
+    fake_bin = _write_fake_git(repo, order_log)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "FAKE_GIT_TOPLEVEL": str(repo),
+        "FAKE_GIT_LOG": str(order_log),
+        "ORDER_LOG": str(order_log),
+    }
+
+    result = subprocess.run(
+        ["bash", "scripts/push_pr.sh", str(body), "--follow-tags", "origin", "HEAD"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "push mode '--follow-tags'" in result.stderr
+    assert "git fetch --quiet origin main" not in order_log.read_text(encoding="utf-8")
+
+
+def test_push_pr_rejects_clustered_delete_flag_before_fetch(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    order_log = repo / "order.log"
+    fake_bin = _write_fake_git(repo, order_log)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "FAKE_GIT_TOPLEVEL": str(repo),
+        "FAKE_GIT_LOG": str(order_log),
+        "ORDER_LOG": str(order_log),
+    }
+
+    result = subprocess.run(
+        [
+            "bash",
+            "scripts/push_pr.sh",
+            str(body),
+            "-fd",
+            "origin",
+            "claude/pr-test",
+        ],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "push mode '-fd'" in result.stderr
+    assert "git fetch --quiet origin main" not in order_log.read_text(encoding="utf-8")
+
+
+def test_push_pr_rejects_option_only_push_before_fetch(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    order_log = repo / "order.log"
+    fake_bin = _write_fake_git(repo, order_log)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "FAKE_GIT_TOPLEVEL": str(repo),
+        "FAKE_GIT_LOG": str(order_log),
+        "ORDER_LOG": str(order_log),
+    }
+
+    result = subprocess.run(
+        ["bash", "scripts/push_pr.sh", str(body), "--force"],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "push must explicitly name HEAD" in result.stderr
+    assert "git fetch --quiet origin main" not in order_log.read_text(encoding="utf-8")
+
+
 def test_push_pr_dependabot_author_keeps_generated_body_exemption(tmp_path: Path) -> None:
     repo = _write_fixture_repo(tmp_path)
     _git(repo, "switch", "-c", "dependabot/pip/security-update")


### PR DESCRIPTION
Plan: plans/PR-Branch-Naming-Gate.md
Slice phase: Workflow/process
Ownership lane: dev-workflow/branch-naming

The mechanical-enforcement audit found that Atlas branch naming was still prose-only: builders are told to use `claude/pr-<slice-name>`, but the publication wrappers accepted any current branch. This slice adds an admission checker and calls it from both PR wrappers before fetch, review, push, or GitHub mutation.

Diff-budget override: Codex review found refspec, unqualified/bulk push, tag-pushing, option-only push, clustered-delete, and Dependabot bypass gaps in the same wrapper admission boundary, so the checker, wrapper wiring, and direct/wrapper regression tests are indivisible for this PR.

## Intentional
- Planned PR bodies must use the branch slug derived from `Plan: plans/PR-<Slice>.md`.
- Docs-only bodies keep their planless exemption but still require a `claude/pr-*` branch.
- Enforcement lives in `push_pr.sh` and `open_pr.sh`, where the local branch exists; no branch-protection change in this slice.
- Dependabot authors bypass the builder-only branch/body contract to preserve the existing generated-PR exemption.

## AI reconciliation
- Validate the pushed refspec too -- fixed-in: scripts/check_pr_branch_name.py and tests/test_push_pr_wrapper.py.
- Preserve Dependabot body exemption -- fixed-in: scripts/check_pr_branch_name.py, scripts/push_pr.sh, scripts/open_pr.sh, tests/test_push_pr_wrapper.py, and tests/test_open_pr_wrapper.py.
- Reject unqualified and bulk push refs -- fixed-in: scripts/check_pr_branch_name.py, tests/test_check_pr_branch_name.py, and tests/test_push_pr_wrapper.py.
- Reject --follow-tags in the push ref guard -- fixed-in: scripts/check_pr_branch_name.py, tests/test_check_pr_branch_name.py, and tests/test_push_pr_wrapper.py.
- Require explicit refs for option-only pushes -- fixed-in: scripts/check_pr_branch_name.py, tests/test_check_pr_branch_name.py, and tests/test_push_pr_wrapper.py.
- Parse clustered -d push flags -- fixed-in: scripts/check_pr_branch_name.py, tests/test_check_pr_branch_name.py, and tests/test_push_pr_wrapper.py.

All findings fixed or waived: yes.

## Deferred
- Commit-message contract enforcement remains a separate follow-up slice.

## Parked hardening
- None.

## Cold diff reconstruction
- Changed: `scripts/check_pr_branch_name.py:12` defines the accepted plan marker, docs-only marker, and `claude/pr-*` branch regex.
- Changed: `scripts/check_pr_branch_name.py:41` rejects detached, non-PR, missing-marker, and plan/branch mismatch cases while preserving Dependabot author exemption.
- Changed: `scripts/check_pr_branch_name.py:71` validates forwarded push args as `git push` positionals: first positional is the repository, later positionals are refspecs, bulk/tag/delete push modes fail closed before fetch, clustered short delete flags are rejected, and option-only forwarded pushes must name an explicit `HEAD` or current-branch refspec.
- Changed: `scripts/push_pr.sh:38` calls the checker with current branch, PR author, PR body, and forwarded push args before dry-run output, fetch, review, or push.
- Changed: `scripts/open_pr.sh:278` calls the checker with current branch, PR author, and PR body before origin refresh, body audit, lock acquisition, or GitHub mutation.
- Changed: `tests/test_check_pr_branch_name.py:21` covers slug normalization, matching branches, mismatches, docs-only prefix admission, missing body marker, and detached branch failures.
- Changed: `tests/test_check_pr_branch_name.py:80` adds `pytest.raises(SystemExit)` coverage for the CLI parser's missing required arguments path.
- Changed: `tests/test_check_pr_branch_name.py:85` covers Dependabot bypass; `tests/test_check_pr_branch_name.py:93` and `tests/test_check_pr_branch_name.py:114` cover mismatched, unqualified, bulk, follow-tags, clustered delete, option-only, and repository-only push args.
- Changed: `tests/test_push_pr_wrapper.py:130`, `tests/test_push_pr_wrapper.py:158`, `tests/test_push_pr_wrapper.py:185`, and `tests/test_open_pr_wrapper.py:72` prove mismatched branches/refspecs, unqualified refs, bulk modes, follow-tags, clustered delete flags, and option-only pushes fail before fetch/GitHub side effects.
- Changed: `tests/test_push_pr_wrapper.py:239` and `tests/test_open_pr_wrapper.py:85` prove Dependabot generated bodies keep their exemption through both wrappers.
- Contract match: every non-plan change mechanizes the branch-name prose rule without changing product code, PR ownership, draft consent, docs-only body semantics, or Dependabot generated-PR semantics.
- Gaps: none.

## Verification
- `python -m pytest tests/test_check_pr_branch_name.py tests/test_push_pr_wrapper.py tests/test_open_pr_wrapper.py` - 92 passed.
- `python scripts/maturity_sweep.py scripts --tests-root tests --baseline tests/maturity_sweep/baseline_scripts.json --min-score 8 --sensitive-glob 'scripts/**'` - passed.

## Mechanical verification
- Command: `python -m pytest tests/test_check_pr_branch_name.py tests/test_push_pr_wrapper.py tests/test_open_pr_wrapper.py` - Result: 92 passed - Environment: local
- Command: `python scripts/maturity_sweep.py scripts --tests-root tests --baseline tests/maturity_sweep/baseline_scripts.json --min-score 8 --sensitive-glob 'scripts/**'` - Result: passed - Environment: local

## Diff size
7 files, 873 LOC
