### PR TITLE
Record required workflow enrollment decision

### DIFF
--- a/.github/workflows/unit_gate.yml
+++ b/.github/workflows/unit_gate.yml
@@ -8,8 +8,9 @@ name: Unit Gate
 # selector is absent or returns FULL, and runs the baseline growth guard only when
 # no changed file is reachable from a test.
 #
-# Advisory at birth: this check is not yet in branch-protection required checks;
-# enrolling it is the next slice, once it is proven on live PRs.
+# Visible CI, not branch-required: the 2026-08-04 enrollment audit keeps this
+# check outside branch protection until the docs/security selector coverage gap
+# and other recorded blockers are closed.
 
 permissions:
   contents: read

--- a/docs/audits/agents-mechanical-enforcement-audit-2026-07-29.md
+++ b/docs/audits/agents-mechanical-enforcement-audit-2026-07-29.md
@@ -100,9 +100,10 @@ branch protection may be superseded by the 2026-08-04 update above.
 1. `PR-Required-Status-Check-Alignment`: closed 2026-08-04 by updating live
    branch protection so `scripts/check_required_status_checks.py` passes against
    the GitHub payload.
-2. `PR-Required-Workflow-Enrollment-Audit`: decide which existing CI-only
-   process checks must become branch-protection required, starting with
-   `pre-push-audit` and the impacted-test/growth-only `unit-gate`.
+2. `PR-Required-Workflow-Enrollment-Audit`: closed 2026-08-04 in
+   `docs/audits/required-workflow-enrollment-audit-2026-08-04.md`. Decision:
+   keep `pre-push-audit` and `unit-gate` visible-but-not-branch-required until
+   the documented enrollment blockers are closed.
 3. `PR-PR-Mutation-Ownership-Wrapper`: wire `check_session_pr_ownership.py` into
    the PR mutation helpers, or downgrade the AGENTS wording to manual-only.
 4. `PR-Commit-Message-Contract-Gate`: validate canonical commit-message
@@ -126,6 +127,8 @@ branch protection may be superseded by the 2026-08-04 update above.
 
 As of 2026-08-04, the biggest branch-protection contradiction identified here
 has been closed: live protection requires the registry's `branch_required`
-contexts. The remaining mechanical gaps are local/manual promises that GitHub
-cannot prove directly, plus follow-up decisions about whether `pre-push-audit`
-and `unit-gate` should stay visible-but-not-required or become branch-required.
+contexts. The `pre-push-audit` / `unit-gate` enrollment decision is also recorded:
+both remain visible-but-not-branch-required until their enrollment blockers are
+closed. The remaining mechanical gaps are local/manual promises that GitHub
+cannot prove directly and the follow-up hardening called out by the enrollment
+audit.

--- a/docs/audits/required-workflow-enrollment-audit-2026-08-04.md
+++ b/docs/audits/required-workflow-enrollment-audit-2026-08-04.md
@@ -1,0 +1,108 @@
+# Required Workflow Enrollment Audit - 2026-08-04
+
+## Decision
+
+Keep `pre-push-audit` and `unit-gate` at `ci_blocking_not_required` for now.
+Do not add either context to `ci/gates.yml` `branch_required` or live branch
+protection in this slice.
+
+This is not a downgrade. Both checks remain real CI signals, and red runs must
+be fixed before calling a PR ready. The decision is that neither is ready to be
+made part of the hard branch-protection contract without first closing the
+specific enrollment blockers below.
+
+## Evidence
+
+Current registry state:
+
+```bash
+sed -n '72,92p' ci/gates.yml
+```
+
+- `pre-push-audit`: `ci_blocking_not_required`
+- `unit-gate`: `ci_blocking_not_required`
+
+Live branch protection as of this audit contains every existing
+`branch_required` registry context pinned to the GitHub Actions app source, and
+does not include `pre-push-audit` or `unit-gate`:
+
+```bash
+gh api repos/canfieldjuan/ATLAS/branches/main/protection/required_status_checks
+python scripts/check_required_status_checks.py \
+  --payload-file /tmp/atlas-required-status-checks-live-required-workflow.json
+```
+
+The checker passed for the current registry-required set.
+
+Recent `pre-push-audit` sample:
+
+```bash
+gh run list --workflow pre_push_audit.yml --limit 20 \
+  --json databaseId,status,conclusion,createdAt,updatedAt,event,headBranch,displayTitle
+```
+
+The first ten terminal sampled runs
+(`30961794217`, `30961778404`, `30961650737`, `30961567962`, `30961537815`,
+`30960553412`, `30960353619`, `30960181583`, `30960167467`, `30959465034`) had
+3 success and 7 failure outcomes. The sampled median duration was about 106
+seconds, with a max of 146 seconds. The recent failures were legitimate
+process/test failures, not runner flakes; one example failed
+`tests/test_security_guardrails_workflow.py` after the required status docs
+changed.
+
+Recent `unit-gate` sample:
+
+```bash
+gh run list --workflow unit_gate.yml --limit 20 \
+  --json databaseId,status,conclusion,createdAt,updatedAt,event,headBranch,displayTitle
+```
+
+The first ten terminal sampled runs
+(`30961651974`, `30961539028`, `30960553450`, `30960168490`, `30959465237`,
+`30958679496`, `30958429073`, `30956838206`, `30956772059`, `30955811357`) had
+7 success, 1 failure, and 2 cancelled outcomes. The sampled median duration was
+about 631 seconds, with a max of 699 seconds. The recent failure was the same
+stale security-guardrails docs test that `pre-push-audit` reported.
+
+## Trust model
+
+`pre-push-audit` runs on `pull_request_target` from trusted base code. It checks
+out the PR base SHA, materializes the PR head as data, runs
+`scripts/local_pr_review.sh` against that PR worktree, and then runs trusted-base
+PR-review tooling tests. That protects the gate from PR-side edits to its own
+checker code, but it also means a PR can change gate docs/tests in ways the
+trusted-base test list only observes after merge.
+
+`unit-gate` runs on `pull_request` against the PR head SHA. It installs the PR's
+dependencies, selects impacted tests when possible, falls back to the full
+non-integration/e2e unit suite when selection escalates to `FULL`, and runs the
+baseline growth guard when no changed file maps to a reachable test. It cancels
+superseded in-progress runs on the same PR ref.
+
+## Enrollment blockers
+
+`pre-push-audit` is trusted-base and valuable, but requiring it would not have
+prevented the stale docs/test mismatch that followed the required-status record
+merge. On pull requests, the workflow executes trusted base scripts and tooling
+tests. That is the right security model for PR-authored gate changes, but it
+means a PR that changes docs/tests for the gate can pass before merge and fail
+the push-to-main variant after merge. That behavior should be fixed or made
+explicit before treating the context as a hard merge contract.
+
+`unit-gate` is not ready for branch protection because its selector did not run
+the security-guardrails docs test for the docs-only required-status PR. The PR
+run selected no reachable tests and passed growth-only, while a later full-suite
+path failed on `tests/test_security_guardrails_workflow.py`. Making `unit-gate`
+required before fixing that selector coverage would add wait time without
+closing the observed gap.
+
+## Result
+
+The correct next hardening slice is not "require both checks." It is to close
+the observed coverage gap first:
+
+- Map `docs/SECURITY_GUARDRAILS.md` and branch-protection docs to
+  `tests/test_security_guardrails_workflow.py` in the unit-gate selector.
+- Decide whether trusted-base `pre-push-audit` needs a PR-side docs/test
+  consistency probe that still avoids executing untrusted PR code.
+- Re-run this enrollment decision after those blockers are closed.

--- a/docs/ci_cd_autonomous_coding_map.md
+++ b/docs/ci_cd_autonomous_coding_map.md
@@ -71,7 +71,7 @@ These workflows use `pull_request_target` but execute trusted base-branch code
 and inspect PR content as data. They exist because a PR can edit the gate it is
 trying to pass.
 
-| Workflow | Required job/context | Purpose |
+| Workflow | Published job/context | Purpose |
 |---|---|---|
 | `ai_reconciliation_live.yml` | `live-reconciliation` | Fails when PR body claims AI findings are fixed/waived while Codex connector threads remain open |
 | `pr_body_contract.yml` | `pr-body-contract` | Ensures PR body names the plan and follows AGENTS.md body shape |
@@ -89,7 +89,9 @@ trying to pass.
 `pr-body-contract`, `Gitleaks PR secret scan`, and
 `Gitleaks baseline growth guard`. Live branch protection can drift from that
 expected set; the audit workflow reports that drift when its read token is
-configured.
+configured. `pre-push-audit` and `unit-gate` are visible CI signals, not
+branch-required contexts, until the blockers recorded in
+`docs/audits/required-workflow-enrollment-audit-2026-08-04.md` are closed.
 
 ### PR secret and product gates
 

--- a/docs/ci_cd_runtime_duplication_audit.md
+++ b/docs/ci_cd_runtime_duplication_audit.md
@@ -25,10 +25,10 @@ and are better for optimization decisions.
 
 ## Non-Negotiable Gates
 
-Do not weaken these to save time. Branch protection requires only the four
-contexts in the first table; the process guardrails in the second table are
-still non-negotiable for Atlas PR work, but they are not current
-branch-protection required contexts.
+Do not weaken these to save time. As of 2026-08-04, branch protection contains
+every `ci/gates.yml` `branch_required` context. The process guardrails in the
+second table are still non-negotiable for Atlas PR work, but only the contexts
+marked `branch_required` are hard branch-protection gates.
 
 ### Branch-Protection Gate Set
 
@@ -37,14 +37,18 @@ branch-protection required contexts.
 | `live-reconciliation` | Prevents stale "fixed/waived" AI-review claims while automated review threads remain open. |
 | `Gitleaks PR secret scan` | Blocks leaked secrets before merge. |
 | `Gitleaks baseline growth guard` | Prevents PR-side poisoning or expansion of the secret baseline. |
-| `diff-budget` | Keeps slices small or forces an explicit override. Repo code expects this context, but live branch protection may need alignment. |
+| `diff-budget` | Keeps slices small or forces an explicit override. Live branch protection is aligned with this registry-required context as of 2026-08-04. |
+| `plan-admission` | Enforces plan/doc admission rules for non-docs-only PRs. |
+| `session-lane` | Checks session lane/body drift against the PR. |
+| `review-contract` | Checks plan Review Contract shape and triggered rules. |
+| `pr-body-contract` | Keeps PR bodies tied to the plan contract. |
 
 ### Process Guardrails
 
 | Gate | Why it stays non-negotiable |
 |---|---|
-| `pr-body-contract` | Keeps PR bodies tied to the plan contract, even though it is not in the current branch-protection required-context set. |
-| `pre-push-audit` trusted-base local review | Re-runs the local mechanical bundle from trusted base so a PR cannot weaken its own audit. |
+| `pre-push-audit` trusted-base local review | Re-runs the local mechanical bundle from trusted base so a PR cannot weaken its own audit. It remains visible CI, not branch-required, per the 2026-08-04 enrollment audit. |
+| `unit-gate` | Runs impacted unit tests, full-suite fallback, or baseline growth guard on every PR. It remains visible CI, not branch-required, per the 2026-08-04 enrollment audit. |
 | Session-scoped state file ownership guard | Prevents long-running sessions from touching another lane's PR before review, push, comment handling, or merge. |
 
 The optimization target is redundant runtime and broad triggering, not removing
@@ -54,8 +58,8 @@ these gates.
 
 | Class | Examples | Optimization posture |
 |---|---|---|
-| Branch-required meta gates | Live today: `live-reconciliation`, `Gitleaks PR secret scan`, `Gitleaks baseline growth guard`. Expected by `ci/gates.yml` / repo checker: those plus `diff-budget`, `plan-admission`, `session-lane`, `review-contract`, `pr-body-contract`. | Keep the intended gate set explicit; optimize only by making implementation faster without weakening coverage. |
-| Process/meta CI contexts | `pr-body-contract`, `pre-push-audit`, branch-protection audit workflows | Keep as workflow guardrails; distinguish their latency from branch-required merge latency. |
+| Branch-required meta gates | `live-reconciliation`, `diff-budget`, `plan-admission`, `session-lane`, `review-contract`, `pr-body-contract`, `Gitleaks PR secret scan`, and `Gitleaks baseline growth guard`. | Keep the intended gate set explicit; optimize only by making implementation faster without weakening coverage. |
+| Process/meta CI contexts | `pre-push-audit`, `unit-gate`, branch-protection audit workflows | Keep as workflow guardrails; distinguish their latency from branch-required merge latency. |
 | Product/package gates | Content-ops checks, extracted pipeline checks, Reddit listening checks, deflection package checks | Optimize with caching, narrower triggers, or safe decomposition while preserving package coverage. |
 | Advisory checks | Advisory maturity sweeps, non-blocking detector runs, informational audits | Keep visible; reduce noise and runtime after required gates and product checks are stable. |
 | Local-only gates | `scripts/local_pr_review.sh`, `scripts/push_pr.sh` hook path, package gauntlets run before push, session ownership guard | Treat as developer-loop cost and trusted-source duplication inputs; do not misread them as GitHub branch-protection contexts. |
@@ -84,8 +88,8 @@ Advisor (advisory).
 | Atlas Reddit Listening Checks | `pull_request` | 1 | 18s | 18s | Fast targeted package check. |
 | AI Reconciliation (live) | `pull_request_target` | 14 | 17s | 633s | Typical job is ~10s; review-event outliers affect run envelope. |
 | Security Guardrails | `pull_request` | 9 | 15s | 168s | PR secret scan job is fast; skipped heavy jobs still add envelope. |
-| PR Body Contract | `pull_request_target` | 14 | 14s | 155s | Fast process/meta context, not currently branch-required. |
-| Diff Budget | `pull_request_target` | 14 | 12s | 143s | Fast expected meta gate; repo code expects branch protection to require it, but live protection may need alignment. |
+| PR Body Contract | `pull_request_target` | 14 | 14s | 155s | Fast registry-required process/meta context. |
+| Diff Budget | `pull_request_target` | 14 | 12s | 143s | Fast registry-required meta gate. |
 | Gitleaks Baseline Growth Guard | `pull_request_target` | 9 | 10s | 164s | Fast required meta gate. |
 
 ## Step-Level Findings

--- a/plans/PR-Required-Workflow-Enrollment-Audit.md
+++ b/plans/PR-Required-Workflow-Enrollment-Audit.md
@@ -1,0 +1,173 @@
+# PR-Required-Workflow-Enrollment-Audit
+
+## Why this slice exists
+
+The mechanical-enforcement audit's next open follow-up is
+`PR-Required-Workflow-Enrollment-Audit`: decide whether the existing CI-only
+process checks `pre-push-audit` and `unit-gate` should remain visible-but-not
+branch-required or become part of live branch protection. This follows the
+2026-08-04 required-status alignment, which made the registry's existing
+`branch_required` contexts live, but intentionally left these two checks at
+`ci_blocking_not_required`.
+
+User request: after repeated red checks and review churn, identify the
+mechanical checks that are not being respected and fix the root rather than
+patching PR by PR.
+
+### Problem-derived contract
+
+- Root cause: Atlas now has a live branch-required registry, but two checks that
+  look merge-relevant in PRs (`pre-push-audit`, `unit-gate`) are still
+  classified as CI-blocking-but-not-required without a current evidence record
+  explaining why. That ambiguity lets agents treat red or pending checks as
+  optional in some threads and blocking in others.
+- Correct fix must touch/change: gather current workflow evidence for
+  `pre-push-audit` and `unit-gate`; record the enrollment decision and rationale
+  in a durable audit doc; update `ci/gates.yml` and related docs only if the
+  evidence supports changing their enforcement class; keep live branch
+  protection untouched unless the registry changes and the live GitHub payload is
+  explicitly verified after the change.
+- Must not change: do not change product behavior, EOM lanes, dependency PRs,
+  workflow job implementations, test selection logic, or branch protection by
+  default. Do not make `unit-gate` branch-required if the evidence shows its
+  runtime/flakiness/self-owned workflow semantics would increase churn without
+  closing a proven merge-safety gap.
+
+## Scope (this PR)
+
+Ownership lane: dev-workflow/required-workflow-enrollment
+Slice phase: Workflow/process
+
+1. Audit current `pre-push-audit` and `unit-gate` workflow behavior, including
+   live enforcement class, trust model, recent run outcomes, and runtime/churn
+   implications.
+2. Record the decision: keep one or both as `ci_blocking_not_required`, or
+   promote one or both to `branch_required` with matching documentation.
+3. If the decision changes the registry, update only the registry/docs required
+   to keep the branch-protection checker and docs consistent.
+
+### Review Contract
+
+- Acceptance criteria:
+  1. The audit doc names the current enforcement class for `pre-push-audit` and
+     `unit-gate`, settled by `ci/gates.yml`.
+  2. The audit doc cites recent GitHub Actions outcome/runtime evidence for both
+     workflows, settled by the recorded `gh run list` / `gh run view` commands
+     in the audit doc.
+  3. The audit doc names the trust model for both workflows, settled by
+     `.github/workflows/pre_push_audit.yml`, `.github/workflows/unit_gate.yml`,
+     and `docs/SECURITY_GUARDRAILS.md`.
+  4. Any registry or docs enforcement-class change is mirrored consistently in
+     `ci/gates.yml`, `docs/ci_cd_autonomous_coding_map.md`, and the new audit
+     doc; if no registry change is made, the audit doc explicitly says why.
+  5. `python scripts/check_required_status_checks.py --payload-file <fresh live
+     payload>` still passes after the slice.
+- Reachability proof: the real entrypoint is the branch-protection checker
+  command against a fresh GitHub payload; the observable effect is PASS after
+  the recorded decision.
+- Affected surfaces: `ci/gates.yml` if enforcement changes; workflow/process
+  docs and the plan.
+- Risk areas: accidental branch-protection churn, over-requiring slow/flaky
+  checks, stale enforcement docs, and widening outside the workflow lane.
+- Reviewer rules triggered: R1, R2, R10, R11, R12, R14.
+
+### Boundary-change enumeration
+
+Required when this diff changes a guard, validator, normalizer, resolver,
+router/classifier, or admission boundary. Name each changed boundary path or
+seam in the enumeration; otherwise write "N/A - no boundary change."
+
+- Boundary path/seam: live merge gate enrollment for CI contexts.
+- Replaced-path behaviors: before this slice, `pre-push-audit` and `unit-gate`
+  are visible CI checks but not registry branch-required checks.
+- Guard-relevant fields: `ci/gates.yml` `enforcement`, workflow context names,
+  branch-protection required check payload, and GitHub Actions app source.
+- Caller x input shape: PRs that produce `pre-push-audit` and `unit-gate`
+  contexts.
+
+### Deployed-config probing
+
+Required for guard, validator, resolver, admission-boundary, or env/config
+fallback changes; otherwise write "N/A - no guard/config boundary change."
+
+- Deployed/default config values: live `main` branch protection required-status
+  payload.
+- Explicit value probe: run `scripts/check_required_status_checks.py` against a
+  fresh live payload after the decision.
+- Absent value probe: audit doc records whether `pre-push-audit` and `unit-gate`
+  are absent from the required set by design or promoted.
+- Default-session/default-context probe: N/A; no runtime app config.
+- Side-effect ordering: do not patch live branch protection unless the registry
+  changes and the branch-protection update is explicitly part of the verified
+  decision.
+
+### Files touched
+
+- `.github/workflows/unit_gate.yml`
+- `docs/audits/agents-mechanical-enforcement-audit-2026-07-29.md`
+- `docs/audits/required-workflow-enrollment-audit-2026-08-04.md`
+- `docs/ci_cd_autonomous_coding_map.md`
+- `docs/ci_cd_runtime_duplication_audit.md`
+- `plans/PR-Required-Workflow-Enrollment-Audit.md`
+- `tests/test_security_guardrails_workflow.py`
+
+## Mechanism
+
+This slice uses code and live CI as evidence, then records a decision. The
+branch-required registry remains the source of truth; the audit doc explains
+whether `pre-push-audit` and `unit-gate` should join that registry or remain
+visible CI. If the registry changes, documentation and live-payload verification
+move with it in the same slice.
+
+The evidence does not support promotion yet, so this slice leaves `ci/gates.yml`
+and live branch protection unchanged, records the blockers, updates stale
+workflow/process docs, and fixes the stale security-guardrails test assertion
+that current CI is already reporting.
+
+## Intentional
+
+- No live branch-protection mutation before evidence: the previous slice already
+  aligned the known registry gap, and this slice is about deciding whether the
+  registry itself should change.
+- `pre-push-audit` and `unit-gate` are evaluated separately; one can be promoted
+  without forcing the other.
+
+## Deferred
+
+- Unit-gate selector coverage for branch-protection/security docs so the stale
+  docs/test mismatch is caught before merge.
+- Trusted-base `pre-push-audit` PR-side docs/test consistency probe, if a safe
+  data-only probe can be designed without executing untrusted PR code.
+- Re-run enrollment after those blockers close; live branch protection changes
+  only if `ci/gates.yml` promotes one of these contexts.
+
+Parked hardening: none.
+
+## Verification
+
+- `gh pr list --state open --json number,title,headRefName,author,isDraft,mergeStateStatus --limit 30`
+- `git fetch origin main --prune`
+- `git log --oneline -15 origin/main`
+- `gh api repos/canfieldjuan/ATLAS/branches/main/protection/required_status_checks > /tmp/atlas-required-status-checks-live-required-workflow.json`
+- `python scripts/check_required_status_checks.py --payload-file /tmp/atlas-required-status-checks-live-required-workflow.json` - PASS
+- `gh run list --workflow pre_push_audit.yml --limit 20 --json databaseId,status,conclusion,createdAt,updatedAt,event,headBranch,displayTitle`
+- `gh run list --workflow unit_gate.yml --limit 20 --json databaseId,status,conclusion,createdAt,updatedAt,event,headBranch,displayTitle`
+- `gh run view 30961567962 --log-failed`
+- `gh run view 30960553450 --log-failed`
+- `python -m pytest tests/test_security_guardrails_workflow.py::test_security_guardrails_docs_name_required_gitleaks_checks` - 1 passed
+- `python -m pytest tests/test_security_guardrails_workflow.py` - 35 passed
+- `python scripts/audit_pr_body.py /tmp/atlas-pr-body-required-workflow-enrollment.md --base-ref origin/main` - PASS
+- `python scripts/audit_ai_reconciliation.py --current-pr-body-file /tmp/atlas-pr-body-required-workflow-enrollment.md --require` - PASS
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/unit_gate.yml` | 5 |
+| `docs/audits/agents-mechanical-enforcement-audit-2026-07-29.md` | 15 |
+| `docs/audits/required-workflow-enrollment-audit-2026-08-04.md` | 108 |
+| `docs/ci_cd_autonomous_coding_map.md` | 6 |
+| `docs/ci_cd_runtime_duplication_audit.md` | 26 |
+| `plans/PR-Required-Workflow-Enrollment-Audit.md` | 173 |
+| `tests/test_security_guardrails_workflow.py` | 4 |
+| **Total** | **337** |

--- a/tests/test_security_guardrails_workflow.py
+++ b/tests/test_security_guardrails_workflow.py
@@ -123,8 +123,8 @@ def test_security_guardrails_docs_name_required_gitleaks_checks() -> None:
     for context in REQUIRED_STATUS_CONTEXTS:
         assert f"`{context}`" in text
     assert "`Branch Protection Required Checks` workflow" in text
-    assert "live GitHub settings still require only" in normalized_text
-    assert "REST PATCH" in text
+    assert "live GitHub settings contain every registry-required context" in normalized_text
+    assert "not an exact-set audit for extra required contexts" in normalized_text
 
 
 def test_branch_protection_workflow_audits_live_required_checks() -> None:


### PR DESCRIPTION
Plan: plans/PR-Required-Workflow-Enrollment-Audit.md
Slice phase: Workflow/process
Ownership lane: dev-workflow/required-workflow-enrollment

This slice records the required-workflow enrollment decision after the required-status alignment work: keep `pre-push-audit` and `unit-gate` visible in CI but outside hard branch protection until their documented coverage/trust blockers are closed, and fix the stale security-guardrails test assertion that current CI is already reporting.

## Intentional
- No `ci/gates.yml` or live branch-protection mutation: the evidence does not support promotion yet.
- `pre-push-audit` and `unit-gate` are evaluated separately, but both remain `ci_blocking_not_required` in this decision.
- The unit-gate workflow implementation is not changed beyond its status comment; selector coverage is deferred as its own root-cause slice.

## AI reconciliation
- no-findings

## Deferred
- Unit-gate selector coverage for branch-protection/security docs so the stale docs/test mismatch is caught before merge.
- Trusted-base `pre-push-audit` PR-side docs/test consistency probe, if a safe data-only probe can be designed without executing untrusted PR code.
- Re-run enrollment after those blockers close; live branch protection changes only if `ci/gates.yml` promotes one of these contexts.

## Parked hardening
- None.

## Cold diff reconstruction
- Changed: docs/audits/required-workflow-enrollment-audit-2026-08-04.md:5 records the decision to keep `pre-push-audit` and `unit-gate` at `ci_blocking_not_required`; docs/audits/required-workflow-enrollment-audit-2026-08-04.md:22 names the current registry classes; docs/audits/required-workflow-enrollment-audit-2026-08-04.md:25 records the live branch-protection absence by design.
- Changed: docs/audits/required-workflow-enrollment-audit-2026-08-04.md:44 records recent `pre-push-audit` outcomes/runtime; docs/audits/required-workflow-enrollment-audit-2026-08-04.md:60 records recent `unit-gate` outcomes/runtime; docs/audits/required-workflow-enrollment-audit-2026-08-04.md:67 names each workflow trust model.
- Changed: docs/audits/required-workflow-enrollment-audit-2026-08-04.md:82 records the enrollment blockers and docs/audits/required-workflow-enrollment-audit-2026-08-04.md:99 records the next hardening path instead of promoting checks now.
- Changed: docs/audits/agents-mechanical-enforcement-audit-2026-07-29.md:103 closes the follow-up with the new audit doc, and docs/audits/agents-mechanical-enforcement-audit-2026-07-29.md:128 updates the bottom line after the enrollment decision.
- Changed: .github/workflows/unit_gate.yml:11 updates the stale comment so the workflow says it is visible CI but not branch-required until selector coverage blockers close.
- Changed: docs/ci_cd_runtime_duplication_audit.md:28 and docs/ci_cd_runtime_duplication_audit.md:33 update the branch-required gate set to the current aligned registry; docs/ci_cd_runtime_duplication_audit.md:46 separates visible process guardrails from hard branch-protection gates; docs/ci_cd_runtime_duplication_audit.md:57 and docs/ci_cd_runtime_duplication_audit.md:78 remove stale branch-protection mismatch wording.
- Changed: docs/ci_cd_autonomous_coding_map.md:74 renames the trusted-base table column from required context to published context, and docs/ci_cd_autonomous_coding_map.md:85 states that `pre-push-audit` and `unit-gate` are visible CI signals, not branch-required contexts.
- Changed: tests/test_security_guardrails_workflow.py:126 updates the stale expected security-guardrails docs wording so the current branch-protection docs/test contract passes again.
- Contract match: every change traces to the Problem-derived contract by recording the enrollment decision, updating stale workflow/process docs that contradicted the decision, avoiding branch-protection mutation, and fixing the red test caused by the prior required-status docs change.
- Gaps: none. No registry, product, EOM, dependency, test selector, or workflow behavior changes are included.

## Verification
- `gh pr list --state open --json number,title,headRefName,author,isDraft,mergeStateStatus --limit 30`
- `git fetch origin main --prune`
- `git log --oneline -15 origin/main`
- `gh api repos/canfieldjuan/ATLAS/branches/main/protection/required_status_checks > /tmp/atlas-required-status-checks-live-required-workflow.json`
- `python scripts/check_required_status_checks.py --payload-file /tmp/atlas-required-status-checks-live-required-workflow.json` - PASS
- `gh run list --workflow pre_push_audit.yml --limit 20 --json databaseId,status,conclusion,createdAt,updatedAt,event,headBranch,displayTitle`
- `gh run list --workflow unit_gate.yml --limit 20 --json databaseId,status,conclusion,createdAt,updatedAt,event,headBranch,displayTitle`
- `gh run view 30961567962 --log-failed`
- `gh run view 30960553450 --log-failed`
- `python -m pytest tests/test_security_guardrails_workflow.py::test_security_guardrails_docs_name_required_gitleaks_checks` - 1 passed
- `python -m pytest tests/test_security_guardrails_workflow.py` - 35 passed
- `python scripts/sync_pr_plan.py plans/PR-Required-Workflow-Enrollment-Audit.md --check` - PASS
- `python scripts/audit_plan_doc.py plans/PR-Required-Workflow-Enrollment-Audit.md` - PASS

## Mechanical verification
- Command: python scripts/sync_pr_plan.py plans/PR-Required-Workflow-Enrollment-Audit.md --check - Result: passed - Environment: local
- Command: python scripts/audit_plan_doc.py plans/PR-Required-Workflow-Enrollment-Audit.md - Result: passed - Environment: local
- Command: python scripts/audit_pr_body.py /tmp/atlas-pr-body-required-workflow-enrollment.md --base-ref origin/main - Result: passed - Environment: local
- Command: python scripts/audit_ai_reconciliation.py --current-pr-body-file /tmp/atlas-pr-body-required-workflow-enrollment.md --require - Result: passed - Environment: local

## Diff size
7 files, 335 LOC.
