### PR TITLE
Enforce PR ready-state and wrapper body path

### DIFF
--- a/.github/workflows/pr_body_contract.yml
+++ b/.github/workflows/pr_body_contract.yml
@@ -47,6 +47,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           python3 scripts/audit_pr_body.py \
+            --require-wrapper-marker \
             --pr-author "$PR_AUTHOR" \
             --base-ref "origin/${BASE_REF}" \
             --head-ref "refs/remotes/origin/pr-${PR_NUMBER}" \

--- a/docs/SECURITY_GUARDRAILS.md
+++ b/docs/SECURITY_GUARDRAILS.md
@@ -71,8 +71,7 @@ marked `branch_required`: `live-reconciliation`, `diff-budget`,
 `plan-admission`, `session-lane`, `review-contract`, `pr-body-contract`,
 `Gitleaks PR secret scan`, `Gitleaks baseline growth guard`, and `unit-gate`,
 all pinned to the GitHub Actions app source instead of legacy bare context
-names. As of 2026-08-05, live GitHub settings contain every registry-required
-context pinned
+names. Live GitHub settings must contain every registry-required context pinned
 to the GitHub Actions app source. The checker intentionally proves required
 registry coverage and source pinning; it is not an exact-set audit for extra
 required contexts. Verification:
@@ -103,6 +102,12 @@ The same auditor admits
 guard shape. The workflow completed its #2104 burn-in and is now
 branch-required. It checks out trusted base code, materializes the PR head as git
 data, and runs the base-owned plan-admission auditor against that data worktree.
+
+The future `pr-ready-state` workflow is intentionally split from its
+trusted-base allowlist bootstrap. This slice teaches the workflow posture audit
+to recognize the eventual trusted-base job shape first; a follow-up can then add
+the new `pull_request_target` workflow and emit the context from `main` before
+live branch protection promotes it to `branch_required`.
 
 The `pre-push-audit` workflow keeps its trusted-base split while checking one
 PR-side docs/test consistency contract as data: `ci/gates.yml` branch-required

--- a/docs/ci_cd_autonomous_coding_map.md
+++ b/docs/ci_cd_autonomous_coding_map.md
@@ -86,10 +86,12 @@ trying to pass.
 `branch_required` produce the default expected context set consumed by
 `scripts/check_required_status_checks.py`: `live-reconciliation`,
 `diff-budget`, `plan-admission`, `session-lane`, `review-contract`,
-`pr-body-contract`, `Gitleaks PR secret scan`, and
-`Gitleaks baseline growth guard`, and `unit-gate`. Live branch protection can
-drift from that expected set; the audit workflow reports that drift when its
-read token is configured. `unit-gate` was promoted after the #2290 selector
+`pr-body-contract`, `Gitleaks PR secret scan`, and `Gitleaks baseline growth
+guard`, and `unit-gate`. Live branch protection can drift from that expected set;
+the audit workflow reports that drift when its read token is configured.
+`pr-ready-state` remains a follow-up after its trusted-base allowlist bootstrap
+lands; promote it after the emitted context is visible. `unit-gate` was promoted
+after the #2290 selector
 coverage fix. `pre-push-audit` remains a visible CI signal, not a
 branch-required context. Its trusted-base PR-side docs/test consistency blocker
 now has a data-only probe; a later enrollment recheck must decide whether that

--- a/plans/PR-Ready-State-Gate.md
+++ b/plans/PR-Ready-State-Gate.md
@@ -1,0 +1,178 @@
+# PR-Ready-State-Gate
+
+## Why this slice exists
+
+The operator identified a repeated process failure: `AGENTS.md` says human PRs
+open ready for review and several other rules are already written, but agents
+still bypass the compliant path. This slice turns the first objective part of
+that rule into mechanism: human full PR bodies prove they were published
+through `scripts/open_pr.sh`. It also bootstraps the trusted-base workflow
+posture allowlist needed before a future ready-state workflow can safely land.
+
+Diff budget overage is accepted for this workflow/process slice because the
+wrapper marker, trusted-base allowlist bootstrap, required PR-body workflow
+enrollment, docs, and tests must land atomically; shipping any one without the
+others would create a self-contradicting admission gate.
+
+### Problem-derived contract
+
+- Root cause: The open-wrapper rule is enforced only when builders use
+  `scripts/open_pr.sh`; hand-rolled PR creation can still publish an unstamped
+  full body, and the existing required PR-body gate had no direct proof that the
+  wrapper path was used.
+- Correct fix must touch/change: Stamp wrapper-published full PR bodies, make
+  PR-body audit able to require that stamp through the existing
+  branch-required PR-body context, and bootstrap the future `pr-ready-state`
+  trusted-base allowlist before adding that workflow in a follow-up. The unit
+  gate selector must also know the PR-body workflow's owning test so this slice
+  can run the same pre-open unit gate locally without escalating to FULL.
+- Must not change: Do not change product code, Codex review policy severity,
+  `live-reconciliation`, docs-only admission semantics, or Dependabot
+  exemptions.
+
+## Scope (this PR)
+
+Ownership lane: atlas-workflow/pr-enforcement
+Slice phase: Workflow/process
+
+1. Human full PR bodies must include an `atlas-open-pr-wrapper` marker when the
+   PR-body audit is run in wrapper-required mode.
+2. `scripts/open_pr.sh` adds that marker to the exact temporary body it audits
+   and sends to GitHub.
+3. The workflow posture allowlist recognizes the future `pr-ready-state`
+   trusted-base job shape before that workflow is added in the next slice.
+4. The unit-gate selector maps the PR-body workflow to its owning workflow test
+   instead of escalating to FULL.
+
+### Review Contract
+
+- Acceptance criteria: `scripts/open_pr.sh` publishes a stamped full PR body
+  without mutating the caller's body file; `scripts/audit_pr_body.py
+  --require-wrapper-marker` rejects unstamped human full bodies and keeps
+  docs-only/Dependabot exemptions; `scripts/audit_workflow_security_posture.py`
+  recognizes the future ready-state trusted-base job shape without this PR
+  adding that workflow.
+- Reachability proof: The real entrypoints are `scripts/open_pr.sh` and
+  `scripts/audit_pr_body.py --require-wrapper-marker`; observable effects are
+  tests and the existing `pr-body-contract` context once this lands on `main`.
+- Affected surfaces: PR-opening wrapper, PR-body audit, workflow posture
+  allowlist, unit-gate selector, workflow/security docs.
+- Risk areas: PR-body exactness, existing docs-only admission, Dependabot
+  generated PRs, future pull_request_target workflow bootstrap, local-vs-CI
+  unit-gate parity.
+- Reviewer rules triggered: R1, R2, R10, R11, R12, R14.
+
+### Boundary-change enumeration
+
+Required when this diff changes a guard, validator, normalizer, resolver,
+router/classifier, or admission boundary. Name each changed boundary path or
+seam in the enumeration; otherwise write "N/A - no boundary change."
+
+- Boundary path/seam: PR body publication and future trusted-base workflow
+  admission.
+- Replaced-path behaviors: Hand-rolled full PR bodies become rejectable by
+  audit; future ready-state workflow admission is bootstrapped before the
+  workflow file exists.
+- Guard-relevant fields: docs-only body marker, wrapper marker, future workflow
+  file/job name.
+- Caller x input shape: Local wrapper arguments/body file.
+
+### Deployed-config probing
+
+Required for guard, validator, resolver, admission-boundary, or env/config
+fallback changes; otherwise write "N/A - no guard/config boundary change."
+
+- Deployed/default config values: No runtime config.
+- Explicit value probe: Unit tests cover wrapper marker required/present.
+- Absent value probe: Unit tests cover missing/empty title/body and missing
+  wrapper marker.
+- Default-session/default-context probe: Wrapper tests cover the default
+  non-draft create path.
+- Side-effect ordering: Wrapper tests prove local review runs before GitHub
+  mutation and the body sent to GitHub is the stamped reviewed body.
+
+### Files touched
+
+- `.github/workflows/pr_body_contract.yml`
+- `docs/SECURITY_GUARDRAILS.md`
+- `docs/ci_cd_autonomous_coding_map.md`
+- `plans/PR-Ready-State-Gate.md`
+- `scripts/audit_pr_body.py`
+- `scripts/audit_workflow_security_posture.py`
+- `scripts/open_pr.sh`
+- `scripts/select_impacted_tests.py`
+- `tests/test_audit_pr_body.py`
+- `tests/test_audit_workflow_security_posture.py`
+- `tests/test_open_pr_wrapper.py`
+- `tests/test_pr_body_contract_workflow.py`
+- `tests/test_security_guardrails_workflow.py`
+- `tests/test_select_impacted_tests.py`
+
+## Mechanism
+
+`open_pr.sh` derives a temporary publish body from the caller's body file. Full
+plan-backed bodies receive `<!-- atlas-open-pr-wrapper: v1 -->`; docs-only
+bodies are left untouched. The wrapper then runs the existing audit, local
+review, hash checks, and `gh` stdin mutation against that temporary file.
+
+`audit_pr_body.py` gains `--require-wrapper-marker`, used by trusted CI, which
+rejects human full bodies missing the marker while preserving docs-only and
+Dependabot paths. `audit_workflow_security_posture.py` gains the future
+ready-state trusted-base allowlist entry first. That split is required because
+trusted-base pre-push CI runs the allowlist from `origin/main`; adding a new
+`pull_request_target` workflow before the allowlist is on `main` fails the
+security posture gate before the workflow can land.
+
+`select_impacted_tests.py` maps the PR-body workflow to
+`tests/test_pr_body_contract_workflow.py`, keeping unit-gate local and CI runs
+on the same selected-files path instead of escalating to the repo-wide suite for
+this known governance workflow.
+
+## Intentional
+
+- The pause escape hatch is explicit text, not a new label, so the trusted-base
+  workflow can decide from event metadata without extra API permission.
+- Docs-only PRs are not wrapper-marker-gated; their first-line marker is already
+  the narrow admission proof.
+- Reviewer-scope heuristics stay advisory/reactive in this slice; this PR only
+  mechanizes objective PR admission behavior.
+- The ready-state workflow itself is deferred; a new `pull_request_target`
+  workflow must be allowlisted on `main` before CI can evaluate it as trusted.
+
+## Deferred
+
+- Promote or retire heuristic review-scope checks after measuring false
+  positives; do not make seam convergence, guard class closure, or boundary
+  enumeration required in this slice.
+- A complete AGENTS.md rule enforcement matrix can follow once this first
+  targeted strict gate proves clean.
+- Add the `pr-ready-state` workflow/checker, then promote it to
+  `branch_required` and enroll it in live branch protection after the workflow
+  emits the context from `main`.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_audit_pr_body.py tests/test_open_pr_wrapper.py tests/test_pr_body_contract_workflow.py tests/test_security_guardrails_workflow.py tests/test_audit_workflow_security_posture.py tests/test_select_impacted_tests.py -q` - 308 passed.
+- Local unit-gate mirror: selected 10 governance test files and `python scripts/check_unit_gate.py --baseline tests/unit_gate_baseline.txt --base-baseline /tmp/base_baseline.txt --selected-files /tmp/selected.txt --pytest-args ...` reported 0 regressions.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/pr_body_contract.yml` | 1 |
+| `docs/SECURITY_GUARDRAILS.md` | 9 |
+| `docs/ci_cd_autonomous_coding_map.md` | 10 |
+| `plans/PR-Ready-State-Gate.md` | 178 |
+| `scripts/audit_pr_body.py` | 29 |
+| `scripts/audit_workflow_security_posture.py` | 1 |
+| `scripts/open_pr.sh` | 50 |
+| `scripts/select_impacted_tests.py` | 3 |
+| `tests/test_audit_pr_body.py` | 18 |
+| `tests/test_audit_workflow_security_posture.py` | 1 |
+| `tests/test_open_pr_wrapper.py` | 28 |
+| `tests/test_pr_body_contract_workflow.py` | 1 |
+| `tests/test_security_guardrails_workflow.py` | 2 |
+| `tests/test_select_impacted_tests.py` | 4 |
+| **Total** | **335** |

--- a/scripts/audit_pr_body.py
+++ b/scripts/audit_pr_body.py
@@ -57,6 +57,7 @@ REQUIRED_SECTIONS = (
     "Diff size",
 )
 DOCS_ONLY_RE = re.compile(r"^Docs-only:\s*true\s*$", re.IGNORECASE)
+OPEN_PR_WRAPPER_MARKER = "<!-- atlas-open-pr-wrapper: v1 -->"
 COMMAND_PREFIX_RE = re.compile(r"^\s*[-*]\s+command\s*:\s*\S", re.IGNORECASE)
 MECHANICAL_FIELD_RE = re.compile(
     r"(?P<prefix>^\s*[-*]\s+|\s+-\s+)"
@@ -92,6 +93,12 @@ def is_docs_only_body(body: str) -> bool:
 
     first_nonempty = next((line.strip() for line in body.splitlines() if line.strip()), "")
     return DOCS_ONLY_RE.fullmatch(first_nonempty) is not None
+
+
+def has_open_pr_wrapper_marker(body: str) -> bool:
+    """Return true when a full PR body carries the open wrapper stamp."""
+
+    return any(line.strip() == OPEN_PR_WRAPPER_MARKER for line in body.splitlines())
 
 
 def first_nonempty_raw_line_index(lines: list[str]) -> tuple[int, str] | None:
@@ -340,6 +347,7 @@ def audit_pr_body(
     *,
     root: Path = ROOT,
     plan_exists: Callable[[str], bool] | None = None,
+    require_wrapper_marker: bool = False,
 ) -> list[str]:
     """Return a list of contract failures (empty means the body passes)."""
 
@@ -354,6 +362,12 @@ def audit_pr_body(
     nonempty = [line.strip() for line in lines if line.strip()]
     if not nonempty:
         return ["PR body is empty"]
+
+    if require_wrapper_marker and not has_open_pr_wrapper_marker(body):
+        failures.append(
+            "missing open PR wrapper marker; publish full human PR bodies "
+            "through scripts/open_pr.sh"
+        )
 
     if raw_header_start is None:
         return ["PR body is empty"]
@@ -481,6 +495,14 @@ def main(argv: Sequence[str] | None = None) -> int:
             "trusted-base gates pass their fetched PR head"
         ),
     )
+    parser.add_argument(
+        "--require-wrapper-marker",
+        action="store_true",
+        help=(
+            "require the scripts/open_pr.sh marker on full human PR bodies; "
+            "docs-only and Dependabot bodies keep their separate exemptions"
+        ),
+    )
     parser.add_argument("body_file", help="path to a file holding the PR body")
     args = parser.parse_args(argv)
 
@@ -549,7 +571,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         print("pr body audit: PASS (explicit Markdown-only body exemption)")
         return 0
 
-    failures = audit_pr_body(body, root=repo_root, plan_exists=plan_exists)
+    failures = audit_pr_body(
+        body,
+        root=repo_root,
+        plan_exists=plan_exists,
+        require_wrapper_marker=args.require_wrapper_marker,
+    )
     if failures:
         print("pr body audit: FAIL (AGENTS.md section 1b contract)")
         for failure in failures:

--- a/scripts/audit_workflow_security_posture.py
+++ b/scripts/audit_workflow_security_posture.py
@@ -25,6 +25,7 @@ ALLOWED_PULL_REQUEST_TARGET_JOBS = frozenset(
         ("diff_budget.yml", "diff-budget"),
         ("ai_reconciliation_live.yml", "live-reconciliation"),
         ("pr_body_contract.yml", "pr-body-contract"),
+        ("pr_ready_state.yml", "pr-ready-state"),
         ("pre_push_audit.yml", "pre-push-audit"),
         ("session_lane.yml", "session-lane"),
         ("plan_admission.yml", "plan-admission"),

--- a/scripts/open_pr.sh
+++ b/scripts/open_pr.sh
@@ -49,14 +49,24 @@ if [ "$#" -lt 1 ] || [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
     exit 2
 fi
 
-body_file="$1"
+input_body_file="$1"
 shift
 
-if [ ! -f "$body_file" ]; then
-    echo "open_pr.sh: PR body file not found: $body_file" >&2
+if [ ! -f "$input_body_file" ]; then
+    echo "open_pr.sh: PR body file not found: $input_body_file" >&2
     echo "Create the body file first, then rerun this wrapper." >&2
     exit 2
 fi
+
+body_file="$input_body_file"
+open_pr_wrapper_marker="<!-- atlas-open-pr-wrapper: v1 -->"
+temporary_body_file=""
+cleanup_open_pr_body() {
+    if [ -n "$temporary_body_file" ]; then
+        rm -f "$temporary_body_file"
+    fi
+}
+trap cleanup_open_pr_body EXIT
 
 refresh_base_ref() {
     echo "Refreshing origin/main before PR body audit..."
@@ -265,6 +275,39 @@ body_hash() {
     git hash-object "$body_file"
 }
 
+body_uses_docs_only_marker() {
+    "$python_bin" - "$1" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+body = Path(sys.argv[1]).read_text(encoding="utf-8", errors="replace")
+first = next((line.strip() for line in body.splitlines() if line.strip()), "")
+raise SystemExit(0 if re.fullmatch(r"Docs-only:\s*true", first, re.IGNORECASE) else 1)
+PY
+}
+
+body_has_open_pr_wrapper_marker() {
+    grep -Fxq "$open_pr_wrapper_marker" "$1"
+}
+
+body_author_is_dependabot() {
+    local author_lc="${ATLAS_CURRENT_PR_AUTHOR:-}"
+    author_lc="${author_lc,,}"
+    [ "$author_lc" = "dependabot[bot]" ] || [ "$author_lc" = "app/dependabot" ] || [ "$author_lc" = "dependabot" ]
+}
+
+prepare_publish_body() {
+    if body_author_is_dependabot || body_uses_docs_only_marker "$input_body_file" || body_has_open_pr_wrapper_marker "$input_body_file"; then
+        body_file="$input_body_file"
+        return 0
+    fi
+    temporary_body_file="$(mktemp "${TMPDIR:-/tmp}/atlas-open-pr-body.XXXXXX")"
+    cp "$input_body_file" "$temporary_body_file"
+    printf '\n%s\n' "$open_pr_wrapper_marker" >> "$temporary_body_file"
+    body_file="$temporary_body_file"
+}
+
 verify_body_hash() {
     local expected="$1" current
     current="$(body_hash)"
@@ -403,6 +446,7 @@ for arg in "$@"; do
     esac
 done
 reject_target_overrides "$@"
+prepare_publish_body
 
 branch="$(git branch --show-current)"
 if [ -z "$branch" ]; then

--- a/scripts/select_impacted_tests.py
+++ b/scripts/select_impacted_tests.py
@@ -76,6 +76,9 @@ EXPLICIT_TEST_OWNERS: dict[str, tuple[str, ...]] = {
     ".github/workflows/ai_reconciliation_review_retrigger.yml": (
         "tests/test_check_ai_reconciliation_live.py",
     ),
+    ".github/workflows/pr_body_contract.yml": (
+        "tests/test_pr_body_contract_workflow.py",
+    ),
     ".github/workflows/unit_gate.yml": (
         "tests/test_check_unit_gate.py",
         "tests/test_select_impacted_tests.py",

--- a/tests/test_audit_pr_body.py
+++ b/tests/test_audit_pr_body.py
@@ -21,6 +21,7 @@ SPEC.loader.exec_module(audit_pr_body_module)
 
 audit_pr_body = audit_pr_body_module.audit_pr_body
 is_dependabot_author = audit_pr_body_module.is_dependabot_author
+OPEN_PR_WRAPPER_MARKER = audit_pr_body_module.OPEN_PR_WRAPPER_MARKER
 
 
 def _valid_body(plan: str = "plans/PR-Example.md") -> str:
@@ -70,6 +71,21 @@ def test_valid_body_passes(tmp_path: Path) -> None:
     root = _write_plan(tmp_path)
 
     assert audit_pr_body(_valid_body(), root=root) == []
+
+
+def test_wrapper_marker_requirement_rejects_unstamped_full_body(tmp_path: Path) -> None:
+    root = _write_plan(tmp_path)
+
+    failures = audit_pr_body(_valid_body(), root=root, require_wrapper_marker=True)
+
+    assert any("missing open PR wrapper marker" in failure for failure in failures)
+
+
+def test_wrapper_marker_requirement_accepts_stamped_full_body(tmp_path: Path) -> None:
+    root = _write_plan(tmp_path)
+    body = _valid_body() + f"\n\n{OPEN_PR_WRAPPER_MARKER}\n"
+
+    assert audit_pr_body(body, root=root, require_wrapper_marker=True) == []
 
 
 def test_empty_body_fails() -> None:
@@ -617,6 +633,7 @@ def test_dependabot_cli_exempts_invalid_body() -> None:
             [
                 sys.executable,
                 str(SCRIPT),
+                "--require-wrapper-marker",
                 "--pr-author",
                 "app/dependabot",
                 str(body_path),
@@ -666,6 +683,7 @@ def test_docs_only_marker_passes_for_markdown_only_human_diff(tmp_path: Path) ->
         [
             sys.executable,
             str(SCRIPT),
+            "--require-wrapper-marker",
             "--repo-root",
             str(repo),
             "--base-ref",

--- a/tests/test_audit_workflow_security_posture.py
+++ b/tests/test_audit_workflow_security_posture.py
@@ -413,6 +413,7 @@ def test_converted_meta_gates_pull_request_target_is_allowed(tmp_path: Path) -> 
         ("diff_budget.yml", "diff-budget"),
         ("ai_reconciliation_live.yml", "live-reconciliation"),
         ("pr_body_contract.yml", "pr-body-contract"),
+        ("pr_ready_state.yml", "pr-ready-state"),
         ("pre_push_audit.yml", "pre-push-audit"),
         ("session_lane.yml", "session-lane"),
         ("plan_admission.yml", "plan-admission"),

--- a/tests/test_open_pr_wrapper.py
+++ b/tests/test_open_pr_wrapper.py
@@ -16,6 +16,7 @@ AI_RECONCILIATION_SCRIPT = REPO_ROOT / "scripts" / "audit_ai_reconciliation.py"
 CHANGE_POLICY_SCRIPT = REPO_ROOT / "scripts" / "_pr_change_policy.py"
 LOCAL_REVIEW_SCRIPT = REPO_ROOT / "scripts" / "local_pr_review.sh"
 BRANCH_NAME_SCRIPT = REPO_ROOT / "scripts" / "check_pr_branch_name.py"
+OPEN_PR_WRAPPER_MARKER = "<!-- atlas-open-pr-wrapper: v1 -->"
 
 
 def test_open_pr_create_passes_body_via_stdin_not_path(tmp_path: Path) -> None:
@@ -27,9 +28,12 @@ def test_open_pr_create_passes_body_via_stdin_not_path(tmp_path: Path) -> None:
     assert log.read_text(encoding="utf-8").strip() == (
         "pr create --title Workflow wrapper --repo canfieldjuan/ATLAS --base main --body-file -"
     )
-    assert (repo / "local-review.log").read_text(encoding="utf-8").strip() == f"local_pr_review {body}"
+    assert (repo / "local-review.log").read_text(encoding="utf-8").strip().startswith(
+        "local_pr_review /tmp/atlas-open-pr-body."
+    )
     assert str(body) not in log.read_text(encoding="utf-8")
-    assert stdin_capture.read_text(encoding="utf-8") == body.read_text(encoding="utf-8")
+    assert stdin_capture.read_text(encoding="utf-8") == _stamped_body(body)
+    assert OPEN_PR_WRAPPER_MARKER not in body.read_text(encoding="utf-8")
 
 
 def test_open_pr_edit_passes_body_via_stdin_not_path(tmp_path: Path) -> None:
@@ -44,7 +48,7 @@ def test_open_pr_edit_passes_body_via_stdin_not_path(tmp_path: Path) -> None:
         f"--pr 17 --branch claude/pr-test --head-sha {_git_output(repo, 'rev-parse', 'HEAD')}"
     )
     assert str(body) not in log.read_text(encoding="utf-8")
-    assert stdin_capture.read_text(encoding="utf-8") == body.read_text(encoding="utf-8")
+    assert stdin_capture.read_text(encoding="utf-8") == _stamped_body(body)
 
 
 def test_open_pr_existing_pr_ownership_guard_failure_blocks_before_edit(tmp_path: Path) -> None:
@@ -163,7 +167,7 @@ def test_open_pr_forwards_draft_when_operator_consent_flag_is_set(tmp_path: Path
     assert log.read_text(encoding="utf-8").strip() == (
         "pr create --draft --title Draft wrapper --repo canfieldjuan/ATLAS --base main --body-file -"
     )
-    assert stdin_capture.read_text(encoding="utf-8") == body.read_text(encoding="utf-8")
+    assert stdin_capture.read_text(encoding="utf-8") == _stamped_body(body)
 
 
 def test_open_pr_forwards_draft_assignment_when_operator_consent_flag_is_set(tmp_path: Path) -> None:
@@ -176,7 +180,7 @@ def test_open_pr_forwards_draft_assignment_when_operator_consent_flag_is_set(tmp
     assert log.read_text(encoding="utf-8").strip() == (
         "pr create --draft=true --title Draft wrapper --repo canfieldjuan/ATLAS --base main --body-file -"
     )
-    assert stdin_capture.read_text(encoding="utf-8") == body.read_text(encoding="utf-8")
+    assert stdin_capture.read_text(encoding="utf-8") == _stamped_body(body)
 
 
 def test_open_pr_allows_value_shorthand_containing_d_without_consent(tmp_path: Path) -> None:
@@ -190,7 +194,7 @@ def test_open_pr_allows_value_shorthand_containing_d_without_consent(tmp_path: P
     assert log.read_text(encoding="utf-8").strip() == (
         "pr create -tdraft-note --repo canfieldjuan/ATLAS --base main --body-file -"
     )
-    assert stdin_capture.read_text(encoding="utf-8") == body.read_text(encoding="utf-8")
+    assert stdin_capture.read_text(encoding="utf-8") == _stamped_body(body)
 
 
 @pytest.mark.parametrize("args", [["--title", "--draft"], ["-t", "-d"]])
@@ -208,7 +212,7 @@ def test_open_pr_allows_draft_shaped_value_of_title_without_consent(
     assert log.read_text(encoding="utf-8").strip() == (
         f"pr create {' '.join(args)} --repo canfieldjuan/ATLAS --base main --body-file -"
     )
-    assert stdin_capture.read_text(encoding="utf-8") == body.read_text(encoding="utf-8")
+    assert stdin_capture.read_text(encoding="utf-8") == _stamped_body(body)
 
 
 def test_open_pr_disables_gh_prompts_so_interactive_draft_is_unreachable(tmp_path: Path) -> None:
@@ -429,7 +433,7 @@ def test_open_pr_accepts_normal_ssh_origin_url(tmp_path: Path) -> None:
     assert log.read_text(encoding="utf-8").strip() == (
         "pr create --title Workflow wrapper --repo canfieldjuan/ATLAS --base main --body-file -"
     )
-    assert stdin_capture.read_text(encoding="utf-8") == body.read_text(encoding="utf-8")
+    assert stdin_capture.read_text(encoding="utf-8") == _stamped_body(body)
 
 
 def test_open_pr_accepts_case_insensitive_repo_identity_after_create(tmp_path: Path) -> None:
@@ -443,7 +447,7 @@ def test_open_pr_accepts_case_insensitive_repo_identity_after_create(tmp_path: P
     assert log.read_text(encoding="utf-8").strip() == (
         "pr create --title Workflow wrapper --repo canfieldjuan/atlas --base main --body-file -"
     )
-    assert stdin_capture.read_text(encoding="utf-8") == body.read_text(encoding="utf-8")
+    assert stdin_capture.read_text(encoding="utf-8") == _stamped_body(body)
 
 
 def test_open_pr_rejects_unpublished_current_head_before_gh(tmp_path: Path) -> None:
@@ -495,7 +499,7 @@ def test_open_pr_reads_fetched_head_without_tracking_ref(tmp_path: Path) -> None
     assert log.read_text(encoding="utf-8").strip() == (
         "pr create --title Workflow wrapper --repo canfieldjuan/ATLAS --base main --body-file -"
     )
-    assert stdin_capture.read_text(encoding="utf-8") == body.read_text(encoding="utf-8")
+    assert stdin_capture.read_text(encoding="utf-8") == _stamped_body(body)
 
 
 def test_open_pr_rejects_local_review_failure_before_gh(tmp_path: Path) -> None:
@@ -609,6 +613,10 @@ def _run(repo: Path, env: dict[str, str], body: Path, *args: str) -> subprocess.
         capture_output=True,
         text=True,
     )
+
+
+def _stamped_body(body: Path) -> str:
+    return body.read_text(encoding="utf-8") + f"\n{OPEN_PR_WRAPPER_MARKER}\n"
 
 
 def _write_fixture_repo(

--- a/tests/test_pr_body_contract_workflow.py
+++ b/tests/test_pr_body_contract_workflow.py
@@ -11,5 +11,6 @@ def test_pr_body_contract_workflow_validates_docs_only_against_fetched_pr_head()
 
     assert "BASE_REF: ${{ github.event.pull_request.base.ref }}" in text
     assert '"+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"' in text
+    assert "--require-wrapper-marker" in text
     assert '--base-ref "origin/${BASE_REF}"' in text
     assert '--head-ref "refs/remotes/origin/pr-${PR_NUMBER}"' in text

--- a/tests/test_security_guardrails_workflow.py
+++ b/tests/test_security_guardrails_workflow.py
@@ -125,7 +125,7 @@ def test_security_guardrails_docs_name_required_gitleaks_checks() -> None:
     for context in REQUIRED_STATUS_CONTEXTS:
         assert f"`{context}`" in text
     assert "`Branch Protection Required Checks` workflow" in text
-    assert "live GitHub settings contain every registry-required context" in normalized_text
+    assert "Live GitHub settings must contain every registry-required context" in normalized_text
     assert "not an exact-set audit for extra required contexts" in normalized_text
 
 

--- a/tests/test_select_impacted_tests.py
+++ b/tests/test_select_impacted_tests.py
@@ -154,6 +154,10 @@ def test_global_files_escalate_to_full(tmp_path, path):
         ["tests/test_check_ai_reconciliation_live.py"],
     ),
     (
+        ".github/workflows/pr_body_contract.yml",
+        ["tests/test_pr_body_contract_workflow.py"],
+    ),
+    (
         ".github/workflows/unit_gate.yml",
         [
             "tests/test_check_unit_gate.py",


### PR DESCRIPTION
Plan: plans/PR-Ready-State-Gate.md
Slice phase: Workflow/process
Ownership lane: atlas-workflow/pr-enforcement

This slice turns the written open-wrapper rule into enforceable mechanism: full human PR bodies must prove they were published through `scripts/open_pr.sh`. It also bootstraps the trusted-base workflow posture allowlist needed before a future `pr-ready-state` workflow can safely land, and maps the PR-body workflow to its owning unit-gate tests so local and CI unit-gate runs avoid a false FULL-suite escalation.

## Intentional
- Docs-only PRs are not wrapper-marker-gated; their `Docs-only: true` first line remains the narrow admission proof.
- Reviewer-scope heuristics stay deferred; this slice only mechanizes objective PR admission behavior.
- The ready-state workflow/checker is deferred. Trusted-base pre-push CI runs the workflow posture allowlist from `origin/main`, so adding a brand-new `pull_request_target` workflow before the allowlist lands creates a guaranteed red check.
- The unit-gate selector gets one explicit workflow-owner mapping for `pr_body_contract.yml`; this prevents unrelated repo-wide failures from blocking a PR-body workflow edit.

## AI reconciliation
- no-findings

## Deferred
- Promote or retire heuristic review-scope checks after measuring false positives.
- Complete AGENTS.md rule enforcement matrix after this targeted strict gate proves clean.
- Add the `pr-ready-state` workflow/checker, then promote it to `branch_required` and enroll it in live branch protection after the workflow emits the context from `main`.

## Parked hardening
- None.

## Cold diff reconstruction
- Changed: `scripts/open_pr.sh` stamps full non-Dependabot/non-docs-only publish bodies with `<!-- atlas-open-pr-wrapper: v1 -->`, audits the stamped temporary body, and sends that exact body to GitHub while leaving the caller file unchanged.
- Changed: `scripts/audit_pr_body.py` adds `--require-wrapper-marker` and rejects unstamped full human PR bodies while preserving docs-only and Dependabot exemptions.
- Changed: `scripts/audit_workflow_security_posture.py` and its tests allowlist the future ready-state trusted-base job shape so a later PR can add the workflow after this bootstrap is on `main`.
- Changed: `scripts/select_impacted_tests.py` maps `.github/workflows/pr_body_contract.yml` to `tests/test_pr_body_contract_workflow.py`, so unit-gate selects targeted governance tests instead of FULL.
- Changed: docs and CI-map prose describe the split bootstrap and defer ready-state workflow enrollment.
- Contract match: every code/doc/test change traces to the Problem-derived contract in `plans/PR-Ready-State-Gate.md`; product behavior, Codex review severity, live reconciliation, docs-only admission, Dependabot exemptions, and live branch-protection requirements are unchanged.
- Gaps: none.

## Verification
- `python -m pytest tests/test_audit_pr_body.py tests/test_open_pr_wrapper.py tests/test_pr_body_contract_workflow.py tests/test_security_guardrails_workflow.py tests/test_audit_workflow_security_posture.py tests/test_select_impacted_tests.py -q` - 308 passed.
- Local unit-gate mirror selected 10 governance test files and `python scripts/check_unit_gate.py --baseline tests/unit_gate_baseline.txt --base-baseline /tmp/base_baseline.txt --selected-files /tmp/selected.txt --pytest-args ...` reported 0 regressions.

## Mechanical verification
- Command: `python scripts/audit_plan_doc.py plans/PR-Ready-State-Gate.md` - Result: pass - Environment: local
- Command: `python scripts/sync_pr_plan.py plans/PR-Ready-State-Gate.md --check` - Result: pass - Environment: local

## Diff size
14 files, estimated 335 LOC including plan and tests.

<!-- atlas-open-pr-wrapper: v1 -->
