### PR TITLE
Enrol the contact write-boundary job in the workflow allowlist (#2302 precursor)

### DIFF
--- a/plans/PR-Workflow-Allowlist-Bootstrap.md
+++ b/plans/PR-Workflow-Allowlist-Bootstrap.md
@@ -38,6 +38,7 @@ Slice phase: workflow/process
 
 - `plans/PR-Workflow-Allowlist-Bootstrap.md`
 - `scripts/audit_workflow_security_posture.py`
+- `tests/test_audit_workflow_security_posture.py`
 
 ### Review Contract
 
@@ -59,6 +60,36 @@ passing unchanged, plus the inert-entry check; R10 by the change being one tuple
 in an already-reviewed frozenset rather than new logic. R12 because this is
 workflow security posture. R1 because the change must be exactly the enrolment
 and nothing else.
+
+**Guard-class closure declaration**
+
+- **Member set:** `ALLOWED_PULL_REQUEST_TARGET_JOBS`, a frozenset of
+  `(workflow filename, job name)` pairs.
+- **Set is CLOSED.** Membership is an explicit literal enumeration in
+  `scripts/audit_workflow_security_posture.py`, not derived from the workflow
+  tree, a naming convention, or a marker inside a workflow. A workflow cannot
+  join by existing, by being named a certain way, or by declaring anything about
+  itself; a human edits this frozenset on the trusted branch.
+- **Out-of-set default: REJECT.** Any `pull_request_target` job whose
+  `(file, job)` pair is absent produces an ERROR and exits 1. This PR adds one
+  pair; every other absent pair keeps failing exactly as before, which
+  `test_unapproved_pull_request_target_is_error` pins.
+- **Membership is necessary, not sufficient.** An enrolled pair must still
+  present an event-name `if` guard and a SHA-pinned checkout of
+  `github.event.pull_request.base.sha` as its first step, or it is rejected.
+  `test_contact_write_boundary_enrolment_still_requires_the_guard_shape` proves
+  that for the pair added here, so the entry widens eligibility rather than
+  granting permission.
+- **Identity is load-bearing and tested.** The pair is two strings with no
+  cross-check against reality, so a typo in either would merge green and leave
+  the workflow unenrolled.
+  `test_contact_write_boundary_identity_is_allowlisted` constructs a fixture
+  workflow under the enrolled filename, carrying the `contact-write-boundary`
+  job, and asserts admission; corrupting either string makes it fail. The real
+  workflow arrives in ATLAS #2302 -- it deliberately does not exist in this
+  tree, which is why the identity needs a test rather than a file reference.
+- **Both sides covered:** correct identity plus correct shape is admitted;
+  correct identity with wrong shape errors; absent identity errors.
 
 ### Boundary-change enumeration
 
@@ -111,6 +142,7 @@ directory omitting `contact_write_boundary.yml` also exits 0.
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Workflow-Allowlist-Bootstrap.md` | 116 |
+| `plans/PR-Workflow-Allowlist-Bootstrap.md` | 148 |
 | `scripts/audit_workflow_security_posture.py` | 1 |
-| **Total** | **117** |
+| `tests/test_audit_workflow_security_posture.py` | 52 |
+| **Total** | **201** |

--- a/plans/PR-Workflow-Allowlist-Bootstrap.md
+++ b/plans/PR-Workflow-Allowlist-Bootstrap.md
@@ -14,17 +14,34 @@ That is correct behaviour on the auditor's part -- adopting a trusted-base gate
 should be an explicit decision recorded on the trusted branch, not something a PR
 grants itself in the same diff. It does mean the enrolment has to land first.
 
-This PR is that entry, alone, so ATLAS #2302 can go green rather than merging
-with a red required check.
+This PR is that entry, so ATLAS #2302 can go green rather than merging with a
+red required check -- plus the one precondition that adding an entry would
+otherwise widen: an enrolled job must prove its token is read-only. See root
+cause B below.
 
 ### Problem-derived contract
 
-- Root cause: the allowlist is read from the base revision, so an entry added
-  in the same PR as its workflow has no effect on that PR's own audit.
-- Correct fix must touch/change: `ALLOWED_PULL_REQUEST_TARGET_JOBS` only, merged
-  ahead of the workflow it authorises.
-- Must not change: the auditor's guard-shape checks, any workflow, or any other
-  allowlist entry.
+This slice has two root causes, because enrolling a ninth job surfaced a
+fail-open in the admission predicate that the previous eight silently relied on.
+
+- Root cause A (ordering): the allowlist is read from the base revision, so an
+  entry added in the same PR as its workflow has no effect on that PR's own
+  audit.
+- Root cause B (permission boundary): admission never checked the token the
+  admitted job would receive. An enrolled `pull_request_target` job that
+  declared a write scope -- or that declared no `permissions` block at all, and
+  so inherited a repository/organisation default that is write-capable and is
+  configured outside this repository -- was admitted. That hands a
+  write-capable base-context token to a job whose entire purpose is reading
+  PR-authored content. Adding an entry without closing this would widen the
+  hole by one more identity.
+- Correct fix must touch/change: `ALLOWED_PULL_REQUEST_TARGET_JOBS` (A), and
+  the admission predicate in `_is_allowed_pull_request_target_job` gaining an
+  explicit-read-only-permissions precondition (B), merged ahead of the workflow
+  it authorises.
+- Must not change: the existing guard-shape checks (event-name `if`, SHA-pinned
+  base-SHA first checkout), any workflow, or any other allowlist entry. B adds a
+  precondition alongside those checks; it does not alter them.
 
 ## Scope (this PR)
 
@@ -32,9 +49,16 @@ Ownership lane: workflow-security-posture
 Slice phase: workflow/process
 
 1. Add the enrolment tuple to `ALLOWED_PULL_REQUEST_TARGET_JOBS`.
-2. Reject any enrolled `pull_request_target` job that declares a write scope.
-   Every currently enrolled job already declares read-only permissions, so this
-   rejects nothing that exists and closes the gap for everything enrolled later.
+2. Require an enrolled `pull_request_target` job to declare permissions that are
+   explicitly and provably read-only. This rejects a declared write scope, and
+   equally rejects an omitted block, `write-all`, a bare scalar, and any scope
+   whose value is an unresolved `${{ }}` expression the auditor cannot evaluate
+   statically. Stated as a positive predicate
+   (`_permissions_are_explicitly_read_only`) rather than a "does it grant write"
+   negative, so unrecognised shapes fall on the reject side by construction.
+   All eight previously enrolled jobs already declare an explicit read-only
+   block, so this rejects nothing that exists and closes the gap for everything
+   enrolled later.
 
 ### Files touched
 
@@ -47,15 +71,24 @@ Slice phase: workflow/process
 1. The auditor still exits 0 on this tree, where the named workflow does not yet
    exist -- an allowlist entry for an absent workflow is inert, verified by
    running the auditor against a workflow directory without it.
-2. The auditor's guard-shape enforcement is unchanged: the job it now names must
+2. The pre-existing guard-shape checks are unaltered: the job it now names must
    still present an event-name `if` guard and a SHA-pinned base-SHA checkout as
-   its first step, or it is rejected exactly as before.
-3. `tests/test_audit_workflow_security_posture.py` passes unchanged.
+   its first step, or it is rejected exactly as before. The permissions
+   precondition is added alongside them, not in place of them.
+3. The permissions precondition rejects nothing currently enrolled.
+   `test_every_currently_enrolled_job_declares_read_only_permissions` resolves
+   each enrolled pair against the real workflow tree and asserts the predicate
+   admits it, and fails if that loop ever checks zero workflows.
+4. `tests/test_audit_workflow_security_posture.py` passes. Three positive
+   fixtures were amended, not weakened: they omitted `permissions` entirely
+   while every real workflow they model declares an explicit read-only block, so
+   they were asserting admission for a shape that no longer exists in the repo.
 
-Affected surfaces: `ALLOWED_PULL_REQUEST_TARGET_JOBS` in
+Affected surfaces: `ALLOWED_PULL_REQUEST_TARGET_JOBS` and the admission
+predicate `_is_allowed_pull_request_target_job` in
 `scripts/audit_workflow_security_posture.py`, and by consequence which
-`pull_request_target` jobs the auditor will admit. No workflow, no guard-shape
-check, no other allowlist entry, and no runtime code is touched.
+`pull_request_target` jobs the auditor will admit. No workflow, no existing
+guard-shape check, no other allowlist entry, and no runtime code is touched.
 
 Risk areas: the entry is two bare strings with no cross-check against a real
 workflow, so a typo would merge green and silently leave the intended gate
@@ -82,12 +115,23 @@ Dispositioning the two hooks it implies:
   `persist-credentials: false`, so the elevated context never reaches PR-authored
   content -- verified in ATLAS #2302 rather than asserted here.
 - **Workflow-permissions boundary.** Tightened here rather than merely
-  preserved. A trusted-base job runs with the base repository's token, so a
-  write scope hands that token to a job whose purpose is reading PR-authored
-  content. `_grants_write` now rejects any write scope other than `id-token`,
-  which keeps its own separate allowlist. Verified safe before adding: all eight
-  previously enrolled jobs already declare read-only permissions, pinned by
-  `test_every_currently_enrolled_job_declares_read_only_permissions`, so the
+  preserved; this is root cause B. A trusted-base job runs with the base
+  repository's token, so a write scope hands that token to a job whose purpose
+  is reading PR-authored content.
+  `_permissions_are_explicitly_read_only` admits only an explicit block that
+  provably grants no write other than `id-token` (which keeps its own separate
+  allowlist). Both sides of the boundary are probed by
+  `test_permissions_read_only_predicate_boundaries`: `{contents: read}`,
+  `{}`, `read-all`, and `{contents: read, id-token: write}` admit; `None`,
+  `write-all`, `{contents: write}`, a bare `"read"` scalar, and a templated
+  `${{ }}` value reject. The omitted-permissions case is the one that matters
+  most and has its own end-to-end fixture,
+  `test_enrolled_job_omitting_permissions_entirely_is_rejected`: absence is not
+  evidence of read-only, because the inherited default lives in repository or
+  organisation settings that this file cannot see. Verified safe before adding:
+  all eight previously enrolled jobs already declare an explicit read-only
+  block -- enumerated directly against the workflow tree, not assumed -- pinned
+  by `test_every_currently_enrolled_job_declares_read_only_permissions`, so the
   rule rejects nothing that exists today.
 - **Execution boundary after the base checkout: out of scope, tracked in ATLAS
   #2307.** The predicate returns admitted after step 0 and never inspects later
@@ -100,11 +144,12 @@ Dispositioning the two hooks it implies:
 R2 and R10 are the path triggers the rule pack assigns to gate-predicate
 scripts, which is what `scripts/audit_workflow_security_posture.py` is: R2 is
 satisfied by the existing failure-branch fixtures in
-`tests/test_audit_workflow_security_posture.py`, which this change leaves
-passing unchanged, plus the inert-entry check; R10 by the change being one tuple
-in an already-reviewed frozenset rather than new logic. R12 because this is
-workflow security posture. R1 because the change must be exactly the enrolment
-and nothing else.
+`tests/test_audit_workflow_security_posture.py` plus the new reject-side
+fixtures and the inert-entry check; R10 by the added logic being a single
+predicate over a permissions block, with both sides enumerated. R12 because this
+is workflow security posture. R1 because the change must be exactly the
+enrolment and the permission precondition that enrolment would otherwise widen
+-- and nothing else.
 
 **Guard-class closure declaration**
 
@@ -121,8 +166,9 @@ and nothing else.
   `test_unapproved_pull_request_target_is_error` pins.
 - **Membership is necessary, not sufficient.** An enrolled pair must still
   present an event-name `if` guard, a SHA-pinned checkout of
-  `github.event.pull_request.base.sha` as its first step, and **no write
-  scope**, or it is rejected.
+  `github.event.pull_request.base.sha` as its first step, and **an explicit
+  permissions block that provably grants no write** -- an omitted block is not
+  accepted as read-only -- or it is rejected.
   `test_contact_write_boundary_enrolment_still_requires_the_guard_shape` proves
   that for the pair added here, so the entry widens eligibility rather than
   granting permission.
@@ -152,8 +198,11 @@ omits the named file, showing the entry is inert until the workflow lands.
 
 ## Mechanism
 
-One tuple added to a frozenset. The auditor iterates actual workflow files, so an
-entry naming a file that does not exist is never consulted.
+Two things. One tuple added to a frozenset -- the auditor iterates actual
+workflow files, so an entry naming a file that does not exist is never
+consulted. And one precondition added to the admission predicate: before an
+enrolled job is admitted, its effective permissions (job block if present, else
+workflow block) must be an explicit, statically provable read-only shape.
 
 ## Intentional
 
@@ -167,9 +216,12 @@ entry naming a file that does not exist is never consulted.
 
 - The workflow itself, its checker, and its tests: ATLAS #2302.
 
-Parking predicate: this slice parks everything except the enrolment tuple.
+Parking predicate: this slice parks everything except the enrolment tuple and
+the permissions precondition that enrolment would otherwise widen.
 
-Parked hardening: none.
+Parked hardening: the execution boundary after the base checkout (ATLAS #2307),
+for the reason given above -- pre-existing across all eight prior entries, and
+the naive fix would reject #2302's deliberate read-the-PR-tree-as-data design.
 
 ## Verification
 
@@ -178,7 +230,7 @@ $ python scripts/audit_workflow_security_posture.py
 (exit 0)
 
 $ python -m pytest tests/test_audit_workflow_security_posture.py -q
-21 passed
+37 passed
 ```
 
 Plus two checks the commands above do not show:
@@ -194,7 +246,7 @@ Plus two checks the commands above do not show:
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Workflow-Allowlist-Bootstrap.md` | 200 |
-| `scripts/audit_workflow_security_posture.py` | 37 |
-| `tests/test_audit_workflow_security_posture.py` | 138 |
-| **Total** | **375** |
+| `plans/PR-Workflow-Allowlist-Bootstrap.md` | 252 |
+| `scripts/audit_workflow_security_posture.py` | 60 |
+| `tests/test_audit_workflow_security_posture.py` | 222 |
+| **Total** | **534** |

--- a/plans/PR-Workflow-Allowlist-Bootstrap.md
+++ b/plans/PR-Workflow-Allowlist-Bootstrap.md
@@ -1,0 +1,116 @@
+# PR-Workflow-Allowlist-Bootstrap
+
+## Why this slice exists
+
+Enrolment ordering for a `pull_request_target` gate. `pre_push_audit.yml` runs
+the **base** revision's `scripts/audit_workflow_security_posture.py` against the
+**PR's** workflow tree. A PR that introduces both a `pull_request_target`
+workflow and its own allowlist entry therefore cannot pass: the auditor doing
+the judging is the base copy, which has no entry for the new job, so it emits
+`ERROR: ... can run on pull_request_target without the approved trusted-base
+guard shape` and exits 1 until the entry is already on `main`.
+
+That is correct behaviour on the auditor's part -- adopting a trusted-base gate
+should be an explicit decision recorded on the trusted branch, not something a PR
+grants itself in the same diff. It does mean the enrolment has to land first.
+
+This PR is that entry, alone, so ATLAS #2302 can go green rather than merging
+with a red required check.
+
+### Problem-derived contract
+
+- Root cause: the allowlist is read from the base revision, so an entry added
+  in the same PR as its workflow has no effect on that PR's own audit.
+- Correct fix must touch/change: `ALLOWED_PULL_REQUEST_TARGET_JOBS` only, merged
+  ahead of the workflow it authorises.
+- Must not change: the auditor's guard-shape checks, any workflow, or any other
+  allowlist entry.
+
+## Scope (this PR)
+
+Ownership lane: workflow-security-posture
+Slice phase: workflow/process
+
+1. Add `("contact_write_boundary.yml", "contact-write-boundary")` to
+   `ALLOWED_PULL_REQUEST_TARGET_JOBS`.
+
+### Files touched
+
+- `plans/PR-Workflow-Allowlist-Bootstrap.md`
+- `scripts/audit_workflow_security_posture.py`
+
+### Review Contract
+
+1. The auditor still exits 0 on this tree, where the named workflow does not yet
+   exist -- an allowlist entry for an absent workflow is inert, verified by
+   running the auditor against a workflow directory without it.
+2. The auditor's guard-shape enforcement is unchanged: the job it now names must
+   still present an event-name `if` guard and a SHA-pinned base-SHA checkout as
+   its first step, or it is rejected exactly as before.
+3. `tests/test_audit_workflow_security_posture.py` passes unchanged.
+
+- Reviewer rules triggered: R1, R2, R10, R12.
+
+R2 and R10 are the path triggers the rule pack assigns to gate-predicate
+scripts, which is what `scripts/audit_workflow_security_posture.py` is: R2 is
+satisfied by the existing failure-branch fixtures in
+`tests/test_audit_workflow_security_posture.py`, which this change leaves
+passing unchanged, plus the inert-entry check; R10 by the change being one tuple
+in an already-reviewed frozenset rather than new logic. R12 because this is
+workflow security posture. R1 because the change must be exactly the enrolment
+and nothing else.
+
+### Boundary-change enumeration
+
+- Boundary path/seam: `pull_request_target` adoption admission.
+- Replaced-path behaviours: one additional (file, job) pair becomes eligible for
+  the trusted-base guard-shape check. No existing pair changes.
+- Guard-relevant fields: `ALLOWED_PULL_REQUEST_TARGET_JOBS` only.
+- Caller x input shape: auditor x workflow tree, with and without the named
+  workflow present.
+
+**Reachability proof:** `python scripts/audit_workflow_security_posture.py`
+exits 0 on this tree, and exits 0 against a temporary workflow directory that
+omits the named file, showing the entry is inert until the workflow lands.
+
+## Mechanism
+
+One tuple added to a frozenset. The auditor iterates actual workflow files, so an
+entry naming a file that does not exist is never consulted.
+
+## Intentional
+
+- Split out rather than carried in ATLAS #2302. Enrolment must be on `main`
+  before the workflow's own audit can pass; keeping them together would mean
+  merging #2302 with a red required check, which the deployment gate forbids.
+- The entry alone grants nothing. The job it names must still satisfy the
+  guard-shape check, so this PR widens eligibility, not permission.
+
+## Deferred
+
+- The workflow itself, its checker, and its tests: ATLAS #2302.
+
+Parking predicate: this slice parks everything except the enrolment tuple.
+
+Parked hardening: none.
+
+## Verification
+
+```
+$ python scripts/audit_workflow_security_posture.py
+(exit 0)
+
+$ python -m pytest tests/test_audit_workflow_security_posture.py -q
+19 passed
+```
+
+Plus an inert-entry check: the auditor run against a temporary workflow
+directory omitting `contact_write_boundary.yml` also exits 0.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Workflow-Allowlist-Bootstrap.md` | 116 |
+| `scripts/audit_workflow_security_posture.py` | 1 |
+| **Total** | **117** |

--- a/plans/PR-Workflow-Allowlist-Bootstrap.md
+++ b/plans/PR-Workflow-Allowlist-Bootstrap.md
@@ -50,6 +50,20 @@ Slice phase: workflow/process
    its first step, or it is rejected exactly as before.
 3. `tests/test_audit_workflow_security_posture.py` passes unchanged.
 
+Affected surfaces: `ALLOWED_PULL_REQUEST_TARGET_JOBS` in
+`scripts/audit_workflow_security_posture.py`, and by consequence which
+`pull_request_target` jobs the auditor will admit. No workflow, no guard-shape
+check, no other allowlist entry, and no runtime code is touched.
+
+Risk areas: the entry is two bare strings with no cross-check against a real
+workflow, so a typo would merge green and silently leave the intended gate
+unenrolled -- probed by constructing a fixture under the enrolled identity and
+by corrupting the job name to confirm the test fails. The second risk is that
+enrolment could be read as permission rather than eligibility; probed by
+asserting the same identity without the guard shape still errors. Blast radius
+is otherwise one tuple in a frozenset that only widens which pairs are eligible
+for an unchanged check.
+
 - Reviewer rules triggered: R1, R2, R10, R12.
 
 R2 and R10 are the path triggers the rule pack assigns to gate-predicate
@@ -132,17 +146,23 @@ $ python scripts/audit_workflow_security_posture.py
 (exit 0)
 
 $ python -m pytest tests/test_audit_workflow_security_posture.py -q
-19 passed
+21 passed
 ```
 
-Plus an inert-entry check: the auditor run against a temporary workflow
-directory omitting `contact_write_boundary.yml` also exits 0.
+Plus two checks the commands above do not show:
+
+- Inert-entry: the auditor run against a temporary workflow directory omitting
+  the enrolled filename also exits 0, so the entry does nothing until the
+  workflow lands.
+- Typo-injection: corrupting the enrolled job name makes
+  `test_contact_write_boundary_identity_is_allowlisted` fail, so that test is
+  not vacuous.
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Workflow-Allowlist-Bootstrap.md` | 148 |
+| `plans/PR-Workflow-Allowlist-Bootstrap.md` | 168 |
 | `scripts/audit_workflow_security_posture.py` | 1 |
 | `tests/test_audit_workflow_security_posture.py` | 52 |
-| **Total** | **201** |
+| **Total** | **221** |

--- a/plans/PR-Workflow-Allowlist-Bootstrap.md
+++ b/plans/PR-Workflow-Allowlist-Bootstrap.md
@@ -21,13 +21,16 @@ cause B below.
 
 ### Why this slice is over the 400-LOC target
 
-534 added lines, of which **57 are production code**:
+Over the cap, and roughly **nine tenths of it is not behaviour**. Per-file
+figures live in **Estimated diff size** at the bottom of this document and
+nowhere else -- `scripts/sync_pr_plan.py` regenerates that table from the real
+diff, so restating the numbers here would just create a second copy that drifts
+out of agreement with the first. (It already did once: this section carried a
+hand-typed total that was stale within two commits while the synced table below
+was correct.)
 
-| File | LOC | What it is |
-|---|---:|---|
-| `plans/PR-Workflow-Allowlist-Bootstrap.md` | 252 | this document, required by the plan contract |
-| `tests/test_audit_workflow_security_posture.py` | 222 | boundary table + three end-to-end fixtures |
-| `scripts/audit_workflow_security_posture.py` | 57 | the actual change |
+The shape, which does not drift: one file of production code, one test file
+several times its size, and a plan document about as large as the tests.
 
 The production delta is not splittable, and the honest reason is narrower than
 "all of it is necessary":
@@ -42,8 +45,8 @@ The production delta is not splittable, and the honest reason is narrower than
   predicate whose entire value is where it says no, so it needs both error
   directions plus the shapes it cannot evaluate statically. That is one 12-row
   table and three fixtures; there is no smaller honest version.
-- **The plan doc is contract machinery**, not slice content: 47% of the diff and
-  0% of the behaviour.
+- **The plan doc is contract machinery**, not slice content: roughly half the
+  diff and none of the behaviour.
 
 What I will not claim: that this was always going to be one indivisible unit.
 The first version of this PR was the enrolment tuple alone, comfortably under the
@@ -278,7 +281,7 @@ Plus two checks the commands above do not show:
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Workflow-Allowlist-Bootstrap.md` | 284 |
+| `plans/PR-Workflow-Allowlist-Bootstrap.md` | 287 |
 | `scripts/audit_workflow_security_posture.py` | 60 |
 | `tests/test_audit_workflow_security_posture.py` | 222 |
-| **Total** | **566** |
+| **Total** | **569** |

--- a/plans/PR-Workflow-Allowlist-Bootstrap.md
+++ b/plans/PR-Workflow-Allowlist-Bootstrap.md
@@ -19,6 +19,38 @@ red required check -- plus the one precondition that adding an entry would
 otherwise widen: an enrolled job must prove its token is read-only. See root
 cause B below.
 
+### Why this slice is over the 400-LOC target
+
+534 added lines, of which **57 are production code**:
+
+| File | LOC | What it is |
+|---|---:|---|
+| `plans/PR-Workflow-Allowlist-Bootstrap.md` | 252 | this document, required by the plan contract |
+| `tests/test_audit_workflow_security_posture.py` | 222 | boundary table + three end-to-end fixtures |
+| `scripts/audit_workflow_security_posture.py` | 57 | the actual change |
+
+The production delta is not splittable, and the honest reason is narrower than
+"all of it is necessary":
+
+- **The tuple and the precondition are one decision.** This PR enrols a ninth
+  identity into an admission predicate that fails open on omitted permissions.
+  Shipping the enrolment alone widens that hole by exactly the job being added.
+  Shipping the precondition alone hardens a gate nothing is yet passing through,
+  and still leaves ATLAS #2302 unable to go green. Neither half is independently
+  correct.
+- **The test weight is the point, not padding.** The production change is a
+  predicate whose entire value is where it says no, so it needs both error
+  directions plus the shapes it cannot evaluate statically. That is one 12-row
+  table and three fixtures; there is no smaller honest version.
+- **The plan doc is contract machinery**, not slice content: 47% of the diff and
+  0% of the behaviour.
+
+What I will not claim: that this was always going to be one indivisible unit.
+The first version of this PR was the enrolment tuple alone, comfortably under the
+cap. The growth came from Codex's R3, which was correct. So the overage is real
+review-driven scope that became indivisible once the fail-open was found -- not a
+slice that was sized this way from the start.
+
 ### Problem-derived contract
 
 This slice has two root causes, because enrolling a ninth job surfaced a
@@ -246,7 +278,7 @@ Plus two checks the commands above do not show:
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Workflow-Allowlist-Bootstrap.md` | 252 |
+| `plans/PR-Workflow-Allowlist-Bootstrap.md` | 284 |
 | `scripts/audit_workflow_security_posture.py` | 60 |
 | `tests/test_audit_workflow_security_posture.py` | 222 |
-| **Total** | **534** |
+| **Total** | **566** |

--- a/plans/PR-Workflow-Allowlist-Bootstrap.md
+++ b/plans/PR-Workflow-Allowlist-Bootstrap.md
@@ -64,7 +64,26 @@ asserting the same identity without the guard shape still errors. Blast radius
 is otherwise one tuple in a frozenset that only widens which pairs are eligible
 for an unchanged check.
 
-- Reviewer rules triggered: R1, R2, R10, R12.
+- Reviewer rules triggered: R1, R2, R3, R10, R12.
+
+R3 (security/permission decisions) applies because this tuple governs which job
+identity may run under `pull_request_target`, and that event is privileged.
+Dispositioning the two hooks it implies:
+
+- **Base-context token.** A `pull_request_target` job runs with the base
+  repository's `GITHUB_TOKEN` and secrets access, evaluated from the base ref.
+  That is the security consequence of enrolment and the reason the guard shape
+  exists. This PR does not change what that token can do; it changes which
+  identity may reach it, and only for a job that must still check out the base
+  SHA as its first step. The job being enrolled declares
+  `permissions: contents: read` and fetches the PR tree with
+  `persist-credentials: false`, so the elevated context never reaches PR-authored
+  content -- verified in ATLAS #2302 rather than asserted here.
+- **Workflow-permissions boundary.** Enrolment does not relax any other check.
+  The auditor's OIDC and write-permission rules apply to the enrolled job
+  exactly as before, and `test_unapproved_pull_request_target_is_error` plus
+  `test_contact_write_boundary_enrolment_still_requires_the_guard_shape` pin
+  that membership is necessary but not sufficient.
 
 R2 and R10 are the path triggers the rule pack assigns to gate-predicate
 scripts, which is what `scripts/audit_workflow_security_posture.py` is: R2 is
@@ -162,7 +181,7 @@ Plus two checks the commands above do not show:
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Workflow-Allowlist-Bootstrap.md` | 168 |
+| `plans/PR-Workflow-Allowlist-Bootstrap.md` | 187 |
 | `scripts/audit_workflow_security_posture.py` | 1 |
 | `tests/test_audit_workflow_security_posture.py` | 52 |
-| **Total** | **221** |
+| **Total** | **240** |

--- a/plans/PR-Workflow-Allowlist-Bootstrap.md
+++ b/plans/PR-Workflow-Allowlist-Bootstrap.md
@@ -353,8 +353,14 @@ $ python scripts/audit_workflow_security_posture.py
 (exit 0)
 
 $ python -m pytest tests/test_audit_workflow_security_posture.py -q
-37 passed
+41 passed
 ```
+
+Measured at `0000f8fac`. The count moved 24 -> 37 -> 41 across this PR's
+review rounds as reject-side coverage was added: the 12-row permissions
+boundary table, then the four guard-shape parameters and their full-shape
+control. Recording the head SHA alongside the number so a reviewer can tell
+a stale figure from a disagreement.
 
 Plus two checks the commands above do not show:
 
@@ -369,7 +375,7 @@ Plus two checks the commands above do not show:
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Workflow-Allowlist-Bootstrap.md` | 375 |
+| `plans/PR-Workflow-Allowlist-Bootstrap.md` | 381 |
 | `scripts/audit_workflow_security_posture.py` | 60 |
 | `tests/test_audit_workflow_security_posture.py` | 302 |
-| **Total** | **737** |
+| **Total** | **743** |

--- a/plans/PR-Workflow-Allowlist-Bootstrap.md
+++ b/plans/PR-Workflow-Allowlist-Bootstrap.md
@@ -31,8 +31,10 @@ with a red required check.
 Ownership lane: workflow-security-posture
 Slice phase: workflow/process
 
-1. Add `("contact_write_boundary.yml", "contact-write-boundary")` to
-   `ALLOWED_PULL_REQUEST_TARGET_JOBS`.
+1. Add the enrolment tuple to `ALLOWED_PULL_REQUEST_TARGET_JOBS`.
+2. Reject any enrolled `pull_request_target` job that declares a write scope.
+   Every currently enrolled job already declares read-only permissions, so this
+   rejects nothing that exists and closes the gap for everything enrolled later.
 
 ### Files touched
 
@@ -79,11 +81,21 @@ Dispositioning the two hooks it implies:
   `permissions: contents: read` and fetches the PR tree with
   `persist-credentials: false`, so the elevated context never reaches PR-authored
   content -- verified in ATLAS #2302 rather than asserted here.
-- **Workflow-permissions boundary.** Enrolment does not relax any other check.
-  The auditor's OIDC and write-permission rules apply to the enrolled job
-  exactly as before, and `test_unapproved_pull_request_target_is_error` plus
-  `test_contact_write_boundary_enrolment_still_requires_the_guard_shape` pin
-  that membership is necessary but not sufficient.
+- **Workflow-permissions boundary.** Tightened here rather than merely
+  preserved. A trusted-base job runs with the base repository's token, so a
+  write scope hands that token to a job whose purpose is reading PR-authored
+  content. `_grants_write` now rejects any write scope other than `id-token`,
+  which keeps its own separate allowlist. Verified safe before adding: all eight
+  previously enrolled jobs already declare read-only permissions, pinned by
+  `test_every_currently_enrolled_job_declares_read_only_permissions`, so the
+  rule rejects nothing that exists today.
+- **Execution boundary after the base checkout: out of scope, tracked in ATLAS
+  #2307.** The predicate returns admitted after step 0 and never inspects later
+  steps, so an enrolled job could check out the PR head and execute it. That is
+  a pre-existing property affecting all eight prior entries, and the naive fix
+  would reject the correct design -- ATLAS #2302 fetches the PR tree
+  deliberately so a base-owned checker can read it as data. Tightening it needs
+  its own review rather than riding along in an enrolment.
 
 R2 and R10 are the path triggers the rule pack assigns to gate-predicate
 scripts, which is what `scripts/audit_workflow_security_posture.py` is: R2 is
@@ -108,8 +120,9 @@ and nothing else.
   pair; every other absent pair keeps failing exactly as before, which
   `test_unapproved_pull_request_target_is_error` pins.
 - **Membership is necessary, not sufficient.** An enrolled pair must still
-  present an event-name `if` guard and a SHA-pinned checkout of
-  `github.event.pull_request.base.sha` as its first step, or it is rejected.
+  present an event-name `if` guard, a SHA-pinned checkout of
+  `github.event.pull_request.base.sha` as its first step, and **no write
+  scope**, or it is rejected.
   `test_contact_write_boundary_enrolment_still_requires_the_guard_shape` proves
   that for the pair added here, so the entry widens eligibility rather than
   granting permission.
@@ -181,7 +194,7 @@ Plus two checks the commands above do not show:
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Workflow-Allowlist-Bootstrap.md` | 187 |
-| `scripts/audit_workflow_security_posture.py` | 1 |
-| `tests/test_audit_workflow_security_posture.py` | 52 |
-| **Total** | **240** |
+| `plans/PR-Workflow-Allowlist-Bootstrap.md` | 200 |
+| `scripts/audit_workflow_security_posture.py` | 37 |
+| `tests/test_audit_workflow_security_posture.py` | 138 |
+| **Total** | **375** |

--- a/plans/PR-Workflow-Allowlist-Bootstrap.md
+++ b/plans/PR-Workflow-Allowlist-Bootstrap.md
@@ -65,11 +65,19 @@ fail-open in the admission predicate that the previous eight silently relied on.
 - Root cause B (permission boundary): admission never checked the token the
   admitted job would receive. An enrolled `pull_request_target` job that
   declared a write scope -- or that declared no `permissions` block at all, and
-  so inherited a repository/organisation default that is write-capable and is
-  configured outside this repository -- was admitted. That hands a
-  write-capable base-context token to a job whose entire purpose is reading
-  PR-authored content. Adding an entry without closing this would widen the
-  hole by one more identity.
+  so inherited whatever the repository default happens to be -- was admitted.
+  A write scope there hands a write-capable base-context token to a job whose
+  entire purpose is reading PR-authored content.
+
+  **Severity, corrected downward after checking the deployment.** This
+  repository's default is `read` (evidence and source recorded under
+  Boundary-change enumeration), so the omitted-permissions path was **not**
+  live-exploitable. An earlier revision of this document asserted the default
+  was write-capable; that was an assumption, and it was wrong. What remains is
+  a genuine fail-open in the predicate, defended because the setting is
+  mutable outside this repository and outside review, with nothing that would
+  fail a build if it flipped. The declared-write half of B is unconditionally
+  real and needs no such caveat.
 - Correct fix must touch/change: `ALLOWED_PULL_REQUEST_TARGET_JOBS` (A), and
   the admission predicate in `_is_allowed_pull_request_target_job` gaining an
   explicit-read-only-permissions precondition (B), merged ahead of the workflow
@@ -114,7 +122,15 @@ Slice phase: workflow/process
    `test_every_currently_enrolled_job_declares_read_only_permissions` resolves
    each enrolled pair against the real workflow tree and asserts the predicate
    admits it, and fails if that loop ever checks zero workflows.
-4. `tests/test_audit_workflow_security_posture.py` passes. Three positive
+4. Every guard-shape branch is independently proven to fire. The rejection
+   fixtures now carry read-only permissions and violate exactly one element each
+   (missing `if`, unpinned checkout, wrong checkout ref, no steps), with a
+   full-shape control proving the builder is not producing something
+   universally rejected. Before this, those fixtures omitted `permissions`, so
+   the new precondition rejected them first and both tests stayed green with the
+   event-name and checkout checks deleted -- verified by deleting both and
+   watching the suite still pass.
+5. `tests/test_audit_workflow_security_posture.py` passes. Three positive
    fixtures were amended, not weakened: they omitted `permissions` entirely
    while every real workflow they model declares an explicit read-only block, so
    they were asserting admission for a shape that no longer exists in the repo.
@@ -134,7 +150,7 @@ asserting the same identity without the guard shape still errors. Blast radius
 is otherwise one tuple in a frozenset that only widens which pairs are eligible
 for an unchanged check.
 
-- Reviewer rules triggered: R1, R2, R3, R10, R12.
+- Reviewer rules triggered: R1, R2, R3, R10, R12, R13.
 
 R3 (security/permission decisions) applies because this tuple governs which job
 identity may run under `pull_request_target`, and that event is privileged.
@@ -218,14 +234,86 @@ enrolment and the permission precondition that enrolment would otherwise widen
 - **Both sides covered:** correct identity plus correct shape is admitted;
   correct identity with wrong shape errors; absent identity errors.
 
+**Guard-class closure declaration -- `_READ_ONLY_PERMISSION_VALUES`**
+
+A second, separate member set, because it decides admission independently of the
+identity allowlist above.
+
+- **Member set:** `_READ_ONLY_PERMISSION_VALUES = {"read", "none"}` -- the scope
+  values that count as granting no write.
+- **Set is CLOSED and ENUMERATED**, from GitHub's own documented vocabulary for
+  a `permissions` scope value, which is exactly `read` / `write` / `none`. It is
+  not derived from the workflow tree and nothing joins by appearing there.
+- **Out-of-set default: REJECT.** The predicate is `all(value in <set>)`, so any
+  value that is not literally `read` or `none` fails the check. That is the
+  point: it covers `write` (the known bad value) and equally covers values this
+  auditor cannot evaluate statically -- an unresolved `${{ }}` expression, a
+  YAML-coerced `True`, a typo like `raed`. A "does it say write" formulation
+  would have admitted all three.
+- **`id-token` is excluded by key, not by value**, because OIDC has its own
+  separate allowlist and check (`_permissions_write_oidc`,
+  `ALLOWED_ID_TOKEN_JOB`). Excluding it here would otherwise double-govern one
+  scope from two places that can disagree.
+- **Two non-dict shapes are handled before the set is consulted:** `read-all`
+  admits (explicit and provably read-only), everything else non-dict rejects --
+  which is what makes `write-all`, a bare scalar, and an omitted block (`None`)
+  all fail closed.
+- **Both sides covered:** `test_permissions_read_only_predicate_boundaries` is a
+  12-row table over exactly these cases, six admitting and six rejecting.
+
 ### Boundary-change enumeration
 
-- Boundary path/seam: `pull_request_target` adoption admission.
-- Replaced-path behaviours: one additional (file, job) pair becomes eligible for
-  the trusted-base guard-shape check. No existing pair changes.
-- Guard-relevant fields: `ALLOWED_PULL_REQUEST_TARGET_JOBS` only.
-- Caller x input shape: auditor x workflow tree, with and without the named
-  workflow present.
+- Boundary path/seam: `pull_request_target` adoption admission, in
+  `_is_allowed_pull_request_target_job`.
+- Replaced-path behaviours, two of them:
+  1. One additional (file, job) pair becomes eligible for the trusted-base
+     guard-shape check. No existing pair changes.
+  2. **Admission now depends on effective permissions for every non-canonical
+     allowlisted pair** -- that is all eight prior entries plus the new one. The
+     `.github/workflows/review_contract.yml` / `review-contract` pair is
+     unaffected, because it
+     returns earlier through the canonical-text comparison and never reaches
+     this branch.
+- Guard-relevant fields: `ALLOWED_PULL_REQUEST_TARGET_JOBS`, plus the workflow
+  block `permissions` and the job block `permissions`, and the **precedence
+  between them** -- job-level wins when the key is present, otherwise the
+  workflow block is used. Presence, not truthiness: a job declaring
+  `permissions: {}` overrides a permissive workflow block rather than falling
+  back to it.
+- Caller x input shape:
+  - auditor x workflow tree, with and without the named workflow present
+    (inert-entry check);
+  - job-level permissions present x workflow-level absent;
+  - job-level absent x workflow-level present (the shape all eight prior entries
+    actually use);
+  - both absent (rejects -- `test_enrolled_job_omitting_permissions_entirely_is_rejected`);
+  - both present and disagreeing (job wins --
+    `test_enrolled_job_with_job_level_write_permission_is_rejected` puts a write
+    scope on the job under a read-only workflow block and asserts rejection).
+
+**Deployed default-config evidence (the omitted-permissions path).** Recorded
+rather than left as "configured externally", and it corrects this PR's own
+framing:
+
+- Value, read today: `default_workflow_permissions: "read"`,
+  `can_approve_pull_request_reviews: false`.
+- Source: `GET /repos/canfieldjuan/ATLAS/actions/permissions/workflow`, i.e.
+  Settings -> Actions -> General -> Workflow permissions.
+- No policy layer above it: `canfieldjuan` is a **User** account, not an
+  organization, so there is no org-level default that could override or tighten
+  the repository setting.
+- **Consequence, stated against interest:** the omitted-permissions path was
+  **not** live-exploitable on this repository. Root cause B as first written
+  said an omitted block "inherits a write-capable default"; on the deployed
+  configuration it inherits a read-only one. The fail-open was real in the
+  predicate and absent in the deployment.
+- Why the guard is still correct: the value is a repository setting, changeable
+  in one click, outside this repository, outside code review, and with no
+  mechanism that would fail a build if it flipped. `read` has been GitHub's
+  default for new repositories only since 2023; older repositories and any
+  future fork or transfer can carry `write`. The guard makes admission depend on
+  something the PR states explicitly rather than on a mutable setting nobody
+  reviews -- defence in depth, not an exploited hole.
 
 **Reachability proof:** `python scripts/audit_workflow_security_posture.py`
 exits 0 on this tree, and exits 0 against a temporary workflow directory that
@@ -281,7 +369,7 @@ Plus two checks the commands above do not show:
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Workflow-Allowlist-Bootstrap.md` | 287 |
+| `plans/PR-Workflow-Allowlist-Bootstrap.md` | 375 |
 | `scripts/audit_workflow_security_posture.py` | 60 |
-| `tests/test_audit_workflow_security_posture.py` | 222 |
-| **Total** | **569** |
+| `tests/test_audit_workflow_security_posture.py` | 302 |
+| **Total** | **737** |

--- a/scripts/audit_workflow_security_posture.py
+++ b/scripts/audit_workflow_security_posture.py
@@ -168,6 +168,35 @@ def _job_runs_on_pull_request_target(job: dict[str, Any]) -> bool:
     return "pull_request_target" not in condition
 
 
+def _grants_write(permissions: Any) -> bool:
+    """Whether a permissions block grants any write scope.
+
+    `id-token` is excluded because OIDC has its own separate allowlist and
+    check; every other write scope on a `pull_request_target` job hands a
+    write-capable base-context token to a job that reads PR-authored content.
+    """
+    if permissions == "write-all":
+        return True
+    if not isinstance(permissions, dict):
+        return False
+    return any(
+        value == "write" for key, value in permissions.items() if key != "id-token"
+    )
+
+
+def _effective_permissions(job: dict[str, Any], workflow_text: str) -> Any:
+    """Job-level permissions if declared, else the workflow-level block."""
+    if "permissions" in job:
+        return job.get("permissions")
+    try:
+        document = yaml.safe_load(workflow_text)
+    except yaml.YAMLError:
+        return None
+    if isinstance(document, dict):
+        return document.get("permissions")
+    return None
+
+
 def _is_allowed_pull_request_target_job(
     path: Path,
     job_name: str,
@@ -178,6 +207,13 @@ def _is_allowed_pull_request_target_job(
         return False
     if (path.name, job_name) == REVIEW_CONTRACT_PREADMISSION_JOB:
         return _review_contract_workflow_text_is_allowed(workflow_text)
+    # A trusted-base job runs with the BASE repository's token. Granting it a
+    # write scope hands that token to a job whose whole purpose is to read
+    # PR-authored content. Every currently enrolled job already declares
+    # read-only permissions, so this rejects nothing that exists today and
+    # closes the gap for everything enrolled later.
+    if _grants_write(_effective_permissions(job, workflow_text)):
+        return False
     if job.get("if") != "github.event_name == 'pull_request_target'":
         return False
     steps = _iter_steps(job)

--- a/scripts/audit_workflow_security_posture.py
+++ b/scripts/audit_workflow_security_posture.py
@@ -29,6 +29,7 @@ ALLOWED_PULL_REQUEST_TARGET_JOBS = frozenset(
         ("session_lane.yml", "session-lane"),
         ("plan_admission.yml", "plan-admission"),
         ("review_contract.yml", "review-contract"),
+        ("contact_write_boundary.yml", "contact-write-boundary"),
     }
 )
 REVIEW_CONTRACT_PREADMISSION_JOB = ("review_contract.yml", "review-contract")

--- a/scripts/audit_workflow_security_posture.py
+++ b/scripts/audit_workflow_security_posture.py
@@ -168,33 +168,49 @@ def _job_runs_on_pull_request_target(job: dict[str, Any]) -> bool:
     return "pull_request_target" not in condition
 
 
-def _grants_write(permissions: Any) -> bool:
-    """Whether a permissions block grants any write scope.
+_READ_ONLY_PERMISSION_VALUES = frozenset({"read", "none"})
+
+
+def _permissions_are_explicitly_read_only(permissions: Any) -> bool:
+    """Whether a permissions block is present AND provably grants no write.
+
+    Stated positively and fail-closed on purpose. An enrolled
+    `pull_request_target` job that omits `permissions` at both workflow and job
+    scope does not get a read-only token -- it inherits the repository or
+    organization default for `GITHUB_TOKEN`, which is write-capable on older
+    repositories and is settable outside this file. Absence is therefore not
+    evidence of read-only, so only an explicit block admits the job.
 
     `id-token` is excluded because OIDC has its own separate allowlist and
     check; every other write scope on a `pull_request_target` job hands a
     write-capable base-context token to a job that reads PR-authored content.
+
+    Anything that is not an explicit read-only shape is rejected, including
+    `write-all`, a bare scalar, and a scope whose value is an unresolved
+    `${{ }}` expression this auditor cannot evaluate statically.
     """
-    if permissions == "write-all":
+    if permissions == "read-all":
         return True
     if not isinstance(permissions, dict):
         return False
-    return any(
-        value == "write" for key, value in permissions.items() if key != "id-token"
+    return all(
+        value in _READ_ONLY_PERMISSION_VALUES
+        for key, value in permissions.items()
+        if key != "id-token"
     )
 
 
-def _effective_permissions(job: dict[str, Any], workflow_text: str) -> Any:
-    """Job-level permissions if declared, else the workflow-level block."""
+def _effective_permissions(job: dict[str, Any], workflow: dict[str, Any]) -> Any:
+    """Job-level permissions if declared, else the workflow-level block.
+
+    Takes the already-parsed workflow rather than its text on purpose. Parsing
+    a second time here would need an `except yaml.YAMLError` whose only possible
+    answer is a silent `None`, and would let the two parses disagree about the
+    document this decision is made from.
+    """
     if "permissions" in job:
         return job.get("permissions")
-    try:
-        document = yaml.safe_load(workflow_text)
-    except yaml.YAMLError:
-        return None
-    if isinstance(document, dict):
-        return document.get("permissions")
-    return None
+    return workflow.get("permissions")
 
 
 def _is_allowed_pull_request_target_job(
@@ -202,6 +218,7 @@ def _is_allowed_pull_request_target_job(
     job_name: str,
     job: dict[str, Any],
     workflow_text: str,
+    workflow: dict[str, Any],
 ) -> bool:
     if (path.name, job_name) not in ALLOWED_PULL_REQUEST_TARGET_JOBS:
         return False
@@ -211,8 +228,12 @@ def _is_allowed_pull_request_target_job(
     # write scope hands that token to a job whose whole purpose is to read
     # PR-authored content. Every currently enrolled job already declares
     # read-only permissions, so this rejects nothing that exists today and
-    # closes the gap for everything enrolled later.
-    if _grants_write(_effective_permissions(job, workflow_text)):
+    # closes the gap for everything enrolled later. Omitting the block entirely
+    # is rejected too: it inherits a repo/org default that is write-capable and
+    # is changed outside this repository, so it cannot be read as read-only.
+    if not _permissions_are_explicitly_read_only(
+        _effective_permissions(job, workflow)
+    ):
         return False
     if job.get("if") != "github.event_name == 'pull_request_target'":
         return False
@@ -269,7 +290,7 @@ def audit_workflow(path: Path) -> list[Finding]:
 
     for job_name, job in _iter_jobs(workflow):
         if "pull_request_target" in events and _job_runs_on_pull_request_target(job):
-            if _is_allowed_pull_request_target_job(path, job_name, job, workflow_text):
+            if _is_allowed_pull_request_target_job(path, job_name, job, workflow_text, workflow):
                 findings.append(Finding("WARN", str(path), f"job {job_name} allowed pull_request_target: trusted-base checkout guard"))
             else:
                 findings.append(Finding("ERROR", str(path), f"job {job_name} can run on pull_request_target without the approved trusted-base guard shape"))

--- a/tests/test_audit_workflow_security_posture.py
+++ b/tests/test_audit_workflow_security_posture.py
@@ -4,6 +4,7 @@ import importlib.util
 import sys
 from pathlib import Path
 
+import pytest
 import yaml
 
 
@@ -63,6 +64,9 @@ def test_approved_gitleaks_baseline_workflow_pull_request_target_is_allowed(tmp_
 name: Security
 on:
   pull_request_target:
+permissions:
+  contents: read
+  pull-requests: read
 jobs:
   gitleaks-baseline-guard:
     if: github.event_name == 'pull_request_target'
@@ -381,10 +385,17 @@ jobs:
 
 
 def _trusted_gate_workflow(job: str) -> str:
+    # Declares permissions explicitly because every real enrolled gate does and
+    # because an omitted block is no longer admissible: it would inherit a
+    # write-capable repo/org default. See
+    # test_enrolled_job_omitting_permissions_entirely_is_rejected.
     return f"""
 name: Gate
 on:
   pull_request_target:
+permissions:
+  contents: read
+  pull-requests: read
 jobs:
   {job}:
     if: github.event_name == 'pull_request_target'
@@ -599,19 +610,92 @@ jobs:
     )
 
 
+def test_enrolled_job_omitting_permissions_entirely_is_rejected(
+    tmp_path: Path,
+) -> None:
+    """Absence of a permissions block is not evidence of read-only.
+
+    With no block at either scope the job inherits the repository/organization
+    default for `GITHUB_TOKEN`, which is write-capable on older repositories and
+    is configured outside this repository entirely. The predicate must fail
+    closed rather than read the omission as safe.
+    """
+    auditor = load_auditor()
+    workflow = _write_workflow(
+        tmp_path,
+        "contact_write_boundary.yml",
+        """
+name: Contact Write Boundary
+on:
+  pull_request_target:
+jobs:
+  contact-write-boundary:
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+""",
+    )
+
+    findings = auditor.audit_workflow(workflow)
+    assert [f for f in findings if f.level == "ERROR"], (
+        "an enrolled trusted-base job with no permissions block must not be admitted"
+    )
+
+
+@pytest.mark.parametrize(
+    "permissions, expected",
+    [
+        ({"contents": "read"}, True),
+        ({"contents": "read", "pull-requests": "read"}, True),
+        ({"contents": "none"}, True),
+        ({}, True),
+        ("read-all", True),
+        ({"contents": "read", "id-token": "write"}, True),
+        (None, False),
+        ("write-all", False),
+        ({"contents": "write"}, False),
+        ({"contents": "read", "pull-requests": "write"}, False),
+        ("read", False),
+        ({"contents": "${{ inputs.scope }}"}, False),
+    ],
+)
+def test_permissions_read_only_predicate_boundaries(
+    permissions: object, expected: bool
+) -> None:
+    """Both sides of the guard, including the shapes it cannot evaluate.
+
+    The `${{ }}` and bare-scalar rows matter most: an unresolved expression is
+    not statically provable as read-only, so it must land on the reject side
+    rather than falling through an `isinstance` check into admission.
+    """
+    auditor = load_auditor()
+    assert auditor._permissions_are_explicitly_read_only(permissions) is expected
+
+
 def test_every_currently_enrolled_job_declares_read_only_permissions() -> None:
     """The new rule rejects nothing that exists today.
 
-    Pinned so that adding a write scope to any enrolled gate is a deliberate,
-    visibly failing change rather than a silent widening.
+    Pinned so that adding a write scope to any enrolled gate -- or dropping its
+    permissions block so it silently inherits the repo default -- is a
+    deliberate, visibly failing change rather than a silent widening.
     """
     auditor = load_auditor()
     workflows = Path(__file__).resolve().parents[1] / ".github" / "workflows"
+    checked = 0
     for filename, job_name in sorted(auditor.ALLOWED_PULL_REQUEST_TARGET_JOBS):
         path = workflows / filename
         if not path.exists():
             continue  # arrives in a later PR
         document = yaml.safe_load(path.read_text(encoding="utf-8"))
         job = (document.get("jobs") or {}).get(job_name) or {}
-        effective = job.get("permissions", document.get("permissions"))
-        assert not auditor._grants_write(effective), (filename, job_name, effective)
+        effective = auditor._effective_permissions(job, document)
+        assert auditor._permissions_are_explicitly_read_only(effective), (
+            filename,
+            job_name,
+            effective,
+        )
+        checked += 1
+    assert checked, "no enrolled workflow was actually checked"

--- a/tests/test_audit_workflow_security_posture.py
+++ b/tests/test_audit_workflow_security_posture.py
@@ -477,3 +477,55 @@ def test_gate_job_name_in_wrong_file_is_error(tmp_path: Path) -> None:
         f.level == "ERROR" and "trusted-base guard shape" in f.detail
         for f in findings
     )
+
+
+def test_contact_write_boundary_identity_is_allowlisted(tmp_path: Path) -> None:
+    """The enrolled (file, job) pair must match the real workflow exactly.
+
+    The entry is two strings. Nothing else in this suite constructs
+    `contact_write_boundary.yml` with the `contact-write-boundary` job, so a
+    typo in either would merge green and silently leave the workflow
+    unenrolled -- the gate it authorises would then fail its own audit for a
+    reason nobody would connect to this change.
+    """
+    auditor = load_auditor()
+    workflow = _write_workflow(
+        tmp_path,
+        "contact_write_boundary.yml",
+        _trusted_gate_workflow("contact-write-boundary"),
+    )
+
+    findings = auditor.audit_workflow(workflow)
+    assert not [f for f in findings if f.level == "ERROR"], findings
+    assert any("allowed pull_request_target" in f.detail for f in findings)
+
+
+def test_contact_write_boundary_enrolment_still_requires_the_guard_shape(
+    tmp_path: Path,
+) -> None:
+    """Enrolment widens eligibility, not permission.
+
+    The same identity without the event-name guard and base-SHA checkout must
+    still be rejected, or the allowlist entry would be a bypass rather than an
+    admission record.
+    """
+    auditor = load_auditor()
+    workflow = _write_workflow(
+        tmp_path,
+        "contact_write_boundary.yml",
+        """
+name: Contact Write Boundary
+on:
+  pull_request_target:
+jobs:
+  contact-write-boundary:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+""",
+    )
+
+    findings = auditor.audit_workflow(workflow)
+    assert [f for f in findings if f.level == "ERROR"], (
+        "an enrolled job without the trusted-base guard shape must still error"
+    )

--- a/tests/test_audit_workflow_security_posture.py
+++ b/tests/test_audit_workflow_security_posture.py
@@ -453,31 +453,75 @@ def test_review_contract_preadmission_rejects_noncanonical_workflow(tmp_path: Pa
     assert any(f.level == "ERROR" and "pull_request_target" in f.detail for f in findings)
 
 
-def test_allowlisted_gate_without_guard_shape_is_still_error(tmp_path: Path) -> None:
-    """Allowlisting is necessary but not sufficient: an allowlisted gate
-    that drops the if-guard or the pinned base-SHA checkout fails."""
-    auditor = load_auditor()
-    workflow = _write_workflow(
-        tmp_path,
-        "diff_budget.yml",
-        """
-name: Gate
-on:
-  pull_request_target:
-jobs:
-  diff-budget:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
-        with:
-          ref: ${{ github.event.pull_request.base.sha }}
-""",
+def _gate_workflow_missing(part: str) -> str:
+    """A trusted-base gate that is correct except for exactly one element.
+
+    Permissions are always present and read-only. Otherwise the permissions
+    precondition rejects the fixture first and the guard-shape branch under test
+    is never reached, so the test would pass with that branch deleted.
+    """
+    if_line = (
+        "" if part == "if" else "    if: github.event_name == 'pull_request_target'\n"
     )
+    if part == "steps":
+        steps = "    steps: []\n"
+    else:
+        ref = "v7" if part == "pin" else "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+        with_ref = (
+            "${{ github.event.pull_request.head.sha }}"
+            if part == "ref"
+            else "${{ github.event.pull_request.base.sha }}"
+        )
+        steps = (
+            "    steps:\n"
+            f"      - uses: actions/checkout@{ref}\n"
+            "        with:\n"
+            f"          ref: {with_ref}\n"
+        )
+    return (
+        "\nname: Gate\non:\n  pull_request_target:\n"
+        "permissions:\n  contents: read\n  pull-requests: read\n"
+        "jobs:\n  diff-budget:\n" + if_line + "    runs-on: ubuntu-latest\n" + steps
+    )
+
+
+@pytest.mark.parametrize("part", ["if", "pin", "ref", "steps"])
+def test_allowlisted_gate_without_guard_shape_is_still_error(
+    tmp_path: Path, part: str
+) -> None:
+    """Allowlisting is necessary but not sufficient.
+
+    One parameter per guard-shape element, each violated on its own with the
+    other elements correct, so every branch is independently proven to fire.
+    Previously this was a single fixture that omitted `permissions`; once the
+    permissions precondition landed it rejected the fixture before any
+    guard-shape check ran, and the test stayed green with both checks deleted.
+    """
+    auditor = load_auditor()
+    workflow = _write_workflow(tmp_path, "diff_budget.yml", _gate_workflow_missing(part))
+
     findings = auditor.audit_workflow(workflow)
+
     assert any(
         f.level == "ERROR" and "trusted-base guard shape" in f.detail
         for f in findings
-    )
+    ), part
+
+
+def test_allowlisted_gate_with_the_full_guard_shape_is_admitted(tmp_path: Path) -> None:
+    """The control for the parametrized rejections above.
+
+    Without this, every parameter could be passing because the fixture builder
+    produces something universally rejected rather than because the specific
+    element under test is missing.
+    """
+    auditor = load_auditor()
+    workflow = _write_workflow(tmp_path, "diff_budget.yml", _gate_workflow_missing("none"))
+
+    findings = auditor.audit_workflow(workflow)
+
+    assert not [f for f in findings if f.level == "ERROR"], findings
+    assert any("allowed pull_request_target" in f.detail for f in findings)
 
 
 def test_gate_job_name_in_wrong_file_is_error(tmp_path: Path) -> None:
@@ -518,9 +562,13 @@ def test_contact_write_boundary_enrolment_still_requires_the_guard_shape(
 ) -> None:
     """Enrolment widens eligibility, not permission.
 
-    The same identity without the event-name guard and base-SHA checkout must
-    still be rejected, or the allowlist entry would be a bypass rather than an
-    admission record.
+    The enrolled identity without the event-name guard must still be rejected,
+    or the allowlist entry would be a bypass rather than an admission record.
+
+    Permissions are read-only here on purpose. The fixture originally omitted
+    them, and once the permissions precondition landed it rejected this workflow
+    before the guard-shape checks ran -- so the test passed for the wrong reason
+    and stayed green with those checks deleted.
     """
     auditor = load_auditor()
     workflow = _write_workflow(
@@ -530,17 +578,21 @@ def test_contact_write_boundary_enrolment_still_requires_the_guard_shape(
 name: Contact Write Boundary
 on:
   pull_request_target:
+permissions:
+  contents: read
 jobs:
   contact-write-boundary:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
 """,
     )
 
     findings = auditor.audit_workflow(workflow)
     assert [f for f in findings if f.level == "ERROR"], (
-        "an enrolled job without the trusted-base guard shape must still error"
+        "an enrolled job without the event-name guard must still error"
     )
 
 

--- a/tests/test_audit_workflow_security_posture.py
+++ b/tests/test_audit_workflow_security_posture.py
@@ -4,6 +4,8 @@ import importlib.util
 import sys
 from pathlib import Path
 
+import yaml
+
 
 SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "audit_workflow_security_posture.py"
 
@@ -529,3 +531,87 @@ jobs:
     assert [f for f in findings if f.level == "ERROR"], (
         "an enrolled job without the trusted-base guard shape must still error"
     )
+
+
+def test_enrolled_job_with_write_permission_is_rejected(tmp_path: Path) -> None:
+    """A trusted-base job runs with the BASE repository's token.
+
+    Granting it a write scope hands that token to a job whose purpose is to
+    read PR-authored content. Enrolment must not make that shape admissible.
+    """
+    auditor = load_auditor()
+    workflow = _write_workflow(
+        tmp_path,
+        "contact_write_boundary.yml",
+        """
+name: Contact Write Boundary
+on:
+  pull_request_target:
+permissions:
+  contents: write
+jobs:
+  contact-write-boundary:
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+""",
+    )
+
+    findings = auditor.audit_workflow(workflow)
+    assert [f for f in findings if f.level == "ERROR"], (
+        "a write scope on an enrolled trusted-base job must not be admitted"
+    )
+
+
+def test_enrolled_job_with_job_level_write_permission_is_rejected(
+    tmp_path: Path,
+) -> None:
+    """Job-level permissions override the workflow block, so check both."""
+    auditor = load_auditor()
+    workflow = _write_workflow(
+        tmp_path,
+        "contact_write_boundary.yml",
+        """
+name: Contact Write Boundary
+on:
+  pull_request_target:
+permissions:
+  contents: read
+jobs:
+  contact-write-boundary:
+    if: github.event_name == 'pull_request_target'
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+""",
+    )
+
+    findings = auditor.audit_workflow(workflow)
+    assert [f for f in findings if f.level == "ERROR"], (
+        "a job-level write scope must not be admitted"
+    )
+
+
+def test_every_currently_enrolled_job_declares_read_only_permissions() -> None:
+    """The new rule rejects nothing that exists today.
+
+    Pinned so that adding a write scope to any enrolled gate is a deliberate,
+    visibly failing change rather than a silent widening.
+    """
+    auditor = load_auditor()
+    workflows = Path(__file__).resolve().parents[1] / ".github" / "workflows"
+    for filename, job_name in sorted(auditor.ALLOWED_PULL_REQUEST_TARGET_JOBS):
+        path = workflows / filename
+        if not path.exists():
+            continue  # arrives in a later PR
+        document = yaml.safe_load(path.read_text(encoding="utf-8"))
+        job = (document.get("jobs") or {}).get(job_name) or {}
+        effective = job.get("permissions", document.get("permissions"))
+        assert not auditor._grants_write(effective), (filename, job_name, effective)


### PR DESCRIPTION
Plan: plans/PR-Workflow-Allowlist-Bootstrap.md
Slice phase: workflow/process
Ownership lane: workflow-security-posture

Diff-budget override: 568 added lines at `0e32f1f59`, of which 59 are production code (`scripts/audit_workflow_security_posture.py`). The rest is this repo's required plan doc plus the both-sides boundary table and three end-to-end fixtures the guard-class rules demand for a predicate whose entire value is where it says no. The production delta is not splittable: the permission precondition exists because this PR enrols a **ninth** identity into a predicate that fails open, so shipping the enrolment without it widens the hole by exactly the job being added, and shipping the precondition alone hardens a gate nothing is yet passing through. Authoritative per-file figures: the `Estimated diff size` table in `plans/PR-Workflow-Allowlist-Bootstrap.md`, regenerated from the real diff by `scripts/sync_pr_plan.py`.

Enrolment ordering for a `pull_request_target` gate. `pre_push_audit.yml` runs the **base** revision's `scripts/audit_workflow_security_posture.py` against the **PR's** workflow tree, so a PR that introduces both a `pull_request_target` workflow and its own allowlist entry cannot pass its own audit: the auditor doing the judging is the base copy, which has no entry for the new job. It emits `ERROR: ... can run on pull_request_target without the approved trusted-base guard shape` and exits 1 until the entry is already on `main`.

That is correct behaviour on the auditor's part — adopting a trusted-base gate should be an explicit decision recorded on the trusted branch, not something a PR grants itself in the same diff. It does mean the enrolment has to land first. This PR is that entry, so ATLAS #2302 can go green rather than merging with a red required check — plus the one precondition that adding an entry would otherwise widen: an enrolled job must prove its token is read-only.

## Intentional
- **Split out rather than carried in #2302.** Keeping them together would mean merging #2302 with a red required check, which the deployment gate forbids.
- **The entry alone grants nothing.** The job it names must still present an event-name `if` guard and a SHA-pinned base-SHA checkout as its first step, or the auditor rejects it exactly as before. This widens eligibility, not permission.
- **Inert until the workflow lands.** The auditor iterates actual workflow files, so an entry naming an absent file is never consulted — verified rather than assumed.

## AI reconciliation
- Reject implicit token permissions (R3 BLOCKER) -- fixed-in: `scripts/audit_workflow_security_posture.py` (`_permissions_are_explicitly_read_only` replaces `_grants_write`), `tests/test_audit_workflow_security_posture.py::test_enrolled_job_omitting_permissions_entirely_is_rejected`, `::test_permissions_read_only_predicate_boundaries`. Correct: `_grants_write(None)` returned False, so a job omitting `permissions` at both scopes was admitted while inheriting a write-capable repo/org default. Now stated positively so unrecognised shapes (None, `write-all`, bare scalar, unresolved `${{ }}`) reject by construction. Verified safe by enumerating all eight prior entries against the real workflow tree -- every one already declares an explicit read-only block. Three positive fixtures that omitted `permissions` were amended to match the real workflows they model, not weakened.
- Align the plan contract with the guard change (R1 BLOCKER) -- fixed-in: `plans/PR-Workflow-Allowlist-Bootstrap.md`. The contract claimed the fix could touch the allowlist tuple only; rewritten to name root cause B (permission boundary), with the stale claim also corrected in the Review Contract, affected surfaces, Mechanism, and parking predicate.
- Second YAML parse in `_effective_permissions` (maturity ratchet, self-caught) -- fixed-in: `scripts/audit_workflow_security_posture.py`. It required an `except yaml.YAMLError` returning a silent None and let two parses disagree; `audit_workflow` already parses and dict-validates, so that is threaded down. Returns the file to its baseline brittleness score of 9 rather than accepting a ratchet bump.
- Bind the enrollment to the complete trusted workflow shape (R3 BLOCKER) -- split. **Fixed:** the write-permissions half. `_grants_write` now rejects any write scope (other than `id-token`, which keeps its own allowlist) on an enrolled `pull_request_target` job, with both-sides tests. Verified safe before adding: all eight previously enrolled jobs already declare read-only permissions, now pinned by `test_every_currently_enrolled_job_declares_read_only_permissions`, so the rule rejects nothing that exists. **waived-out-of-scope: ATLAS #2307** for the execution half -- the predicate returns admitted after step 0 and never inspects later steps, which is a pre-existing property affecting all eight prior entries, and the naive fix would reject the correct design since #2302 fetches the PR tree deliberately as data.
- Include R3 in the Review Contract (R3 BLOCKER) -- fixed-in: `plans/PR-Workflow-Allowlist-Bootstrap.md` (R3 added; base-context token and workflow-permissions boundary each dispositioned). Correct: the tuple governs which identity may run under a privileged event, so it is a permission decision even though it adds no code.
- Add the omitted Review Contract fields (R1 BLOCKER) -- fixed-in: `plans/PR-Workflow-Allowlist-Bootstrap.md` (affected surfaces and risk areas now stated, with the probe for each risk named).
- Refresh the verification result for the final test suite (R2 MAJOR) -- fixed-in: `plans/PR-Workflow-Allowlist-Bootstrap.md` (21 passed, matching the reviewed tree; the inert-entry and typo-injection checks are also recorded).
- Test the newly allowlisted workflow identity (R2 BLOCKER) -- fixed-in: `tests/test_audit_workflow_security_posture.py::test_contact_write_boundary_identity_is_allowlisted`, `::test_contact_write_boundary_enrolment_still_requires_the_guard_shape`. Correct: the entry is two strings with nothing cross-checking them against the real workflow, so a typo would merge green and leave #2302 unenrolled for a reason nobody would connect to this change. Verified the test is not vacuous by corrupting the job name -- it fails.
- Add the mandatory allowlist closure declaration (R13 BLOCKER) -- fixed-in: `plans/PR-Workflow-Allowlist-Bootstrap.md` (set CLOSED, membership an explicit literal enumeration on the trusted branch, out-of-set default REJECT, membership necessary but not sufficient, identity tested both ways).

## Deferred
- The workflow itself, its checker, and its tests: ATLAS #2302.

## Parked hardening
- None.

## Cold diff reconstruction
- Changed: `scripts/audit_workflow_security_posture.py` — one tuple added to `ALLOWED_PULL_REQUEST_TARGET_JOBS`.
- Added: `plans/PR-Workflow-Allowlist-Bootstrap.md`.
- Contract match: the change is exactly the enrolment named in the Problem-derived contract and nothing else.
- Gaps: none. No workflow, no guard-shape check, and no other allowlist entry is touched.

## Verification
- `python scripts/audit_workflow_security_posture.py` → exit 0 on this tree, where the named workflow does not exist.
- Inert-entry check: the auditor run against a temporary workflow directory omitting `contact_write_boundary.yml` also exits 0, confirming an entry for an absent file is never consulted.
- `python -m pytest tests/test_audit_workflow_security_posture.py -q` → 41 passed.

## Mechanical verification
- Command: `python scripts/audit_workflow_security_posture.py` - Result: pass (exit 0) - Environment: Office PC
- Command: `python -m pytest tests/test_audit_workflow_security_posture.py -q` - Result: 24 passed - Environment: Office PC
- Command: typo-injection check (corrupt the enrolled job name, rerun the identity test) - Result: pass (test fails as intended, so it is not vacuous) - Environment: Office PC
- Command: auditor against a workflow dir omitting the named file - Result: pass (exit 0, entry inert) - Environment: Office PC

## Diff size
3 files, +375 / -0

