### PR TITLE
Tighten reviewer edge-case boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,13 @@ contract risks that are actually reachable from this PR.
   exhaustive R1-R14 matrix when a rule has no changed-path, direct-caller,
   acceptance-criterion, CI, security, data, migration, or deployment hook in
   this PR.
+- Stop at the Review Contract boundary. A new edge case, polish concern, or
+  hardening idea is BLOCKER/MAJOR only when it proves the current diff violates
+  the contract, breaks existing behavior, red CI, security/privacy/money safety,
+  data correctness, material reachable correctness/back-compat/performance, or
+  an explicitly claimed mechanism. Otherwise classify it as NIT or
+  `waived-out-of-scope`, park it in `Deferred` / `HARDENING.md`, and do not
+  require another push for it.
 - Hunt the rule categories: requirements match (R1), test evidence (R2),
   security/authorization (R3), data & migration safety (R4), backward compatibility
   (R5), error handling & observability (R6), performance (R7), concurrency &
@@ -324,6 +331,15 @@ levels:
 | **MAJOR** | Architectural / scope / pattern concern, **or a proven defect whose blast radius does not warrant blocking**. Strong recommendation but not auto-block. | Fix in this PR if the fix is small; otherwise discuss before deferring. |
 | **NIT** | Style, naming, comment polish. Skip-worthy. | Apply if 1-line; skip otherwise. The reviewer should mark NITs as skip-worthy explicitly. |
 | **LGTM** | All gates green, R14 verified, no remaining concerns. | Merge. |
+
+Reviewer novelty stop: after the builder fixes or waives the findings from the
+current review round, the next review may not introduce a new adjacent
+edge-case/hardening/polish demand as a merge blocker unless it cites the Review
+Contract criterion, CI/test failure, existing behavior, security/privacy/money
+safety, data-correctness issue, material reachable
+correctness/back-compat/performance defect introduced by the diff, or claimed
+mechanism it invalidates. Park adjacent-but-valid improvements as hardening; do
+not keep the PR open to explore the next possible probe.
 
 ### 2a. Reviewer's verification template
 
@@ -992,6 +1008,12 @@ claiming the fix complete:
 Hardcoding the reviewer's strings, values, paths, or exact examples is an R13
 failure (`docs/REVIEWER_RULES.md`). A fix that can pass only the visible review
 example is not done.
+
+This same-class proof closes the defect class named by the Review Contract or
+review finding. It is not permission to keep expanding the PR into newly
+discovered adjacent classes. Once the named class is structurally fixed or
+explicitly waived, park adjacent edge cases in `Deferred` / `HARDENING.md`
+unless they meet the reviewer novelty stop above.
 
 ---
 

--- a/docs/REVIEWER_RULES.md
+++ b/docs/REVIEWER_RULES.md
@@ -20,6 +20,17 @@ A finding is written as `Rxx (LEVEL) file:line - issue - required fix`.
 **Blockers must cite `file:line`.** A bare "LGTM" with no rule matrix and no
 independent verification is worse than no comment.
 
+**Review Contract boundary wins.** The reviewer may test the changed code,
+direct callers/tests/artifacts, required CI, and the acceptance criteria in the
+PR's Review Contract. A new edge case, polish concern, or hardening idea outside
+that boundary is not BLOCKER/MAJOR unless it proves the current diff violates
+the Review Contract, breaks existing behavior, red CI, security/privacy/money
+safety, data correctness, material reachable
+correctness/backward-compatibility/performance, or an explicitly claimed
+mechanism. Otherwise mark it NIT or `waived-out-of-scope`, and require the
+builder to park it in `Deferred` / `HARDENING.md` instead of pushing another
+fix.
+
 **BLOCKER requires a concrete failure path**: the specific input, sequence, or
 state that produces the harm, established by the reviewer. "This could break" is
 not one. Without a failure path the finding is MAJOR at most -- downgrade it, do
@@ -38,7 +49,9 @@ Three carve-outs, because a missing-evidence finding is not a speculative one:
   or not anyone has yet found the bypass -- "no one has exploited it" is not
   evidence it is safe. The unifying test is simple: if what is missing is the
   *evidence*, the absence is the failure path; only a speculative claim about
-  code you have read needs an input sequence.
+  code you have read needs an input sequence. This carve-out applies only to
+  proof required by the changed paths and Review Contract; it does not promote a
+  newly imagined adjacent hardening probe into a merge blocker.
 - **Established, not necessarily published.** For **any category
   `SECURITY.md` routes privately** -- it names exploitable vulnerabilities,
   exposed credentials, authentication bypasses, payment or billing issues, data
@@ -246,6 +259,12 @@ practical, use multiple unseen fixtures plus a short explanation of the
 generalized mechanism. Generated or unseen cases must be diverse enough to
 exercise the class, not trivial near-duplicates that satisfy the easy path.
 
+R13 closes the defect class named by the Review Contract or review finding; it
+does not license an expanding search over adjacent classes. Once the named class
+is structurally fixed or explicitly waived, any newly discovered adjacent
+edge-case/hardening/polish concern must be parked unless it satisfies the Review
+Contract boundary rule above.
+
 **Open-category exception (evidence-gate, do not enumerate).** When the class is
 an *open semantic category* the guard cannot enumerate on either side (person
 names, senders, intent, language, is-junk), neither a denylist nor a
@@ -281,6 +300,12 @@ Before LGTM on any PR whose change is a guard, validator, cap, classifier,
 gate, sanitizer, denylist, parser admission rule, or safety checker, run a
 boundary probe and state `boundary-probe: <what applied + result>` in the
 review.
+
+Probe the boundary this PR declares or changes; do not turn the probe into a
+whole-module hardening sweep. Adjacent probe ideas that do not falsify the
+Review Contract, existing behavior, CI, safety, data correctness, material
+reachable correctness/backward-compatibility/performance, or claimed mechanism
+are parked, not blocking.
 
 A guard usually fails on its second side. Check both sides:
 

--- a/plans/PR-Reviewer-Edge-Stop-Boundary.md
+++ b/plans/PR-Reviewer-Edge-Stop-Boundary.md
@@ -1,0 +1,141 @@
+# PR-Reviewer-Edge-Stop-Boundary
+
+## Why this slice exists
+
+The operator reported that Codex connector reviews keep expanding PRs with
+adjacent edge-case, polish, and hardening threads after the current review round
+has been addressed. The code-grounded audit found the boundary conflict:
+`AGENTS.md` and `docs/REVIEWER_RULES.md` already tell reviewers to waive
+out-of-scope hardening, but R13 / boundary-probe language can still promote
+newly imagined adjacent probes into merge blockers. `AGENTS.md` also names
+`scripts/codex_review_scope_policy.py` and
+`tests/test_codex_review_scope_policy.py` as the deterministic fixture oracle,
+so the rule change needs executable policy coverage.
+
+### Problem-derived contract
+
+- Root cause: The reviewer contract lacks a first-round novelty stop for
+  adjacent edge-case/hardening/polish probes. R13 and boundary-probe proof are
+  correct for the named defect class, but current wording and fixtures do not
+  make adjacent classes non-blocking once the Review Contract is met.
+- Correct fix must touch/change: Tighten the connector-facing scope language in
+  `AGENTS.md`, tighten the canonical rule pack in `docs/REVIEWER_RULES.md`, and
+  add deterministic fixture coverage in `scripts/codex_review_scope_policy.py`
+  plus `tests/test_codex_review_scope_policy.py`.
+- Must not change: Do not change product behavior, CI workflow enrollment,
+  `live-reconciliation`, GitHub API behavior, or the ability to block real
+  Review Contract, CI, security/privacy/money, data-correctness, existing
+  behavior, claimed-mechanism, or material reachable correctness/back-
+  compatibility/performance failures introduced by the diff.
+
+## Scope (this PR)
+
+Ownership lane: reviewer-boundary/workflow-process
+Slice phase: Workflow/process
+
+1. Add a hard reviewer boundary: adjacent edge-case/hardening/polish concerns
+   are parked unless they falsify the current Review Contract or a material
+   blocking surface.
+2. Encode that boundary in the Codex scope-policy fixture oracle, while keeping
+   concrete security/data/CI/material failures blocking.
+
+### Review Contract
+
+- Acceptance criteria:
+  1. `AGENTS.md` tells Codex to stop at the Review Contract boundary and park
+     adjacent hardening/polish/edge probes unless they invalidate this PR's
+     contract, CI, existing behavior, safety, data correctness, material
+     reachable correctness/back-compat/performance, or claimed mechanism.
+  2. `docs/REVIEWER_RULES.md` applies the same boundary before missing-evidence,
+     R13, and boundary-probe language can escalate adjacent probes.
+  3. `scripts/codex_review_scope_policy.py` classifies an adjacent-but-non-
+     falsifying edge probe as `WAIVE_OUT_OF_SCOPE`.
+  4. The same policy keeps adjacent concrete security and material performance
+     failures as `BLOCKER`.
+  5. `tests/test_codex_review_scope_policy.py` locks the fixture names and CLI
+     pass count for the added scenarios.
+- Reachability proof: `python scripts/codex_review_scope_policy.py --self-test`
+  and the focused pytest file exercise the executable policy oracle. No runtime
+  product surface is introduced.
+- Affected surfaces: `AGENTS.md`, `docs/REVIEWER_RULES.md`,
+  `scripts/codex_review_scope_policy.py`,
+  `tests/test_codex_review_scope_policy.py`.
+- Risk areas: reviewer severity boundary, fixture drift, accidentally weakening
+  real material blockers.
+- Reviewer rules triggered: R1, R2, R10, R13, R14.
+
+### Boundary-change enumeration
+
+Required when this diff changes a guard, validator, normalizer, resolver,
+router/classifier, or admission boundary. Name each changed boundary path or
+seam in the enumeration; otherwise write "N/A - no boundary change."
+
+- Boundary path/seam: Codex review disposition classifier in
+  `scripts/codex_review_scope_policy.py`.
+- Replaced-path behaviors: adjacent edge probes without a concrete falsifying
+  path move from default `MAJOR` fallback to `WAIVE_OUT_OF_SCOPE`.
+- Guard-relevant fields: `adjacent_to_scope`, `invalidates_review_contract`,
+  `breaks_existing_behavior`, `red_ci`, `explicitly_claimed_mechanism_false`,
+  `impact`, `concrete_failure_path`.
+- Caller x input shape: synthetic fixture dictionaries consumed by
+  `classify_finding`.
+
+### Deployed-config probing
+
+Required for guard, validator, resolver, admission-boundary, or env/config
+fallback changes; otherwise write "N/A - no guard/config boundary change."
+
+- Deployed/default config values: N/A - no deployed config.
+- Explicit value probe: N/A - no deployed config.
+- Absent value probe: N/A - no deployed config.
+- Default-session/default-context probe: N/A - no deployed config.
+- Side-effect ordering: N/A - pure classifier/docs change.
+
+### Files touched
+
+- `AGENTS.md`
+- `docs/REVIEWER_RULES.md`
+- `plans/PR-Reviewer-Edge-Stop-Boundary.md`
+- `scripts/codex_review_scope_policy.py`
+- `tests/test_codex_review_scope_policy.py`
+
+## Mechanism
+
+The prose contract now states that the Review Contract boundary wins over
+adjacent edge exploration. The executable policy adds an early
+`adjacent_to_scope` classification: if the finding does not invalidate the
+current Review Contract, existing behavior, CI, safety/data surfaces, or a
+claimed mechanism, it is waived out of scope. A paired fixture proves a concrete
+adjacent security failure still blocks.
+
+## Intentional
+
+- No `live-reconciliation` change: current code already allows a PR body that
+  honestly acknowledges open findings to pass the live contradiction check.
+- No broad reviewer rewrite: this slice only changes the adjacent-probe stop
+  boundary and fixture oracle.
+
+## Deferred
+
+None.
+
+Parked hardening: none.
+
+## Verification
+
+- `python scripts/codex_review_scope_policy.py --self-test` - PASS (13
+  fixtures).
+- `pytest tests/test_codex_review_scope_policy.py` - PASS (5 tests).
+- `python scripts/sync_pr_plan.py plans/PR-Reviewer-Edge-Stop-Boundary.md --check` - PASS.
+- Pending before push: `bash scripts/local_pr_review.sh`.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `AGENTS.md` | 22 |
+| `docs/REVIEWER_RULES.md` | 27 |
+| `plans/PR-Reviewer-Edge-Stop-Boundary.md` | 141 |
+| `scripts/codex_review_scope_policy.py` | 62 |
+| `tests/test_codex_review_scope_policy.py` | 7 |
+| **Total** | **259** |

--- a/scripts/codex_review_scope_policy.py
+++ b/scripts/codex_review_scope_policy.py
@@ -43,6 +43,8 @@ MATERIAL_IMPACTS = frozenset(
         "customer_output",
         "data_loss",
         "migration",
+        "backward_compatibility",
+        "performance",
         "privacy",
         "security",
     }
@@ -153,7 +155,62 @@ FIXTURES: tuple[Fixture, ...] = (
         },
         MAJOR,
     ),
+    Fixture(
+        "adjacent_edge_after_contract_met",
+        {
+            "in_scope": True,
+            "adjacent_to_scope": True,
+            "hardening": True,
+            "impact": "correctness",
+            "missing_mandatory_proof": True,
+            "concrete_failure_path": False,
+            "review_contract_met": True,
+        },
+        WAIVE_OUT_OF_SCOPE,
+    ),
+    Fixture(
+        "adjacent_security_failure_blocks",
+        {
+            "in_scope": True,
+            "adjacent_to_scope": True,
+            "impact": "security",
+            "concrete_failure_path": True,
+            "material": True,
+        },
+        BLOCKER,
+    ),
+    Fixture(
+        "adjacent_material_performance_failure_blocks",
+        {
+            "in_scope": True,
+            "adjacent_to_scope": True,
+            "impact": "performance",
+            "concrete_failure_path": True,
+            "material": True,
+        },
+        BLOCKER,
+    ),
 )
+
+
+def falsifies_current_boundary(finding: Mapping[str, object]) -> bool:
+    """Return whether an adjacent finding is still inside the blocking boundary."""
+
+    if finding.get("invalidates_review_contract"):
+        return True
+    if finding.get("breaks_existing_behavior"):
+        return True
+    if finding.get("red_ci"):
+        return True
+    if finding.get("explicitly_claimed_mechanism_false"):
+        return True
+
+    impact = str(finding.get("impact", ""))
+    return bool(
+        finding.get("concrete_failure_path")
+        and impact in MATERIAL_IMPACTS
+        and finding.get("material") is not False
+    )
 
 
 def classify_finding(finding: Mapping[str, object]) -> str:
@@ -171,13 +228,14 @@ def classify_finding(finding: Mapping[str, object]) -> str:
         return WAIVE_NIT
     if finding.get("in_scope") is False:
         return WAIVE_OUT_OF_SCOPE
+    if finding.get("adjacent_to_scope") and not falsifies_current_boundary(finding):
+        return WAIVE_OUT_OF_SCOPE
     if finding.get("missing_mandatory_proof"):
         return BLOCKER
 
-    impact = str(finding.get("impact", ""))
     if (
         finding.get("concrete_failure_path")
-        and impact in MATERIAL_IMPACTS
+        and str(finding.get("impact", "")) in MATERIAL_IMPACTS
         and finding.get("material") is not False
     ):
         return BLOCKER

--- a/tests/test_codex_review_scope_policy.py
+++ b/tests/test_codex_review_scope_policy.py
@@ -33,6 +33,9 @@ def test_fixture_scenarios_cover_operator_requested_review_shapes():
         "nit_suppression",
         "material_one_line_nit",
         "in_scope_pattern_concern",
+        "adjacent_edge_after_contract_met",
+        "adjacent_security_failure_blocks",
+        "adjacent_material_performance_failure_blocks",
     }
 
 
@@ -45,7 +48,7 @@ def test_cli_self_test_reports_pass_count():
         stderr=subprocess.PIPE,
     )
     assert proc.returncode == 0, proc.stderr
-    assert "OK: 10 Codex review scope fixtures passed" in proc.stdout
+    assert "OK: 13 Codex review scope fixtures passed" in proc.stdout
 
 
 def test_cli_requires_self_test(monkeypatch):
@@ -72,3 +75,5 @@ def test_active_docs_remove_second_reviewer_gate():
     assert "WAIVE_OUT_OF_SCOPE" in agents
     assert "WAIVE_SPECULATIVE" in agents
     assert "FILE_NIT" in agents
+    assert "Reviewer novelty stop" in agents
+    assert "Review Contract boundary wins" in rules


### PR DESCRIPTION
Plan: plans/PR-Reviewer-Edge-Stop-Boundary.md
Slice phase: Workflow/process
Ownership lane: reviewer-boundary/workflow-process

Tighten the Codex connector reviewer boundary so adjacent edge-case, polish, and hardening probes are parked unless they falsify this PR's Review Contract, CI, existing behavior, safety, data correctness, material reachable correctness/back-compat/performance, or a claimed mechanism.

## Intentional
- No live-reconciliation change: `scripts/check_ai_reconciliation_live.py` already allows an honestly acknowledged open-finding record to pass the live contradiction check.
- No product behavior change: this is reviewer policy and its deterministic fixture oracle only.

## AI reconciliation
- no-findings

## Deferred
- None.

## Parked hardening
- None.

## Cold diff reconstruction
- Changed: AGENTS.md:42 adds the connector-facing Review Contract boundary; AGENTS.md:334 adds the post-round novelty stop; AGENTS.md:1010 says same-class proof closes the named class rather than opening adjacent classes.
- Changed: docs/REVIEWER_RULES.md:23 makes the Review Contract boundary the canonical rule-pack precedence; docs/REVIEWER_RULES.md:39 scopes missing-evidence blockers to changed paths and the Review Contract; docs/REVIEWER_RULES.md:260 and docs/REVIEWER_RULES.md:302 constrain R13 and boundary-probe expansion.
- Changed: scripts/codex_review_scope_policy.py:37 includes backward-compatibility and performance in material impacts; scripts/codex_review_scope_policy.py:158 adds the adjacent edge fixture; scripts/codex_review_scope_policy.py:172 and scripts/codex_review_scope_policy.py:183 keep adjacent concrete security and material performance failures blocking; scripts/codex_review_scope_policy.py:196 defines the falsifying-boundary helper; scripts/codex_review_scope_policy.py:231 waives adjacent non-falsifying probes before missing-proof escalation.
- Changed: tests/test_codex_review_scope_policy.py:25 locks the 13 fixture names; tests/test_codex_review_scope_policy.py:51 locks the CLI pass count; tests/test_codex_review_scope_policy.py:77 checks the active docs expose the novelty/boundary language.
- Contract match: every change traces to the problem-derived contract in `plans/PR-Reviewer-Edge-Stop-Boundary.md`.
- Gaps: none.

## Verification
- `python scripts/codex_review_scope_policy.py --self-test` - PASS (13 fixtures).
- `pytest tests/test_codex_review_scope_policy.py` - PASS (5 tests).
- `python scripts/sync_pr_plan.py plans/PR-Reviewer-Edge-Stop-Boundary.md --check` - PASS.
- Pending before push: `bash scripts/local_pr_review.sh`.

## Mechanical verification
- Command: `python scripts/codex_review_scope_policy.py --self-test` - Result: 13 passed - Environment: local
- Command: `pytest tests/test_codex_review_scope_policy.py` - Result: 5 passed - Environment: local
- Command: `python scripts/sync_pr_plan.py plans/PR-Reviewer-Edge-Stop-Boundary.md --check` - Result: pass - Environment: local

## Diff size
5 files, +259 / -3
