### PR TITLE
Map governance docs to unit gate owners

### DIFF
--- a/plans/PR-Unit-Gate-Governance-Selector.md
+++ b/plans/PR-Unit-Gate-Governance-Selector.md
@@ -49,6 +49,8 @@ Slice phase: Workflow/process
   - `tests/test_audit_pr_watcher_safety.py` proves the watcher safety audit
     catches unsafe merge-authority wording in
     `docs/ci_cd_autonomous_coding_map.md`.
+  - `tests/test_audit_pr_watcher_safety.py` runs the watcher safety audit
+    against the checked-out repository docs, not only fixture docs.
   - `scripts/select_impacted_tests.py` has only one explicit-owner entry for
     `scripts/check_ai_reconciliation_live.py`.
 - Reachability proof: `python -m pytest tests/test_select_impacted_tests.py -q`
@@ -129,6 +131,8 @@ also selects `tests/test_security_policy_docs.py` for the repo-label manifest
 checks that directly read that file, and
 `docs/ci_cd_autonomous_coding_map.md` selects
 `tests/test_audit_pr_watcher_safety.py` for watcher merge-authority claims.
+That suite now runs both a fixture-level failure proof and a checked-out-repo
+audit, so scoped unit-gate runs exercise the actual changed doc content.
 The slice also removes a duplicate `scripts/check_ai_reconciliation_live.py`
 entry. The existing owner-file existence check continues to escalate stale
 owners to FULL.
@@ -160,15 +164,17 @@ Parked hardening: none.
 - `/tmp/atlas-pr2259-venv/bin/python -m pytest tests/test_security_policy_docs.py tests/test_security_guardrails_workflow.py tests/test_select_impacted_tests.py -q`
   -- passed locally, 116 passed, 43 subtests passed.
 - `/tmp/atlas-pr2259-venv/bin/python -m pytest tests/test_audit_pr_watcher_safety.py tests/test_security_policy_docs.py tests/test_security_guardrails_workflow.py tests/test_select_impacted_tests.py -q`
-  -- passed locally, 138 passed, 43 subtests passed.
+  -- passed locally, 139 passed, 43 subtests passed.
+- `/tmp/atlas-pr2259-venv/bin/python -m pytest tests/test_audit_pr_watcher_safety.py tests/test_select_impacted_tests.py -q`
+  -- passed locally, 84 passed.
 - `python3 -m py_compile scripts/select_impacted_tests.py` -- passed locally.
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Unit-Gate-Governance-Selector.md` | 174 |
+| `plans/PR-Unit-Gate-Governance-Selector.md` | 180 |
 | `scripts/select_impacted_tests.py` | 19 |
-| `tests/test_audit_pr_watcher_safety.py` | 15 |
+| `tests/test_audit_pr_watcher_safety.py` | 28 |
 | `tests/test_select_impacted_tests.py` | 41 |
-| **Total** | **249** |
+| **Total** | **268** |

--- a/plans/PR-Unit-Gate-Governance-Selector.md
+++ b/plans/PR-Unit-Gate-Governance-Selector.md
@@ -1,0 +1,150 @@
+# PR-Unit-Gate-Governance-Selector
+
+## Why this slice exists
+
+Issue #2260 and the #2283 required-workflow enrollment audit found that
+`unit-gate` is not ready for branch protection because governance docs can fall
+through the selector as test-free Markdown. The concrete failure mode was a
+required-status/security doc change that selected no reachable tests, passed
+growth-only, and then failed `tests/test_security_guardrails_workflow.py` in a
+later broader path.
+
+### Problem-derived contract
+
+- Root cause: `scripts/select_impacted_tests.py` only treats known code/workflow
+  CI surfaces as explicit owners. Markdown docs default to test-free selection,
+  so CI/security governance docs whose claims are validated by
+  `tests/test_security_guardrails_workflow.py` can skip that owning suite.
+- Correct fix must touch/change: add explicit selector ownership for the
+  current required-status/security governance docs, prove each selects
+  `tests/test_security_guardrails_workflow.py`, and keep the missing-owner
+  fallback fail-closed.
+- Must not change: no `ci/gates.yml` enforcement promotion, no live branch
+  protection mutation, no `unit_gate.yml` runtime change, no product behavior,
+  and no broader full-suite policy change.
+
+## Scope (this PR)
+
+Ownership lane: dev-workflow/unit-gate-selector
+Slice phase: Workflow/process
+
+1. Map CI/security governance docs that feed required-status/security claims to
+   their owning selector tests instead of Markdown growth-only.
+2. Add regression coverage proving the mapped docs select
+   `tests/test_security_guardrails_workflow.py`.
+3. Remove duplicate explicit-owner membership while editing the same decision
+   set.
+
+### Review Contract
+
+- Acceptance criteria:
+  - `scripts/select_impacted_tests.py` maps
+    `docs/SECURITY_GUARDRAILS.md` to
+    `tests/test_security_guardrails_workflow.py`.
+  - `scripts/select_impacted_tests.py` maps the current CI/CD governance audit
+    docs in scope to `tests/test_security_guardrails_workflow.py`.
+  - `tests/test_select_impacted_tests.py::test_explicit_ci_surface_owners_are_selected`
+    proves those mappings select the owning suite.
+  - `scripts/select_impacted_tests.py` has only one explicit-owner entry for
+    `scripts/check_ai_reconciliation_live.py`.
+- Reachability proof: `python -m pytest tests/test_select_impacted_tests.py -q`
+  exercises the real selector entrypoint and observes selected test paths.
+- Affected surfaces: `scripts/select_impacted_tests.py`,
+  `tests/test_select_impacted_tests.py`, and this plan.
+- Risk areas: under-selection of CI governance tests, stale owner paths,
+  over-broad selector escalation, and duplicate owner-map membership.
+- Reviewer rules triggered: R1, R2, R10, R12, R13, R14.
+
+Closure declaration for explicit governance-doc owners:
+
+- Set status: CLOSED for this slice. The set is the current docs whose
+  required-status/security governance claims are directly coupled to
+  `tests/test_security_guardrails_workflow.py`: `docs/SECURITY_GUARDRAILS.md`,
+  `docs/ci_cd_autonomous_coding_map.md`,
+  `docs/ci_cd_runtime_duplication_audit.md`,
+  `docs/audits/agents-mechanical-enforcement-audit-2026-07-29.md`, and
+  `docs/audits/required-workflow-enrollment-audit-2026-08-04.md`.
+- Membership source: ENUMERATED from issue #2260, the #2283 audit's named
+  blocker, and the current repository docs that state required-status/security
+  gate policy. A future governance doc that makes the same kind of claim must
+  add an explicit owner in the PR that introduces it.
+- Outside-set behavior: unlisted Markdown remains test-free by default, which is
+  the cheap side for normal docs. Unlisted non-Markdown or unknown runtime
+  assets retain the existing fail-closed/FULL behavior.
+
+### Boundary-change enumeration
+
+Required when this diff changes a guard, validator, normalizer, resolver,
+router/classifier, or admission boundary. Name each changed boundary path or
+seam in the enumeration; otherwise write "N/A - no boundary change."
+
+- Boundary path/seam: `scripts/select_impacted_tests.py` explicit owner map.
+- Replaced-path behaviors: listed governance docs select
+  `tests/test_security_guardrails_workflow.py`; ordinary Markdown docs remain
+  test-free; missing owner files still escalate to FULL.
+- Guard-relevant fields: changed path string, explicit owner tuple, owner file
+  existence.
+- Caller x input shape: unit-gate passes newline-separated changed paths from
+  git diff; direct tests pass single changed-path fixtures.
+
+### Deployed-config probing
+
+Required for guard, validator, resolver, admission-boundary, or env/config
+fallback changes; otherwise write "N/A - no guard/config boundary change."
+
+- Deployed/default config values: N/A - selector has no env/config fallback.
+- Explicit value probe: `tests/test_select_impacted_tests.py` fixture paths for
+  each mapped governance doc.
+- Absent value probe: existing missing-owner fixture still proves FULL fallback.
+- Default-session/default-context probe: N/A - no session context.
+- Side-effect ordering: N/A - pure selector, no mutation.
+
+### Files touched
+
+- `plans/PR-Unit-Gate-Governance-Selector.md`
+- `scripts/select_impacted_tests.py`
+- `tests/test_select_impacted_tests.py`
+
+## Mechanism
+
+`scripts/select_impacted_tests.py` keeps its existing import-graph selector and
+explicit-owner fallback. This slice adds the current CI/security governance docs
+to `EXPLICIT_TEST_OWNERS`, pointing them at
+`tests/test_security_guardrails_workflow.py`, and removes a duplicate
+`scripts/check_ai_reconciliation_live.py` entry. The existing owner-file
+existence check continues to escalate stale owners to FULL.
+
+## Intentional
+
+- This does not promote `unit-gate` to branch protection. It only closes the
+  selector blocker identified before promotion.
+- This does not derive doc ownership from prose. The governance-doc set is
+  closed and enumerated for this slice because regular Markdown remains
+  intentionally test-free.
+
+## Deferred
+
+- Re-run the #2283 required workflow enrollment decision after selector coverage
+  is proven in CI.
+- Decide branch-protection `strict` behavior separately from selector coverage.
+- Decide whether `pre-push-audit` needs a safe PR-side docs/test consistency
+  probe.
+
+Parked hardening: none.
+
+## Verification
+
+- `/tmp/atlas-pr2259-venv/bin/python -m pytest tests/test_select_impacted_tests.py -q`
+  -- passed locally, 61 passed.
+- `/tmp/atlas-pr2259-venv/bin/python -m pytest tests/test_security_guardrails_workflow.py tests/test_select_impacted_tests.py -q`
+  -- passed locally, 96 passed.
+- `python3 -m py_compile scripts/select_impacted_tests.py` -- passed locally.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Unit-Gate-Governance-Selector.md` | 145 |
+| `scripts/select_impacted_tests.py` | 18 |
+| `tests/test_select_impacted_tests.py` | 35 |
+| **Total** | **198** |

--- a/plans/PR-Unit-Gate-Governance-Selector.md
+++ b/plans/PR-Unit-Gate-Governance-Selector.md
@@ -40,7 +40,8 @@ Slice phase: Workflow/process
 - Acceptance criteria:
   - `scripts/select_impacted_tests.py` maps
     `docs/SECURITY_GUARDRAILS.md` to
-    `tests/test_security_guardrails_workflow.py`.
+    `tests/test_security_guardrails_workflow.py` and
+    `tests/test_security_policy_docs.py`.
   - `scripts/select_impacted_tests.py` maps the current CI/CD governance audit
     docs in scope to `tests/test_security_guardrails_workflow.py`.
   - `tests/test_select_impacted_tests.py::test_explicit_ci_surface_owners_are_selected`
@@ -64,6 +65,9 @@ Closure declaration for explicit governance-doc owners:
   `docs/ci_cd_runtime_duplication_audit.md`,
   `docs/audits/agents-mechanical-enforcement-audit-2026-07-29.md`, and
   `docs/audits/required-workflow-enrollment-audit-2026-08-04.md`.
+  `docs/SECURITY_GUARDRAILS.md` also selects
+  `tests/test_security_policy_docs.py` because that suite directly reads the
+  same doc and enforces the repo-label manifest markers.
 - Membership source: ENUMERATED from issue #2260, the #2283 audit's named
   blocker, and the current repository docs that state required-status/security
   gate policy. A future governance doc that makes the same kind of claim must
@@ -80,8 +84,9 @@ seam in the enumeration; otherwise write "N/A - no boundary change."
 
 - Boundary path/seam: `scripts/select_impacted_tests.py` explicit owner map.
 - Replaced-path behaviors: listed governance docs select
-  `tests/test_security_guardrails_workflow.py`; ordinary Markdown docs remain
-  test-free; missing owner files still escalate to FULL.
+  `tests/test_security_guardrails_workflow.py`; `docs/SECURITY_GUARDRAILS.md`
+  also selects `tests/test_security_policy_docs.py`; ordinary Markdown docs
+  remain test-free; missing owner files still escalate to FULL.
 - Guard-relevant fields: changed path string, explicit owner tuple, owner file
   existence.
 - Caller x input shape: unit-gate passes newline-separated changed paths from
@@ -110,7 +115,9 @@ fallback changes; otherwise write "N/A - no guard/config boundary change."
 `scripts/select_impacted_tests.py` keeps its existing import-graph selector and
 explicit-owner fallback. This slice adds the current CI/security governance docs
 to `EXPLICIT_TEST_OWNERS`, pointing them at
-`tests/test_security_guardrails_workflow.py`, and removes a duplicate
+`tests/test_security_guardrails_workflow.py`; `docs/SECURITY_GUARDRAILS.md`
+also selects `tests/test_security_policy_docs.py` for the repo-label manifest
+checks that directly read that file. The slice also removes a duplicate
 `scripts/check_ai_reconciliation_live.py` entry. The existing owner-file
 existence check continues to escalate stale owners to FULL.
 
@@ -138,13 +145,15 @@ Parked hardening: none.
   -- passed locally, 61 passed.
 - `/tmp/atlas-pr2259-venv/bin/python -m pytest tests/test_security_guardrails_workflow.py tests/test_select_impacted_tests.py -q`
   -- passed locally, 96 passed.
+- `/tmp/atlas-pr2259-venv/bin/python -m pytest tests/test_security_policy_docs.py tests/test_security_guardrails_workflow.py tests/test_select_impacted_tests.py -q`
+  -- passed locally, 116 passed, 43 subtests passed.
 - `python3 -m py_compile scripts/select_impacted_tests.py` -- passed locally.
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Unit-Gate-Governance-Selector.md` | 145 |
-| `scripts/select_impacted_tests.py` | 18 |
-| `tests/test_select_impacted_tests.py` | 35 |
-| **Total** | **198** |
+| `plans/PR-Unit-Gate-Governance-Selector.md` | 159 |
+| `scripts/select_impacted_tests.py` | 19 |
+| `tests/test_select_impacted_tests.py` | 41 |
+| **Total** | **219** |

--- a/plans/PR-Unit-Gate-Governance-Selector.md
+++ b/plans/PR-Unit-Gate-Governance-Selector.md
@@ -43,14 +43,18 @@ Slice phase: Workflow/process
     `tests/test_security_guardrails_workflow.py` and
     `tests/test_security_policy_docs.py`.
   - `scripts/select_impacted_tests.py` maps the current CI/CD governance audit
-    docs in scope to `tests/test_security_guardrails_workflow.py`.
+    docs in scope to their owning pytest suites.
   - `tests/test_select_impacted_tests.py::test_explicit_ci_surface_owners_are_selected`
     proves those mappings select the owning suite.
+  - `tests/test_audit_pr_watcher_safety.py` proves the watcher safety audit
+    catches unsafe merge-authority wording in
+    `docs/ci_cd_autonomous_coding_map.md`.
   - `scripts/select_impacted_tests.py` has only one explicit-owner entry for
     `scripts/check_ai_reconciliation_live.py`.
 - Reachability proof: `python -m pytest tests/test_select_impacted_tests.py -q`
   exercises the real selector entrypoint and observes selected test paths.
 - Affected surfaces: `scripts/select_impacted_tests.py`,
+  `tests/test_audit_pr_watcher_safety.py`,
   `tests/test_select_impacted_tests.py`, and this plan.
 - Risk areas: under-selection of CI governance tests, stale owner paths,
   over-broad selector escalation, and duplicate owner-map membership.
@@ -61,13 +65,15 @@ Closure declaration for explicit governance-doc owners:
 - Set status: CLOSED for this slice. The set is the current docs whose
   required-status/security governance claims are directly coupled to
   `tests/test_security_guardrails_workflow.py`: `docs/SECURITY_GUARDRAILS.md`,
-  `docs/ci_cd_autonomous_coding_map.md`,
   `docs/ci_cd_runtime_duplication_audit.md`,
   `docs/audits/agents-mechanical-enforcement-audit-2026-07-29.md`, and
   `docs/audits/required-workflow-enrollment-audit-2026-08-04.md`.
   `docs/SECURITY_GUARDRAILS.md` also selects
   `tests/test_security_policy_docs.py` because that suite directly reads the
   same doc and enforces the repo-label manifest markers.
+  `docs/ci_cd_autonomous_coding_map.md` selects
+  `tests/test_audit_pr_watcher_safety.py` because the watcher safety audit
+  scans that doc for unsafe watcher merge-authority claims.
 - Membership source: ENUMERATED from issue #2260, the #2283 audit's named
   blocker, and the current repository docs that state required-status/security
   gate policy. A future governance doc that makes the same kind of claim must
@@ -86,7 +92,9 @@ seam in the enumeration; otherwise write "N/A - no boundary change."
 - Replaced-path behaviors: listed governance docs select
   `tests/test_security_guardrails_workflow.py`; `docs/SECURITY_GUARDRAILS.md`
   also selects `tests/test_security_policy_docs.py`; ordinary Markdown docs
-  remain test-free; missing owner files still escalate to FULL.
+  remain test-free; `docs/ci_cd_autonomous_coding_map.md` selects
+  `tests/test_audit_pr_watcher_safety.py`; missing owner files still escalate
+  to FULL.
 - Guard-relevant fields: changed path string, explicit owner tuple, owner file
   existence.
 - Caller x input shape: unit-gate passes newline-separated changed paths from
@@ -108,6 +116,7 @@ fallback changes; otherwise write "N/A - no guard/config boundary change."
 
 - `plans/PR-Unit-Gate-Governance-Selector.md`
 - `scripts/select_impacted_tests.py`
+- `tests/test_audit_pr_watcher_safety.py`
 - `tests/test_select_impacted_tests.py`
 
 ## Mechanism
@@ -117,9 +126,12 @@ explicit-owner fallback. This slice adds the current CI/security governance docs
 to `EXPLICIT_TEST_OWNERS`, pointing them at
 `tests/test_security_guardrails_workflow.py`; `docs/SECURITY_GUARDRAILS.md`
 also selects `tests/test_security_policy_docs.py` for the repo-label manifest
-checks that directly read that file. The slice also removes a duplicate
-`scripts/check_ai_reconciliation_live.py` entry. The existing owner-file
-existence check continues to escalate stale owners to FULL.
+checks that directly read that file, and
+`docs/ci_cd_autonomous_coding_map.md` selects
+`tests/test_audit_pr_watcher_safety.py` for watcher merge-authority claims.
+The slice also removes a duplicate `scripts/check_ai_reconciliation_live.py`
+entry. The existing owner-file existence check continues to escalate stale
+owners to FULL.
 
 ## Intentional
 
@@ -147,13 +159,16 @@ Parked hardening: none.
   -- passed locally, 96 passed.
 - `/tmp/atlas-pr2259-venv/bin/python -m pytest tests/test_security_policy_docs.py tests/test_security_guardrails_workflow.py tests/test_select_impacted_tests.py -q`
   -- passed locally, 116 passed, 43 subtests passed.
+- `/tmp/atlas-pr2259-venv/bin/python -m pytest tests/test_audit_pr_watcher_safety.py tests/test_security_policy_docs.py tests/test_security_guardrails_workflow.py tests/test_select_impacted_tests.py -q`
+  -- passed locally, 138 passed, 43 subtests passed.
 - `python3 -m py_compile scripts/select_impacted_tests.py` -- passed locally.
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Unit-Gate-Governance-Selector.md` | 159 |
+| `plans/PR-Unit-Gate-Governance-Selector.md` | 174 |
 | `scripts/select_impacted_tests.py` | 19 |
+| `tests/test_audit_pr_watcher_safety.py` | 15 |
 | `tests/test_select_impacted_tests.py` | 41 |
-| **Total** | **219** |
+| **Total** | **249** |

--- a/scripts/select_impacted_tests.py
+++ b/scripts/select_impacted_tests.py
@@ -86,6 +86,7 @@ EXPLICIT_TEST_OWNERS: dict[str, tuple[str, ...]] = {
     ),
     "docs/SECURITY_GUARDRAILS.md": (
         "tests/test_security_guardrails_workflow.py",
+        "tests/test_security_policy_docs.py",
     ),
     "docs/ci_cd_autonomous_coding_map.md": (
         "tests/test_security_guardrails_workflow.py",

--- a/scripts/select_impacted_tests.py
+++ b/scripts/select_impacted_tests.py
@@ -89,7 +89,7 @@ EXPLICIT_TEST_OWNERS: dict[str, tuple[str, ...]] = {
         "tests/test_security_policy_docs.py",
     ),
     "docs/ci_cd_autonomous_coding_map.md": (
-        "tests/test_security_guardrails_workflow.py",
+        "tests/test_audit_pr_watcher_safety.py",
     ),
     "docs/ci_cd_runtime_duplication_audit.md": (
         "tests/test_security_guardrails_workflow.py",

--- a/scripts/select_impacted_tests.py
+++ b/scripts/select_impacted_tests.py
@@ -84,6 +84,21 @@ EXPLICIT_TEST_OWNERS: dict[str, tuple[str, ...]] = {
     "ci/gates.yml": (
         "tests/test_security_guardrails_workflow.py",
     ),
+    "docs/SECURITY_GUARDRAILS.md": (
+        "tests/test_security_guardrails_workflow.py",
+    ),
+    "docs/ci_cd_autonomous_coding_map.md": (
+        "tests/test_security_guardrails_workflow.py",
+    ),
+    "docs/ci_cd_runtime_duplication_audit.md": (
+        "tests/test_security_guardrails_workflow.py",
+    ),
+    "docs/audits/agents-mechanical-enforcement-audit-2026-07-29.md": (
+        "tests/test_security_guardrails_workflow.py",
+    ),
+    "docs/audits/required-workflow-enrollment-audit-2026-08-04.md": (
+        "tests/test_security_guardrails_workflow.py",
+    ),
     "scripts/audit_ai_reconciliation.py": (
         "tests/test_audit_ai_reconciliation.py",
         "tests/test_audit_pr_body.py",
@@ -101,9 +116,6 @@ EXPLICIT_TEST_OWNERS: dict[str, tuple[str, ...]] = {
     ),
     "scripts/check_required_status_checks.py": (
         "tests/test_security_guardrails_workflow.py",
-    ),
-    "scripts/check_ai_reconciliation_live.py": (
-        "tests/test_check_ai_reconciliation_live.py",
     ),
     "scripts/codex_wake_bridge.py": (
         "tests/test_codex_wake_bridge.py",

--- a/tests/test_audit_pr_watcher_safety.py
+++ b/tests/test_audit_pr_watcher_safety.py
@@ -166,6 +166,21 @@ def test_fails_on_docs_that_grant_watcher_merge_authority(tmp_path: Path) -> Non
     assert "repo docs/templates must not grant merge authority" in result.stdout
 
 
+def test_fails_on_autonomous_coding_map_that_grants_watcher_merge_authority(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    autonomous_map = repo / "docs" / "ci_cd_autonomous_coding_map.md"
+    autonomous_map.write_text(
+        "The watcher may merge once checks are green.\n",
+        encoding="utf-8",
+    )
+
+    result = _run(tmp_path, "--repo-root", str(repo), "--repo-only")
+
+    assert result.returncode == 1
+    assert "docs/ci_cd_autonomous_coding_map.md" in result.stdout
+    assert "repo docs/templates must not grant merge authority" in result.stdout
+
+
 @pytest.mark.parametrize("surface", ["timer", "notification", "bridge", "wake bridge"])
 def test_fails_on_docs_that_grant_wake_surface_merge_authority(
     tmp_path: Path,

--- a/tests/test_audit_pr_watcher_safety.py
+++ b/tests/test_audit_pr_watcher_safety.py
@@ -181,6 +181,19 @@ def test_fails_on_autonomous_coding_map_that_grants_watcher_merge_authority(tmp_
     assert "repo docs/templates must not grant merge authority" in result.stdout
 
 
+def test_checked_out_repo_docs_do_not_grant_watcher_merge_authority() -> None:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--repo-root", str(REPO_ROOT), "--repo-only"],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "OK: watcher docs/config/source grant no merge authority" in result.stdout
+
+
 @pytest.mark.parametrize("surface", ["timer", "notification", "bridge", "wake bridge"])
 def test_fails_on_docs_that_grant_wake_surface_merge_authority(
     tmp_path: Path,

--- a/tests/test_select_impacted_tests.py
+++ b/tests/test_select_impacted_tests.py
@@ -7,6 +7,7 @@ that the run escalates to FULL.
 """
 from __future__ import annotations
 
+import ast
 import importlib.util
 from pathlib import Path
 
@@ -161,6 +162,17 @@ def test_global_files_escalate_to_full(tmp_path, path):
         ],
     ),
     ("ci/gates.yml", ["tests/test_security_guardrails_workflow.py"]),
+    ("docs/SECURITY_GUARDRAILS.md", ["tests/test_security_guardrails_workflow.py"]),
+    ("docs/ci_cd_autonomous_coding_map.md", ["tests/test_security_guardrails_workflow.py"]),
+    ("docs/ci_cd_runtime_duplication_audit.md", ["tests/test_security_guardrails_workflow.py"]),
+    (
+        "docs/audits/agents-mechanical-enforcement-audit-2026-07-29.md",
+        ["tests/test_security_guardrails_workflow.py"],
+    ),
+    (
+        "docs/audits/required-workflow-enrollment-audit-2026-08-04.md",
+        ["tests/test_security_guardrails_workflow.py"],
+    ),
     (
         "scripts/audit_ai_reconciliation.py",
         [
@@ -188,10 +200,6 @@ def test_global_files_escalate_to_full(tmp_path, path):
         ["tests/test_security_guardrails_workflow.py"],
     ),
     (
-        "scripts/check_ai_reconciliation_live.py",
-        ["tests/test_check_ai_reconciliation_live.py"],
-    ),
-    (
         "scripts/codex_wake_bridge.py",
         ["tests/test_codex_wake_bridge.py"],
     ),
@@ -217,6 +225,25 @@ def test_explicit_ci_surface_owners_are_selected(tmp_path, path, owners):
     repo = _mkrepo(tmp_path, files)
 
     assert sel.select([path], repo) == sorted(owners)
+
+
+def test_explicit_owner_map_has_no_duplicate_keys():
+    text = (REPO / "scripts" / "select_impacted_tests.py").read_text(encoding="utf-8")
+    tree = compile(text, "select_impacted_tests.py", "exec", ast.PyCF_ONLY_AST)
+    owner_map = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.AnnAssign)
+        and getattr(node.target, "id", None) == "EXPLICIT_TEST_OWNERS"
+    )
+    assert isinstance(owner_map.value, ast.Dict)
+    keys = [
+        key.value
+        for key in owner_map.value.keys
+        if isinstance(key, ast.Constant) and isinstance(key.value, str)
+    ]
+
+    assert len(keys) == len(set(keys))
 
 
 def test_explicit_ci_surface_with_missing_owner_escalates_to_full(tmp_path):

--- a/tests/test_select_impacted_tests.py
+++ b/tests/test_select_impacted_tests.py
@@ -162,7 +162,13 @@ def test_global_files_escalate_to_full(tmp_path, path):
         ],
     ),
     ("ci/gates.yml", ["tests/test_security_guardrails_workflow.py"]),
-    ("docs/SECURITY_GUARDRAILS.md", ["tests/test_security_guardrails_workflow.py"]),
+    (
+        "docs/SECURITY_GUARDRAILS.md",
+        [
+            "tests/test_security_guardrails_workflow.py",
+            "tests/test_security_policy_docs.py",
+        ],
+    ),
     ("docs/ci_cd_autonomous_coding_map.md", ["tests/test_security_guardrails_workflow.py"]),
     ("docs/ci_cd_runtime_duplication_audit.md", ["tests/test_security_guardrails_workflow.py"]),
     (

--- a/tests/test_select_impacted_tests.py
+++ b/tests/test_select_impacted_tests.py
@@ -169,7 +169,7 @@ def test_global_files_escalate_to_full(tmp_path, path):
             "tests/test_security_policy_docs.py",
         ],
     ),
-    ("docs/ci_cd_autonomous_coding_map.md", ["tests/test_security_guardrails_workflow.py"]),
+    ("docs/ci_cd_autonomous_coding_map.md", ["tests/test_audit_pr_watcher_safety.py"]),
     ("docs/ci_cd_runtime_duplication_audit.md", ["tests/test_security_guardrails_workflow.py"]),
     (
         "docs/audits/agents-mechanical-enforcement-audit-2026-07-29.md",


### PR DESCRIPTION
Plan: plans/PR-Unit-Gate-Governance-Selector.md
Slice phase: Workflow/process
Ownership lane: dev-workflow/unit-gate-selector

This PR closes the unit-gate selector coverage gap from issue #2260/#2283 by making CI/security governance docs select their owning required-status/security tests instead of passing through Markdown growth-only.

## Intentional

- Keep `unit-gate` visible-but-not-branch-required; this slice closes a blocker before any promotion decision.
- Do not mutate `ci/gates.yml`, live branch protection, or `unit_gate.yml`.
- Keep ordinary Markdown docs test-free by default; only governance docs in the closed set get explicit owners.

## AI reconciliation

- Add all security-guardrails doc owners -- fixed-in: scripts/select_impacted_tests.py, tests/test_select_impacted_tests.py, plans/PR-Unit-Gate-Governance-Selector.md
- Select actual owners for watcher-governance docs -- fixed-in: scripts/select_impacted_tests.py, tests/test_select_impacted_tests.py, tests/test_audit_pr_watcher_safety.py, plans/PR-Unit-Gate-Governance-Selector.md
- Run the watcher audit against changed docs -- fixed-in: tests/test_audit_pr_watcher_safety.py, plans/PR-Unit-Gate-Governance-Selector.md

## Deferred

- Re-run the #2283 required workflow enrollment decision after selector coverage is proven in CI.
- Decide branch-protection `strict` behavior separately from selector coverage.
- Decide whether `pre-push-audit` needs a safe PR-side docs/test consistency probe.

## Parked hardening

- None.

## Cold diff reconstruction

- `scripts/select_impacted_tests.py` adds explicit test owners for CI/security governance docs that carry required-status/security claims.
- `scripts/select_impacted_tests.py` maps `docs/SECURITY_GUARDRAILS.md` to `tests/test_security_policy_docs.py` as an additional direct owner for repo-label manifest assertions.
- `scripts/select_impacted_tests.py` maps `docs/ci_cd_autonomous_coding_map.md` to `tests/test_audit_pr_watcher_safety.py` instead of the unrelated security-guardrails suite.
- `scripts/select_impacted_tests.py` removes the duplicate explicit-owner key for `scripts/check_ai_reconciliation_live.py`.
- `tests/test_select_impacted_tests.py` proves each mapped governance doc selects `tests/test_security_guardrails_workflow.py`.
- `tests/test_select_impacted_tests.py` proves `docs/SECURITY_GUARDRAILS.md` also selects `tests/test_security_policy_docs.py`.
- `tests/test_select_impacted_tests.py` proves `docs/ci_cd_autonomous_coding_map.md` selects `tests/test_audit_pr_watcher_safety.py`.
- `tests/test_audit_pr_watcher_safety.py` proves the watcher audit catches unsafe merge-authority wording in `docs/ci_cd_autonomous_coding_map.md`.
- `tests/test_audit_pr_watcher_safety.py` runs the watcher audit against the checked-out repository docs with `--repo-only`.
- `tests/test_select_impacted_tests.py` adds an AST check that the explicit-owner map has no duplicate keys.
- `plans/PR-Unit-Gate-Governance-Selector.md` records the problem-derived contract, closure declaration, and verification.

## Verification

- `/tmp/atlas-pr2259-venv/bin/python -m pytest tests/test_select_impacted_tests.py -q`
- `/tmp/atlas-pr2259-venv/bin/python -m pytest tests/test_security_guardrails_workflow.py tests/test_select_impacted_tests.py -q`
- `/tmp/atlas-pr2259-venv/bin/python -m pytest tests/test_security_policy_docs.py tests/test_security_guardrails_workflow.py tests/test_select_impacted_tests.py -q`
- `/tmp/atlas-pr2259-venv/bin/python -m pytest tests/test_audit_pr_watcher_safety.py tests/test_security_policy_docs.py tests/test_security_guardrails_workflow.py tests/test_select_impacted_tests.py -q`
- `/tmp/atlas-pr2259-venv/bin/python -m pytest tests/test_audit_pr_watcher_safety.py tests/test_select_impacted_tests.py -q`
- `python3 -m py_compile scripts/select_impacted_tests.py`

## Mechanical verification

- Command: /tmp/atlas-pr2259-venv/bin/python -m pytest tests/test_select_impacted_tests.py -q - Result: 61 passed - Environment: local
- Command: /tmp/atlas-pr2259-venv/bin/python -m pytest tests/test_security_guardrails_workflow.py tests/test_select_impacted_tests.py -q - Result: 96 passed - Environment: local
- Command: /tmp/atlas-pr2259-venv/bin/python -m pytest tests/test_security_policy_docs.py tests/test_security_guardrails_workflow.py tests/test_select_impacted_tests.py -q - Result: 116 passed; 43 subtests passed - Environment: local
- Command: /tmp/atlas-pr2259-venv/bin/python -m pytest tests/test_audit_pr_watcher_safety.py tests/test_security_policy_docs.py tests/test_security_guardrails_workflow.py tests/test_select_impacted_tests.py -q - Result: 139 passed; 43 subtests passed - Environment: local
- Command: /tmp/atlas-pr2259-venv/bin/python -m pytest tests/test_audit_pr_watcher_safety.py tests/test_select_impacted_tests.py -q - Result: 84 passed - Environment: local
- Command: python3 -m py_compile scripts/select_impacted_tests.py - Result: passed - Environment: local

## Diff size

- Final local diff size: 4 files, 268 changed lines.
