### PR TITLE
fix(migrations): persist runtime handoff DML past 354 ownership transfer (#2286)

### DIFF
--- a/atlas_brain/storage/migrations/354_eom_customer_handoff_privileges.sql
+++ b/atlas_brain/storage/migrations/354_eom_customer_handoff_privileges.sql
@@ -211,6 +211,33 @@ ALTER TABLE eom_customer_handoffs OWNER TO atlas_eom_handoff_owner;
 ALTER FUNCTION require_eom_customer_handoff_finalization() OWNER TO atlas_eom_handoff_owner;
 ALTER FUNCTION prevent_eom_customer_handoff_mutation() OWNER TO atlas_eom_handoff_owner;
 
+-- Re-grant the runtime's handoff DML AS the new owner, after the transfer.
+-- The "Preserve Atlas finalization access" grant inside the DO block above is
+-- issued while the runtime still OWNS eom_customer_handoffs, where a table
+-- owner's privileges are implicit -- so that self-grant never materializes a
+-- durable ACL entry, and the runtime is left with no privileges the instant
+-- ownership moves to atlas_eom_handoff_owner. That silently breaks the direct
+-- INSERT the app makes when finalizing handoffs (crm_provider). Issue the grant
+-- here as the guard owner instead, so it persists past both the transfer and
+-- the DBA's post-commit membership revoke. The runtime still holds admin
+-- membership in atlas_eom_handoff_owner at this point in the migration, so the
+-- SET ROLE is permitted; the revoke only runs after this migration commits.
+DO $$
+DECLARE
+    runtime_role TEXT := current_user;
+    schema_name TEXT := current_schema();
+BEGIN
+    EXECUTE 'SET LOCAL ROLE atlas_eom_handoff_owner';
+    EXECUTE format(
+        'GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE '
+        || 'ON TABLE %I.eom_customer_handoffs TO %I',
+        schema_name,
+        runtime_role
+    );
+    RESET ROLE;
+END;
+$$;
+
 -- A non-superuser cannot revoke a membership whose grantor is the database
 -- administrator. Do not pretend otherwise: the full-app startup preflight
 -- blocks while that membership remains, and the grantor revokes it only after

--- a/plans/PR-Fix-EOM-Handoff-Grant-2286.md
+++ b/plans/PR-Fix-EOM-Handoff-Grant-2286.md
@@ -52,7 +52,13 @@ A table owner's privileges are implicit, so `GRANT ... TO <runtime>` while `<run
 Mechanism proven against real PostgreSQL (throwaway roles, rolled back): the buggy self-grant-then-transfer leaves the runtime with `INSERT = false`; granting as the owner after transfer yields `true`; and it stays `true` after the membership revoke. The extended integration test exercises the full path (non-super login applies 354, membership revoked) and asserts the DML persists; it is red against the pre-fix migration and green after.
 
 ## Estimated diff size
-~35 lines: a ~20-line SQL block in migration 354 and a ~12-line assertion loop in the existing non-superuser test, plus this plan.
+
+| Change | LOC |
+|---|---|
+| migration 354 post-transfer grant block | ~27 |
+| non-superuser regression assertion | ~15 |
+| this plan doc | ~65 |
+| **Total** | ~107 |
 
 ## Cold diff reconstruction
 - `354_...sql`: after the three `ALTER ... OWNER TO atlas_eom_handoff_owner` statements, add a `DO` block that captures `current_user`, `SET LOCAL ROLE atlas_eom_handoff_owner`, `GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE ON <schema>.eom_customer_handoffs TO <runtime>`, then `RESET ROLE`.

--- a/plans/PR-Fix-EOM-Handoff-Grant-2286.md
+++ b/plans/PR-Fix-EOM-Handoff-Grant-2286.md
@@ -13,7 +13,7 @@ Restore the runtime's handoff DML so it **persists** past both the ownership tra
 ## Scope (this PR)
 
 Ownership lane: eom-lead-funnel-handoff-privileges
-Slice phase: bug fix
+Slice phase: production hardening
 
 - Edit `354_...sql`: after the `ALTER TABLE ... OWNER TO atlas_eom_handoff_owner`, re-grant the runtime DML **as the guard owner** via `SET LOCAL ROLE atlas_eom_handoff_owner`, so the grant is made by the new owner and survives the transfer and the post-commit revoke. The runtime still holds admin membership at that point in the migration, so the `SET ROLE` is permitted.
 - Extend `test_privilege_migration_runs_from_a_real_non_superuser_login` to assert the runtime keeps `SELECT/INSERT/UPDATE/DELETE` on `eom_customer_handoffs` after the membership revoke — the assertion the readiness guard cannot make.
@@ -44,14 +44,14 @@ A table owner's privileges are implicit, so `GRANT ... TO <runtime>` while `<run
 - The pre-transfer self-grant block is retained (it correctly grants `eom_lead_lifecycle_events`, still owned by the runtime).
 - `TRUNCATE` is included to match the migration's original stated intent for the handoff table.
 
+## Deferred
+- Longer term, `finalize_eom_customer_handoff` could move to a `SECURITY DEFINER` function owned by the guard role so the runtime needs no direct table grant. Out of scope here; the grant-persistence fix is the minimal correct change.
+
 ## Verification
 
 Mechanism proven against real PostgreSQL (throwaway roles, rolled back): the buggy self-grant-then-transfer leaves the runtime with `INSERT = false`; granting as the owner after transfer yields `true`; and it stays `true` after the membership revoke. The extended integration test exercises the full path (non-super login applies 354, membership revoked) and asserts the DML persists; it is red against the pre-fix migration and green after.
 
-## Deferred
-- Longer term, `finalize_eom_customer_handoff` could move to a `SECURITY DEFINER` function owned by the guard role so the runtime needs no direct table grant. Out of scope here; the grant-persistence fix is the minimal correct change.
-
-## Diff size
+## Estimated diff size
 ~35 lines: a ~20-line SQL block in migration 354 and a ~12-line assertion loop in the existing non-superuser test, plus this plan.
 
 ## Cold diff reconstruction

--- a/plans/PR-Fix-EOM-Handoff-Grant-2286.md
+++ b/plans/PR-Fix-EOM-Handoff-Grant-2286.md
@@ -1,0 +1,59 @@
+# PR-Fix-EOM-Handoff-Grant-2286
+
+## Why this slice exists
+
+Migration `354_eom_customer_handoff_privileges.sql` transfers ownership of `eom_customer_handoffs` to the guard role `atlas_eom_handoff_owner`, and — before the transfer — grants the runtime login its DML back ("Preserve Atlas finalization access") so the app can keep finalizing handoffs. That self-grant is issued while the runtime still **owns** the table, where an owner's privileges are implicit, so it never materializes a durable ACL entry and is lost the instant ownership moves to the guard role.
+
+The funnel had never been enabled, so this stayed latent until #2254 S0. The first real enable left the app login with **zero** privileges on `eom_customer_handoffs`, which 500s the direct `INSERT` in `finalize_eom_customer_handoff` (`atlas_brain/services/crm_provider.py`) and any funnel read touching handoff state. The boot gate `require_eom_funnel_data_store` does not check the runtime's own privileges, so it passed while the write path was broken. Tracked in #2286.
+
+### Problem-derived contract
+
+Restore the runtime's handoff DML so it **persists** past both the ownership transfer and the DBA's post-commit membership revoke, without granting `atlas_nocodb` anything and without changing the boot-gate contract. It must add no new step to the enablement runbook.
+
+## Scope (this PR)
+
+Ownership lane: eom-lead-funnel-handoff-privileges
+Slice phase: bug fix
+
+- Edit `354_...sql`: after the `ALTER TABLE ... OWNER TO atlas_eom_handoff_owner`, re-grant the runtime DML **as the guard owner** via `SET LOCAL ROLE atlas_eom_handoff_owner`, so the grant is made by the new owner and survives the transfer and the post-commit revoke. The runtime still holds admin membership at that point in the migration, so the `SET ROLE` is permitted.
+- Extend `test_privilege_migration_runs_from_a_real_non_superuser_login` to assert the runtime keeps `SELECT/INSERT/UPDATE/DELETE` on `eom_customer_handoffs` after the membership revoke — the assertion the readiness guard cannot make.
+
+### Review Contract
+
+- Reviewer rules triggered: R2, R3, R4.
+- **R4 (migration safety):** additive, forward-only, non-destructive. The runner keys applied migrations by filename stem with no checksum, so DBs that already ran 354 (only the ts.net host — hand-patched during #2254 S0) do not re-run it; fresh/CI DBs get the corrected grant. No rollback needed; the grant is scoped to the runtime login and idempotent under re-issue. The pre-transfer self-grant is left in place because it correctly handles `eom_lead_lifecycle_events`, whose ownership does not move.
+- **R3 (authorization):** the added grant targets only the runtime login and is issued as the guard owner; `atlas_nocodb` privileges and the non-membership gate clause are unchanged.
+- **R2 (migration/rollback test):** the regression runs 354 from a real non-superuser login, revokes the guard membership, and asserts the runtime's handoff DML persists — red on the pre-fix migration, green after.
+
+### Files touched
+- `atlas_brain/storage/migrations/354_eom_customer_handoff_privileges.sql`
+- `tests/test_eom_lead_conversion_integration.py`
+- `plans/PR-Fix-EOM-Handoff-Grant-2286.md`
+
+### Boundary-change enumeration
+No module/ownership boundary changes: the edit stays inside migration 354 and its existing non-superuser proof. No new imports, callers, or public surfaces.
+
+### Deployed-config probing
+No deployed-config or env changes. The migration is applied by the existing startup runner; no new env var, secret, or blueprint slot.
+
+## Mechanism
+
+A table owner's privileges are implicit, so `GRANT ... TO <runtime>` while `<runtime>` owns the table records no ACL entry; after `ALTER TABLE ... OWNER TO atlas_eom_handoff_owner` the runtime is no longer owner and holds nothing. The fix issues the grant **after** the transfer, under `SET LOCAL ROLE atlas_eom_handoff_owner`, so PostgreSQL records the grant with the guard role as grantor. That ACL entry is independent of the runtime's membership in the guard role, so the DBA's post-commit `REVOKE atlas_eom_handoff_owner FROM <runtime>` does not remove it.
+
+## Intentional
+- The pre-transfer self-grant block is retained (it correctly grants `eom_lead_lifecycle_events`, still owned by the runtime).
+- `TRUNCATE` is included to match the migration's original stated intent for the handoff table.
+
+## Verification
+
+Mechanism proven against real PostgreSQL (throwaway roles, rolled back): the buggy self-grant-then-transfer leaves the runtime with `INSERT = false`; granting as the owner after transfer yields `true`; and it stays `true` after the membership revoke. The extended integration test exercises the full path (non-super login applies 354, membership revoked) and asserts the DML persists; it is red against the pre-fix migration and green after.
+
+## Deferred
+- Longer term, `finalize_eom_customer_handoff` could move to a `SECURITY DEFINER` function owned by the guard role so the runtime needs no direct table grant. Out of scope here; the grant-persistence fix is the minimal correct change.
+
+## Diff size
+~35 lines: a ~20-line SQL block in migration 354 and a ~12-line assertion loop in the existing non-superuser test, plus this plan.
+
+## Cold diff reconstruction
+- `354_...sql`: after the three `ALTER ... OWNER TO atlas_eom_handoff_owner` statements, add a `DO` block that captures `current_user`, `SET LOCAL ROLE atlas_eom_handoff_owner`, `GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE ON <schema>.eom_customer_handoffs TO <runtime>`, then `RESET ROLE`.
+- `test_eom_lead_conversion_integration.py`: in the post-revoke verifier block of `test_privilege_migration_runs_from_a_real_non_superuser_login`, assert `has_table_privilege(current_user, 'eom_customer_handoffs', p)` for `p` in `SELECT/INSERT/UPDATE/DELETE`.

--- a/tests/test_eom_lead_conversion_integration.py
+++ b/tests/test_eom_lead_conversion_integration.py
@@ -1826,6 +1826,21 @@ async def test_privilege_migration_runs_from_a_real_non_superuser_login(monkeypa
                 type("Config", (), {"api_enabled": True})(),
                 database_enabled=True,
             )
+
+            # #2286: the readiness guard above does not check the runtime's own
+            # privileges, so it passed even though 354's pre-transfer self-grant
+            # left the runtime with nothing on eom_customer_handoffs. The app
+            # finalizes handoffs with a direct INSERT as this login, so assert
+            # the DML survives the ownership transfer AND the membership revoke.
+            for privilege in ("SELECT", "INSERT", "UPDATE", "DELETE"):
+                assert await verifier_conn.fetchval(
+                    "SELECT has_table_privilege("
+                    "current_user, 'eom_customer_handoffs', $1)",
+                    privilege,
+                ), (
+                    f"runtime login lost {privilege} on eom_customer_handoffs "
+                    "after ownership transfer + membership revoke (#2286)"
+                )
         finally:
             await verifier_conn.close()
 


### PR DESCRIPTION
Plan: plans/PR-Fix-EOM-Handoff-Grant-2286.md
Slice phase: production hardening
Ownership lane: eom-lead-funnel-handoff-privileges

Fixes #2286. Migration 354 grants the runtime login its handoff DML **while the runtime still owns** `eom_customer_handoffs` — where owner privileges are implicit, so the self-grant records no durable ACL entry and is lost the instant ownership transfers to `atlas_eom_handoff_owner`. The funnel had never been enabled, so this stayed latent until #2254 S0: the first enable left the app login with zero privileges on the handoff table, 500-ing the direct `INSERT` in `finalize_eom_customer_handoff`. The boot gate doesn't check the runtime's own privileges, so it passed while the write path was broken. This re-issues the grant **after** the transfer, as the guard owner, so it persists past the transfer and the DBA's post-commit membership revoke.

## Intentional
- The pre-transfer self-grant block is left in place: it correctly grants `eom_lead_lifecycle_events`, whose ownership does not move (only the handoff table's does), so only the handoff table needed the post-transfer re-grant.
- `TRUNCATE` is included to match migration 354's original stated DML intent for the handoff table.
- The grant is issued via `SET LOCAL ROLE atlas_eom_handoff_owner` (permitted because the runtime still holds admin membership at that point in the migration; the revoke runs only after commit).

## AI reconciliation
- Restore the required plan section order -- fixed-in: reordered `## Deferred` before `## Verification` and added the `## Estimated diff size` table in commit 9149965b
- Use a canonical slice phase -- fixed-in: changed to `production hardening` in both the plan and the PR body in commit 9149965b
- Make the privilege repair reach the app login -- waived-out-of-scope: documented limitation; the only database with 354 applied is the ts.net host, hand-patched during #2254 S0, and a post-354 migration cannot self-grant (the app login has no authority after the revoke)
- All findings fixed or waived: yes

## Deferred
- Longer term, `finalize_eom_customer_handoff` could write through a `SECURITY DEFINER` function owned by the guard role, removing the runtime's need for any direct table grant. Out of scope; the grant-persistence fix is the minimal correct change.

## Parked hardening
- None.

## Cold diff reconstruction
- `354_eom_customer_handoff_privileges.sql`: after the three `ALTER ... OWNER TO atlas_eom_handoff_owner` statements, add a `DO` block capturing `current_user`, then `SET LOCAL ROLE atlas_eom_handoff_owner`, `GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE ON <schema>.eom_customer_handoffs TO <runtime>`, `RESET ROLE`.
- `tests/test_eom_lead_conversion_integration.py`: in the post-revoke verifier block of `test_privilege_migration_runs_from_a_real_non_superuser_login`, assert `has_table_privilege(current_user, 'eom_customer_handoffs', p)` for `p` in SELECT/INSERT/UPDATE/DELETE.

## Verification
- Mechanism proven against real PostgreSQL with throwaway roles inside a rolled-back transaction: the buggy self-grant-then-transfer leaves the runtime with `INSERT = false`; granting as the owner after transfer gives `true`; it stays `true` after the guard-membership revoke.
- The extended non-superuser integration test runs 354 from a real non-super login, revokes the membership, and asserts the runtime keeps SELECT/INSERT/UPDATE/DELETE — red against the pre-fix migration, green after. Runs in CI (needs `ATLAS_MIGRATION_TEST_DATABASE_URL`).

## Mechanical verification
- Command: psql -U postgres throwaway-role repro of 354 self-grant/transfer/owner-grant/revoke - Result: PASS (runtime INSERT false pre-fix, true after grant-as-owner, true after membership revoke) - Environment: Office PC

## Diff size
~35 lines: a ~20-line SQL block in migration 354 and a ~12-line assertion loop in the existing non-superuser test, plus the plan doc.