### PR TITLE
Require a resolvable tenant to create an MCP contact (website #124, D1)

### DIFF
--- a/atlas_brain/mcp/crm_server.py
+++ b/atlas_brain/mcp/crm_server.py
@@ -558,6 +558,26 @@ async def create_contact(
         # produces an unclassified row. A missing tenant is a typed refusal, not
         # a silent default. This runs BEFORE the EOM guard below because a NULL
         # tenant is never the EOM tenant and would otherwise slip past it.
+        #
+        # Admission closure (the axis this guard owns): tenant PRESENCE.
+        #   reject  iff  str(x or "").strip() == ""      -> "required" refusal
+        #   reject  iff  the resolved id == EOM tenant    -> EOM-ingress refusal
+        #   admit   otherwise (reaches the provider)
+        # It deliberately does NOT validate tenant EXISTENCE. Binding admission
+        # to the `business_contexts` registry is non-viable today: that table is
+        # empty (0 rows) and there is no FK on contacts.business_context_id
+        # (035_contacts.sql:27), so the real tenants (effingham_maids,
+        # churnsignals) live only as strings on `contacts` -- validating against
+        # the registry would reject every real tenant and break all creates. A
+        # non-blank-but-unknown id therefore reaches the provider and is stamped
+        # verbatim; that row is invisible to every tenant-scoped read (matches no
+        # real tenant -> orphan, not a cross-tenant leak) and is backfillable.
+        # Admitting it also preserves pre-existing behavior -- before D1,
+        # create_contact("garbage") already produced a "garbage"-stamped row; D1
+        # only adds the null/blank rejection. Closing the existence axis (seed
+        # the registry + add the FK, then gate on it) is tracked in #2318. The
+        # property proof for this closure is
+        # test_create_contact_tenant_admission_closure.
         if not str(effective_business_context_id or "").strip():
             return json.dumps({
                 "success": False,

--- a/atlas_brain/mcp/crm_server.py
+++ b/atlas_brain/mcp/crm_server.py
@@ -550,6 +550,24 @@ async def create_contact(
             "source": source,
             "tags": tags or [],
         }
+        # Tenant is required (website #124, D1). An agent-callable create must
+        # not mint a NULL-context contact under weaker rules than the CRM UI,
+        # which always writes a tenant. `_default_context()` returns None when
+        # no deployment default is configured (the live runtime sets none), so
+        # without this a create with no explicit business_context_id silently
+        # produces an unclassified row. A missing tenant is a typed refusal, not
+        # a silent default. This runs BEFORE the EOM guard below because a NULL
+        # tenant is never the EOM tenant and would otherwise slip past it.
+        if not str(effective_business_context_id or "").strip():
+            return json.dumps({
+                "success": False,
+                "error": (
+                    "business_context_id is required to create a contact; no "
+                    "deployment default is configured. Specify the tenant "
+                    "explicitly."
+                ),
+            })
+
         from ..services.eom_lead_ingress import EOM_BUSINESS_CONTEXT_ID
 
         if str(effective_business_context_id or "").strip() == EOM_BUSINESS_CONTEXT_ID:

--- a/plans/PR-D1-MCP-Tenant-Required.md
+++ b/plans/PR-D1-MCP-Tenant-Required.md
@@ -1,0 +1,132 @@
+# PR-D1-MCP-Tenant-Required
+
+## Why this slice exists
+
+Website #124 (D1), the highest-risk 0D child: the agent-callable MCP
+`create_contact` could mint a contact with no tenant.
+
+### Correction to the issue premise (verified on `main` d855836a6)
+
+Most of #124's stated hole is already closed by #2298. What is actually true:
+
+- `create_contact` already **refuses EOM-tenant creation** and routes it to
+  ingress (`crm_server.py`, the `== EOM_BUSINESS_CONTEXT_ID` guard).
+- `update_contact` is already tenant-safe: scoped lookup (`_guarded_contact`),
+  claim-on-write (`_claim_if_legacy`), and an EOM stage-change guard. It never
+  mints a tenant.
+- Criterion 1 ("route through the canonical domain tier") does not map: the
+  boundary is EOM-specific and EOM is already blocked; there is no generic tier
+  for a non-EOM (e.g. churnsignals) contact.
+- Criterion 3 ("normalized matcher, not substring") is a provider-wide
+  `search_contacts` change shared by all callers -- deferred, as in D4.
+
+The one real, reachable, unmet gap is **criterion 2**: a NULL-tenant create.
+
+### Problem-derived contract
+
+- Root cause: `effective_business_context_id = business_context_id or
+  _default_context()` can be `None`, the EOM guard does not catch `None`, and the
+  provider then writes a tenantless row. Prod is exposed -- the live runtime sets
+  no `ATLAS_MCP_CRM_DEFAULT_BUSINESS_CONTEXT`, so `_default_context()` returns
+  `None`.
+- Correct fix touches: `create_contact` gains a tenant-required refusal before
+  the provider write; tests pin it.
+- Must not change: the EOM guards, `update_contact`, `_default_context()`
+  semantics, the provider matcher, or non-EOM creates that supply a tenant.
+
+## Scope (this PR)
+
+Ownership lane: eom-crm/lead-funnel
+Slice phase: production hardening
+
+1. In `create_contact`, after computing `effective_business_context_id`, refuse
+   with a typed error when it is `None`/blank -- before the EOM guard (a NULL
+   tenant is never EOM and would otherwise slip past it) and before the provider
+   write.
+
+### Files touched
+
+- `atlas_brain/mcp/crm_server.py`
+- `plans/PR-D1-MCP-Tenant-Required.md`
+- `tests/test_crm_read_scoping.py`
+
+### Review Contract
+
+1. An agent create with no resolvable tenant is refused and the provider is
+   never called.
+2. A create with an explicit tenant, or with a configured default, still creates
+   -- only "no tenant at all" is newly rejected.
+3. A whitespace-only tenant is treated as missing (the `.strip()` is
+   load-bearing).
+4. The EOM-creation guard and `update_contact` are unchanged.
+
+Affected surfaces: `create_contact` only. No provider change (the two `INSERT
+INTO contacts` sites are untouched; 0A's guard passes). No schema change.
+
+Risk areas: over-refusal breaking a legitimate agent create. Probed by the
+explicit-tenant and configured-default tests, which must still create. The only
+newly-rejected case is a create that would have produced a NULL-context row --
+which is the intended fix (criterion 4: a write that previously succeeded now
+fails).
+
+- Reviewer rules triggered: R1, R2, R3, R5, R14. (R3: this governs which
+  agent-authored writes reach the CRM under which tenant. R5: it changes the
+  `create_contact` response contract -- a create with no resolvable tenant now
+  returns `{success: false}` where it previously returned a created contact.
+  That is deliberate and is criterion 4's required break; it is not a silent
+  schema change -- the response shape (`{success, error}` vs `{success,
+  contact}`) is the tool's existing error convention, and every call that
+  supplies a tenant, explicitly or by configured default, is unchanged. No
+  persisted-data or wire-format compatibility is affected.)
+
+**boundary-probe:** both sides -- missing/blank tenant refuses; explicit and
+default-configured tenants create.
+
+**Mutation-probe (run, not asserted):** removing the guard fails 2 tests;
+weakening it to a truthiness check (dropping `.strip()`) fails the blank-tenant
+test.
+
+## Mechanism
+
+One typed-refusal branch inserted before the existing EOM guard.
+
+## Intentional
+
+- **Refuse, do not default.** #124 criterion 2 is explicit: a missing tenant is
+  a typed refusal, not a silent default. Inventing a fallback tenant would
+  reproduce the mis-tenanting this closes.
+- **Before the EOM guard.** A NULL tenant is never the EOM tenant, so ordering
+  matters -- the tenant check must run first or `None` slips past.
+
+## Deferred
+
+- The provider substring matcher in `search_contacts` -- provider-wide, separate
+  change (as in D4).
+- D3, D5 (website #126, #128).
+
+Parking predicate: this slice parks everything except the create-time tenant
+requirement.
+
+Parked hardening: none.
+
+## Verification
+
+```
+$ python -m pytest tests/test_crm_read_scoping.py -q
+76 passed
+
+$ python scripts/check_contact_write_boundary.py --baseline ... --inventory-baseline ...
+(exit 0 -- no new contact write site)
+```
+
+The 6 pre-existing `test_mcp_servers.py` failures (Email/IMAP/Twilio/Calendar
+tools) are unrelated to CRM and present on `main` before this change.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/mcp/crm_server.py` | 18 |
+| `plans/PR-D1-MCP-Tenant-Required.md` | 132 |
+| `tests/test_crm_read_scoping.py` | 84 |
+| **Total** | **234** |

--- a/plans/PR-D1-MCP-Tenant-Required.md
+++ b/plans/PR-D1-MCP-Tenant-Required.md
@@ -163,7 +163,7 @@ Parked hardening: none.
 
 ```
 $ python -m pytest tests/test_crm_read_scoping.py -q
-89 passed            # 76 + the 13-case admission-closure property proof
+231 passed           # 76 + the ~155-case generated admission-closure property proof
 
 $ python scripts/check_unit_gate.py --baseline tests/unit_gate_baseline.txt \
     --selected-files <CI selection> --pytest-args <9 impacted files> ...

--- a/plans/PR-D1-MCP-Tenant-Required.md
+++ b/plans/PR-D1-MCP-Tenant-Required.md
@@ -49,6 +49,11 @@ Slice phase: production hardening
 - `atlas_brain/mcp/crm_server.py`
 - `plans/PR-D1-MCP-Tenant-Required.md`
 - `tests/test_crm_read_scoping.py`
+- `tests/test_mcp_servers.py` (review fix: the pre-existing
+  test_create_contact_success called create_contact with no tenant and asserted
+  success; the D1 guard now refuses that, so the required Unit Gate could not
+  pass. Updated to supply an explicit non-EOM tenant. No new test logic, just a
+  valid tenant on the existing success-path assertion.)
 
 ### Review Contract
 
@@ -86,6 +91,43 @@ default-configured tenants create.
 weakening it to a truthiness check (dropping `.strip()`) fails the blank-tenant
 test.
 
+### Admission-closure declaration (R2/R3, open-input guard)
+
+`business_context_id` is free text, so this guard's admission class must be
+declared and proven, not left implicit. The guard owns exactly **one** axis --
+tenant **presence** -- and the decision is a total function of the resolved id:
+
+| resolved `business_context_id` | verdict | provider reached? |
+|---|---|---|
+| `None` / `""` / whitespace-only (`.strip() == ""`) | refuse: "required" | no |
+| `== EOM_BUSINESS_CONTEXT_ID` (after strip) | refuse: EOM-ingress | no |
+| any other non-blank string | **admit** (stamped verbatim) | yes |
+
+It **deliberately does not validate tenant existence.** Binding admission to the
+`business_contexts` source of truth (the reviewer's preferred fix) is non-viable
+today, verified against the live DB:
+
+- `business_contexts` exists but is **empty (0 rows)**;
+- there is **no FK** on `contacts.business_context_id` (`035_contacts.sql:27`,
+  bare `VARCHAR(64)`);
+- the real tenants (`effingham_maids` 706, `churnsignals` 1) exist only as
+  strings on `contacts`.
+
+So validating against the registry would return `None` for every real tenant and
+reject **all** creation, breaking prod. The safe behavior for an unrecognized id
+is therefore to **admit** it: it is stamped verbatim, is invisible to every
+tenant-scoped read (matches no real tenant -> orphan, not a cross-tenant leak),
+and is backfillable -- and admitting it **preserves pre-existing behavior**
+(before D1, `create_contact("garbage")` already produced a "garbage" row; D1 only
+adds the null/blank rejection). Closing the existence axis (seed the registry +
+add the FK, then gate on it) is filed as **#2318**.
+
+**Property proof:** `test_create_contact_tenant_admission_closure` drives 13
+grammar inputs (null, empty, several whitespace forms, the EOM id, a stripped EOM
+id, and assorted non-blank ids including an explicitly unknown one) and asserts
+the exact verdict + provider-reached state for each -- the closure above, proven
+rather than asserted in prose.
+
 ## Mechanism
 
 One typed-refusal branch inserted before the existing EOM guard.
@@ -113,20 +155,29 @@ Parked hardening: none.
 
 ```
 $ python -m pytest tests/test_crm_read_scoping.py -q
-76 passed
+89 passed            # 76 + the 13-case admission-closure property proof
+
+$ python scripts/check_unit_gate.py --baseline tests/unit_gate_baseline.txt \
+    --selected-files <CI selection> --pytest-args <9 impacted files> ...
+unit gate: 6 failing/errored node(s); baseline=6; regressions=0; newly-passing=0
+(exit 0 -- CI-scoped: the 6 in-scope failures are the baselined
+ Email/IMAP/Twilio/Calendar infra tests; my diff adds no regression)
 
 $ python scripts/check_contact_write_boundary.py --baseline ... --inventory-baseline ...
 (exit 0 -- no new contact write site)
 ```
 
 The 6 pre-existing `test_mcp_servers.py` failures (Email/IMAP/Twilio/Calendar
-tools) are unrelated to CRM and present on `main` before this change.
+tools) are unrelated to CRM and present on `main` before this change; they are in
+the unit-gate baseline. `test_create_contact_success` is *not* baselined and now
+passes with the supplied tenant.
 
 ## Estimated diff size
 
-| File | LOC |
+| File | LOC (added) |
 |---|---:|
-| `atlas_brain/mcp/crm_server.py` | 18 |
-| `plans/PR-D1-MCP-Tenant-Required.md` | 132 |
-| `tests/test_crm_read_scoping.py` | 84 |
-| **Total** | **234** |
+| `atlas_brain/mcp/crm_server.py` | 38 |
+| `plans/PR-D1-MCP-Tenant-Required.md` | 174 |
+| `tests/test_crm_read_scoping.py` | 136 |
+| `tests/test_mcp_servers.py` | 5 |
+| **Total** | **353** |

--- a/plans/PR-D1-MCP-Tenant-Required.md
+++ b/plans/PR-D1-MCP-Tenant-Required.md
@@ -122,11 +122,19 @@ and is backfillable -- and admitting it **preserves pre-existing behavior**
 adds the null/blank rejection). Closing the existence axis (seed the registry +
 add the FK, then gate on it) is filed as **#2318**.
 
-**Property proof:** `test_create_contact_tenant_admission_closure` drives 13
-grammar inputs (null, empty, several whitespace forms, the EOM id, a stripped EOM
-id, and assorted non-blank ids including an explicitly unknown one) and asserts
-the exact verdict + provider-reached state for each -- the closure above, proven
-rather than asserted in prose.
+**Property proof (GUARD_CLASS_CLOSURE.md section 3):**
+`test_create_contact_tenant_admission_closure` **generates** ~155 inputs across
+the presence grammar -- the blank class by systematic whitespace products (every
+combo up to length 2 + longer seeded runs), the non-blank and EOM-near-miss
+classes by seeded sampling (deterministic fixed seed) -- and asserts each against
+a **semantic oracle** (`_spec_expected_verdict`) derived from the Review Contract,
+not against the guard's own verdict and not from a fixed table. So a regression on
+any same-class input, not just a listed one, turns it red. `hypothesis` is not a
+repo dependency, hence the stdlib generator. The guard's input is a scalar string
+(the MCP tool signature), so section 3's container-shape axis does not apply; the
+covered axes are whitespace placement, casing, affixes, and length.
+Mutation-probed: dropping the guard's `.strip()` reddens 48 generated
+whitespace-class inputs.
 
 ## Mechanism
 
@@ -177,7 +185,7 @@ passes with the supplied tenant.
 | File | LOC (added) |
 |---|---:|
 | `atlas_brain/mcp/crm_server.py` | 38 |
-| `plans/PR-D1-MCP-Tenant-Required.md` | 174 |
-| `tests/test_crm_read_scoping.py` | 136 |
+| `plans/PR-D1-MCP-Tenant-Required.md` | 191 |
+| `tests/test_crm_read_scoping.py` | 186 |
 | `tests/test_mcp_servers.py` | 5 |
-| **Total** | **353** |
+| **Total** | **420** |

--- a/tests/test_crm_read_scoping.py
+++ b/tests/test_crm_read_scoping.py
@@ -1119,3 +1119,87 @@ async def test_list_contacts_uses_default(default_ctx, monkeypatch):
     await crm_srv.list_contacts()
     first = provider.list_contacts.await_args_list[0]
     assert first.kwargs["business_context_id"] == EOM
+
+
+# ---------------------------------------------------------------------------
+# D1 (website #124): tenant is required to create -- no silent NULL-context row
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_contact_refuses_when_no_tenant_resolvable(no_default, monkeypatch):
+    """The core D1 guarantee: an agent cannot mint a tenantless contact.
+
+    With no explicit business_context_id and no deployment default (the live
+    runtime configures none), `_default_context()` returns None. Before this
+    guard the provider was called with business_context_id=None, producing an
+    unclassified row under weaker rules than the CRM UI. Now it is a typed
+    refusal and the provider is never reached.
+    """
+    provider = _provider_mock(monkeypatch)
+    provider.create_contact = AsyncMock(return_value={"id": "should-not-exist"})
+
+    out = json.loads(await crm_srv.create_contact(full_name="Untenanted Agent Row"))
+
+    assert out["success"] is False
+    assert "business_context_id is required" in out["error"]
+    provider.create_contact.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_contact_with_explicit_tenant_still_creates(no_default, monkeypatch):
+    """The guard rejects only a missing tenant, not a supplied one.
+
+    An explicit business_context_id must still create even with no default
+    configured -- otherwise the guard would break every legitimate agent create.
+    """
+    provider = _provider_mock(monkeypatch)
+    provider.create_contact = AsyncMock(return_value={"id": "new-1"})
+
+    out = json.loads(
+        await crm_srv.create_contact(
+            full_name="B2B Prospect", business_context_id="churnsignals"
+        )
+    )
+
+    assert out["success"] is True
+    provider.create_contact.assert_awaited_once()
+    assert provider.create_contact.await_args.args[0]["business_context_id"] == "churnsignals"
+
+
+@pytest.mark.asyncio
+async def test_create_contact_blank_tenant_is_treated_as_missing(no_default, monkeypatch):
+    """A whitespace-only tenant is not a tenant.
+
+    Without this, `business_context_id="  "` would pass a truthiness check but
+    write an effectively-null tenant -- the same hole through a side door.
+    """
+    provider = _provider_mock(monkeypatch)
+    provider.create_contact = AsyncMock(return_value={"id": "should-not-exist"})
+
+    out = json.loads(
+        await crm_srv.create_contact(full_name="Whitespace", business_context_id="   ")
+    )
+
+    assert out["success"] is False
+    assert "business_context_id is required" in out["error"]
+    provider.create_contact.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_contact_uses_configured_default_when_no_explicit_tenant(monkeypatch):
+    """A configured default still satisfies the requirement.
+
+    The guard demands a *resolvable* tenant, not an explicit argument -- a
+    deployment default is a valid resolution, so this path is unchanged.
+    """
+    from atlas_brain.config import settings
+
+    monkeypatch.setattr(settings.mcp, "crm_default_business_context", "churnsignals")
+    provider = _provider_mock(monkeypatch)
+    provider.create_contact = AsyncMock(return_value={"id": "new-2"})
+
+    out = json.loads(await crm_srv.create_contact(full_name="Defaulted"))
+
+    assert out["success"] is True
+    assert provider.create_contact.await_args.args[0]["business_context_id"] == "churnsignals"

--- a/tests/test_crm_read_scoping.py
+++ b/tests/test_crm_read_scoping.py
@@ -1203,3 +1203,55 @@ async def test_create_contact_uses_configured_default_when_no_explicit_tenant(mo
 
     assert out["success"] is True
     assert provider.create_contact.await_args.args[0]["business_context_id"] == "churnsignals"
+
+
+# Grammar-derived property proof for the create_contact tenant-admission closure
+# (D1 review thread R2/R3). The guard owns ONE axis -- tenant PRESENCE -- and the
+# decision is a total function of the resolved id:
+#   blank (null / "" / any whitespace-only)  -> "required" refusal, provider unreached
+#   == EOM tenant                             -> EOM-ingress refusal, provider unreached
+#   any other non-blank string                -> ADMITTED (reaches provider verbatim)
+# The final row asserts the deliberately-open behavior: a non-blank-but-unknown
+# tenant is admitted, because existence is not validated here (empty registry +
+# no FK; deferred to #2318). This is the "safe behavior for unrecognized IDs"
+# the closure declares, proven rather than asserted in prose.
+_ADMISSION_GRAMMAR = [
+    (None, "missing"),
+    ("", "missing"),
+    ("   ", "missing"),
+    ("\t", "missing"),
+    ("\n", "missing"),
+    ("\t \n ", "missing"),
+    (EOM, "eom"),
+    ("  effingham_maids  ", "eom"),   # stripped id still resolves to the EOM tenant
+    ("churnsignals", "admit"),
+    ("a", "admit"),
+    ("x" * 64, "admit"),
+    ("unknown_tenant_xyz", "admit"),  # non-blank + unknown -> admitted (existence not gated)
+    ("  churnsignals  ", "admit"),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("raw, verdict", _ADMISSION_GRAMMAR)
+async def test_create_contact_tenant_admission_closure(no_default, monkeypatch, raw, verdict):
+    provider = _provider_mock(monkeypatch)
+    provider.create_contact = AsyncMock(return_value={"id": "created"})
+
+    kwargs = {"full_name": "Grammar Probe"}
+    if raw is not None:
+        kwargs["business_context_id"] = raw
+    out = json.loads(await crm_srv.create_contact(**kwargs))
+
+    if verdict == "missing":
+        assert out["success"] is False
+        assert "business_context_id is required" in out["error"]
+        provider.create_contact.assert_not_awaited()
+    elif verdict == "eom":
+        assert out["success"] is False
+        assert "EOM ingress" in out["error"]
+        provider.create_contact.assert_not_awaited()
+    else:  # admit
+        assert out["success"] is True
+        provider.create_contact.assert_awaited_once()
+        assert provider.create_contact.await_args.args[0]["business_context_id"] == raw

--- a/tests/test_crm_read_scoping.py
+++ b/tests/test_crm_read_scoping.py
@@ -16,7 +16,10 @@ Semantics under test (plans/PR-EOM-Read-Scoping.md):
 from __future__ import annotations
 
 import ast
+import itertools
 import json
+import random
+import string
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -34,6 +37,9 @@ sys.modules.setdefault("asyncpg", _asyncpg_mock)
 sys.modules.setdefault("asyncpg.exceptions", _asyncpg_exceptions)
 
 import atlas_brain.mcp.crm_server as crm_srv  # noqa: E402
+from atlas_brain.services.eom_lead_ingress import (  # noqa: E402
+    EOM_BUSINESS_CONTEXT_ID as _EOM_ID,
+)
 
 EOM = "effingham_maids"
 UUID = "12345678-1234-5678-1234-567812345678"
@@ -1206,35 +1212,78 @@ async def test_create_contact_uses_configured_default_when_no_explicit_tenant(mo
 
 
 # Grammar-derived property proof for the create_contact tenant-admission closure
-# (D1 review thread R2/R3). The guard owns ONE axis -- tenant PRESENCE -- and the
-# decision is a total function of the resolved id:
-#   blank (null / "" / any whitespace-only)  -> "required" refusal, provider unreached
-#   == EOM tenant                             -> EOM-ingress refusal, provider unreached
-#   any other non-blank string                -> ADMITTED (reaches provider verbatim)
-# The final row asserts the deliberately-open behavior: a non-blank-but-unknown
-# tenant is admitted, because existence is not validated here (empty registry +
-# no FK; deferred to #2318). This is the "safe behavior for unrecognized IDs"
-# the closure declares, proven rather than asserted in prose.
-_ADMISSION_GRAMMAR = [
-    (None, "missing"),
-    ("", "missing"),
-    ("   ", "missing"),
-    ("\t", "missing"),
-    ("\n", "missing"),
-    ("\t \n ", "missing"),
-    (EOM, "eom"),
-    ("  effingham_maids  ", "eom"),   # stripped id still resolves to the EOM tenant
-    ("churnsignals", "admit"),
-    ("a", "admit"),
-    ("x" * 64, "admit"),
-    ("unknown_tenant_xyz", "admit"),  # non-blank + unknown -> admitted (existence not gated)
-    ("  churnsignals  ", "admit"),
-]
+# (D1 review threads R2/R3/R13). Per docs/GUARD_CLASS_CLOSURE.md section 3, the
+# acceptance gate for an open-input guard is a test that GENERATES inputs across
+# the grammar and asserts each against a SEMANTIC ORACLE derived from the spec --
+# NOT a fixed table of examples, and NOT the guard's own verdict. `hypothesis` is
+# not a repo dependency, so the generator below is a deterministic stdlib one
+# (fixed seed): it covers the blank class by systematic whitespace products and
+# the non-blank / EOM-near-miss classes by seeded sampling, so a regression on any
+# same-class input -- not just a listed one -- turns it red.
+#
+# The guard's input is a scalar string (the MCP tool signature), so section 3's
+# container-shape axis (list/tuple/set/nested/wrapped) does not apply; the
+# applicable axes are whitespace placement, casing, affixes, and length.
+
+_WS = (" ", "\t", "\n", "\r", "\x0b", "\x0c")
+
+
+def _spec_expected_verdict(raw):
+    """Semantic oracle from the spec (plan Review Contract), independent of the guard.
+
+    Spec: surrounding whitespace on a tenant id is insignificant; a
+    whitespace-only id is "no tenant" -> refuse (criterion 3); the EOM tenant is
+    routed to ingress -> refuse (criterion 4); every other non-blank id creates.
+    Derived from the contract, so it stays a real check even if the guard is
+    reimplemented.
+    """
+    stripped = str(raw or "").strip()
+    if stripped == "":
+        return "missing"
+    if stripped == _EOM_ID:
+        return "eom"
+    return "admit"
+
+
+def _generate_presence_grammar():
+    """Generate inputs across the presence grammar (deterministic; fixed seed)."""
+    rng = random.Random(20260807)
+    inputs = [None, ""]
+    # blank class -- systematic whitespace products (every combo up to length 2)
+    for n in (1, 2):
+        for combo in itertools.product(_WS, repeat=n):
+            inputs.append("".join(combo))
+    # blank class -- longer seeded whitespace runs
+    for _ in range(6):
+        inputs.append("".join(rng.choice(_WS) for _ in range(rng.randint(3, 8))))
+    # non-blank class -- seeded arbitrary ids (may contain internal whitespace),
+    # each forced to have at least one non-whitespace char
+    alphabet = string.ascii_letters + string.digits + "._-+@ \t"
+    for _ in range(90):
+        s = "".join(rng.choice(alphabet) for _ in range(rng.randint(1, 40)))
+        if s.strip() == "":
+            s = "x" + s
+        inputs.append(s)
+    # EOM class + near-misses (wrapping / casing / affixes)
+    inputs.append(_EOM_ID)
+    for _ in range(8):
+        lead = "".join(rng.choice(_WS) for _ in range(rng.randint(1, 4)))
+        tail = "".join(rng.choice(_WS) for _ in range(rng.randint(1, 4)))
+        inputs.append(lead + _EOM_ID + tail)
+    inputs.extend([
+        _EOM_ID.upper(), _EOM_ID.title(), _EOM_ID.capitalize(),   # casing -> admit
+        _EOM_ID[:-1], _EOM_ID + "_x", "x_" + _EOM_ID,             # sub/superstring -> admit
+    ])
+    return list(dict.fromkeys(inputs))  # dedupe, preserve order
+
+
+_PRESENCE_GRAMMAR = _generate_presence_grammar()
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("raw, verdict", _ADMISSION_GRAMMAR)
-async def test_create_contact_tenant_admission_closure(no_default, monkeypatch, raw, verdict):
+@pytest.mark.parametrize("raw", _PRESENCE_GRAMMAR)
+async def test_create_contact_tenant_admission_closure(no_default, monkeypatch, raw):
+    """Each generated input's actual verdict must equal the semantic oracle's."""
     provider = _provider_mock(monkeypatch)
     provider.create_contact = AsyncMock(return_value={"id": "created"})
 
@@ -1243,11 +1292,12 @@ async def test_create_contact_tenant_admission_closure(no_default, monkeypatch, 
         kwargs["business_context_id"] = raw
     out = json.loads(await crm_srv.create_contact(**kwargs))
 
-    if verdict == "missing":
+    expected = _spec_expected_verdict(raw)
+    if expected == "missing":
         assert out["success"] is False
         assert "business_context_id is required" in out["error"]
         provider.create_contact.assert_not_awaited()
-    elif verdict == "eom":
+    elif expected == "eom":
         assert out["success"] is False
         assert "EOM ingress" in out["error"]
         provider.create_contact.assert_not_awaited()

--- a/tests/test_mcp_servers.py
+++ b/tests/test_mcp_servers.py
@@ -314,6 +314,11 @@ class TestCRMMCPTools:
                 full_name="Jane Smith",
                 phone="618-555-0100",
                 email="jane@example.com",
+                # D1 (#2317): create_contact now requires a resolvable tenant and
+                # crm_default_business_context defaults to None, so the success
+                # contract must supply an explicit non-EOM tenant. (EOM would hit
+                # the separate ingress refusal, not this success path.)
+                business_context_id="churnsignals",
             )
 
         data = json.loads(raw)


### PR DESCRIPTION
Plan: plans/PR-D1-MCP-Tenant-Required.md
Slice phase: production hardening
Ownership lane: eom-crm/lead-funnel

Website #124 (D1), highest-risk 0D child: the agent-callable MCP `create_contact` could mint a contact with **no tenant**.

## Correction to the issue premise (verified on `main` d855836a6)
Most of #124's hole is already closed by #2298:
- `create_contact` already **refuses EOM-tenant creation** → routes to ingress.
- `update_contact` is already tenant-safe (scoped lookup, claim-on-write, EOM stage guard); it never mints a tenant.
- Criterion 1 ("route through the canonical domain tier") doesn't map — the boundary is EOM-specific and EOM is already blocked; there's no generic tier for a non-EOM contact.
- Criterion 3 ("normalized matcher") is a provider-wide `search_contacts` change shared by all callers — deferred, as in D4.

**The one real, reachable, unmet gap is criterion 2: NULL-tenant creation.** `effective_business_context_id = business_context_id or _default_context()` can be `None`, the EOM guard doesn't catch `None`, and the provider writes a tenantless row. Prod is exposed — the live runtime sets no `ATLAS_MCP_CRM_DEFAULT_BUSINESS_CONTEXT`, so `_default_context()` returns `None`.

## What changed
One typed-refusal branch in `create_contact`: if the effective tenant is `None`/blank, refuse ("business_context_id is required…") **before** the EOM guard (a NULL tenant is never EOM and would slip past it) and before the provider write. The guard is comment-documented with an explicit admission-closure declaration (presence axis owned; existence axis deferred to #2318). Pure insertion.

## Intentional
- **Refuse, don't default** — criterion 2 is explicit that a missing tenant is a typed refusal, not a silent fallback.
- **Before the EOM guard** — ordering matters; `None` would otherwise pass the `== EOM` check.

## Backward compatibility (R5)
This changes the `create_contact` response contract: a create with no resolvable tenant now returns `{success:false, error}` instead of a created contact. Deliberate — criterion 4's required break. It uses the tool's existing error-response convention, affects no persisted data or wire format, and every call that supplies a tenant (explicit or configured default) is unchanged.

## Explicit non-scope (verified by diff)
The EOM-creation guard, `update_contact`, `_default_context()`, and the provider substring matcher are all untouched (0 deletions; only the new branch added). No schema change, no other MCP tool. 0A's write-boundary guard passes.

## AI reconciliation
- Close the tenant-admission input class — fixed-in: 40ce22ca4 declares the guard's presence-axis closure (guard comment + plan "Admission-closure declaration") and proves it with the grammar-derived property test test_create_contact_tenant_admission_closure (made generative in 7c5515263 — see below). The reviewer's preferred bind-to-registry fix is non-viable — `business_contexts` is empty (0 rows) and there is no FK on `contacts.business_context_id`, so validating against it would reject every real tenant. The existence axis is filed as #2318.
- Update the existing MCP success contract test — fixed-in: 40ce22ca4 makes `test_create_contact_success` supply an explicit non-EOM tenant so the required Unit Gate passes; CI-scoped gate reports regressions=0.
- Generate the tenant-admission class instead of listing fixtures — fixed-in: 7c5515263 replaces the fixed 13-row table with a generated presence grammar (~155 inputs: systematic whitespace products + seeded non-blank / EOM-near-miss sampling) asserted against a semantic oracle derived from the Review Contract (per GUARD_CLASS_CLOSURE.md section 3). `hypothesis` is not a repo dependency, so the generator is stdlib. Mutation-probed: dropping the guard's strip reddens 48 generated whitespace-class inputs.
- Re-run and record the expanded property test — fixed-in: c95d3cb8b re-ran `tests/test_crm_read_scoping.py` at this head (231 passed) and replaced the stale `89 passed / 13-case` line in both the plan Verification block and this body.

## Deferred
- The provider substring matcher in `search_contacts` — provider-wide, separate change (as in D4).
- D3, D5 (website #126, #128).

## Parked hardening
- None.

## Cold diff reconstruction
- Changed: `atlas_brain/mcp/crm_server.py` — one typed-refusal branch before the EOM guard; refuses when `effective_business_context_id` is None/blank; plus a comment-only admission-closure declaration. 0 logic deletions.
- Changed: `tests/test_crm_read_scoping.py` — the original 4 tenant tests (refuse-no-tenant, explicit-tenant-creates, blank-treated-as-missing, configured-default-creates) plus a generated admission-closure property proof (~155 inputs across the presence grammar, asserted against a semantic oracle).
- Changed: `tests/test_mcp_servers.py` — the pre-existing `test_create_contact_success` supplied no tenant and asserted success; the D1 guard refuses that, so it now supplies an explicit non-EOM tenant. Test-only.
- Added: `plans/PR-D1-MCP-Tenant-Required.md`.
- Contract match: the only production change is the tenant-required guard; every non-scope item (EOM guard, update_contact, _default_context, provider matcher) is untouched.
- Gaps: none.

## Verification
- `pytest tests/test_crm_read_scoping.py` → **231 passed** (76 + the ~155-case generated admission-closure property proof)
- `check_contact_write_boundary.py` → exit 0
- **Mutation-probed:** removing the guard fails 2 tests; dropping its `.strip()` (truthiness only) fails the blank-tenant test.
- CI-scoped unit gate (9 impacted files for this diff) → `regressions=0; newly-passing=0` (exit 0). The 6 in-scope `test_mcp_servers.py` failures (Email/IMAP/Twilio/Calendar) are baselined, unrelated to CRM, and present on `main`; the success test I changed is not among them.

## Mechanical verification
- Command: `python -m pytest tests/test_crm_read_scoping.py -q` - Result: pass (231 passed) - Environment: Office PC

## Diff size
| File | LOC (added) |
|---|---:|
| `plans/PR-D1-MCP-Tenant-Required.md` | 191 |
| `tests/test_crm_read_scoping.py` | 186 |
| `atlas_brain/mcp/crm_server.py` | 38 |
| `tests/test_mcp_servers.py` | 5 |
| **Total** | **420** |

Diff-budget override: this is one atomic guard — 38 LOC of production change in `create_contact`. The 420 total is dominated by the two artifacts that cannot be split from a single-guard slice: the mandated GUARD_CLASS_CLOSURE.md §3 generative property proof (186 LOC in `test_crm_read_scoping.py`) and the required PR-contract plan doc (191 LOC). Splitting would either orphan the contract or move the guard's acceptance gate into a separate PR from the guard it gates.


<!-- atlas-open-pr-wrapper: v1 -->
