### PR TITLE
Promote unit gate to required status

### DIFF
--- a/.github/workflows/branch_protection_required_checks.yml
+++ b/.github/workflows/branch_protection_required_checks.yml
@@ -17,6 +17,7 @@ on:
       - ".github/workflows/review_contract.yml"
       - ".github/workflows/security_guardrails.yml"
       - ".github/workflows/session_lane.yml"
+      - ".github/workflows/unit_gate.yml"
       - "ci/gates.yml"
       - "docs/SECURITY_GUARDRAILS.md"
       - "scripts/check_required_status_checks.py"

--- a/.github/workflows/unit_gate.yml
+++ b/.github/workflows/unit_gate.yml
@@ -8,9 +8,9 @@ name: Unit Gate
 # selector is absent or returns FULL, and runs the baseline growth guard only when
 # no changed file is reachable from a test.
 #
-# Visible CI, not branch-required: the 2026-08-04 enrollment audit keeps this
-# check outside branch protection until the docs/security selector coverage gap
-# and other recorded blockers are closed.
+# Branch-required as of the 2026-08-05 enrollment recheck: the governance-doc
+# selector blocker from the 2026-08-04 audit was closed in #2290, so the gate is
+# now part of the hard merge contract.
 
 permissions:
   contents: read

--- a/ci/gates.yml
+++ b/ci/gates.yml
@@ -85,7 +85,7 @@ gates:
   - id: unit-gate
     name: Unit Gate
     context: unit-gate
-    enforcement: ci_blocking_not_required
+    enforcement: branch_required
     trusted_base: false
     workflow: .github/workflows/unit_gate.yml
     local_command: null

--- a/docs/SECURITY_GUARDRAILS.md
+++ b/docs/SECURITY_GUARDRAILS.md
@@ -69,9 +69,10 @@ trusted sweep, parked in plans/PR-Trusted-Base-Gate-Execution.md.
 Target branch protection for `main` is derived from `ci/gates.yml` entries
 marked `branch_required`: `live-reconciliation`, `diff-budget`,
 `plan-admission`, `session-lane`, `review-contract`, `pr-body-contract`,
-`Gitleaks PR secret scan`, and `Gitleaks baseline growth guard`, all pinned to
-the GitHub Actions app source instead of legacy bare context names. As of
-2026-08-04, live GitHub settings contain every registry-required context pinned
+`Gitleaks PR secret scan`, `Gitleaks baseline growth guard`, and `unit-gate`,
+all pinned to the GitHub Actions app source instead of legacy bare context
+names. As of 2026-08-05, live GitHub settings contain every registry-required
+context pinned
 to the GitHub Actions app source. The checker intentionally proves required
 registry coverage and source pinning; it is not an exact-set audit for extra
 required contexts. Verification:

--- a/docs/audits/agents-mechanical-enforcement-audit-2026-07-29.md
+++ b/docs/audits/agents-mechanical-enforcement-audit-2026-07-29.md
@@ -1,5 +1,13 @@
 # AGENTS Mechanical Enforcement Audit - 2026-07-29
 
+## 2026-08-05 Update
+
+The `unit-gate` enrollment blocker recorded on 2026-08-04 was closed by #2290.
+`unit-gate` is now a `ci/gates.yml` `branch_required` context and live branch
+protection requires it, pinned to the GitHub Actions app source. `pre-push-audit`
+remains `ci_blocking_not_required` until its trusted-base PR-side docs/test
+consistency blocker is closed.
+
 ## 2026-08-04 Update
 
 The required-status contradiction found in this audit has been closed in live
@@ -7,8 +15,9 @@ branch protection. `main` now contains every `ci/gates.yml` `branch_required`
 context pinned to the GitHub Actions app source: `live-reconciliation`,
 `diff-budget`, `plan-admission`, `session-lane`, `review-contract`,
 `pr-body-contract`, `Gitleaks PR secret scan`, and
-`Gitleaks baseline growth guard`. The checker proves required registry coverage
-and source pinning; it is not an exact-set audit for extra required contexts.
+`Gitleaks baseline growth guard`. The 2026-08-05 update adds `unit-gate` to the
+required set. The checker proves required registry coverage and source pinning;
+it is not an exact-set audit for extra required contexts.
 
 Verification:
 
@@ -100,10 +109,11 @@ branch protection may be superseded by the 2026-08-04 update above.
 1. `PR-Required-Status-Check-Alignment`: closed 2026-08-04 by updating live
    branch protection so `scripts/check_required_status_checks.py` passes against
    the GitHub payload.
-2. `PR-Required-Workflow-Enrollment-Audit`: closed 2026-08-04 in
-   `docs/audits/required-workflow-enrollment-audit-2026-08-04.md`. Decision:
-   keep `pre-push-audit` and `unit-gate` visible-but-not-branch-required until
-   the documented enrollment blockers are closed.
+2. `PR-Required-Workflow-Enrollment-Audit`: initial audit closed 2026-08-04 in
+   `docs/audits/required-workflow-enrollment-audit-2026-08-04.md`; the
+   2026-08-05 recheck promotes `unit-gate` after #2290 closed its selector
+   blocker. `pre-push-audit` remains visible-but-not-branch-required until its
+   trusted-base PR-side docs/test consistency blocker is closed.
 3. `PR-PR-Mutation-Ownership-Wrapper`: wire `check_session_pr_ownership.py` into
    the PR mutation helpers, or downgrade the AGENTS wording to manual-only.
 4. `PR-Commit-Message-Contract-Gate`: validate canonical commit-message

--- a/docs/audits/required-workflow-enrollment-audit-2026-08-04.md
+++ b/docs/audits/required-workflow-enrollment-audit-2026-08-04.md
@@ -1,5 +1,30 @@
 # Required Workflow Enrollment Audit - 2026-08-04
 
+## 2026-08-05 Recheck
+
+#2290 closed the `unit-gate` selector blocker by mapping CI/security governance
+docs to their owning tests and by making the watcher governance doc owner run
+against the checked-out repository docs. The recheck decision is:
+
+- `unit-gate`: promote to `branch_required` and require it in live branch
+  protection.
+- `pre-push-audit`: keep at `ci_blocking_not_required` until the trusted-base
+  PR-side docs/test consistency blocker has a safe data-only probe.
+
+Fresh evidence on 2026-08-05:
+
+- #2290's `unit-gate` run passed in about 2m21s.
+- The latest sampled `unit_gate.yml` runs show the selector now produces bounded
+  runs for governance-doc changes. Recent failures were legitimate PR test
+  failures, not runner flakes.
+- A fresh live branch-protection payload now includes `unit-gate` pinned to the
+  GitHub Actions app source with `strict: false`, and
+  `scripts/check_required_status_checks.py` passes against that payload.
+- `pre-push-audit` remains useful and green in recent samples, but its open
+  blocker is different: because PR events run trusted base code, PR-side changes
+  to gate docs/tests can still be observed only after merge unless a safe
+  data-only consistency probe is added.
+
 ## Decision
 
 Keep `pre-push-audit` and `unit-gate` at `ci_blocking_not_required` for now.

--- a/docs/audits/required-workflow-enrollment-audit-2026-08-04.md
+++ b/docs/audits/required-workflow-enrollment-audit-2026-08-04.md
@@ -25,11 +25,15 @@ Fresh evidence on 2026-08-05:
   to gate docs/tests can still be observed only after merge unless a safe
   data-only consistency probe is added.
 
-## Decision
+## 2026-08-04 Initial Decision
 
-Keep `pre-push-audit` and `unit-gate` at `ci_blocking_not_required` for now.
-Do not add either context to `ci/gates.yml` `branch_required` or live branch
-protection in this slice.
+Initial decision on 2026-08-04: keep `pre-push-audit` and `unit-gate` at
+`ci_blocking_not_required` for that slice. Do not add either context to
+`ci/gates.yml` `branch_required` or live branch protection in that slice.
+
+As of the 2026-08-05 recheck above, this initial decision remains current for
+`pre-push-audit` only. It is superseded for `unit-gate` because #2290 closed the
+specific selector blocker named by this audit.
 
 This is not a downgrade. Both checks remain real CI signals, and red runs must
 be fixed before calling a PR ready. The decision is that neither is ready to be
@@ -38,16 +42,16 @@ specific enrollment blockers below.
 
 ## Evidence
 
-Current registry state:
+Registry state at the 2026-08-04 initial decision:
 
 ```bash
-sed -n '72,92p' ci/gates.yml
+git show 9b4a37e6f7e3f7e34c1e87910591c65fcb8fa5b5:ci/gates.yml | sed -n '72,92p'
 ```
 
 - `pre-push-audit`: `ci_blocking_not_required`
 - `unit-gate`: `ci_blocking_not_required`
 
-Live branch protection as of this audit contains every existing
+Live branch protection as of the 2026-08-04 initial decision contained every existing
 `branch_required` registry context pinned to the GitHub Actions app source, and
 does not include `pre-push-audit` or `unit-gate`:
 
@@ -57,7 +61,8 @@ python scripts/check_required_status_checks.py \
   --payload-file /tmp/atlas-required-status-checks-live-required-workflow.json
 ```
 
-The checker passed for the current registry-required set.
+The checker passed for the then-current registry-required set. The 2026-08-05
+recheck above is the current deployed state for `unit-gate`.
 
 Recent `pre-push-audit` sample:
 
@@ -114,20 +119,23 @@ means a PR that changes docs/tests for the gate can pass before merge and fail
 the push-to-main variant after merge. That behavior should be fixed or made
 explicit before treating the context as a hard merge contract.
 
-`unit-gate` is not ready for branch protection because its selector did not run
-the security-guardrails docs test for the docs-only required-status PR. The PR
-run selected no reachable tests and passed growth-only, while a later full-suite
-path failed on `tests/test_security_guardrails_workflow.py`. Making `unit-gate`
-required before fixing that selector coverage would add wait time without
-closing the observed gap.
+At the 2026-08-04 initial decision, `unit-gate` was not ready for branch
+protection because its selector did not run the security-guardrails docs test
+for the docs-only required-status PR. The PR run selected no reachable tests and
+passed growth-only, while a later full-suite path failed on
+`tests/test_security_guardrails_workflow.py`. Making `unit-gate` required before
+fixing that selector coverage would have added wait time without closing the
+observed gap. #2290 later closed this specific blocker; see the 2026-08-05
+recheck above for the current `unit-gate` decision.
 
 ## Result
 
-The correct next hardening slice is not "require both checks." It is to close
-the observed coverage gap first:
+The 2026-08-04 initial result was not "require both checks." It was to close the
+observed coverage gap first:
 
 - Map `docs/SECURITY_GUARDRAILS.md` and branch-protection docs to
-  `tests/test_security_guardrails_workflow.py` in the unit-gate selector.
+  `tests/test_security_guardrails_workflow.py` in the unit-gate selector
+  (closed by #2290 before the 2026-08-05 recheck).
 - Decide whether trusted-base `pre-push-audit` needs a PR-side docs/test
   consistency probe that still avoids executing untrusted PR code.
 - Re-run this enrollment decision after those blockers are closed.

--- a/docs/ci_cd_autonomous_coding_map.md
+++ b/docs/ci_cd_autonomous_coding_map.md
@@ -87,11 +87,13 @@ trying to pass.
 `scripts/check_required_status_checks.py`: `live-reconciliation`,
 `diff-budget`, `plan-admission`, `session-lane`, `review-contract`,
 `pr-body-contract`, `Gitleaks PR secret scan`, and
-`Gitleaks baseline growth guard`. Live branch protection can drift from that
-expected set; the audit workflow reports that drift when its read token is
-configured. `pre-push-audit` and `unit-gate` are visible CI signals, not
-branch-required contexts, until the blockers recorded in
-`docs/audits/required-workflow-enrollment-audit-2026-08-04.md` are closed.
+`Gitleaks baseline growth guard`, and `unit-gate`. Live branch protection can
+drift from that expected set; the audit workflow reports that drift when its
+read token is configured. `unit-gate` was promoted after the #2290 selector
+coverage fix. `pre-push-audit` remains a visible CI signal, not a
+branch-required context, until the trusted-base PR-side docs/test consistency
+blocker recorded in `docs/audits/required-workflow-enrollment-audit-2026-08-04.md`
+is closed.
 
 ### PR secret and product gates
 

--- a/docs/ci_cd_runtime_duplication_audit.md
+++ b/docs/ci_cd_runtime_duplication_audit.md
@@ -25,7 +25,7 @@ and are better for optimization decisions.
 
 ## Non-Negotiable Gates
 
-Do not weaken these to save time. As of 2026-08-04, branch protection contains
+Do not weaken these to save time. As of 2026-08-05, branch protection contains
 every `ci/gates.yml` `branch_required` context. The process guardrails in the
 second table are still non-negotiable for Atlas PR work, but only the contexts
 marked `branch_required` are hard branch-protection gates.
@@ -42,13 +42,13 @@ marked `branch_required` are hard branch-protection gates.
 | `session-lane` | Checks session lane/body drift against the PR. |
 | `review-contract` | Checks plan Review Contract shape and triggered rules. |
 | `pr-body-contract` | Keeps PR bodies tied to the plan contract. |
+| `unit-gate` | Runs impacted unit tests, full-suite fallback, or baseline growth guard on every PR. The #2290 selector fix closed the governance-doc blocker, so it is now branch-required. |
 
 ### Process Guardrails
 
 | Gate | Why it stays non-negotiable |
 |---|---|
 | `pre-push-audit` trusted-base local review | Re-runs the local mechanical bundle from trusted base so a PR cannot weaken its own audit. It remains visible CI, not branch-required, per the 2026-08-04 enrollment audit. |
-| `unit-gate` | Runs impacted unit tests, full-suite fallback, or baseline growth guard on every PR. It remains visible CI, not branch-required, per the 2026-08-04 enrollment audit. |
 | Session-scoped state file ownership guard | Prevents long-running sessions from touching another lane's PR before review, push, comment handling, or merge. |
 
 The optimization target is redundant runtime and broad triggering, not removing
@@ -58,8 +58,8 @@ these gates.
 
 | Class | Examples | Optimization posture |
 |---|---|---|
-| Branch-required meta gates | `live-reconciliation`, `diff-budget`, `plan-admission`, `session-lane`, `review-contract`, `pr-body-contract`, `Gitleaks PR secret scan`, and `Gitleaks baseline growth guard`. | Keep the intended gate set explicit; optimize only by making implementation faster without weakening coverage. |
-| Process/meta CI contexts | `pre-push-audit`, `unit-gate`, branch-protection audit workflows | Keep as workflow guardrails; distinguish their latency from branch-required merge latency. |
+| Branch-required meta gates | `live-reconciliation`, `diff-budget`, `plan-admission`, `session-lane`, `review-contract`, `pr-body-contract`, `Gitleaks PR secret scan`, `Gitleaks baseline growth guard`, and `unit-gate`. | Keep the intended gate set explicit; optimize only by making implementation faster without weakening coverage. |
+| Process/meta CI contexts | `pre-push-audit`, branch-protection audit workflows | Keep as workflow guardrails; distinguish their latency from branch-required merge latency. |
 | Product/package gates | Content-ops checks, extracted pipeline checks, Reddit listening checks, deflection package checks | Optimize with caching, narrower triggers, or safe decomposition while preserving package coverage. |
 | Advisory checks | Advisory maturity sweeps, non-blocking detector runs, informational audits | Keep visible; reduce noise and runtime after required gates and product checks are stable. |
 | Local-only gates | `scripts/local_pr_review.sh`, `scripts/push_pr.sh` hook path, package gauntlets run before push, session ownership guard | Treat as developer-loop cost and trusted-source duplication inputs; do not misread them as GitHub branch-protection contexts. |

--- a/plans/PR-Unit-Gate-Enrollment-Recheck.md
+++ b/plans/PR-Unit-Gate-Enrollment-Recheck.md
@@ -66,6 +66,28 @@ Slice phase: Workflow/process
   this slice.
 - Reviewer rules triggered: R1, R2, R10, R11, R12, R14.
 
+### Closure declaration
+
+The branch-required required-status context set is a decision-driving
+set-valued dependency, so this slice declares its closure per
+`docs/GUARD_CLASS_CLOSURE.md`.
+
+1. **Closed or open:** CLOSED. The decision input is the finite set of Atlas
+   required GitHub status/check contexts for `main` branch protection.
+2. **Where membership comes from:** DERIVED. Membership is derived from
+   `ci/gates.yml` entries whose `enforcement` is `branch_required`; the live
+   GitHub branch-protection payload is the deployed copy, and
+   `scripts/check_required_status_checks.py` recomputes the expected set from
+   the registry when verifying live state.
+3. **Outside-set behavior:** contexts not derived from that registry are not
+   hard merge requirements by default. They may still run as visible CI or
+   advisory/process checks, but they do not block merge until a future slice
+   explicitly promotes them in `ci/gates.yml` and verifies the live payload. This
+   is the cheaper/safe side for workflow process checks because accidental
+   branch-required enrollment can block every PR, while visible non-required
+   checks still surface failures for builder/reviewer action without changing
+   the hard merge contract.
+
 ### Boundary-change enumeration
 
 Required when this diff changes a guard, validator, normalizer, resolver,
@@ -155,6 +177,14 @@ Parked hardening: none.
   -- fetched fresh live payload after the update.
 - `python3 scripts/check_required_status_checks.py --payload-file /tmp/atlas-required-status-checks-unit-gate-recheck-after-fresh.json`
   -- passed locally; required set includes `unit-gate`.
+- `python scripts/audit_plan_doc.py plans/PR-Unit-Gate-Enrollment-Recheck.md`
+  -- passed locally after adding the closure declaration.
+- `python scripts/sync_pr_plan.py plans/PR-Unit-Gate-Enrollment-Recheck.md --check`
+  -- passed locally; plan file list and diff size are in sync.
+- `python -m pytest tests/test_security_guardrails_workflow.py tests/test_select_impacted_tests.py tests/test_unit_gate_selector_fallback.py -q`
+  -- passed locally, 101 passed.
+- `gh api repos/canfieldjuan/ATLAS/branches/main/protection/required_status_checks > /tmp/atlas-required-status-checks-unit-gate-recheck-after-fresh.json && python scripts/check_required_status_checks.py --payload-file /tmp/atlas-required-status-checks-unit-gate-recheck-after-fresh.json`
+  -- passed locally; required set includes `unit-gate`.
 
 ## Estimated diff size
 
@@ -165,9 +195,9 @@ Parked hardening: none.
 | `ci/gates.yml` | 2 |
 | `docs/SECURITY_GUARDRAILS.md` | 7 |
 | `docs/audits/agents-mechanical-enforcement-audit-2026-07-29.md` | 22 |
-| `docs/audits/required-workflow-enrollment-audit-2026-08-04.md` | 25 |
+| `docs/audits/required-workflow-enrollment-audit-2026-08-04.md` | 67 |
 | `docs/ci_cd_autonomous_coding_map.md` | 12 |
 | `docs/ci_cd_runtime_duplication_audit.md` | 8 |
-| `plans/PR-Unit-Gate-Enrollment-Recheck.md` | 173 |
+| `plans/PR-Unit-Gate-Enrollment-Recheck.md` | 203 |
 | `tests/test_security_guardrails_workflow.py` | 12 |
-| **Total** | **268** |
+| **Total** | **340** |

--- a/plans/PR-Unit-Gate-Enrollment-Recheck.md
+++ b/plans/PR-Unit-Gate-Enrollment-Recheck.md
@@ -1,0 +1,173 @@
+# PR-Unit-Gate-Enrollment-Recheck
+
+## Why this slice exists
+
+Issue #2260 tracks the CI/CD enforcement arc. The 2026-08-04 required-workflow
+enrollment audit deferred `unit-gate` branch protection because its selector let
+governance-doc changes pass growth-only without running their owning tests.
+#2290 closed that blocker by mapping the governance docs to concrete pytest
+owners and by making the watcher governance owner audit the checked-out repo
+docs, not only fixture docs.
+
+### Problem-derived contract
+
+- Root cause: `unit-gate` remained classified as `ci_blocking_not_required`
+  after its named selector blocker was fixed, leaving the merge contract weaker
+  than the repo's current mechanical-check intent.
+- Correct fix must touch/change: promote only `unit-gate` to
+  `branch_required`, update branch-protection docs and tests to include the
+  context, update live `main` branch protection to require the GitHub Actions
+  `unit-gate` check, and verify the required-status checker against a fresh live
+  payload.
+- Must not change: do not promote `pre-push-audit`, do not change branch
+  protection `strict`, do not alter `unit_gate.yml` execution semantics, and do
+  not weaken any existing branch-required context.
+
+## Scope (this PR)
+
+Ownership lane: dev-workflow/unit-gate-enrollment
+Slice phase: Workflow/process
+
+1. Promote `unit-gate` from `ci_blocking_not_required` to `branch_required` in
+   `ci/gates.yml`.
+2. Update required-status docs/tests/workflow-path auditing to include
+   `.github/workflows/unit_gate.yml` and the `unit-gate` context.
+3. Record that `pre-push-audit` remains visible CI, not branch-required, because
+   its trusted-base PR-side docs/test consistency blocker is separate.
+4. Update live branch protection for `main` to require the GitHub Actions
+   `unit-gate` context and verify the fresh payload.
+
+### Review Contract
+
+- Acceptance criteria:
+  - `ci/gates.yml` marks `unit-gate` as `branch_required`.
+  - `ci/gates.yml` leaves `pre-push-audit` as `ci_blocking_not_required`.
+  - `tests/test_security_guardrails_workflow.py::REQUIRED_STATUS_CONTEXTS`
+    includes `unit-gate`.
+  - `.github/workflows/branch_protection_required_checks.yml` watches
+    `.github/workflows/unit_gate.yml` changes.
+  - `docs/SECURITY_GUARDRAILS.md` and
+    `docs/ci_cd_autonomous_coding_map.md` name `unit-gate` in the
+    branch-required context set.
+  - `docs/audits/required-workflow-enrollment-audit-2026-08-04.md` records the
+    2026-08-05 recheck decision: promote `unit-gate`, keep `pre-push-audit`
+    deferred.
+  - `python3 scripts/check_required_status_checks.py --payload-file <fresh live
+    payload>` passes after live branch protection is updated.
+- Reachability proof: the real deployed config is GitHub `main` branch
+  protection; the observable output is the required-status checker PASS against
+  a fresh payload after the live update.
+- Affected surfaces: `ci/gates.yml`, branch-protection audit workflow paths,
+  security/CI docs, required-status tests, live `main` branch protection, and
+  this plan.
+- Risk areas: accidental `pre-push-audit` promotion, missing live branch
+  protection update, stale docs/tests omitting `unit-gate`, requiring the wrong
+  app/source for the `unit-gate` context, and changing branch `strict` outside
+  this slice.
+- Reviewer rules triggered: R1, R2, R10, R11, R12, R14.
+
+### Boundary-change enumeration
+
+Required when this diff changes a guard, validator, normalizer, resolver,
+router/classifier, or admission boundary. Name each changed boundary path or
+seam in the enumeration; otherwise write "N/A - no boundary change."
+
+- Boundary path/seam: `ci/gates.yml` branch-required merge gate registry and
+  live GitHub branch protection required-status set.
+- Replaced-path behaviors: `unit-gate` moves from visible CI to hard
+  branch-required merge gate; `pre-push-audit` remains visible CI.
+- Guard-relevant fields: gate `context`, gate `enforcement`, GitHub Actions
+  `app_id`, branch-protection `strict`, and required-status `checks`.
+- Caller x input shape: PRs targeting `main` that publish a `unit-gate` GitHub
+  Actions check.
+
+### Deployed-config probing
+
+Required for guard, validator, resolver, admission-boundary, or env/config
+fallback changes; otherwise write "N/A - no guard/config boundary change."
+
+- Deployed/default config values: live
+  `repos/canfieldjuan/ATLAS/branches/main/protection/required_status_checks`.
+- Explicit value probe: fetch fresh live payload after update and run
+  `python3 scripts/check_required_status_checks.py --payload-file
+  /tmp/atlas-required-status-checks-unit-gate-recheck-after.json`.
+- Absent value probe: `pre-push-audit` remains absent from the required set by
+  design; docs name its remaining blocker.
+- Default-session/default-context probe: keep `strict: false`; this slice does
+  not decide stale-branch merge policy.
+- Side-effect ordering: update repo registry/docs/tests first, then patch live
+  branch protection to add only `unit-gate`, then verify the fresh payload.
+
+### Files touched
+
+- `.github/workflows/branch_protection_required_checks.yml`
+- `.github/workflows/unit_gate.yml`
+- `ci/gates.yml`
+- `docs/SECURITY_GUARDRAILS.md`
+- `docs/audits/agents-mechanical-enforcement-audit-2026-07-29.md`
+- `docs/audits/required-workflow-enrollment-audit-2026-08-04.md`
+- `docs/ci_cd_autonomous_coding_map.md`
+- `docs/ci_cd_runtime_duplication_audit.md`
+- `plans/PR-Unit-Gate-Enrollment-Recheck.md`
+- `tests/test_security_guardrails_workflow.py`
+
+## Mechanism
+
+The required-status checker derives its expected contexts from
+`ci/gates.yml`. This slice changes only the `unit-gate` row to
+`branch_required`, updates docs/tests to include the new required context, and
+adds `.github/workflows/unit_gate.yml` to the branch-protection audit workflow's
+trusted `main` push path filters.
+
+Live branch protection is updated out-of-band through the GitHub API because
+`ci/gates.yml` is policy intent while GitHub branch protection is deployed
+config. The update preserves `strict: false` and the existing required GitHub
+Actions checks, adding only `unit-gate` with app id `15368`.
+
+## Intentional
+
+- `pre-push-audit` remains `ci_blocking_not_required`; its trusted-base PR-side
+  docs/test consistency blocker is not solved by #2290.
+- Branch protection `strict` remains `false`; stale-branch merge policy is a
+  separate decision.
+- No `unit_gate.yml` runtime behavior changes are included. This is enrollment,
+  not runtime optimization.
+
+## Deferred
+
+- Add a safe trusted-base `pre-push-audit` PR-side docs/test consistency probe,
+  then re-evaluate whether `pre-push-audit` should become branch-required.
+- Decide branch-protection `strict` behavior separately from required-context
+  enrollment.
+
+Parked hardening: none.
+
+## Verification
+
+- `python3 scripts/check_required_status_checks.py --payload-file /tmp/atlas-required-status-checks-unit-gate-recheck-before.json`
+  -- failed before live update with `unit-gate: missing required check`.
+- `/tmp/atlas-pr2259-venv/bin/python -m pytest tests/test_security_guardrails_workflow.py tests/test_select_impacted_tests.py tests/test_unit_gate_selector_fallback.py -q`
+  -- passed locally, 101 passed.
+- `gh api --method PATCH repos/canfieldjuan/ATLAS/branches/main/protection/required_status_checks --input /tmp/atlas-required-status-checks-unit-gate-patch.json`
+  -- applied live branch-protection update preserving `strict: false` and adding
+  `unit-gate` with GitHub Actions app id `15368`.
+- `gh api repos/canfieldjuan/ATLAS/branches/main/protection/required_status_checks > /tmp/atlas-required-status-checks-unit-gate-recheck-after-fresh.json`
+  -- fetched fresh live payload after the update.
+- `python3 scripts/check_required_status_checks.py --payload-file /tmp/atlas-required-status-checks-unit-gate-recheck-after-fresh.json`
+  -- passed locally; required set includes `unit-gate`.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/branch_protection_required_checks.yml` | 1 |
+| `.github/workflows/unit_gate.yml` | 6 |
+| `ci/gates.yml` | 2 |
+| `docs/SECURITY_GUARDRAILS.md` | 7 |
+| `docs/audits/agents-mechanical-enforcement-audit-2026-07-29.md` | 22 |
+| `docs/audits/required-workflow-enrollment-audit-2026-08-04.md` | 25 |
+| `docs/ci_cd_autonomous_coding_map.md` | 12 |
+| `docs/ci_cd_runtime_duplication_audit.md` | 8 |
+| `plans/PR-Unit-Gate-Enrollment-Recheck.md` | 173 |
+| `tests/test_security_guardrails_workflow.py` | 12 |
+| **Total** | **268** |

--- a/tests/test_security_guardrails_workflow.py
+++ b/tests/test_security_guardrails_workflow.py
@@ -26,6 +26,7 @@ REQUIRED_STATUS_CONTEXTS = (
     "pr-body-contract",
     "Gitleaks PR secret scan",
     "Gitleaks baseline growth guard",
+    "unit-gate",
 )
 
 REQUIRED_STATUS_WORKFLOW_PATHS = (
@@ -37,6 +38,7 @@ REQUIRED_STATUS_WORKFLOW_PATHS = (
     ".github/workflows/session_lane.yml",
     ".github/workflows/gitleaks_baseline_growth_guard.yml",
     ".github/workflows/security_guardrails.yml",
+    ".github/workflows/unit_gate.yml",
     "ci/gates.yml",
 )
 
@@ -171,6 +173,7 @@ def test_required_status_check_audit_accepts_contexts_and_checks_shapes() -> Non
             {"context": "review-contract"},
             {"context": "Gitleaks PR secret scan"},
             {"context": "Gitleaks baseline growth guard"},
+            {"context": "unit-gate"},
         ],
     }
 
@@ -553,7 +556,12 @@ def test_required_status_check_audit_rejects_wrong_check_source() -> None:
     payload = {
         "checks": [
             {"context": context, "app_id": checker.GITHUB_ACTIONS_APP_ID}
-            for context in REQUIRED_STATUS_CONTEXTS[:-2]
+            for context in REQUIRED_STATUS_CONTEXTS
+            if context
+            not in {
+                "Gitleaks PR secret scan",
+                "Gitleaks baseline growth guard",
+            }
         ] + [
             {"context": "Gitleaks PR secret scan", "app_id": -1},
             {"context": "Gitleaks baseline growth guard", "app_id": None},
@@ -586,6 +594,7 @@ def test_required_status_check_audit_fails_when_target_contexts_missing() -> Non
         "pr-body-contract",
         "Gitleaks PR secret scan",
         "Gitleaks baseline growth guard",
+        "unit-gate",
     ]
 
 
@@ -610,5 +619,6 @@ def test_required_status_check_audit_fails_current_live_payload_until_enrolled()
         "session-lane",
         "review-contract",
         "pr-body-contract",
+        "unit-gate",
     ]
     assert all(failure.reason == "missing required check" for failure in failures)


### PR DESCRIPTION
Plan: plans/PR-Unit-Gate-Enrollment-Recheck.md
Slice phase: Workflow/process
Ownership lane: dev-workflow/unit-gate-enrollment

This PR promotes `unit-gate` from visible CI to branch-required after #2290 closed the selector blocker named by the 2026-08-04 required-workflow enrollment audit. `pre-push-audit` remains visible CI because its trusted-base PR-side docs/test consistency blocker is separate.

## Intentional

- Promote only `unit-gate`; do not promote `pre-push-audit`.
- Preserve branch protection `strict: false`; stale-branch merge policy is deferred.
- Do not change `unit_gate.yml` runtime behavior beyond the enrollment comment.
- Preserve all existing branch-required contexts and GitHub Actions app pinning.

## AI reconciliation

- Add the required closure declaration -- fixed-in: plans/PR-Unit-Gate-Enrollment-Recheck.md
- Add the required closure declaration duplicate thread -- waived-duplicate: Add the required closure declaration fixed in plans/PR-Unit-Gate-Enrollment-Recheck.md
- Reconcile the recheck with the audit decision -- fixed-in: docs/audits/required-workflow-enrollment-audit-2026-08-04.md

## Deferred

- Add a safe trusted-base `pre-push-audit` PR-side docs/test consistency probe, then re-evaluate whether `pre-push-audit` should become branch-required.
- Decide branch-protection `strict` behavior separately from required-context enrollment.

## Parked hardening

- None.

## Cold diff reconstruction

- `ci/gates.yml` changes `unit-gate` from `ci_blocking_not_required` to `branch_required`.
- `.github/workflows/branch_protection_required_checks.yml` watches `.github/workflows/unit_gate.yml` changes.
- `.github/workflows/unit_gate.yml` updates its enrollment comment without changing execution behavior.
- `tests/test_security_guardrails_workflow.py` adds `unit-gate` to the required-status context fixtures.
- CI/security docs record the 2026-08-05 decision: `unit-gate` promoted, `pre-push-audit` deferred.
- `plans/PR-Unit-Gate-Enrollment-Recheck.md:69` adds the required closure declaration for the branch-required context set: CLOSED, DERIVED from `ci/gates.yml`, with non-registry contexts defaulting to visible/non-required until explicitly promoted.
- `docs/audits/required-workflow-enrollment-audit-2026-08-04.md:28` labels the 2026-08-04 decision as initial/historical, and `docs/audits/required-workflow-enrollment-audit-2026-08-04.md:34` states that the 2026-08-05 recheck supersedes it for `unit-gate` only.
- Live branch protection for `main` was updated through the GitHub API to add `unit-gate` with GitHub Actions app id `15368` while preserving `strict: false`.

## Verification

- `python3 scripts/check_required_status_checks.py --payload-file /tmp/atlas-required-status-checks-unit-gate-recheck-before.json`
- `/tmp/atlas-pr2259-venv/bin/python -m pytest tests/test_security_guardrails_workflow.py tests/test_select_impacted_tests.py tests/test_unit_gate_selector_fallback.py -q`
- `gh api --method PATCH repos/canfieldjuan/ATLAS/branches/main/protection/required_status_checks --input /tmp/atlas-required-status-checks-unit-gate-patch.json`
- `gh api repos/canfieldjuan/ATLAS/branches/main/protection/required_status_checks > /tmp/atlas-required-status-checks-unit-gate-recheck-after-fresh.json`
- `python3 scripts/check_required_status_checks.py --payload-file /tmp/atlas-required-status-checks-unit-gate-recheck-after-fresh.json`
- `python scripts/audit_plan_doc.py plans/PR-Unit-Gate-Enrollment-Recheck.md`
- `python scripts/sync_pr_plan.py plans/PR-Unit-Gate-Enrollment-Recheck.md --check`
- `python -m pytest tests/test_security_guardrails_workflow.py tests/test_select_impacted_tests.py tests/test_unit_gate_selector_fallback.py -q`
- `gh api repos/canfieldjuan/ATLAS/branches/main/protection/required_status_checks > /tmp/atlas-required-status-checks-unit-gate-recheck-after-fresh.json && python scripts/check_required_status_checks.py --payload-file /tmp/atlas-required-status-checks-unit-gate-recheck-after-fresh.json`

## Mechanical verification

- Command: python3 scripts/check_required_status_checks.py --payload-file /tmp/atlas-required-status-checks-unit-gate-recheck-before.json - Result: failed before live update with unit-gate missing - Environment: local
- Command: /tmp/atlas-pr2259-venv/bin/python -m pytest tests/test_security_guardrails_workflow.py tests/test_select_impacted_tests.py tests/test_unit_gate_selector_fallback.py -q - Result: 101 passed - Environment: local
- Command: gh api --method PATCH repos/canfieldjuan/ATLAS/branches/main/protection/required_status_checks --input /tmp/atlas-required-status-checks-unit-gate-patch.json - Result: passed; live branch protection updated - Environment: local
- Command: python3 scripts/check_required_status_checks.py --payload-file /tmp/atlas-required-status-checks-unit-gate-recheck-after-fresh.json - Result: passed; required set includes unit-gate - Environment: local
- Command: python scripts/audit_plan_doc.py plans/PR-Unit-Gate-Enrollment-Recheck.md - Result: passed - Environment: local
- Command: python scripts/sync_pr_plan.py plans/PR-Unit-Gate-Enrollment-Recheck.md --check - Result: passed - Environment: local
- Command: python -m pytest tests/test_security_guardrails_workflow.py tests/test_select_impacted_tests.py tests/test_unit_gate_selector_fallback.py -q - Result: 101 passed - Environment: local
- Command: gh api repos/canfieldjuan/ATLAS/branches/main/protection/required_status_checks > /tmp/atlas-required-status-checks-unit-gate-recheck-after-fresh.json && python scripts/check_required_status_checks.py --payload-file /tmp/atlas-required-status-checks-unit-gate-recheck-after-fresh.json - Result: passed; required set includes unit-gate - Environment: local

## Diff size

- Final local diff size: 10 files, 340 changed lines.
