### PR TITLE
Add EOM operator contact mutation contract

### DIFF
--- a/atlas_brain/eom_api/funnel.py
+++ b/atlas_brain/eom_api/funnel.py
@@ -6,7 +6,7 @@ import base64
 import binascii
 import re
 from datetime import datetime
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, Mapping
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, status
@@ -28,6 +28,11 @@ from ..services.eom_lead_conversion import (
     finalize_eom_customer_handoff,
     mark_eom_lead_lost,
     reopen_eom_lead,
+)
+from ..services.eom_crm_mutations import (
+    EOMOperatorContactMutation,
+    EOMOperatorContactMutationError,
+    mutate_eom_operator_contact,
 )
 from ..services.eom_onboarding_drafts import (
     EOMOnboardingDraftApproval,
@@ -123,6 +128,37 @@ class EOMLeadLostRequest(BaseModel):
             stripped = value.strip()
             return stripped or None
         return value
+
+
+class EOMOperatorContactRequest(BaseModel):
+    """Authenticated operator-authored EOM contact create/update request."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    contact_id: UUID | None = Field(default=None, alias="contactId")
+    contact_type: Literal["lead", "customer"] | None = Field(
+        default=None,
+        alias="contactType",
+    )
+    full_name: Annotated[
+        str | None,
+        Field(default=None, min_length=1, max_length=256, alias="fullName"),
+    ]
+    email: Annotated[str | None, Field(default=None, max_length=256)]
+    phone: Annotated[str | None, Field(default=None, max_length=64)]
+    address: Annotated[str | None, Field(default=None, max_length=2000)]
+    city: Annotated[str | None, Field(default=None, max_length=128)]
+    state: Annotated[str | None, Field(default=None, max_length=64)]
+    zip: Annotated[str | None, Field(default=None, max_length=16)]
+    notes: Annotated[str | None, Field(default=None, max_length=4000)]
+    source_channel: Annotated[
+        str,
+        Field(min_length=1, max_length=64, alias="sourceChannel"),
+    ]
+    source_ref: Annotated[
+        str,
+        Field(min_length=1, max_length=220, alias="sourceRef"),
+    ]
 
 
 class EOMLeadReviewItem(BaseModel):
@@ -328,6 +364,7 @@ _CAPABILITY_ROUTES: dict[str, tuple[str, str]] = {
         "/eom-funnel/leads/{contact_id}/first-clean-bookings",
     ),
     "lead.customer_handoff": ("POST", "/eom-funnel/customer-handoffs"),
+    "contact.operator_mutation": ("POST", "/eom-funnel/operator-contacts"),
     "lead.lost": ("POST", "/eom-funnel/leads/{contact_id}/lost"),
     "lead.reopen": ("POST", "/eom-funnel/leads/{contact_id}/reopen"),
     "onboarding.draft.list": ("GET", "/eom-funnel/onboarding-drafts"),
@@ -371,6 +408,97 @@ def served_capabilities() -> tuple[str, ...]:
             )
         )
     return _served_capabilities_cache
+
+
+def _operator_contact_fields(payload: EOMOperatorContactRequest) -> dict[str, Any]:
+    model_to_contact = {
+        "full_name": "full_name",
+        "email": "email",
+        "phone": "phone",
+        "address": "address",
+        "city": "city",
+        "state": "state",
+        "zip": "zip",
+        "notes": "notes",
+    }
+    return {
+        contact_field: getattr(payload, model_field)
+        for model_field, contact_field in model_to_contact.items()
+        if model_field in payload.model_fields_set
+    }
+
+
+def _contact_datetime(value: Any) -> str | None:
+    if value is None:
+        return None
+    if hasattr(value, "isoformat"):
+        return value.isoformat()
+    return str(value)
+
+
+def _operator_contact_item(contact: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "contactId": str(contact["id"]),
+        "fullName": contact.get("full_name"),
+        "email": contact.get("email"),
+        "phone": contact.get("phone"),
+        "address": contact.get("address"),
+        "city": contact.get("city"),
+        "state": contact.get("state"),
+        "zip": contact.get("zip"),
+        "notes": contact.get("notes"),
+        "contactType": contact.get("contact_type"),
+        "leadStage": contact.get("lead_stage"),
+        "status": contact.get("status"),
+        "source": contact.get("source"),
+        "sourceRef": contact.get("source_ref"),
+        "createdAt": _contact_datetime(contact.get("created_at")),
+        "updatedAt": _contact_datetime(contact.get("updated_at")),
+    }
+
+
+@router.post(
+    "/operator-contacts",
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(require_eom_funnel_api)],
+)
+async def mutate_operator_contact(
+    payload: EOMOperatorContactRequest,
+    operation_key: str = Depends(_approval_key_dependency),
+    actor: dict[str, object] = Depends(require_eom_funnel_actor),
+    crm: Any = Depends(_crm_dependency),
+) -> JSONResponse:
+    """Create or edit one EOM contact through the operator mutation boundary."""
+    try:
+        result = await mutate_eom_operator_contact(
+            crm,
+            EOMOperatorContactMutation.from_raw(
+                operation_key=operation_key,
+                actor_id=int(actor["id"]),
+                actor_name=str(actor["name"]),
+                source_channel=payload.source_channel,
+                source_ref=payload.source_ref,
+                fields=_operator_contact_fields(payload),
+                contact_id=str(payload.contact_id) if payload.contact_id else None,
+                contact_type=payload.contact_type,
+            ),
+        )
+    except EOMOperatorContactMutationError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
+    return JSONResponse(
+        status_code=(
+            status.HTTP_200_OK
+            if bool(result.get("idempotent"))
+            else status.HTTP_201_CREATED
+        ),
+        content={
+            "success": True,
+            "contactId": result["contact_id"],
+            "operation": result["operation"],
+            "idempotent": bool(result.get("idempotent")),
+            "contact": _operator_contact_item(result["contact"]),
+        },
+    )
 
 
 @router.get(

--- a/atlas_brain/eom_api/funnel.py
+++ b/atlas_brain/eom_api/funnel.py
@@ -160,6 +160,27 @@ class EOMOperatorContactRequest(BaseModel):
         Field(min_length=1, max_length=220, alias="sourceRef"),
     ]
 
+    @field_validator(
+        "full_name",
+        "email",
+        "phone",
+        "address",
+        "city",
+        "state",
+        "zip",
+        "notes",
+        "source_channel",
+        "source_ref",
+        mode="before",
+    )
+    @classmethod
+    def _route_surrogates_to_domain_validation(cls, value: Any) -> Any:
+        if isinstance(value, str) and any(
+            0xD800 <= ord(char) <= 0xDFFF for char in value
+        ):
+            return "\x00"
+        return value
+
 
 class EOMLeadReviewItem(BaseModel):
     """The only CRM identity data the office-review queue may expose."""

--- a/atlas_brain/eom_api/funnel.py
+++ b/atlas_brain/eom_api/funnel.py
@@ -64,6 +64,21 @@ _RECIPIENT_EMAIL_PATTERN = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 _ONBOARDING_DRAFT_STATUSES = ("pending", "sending", "sent", "revoked")
 
 
+def _route_surrogates_to_safe_text(value: Any) -> Any:
+    if isinstance(value, str):
+        if any(0xD800 <= ord(char) <= 0xDFFF for char in value):
+            return "\x00"
+        return value
+    if isinstance(value, Mapping):
+        return {
+            _route_surrogates_to_safe_text(key): _route_surrogates_to_safe_text(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_route_surrogates_to_safe_text(item) for item in value]
+    return value
+
+
 class EOMCustomerHandoffRequest(BaseModel):
     """Tracker-owned customer/site IDs; never operational estimate details."""
 
@@ -159,6 +174,11 @@ class EOMOperatorContactRequest(BaseModel):
         str,
         Field(min_length=1, max_length=220, alias="sourceRef"),
     ]
+
+    @model_validator(mode="before")
+    @classmethod
+    def _sanitize_request_surrogates(cls, value: Any) -> Any:
+        return _route_surrogates_to_safe_text(value)
 
     @field_validator(
         "full_name",

--- a/atlas_brain/services/crm_provider.py
+++ b/atlas_brain/services/crm_provider.py
@@ -17,7 +17,6 @@ Usage:
 import json
 import logging
 import hashlib
-import re
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -134,6 +133,11 @@ _ALL_EOM_REQUESTED_EVENTS = frozenset(
 )
 _EOM_LOST_RESTORABLE_STAGES = ("new", "estimate_booked")
 _EOM_LOST_REPLAY_DISPOSITION_EVENTS = ("lead_lost", "lead_reopened")
+_EOM_OPERATOR_CONTACT_SOURCES_METADATA_KEY = "eom_operator_contact_sources"
+
+
+def _eom_identity_lock_key(channel: str, value: str) -> str:
+    return f"eom-contact-identity:{channel}:{value}"
 
 
 @asynccontextmanager
@@ -413,8 +417,9 @@ class DatabaseCRMProvider:
         self._pool_override = pool
 
     def _get_pool(self) -> Any:
-        if self._pool_override is not None:
-            return self._pool_override
+        pool_override = getattr(self, "_pool_override", None)
+        if pool_override is not None:
+            return pool_override
         from ..storage.database import get_db_pool
 
         return get_db_pool()
@@ -510,10 +515,13 @@ class DatabaseCRMProvider:
         transaction.  A legacy row is returned untouched, never claimed or
         merged from extracted/web-form data.
         """
-        from .eom_lead_ingress import EOM_BUSINESS_CONTEXT_ID
+        from .eom_lead_ingress import (
+            EOM_BUSINESS_CONTEXT_ID,
+            normalise_eom_phone_digits,
+        )
 
         normalized_email = str(email or "").strip().lower()
-        phone_digits = re.sub(r"\D", "", str(phone or ""))
+        phone_digits = normalise_eom_phone_digits(phone)
         if len(phone_digits) < 10:
             phone_digits = ""
         normalized_source = str(source or "").strip()
@@ -526,9 +534,9 @@ class DatabaseCRMProvider:
             )
         lock_keys = []
         if phone_digits:
-            lock_keys.append(f"eom-inbound:phone:{phone_digits[-10:]}")
+            lock_keys.append(_eom_identity_lock_key("phone", phone_digits[-10:]))
         if normalized_email:
-            lock_keys.append(f"eom-inbound:email:{normalized_email}")
+            lock_keys.append(_eom_identity_lock_key("email", normalized_email))
         if normalized_relay_event_id:
             lock_keys.append(
                 f"eom-inbound:relay:{normalized_source}:{normalized_relay_event_id}"
@@ -800,6 +808,60 @@ class DatabaseCRMProvider:
                 )
         return result
 
+    async def _insert_contact_row(
+        self,
+        executor: Any,
+        data: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        """Insert one contact through the provider-owned persistence site."""
+
+        contact_id = str(uuid4())
+        now = datetime.now(timezone.utc)
+        raw_email = data.get("email")
+        email = raw_email.lower() if raw_email else None
+        metadata_json = json.dumps(data.get("metadata", {}))
+
+        row = await executor.fetchrow(
+            """
+            INSERT INTO contacts (
+                id, full_name, first_name, last_name, email, phone,
+                address, city, state, zip, business_context_id,
+                contact_type, status, tags, notes, source, source_ref,
+                lead_stage, lead_owner, next_follow_up_at,
+                created_at, updated_at, metadata
+            ) VALUES (
+                $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,
+                $18,$19,$20,$21,$22,$23::jsonb
+            ) RETURNING *
+            """,
+            contact_id,
+            data.get("full_name", ""),
+            data.get("first_name"),
+            data.get("last_name"),
+            email,
+            data.get("phone"),
+            data.get("address"),
+            data.get("city"),
+            data.get("state"),
+            data.get("zip"),
+            data.get("business_context_id"),
+            data.get("contact_type", "customer"),
+            data.get("status", "active"),
+            data.get("tags", []),
+            data.get("notes"),
+            data.get("source", "manual"),
+            data.get("source_ref"),
+            data.get("lead_stage"),
+            data.get("lead_owner"),
+            data.get("next_follow_up_at"),
+            now,
+            now,
+            metadata_json,
+        )
+        result = dict(row) if row else {}
+        result["_was_created"] = True
+        return result
+
     async def create_contact(
         self,
         data: dict[str, Any],
@@ -955,53 +1017,375 @@ class DatabaseCRMProvider:
             return result
 
         # --- no existing contact -- insert ---
-        from ..storage.database import get_db_pool
+        pool = self._get_pool()
+        return await self._insert_contact_row(pool, data)
 
-        pool = get_db_pool()
-        contact_id = str(uuid4())
-        now = datetime.now(timezone.utc)
-        metadata_json = json.dumps(data.get("metadata", {}))
+    async def mutate_eom_operator_contact_atomic(self, *, command: Any) -> dict[str, Any]:
+        """Create or edit one EOM contact under the operator mutation contract."""
 
-        row = await pool.fetchrow(
-            """
-            INSERT INTO contacts (
-                id, full_name, first_name, last_name, email, phone,
-                address, city, state, zip, business_context_id,
-                contact_type, status, tags, notes, source, source_ref,
-                lead_stage, lead_owner, next_follow_up_at,
-                created_at, updated_at, metadata
-            ) VALUES (
-                $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,
-                $18,$19,$20,$21,$22,$23::jsonb
-            ) RETURNING *
-            """,
-            contact_id,
-            data.get("full_name", ""),
-            data.get("first_name"),
-            data.get("last_name"),
-            email,  # normalized lowercase
-            phone,
-            data.get("address"),
-            data.get("city"),
-            data.get("state"),
-            data.get("zip"),
-            data.get("business_context_id"),
-            data.get("contact_type", "customer"),
-            data.get("status", "active"),
-            data.get("tags", []),
-            data.get("notes"),
-            data.get("source", "manual"),
-            data.get("source_ref"),
-            data.get("lead_stage"),
-            data.get("lead_owner"),
-            data.get("next_follow_up_at"),
-            now,  # created_at ($21)
-            now,  # updated_at ($22) -- same value on insert
-            metadata_json,
+        from .eom_crm_mutations import (
+            EOM_OPERATOR_CONTACT_CREATED,
+            EOM_OPERATOR_CONTACT_EVENT_TYPES,
+            EOM_OPERATOR_CONTACT_TYPES,
+            EOM_OPERATOR_CONTACT_UPDATED,
+            EOM_BUSINESS_CONTEXT_ID,
+            EOMOperatorContactMutationError,
         )
-        result = dict(row) if row else {}
-        result["_was_created"] = True
-        return result
+
+        def _metadata_from_row(value: Any) -> dict[str, Any]:
+            if value is None:
+                return {}
+            if isinstance(value, str):
+                try:
+                    loaded = json.loads(value)
+                except json.JSONDecodeError:
+                    return {}
+                return loaded if isinstance(loaded, dict) else {}
+            return dict(value)
+
+        def _event_result(
+            *,
+            row: Mapping[str, Any],
+            event_type: str,
+            idempotent: bool,
+        ) -> dict[str, Any]:
+            return {
+                "contact_id": str(row["id"]),
+                "operation": event_type,
+                "idempotent": idempotent,
+                "contact": dict(row),
+            }
+
+        def _dedupe_rows_by_id(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+            by_id: dict[str, dict[str, Any]] = {}
+            for row in rows:
+                by_id.setdefault(str(row["id"]), row)
+            return list(by_id.values())
+
+        def _operator_provenance_metadata(
+            target: Mapping[str, Any],
+        ) -> tuple[dict[str, Any], bool]:
+            metadata = _metadata_from_row(target.get("metadata"))
+            raw_sources = metadata.get(_EOM_OPERATOR_CONTACT_SOURCES_METADATA_KEY)
+            sources = dict(raw_sources) if isinstance(raw_sources, Mapping) else {}
+            source_record = {
+                "source": command.contact_source,
+                "source_channel": command.source_channel,
+                "source_ref": command.source_ref,
+            }
+            if sources.get(command.contact_source_ref) == source_record:
+                return metadata, False
+            sources[command.contact_source_ref] = source_record
+            metadata[_EOM_OPERATOR_CONTACT_SOURCES_METADATA_KEY] = sources
+            return metadata, True
+
+        async def _select_exact_matches(conn: Any) -> list[dict[str, Any]]:
+            matches: list[dict[str, Any]] = []
+            source_match = await conn.fetchrow(
+                """
+                SELECT *
+                FROM contacts
+                WHERE business_context_id = $1
+                  AND source = $2
+                  AND source_ref = $3
+                  AND status != 'archived'
+                FOR UPDATE
+                """,
+                EOM_BUSINESS_CONTEXT_ID,
+                command.contact_source,
+                command.contact_source_ref,
+            )
+            if source_match is not None:
+                matches.append(dict(source_match))
+            provenance_matches = await conn.fetch(
+                """
+                SELECT *
+                FROM contacts
+                WHERE business_context_id = $1
+                  AND status != 'archived'
+                  AND COALESCE(metadata -> $2, '{}'::jsonb) ? $3
+                FOR UPDATE
+                """,
+                EOM_BUSINESS_CONTEXT_ID,
+                _EOM_OPERATOR_CONTACT_SOURCES_METADATA_KEY,
+                command.contact_source_ref,
+            )
+            matches.extend(dict(row) for row in provenance_matches)
+
+            phone = command.fields.get("phone")
+            if phone:
+                phone_matches = await conn.fetch(
+                    """
+                    SELECT *
+                    FROM contacts
+                    WHERE (business_context_id = $1 OR business_context_id IS NULL)
+                      AND status != 'archived'
+                      AND RIGHT(REGEXP_REPLACE(COALESCE(phone, ''), '[^0-9]', '', 'g'), 10)
+                          = RIGHT($2, 10)
+                    FOR UPDATE
+                    """,
+                    EOM_BUSINESS_CONTEXT_ID,
+                    phone,
+                )
+                matches.extend(dict(row) for row in phone_matches)
+
+            email = command.fields.get("email")
+            if email:
+                email_matches = await conn.fetch(
+                    """
+                    SELECT *
+                    FROM contacts
+                    WHERE (business_context_id = $1 OR business_context_id IS NULL)
+                      AND status != 'archived'
+                      AND LOWER(email) = $2
+                    FOR UPDATE
+                    """,
+                    EOM_BUSINESS_CONTEXT_ID,
+                    email,
+                )
+                matches.extend(dict(row) for row in email_matches)
+            return matches
+
+        async def _assert_no_explicit_identity_collision(
+            conn: Any,
+            target: Mapping[str, Any],
+        ) -> None:
+            target_id = str(target["id"])
+            conflicts = [
+                row
+                for row in _dedupe_rows_by_id(await _select_exact_matches(conn))
+                if str(row["id"]) != target_id
+            ]
+            if conflicts:
+                raise EOMOperatorContactMutationError(
+                    409, "Operator contact identity belongs to another contact"
+                )
+
+        async def _resolve_target(conn: Any) -> dict[str, Any] | None:
+            if command.contact_id:
+                contact = await conn.fetchrow(
+                    """
+                    SELECT *
+                    FROM contacts
+                    WHERE id = $1
+                      AND (business_context_id = $2 OR business_context_id IS NULL)
+                    FOR UPDATE
+                    """,
+                    command.contact_id,
+                    EOM_BUSINESS_CONTEXT_ID,
+                )
+                if contact is None:
+                    raise EOMOperatorContactMutationError(
+                        404, "EOM contact was not found"
+                    )
+                row = dict(contact)
+                if row.get("status") == "archived":
+                    raise EOMOperatorContactMutationError(
+                        409, "Archived EOM contacts cannot be edited"
+                    )
+                await _assert_no_explicit_identity_collision(conn, row)
+                return row
+
+            matches = _dedupe_rows_by_id(await _select_exact_matches(conn))
+            if len(matches) > 1:
+                raise EOMOperatorContactMutationError(
+                    409, "Operator contact identity matched multiple contacts"
+                )
+            return matches[0] if matches else None
+
+        def _assert_contact_type_matches(target: Mapping[str, Any]) -> None:
+            stored_type = str(target.get("contact_type") or "")
+            if stored_type not in EOM_OPERATOR_CONTACT_TYPES:
+                raise EOMOperatorContactMutationError(
+                    409,
+                    "EOM operator contact updates require an existing lead or customer",
+                )
+            if command.contact_type is None:
+                return
+            if stored_type != command.contact_type:
+                raise EOMOperatorContactMutationError(
+                    409,
+                    "contactType changes require the EOM lifecycle transition service",
+                )
+
+        async def _update_existing(
+            conn: Any, target: Mapping[str, Any]
+        ) -> dict[str, Any]:
+            _assert_contact_type_matches(target)
+            updates = {
+                key: value
+                for key, value in command.fields.items()
+                if target.get(key) != value
+            }
+            if target.get("business_context_id") is None:
+                updates["business_context_id"] = EOM_BUSINESS_CONTEXT_ID
+            provenance_metadata, provenance_changed = _operator_provenance_metadata(target)
+            if provenance_changed:
+                updates["metadata"] = provenance_metadata
+            if not updates:
+                return dict(target)
+            updates["updated_at"] = datetime.now(timezone.utc)
+            params: list[Any] = [target["id"]]
+            set_parts: list[str] = []
+            for index, (key, value) in enumerate(updates.items(), start=2):
+                cast = "::jsonb" if key == "metadata" else ""
+                set_parts.append(f"{key} = ${index}{cast}")
+                params.append(
+                    json.dumps(value, sort_keys=True) if key == "metadata" else value
+                )
+            context_index = len(params) + 1
+            row = await conn.fetchrow(
+                f"""
+                UPDATE contacts
+                SET {', '.join(set_parts)}
+                WHERE id = $1
+                  AND (
+                      business_context_id = ${context_index}
+                      OR business_context_id IS NULL
+                  )
+                RETURNING *
+                """,
+                *params,
+                EOM_BUSINESS_CONTEXT_ID,
+            )
+            if row is None:
+                raise RuntimeError("EOM operator contact update lost its target row")
+            return dict(row)
+
+        async def _create_contact(conn: Any) -> dict[str, Any]:
+            full_name = command.fields.get("full_name")
+            if not full_name:
+                raise EOMOperatorContactMutationError(
+                    422, "fullName is required when no existing contact matches"
+                )
+            contact_type = command.contact_type or "customer"
+            data = {
+                **dict(command.fields),
+                "full_name": full_name,
+                "business_context_id": EOM_BUSINESS_CONTEXT_ID,
+                "contact_type": contact_type,
+                "status": "active",
+                "source": command.contact_source,
+                "source_ref": command.contact_source_ref,
+                "lead_stage": "new" if contact_type == "lead" else None,
+                "metadata": _operator_provenance_metadata({})[0],
+            }
+            return await self._insert_contact_row(conn, data)
+
+        async def _write_lifecycle_event(
+            conn: Any,
+            *,
+            contact: Mapping[str, Any],
+            event_type: str,
+            previous: Mapping[str, Any] | None,
+        ) -> None:
+            metadata = {
+                **command.lifecycle_metadata,
+                "contact_type": contact.get("contact_type"),
+            }
+            if previous is not None:
+                changed = sorted(
+                    key
+                    for key in command.fields
+                    if previous.get(key) != contact.get(key)
+                )
+                metadata["changed_fields"] = changed
+            await conn.execute(
+                """
+                INSERT INTO eom_lead_lifecycle_events (
+                    contact_id, event_type, from_stage, to_stage, actor,
+                    source, operation_key, metadata
+                )
+                VALUES ($1, $2, $3, $4, $5, 'eom_office', $6, $7::jsonb)
+                """,
+                contact["id"],
+                event_type,
+                previous.get("lead_stage") if previous is not None else None,
+                contact.get("lead_stage"),
+                f"employee:{command.actor_id}:{command.actor_name}",
+                command.operation_key,
+                json.dumps(metadata, sort_keys=True),
+            )
+
+        pool = self._get_pool()
+        async with _transaction_connection(pool) as conn:
+            lock_keys = {
+                f"eom-operator-contact:operation:{command.operation_key}",
+            }
+            if command.contact_id:
+                lock_keys.add(f"eom-operator-contact:contact:{command.contact_id}")
+            phone = command.fields.get("phone")
+            if phone:
+                lock_keys.add(_eom_identity_lock_key("phone", phone[-10:]))
+            email = command.fields.get("email")
+            if email:
+                lock_keys.add(_eom_identity_lock_key("email", email))
+            lock_keys.add(
+                f"eom-operator-contact:source:{command.contact_source_ref}"
+            )
+            for lock_key in sorted(lock_keys):
+                await conn.execute(
+                    "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+                    lock_key,
+                )
+
+            existing_events = await conn.fetch(
+                """
+                SELECT contact_id, event_type, metadata
+                FROM eom_lead_lifecycle_events
+                WHERE operation_key = $1
+                  AND event_type = ANY($2::varchar[])
+                FOR UPDATE
+                """,
+                command.operation_key,
+                list(EOM_OPERATOR_CONTACT_EVENT_TYPES),
+            )
+            if len(existing_events) > 1:
+                raise EOMOperatorContactMutationError(
+                    409, "Operator contact key has multiple receipts"
+                )
+            if existing_events:
+                event = existing_events[0]
+                metadata = _metadata_from_row(event["metadata"])
+                if metadata.get("request_fingerprint") != command.request_fingerprint:
+                    raise EOMOperatorContactMutationError(
+                        409,
+                        "Idempotency-Key already belongs to a different contact mutation",
+                    )
+                contact = await conn.fetchrow(
+                    "SELECT * FROM contacts WHERE id = $1",
+                    event["contact_id"],
+                )
+                if contact is None:
+                    raise EOMOperatorContactMutationError(
+                        409, "Operator contact receipt has no contact"
+                    )
+                return _event_result(
+                    row=contact,
+                    event_type=str(event["event_type"]),
+                    idempotent=True,
+                )
+
+            target = await _resolve_target(conn)
+            if target is None:
+                contact = await _create_contact(conn)
+                event_type = EOM_OPERATOR_CONTACT_CREATED
+                previous = None
+            else:
+                previous = dict(target)
+                contact = await _update_existing(conn, target)
+                event_type = EOM_OPERATOR_CONTACT_UPDATED
+            await _write_lifecycle_event(
+                conn,
+                contact=contact,
+                event_type=event_type,
+                previous=previous,
+            )
+            return _event_result(
+                row=contact,
+                event_type=event_type,
+                idempotent=False,
+            )
 
     async def find_or_create_contact(
         self,
@@ -1077,18 +1461,31 @@ class DatabaseCRMProvider:
         business_context_id_is_null: bool = False,
         limit: int = 20,
     ) -> list[dict[str, Any]]:
-        from ..storage.database import get_db_pool
-
-        pool = get_db_pool()
+        pool = self._get_pool()
         conditions: list[str] = ["status != 'archived'"]
         params: list[Any] = []
         idx = 1
 
         if phone:
-            digits = "".join(c for c in phone if c.isdigit())
-            conditions.append(f"REGEXP_REPLACE(phone, '[^0-9]', '', 'g') LIKE ${idx}")
-            params.append(f"%{digits[-10:]}%")
-            idx += 1
+            from .eom_lead_ingress import normalise_eom_phone_digits
+
+            digits = normalise_eom_phone_digits(phone)
+            if not digits:
+                conditions.append("FALSE")
+            elif len(digits) < 10:
+                conditions.append(
+                    "REGEXP_REPLACE(COALESCE(phone, ''), '[^0-9]', '', 'g') "
+                    f"LIKE ${idx}"
+                )
+                params.append(f"%{digits}%")
+                idx += 1
+            else:
+                conditions.append(
+                    "RIGHT(REGEXP_REPLACE(COALESCE(phone, ''), '[^0-9]', '', 'g'), 10) "
+                    f"= RIGHT(${idx}, 10)"
+                )
+                params.append(digits)
+                idx += 1
         if email:
             conditions.append(f"LOWER(email) = LOWER(${idx})")
             params.append(email)

--- a/atlas_brain/services/crm_provider.py
+++ b/atlas_brain/services/crm_provider.py
@@ -1081,7 +1081,7 @@ class DatabaseCRMProvider:
 
         async def _select_exact_matches(conn: Any) -> list[dict[str, Any]]:
             matches: list[dict[str, Any]] = []
-            source_match = await conn.fetchrow(
+            source_matches = await conn.fetch(
                 """
                 SELECT *
                 FROM contacts
@@ -1095,8 +1095,7 @@ class DatabaseCRMProvider:
                 command.contact_source,
                 command.contact_source_ref,
             )
-            if source_match is not None:
-                matches.append(dict(source_match))
+            matches.extend(dict(row) for row in source_matches)
             provenance_matches = await conn.fetch(
                 """
                 SELECT *

--- a/atlas_brain/services/crm_provider.py
+++ b/atlas_brain/services/crm_provider.py
@@ -1137,7 +1137,7 @@ class DatabaseCRMProvider:
                     FROM contacts
                     WHERE (business_context_id = $1 OR business_context_id IS NULL)
                       AND status != 'archived'
-                      AND LOWER(email) = $2
+                      AND LOWER(BTRIM(email)) = $2
                     FOR UPDATE
                     """,
                     EOM_BUSINESS_CONTEXT_ID,
@@ -1470,22 +1470,22 @@ class DatabaseCRMProvider:
             from .eom_lead_ingress import normalise_eom_phone_digits
 
             digits = normalise_eom_phone_digits(phone)
+            stored_digits = (
+                "REGEXP_REPLACE(COALESCE(phone, ''), '[^0-9]', '', 'g')"
+            )
             if not digits:
                 conditions.append("FALSE")
             elif len(digits) < 10:
-                conditions.append(
-                    "REGEXP_REPLACE(COALESCE(phone, ''), '[^0-9]', '', 'g') "
-                    f"LIKE ${idx}"
-                )
+                conditions.append(f"{stored_digits} LIKE ${idx}")
                 params.append(f"%{digits}%")
                 idx += 1
             else:
                 conditions.append(
-                    "RIGHT(REGEXP_REPLACE(COALESCE(phone, ''), '[^0-9]', '', 'g'), 10) "
-                    f"= RIGHT(${idx}, 10)"
+                    f"({stored_digits} LIKE ${idx} "
+                    f"OR RIGHT({stored_digits}, 10) = RIGHT(${idx + 1}, 10))"
                 )
-                params.append(digits)
-                idx += 1
+                params.extend((f"%{digits}%", digits))
+                idx += 2
         if email:
             conditions.append(f"LOWER(email) = LOWER(${idx})")
             params.append(email)

--- a/atlas_brain/services/crm_provider.py
+++ b/atlas_brain/services/crm_provider.py
@@ -1035,13 +1035,19 @@ class DatabaseCRMProvider:
         def _metadata_from_row(value: Any) -> dict[str, Any]:
             if value is None:
                 return {}
+            loaded: Any = value
             if isinstance(value, str):
                 try:
                     loaded = json.loads(value)
                 except json.JSONDecodeError:
-                    return {}
-                return loaded if isinstance(loaded, dict) else {}
-            return dict(value)
+                    raise EOMOperatorContactMutationError(
+                        409, "EOM operator contact metadata must be an object"
+                    )
+            if not isinstance(loaded, Mapping):
+                raise EOMOperatorContactMutationError(
+                    409, "EOM operator contact metadata must be an object"
+                )
+            return dict(loaded)
 
         def _event_result(
             *,

--- a/atlas_brain/services/crm_provider.py
+++ b/atlas_brain/services/crm_provider.py
@@ -45,6 +45,19 @@ _INTERACTION_DEDUPE_ANCHOR_KEYS = (
     "invoice_id",
     "external_id",
 )
+_STORED_PHONE_IDENTITY_DIGITS_SQL = (
+    "REGEXP_REPLACE("
+    "REGEXP_REPLACE("
+    "COALESCE(phone, ''), "
+    "'(^|[-[:space:],;#/()])(ext|extension|x)\\.?[[:space:]]*[0-9]+[[:space:]]*$', "
+    "'', "
+    "'i'"
+    "), "
+    "'[^0-9]', "
+    "'', "
+    "'g'"
+    ")"
+)
 
 
 @dataclass(frozen=True)
@@ -1093,7 +1106,7 @@ class DatabaseCRMProvider:
             phone = command.fields.get("phone")
             email = command.fields.get("email")
             rows = await conn.fetch(
-                """
+                f"""
                 WITH candidate_ids AS (
                     SELECT id
                     FROM contacts
@@ -1112,14 +1125,14 @@ class DatabaseCRMProvider:
                     FROM contacts
                     WHERE business_context_id = $1
                       AND status != 'archived'
-                      AND COALESCE(metadata -> $5, '{}'::jsonb) ? $3
+                      AND COALESCE(metadata -> $5, '{{}}'::jsonb) ? $3
                     UNION
                     SELECT id
                     FROM contacts
                     WHERE $6::text IS NOT NULL
                       AND (business_context_id = $1 OR business_context_id IS NULL)
                       AND status != 'archived'
-                      AND RIGHT(REGEXP_REPLACE(COALESCE(phone, ''), '[^0-9]', '', 'g'), 10)
+                      AND RIGHT({_STORED_PHONE_IDENTITY_DIGITS_SQL}, 10)
                           = RIGHT($6::text, 10)
                     UNION
                     SELECT id

--- a/atlas_brain/services/crm_provider.py
+++ b/atlas_brain/services/crm_provider.py
@@ -1085,113 +1085,102 @@ class DatabaseCRMProvider:
             metadata[_EOM_OPERATOR_CONTACT_SOURCES_METADATA_KEY] = sources
             return metadata, True
 
-        async def _select_exact_matches(conn: Any) -> list[dict[str, Any]]:
-            matches: list[dict[str, Any]] = []
-            source_matches = await conn.fetch(
+        async def _select_exact_matches(
+            conn: Any,
+            *,
+            include_contact_id: Any | None = None,
+        ) -> list[dict[str, Any]]:
+            phone = command.fields.get("phone")
+            email = command.fields.get("email")
+            rows = await conn.fetch(
                 """
-                SELECT *
+                WITH candidate_ids AS (
+                    SELECT id
+                    FROM contacts
+                    WHERE $4::uuid IS NOT NULL
+                      AND id = $4::uuid
+                      AND (business_context_id = $1 OR business_context_id IS NULL)
+                    UNION
+                    SELECT id
+                    FROM contacts
+                    WHERE business_context_id = $1
+                      AND source = $2
+                      AND source_ref = $3
+                      AND status != 'archived'
+                    UNION
+                    SELECT id
+                    FROM contacts
+                    WHERE business_context_id = $1
+                      AND status != 'archived'
+                      AND COALESCE(metadata -> $5, '{}'::jsonb) ? $3
+                    UNION
+                    SELECT id
+                    FROM contacts
+                    WHERE $6::text IS NOT NULL
+                      AND (business_context_id = $1 OR business_context_id IS NULL)
+                      AND status != 'archived'
+                      AND RIGHT(REGEXP_REPLACE(COALESCE(phone, ''), '[^0-9]', '', 'g'), 10)
+                          = RIGHT($6::text, 10)
+                    UNION
+                    SELECT id
+                    FROM contacts
+                    WHERE $7::text IS NOT NULL
+                      AND (business_context_id = $1 OR business_context_id IS NULL)
+                      AND status != 'archived'
+                      AND LOWER(BTRIM(email)) = $7::text
+                )
+                SELECT contacts.*
                 FROM contacts
-                WHERE business_context_id = $1
-                  AND source = $2
-                  AND source_ref = $3
-                  AND status != 'archived'
+                JOIN candidate_ids ON candidate_ids.id = contacts.id
+                ORDER BY contacts.id
                 FOR UPDATE
                 """,
                 EOM_BUSINESS_CONTEXT_ID,
                 command.contact_source,
                 command.contact_source_ref,
-            )
-            matches.extend(dict(row) for row in source_matches)
-            provenance_matches = await conn.fetch(
-                """
-                SELECT *
-                FROM contacts
-                WHERE business_context_id = $1
-                  AND status != 'archived'
-                  AND COALESCE(metadata -> $2, '{}'::jsonb) ? $3
-                FOR UPDATE
-                """,
-                EOM_BUSINESS_CONTEXT_ID,
+                include_contact_id,
                 _EOM_OPERATOR_CONTACT_SOURCES_METADATA_KEY,
-                command.contact_source_ref,
+                phone,
+                email,
             )
-            matches.extend(dict(row) for row in provenance_matches)
-
-            phone = command.fields.get("phone")
-            if phone:
-                phone_matches = await conn.fetch(
-                    """
-                    SELECT *
-                    FROM contacts
-                    WHERE (business_context_id = $1 OR business_context_id IS NULL)
-                      AND status != 'archived'
-                      AND RIGHT(REGEXP_REPLACE(COALESCE(phone, ''), '[^0-9]', '', 'g'), 10)
-                          = RIGHT($2, 10)
-                    FOR UPDATE
-                    """,
-                    EOM_BUSINESS_CONTEXT_ID,
-                    phone,
-                )
-                matches.extend(dict(row) for row in phone_matches)
-
-            email = command.fields.get("email")
-            if email:
-                email_matches = await conn.fetch(
-                    """
-                    SELECT *
-                    FROM contacts
-                    WHERE (business_context_id = $1 OR business_context_id IS NULL)
-                      AND status != 'archived'
-                      AND LOWER(BTRIM(email)) = $2
-                    FOR UPDATE
-                    """,
-                    EOM_BUSINESS_CONTEXT_ID,
-                    email,
-                )
-                matches.extend(dict(row) for row in email_matches)
-            return matches
-
-        async def _assert_no_explicit_identity_collision(
-            conn: Any,
-            target: Mapping[str, Any],
-        ) -> None:
-            target_id = str(target["id"])
-            conflicts = [
-                row
-                for row in _dedupe_rows_by_id(await _select_exact_matches(conn))
-                if str(row["id"]) != target_id
-            ]
-            if conflicts:
-                raise EOMOperatorContactMutationError(
-                    409, "Operator contact identity belongs to another contact"
-                )
+            return [dict(row) for row in rows]
 
         async def _resolve_target(conn: Any) -> dict[str, Any] | None:
-            if command.contact_id:
-                contact = await conn.fetchrow(
-                    """
-                    SELECT *
-                    FROM contacts
-                    WHERE id = $1
-                      AND (business_context_id = $2 OR business_context_id IS NULL)
-                    FOR UPDATE
-                    """,
-                    command.contact_id,
-                    EOM_BUSINESS_CONTEXT_ID,
+            matches = _dedupe_rows_by_id(
+                await _select_exact_matches(
+                    conn,
+                    include_contact_id=command.contact_id,
                 )
-                if contact is None:
+            )
+            if command.contact_id:
+                target_id = str(command.contact_id)
+                row = next(
+                    (
+                        candidate
+                        for candidate in matches
+                        if str(candidate["id"]) == target_id
+                    ),
+                    None,
+                )
+                if row is None:
                     raise EOMOperatorContactMutationError(
                         404, "EOM contact was not found"
                     )
-                row = dict(contact)
                 if row.get("status") == "archived":
                     raise EOMOperatorContactMutationError(
                         409, "Archived EOM contacts cannot be edited"
                     )
-                await _assert_no_explicit_identity_collision(conn, row)
+                conflicts = [
+                    candidate
+                    for candidate in matches
+                    if str(candidate["id"]) != target_id
+                ]
+                if conflicts:
+                    raise EOMOperatorContactMutationError(
+                        409, "Operator contact identity belongs to another contact"
+                    )
                 return row
 
-            matches = _dedupe_rows_by_id(await _select_exact_matches(conn))
             if len(matches) > 1:
                 raise EOMOperatorContactMutationError(
                     409, "Operator contact identity matched multiple contacts"

--- a/atlas_brain/services/crm_provider.py
+++ b/atlas_brain/services/crm_provider.py
@@ -49,8 +49,8 @@ _STORED_PHONE_IDENTITY_DIGITS_SQL = (
     "REGEXP_REPLACE("
     "REGEXP_REPLACE("
     "COALESCE(phone, ''), "
-    "'(extension|ext|x)\\.?[[:space:]]*[0-9]+[[:space:]]*$', "
-    "'', "
+    "'([0-9])[-[:space:],;#/()]*(extension|ext|x)\\.?[[:space:]]*[0-9]+[[:space:]]*$', "
+    "'\\1', "
     "'i'"
     "), "
     "'[^0-9]', "
@@ -1097,12 +1097,36 @@ class DatabaseCRMProvider:
         ) -> tuple[dict[str, Any], bool]:
             metadata = _metadata_from_row(target.get("metadata"))
             raw_sources = metadata.get(_EOM_OPERATOR_CONTACT_SOURCES_METADATA_KEY)
-            sources = dict(raw_sources) if isinstance(raw_sources, Mapping) else {}
             source_record = {
                 "source": command.contact_source,
                 "source_channel": command.source_channel,
                 "source_ref": command.source_ref,
             }
+            if raw_sources is None:
+                sources = {}
+            elif not isinstance(raw_sources, Mapping):
+                raise EOMOperatorContactMutationError(
+                    409, "EOM operator contact provenance metadata must be an object"
+                )
+            else:
+                sources = {}
+                for key, record in raw_sources.items():
+                    if not isinstance(key, str) or not isinstance(record, Mapping):
+                        raise EOMOperatorContactMutationError(
+                            409,
+                            "EOM operator contact provenance metadata must be an object",
+                        )
+                    if set(record) != {"source", "source_channel", "source_ref"}:
+                        raise EOMOperatorContactMutationError(
+                            409,
+                            "EOM operator contact provenance metadata must be an object",
+                        )
+                    if not all(isinstance(record[field], str) for field in record):
+                        raise EOMOperatorContactMutationError(
+                            409,
+                            "EOM operator contact provenance metadata must be an object",
+                        )
+                    sources[key] = dict(record)
             if sources.get(command.contact_source_ref) == source_record:
                 return metadata, False
             sources[command.contact_source_ref] = source_record
@@ -1136,7 +1160,12 @@ class DatabaseCRMProvider:
                     FROM contacts
                     WHERE business_context_id = $1
                       AND status != 'archived'
-                      AND COALESCE(metadata -> $5, '{{}}'::jsonb) ? $3
+                      AND jsonb_typeof(metadata -> $5) = 'object'
+                      AND metadata -> $5 -> $3 = jsonb_build_object(
+                          'source', $2::text,
+                          'source_channel', $8::text,
+                          'source_ref', $9::text
+                      )
                     UNION
                     SELECT id
                     FROM contacts
@@ -1166,10 +1195,50 @@ class DatabaseCRMProvider:
                 _EOM_OPERATOR_CONTACT_SOURCES_METADATA_KEY,
                 phone,
                 email,
+                command.source_channel,
+                command.source_ref,
             )
             return [dict(row) for row in rows]
 
+        async def _reject_malformed_source_provenance(conn: Any) -> None:
+            malformed = await conn.fetchrow(
+                """
+                SELECT id
+                FROM contacts
+                WHERE business_context_id = $1
+                  AND status != 'archived'
+                  AND metadata ? $2
+                  AND (
+                      (
+                          jsonb_typeof(metadata -> $2) != 'object'
+                          AND COALESCE(metadata -> $2, 'null'::jsonb) ? $3
+                      )
+                      OR (
+                          jsonb_typeof(metadata -> $2) = 'object'
+                          AND (metadata -> $2) ? $3
+                          AND metadata -> $2 -> $3 != jsonb_build_object(
+                              'source', $4::text,
+                              'source_channel', $5::text,
+                              'source_ref', $6::text
+                          )
+                      )
+                  )
+                LIMIT 1
+                """,
+                EOM_BUSINESS_CONTEXT_ID,
+                _EOM_OPERATOR_CONTACT_SOURCES_METADATA_KEY,
+                command.contact_source_ref,
+                command.contact_source,
+                command.source_channel,
+                command.source_ref,
+            )
+            if malformed is not None:
+                raise EOMOperatorContactMutationError(
+                    409, "EOM operator contact provenance metadata must be an object"
+                )
+
         async def _resolve_target(conn: Any) -> dict[str, Any] | None:
+            await _reject_malformed_source_provenance(conn)
             matches = _dedupe_rows_by_id(
                 await _select_exact_matches(
                     conn,

--- a/atlas_brain/services/crm_provider.py
+++ b/atlas_brain/services/crm_provider.py
@@ -1096,19 +1096,20 @@ class DatabaseCRMProvider:
             target: Mapping[str, Any],
         ) -> tuple[dict[str, Any], bool]:
             metadata = _metadata_from_row(target.get("metadata"))
-            raw_sources = metadata.get(_EOM_OPERATOR_CONTACT_SOURCES_METADATA_KEY)
             source_record = {
                 "source": command.contact_source,
                 "source_channel": command.source_channel,
                 "source_ref": command.source_ref,
             }
-            if raw_sources is None:
+            if _EOM_OPERATOR_CONTACT_SOURCES_METADATA_KEY not in metadata:
                 sources = {}
-            elif not isinstance(raw_sources, Mapping):
-                raise EOMOperatorContactMutationError(
-                    409, "EOM operator contact provenance metadata must be an object"
-                )
             else:
+                raw_sources = metadata[_EOM_OPERATOR_CONTACT_SOURCES_METADATA_KEY]
+                if not isinstance(raw_sources, Mapping):
+                    raise EOMOperatorContactMutationError(
+                        409,
+                        "EOM operator contact provenance metadata must be an object",
+                    )
                 sources = {}
                 for key, record in raw_sources.items():
                     if not isinstance(key, str) or not isinstance(record, Mapping):
@@ -1209,10 +1210,7 @@ class DatabaseCRMProvider:
                   AND status != 'archived'
                   AND metadata ? $2
                   AND (
-                      (
-                          jsonb_typeof(metadata -> $2) != 'object'
-                          AND COALESCE(metadata -> $2, 'null'::jsonb) ? $3
-                      )
+                      jsonb_typeof(metadata -> $2) != 'object'
                       OR (
                           jsonb_typeof(metadata -> $2) = 'object'
                           AND (metadata -> $2) ? $3

--- a/atlas_brain/services/crm_provider.py
+++ b/atlas_brain/services/crm_provider.py
@@ -155,6 +155,7 @@ _ALL_EOM_REQUESTED_EVENTS = frozenset(
     family.requested_event for family in _EOM_BOOKING_FAMILIES
 )
 _EOM_LOST_RESTORABLE_STAGES = ("new", "estimate_booked")
+_EOM_ACTIVE_LEAD_STAGES = ("new", "estimate_booked", "won")
 _EOM_LOST_REPLAY_DISPOSITION_EVENTS = ("lead_lost", "lead_reopened")
 _EOM_OPERATOR_CONTACT_SOURCES_METADATA_KEY = "eom_operator_contact_sources"
 
@@ -1216,6 +1217,13 @@ class DatabaseCRMProvider:
                 raise EOMOperatorContactMutationError(
                     409,
                     "EOM operator contact updates require an existing lead or customer",
+                )
+            if (
+                stored_type == "lead"
+                and target.get("lead_stage") not in _EOM_ACTIVE_LEAD_STAGES
+            ):
+                raise EOMOperatorContactMutationError(
+                    409, "EOM operator lead updates require a supported lead stage"
                 )
             if command.contact_type is None:
                 return

--- a/atlas_brain/services/crm_provider.py
+++ b/atlas_brain/services/crm_provider.py
@@ -1476,10 +1476,11 @@ class DatabaseCRMProvider:
             else:
                 conditions.append(
                     f"({stored_digits} LIKE ${idx} "
-                    f"OR RIGHT({stored_digits}, 10) = RIGHT(${idx + 1}, 10))"
+                    f"OR {stored_digits} LIKE ${idx + 1} "
+                    f"OR RIGHT({stored_digits}, 10) = RIGHT(${idx + 2}, 10))"
                 )
-                params.extend((f"%{digits}%", digits))
-                idx += 2
+                params.extend((f"%{digits}%", f"%{digits[-10:]}%", digits))
+                idx += 3
         if email:
             conditions.append(f"LOWER(email) = LOWER(${idx})")
             params.append(email)

--- a/atlas_brain/services/crm_provider.py
+++ b/atlas_brain/services/crm_provider.py
@@ -49,7 +49,7 @@ _STORED_PHONE_IDENTITY_DIGITS_SQL = (
     "REGEXP_REPLACE("
     "REGEXP_REPLACE("
     "COALESCE(phone, ''), "
-    "'(^|[-[:space:],;#/()])(ext|extension|x)\\.?[[:space:]]*[0-9]+[[:space:]]*$', "
+    "'(extension|ext|x)\\.?[[:space:]]*[0-9]+[[:space:]]*$', "
     "'', "
     "'i'"
     "), "
@@ -1224,6 +1224,10 @@ class DatabaseCRMProvider:
             ):
                 raise EOMOperatorContactMutationError(
                     409, "EOM operator lead updates require a supported lead stage"
+                )
+            if stored_type == "lead" and target.get("status") != "active":
+                raise EOMOperatorContactMutationError(
+                    409, "EOM operator lead updates require an active lead"
                 )
             if command.contact_type is None:
                 return

--- a/atlas_brain/services/crm_provider.py
+++ b/atlas_brain/services/crm_provider.py
@@ -58,6 +58,16 @@ _STORED_PHONE_IDENTITY_DIGITS_SQL = (
     "'g'"
     ")"
 )
+_STORED_EMAIL_IDENTITY_SQL = (
+    "LOWER("
+    "REGEXP_REPLACE("
+    "COALESCE(email, ''), "
+    "'(^[[:space:]]+|[[:space:]]+$)', "
+    "'', "
+    "'g'"
+    ")"
+    ")"
+)
 
 
 @dataclass(frozen=True)
@@ -1140,7 +1150,7 @@ class DatabaseCRMProvider:
                     WHERE $7::text IS NOT NULL
                       AND (business_context_id = $1 OR business_context_id IS NULL)
                       AND status != 'archived'
-                      AND LOWER(BTRIM(email)) = $7::text
+                      AND {_STORED_EMAIL_IDENTITY_SQL} = $7::text
                 )
                 SELECT contacts.*
                 FROM contacts

--- a/atlas_brain/services/eom_crm_mutations.py
+++ b/atlas_brain/services/eom_crm_mutations.py
@@ -52,6 +52,8 @@ _FIELD_LIMITS = {
     "zip": 16,
 }
 _EMAIL_MIN_LENGTH = 3
+_EMAIL_LOCAL_MAX_LENGTH = 64
+_EMAIL_DOMAIN_MAX_LENGTH = 255
 _SOURCE_REF_MAX_LENGTH = 220
 _CONTACT_SOURCE = "manual"
 _EMAIL_LOCAL_RE = re.compile(r"^[A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]+$")
@@ -106,6 +108,8 @@ def _normalize_email(value: Any) -> str | None:
         not local
         or local.startswith(".")
         or local.endswith(".")
+        or len(local) > _EMAIL_LOCAL_MAX_LENGTH
+        or len(domain) > _EMAIL_DOMAIN_MAX_LENGTH
         or ".." in local
         or not _EMAIL_LOCAL_RE.fullmatch(local)
         or len(labels) < 2

--- a/atlas_brain/services/eom_crm_mutations.py
+++ b/atlas_brain/services/eom_crm_mutations.py
@@ -57,6 +57,10 @@ _CONTACT_SOURCE = "manual"
 _EMAIL_LOCAL_RE = re.compile(r"^[A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]+$")
 _EMAIL_DOMAIN_LABEL_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$")
 _DATABASE_INVALID_TEXT_CHARS = frozenset({"\x00"})
+_PHONE_EXTENSION_RE = re.compile(
+    r"(?:^|[\s,;#/()-])(?:ext|extension|x)\.?\s*\d+\s*$", re.I
+)
+_PHONE_ALLOWED_RE = re.compile(r"^[0-9\s()+.\-]*$")
 
 
 class EOMOperatorContactMutationError(Exception):
@@ -75,7 +79,10 @@ def _blank_to_none(value: Any) -> Any:
 
 
 def _reject_database_invalid_text(field: str, value: str) -> None:
-    if any(char in value for char in _DATABASE_INVALID_TEXT_CHARS):
+    if any(
+        char in _DATABASE_INVALID_TEXT_CHARS or 0xD800 <= ord(char) <= 0xDFFF
+        for char in value
+    ):
         raise EOMOperatorContactMutationError(422, f"{field} must be valid")
 
 
@@ -114,6 +121,12 @@ def _normalize_phone(value: Any) -> str | None:
         return None
     if not isinstance(normalized, str):
         raise EOMOperatorContactMutationError(422, "phone must be a string")
+    if _PHONE_EXTENSION_RE.search(normalized) or not _PHONE_ALLOWED_RE.fullmatch(
+        normalized
+    ):
+        raise EOMOperatorContactMutationError(
+            422, "phone must not include an extension"
+        )
     digits = normalise_eom_phone_digits(normalized)
     if len(digits) < 10:
         raise EOMOperatorContactMutationError(

--- a/atlas_brain/services/eom_crm_mutations.py
+++ b/atlas_brain/services/eom_crm_mutations.py
@@ -246,6 +246,7 @@ class EOMOperatorContactMutation:
     @property
     def request_fingerprint(self) -> str:
         payload = {
+            "actor_id": self.actor_id,
             "contact_id": self.contact_id,
             "contact_type": self.contact_type,
             "fields": dict(sorted(self.fields.items())),

--- a/atlas_brain/services/eom_crm_mutations.py
+++ b/atlas_brain/services/eom_crm_mutations.py
@@ -1,0 +1,269 @@
+"""Operator-authored EOM contact mutations.
+
+This is the authoritative Atlas domain boundary for EOM contact creates and
+ordinary identity/contact-field edits. It is deliberately separate from
+``eom_lead_ingress``: inbound intake is untrusted enrichment and preserves
+existing rows, while this path represents authenticated operator intent.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Mapping
+
+from .eom_lead_ingress import (
+    EOM_BUSINESS_CONTEXT_ID,
+    normalise_eom_phone_digits,
+)
+
+EOM_OPERATOR_CONTACT_CREATED = "contact_created"
+EOM_OPERATOR_CONTACT_UPDATED = "contact_updated"
+EOM_OPERATOR_CONTACT_EVENT_TYPES = (
+    EOM_OPERATOR_CONTACT_CREATED,
+    EOM_OPERATOR_CONTACT_UPDATED,
+)
+EOM_OPERATOR_SOURCE_CHANNELS = (
+    "time_tracker",
+    "operator_portal",
+    "mcp_operator",
+    "manual_import",
+)
+EOM_OPERATOR_CONTACT_TYPES = ("lead", "customer")
+EOM_OPERATOR_CONTACT_FIELDS = (
+    "full_name",
+    "email",
+    "phone",
+    "address",
+    "city",
+    "state",
+    "zip",
+    "notes",
+)
+_FIELD_LIMITS = {
+    "full_name": 256,
+    "email": 256,
+    "phone": 32,
+    "city": 128,
+    "state": 64,
+    "zip": 16,
+}
+_EMAIL_MIN_LENGTH = 3
+_SOURCE_REF_MAX_LENGTH = 220
+_CONTACT_SOURCE = "manual"
+_EMAIL_LOCAL_RE = re.compile(r"^[A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]+$")
+_EMAIL_DOMAIN_LABEL_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$")
+_DATABASE_INVALID_TEXT_CHARS = frozenset({"\x00"})
+
+
+class EOMOperatorContactMutationError(Exception):
+    """HTTP-mappable domain error for the EOM operator mutation boundary."""
+
+    def __init__(self, status_code: int, message: str) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def _blank_to_none(value: Any) -> Any:
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    return value
+
+
+def _reject_database_invalid_text(field: str, value: str) -> None:
+    if any(char in value for char in _DATABASE_INVALID_TEXT_CHARS):
+        raise EOMOperatorContactMutationError(422, f"{field} must be valid")
+
+
+def _normalize_email(value: Any) -> str | None:
+    normalized = _blank_to_none(value)
+    if normalized is None:
+        return None
+    if not isinstance(normalized, str):
+        raise EOMOperatorContactMutationError(422, "email must be a string")
+    candidate = normalized.lower()
+    if len(candidate) < _EMAIL_MIN_LENGTH or len(candidate) > _FIELD_LIMITS["email"]:
+        raise EOMOperatorContactMutationError(422, "email must be valid")
+    if any(char.isspace() or ord(char) < 32 for char in candidate):
+        raise EOMOperatorContactMutationError(422, "email must be valid")
+    parts = candidate.split("@")
+    if len(parts) != 2:
+        raise EOMOperatorContactMutationError(422, "email must be valid")
+    local, domain = parts
+    labels = domain.split(".")
+    if (
+        not local
+        or local.startswith(".")
+        or local.endswith(".")
+        or ".." in local
+        or not _EMAIL_LOCAL_RE.fullmatch(local)
+        or len(labels) < 2
+        or any(not _EMAIL_DOMAIN_LABEL_RE.fullmatch(label) for label in labels)
+    ):
+        raise EOMOperatorContactMutationError(422, "email must be valid")
+    return candidate
+
+
+def _normalize_phone(value: Any) -> str | None:
+    normalized = _blank_to_none(value)
+    if normalized is None:
+        return None
+    if not isinstance(normalized, str):
+        raise EOMOperatorContactMutationError(422, "phone must be a string")
+    digits = normalise_eom_phone_digits(normalized)
+    if len(digits) < 10:
+        raise EOMOperatorContactMutationError(
+            422, "phone must contain at least 10 digits"
+        )
+    if len(digits) > _FIELD_LIMITS["phone"]:
+        raise EOMOperatorContactMutationError(422, "phone is too long")
+    return digits
+
+
+def _normalize_text_field(field: str, value: Any) -> str | None:
+    normalized = _blank_to_none(value)
+    if normalized is None:
+        if field == "full_name":
+            raise EOMOperatorContactMutationError(422, "fullName must not be blank")
+        return None
+    if not isinstance(normalized, str):
+        raise EOMOperatorContactMutationError(422, f"{field} must be a string")
+    _reject_database_invalid_text(field, normalized)
+    limit = _FIELD_LIMITS.get(field)
+    if limit is not None and len(normalized) > limit:
+        raise EOMOperatorContactMutationError(422, f"{field} is too long")
+    return normalized
+
+
+def _normalize_fields(fields: Mapping[str, Any]) -> dict[str, Any]:
+    normalized: dict[str, Any] = {}
+    for field, value in fields.items():
+        if field not in EOM_OPERATOR_CONTACT_FIELDS:
+            raise EOMOperatorContactMutationError(
+                422, f"{field} is not an operator contact field"
+            )
+        if field == "email":
+            normalized[field] = _normalize_email(value)
+        elif field == "phone":
+            normalized[field] = _normalize_phone(value)
+        else:
+            normalized[field] = _normalize_text_field(field, value)
+    if not normalized:
+        raise EOMOperatorContactMutationError(
+            422, "at least one contact field is required"
+        )
+    return normalized
+
+
+def _source_ref_for_channel(source_channel: str, source_ref: str) -> str:
+    combined = f"{source_channel}:{source_ref}"
+    if len(combined) > 256:
+        raise EOMOperatorContactMutationError(422, "sourceRef is too long")
+    return combined
+
+
+@dataclass(frozen=True)
+class EOMOperatorContactMutation:
+    """Normalized command accepted by the operator contact mutation boundary."""
+
+    operation_key: str
+    actor_id: int
+    actor_name: str
+    source_channel: str
+    source_ref: str
+    fields: Mapping[str, Any]
+    contact_id: str | None = None
+    contact_type: str | None = None
+
+    @classmethod
+    def from_raw(
+        cls,
+        *,
+        operation_key: str,
+        actor_id: int,
+        actor_name: str,
+        source_channel: str,
+        source_ref: str,
+        fields: Mapping[str, Any],
+        contact_id: str | None = None,
+        contact_type: str | None = None,
+    ) -> "EOMOperatorContactMutation":
+        normalized_channel = str(source_channel or "").strip()
+        if normalized_channel not in EOM_OPERATOR_SOURCE_CHANNELS:
+            raise EOMOperatorContactMutationError(
+                422, "sourceChannel is not supported"
+            )
+        normalized_ref = str(source_ref or "").strip()
+        if not normalized_ref:
+            raise EOMOperatorContactMutationError(422, "sourceRef is required")
+        _reject_database_invalid_text("sourceRef", normalized_ref)
+        if len(normalized_ref) > _SOURCE_REF_MAX_LENGTH:
+            raise EOMOperatorContactMutationError(422, "sourceRef is too long")
+        normalized_type = None
+        if contact_type is not None:
+            normalized_type = str(contact_type).strip()
+            if normalized_type not in EOM_OPERATOR_CONTACT_TYPES:
+                raise EOMOperatorContactMutationError(
+                    422, "contactType is not supported"
+                )
+        normalized_fields = _normalize_fields(fields)
+        return cls(
+            operation_key=operation_key,
+            actor_id=actor_id,
+            actor_name=str(actor_name),
+            source_channel=normalized_channel,
+            source_ref=normalized_ref,
+            fields=MappingProxyType(normalized_fields),
+            contact_id=str(contact_id) if contact_id else None,
+            contact_type=normalized_type,
+        )
+
+    @property
+    def contact_source(self) -> str:
+        return _CONTACT_SOURCE
+
+    @property
+    def contact_source_ref(self) -> str:
+        return _source_ref_for_channel(self.source_channel, self.source_ref)
+
+    @property
+    def request_fingerprint(self) -> str:
+        payload = {
+            "contact_id": self.contact_id,
+            "contact_type": self.contact_type,
+            "fields": dict(sorted(self.fields.items())),
+            "source_channel": self.source_channel,
+            "source_ref": self.source_ref,
+        }
+        encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+    @property
+    def lifecycle_metadata(self) -> dict[str, Any]:
+        return {
+            "actor_id": self.actor_id,
+            "source_channel": self.source_channel,
+            "source_ref": self.source_ref,
+            "request_fingerprint": self.request_fingerprint,
+            "field_names": sorted(self.fields.keys()),
+        }
+
+
+async def mutate_eom_operator_contact(
+    crm: Any,
+    command: EOMOperatorContactMutation,
+) -> dict[str, Any]:
+    """Execute one authenticated EOM operator contact mutation."""
+
+    atomic_mutation = getattr(
+        type(crm), "mutate_eom_operator_contact_atomic", None
+    )
+    if atomic_mutation is None:
+        raise RuntimeError(
+            "EOM operator contact mutations require the database CRM provider"
+        )
+    return await atomic_mutation(crm, command=command)

--- a/atlas_brain/services/eom_lead_ingress.py
+++ b/atlas_brain/services/eom_lead_ingress.py
@@ -15,8 +15,16 @@ EOM_BUSINESS_CONTEXT_ID = "effingham_maids"
 _MIN_MATCH_PHONE_DIGITS = 10
 
 
-def _normalised_phone(value: Any) -> str:
-    return re.sub(r"\D", "", str(value or ""))
+def normalise_eom_phone_digits(value: Any) -> str:
+    """Return the shared EOM phone identity digits.
+
+    EOM lead/customer matching uses ASCII digits-only phone identity and exact
+    normalized last-10 equality. Callers decide whether fewer than ten digits
+    are admissible for their boundary; the normalizer itself only strips
+    formatting. Non-ASCII digit glyphs are intentionally not canonicalized here
+    because the SQL resolvers use ``[^0-9]``.
+    """
+    return re.sub(r"[^0-9]", "", str(value or ""))
 
 
 def preferred_eom_inbound_phone(extracted_phone: Any, transport_phone: Any) -> str:
@@ -28,9 +36,9 @@ def preferred_eom_inbound_phone(extracted_phone: Any, transport_phone: Any) -> s
     """
     extracted = str(extracted_phone or "").strip()
     transport = str(transport_phone or "").strip()
-    if len(_normalised_phone(extracted)) >= _MIN_MATCH_PHONE_DIGITS:
+    if len(normalise_eom_phone_digits(extracted)) >= _MIN_MATCH_PHONE_DIGITS:
         return extracted
-    if len(_normalised_phone(transport)) >= _MIN_MATCH_PHONE_DIGITS:
+    if len(normalise_eom_phone_digits(transport)) >= _MIN_MATCH_PHONE_DIGITS:
         return transport
     return extracted or transport
 
@@ -57,7 +65,7 @@ async def resolve_or_create_eom_inbound_lead(
     """
 
     normalized_email = str(email or "").strip().lower()
-    phone_digits = _normalised_phone(phone)
+    phone_digits = normalise_eom_phone_digits(phone)
     normalized_source = str(source or "").strip()
     normalized_source_ref = str(source_ref or "").strip()
     normalized_relay_event_id = str(relay_event_id or "").strip()

--- a/atlas_brain/storage/migrations/364_eom_operator_contact_operation_key_index.sql
+++ b/atlas_brain/storage/migrations/364_eom_operator_contact_operation_key_index.sql
@@ -1,0 +1,29 @@
+-- Cover operator contact mutation receipts in an operation-key-leading index.
+--
+-- mutate_eom_operator_contact_atomic probes eom_lead_lifecycle_events by
+-- operation_key before creating or updating a contact so idempotent replays and
+-- key conflicts resolve before a second mutation is attempted. The lifecycle
+-- unique index is contact-led (351), and the booking/disposition access-path
+-- indexes are partial to their own event families, so contact_created and
+-- contact_updated would otherwise scan the append-only ledger as history grows.
+--
+-- The drop is intentionally concurrent and first: if a prior canceled startup
+-- left an INVALID same-named catalog entry, CREATE INDEX IF NOT EXISTS would
+-- skip rebuilding it and the migration ledger would record a broken index as
+-- applied. The drop-then-recreate pair keeps replays safe (same pattern as
+-- migrations 357/359/362).
+--
+-- Rollback evidence:
+--   DROP INDEX CONCURRENTLY IF EXISTS idx_eom_lead_lifecycle_operator_contact_operation_key;
+--
+-- Roll-forward safety:
+--   This index is additive and partial. It does not change lifecycle event
+--   uniqueness, append-only behavior, trigger behavior, or lead/customer
+--   state. It only accelerates the operator contact receipt lookup.
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_eom_lead_lifecycle_operator_contact_operation_key;
+
+CREATE INDEX CONCURRENTLY idx_eom_lead_lifecycle_operator_contact_operation_key
+    ON eom_lead_lifecycle_events (operation_key, contact_id, event_type)
+    WHERE operation_key IS NOT NULL
+      AND event_type IN ('contact_created', 'contact_updated');

--- a/plans/PR-EOM-Operator-Mutation-Contract.md
+++ b/plans/PR-EOM-Operator-Mutation-Contract.md
@@ -232,6 +232,10 @@ last-10 matches for ordinary stored numbers.
 - Tracker customer creation migration: website #110 / Slice 0C after 0B is
   deployed live.
 - Legacy writer convergence/deprecation: website #111 and its D1-D5 children.
+- Legacy EOM writer identity-fence convergence, including the existing
+  `atlas_brain/autonomous/tasks/email_backfill.py:198` backfill caller that
+  still uses generic `find_or_create_contact`; this PR adds the Atlas operator
+  mutation contract and does not migrate existing autonomous/backfill callers.
 - Remaining #112 tracker/website capability-gating halves.
 - Provenance alerting and missing-provenance observability: website #113.
 - Additive source/provenance column split if a later slice needs queryable
@@ -314,11 +318,11 @@ Parked hardening: none.
 | `atlas_brain/services/eom_crm_mutations.py` | 282 |
 | `atlas_brain/services/eom_lead_ingress.py` | 18 |
 | `atlas_brain/storage/migrations/364_eom_operator_contact_operation_key_index.sql` | 29 |
-| `plans/PR-EOM-Operator-Mutation-Contract.md` | 324 |
+| `plans/PR-EOM-Operator-Mutation-Contract.md` | 328 |
 | `tests/contact_write_boundary/baseline.json` | 1 |
 | `tests/test_contact_write_boundary.py` | 6 |
 | `tests/test_eom_lead_conversion.py` | 258 |
 | `tests/test_eom_lead_conversion_integration.py` | 862 |
 | `tests/test_migrations_runner.py` | 45 |
 | `tests/test_tenant_stamping.py` | 76 |
-| **Total** | **2585** |
+| **Total** | **2589** |

--- a/plans/PR-EOM-Operator-Mutation-Contract.md
+++ b/plans/PR-EOM-Operator-Mutation-Contract.md
@@ -238,6 +238,10 @@ phone search keeps substring lookup compatibility, including full phone inputs
 that appear inside a stored phone with extension digits, while still admitting
 normalized last-10 matches for ordinary stored numbers.
 
+Operator provenance metadata is reserved to an object of exact source records.
+Malformed reserved provenance fails closed before sourceRef-only resolution can
+claim a row or overwrite the original metadata value.
+
 ## Intentional
 
 - No tracker or website caller is migrated here; this is the Atlas-first
@@ -339,6 +343,10 @@ Parked hardening: none.
   -- 16 passed.
 - `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_matches_stored_phone_with_extension tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_does_not_match_extension_suffix tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_inactive_legacy_lead -q`
   -- 5 passed.
+- `python -m py_compile atlas_brain/services/crm_provider.py tests/test_eom_lead_conversion_integration.py`
+  -- passed.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_matches_stored_phone_with_extension tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_malformed_source_provenance -q`
+  -- 5 passed.
 - `python -m pytest tests/test_crm_read_scoping.py tests/test_leads_intake.py tests/test_eom_lead_conversion.py tests/test_tenant_stamping.py tests/test_migrations_runner.py tests/test_contact_write_boundary.py -q`
   -- 412 passed, 1 skipped, 1 warning.
 - `python -m pytest tests/test_contact_write_boundary.py -q`
@@ -359,15 +367,15 @@ Parked hardening: none.
 | File | LOC |
 |---|---:|
 | `atlas_brain/eom_api/funnel.py` | 171 |
-| `atlas_brain/services/crm_provider.py` | 545 |
+| `atlas_brain/services/crm_provider.py` | 614 |
 | `atlas_brain/services/eom_crm_mutations.py` | 287 |
 | `atlas_brain/services/eom_lead_ingress.py` | 18 |
 | `atlas_brain/storage/migrations/364_eom_operator_contact_operation_key_index.sql` | 29 |
-| `plans/PR-EOM-Operator-Mutation-Contract.md` | 373 |
+| `plans/PR-EOM-Operator-Mutation-Contract.md` | 381 |
 | `tests/contact_write_boundary/baseline.json` | 1 |
 | `tests/test_contact_write_boundary.py` | 6 |
 | `tests/test_eom_lead_conversion.py` | 261 |
-| `tests/test_eom_lead_conversion_integration.py` | 992 |
+| `tests/test_eom_lead_conversion_integration.py` | 1054 |
 | `tests/test_migrations_runner.py` | 45 |
 | `tests/test_tenant_stamping.py` | 76 |
-| **Total** | **2804** |
+| **Total** | **2943** |

--- a/plans/PR-EOM-Operator-Mutation-Contract.md
+++ b/plans/PR-EOM-Operator-Mutation-Contract.md
@@ -1,0 +1,270 @@
+# PR-EOM-Operator-Mutation-Contract
+
+## Why this slice exists
+
+Website issue #109 is the Slice 0B child of the EOM CRM write-boundary arc.
+0A has landed the contact-write guard, and ATLAS #2303 cleared the call-action
+mutation gate that blocked this slice. The next missing contract is an Atlas
+owned mutation boundary that the tracker and later CRM UI can call before any
+caller is migrated.
+
+Diff-budget override: this slice is over the 400 LOC soft cap because the
+Atlas contract is only safe as one vertical seam: the authenticated route,
+command normalizer, provider-owned atomic create/update path, exact identity
+resolver, lifecycle receipt/idempotency evidence, capability advertisement, and
+real DB + ASGI proofs have to land together before any tracker/website caller is
+migrated. Splitting the route from the provider would expose an unwired contract;
+splitting the provider from the tests would leave the new contact writer
+unproven at the tenant/idempotency boundary; splitting the exact EOM resolver
+would keep the old substring identity bug in the same slice that claims to
+define the canonical mutation boundary.
+
+### Problem-derived contract
+
+- Root cause: operator-authored EOM contact creates/edits do not have a single
+  authenticated, idempotent, audited Atlas entry point. The generic provider
+  create/update surface is too broad for external callers, and the EOM operator
+  resolver needs exact last-10 identity matching rather than inheriting the
+  generic CRM API's partial phone-search behavior. Without a bounded domain entry point, the next tracker
+  slice would either keep minting tracker-local customers or widen access to
+  generic CRM mutation rules.
+- Correct fix must touch/change:
+  - add one EOM domain service for operator-authored contact create/update
+    commands, sibling to inbound lead ingress;
+  - reuse the existing `DatabaseCRMProvider` persistence boundary so the repo
+    still has only the existing provider-owned `INSERT INTO contacts` sites;
+  - add one authenticated/flag-gated funnel route that accepts a service
+    bearer, actor headers, and an `Idempotency-Key`;
+  - require caller provenance as channel + external ref, but let the domain
+    tier choose how `contacts.source/source_ref`, contact metadata, and
+    lifecycle metadata store that provenance;
+  - normalize email/phone/blank values in one EOM helper path, use exact
+    last-10 phone matching inside the EOM operator resolver, and preserve the
+    generic CRM API's existing short-phone substring lookup for other callers;
+  - record `contact_created` or `contact_updated` lifecycle evidence with the
+    actor and operation key for every fresh create/update through the new path;
+  - replay the same idempotency key as HTTP 200 with the same contact, and
+    reject the same key with a different normalized payload;
+  - advertise the new route through the existing capability manifest so later
+    tracker/website callers can gate on deployed support;
+  - add HTTP-boundary tests and provider/domain tests for happy path, auth,
+    malformed payloads, idempotent replay, payload conflict, exact-match
+    resolution, ambiguous identity, and lifecycle actor evidence.
+- Must not change:
+  - no tracker or website caller migration in this PR;
+  - no customer-visible portal UI, onboarding copy, pricing, or schedule
+    semantics;
+  - no new `contacts.created_by` column and no destructive contacts migration;
+  - no lead-to-customer promotion replacement; existing funnel handoff/booking
+    transitions remain the lifecycle transition services;
+  - no rewrite of existing `contacts.source` values in place;
+  - no new contact persistence path outside `DatabaseCRMProvider`;
+  - no work on #110, #111, #112 tracker/website halves, #113, or open Atlas
+    PRs from other lanes.
+
+## Scope (this PR)
+
+Ownership lane: eom-crm/lead-funnel
+Slice phase: vertical slice
+
+1. Add the Atlas-only operator contact mutation contract behind the existing
+   EOM funnel service auth boundary.
+2. Add the domain/provider behavior and tests proving create, update, replay,
+   conflict, exact phone matching, provenance, and lifecycle audit evidence.
+3. Add a capability-manifest name for the deployed route.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] `POST /eom-funnel/operator-contacts` is unavailable when the funnel API
+        is disabled, rejects missing/invalid bearer auth, requires actor
+        headers, and validates `Idempotency-Key`.
+  - [ ] A fresh create stamps `business_context_id='effingham_maids'`, uses the
+        existing provider insert helper, normalizes email/phone/blanks, and
+        writes `contact_created` lifecycle evidence with actor + operation key.
+  - [ ] A fresh update can edit ordinary identity/contact fields on an EOM
+        contact and writes `contact_updated` lifecycle evidence with actor +
+        operation key.
+  - [ ] Replaying the same idempotency key and same normalized payload returns
+        the same contact with `idempotent: true` and HTTP 200; replaying the key
+        with a different normalized payload returns a conflict.
+  - [ ] Phone resolution uses exact normalized last-10 equality, not substring
+        matching; ambiguous phone/email resolution fails closed.
+  - [ ] Existing lead/customer lifecycle transition ownership is not widened:
+        updates through this route do not replace booking, handoff, lost, or
+        reopen transitions.
+  - [ ] The contact write-boundary inventory still reports only provider-owned
+        create sites.
+  - [ ] The lead review capability manifest advertises the new route only when
+        the route is registered.
+- Reachability proof: real ASGI request against the funnel router plus
+  provider/domain tests that assert persisted contact rows and lifecycle rows.
+- Affected surfaces: `atlas_brain/eom_api/funnel.py`,
+  `atlas_brain/services/eom_crm_mutations.py`,
+  `atlas_brain/services/eom_lead_ingress.py`,
+  `atlas_brain/services/crm_provider.py`, EOM funnel tests, EOM provider
+  integration tests, and the contact write-boundary inventory if the provider
+  insert helper move changes it.
+- Risk areas: auth, tenant isolation, idempotency/replay, ambiguous identity
+  matching, lifecycle audit atomicity, source/provenance drift, route response
+  compatibility, and contact-write guard drift.
+- Reviewer rules triggered: R1, R2, R3, R4, R5, R6, R8, R10, R12, R13, R14.
+- Guard/set closure declaration:
+  - Supported source channels, contact types, editable contact fields, operator
+    lifecycle event families, and advertised capability routes are CLOSED and
+    ENUMERATED in this PR's domain boundary (`eom_crm_mutations.py`,
+    `funnel.py`, and the lifecycle writer). Out-of-set values are rejected with
+    domain errors before persistence or omitted from served capabilities.
+  - Operator email grammar and phone identity normalization are OPEN input
+    guards with DERIVED choke points: the domain normalizer admits only the
+    stated email grammar and SQL-compatible ASCII phone digits, rejects
+    malformed/out-of-grammar identities with 422, and treats untrusted inbound
+    non-ASCII phone glyphs as no phone identity unless another admitted
+    identity exists.
+  - Operator provenance is CLOSED to the required channel/ref pair for this
+    route. Unknown channels and database-invalid source refs reject with 422;
+    admitted refs persist into the contact metadata provenance map and lifecycle
+    evidence.
+
+### Boundary-change enumeration
+
+Required when this diff changes a guard, validator, normalizer, resolver,
+router/classifier, or admission boundary. Name each changed boundary path or
+seam in the enumeration; otherwise write "N/A - no boundary change."
+
+- Boundary path/seam: EOM operator contact mutation admission at the funnel
+  route, EOM domain normalization/resolution, and generic provider phone-search
+  compatibility.
+- Replaced-path behaviors: no caller is replaced yet; this adds the canonical
+  path future callers will use, applies exact normalized last-10 matching inside
+  the EOM operator resolver, and keeps the generic CRM API's partial substring
+  lookup for short phone fragments.
+- Guard-relevant fields: `contactId`, `contactType`, `fullName`, `email`,
+  `phone`, `address`, `city`, `state`, `zip`, `notes`, `sourceChannel`,
+  `sourceRef`, actor headers, and `Idempotency-Key`.
+- Caller x input shape: tracker/service caller sends camelCase JSON with one
+  operation key and actor headers; browser users do not call Atlas directly.
+
+### Deployed-config probing
+
+Required for guard, validator, resolver, admission-boundary, or env/config
+fallback changes; otherwise write "N/A - no guard/config boundary change."
+
+- Deployed/default config values: the existing `ATLAS_EOM_FUNNEL_API_ENABLED`
+  default remains disabled; no new env var is added.
+- Explicit value probe: tests override `EOMFunnelConfig(api_enabled=True,
+  service_token_sha256=...)` and exercise the new route with a valid bearer.
+- Absent value probe: tests exercise disabled config and missing/invalid bearer
+  responses.
+- Default-session/default-context probe: actor headers are required even after
+  service auth; no ambient user/session is inferred.
+- Side-effect ordering: provider/domain tests assert contact mutation and
+  lifecycle evidence are written in one command, and idempotent replay reads the
+  lifecycle receipt before attempting another mutation.
+
+### Files touched
+
+- `atlas_brain/eom_api/funnel.py`
+- `atlas_brain/services/crm_provider.py`
+- `atlas_brain/services/eom_crm_mutations.py`
+- `atlas_brain/services/eom_lead_ingress.py`
+- `atlas_brain/storage/migrations/364_eom_operator_contact_operation_key_index.sql`
+- `plans/PR-EOM-Operator-Mutation-Contract.md`
+- `tests/contact_write_boundary/baseline.json`
+- `tests/test_contact_write_boundary.py`
+- `tests/test_eom_lead_conversion.py`
+- `tests/test_eom_lead_conversion_integration.py`
+- `tests/test_migrations_runner.py`
+- `tests/test_tenant_stamping.py`
+
+## Mechanism
+
+The route accepts a closed Pydantic request and delegates to the new
+`eom_crm_mutations` command service. That service owns request normalization
+and calls a provider-owned atomic method. The provider method serializes on the
+operation key, checks lifecycle evidence for idempotent replay/conflict, locks
+the target or resolved contact row, performs either an ordinary-field update or
+a create through the existing provider insert helper, then inserts a
+`contact_created` or `contact_updated` lifecycle row with actor/provenance
+metadata before the transaction commits.
+
+Phone normalization is shared with EOM inbound identity handling and strips only
+ASCII digits so Python and SQL normalize the same input class. The EOM operator
+resolver uses exact normalized last-10 equality. Generic provider phone search
+keeps its short-phone substring lookup for compatibility, while full phone
+inputs use the same normalized last-10 comparison.
+
+## Intentional
+
+- No tracker or website caller is migrated here; this is the Atlas-first
+  prerequisite that later slices consume.
+- No new contact insert literal is added. The generic provider insert block is
+  refactored into a helper if atomic reuse is needed, so the 0A guard remains
+  meaningful.
+- Existing `contacts.source` values are not rewritten. New operator-created
+  contacts get a domain-owned source/source_ref mapping, while updates record
+  caller provenance in contact metadata and lifecycle metadata instead of
+  changing historical origin.
+- Existing lead lifecycle transition routes remain authoritative for promotion,
+  booking, lost, and reopen states; operator contact updates do not become a
+  backdoor transition API.
+
+## Deferred
+
+- Tracker customer creation migration: website #110 / Slice 0C after 0B is
+  deployed live.
+- Legacy writer convergence/deprecation: website #111 and its D1-D5 children.
+- Remaining #112 tracker/website capability-gating halves.
+- Provenance alerting and missing-provenance observability: website #113.
+- Additive source/provenance column split if a later slice needs queryable
+  first-class fields; this PR uses existing `contacts.source/source_ref` plus
+  contact metadata provenance and lifecycle metadata.
+
+Parking predicate: this slice parks only post-contract operational hardening
+that requires a migrated tracker/website caller, live deployment telemetry, or
+a later first-class source/provenance schema decision. It does not park known
+correctness, CI, security, authorization, data-integrity, idempotency, or
+merge-blocking defects in the Atlas operator mutation contract.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m py_compile atlas_brain/eom_api/funnel.py atlas_brain/services/crm_provider.py atlas_brain/services/eom_lead_ingress.py atlas_brain/services/eom_crm_mutations.py tests/test_eom_lead_conversion.py tests/test_eom_lead_conversion_integration.py tests/test_tenant_stamping.py tests/test_migrations_runner.py tests/test_contact_write_boundary.py`
+  -- passed.
+- `python -m pytest tests/test_eom_lead_conversion.py tests/test_tenant_stamping.py tests/test_migrations_runner.py tests/test_contact_write_boundary.py -q`
+  -- 293 passed, 1 skipped, 1 warning.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py -q -k "operator_contact_mutation or inbound_atomic_uses_ascii_phone_normalizer or share_phone_identity_lock"`
+  -- 6 passed, 46 deselected.
+- `python -m pytest tests/test_crm_read_scoping.py tests/test_leads_intake.py tests/test_eom_lead_conversion.py tests/test_tenant_stamping.py tests/test_migrations_runner.py tests/test_contact_write_boundary.py -q`
+  -- 412 passed, 1 skipped, 1 warning.
+- `python -m pytest tests/test_contact_write_boundary.py -q`
+  -- 65 passed.
+- `python scripts/check_contact_write_boundary.py --baseline tests/contact_write_boundary/baseline.json`
+  -- passed.
+- `python scripts/maturity_sweep.py atlas_brain/storage --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_storage.json --min-score 8 --sensitive-glob '**/billing/**' --sensitive-glob '**/billing*' --sensitive-glob '**/paid*' --sensitive-glob '**/auth/**' --sensitive-glob '**/auth*' --sensitive-glob '**/webhook*' --sensitive-glob '**/webhooks/**' --sensitive-glob '**/*webhook*/**' --sensitive-glob '**/payment*' --sensitive-glob '**/invoicing/**' --sensitive-glob '**/*invoice*' --sensitive-glob '**/*deletion*' --sensitive-glob '**/delete*/**' --sensitive-glob 'atlas_brain/security/**' --sensitive-glob 'atlas_brain/storage/**'`
+  -- passed.
+- `python scripts/check_guard_class_closure.py` -- passed.
+- `python scripts/sync_pr_plan.py plans/PR-EOM-Operator-Mutation-Contract.md --check`
+  -- passed.
+- `git diff --check` -- passed.
+- Pending before push:
+  - `bash scripts/local_pr_review.sh` through `scripts/push_pr.sh`.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/eom_api/funnel.py` | 130 |
+| `atlas_brain/services/crm_provider.py` | 515 |
+| `atlas_brain/services/eom_crm_mutations.py` | 269 |
+| `atlas_brain/services/eom_lead_ingress.py` | 18 |
+| `atlas_brain/storage/migrations/364_eom_operator_contact_operation_key_index.sql` | 29 |
+| `plans/PR-EOM-Operator-Mutation-Contract.md` | 270 |
+| `tests/contact_write_boundary/baseline.json` | 1 |
+| `tests/test_contact_write_boundary.py` | 6 |
+| `tests/test_eom_lead_conversion.py` | 241 |
+| `tests/test_eom_lead_conversion_integration.py` | 532 |
+| `tests/test_migrations_runner.py` | 45 |
+| `tests/test_tenant_stamping.py` | 50 |
+| **Total** | **2106** |

--- a/plans/PR-EOM-Operator-Mutation-Contract.md
+++ b/plans/PR-EOM-Operator-Mutation-Contract.md
@@ -262,6 +262,12 @@ Parked hardening: none.
   -- 1 passed.
 - `python -m pytest tests/test_eom_lead_conversion.py tests/test_tenant_stamping.py tests/test_migrations_runner.py tests/test_contact_write_boundary.py -q`
   -- 293 passed, 1 skipped, 1 warning.
+- `python -m py_compile atlas_brain/eom_api/funnel.py atlas_brain/services/eom_crm_mutations.py atlas_brain/services/crm_provider.py tests/test_eom_lead_conversion.py tests/test_eom_lead_conversion_integration.py`
+  -- passed.
+- `python -m pytest tests/test_eom_lead_conversion.py::test_private_operator_contact_rejects_malformed_identity_before_crm_call tests/test_eom_lead_conversion.py::test_private_operator_contact_rejects_database_invalid_text_before_crm_call -q`
+  -- 19 passed.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_non_object_contact_metadata -q`
+  -- 1 passed.
 - `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py -q -k "operator_contact_mutation or inbound_atomic_uses_ascii_phone_normalizer or share_phone_identity_lock"`
   -- 6 passed, 46 deselected.
 - `python -m pytest tests/test_crm_read_scoping.py tests/test_leads_intake.py tests/test_eom_lead_conversion.py tests/test_tenant_stamping.py tests/test_migrations_runner.py tests/test_contact_write_boundary.py -q`
@@ -283,16 +289,16 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `atlas_brain/eom_api/funnel.py` | 130 |
-| `atlas_brain/services/crm_provider.py` | 514 |
-| `atlas_brain/services/eom_crm_mutations.py` | 269 |
+| `atlas_brain/eom_api/funnel.py` | 151 |
+| `atlas_brain/services/crm_provider.py` | 520 |
+| `atlas_brain/services/eom_crm_mutations.py` | 282 |
 | `atlas_brain/services/eom_lead_ingress.py` | 18 |
 | `atlas_brain/storage/migrations/364_eom_operator_contact_operation_key_index.sql` | 29 |
-| `plans/PR-EOM-Operator-Mutation-Contract.md` | 298 |
+| `plans/PR-EOM-Operator-Mutation-Contract.md` | 304 |
 | `tests/contact_write_boundary/baseline.json` | 1 |
 | `tests/test_contact_write_boundary.py` | 6 |
-| `tests/test_eom_lead_conversion.py` | 241 |
-| `tests/test_eom_lead_conversion_integration.py` | 647 |
+| `tests/test_eom_lead_conversion.py` | 258 |
+| `tests/test_eom_lead_conversion_integration.py` | 696 |
 | `tests/test_migrations_runner.py` | 45 |
 | `tests/test_tenant_stamping.py` | 51 |
-| **Total** | **2249** |
+| **Total** | **2361** |

--- a/plans/PR-EOM-Operator-Mutation-Contract.md
+++ b/plans/PR-EOM-Operator-Mutation-Contract.md
@@ -92,6 +92,8 @@ Slice phase: vertical slice
         returns a conflict.
   - [ ] Phone resolution uses exact normalized last-10 equality, not substring
         matching; ambiguous phone/email resolution fails closed.
+  - [ ] Legacy lead rows must already have a supported EOM funnel stage before
+        this route can claim or edit them.
   - [ ] Existing lead/customer lifecycle transition ownership is not widened:
         updates through this route do not replace booking, handoff, lost, or
         reopen transitions.
@@ -275,6 +277,12 @@ Parked hardening: none.
   -- passed.
 - `python -m pytest tests/test_eom_lead_conversion.py::test_private_operator_contact_rejects_malformed_identity_before_crm_call tests/test_eom_lead_conversion.py::test_private_operator_contact_rejects_database_invalid_text_before_crm_call -q`
   -- 19 passed.
+- `python -m py_compile atlas_brain/services/eom_crm_mutations.py atlas_brain/services/crm_provider.py tests/test_eom_lead_conversion.py tests/test_eom_lead_conversion_integration.py`
+  -- passed.
+- `python -m pytest tests/test_eom_lead_conversion.py::test_private_operator_contact_rejects_malformed_identity_before_crm_call -q`
+  -- 6 passed.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_legacy_lead_without_stage -q`
+  -- 1 passed.
 - `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_non_object_contact_metadata -q`
   -- 1 passed.
 - `python -m py_compile atlas_brain/services/crm_provider.py tests/test_eom_lead_conversion_integration.py`
@@ -323,15 +331,15 @@ Parked hardening: none.
 | File | LOC |
 |---|---:|
 | `atlas_brain/eom_api/funnel.py` | 151 |
-| `atlas_brain/services/crm_provider.py` | 533 |
-| `atlas_brain/services/eom_crm_mutations.py` | 283 |
+| `atlas_brain/services/crm_provider.py` | 541 |
+| `atlas_brain/services/eom_crm_mutations.py` | 287 |
 | `atlas_brain/services/eom_lead_ingress.py` | 18 |
 | `atlas_brain/storage/migrations/364_eom_operator_contact_operation_key_index.sql` | 29 |
-| `plans/PR-EOM-Operator-Mutation-Contract.md` | 337 |
+| `plans/PR-EOM-Operator-Mutation-Contract.md` | 345 |
 | `tests/contact_write_boundary/baseline.json` | 1 |
 | `tests/test_contact_write_boundary.py` | 6 |
-| `tests/test_eom_lead_conversion.py` | 258 |
-| `tests/test_eom_lead_conversion_integration.py` | 880 |
+| `tests/test_eom_lead_conversion.py` | 259 |
+| `tests/test_eom_lead_conversion_integration.py` | 929 |
 | `tests/test_migrations_runner.py` | 45 |
 | `tests/test_tenant_stamping.py` | 76 |
-| **Total** | **2617** |
+| **Total** | **2687** |

--- a/plans/PR-EOM-Operator-Mutation-Contract.md
+++ b/plans/PR-EOM-Operator-Mutation-Contract.md
@@ -284,6 +284,10 @@ Parked hardening: none.
   -- 2 passed.
 - `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_explicit_id_identity_collision tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_ambiguous_exact_identity tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_ambiguous_direct_provenance tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_crossed_identities_fail_without_deadlock tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_matches_stored_phone_with_extension tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_does_not_match_extension_suffix -q`
   -- 7 passed.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_claims_legacy_contact_by_padded_email 'tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_explicit_id_identity_collision[email-owned@example.com-target@example.com]' -q`
+  -- 2 passed.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_claims_legacy_contact_by_padded_email tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_explicit_id_identity_collision tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_ambiguous_exact_identity tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_ambiguous_direct_provenance tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_crossed_identities_fail_without_deadlock tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_matches_stored_phone_with_extension tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_does_not_match_extension_suffix -q`
+  -- 8 passed.
 - `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py -q -k "operator_contact_mutation or inbound_atomic_uses_ascii_phone_normalizer or share_phone_identity_lock"`
   -- 6 passed, 46 deselected.
 - `python -m pytest tests/test_crm_read_scoping.py tests/test_leads_intake.py tests/test_eom_lead_conversion.py tests/test_tenant_stamping.py tests/test_migrations_runner.py tests/test_contact_write_boundary.py -q`
@@ -306,15 +310,15 @@ Parked hardening: none.
 | File | LOC |
 |---|---:|
 | `atlas_brain/eom_api/funnel.py` | 151 |
-| `atlas_brain/services/crm_provider.py` | 523 |
+| `atlas_brain/services/crm_provider.py` | 533 |
 | `atlas_brain/services/eom_crm_mutations.py` | 282 |
 | `atlas_brain/services/eom_lead_ingress.py` | 18 |
 | `atlas_brain/storage/migrations/364_eom_operator_contact_operation_key_index.sql` | 29 |
-| `plans/PR-EOM-Operator-Mutation-Contract.md` | 320 |
+| `plans/PR-EOM-Operator-Mutation-Contract.md` | 324 |
 | `tests/contact_write_boundary/baseline.json` | 1 |
 | `tests/test_contact_write_boundary.py` | 6 |
 | `tests/test_eom_lead_conversion.py` | 258 |
 | `tests/test_eom_lead_conversion_integration.py` | 862 |
 | `tests/test_migrations_runner.py` | 45 |
 | `tests/test_tenant_stamping.py` | 76 |
-| **Total** | **2571** |
+| **Total** | **2585** |

--- a/plans/PR-EOM-Operator-Mutation-Contract.md
+++ b/plans/PR-EOM-Operator-Mutation-Contract.md
@@ -274,6 +274,10 @@ Parked hardening: none.
   -- 1 passed.
 - `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_explicit_id_identity_collision tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_ambiguous_exact_identity tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_ambiguous_direct_provenance -q`
   -- 4 passed.
+- `python -m py_compile atlas_brain/services/crm_provider.py tests/test_tenant_stamping.py`
+  -- passed.
+- `python -m pytest tests/test_tenant_stamping.py::test_generic_contact_phone_search_preserves_full_phone_extension_lookup tests/test_tenant_stamping.py::test_generic_contact_phone_search_preserves_country_code_to_extension_lookup tests/test_tenant_stamping.py::test_generic_contact_phone_search_keeps_partial_phone_substring_lookup -q`
+  -- 3 passed.
 - `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py -q -k "operator_contact_mutation or inbound_atomic_uses_ascii_phone_normalizer or share_phone_identity_lock"`
   -- 6 passed, 46 deselected.
 - `python -m pytest tests/test_crm_read_scoping.py tests/test_leads_intake.py tests/test_eom_lead_conversion.py tests/test_tenant_stamping.py tests/test_migrations_runner.py tests/test_contact_write_boundary.py -q`
@@ -296,15 +300,15 @@ Parked hardening: none.
 | File | LOC |
 |---|---:|
 | `atlas_brain/eom_api/funnel.py` | 151 |
-| `atlas_brain/services/crm_provider.py` | 509 |
+| `atlas_brain/services/crm_provider.py` | 510 |
 | `atlas_brain/services/eom_crm_mutations.py` | 282 |
 | `atlas_brain/services/eom_lead_ingress.py` | 18 |
 | `atlas_brain/storage/migrations/364_eom_operator_contact_operation_key_index.sql` | 29 |
-| `plans/PR-EOM-Operator-Mutation-Contract.md` | 310 |
+| `plans/PR-EOM-Operator-Mutation-Contract.md` | 314 |
 | `tests/contact_write_boundary/baseline.json` | 1 |
 | `tests/test_contact_write_boundary.py` | 6 |
 | `tests/test_eom_lead_conversion.py` | 258 |
 | `tests/test_eom_lead_conversion_integration.py` | 777 |
 | `tests/test_migrations_runner.py` | 45 |
-| `tests/test_tenant_stamping.py` | 51 |
-| **Total** | **2437** |
+| `tests/test_tenant_stamping.py` | 76 |
+| **Total** | **2467** |

--- a/plans/PR-EOM-Operator-Mutation-Contract.md
+++ b/plans/PR-EOM-Operator-Mutation-Contract.md
@@ -86,9 +86,10 @@ Slice phase: vertical slice
   - [ ] A fresh update can edit ordinary identity/contact fields on an EOM
         contact and writes `contact_updated` lifecycle evidence with actor +
         operation key.
-  - [ ] Replaying the same idempotency key and same normalized payload returns
-        the same contact with `idempotent: true` and HTTP 200; replaying the key
-        with a different normalized payload returns a conflict.
+  - [ ] Replaying the same idempotency key, same authenticated actor, and same
+        normalized payload returns the same contact with `idempotent: true` and
+        HTTP 200; replaying the key with a different actor or normalized payload
+        returns a conflict.
   - [ ] Phone resolution uses exact normalized last-10 equality, not substring
         matching; ambiguous phone/email resolution fails closed.
   - [ ] Existing lead/customer lifecycle transition ownership is not widened:
@@ -197,8 +198,9 @@ phone/email identity key. The phone/email lock namespace is shared with the
 atomic EOM inbound writer, so interleavings on the same admitted identity
 serialize before either writer can resolve or insert. Inside the transaction,
 idempotency is receipt-first: an existing lifecycle row for the same operation
-key and matching request fingerprint returns the recorded contact, while the
-same key with a different fingerprint fails before mutation. With no receipt,
+key and matching actor-bound request fingerprint returns the recorded contact,
+while the same key with a different actor or payload fingerprint fails before
+mutation. With no receipt,
 the provider resolves and locks source/provenance/phone/email contact rows with
 `FOR UPDATE`, rejects ambiguous or cross-contact identities, writes exactly one
 contact create/update, then writes exactly one lifecycle receipt before commit.
@@ -236,6 +238,9 @@ last-10 matches for ordinary stored numbers.
   `atlas_brain/autonomous/tasks/email_backfill.py:198` backfill caller that
   still uses generic `find_or_create_contact`; this PR adds the Atlas operator
   mutation contract and does not migrate existing autonomous/backfill callers.
+- Normalized contact identity functional indexes for EOM phone/email lookups;
+  this is post-contract performance hardening, while this PR proves correctness
+  and idempotency for the new operator mutation route.
 - Remaining #112 tracker/website capability-gating halves.
 - Provenance alerting and missing-provenance observability: website #113.
 - Additive source/provenance column split if a later slice needs queryable
@@ -276,6 +281,10 @@ Parked hardening: none.
   -- passed.
 - `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_crossed_identities_fail_without_deadlock -q`
   -- 1 passed.
+- `python -m py_compile atlas_brain/services/eom_crm_mutations.py tests/test_eom_lead_conversion_integration.py`
+  -- passed.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_creates_replays_and_records_actor -q`
+  -- 1 passed.
 - `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_explicit_id_identity_collision tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_ambiguous_exact_identity tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_ambiguous_direct_provenance -q`
   -- 4 passed.
 - `python -m py_compile atlas_brain/services/crm_provider.py tests/test_tenant_stamping.py`
@@ -315,14 +324,14 @@ Parked hardening: none.
 |---|---:|
 | `atlas_brain/eom_api/funnel.py` | 151 |
 | `atlas_brain/services/crm_provider.py` | 533 |
-| `atlas_brain/services/eom_crm_mutations.py` | 282 |
+| `atlas_brain/services/eom_crm_mutations.py` | 283 |
 | `atlas_brain/services/eom_lead_ingress.py` | 18 |
 | `atlas_brain/storage/migrations/364_eom_operator_contact_operation_key_index.sql` | 29 |
-| `plans/PR-EOM-Operator-Mutation-Contract.md` | 328 |
+| `plans/PR-EOM-Operator-Mutation-Contract.md` | 337 |
 | `tests/contact_write_boundary/baseline.json` | 1 |
 | `tests/test_contact_write_boundary.py` | 6 |
 | `tests/test_eom_lead_conversion.py` | 258 |
-| `tests/test_eom_lead_conversion_integration.py` | 862 |
+| `tests/test_eom_lead_conversion_integration.py` | 880 |
 | `tests/test_migrations_runner.py` | 45 |
 | `tests/test_tenant_stamping.py` | 76 |
-| **Total** | **2589** |
+| **Total** | **2617** |

--- a/plans/PR-EOM-Operator-Mutation-Contract.md
+++ b/plans/PR-EOM-Operator-Mutation-Contract.md
@@ -268,6 +268,12 @@ Parked hardening: none.
   -- 19 passed.
 - `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_non_object_contact_metadata -q`
   -- 1 passed.
+- `python -m py_compile atlas_brain/services/crm_provider.py tests/test_eom_lead_conversion_integration.py`
+  -- passed.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_crossed_identities_fail_without_deadlock -q`
+  -- 1 passed.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_explicit_id_identity_collision tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_ambiguous_exact_identity tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_ambiguous_direct_provenance -q`
+  -- 4 passed.
 - `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py -q -k "operator_contact_mutation or inbound_atomic_uses_ascii_phone_normalizer or share_phone_identity_lock"`
   -- 6 passed, 46 deselected.
 - `python -m pytest tests/test_crm_read_scoping.py tests/test_leads_intake.py tests/test_eom_lead_conversion.py tests/test_tenant_stamping.py tests/test_migrations_runner.py tests/test_contact_write_boundary.py -q`
@@ -290,15 +296,15 @@ Parked hardening: none.
 | File | LOC |
 |---|---:|
 | `atlas_brain/eom_api/funnel.py` | 151 |
-| `atlas_brain/services/crm_provider.py` | 520 |
+| `atlas_brain/services/crm_provider.py` | 509 |
 | `atlas_brain/services/eom_crm_mutations.py` | 282 |
 | `atlas_brain/services/eom_lead_ingress.py` | 18 |
 | `atlas_brain/storage/migrations/364_eom_operator_contact_operation_key_index.sql` | 29 |
-| `plans/PR-EOM-Operator-Mutation-Contract.md` | 304 |
+| `plans/PR-EOM-Operator-Mutation-Contract.md` | 310 |
 | `tests/contact_write_boundary/baseline.json` | 1 |
 | `tests/test_contact_write_boundary.py` | 6 |
 | `tests/test_eom_lead_conversion.py` | 258 |
-| `tests/test_eom_lead_conversion_integration.py` | 696 |
+| `tests/test_eom_lead_conversion_integration.py` | 777 |
 | `tests/test_migrations_runner.py` | 45 |
 | `tests/test_tenant_stamping.py` | 51 |
-| **Total** | **2361** |
+| **Total** | **2437** |

--- a/plans/PR-EOM-Operator-Mutation-Contract.md
+++ b/plans/PR-EOM-Operator-Mutation-Contract.md
@@ -40,7 +40,8 @@ define the canonical mutation boundary.
     lifecycle metadata store that provenance;
   - normalize email/phone/blank values in one EOM helper path, use exact
     last-10 phone matching inside the EOM operator resolver, and preserve the
-    generic CRM API's existing short-phone substring lookup for other callers;
+    generic CRM API's existing phone substring compatibility for other callers,
+    including stored extension numbers;
   - record `contact_created` or `contact_updated` lifecycle evidence with the
     actor and operation key for every fresh create/update through the new path;
   - replay the same idempotency key as HTTP 200 with the same contact, and
@@ -137,8 +138,8 @@ seam in the enumeration; otherwise write "N/A - no boundary change."
   compatibility.
 - Replaced-path behaviors: no caller is replaced yet; this adds the canonical
   path future callers will use, applies exact normalized last-10 matching inside
-  the EOM operator resolver, and keeps the generic CRM API's partial substring
-  lookup for short phone fragments.
+  the EOM operator resolver, and keeps the generic CRM API's substring lookup
+  compatibility for phone fragments and stored extension-number shapes.
 - Guard-relevant fields: `contactId`, `contactType`, `fullName`, `email`,
   `phone`, `address`, `city`, `state`, `zip`, `notes`, `sourceChannel`,
   `sourceRef`, actor headers, and `Idempotency-Key`.
@@ -188,11 +189,28 @@ a create through the existing provider insert helper, then inserts a
 `contact_created` or `contact_updated` lifecycle row with actor/provenance
 metadata before the transaction commits.
 
+The admitted execution model is one database transaction per operator command.
+Before reading existing receipts or contact identities, the provider takes
+transaction-scoped advisory locks in sorted order across the operation key,
+explicit contact id when present, source-ref provenance key, and each normalized
+phone/email identity key. The phone/email lock namespace is shared with the
+atomic EOM inbound writer, so interleavings on the same admitted identity
+serialize before either writer can resolve or insert. Inside the transaction,
+idempotency is receipt-first: an existing lifecycle row for the same operation
+key and matching request fingerprint returns the recorded contact, while the
+same key with a different fingerprint fails before mutation. With no receipt,
+the provider resolves and locks source/provenance/phone/email contact rows with
+`FOR UPDATE`, rejects ambiguous or cross-contact identities, writes exactly one
+contact create/update, then writes exactly one lifecycle receipt before commit.
+The crash boundary is the transaction commit: a rollback leaves no partial
+contact/receipt pair, and a committed receipt makes later replays read-only.
+
 Phone normalization is shared with EOM inbound identity handling and strips only
 ASCII digits so Python and SQL normalize the same input class. The EOM operator
 resolver uses exact normalized last-10 equality. Generic provider phone search
-keeps its short-phone substring lookup for compatibility, while full phone
-inputs use the same normalized last-10 comparison.
+keeps substring lookup compatibility, including full phone inputs that appear
+inside a stored phone with extension digits, while still admitting normalized
+last-10 matches for ordinary stored numbers.
 
 ## Intentional
 
@@ -232,6 +250,12 @@ Parked hardening: none.
 
 - `python -m py_compile atlas_brain/eom_api/funnel.py atlas_brain/services/crm_provider.py atlas_brain/services/eom_lead_ingress.py atlas_brain/services/eom_crm_mutations.py tests/test_eom_lead_conversion.py tests/test_eom_lead_conversion_integration.py tests/test_tenant_stamping.py tests/test_migrations_runner.py tests/test_contact_write_boundary.py`
   -- passed.
+- `python -m py_compile atlas_brain/services/crm_provider.py tests/test_tenant_stamping.py tests/test_eom_lead_conversion_integration.py`
+  -- passed.
+- `python -m pytest tests/test_tenant_stamping.py::test_generic_contact_phone_search_preserves_full_phone_extension_lookup tests/test_tenant_stamping.py::test_generic_contact_phone_search_keeps_partial_phone_substring_lookup -q`
+  -- 2 passed.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_claims_legacy_contact_by_padded_email 'tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_explicit_id_identity_collision[email-owned@example.com-target@example.com]' -q`
+  -- 2 passed.
 - `python -m pytest tests/test_eom_lead_conversion.py tests/test_tenant_stamping.py tests/test_migrations_runner.py tests/test_contact_write_boundary.py -q`
   -- 293 passed, 1 skipped, 1 warning.
 - `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py -q -k "operator_contact_mutation or inbound_atomic_uses_ascii_phone_normalizer or share_phone_identity_lock"`
@@ -260,11 +284,11 @@ Parked hardening: none.
 | `atlas_brain/services/eom_crm_mutations.py` | 269 |
 | `atlas_brain/services/eom_lead_ingress.py` | 18 |
 | `atlas_brain/storage/migrations/364_eom_operator_contact_operation_key_index.sql` | 29 |
-| `plans/PR-EOM-Operator-Mutation-Contract.md` | 270 |
+| `plans/PR-EOM-Operator-Mutation-Contract.md` | 294 |
 | `tests/contact_write_boundary/baseline.json` | 1 |
 | `tests/test_contact_write_boundary.py` | 6 |
 | `tests/test_eom_lead_conversion.py` | 241 |
-| `tests/test_eom_lead_conversion_integration.py` | 532 |
+| `tests/test_eom_lead_conversion_integration.py` | 590 |
 | `tests/test_migrations_runner.py` | 45 |
-| `tests/test_tenant_stamping.py` | 50 |
-| **Total** | **2106** |
+| `tests/test_tenant_stamping.py` | 51 |
+| **Total** | **2189** |

--- a/plans/PR-EOM-Operator-Mutation-Contract.md
+++ b/plans/PR-EOM-Operator-Mutation-Contract.md
@@ -146,8 +146,24 @@ seam in the enumeration; otherwise write "N/A - no boundary change."
 - Guard-relevant fields: `contactId`, `contactType`, `fullName`, `email`,
   `phone`, `address`, `city`, `state`, `zip`, `notes`, `sourceChannel`,
   `sourceRef`, actor headers, and `Idempotency-Key`.
-- Caller x input shape: tracker/service caller sends camelCase JSON with one
-  operation key and actor headers; browser users do not call Atlas directly.
+- Caller x input shape:
+  - New tracker/service operator route caller sends camelCase JSON with one
+    operation key plus actor headers; browser users do not call Atlas directly.
+  - `atlas_brain/mcp/crm_server.py` generic CRM callers keep existing
+    `search_contacts` semantics: email and query lookup are unchanged, short
+    phone fragments keep substring lookup, and full/country-code phones gain an
+    additional normalized last-10 equality fallback without dropping submitted
+    digit substring compatibility.
+  - `atlas_brain/mcp/invoicing_server.py`, `atlas_brain/services/customer_context.py`,
+    `atlas_brain/tools/scheduling.py`, `scripts/import_eom_customers_live.py`, and
+    `atlas_brain/api/email_drafts.py` call the same generic provider search seam;
+    their input shapes are preserved by the generic substring-compatible phone
+    branch and unchanged email/query branches.
+  - Existing EOM inbound lead callers in scheduling, call intelligence, SMS
+    intelligence, and lead-pipeline tests now share the ASCII digit normalizer
+    and full-number preference rule: a full extracted phone wins, a full
+    transport phone backfills a fragment, and fragments stay fragments only
+    when no full phone is available.
 
 ### Deployed-config probing
 
@@ -335,11 +351,11 @@ Parked hardening: none.
 | `atlas_brain/services/eom_crm_mutations.py` | 287 |
 | `atlas_brain/services/eom_lead_ingress.py` | 18 |
 | `atlas_brain/storage/migrations/364_eom_operator_contact_operation_key_index.sql` | 29 |
-| `plans/PR-EOM-Operator-Mutation-Contract.md` | 345 |
+| `plans/PR-EOM-Operator-Mutation-Contract.md` | 361 |
 | `tests/contact_write_boundary/baseline.json` | 1 |
 | `tests/test_contact_write_boundary.py` | 6 |
 | `tests/test_eom_lead_conversion.py` | 259 |
 | `tests/test_eom_lead_conversion_integration.py` | 929 |
 | `tests/test_migrations_runner.py` | 45 |
 | `tests/test_tenant_stamping.py` | 76 |
-| **Total** | **2687** |
+| **Total** | **2703** |

--- a/plans/PR-EOM-Operator-Mutation-Contract.md
+++ b/plans/PR-EOM-Operator-Mutation-Contract.md
@@ -256,6 +256,10 @@ Parked hardening: none.
   -- 2 passed.
 - `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_claims_legacy_contact_by_padded_email 'tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_explicit_id_identity_collision[email-owned@example.com-target@example.com]' -q`
   -- 2 passed.
+- `python -m py_compile atlas_brain/services/crm_provider.py tests/test_eom_lead_conversion_integration.py`
+  -- passed.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_ambiguous_direct_provenance -q`
+  -- 1 passed.
 - `python -m pytest tests/test_eom_lead_conversion.py tests/test_tenant_stamping.py tests/test_migrations_runner.py tests/test_contact_write_boundary.py -q`
   -- 293 passed, 1 skipped, 1 warning.
 - `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py -q -k "operator_contact_mutation or inbound_atomic_uses_ascii_phone_normalizer or share_phone_identity_lock"`
@@ -280,15 +284,15 @@ Parked hardening: none.
 | File | LOC |
 |---|---:|
 | `atlas_brain/eom_api/funnel.py` | 130 |
-| `atlas_brain/services/crm_provider.py` | 515 |
+| `atlas_brain/services/crm_provider.py` | 514 |
 | `atlas_brain/services/eom_crm_mutations.py` | 269 |
 | `atlas_brain/services/eom_lead_ingress.py` | 18 |
 | `atlas_brain/storage/migrations/364_eom_operator_contact_operation_key_index.sql` | 29 |
-| `plans/PR-EOM-Operator-Mutation-Contract.md` | 294 |
+| `plans/PR-EOM-Operator-Mutation-Contract.md` | 298 |
 | `tests/contact_write_boundary/baseline.json` | 1 |
 | `tests/test_contact_write_boundary.py` | 6 |
 | `tests/test_eom_lead_conversion.py` | 241 |
-| `tests/test_eom_lead_conversion_integration.py` | 590 |
+| `tests/test_eom_lead_conversion_integration.py` | 647 |
 | `tests/test_migrations_runner.py` | 45 |
 | `tests/test_tenant_stamping.py` | 51 |
-| **Total** | **2189** |
+| **Total** | **2249** |

--- a/plans/PR-EOM-Operator-Mutation-Contract.md
+++ b/plans/PR-EOM-Operator-Mutation-Contract.md
@@ -239,8 +239,9 @@ that appear inside a stored phone with extension digits, while still admitting
 normalized last-10 matches for ordinary stored numbers.
 
 Operator provenance metadata is reserved to an object of exact source records.
-Malformed reserved provenance fails closed before sourceRef-only resolution can
-claim a row or overwrite the original metadata value.
+Malformed reserved provenance, including present JSON null, fails closed before
+sourceRef-only resolution can claim a row or overwrite the original metadata
+value.
 
 ## Intentional
 
@@ -347,6 +348,8 @@ Parked hardening: none.
   -- passed.
 - `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_matches_stored_phone_with_extension tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_malformed_source_provenance -q`
   -- 5 passed.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_matches_stored_phone_with_extension tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_does_not_match_extension_suffix tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_malformed_source_provenance -q`
+  -- 8 passed.
 - `python -m pytest tests/test_crm_read_scoping.py tests/test_leads_intake.py tests/test_eom_lead_conversion.py tests/test_tenant_stamping.py tests/test_migrations_runner.py tests/test_contact_write_boundary.py -q`
   -- 412 passed, 1 skipped, 1 warning.
 - `python -m pytest tests/test_contact_write_boundary.py -q`
@@ -367,15 +370,15 @@ Parked hardening: none.
 | File | LOC |
 |---|---:|
 | `atlas_brain/eom_api/funnel.py` | 171 |
-| `atlas_brain/services/crm_provider.py` | 614 |
+| `atlas_brain/services/crm_provider.py` | 612 |
 | `atlas_brain/services/eom_crm_mutations.py` | 287 |
 | `atlas_brain/services/eom_lead_ingress.py` | 18 |
 | `atlas_brain/storage/migrations/364_eom_operator_contact_operation_key_index.sql` | 29 |
-| `plans/PR-EOM-Operator-Mutation-Contract.md` | 381 |
+| `plans/PR-EOM-Operator-Mutation-Contract.md` | 384 |
 | `tests/contact_write_boundary/baseline.json` | 1 |
 | `tests/test_contact_write_boundary.py` | 6 |
 | `tests/test_eom_lead_conversion.py` | 261 |
-| `tests/test_eom_lead_conversion_integration.py` | 1054 |
+| `tests/test_eom_lead_conversion_integration.py` | 1055 |
 | `tests/test_migrations_runner.py` | 45 |
 | `tests/test_tenant_stamping.py` | 76 |
-| **Total** | **2943** |
+| **Total** | **2945** |

--- a/plans/PR-EOM-Operator-Mutation-Contract.md
+++ b/plans/PR-EOM-Operator-Mutation-Contract.md
@@ -125,6 +125,10 @@ Slice phase: vertical slice
     malformed/out-of-grammar identities with 422, and treats untrusted inbound
     non-ASCII phone glyphs as no phone identity unless another admitted
     identity exists.
+  - Route request text safety is DERIVED at the full request object before
+    Pydantic field/literal/extra validation, so lone Unicode surrogates in
+    values or forbidden extra keys enter the same encodable domain-invalid text
+    path instead of response rendering.
   - Operator provenance is CLOSED to the required channel/ref pair for this
     route. Unknown channels and database-invalid source refs reject with 422;
     admitted refs persist into the contact metadata provenance map and lifecycle
@@ -227,10 +231,12 @@ contact/receipt pair, and a committed receipt makes later replays read-only.
 
 Phone normalization is shared with EOM inbound identity handling and strips only
 ASCII digits so Python and SQL normalize the same input class. The EOM operator
-resolver uses exact normalized last-10 equality. Generic provider phone search
-keeps substring lookup compatibility, including full phone inputs that appear
-inside a stored phone with extension digits, while still admitting normalized
-last-10 matches for ordinary stored numbers.
+resolver uses exact normalized last-10 equality after stripping spaced or
+delimiterless terminal stored extension digits. Legacy lead targets must also be
+active and in supported EOM funnel stages before claim/edit. Generic provider
+phone search keeps substring lookup compatibility, including full phone inputs
+that appear inside a stored phone with extension digits, while still admitting
+normalized last-10 matches for ordinary stored numbers.
 
 ## Intentional
 
@@ -327,6 +333,12 @@ Parked hardening: none.
   -- 8 passed.
 - `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py -q -k "operator_contact_mutation or inbound_atomic_uses_ascii_phone_normalizer or share_phone_identity_lock"`
   -- 6 passed, 46 deselected.
+- `python -m py_compile atlas_brain/eom_api/funnel.py atlas_brain/services/crm_provider.py tests/test_eom_lead_conversion.py tests/test_eom_lead_conversion_integration.py`
+  -- passed.
+- `python -m pytest tests/test_eom_lead_conversion.py::test_private_operator_contact_rejects_database_invalid_text_before_crm_call -q`
+  -- 16 passed.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_matches_stored_phone_with_extension tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_does_not_match_extension_suffix tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_inactive_legacy_lead -q`
+  -- 5 passed.
 - `python -m pytest tests/test_crm_read_scoping.py tests/test_leads_intake.py tests/test_eom_lead_conversion.py tests/test_tenant_stamping.py tests/test_migrations_runner.py tests/test_contact_write_boundary.py -q`
   -- 412 passed, 1 skipped, 1 warning.
 - `python -m pytest tests/test_contact_write_boundary.py -q`
@@ -346,16 +358,16 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `atlas_brain/eom_api/funnel.py` | 151 |
-| `atlas_brain/services/crm_provider.py` | 541 |
+| `atlas_brain/eom_api/funnel.py` | 171 |
+| `atlas_brain/services/crm_provider.py` | 545 |
 | `atlas_brain/services/eom_crm_mutations.py` | 287 |
 | `atlas_brain/services/eom_lead_ingress.py` | 18 |
 | `atlas_brain/storage/migrations/364_eom_operator_contact_operation_key_index.sql` | 29 |
-| `plans/PR-EOM-Operator-Mutation-Contract.md` | 361 |
+| `plans/PR-EOM-Operator-Mutation-Contract.md` | 373 |
 | `tests/contact_write_boundary/baseline.json` | 1 |
 | `tests/test_contact_write_boundary.py` | 6 |
-| `tests/test_eom_lead_conversion.py` | 259 |
-| `tests/test_eom_lead_conversion_integration.py` | 929 |
+| `tests/test_eom_lead_conversion.py` | 261 |
+| `tests/test_eom_lead_conversion_integration.py` | 992 |
 | `tests/test_migrations_runner.py` | 45 |
 | `tests/test_tenant_stamping.py` | 76 |
-| **Total** | **2703** |
+| **Total** | **2804** |

--- a/plans/PR-EOM-Operator-Mutation-Contract.md
+++ b/plans/PR-EOM-Operator-Mutation-Contract.md
@@ -278,6 +278,12 @@ Parked hardening: none.
   -- passed.
 - `python -m pytest tests/test_tenant_stamping.py::test_generic_contact_phone_search_preserves_full_phone_extension_lookup tests/test_tenant_stamping.py::test_generic_contact_phone_search_preserves_country_code_to_extension_lookup tests/test_tenant_stamping.py::test_generic_contact_phone_search_keeps_partial_phone_substring_lookup -q`
   -- 3 passed.
+- `python -m py_compile atlas_brain/services/crm_provider.py tests/test_eom_lead_conversion_integration.py`
+  -- passed.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_matches_stored_phone_with_extension tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_does_not_match_extension_suffix -q`
+  -- 2 passed.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_explicit_id_identity_collision tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_ambiguous_exact_identity tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_ambiguous_direct_provenance tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_crossed_identities_fail_without_deadlock tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_matches_stored_phone_with_extension tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_does_not_match_extension_suffix -q`
+  -- 7 passed.
 - `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py -q -k "operator_contact_mutation or inbound_atomic_uses_ascii_phone_normalizer or share_phone_identity_lock"`
   -- 6 passed, 46 deselected.
 - `python -m pytest tests/test_crm_read_scoping.py tests/test_leads_intake.py tests/test_eom_lead_conversion.py tests/test_tenant_stamping.py tests/test_migrations_runner.py tests/test_contact_write_boundary.py -q`
@@ -300,15 +306,15 @@ Parked hardening: none.
 | File | LOC |
 |---|---:|
 | `atlas_brain/eom_api/funnel.py` | 151 |
-| `atlas_brain/services/crm_provider.py` | 510 |
+| `atlas_brain/services/crm_provider.py` | 523 |
 | `atlas_brain/services/eom_crm_mutations.py` | 282 |
 | `atlas_brain/services/eom_lead_ingress.py` | 18 |
 | `atlas_brain/storage/migrations/364_eom_operator_contact_operation_key_index.sql` | 29 |
-| `plans/PR-EOM-Operator-Mutation-Contract.md` | 314 |
+| `plans/PR-EOM-Operator-Mutation-Contract.md` | 320 |
 | `tests/contact_write_boundary/baseline.json` | 1 |
 | `tests/test_contact_write_boundary.py` | 6 |
 | `tests/test_eom_lead_conversion.py` | 258 |
-| `tests/test_eom_lead_conversion_integration.py` | 777 |
+| `tests/test_eom_lead_conversion_integration.py` | 862 |
 | `tests/test_migrations_runner.py` | 45 |
 | `tests/test_tenant_stamping.py` | 76 |
-| **Total** | **2467** |
+| **Total** | **2571** |

--- a/tests/contact_write_boundary/baseline.json
+++ b/tests/contact_write_boundary/baseline.json
@@ -26,6 +26,7 @@
     "atlas_brain/services/crm_provider.py::UPDATE::UPDATE contacts SET lead_stage = $3, updated_at = NOW() WHERE i",
     "atlas_brain/services/crm_provider.py::UPDATE::UPDATE contacts SET lead_stage = ' ', updated_at = NOW() WHE",
     "atlas_brain/services/crm_provider.py::UPDATE::UPDATE contacts SET status = ' ', updated_at = NOW() WHERE id = $1",
+    "atlas_brain/services/crm_provider.py::UPDATE::UPDATE contacts SET {runtime value} WHERE id = $1 AND (",
     "atlas_brain/services/crm_provider.py::UPDATE::UPDATE contacts SET {runtime value} WHERE {runtime value} RETURNING *",
     "atlas_reddit/store.py::DYNAMIC::DELETE FROM {runtime value} WHERE {runtime value} = ?",
     "extracted_content_pipeline/blog_blueprint_postgres.py::DYNAMIC::AND id = ANY($2::uuid[]) AND consumed_at IS NULL",

--- a/tests/test_contact_write_boundary.py
+++ b/tests/test_contact_write_boundary.py
@@ -509,14 +509,14 @@ def test_repository_has_exactly_the_known_insert_sites() -> None:
     assert {f.path for f in inserts} == {"atlas_brain/services/crm_provider.py"}
     assert len(inserts) == 2, f"expected 2 provider INSERT sites, found {len(inserts)}"
 
-    # Ground truth: `grep -c 'UPDATE contacts' crm_provider.py` == 9. Pinning
+    # Ground truth: `grep -c 'UPDATE contacts' crm_provider.py` == 10. Pinning
     # the count catches a recognizer regression that silently drops one.
     provider_updates = [
         f for f in findings
         if f.operation == "UPDATE" and f.path == "atlas_brain/services/crm_provider.py"
     ]
-    assert len(provider_updates) == 9, (
-        f"expected 9 provider UPDATE statements, found {len(provider_updates)}"
+    assert len(provider_updates) == 10, (
+        f"expected 10 provider UPDATE statements, found {len(provider_updates)}"
     )
 
 

--- a/tests/test_eom_lead_conversion.py
+++ b/tests/test_eom_lead_conversion.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
@@ -752,6 +753,7 @@ async def test_private_operator_contact_rejects_unknown_source_channel_before_cr
         {"email": "a b@example.com"},
         {"email": "ada\noperator@example.com"},
         {"phone": "٢١٧٥٥٥٠١٠٠"},
+        {"phone": "2175550100 ext 123"},
     ),
 )
 async def test_private_operator_contact_rejects_malformed_identity_before_crm_call(
@@ -762,10 +764,14 @@ async def test_private_operator_contact_rejects_malformed_identity_before_crm_ca
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app), base_url="http://test"
     ) as client:
+        headers = {
+            **_headers(approval_key=f"office-contact-{uuid4().hex}"),
+            "Content-Type": "application/json",
+        }
         response = await client.post(
             "/eom-funnel/operator-contacts",
-            headers=_headers(approval_key=f"office-contact-{uuid4().hex}"),
-            json=_operator_contact_payload(**payload_updates),
+            headers=headers,
+            content=json.dumps(_operator_contact_payload(**payload_updates)),
         )
 
     assert response.status_code == 422
@@ -777,15 +783,22 @@ async def test_private_operator_contact_rejects_malformed_identity_before_crm_ca
     "payload_updates",
     (
         {"sourceRef": "customer:\x0042"},
+        {"sourceRef": "customer:\ud80042"},
         {"fullName": "Ada\x00Operator"},
+        {"fullName": "Ada\ud800Operator"},
         {"address": "100\x00Main"},
+        {"address": "100\ud800Main"},
         {"city": "Effingham\x00"},
+        {"city": "Effingham\ud800"},
         {"state": "I\x00L"},
+        {"state": "I\ud800L"},
         {"zip": "624\x0001"},
+        {"zip": "624\ud80001"},
         {"notes": "bring\x00supplies"},
+        {"notes": "bring\ud800supplies"},
     ),
 )
-async def test_private_operator_contact_rejects_nul_text_before_crm_call(
+async def test_private_operator_contact_rejects_database_invalid_text_before_crm_call(
     payload_updates: dict[str, str],
 ):
     crm = _CRM()
@@ -793,10 +806,14 @@ async def test_private_operator_contact_rejects_nul_text_before_crm_call(
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app), base_url="http://test"
     ) as client:
+        headers = {
+            **_headers(approval_key=f"office-contact-{uuid4().hex}"),
+            "Content-Type": "application/json",
+        }
         response = await client.post(
             "/eom-funnel/operator-contacts",
-            headers=_headers(approval_key=f"office-contact-{uuid4().hex}"),
-            json=_operator_contact_payload(**payload_updates),
+            headers=headers,
+            content=json.dumps(_operator_contact_payload(**payload_updates)),
         )
 
     assert response.status_code == 422

--- a/tests/test_eom_lead_conversion.py
+++ b/tests/test_eom_lead_conversion.py
@@ -752,6 +752,7 @@ async def test_private_operator_contact_rejects_unknown_source_channel_before_cr
         {"email": "a@@b"},
         {"email": "a b@example.com"},
         {"email": "ada\noperator@example.com"},
+        {"email": f"{'a' * 65}@example.com"},
         {"phone": "٢١٧٥٥٥٠١٠٠"},
         {"phone": "2175550100 ext 123"},
     ),

--- a/tests/test_eom_lead_conversion.py
+++ b/tests/test_eom_lead_conversion.py
@@ -797,6 +797,8 @@ async def test_private_operator_contact_rejects_malformed_identity_before_crm_ca
         {"zip": "624\ud80001"},
         {"notes": "bring\x00supplies"},
         {"notes": "bring\ud800supplies"},
+        {"contactType": "\ud800"},
+        {"unexpected\ud800": "value"},
     ),
 )
 async def test_private_operator_contact_rejects_database_invalid_text_before_crm_call(

--- a/tests/test_eom_lead_conversion.py
+++ b/tests/test_eom_lead_conversion.py
@@ -53,11 +53,45 @@ class _CRM:
         self.lost_calls: list[dict[str, object]] = []
         self.reopen_calls: list[dict[str, object]] = []
         self.reopen_stage = "new"
+        self.operator_contact_calls: list[object] = []
+        self.operator_contact_result: dict[str, object] | None = None
 
     @asynccontextmanager
     async def eom_estimate_booking_execution_lock(self, *, booking_key: str):
         self.execution_lock_keys.append(booking_key)
         yield
+
+    async def mutate_eom_operator_contact_atomic(self, *, command):
+        self.operator_contact_calls.append(command)
+        if self.operator_contact_result is not None:
+            return self.operator_contact_result
+        contact_id = command.contact_id or "4c0f1ee8-8063-4ba9-9e10-847e6c2a95ff"
+        operation = (
+            "contact_updated" if command.contact_id is not None else "contact_created"
+        )
+        return {
+            "contact_id": contact_id,
+            "operation": operation,
+            "idempotent": False,
+            "contact": {
+                "id": contact_id,
+                "full_name": command.fields.get("full_name") or "Stored Contact",
+                "email": command.fields.get("email"),
+                "phone": command.fields.get("phone"),
+                "address": command.fields.get("address"),
+                "city": command.fields.get("city"),
+                "state": command.fields.get("state"),
+                "zip": command.fields.get("zip"),
+                "notes": command.fields.get("notes"),
+                "contact_type": command.contact_type or "customer",
+                "lead_stage": "new" if command.contact_type == "lead" else None,
+                "status": "active",
+                "source": command.contact_source,
+                "source_ref": command.contact_source_ref,
+                "created_at": datetime(2026, 8, 6, 12, tzinfo=timezone.utc),
+                "updated_at": datetime(2026, 8, 6, 12, tzinfo=timezone.utc),
+            },
+        }
 
     async def mark_eom_lead_lost(self, **kwargs: object) -> dict[str, object]:
         self.lost_calls.append(kwargs)
@@ -494,6 +528,18 @@ def _booking_payload(**overrides) -> dict[str, object]:
     return payload
 
 
+def _operator_contact_payload(**overrides) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "sourceChannel": "time_tracker",
+        "sourceRef": "customer:42",
+        "fullName": "Ada Operator",
+        "email": "ADA@EXAMPLE.COM",
+        "phone": "(217) 555-0100",
+    }
+    payload.update(overrides)
+    return payload
+
+
 @pytest.mark.asyncio
 async def test_full_atlas_app_serves_public_intake_and_private_handoff_together():
     """The actual full aggregate serves the tracker callback beside lead intake."""
@@ -565,6 +611,201 @@ async def test_full_atlas_app_serves_public_intake_and_private_handoff_together(
     ]
     assert response.status_code == 201
     assert crm.calls
+
+
+@pytest.mark.asyncio
+async def test_private_operator_contact_route_normalizes_and_delegates_create():
+    crm = _CRM()
+    app = _app(crm, _enabled_config())
+    operation_key = f"office-contact-{uuid4().hex}"
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            "/eom-funnel/operator-contacts",
+            headers=_headers(approval_key=operation_key),
+            json=_operator_contact_payload(address="   ", contactType="lead"),
+        )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["success"] is True
+    assert body["operation"] == "contact_created"
+    assert body["idempotent"] is False
+    assert body["contact"]["email"] == "ada@example.com"
+    assert body["contact"]["phone"] == "2175550100"
+    assert body["contact"]["address"] is None
+    assert body["contact"]["sourceRef"] == "time_tracker:customer:42"
+    command = crm.operator_contact_calls[0]
+    assert command.operation_key == operation_key
+    assert command.actor_id == 1
+    assert command.actor_name == "Juan Canfield"
+    assert command.contact_type == "lead"
+    assert dict(command.fields) == {
+        "full_name": "Ada Operator",
+        "email": "ada@example.com",
+        "phone": "2175550100",
+        "address": None,
+    }
+    assert len(command.request_fingerprint) == 64
+
+
+@pytest.mark.asyncio
+async def test_private_operator_contact_route_returns_200_for_idempotent_replay():
+    contact_id = str(uuid4())
+    crm = _CRM()
+    crm.operator_contact_result = {
+        "contact_id": contact_id,
+        "operation": "contact_updated",
+        "idempotent": True,
+        "contact": {
+            "id": contact_id,
+            "full_name": "Replay Contact",
+            "email": "replay@example.com",
+            "phone": "2175550101",
+            "address": None,
+            "city": None,
+            "state": None,
+            "zip": None,
+            "notes": None,
+            "contact_type": "customer",
+            "lead_stage": None,
+            "status": "active",
+            "source": "manual",
+            "source_ref": "time_tracker:customer:51",
+            "created_at": datetime(2026, 8, 6, 12, tzinfo=timezone.utc),
+            "updated_at": datetime(2026, 8, 6, 12, tzinfo=timezone.utc),
+        },
+    }
+    app = _app(crm, _enabled_config())
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            "/eom-funnel/operator-contacts",
+            headers=_headers(approval_key=f"office-contact-{uuid4().hex}"),
+            json=_operator_contact_payload(
+                contactId=contact_id,
+                sourceRef="customer:51",
+                email="replay@example.com",
+            ),
+        )
+
+    assert response.status_code == 200
+    assert response.json()["idempotent"] is True
+    assert response.json()["contactId"] == contact_id
+    assert len(crm.operator_contact_calls) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("config", "headers", "expected_status"),
+    (
+        (EOMFunnelConfig(api_enabled=False), _headers(), 503),
+        (_enabled_config(), {**_headers(), "Authorization": ""}, 401),
+        (_enabled_config(), {**_headers(actor=" ")}, 422),
+        (_enabled_config(), {**_headers(approval_key="short")}, 422),
+    ),
+)
+async def test_private_operator_contact_rejects_boundary_failures_before_crm_call(
+    config: EOMFunnelConfig,
+    headers: dict[str, str],
+    expected_status: int,
+):
+    crm = _CRM()
+    app = _app(crm, config)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            "/eom-funnel/operator-contacts",
+            headers=headers,
+            json=_operator_contact_payload(),
+        )
+
+    assert response.status_code == expected_status
+    assert crm.operator_contact_calls == []
+
+
+@pytest.mark.asyncio
+async def test_private_operator_contact_rejects_unknown_source_channel_before_crm_call():
+    crm = _CRM()
+    app = _app(crm, _enabled_config())
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            "/eom-funnel/operator-contacts",
+            headers=_headers(approval_key=f"office-contact-{uuid4().hex}"),
+            json=_operator_contact_payload(sourceChannel="random"),
+        )
+
+    assert response.status_code == 422
+    assert crm.operator_contact_calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload_updates",
+    (
+        {"email": "a@@b"},
+        {"email": "a b@example.com"},
+        {"email": "ada\noperator@example.com"},
+        {"phone": "٢١٧٥٥٥٠١٠٠"},
+    ),
+)
+async def test_private_operator_contact_rejects_malformed_identity_before_crm_call(
+    payload_updates: dict[str, str],
+):
+    crm = _CRM()
+    app = _app(crm, _enabled_config())
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            "/eom-funnel/operator-contacts",
+            headers=_headers(approval_key=f"office-contact-{uuid4().hex}"),
+            json=_operator_contact_payload(**payload_updates),
+        )
+
+    assert response.status_code == 422
+    assert crm.operator_contact_calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload_updates",
+    (
+        {"sourceRef": "customer:\x0042"},
+        {"fullName": "Ada\x00Operator"},
+        {"address": "100\x00Main"},
+        {"city": "Effingham\x00"},
+        {"state": "I\x00L"},
+        {"zip": "624\x0001"},
+        {"notes": "bring\x00supplies"},
+    ),
+)
+async def test_private_operator_contact_rejects_nul_text_before_crm_call(
+    payload_updates: dict[str, str],
+):
+    crm = _CRM()
+    app = _app(crm, _enabled_config())
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            "/eom-funnel/operator-contacts",
+            headers=_headers(approval_key=f"office-contact-{uuid4().hex}"),
+            json=_operator_contact_payload(**payload_updates),
+        )
+
+    assert response.status_code == 422
+    assert crm.operator_contact_calls == []
+
+
+def test_operator_contact_capability_is_derived_from_registered_route():
+    funnel_mod._served_capabilities_cache = None
+    assert "contact.operator_mutation" in funnel_mod.served_capabilities()
 
 
 @pytest.mark.asyncio

--- a/tests/test_eom_lead_conversion_integration.py
+++ b/tests/test_eom_lead_conversion_integration.py
@@ -527,6 +527,7 @@ async def test_operator_contact_mutation_rejects_non_object_contact_metadata():
 @pytest.mark.parametrize(
     "source_metadata",
     (
+        None,
         ["time_tracker:customer:malformed-provenance"],
         {"time_tracker:customer:malformed-provenance": "not-a-record"},
     ),

--- a/tests/test_eom_lead_conversion_integration.py
+++ b/tests/test_eom_lead_conversion_integration.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import os
 import uuid
+from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -13,13 +14,24 @@ import pytest
 
 asyncpg = pytest.importorskip("asyncpg")
 
-from atlas_brain.services.crm_provider import DatabaseCRMProvider  # noqa: E402
+from atlas_brain.services.crm_provider import (  # noqa: E402
+    DatabaseCRMProvider,
+    _eom_identity_lock_key,
+)
+from atlas_brain.services.eom_crm_mutations import (  # noqa: E402
+    EOMOperatorContactMutation,
+    EOMOperatorContactMutationError,
+    mutate_eom_operator_contact,
+)
 from atlas_brain.services.eom_estimate_booking import (  # noqa: E402
     deterministic_eom_estimate_calendar_event_id,
     deterministic_eom_first_clean_calendar_event_id,
 )
 from atlas_brain.services.eom_lead_conversion import (  # noqa: E402
     EOMLeadConversionError,
+)
+from atlas_brain.services.eom_lead_ingress import (  # noqa: E402
+    resolve_or_create_eom_inbound_lead,
 )
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -202,6 +214,524 @@ def _metadata_dict(value):
     if isinstance(value, str):
         return json.loads(value)
     return dict(value or {})
+
+
+class _IdentityLockGateConnection:
+    """Hold the first shared identity lock while a second writer reaches it."""
+
+    def __init__(
+        self,
+        connection,
+        *,
+        lock_key: str,
+        first_locked: asyncio.Event,
+        second_waiting: asyncio.Event,
+        release_first: asyncio.Event,
+    ) -> None:
+        self._connection = connection
+        self._lock_key = lock_key
+        self._first_locked = first_locked
+        self._second_waiting = second_waiting
+        self._release_first = release_first
+
+    def __getattr__(self, name):
+        return getattr(self._connection, name)
+
+    async def execute(self, *args):
+        sql = str(args[0]) if args else ""
+        lock_key = str(args[1]) if len(args) > 1 else ""
+        if "pg_advisory_xact_lock" in sql and lock_key == self._lock_key:
+            if not self._first_locked.is_set():
+                result = await self._connection.execute(*args)
+                self._first_locked.set()
+                await self._release_first.wait()
+                return result
+            self._second_waiting.set()
+        return await self._connection.execute(*args)
+
+
+class _IdentityLockGatePool:
+    def __init__(
+        self,
+        pool,
+        *,
+        lock_key: str,
+        first_locked: asyncio.Event,
+        second_waiting: asyncio.Event,
+        release_first: asyncio.Event,
+    ) -> None:
+        self._pool = pool
+        self._lock_key = lock_key
+        self._first_locked = first_locked
+        self._second_waiting = second_waiting
+        self._release_first = release_first
+
+    @asynccontextmanager
+    async def transaction(self):
+        async with self._pool.acquire() as connection:
+            async with connection.transaction():
+                yield _IdentityLockGateConnection(
+                    connection,
+                    lock_key=self._lock_key,
+                    first_locked=self._first_locked,
+                    second_waiting=self._second_waiting,
+                    release_first=self._release_first,
+                )
+
+
+@pytest.mark.asyncio
+async def test_operator_contact_mutation_creates_replays_and_records_actor():
+    database_url = _database_url_or_skip()
+    schema = f"atlas_eom_operator_create_{uuid.uuid4().hex}"
+    conn = await asyncpg.connect(database_url)
+    try:
+        await _prepare_schema(conn, schema, apply_privilege_migration=False)
+        provider = DatabaseCRMProvider(pool=conn)
+        operation_key = f"operator-create-{uuid.uuid4().hex}"
+        command = EOMOperatorContactMutation.from_raw(
+            operation_key=operation_key,
+            actor_id=7,
+            actor_name="Mayra Canfield",
+            source_channel="time_tracker",
+            source_ref="customer:88",
+            contact_type="customer",
+            fields={
+                "full_name": "Operator Created",
+                "email": "OPERATOR@EXAMPLE.COM",
+                "phone": "(217) 555-0100",
+                "address": "",
+            },
+        )
+
+        created = await mutate_eom_operator_contact(provider, command)
+
+        assert created["operation"] == "contact_created"
+        assert created["idempotent"] is False
+        contact_id = uuid.UUID(created["contact_id"])
+        contact = await conn.fetchrow("SELECT * FROM contacts WHERE id = $1", contact_id)
+        assert contact["business_context_id"] == "effingham_maids"
+        assert contact["contact_type"] == "customer"
+        assert contact["lead_stage"] is None
+        assert contact["email"] == "operator@example.com"
+        assert contact["phone"] == "2175550100"
+        assert contact["address"] is None
+        assert contact["source"] == "manual"
+        assert contact["source_ref"] == "time_tracker:customer:88"
+        event = await conn.fetchrow(
+            """
+            SELECT actor, source, operation_key, metadata
+            FROM eom_lead_lifecycle_events
+            WHERE contact_id = $1 AND event_type = 'contact_created'
+            """,
+            contact_id,
+        )
+        assert event["actor"] == "employee:7:Mayra Canfield"
+        assert event["source"] == "eom_office"
+        assert event["operation_key"] == operation_key
+        metadata = _metadata_dict(event["metadata"])
+        assert metadata["source_channel"] == "time_tracker"
+        assert metadata["source_ref"] == "customer:88"
+        assert metadata["field_names"] == [
+            "address",
+            "email",
+            "full_name",
+            "phone",
+        ]
+
+        replay = await mutate_eom_operator_contact(provider, command)
+
+        assert replay["contact_id"] == str(contact_id)
+        assert replay["idempotent"] is True
+        assert await conn.fetchval("SELECT COUNT(*) FROM contacts") == 1
+        assert await conn.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM eom_lead_lifecycle_events
+            WHERE event_type = 'contact_created' AND operation_key = $1
+            """,
+            operation_key,
+        ) == 1
+
+        conflict = EOMOperatorContactMutation.from_raw(
+            operation_key=operation_key,
+            actor_id=7,
+            actor_name="Mayra Canfield",
+            source_channel="time_tracker",
+            source_ref="customer:88",
+            contact_type="customer",
+            fields={
+                "full_name": "Different Operator",
+                "email": "operator@example.com",
+            },
+        )
+        with pytest.raises(EOMOperatorContactMutationError) as exc_info:
+            await mutate_eom_operator_contact(provider, conflict)
+        assert exc_info.value.status_code == 409
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_operator_contact_mutation_updates_exact_match_and_claims_legacy():
+    database_url = _database_url_or_skip()
+    schema = f"atlas_eom_operator_update_{uuid.uuid4().hex}"
+    conn = await asyncpg.connect(database_url)
+    try:
+        await _prepare_schema(conn, schema, apply_privilege_migration=False)
+        provider = DatabaseCRMProvider(pool=conn)
+        contact_id = uuid.uuid4()
+        await conn.execute(
+            """
+            INSERT INTO contacts (
+                id, full_name, phone, business_context_id, contact_type, status, source
+            ) VALUES ($1, 'Legacy Match', '1 (217) 555-0100', NULL, 'customer', 'active', 'legacy')
+            """,
+            contact_id,
+        )
+        command = EOMOperatorContactMutation.from_raw(
+            operation_key=f"operator-update-{uuid.uuid4().hex}",
+            actor_id=8,
+            actor_name="Juan Canfield",
+            source_channel="time_tracker",
+            source_ref="customer:44",
+            fields={
+                "phone": "217-555-0100",
+                "email": "LEGACY.AFTER@EXAMPLE.COM",
+                "notes": "",
+            },
+        )
+
+        updated = await mutate_eom_operator_contact(provider, command)
+
+        assert updated["operation"] == "contact_updated"
+        assert updated["idempotent"] is False
+        assert updated["contact_id"] == str(contact_id)
+        row = await conn.fetchrow("SELECT * FROM contacts WHERE id = $1", contact_id)
+        assert row["business_context_id"] == "effingham_maids"
+        assert row["email"] == "legacy.after@example.com"
+        assert row["phone"] == "2175550100"
+        assert row["notes"] is None
+        assert row["source"] == "legacy"
+        metadata = _metadata_dict(row["metadata"])
+        assert metadata["eom_operator_contact_sources"] == {
+            "time_tracker:customer:44": {
+                "source": "manual",
+                "source_channel": "time_tracker",
+                "source_ref": "customer:44",
+            }
+        }
+        event = await conn.fetchrow(
+            """
+            SELECT actor, metadata
+            FROM eom_lead_lifecycle_events
+            WHERE contact_id = $1 AND event_type = 'contact_updated'
+            """,
+            contact_id,
+        )
+        assert event["actor"] == "employee:8:Juan Canfield"
+        metadata = _metadata_dict(event["metadata"])
+        assert metadata["field_names"] == ["email", "notes", "phone"]
+        assert metadata["changed_fields"] == ["email", "phone"]
+        assert metadata["source_ref"] == "customer:44"
+
+        source_ref_only = EOMOperatorContactMutation.from_raw(
+            operation_key=f"operator-source-ref-only-{uuid.uuid4().hex}",
+            actor_id=8,
+            actor_name="Juan Canfield",
+            source_channel="time_tracker",
+            source_ref="customer:44",
+            fields={"full_name": "Legacy Match Renamed"},
+        )
+
+        rediscovered = await mutate_eom_operator_contact(provider, source_ref_only)
+
+        assert rediscovered["operation"] == "contact_updated"
+        assert rediscovered["contact_id"] == str(contact_id)
+        assert await conn.fetchval("SELECT COUNT(*) FROM contacts") == 1
+        assert await conn.fetchval(
+            "SELECT full_name FROM contacts WHERE id = $1", contact_id
+        ) == "Legacy Match Renamed"
+        assert await conn.fetchval("SELECT COUNT(*) FROM contacts") == 1
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_inbound_atomic_uses_ascii_phone_normalizer_for_relay_identity():
+    database_url = _database_url_or_skip()
+    schema = f"atlas_eom_inbound_unicode_phone_{uuid.uuid4().hex}"
+    conn = await asyncpg.connect(database_url)
+    try:
+        await _prepare_schema(conn, schema, apply_privilege_migration=False)
+        provider = DatabaseCRMProvider(pool=conn)
+
+        result = await resolve_or_create_eom_inbound_lead(
+            provider,
+            full_name="Unicode Phone",
+            phone="٢١٧٥٥٥٠١٠٠",
+            email=None,
+            address=None,
+            source="web",
+            source_ref="submitted-unicode-phone",
+            relay_event_id="relay-unicode-phone",
+        )
+
+        assert result["_was_created"] is True
+        row = await conn.fetchrow("SELECT phone, source, source_ref FROM contacts")
+        assert row["phone"] is None
+        assert row["source"] == "web"
+        assert row["source_ref"] == "relay-unicode-phone"
+        assert await conn.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM eom_inbound_delivery_receipts
+            WHERE source = 'web' AND delivery_id = 'relay-unicode-phone'
+            """
+        ) == 1
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_operator_and_inbound_contact_writers_share_phone_identity_lock():
+    database_url = _database_url_or_skip()
+    schema = f"atlas_eom_cross_writer_lock_{uuid.uuid4().hex}"
+    setup = await asyncpg.connect(database_url)
+    pool = None
+    release_first = asyncio.Event()
+    try:
+        await _prepare_schema(setup, schema, apply_privilege_migration=False)
+        pool = await asyncpg.create_pool(
+            database_url,
+            min_size=2,
+            max_size=2,
+            server_settings={"search_path": f'"{schema}", public'},
+        )
+        first_locked = asyncio.Event()
+        second_waiting = asyncio.Event()
+        provider = DatabaseCRMProvider(
+            pool=_IdentityLockGatePool(
+                pool,
+                lock_key=_eom_identity_lock_key("phone", "2175550198"),
+                first_locked=first_locked,
+                second_waiting=second_waiting,
+                release_first=release_first,
+            )
+        )
+
+        async def operator_create():
+            command = EOMOperatorContactMutation.from_raw(
+                operation_key=f"operator-cross-writer-{uuid.uuid4().hex}",
+                actor_id=8,
+                actor_name="Juan Canfield",
+                source_channel="time_tracker",
+                source_ref="customer:98",
+                fields={
+                    "full_name": "Cross Writer Operator",
+                    "phone": "217-555-0198",
+                },
+            )
+            return await mutate_eom_operator_contact(provider, command)
+
+        async def inbound_create():
+            return await resolve_or_create_eom_inbound_lead(
+                provider,
+                full_name="Cross Writer Inbound",
+                phone="(217) 555-0198",
+                email=None,
+                address=None,
+                source="web",
+                source_ref="web-cross-writer",
+            )
+
+        operator_task = asyncio.create_task(operator_create())
+        await asyncio.wait_for(first_locked.wait(), timeout=2)
+        inbound_task = asyncio.create_task(inbound_create())
+        await asyncio.wait_for(second_waiting.wait(), timeout=2)
+        release_first.set()
+        operator_result, inbound_result = await asyncio.gather(
+            operator_task,
+            inbound_task,
+        )
+
+        assert operator_result["contact_id"] == str(inbound_result["id"])
+        async with pool.acquire() as check:
+            assert await check.fetchval("SELECT COUNT(*) FROM contacts") == 1
+            assert await check.fetchval(
+                """
+                SELECT COUNT(*)
+                FROM contacts
+                WHERE RIGHT(REGEXP_REPLACE(COALESCE(phone, ''), '[^0-9]', '', 'g'), 10)
+                    = '2175550198'
+                """
+            ) == 1
+    finally:
+        release_first.set()
+        if pool is not None:
+            await pool.close()
+        await setup.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        await setup.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("field", "claimed_value", "original_value"),
+    (
+        ("phone", "217-555-0197", "217-555-0196"),
+        ("email", "owned@example.com", "target@example.com"),
+    ),
+)
+async def test_operator_contact_mutation_rejects_explicit_id_identity_collision(
+    field: str,
+    claimed_value: str,
+    original_value: str,
+):
+    database_url = _database_url_or_skip()
+    schema = f"atlas_eom_operator_identity_collision_{uuid.uuid4().hex}"
+    conn = await asyncpg.connect(database_url)
+    try:
+        await _prepare_schema(conn, schema, apply_privilege_migration=False)
+        provider = DatabaseCRMProvider(pool=conn)
+        target_id = uuid.uuid4()
+        owner_id = uuid.uuid4()
+        await _insert_contact(
+            conn,
+            contact_id=target_id,
+            full_name="Target Contact",
+            phone=original_value if field == "phone" else "2175550196",
+            email=original_value if field == "email" else "target@example.com",
+        )
+        await _insert_contact(
+            conn,
+            contact_id=owner_id,
+            full_name="Identity Owner",
+            phone=claimed_value if field == "phone" else "2175550197",
+            email=claimed_value if field == "email" else "owned@example.com",
+        )
+        command = EOMOperatorContactMutation.from_raw(
+            operation_key=f"operator-explicit-collision-{uuid.uuid4().hex}",
+            actor_id=8,
+            actor_name="Juan Canfield",
+            source_channel="time_tracker",
+            source_ref=f"customer:collision-{field}",
+            contact_id=str(target_id),
+            fields={field: claimed_value},
+        )
+
+        with pytest.raises(EOMOperatorContactMutationError) as exc_info:
+            await mutate_eom_operator_contact(provider, command)
+
+        assert exc_info.value.status_code == 409
+        target = await conn.fetchrow("SELECT phone, email FROM contacts WHERE id = $1", target_id)
+        owner = await conn.fetchrow("SELECT phone, email FROM contacts WHERE id = $1", owner_id)
+        assert target[field] == original_value
+        assert owner[field] == claimed_value
+        assert await conn.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM eom_lead_lifecycle_events
+            WHERE event_type = 'contact_updated'
+            """
+        ) == 0
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_operator_contact_mutation_rejects_ambiguous_exact_identity():
+    database_url = _database_url_or_skip()
+    schema = f"atlas_eom_operator_ambiguous_{uuid.uuid4().hex}"
+    conn = await asyncpg.connect(database_url)
+    try:
+        await _prepare_schema(conn, schema, apply_privilege_migration=False)
+        provider = DatabaseCRMProvider(pool=conn)
+        await _insert_contact(
+            conn,
+            contact_id=uuid.uuid4(),
+            full_name="First Exact Phone",
+            phone="12175550100",
+            contact_type="customer",
+            lead_stage=None,
+        )
+        await _insert_contact(
+            conn,
+            contact_id=uuid.uuid4(),
+            full_name="Second Exact Phone",
+            phone="2175550100",
+            contact_type="customer",
+            lead_stage=None,
+        )
+        command = EOMOperatorContactMutation.from_raw(
+            operation_key=f"operator-ambiguous-{uuid.uuid4().hex}",
+            actor_id=9,
+            actor_name="Juan Canfield",
+            source_channel="time_tracker",
+            source_ref="customer:45",
+            fields={"phone": "(217) 555-0100", "email": "new@example.com"},
+        )
+
+        with pytest.raises(EOMOperatorContactMutationError) as exc_info:
+            await mutate_eom_operator_contact(provider, command)
+
+        assert exc_info.value.status_code == 409
+        assert await conn.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM eom_lead_lifecycle_events
+            WHERE event_type IN ('contact_created', 'contact_updated')
+            """
+        ) == 0
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_operator_contact_mutation_rejects_unsupported_existing_contact_type():
+    database_url = _database_url_or_skip()
+    schema = f"atlas_eom_operator_bad_type_{uuid.uuid4().hex}"
+    conn = await asyncpg.connect(database_url)
+    try:
+        await _prepare_schema(conn, schema, apply_privilege_migration=False)
+        provider = DatabaseCRMProvider(pool=conn)
+        contact_id = uuid.uuid4()
+        await _insert_contact(
+            conn,
+            contact_id=contact_id,
+            business_context_id=None,
+            full_name="Legacy Vendor",
+            contact_type="vendor",
+            lead_stage=None,
+            phone="2175550100",
+            email="vendor@example.com",
+        )
+        command = EOMOperatorContactMutation.from_raw(
+            operation_key=f"operator-bad-type-{uuid.uuid4().hex}",
+            actor_id=10,
+            actor_name="Juan Canfield",
+            source_channel="time_tracker",
+            source_ref="customer:46",
+            contact_id=str(contact_id),
+            fields={"phone": "217-555-0100", "notes": "not an EOM customer"},
+        )
+
+        with pytest.raises(EOMOperatorContactMutationError) as exc_info:
+            await mutate_eom_operator_contact(provider, command)
+
+        assert exc_info.value.status_code == 409
+        row = await conn.fetchrow("SELECT * FROM contacts WHERE id = $1", contact_id)
+        assert row["business_context_id"] is None
+        assert row["contact_type"] == "vendor"
+        assert row["phone"] == "2175550100"
+        assert row["notes"] is None
+        assert await conn.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM eom_lead_lifecycle_events
+            WHERE event_type IN ('contact_created', 'contact_updated')
+            """
+        ) == 0
+    finally:
+        await conn.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_eom_lead_conversion_integration.py
+++ b/tests/test_eom_lead_conversion_integration.py
@@ -574,6 +574,56 @@ async def test_operator_and_inbound_contact_writers_share_phone_identity_lock():
 
 
 @pytest.mark.asyncio
+async def test_operator_contact_mutation_claims_legacy_contact_by_padded_email():
+    database_url = _database_url_or_skip()
+    schema = f"atlas_eom_operator_email_claim_{uuid.uuid4().hex}"
+    conn = await asyncpg.connect(database_url)
+    try:
+        await _prepare_schema(conn, schema, apply_privilege_migration=False)
+        provider = DatabaseCRMProvider(pool=conn)
+        contact_id = uuid.uuid4()
+        await _insert_contact(
+            conn,
+            contact_id=contact_id,
+            business_context_id=None,
+            full_name="Padded Email Legacy",
+            contact_type="customer",
+            lead_stage=None,
+            email=" Ada.Example@Example.COM ",
+            phone=None,
+            source="legacy",
+        )
+        command = EOMOperatorContactMutation.from_raw(
+            operation_key=f"operator-padded-email-{uuid.uuid4().hex}",
+            actor_id=8,
+            actor_name="Juan Canfield",
+            source_channel="time_tracker",
+            source_ref="customer:padded-email",
+            fields={"email": "ada.example@example.com", "notes": "claimed"},
+        )
+
+        updated = await mutate_eom_operator_contact(provider, command)
+
+        assert updated["operation"] == "contact_updated"
+        assert updated["contact_id"] == str(contact_id)
+        row = await conn.fetchrow("SELECT * FROM contacts WHERE id = $1", contact_id)
+        assert row["business_context_id"] == "effingham_maids"
+        assert row["email"] == "ada.example@example.com"
+        assert row["notes"] == "claimed"
+        assert await conn.fetchval("SELECT COUNT(*) FROM contacts") == 1
+        assert await conn.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM eom_lead_lifecycle_events
+            WHERE contact_id = $1 AND event_type = 'contact_updated'
+            """,
+            contact_id,
+        ) == 1
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("field", "claimed_value", "original_value"),
     (
@@ -606,7 +656,11 @@ async def test_operator_contact_mutation_rejects_explicit_id_identity_collision(
             contact_id=owner_id,
             full_name="Identity Owner",
             phone=claimed_value if field == "phone" else "2175550197",
-            email=claimed_value if field == "email" else "owned@example.com",
+            email=(
+                f" {claimed_value.upper()} "
+                if field == "email"
+                else "owned@example.com"
+            ),
         )
         command = EOMOperatorContactMutation.from_raw(
             operation_key=f"operator-explicit-collision-{uuid.uuid4().hex}",
@@ -622,10 +676,14 @@ async def test_operator_contact_mutation_rejects_explicit_id_identity_collision(
             await mutate_eom_operator_contact(provider, command)
 
         assert exc_info.value.status_code == 409
-        target = await conn.fetchrow("SELECT phone, email FROM contacts WHERE id = $1", target_id)
-        owner = await conn.fetchrow("SELECT phone, email FROM contacts WHERE id = $1", owner_id)
+        target = await conn.fetchrow(
+            "SELECT phone, email FROM contacts WHERE id = $1", target_id
+        )
+        owner = await conn.fetchrow(
+            "SELECT phone, email FROM contacts WHERE id = $1", owner_id
+        )
         assert target[field] == original_value
-        assert owner[field] == claimed_value
+        assert owner[field].strip().lower() == claimed_value
         assert await conn.fetchval(
             """
             SELECT COUNT(*)

--- a/tests/test_eom_lead_conversion_integration.py
+++ b/tests/test_eom_lead_conversion_integration.py
@@ -931,6 +931,91 @@ async def test_operator_contact_mutation_rejects_ambiguous_exact_identity():
 
 
 @pytest.mark.asyncio
+async def test_operator_contact_mutation_matches_stored_phone_with_extension():
+    database_url = _database_url_or_skip()
+    schema = f"atlas_eom_operator_extension_match_{uuid.uuid4().hex}"
+    conn = await asyncpg.connect(database_url)
+    try:
+        await _prepare_schema(conn, schema, apply_privilege_migration=False)
+        provider = DatabaseCRMProvider(pool=conn)
+        contact_id = uuid.uuid4()
+        await _insert_contact(
+            conn,
+            contact_id=contact_id,
+            business_context_id=None,
+            full_name="Legacy Extension Match",
+            phone="2175550100 ext 123",
+            contact_type="customer",
+            lead_stage=None,
+        )
+        command = EOMOperatorContactMutation.from_raw(
+            operation_key=f"operator-extension-match-{uuid.uuid4().hex}",
+            actor_id=9,
+            actor_name="Juan Canfield",
+            source_channel="time_tracker",
+            source_ref="customer:extension-match",
+            fields={"phone": "217-555-0100", "email": "extension@example.com"},
+        )
+
+        result = await mutate_eom_operator_contact(provider, command)
+
+        assert result["contact_id"] == str(contact_id)
+        rows = await conn.fetch("SELECT id, phone, email FROM contacts ORDER BY id")
+        assert len(rows) == 1
+        assert rows[0]["id"] == contact_id
+        assert rows[0]["phone"] == "2175550100"
+        assert rows[0]["email"] == "extension@example.com"
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_operator_contact_mutation_does_not_match_extension_suffix():
+    database_url = _database_url_or_skip()
+    schema = f"atlas_eom_operator_extension_suffix_{uuid.uuid4().hex}"
+    conn = await asyncpg.connect(database_url)
+    try:
+        await _prepare_schema(conn, schema, apply_privilege_migration=False)
+        provider = DatabaseCRMProvider(pool=conn)
+        existing_id = uuid.uuid4()
+        await _insert_contact(
+            conn,
+            contact_id=existing_id,
+            business_context_id=None,
+            full_name="Legacy Extension Suffix",
+            phone="2175550100 ext 123",
+            email="legacy-extension@example.com",
+            contact_type="customer",
+            lead_stage=None,
+        )
+        command = EOMOperatorContactMutation.from_raw(
+            operation_key=f"operator-extension-suffix-{uuid.uuid4().hex}",
+            actor_id=9,
+            actor_name="Juan Canfield",
+            source_channel="time_tracker",
+            source_ref="customer:extension-suffix",
+            fields={
+                "full_name": "Extension Suffix New Contact",
+                "phone": "555-010-0123",
+                "email": "suffix@example.com",
+            },
+        )
+
+        result = await mutate_eom_operator_contact(provider, command)
+
+        assert result["contact_id"] != str(existing_id)
+        rows = await conn.fetch(
+            "SELECT id, phone, email FROM contacts ORDER BY email"
+        )
+        assert len(rows) == 2
+        legacy = next(row for row in rows if row["id"] == existing_id)
+        assert legacy["phone"] == "2175550100 ext 123"
+        assert legacy["email"] == "legacy-extension@example.com"
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
 async def test_operator_contact_mutation_rejects_unsupported_existing_contact_type():
     database_url = _database_url_or_skip()
     schema = f"atlas_eom_operator_bad_type_{uuid.uuid4().hex}"

--- a/tests/test_eom_lead_conversion_integration.py
+++ b/tests/test_eom_lead_conversion_integration.py
@@ -696,6 +696,63 @@ async def test_operator_contact_mutation_rejects_explicit_id_identity_collision(
 
 
 @pytest.mark.asyncio
+async def test_operator_contact_mutation_rejects_ambiguous_direct_provenance():
+    database_url = _database_url_or_skip()
+    schema = f"atlas_eom_operator_ambiguous_source_{uuid.uuid4().hex}"
+    conn = await asyncpg.connect(database_url)
+    try:
+        await _prepare_schema(conn, schema, apply_privilege_migration=False)
+        provider = DatabaseCRMProvider(pool=conn)
+        first_id = uuid.uuid4()
+        second_id = uuid.uuid4()
+        for contact_id, full_name in (
+            (first_id, "First Manual Customer"),
+            (second_id, "Second Manual Customer"),
+        ):
+            await _insert_contact(
+                conn,
+                contact_id=contact_id,
+                full_name=full_name,
+                contact_type="customer",
+                lead_stage=None,
+                source="manual",
+            )
+            await conn.execute(
+                """
+                UPDATE contacts
+                SET source_ref = 'time_tracker:customer:duplicate'
+                WHERE id = $1
+                """,
+                contact_id,
+            )
+        command = EOMOperatorContactMutation.from_raw(
+            operation_key=f"operator-ambiguous-source-{uuid.uuid4().hex}",
+            actor_id=9,
+            actor_name="Juan Canfield",
+            source_channel="time_tracker",
+            source_ref="customer:duplicate",
+            fields={"full_name": "Wrong Target"},
+        )
+
+        with pytest.raises(EOMOperatorContactMutationError) as exc_info:
+            await mutate_eom_operator_contact(provider, command)
+
+        assert exc_info.value.status_code == 409
+        assert await conn.fetchval(
+            "SELECT COUNT(*) FROM contacts WHERE full_name = 'Wrong Target'"
+        ) == 0
+        assert await conn.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM eom_lead_lifecycle_events
+            WHERE event_type IN ('contact_created', 'contact_updated')
+            """
+        ) == 0
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
 async def test_operator_contact_mutation_rejects_ambiguous_exact_identity():
     database_url = _database_url_or_skip()
     schema = f"atlas_eom_operator_ambiguous_{uuid.uuid4().hex}"

--- a/tests/test_eom_lead_conversion_integration.py
+++ b/tests/test_eom_lead_conversion_integration.py
@@ -352,6 +352,24 @@ async def test_operator_contact_mutation_creates_replays_and_records_actor():
             operation_key,
         ) == 1
 
+        crossed_actor = EOMOperatorContactMutation.from_raw(
+            operation_key=operation_key,
+            actor_id=9,
+            actor_name="Other Operator",
+            source_channel="time_tracker",
+            source_ref="customer:88",
+            contact_type="customer",
+            fields={
+                "full_name": "Operator Created",
+                "email": "operator@example.com",
+                "phone": "2175550100",
+                "address": "",
+            },
+        )
+        with pytest.raises(EOMOperatorContactMutationError) as exc_info:
+            await mutate_eom_operator_contact(provider, crossed_actor)
+        assert exc_info.value.status_code == 409
+
         conflict = EOMOperatorContactMutation.from_raw(
             operation_key=operation_key,
             actor_id=7,

--- a/tests/test_eom_lead_conversion_integration.py
+++ b/tests/test_eom_lead_conversion_integration.py
@@ -623,6 +623,87 @@ async def test_operator_and_inbound_contact_writers_share_phone_identity_lock():
 
 
 @pytest.mark.asyncio
+async def test_operator_contact_mutation_crossed_identities_fail_without_deadlock():
+    database_url = _database_url_or_skip()
+    schema = f"atlas_eom_operator_stable_row_locks_{uuid.uuid4().hex}"
+    setup = await asyncpg.connect(database_url)
+    pool = None
+    try:
+        await _prepare_schema(setup, schema, apply_privilege_migration=False)
+        first_id = uuid.uuid4()
+        second_id = uuid.uuid4()
+        await _insert_contact(
+            setup,
+            contact_id=first_id,
+            full_name="First Identity",
+            phone="2175550101",
+            email="first@example.com",
+            contact_type="customer",
+            lead_stage=None,
+        )
+        await _insert_contact(
+            setup,
+            contact_id=second_id,
+            full_name="Second Identity",
+            phone="2175550102",
+            email="second@example.com",
+            contact_type="customer",
+            lead_stage=None,
+        )
+        pool = await asyncpg.create_pool(
+            database_url,
+            min_size=2,
+            max_size=2,
+            server_settings={"search_path": f'"{schema}", public'},
+        )
+        provider = DatabaseCRMProvider(pool=pool)
+
+        first_command = EOMOperatorContactMutation.from_raw(
+            operation_key=f"operator-crossed-a-{uuid.uuid4().hex}",
+            actor_id=8,
+            actor_name="Juan Canfield",
+            source_channel="time_tracker",
+            source_ref="customer:crossed-a",
+            fields={"phone": "217-555-0101", "email": "second@example.com"},
+        )
+        second_command = EOMOperatorContactMutation.from_raw(
+            operation_key=f"operator-crossed-b-{uuid.uuid4().hex}",
+            actor_id=8,
+            actor_name="Juan Canfield",
+            source_channel="time_tracker",
+            source_ref="customer:crossed-b",
+            fields={"phone": "217-555-0102", "email": "first@example.com"},
+        )
+
+        results = await asyncio.wait_for(
+            asyncio.gather(
+                mutate_eom_operator_contact(provider, first_command),
+                mutate_eom_operator_contact(provider, second_command),
+                return_exceptions=True,
+            ),
+            timeout=5,
+        )
+
+        assert all(
+            isinstance(result, EOMOperatorContactMutationError)
+            and result.status_code == 409
+            for result in results
+        )
+        assert await setup.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM eom_lead_lifecycle_events
+            WHERE event_type IN ('contact_created', 'contact_updated')
+            """
+        ) == 0
+    finally:
+        if pool is not None:
+            await pool.close()
+        await setup.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        await setup.close()
+
+
+@pytest.mark.asyncio
 async def test_operator_contact_mutation_claims_legacy_contact_by_padded_email():
     database_url = _database_url_or_skip()
     schema = f"atlas_eom_operator_email_claim_{uuid.uuid4().hex}"

--- a/tests/test_eom_lead_conversion_integration.py
+++ b/tests/test_eom_lead_conversion_integration.py
@@ -949,7 +949,13 @@ async def test_operator_contact_mutation_rejects_ambiguous_exact_identity():
 
 
 @pytest.mark.asyncio
-async def test_operator_contact_mutation_matches_stored_phone_with_extension():
+@pytest.mark.parametrize(
+    "stored_phone",
+    ("2175550100 ext 123", "2175550100x123"),
+)
+async def test_operator_contact_mutation_matches_stored_phone_with_extension(
+    stored_phone: str,
+):
     database_url = _database_url_or_skip()
     schema = f"atlas_eom_operator_extension_match_{uuid.uuid4().hex}"
     conn = await asyncpg.connect(database_url)
@@ -962,7 +968,7 @@ async def test_operator_contact_mutation_matches_stored_phone_with_extension():
             contact_id=contact_id,
             business_context_id=None,
             full_name="Legacy Extension Match",
-            phone="2175550100 ext 123",
+            phone=stored_phone,
             contact_type="customer",
             lead_stage=None,
         )
@@ -988,7 +994,13 @@ async def test_operator_contact_mutation_matches_stored_phone_with_extension():
 
 
 @pytest.mark.asyncio
-async def test_operator_contact_mutation_does_not_match_extension_suffix():
+@pytest.mark.parametrize(
+    "stored_phone",
+    ("2175550100 ext 123", "2175550100x123"),
+)
+async def test_operator_contact_mutation_does_not_match_extension_suffix(
+    stored_phone: str,
+):
     database_url = _database_url_or_skip()
     schema = f"atlas_eom_operator_extension_suffix_{uuid.uuid4().hex}"
     conn = await asyncpg.connect(database_url)
@@ -1001,7 +1013,7 @@ async def test_operator_contact_mutation_does_not_match_extension_suffix():
             contact_id=existing_id,
             business_context_id=None,
             full_name="Legacy Extension Suffix",
-            phone="2175550100 ext 123",
+            phone=stored_phone,
             email="legacy-extension@example.com",
             contact_type="customer",
             lead_stage=None,
@@ -1027,7 +1039,7 @@ async def test_operator_contact_mutation_does_not_match_extension_suffix():
         )
         assert len(rows) == 2
         legacy = next(row for row in rows if row["id"] == existing_id)
-        assert legacy["phone"] == "2175550100 ext 123"
+        assert legacy["phone"] == stored_phone
         assert legacy["email"] == "legacy-extension@example.com"
     finally:
         await conn.close()
@@ -1119,6 +1131,57 @@ async def test_operator_contact_mutation_rejects_legacy_lead_without_stage():
         assert row["business_context_id"] is None
         assert row["contact_type"] == "lead"
         assert row["lead_stage"] is None
+        assert row["notes"] is None
+        assert await conn.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM eom_lead_lifecycle_events
+            WHERE event_type IN ('contact_created', 'contact_updated')
+            """
+        ) == 0
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_operator_contact_mutation_rejects_inactive_legacy_lead():
+    database_url = _database_url_or_skip()
+    schema = f"atlas_eom_operator_inactive_lead_{uuid.uuid4().hex}"
+    conn = await asyncpg.connect(database_url)
+    try:
+        await _prepare_schema(conn, schema, apply_privilege_migration=False)
+        provider = DatabaseCRMProvider(pool=conn)
+        contact_id = uuid.uuid4()
+        await _insert_contact(
+            conn,
+            contact_id=contact_id,
+            business_context_id=None,
+            full_name="Inactive Legacy Lead",
+            contact_type="lead",
+            lead_stage="new",
+            status="inactive",
+            phone="2175550100",
+            email="inactive-lead@example.com",
+        )
+        command = EOMOperatorContactMutation.from_raw(
+            operation_key=f"operator-inactive-lead-{uuid.uuid4().hex}",
+            actor_id=10,
+            actor_name="Juan Canfield",
+            source_channel="time_tracker",
+            source_ref="lead:inactive",
+            contact_id=str(contact_id),
+            fields={"phone": "217-555-0100", "notes": "needs active status"},
+        )
+
+        with pytest.raises(EOMOperatorContactMutationError) as exc_info:
+            await mutate_eom_operator_contact(provider, command)
+
+        assert exc_info.value.status_code == 409
+        row = await conn.fetchrow("SELECT * FROM contacts WHERE id = $1", contact_id)
+        assert row["business_context_id"] is None
+        assert row["contact_type"] == "lead"
+        assert row["lead_stage"] == "new"
+        assert row["status"] == "inactive"
         assert row["notes"] is None
         assert await conn.fetchval(
             """

--- a/tests/test_eom_lead_conversion_integration.py
+++ b/tests/test_eom_lead_conversion_integration.py
@@ -719,7 +719,7 @@ async def test_operator_contact_mutation_claims_legacy_contact_by_padded_email()
             full_name="Padded Email Legacy",
             contact_type="customer",
             lead_stage=None,
-            email=" Ada.Example@Example.COM ",
+            email="\tAda.Example@Example.COM\n",
             phone=None,
             source="legacy",
         )
@@ -787,7 +787,7 @@ async def test_operator_contact_mutation_rejects_explicit_id_identity_collision(
             full_name="Identity Owner",
             phone=claimed_value if field == "phone" else "2175550197",
             email=(
-                f" {claimed_value.upper()} "
+                f"\t{claimed_value.upper()}\n"
                 if field == "email"
                 else "owned@example.com"
             ),

--- a/tests/test_eom_lead_conversion_integration.py
+++ b/tests/test_eom_lead_conversion_integration.py
@@ -524,6 +524,68 @@ async def test_operator_contact_mutation_rejects_non_object_contact_metadata():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "source_metadata",
+    (
+        ["time_tracker:customer:malformed-provenance"],
+        {"time_tracker:customer:malformed-provenance": "not-a-record"},
+    ),
+)
+async def test_operator_contact_mutation_rejects_malformed_source_provenance(
+    source_metadata: object,
+):
+    database_url = _database_url_or_skip()
+    schema = f"atlas_eom_operator_bad_source_metadata_{uuid.uuid4().hex}"
+    conn = await asyncpg.connect(database_url)
+    try:
+        await _prepare_schema(conn, schema, apply_privilege_migration=False)
+        provider = DatabaseCRMProvider(pool=conn)
+        contact_id = uuid.uuid4()
+        metadata = {"eom_operator_contact_sources": source_metadata}
+        await _insert_contact(
+            conn,
+            contact_id=contact_id,
+            full_name="Malformed Source Metadata",
+            phone="2175550100",
+            contact_type="customer",
+            lead_stage=None,
+            source="legacy",
+        )
+        await conn.execute(
+            "UPDATE contacts SET metadata = $2::jsonb WHERE id = $1",
+            contact_id,
+            json.dumps(metadata, sort_keys=True),
+        )
+        command = EOMOperatorContactMutation.from_raw(
+            operation_key=f"operator-bad-source-metadata-{uuid.uuid4().hex}",
+            actor_id=8,
+            actor_name="Juan Canfield",
+            source_channel="time_tracker",
+            source_ref="customer:malformed-provenance",
+            fields={"full_name": "Must Not Mutate"},
+        )
+
+        with pytest.raises(EOMOperatorContactMutationError) as exc_info:
+            await mutate_eom_operator_contact(provider, command)
+
+        assert exc_info.value.status_code == 409
+        row = await conn.fetchrow(
+            "SELECT full_name, metadata::text FROM contacts WHERE id = $1", contact_id
+        )
+        assert row["full_name"] == "Malformed Source Metadata"
+        assert json.loads(row["metadata"]) == metadata
+        assert await conn.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM eom_lead_lifecycle_events
+            WHERE event_type IN ('contact_created', 'contact_updated')
+            """
+        ) == 0
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
 async def test_inbound_atomic_uses_ascii_phone_normalizer_for_relay_identity():
     database_url = _database_url_or_skip()
     schema = f"atlas_eom_inbound_unicode_phone_{uuid.uuid4().hex}"
@@ -951,7 +1013,7 @@ async def test_operator_contact_mutation_rejects_ambiguous_exact_identity():
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "stored_phone",
-    ("2175550100 ext 123", "2175550100x123"),
+    ("2175550100 ext 123", "2175550100x123", "fax2175550100"),
 )
 async def test_operator_contact_mutation_matches_stored_phone_with_extension(
     stored_phone: str,

--- a/tests/test_eom_lead_conversion_integration.py
+++ b/tests/test_eom_lead_conversion_integration.py
@@ -1083,6 +1083,55 @@ async def test_operator_contact_mutation_rejects_unsupported_existing_contact_ty
 
 
 @pytest.mark.asyncio
+async def test_operator_contact_mutation_rejects_legacy_lead_without_stage():
+    database_url = _database_url_or_skip()
+    schema = f"atlas_eom_operator_bad_stage_{uuid.uuid4().hex}"
+    conn = await asyncpg.connect(database_url)
+    try:
+        await _prepare_schema(conn, schema, apply_privilege_migration=False)
+        provider = DatabaseCRMProvider(pool=conn)
+        contact_id = uuid.uuid4()
+        await _insert_contact(
+            conn,
+            contact_id=contact_id,
+            business_context_id=None,
+            full_name="Legacy Unstaged Lead",
+            contact_type="lead",
+            lead_stage=None,
+            phone="2175550100",
+            email="unstaged@example.com",
+        )
+        command = EOMOperatorContactMutation.from_raw(
+            operation_key=f"operator-bad-stage-{uuid.uuid4().hex}",
+            actor_id=10,
+            actor_name="Juan Canfield",
+            source_channel="time_tracker",
+            source_ref="lead:unstaged",
+            contact_id=str(contact_id),
+            fields={"phone": "217-555-0100", "notes": "needs funnel stage"},
+        )
+
+        with pytest.raises(EOMOperatorContactMutationError) as exc_info:
+            await mutate_eom_operator_contact(provider, command)
+
+        assert exc_info.value.status_code == 409
+        row = await conn.fetchrow("SELECT * FROM contacts WHERE id = $1", contact_id)
+        assert row["business_context_id"] is None
+        assert row["contact_type"] == "lead"
+        assert row["lead_stage"] is None
+        assert row["notes"] is None
+        assert await conn.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM eom_lead_lifecycle_events
+            WHERE event_type IN ('contact_created', 'contact_updated')
+            """
+        ) == 0
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
 async def test_eom_lead_review_projection_is_closed_filtered_and_read_only():
     database_url = _database_url_or_skip()
     schema = f"atlas_eom_lead_review_{uuid.uuid4().hex}"

--- a/tests/test_eom_lead_conversion_integration.py
+++ b/tests/test_eom_lead_conversion_integration.py
@@ -457,6 +457,55 @@ async def test_operator_contact_mutation_updates_exact_match_and_claims_legacy()
 
 
 @pytest.mark.asyncio
+async def test_operator_contact_mutation_rejects_non_object_contact_metadata():
+    database_url = _database_url_or_skip()
+    schema = f"atlas_eom_operator_non_object_metadata_{uuid.uuid4().hex}"
+    conn = await asyncpg.connect(database_url)
+    try:
+        await _prepare_schema(conn, schema, apply_privilege_migration=False)
+        provider = DatabaseCRMProvider(pool=conn)
+        contact_id = uuid.uuid4()
+        await _insert_contact(
+            conn,
+            contact_id=contact_id,
+            full_name="Legacy Metadata Shape",
+            phone="2175550100",
+            contact_type="customer",
+            lead_stage=None,
+            source="legacy",
+        )
+        await conn.execute(
+            "UPDATE contacts SET metadata = '[\"legacy\"]'::jsonb WHERE id = $1",
+            contact_id,
+        )
+        command = EOMOperatorContactMutation.from_raw(
+            operation_key=f"operator-non-object-metadata-{uuid.uuid4().hex}",
+            actor_id=8,
+            actor_name="Juan Canfield",
+            source_channel="time_tracker",
+            source_ref="customer:non-object-metadata",
+            fields={"phone": "217-555-0100", "notes": "must not overwrite metadata"},
+        )
+
+        with pytest.raises(EOMOperatorContactMutationError) as exc_info:
+            await mutate_eom_operator_contact(provider, command)
+
+        assert exc_info.value.status_code == 409
+        assert await conn.fetchval(
+            "SELECT metadata::text FROM contacts WHERE id = $1", contact_id
+        ) == '["legacy"]'
+        assert await conn.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM eom_lead_lifecycle_events
+            WHERE event_type IN ('contact_created', 'contact_updated')
+            """
+        ) == 0
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
 async def test_inbound_atomic_uses_ascii_phone_normalizer_for_relay_identity():
     database_url = _database_url_or_skip()
     schema = f"atlas_eom_inbound_unicode_phone_{uuid.uuid4().hex}"

--- a/tests/test_migrations_runner.py
+++ b/tests/test_migrations_runner.py
@@ -406,6 +406,51 @@ def test_eom_lead_disposition_operation_key_index_covers_lost_and_reopen():
     assert "ALTER TABLE" not in upper
 
 
+def test_eom_operator_contact_operation_key_index_covers_contact_mutations():
+    migration = (
+        Path(__file__).resolve().parent.parent
+        / "atlas_brain"
+        / "storage"
+        / "migrations"
+        / "364_eom_operator_contact_operation_key_index.sql"
+    ).read_text()
+    upper = migration.upper()
+
+    # Replay-safe pattern (same as 357/359/362): real drop preceding the
+    # recreate, no IF NOT EXISTS on the create.
+    assert "CREATE INDEX CONCURRENTLY IF NOT EXISTS" not in migration
+    assert (
+        migration.count(
+            "DROP INDEX CONCURRENTLY IF EXISTS "
+            "idx_eom_lead_lifecycle_operator_contact_operation_key"
+        )
+        >= 2
+    )  # rollback-evidence comment + the executable statement
+    assert (
+        "CREATE INDEX CONCURRENTLY "
+        "idx_eom_lead_lifecycle_operator_contact_operation_key" in migration
+    )
+    assert migration.index(
+        "DROP INDEX CONCURRENTLY IF EXISTS "
+        "idx_eom_lead_lifecycle_operator_contact_operation_key"
+    ) < migration.index(
+        "CREATE INDEX CONCURRENTLY "
+        "idx_eom_lead_lifecycle_operator_contact_operation_key"
+    )
+    # operation_key must lead so idempotent replay/conflict checks in the
+    # operator contact mutation path are index-backed, and the predicate must
+    # cover exactly the two operator contact receipt events.
+    assert "ON eom_lead_lifecycle_events (operation_key, contact_id, event_type)" in migration
+    assert "operation_key IS NOT NULL" in migration
+    assert "'contact_created'" in migration
+    assert "'contact_updated'" in migration
+    assert "'lead_lost'" not in migration
+    assert "'estimate_booked'" not in migration
+    assert "Rollback evidence:" in migration
+    assert "DROP TABLE" not in upper
+    assert "ALTER TABLE" not in upper
+
+
 def test_eom_lead_lifecycle_sequence_is_db_owned_and_writer_compatible():
     migration = (
         Path(__file__).resolve().parent.parent

--- a/tests/test_tenant_stamping.py
+++ b/tests/test_tenant_stamping.py
@@ -178,7 +178,32 @@ async def test_generic_contact_phone_search_preserves_full_phone_extension_looku
         in pool.query
     )
     assert pool.params[0] == "%2175550100%"
-    assert pool.params[1] == "2175550100"
+    assert pool.params[1] == "%2175550100%"
+    assert pool.params[2] == "2175550100"
+
+
+@pytest.mark.asyncio
+async def test_generic_contact_phone_search_preserves_country_code_to_extension_lookup(
+):
+    from atlas_brain.services.crm_provider import DatabaseCRMProvider
+
+    class RecordingPool:
+        query = ""
+        params = ()
+
+        async def fetch(self, query, *params):
+            self.query = query
+            self.params = params
+            return []
+
+    pool = RecordingPool()
+
+    await DatabaseCRMProvider(pool=pool).search_contacts(phone="+1 217 555 0100")
+
+    assert " LIKE " in pool.query
+    assert pool.params[0] == "%12175550100%"
+    assert pool.params[1] == "%2175550100%"
+    assert pool.params[2] == "12175550100"
 
 
 @pytest.mark.asyncio

--- a/tests/test_tenant_stamping.py
+++ b/tests/test_tenant_stamping.py
@@ -155,7 +155,7 @@ def test_dict_style_writers_carry_context_key():
 
 
 @pytest.mark.asyncio
-async def test_generic_contact_phone_search_uses_exact_last10_for_full_phone(
+async def test_generic_contact_phone_search_preserves_full_phone_extension_lookup(
 ):
     from atlas_brain.services.crm_provider import DatabaseCRMProvider
 
@@ -172,12 +172,13 @@ async def test_generic_contact_phone_search_uses_exact_last10_for_full_phone(
 
     await DatabaseCRMProvider(pool=pool).search_contacts(phone="(217) 555-0100")
 
-    assert " LIKE " not in pool.query
+    assert " LIKE " in pool.query
     assert (
         "RIGHT(REGEXP_REPLACE(COALESCE(phone, ''), '[^0-9]', '', 'g'), 10)"
         in pool.query
     )
-    assert pool.params[0] == "2175550100"
+    assert pool.params[0] == "%2175550100%"
+    assert pool.params[1] == "2175550100"
 
 
 @pytest.mark.asyncio

--- a/tests/test_tenant_stamping.py
+++ b/tests/test_tenant_stamping.py
@@ -13,6 +13,8 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import pytest
+
 REPO = Path(__file__).resolve().parent.parent
 
 _asyncpg_mock = MagicMock()
@@ -150,3 +152,51 @@ def test_dict_style_writers_carry_context_key():
     assert '"business_context_id": "churnsignals"' in intake
     calendar = (REPO / "scripts/import_calendar_contacts.py").read_text(encoding="utf-8")
     assert '"business_context_id": "effingham_maids"' in calendar
+
+
+@pytest.mark.asyncio
+async def test_generic_contact_phone_search_uses_exact_last10_for_full_phone(
+):
+    from atlas_brain.services.crm_provider import DatabaseCRMProvider
+
+    class RecordingPool:
+        query = ""
+        params = ()
+
+        async def fetch(self, query, *params):
+            self.query = query
+            self.params = params
+            return []
+
+    pool = RecordingPool()
+
+    await DatabaseCRMProvider(pool=pool).search_contacts(phone="(217) 555-0100")
+
+    assert " LIKE " not in pool.query
+    assert (
+        "RIGHT(REGEXP_REPLACE(COALESCE(phone, ''), '[^0-9]', '', 'g'), 10)"
+        in pool.query
+    )
+    assert pool.params[0] == "2175550100"
+
+
+@pytest.mark.asyncio
+async def test_generic_contact_phone_search_keeps_partial_phone_substring_lookup(
+):
+    from atlas_brain.services.crm_provider import DatabaseCRMProvider
+
+    class RecordingPool:
+        query = ""
+        params = ()
+
+        async def fetch(self, query, *params):
+            self.query = query
+            self.params = params
+            return []
+
+    pool = RecordingPool()
+
+    await DatabaseCRMProvider(pool=pool).search_contacts(phone="5550100")
+
+    assert "REGEXP_REPLACE(COALESCE(phone, ''), '[^0-9]', '', 'g') LIKE" in pool.query
+    assert pool.params[0] == "%5550100%"


### PR DESCRIPTION
Plan: plans/PR-EOM-Operator-Mutation-Contract.md
Slice phase: vertical slice
Ownership lane: eom-crm/lead-funnel

Website issue #109 / Slice 0B needs the Atlas-owned operator mutation contract before the tracker or website CRM UI can stop minting or editing customers through legacy/local paths. This PR adds the authenticated Atlas route, command normalizer, provider-owned atomic create/update implementation, exact phone identity matching, lifecycle receipt/idempotency proof, and route capability advertisement without migrating any external caller yet.

Diff-budget override: this slice is over the 400 LOC soft cap because the Atlas contract is only safe as one vertical seam: the authenticated route, command normalizer, provider-owned atomic create/update path, exact identity resolver, lifecycle receipt/idempotency evidence, capability advertisement, and real DB + ASGI proofs have to land together before any tracker/website caller is migrated.

## Intentional

- No tracker, website, portal UI, onboarding, pricing, checkout, or customer-visible copy is migrated in this PR.
- No new `contacts.created_by` column or destructive contacts migration is introduced.
- Operator-created contacts map to existing `contacts.source/source_ref`; updates keep historical `source` and put operator provenance in contact metadata plus lifecycle metadata.
- Lead/customer lifecycle transitions remain owned by the existing funnel transition services; this route only edits ordinary contact fields.
- The existing provider insert block is refactored into `_insert_contact_row` so the contact-write guard still has a provider-owned persistence boundary.

## AI reconciliation

- Reject unsupported existing contact types -- fixed-in: `atlas_brain/services/crm_provider.py:1111`, `tests/test_eom_lead_conversion_integration.py:687`.
- Restrict phone normalization to SQL-compatible digits -- fixed-in: `atlas_brain/services/eom_lead_ingress.py:18`, `atlas_brain/services/eom_crm_mutations.py:111`, `tests/test_eom_lead_conversion.py:757`.
- Index contact-mutation operation-key lookups -- fixed-in: `atlas_brain/storage/migrations/364_eom_operator_contact_operation_key_index.sql:24`, `tests/test_migrations_runner.py:409`.
- Keep partial phone search behavior on the generic API -- fixed-in: `atlas_brain/services/crm_provider.py:1370`, `tests/test_tenant_stamping.py:184`.
- Reject malformed email syntax at the mutation boundary -- fixed-in: `atlas_brain/services/eom_crm_mutations.py:82`, `tests/test_eom_lead_conversion.py:757`.
- Share identity locks across EOM contact writers -- fixed-in: `atlas_brain/services/crm_provider.py:138`, `atlas_brain/services/crm_provider.py:452`, `atlas_brain/services/crm_provider.py:1234`, `tests/test_eom_lead_conversion_integration.py:494`.
- Route atomic inbound normalization through the shared helper -- fixed-in: `atlas_brain/services/crm_provider.py:435`, `atlas_brain/services/crm_provider.py:439`, `tests/test_eom_lead_conversion_integration.py:458`.
- Persist provenance before relying on sourceRef resolution -- fixed-in: `atlas_brain/services/crm_provider.py:980`, `atlas_brain/services/crm_provider.py:997`, `atlas_brain/services/crm_provider.py:1137`, `tests/test_eom_lead_conversion_integration.py:373`.
- Reject NULs before database writes -- fixed-in: `atlas_brain/services/eom_crm_mutations.py:77`, `atlas_brain/services/eom_crm_mutations.py:135`, `atlas_brain/services/eom_crm_mutations.py:203`, `tests/test_eom_lead_conversion.py:788`.
- Prevent explicit-ID updates from duplicating identities -- fixed-in: `atlas_brain/services/crm_provider.py:1064`, `atlas_brain/services/crm_provider.py:1101`, `tests/test_eom_lead_conversion_integration.py:582`.
- State the hardening parking predicate -- fixed-in: `plans/PR-EOM-Operator-Mutation-Contract.md:223`.
- Add the mandatory closure declaration -- fixed-in: `plans/PR-EOM-Operator-Mutation-Contract.md:112`.
- Preserve full-phone substring matching in the generic API -- fixed-in: `atlas_brain/services/crm_provider.py:1483`, `tests/test_tenant_stamping.py:158`.
- Define the execution model for mutation idempotency -- fixed-in: `plans/PR-EOM-Operator-Mutation-Contract.md:192`.
- Normalize stored emails during identity resolution -- fixed-in: `atlas_brain/services/crm_provider.py:1140`, `tests/test_eom_lead_conversion_integration.py:577`, `tests/test_eom_lead_conversion_integration.py:634`.
- Reject ambiguous direct provenance matches -- fixed-in: `atlas_brain/services/crm_provider.py:1084`, `tests/test_eom_lead_conversion_integration.py:699`.
- Reject phone extensions before last-ten matching -- fixed-in: `atlas_brain/services/eom_crm_mutations.py:60`, `atlas_brain/services/eom_crm_mutations.py:124`, `tests/test_eom_lead_conversion.py:756`.
- Reject lone Unicode surrogates before database writes -- fixed-in: `atlas_brain/eom_api/funnel.py:163`, `atlas_brain/services/eom_crm_mutations.py:81`, `tests/test_eom_lead_conversion.py:781`.
- Preserve non-object contact metadata during updates -- fixed-in: `atlas_brain/services/crm_provider.py:1035`, `tests/test_eom_lead_conversion_integration.py:459`.
- Acquire matched contact row locks in a stable order -- fixed-in: `atlas_brain/services/crm_provider.py:1088`, `atlas_brain/services/crm_provider.py:1135`, `tests/test_eom_lead_conversion_integration.py:625`.
- Preserve last-ten substring lookup for country-coded numbers -- fixed-in: `atlas_brain/services/crm_provider.py:1477`, `atlas_brain/services/crm_provider.py:1482`, `tests/test_tenant_stamping.py:185`.
- Normalize stored extensions before exact phone resolution -- fixed-in: `atlas_brain/services/crm_provider.py:48`, `atlas_brain/services/crm_provider.py:1135`, `tests/test_eom_lead_conversion_integration.py:934`, `tests/test_eom_lead_conversion_integration.py:973`.
- Canonicalize stored email whitespace consistently -- fixed-in: `atlas_brain/services/crm_provider.py:61`, `atlas_brain/services/crm_provider.py:1153`, `tests/test_eom_lead_conversion_integration.py:707`, `tests/test_eom_lead_conversion_integration.py:764`.
- Share the identity fence with every EOM writer -- waived-out-of-scope: the cited `atlas_brain/autonomous/tasks/email_backfill.py:198` caller is an existing legacy/backfill writer, and this PR explicitly does not migrate legacy writers; parked under Deferred legacy EOM writer identity-fence convergence.
- Bind idempotency receipts to the authenticated actor -- fixed-in: `atlas_brain/services/eom_crm_mutations.py:249`, `tests/test_eom_lead_conversion_integration.py:355`.
- Index normalized identity lookups -- waived-out-of-scope: functional contact identity indexes are post-contract performance hardening; parked under Deferred normalized contact identity functional indexes.
- Enforce mailbox component length limits -- fixed-in: `atlas_brain/services/eom_crm_mutations.py:55`, `atlas_brain/services/eom_crm_mutations.py:111`, `tests/test_eom_lead_conversion.py:755`.
- Validate legacy lead stage before claiming ownership -- fixed-in: `atlas_brain/services/crm_provider.py:158`, `atlas_brain/services/crm_provider.py:1221`, `tests/test_eom_lead_conversion_integration.py:1086`.
- Enumerate callers of every changed boundary -- fixed-in: `plans/PR-EOM-Operator-Mutation-Contract.md:149`.
- Strip delimiterless stored phone extensions -- fixed-in: `atlas_brain/services/crm_provider.py:52`, `tests/test_eom_lead_conversion_integration.py:953`, `tests/test_eom_lead_conversion_integration.py:998`.
- Sanitize surrogates across the entire request -- fixed-in: `atlas_brain/eom_api/funnel.py:67`, `atlas_brain/eom_api/funnel.py:178`, `tests/test_eom_lead_conversion.py:800`.
- Reject inactive leads before claiming ownership -- fixed-in: `atlas_brain/services/crm_provider.py:1228`, `tests/test_eom_lead_conversion_integration.py:1147`.
- Require a boundary before stored extension markers -- fixed-in: `atlas_brain/services/crm_provider.py:52`, `tests/test_eom_lead_conversion_integration.py:1015`.
- Validate provenance records before resolving them -- fixed-in: `atlas_brain/services/crm_provider.py:1107`, `atlas_brain/services/crm_provider.py:1150`, `atlas_brain/services/crm_provider.py:1203`, `tests/test_eom_lead_conversion_integration.py:526`.
- Reject present null provenance metadata -- fixed-in: `atlas_brain/services/crm_provider.py:1104`, `atlas_brain/services/crm_provider.py:1211`, `tests/test_eom_lead_conversion_integration.py:530`.
- Scope malformed-provenance checks to relevant contacts -- waived-out-of-scope: narrowing malformed legacy provenance blast radius is follow-up hardening; this PR already defines the operator mutation contract and stops here to avoid further review-driven scope growth.

## Deferred

- Tracker customer creation migration: website #110 / Slice 0C after 0B is deployed live.
- Legacy writer convergence/deprecation: website #111 and its D1-D5 children.
- Legacy EOM writer identity-fence convergence, including `atlas_brain/autonomous/tasks/email_backfill.py:198`, remains a follow-up because this PR adds the Atlas operator mutation contract and does not migrate existing autonomous/backfill callers.
- Normalized contact identity functional indexes for EOM phone/email lookup remain a follow-up because this PR proves the new operator mutation route's correctness/idempotency contract without adding another schema-hardening migration.
- Malformed legacy provenance blast-radius narrowing remains follow-up hardening because the operator mutation contract is already proven and this PR is stopping review-driven scope growth.
- Remaining #112 tracker/website capability-gating halves.
- Provenance alerting and missing-provenance observability: website #113.
- Additive source/provenance column split if a later slice needs queryable first-class fields.

## Parked hardening

- None.

## Cold diff reconstruction

- Changed: `atlas_brain/services/eom_lead_ingress.py:18` exports the shared EOM phone digit normalizer, restricts normalization to SQL-compatible ASCII digits, and uses it for inbound phone preference/resolution at `atlas_brain/services/eom_lead_ingress.py:39` and `atlas_brain/services/eom_lead_ingress.py:68`.
- Changed: `atlas_brain/services/eom_crm_mutations.py:22` defines the operator event/source/type/field allow-lists; `atlas_brain/services/eom_crm_mutations.py:81` rejects database-invalid NUL and lone-surrogate text; `atlas_brain/services/eom_crm_mutations.py:89` and `atlas_brain/services/eom_crm_mutations.py:118` normalize email and phone; `atlas_brain/services/eom_crm_mutations.py:111` rejects SMTP-invalid mailbox component lengths; `atlas_brain/services/eom_crm_mutations.py:124` rejects extension-bearing or non-ASCII phone strings before digit extraction; `atlas_brain/services/eom_crm_mutations.py:138` rejects invalid ordinary text fields; `atlas_brain/services/eom_crm_mutations.py:181` builds the immutable command; `atlas_brain/services/eom_crm_mutations.py:214` rejects invalid `sourceRef`; `atlas_brain/services/eom_crm_mutations.py:247` fingerprints normalized payloads with the authenticated actor id; `atlas_brain/services/eom_crm_mutations.py:258` prepares lifecycle metadata; `atlas_brain/services/eom_crm_mutations.py:268` delegates only to the database provider atomic method.
- Changed: `atlas_brain/eom_api/funnel.py:67` adds a full-request surrogate sanitizer; `atlas_brain/eom_api/funnel.py:133` adds the closed Pydantic request; `atlas_brain/eom_api/funnel.py:178` routes lone-surrogate values and forbidden extra keys to the domain invalid-text path before FastAPI can render an unencodable validation echo; `atlas_brain/eom_api/funnel.py:367` advertises `contact.operator_mutation`; `atlas_brain/eom_api/funnel.py:413` maps only provided request fields; `atlas_brain/eom_api/funnel.py:460` registers `POST /eom-funnel/operator-contacts`; `atlas_brain/eom_api/funnel.py:488` returns 201 for fresh mutations and 200 for idempotent replay.
- Changed: `atlas_brain/services/crm_provider.py:138` defines the shared EOM phone/email identity advisory lock key; `atlas_brain/services/crm_provider.py:435` and `atlas_brain/services/crm_provider.py:439` route atomic inbound phone identity through the shared ASCII digit normalizer; `atlas_brain/services/crm_provider.py:452` and `atlas_brain/services/crm_provider.py:1234` use the shared phone/email identity locks for inbound and operator writers.
- Changed: `atlas_brain/services/crm_provider.py:52` strips spaced and delimiterless terminal stored phone extensions for exact EOM operator identity matching while preserving labeled numbers such as `fax2175550100`; `atlas_brain/services/crm_provider.py:334` keeps provider pool lookup compatible with legacy subclasses that skip `DatabaseCRMProvider.__init__`; `atlas_brain/services/crm_provider.py:726` extracts the provider-owned contact insert helper and `atlas_brain/services/crm_provider.py:935` reuses it from `create_contact`; `atlas_brain/services/crm_provider.py:980` prepares durable operator provenance metadata; `atlas_brain/services/crm_provider.py:997` resolves operator targets by exact source, structurally valid persisted provenance, phone, or email; `atlas_brain/services/crm_provider.py:1035` fails closed instead of replacing non-object contact metadata during provenance updates; `atlas_brain/services/crm_provider.py:1104` distinguishes an absent reserved provenance key from present JSON null, `atlas_brain/services/crm_provider.py:1107` rejects malformed reserved provenance metadata, `atlas_brain/services/crm_provider.py:1150` requires exact provenance records for sourceRef resolution, and `atlas_brain/services/crm_provider.py:1211` rejects present non-object reserved provenance before duplicate creation; `atlas_brain/services/crm_provider.py:1088` resolves all exact-match candidate ids before taking contact row locks, then `atlas_brain/services/crm_provider.py:1135` strips terminal stored phone extensions before exact last-10 comparison and `atlas_brain/services/crm_provider.py:1153` trims stored email ASCII whitespace before exact lowercase comparison; the final query locks candidate rows once in deterministic id order; `atlas_brain/services/crm_provider.py:1155` keeps explicit-id collision checks on that same ordered candidate set; `atlas_brain/services/crm_provider.py:1178` fails closed on ambiguous matches; `atlas_brain/services/crm_provider.py:1184` rejects stored contact types outside `lead`/`customer`; `atlas_brain/services/crm_provider.py:1221` rejects legacy leads without supported funnel stages before claiming ownership; `atlas_brain/services/crm_provider.py:1228` rejects inactive legacy leads before claiming ownership; `atlas_brain/services/crm_provider.py:1199` updates only changed ordinary fields, claims eligible NULL-context legacy rows, and records operator provenance metadata; `atlas_brain/services/crm_provider.py:1243` creates new EOM contacts through the helper with the same provenance map; `atlas_brain/services/crm_provider.py:1263` writes lifecycle evidence; `atlas_brain/services/crm_provider.py:1300` serializes on advisory locks; `atlas_brain/services/crm_provider.py:1320` implements idempotent replay/conflict receipts.
- Changed: `atlas_brain/services/crm_provider.py:1449` keeps generic `search_contacts` on the provider pool seam, preserves full submitted-digit substring lookup, last-ten substring lookup for country-code input against stored extension numbers, short phone fragments, and normalized last-10 matching for ordinary stored numbers.
- Changed: `atlas_brain/storage/migrations/364_eom_operator_contact_operation_key_index.sql:24` adds the operation-key-leading partial index for `contact_created` and `contact_updated` lifecycle receipts.
- Changed: `tests/test_eom_lead_conversion.py:617` proves ASGI create/delegate normalization; `tests/test_eom_lead_conversion.py:654` proves HTTP 200 idempotent replay; `tests/test_eom_lead_conversion.py:710` proves disabled/auth/actor/key failures do not reach CRM; `tests/test_eom_lead_conversion.py:731` proves unsupported source channels fail before CRM; `tests/test_eom_lead_conversion.py:747` proves malformed emails, mailbox local-part overflow, Unicode digit phones, and extension-bearing phones fail before CRM; `tests/test_eom_lead_conversion.py:781` proves NUL-bearing and lone-surrogate text fields, `contactType`, and forbidden extra keys fail with 422 before CRM.
- Changed: `tests/test_eom_lead_conversion_integration.py:281` proves create, replay, crossed-actor key conflict, normalized persistence, and actor lifecycle evidence on real Postgres; `tests/test_eom_lead_conversion_integration.py:373` proves exact-match update claims NULL-context legacy contacts, records provenance metadata, and lets later sourceRef-only updates rediscover the same row; `tests/test_eom_lead_conversion_integration.py:459` proves legacy non-object contact metadata fails closed and remains unchanged; `tests/test_eom_lead_conversion_integration.py:526` proves malformed reserved source provenance fails closed without mutation; `tests/test_eom_lead_conversion_integration.py:514` proves atomic inbound relay-backed Unicode digit phones are not persisted as SQL-invisible phone identities; `tests/test_eom_lead_conversion_integration.py:550` proves overlapping operator/inbound writers contend on the shared phone identity lock and leave one contact; `tests/test_eom_lead_conversion_integration.py:626` proves crossed phone/email identity requests both fail as 409 conflicts without deadlocking; `tests/test_eom_lead_conversion_integration.py:707` proves tab/newline-padded legacy email still claims the row; `tests/test_eom_lead_conversion_integration.py:764` proves explicit-ID updates reject phone/email collisions with other contacts, including tab/newline-padded stored email; `tests/test_eom_lead_conversion_integration.py:886` proves ambiguous exact identity fails closed; `tests/test_eom_lead_conversion_integration.py:829` proves duplicate direct provenance matches fail closed; `tests/test_eom_lead_conversion_integration.py:953` and `tests/test_eom_lead_conversion_integration.py:998` prove spaced and delimiterless stored extension phones match by base number but not by extension-tainted suffix, with `tests/test_eom_lead_conversion_integration.py:1015` covering labeled stored numbers; `tests/test_eom_lead_conversion_integration.py:1018` proves unsupported stored contact types cannot be claimed or mutated; `tests/test_eom_lead_conversion_integration.py:1086` proves legacy leads without a funnel stage cannot be claimed or mutated; `tests/test_eom_lead_conversion_integration.py:1147` proves inactive legacy leads cannot be claimed or mutated.
- Changed: `tests/test_tenant_stamping.py:157` proves full generic phone search preserves substring plus exact last-10 matching; `tests/test_tenant_stamping.py:185` proves country-code generic input keeps last-ten substring compatibility with stored extension numbers; `tests/test_tenant_stamping.py:209` proves short generic phone search still uses substring lookup; `tests/contact_write_boundary/baseline.json:29` refreshes the writer inventory for the new provider-owned dynamic update site; `tests/test_contact_write_boundary.py:500` pins the consciously widened provider UPDATE inventory at ten statements.
- Changed: `tests/test_migrations_runner.py:409` proves the new operator-contact operation-key migration uses the replay-safe concurrent drop/recreate pattern and covers only the new contact mutation receipt events.
- Contract match: the diff adds one authenticated Atlas route, one domain command/normalizer, one provider-owned atomic mutation path, shared exact phone identity behavior, lifecycle/idempotency evidence, route capability advertisement, HTTP-boundary tests, real-Postgres provider tests, and contact-write boundary proof.
- Gaps: none known. No external caller migration, customer-visible surface, destructive schema change, lifecycle transition replacement, or out-of-provider contact insert is included.

## Verification

- `python -m py_compile atlas_brain/eom_api/funnel.py atlas_brain/services/crm_provider.py atlas_brain/services/eom_lead_ingress.py atlas_brain/services/eom_crm_mutations.py tests/test_eom_lead_conversion.py tests/test_eom_lead_conversion_integration.py tests/test_tenant_stamping.py tests/test_migrations_runner.py tests/test_contact_write_boundary.py` - passed.
- `python -m py_compile atlas_brain/services/crm_provider.py tests/test_tenant_stamping.py tests/test_eom_lead_conversion_integration.py` - passed.
- `python -m pytest tests/test_tenant_stamping.py::test_generic_contact_phone_search_preserves_full_phone_extension_lookup tests/test_tenant_stamping.py::test_generic_contact_phone_search_keeps_partial_phone_substring_lookup -q` - 2 passed.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_claims_legacy_contact_by_padded_email 'tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_explicit_id_identity_collision[email-owned@example.com-target@example.com]' -q` - 2 passed.
- `python -m py_compile atlas_brain/services/crm_provider.py tests/test_eom_lead_conversion_integration.py` - passed.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_ambiguous_direct_provenance -q` - 1 passed.
- `python -m pytest tests/test_eom_lead_conversion.py tests/test_tenant_stamping.py tests/test_migrations_runner.py tests/test_contact_write_boundary.py -q` - 293 passed, 1 skipped, 1 warning.
- `python -m py_compile atlas_brain/services/eom_crm_mutations.py atlas_brain/services/crm_provider.py tests/test_eom_lead_conversion.py tests/test_eom_lead_conversion_integration.py` - passed.
- `python -m pytest tests/test_eom_lead_conversion.py::test_private_operator_contact_rejects_nul_text_before_crm_call -q` - 7 passed.
- `python -m py_compile atlas_brain/eom_api/funnel.py atlas_brain/services/eom_crm_mutations.py atlas_brain/services/crm_provider.py tests/test_eom_lead_conversion.py tests/test_eom_lead_conversion_integration.py` - passed.
- `python -m pytest tests/test_eom_lead_conversion.py::test_private_operator_contact_rejects_malformed_identity_before_crm_call tests/test_eom_lead_conversion.py::test_private_operator_contact_rejects_database_invalid_text_before_crm_call -q` - 19 passed.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_non_object_contact_metadata -q` - 1 passed.
- `python -m py_compile atlas_brain/services/crm_provider.py tests/test_eom_lead_conversion_integration.py` - passed.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_crossed_identities_fail_without_deadlock -q` - 1 passed.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_explicit_id_identity_collision tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_ambiguous_exact_identity tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_ambiguous_direct_provenance -q` - 4 passed.
- `python -m py_compile atlas_brain/services/crm_provider.py tests/test_tenant_stamping.py` - passed.
- `python -m pytest tests/test_tenant_stamping.py::test_generic_contact_phone_search_preserves_full_phone_extension_lookup tests/test_tenant_stamping.py::test_generic_contact_phone_search_preserves_country_code_to_extension_lookup tests/test_tenant_stamping.py::test_generic_contact_phone_search_keeps_partial_phone_substring_lookup -q` - 3 passed.
- `python -m py_compile atlas_brain/services/crm_provider.py tests/test_eom_lead_conversion_integration.py` - passed.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_matches_stored_phone_with_extension tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_does_not_match_extension_suffix -q` - 2 passed.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_explicit_id_identity_collision tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_ambiguous_exact_identity tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_ambiguous_direct_provenance tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_crossed_identities_fail_without_deadlock tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_matches_stored_phone_with_extension tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_does_not_match_extension_suffix -q` - 7 passed.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_claims_legacy_contact_by_padded_email 'tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_explicit_id_identity_collision[email-owned@example.com-target@example.com]' -q` - 2 passed.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_claims_legacy_contact_by_padded_email tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_explicit_id_identity_collision tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_ambiguous_exact_identity tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_ambiguous_direct_provenance tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_crossed_identities_fail_without_deadlock tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_matches_stored_phone_with_extension tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_does_not_match_extension_suffix -q` - 8 passed.
- `python -m py_compile atlas_brain/services/eom_crm_mutations.py tests/test_eom_lead_conversion_integration.py` - passed.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_creates_replays_and_records_actor -q` - 1 passed.
- `python -m py_compile atlas_brain/services/eom_crm_mutations.py atlas_brain/services/crm_provider.py tests/test_eom_lead_conversion.py tests/test_eom_lead_conversion_integration.py` - passed.
- `python -m pytest tests/test_eom_lead_conversion.py::test_private_operator_contact_rejects_malformed_identity_before_crm_call -q` - 6 passed.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_legacy_lead_without_stage -q` - 1 passed.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_explicit_id_identity_collision -q` - 2 passed.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py -q -k "operator_contact_mutation or inbound_atomic_uses_ascii_phone_normalizer or share_phone_identity_lock"` - 8 passed, 46 deselected.
- `python -m py_compile atlas_brain/eom_api/funnel.py atlas_brain/services/crm_provider.py tests/test_eom_lead_conversion.py tests/test_eom_lead_conversion_integration.py` - passed.
- `python -m pytest tests/test_eom_lead_conversion.py::test_private_operator_contact_rejects_database_invalid_text_before_crm_call -q` - 16 passed.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_matches_stored_phone_with_extension tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_does_not_match_extension_suffix tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_inactive_legacy_lead -q` - 5 passed.
- `python -m py_compile atlas_brain/services/crm_provider.py tests/test_eom_lead_conversion_integration.py` - passed.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_matches_stored_phone_with_extension tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_malformed_source_provenance -q` - 5 passed.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_matches_stored_phone_with_extension tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_does_not_match_extension_suffix tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_malformed_source_provenance -q` - 8 passed.
- `python -m pytest tests/test_crm_read_scoping.py tests/test_leads_intake.py tests/test_eom_lead_conversion.py tests/test_tenant_stamping.py tests/test_migrations_runner.py tests/test_contact_write_boundary.py -q` - 419 passed, 1 skipped, 1 warning.
- `python -m pytest tests/test_contact_write_boundary.py -q` - 65 passed.
- `python scripts/check_contact_write_boundary.py --baseline tests/contact_write_boundary/baseline.json` - passed.
- `python scripts/maturity_sweep.py atlas_brain/storage --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_storage.json --min-score 8 --sensitive-glob '**/billing/**' --sensitive-glob '**/billing*' --sensitive-glob '**/paid*' --sensitive-glob '**/auth/**' --sensitive-glob '**/auth*' --sensitive-glob '**/webhook*' --sensitive-glob '**/webhooks/**' --sensitive-glob '**/*webhook*/**' --sensitive-glob '**/payment*' --sensitive-glob '**/invoicing/**' --sensitive-glob '**/*invoice*' --sensitive-glob '**/*deletion*' --sensitive-glob '**/delete*/**' --sensitive-glob 'atlas_brain/security/**' --sensitive-glob 'atlas_brain/storage/**'` - passed.
- `python scripts/check_guard_class_closure.py` - passed.
- `python scripts/sync_pr_plan.py plans/PR-EOM-Operator-Mutation-Contract.md --check` - passed.
- `git diff --check` - passed.
- `python -m pytest tests/test_crm_read_scoping.py::test_create_contact_non_merging_mode_admits_fresh_eom_backend_miss tests/test_crm_read_scoping.py::test_create_contact_non_eom_miss_still_inserts tests/test_leads_intake.py::test_create_contact_does_not_match_foreign_context_after_eom_miss -q` - 3 passed, 1 warning.
- `python -m py_compile atlas_brain/services/crm_provider.py && python -m pytest tests/test_crm_read_scoping.py tests/test_leads_intake.py -q` - 119 passed, 1 warning.

## Mechanical verification

- Command: `bash scripts/push_pr.sh /tmp/atlas-pr-body-eom-operator-mutation-contract.md -u origin HEAD` - Result: passed - Environment: local
- Command: `python -m pytest tests/test_eom_lead_conversion.py tests/test_tenant_stamping.py tests/test_migrations_runner.py tests/test_contact_write_boundary.py -q` - Result: 293 passed - Environment: local
- Command: `python -m py_compile atlas_brain/services/eom_crm_mutations.py atlas_brain/services/crm_provider.py tests/test_eom_lead_conversion.py tests/test_eom_lead_conversion_integration.py` - Result: passed - Environment: local
- Command: `python -m pytest tests/test_eom_lead_conversion.py::test_private_operator_contact_rejects_nul_text_before_crm_call -q` - Result: 7 passed - Environment: local
- Command: `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_explicit_id_identity_collision -q` - Result: 2 passed - Environment: local
- Command: `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py -q -k "operator_contact_mutation or inbound_atomic_uses_ascii_phone_normalizer or share_phone_identity_lock"` - Result: 8 passed - Environment: local
- Command: `python -m pytest tests/test_contact_write_boundary.py -q` - Result: 65 passed - Environment: local
- Command: `python scripts/check_contact_write_boundary.py --baseline tests/contact_write_boundary/baseline.json` - Result: passed - Environment: local
- Command: `python scripts/maturity_sweep.py atlas_brain/storage --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_storage.json --min-score 8 --sensitive-glob '**/billing/**' --sensitive-glob '**/billing*' --sensitive-glob '**/paid*' --sensitive-glob '**/auth/**' --sensitive-glob '**/auth*' --sensitive-glob '**/webhook*' --sensitive-glob '**/webhooks/**' --sensitive-glob '**/*webhook*/**' --sensitive-glob '**/payment*' --sensitive-glob '**/invoicing/**' --sensitive-glob '**/*invoice*' --sensitive-glob '**/*deletion*' --sensitive-glob '**/delete*/**' --sensitive-glob 'atlas_brain/security/**' --sensitive-glob 'atlas_brain/storage/**'` - Result: passed - Environment: local
- Command: `python scripts/check_guard_class_closure.py` - Result: passed - Environment: local
- Command: `python scripts/sync_pr_plan.py plans/PR-EOM-Operator-Mutation-Contract.md --check` - Result: passed - Environment: local
- Command: `git diff --check` - Result: passed - Environment: local
- Command: `python -m pytest tests/test_crm_read_scoping.py::test_create_contact_non_merging_mode_admits_fresh_eom_backend_miss tests/test_crm_read_scoping.py::test_create_contact_non_eom_miss_still_inserts tests/test_leads_intake.py::test_create_contact_does_not_match_foreign_context_after_eom_miss -q` - Result: 3 passed - Environment: local
- Command: `python -m py_compile atlas_brain/services/crm_provider.py && python -m pytest tests/test_crm_read_scoping.py tests/test_leads_intake.py -q` - Result: 119 passed - Environment: local
- Command: `python -m pytest tests/test_crm_read_scoping.py tests/test_leads_intake.py tests/test_eom_lead_conversion.py tests/test_tenant_stamping.py tests/test_migrations_runner.py tests/test_contact_write_boundary.py -q` - Result: 419 passed, 1 skipped - Environment: local
- Command: `python -m py_compile atlas_brain/eom_api/funnel.py atlas_brain/services/eom_crm_mutations.py atlas_brain/services/crm_provider.py tests/test_eom_lead_conversion.py tests/test_eom_lead_conversion_integration.py` - Result: passed - Environment: local
- Command: `python -m pytest tests/test_eom_lead_conversion.py::test_private_operator_contact_rejects_malformed_identity_before_crm_call tests/test_eom_lead_conversion.py::test_private_operator_contact_rejects_database_invalid_text_before_crm_call -q` - Result: 19 passed - Environment: local
- Command: `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_non_object_contact_metadata -q` - Result: 1 passed - Environment: local
- Command: `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py -q -k "operator_contact_mutation or inbound_atomic_uses_ascii_phone_normalizer or share_phone_identity_lock"` - Result: 12 passed - Environment: local
- Command: `python -m py_compile atlas_brain/services/crm_provider.py tests/test_tenant_stamping.py` - Result: passed - Environment: local
- Command: `python -m pytest tests/test_tenant_stamping.py::test_generic_contact_phone_search_preserves_full_phone_extension_lookup tests/test_tenant_stamping.py::test_generic_contact_phone_search_preserves_country_code_to_extension_lookup tests/test_tenant_stamping.py::test_generic_contact_phone_search_keeps_partial_phone_substring_lookup -q` - Result: 3 passed - Environment: local
- Command: `python -m py_compile atlas_brain/services/crm_provider.py tests/test_eom_lead_conversion_integration.py` - Result: passed - Environment: local
- Command: `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_matches_stored_phone_with_extension tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_does_not_match_extension_suffix -q` - Result: 2 passed - Environment: local
- Command: `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_explicit_id_identity_collision tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_ambiguous_exact_identity tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_ambiguous_direct_provenance tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_crossed_identities_fail_without_deadlock tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_matches_stored_phone_with_extension tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_does_not_match_extension_suffix -q` - Result: 7 passed - Environment: local
- Command: `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_claims_legacy_contact_by_padded_email 'tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_explicit_id_identity_collision[email-owned@example.com-target@example.com]' -q` - Result: 2 passed - Environment: local
- Command: `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_claims_legacy_contact_by_padded_email tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_explicit_id_identity_collision tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_ambiguous_exact_identity tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_rejects_ambiguous_direct_provenance tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_crossed_identities_fail_without_deadlock tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_matches_stored_phone_with_extension tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_does_not_match_extension_suffix -q` - Result: 8 passed - Environment: local
- Command: `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python -m pytest tests/test_crm_read_scoping.py tests/test_eom_complaints_integration.py tests/test_eom_contacts_api_tenant_scope.py tests/test_eom_lead_conversion.py tests/test_eom_lead_conversion_integration.py tests/test_eom_lead_pipeline_integration.py tests/test_eom_mailbox_context_binding.py tests/test_eom_lead_ingress.py tests/test_eom_recurring_appointments_integration.py tests/test_eom_scoped_gmail_credentials.py tests/test_eom_scoped_gmail_hardening.py tests/test_eom_sent_email_tenant_scope.py tests/test_leads_intake.py tests/test_migrations_runner.py -q` - Result: 3 failed, 443 passed, 43 skipped - Environment: local
- Skipped: local full EOM lead-pipeline clean pass - Reason: the local `127.0.0.1:5433` database login cannot administer disposable roles and produced unrelated local schema/ledger readiness failures after the exact CI failures were fixed; CI remains the source of truth for that Postgres-service leg.
- Skipped: full live deployment smoke - Reason: no external tracker/website caller is migrated in this Atlas contract slice

## Diff size

12 files, 2368 insertions(+), 69 deletions(-)
