### PR TITLE
Add EOM execution receipts v2

### DIFF
--- a/docs/EOM_RECONCILIATION_RECEIPTS.md
+++ b/docs/EOM_RECONCILIATION_RECEIPTS.md
@@ -1,0 +1,31 @@
+# EOM reconciliation execution receipts
+
+The live EOM Calendar import and portal customer sync write private JSON
+receipts for production write/apply runs.
+
+Recommended local operator directory:
+
+```bash
+mkdir -p ~/.local/state/atlas/eom-receipts
+chmod 700 ~/.local/state/atlas/eom-receipts
+```
+
+Write/apply runs require that directory explicitly:
+
+```bash
+python scripts/import_eom_customers_live.py \
+  --receipt-dir ~/.local/state/atlas/eom-receipts
+
+python scripts/sync_eom_portal_customers.py \
+  --apply \
+  --receipt-dir ~/.local/state/atlas/eom-receipts
+```
+
+Dry runs may omit `--receipt-dir`. If supplied, a dry run also writes a receipt.
+
+Receipts are private operator evidence. They record only allowlisted non-PII
+fields: schema version, receipt id, tool, mode, UTC start/end, Git SHA, script
+hash, exit code, outcome counts, demotion totals where applicable, changed
+contact UUIDs, and whether a mutation was interrupted with an indeterminate
+result. They do not record credentials, tokens, customer names, emails, phones,
+addresses, portal URLs, or receipt-directory paths.

--- a/plans/PR-EOM-Execution-Receipts-V2.md
+++ b/plans/PR-EOM-Execution-Receipts-V2.md
@@ -1,0 +1,182 @@
+# PR-EOM-Execution-Receipts-V2
+
+## Why this slice exists
+
+Issue #2190 blocks production EOM reconciliation apply/onboarding because the
+operator tools that mutate the EOM customer master can claim a run happened
+without leaving a private, reproducible, source-bound artifact.  PR #2195 tried
+to close that gap, but it grew into a frozen 34-commit branch with unresolved
+stop-sign threads around cancellation/process semantics.  This successor mines
+the useful receipt idea and rebuilds it as the narrow issue #2190 contract
+instead of patching #2195 in place.
+
+Diff-budget override: issue #2190 is indivisible because one shared receipt primitive, both mutating EOM entrypoints, the operator runbook, and source/privacy/cancellation tests must ship together or either Calendar import or portal sync remains able to run production writes without durable evidence.
+
+### Problem-derived contract
+
+- Root cause: the live EOM Calendar import and portal customer sync are
+  side-effectful operator scripts, but their write/apply modes have no durable
+  private artifact that binds the run to the executed source and the non-PII
+  outcome.  A successful shell output, screenshot, or deployment note can drift
+  from the actual code and cannot prove which contacts were changed.  The prior
+  #2195 branch also exposed a deeper execution-boundary issue: if cancellation
+  lands while a mutation await is in flight, the process may not know whether
+  the mutation committed, so finalizing a normal success/failure receipt would
+  overstate certainty.
+- Correct fix must touch/change:
+  1. Add one shared EOM execution-receipt primitive under `scripts/` that
+     creates a mode-0600 in-progress JSON receipt before writes, records only
+     allowlisted non-PII fields, binds the payload to the current Git SHA and
+     executing script hash, finalizes by atomic non-overwriting publication, and
+     leaves the receipt in-progress/indeterminate when cancellation interrupts a
+     mutation boundary with unknown commit state.
+  2. Wire `scripts/import_eom_customers_live.py` so live writes require
+     `--receipt-dir`, dry runs may omit it, outcome counts and changed contact
+     UUIDs are recorded, and each CRM/timeline mutation is wrapped in the
+     mutation-boundary model.
+  3. Wire `scripts/sync_eom_portal_customers.py` so `--apply` requires
+     `--receipt-dir`, dry runs may omit it, outcome counts, demotion/keep totals,
+     and changed contact UUIDs are recorded, and contact create/update/demotion
+     mutations are wrapped in the same mutation-boundary model.
+  4. Add focused tests for admission, 0600/private payload shape, atomic
+     no-overwrite finalization, source binding, changed-contact capture, and the
+     indeterminate cancellation path.
+- Must not change: CRM matching semantics, Calendar parsing/deduplication,
+  portal roster resolution, demotion eligibility/veto rules, credential
+  acquisition, database schema, public APIs, Render/service configuration,
+  EOM funnel/customer-onboarding behavior, billing/receivables, website UI, or
+  the stale #2195 branch itself.
+
+## Scope (this PR)
+
+Ownership lane: eom/operational-evidence
+Slice phase: Production hardening
+
+1. Add private execution receipts to the two issue #2190 EOM operator tools:
+   `scripts/import_eom_customers_live.py` and
+   `scripts/sync_eom_portal_customers.py`.
+2. Add source-bound, non-PII, mutation-aware receipt tests without importing
+   host database services into extracted-check collection.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Calendar live write admission fails before provider/database work when
+        `--dry-run` is absent and `--receipt-dir` is absent.
+  - [ ] Portal sync apply admission fails before login/database work when
+        `--apply` is present and `--receipt-dir` is absent.
+  - [ ] Receipt creation writes a mode-0600 in-progress artifact before the
+        first wrapped mutation and finalizes to a mode-0600 unique final JSON
+        path without overwriting an existing final receipt.
+  - [ ] Receipt payload contains schema version, receipt id, tool, mode,
+        started/ended UTC, git SHA, script hash, exit code, allowlisted outcome
+        counts, optional demotion/keep totals, and changed contact UUIDs, and
+        does not record customer names, emails, phones, addresses, tokens, base
+        URLs, or credentials.
+  - [ ] Calendar import records changed contact UUIDs for successful CRM/timeline
+        mutations and updates receipt outcome counts after progress.
+  - [ ] Portal sync records changed contact UUIDs for create/update/demotion
+        mutations and records demotion/keep totals.
+  - [ ] If cancellation interrupts while a mutation boundary is active, the
+        runner leaves the in-progress receipt indeterminate rather than
+        publishing a misleading final receipt.
+- Reachability proof: real script entrypoints are exercised via focused tests
+  for CLI admission and the shared receipt runner; mutation reachability is
+  exercised through the existing script-level stub harnesses for Calendar import
+  and portal sync.
+- Affected surfaces: `scripts/eom_execution_receipt.py`,
+  `scripts/import_eom_customers_live.py`, `scripts/sync_eom_portal_customers.py`,
+  focused EOM receipt tests, and this plan.
+- Risk areas: operator write admission, artifact privacy, source/run
+  reproducibility, cancellation/process semantics, and accidental changes to
+  existing CRM reconciliation behavior.
+- Reviewer rules triggered: R1, R2, R3, R4, R6, R8, R10, R11, R12, R13, R14.
+
+### Boundary-change enumeration
+
+Required when this diff changes a guard, validator, normalizer, resolver,
+router/classifier, or admission boundary. Name each changed boundary path or
+seam in the enumeration; otherwise write "N/A - no boundary change."
+
+- Boundary path/seam: EOM operator write/apply admission for Calendar import
+  and portal sync; receipt finalization/persistence boundary.
+- Replaced-path behaviors: live Calendar writes and portal apply previously
+  could run without a durable receipt; after this slice they fail before the
+  first mutation unless `--receipt-dir` is supplied.
+- Guard-relevant fields: `--dry-run`, `--apply`, `--receipt-dir`, receipt tool
+  name, receipt mode, exit code, changed contact UUIDs, outcome count keys.
+- Caller x input shape: operator CLI invocation for dry-run/write/apply modes;
+  script-level mutation helpers receiving CRM/pool stubs and optional receipt.
+
+### Deployed-config probing
+
+Required for guard, validator, resolver, admission-boundary, or env/config
+fallback changes; otherwise write "N/A - no guard/config boundary change."
+
+- Deployed/default config values: no new environment setting; the operator
+  supplies `--receipt-dir` explicitly for write/apply.  The documented default
+  is under local private state.
+- Explicit value probe: focused CLI/receipt tests pass a temporary receipt
+  directory and assert in-progress/final artifact behavior.
+- Absent value probe: focused CLI admission tests call write/apply without
+  `--receipt-dir` and assert pre-mutation parser failure.
+- Default-session/default-context probe: N/A - no tenant/default-context config
+  changes.
+- Side-effect ordering: receipt is constructed before wrapped mutations; each
+  mutation await runs inside a receipt mutation boundary; indeterminate
+  cancellation leaves the in-progress artifact unfinalized.
+
+### Files touched
+
+- `docs/EOM_RECONCILIATION_RECEIPTS.md`
+- `plans/PR-EOM-Execution-Receipts-V2.md`
+- `scripts/eom_execution_receipt.py`
+- `scripts/import_eom_customers_live.py`
+- `scripts/sync_eom_portal_customers.py`
+- `tests/test_eom_execution_receipts.py`
+
+## Mechanism
+
+The shared receipt module owns JSON payload validation, private file creation,
+source binding, and finalization.  Scripts create a receipt only when
+`--receipt-dir` is provided; write/apply admission rejects missing receipt dirs
+before provider/login/database setup.  Mutating awaits run inside a small
+receipt boundary that marks the receipt indeterminate if cancellation lands
+before the await completes.  Successful mutation returns then record the
+changed contact UUID and update aggregate counts/totals.
+
+## Intentional
+
+- This slice does not keep #2195's reviewed-SHA launcher/snapshot execution
+  model.  The issue #2190 root need is private durable source-bound receipts;
+  reviewed-SHA process attestation was the scope-expanding branch of #2195.
+- Receipt directories are CLI-provided and documented, not configured through a
+  new env var, so there is no new deployed config to provision.
+- Indeterminate cancellation keeps the in-progress receipt instead of forcing a
+  final failure receipt, because the mutation result is unknown at that point.
+
+## Deferred
+
+- Reviewed-SHA launcher/snapshot attestation from #2195 remains deferred unless
+  a future operator run needs tamper-evident reviewed-source execution.
+- Receipt retention/rotation remains deferred until real artifact volume exists.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m py_compile scripts/eom_execution_receipt.py scripts/import_eom_customers_live.py scripts/sync_eom_portal_customers.py tests/test_eom_execution_receipts.py` — passed.
+- `python -m pytest tests/test_eom_execution_receipts.py tests/test_eom_live_calendar_import.py tests/test_sync_eom_portal_customers.py -q` — 113 passed.
+- `python -m ruff check scripts/eom_execution_receipt.py scripts/import_eom_customers_live.py scripts/sync_eom_portal_customers.py tests/test_eom_execution_receipts.py` — passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `docs/EOM_RECONCILIATION_RECEIPTS.md` | 31 |
+| `plans/PR-EOM-Execution-Receipts-V2.md` | 182 |
+| `scripts/eom_execution_receipt.py` | 268 |
+| `scripts/import_eom_customers_live.py` | 172 |
+| `scripts/sync_eom_portal_customers.py` | 130 |
+| `tests/test_eom_execution_receipts.py` | 239 |
+| **Total** | **1022** |

--- a/plans/PR-EOM-Execution-Receipts-V2.md
+++ b/plans/PR-EOM-Execution-Receipts-V2.md
@@ -167,19 +167,19 @@ Parked hardening: none.
 ## Verification
 
 - `python -m py_compile scripts/eom_execution_receipt.py scripts/import_eom_customers_live.py scripts/sync_eom_portal_customers.py tests/test_eom_execution_receipts.py tests/test_sync_eom_portal_customers.py` — passed.
-- `python -m pytest tests/test_eom_execution_receipts.py tests/test_eom_live_calendar_import.py tests/test_sync_eom_portal_customers.py -q` — 117 passed.
+- `python -m pytest tests/test_eom_execution_receipts.py tests/test_eom_live_calendar_import.py tests/test_sync_eom_portal_customers.py -q` — 118 passed.
 - `python -m ruff check scripts/eom_execution_receipt.py scripts/import_eom_customers_live.py scripts/sync_eom_portal_customers.py tests/test_eom_execution_receipts.py tests/test_sync_eom_portal_customers.py` — passed.
-- `python scripts/maturity_sweep.py scripts --tests-root tests --baseline tests/maturity_sweep/baseline_scripts.json --min-score 8 --top 25` — passed.
+- `python scripts/maturity_sweep.py scripts --tests-root tests --baseline tests/maturity_sweep/baseline_scripts.json --min-score 8 --sensitive-glob '**/*' --top 25` — passed.
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
 | `docs/EOM_RECONCILIATION_RECEIPTS.md` | 31 |
-| `plans/PR-EOM-Execution-Receipts-V2.md` | 182 |
-| `scripts/eom_execution_receipt.py` | 293 |
+| `plans/PR-EOM-Execution-Receipts-V2.md` | 185 |
+| `scripts/eom_execution_receipt.py` | 290 |
 | `scripts/import_eom_customers_live.py` | 184 |
-| `scripts/sync_eom_portal_customers.py` | 153 |
+| `scripts/sync_eom_portal_customers.py` | 151 |
 | `tests/test_eom_execution_receipts.py` | 310 |
-| `tests/test_sync_eom_portal_customers.py` | 62 |
-| **Total** | **1218** |
+| `tests/test_sync_eom_portal_customers.py` | 137 |
+| **Total** | **1288** |

--- a/plans/PR-EOM-Execution-Receipts-V2.md
+++ b/plans/PR-EOM-Execution-Receipts-V2.md
@@ -167,7 +167,7 @@ Parked hardening: none.
 ## Verification
 
 - `python -m py_compile scripts/eom_execution_receipt.py scripts/import_eom_customers_live.py scripts/sync_eom_portal_customers.py tests/test_eom_execution_receipts.py tests/test_sync_eom_portal_customers.py` — passed.
-- `python -m pytest tests/test_eom_execution_receipts.py tests/test_eom_live_calendar_import.py tests/test_sync_eom_portal_customers.py -q` — 116 passed.
+- `python -m pytest tests/test_eom_execution_receipts.py tests/test_eom_live_calendar_import.py tests/test_sync_eom_portal_customers.py -q` — 117 passed.
 - `python -m ruff check scripts/eom_execution_receipt.py scripts/import_eom_customers_live.py scripts/sync_eom_portal_customers.py tests/test_eom_execution_receipts.py tests/test_sync_eom_portal_customers.py` — passed.
 - `python scripts/maturity_sweep.py scripts --tests-root tests --baseline tests/maturity_sweep/baseline_scripts.json --min-score 8 --top 25` — passed.
 
@@ -178,8 +178,8 @@ Parked hardening: none.
 | `docs/EOM_RECONCILIATION_RECEIPTS.md` | 31 |
 | `plans/PR-EOM-Execution-Receipts-V2.md` | 182 |
 | `scripts/eom_execution_receipt.py` | 293 |
-| `scripts/import_eom_customers_live.py` | 172 |
-| `scripts/sync_eom_portal_customers.py` | 132 |
-| `tests/test_eom_execution_receipts.py` | 280 |
-| `tests/test_sync_eom_portal_customers.py` | 51 |
-| **Total** | **1141** |
+| `scripts/import_eom_customers_live.py` | 184 |
+| `scripts/sync_eom_portal_customers.py` | 153 |
+| `tests/test_eom_execution_receipts.py` | 310 |
+| `tests/test_sync_eom_portal_customers.py` | 62 |
+| **Total** | **1218** |

--- a/plans/PR-EOM-Execution-Receipts-V2.md
+++ b/plans/PR-EOM-Execution-Receipts-V2.md
@@ -86,7 +86,7 @@ Slice phase: Production hardening
   and portal sync.
 - Affected surfaces: `scripts/eom_execution_receipt.py`,
   `scripts/import_eom_customers_live.py`, `scripts/sync_eom_portal_customers.py`,
-  focused EOM receipt tests, and this plan.
+  focused EOM receipt/portal-sync tests, and this plan.
 - Risk areas: operator write admission, artifact privacy, source/run
   reproducibility, cancellation/process semantics, and accidental changes to
   existing CRM reconciliation behavior.
@@ -134,6 +134,7 @@ fallback changes; otherwise write "N/A - no guard/config boundary change."
 - `scripts/import_eom_customers_live.py`
 - `scripts/sync_eom_portal_customers.py`
 - `tests/test_eom_execution_receipts.py`
+- `tests/test_sync_eom_portal_customers.py`
 
 ## Mechanism
 
@@ -165,9 +166,10 @@ Parked hardening: none.
 
 ## Verification
 
-- `python -m py_compile scripts/eom_execution_receipt.py scripts/import_eom_customers_live.py scripts/sync_eom_portal_customers.py tests/test_eom_execution_receipts.py` — passed.
-- `python -m pytest tests/test_eom_execution_receipts.py tests/test_eom_live_calendar_import.py tests/test_sync_eom_portal_customers.py -q` — 113 passed.
-- `python -m ruff check scripts/eom_execution_receipt.py scripts/import_eom_customers_live.py scripts/sync_eom_portal_customers.py tests/test_eom_execution_receipts.py` — passed.
+- `python -m py_compile scripts/eom_execution_receipt.py scripts/import_eom_customers_live.py scripts/sync_eom_portal_customers.py tests/test_eom_execution_receipts.py tests/test_sync_eom_portal_customers.py` — passed.
+- `python -m pytest tests/test_eom_execution_receipts.py tests/test_eom_live_calendar_import.py tests/test_sync_eom_portal_customers.py -q` — 116 passed.
+- `python -m ruff check scripts/eom_execution_receipt.py scripts/import_eom_customers_live.py scripts/sync_eom_portal_customers.py tests/test_eom_execution_receipts.py tests/test_sync_eom_portal_customers.py` — passed.
+- `python scripts/maturity_sweep.py scripts --tests-root tests --baseline tests/maturity_sweep/baseline_scripts.json --min-score 8 --top 25` — passed.
 
 ## Estimated diff size
 
@@ -175,8 +177,9 @@ Parked hardening: none.
 |---|---:|
 | `docs/EOM_RECONCILIATION_RECEIPTS.md` | 31 |
 | `plans/PR-EOM-Execution-Receipts-V2.md` | 182 |
-| `scripts/eom_execution_receipt.py` | 268 |
+| `scripts/eom_execution_receipt.py` | 293 |
 | `scripts/import_eom_customers_live.py` | 172 |
-| `scripts/sync_eom_portal_customers.py` | 130 |
-| `tests/test_eom_execution_receipts.py` | 239 |
-| **Total** | **1022** |
+| `scripts/sync_eom_portal_customers.py` | 132 |
+| `tests/test_eom_execution_receipts.py` | 280 |
+| `tests/test_sync_eom_portal_customers.py` | 51 |
+| **Total** | **1141** |

--- a/scripts/eom_execution_receipt.py
+++ b/scripts/eom_execution_receipt.py
@@ -137,12 +137,9 @@ class EomExecutionReceipt:
         if mode not in TOOL_MODES.get(tool, set()):
             raise ValueError(f"unsupported EOM receipt tool/mode: {tool}/{mode}")
         self.receipt_dir = Path(receipt_dir).expanduser().resolve()
-        created = False
-        try:
+        created = not self.receipt_dir.exists()
+        if created:
             self.receipt_dir.mkdir(mode=0o700, parents=True, exist_ok=False)
-            created = True
-        except FileExistsError:
-            pass
         if not self.receipt_dir.is_dir():
             raise ValueError("receipt directory must be a directory")
         if created:

--- a/scripts/eom_execution_receipt.py
+++ b/scripts/eom_execution_receipt.py
@@ -285,8 +285,8 @@ def run_receipted(receipt: EomExecutionReceipt | None, operation) -> int:
         if receipt is not None:
             try:
                 receipt.finalize(exit_code_for_exception(exc))
-            except IndeterminateMutation as indeterminate:
-                indeterminate.add_note("left in-progress receipt for operator review")
+            except IndeterminateMutation:
+                exc.add_note("left in-progress receipt for operator review")
         raise
     if receipt is not None:
         receipt.finalize(exit_code)

--- a/scripts/eom_execution_receipt.py
+++ b/scripts/eom_execution_receipt.py
@@ -9,6 +9,7 @@ import os
 import stat
 import subprocess
 import uuid
+from collections.abc import AsyncIterator
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Mapping
@@ -64,9 +65,12 @@ def _git_sha_for(path: Path) -> str:
 
 def _sha256_file(path: Path) -> str:
     digest = hashlib.sha256()
-    with path.open("rb") as handle:
-        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-            digest.update(chunk)
+    try:
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError as exc:
+        raise RuntimeError(f"failed to hash receipt script: {path}") from exc
     return digest.hexdigest()
 
 
@@ -98,7 +102,10 @@ def _write_json_exclusive(path: Path, payload: Mapping[str, object]) -> None:
 
 
 def _fsync_directory(path: Path) -> None:
-    fd = os.open(path, os.O_RDONLY)
+    try:
+        fd = os.open(path, os.O_RDONLY)
+    except OSError as exc:
+        raise RuntimeError(f"failed to open receipt directory for fsync: {path}") from exc
     try:
         os.fsync(fd)
     finally:
@@ -193,7 +200,7 @@ class EomExecutionReceipt:
         self._persist_in_progress()
 
     @contextlib.asynccontextmanager
-    async def mutation_boundary(self):
+    async def mutation_boundary(self) -> AsyncIterator[None]:
         """Mark the receipt indeterminate if cancellation interrupts a mutation."""
         try:
             yield
@@ -260,8 +267,8 @@ def run_receipted(receipt: EomExecutionReceipt | None, operation) -> int:
         if receipt is not None:
             try:
                 receipt.finalize(exit_code_for_exception(exc))
-            except IndeterminateMutation:
-                pass
+            except IndeterminateMutation as indeterminate:
+                indeterminate.add_note("left in-progress receipt for operator review")
         raise
     if receipt is not None:
         receipt.finalize(exit_code)

--- a/scripts/eom_execution_receipt.py
+++ b/scripts/eom_execution_receipt.py
@@ -1,0 +1,268 @@
+"""Private, source-bound execution receipts for EOM operator tools."""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import os
+import stat
+import subprocess
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Mapping
+
+SCHEMA_VERSION = 1
+
+TOOL_MODES = {
+    "import_eom_customers_live": {"dry-run", "write"},
+    "sync_eom_portal_customers": {"dry-run", "apply"},
+}
+
+OUTCOME_KEYS = {
+    "created",
+    "updated",
+    "unchanged",
+    "skipped",
+    "errors",
+    "create-planned",
+    "update-planned",
+    "import-planned",
+}
+
+
+class IndeterminateMutation(RuntimeError):
+    """Raised when a mutation may have committed but the process was interrupted."""
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _repo_root_for(path: Path) -> Path:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        cwd=path.parent,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return Path(result.stdout.strip())
+
+
+def _git_sha_for(path: Path) -> str:
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=_repo_root_for(path),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _validated_counts(counts: Mapping[str, int]) -> dict[str, int]:
+    clean: dict[str, int] = {}
+    for key, value in counts.items():
+        if key not in OUTCOME_KEYS:
+            raise ValueError(f"unsupported outcome count: {key}")
+        if type(value) is not int or value < 0:
+            raise ValueError(f"outcome count {key} must be a non-negative int")
+        clean[key] = value
+    return clean
+
+
+def _write_json_exclusive(path: Path, payload: Mapping[str, object]) -> None:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    fd = os.open(path, flags, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, sort_keys=True, separators=(",", ":"))
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.close(fd)
+        path.unlink(missing_ok=True)
+        raise
+
+
+def _fsync_directory(path: Path) -> None:
+    fd = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+class EomExecutionReceipt:
+    """Durable non-PII artifact for one EOM operator-tool invocation."""
+
+    def __init__(
+        self,
+        *,
+        receipt_dir: str | Path,
+        tool: str,
+        mode: str,
+        script_path: str | Path,
+        receipt_id: str | uuid.UUID | None = None,
+    ) -> None:
+        if mode not in TOOL_MODES.get(tool, set()):
+            raise ValueError(f"unsupported EOM receipt tool/mode: {tool}/{mode}")
+        self.receipt_dir = Path(receipt_dir).expanduser().resolve()
+        self.receipt_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+        if not self.receipt_dir.is_dir():
+            raise ValueError("receipt directory must be a directory")
+        script = Path(script_path).resolve()
+        self.receipt_id = str(uuid.UUID(str(receipt_id or uuid.uuid4())))
+        self._changed_contact_ids: set[str] = set()
+        self._finalized = False
+        self._indeterminate = False
+        self._payload: dict[str, object] = {
+            "schema_version": SCHEMA_VERSION,
+            "receipt_id": self.receipt_id,
+            "tool": tool,
+            "mode": mode,
+            "started_at_utc": _utc_now(),
+            "git_sha": _git_sha_for(script),
+            "script_hash_sha256": _sha256_file(script),
+            "outcome_counts": {},
+            "changed_contact_ids": [],
+            "indeterminate": False,
+        }
+        self.in_progress_path = (
+            self.receipt_dir / f".eom-{tool}-{self.receipt_id}.in-progress.json"
+        )
+        self._final_stem = f"eom-{tool}-{self.receipt_id}"
+        self._persist_in_progress()
+
+    def _assert_private_file(self, path: Path) -> None:
+        mode = stat.S_IMODE(path.stat().st_mode)
+        if mode != 0o600:
+            raise RuntimeError(f"receipt file is not private: {path}")
+
+    def _persist_in_progress(self) -> None:
+        staged = self.in_progress_path.with_name(
+            f"{self.in_progress_path.name}.{uuid.uuid4()}.tmp"
+        )
+        try:
+            _write_json_exclusive(staged, self._payload)
+            os.replace(staged, self.in_progress_path)
+            self._assert_private_file(self.in_progress_path)
+            _fsync_directory(self.receipt_dir)
+        finally:
+            staged.unlink(missing_ok=True)
+
+    def record_outcome_counts(self, counts: Mapping[str, int]) -> None:
+        self._payload["outcome_counts"] = _validated_counts(counts)
+        self._persist_in_progress()
+
+    def record_changed_contact_id(self, contact_id: str | uuid.UUID | None) -> None:
+        if not contact_id:
+            return
+        normalized = str(uuid.UUID(str(contact_id)))
+        if normalized in self._changed_contact_ids:
+            return
+        self._changed_contact_ids.add(normalized)
+        self._payload["changed_contact_ids"] = sorted(self._changed_contact_ids)
+        self._persist_in_progress()
+
+    def record_demotions(self, *, demoted: int, eligible: int, kept: int) -> None:
+        for label, value in {
+            "demoted": demoted,
+            "eligible": eligible,
+            "kept": kept,
+        }.items():
+            if type(value) is not int or value < 0:
+                raise ValueError(f"demotion total {label} must be a non-negative int")
+        self._payload["demotion_totals"] = {
+            "demoted": demoted,
+            "eligible": eligible,
+            "kept": kept,
+        }
+        self._persist_in_progress()
+
+    @contextlib.asynccontextmanager
+    async def mutation_boundary(self):
+        """Mark the receipt indeterminate if cancellation interrupts a mutation."""
+        try:
+            yield
+        except BaseException:
+            self._indeterminate = True
+            self._payload["indeterminate"] = True
+            self._persist_in_progress()
+            raise
+
+    def final_path_for(self, exit_code: int) -> Path:
+        return self.receipt_dir / f"{self._final_stem}.exit-{exit_code}.json"
+
+    def finalize(self, exit_code: int) -> Path:
+        if self._finalized:
+            raise RuntimeError("receipt is already finalized")
+        if self._indeterminate:
+            raise IndeterminateMutation(
+                "mutation outcome is indeterminate; leaving in-progress receipt"
+            )
+        if type(exit_code) is not int or exit_code < 0:
+            raise ValueError("exit code must be a non-negative int")
+        final_payload = {
+            **self._payload,
+            "ended_at_utc": _utc_now(),
+            "exit_code": exit_code,
+            "changed_contact_ids": sorted(self._changed_contact_ids),
+        }
+        final_path = self.final_path_for(exit_code)
+        staged = self.in_progress_path.with_name(
+            f"{self.in_progress_path.name}.{uuid.uuid4()}.tmp"
+        )
+        linked = False
+        try:
+            _write_json_exclusive(staged, final_payload)
+            os.link(staged, final_path)
+            linked = True
+            self._assert_private_file(final_path)
+            _fsync_directory(self.receipt_dir)
+        except BaseException:
+            if linked:
+                final_path.unlink(missing_ok=True)
+                _fsync_directory(self.receipt_dir)
+            raise
+        finally:
+            staged.unlink(missing_ok=True)
+        self._payload = final_payload
+        self._finalized = True
+        self.in_progress_path.unlink(missing_ok=True)
+        _fsync_directory(self.receipt_dir)
+        return final_path
+
+
+def exit_code_for_exception(exc: BaseException) -> int:
+    code = getattr(exc, "code", None)
+    if type(code) is int and code >= 0:
+        return code
+    return 130 if isinstance(exc, KeyboardInterrupt) else 1
+
+
+def run_receipted(receipt: EomExecutionReceipt | None, operation) -> int:
+    try:
+        exit_code = operation()
+    except BaseException as exc:
+        if receipt is not None:
+            try:
+                receipt.finalize(exit_code_for_exception(exc))
+            except IndeterminateMutation:
+                pass
+        raise
+    if receipt is not None:
+        receipt.finalize(exit_code)
+    return exit_code

--- a/scripts/eom_execution_receipt.py
+++ b/scripts/eom_execution_receipt.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import asyncio
 import hashlib
 import json
 import os
@@ -112,6 +113,15 @@ def _fsync_directory(path: Path) -> None:
         os.close(fd)
 
 
+def _assert_private_directory(path: Path) -> None:
+    stat_result = path.stat()
+    if stat_result.st_uid != os.getuid():
+        raise ValueError(f"receipt directory is not owned by the current user: {path}")
+    mode = stat.S_IMODE(stat_result.st_mode)
+    if mode != 0o700:
+        raise ValueError(f"receipt directory must be private mode 0700: {path}")
+
+
 class EomExecutionReceipt:
     """Durable non-PII artifact for one EOM operator-tool invocation."""
 
@@ -127,9 +137,17 @@ class EomExecutionReceipt:
         if mode not in TOOL_MODES.get(tool, set()):
             raise ValueError(f"unsupported EOM receipt tool/mode: {tool}/{mode}")
         self.receipt_dir = Path(receipt_dir).expanduser().resolve()
-        self.receipt_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+        created = False
+        try:
+            self.receipt_dir.mkdir(mode=0o700, parents=True, exist_ok=False)
+            created = True
+        except FileExistsError:
+            pass
         if not self.receipt_dir.is_dir():
             raise ValueError("receipt directory must be a directory")
+        if created:
+            self.receipt_dir.chmod(0o700)
+        _assert_private_directory(self.receipt_dir)
         script = Path(script_path).resolve()
         self.receipt_id = str(uuid.UUID(str(receipt_id or uuid.uuid4())))
         self._changed_contact_ids: set[str] = set()
@@ -204,7 +222,7 @@ class EomExecutionReceipt:
         """Mark the receipt indeterminate if cancellation interrupts a mutation."""
         try:
             yield
-        except BaseException:
+        except (asyncio.CancelledError, KeyboardInterrupt, SystemExit):
             self._indeterminate = True
             self._payload["indeterminate"] = True
             self._persist_in_progress()

--- a/scripts/import_eom_customers_live.py
+++ b/scripts/import_eom_customers_live.py
@@ -20,8 +20,8 @@ is cwd-relative; the deploy runbook covers the runtime worktree symlink).
 
 Usage:
   python scripts/import_eom_customers_live.py --dry-run
-  python scripts/import_eom_customers_live.py
-  python scripts/import_eom_customers_live.py --calendar residential --months-back 12
+  python scripts/import_eom_customers_live.py --receipt-dir ~/.local/state/atlas/eom-receipts
+  python scripts/import_eom_customers_live.py --receipt-dir ~/.local/state/atlas/eom-receipts --calendar residential --months-back 12
 """
 
 import argparse
@@ -36,6 +36,7 @@ sys.path.insert(0, str(Path(__file__).parent))          # sibling script import
 sys.path.insert(0, str(Path(__file__).parent.parent))   # atlas_brain import
 
 import import_calendar_contacts as ics  # noqa: E402  (reused extraction core)
+from eom_execution_receipt import EomExecutionReceipt, run_receipted  # noqa: E402
 
 EOM_CONTEXT_ID = "effingham_maids"
 
@@ -535,7 +536,19 @@ async def _search_channel(crm, **channel):
     return (legacy[0], True) if legacy else (None, False)
 
 
-async def import_one(rec, crm, pool) -> str:
+async def _await_receipted_mutation(receipt, awaitable):
+    if receipt is None:
+        return await awaitable
+    async with receipt.mutation_boundary():
+        return await awaitable
+
+
+def _record_receipt_contact(receipt, contact_id) -> None:
+    if receipt is not None and contact_id:
+        receipt.record_changed_contact_id(contact_id)
+
+
+async def import_one(rec, crm, pool, receipt=None) -> str:
     """Import a single record; returns 'created' or 'updated'.
 
     Resolution order: tenant-scoped phone, then email (provider priority),
@@ -578,14 +591,23 @@ async def import_one(rec, crm, pool) -> str:
         # from a phone/email match is strong, so those claims require only
         # unarchived; the weaker address-only match additionally requires
         # calendar_import provenance (rounds 3+7 semantics, race-proof).
-        existing = await claim_legacy_row(
-            pool, str(existing["id"]),
-            require_import_source=claim_by_address,
-            identity=matched_identity,
+        existing = await _await_receipted_mutation(
+            receipt,
+            claim_legacy_row(
+                pool, str(existing["id"]),
+                require_import_source=claim_by_address,
+                identity=matched_identity,
+            ),
         )
+        if existing is not None:
+            _record_receipt_contact(receipt, existing["id"])
 
     if existing is not None:
-        contact_id, outcome = await _update_matched(pool, existing, data)
+        contact_id, outcome = await _await_receipted_mutation(
+            receipt, _update_matched(pool, existing, data)
+        )
+        if outcome == "updated":
+            _record_receipt_contact(receipt, contact_id)
     else:
         create_data = dict(data)
         # create_contact can still race-merge into a contact created
@@ -594,14 +616,20 @@ async def import_one(rec, crm, pool) -> str:
         # so both ride the controlled paths only (Codex rounds 6-7, R1/R8).
         create_data.pop("source", None)
         create_data.pop("tags", None)
-        result = await crm.create_contact(create_data)
+        result = await _await_receipted_mutation(
+            receipt, crm.create_contact(create_data)
+        )
         if result.get("_was_created"):
             contact_id = str(result.get("id", ""))
             outcome = "created"
+            _record_receipt_contact(receipt, contact_id)
             if contact_id:
-                stamp = await _guarded_update(
-                    pool, contact_id,
-                    {"source": "calendar_import", "tags": data["tags"]},
+                stamp = await _await_receipted_mutation(
+                    receipt,
+                    _guarded_update(
+                        pool, contact_id,
+                        {"source": "calendar_import", "tags": data["tags"]},
+                    ),
                 )
                 if stamp is None:
                     # Archived/reassigned within the create window: the row
@@ -614,7 +642,11 @@ async def import_one(rec, crm, pool) -> str:
         else:
             # Race-merged: reconcile exactly like any matched contact
             # (Codex round 7, R1/R8).
-            contact_id, outcome = await _update_matched(pool, result, data)
+            contact_id, outcome = await _await_receipted_mutation(
+                receipt, _update_matched(pool, result, data)
+            )
+            if outcome == "updated":
+                _record_receipt_contact(receipt, contact_id)
 
     if contact_id and rec.last_event_date and outcome != "skipped":
         # The archive can land after the contact write but before this log:
@@ -633,33 +665,38 @@ async def import_one(rec, crm, pool) -> str:
         # source_ref inside metadata is a dedupe anchor (migration 256): the
         # same address never accumulates duplicate import interactions across
         # re-runs.
-        await crm.log_interaction(
-            contact_id=contact_id,
-            interaction_type="appointment",
-            summary=(
-                f"Live calendar import: {rec.event_count} booking event(s). "
-                f"Most recent: {rec.last_event_date.isoformat()}. "
-                f"Source: {rec.source_calendar}"
+        interaction = await _await_receipted_mutation(
+            receipt,
+            crm.log_interaction(
+                contact_id=contact_id,
+                interaction_type="appointment",
+                summary=(
+                    f"Live calendar import: {rec.event_count} booking event(s). "
+                    f"Most recent: {rec.last_event_date.isoformat()}. "
+                    f"Source: {rec.source_calendar}"
+                ),
+                occurred_at=(
+                    getattr(rec, "latest_event_dt", None)
+                    or datetime.combine(rec.last_event_date, datetime.min.time())
+                    .replace(tzinfo=timezone.utc)
+                ).isoformat(),
+                # Date-scoped anchor: re-runs with the same latest booking dedupe,
+                # while each NEW latest booking advances the timeline instead of
+                # colliding with the old anchored row forever (Codex round 11,
+                # R1/R6).
+                metadata={
+                    # Timestamp-scoped: a same-day newer booking advances the
+                    # timeline too (Codex rounds 11+15, R1/R6).
+                    "source_ref": (
+                        f"eom_live_calendar:{rec.address.lower()}:"
+                        + (getattr(rec, "latest_event_dt", None)
+                           or rec.last_event_date).isoformat()
+                    )
+                },
             ),
-            occurred_at=(
-                getattr(rec, "latest_event_dt", None)
-                or datetime.combine(rec.last_event_date, datetime.min.time())
-                .replace(tzinfo=timezone.utc)
-            ).isoformat(),
-            # Date-scoped anchor: re-runs with the same latest booking dedupe,
-            # while each NEW latest booking advances the timeline instead of
-            # colliding with the old anchored row forever (Codex round 11,
-            # R1/R6).
-            metadata={
-                # Timestamp-scoped: a same-day newer booking advances the
-                # timeline too (Codex rounds 11+15, R1/R6).
-                "source_ref": (
-                    f"eom_live_calendar:{rec.address.lower()}:"
-                    + (getattr(rec, "latest_event_dt", None)
-                       or rec.last_event_date).isoformat()
-                )
-            },
         )
+        if interaction.get("inserted") is True:
+            _record_receipt_contact(receipt, contact_id)
     return outcome
 
 
@@ -669,8 +706,12 @@ def exit_code_for(counts: dict) -> int:
     return 1 if counts.get("errors") else 0
 
 
-async def run_import(records, dry_run: bool) -> dict:
+async def run_import(records, dry_run: bool, receipt=None) -> dict:
     counts = {"created": 0, "updated": 0, "unchanged": 0, "skipped": 0, "errors": 0}
+    if dry_run:
+        counts["import-planned"] = len(records)
+    if receipt is not None:
+        receipt.record_outcome_counts(counts)
     crm = None
     pool = None
     if not dry_run:
@@ -690,27 +731,16 @@ async def run_import(records, dry_run: bool) -> dict:
         if dry_run:
             continue
         try:
-            counts[await import_one(rec, crm, pool)] += 1
+            counts[await import_one(rec, crm, pool, receipt=receipt)] += 1
         except Exception as e:  # noqa: BLE001 -- operator script: report and continue
             print(f"    ERROR: {rec.name} -- {e}")
             counts["errors"] += 1
+        if receipt is not None:
+            receipt.record_outcome_counts(counts)
     return counts
 
 
-async def main():
-    parser = argparse.ArgumentParser(
-        description="Import EOM customers from the live booking calendars"
-    )
-    parser.add_argument("--dry-run", action="store_true", help="Preview only -- no DB writes")
-    parser.add_argument(
-        "--calendar",
-        choices=["commercial", "residential", "one_time", "all"],
-        default="all",
-    )
-    parser.add_argument("--months-back", type=int, default=24)
-    parser.add_argument("--months-forward", type=int, default=12)
-    args = parser.parse_args()
-
+async def run(args, receipt=None):
     calendar_ids = resolve_calendar_ids(effective_calendar_env(os.environ), args.calendar)
 
     now = datetime.now(timezone.utc)
@@ -758,7 +788,7 @@ async def main():
         await pool.initialize()
         print("Database pool initialized.\n")
 
-    counts = await run_import(records, args.dry_run)
+    counts = await run_import(records, args.dry_run, receipt=receipt)
 
     print(f"\n{'=' * 70}")
     if args.dry_run:
@@ -774,5 +804,35 @@ async def main():
     return exit_code_for(counts)
 
 
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Import EOM customers from the live booking calendars"
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Preview only -- no DB writes")
+    parser.add_argument(
+        "--calendar",
+        choices=["commercial", "residential", "one_time", "all"],
+        default="all",
+    )
+    parser.add_argument("--months-back", type=int, default=24)
+    parser.add_argument("--months-forward", type=int, default=12)
+    parser.add_argument(
+        "--receipt-dir",
+        help="Private execution-receipt directory; required for live writes",
+    )
+    args = parser.parse_args(argv)
+    if not args.dry_run and not args.receipt_dir:
+        parser.error("live writes require --receipt-dir")
+    receipt = None
+    if args.receipt_dir:
+        receipt = EomExecutionReceipt(
+            receipt_dir=args.receipt_dir,
+            tool="import_eom_customers_live",
+            mode="dry-run" if args.dry_run else "write",
+            script_path=Path(__file__),
+        )
+    return run_receipted(receipt, lambda: asyncio.run(run(args, receipt=receipt)))
+
+
 if __name__ == "__main__":
-    sys.exit(asyncio.run(main()))
+    sys.exit(main())

--- a/scripts/import_eom_customers_live.py
+++ b/scripts/import_eom_customers_live.py
@@ -536,11 +536,14 @@ async def _search_channel(crm, **channel):
     return (legacy[0], True) if legacy else (None, False)
 
 
-async def _await_receipted_mutation(receipt, awaitable):
+async def _await_receipted_mutation(receipt, awaitable, *, changed_contact_id_from=None):
     if receipt is None:
         return await awaitable
     async with receipt.mutation_boundary():
-        return await awaitable
+        result = await awaitable
+        if changed_contact_id_from is not None:
+            _record_receipt_contact(receipt, changed_contact_id_from(result))
+        return result
 
 
 def _record_receipt_contact(receipt, contact_id) -> None:
@@ -598,16 +601,17 @@ async def import_one(rec, crm, pool, receipt=None) -> str:
                 require_import_source=claim_by_address,
                 identity=matched_identity,
             ),
+            changed_contact_id_from=lambda row: row and row["id"],
         )
-        if existing is not None:
-            _record_receipt_contact(receipt, existing["id"])
 
     if existing is not None:
         contact_id, outcome = await _await_receipted_mutation(
-            receipt, _update_matched(pool, existing, data)
+            receipt,
+            _update_matched(pool, existing, data),
+            changed_contact_id_from=(
+                lambda result: result[0] if result[1] == "updated" else None
+            ),
         )
-        if outcome == "updated":
-            _record_receipt_contact(receipt, contact_id)
     else:
         create_data = dict(data)
         # create_contact can still race-merge into a contact created
@@ -617,12 +621,15 @@ async def import_one(rec, crm, pool, receipt=None) -> str:
         create_data.pop("source", None)
         create_data.pop("tags", None)
         result = await _await_receipted_mutation(
-            receipt, crm.create_contact(create_data)
+            receipt,
+            crm.create_contact(create_data),
+            changed_contact_id_from=(
+                lambda row: row.get("id") if row.get("_was_created") else None
+            ),
         )
         if result.get("_was_created"):
             contact_id = str(result.get("id", ""))
             outcome = "created"
-            _record_receipt_contact(receipt, contact_id)
             if contact_id:
                 stamp = await _await_receipted_mutation(
                     receipt,
@@ -643,10 +650,14 @@ async def import_one(rec, crm, pool, receipt=None) -> str:
             # Race-merged: reconcile exactly like any matched contact
             # (Codex round 7, R1/R8).
             contact_id, outcome = await _await_receipted_mutation(
-                receipt, _update_matched(pool, result, data)
+                receipt,
+                _update_matched(pool, result, data),
+                changed_contact_id_from=(
+                    lambda update_result: (
+                        update_result[0] if update_result[1] == "updated" else None
+                    )
+                ),
             )
-            if outcome == "updated":
-                _record_receipt_contact(receipt, contact_id)
 
     if contact_id and rec.last_event_date and outcome != "skipped":
         # The archive can land after the contact write but before this log:
@@ -665,7 +676,7 @@ async def import_one(rec, crm, pool, receipt=None) -> str:
         # source_ref inside metadata is a dedupe anchor (migration 256): the
         # same address never accumulates duplicate import interactions across
         # re-runs.
-        interaction = await _await_receipted_mutation(
+        await _await_receipted_mutation(
             receipt,
             crm.log_interaction(
                 contact_id=contact_id,
@@ -694,9 +705,10 @@ async def import_one(rec, crm, pool, receipt=None) -> str:
                     )
                 },
             ),
+            changed_contact_id_from=(
+                lambda row: contact_id if row.get("inserted") is True else None
+            ),
         )
-        if interaction.get("inserted") is True:
-            _record_receipt_contact(receipt, contact_id)
     return outcome
 
 

--- a/scripts/sync_eom_portal_customers.py
+++ b/scripts/sync_eom_portal_customers.py
@@ -49,11 +49,14 @@ DEMOTABLE_SOURCES = ("calendar_import", "portal_sync")
 MANAGED_TAGS = {"portal", "residential", "commercial", "one_time", "past_customer"}
 
 
-async def _await_receipted_mutation(receipt, awaitable):
+async def _await_receipted_mutation(receipt, awaitable, *, changed_contact_id_from=None):
     if receipt is None:
         return await awaitable
     async with receipt.mutation_boundary():
-        return await awaitable
+        result = await awaitable
+        if changed_contact_id_from is not None:
+            _record_receipt_contact(receipt, changed_contact_id_from(result))
+        return result
 
 
 def _record_receipt_contact(receipt, contact_id) -> None:
@@ -513,21 +516,25 @@ async def sync_one(
                 needs_claim=needs_claim,
                 identity=identity,
             ),
+            changed_contact_id_from=(
+                lambda result: result[0] if result[1] == "updated" else None
+            ),
         )
         if outcome == "rejected":
             return "errors", None
-        if outcome == "updated":
-            _record_receipt_contact(receipt, contact_id)
     else:
         create_data = dict(data)
         create_data["metadata"] = {"portal_customer_id": portal_id}
         result = await _await_receipted_mutation(
-            receipt, crm.create_contact(create_data, merge_existing=False)
+            receipt,
+            crm.create_contact(create_data, merge_existing=False),
+            changed_contact_id_from=(
+                lambda row: row.get("id") if row.get("_was_created") else None
+            ),
         )
         contact_id = str(result.get("id", ""))
         if result.get("_was_created"):
             outcome = "created"
-            _record_receipt_contact(receipt, contact_id)
         else:
             race_identity = ("email", data["email"]) if data.get("email") else None
             contact_id, outcome = await _await_receipted_mutation(
@@ -540,11 +547,16 @@ async def sync_one(
                     needs_claim=False,
                     identity=race_identity,
                 ),
+                changed_contact_id_from=(
+                    lambda reconcile_result: (
+                        reconcile_result[0]
+                        if reconcile_result[1] == "updated"
+                        else None
+                    )
+                ),
             )
             if outcome == "rejected":
                 return "errors", None
-            if outcome == "updated":
-                _record_receipt_contact(receipt, contact_id)
     return outcome, contact_id
 
 
@@ -678,10 +690,10 @@ async def demote_unmatched(pool, matched_ids: set, apply: bool,
                 EOM_CONTEXT_ID,
                 list(DEMOTABLE_SOURCES),
             ),
+            changed_contact_id_from=lambda row: row and row["id"],
         )
         if result is not None:
             demoted += 1
-            _record_receipt_contact(receipt, row["id"])
     if kept:
         print(f"\n  {kept} calendar-active customer(s) kept; reconcile them "
               "in the portal.")
@@ -741,6 +753,9 @@ async def run(args, receipt=None) -> int:
                   f"name={c.get('name')!r}")
         print(f"\n  ABORTED: {len(invalid)} malformed portal record(s); "
               "nothing written.")
+        counts["errors"] += len(invalid)
+        if receipt is not None:
+            receipt.record_outcome_counts(counts)
         return 1
 
     resolutions = {}
@@ -751,6 +766,9 @@ async def run(args, receipt=None) -> int:
             )
         except Exception as e:  # noqa: BLE001 -- no writes have started
             print(f"\n  ABORTED: roster preflight failed ({e}); nothing written.")
+            counts["errors"] += 1
+            if receipt is not None:
+                receipt.record_outcome_counts(counts)
             return 1
         if collision_errors:
             for error in collision_errors:
@@ -759,6 +777,9 @@ async def run(args, receipt=None) -> int:
                 f"\n  ABORTED: {len(collision_errors)} roster collision(s); "
                 "nothing written."
             )
+            counts["errors"] += len(collision_errors)
+            if receipt is not None:
+                receipt.record_outcome_counts(counts)
             return 1
 
     matched_ids: set = set()

--- a/scripts/sync_eom_portal_customers.py
+++ b/scripts/sync_eom_portal_customers.py
@@ -645,55 +645,61 @@ async def demote_unmatched(pool, matched_ids: set, apply: bool,
     calendars (owner veto rule). Only rows this pipeline claimed as active
     (calendar_import / portal_sync provenance) are eligible; leads, manual,
     web, and every other source are never touched."""
-    rows = await pool.fetch(
-        """
-        SELECT id, full_name, tags, phone, email, address FROM contacts
-        WHERE business_context_id = $1
-          AND contact_type = 'customer'
-          AND status = 'active'
-          AND source = ANY($2::text[])
-        ORDER BY lower(full_name)
-        """,
-        EOM_CONTEXT_ID,
-        list(DEMOTABLE_SOURCES),
-    )
+    rows = []
     demoted = 0
     kept = 0
-    for row in rows:
-        if str(row["id"]) in matched_ids:
-            continue
-        if on_calendar(row, guard_keys):
-            kept += 1
-            print(f"  KEPT (on your calendar, missing from portal): "
-                  f"{row['full_name']} -- add them to the portal")
-            continue
-        print(f"  DEMOTE (past customer): {row['full_name']}")
-        if not apply:
-            demoted += 1
-            continue
-        tags = sorted(set(row["tags"] or []) | {"past_customer"})
-        result = await _await_receipted_mutation(
-            receipt,
-            pool.fetchrow(
-                """
-                UPDATE contacts
-                   SET status = 'inactive', tags = $2, updated_at = NOW()
-                 WHERE id = $1
-                   AND business_context_id = $3
-                   AND contact_type = 'customer'
-                   AND status = 'active'
-                   AND source = ANY($4::text[])
-                RETURNING id
-                """,
-                str(row["id"]),
-                tags,
-                EOM_CONTEXT_ID,
-                list(DEMOTABLE_SOURCES),
-            ),
-            changed_contact_id_from=lambda row: row and row["id"],
+    try:
+        rows = await pool.fetch(
+            """
+            SELECT id, full_name, tags, phone, email, address FROM contacts
+            WHERE business_context_id = $1
+              AND contact_type = 'customer'
+              AND status = 'active'
+              AND source = ANY($2::text[])
+            ORDER BY lower(full_name)
+            """,
+            EOM_CONTEXT_ID,
+            list(DEMOTABLE_SOURCES),
         )
-        if result is not None:
-            demoted += 1
+        for row in rows:
+            if str(row["id"]) in matched_ids:
+                continue
+            if on_calendar(row, guard_keys):
+                kept += 1
+                print(f"  KEPT (on your calendar, missing from portal): "
+                      f"{row['full_name']} -- add them to the portal")
+                continue
+            print(f"  DEMOTE (past customer): {row['full_name']}")
+            if not apply:
+                demoted += 1
+                continue
+            tags = sorted(set(row["tags"] or []) | {"past_customer"})
+            result = await _await_receipted_mutation(
+                receipt,
+                pool.fetchrow(
+                    """
+                    UPDATE contacts
+                       SET status = 'inactive', tags = $2, updated_at = NOW()
+                     WHERE id = $1
+                       AND business_context_id = $3
+                       AND contact_type = 'customer'
+                       AND status = 'active'
+                       AND source = ANY($4::text[])
+                    RETURNING id
+                    """,
+                    str(row["id"]),
+                    tags,
+                    EOM_CONTEXT_ID,
+                    list(DEMOTABLE_SOURCES),
+                ),
+                changed_contact_id_from=lambda row: row and row["id"],
+            )
+            if result is not None:
+                demoted += 1
+    except Exception:
+        if receipt is not None:
+            receipt.record_demotions(demoted=demoted, eligible=len(rows), kept=kept)
+        raise
     if kept:
         print(f"\n  {kept} calendar-active customer(s) kept; reconcile them "
               "in the portal.")
@@ -822,9 +828,15 @@ async def run(args, receipt=None) -> int:
         if guard_keys is None:
             demoted, eligible = 0, 0
         else:
-            demoted, eligible = await demote_unmatched(
-                pool, matched_ids, args.apply, guard_keys, receipt=receipt
-            )
+            try:
+                demoted, eligible = await demote_unmatched(
+                    pool, matched_ids, args.apply, guard_keys, receipt=receipt
+                )
+            except Exception:
+                counts["errors"] += 1
+                if receipt is not None:
+                    receipt.record_outcome_counts(counts)
+                raise
     if receipt is not None:
         receipt.record_outcome_counts(counts)
 

--- a/scripts/sync_eom_portal_customers.py
+++ b/scripts/sync_eom_portal_customers.py
@@ -804,6 +804,8 @@ async def run(args, receipt=None) -> int:
             demoted, eligible = await demote_unmatched(
                 pool, matched_ids, args.apply, guard_keys, receipt=receipt
             )
+    if receipt is not None:
+        receipt.record_outcome_counts(counts)
 
     print(f"\n{'=' * 70}")
     if args.apply:

--- a/scripts/sync_eom_portal_customers.py
+++ b/scripts/sync_eom_portal_customers.py
@@ -21,7 +21,7 @@ disk, argv, or logs.
 
 Usage:
   python scripts/sync_eom_portal_customers.py            # dry-run
-  python scripts/sync_eom_portal_customers.py --apply
+  python scripts/sync_eom_portal_customers.py --apply --receipt-dir ~/.local/state/atlas/eom-receipts
   python scripts/sync_eom_portal_customers.py --base-url http://localhost:8000
 """
 
@@ -39,6 +39,7 @@ sys.path.insert(0, str(Path(__file__).parent))          # sibling script import
 sys.path.insert(0, str(Path(__file__).parent.parent))   # atlas_brain import
 
 import import_eom_customers_live as live  # noqa: E402  (slice-A machinery)
+from eom_execution_receipt import EomExecutionReceipt, run_receipted  # noqa: E402
 
 EOM_CONTEXT_ID = live.EOM_CONTEXT_ID
 DEFAULT_BASE_URL = "https://eom-timetracker.onrender.com"
@@ -46,6 +47,18 @@ DEMOTABLE_SOURCES = ("calendar_import", "portal_sync")
 # Tags this pipeline manages: the portal replaces them on a match; every
 # other (foreign) tag is preserved (Codex A2 round 4).
 MANAGED_TAGS = {"portal", "residential", "commercial", "one_time", "past_customer"}
+
+
+async def _await_receipted_mutation(receipt, awaitable):
+    if receipt is None:
+        return await awaitable
+    async with receipt.mutation_boundary():
+        return await awaitable
+
+
+def _record_receipt_contact(receipt, contact_id) -> None:
+    if receipt is not None and contact_id:
+        receipt.record_changed_contact_id(contact_id)
 
 
 def settings_default(attr: str):
@@ -422,7 +435,9 @@ async def portal_id_current(pool, contact_id: str):
     return (row is not None), (row.get("pid") if row else None)
 
 
-async def sync_one(customer: dict, crm, pool, apply: bool, *, resolved=None) -> tuple:
+async def sync_one(
+    customer: dict, crm, pool, apply: bool, *, resolved=None, receipt=None
+) -> tuple:
     """Sync a single portal customer; returns (outcome, contact_id)."""
     data = customer_to_contact_data(customer)
     if not data["full_name"]:
@@ -488,35 +503,48 @@ async def sync_one(customer: dict, crm, pool, apply: bool, *, resolved=None) -> 
             return "errors", None
 
     if existing is not None:
-        contact_id, outcome = await reconcile_portal_contact(
-            pool,
-            existing,
-            data,
-            portal_id,
-            needs_claim=needs_claim,
-            identity=identity,
+        contact_id, outcome = await _await_receipted_mutation(
+            receipt,
+            reconcile_portal_contact(
+                pool,
+                existing,
+                data,
+                portal_id,
+                needs_claim=needs_claim,
+                identity=identity,
+            ),
         )
         if outcome == "rejected":
             return "errors", None
+        if outcome == "updated":
+            _record_receipt_contact(receipt, contact_id)
     else:
         create_data = dict(data)
         create_data["metadata"] = {"portal_customer_id": portal_id}
-        result = await crm.create_contact(create_data, merge_existing=False)
+        result = await _await_receipted_mutation(
+            receipt, crm.create_contact(create_data, merge_existing=False)
+        )
         contact_id = str(result.get("id", ""))
         if result.get("_was_created"):
             outcome = "created"
+            _record_receipt_contact(receipt, contact_id)
         else:
             race_identity = ("email", data["email"]) if data.get("email") else None
-            contact_id, outcome = await reconcile_portal_contact(
-                pool,
-                result,
-                data,
-                portal_id,
-                needs_claim=False,
-                identity=race_identity,
+            contact_id, outcome = await _await_receipted_mutation(
+                receipt,
+                reconcile_portal_contact(
+                    pool,
+                    result,
+                    data,
+                    portal_id,
+                    needs_claim=False,
+                    identity=race_identity,
+                ),
             )
             if outcome == "rejected":
                 return "errors", None
+            if outcome == "updated":
+                _record_receipt_contact(receipt, contact_id)
     return outcome, contact_id
 
 
@@ -599,7 +627,7 @@ def on_calendar(row: dict, guard_keys: dict) -> bool:
 
 
 async def demote_unmatched(pool, matched_ids: set, apply: bool,
-                           guard_keys: dict) -> tuple:
+                           guard_keys: dict, receipt=None) -> tuple:
     """Previously-imported active 'customers' that matched no portal customer
     this run become past customers -- UNLESS they appear on the live booking
     calendars (owner veto rule). Only rows this pipeline claimed as active
@@ -632,35 +660,43 @@ async def demote_unmatched(pool, matched_ids: set, apply: bool,
             demoted += 1
             continue
         tags = sorted(set(row["tags"] or []) | {"past_customer"})
-        result = await pool.fetchrow(
-            """
-            UPDATE contacts
-               SET status = 'inactive', tags = $2, updated_at = NOW()
-             WHERE id = $1
-               AND business_context_id = $3
-               AND contact_type = 'customer'
-               AND status = 'active'
-               AND source = ANY($4::text[])
-            RETURNING id
-            """,
-            str(row["id"]),
-            tags,
-            EOM_CONTEXT_ID,
-            list(DEMOTABLE_SOURCES),
+        result = await _await_receipted_mutation(
+            receipt,
+            pool.fetchrow(
+                """
+                UPDATE contacts
+                   SET status = 'inactive', tags = $2, updated_at = NOW()
+                 WHERE id = $1
+                   AND business_context_id = $3
+                   AND contact_type = 'customer'
+                   AND status = 'active'
+                   AND source = ANY($4::text[])
+                RETURNING id
+                """,
+                str(row["id"]),
+                tags,
+                EOM_CONTEXT_ID,
+                list(DEMOTABLE_SOURCES),
+            ),
         )
         if result is not None:
             demoted += 1
+            _record_receipt_contact(receipt, row["id"])
     if kept:
         print(f"\n  {kept} calendar-active customer(s) kept; reconcile them "
               "in the portal.")
+    if receipt is not None:
+        receipt.record_demotions(demoted=demoted, eligible=len(rows), kept=kept)
     return demoted, len(rows)
 
 
-async def run(args) -> int:
+async def run(args, receipt=None) -> int:
     import httpx
 
     counts = {"created": 0, "updated": 0, "unchanged": 0, "skipped": 0,
               "errors": 0, "create-planned": 0, "update-planned": 0}
+    if receipt is not None:
+        receipt.record_outcome_counts(counts)
     with httpx.Client(timeout=30.0) as client:
         token = portal_login(client, args.base_url, os.environ)
         customers = fetch_portal_customers(client, args.base_url, token)
@@ -733,7 +769,7 @@ async def run(args) -> int:
                   f"[{','.join(segment_tags(customer))}]")
             resolved = resolutions.get(customer["id"]) if args.apply else None
             outcome, contact_id = await sync_one(
-                customer, crm, pool, args.apply, resolved=resolved
+                customer, crm, pool, args.apply, resolved=resolved, receipt=receipt
             )
             counts[outcome] += 1
             if contact_id:
@@ -741,6 +777,8 @@ async def run(args) -> int:
         except Exception as e:  # noqa: BLE001 -- operator script: report, continue
             print(f"    ERROR: {customer.get('name')} -- {e}")
             counts["errors"] += 1
+        if receipt is not None:
+            receipt.record_outcome_counts(counts)
 
     print(f"\n{'-' * 70}")
     if counts["errors"]:
@@ -764,7 +802,7 @@ async def run(args) -> int:
             demoted, eligible = 0, 0
         else:
             demoted, eligible = await demote_unmatched(
-                pool, matched_ids, args.apply, guard_keys
+                pool, matched_ids, args.apply, guard_keys, receipt=receipt
             )
 
     print(f"\n{'=' * 70}")
@@ -780,7 +818,7 @@ async def run(args) -> int:
     return 1 if counts["errors"] else 0
 
 
-def main():
+def main(argv=None):
     parser = argparse.ArgumentParser(
         description="Sync the portal Customer aggregate into the Atlas CRM"
     )
@@ -792,8 +830,22 @@ def main():
         or settings_default("eom_portal_base_url")
         or DEFAULT_BASE_URL,
     )
-    args = parser.parse_args()
-    return asyncio.run(run(args))
+    parser.add_argument(
+        "--receipt-dir",
+        help="Private execution-receipt directory; required with --apply",
+    )
+    args = parser.parse_args(argv)
+    if args.apply and not args.receipt_dir:
+        parser.error("--apply requires --receipt-dir")
+    receipt = None
+    if args.receipt_dir:
+        receipt = EomExecutionReceipt(
+            receipt_dir=args.receipt_dir,
+            tool="sync_eom_portal_customers",
+            mode="apply" if args.apply else "dry-run",
+            script_path=Path(__file__),
+        )
+    return run_receipted(receipt, lambda: asyncio.run(run(args, receipt=receipt)))
 
 
 if __name__ == "__main__":

--- a/tests/test_eom_execution_receipts.py
+++ b/tests/test_eom_execution_receipts.py
@@ -1,0 +1,239 @@
+"""Durable private receipts for EOM operator scripts."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+sys.path.insert(0, str(REPO / "tests"))
+
+import import_eom_customers_live as calendar_import  # noqa: E402
+import sync_eom_portal_customers as portal_sync  # noqa: E402
+from eom_execution_receipt import EomExecutionReceipt, run_receipted  # noqa: E402
+from test_eom_live_calendar_import import StubPool, _record  # noqa: E402
+from test_sync_eom_portal_customers import SyncPool, _customer  # noqa: E402
+
+
+UUID_A = "11111111-1111-4111-8111-111111111111"
+UUID_B = "22222222-2222-4222-8222-222222222222"
+
+
+def _payload(path: Path) -> dict:
+    return json.loads(path.read_text())
+
+
+def _private(path: Path) -> bool:
+    return stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+def test_receipt_publishes_private_source_bound_non_pii_payload(tmp_path):
+    receipt = EomExecutionReceipt(
+        receipt_dir=tmp_path,
+        tool="import_eom_customers_live",
+        mode="write",
+        script_path=REPO / "scripts" / "import_eom_customers_live.py",
+        receipt_id=UUID_A,
+    )
+    assert receipt.in_progress_path.exists()
+    assert _private(receipt.in_progress_path)
+
+    receipt.record_outcome_counts({"created": 1, "errors": 0})
+    receipt.record_changed_contact_id(UUID_B)
+    receipt.record_demotions(demoted=0, eligible=3, kept=2)
+    final = receipt.finalize(0)
+
+    assert final.exists()
+    assert _private(final)
+    assert not receipt.in_progress_path.exists()
+    payload = _payload(final)
+    assert payload["schema_version"] == 1
+    assert payload["receipt_id"] == UUID_A
+    assert payload["tool"] == "import_eom_customers_live"
+    assert payload["mode"] == "write"
+    assert payload["git_sha"]
+    assert len(payload["script_hash_sha256"]) == 64
+    assert payload["exit_code"] == 0
+    assert payload["outcome_counts"] == {"created": 1, "errors": 0}
+    assert payload["changed_contact_ids"] == [UUID_B]
+    assert payload["demotion_totals"] == {"demoted": 0, "eligible": 3, "kept": 2}
+    serialized = json.dumps(payload)
+    for forbidden in (
+        "customer@example.com",
+        "217-555-1212",
+        "123 Main",
+        "token",
+        "baseUrl",
+        str(tmp_path),
+    ):
+        assert forbidden not in serialized
+
+
+def test_receipt_finalization_never_overwrites_existing_final(tmp_path):
+    first = EomExecutionReceipt(
+        receipt_dir=tmp_path,
+        tool="sync_eom_portal_customers",
+        mode="apply",
+        script_path=REPO / "scripts" / "sync_eom_portal_customers.py",
+        receipt_id=UUID_A,
+    )
+    first_final = first.finalize(0)
+    first_payload = first_final.read_text()
+
+    second = EomExecutionReceipt(
+        receipt_dir=tmp_path,
+        tool="sync_eom_portal_customers",
+        mode="apply",
+        script_path=REPO / "scripts" / "sync_eom_portal_customers.py",
+        receipt_id=UUID_A,
+    )
+    with pytest.raises(FileExistsError):
+        second.finalize(0)
+    assert first_final.read_text() == first_payload
+
+
+def test_indeterminate_mutation_keeps_in_progress_and_no_final(tmp_path):
+    receipt = EomExecutionReceipt(
+        receipt_dir=tmp_path,
+        tool="import_eom_customers_live",
+        mode="write",
+        script_path=REPO / "scripts" / "import_eom_customers_live.py",
+        receipt_id=UUID_A,
+    )
+
+    async def interrupted():
+        async with receipt.mutation_boundary():
+            raise KeyboardInterrupt
+
+    with pytest.raises(KeyboardInterrupt):
+        run_receipted(receipt, lambda: asyncio.run(interrupted()))
+
+    assert receipt.in_progress_path.exists()
+    assert not list(tmp_path.glob("eom-*.exit-*.json"))
+    assert _payload(receipt.in_progress_path)["indeterminate"] is True
+
+
+def test_calendar_live_write_requires_receipt_before_runtime_work(monkeypatch):
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("provider/database work must not start")
+
+    monkeypatch.setattr(calendar_import, "resolve_calendar_ids", fail_if_called)
+    with pytest.raises(SystemExit):
+        calendar_import.main(["--calendar", "residential"])
+
+
+def test_portal_apply_requires_receipt_before_runtime_work(monkeypatch):
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("login/runtime work must not start")
+
+    monkeypatch.setattr(portal_sync, "portal_login", fail_if_called)
+    with pytest.raises(SystemExit):
+        portal_sync.main(["--apply"])
+
+
+class _ReceiptSpy:
+    def __init__(self):
+        self.changed = []
+        self.counts = []
+        self.demotions = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return False
+
+    def mutation_boundary(self):
+        return self
+
+    def record_changed_contact_id(self, contact_id):
+        self.changed.append(str(contact_id))
+
+    def record_outcome_counts(self, counts):
+        self.counts.append(dict(counts))
+
+    def record_demotions(self, **totals):
+        self.demotions = totals
+
+
+class _CalendarCRM:
+    async def search_contacts(self, **_kwargs):
+        return []
+
+    async def create_contact(self, data):
+        self.created = data
+        return {"id": UUID_A, "_was_created": True, "status": data["status"]}
+
+    async def log_interaction(self, **_kwargs):
+        return {"inserted": True}
+
+
+def test_calendar_import_records_changed_contacts_and_counts():
+    receipt = _ReceiptSpy()
+    outcome = asyncio.run(
+        calendar_import.import_one(
+            _record(), _CalendarCRM(), StubPool(rows=[None, None]), receipt=receipt
+        )
+    )
+    assert outcome == "created"
+    assert UUID_A in receipt.changed
+
+    counts = asyncio.run(
+        calendar_import.run_import([], dry_run=True, receipt=receipt)
+    )
+    assert counts["import-planned"] == 0
+    assert receipt.counts[-1]["import-planned"] == 0
+
+
+class _PortalCRM:
+    async def create_contact(self, data, *, merge_existing=True):
+        self.created = (data, merge_existing)
+        return {"id": UUID_A, "_was_created": True}
+
+
+def test_portal_sync_records_changed_contacts_and_demotion_totals():
+    receipt = _ReceiptSpy()
+    outcome, contact_id = asyncio.run(
+        portal_sync.sync_one(
+            _customer(primaryPhone=None, primaryEmail=None, sites=[]),
+            _PortalCRM(),
+            SyncPool(rows=[None]),
+            apply=True,
+            receipt=receipt,
+        )
+    )
+    assert (outcome, contact_id) == ("created", UUID_A)
+    assert receipt.changed == [UUID_A]
+
+    pool = SyncPool(demotion_rows=[
+        {"id": UUID_B, "full_name": "Moved Away", "tags": []},
+        {
+            "id": "33333333-3333-4333-8333-333333333333",
+            "full_name": "Still Here",
+            "tags": [],
+            "email": "kept@example.com",
+        },
+    ])
+    demoted, eligible = asyncio.run(
+        portal_sync.demote_unmatched(
+            pool,
+            set(),
+            apply=True,
+            guard_keys={
+                "phones": set(),
+                "emails": {"kept@example.com"},
+                "addrs": set(),
+                "names": set(),
+            },
+            receipt=receipt,
+        )
+    )
+    assert (demoted, eligible) == (1, 2)
+    assert UUID_B in receipt.changed
+    assert receipt.demotions == {"demoted": 1, "eligible": 2, "kept": 1}

--- a/tests/test_eom_execution_receipts.py
+++ b/tests/test_eom_execution_receipts.py
@@ -33,6 +33,23 @@ def _private(path: Path) -> bool:
     return stat.S_IMODE(path.stat().st_mode) == 0o600
 
 
+def test_existing_receipt_directory_must_be_private(tmp_path):
+    unsafe = tmp_path / "unsafe-receipts"
+    unsafe.mkdir()
+    unsafe.chmod(0o755)
+    try:
+        with pytest.raises(ValueError, match="private mode 0700"):
+            EomExecutionReceipt(
+                receipt_dir=unsafe,
+                tool="import_eom_customers_live",
+                mode="write",
+                script_path=REPO / "scripts" / "import_eom_customers_live.py",
+                receipt_id=UUID_A,
+            )
+    finally:
+        unsafe.chmod(0o700)
+
+
 def test_receipt_publishes_private_source_bound_non_pii_payload(tmp_path):
     receipt = EomExecutionReceipt(
         receipt_dir=tmp_path,
@@ -117,6 +134,30 @@ def test_indeterminate_mutation_keeps_in_progress_and_no_final(tmp_path):
     assert receipt.in_progress_path.exists()
     assert not list(tmp_path.glob("eom-*.exit-*.json"))
     assert _payload(receipt.in_progress_path)["indeterminate"] is True
+
+
+def test_ordinary_mutation_exception_finalizes_failure_receipt(tmp_path):
+    receipt = EomExecutionReceipt(
+        receipt_dir=tmp_path,
+        tool="import_eom_customers_live",
+        mode="write",
+        script_path=REPO / "scripts" / "import_eom_customers_live.py",
+        receipt_id=UUID_A,
+    )
+
+    async def failed_mutation():
+        async with receipt.mutation_boundary():
+            raise RuntimeError("database timeout")
+
+    with pytest.raises(RuntimeError, match="database timeout"):
+        run_receipted(receipt, lambda: asyncio.run(failed_mutation()))
+
+    final = receipt.final_path_for(1)
+    assert final.exists()
+    assert not receipt.in_progress_path.exists()
+    payload = _payload(final)
+    assert payload["exit_code"] == 1
+    assert payload["indeterminate"] is False
 
 
 def test_calendar_live_write_requires_receipt_before_runtime_work(monkeypatch):

--- a/tests/test_eom_execution_receipts.py
+++ b/tests/test_eom_execution_receipts.py
@@ -136,6 +136,27 @@ def test_indeterminate_mutation_keeps_in_progress_and_no_final(tmp_path):
     assert _payload(receipt.in_progress_path)["indeterminate"] is True
 
 
+def test_indeterminate_mutation_note_is_attached_to_original_interrupt(tmp_path):
+    receipt = EomExecutionReceipt(
+        receipt_dir=tmp_path,
+        tool="import_eom_customers_live",
+        mode="write",
+        script_path=REPO / "scripts" / "import_eom_customers_live.py",
+        receipt_id=UUID_A,
+    )
+
+    async def interrupted():
+        async with receipt.mutation_boundary():
+            raise KeyboardInterrupt
+
+    with pytest.raises(KeyboardInterrupt) as raised:
+        run_receipted(receipt, lambda: asyncio.run(interrupted()))
+
+    assert "left in-progress receipt" in "\n".join(
+        getattr(raised.value, "__notes__", [])
+    )
+
+
 def test_ordinary_mutation_exception_finalizes_failure_receipt(tmp_path):
     receipt = EomExecutionReceipt(
         receipt_dir=tmp_path,
@@ -183,11 +204,15 @@ class _ReceiptSpy:
         self.changed = []
         self.counts = []
         self.demotions = None
+        self.boundary_open = False
+        self.changed_recorded_inside_boundary = []
 
     async def __aenter__(self):
+        self.boundary_open = True
         return self
 
     async def __aexit__(self, *_exc):
+        self.boundary_open = False
         return False
 
     def mutation_boundary(self):
@@ -195,6 +220,7 @@ class _ReceiptSpy:
 
     def record_changed_contact_id(self, contact_id):
         self.changed.append(str(contact_id))
+        self.changed_recorded_inside_boundary.append(self.boundary_open)
 
     def record_outcome_counts(self, counts):
         self.counts.append(dict(counts))
@@ -224,6 +250,8 @@ def test_calendar_import_records_changed_contacts_and_counts():
     )
     assert outcome == "created"
     assert UUID_A in receipt.changed
+    assert receipt.changed_recorded_inside_boundary
+    assert all(receipt.changed_recorded_inside_boundary)
 
     counts = asyncio.run(
         calendar_import.run_import([], dry_run=True, receipt=receipt)
@@ -277,4 +305,6 @@ def test_portal_sync_records_changed_contacts_and_demotion_totals():
     )
     assert (demoted, eligible) == (1, 2)
     assert UUID_B in receipt.changed
+    assert receipt.changed_recorded_inside_boundary
+    assert all(receipt.changed_recorded_inside_boundary)
     assert receipt.demotions == {"demoted": 1, "eligible": 2, "kept": 1}

--- a/tests/test_sync_eom_portal_customers.py
+++ b/tests/test_sync_eom_portal_customers.py
@@ -9,10 +9,13 @@ tested at the seam (env token short-circuits any prompt; failures exit).
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
+
+import pytest
 
 REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "scripts"))
@@ -930,3 +933,76 @@ def test_demotion_dry_run_counts_without_writing():
         demote_unmatched(pool, set(), apply=False, guard_keys=NO_GUARD))
     assert (demoted, eligible) == (1, 1)
     assert pool.updates == []
+
+
+def test_demotion_failure_persists_partial_receipt_before_reraising(monkeypatch):
+    import httpx
+    import atlas_brain.services.crm_provider as crm_provider_mod
+    import atlas_brain.storage.database as database_mod
+    import sync_eom_portal_customers as sync_mod
+
+    class Client:
+        def __init__(self, **_kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+    class Pool(SyncPool):
+        async def initialize(self):
+            return None
+
+        async def fetchrow(self, sql, *args):
+            if "SET status = 'inactive'" in sql and self.updates:
+                raise RuntimeError("second demotion failed")
+            return await super().fetchrow(sql, *args)
+
+    class Receipt:
+        def __init__(self):
+            self.changed = []
+            self.counts = []
+            self.demotions = []
+
+        @contextlib.asynccontextmanager
+        async def mutation_boundary(self):
+            yield
+
+        def record_changed_contact_id(self, contact_id):
+            self.changed.append(str(contact_id))
+
+        def record_outcome_counts(self, counts):
+            self.counts.append(dict(counts))
+
+        def record_demotions(self, **totals):
+            self.demotions.append(dict(totals))
+
+    async def guard_keys():
+        return NO_GUARD
+
+    pool = Pool(demotion_rows=[
+        {"id": "gone", "full_name": "Moved Away", "tags": []},
+        {"id": "also-gone", "full_name": "Also Gone", "tags": []},
+    ])
+    receipt = Receipt()
+    monkeypatch.setattr(httpx, "Client", Client)
+    monkeypatch.setattr(sync_mod, "portal_login", lambda *_args: "token")
+    monkeypatch.setattr(sync_mod, "fetch_portal_customers", lambda *_args: [])
+    monkeypatch.setattr(sync_mod, "fetch_calendar_guard_keys", guard_keys)
+    monkeypatch.setattr(crm_provider_mod, "get_crm_provider", StubCRM)
+    previous_pool = database_mod._db_pool
+    database_mod._db_pool = pool
+    try:
+        with pytest.raises(RuntimeError, match="second demotion failed"):
+            asyncio.run(sync_mod.run(
+                SimpleNamespace(apply=True, base_url="https://example.invalid"),
+                receipt=receipt,
+            ))
+    finally:
+        database_mod._db_pool = previous_pool
+
+    assert receipt.changed == ["gone"]
+    assert receipt.demotions[-1] == {"demoted": 1, "eligible": 2, "kept": 0}
+    assert receipt.counts[-1]["errors"] == 1

--- a/tests/test_sync_eom_portal_customers.py
+++ b/tests/test_sync_eom_portal_customers.py
@@ -555,6 +555,57 @@ def test_apply_entrypoint_aborts_roster_collision_before_sync(monkeypatch):
     assert pool.updates == [] and pool.atomic_writes == []
 
 
+def test_apply_run_persists_calendar_guard_error_counts(monkeypatch):
+    import httpx
+    import atlas_brain.services.crm_provider as crm_provider_mod
+    import atlas_brain.storage.database as database_mod
+    import sync_eom_portal_customers as sync_mod
+
+    class Client:
+        def __init__(self, **_kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+    class Pool(SyncPool):
+        async def initialize(self):
+            return None
+
+    class Receipt:
+        def __init__(self):
+            self.counts = []
+
+        def record_outcome_counts(self, counts):
+            self.counts.append(dict(counts))
+
+    async def unavailable_guard():
+        raise RuntimeError("calendar offline")
+
+    pool = Pool(rows=[])
+    receipt = Receipt()
+    monkeypatch.setattr(httpx, "Client", Client)
+    monkeypatch.setattr(sync_mod, "portal_login", lambda *_args: "token")
+    monkeypatch.setattr(sync_mod, "fetch_portal_customers", lambda *_args: [])
+    monkeypatch.setattr(sync_mod, "fetch_calendar_guard_keys", unavailable_guard)
+    monkeypatch.setattr(crm_provider_mod, "get_crm_provider", StubCRM)
+    previous_pool = database_mod._db_pool
+    database_mod._db_pool = pool
+    try:
+        result = asyncio.run(sync_mod.run(
+            SimpleNamespace(apply=True, base_url="https://example.invalid"),
+            receipt=receipt,
+        ))
+    finally:
+        database_mod._db_pool = previous_pool
+
+    assert result == 1
+    assert receipt.counts[-1]["errors"] == 1
+
+
 def test_boolean_portal_id_is_rejected_before_writes():
     # Codex A2 round 5: bool subclasses int; id=true must not pass.
     crm = StubCRM(scoped_hit={"id": "k", "tags": [], "status": "active"})

--- a/tests/test_sync_eom_portal_customers.py
+++ b/tests/test_sync_eom_portal_customers.py
@@ -525,6 +525,14 @@ def test_apply_entrypoint_aborts_roster_collision_before_sync(monkeypatch):
             return None
 
     pool = Pool(rows=[None, None])
+    class Receipt:
+        def __init__(self):
+            self.counts = []
+
+        def record_outcome_counts(self, counts):
+            self.counts.append(dict(counts))
+
+    receipt = Receipt()
     monkeypatch.setattr(httpx, "Client", Client)
     monkeypatch.setattr(sync_mod, "portal_login", lambda *_args: "token")
     monkeypatch.setattr(
@@ -547,12 +555,13 @@ def test_apply_entrypoint_aborts_roster_collision_before_sync(monkeypatch):
         result = asyncio.run(sync_mod.run(SimpleNamespace(
             apply=True,
             base_url="https://example.invalid",
-        )))
+        ), receipt=receipt))
     finally:
         database_mod._db_pool = previous_pool
     assert result == 1
     assert sync_calls == []
     assert pool.updates == [] and pool.atomic_writes == []
+    assert receipt.counts[-1]["errors"] == 1
 
 
 def test_apply_run_persists_calendar_guard_error_counts(monkeypatch):


### PR DESCRIPTION
Plan: plans/PR-EOM-Execution-Receipts-V2.md
Slice phase: Production hardening
Ownership lane: eom/operational-evidence

Issue #2190 blocks production EOM reconciliation apply/onboarding because the live Calendar import and portal customer sync can mutate the EOM customer master without leaving a private source-bound non-PII receipt. This successor mines the useful receipt idea from frozen PR #2195 without reviving its reviewed-SHA launcher/snapshot scope.

Diff-budget override: issue #2190 is indivisible because one shared receipt primitive, both mutating EOM entrypoints, the operator runbook, and source/privacy/cancellation tests must ship together or either Calendar import or portal sync remains able to run production writes without durable evidence.

## Intentional

- This slice does not keep #2195's reviewed-SHA launcher/snapshot execution model. The issue #2190 root need is private durable source-bound receipts; reviewed-SHA process attestation was the scope-expanding branch of #2195.
- Receipt directories are CLI-provided and documented, not configured through a new env var, so there is no new deployed config to provision.
- Indeterminate cancellation keeps the in-progress receipt instead of forcing a final failure receipt, because the mutation result is unknown at that point.

## AI reconciliation

- Restrict indeterminate handling to cancellation -- fixed-in: scripts/eom_execution_receipt.py and tests/test_eom_execution_receipts.py
- Persist post-loop portal error counts -- fixed-in: scripts/sync_eom_portal_customers.py and tests/test_sync_eom_portal_customers.py
- Reject non-private receipt directories -- fixed-in: scripts/eom_execution_receipt.py and tests/test_eom_execution_receipts.py
- Persist failure counts before finalizing receipts -- fixed-in: scripts/sync_eom_portal_customers.py and tests/test_sync_eom_portal_customers.py
- Attach the in-progress note to the raised exception -- fixed-in: scripts/eom_execution_receipt.py and tests/test_eom_execution_receipts.py
- Record changed IDs inside the mutation boundary -- fixed-in: scripts/import_eom_customers_live.py, scripts/sync_eom_portal_customers.py, and tests/test_eom_execution_receipts.py
- Persist demotion failures before finalizing -- fixed-in: scripts/sync_eom_portal_customers.py and tests/test_sync_eom_portal_customers.py

## Deferred

- Reviewed-SHA launcher/snapshot attestation from #2195 remains deferred unless a future operator run needs tamper-evident reviewed-source execution.
- Receipt retention/rotation remains deferred until real artifact volume exists.

## Parked hardening

- None.

## Cold diff reconstruction

- Gaps: none found in the cold reconstruction. Every changed surface traces to the problem-derived contract, and no declared must-not-change surface moved.
- Changed: `scripts/eom_execution_receipt.py` adds the shared receipt contract: admitted tool/mode and outcome keys, Git SHA + script hash binding, explicit private-directory setup, mode-0600 in-progress persistence, allowlisted count/contact/demotion recorders, mutation-boundary indeterminate marking, atomic non-overwriting final publication, and `run_receipted` finalization behavior (`scripts/eom_execution_receipt.py:18`, `scripts/eom_execution_receipt.py:120`, `scripts/eom_execution_receipt.py:140`, `scripts/eom_execution_receipt.py:166`, `scripts/eom_execution_receipt.py:180`, `scripts/eom_execution_receipt.py:196`, `scripts/eom_execution_receipt.py:209`, `scripts/eom_execution_receipt.py:256`).
- Changed: `scripts/import_eom_customers_live.py` documents the receipt CLI, imports the shared receipt module, wraps existing contact/timeline mutation awaits, records changed contacts and outcome counts, and rejects live writes without `--receipt-dir` before runtime Calendar/database work (`scripts/import_eom_customers_live.py:21`, `scripts/import_eom_customers_live.py:39`, `scripts/import_eom_customers_live.py:539`, `scripts/import_eom_customers_live.py:594`, `scripts/import_eom_customers_live.py:668`, `scripts/import_eom_customers_live.py:709`, `scripts/import_eom_customers_live.py:807`).
- Changed: `scripts/sync_eom_portal_customers.py` documents the receipt CLI, imports the shared receipt module, wraps existing portal/contact/demotion mutation awaits, records changed contacts, counts, and demotion totals, persists partial demotion totals/errors before re-raising a demotion failure, and rejects `--apply` without `--receipt-dir` before login/runtime work (`scripts/sync_eom_portal_customers.py:24`, `scripts/sync_eom_portal_customers.py:42`, `scripts/sync_eom_portal_customers.py:50`, `scripts/sync_eom_portal_customers.py:506`, `scripts/sync_eom_portal_customers.py:677`, `scripts/sync_eom_portal_customers.py:699`, `scripts/sync_eom_portal_customers.py:831`).
- Changed: `docs/EOM_RECONCILIATION_RECEIPTS.md` documents the local private receipt directory, write/apply invocations, dry-run behavior, and the non-PII payload boundary (`docs/EOM_RECONCILIATION_RECEIPTS.md:6`, `docs/EOM_RECONCILIATION_RECEIPTS.md:13`, `docs/EOM_RECONCILIATION_RECEIPTS.md:24`, `docs/EOM_RECONCILIATION_RECEIPTS.md:26`).
- Changed: `tests/test_eom_execution_receipts.py` proves private source-bound payloads, non-overwrite finalization, indeterminate cancellation, pre-runtime CLI admission, and script-level changed-contact/demotion recording through existing stubs (`tests/test_eom_execution_receipts.py:36`, `tests/test_eom_execution_receipts.py:78`, `tests/test_eom_execution_receipts.py:101`, `tests/test_eom_execution_receipts.py:122`, `tests/test_eom_execution_receipts.py:131`, `tests/test_eom_execution_receipts.py:177`, `tests/test_eom_execution_receipts.py:200`).
- Changed: `tests/test_sync_eom_portal_customers.py` proves a second demotion write failure records the first changed contact, partial demotion totals, and an error count before re-raising (`tests/test_sync_eom_portal_customers.py:938`, `tests/test_sync_eom_portal_customers.py:954`, `tests/test_sync_eom_portal_customers.py:998`, `tests/test_sync_eom_portal_customers.py:1006`).
- Contract match: the shared primitive satisfies the source-bound/private/atomic/indeterminate receipt contract; the two operator scripts satisfy the issue #2190 "both tools" admission and mutation-recording contract; the doc satisfies the operator default requirement; the tests cover the listed review contract criteria.
- Nothing outside scope moved: CRM matching, Calendar parsing/deduplication, portal roster resolution, demotion eligibility/veto rules, credential acquisition, schemas, APIs, Render config, funnel/customer onboarding, billing/receivables, website UI, and the stale #2195 branch are untouched.

## Verification

- `python -m py_compile scripts/eom_execution_receipt.py scripts/import_eom_customers_live.py scripts/sync_eom_portal_customers.py tests/test_eom_execution_receipts.py tests/test_sync_eom_portal_customers.py` — passed.
- `python -m pytest tests/test_eom_execution_receipts.py tests/test_eom_live_calendar_import.py tests/test_sync_eom_portal_customers.py -q` — 118 passed.
- `python -m ruff check scripts/eom_execution_receipt.py scripts/import_eom_customers_live.py scripts/sync_eom_portal_customers.py tests/test_eom_execution_receipts.py tests/test_sync_eom_portal_customers.py` — passed.
- `python scripts/maturity_sweep.py scripts --tests-root tests --baseline tests/maturity_sweep/baseline_scripts.json --min-score 8 --sensitive-glob '**/*' --top 25` — passed.
- `python scripts/audit_plan_doc.py plans/PR-EOM-Execution-Receipts-V2.md` — passed.
- `python scripts/audit_plan_doc_files_touched.py plans/PR-EOM-Execution-Receipts-V2.md origin/main` — passed.
- `python scripts/audit_plan_doc_diff_size.py plans/PR-EOM-Execution-Receipts-V2.md origin/main` — passed.
- `python scripts/audit_review_rules_triggered.py origin/main --plan plans/PR-EOM-Execution-Receipts-V2.md` — passed.
- `python scripts/check_diff_budget.py --additions 1122 --body-file plans/PR-EOM-Execution-Receipts-V2.md` — passed with explicit override.

## Mechanical verification

- Command: python -m py_compile scripts/eom_execution_receipt.py scripts/import_eom_customers_live.py scripts/sync_eom_portal_customers.py tests/test_eom_execution_receipts.py tests/test_sync_eom_portal_customers.py - Result: passed - Environment: local
- Command: python -m pytest tests/test_eom_execution_receipts.py tests/test_eom_live_calendar_import.py tests/test_sync_eom_portal_customers.py -q - Result: 118 passed - Environment: local
- Command: python -m ruff check scripts/eom_execution_receipt.py scripts/import_eom_customers_live.py scripts/sync_eom_portal_customers.py tests/test_eom_execution_receipts.py tests/test_sync_eom_portal_customers.py - Result: passed - Environment: local
- Command: python scripts/maturity_sweep.py scripts --tests-root tests --baseline tests/maturity_sweep/baseline_scripts.json --min-score 8 --sensitive-glob '**/*' --top 25 - Result: passed - Environment: local
- Command: python scripts/audit_plan_doc.py plans/PR-EOM-Execution-Receipts-V2.md - Result: passed - Environment: local
- Command: python scripts/audit_plan_doc_files_touched.py plans/PR-EOM-Execution-Receipts-V2.md origin/main - Result: passed - Environment: local
- Command: python scripts/audit_plan_doc_diff_size.py plans/PR-EOM-Execution-Receipts-V2.md origin/main - Result: passed - Environment: local
- Command: python scripts/audit_review_rules_triggered.py origin/main --plan plans/PR-EOM-Execution-Receipts-V2.md - Result: passed - Environment: local
- Command: python scripts/check_diff_budget.py --additions 1122 --body-file plans/PR-EOM-Execution-Receipts-V2.md - Result: passed - Environment: local

## Diff size

7 files, +1232 / -121.
