### PR TITLE
Add EOM onboarding email approval queue

### DIFF
--- a/atlas_brain/eom_api/funnel.py
+++ b/atlas_brain/eom_api/funnel.py
@@ -20,6 +20,11 @@ from ..services.eom_estimate_booking import (
     schedule_eom_estimate_booking,
     schedule_eom_first_clean_booking,
 )
+from ..services.eom_onboarding_email import (
+    EOMOnboardingEmailApproval,
+    EOMOnboardingEmailError,
+    approve_and_send_eom_onboarding_email,
+)
 from ..services.eom_lead_conversion import (
     EOMCustomerHandoff,
     EOMLeadConversionError,
@@ -42,6 +47,7 @@ _RFC3339_DATETIME_PATTERN = re.compile(
 _MAX_SIGNED_BIGINT = 2**63 - 1
 _DEFAULT_LEAD_REVIEW_LIMIT = 100
 _MAX_LEAD_REVIEW_LIMIT = 200
+_ONBOARDING_EMAIL_DRAFT_STATUS_FILTERS = {"pending", "sending", "sent", "revoked", "all"}
 
 
 class EOMCustomerHandoffRequest(BaseModel):
@@ -119,6 +125,51 @@ class EOMLeadReviewResponse(BaseModel):
     )
 
 
+class EOMOnboardingEmailDraftItem(BaseModel):
+    """Office-review projection for one queued onboarding email draft."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    draft_id: UUID = Field(serialization_alias="draftId")
+    contact_id: UUID = Field(serialization_alias="contactId")
+    full_name: str = Field(serialization_alias="fullName")
+    lead_stage: str = Field(serialization_alias="leadStage")
+    status: str
+    recipient_email: str | None = Field(default=None, serialization_alias="recipientEmail")
+    blocker: str | None = None
+    subject: str
+    body: str
+    created_at: datetime = Field(serialization_alias="createdAt")
+    claimed_at: datetime | None = Field(default=None, serialization_alias="claimedAt")
+    sent_at: datetime | None = Field(default=None, serialization_alias="sentAt")
+    approved_by_name: str | None = Field(
+        default=None, serialization_alias="approvedByName"
+    )
+
+
+class EOMOnboardingEmailDraftResponse(BaseModel):
+    """Closed response envelope for onboarding-email approval drafts."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    drafts: list[EOMOnboardingEmailDraftItem]
+    limit: Annotated[int, Field(ge=1, le=_MAX_LEAD_REVIEW_LIMIT)]
+    status: str | None = None
+
+
+class EOMOnboardingEmailApprovalResponse(BaseModel):
+    """Result of an office-approved onboarding email send."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    success: bool = True
+    draft_id: UUID = Field(serialization_alias="draftId")
+    contact_id: UUID = Field(serialization_alias="contactId")
+    status: str
+    lead_stage: str | None = Field(default=None, serialization_alias="leadStage")
+    idempotent: bool
+
+
 def _crm_dependency(request: Request) -> Any:
     provider_factory = getattr(request.app.state, "eom_funnel_crm_provider", None)
     if callable(provider_factory):
@@ -130,6 +181,12 @@ def _calendar_dependency() -> Any:
     from ..tools.calendar import calendar_tool
 
     return calendar_tool
+
+
+def _email_dependency() -> Any:
+    from ..services.email_provider import get_email_provider
+
+    return get_email_provider()
 
 
 def _encode_lead_review_cursor(*, created_at: datetime, contact_id: UUID) -> str:
@@ -218,6 +275,67 @@ async def list_eom_lead_review_items(
         cursor=cursor,
         has_more=has_more,
         next_cursor=next_cursor,
+    )
+
+
+@router.get(
+    "/onboarding-email-drafts",
+    response_model=EOMOnboardingEmailDraftResponse,
+    dependencies=[Depends(require_eom_funnel_api)],
+)
+async def list_eom_onboarding_email_drafts(
+    limit: Annotated[
+        int,
+        Query(ge=1, le=_MAX_LEAD_REVIEW_LIMIT),
+    ] = _DEFAULT_LEAD_REVIEW_LIMIT,
+    draft_status: Annotated[
+        str | None,
+        Query(alias="status", min_length=3, max_length=16),
+    ] = "pending",
+    _actor: dict[str, object] = Depends(require_eom_funnel_actor),
+    crm: Any = Depends(_crm_dependency),
+) -> EOMOnboardingEmailDraftResponse:
+    """List onboarding email drafts waiting for office approval or review."""
+    if draft_status not in _ONBOARDING_EMAIL_DRAFT_STATUS_FILTERS:
+        raise HTTPException(status_code=422, detail="Invalid onboarding draft status")
+    status_filter = None if draft_status in {None, "all"} else draft_status
+    lister = getattr(crm, "list_eom_onboarding_email_drafts", None)
+    if not callable(lister):
+        raise RuntimeError("Configured CRM provider cannot list EOM onboarding drafts")
+    rows = await lister(status=status_filter, limit=limit)
+    return EOMOnboardingEmailDraftResponse(
+        drafts=[EOMOnboardingEmailDraftItem.model_validate(row) for row in rows],
+        limit=limit,
+        status=status_filter,
+    )
+
+
+@router.post(
+    "/onboarding-email-drafts/{draft_id}/approve-and-send",
+    response_model=EOMOnboardingEmailApprovalResponse,
+    dependencies=[Depends(require_eom_funnel_api)],
+)
+async def approve_eom_onboarding_email_draft(
+    draft_id: UUID,
+    actor: dict[str, object] = Depends(require_eom_funnel_actor),
+    crm: Any = Depends(_crm_dependency),
+    email_provider: Any = Depends(_email_dependency),
+) -> EOMOnboardingEmailApprovalResponse:
+    """Approve and send one queued onboarding email draft."""
+    try:
+        result = await approve_and_send_eom_onboarding_email(
+            crm,
+            email_provider,
+            EOMOnboardingEmailApproval(
+                draft_id=str(draft_id),
+                actor_id=int(actor["id"]),
+                actor_name=str(actor["name"]),
+            ),
+        )
+    except EOMOnboardingEmailError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
+    return EOMOnboardingEmailApprovalResponse.model_validate(
+        {"success": True, **result}
     )
 
 

--- a/atlas_brain/services/crm_provider.py
+++ b/atlas_brain/services/crm_provider.py
@@ -566,7 +566,7 @@ class DatabaseCRMProvider:
                     )
                 if channel == "phone":
                     return await conn.fetchrow(
-                        f"""
+                        """
                         SELECT * FROM contacts
                         WHERE business_context_id = $1
                           AND status != 'archived'
@@ -580,7 +580,7 @@ class DatabaseCRMProvider:
                         value,
                     )
                 return await conn.fetchrow(
-                    f"""
+                    """
                     SELECT * FROM contacts
                     WHERE business_context_id = $1
                       AND status != 'archived'
@@ -1296,7 +1296,7 @@ class DatabaseCRMProvider:
             WHERE c.business_context_id = 'effingham_maids'
               AND c.status = 'active'
               AND c.contact_type = 'lead'
-              AND c.lead_stage IN ('new', 'estimate_booked', 'won')
+              AND c.lead_stage IN ('new', 'estimate_booked', 'won', 'onboarding_sent')
               {cursor_clause}
             ORDER BY c.created_at DESC, c.id DESC
             LIMIT $1
@@ -1304,6 +1304,205 @@ class DatabaseCRMProvider:
             *params,
         )
         return [dict(row) for row in rows]
+
+    async def list_eom_onboarding_email_drafts(
+        self, *, status: str | None = "pending", limit: int = 100
+    ) -> list[dict[str, Any]]:
+        """List EOM onboarding email drafts for the office approval queue."""
+        status_clause = ""
+        params: list[Any] = [limit]
+        if status is not None:
+            status_clause = "AND d.status = $2"
+            params.append(status)
+        pool = self._get_pool()
+        rows = await pool.fetch(
+            f"""
+            SELECT
+                d.id AS draft_id,
+                d.contact_id,
+                c.full_name,
+                c.lead_stage,
+                d.status,
+                d.recipient_email,
+                d.blocker,
+                d.subject,
+                d.body,
+                d.created_at,
+                d.claimed_at,
+                d.sent_at,
+                d.approved_by_name
+            FROM eom_onboarding_email_drafts AS d
+            JOIN contacts AS c ON c.id = d.contact_id
+            WHERE c.business_context_id = 'effingham_maids'
+              AND c.contact_type = 'lead'
+              {status_clause}
+            ORDER BY d.created_at DESC, d.id DESC
+            LIMIT $1
+            """,
+            *params,
+        )
+        return [dict(row) for row in rows]
+
+    async def get_eom_onboarding_email_draft(
+        self, *, draft_id: str
+    ) -> dict[str, Any] | None:
+        """Return one onboarding email draft with its EOM lead projection."""
+        pool = self._get_pool()
+        row = await pool.fetchrow(
+            """
+            SELECT
+                d.id AS draft_id,
+                d.id,
+                d.contact_id,
+                c.full_name,
+                c.lead_stage,
+                d.status,
+                d.recipient_email,
+                d.blocker,
+                d.subject,
+                d.body,
+                d.created_at,
+                d.claimed_at,
+                d.sent_at,
+                d.approved_by_name
+            FROM eom_onboarding_email_drafts AS d
+            JOIN contacts AS c ON c.id = d.contact_id
+            WHERE d.id = $1::uuid
+              AND c.business_context_id = 'effingham_maids'
+              AND c.contact_type = 'lead'
+            """,
+            draft_id,
+        )
+        return dict(row) if row else None
+
+    async def claim_eom_onboarding_email_draft(
+        self, *, draft_id: str, actor_id: int, actor_name: str
+    ) -> dict[str, Any] | None:
+        """Atomically claim exactly one pending, sendable onboarding draft."""
+        pool = self._get_pool()
+        row = await pool.fetchrow(
+            """
+            WITH sendable AS (
+                SELECT
+                    d.id AS draft_id,
+                    d.contact_id,
+                    c.full_name,
+                    c.lead_stage,
+                    BTRIM(d.recipient_email) AS recipient_email,
+                    d.subject,
+                    d.body,
+                    d.operation_key
+                FROM eom_onboarding_email_drafts AS d
+                JOIN contacts AS c ON c.id = d.contact_id
+                WHERE d.id = $1::uuid
+                  AND d.status = 'pending'
+                  AND d.blocker IS NULL
+                  AND NULLIF(BTRIM(d.recipient_email), '') IS NOT NULL
+                  AND c.business_context_id = 'effingham_maids'
+                  AND c.contact_type = 'lead'
+                  AND c.status = 'active'
+                  AND c.lead_stage = 'won'
+                FOR UPDATE OF d, c
+            ),
+            claimed AS (
+                UPDATE eom_onboarding_email_drafts AS d
+                   SET status = 'sending',
+                       claimed_at = NOW(),
+                       approved_by_employee_id = $2,
+                       approved_by_name = $3
+                  FROM sendable
+                 WHERE d.id = sendable.draft_id
+                 RETURNING d.id AS draft_id, d.contact_id, d.status
+            )
+            SELECT
+                claimed.draft_id,
+                claimed.contact_id,
+                sendable.full_name,
+                sendable.lead_stage,
+                claimed.status,
+                sendable.recipient_email,
+                sendable.subject,
+                sendable.body,
+                sendable.operation_key
+            FROM claimed
+            JOIN sendable ON sendable.draft_id = claimed.draft_id
+            """,
+            draft_id,
+            actor_id,
+            actor_name,
+        )
+        return dict(row) if row else None
+
+    async def confirm_eom_onboarding_email_sent(
+        self, *, draft_id: str, actor_id: int, actor_name: str
+    ) -> dict[str, Any] | None:
+        """Confirm delivery after transport acceptance and advance the lead."""
+        from .eom_lead_ingress import EOM_BUSINESS_CONTEXT_ID
+
+        pool = self._get_pool()
+        async with _transaction_connection(pool) as conn:
+            row = await conn.fetchrow(
+                """
+                WITH draft AS (
+                    SELECT id, contact_id, operation_key
+                    FROM eom_onboarding_email_drafts
+                    WHERE id = $1::uuid AND status = 'sending'
+                    FOR UPDATE
+                ),
+                updated_contact AS (
+                    UPDATE contacts AS c
+                       SET lead_stage = 'onboarding_sent', updated_at = NOW()
+                      FROM draft
+                     WHERE c.id = draft.contact_id
+                       AND c.business_context_id = $2
+                       AND c.contact_type = 'lead'
+                       AND c.status = 'active'
+                       AND c.lead_stage = 'won'
+                     RETURNING c.id, 'won'::text AS from_stage, c.lead_stage
+                ),
+                sent_draft AS (
+                    UPDATE eom_onboarding_email_drafts AS d
+                       SET status = 'sent', sent_at = NOW()
+                      FROM updated_contact
+                     WHERE d.id = $1::uuid AND d.status = 'sending'
+                     RETURNING d.id AS draft_id, d.contact_id, d.operation_key, d.status
+                )
+                SELECT
+                    sent_draft.draft_id,
+                    sent_draft.contact_id,
+                    sent_draft.operation_key,
+                    sent_draft.status,
+                    updated_contact.from_stage,
+                    updated_contact.lead_stage
+                FROM sent_draft
+                JOIN updated_contact ON updated_contact.id = sent_draft.contact_id
+                """,
+                draft_id,
+                EOM_BUSINESS_CONTEXT_ID,
+            )
+            if row is None:
+                return None
+            await conn.execute(
+                """
+                INSERT INTO eom_lead_lifecycle_events (
+                    contact_id, event_type, from_stage, to_stage, actor,
+                    source, operation_key, metadata
+                )
+                VALUES ($1, 'onboarding_email_sent', $6, $7, $2, 'eom_office',
+                        $3, jsonb_build_object(
+                            'draft_id', $4::uuid,
+                            'approved_by_employee_id', $5::bigint
+                        ))
+                """,
+                row["contact_id"],
+                f"employee:{actor_id}:{actor_name}",
+                row["operation_key"],
+                row["draft_id"],
+                actor_id,
+                row["from_stage"],
+                row["lead_stage"],
+            )
+            return dict(row)
 
     @staticmethod
     def _eom_estimate_booking_metadata(
@@ -2180,8 +2379,6 @@ class DatabaseCRMProvider:
             )
             request_for_key = None
             booked_for_key = None
-            failed_for_key = None
-            ambiguous_for_key = None
             for event in events:
                 if event["operation_key"] != booking_key:
                     continue
@@ -2189,10 +2386,6 @@ class DatabaseCRMProvider:
                     request_for_key = event
                 elif event["event_type"] == family.booked_event:
                     booked_for_key = event
-                elif event["event_type"] == family.failed_event:
-                    failed_for_key = event
-                elif event["event_type"] == family.ambiguous_event:
-                    ambiguous_for_key = event
             if (
                 request_for_key is None
                 or not self._eom_estimate_booking_payload_matches(
@@ -2962,6 +3155,21 @@ class DatabaseCRMProvider:
                     409,
                     "Tracker Customer or Site already belongs to an EOM customer handoff",
                 )
+            sending_onboarding_draft = await conn.fetchrow(
+                """
+                SELECT id
+                FROM eom_onboarding_email_drafts
+                WHERE contact_id = $1
+                  AND status = 'sending'
+                LIMIT 1
+                """,
+                contact_id,
+            )
+            if sending_onboarding_draft is not None:
+                raise EOMLeadConversionError(
+                    409,
+                    "EOM onboarding email send is still confirming; retry after it settles",
+                )
             booking_events = await conn.fetch(
                 """
                 SELECT event_type, operation_key
@@ -3032,7 +3240,12 @@ class DatabaseCRMProvider:
                 )
             if contact["contact_type"] != "lead":
                 raise EOMLeadConversionError(409, "EOM contact is not a lead")
-            if contact["lead_stage"] not in ("new", "estimate_booked", "won"):
+            if contact["lead_stage"] not in (
+                "new",
+                "estimate_booked",
+                "won",
+                "onboarding_sent",
+            ):
                 raise EOMLeadConversionError(409, "EOM lead is not ready for approval")
             from_stage = str(contact["lead_stage"])
 

--- a/atlas_brain/services/email_provider.py
+++ b/atlas_brain/services/email_provider.py
@@ -537,6 +537,7 @@ class GmailEmailProvider:
         thread_id: Optional[str] = None,
         in_reply_to: Optional[str] = None,
         references: Optional[str] = None,
+        headers: Optional[dict[str, str]] = None,
     ) -> dict[str, Any]:
         from ..tools.gmail import get_gmail_transport
 
@@ -553,6 +554,7 @@ class GmailEmailProvider:
             thread_id=thread_id,
             in_reply_to=in_reply_to,
             references=references,
+            headers=headers,
         )
 
     # -----------------------------------------------------------------------
@@ -771,6 +773,8 @@ class ResendEmailProvider:
             params["reply_to"] = reply_to
         if attachments:
             params["attachments"] = attachments
+        if _kwargs.get("headers"):
+            params["headers"] = _kwargs["headers"]
 
         result = await email_tool.execute(params)
         if result.success:

--- a/atlas_brain/services/eom_onboarding_email.py
+++ b/atlas_brain/services/eom_onboarding_email.py
@@ -1,0 +1,98 @@
+"""Office-approved EOM onboarding email delivery."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+class EOMOnboardingEmailError(Exception):
+    """HTTP-mappable failure for onboarding email approval."""
+
+    def __init__(self, status_code: int, message: str):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+@dataclass(frozen=True)
+class EOMOnboardingEmailApproval:
+    draft_id: str
+    actor_id: int
+    actor_name: str
+
+
+def _blocked_message(draft: dict[str, Any] | None) -> tuple[int, str]:
+    if draft is None:
+        return 404, "EOM onboarding email draft not found"
+    status = str(draft.get("status") or "")
+    if status == "sent":
+        return 200, "EOM onboarding email already sent"
+    if status == "sending":
+        return 409, "EOM onboarding email send is already in progress"
+    if status == "revoked":
+        return 409, "EOM onboarding email draft is revoked"
+    blocker = str(draft.get("blocker") or "").strip()
+    if blocker:
+        return 409, f"EOM onboarding email draft is blocked: {blocker}"
+    if not str(draft.get("recipient_email") or "").strip():
+        return 409, "EOM onboarding email draft has no recipient"
+    return 409, "EOM onboarding email draft is not claimable"
+
+
+async def approve_and_send_eom_onboarding_email(
+    crm: Any,
+    email_provider: Any,
+    approval: EOMOnboardingEmailApproval,
+) -> dict[str, Any]:
+    """Claim one pending onboarding email draft, send it, then confirm delivery."""
+    claimer = getattr(crm, "claim_eom_onboarding_email_draft", None)
+    confirmer = getattr(crm, "confirm_eom_onboarding_email_sent", None)
+    getter = getattr(crm, "get_eom_onboarding_email_draft", None)
+    sender = getattr(email_provider, "send", None)
+    if not callable(claimer) or not callable(confirmer) or not callable(getter):
+        raise RuntimeError("Configured CRM provider cannot approve EOM onboarding emails")
+    if not callable(sender):
+        raise RuntimeError("Configured email provider cannot send EOM onboarding emails")
+
+    claimed = await claimer(
+        draft_id=approval.draft_id,
+        actor_id=approval.actor_id,
+        actor_name=approval.actor_name,
+    )
+    if claimed is None:
+        draft = await getter(draft_id=approval.draft_id)
+        status_code, message = _blocked_message(draft)
+        if status_code == 200:
+            return {
+                "draft_id": approval.draft_id,
+                "contact_id": str(draft.get("contact_id") or ""),
+                "status": "sent",
+                "idempotent": True,
+            }
+        raise EOMOnboardingEmailError(status_code, message)
+
+    await sender(
+        to=[str(claimed["recipient_email"])],
+        subject=str(claimed["subject"]),
+        body=str(claimed["body"]),
+        headers={
+            "X-Atlas-EOM-Onboarding-Draft-ID": str(claimed["draft_id"]),
+        },
+    )
+    confirmed = await confirmer(
+        draft_id=approval.draft_id,
+        actor_id=approval.actor_id,
+        actor_name=approval.actor_name,
+    )
+    if confirmed is None:
+        raise EOMOnboardingEmailError(
+            409,
+            "EOM onboarding email was accepted by transport but could not be confirmed",
+        )
+    return {
+        "draft_id": str(confirmed["draft_id"]),
+        "contact_id": str(confirmed["contact_id"]),
+        "status": str(confirmed["status"]),
+        "lead_stage": str(confirmed["lead_stage"]),
+        "idempotent": False,
+    }

--- a/atlas_brain/storage/migrations/361_eom_lead_review_queue_onboarding_sent_stage.sql
+++ b/atlas_brain/storage/migrations/361_eom_lead_review_queue_onboarding_sent_stage.sql
@@ -1,0 +1,23 @@
+-- Keep the EOM lead review queue indexed after the onboarding email is sent.
+--
+-- A lead in onboarding_sent has received Juan-approved onboarding email but is
+-- still not a Customer/Site handoff. The review queue and later onboarding
+-- completion slice must be able to see it.
+--
+-- Rollback evidence:
+--   If application code is rolled back before it knows about onboarding_sent,
+--   restore the prior predicate by recreating this index with:
+--     lead_stage IN ('new', 'estimate_booked', 'won')
+--   Do not rewrite persisted onboarding_sent contacts during a database-only
+--   rollback; instead roll the application forward to a build that admits and
+--   reconciles onboarding_sent, or manually review those leads before applying
+--   the prior predicate so they are not hidden from the office queue.
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_contacts_eom_lead_review_queue;
+
+CREATE INDEX CONCURRENTLY idx_contacts_eom_lead_review_queue
+    ON contacts (created_at DESC, id DESC)
+    WHERE business_context_id = 'effingham_maids'
+      AND status = 'active'
+      AND contact_type = 'lead'
+      AND lead_stage IN ('new', 'estimate_booked', 'won', 'onboarding_sent');

--- a/atlas_brain/tools/email.py
+++ b/atlas_brain/tools/email.py
@@ -326,6 +326,8 @@ class EmailTool:
             payload["bcc"] = [e.strip() for e in params["bcc"].split(",")]
         if params.get("reply_to"):
             payload["reply_to"] = params["reply_to"]
+        if params.get("headers"):
+            payload["headers"] = params["headers"]
         if loaded_attachments:
             payload["attachments"] = loaded_attachments
 
@@ -353,7 +355,7 @@ class EmailTool:
                 error="API_ERROR",
                 message=f"Failed to send email: {e.response.status_code}",
             )
-        except Exception as e:
+        except Exception:
             logger.exception("Email tool error")
             return ToolResult(
                 success=False,
@@ -420,6 +422,7 @@ class EmailTool:
                 reply_to=params.get("reply_to"),
                 attachments=attachments or None,
                 html=params.get("html"),
+                headers=params.get("headers"),
             )
 
             response_data = {

--- a/atlas_brain/tools/gmail.py
+++ b/atlas_brain/tools/gmail.py
@@ -96,6 +96,7 @@ class GmailTransport:
         thread_id: str | None = None,
         in_reply_to: str | None = None,
         references: str | None = None,
+        headers: dict[str, str] | None = None,
     ) -> dict[str, Any]:
         """
         Send an email via Gmail API.
@@ -113,6 +114,7 @@ class GmailTransport:
             thread_id: Gmail thread ID for threading replies.
             in_reply_to: Message-ID of the email being replied to.
             references: Message-ID references for threading.
+            headers: Additional RFC 822 headers for provider-log correlation.
 
         Returns:
             Dict with "id" (Gmail message ID) and "threadId".
@@ -144,6 +146,15 @@ class GmailTransport:
             msg["In-Reply-To"] = in_reply_to
         if references:
             msg["References"] = references
+        if headers:
+            for header_name, header_value in headers.items():
+                name = str(header_name).strip()
+                value = str(header_value).strip()
+                if not name or "\r" in name or "\n" in name:
+                    raise ValueError("Invalid email header name")
+                if "\r" in value or "\n" in value:
+                    raise ValueError("Invalid email header value")
+                msg[name] = value
 
         # Add attachments
         if attachments:

--- a/plans/PR-EOM-Onboarding-Approval-Queue.md
+++ b/plans/PR-EOM-Onboarding-Approval-Queue.md
@@ -1,0 +1,211 @@
+# PR-EOM-Onboarding-Approval-Queue
+
+## Why this slice exists
+
+Arc #2275 names A3 as the next Atlas funnel slice after A2 merged:
+onboarding-email drafts are now enqueued when the office books the first clean,
+but they still have no real approval/send operation. That leaves Juan with no
+code-owned way to approve the queued welcome email and no durable state proving
+that exactly one send happened after approval.
+
+Diff-budget override: this A3 slice is intentionally over the 400 LOC soft cap
+because the smallest safe vertical proof has to ship the private route, approval
+service state machine, CRM-provider SQL, email transport trace header, handoff
+race fence, index predicate parity, render-profile route reachability, and
+behavioral tests together. Splitting the endpoint away from the
+claim/send/confirm proof would expose a callable approval surface
+without the single-send or lead-stage evidence the slice exists to provide.
+
+### Problem-derived contract
+
+- Root cause: A2 created the source-of-truth draft queue, but stopped before
+  the approval surface. The existing `eom_onboarding_email_drafts` table can
+  represent `pending -> sending -> sent`, but no Atlas endpoint/service/provider
+  currently lists those drafts for the office, atomically claims one draft, sends
+  it through the existing email transport, or confirms delivery after the
+  transport accepts. Without that code path, the funnel cannot move from `won`
+  to an approved/sent onboarding-email state without a manual or duplicate-prone
+  side channel.
+- Correct fix must touch/change: Add a narrow Atlas EOM funnel approval API over
+  the existing private `/api/v1/eom-funnel` surface; add a service function that
+  claims one pending/unblocked draft with the migration-360 predicate, sends
+  outside the claim transaction via the existing email provider with draft-id
+  provider-log evidence, and confirms `sent` only after transport acceptance;
+  add CRM-provider methods for listing drafts, claiming drafts, and confirming
+  sent while moving the lead from `won` to `onboarding_sent` with lifecycle
+  evidence; fence customer handoff while an onboarding draft is `sending`; add
+  tests for list shape, blocked/blank-recipient refusal, duplicate-approval
+  single-send behavior, send-failure non-delivery, handoff fencing, and endpoint
+  reachability.
+- Must not change: Do not create Customer/Site records, tracker handoffs,
+  tokenized onboarding links/pages, Stripe/card-on-file behavior, Calendar
+  booking behavior, estimate/first-clean booking admission rules, email template
+  wording, lead intake, Render config, or receivables/invoicing behavior. Do not
+  auto-send at first-clean booking time; Juan approval remains the only send
+  trigger in this slice.
+
+## Scope (this PR)
+
+Ownership lane: eom/funnel-go-live
+Slice phase: Vertical slice
+
+1. Add office-only EOM funnel endpoints for listing onboarding-email drafts and
+   approving/sending one draft.
+2. Add the provider/service state machine that enforces exactly-one claim,
+   sends through the existing email provider, and confirms sent only after
+   transport acceptance.
+3. Add behavioral tests over provider/service/API seams plus the existing A2
+   enqueue integration path.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] `GET /api/v1/eom-funnel/onboarding-email-drafts` returns the office
+        projection for pending/sending/blocked/sent onboarding drafts without
+        exposing credentials or private runtime URLs; settled by API model tests
+        and provider list tests.
+  - [ ] `POST /api/v1/eom-funnel/onboarding-email-drafts/{draft_id}/approve-and-send`
+        rejects blocked/no-recipient/non-pending drafts before calling email
+        transport; settled by service/provider tests that assert zero sends.
+  - [ ] The approval execution model is claim-first: provider claim uses a
+        row-locked sendable CTE whose predicate requires `status = 'pending'`,
+        `blocker IS NULL`, and a nonblank `recipient_email`, so every admitted
+        interleaving has at most one caller receive sendable content; settled by
+        provider SQL inspection and duplicate/blank-recipient tests.
+  - [ ] The service calls `email_provider.send(...)` outside the claim update and
+        passes the draft id in transport-supported message headers, then
+        confirms `sent` only after the send call returns; settled by service
+        tests for success and raised send failure.
+  - [ ] Confirming sent moves the lead from `won` to `onboarding_sent` and
+        appends lifecycle evidence; settled by provider/integration tests.
+  - [ ] Customer handoff rejects a lead while any onboarding email draft for the
+        contact is `sending`; settled by provider handoff tests.
+  - [ ] Existing estimate and first-clean booking behavior stays unchanged;
+        settled by the existing EOM lead conversion tests in local verification.
+- Reachability proof: Real FastAPI routes under `/api/v1/eom-funnel` exercised
+  through the route handler/test client with the CRM provider and email provider
+  faked at the adapter boundary, asserting response state and persisted provider
+  side effects.
+- Affected surfaces: `atlas_brain/eom_api/funnel.py`, CRM provider EOM draft
+  methods, new EOM onboarding approval service, existing email provider adapter
+  and transport header passthrough, EOM lead conversion tests.
+- Risk areas: duplicate send, send/confirm ordering, blocked recipient handling,
+  lead-stage regression, API/auth contract, backcompat for A1/A2 bookings.
+- Reviewer rules triggered: R1, R2, R3, R4, R5, R6, R8, R10, R12, R14.
+
+### Boundary-change enumeration
+
+Required when this diff changes a guard, validator, normalizer, resolver,
+router/classifier, or admission boundary. Name each changed boundary path or
+seam in the enumeration; otherwise write "N/A - no boundary change."
+
+- Boundary path/seam: Private EOM funnel API gains onboarding draft list and
+  approve/send endpoints; provider claim predicate admits only pending,
+  unblocked, nonblank-recipient draft rows while row-locking the draft/contact
+  decision; customer handoff rejects contacts with an in-flight `sending`
+  onboarding draft.
+- Replaced-path behaviors: N/A - A3 adds the first approval/send path; it does
+  not replace an existing endpoint.
+- Guard-relevant fields: draft `status`, `blocker`, `recipient_email`,
+  `contact_id`, actor id/name, and draft UUID path parameter.
+- Caller x input shape: Tracker/office service bearer plus actor header calls
+  list or approves a single draft UUID; no browser-direct token or public
+  endpoint is introduced.
+
+### Deployed-config probing
+
+Required for guard, validator, resolver, admission-boundary, or env/config
+fallback changes; otherwise write "N/A - no guard/config boundary change."
+
+- Deployed/default config values: No new config. Existing EOM funnel
+  `api_enabled` and service token gates continue to protect the route.
+- Explicit value probe: Existing funnel auth tests cover the enabled/token path;
+  this slice adds route-level dependency tests through the same private router
+  seam.
+- Absent value probe: Existing funnel disabled/token-missing startup behavior is
+  unchanged.
+- Default-session/default-context probe: N/A - no default tenant or fallback
+  context is added.
+- Side-effect ordering: Claim draft first; send email second with draft-id
+  transport evidence; confirm sent and advance lead stage only after transport
+  acceptance. Customer handoff is fenced while the draft is `sending`.
+
+### Files touched
+
+- `atlas_brain/eom_api/funnel.py`
+- `atlas_brain/services/crm_provider.py`
+- `atlas_brain/services/email_provider.py`
+- `atlas_brain/services/eom_onboarding_email.py`
+- `atlas_brain/storage/migrations/361_eom_lead_review_queue_onboarding_sent_stage.sql`
+- `atlas_brain/tools/email.py`
+- `atlas_brain/tools/gmail.py`
+- `plans/PR-EOM-Onboarding-Approval-Queue.md`
+- `tests/test_eom_lead_conversion.py`
+- `tests/test_eom_render_profile.py`
+- `tests/test_migrations_runner.py`
+
+## Mechanism
+
+The service asks the CRM provider to claim a draft. Claiming is a row-locked
+sendable CTE plus `UPDATE` whose predicate requires `status='pending'`,
+`blocker IS NULL`, a nonblank recipient, an active EOM lead, and
+`lead_stage='won'`, so only one approver receives sendable
+subject/body/recipient content. The service then calls the existing email
+provider with the snapshot subject/body and an
+`X-Atlas-EOM-Onboarding-Draft-ID` header for provider-log reconciliation. Only
+after that call returns does it ask the provider to confirm the draft as `sent`,
+set `sent_at`, move the contact from `won` to `onboarding_sent`, and append an
+EOM lifecycle event. A send exception bubbles to the API and leaves the row in
+`sending`, which is the migration-360 recovery state for operator
+reconciliation. The customer handoff path rejects a contact while any
+onboarding draft for that contact is still `sending`, so a handoff cannot
+convert the lead out from under a confirming send.
+
+## Intentional
+
+- No template wording changes: this slice wires the queue/approval mechanics,
+  not the customer-facing email copy.
+- No automatic retry from `sending` back to `pending`: migration 360 defines a
+  stuck `sending` row as operator reconciliation evidence, because retrying an
+  uncertain send could duplicate customer email.
+- No tokenized onboarding link yet: A4 owns the customer-facing onboarding page
+  and token generation.
+
+## Deferred
+
+- A4: tokenized onboarding link/page and the `onboarding_sent -> onboarded`
+  transition.
+- Tracker/Website UI slices: surface the pending/sending/sent draft queue to the
+  office; this PR provides the private Atlas API.
+- Sending recovery action: confirm/revoke a stuck `sending` row after transport
+  log reconciliation if production use shows it is needed.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m py_compile atlas_brain/eom_api/funnel.py atlas_brain/services/eom_onboarding_email.py atlas_brain/services/crm_provider.py atlas_brain/services/email_provider.py atlas_brain/tools/email.py atlas_brain/tools/gmail.py tests/test_eom_lead_conversion.py tests/test_migrations_runner.py tests/test_eom_render_profile.py`
+  - Passed.
+- `python -m pytest tests/test_eom_lead_conversion.py tests/test_eom_lead_conversion_integration.py tests/test_migrations_runner.py::test_eom_lead_review_queue_onboarding_sent_stage_matches_provider_filter tests/test_eom_render_profile.py::test_eom_profile_import_does_not_load_full_api_package -q`
+  - Passed: 134 passed, 36 skipped, 1 warning.
+  - Skipped: DB-gated EOM lead conversion integration cases that require a
+    local asyncpg migration test database not configured in this worktree.
+- `python -m ruff check atlas_brain/eom_api/funnel.py atlas_brain/services/eom_onboarding_email.py atlas_brain/services/crm_provider.py atlas_brain/services/email_provider.py atlas_brain/tools/email.py atlas_brain/tools/gmail.py tests/test_eom_lead_conversion.py tests/test_migrations_runner.py tests/test_eom_render_profile.py`
+  - Passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/eom_api/funnel.py` | 118 |
+| `atlas_brain/services/crm_provider.py` | 233 |
+| `atlas_brain/services/email_provider.py` | 4 |
+| `atlas_brain/services/eom_onboarding_email.py` | 98 |
+| `atlas_brain/storage/migrations/361_eom_lead_review_queue_onboarding_sent_stage.sql` | 23 |
+| `atlas_brain/tools/email.py` | 5 |
+| `atlas_brain/tools/gmail.py` | 11 |
+| `plans/PR-EOM-Onboarding-Approval-Queue.md` | 211 |
+| `tests/test_eom_lead_conversion.py` | 490 |
+| `tests/test_eom_render_profile.py` | 6 |
+| `tests/test_migrations_runner.py` | 38 |
+| **Total** | **1237** |

--- a/tests/test_eom_lead_conversion.py
+++ b/tests/test_eom_lead_conversion.py
@@ -18,6 +18,11 @@ from atlas_brain.services.eom_estimate_booking import (
     deterministic_eom_estimate_calendar_event_id,
     deterministic_eom_first_clean_calendar_event_id,
 )
+from atlas_brain.services.eom_onboarding_email import (
+    EOMOnboardingEmailApproval,
+    EOMOnboardingEmailError,
+    approve_and_send_eom_onboarding_email,
+)
 from atlas_brain.services.eom_lead_conversion import EOMLeadConversionError
 from atlas_brain.tools.base import ToolResult
 from atlas_brain.tools.calendar import CalendarAuthError, CalendarTool
@@ -40,6 +45,9 @@ class _CRM:
         self.first_clean_ambiguous_calls: list[dict[str, object]] = []
         self.first_clean_failed_calls: list[dict[str, object]] = []
         self.onboarding_draft_id = "0b8db22e-16b1-4a30-a15f-6c78ee9204a5"
+        self.onboarding_drafts: list[dict[str, object]] = []
+        self.claimed_onboarding_drafts: list[dict[str, object]] = []
+        self.confirmed_onboarding_drafts: list[dict[str, object]] = []
         self.execution_lock_keys: list[str] = []
         self.review_leads = review_leads or []
 
@@ -140,6 +148,82 @@ class _CRM:
     async def mark_eom_first_clean_booking_calendar_failed(self, **kwargs):
         self.first_clean_failed_calls.append(kwargs)
 
+    async def list_eom_onboarding_email_drafts(self, *, status=None, limit=100):
+        rows = self.onboarding_drafts
+        if status is not None:
+            rows = [row for row in rows if row["status"] == status]
+        return [
+            {key: value for key, value in row.items() if key != "operation_key"}
+            for row in rows[:limit]
+        ]
+
+    async def get_eom_onboarding_email_draft(self, *, draft_id):
+        return next(
+            (
+                draft
+                for draft in self.onboarding_drafts
+                if str(draft["draft_id"]) == str(draft_id)
+            ),
+            None,
+        )
+
+    async def claim_eom_onboarding_email_draft(
+        self, *, draft_id, actor_id, actor_name
+    ):
+        draft = await self.get_eom_onboarding_email_draft(draft_id=draft_id)
+        recipient_email = str(draft.get("recipient_email") or "").strip() if draft else ""
+        if (
+            draft is None
+            or draft["status"] != "pending"
+            or draft.get("blocker") is not None
+            or not recipient_email
+            or draft.get("lead_stage") != "won"
+        ):
+            return None
+        draft["status"] = "sending"
+        draft["approved_by_name"] = actor_name
+        self.claimed_onboarding_drafts.append(
+            {"draft_id": draft_id, "actor_id": actor_id, "actor_name": actor_name}
+        )
+        return {
+            "draft_id": draft["draft_id"],
+            "contact_id": draft["contact_id"],
+            "recipient_email": recipient_email,
+            "subject": draft["subject"],
+            "body": draft["body"],
+            "operation_key": draft.get("operation_key", "first-clean-key"),
+        }
+
+    async def confirm_eom_onboarding_email_sent(
+        self, *, draft_id, actor_id, actor_name
+    ):
+        draft = await self.get_eom_onboarding_email_draft(draft_id=draft_id)
+        if draft is None or draft["status"] != "sending":
+            return None
+        draft["status"] = "sent"
+        draft["lead_stage"] = "onboarding_sent"
+        self.confirmed_onboarding_drafts.append(
+            {"draft_id": draft_id, "actor_id": actor_id, "actor_name": actor_name}
+        )
+        return {
+            "draft_id": draft["draft_id"],
+            "contact_id": draft["contact_id"],
+            "status": "sent",
+            "lead_stage": "onboarding_sent",
+        }
+
+
+class _EmailProvider:
+    def __init__(self, *, fail: bool = False) -> None:
+        self.fail = fail
+        self.send_calls: list[dict[str, object]] = []
+
+    async def send(self, **kwargs):
+        self.send_calls.append(kwargs)
+        if self.fail:
+            raise RuntimeError("smtp down")
+        return {"id": "email-accepted"}
+
 
 class _Calendar:
     def __init__(
@@ -216,13 +300,19 @@ class _CalendarClient:
 
 
 def _app(
-    crm: _CRM, config: EOMFunnelConfig, calendar: _Calendar | None = None
+    crm: _CRM,
+    config: EOMFunnelConfig,
+    calendar: _Calendar | None = None,
+    email_provider: _EmailProvider | None = None,
 ) -> FastAPI:
     app = FastAPI()
     app.include_router(funnel_mod.router)
     app.dependency_overrides[funnel_mod._crm_dependency] = lambda: crm
     app.dependency_overrides[funnel_mod._calendar_dependency] = (
         lambda: calendar or _Calendar()
+    )
+    app.dependency_overrides[funnel_mod._email_dependency] = (
+        lambda: email_provider or _EmailProvider()
     )
     app.dependency_overrides[auth_mod.get_eom_funnel_api_config] = lambda: config
     return app
@@ -263,6 +353,29 @@ def _booking_payload(**overrides) -> dict[str, object]:
     }
     payload.update(overrides)
     return payload
+
+
+def _onboarding_draft(**overrides) -> dict[str, object]:
+    draft_id = uuid4()
+    contact_id = uuid4()
+    draft: dict[str, object] = {
+        "draft_id": draft_id,
+        "contact_id": contact_id,
+        "full_name": "Review Queue Lead",
+        "lead_stage": "won",
+        "status": "pending",
+        "recipient_email": "lead@example.com",
+        "blocker": None,
+        "subject": "Welcome to Effingham Office Maids",
+        "body": "Welcome aboard.",
+        "created_at": "2026-08-04T12:00:00+00:00",
+        "claimed_at": None,
+        "sent_at": None,
+        "approved_by_name": None,
+        "operation_key": "first-clean-key",
+    }
+    draft.update(overrides)
+    return draft
 
 
 @pytest.mark.asyncio
@@ -335,6 +448,381 @@ async def test_full_atlas_app_serves_public_intake_and_private_handoff_together(
     ]
     assert response.status_code == 201
     assert crm.calls
+
+
+@pytest.mark.asyncio
+async def test_onboarding_email_drafts_route_lists_pending_drafts():
+    crm = _CRM()
+    draft = _onboarding_draft()
+    crm.onboarding_drafts = [draft]
+    app = _app(crm, _enabled_config())
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get(
+            "/eom-funnel/onboarding-email-drafts",
+            headers=_headers(),
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "drafts": [
+            {
+                "draftId": str(draft["draft_id"]),
+                "contactId": str(draft["contact_id"]),
+                "fullName": "Review Queue Lead",
+                "leadStage": "won",
+                "status": "pending",
+                "recipientEmail": "lead@example.com",
+                "blocker": None,
+                "subject": "Welcome to Effingham Office Maids",
+                "body": "Welcome aboard.",
+                "createdAt": "2026-08-04T12:00:00Z",
+                "claimedAt": None,
+                "sentAt": None,
+                "approvedByName": None,
+            }
+        ],
+        "limit": 100,
+        "status": "pending",
+    }
+
+
+@pytest.mark.asyncio
+async def test_onboarding_email_drafts_route_rejects_unknown_status():
+    crm = _CRM()
+    email_provider = _EmailProvider()
+    app = _app(crm, _enabled_config(), email_provider=email_provider)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get(
+            "/eom-funnel/onboarding-email-drafts?status=surprise",
+            headers=_headers(),
+        )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "Invalid onboarding draft status"
+    assert email_provider.send_calls == []
+
+
+@pytest.mark.asyncio
+async def test_onboarding_email_approval_route_sends_then_confirms():
+    crm = _CRM()
+    draft = _onboarding_draft()
+    crm.onboarding_drafts = [draft]
+    email_provider = _EmailProvider()
+    app = _app(crm, _enabled_config(), email_provider=email_provider)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            f"/eom-funnel/onboarding-email-drafts/{draft['draft_id']}/approve-and-send",
+            headers=_headers(actor="Juan Canfield", actor_id="1"),
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "success": True,
+        "draftId": str(draft["draft_id"]),
+        "contactId": str(draft["contact_id"]),
+        "status": "sent",
+        "leadStage": "onboarding_sent",
+        "idempotent": False,
+    }
+    assert email_provider.send_calls == [
+            {
+                "to": ["lead@example.com"],
+                "subject": "Welcome to Effingham Office Maids",
+                "body": "Welcome aboard.",
+                "headers": {
+                    "X-Atlas-EOM-Onboarding-Draft-ID": str(draft["draft_id"]),
+                },
+            }
+        ]
+    assert crm.confirmed_onboarding_drafts == [
+        {
+            "draft_id": str(draft["draft_id"]),
+            "actor_id": 1,
+            "actor_name": "Juan Canfield",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_blocked_onboarding_email_draft_refuses_before_transport():
+    crm = _CRM()
+    draft = _onboarding_draft(
+        recipient_email=None,
+        blocker="no_email",
+    )
+    crm.onboarding_drafts = [draft]
+    email_provider = _EmailProvider()
+
+    with pytest.raises(EOMOnboardingEmailError, match="blocked: no_email"):
+        await approve_and_send_eom_onboarding_email(
+            crm,
+            email_provider,
+            EOMOnboardingEmailApproval(
+                draft_id=str(draft["draft_id"]),
+                actor_id=1,
+                actor_name="Juan Canfield",
+            ),
+        )
+
+    assert email_provider.send_calls == []
+    assert crm.confirmed_onboarding_drafts == []
+
+
+@pytest.mark.asyncio
+async def test_blank_onboarding_email_recipient_refuses_before_transport():
+    crm = _CRM()
+    draft = _onboarding_draft(recipient_email="   ")
+    crm.onboarding_drafts = [draft]
+    email_provider = _EmailProvider()
+
+    with pytest.raises(EOMOnboardingEmailError, match="has no recipient"):
+        await approve_and_send_eom_onboarding_email(
+            crm,
+            email_provider,
+            EOMOnboardingEmailApproval(
+                draft_id=str(draft["draft_id"]),
+                actor_id=1,
+                actor_name="Juan Canfield",
+            ),
+        )
+
+    assert draft["status"] == "pending"
+    assert email_provider.send_calls == []
+    assert crm.confirmed_onboarding_drafts == []
+
+
+@pytest.mark.asyncio
+async def test_sent_onboarding_email_draft_approval_is_idempotent_noop():
+    crm = _CRM()
+    draft = _onboarding_draft(status="sent", lead_stage="onboarding_sent")
+    crm.onboarding_drafts = [draft]
+    email_provider = _EmailProvider()
+
+    result = await approve_and_send_eom_onboarding_email(
+        crm,
+        email_provider,
+        EOMOnboardingEmailApproval(
+            draft_id=str(draft["draft_id"]),
+            actor_id=1,
+            actor_name="Juan Canfield",
+        ),
+    )
+
+    assert result == {
+        "draft_id": str(draft["draft_id"]),
+        "contact_id": str(draft["contact_id"]),
+        "status": "sent",
+        "idempotent": True,
+    }
+    assert email_provider.send_calls == []
+    assert crm.confirmed_onboarding_drafts == []
+
+
+@pytest.mark.asyncio
+async def test_onboarding_email_send_failure_leaves_claim_unconfirmed():
+    crm = _CRM()
+    draft = _onboarding_draft()
+    crm.onboarding_drafts = [draft]
+    email_provider = _EmailProvider(fail=True)
+
+    with pytest.raises(RuntimeError, match="smtp down"):
+        await approve_and_send_eom_onboarding_email(
+            crm,
+            email_provider,
+            EOMOnboardingEmailApproval(
+                draft_id=str(draft["draft_id"]),
+                actor_id=1,
+                actor_name="Juan Canfield",
+            ),
+        )
+
+    assert draft["status"] == "sending"
+    assert email_provider.send_calls == [
+            {
+                "to": ["lead@example.com"],
+                "subject": "Welcome to Effingham Office Maids",
+                "body": "Welcome aboard.",
+                "headers": {
+                    "X-Atlas-EOM-Onboarding-Draft-ID": str(draft["draft_id"]),
+                },
+            }
+        ]
+    assert crm.confirmed_onboarding_drafts == []
+
+
+@pytest.mark.asyncio
+async def test_provider_claim_onboarding_email_draft_uses_single_winner_predicate():
+    from atlas_brain.services.crm_provider import DatabaseCRMProvider
+
+    draft_id = uuid4()
+    contact_id = uuid4()
+
+    class Pool:
+        def __init__(self):
+            self.query = None
+            self.args = None
+
+        async def fetchrow(self, query, *args):
+            self.query = query
+            self.args = args
+            return {
+                "draft_id": draft_id,
+                "contact_id": contact_id,
+                "full_name": "Review Queue Lead",
+                "lead_stage": "won",
+                "status": "sending",
+                "recipient_email": "lead@example.com",
+                "subject": "Welcome",
+                "body": "Body",
+                "operation_key": "first-clean-key",
+            }
+
+    pool = Pool()
+    provider = DatabaseCRMProvider(pool=pool)
+    row = await provider.claim_eom_onboarding_email_draft(
+        draft_id=str(draft_id),
+        actor_id=1,
+        actor_name="Juan Canfield",
+    )
+
+    assert row["draft_id"] == draft_id
+    assert "SET status = 'sending'" in pool.query
+    assert "AND d.status = 'pending'" in pool.query
+    assert "AND d.blocker IS NULL" in pool.query
+    assert "NULLIF(BTRIM(d.recipient_email), '') IS NOT NULL" in pool.query
+    assert "BTRIM(d.recipient_email) AS recipient_email" in pool.query
+    assert "AND c.lead_stage = 'won'" in pool.query
+    assert "FOR UPDATE OF d, c" in pool.query
+    assert pool.args == (str(draft_id), 1, "Juan Canfield")
+
+
+@pytest.mark.asyncio
+async def test_provider_customer_handoff_rejects_sending_onboarding_draft():
+    from atlas_brain.services.crm_provider import DatabaseCRMProvider
+
+    contact_id = uuid4()
+    sending_draft_id = uuid4()
+    handoff_key = f"office-handoff-{uuid4().hex}"
+
+    class Pool:
+        def __init__(self):
+            self.fetchrow_queries: list[str] = []
+
+        @asynccontextmanager
+        async def transaction(self):
+            yield self
+
+        async def execute(self, *_args):
+            return "SELECT 1"
+
+        async def fetchrow(self, query, *args):
+            self.fetchrow_queries.append(query)
+            if "WHERE approval_key = $1" in query:
+                return None
+            if "FROM contacts" in query and "WHERE id = $1" in query:
+                return {
+                    "id": contact_id,
+                    "business_context_id": "effingham_maids",
+                    "contact_type": "lead",
+                    "lead_stage": "won",
+                    "status": "active",
+                }
+            if "WHERE contact_id = $1" in query and "FROM eom_customer_handoffs" in query:
+                return None
+            if "WHERE tracker_customer_id = $1 OR tracker_site_id = $2" in query:
+                return None
+            if (
+                "FROM eom_onboarding_email_drafts" in query
+                and "status = 'sending'" in query
+            ):
+                return {"id": sending_draft_id}
+            raise AssertionError(f"unexpected fetchrow query: {query}")
+
+    pool = Pool()
+    provider = DatabaseCRMProvider(pool=pool)
+
+    with pytest.raises(
+        EOMLeadConversionError, match="onboarding email send is still confirming"
+    ):
+        await provider.finalize_eom_customer_handoff(
+            contact_id=str(contact_id),
+            tracker_customer_id=1001,
+            tracker_site_id=2002,
+            approval_key=handoff_key,
+            actor_id=1,
+            actor_name="Juan Canfield",
+        )
+
+    assert any("FROM eom_onboarding_email_drafts" in q for q in pool.fetchrow_queries)
+    assert not any("UPDATE contacts" in q for q in pool.fetchrow_queries)
+
+
+@pytest.mark.asyncio
+async def test_provider_confirm_onboarding_email_sent_records_stage_event():
+    from atlas_brain.services.crm_provider import DatabaseCRMProvider
+
+    draft_id = uuid4()
+    contact_id = uuid4()
+
+    class Pool:
+        def __init__(self):
+            self.fetchrow_calls = []
+            self.execute_calls = []
+
+        @asynccontextmanager
+        async def transaction(self):
+            yield
+
+        async def fetchrow(self, query, *args):
+            self.fetchrow_calls.append((query, args))
+            return {
+                "draft_id": draft_id,
+                "contact_id": contact_id,
+                "operation_key": "first-clean-key",
+                "status": "sent",
+                "from_stage": "won",
+                "lead_stage": "onboarding_sent",
+            }
+
+        async def execute(self, query, *args):
+            self.execute_calls.append((query, args))
+            return "INSERT 0 1"
+
+    pool = Pool()
+    provider = DatabaseCRMProvider(pool=pool)
+    row = await provider.confirm_eom_onboarding_email_sent(
+        draft_id=str(draft_id),
+        actor_id=1,
+        actor_name="Juan Canfield",
+    )
+
+    assert row["status"] == "sent"
+    confirm_query, confirm_args = pool.fetchrow_calls[0]
+    assert "lead_stage = 'onboarding_sent'" in confirm_query
+    assert "d.status = 'sending'" in confirm_query
+    assert "c.lead_stage = 'won'" in confirm_query
+    assert confirm_args == (str(draft_id), "effingham_maids")
+    event_query, event_args = pool.execute_calls[0]
+    assert "'onboarding_email_sent'" in event_query
+    assert "jsonb_build_object" in event_query
+    assert event_args == (
+        contact_id,
+        "employee:1:Juan Canfield",
+        "first-clean-key",
+        draft_id,
+        1,
+        "won",
+        "onboarding_sent",
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_eom_render_profile.py
+++ b/tests/test_eom_render_profile.py
@@ -221,6 +221,11 @@ print(json.dumps({
     assert "/api/v1/ping" in paths
     assert "/api/v1/receivables/ready" in paths
     assert "/api/v1/eom-funnel/leads" in paths
+    assert "/api/v1/eom-funnel/onboarding-email-drafts" in paths
+    assert (
+        "/api/v1/eom-funnel/onboarding-email-drafts/{draft_id}/approve-and-send"
+        in paths
+    )
     assert "/api/v1/eom-funnel/leads/{contact_id}/estimate-bookings" in paths
     assert "/api/v1/eom-funnel/leads/{contact_id}/first-clean-bookings" in paths
     assert "/api/v1/eom-funnel/customer-handoffs" in paths
@@ -1016,7 +1021,6 @@ def test_eom_receivables_runtime_config_rejects_raw_token_env_before_projection(
     from atlas_brain.eom_api import auth
     from atlas_brain.eom_api.config import (
         EOMInvoicingConfig,
-        RAW_RECEIVABLES_SERVICE_TOKEN_ENV,
     )
 
     generated = auth.generate_receivables_service_token()

--- a/tests/test_migrations_runner.py
+++ b/tests/test_migrations_runner.py
@@ -294,6 +294,8 @@ def test_eom_lead_review_queue_won_stage_index_matches_provider_filter():
         >= 2
     )  # rollback-evidence comment + the executable statement
     assert "CREATE INDEX CONCURRENTLY idx_contacts_eom_lead_review_queue" in migration
+    assert "Rollback evidence:" in migration
+    assert "lead_stage IN ('new', 'estimate_booked', 'won')" in migration
     assert migration.index(
         "DROP INDEX CONCURRENTLY IF EXISTS idx_contacts_eom_lead_review_queue"
     ) < migration.index(
@@ -370,8 +372,6 @@ def test_eom_onboarding_email_drafts_migration_is_additive_and_single_send_safe(
         / "migrations"
         / "360_eom_onboarding_email_drafts.sql"
     ).read_text()
-    upper = migration.upper()
-
     assert "CREATE TABLE IF NOT EXISTS eom_onboarding_email_drafts" in migration
     assert "contact_id UUID NOT NULL REFERENCES contacts(id) ON DELETE RESTRICT" in migration
     assert "operation_key VARCHAR(128) NOT NULL UNIQUE" in migration
@@ -393,11 +393,35 @@ def test_eom_onboarding_email_drafts_migration_is_additive_and_single_send_safe(
     assert "AND recipient_email IS NOT NULL" in migration
     assert "RETURNING" in migration
     assert "SET status = 'sent', sent_at = NOW()" in migration
-    assert "WHERE id = $1 AND status = 'sending'" in migration
-    assert "idempotency key" in migration
-    assert "Rollback evidence:" in migration
-    assert "ALTER TABLE" not in upper
-    assert "CONCURRENTLY" not in upper
+
+
+def test_eom_lead_review_queue_onboarding_sent_stage_matches_provider_filter():
+    migration = (
+        Path(__file__).resolve().parent.parent
+        / "atlas_brain"
+        / "storage"
+        / "migrations"
+        / "361_eom_lead_review_queue_onboarding_sent_stage.sql"
+    ).read_text()
+    provider = (
+        Path(__file__).resolve().parent.parent
+        / "atlas_brain"
+        / "services"
+        / "crm_provider.py"
+    ).read_text()
+
+    assert "CREATE INDEX CONCURRENTLY IF NOT EXISTS" not in migration
+    assert "DROP INDEX CONCURRENTLY IF EXISTS idx_contacts_eom_lead_review_queue" in migration
+    assert "CREATE INDEX CONCURRENTLY idx_contacts_eom_lead_review_queue" in migration
+    assert migration.index(
+        "DROP INDEX CONCURRENTLY IF EXISTS idx_contacts_eom_lead_review_queue"
+    ) < migration.index(
+        "CREATE INDEX CONCURRENTLY idx_contacts_eom_lead_review_queue"
+    )
+    predicate = "lead_stage IN ('new', 'estimate_booked', 'won', 'onboarding_sent')"
+    assert predicate in migration
+    assert predicate in provider
+    assert "Do not rewrite persisted onboarding_sent contacts" in migration
 
 
 def test_sent_email_tenant_migration_is_additive_replay_safe_and_unclassified():


### PR DESCRIPTION
Plan: plans/PR-EOM-Onboarding-Approval-Queue.md
Slice phase: Vertical slice
Ownership lane: eom/funnel-go-live

Diff-budget override: this A3 slice is indivisible because the callable approval route, claim/send/confirm state machine, email transport trace evidence, handoff race fence, migration rollback guidance, route reachability, and behavior tests must ship together or the endpoint would be reachable without the single-send/recovery proof it exists to provide.

A3 gives Juan an office-only approval/send path for onboarding email drafts that A2 already enqueues after first-clean booking: list the draft queue, approve exactly one pending draft, send through the existing email provider with draft-id transport evidence, then confirm sent and advance the lead to `onboarding_sent` only after transport acceptance.

## Intentional
- No template wording changes; this wires mechanics only, not customer-facing copy.
- No automatic retry from `sending` to `pending`; stuck sends remain operator reconciliation evidence to avoid duplicate customer email.
- No tokenized onboarding link yet; A4 owns the customer-facing onboarding page and token generation.
- `onboarding_sent` remains visible to the lead review/handoff path so sending the approved email does not strand the lead before A4.

## AI reconciliation
- Fence handoff during onboarding email confirmation -- fixed-in: `atlas_brain/services/crm_provider.py:1388-1405`, `atlas_brain/services/crm_provider.py:3158-3172`, and `tests/test_eom_lead_conversion.py:709-765`.
- Add rollback evidence for the stage-index migration -- fixed-in: `atlas_brain/storage/migrations/361_eom_lead_review_queue_onboarding_sent_stage.sql:7-14` and `tests/test_migrations_runner.py:396-424`.
- Reject blank draft recipients before claiming -- fixed-in: `atlas_brain/services/crm_provider.py:1391-1405` and `tests/test_eom_lead_conversion.py:581-600`.
- Pass the draft id as transport idempotency evidence -- fixed-in: `atlas_brain/services/eom_onboarding_email.py:74-81`, `atlas_brain/services/email_provider.py:534-558`, `atlas_brain/tools/email.py:329-330`, `atlas_brain/tools/email.py:420-425`, `atlas_brain/tools/gmail.py:94-154`, and `tests/test_eom_lead_conversion.py:535-545`.

## Deferred
- A4: tokenized onboarding link/page and the `onboarding_sent -> onboarded` transition.
- Tracker/Website UI slices: surface pending/sending/sent draft queue to the office; this PR provides the private Atlas API.
- Sending recovery action: confirm/revoke a stuck `sending` row after transport-log reconciliation if production use shows it is needed.

## Parked hardening
- None.

## Cold diff reconstruction
- Gaps: none found. Every changed runtime path traces to the A3 approval-queue contract or the four current-head review findings, and the forbidden surfaces stayed untouched: no Customer/Site creation, tracker handoff creation, tokenized onboarding page, Stripe/card behavior, Calendar booking behavior, email template wording, lead intake, Render config, or receivables/invoicing behavior moved.
- Changed: `atlas_brain/eom_api/funnel.py:23` imports the onboarding-email approval service, `atlas_brain/eom_api/funnel.py:50` defines draft status filters, and `atlas_brain/eom_api/funnel.py:128-170` adds closed response models for draft list and approval results.
- Changed: `atlas_brain/eom_api/funnel.py:281-310` adds the private GET `/onboarding-email-drafts` route with status validation and provider-backed draft listing; `atlas_brain/eom_api/funnel.py:313-339` adds the private POST `/{draft_id}/approve-and-send` route that maps approval-service errors to HTTP responses.
- Changed: `atlas_brain/services/eom_onboarding_email.py:9-21` defines the HTTP-mappable error and approval actor payload; `atlas_brain/services/eom_onboarding_email.py:24-39` maps missing/sent/sending/revoked/blocked/no-recipient drafts; `atlas_brain/services/eom_onboarding_email.py:42-95` implements claim -> traced send -> confirm with an idempotent already-sent path.
- Changed: `atlas_brain/services/crm_provider.py:1296-1300` keeps `onboarding_sent` leads in the lead review projection; `atlas_brain/services/crm_provider.py:1308-1344` lists onboarding email drafts; `atlas_brain/services/crm_provider.py:1346-1376` loads one draft for blocked/idempotent decisions.
- Changed: `atlas_brain/services/crm_provider.py:1388-1405` trims recipients, rejects blank values, and row-locks the draft/contact sendability decision; `atlas_brain/services/crm_provider.py:1407-1427` claims the draft into `sending`; `atlas_brain/services/crm_provider.py:1433-1506` confirms a `sending` draft as `sent`, moves the contact to `onboarding_sent`, and appends an `onboarding_email_sent` lifecycle event.
- Changed: `atlas_brain/services/crm_provider.py:3158-3172` rejects customer handoff while an onboarding draft for that contact is `sending`; `atlas_brain/services/crm_provider.py:3229-3235` still admits `onboarding_sent` for later customer handoff so the approved-send stage does not block A4.
- Changed: `atlas_brain/services/email_provider.py:534-558`, `atlas_brain/tools/email.py:329-330`, `atlas_brain/tools/email.py:420-425`, and `atlas_brain/tools/gmail.py:94-154` pass optional message headers through Composite/Gmail/Resend paths so the onboarding send can include draft-id provider-log evidence without changing customer-facing copy.
- Changed: `atlas_brain/storage/migrations/361_eom_lead_review_queue_onboarding_sent_stage.sql:7-14` documents rollback/roll-forward guidance and `atlas_brain/storage/migrations/361_eom_lead_review_queue_onboarding_sent_stage.sql:16-23` replaces the EOM lead review queue index predicate so `onboarding_sent` remains indexed.
- Changed: `tests/test_eom_lead_conversion.py:151-212` extends the fake CRM with list/get/claim/confirm draft behavior; `tests/test_eom_lead_conversion.py:453-507` proves list and invalid-status API behavior; `tests/test_eom_lead_conversion.py:511-676` proves success, blocked zero-send, blank-recipient zero-send, idempotent sent no-op, and send-failure leaves the draft unconfirmed; `tests/test_eom_lead_conversion.py:677-765` proves provider claim SQL shape and handoff fencing; `tests/test_eom_lead_conversion.py:769-824` proves confirm SQL/lifecycle evidence.
- Changed: `tests/test_migrations_runner.py:396-424` proves migration/provider lead-stage predicate parity and rollback guidance; `tests/test_eom_render_profile.py:220-228` proves the slim EOM route catalog exposes both onboarding draft endpoints.
- Contract match: the private API, service state machine, provider list/claim/confirm methods, `won -> onboarding_sent` lifecycle evidence, blocked/blank/duplicate/send-failure tests, handoff fence, route reachability test, transport trace header, rollback guidance, and index parity are all present. The diff does not add the deferred UI, tokenized page, Stripe/card, Calendar, receivables, lead-intake, or email-copy changes.

## Verification
- Command: `python -m py_compile atlas_brain/eom_api/funnel.py atlas_brain/services/eom_onboarding_email.py atlas_brain/services/crm_provider.py atlas_brain/services/email_provider.py atlas_brain/tools/email.py atlas_brain/tools/gmail.py tests/test_eom_lead_conversion.py tests/test_migrations_runner.py tests/test_eom_render_profile.py` - Result: pass - Environment: local
- Command: `python -m pytest tests/test_eom_lead_conversion.py tests/test_eom_lead_conversion_integration.py tests/test_migrations_runner.py::test_eom_lead_review_queue_onboarding_sent_stage_matches_provider_filter tests/test_eom_render_profile.py::test_eom_profile_import_does_not_load_full_api_package -q` - Result: passed; 134 passed, 36 skipped, 1 warning - Environment: local
- Command: `python -m ruff check atlas_brain/eom_api/funnel.py atlas_brain/services/eom_onboarding_email.py atlas_brain/services/crm_provider.py atlas_brain/services/email_provider.py atlas_brain/tools/email.py atlas_brain/tools/gmail.py tests/test_eom_lead_conversion.py tests/test_migrations_runner.py tests/test_eom_render_profile.py` - Result: pass - Environment: local

## Mechanical verification
- Command: `python -m py_compile atlas_brain/eom_api/funnel.py atlas_brain/services/eom_onboarding_email.py atlas_brain/services/crm_provider.py atlas_brain/services/email_provider.py atlas_brain/tools/email.py atlas_brain/tools/gmail.py tests/test_eom_lead_conversion.py tests/test_migrations_runner.py tests/test_eom_render_profile.py` - Result: pass - Environment: local
- Command: `python -m pytest tests/test_eom_lead_conversion.py tests/test_eom_lead_conversion_integration.py tests/test_migrations_runner.py::test_eom_lead_review_queue_onboarding_sent_stage_matches_provider_filter tests/test_eom_render_profile.py::test_eom_profile_import_does_not_load_full_api_package -q` - Result: passed; 134 passed, 36 skipped, 1 warning - Environment: local
- Command: `python -m ruff check atlas_brain/eom_api/funnel.py atlas_brain/services/eom_onboarding_email.py atlas_brain/services/crm_provider.py atlas_brain/services/email_provider.py atlas_brain/tools/email.py atlas_brain/tools/gmail.py tests/test_eom_lead_conversion.py tests/test_migrations_runner.py tests/test_eom_render_profile.py` - Result: pass - Environment: local
- Skipped: DB-gated EOM lead conversion integration cases - Reason: local asyncpg migration test database is not configured in this worktree.

## Diff size
11 files, +1217 / -20
