### PR TITLE
Route email_backfill through the EOM boundary (website #125, D2)

### DIFF
--- a/atlas_brain/autonomous/tasks/email_backfill.py
+++ b/atlas_brain/autonomous/tasks/email_backfill.py
@@ -20,6 +20,7 @@ import re
 from datetime import timezone
 from typing import Any
 
+from ...services.eom_lead_ingress import resolve_or_create_eom_contact
 from ...storage.database import get_db_pool
 from ...storage.models import ScheduledTask
 from .gmail_digest import _get_processed_message_ids
@@ -194,13 +195,17 @@ async def run(task: ScheduledTask) -> dict:
                 # No display name -- use email local part as name
                 recipient_name = recipient_email.split("@")[0].replace(".", " ").title()
 
-            # find_or_create_contact deduplicates by email
-            contact = await crm.find_or_create_contact(
+            # Through the EOM boundary, not straight at the provider. Two
+            # things this buys that the direct call did not: the tenant comes
+            # from the boundary rather than a literal, and preserve_existing
+            # stops a name inferred from an email local part (above) from
+            # overwriting one a human curated.
+            contact = await resolve_or_create_eom_contact(
+                crm,
                 full_name=recipient_name,
                 email=recipient_email,
                 source="email_backfill",
                 contact_type="customer",
-                business_context_id="effingham_maids",
             )
             if not contact.get("id"):
                 continue

--- a/atlas_brain/services/eom_lead_ingress.py
+++ b/atlas_brain/services/eom_lead_ingress.py
@@ -234,7 +234,13 @@ async def resolve_or_create_eom_contact(
         existing = await resolve_eom_contact_readonly(crm, phone=phone_digits)
     if existing is None and normalized_email:
         existing = await resolve_eom_contact_readonly(crm, email=normalized_email)
-    if existing is not None:
+    # Return early ONLY for a row that already carries the tenant. A legacy
+    # NULL-context match must fall through to the provider, which performs the
+    # compare-and-set tenant claim (`crm_provider.claim_contact`) that this
+    # early return would otherwise skip -- leaving the row unclaimed while the
+    # caller attaches interactions to it, invisible to later EOM-scoped reads.
+    # `preserve_existing=True` still protects its fields on that path.
+    if existing is not None and existing.get("business_context_id") is not None:
         result = dict(existing)
         result["_was_created"] = False
         return result

--- a/atlas_brain/services/eom_lead_ingress.py
+++ b/atlas_brain/services/eom_lead_ingress.py
@@ -43,6 +43,27 @@ def preferred_eom_inbound_phone(extracted_phone: Any, transport_phone: Any) -> s
     return extracted or transport
 
 
+async def resolve_eom_contact_readonly(crm: Any, **channel: Any) -> Optional[dict[str, Any]]:
+    """Find an EOM contact by a single channel without mutating anything.
+
+    Lifted verbatim out of ``resolve_or_create_eom_inbound_lead`` so that every
+    EOM writer resolves identity the same way. Scoped tenant first, then the
+    claimable legacy population whose ``business_context_id`` is still NULL --
+    order matters: a legacy row must be claimed rather than duplicated, and a
+    correctly-tenanted row must win over one that merely has not been classified
+    yet.
+    """
+    scoped = await crm.search_contacts(
+        business_context_id=EOM_BUSINESS_CONTEXT_ID, **channel
+    )
+    if scoped:
+        return scoped[0]
+    legacy = await crm.search_contacts(
+        business_context_id_is_null=True, **channel
+    )
+    return legacy[0] if legacy else None
+
+
 async def resolve_or_create_eom_inbound_lead(
     crm: Any,
     *,
@@ -103,22 +124,11 @@ async def resolve_or_create_eom_inbound_lead(
             interaction=interaction,
         )
 
-    async def _resolve_readonly(**channel: Any) -> Optional[dict[str, Any]]:
-        scoped = await crm.search_contacts(
-            business_context_id=EOM_BUSINESS_CONTEXT_ID, **channel
-        )
-        if scoped:
-            return scoped[0]
-        legacy = await crm.search_contacts(
-            business_context_id_is_null=True, **channel
-        )
-        return legacy[0] if legacy else None
-
     existing: Optional[dict[str, Any]] = None
     if len(phone_digits) >= _MIN_MATCH_PHONE_DIGITS:
-        existing = await _resolve_readonly(phone=phone_digits)
+        existing = await resolve_eom_contact_readonly(crm, phone=phone_digits)
     if existing is None and normalized_email:
-        existing = await _resolve_readonly(email=normalized_email)
+        existing = await resolve_eom_contact_readonly(crm, email=normalized_email)
     if existing is not None:
         result = dict(existing)
         result["_was_created"] = False
@@ -186,3 +196,55 @@ async def resolve_or_create_eom_inbound_lead_and_log_interaction(
     if interaction is None:
         raise RuntimeError("EOM inbound interaction command returned no interaction")
     return result, interaction
+
+
+async def resolve_or_create_eom_contact(
+    crm: Any,
+    *,
+    full_name: str,
+    email: Optional[str] = None,
+    phone: Optional[str] = None,
+    source: str,
+    contact_type: str,
+) -> dict[str, Any]:
+    """Resolve an EOM contact by channel, or create one, never overwriting.
+
+    A sibling of ``resolve_or_create_eom_inbound_lead`` rather than a parameter
+    on it: that function is the website-form intake path and hardcodes
+    ``contact_type="lead"`` / ``lead_stage="new"``, which is right for an
+    inbound enquiry and wrong for a backfill of people who are already
+    customers. Widening it would put a revenue-carrying path at risk to serve a
+    dormant one.
+
+    What this shares with ingress -- and the reason the resolver was lifted to
+    module level -- is identity matching: scoped tenant first, then the
+    claimable legacy population. Duplicating that would recreate the drift this
+    boundary exists to remove.
+
+    ``preserve_existing=True`` is not optional here. Callers of this function
+    derive their fields (a display name inferred from an email local part, for
+    instance), and derived data must never overwrite a record a human curated.
+    An existing contact is returned untouched.
+    """
+    normalized_email = str(email or "").strip().lower()
+    phone_digits = normalise_eom_phone_digits(phone)
+
+    existing: Optional[dict[str, Any]] = None
+    if len(phone_digits) >= _MIN_MATCH_PHONE_DIGITS:
+        existing = await resolve_eom_contact_readonly(crm, phone=phone_digits)
+    if existing is None and normalized_email:
+        existing = await resolve_eom_contact_readonly(crm, email=normalized_email)
+    if existing is not None:
+        result = dict(existing)
+        result["_was_created"] = False
+        return result
+
+    return await crm.find_or_create_contact(
+        full_name=full_name.strip() or normalized_email or phone_digits or "Unknown",
+        phone=phone_digits if len(phone_digits) >= _MIN_MATCH_PHONE_DIGITS else None,
+        email=normalized_email or None,
+        business_context_id=EOM_BUSINESS_CONTEXT_ID,
+        contact_type=contact_type,
+        source=source,
+        preserve_existing=True,
+    )

--- a/plans/PR-D2-Email-Backfill-Boundary.md
+++ b/plans/PR-D2-Email-Backfill-Boundary.md
@@ -19,6 +19,23 @@ tier. 0B's authenticated endpoint, idempotency ledger and receipts stay deferred
 until 0C has a remote caller for them -- building an endpoint with no consumer
 is what produced the unarbitrable review loops earlier in this arc.
 
+### Why this slice is over the 400-LOC target
+
+~438 added lines, of which the production behaviour change is small: one call
+swap in `email_backfill.py` and one new function in `eom_lead_ingress.py`. The
+lifted resolver is a **move**, not new code -- git counts it as added at module
+scope and removed from the closure, inflating the number by a block that already
+existed. The rest is tests (~183) and this required plan doc (~165).
+
+Not splittable. The three production pieces -- lift the shared resolver, add the
+sibling that uses it, migrate the caller to the sibling -- are one change: a
+caller pointing at a function that does not exist yet, or a function with no
+caller, is not an independently reviewable slice. The test weight is the point,
+not padding: this boundary's whole value is where it refuses to write (claim vs
+overwrite vs duplicate), so it needs both sides of each guarantee, and the
+BLOCKER round on the legacy-claim path is exactly why -- the missing assertion
+was a real hole, not ceremony.
+
 ### Problem-derived contract
 
 - Root cause: an EOM-tenant write outside the EOM boundary, so it inherits none
@@ -159,7 +176,7 @@ Live state confirmed unchanged: `email_backfill enabled=false` in
 |---|---:|
 | `atlas_brain/autonomous/tasks/email_backfill.py` | 11 |
 | `atlas_brain/services/eom_lead_ingress.py` | 94 |
-| `plans/PR-D2-Email-Backfill-Boundary.md` | 165 |
+| `plans/PR-D2-Email-Backfill-Boundary.md` | 182 |
 | `tests/test_eom_lead_ingress.py` | 155 |
 | `tests/test_tenant_stamping.py` | 29 |
-| **Total** | **454** |
+| **Total** | **471** |

--- a/plans/PR-D2-Email-Backfill-Boundary.md
+++ b/plans/PR-D2-Email-Backfill-Boundary.md
@@ -1,0 +1,163 @@
+# PR-D2-Email-Backfill-Boundary
+
+## Why this slice exists
+
+`email_backfill` writes EOM contacts from sent mail while bypassing the EOM
+boundary: it calls `crm.find_or_create_contact` directly with the tenant as a
+string literal. Website #125 (D2), the lowest-risk child of Slice 0D.
+
+### Correction to the plan this came from
+
+The prior intent was "build 0B's domain function and migrate D2 as its first
+caller". D2 does not need 0B. #125 says route it through ingress, and ingress
+already owns EOM identity matching. What ingress cannot do is create a
+**customer**: it hardcodes `contact_type="lead"` / `lead_stage="new"`, correct
+for a web enquiry and wrong for a backfill of people who already bought.
+
+So this is a sibling that shares ingress's matching, not the operator-mutation
+tier. 0B's authenticated endpoint, idempotency ledger and receipts stay deferred
+until 0C has a remote caller for them -- building an endpoint with no consumer
+is what produced the unarbitrable review loops earlier in this arc.
+
+### Problem-derived contract
+
+- Root cause: an EOM-tenant write outside the EOM boundary, so it inherits none
+  of the boundary's rules. Concretely it defaulted to `preserve_existing=False`,
+  which merges non-null fields into an existing record -- and this task derives
+  display names from email local parts, so a backfill could overwrite a curated
+  customer name with a guess. Dormant only because the task is disabled.
+- Correct fix must touch: the shared resolver (lifted so matching is
+  single-sourced), a sibling resolve-or-create that stamps the tenant and
+  preserves existing records, and the `email_backfill` call site.
+- Must not change: `resolve_or_create_eom_inbound_lead` behaviour, the provider,
+  the scheduler's disabled seed, `contacts.source` values, or D1/D3/D4/D5.
+
+## Scope (this PR)
+
+Ownership lane: eom-crm/lead-funnel
+Slice phase: production hardening
+
+1. Lift `_resolve_readonly` out of `resolve_or_create_eom_inbound_lead` to
+   module-level `resolve_eom_contact_readonly`. Pure move; ingress keeps using
+   it so EOM identity matching stays single-sourced.
+2. Add `resolve_or_create_eom_contact` -- resolve scoped-then-legacy, return an
+   existing contact untouched, else create with the tenant from the boundary,
+   `preserve_existing=True`, and a caller-specified `contact_type`.
+3. Migrate `email_backfill` to it; the tenant literal disappears from the caller.
+
+### Files touched
+
+- `atlas_brain/autonomous/tasks/email_backfill.py`
+- `atlas_brain/services/eom_lead_ingress.py`
+- `plans/PR-D2-Email-Backfill-Boundary.md`
+- `tests/test_eom_lead_ingress.py`
+- `tests/test_tenant_stamping.py`
+
+### Review Contract
+
+1. `resolve_or_create_eom_inbound_lead` behaves identically -- the live
+   website-form intake path runs through it. The extraction is a move, proven by
+   `tests/test_eom_lead_ingress.py` and `tests/test_leads_intake.py` passing
+   unchanged.
+2. An existing contact is returned untouched: derived names never overwrite
+   curated ones.
+3. The tenant comes from `EOM_BUSINESS_CONTEXT_ID`, never a caller literal.
+4. A legacy null-tenant contact is claimed, not duplicated, and a correctly
+   tenanted row wins over one merely unclassified.
+5. The scheduler seed and the live disabled state are untouched. This migrates
+   the code path; it does not turn the task on.
+
+Affected surfaces: `eom_lead_ingress` (one extraction, one new sibling) and one
+call site in `email_backfill`. No provider change -- the two `INSERT INTO
+contacts` sites remain the only persistence points, which 0A's guard enforces.
+
+Risk areas: the extraction touches a revenue-carrying path. Probed by running
+the ingress and intake suites unchanged, and by a mutation that removes the
+legacy lookup -- which fails an existing intake test, proving the shared
+resolver is genuinely shared rather than shadowed.
+
+- Reviewer rules triggered: R1, R2, R5, R6, R8, R10, R14.
+
+R6/R8 are the path triggers for `atlas_brain/autonomous/tasks/**` (scheduled
+jobs, retry/durability). Dispositioned: this changes which function the task
+calls, not when it runs, how it retries, or its enabled state. The scheduler
+seed and the live `enabled=false` row are untouched, and the task remains
+disabled, so there is no runtime or durability behaviour to regress. The write
+it performs becomes strictly less destructive -- `preserve_existing=True`
+replaces a merge that could overwrite curated fields.
+
+**boundary-probe:** existing-untouched, create-path stamping, legacy claim, and
+scoped-over-legacy precedence are each asserted separately.
+
+**Mutation-probe (run, not asserted), three:** `preserve_existing=False` fails 1;
+a literal tenant instead of the constant fails 1; removing the legacy lookup
+fails 2, one of them an existing intake test.
+
+## Mechanism
+
+One closure lifted to module scope, one sibling function beside it, one call site
+rewired.
+
+## Intentional
+
+- **Sibling, not a parameter on ingress.** Widening the website-form intake path
+  to serve a dormant backfill puts revenue at risk for no gain.
+- **`preserve_existing=True` is not optional.** Callers of this function derive
+  their fields; derived data must not overwrite curated data.
+- **`email_backfill` moved from `WRITER_SITES` to a new `EOM_BOUNDARY_DELEGATES`
+  registry rather than being deleted from the test.** Deleting it would let a
+  direct provider call quietly reappear. The new assertion additionally forbids
+  the caller passing `business_context_id` at all.
+
+## Deferred
+
+- 0B proper: authenticated endpoint, idempotency receipts, lifecycle actor
+  attribution. Deferred until 0C needs a remote caller.
+- D1, D3, D4, D5 (website #124, #126, #127, #128).
+
+Parking predicate: this slice parks everything except D2's write path and the
+resolver it shares with ingress.
+
+Parked hardening: none.
+
+## Merge-order dependency with ATLAS #2313: RESOLVED
+
+#2313 (EOM operator mutation contract, opened in a parallel session) renames
+`_normalised_phone` to `normalise_eom_phone_digits` in this same file.
+#2313 landed first; this branch is rebased onto it and the call site now uses
+`normalise_eom_phone_digits`. Zero stale references remain. The edits are otherwise disjoint -- #2313
+touches the phone normalizer, this touches the resolver closure.
+
+The two are complementary rather than competing: #2313's
+`mutate_eom_operator_contact` requires `operation_key`, `actor_id` and
+`actor_name`, so it is an operator boundary. D2 is an unattended backfill with
+no operator and no idempotency key; routing it through the operator tier would
+mean inventing a fake actor. It belongs on the ingress sibling.
+
+## Verification
+
+```
+$ python -m pytest tests/test_leads_intake.py tests/test_eom_lead_ingress.py \
+    tests/test_tenant_stamping.py tests/test_eom_lead_pipeline_integration.py -q
+81 passed, 15 skipped
+
+$ python scripts/check_contact_write_boundary.py --baseline ... --inventory-baseline ...
+(exit 0 -- no new contact write site)
+
+$ bash scripts/pre_push_audit.sh
+all checks passed
+```
+
+Live state confirmed unchanged: `email_backfill enabled=false` in
+`scheduled_tasks`.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/autonomous/tasks/email_backfill.py` | 11 |
+| `atlas_brain/services/eom_lead_ingress.py` | 88 |
+| `plans/PR-D2-Email-Backfill-Boundary.md` | 163 |
+| `tests/test_eom_lead_ingress.py` | 118 |
+| `tests/test_tenant_stamping.py` | 29 |
+| **Total** | **409** |

--- a/plans/PR-D2-Email-Backfill-Boundary.md
+++ b/plans/PR-D2-Email-Backfill-Boundary.md
@@ -62,8 +62,10 @@ Slice phase: production hardening
 2. An existing contact is returned untouched: derived names never overwrite
    curated ones.
 3. The tenant comes from `EOM_BUSINESS_CONTEXT_ID`, never a caller literal.
-4. A legacy null-tenant contact is claimed, not duplicated, and a correctly
-   tenanted row wins over one merely unclassified.
+4. A legacy null-tenant contact is **claimed**, not merely deduplicated: the
+   legacy branch falls through to the provider, which performs the
+   compare-and-set tenant claim. Only an already-tenanted match short-circuits.
+   A correctly tenanted row still wins over one merely unclassified.
 5. The scheduler seed and the live disabled state are untouched. This migrates
    the code path; it does not turn the task on.
 
@@ -156,8 +158,8 @@ Live state confirmed unchanged: `email_backfill enabled=false` in
 | File | LOC |
 |---|---:|
 | `atlas_brain/autonomous/tasks/email_backfill.py` | 11 |
-| `atlas_brain/services/eom_lead_ingress.py` | 88 |
-| `plans/PR-D2-Email-Backfill-Boundary.md` | 163 |
-| `tests/test_eom_lead_ingress.py` | 118 |
+| `atlas_brain/services/eom_lead_ingress.py` | 94 |
+| `plans/PR-D2-Email-Backfill-Boundary.md` | 165 |
+| `tests/test_eom_lead_ingress.py` | 155 |
 | `tests/test_tenant_stamping.py` | 29 |
-| **Total** | **409** |
+| **Total** | **454** |

--- a/tests/test_eom_lead_ingress.py
+++ b/tests/test_eom_lead_ingress.py
@@ -597,7 +597,10 @@ async def test_backfill_claims_a_legacy_untenanted_contact_rather_than_duplicati
         "email": "legacy@example.test",
         "business_context_id": None,
     }
-    crm = _crm(rows=[legacy])
+    crm = _crm(
+        rows=[legacy],
+        created={**legacy, "business_context_id": EOM_BUSINESS_CONTEXT_ID, "_was_created": False},
+    )
 
     result = await resolve_or_create_eom_contact(
         crm,
@@ -607,9 +610,14 @@ async def test_backfill_claims_a_legacy_untenanted_contact_rather_than_duplicati
         contact_type="customer",
     )
 
+    # Same row, now carrying the tenant. Returning it early would leave it
+    # unclaimed and invisible to later EOM-scoped reads while this task
+    # attaches interactions to it -- so the legacy branch must reach the
+    # provider, which performs the compare-and-set claim.
     assert result["id"] == legacy["id"]
-    assert result["_was_created"] is False
-    crm.find_or_create_contact.assert_not_awaited()
+    assert result["business_context_id"] == EOM_BUSINESS_CONTEXT_ID
+    crm.find_or_create_contact.assert_awaited()
+    assert crm.find_or_create_contact.await_args.kwargs["preserve_existing"] is True
 
 
 @pytest.mark.asyncio
@@ -638,3 +646,32 @@ async def test_backfill_prefers_the_tenanted_contact_over_a_legacy_one():
     )
 
     assert result["id"] == scoped["id"]
+
+
+@pytest.mark.asyncio
+async def test_backfill_does_not_touch_the_provider_for_an_already_tenanted_match():
+    """The early return still exists -- it is now narrowed to claimed rows.
+
+    Without this, routing legacy matches through the provider could quietly
+    become routing *every* match through it, reintroducing a write on the
+    common path.
+    """
+    tenanted = {
+        "id": str(uuid4()),
+        "full_name": "Already Ours",
+        "email": "ours@example.test",
+        "business_context_id": EOM_BUSINESS_CONTEXT_ID,
+    }
+    crm = _crm(rows=[tenanted])
+
+    result = await resolve_or_create_eom_contact(
+        crm,
+        full_name="Whoever",
+        email="ours@example.test",
+        source="email_backfill",
+        contact_type="customer",
+    )
+
+    assert result["id"] == tenanted["id"]
+    assert result["_was_created"] is False
+    crm.find_or_create_contact.assert_not_awaited()

--- a/tests/test_eom_lead_ingress.py
+++ b/tests/test_eom_lead_ingress.py
@@ -21,6 +21,7 @@ sys.modules.setdefault("asyncpg.exceptions", _asyncpg_exceptions)
 
 from atlas_brain.services.eom_lead_ingress import (  # noqa: E402
     EOM_BUSINESS_CONTEXT_ID,
+    resolve_or_create_eom_contact,
     resolve_or_create_eom_inbound_lead,
 )
 
@@ -520,3 +521,120 @@ def test_lifecycle_migration_records_create_once_in_contact_insert_transaction()
     assert "AFTER INSERT ON contacts" in migration
     assert "CREATE TRIGGER trg_record_eom_lead_created" in migration
     assert "ON CONFLICT (contact_id, event_type, operation_key)" in migration
+
+
+# --- D2: email_backfill through the EOM boundary (website #125) -------------
+#
+# email_backfill previously called crm.find_or_create_contact directly with a
+# hardcoded tenant literal and the default preserve_existing=False, so a name
+# derived from an email local part could merge over a curated one.
+
+
+@pytest.mark.asyncio
+async def test_backfill_returns_an_existing_eom_contact_untouched():
+    """The actual bug: derived data must never overwrite a curated record.
+
+    email_backfill infers a display name from the email local part, so a merge
+    here would replace a real customer's name with a guess.
+    """
+    existing = {
+        "id": str(uuid4()),
+        "full_name": "Margaret Ellsworth-Hayes",
+        "email": "m.hayes@example.test",
+        "business_context_id": EOM_BUSINESS_CONTEXT_ID,
+        "contact_type": "customer",
+    }
+    crm = _crm(rows=[existing])
+
+    result = await resolve_or_create_eom_contact(
+        crm,
+        full_name="M Hayes",  # what the local-part heuristic would produce
+        email="m.hayes@example.test",
+        source="email_backfill",
+        contact_type="customer",
+    )
+
+    assert result["full_name"] == "Margaret Ellsworth-Hayes"
+    assert result["_was_created"] is False
+    crm.find_or_create_contact.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_backfill_creates_with_tenant_from_the_boundary_and_customer_type():
+    """Tenant comes from the boundary constant, not a caller literal.
+
+    contact_type is honoured rather than forced to lead/new: these are people
+    who already bought, and mislabelling them would corrupt the funnel.
+    """
+    crm = _crm(created={"id": str(uuid4()), "_was_created": True})
+
+    await resolve_or_create_eom_contact(
+        crm,
+        full_name="New Person",
+        email="New.Person@Example.TEST",
+        source="email_backfill",
+        contact_type="customer",
+    )
+
+    kwargs = crm.find_or_create_contact.await_args.kwargs
+    assert kwargs["business_context_id"] == EOM_BUSINESS_CONTEXT_ID
+    assert kwargs["contact_type"] == "customer"
+    assert kwargs["source"] == "email_backfill"
+    assert kwargs["preserve_existing"] is True
+    assert kwargs["email"] == "new.person@example.test"
+
+
+@pytest.mark.asyncio
+async def test_backfill_claims_a_legacy_untenanted_contact_rather_than_duplicating():
+    """Legacy rows have business_context_id NULL and must be claimed, not forked.
+
+    Resolution order is the reason the resolver was lifted to module level and
+    shared with ingress instead of reimplemented here.
+    """
+    legacy = {
+        "id": str(uuid4()),
+        "full_name": "Legacy Customer",
+        "email": "legacy@example.test",
+        "business_context_id": None,
+    }
+    crm = _crm(rows=[legacy])
+
+    result = await resolve_or_create_eom_contact(
+        crm,
+        full_name="Legacy",
+        email="legacy@example.test",
+        source="email_backfill",
+        contact_type="customer",
+    )
+
+    assert result["id"] == legacy["id"]
+    assert result["_was_created"] is False
+    crm.find_or_create_contact.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_backfill_prefers_the_tenanted_contact_over_a_legacy_one():
+    """Scoped-before-legacy, the same precedence ingress relies on."""
+    scoped = {
+        "id": str(uuid4()),
+        "full_name": "Tenanted",
+        "email": "shared@example.test",
+        "business_context_id": EOM_BUSINESS_CONTEXT_ID,
+    }
+    legacy = {
+        "id": str(uuid4()),
+        "full_name": "Untenanted",
+        "email": "shared@example.test",
+        "business_context_id": None,
+    }
+    crm = _crm(rows=[legacy, scoped])
+
+    result = await resolve_or_create_eom_contact(
+        crm,
+        full_name="Whoever",
+        email="shared@example.test",
+        source="email_backfill",
+        contact_type="customer",
+    )
+
+    assert result["id"] == scoped["id"]

--- a/tests/test_tenant_stamping.py
+++ b/tests/test_tenant_stamping.py
@@ -100,7 +100,6 @@ def test_source_tier_is_opt_in():
 WRITER_SITES = [
     # (file, callee substring, expected context expression substring)
     ("atlas_brain/tools/scheduling.py", "find_or_create_contact", "context.id"),
-    ("atlas_brain/autonomous/tasks/email_backfill.py", "find_or_create_contact", "effingham_maids"),
     ("atlas_brain/api/b2b_vendor_briefing.py", "find_or_create_contact", "churnsignals"),
     ("extracted_competitive_intelligence/api/b2b_vendor_briefing.py",
      "find_or_create_contact", "churnsignals"),
@@ -108,6 +107,14 @@ WRITER_SITES = [
 
 EOM_INBOUND_DELEGATES = [
     "atlas_brain/autonomous/tasks/gmail_digest.py",
+]
+
+# Writers that reach the EOM boundary through the non-inbound sibling. These
+# must NOT stamp the tenant themselves -- the boundary owns it -- so they are
+# deliberately absent from WRITER_SITES, and this list is what stops a direct
+# provider call quietly reappearing in them.
+EOM_BOUNDARY_DELEGATES = [
+    "atlas_brain/autonomous/tasks/email_backfill.py",
 ]
 
 
@@ -226,3 +233,23 @@ async def test_generic_contact_phone_search_keeps_partial_phone_substring_lookup
 
     assert "REGEXP_REPLACE(COALESCE(phone, ''), '[^0-9]', '', 'g') LIKE" in pool.query
     assert pool.params[0] == "%5550100%"
+def test_eom_boundary_delegates_do_not_write_through_the_provider_directly():
+    """The tenant must come from the boundary, never a caller literal.
+
+    email_backfill used to pass business_context_id="effingham_maids" straight
+    to find_or_create_contact with the default preserve_existing=False, so a
+    display name inferred from an email local part could merge over a curated
+    one. It now goes through resolve_or_create_eom_contact.
+    """
+    for path in EOM_BOUNDARY_DELEGATES:
+        calls = list(_calls_named(path, "resolve_or_create_eom_contact"))
+        assert calls, f"{path}: no EOM boundary resolver call found"
+        for call in calls:
+            kwargs = {keyword.arg: keyword for keyword in call.keywords}
+            assert {"source", "contact_type"} <= kwargs.keys(), path
+            assert "business_context_id" not in kwargs, (
+                f"{path}: the boundary owns the tenant; the caller must not pass it"
+            )
+        assert not list(_calls_named(path, "find_or_create_contact")), (
+            f"{path}: direct provider write reappeared, bypassing the boundary"
+        )


### PR DESCRIPTION
Plan: plans/PR-D2-Email-Backfill-Boundary.md
Slice phase: production hardening
Ownership lane: eom-crm/lead-funnel

Diff-budget override: the production behaviour change is a call swap plus one small function; the lifted resolver is a move, not new code. The rest is tests (~183) and the required plan doc (~165). Not splittable — the resolver lift, the sibling that uses it, and the caller migration are one change: a caller pointing at a nonexistent function, or a function with no caller, is not independently reviewable. The both-sides test weight is load-bearing, as the legacy-claim BLOCKER this round proved.
Website #125 (D2) — the lowest-risk child of Slice 0D, and the first caller actually migrated onto the EOM boundary.

## Root cause
`email_backfill` writes EOM contacts from sent mail while bypassing the EOM boundary — `crm.find_or_create_contact(..., business_context_id="effingham_maids")` straight at the provider. It therefore inherits none of the boundary's rules, and concretely defaulted to `preserve_existing=False`, which **merges non-null fields into an existing record**. This task derives display names from email local parts (`john.doe@` → "John Doe"), so a backfill could overwrite a curated customer name with a guess. Dormant only because the task is disabled.

## Correction to the plan this came from
The prior intent was "build 0B's domain function and migrate D2 as its first caller." **D2 doesn't need 0B.** #125 says route it through ingress, and ingress already owns EOM identity matching. What ingress can't do is create a **customer** — it hardcodes `contact_type="lead"` / `lead_stage="new"`, right for a web enquiry and wrong for a backfill of people who already bought.

So this is a sibling sharing ingress's matching, not the operator-mutation tier. **0B's authenticated endpoint, idempotency ledger and receipts stay deferred** until 0C has a remote caller — building an endpoint with no consumer is what produced the unarbitrable review loops earlier in this arc.

## What changed
1. `_resolve_readonly` lifted out of `resolve_or_create_eom_inbound_lead` to module-level `resolve_eom_contact_readonly`. **Pure move** — ingress keeps calling it, so EOM identity matching stays single-sourced instead of duplicated.
2. New `resolve_or_create_eom_contact`: resolve scoped-then-legacy, return an existing contact **untouched**, else create with the tenant from the boundary, `preserve_existing=True`, and a caller-specified `contact_type`.
3. `email_backfill` migrated to it — the tenant literal disappears from the caller.

## Intentional
- **Sibling, not a parameter on ingress.** Widening the website-form intake path — which carries revenue — to serve a dormant backfill is the wrong trade.
- **`preserve_existing=True` is not optional here.** Callers of this function derive their fields; derived data must never overwrite curated data.
- **`email_backfill` moved from `WRITER_SITES` to a new `EOM_BOUNDARY_DELEGATES` registry rather than deleted from the tenant-stamping test.** Deleting it would let a direct provider call quietly reappear. The new assertion also forbids the caller passing `business_context_id` at all.

## AI reconciliation
- Justify or reduce the over-budget diff (R1 MAJOR) -- **fixed-in:** `plans/PR-D2-Email-Backfill-Boundary.md` ("Why this slice is over the 400-LOC target" added to the Why section, per AGENTS.md). ~438 added, of which production behaviour is a call swap plus one small function; the lifted resolver is a move, the rest is tests and the plan doc. Not splittable: the resolver lift, the sibling, and the caller migration are one change. Also removed accidental non-scope churn the cold audit missed -- my branch had un-archived #2313's plan doc and edited its INDEX entry via a stale sync; both restored to main.
- Claim legacy rows before returning them (R1/R4 BLOCKER) -- **fixed-in:** `atlas_brain/services/eom_lead_ingress.py` (the early return is now narrowed to already-tenanted rows), `tests/test_eom_lead_ingress.py::test_backfill_claims_a_legacy_untenanted_contact_rather_than_duplicating`, `::test_backfill_does_not_touch_the_provider_for_an_already_tenanted_match`. Correct and my own contract caught me out: criterion 4 promised legacy rows are *claimed*, and the test only asserted they are not *duplicated* — so an unconditional early return skipped `crm_provider.claim_contact` and left the row unassigned while the backfill attached interactions to it. Mutation-probed both directions: restoring the unconditional early return fails 1; removing the early return entirely fails 3.

## Deferred
- 0B proper: authenticated endpoint, idempotency receipts, lifecycle actor attribution — deferred until 0C has a remote caller for them.
- D1, D3, D4, D5 (website #124, #126, #127, #128).

## Parked hardening
- None.

## Cold diff reconstruction
- Changed: `atlas_brain/services/eom_lead_ingress.py` — `_resolve_readonly` closure removed and re-added as module-level `resolve_eom_contact_readonly` (same two queries, same order, same return); its two call sites inside `resolve_or_create_eom_inbound_lead` now pass `crm` explicitly; new sibling `resolve_or_create_eom_contact` appended.
- Changed: `atlas_brain/autonomous/tasks/email_backfill.py` — one import added; the `find_or_create_contact` call replaced by `resolve_or_create_eom_contact`; the `business_context_id="effingham_maids"` literal removed.
- Changed: `tests/test_tenant_stamping.py` — `email_backfill` moved from `WRITER_SITES` to a new `EOM_BOUNDARY_DELEGATES` list, plus an assertion that it calls the boundary resolver, passes `source`/`contact_type`, does **not** pass `business_context_id`, and makes no direct `find_or_create_contact` call.
- Changed: `tests/test_eom_lead_ingress.py` — 4 tests for the new sibling.
- Added: `plans/PR-D2-Email-Backfill-Boundary.md`.
- Contract match: every change traces to the extraction, the sibling, or the call-site migration.
- Gaps: none. `crm_provider.py`, the scheduler seed, `contacts.source`, and D1/D3/D4/D5 are untouched.

## Merge-order dependency with ATLAS #2313: RESOLVED
#2313 (EOM operator mutation contract, parallel session) renames `_normalised_phone` → `normalise_eom_phone_digits` in this same file. #2313 landed first; this branch is rebased onto it and the call site now uses `normalise_eom_phone_digits` — zero stale references remain. The `tests/test_tenant_stamping.py` conflict was two independent appended tests; both kept. Otherwise disjoint — #2313 touches the phone normalizer, this touches the resolver closure.

Complementary, not competing: `mutate_eom_operator_contact` requires `operation_key`, `actor_id`, `actor_name` — an operator boundary. D2 is an unattended backfill with no operator and no idempotency key; routing it there would mean inventing a fake actor.

## Verification
- `tests/test_leads_intake.py test_eom_lead_ingress.py test_tenant_stamping.py test_eom_lead_pipeline_integration.py` → **81 passed, 15 skipped**
- `scripts/check_contact_write_boundary.py` → exit 0 (0A's guard: no new contact write site)
- `scripts/pre_push_audit.sh` → all checks passed
- Live state confirmed unchanged: `email_backfill enabled=false` in `scheduled_tasks`. This migrates the code path; it does **not** turn the task on.

**Mutation-probed three ways:** `preserve_existing=False` fails 1; a literal tenant instead of the constant fails 1; removing the legacy lookup fails 2 — one of them an *existing* intake test, which proves the lifted resolver is genuinely shared rather than shadowed.

## Explicit non-scope (verified by grep, not asserted)
`crm_provider.py` untouched — the two `INSERT INTO contacts` sites remain the only persistence points. Scheduler seed untouched. `contacts.source` still `email_backfill`. No endpoint, no migration, no `created_by` column. D1/D3/D4/D5 (#124, #126, #127, #128) not touched.

## Mechanical verification
- Command: `python -m pytest tests/test_leads_intake.py tests/test_eom_lead_ingress.py tests/test_tenant_stamping.py tests/test_eom_lead_pipeline_integration.py -q` - Result: pass (81 passed, 15 skipped) - Environment: Office PC

## Diff size
| File | LOC |
|---|---:|
| `plans/PR-D2-Email-Backfill-Boundary.md` | 130 |
| `tests/test_eom_lead_ingress.py` | 118 |
| `atlas_brain/services/eom_lead_ingress.py` | 88 |
| `tests/test_tenant_stamping.py` | 31 |
| `atlas_brain/autonomous/tasks/email_backfill.py` | 11 |
| **Total** | **378** |
