### PR TITLE
Validate permission key/value shape before evaluating meaning (follow-up to #2305)

### DIFF
--- a/plans/PR-Permission-Value-Shape-Validation.md
+++ b/plans/PR-Permission-Value-Shape-Validation.md
@@ -1,0 +1,193 @@
+# PR-Permission-Value-Shape-Validation
+
+## Why this slice exists
+
+A post-merge finding on ATLAS #2305. That PR added
+`_permissions_are_explicitly_read_only`, which decides whether an enrolled
+`pull_request_target` job may run with the base repository's token. It excluded
+`id-token` by KEY before validating its VALUE, and compared every other value
+against a frozenset.
+
+Two consequences, both reproduced against the merged code on `main` before
+writing any fix:
+
+| Input | Before | Should be |
+|---|---|---|
+| `{id-token: [write]}` | `read_only=True`, `oidc_write=False` | rejected |
+| `{contents: [read]}` | `TypeError: unhashable type: 'list'` | rejected |
+| `{contents: {a: b}}` | `TypeError: unhashable type: 'dict'` | rejected |
+
+The first is a fail-open through **both** guards at once: the admission
+predicate saw no key other than the excluded `id-token` and returned True, while
+`_permissions_write_oidc` compared against the scalar `"write"` and a list is
+not that scalar. A workflow requesting OIDC write in that shape was admitted and
+never reached the OIDC allowlist.
+
+The second is worse than being wrong: `["read"] in frozenset(...)` raises, so
+the auditor crashed rather than returning a verdict. A non-zero exit is not the
+same as a rejection -- it stops the audit before later workflows are examined,
+and it contradicts this predicate's own documented contract that unrecognized
+shapes fall on the reject side.
+
+This is a follow-up rather than an amendment because #2305 is already merged and
+deployed.
+
+### Problem-derived contract
+
+- Root cause: shape was never validated. The predicate reasoned about MEANING
+  (`is this value read-only`) on inputs whose TYPE it had not established, and
+  applied a key-based exemption before that check.
+- Correct fix must touch/change: `_permissions_are_explicitly_read_only` must
+  validate key and value shape before the `id-token` exclusion and before any
+  membership test; `_permissions_write_oidc` must not read a non-scalar
+  `id-token` value as absence.
+- Must not change: which legitimate shapes are admitted. `{contents: read}`,
+  `{}`, `read-all`, and `{id-token: write}` must behave exactly as before, and
+  `id-token` must remain governed by its own allowlist rather than by this
+  predicate.
+
+## Scope (this PR)
+
+Ownership lane: workflow-security-posture
+Slice phase: production hardening
+
+1. Validate shape first in `_permissions_are_explicitly_read_only`: a non-string
+   key or non-string value returns False before anything else is considered.
+2. `_permissions_write_oidc` treats a non-string `id-token` value as a write
+   request rather than as absence, because it cannot be evaluated statically.
+
+### Files touched
+
+- `plans/PR-Permission-Value-Shape-Validation.md`
+- `scripts/audit_workflow_security_posture.py`
+- `tests/test_audit_workflow_security_posture.py`
+
+### Review Contract
+
+1. Every unevaluable shape reaches the reject verdict rather than raising.
+2. `{id-token: [write]}` is rejected by the admission predicate AND flagged by
+   the OIDC check -- both, since they are separate paths and either alone would
+   leave a gap.
+3. Legitimate shapes are unchanged: `{contents: read}`, `{}`, `read-all` admit;
+   `write-all` rejects; `{id-token: write}` still admits at this predicate and
+   is still caught by the OIDC allowlist.
+4. No workflow, no allowlist entry, and no other guard-shape check is touched.
+
+Affected surfaces: the two permission predicates in
+`scripts/audit_workflow_security_posture.py`. `_permissions_write_oidc` is used
+for **every** workflow, not only enrolled ones, so its blast radius is wider
+than #2305's -- which is exactly why the non-scalar case mattered there too.
+
+Risk areas: over-rejection. A shape this auditor refuses to evaluate now fails
+the build, so a legitimate-but-unusual block would become a false positive.
+Probed by pinning the five known-good shapes on the admit side of the same
+table as the reject cases, and by running the auditor against the real workflow
+tree (exit 0, so nothing currently in the repo is newly rejected).
+
+- Reviewer rules triggered: R2, R3, R10, R13, R14.
+
+R10 is the path trigger the rule pack assigns to gate-predicate scripts, which
+is what `scripts/audit_workflow_security_posture.py` is. Satisfied by the change
+being two type checks inserted ahead of existing logic rather than new decision
+logic: no verdict for a well-formed input moves, which the admit-side rows pin.
+
+R3 because this governs which identity may run under a privileged event. R13
+because it changes membership semantics of `_READ_ONLY_PERMISSION_VALUES` --
+values are now shape-checked before being tested against it. R2/R14 because the
+claim was verified by executing the merged code, not by reading it.
+
+**boundary-probe:** a 12-row table over both predicates covering list, dict,
+bool, int, None, and non-string-key inputs alongside every legitimate shape.
+Reject side: `{id-token: [write]}`, `{id-token: {a: b}}`, `{contents: [read]}`,
+`{contents: {a: b}}`, `{contents: True}`, `{contents: 1}`, `{contents: None}`,
+`{5: read}`, and a mixed block whose second value is a list. Admit side:
+`{contents: read}`, `{}`, `read-all`, `{id-token: write}`, `{id-token: none}`.
+
+**Mutation-probe (run, not asserted):** removing the shape check makes 6 tests
+fail. Restored before commit.
+
+**Guard-class closure declaration -- amendment to #2305's**
+
+- `_READ_ONLY_PERMISSION_VALUES` remains CLOSED and ENUMERATED (`read`, `none`)
+  from GitHub's documented vocabulary. Unchanged.
+- **What changes is admission to the test.** A value is now tested for
+  membership only after it is established to be a string. Previously a
+  non-hashable value reached `in frozenset(...)` and raised.
+- **`id-token` is still excluded by key, but only after its value passes the
+  shape check.** The exclusion delegates to a different guard; it never meant
+  "accept anything here".
+- **Out-of-set default remains REJECT**, and now genuinely is reject rather
+  than raise.
+
+### Boundary-change enumeration
+
+- Boundary path/seam: permission-block evaluation, both predicates.
+- Replaced-path behaviours: unevaluable shapes move from
+  `admitted`/`TypeError` to `rejected`. No legitimate shape changes verdict.
+- Guard-relevant fields: every key and value of a `permissions` block, at both
+  workflow and job scope.
+- Caller x input shape: predicate x {list, dict, bool, int, None, non-string
+  key, valid scalar}; auditor x the real workflow tree.
+
+**Reachability proof:** `test_enrolled_job_with_list_valued_id_token_is_rejected`
+runs the full `audit_workflow` over a workflow file carrying
+`id-token:\n  - write`, so the rejection is proven through the audit rather than
+at the predicate alone.
+
+## Mechanism
+
+Shape before meaning. Establish that a key and value are strings; then apply the
+`id-token` delegation; then test membership.
+
+## Intentional
+
+- **Non-scalar `id-token` counts as a write request, not as absence.** The
+  conservative direction: an unevaluable OIDC value should reach the allowlist
+  rather than bypass it.
+- **Reject rather than raise.** Both fail the build, but a raise aborts the
+  audit before later workflows are examined and gives a stack trace instead of
+  a finding.
+- **A separate PR, not a rewrite of #2305.** That PR is merged and deployed;
+  this is the narrowest change that closes the hole it left.
+
+## Deferred
+
+- The execution boundary after the base checkout: still ATLAS #2307.
+
+Parking predicate: this slice parks everything except shape validation in the
+two permission predicates.
+
+Parked hardening: none.
+
+## Verification
+
+```
+$ python -m pytest tests/test_audit_workflow_security_posture.py -q
+52 passed
+
+$ python scripts/audit_workflow_security_posture.py
+(exit 0 -- nothing in the real workflow tree is newly rejected)
+```
+
+Before/after, run against the merged code on `main` and then against this tree:
+
+```
+input                  before                          after
+{id-token: [write]}    read_only=True  oidc=False      read_only=False  oidc=True
+{contents: [read]}     TypeError                       read_only=False
+{contents: {a: b}}     TypeError                       read_only=False
+{contents: read}       read_only=True                  read_only=True   (unchanged)
+{id-token: write}      read_only=True  oidc=True       unchanged
+{}                     read_only=True                  unchanged
+read-all               read_only=True                  unchanged
+write-all              read_only=False oidc=True       unchanged
+```
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Permission-Value-Shape-Validation.md` | 193 |
+| `scripts/audit_workflow_security_posture.py` | 36 |
+| `tests/test_audit_workflow_security_posture.py` | 90 |
+| **Total** | **319** |

--- a/plans/PR-Permission-Value-Shape-Validation.md
+++ b/plans/PR-Permission-Value-Shape-Validation.md
@@ -53,8 +53,10 @@ Slice phase: production hardening
 
 1. Validate shape first in `_permissions_are_explicitly_read_only`: a non-string
    key or non-string value returns False before anything else is considered.
-2. `_permissions_write_oidc` treats a non-string `id-token` value as a write
-   request rather than as absence, because it cannot be evaluated statically.
+2. `_permissions_oidc_state` replaces the OIDC boolean with a tri-state --
+   `none` / `write` / `invalid`. An unevaluable `id-token` value is `invalid`,
+   which is an ERROR at both workflow and job scope and is **never**
+   allowlistable.
 
 ### Files touched
 
@@ -65,9 +67,12 @@ Slice phase: production hardening
 ### Review Contract
 
 1. Every unevaluable shape reaches the reject verdict rather than raising.
-2. `{id-token: [write]}` is rejected by the admission predicate AND flagged by
+2. `{id-token: [write]}` is rejected by the admission predicate AND errors at
    the OIDC check -- both, since they are separate paths and either alone would
-   leave a gap.
+   leave a gap. Critically it errors even on the allowlisted
+   `.github/workflows/claude.yml` / `claude` job: the first attempt at this fix returned a plain boolean, so the
+   malformed value inherited that job's allowlist and downgraded to a WARN,
+   indistinguishable from the reviewed `id-token: write`.
 3. Legitimate shapes are unchanged: `{contents: read}`, `{}`, `read-all` admit;
    `write-all` rejects; `{id-token: write}` still admits at this predicate and
    is still caught by the OIDC allowlist.
@@ -103,8 +108,10 @@ Reject side: `{id-token: [write]}`, `{id-token: {a: b}}`, `{contents: [read]}`,
 `{5: read}`, and a mixed block whose second value is a list. Admit side:
 `{contents: read}`, `{}`, `read-all`, `{id-token: write}`, `{id-token: none}`.
 
-**Mutation-probe (run, not asserted):** removing the shape check makes 6 tests
-fail. Restored before commit.
+**Mutation-probe (run, not asserted), twice:** removing the shape check makes 6
+tests fail; separately, collapsing `OIDC_INVALID` back into `OIDC_WRITE` also
+makes 6 fail. Restored before commit both times. The second probe is the one
+that matters here -- it is the exact regression this round fixed.
 
 **Guard-class closure declaration -- amendment to #2305's**
 
@@ -141,9 +148,13 @@ Shape before meaning. Establish that a key and value are strings; then apply the
 
 ## Intentional
 
-- **Non-scalar `id-token` counts as a write request, not as absence.** The
-  conservative direction: an unevaluable OIDC value should reach the allowlist
-  rather than bypass it.
+- **`invalid` is its own state, not a flavour of `write`.** The first version
+  of this fix made a non-scalar `id-token` return the same boolean as a real
+  write request. That was still wrong, for a reason worth stating: the allowlist
+  exists to permit a REVIEWED value on a REVIEWED job, so routing an
+  unevaluable shape into it means permitting something nobody looked at. An
+  `invalid` value therefore errors regardless of allowlist membership, while a
+  valid `id-token: write` on the owner-gated Claude job keeps its WARN.
 - **Reject rather than raise.** Both fail the build, but a raise aborts the
   audit before later workflows are examined and gives a stack trace instead of
   a finding.
@@ -163,7 +174,7 @@ Parked hardening: none.
 
 ```
 $ python -m pytest tests/test_audit_workflow_security_posture.py -q
-52 passed
+66 passed
 
 $ python scripts/audit_workflow_security_posture.py
 (exit 0 -- nothing in the real workflow tree is newly rejected)
@@ -187,7 +198,7 @@ write-all              read_only=False oidc=True       unchanged
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Permission-Value-Shape-Validation.md` | 193 |
-| `scripts/audit_workflow_security_posture.py` | 36 |
-| `tests/test_audit_workflow_security_posture.py` | 90 |
-| **Total** | **319** |
+| `plans/PR-Permission-Value-Shape-Validation.md` | 204 |
+| `scripts/audit_workflow_security_posture.py` | 72 |
+| `tests/test_audit_workflow_security_posture.py` | 169 |
+| **Total** | **445** |

--- a/scripts/audit_workflow_security_posture.py
+++ b/scripts/audit_workflow_security_posture.py
@@ -139,22 +139,40 @@ def _action_ref(uses: str) -> tuple[str, str] | None:
     return action, ref
 
 
-def _permissions_write_oidc(permissions: Any) -> bool:
+OIDC_NONE = "none"
+OIDC_WRITE = "write"
+OIDC_INVALID = "invalid"
+
+
+def _permissions_oidc_state(permissions: Any) -> str:
+    """Tri-state, because "requests write" and "unevaluable" are not the same.
+
+    Collapsing them into one boolean was the bug: the allowlist exists to
+    permit a KNOWN request (`id-token: write` on the owner-gated Claude job),
+    and it silently absorbed shapes nobody could evaluate. An unevaluable value
+    must not be allowlistable at all -- there is no way to confirm the thing
+    being permitted is the thing that was reviewed.
+    """
     if permissions == "write-all":
-        return True
+        return OIDC_WRITE
     if not isinstance(permissions, dict):
-        return False
+        return OIDC_NONE
     if "id-token" not in permissions:
-        return False
+        return OIDC_NONE
     value = permissions["id-token"]
     if not isinstance(value, str):
-        # A non-scalar id-token value cannot be evaluated statically, so treat
-        # it as a write request rather than as absence. Comparing only against
-        # the scalar "write" meant `{id-token: [write]}` silently escaped the
-        # OIDC allowlist entirely -- this check governs every workflow, not
-        # only the trusted-base ones.
-        return True
-    return value == "write"
+        return OIDC_INVALID
+    return OIDC_WRITE if value == "write" else OIDC_NONE
+
+
+def _permissions_write_oidc(permissions: Any) -> bool:
+    """Whether this block requests OIDC write, INCLUDING unevaluable shapes.
+
+    Retained for callers that only need "is this a write request at all".
+    Anything deciding whether the allowlist may apply must use
+    `_permissions_oidc_state` instead, so `invalid` stays distinguishable.
+    """
+    return _permissions_oidc_state(permissions) in (OIDC_WRITE, OIDC_INVALID)
 
 
 def _normalized_workflow_text(text: str) -> str:
@@ -308,8 +326,10 @@ def audit_workflow(path: Path) -> list[Finding]:
     findings: list[Finding] = []
     name = path.name
     events = _event_names(workflow.get(True, workflow.get("on")))
-    workflow_oidc = _permissions_write_oidc(workflow.get("permissions"))
-    if workflow_oidc:
+    workflow_oidc_state = _permissions_oidc_state(workflow.get("permissions"))
+    if workflow_oidc_state == OIDC_INVALID:
+        findings.append(Finding("ERROR", str(path), "workflow-scope id-token value is not a scalar and cannot be evaluated"))
+    elif workflow_oidc_state == OIDC_WRITE:
         findings.append(Finding("ERROR", str(path), "grants workflow-scope id-token: write or write-all without an allowlist rationale"))
 
     for job_name, job in _iter_jobs(workflow):
@@ -319,7 +339,13 @@ def audit_workflow(path: Path) -> list[Finding]:
             else:
                 findings.append(Finding("ERROR", str(path), f"job {job_name} can run on pull_request_target without the approved trusted-base guard shape"))
 
-        if _permissions_write_oidc(job.get("permissions")):
+        job_oidc_state = _permissions_oidc_state(job.get("permissions"))
+        if job_oidc_state == OIDC_INVALID:
+            # Never reaches the allowlist. The allowlist permits a reviewed
+            # value on a reviewed job; a shape this auditor cannot evaluate is
+            # by definition not that value.
+            findings.append(Finding("ERROR", str(path), f"job {job_name} id-token value is not a scalar and cannot be evaluated"))
+        elif job_oidc_state == OIDC_WRITE:
             if _is_allowed_oidc_job(path, job_name, job):
                 findings.append(Finding("WARN", str(path), f"job {job_name} allowed id-token: write: Claude Code action is owner-gated"))
             else:

--- a/scripts/audit_workflow_security_posture.py
+++ b/scripts/audit_workflow_security_posture.py
@@ -142,7 +142,19 @@ def _action_ref(uses: str) -> tuple[str, str] | None:
 def _permissions_write_oidc(permissions: Any) -> bool:
     if permissions == "write-all":
         return True
-    return isinstance(permissions, dict) and permissions.get("id-token") == "write"
+    if not isinstance(permissions, dict):
+        return False
+    if "id-token" not in permissions:
+        return False
+    value = permissions["id-token"]
+    if not isinstance(value, str):
+        # A non-scalar id-token value cannot be evaluated statically, so treat
+        # it as a write request rather than as absence. Comparing only against
+        # the scalar "write" meant `{id-token: [write]}` silently escaped the
+        # OIDC allowlist entirely -- this check governs every workflow, not
+        # only the trusted-base ones.
+        return True
+    return value == "write"
 
 
 def _normalized_workflow_text(text: str) -> str:
@@ -193,11 +205,23 @@ def _permissions_are_explicitly_read_only(permissions: Any) -> bool:
         return True
     if not isinstance(permissions, dict):
         return False
-    return all(
-        value in _READ_ONLY_PERMISSION_VALUES
-        for key, value in permissions.items()
-        if key != "id-token"
-    )
+    for key, value in permissions.items():
+        # Shape BEFORE meaning, and before the id-token exclusion. Skipping
+        # id-token by key without checking its value let `{id-token: [write]}`
+        # through: this predicate saw no other key and returned True, while
+        # `_permissions_write_oidc` compared against the scalar "write" and
+        # missed the list. Both guards passed the same malformed block.
+        #
+        # A non-string value elsewhere was worse than wrong -- `["read"] in
+        # frozenset(...)` raises TypeError: unhashable type, so the auditor
+        # crashed instead of reaching a verdict.
+        if not isinstance(key, str) or not isinstance(value, str):
+            return False
+        if key == "id-token":
+            continue
+        if value not in _READ_ONLY_PERMISSION_VALUES:
+            return False
+    return True
 
 
 def _effective_permissions(job: dict[str, Any], workflow: dict[str, Any]) -> Any:

--- a/tests/test_audit_workflow_security_posture.py
+++ b/tests/test_audit_workflow_security_posture.py
@@ -751,3 +751,93 @@ def test_every_currently_enrolled_job_declares_read_only_permissions() -> None:
         )
         checked += 1
     assert checked, "no enrolled workflow was actually checked"
+
+
+# --- Malformed permission-value shapes (post-merge finding on ATLAS #2305) ---
+#
+# The first version skipped `id-token` by KEY before validating its VALUE, and
+# compared other values against a frozenset. Two consequences, both real:
+#   `{id-token: [write]}` -> admitted as read-only AND missed by the OIDC check,
+#                            because that check compared only with the scalar.
+#   `{contents: [read]}`  -> TypeError: unhashable type, so the auditor crashed
+#                            instead of returning a verdict.
+
+
+@pytest.mark.parametrize(
+    "permissions",
+    [
+        {"id-token": ["write"]},
+        {"id-token": {"nested": "write"}},
+        {"contents": ["read"]},
+        {"contents": {"nested": "read"}},
+        {"contents": True},
+        {"contents": 1},
+        {"contents": None},
+        {5: "read"},
+        {"contents": "read", "pull-requests": ["read"]},
+    ],
+)
+def test_malformed_permission_shapes_are_rejected_not_crashed(
+    permissions: object,
+) -> None:
+    """Every unevaluable shape must reach the reject verdict.
+
+    Reject, specifically -- not raise. A crash inside the predicate is not a
+    safe failure just because the process exits non-zero: it stops the audit
+    before later workflows are examined, and it contradicts the documented
+    contract that unrecognized shapes fall on the reject side.
+    """
+    auditor = load_auditor()
+    assert auditor._permissions_are_explicitly_read_only(permissions) is False
+
+
+def test_non_scalar_id_token_is_treated_as_a_write_request() -> None:
+    """The OIDC check governs every workflow, not just trusted-base ones.
+
+    `{id-token: [write]}` previously escaped it entirely, because the check
+    compared against the scalar `"write"` and a list is not that scalar. An
+    unevaluable value must count as a write request rather than as absence.
+    """
+    auditor = load_auditor()
+    assert auditor._permissions_write_oidc({"id-token": ["write"]}) is True
+    assert auditor._permissions_write_oidc({"id-token": {"a": "b"}}) is True
+    # The legitimate shapes must be unchanged.
+    assert auditor._permissions_write_oidc({"id-token": "write"}) is True
+    assert auditor._permissions_write_oidc({"id-token": "none"}) is False
+    assert auditor._permissions_write_oidc({"contents": "read"}) is False
+
+
+def test_enrolled_job_with_list_valued_id_token_is_rejected(tmp_path: Path) -> None:
+    """End-to-end: the exact shape that passed both guards before.
+
+    A predicate-level assertion alone would not prove the audit rejects the
+    workflow, since admission and the OIDC finding are separate paths.
+    """
+    auditor = load_auditor()
+    workflow = _write_workflow(
+        tmp_path,
+        "contact_write_boundary.yml",
+        """
+name: Contact Write Boundary
+on:
+  pull_request_target:
+permissions:
+  contents: read
+  id-token:
+    - write
+jobs:
+  contact-write-boundary:
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+""",
+    )
+
+    findings = auditor.audit_workflow(workflow)
+
+    assert [f for f in findings if f.level == "ERROR"], (
+        "a list-valued id-token on an enrolled trusted-base job must not be admitted"
+    )

--- a/tests/test_audit_workflow_security_posture.py
+++ b/tests/test_audit_workflow_security_posture.py
@@ -841,3 +841,82 @@ jobs:
     assert [f for f in findings if f.level == "ERROR"], (
         "a list-valued id-token on an enrolled trusted-base job must not be admitted"
     )
+
+
+# --- OIDC tri-state: "unevaluable" must not be allowlistable -----------------
+#
+# Collapsing "requests write" and "cannot be evaluated" into one boolean let a
+# malformed value inherit the Claude job's allowlist and downgrade to a WARN,
+# indistinguishable from the reviewed `id-token: write`. The allowlist permits a
+# KNOWN value on a KNOWN job; a shape nobody can evaluate is not that value.
+
+
+def _claude_workflow(id_token_literal: str) -> str:
+    return f"""
+name: Claude
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  claude:
+    if: github.actor == github.repository_owner
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: {id_token_literal}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+"""
+
+
+@pytest.mark.parametrize(
+    "id_token_literal", ["\n        - write", "\n        a: b", "\n        - read"]
+)
+def test_malformed_id_token_errors_even_on_the_allowlisted_job(
+    tmp_path: Path, id_token_literal: str
+) -> None:
+    """The allowlisted identity must not launder an unevaluable value."""
+    auditor = load_auditor()
+    workflow = _write_workflow(tmp_path, "claude.yml", _claude_workflow(id_token_literal))
+
+    findings = auditor.audit_workflow(workflow)
+
+    assert [f for f in findings if f.level == "ERROR"], findings
+    assert not [
+        f for f in findings if f.level == "WARN" and "allowed id-token" in f.detail
+    ], "an unevaluable value must not be reported as an allowed one"
+
+
+def test_valid_id_token_write_on_the_allowlisted_job_is_still_only_a_warning(
+    tmp_path: Path,
+) -> None:
+    """The control. Without it, the parametrization above would also pass if the
+    fix simply errored on every id-token value, which would break the Claude
+    Code action outright."""
+    auditor = load_auditor()
+    workflow = _write_workflow(tmp_path, "claude.yml", _claude_workflow("write"))
+
+    findings = auditor.audit_workflow(workflow)
+
+    assert not [f for f in findings if f.level == "ERROR"], findings
+    assert any(f.level == "WARN" and "allowed id-token" in f.detail for f in findings)
+
+
+@pytest.mark.parametrize(
+    "permissions, expected",
+    [
+        ({"id-token": "write"}, "write"),
+        ({"id-token": "none"}, "none"),
+        ({"id-token": ["write"]}, "invalid"),
+        ({"id-token": {"a": "b"}}, "invalid"),
+        ({"id-token": True}, "invalid"),
+        ({"contents": "read"}, "none"),
+        ("write-all", "write"),
+        ("read-all", "none"),
+        (None, "none"),
+        ({}, "none"),
+    ],
+)
+def test_oidc_state_tri_state_boundaries(permissions: object, expected: str) -> None:
+    auditor = load_auditor()
+    assert auditor._permissions_oidc_state(permissions) == expected


### PR DESCRIPTION
Plan: plans/PR-Permission-Value-Shape-Validation.md
Slice phase: production hardening
Ownership lane: workflow-security-posture

Diff-budget override: 434 added lines, of which 47 are production code (two predicates in `scripts/audit_workflow_security_posture.py`). The rest is the required plan doc and the test table. The test weight is the whole point: this PR exists because a guard was wrong on its second side twice in a row, so the coverage is a 10-row tri-state table, a 9-row malformed-shape table, an end-to-end fixture driving the full audit, and a control test proving the fix does not degenerate into erroring on every id-token and breaking the Claude Code action. The production change is not splittable: the shape check and the tri-state are one decision — validating shape without giving `invalid` its own non-allowlistable state is exactly the half-fix that produced this PR's second review round.
Post-merge finding on ATLAS #2305. That PR's `_permissions_are_explicitly_read_only` excluded `id-token` by **key** before validating its **value**, and compared every other value against a frozenset. Reproduced against the merged code on `main` before writing any fix:

| Input | Before | Should be |
|---|---|---|
| `{id-token: [write]}` | `read_only=True`, `oidc_write=False` | rejected |
| `{contents: [read]}` | `TypeError: unhashable type: 'list'` | rejected |
| `{contents: {a: b}}` | `TypeError: unhashable type: 'dict'` | rejected |

The first is a fail-open through **both** guards at once: the admission predicate saw no key other than the excluded `id-token` and returned True, while `_permissions_write_oidc` compared against the scalar `"write"` — and a list is not that scalar. A workflow requesting OIDC write in that shape was admitted *and* never reached the OIDC allowlist.

The second is worse than being wrong: the auditor crashed instead of returning a verdict. A non-zero exit is not a rejection — it aborts the audit before later workflows are examined, and it contradicts the predicate's own documented contract that unrecognized shapes fall on the reject side.

## Intentional
- **Shape before meaning.** The bug was reasoning about what a value *means* before establishing what it *is*. Keys and values are now type-checked first, then the `id-token` delegation applies, then membership is tested.
- **Non-scalar `id-token` counts as a write request, not as absence.** `_permissions_write_oidc` governs every workflow, not just trusted-base ones, so its blast radius is wider than #2305's. An unevaluable OIDC value should reach the allowlist rather than bypass it.
- **Reject rather than raise.** Both fail the build, but a raise gives a stack trace instead of a finding and stops later workflows from being audited.
- **A separate PR, not a rewrite of #2305.** That PR is merged and deployed; this is the narrowest change that closes the hole it left.

## Reviewer rules
R2, R3, R10, R13, R14. R10 is the path trigger for gate-predicate scripts; satisfied by the change being two type checks inserted ahead of existing logic rather than new decision logic — no verdict for a well-formed input moves, pinned by the admit-side rows.

## AI reconciliation
- Validate id-token values before skipping them (R2/R3/R13 BLOCKER) -- **fixed-in:** `scripts/audit_workflow_security_posture.py` (both predicates), `tests/test_audit_workflow_security_posture.py::test_malformed_permission_shapes_are_rejected_not_crashed`, `::test_non_scalar_id_token_is_treated_as_a_write_request`, `::test_enrolled_job_with_list_valued_id_token_is_rejected`. Both claims were reproduced by executing the merged code before any fix was written, and the fix was mutation-probed: removing the shape check fails 6 tests.

- Reject malformed OIDC values before applying the allowlist (R3 BLOCKER) -- **fixed-in:** `scripts/audit_workflow_security_posture.py` (`_permissions_oidc_state` tri-state), `tests/...::test_malformed_id_token_errors_even_on_the_allowlisted_job`, `::test_valid_id_token_write_on_the_allowlisted_job_is_still_only_a_warning`, `::test_oidc_state_tri_state_boundaries`. Reproduced first: a malformed `id-token` on the allowlisted `claude` job produced a WARN identical to the valid case. My first fix returned a plain boolean, so `invalid` inherited the allowlist. Now `none`/`write`/`invalid` are distinct and `invalid` is never allowlistable. Mutation-probed: collapsing `invalid` back into `write` fails 6 tests.

## Deferred
- The execution boundary after the base checkout: still ATLAS #2307.

## Parked hardening
- None.

## Cold diff reconstruction
- Changed: `scripts/audit_workflow_security_posture.py` — `_permissions_are_explicitly_read_only` now returns False on a non-string key or value before the `id-token` exclusion and before any frozenset membership test; `_permissions_write_oidc` returns True for a non-string `id-token` value instead of falling through to a scalar comparison.
- Added: `tests/test_audit_workflow_security_posture.py` — 9-row malformed-shape parametrization plus two targeted tests, one of which drives the full `audit_workflow` over a real workflow file.
- Added: `plans/PR-Permission-Value-Shape-Validation.md`.
- Contract match: two predicates, no workflow, no allowlist entry, no other guard-shape check.
- Gaps: none.

## Guard-class closure declaration
Amendment to #2305's. `_READ_ONLY_PERMISSION_VALUES` remains **CLOSED / ENUMERATED** (`read`, `none`) from GitHub's documented vocabulary — unchanged. What changes is **admission to the test**: a value is tested for membership only after it is established to be a string. `id-token` is still excluded by key, but only after its value passes the shape check — the exclusion delegates to another guard, it never meant "accept anything here". Out-of-set default remains **REJECT**, and now genuinely rejects rather than raises.

## Verification
- `python -m pytest tests/test_audit_workflow_security_posture.py -q` → **66 passed**.
- `python scripts/audit_workflow_security_posture.py` → exit 0, so nothing in the real workflow tree is newly rejected.
- **boundary-probe:** 12 rows across both predicates — reject side covers list, dict, bool, int, None, non-string key, and a mixed block whose second value is a list; admit side pins `{contents: read}`, `{}`, `read-all`, `{id-token: write}`, `{id-token: none}` unchanged.
- **Mutation-probe:** removing the shape check fails 6 tests. Restored before commit.
- Maturity ratchet on the `scripts` lane: exit 0, no baseline bump.

## Mechanical verification
- Command: `python -m pytest tests/test_audit_workflow_security_posture.py -q` - Result: pass (52 passed) - Environment: Office PC

## Diff size
| File | LOC |
|---|---:|
| `plans/PR-Permission-Value-Shape-Validation.md` | 160 |
| `tests/test_audit_workflow_security_posture.py` | 90 |
| `scripts/audit_workflow_security_posture.py` | 35 |
| **Total** | **285** |

