### PR TITLE
lead intake: accept optional address, persist to contacts.address

### DIFF
--- a/atlas_brain/api/leads.py
+++ b/atlas_brain/api/leads.py
@@ -10,10 +10,11 @@ suppression via the contact_interactions dedupe key.
 
 import logging
 import re
+from collections.abc import Mapping
 from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from ..services.eom_lead_ingress import (
     EOM_BUSINESS_CONTEXT_ID,
@@ -119,6 +120,31 @@ class LeadIntakeRequest(BaseModel):
     referrer: str = Field(default="", max_length=500)
     # Honeypot: hidden on the real form; humans leave it empty.
     website: str = Field(default="", max_length=300)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _route_address_surrogates_to_validation(cls, value: Any) -> Any:
+        if not isinstance(value, Mapping):
+            return value
+        address = value.get("address")
+        if not isinstance(address, str):
+            return value
+        if not any(0xD800 <= ord(char) <= 0xDFFF for char in address):
+            return value
+        sanitized = dict(value)
+        sanitized["address"] = "\x00"
+        return sanitized
+
+    @field_validator("address")
+    @classmethod
+    def _reject_database_invalid_address(cls, value: str) -> str:
+        try:
+            encoded = value.encode("utf-8")
+        except UnicodeEncodeError as exc:
+            raise ValueError("address must be valid") from exc
+        if b"\x00" in encoded:
+            raise ValueError("address must be valid")
+        return value
 
 
 class LeadValidationError(ValueError):

--- a/atlas_brain/api/leads.py
+++ b/atlas_brain/api/leads.py
@@ -101,6 +101,7 @@ class LeadIntakeRequest(BaseModel):
     name: str = Field(min_length=1, max_length=200)
     email: str = Field(default="", max_length=254)
     phone: str = Field(default="", max_length=32)
+    address: str = Field(default="", max_length=300)
     service: str = Field(default="", max_length=120)
     frequency: str = Field(default="", max_length=120)
     square_feet: str = Field(default="", max_length=40)
@@ -271,6 +272,7 @@ async def _process_lead_intake(
         # lost (PR #2153 round 4, R1/R6).
         "submitted_email": email,
         "submitted_phone": phone_digits,
+        "submitted_address": payload.address.strip(),
     }
     if attribution:
         metadata["attribution"] = attribution
@@ -283,7 +285,7 @@ async def _process_lead_intake(
         full_name=payload.name.strip(),
         email=email or None,
         phone=phone_digits if len(phone_digits) >= 10 else None,
-        address=None,
+        address=payload.address.strip() or None,
         source="web",
         source_ref="website_estimate_form",
         tags=["website", "estimate_request"],

--- a/plans/PR-EOM-Lead-Intake-Address.md
+++ b/plans/PR-EOM-Lead-Intake-Address.md
@@ -1,0 +1,139 @@
+# PR-EOM-Lead-Intake-Address
+
+## Why this slice exists
+
+The operator (Juan) asked to add an optional "address" field to the public lead
+forms so a submitted service address is captured in the CRM, without breaking
+existing behavior. The website forms + `script.js` were updated to send an
+optional `address` (Effingham_Office_Maids_Website #140, merged). The Atlas
+intake endpoint dropped it: `LeadIntakeRequest` had no `address` field and
+`_process_lead_intake` hard-coded `address=None` in the CRM write. This slice
+exposes and persists it.
+
+### Problem-derived contract
+
+- Root cause: The intake endpoint cannot capture a submitted address — the
+  request model has no `address` field, and the ingress call passes
+  `address=None` unconditionally, even though the CRM write path and the
+  `contacts.address` column already support it.
+- Correct fix must touch/change: Add an optional `address` field to
+  `LeadIntakeRequest`; pass the submitted address (stripped, blank->None) to
+  `resolve_or_create_eom_inbound_lead_and_log_interaction`; record it on the
+  interaction metadata (`submitted_address`) so it survives even when an
+  existing contact is resolved read-only; add tests proving the passthrough and
+  the blank->None collapse.
+- Must not change: No DB schema/migration (`contacts.address` already exists);
+  do not overwrite an existing contact's address (preserve-existing stays); do
+  not make address required; do not change the email-or-phone admission rule,
+  tenant/source stamping, honeypot, throttle, or acknowledgement-email behavior;
+  do not touch the website (separate merged PR), the time tracker, or unrelated
+  lanes.
+
+## Scope (this PR)
+
+Ownership lane: eom-crm/lead-intake-address
+Slice phase: Vertical slice
+
+1. Accept an optional `address` on the intake model and forward it to the CRM
+   create + interaction metadata (was hardcoded `None`).
+2. Add regression tests: address forwarded to the CRM contact and recorded on
+   the interaction; blank/whitespace address collapses to `None`.
+
+### Review Contract
+
+- Acceptance criteria:
+  - `LeadIntakeRequest` accepts optional `address` (default `""`, max_length
+    300) — settled by the model in `atlas_brain/api/leads.py` and
+    `tests/test_leads_intake.py::test_address_forwarded_to_crm_and_recorded_on_interaction`.
+  - A submitted address reaches the CRM create as `address=` and the interaction
+    metadata as `submitted_address` — settled by the same test (asserts
+    `find_or_create_contact.call_args.kwargs["address"]` and
+    `log_interaction.call_args.kwargs["metadata"]["submitted_address"]`).
+  - Blank/whitespace address collapses to `None` on create — settled by
+    `tests/test_leads_intake.py::test_blank_address_collapses_to_none_on_create`.
+  - Base payload (no address) still passes `address=None` — settled by the added
+    assertion in `test_contact_stamped_with_eom_tenant_and_web_source`.
+  - No behavior change to email-or-phone admission, honeypot, throttle, or ack
+    email — settled by the unchanged existing tests still green (49 total).
+- Reachability proof: `POST /api/v1/leads/intake` with `{"address": "..."}` ->
+  on new-lead create, `contacts.address` is written (atomic insert in
+  `atlas_brain/services/crm_provider.py`, INSERT column `address`); a post-deploy
+  smoke POST persists the address on the created lead.
+- Affected surfaces: `atlas_brain/api/leads.py` (`LeadIntakeRequest`,
+  `_process_lead_intake`); the intake interaction-metadata contract
+  (`submitted_address` added).
+- Risk areas: extra-field admission (model already ignores unknowns, so the
+  website-first deploy was safe); blank/whitespace handling; not overwriting an
+  existing contact's address.
+- Reviewer rules triggered: R1 (input admission/normalization), R2, R5, R6
+  (contract/metadata shape).
+
+### Boundary-change enumeration
+
+The intake model is an admission boundary; this adds one optional field and a
+strip-normalize on it.
+
+- Boundary path/seam: `LeadIntakeRequest` field admission and the
+  `_process_lead_intake` address normalization (`payload.address.strip() or None`).
+- Replaced-path behaviors: previously `address=None` unconditionally; now the
+  stripped submitted address, or `None` when empty.
+- Guard-relevant fields: `address` (optional, default `""`, max_length 300).
+- Caller x input shape: absent address -> `""` -> `None` (unchanged effective
+  behavior); present address -> stripped string; whitespace-only -> `None`.
+
+### Deployed-config probing
+
+N/A - no guard/config/env fallback change. No new config key; the change is a
+data passthrough of an optional field. Model has no `extra='forbid'`, so unknown
+fields were already ignored (the website shipped first safely).
+
+### Files touched
+
+- `atlas_brain/api/leads.py`
+- `plans/PR-EOM-Lead-Intake-Address.md`
+- `tests/test_leads_intake.py`
+
+## Mechanism
+
+The website form posts an optional `address` in the JSON intake body.
+`LeadIntakeRequest` now declares `address` (optional). `_process_lead_intake`
+strips it and passes `address=payload.address.strip() or None` to
+`resolve_or_create_eom_inbound_lead_and_log_interaction`, which already threads
+`address` into the CRM create (`contacts.address`, via the atomic EOM insert)
+for new leads and leaves existing contacts unchanged. The stripped value is also
+added to the interaction metadata as `submitted_address`, mirroring
+`submitted_email`/`submitted_phone`, so a returning contact's newly-submitted
+address is recorded on the interaction even when the contact row is not
+overwritten.
+
+## Intentional
+
+- One combined `address` string (not structured street/city/state/zip): the
+  atomic EOM insert only has an `address` column, so structured fields would
+  require extending that insert. The operator chose a single field.
+- No DB migration: `contacts.address` already exists.
+- Existing-contact address is not overwritten (preserve-existing); the
+  submission is preserved on the interaction record instead.
+
+## Deferred
+
+- Structured address (city/state/zip) if ever needed — would extend the atomic
+  EOM insert and the model.
+
+Parked hardening: none.
+
+## Verification
+
+- Pending before push: `pytest tests/test_leads_intake.py` (49 passed);
+  `atlas_brain/api/leads.py` compiles clean via python -m py_compile. Post-deploy:
+  smoke `POST` with an address -> `success: true` and `contacts.address`
+  populated on the new lead.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/api/leads.py` | 4 |
+| `plans/PR-EOM-Lead-Intake-Address.md` | 139 |
+| `tests/test_leads_intake.py` | 26 |
+| **Total** | **169** |

--- a/plans/PR-EOM-Lead-Intake-Address.md
+++ b/plans/PR-EOM-Lead-Intake-Address.md
@@ -59,7 +59,7 @@ Slice phase: Vertical slice
     interaction logging — settled by
     `tests/test_leads_intake.py::test_route_rejects_database_invalid_address_before_crm_write`.
   - No behavior change to email-or-phone admission, honeypot, throttle, or ack
-    email — settled by the unchanged existing tests still green (54 total).
+    email — settled by the unchanged existing tests still green (50 total).
 - Reachability proof: `POST /api/v1/leads/intake` with `{"address": "..."}` ->
   on new-lead create, `contacts.address` is written (atomic insert in
   `atlas_brain/services/crm_provider.py`, INSERT column `address`); a post-deploy
@@ -100,9 +100,9 @@ strip-normalize on it.
   JSONB columns. Unpaired surrogates are first replaced with a safe invalid
   sentinel so FastAPI can serialize the resulting `422` response.
 - Class invariant: database-invalid text is rejected regardless of where the
-  invalid code point appears. The route regression samples leading, embedded,
-  and trailing NUL plus high and low unpaired surrogates and asserts zero CRM
-  writes.
+  invalid code point appears. The route regression generates valid free-text
+  surroundings, proves they are admitted, then inserts NUL plus high and low
+  unpaired surrogates at every position and asserts zero additional CRM writes.
 
 ### Deployed-config probing
 
@@ -150,7 +150,7 @@ Parked hardening: none.
 
 ## Verification
 
-- `python -m pytest tests/test_leads_intake.py -q` (54 passed);
+- `python -m pytest tests/test_leads_intake.py -q` (50 passed);
   `python -m py_compile atlas_brain/api/leads.py` (passed). Post-deploy:
   smoke `POST` with an address -> `success: true` and `contacts.address`
   populated on the new lead.
@@ -161,5 +161,5 @@ Parked hardening: none.
 |---|---:|
 | `atlas_brain/api/leads.py` | 32 |
 | `plans/PR-EOM-Lead-Intake-Address.md` | 165 |
-| `tests/test_leads_intake.py` | 74 |
-| **Total** | **271** |
+| `tests/test_leads_intake.py` | 115 |
+| **Total** | **312** |

--- a/plans/PR-EOM-Lead-Intake-Address.md
+++ b/plans/PR-EOM-Lead-Intake-Address.md
@@ -20,8 +20,9 @@ exposes and persists it.
   `LeadIntakeRequest`; pass the submitted address (stripped, blank->None) to
   `resolve_or_create_eom_inbound_lead_and_log_interaction`; record it on the
   interaction metadata (`submitted_address`) so it survives even when an
-  existing contact is resolved read-only; add tests proving the passthrough and
-  the blank->None collapse.
+  existing contact is resolved read-only; reject text PostgreSQL cannot persist
+  at the public intake boundary; add tests proving the passthrough, blank->None
+  collapse, and zero-write malformed-input behavior.
 - Must not change: No DB schema/migration (`contacts.address` already exists);
   do not overwrite an existing contact's address (preserve-existing stays); do
   not make address required; do not change the email-or-phone admission rule,
@@ -37,7 +38,8 @@ Slice phase: Vertical slice
 1. Accept an optional `address` on the intake model and forward it to the CRM
    create + interaction metadata (was hardcoded `None`).
 2. Add regression tests: address forwarded to the CRM contact and recorded on
-   the interaction; blank/whitespace address collapses to `None`.
+   the interaction; blank/whitespace address collapses to `None`; database-invalid
+   address text returns `422` before any CRM write.
 
 ### Review Contract
 
@@ -53,8 +55,11 @@ Slice phase: Vertical slice
     `tests/test_leads_intake.py::test_blank_address_collapses_to_none_on_create`.
   - Base payload (no address) still passes `address=None` — settled by the added
     assertion in `test_contact_stamped_with_eom_tenant_and_web_source`.
+  - Database-invalid address text returns `422` before contact creation or
+    interaction logging — settled by
+    `tests/test_leads_intake.py::test_route_rejects_database_invalid_address_before_crm_write`.
   - No behavior change to email-or-phone admission, honeypot, throttle, or ack
-    email — settled by the unchanged existing tests still green (49 total).
+    email — settled by the unchanged existing tests still green (54 total).
 - Reachability proof: `POST /api/v1/leads/intake` with `{"address": "..."}` ->
   on new-lead create, `contacts.address` is written (atomic insert in
   `atlas_brain/services/crm_provider.py`, INSERT column `address`); a post-deploy
@@ -63,8 +68,8 @@ Slice phase: Vertical slice
   `_process_lead_intake`); the intake interaction-metadata contract
   (`submitted_address` added).
 - Risk areas: extra-field admission (model already ignores unknowns, so the
-  website-first deploy was safe); blank/whitespace handling; not overwriting an
-  existing contact's address.
+  website-first deploy was safe); blank/whitespace handling; PostgreSQL-invalid
+  text; not overwriting an existing contact's address.
 - Reviewer rules triggered: R1 (input admission/normalization), R2, R5, R6
   (contract/metadata shape).
 
@@ -79,7 +84,25 @@ strip-normalize on it.
   stripped submitted address, or `None` when empty.
 - Guard-relevant fields: `address` (optional, default `""`, max_length 300).
 - Caller x input shape: absent address -> `""` -> `None` (unchanged effective
-  behavior); present address -> stripped string; whitespace-only -> `None`.
+  behavior); present address -> validated, stripped string; whitespace-only ->
+  `None`; NUL-containing or non-UTF-8-encodable text -> `422` before CRM access.
+
+### Guard class-closure
+
+- Set status: **OPEN**. Address is free text, so possible inputs cannot be
+  enumerated.
+- Membership source: **DERIVED** at the `LeadIntakeRequest.address` validator
+  from Python's UTF-8 encoder and PostgreSQL's text constraint excluding NUL;
+  there is no authored address-character allowlist to drift.
+- Outside-set behavior: any value that is not affirmatively UTF-8 encodable or
+  contains a NUL byte is rejected with `422` before the CRM mutation path. This
+  is the safe side because admitted values are persisted to PostgreSQL text and
+  JSONB columns. Unpaired surrogates are first replaced with a safe invalid
+  sentinel so FastAPI can serialize the resulting `422` response.
+- Class invariant: database-invalid text is rejected regardless of where the
+  invalid code point appears. The route regression samples leading, embedded,
+  and trailing NUL plus high and low unpaired surrogates and asserts zero CRM
+  writes.
 
 ### Deployed-config probing
 
@@ -104,7 +127,10 @@ for new leads and leaves existing contacts unchanged. The stripped value is also
 added to the interaction metadata as `submitted_address`, mirroring
 `submitted_email`/`submitted_phone`, so a returning contact's newly-submitted
 address is recorded on the interaction even when the contact row is not
-overwritten.
+overwritten. Pre-validation routes unpaired surrogates to a safe invalid
+sentinel; the field validator then admits the address only when it is UTF-8
+encodable and contains no NUL byte, matching the downstream PostgreSQL text
+contract before any side effect can run.
 
 ## Intentional
 
@@ -124,8 +150,8 @@ Parked hardening: none.
 
 ## Verification
 
-- Pending before push: `pytest tests/test_leads_intake.py` (49 passed);
-  `atlas_brain/api/leads.py` compiles clean via python -m py_compile. Post-deploy:
+- `python -m pytest tests/test_leads_intake.py -q` (54 passed);
+  `python -m py_compile atlas_brain/api/leads.py` (passed). Post-deploy:
   smoke `POST` with an address -> `success: true` and `contacts.address`
   populated on the new lead.
 
@@ -133,7 +159,7 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `atlas_brain/api/leads.py` | 4 |
-| `plans/PR-EOM-Lead-Intake-Address.md` | 139 |
-| `tests/test_leads_intake.py` | 26 |
-| **Total** | **169** |
+| `atlas_brain/api/leads.py` | 32 |
+| `plans/PR-EOM-Lead-Intake-Address.md` | 165 |
+| `tests/test_leads_intake.py` | 74 |
+| **Total** | **271** |

--- a/tests/test_leads_intake.py
+++ b/tests/test_leads_intake.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 
 import json
 import sys
+from itertools import product
+from random import Random
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -612,17 +614,7 @@ def test_route_smoke_mounted_path_statuses():
     assert throttled.status_code == 429
 
 
-@pytest.mark.parametrize(
-    "address",
-    (
-        "\x00100 Main St",
-        "100\x00 Main St",
-        "100 Main St\x00",
-        "100\ud800 Main St",
-        "100 Main \udfffSt",
-    ),
-)
-def test_route_rejects_database_invalid_address_before_crm_write(address: str):
+def test_route_rejects_database_invalid_address_before_crm_write():
     from fastapi import FastAPI
     from fastapi.testclient import TestClient
 
@@ -644,19 +636,68 @@ def test_route_rejects_database_invalid_address_before_crm_write(address: str):
     app.dependency_overrides[leads_mod._daily_count_dependency] = lambda: fake_count
     app.dependency_overrides[leads_mod._ack_volume_dependency] = lambda: fake_volume
 
-    response = TestClient(app).post(
-        "/api/v1/leads/intake",
-        content=json.dumps({
-            "name": "Jane",
-            "email": "jane@example.com",
-            "address": address,
-        }),
-        headers={"Content-Type": "application/json"},
+    client = TestClient(app)
+    rng = Random(20260807)
+    valid_code_point_ranges = (
+        (0x20, 0x7F),
+        (0xA0, 0xD800),
+        (0xE000, 0x10000),
+        (0x10000, 0x110000),
     )
 
-    assert response.status_code == 422
-    crm.find_or_create_contact.assert_not_awaited()
-    crm.log_interaction.assert_not_awaited()
+    def generated_valid_character() -> str:
+        start, stop = rng.choice(valid_code_point_ranges)
+        return chr(rng.randrange(start, stop))
+
+    valid_addresses = [
+        "".join(generated_valid_character() for _ in range(rng.randint(1, 16)))
+        for _ in range(6)
+    ]
+
+    for address in valid_addresses:
+        response = client.post(
+            "/api/v1/leads/intake",
+            content=json.dumps({
+                "name": "Jane",
+                "email": "jane@example.com",
+                "address": address,
+            }),
+            headers={"Content-Type": "application/json"},
+        )
+        assert response.status_code == 200
+
+    writes_before_invalid_inputs = crm.find_or_create_contact.await_count
+    interactions_before_invalid_inputs = crm.log_interaction.await_count
+    surrogate_ranges = ((0xD800, 0xDC00), (0xDC00, 0xE000))
+    generated_surrogates = (
+        chr(rng.randrange(start, stop))
+        for start, stop in surrogate_ranges
+        for _ in range(4)
+    )
+    invalid_code_points = ("\x00", *generated_surrogates)
+    for valid_address, invalid_code_point in product(
+        valid_addresses,
+        invalid_code_points,
+    ):
+        for position in range(len(valid_address) + 1):
+            address = (
+                valid_address[:position]
+                + invalid_code_point
+                + valid_address[position:]
+            )
+            response = client.post(
+                "/api/v1/leads/intake",
+                content=json.dumps({
+                    "name": "Jane",
+                    "email": "jane@example.com",
+                    "address": address,
+                }),
+                headers={"Content-Type": "application/json"},
+            )
+            assert response.status_code == 422
+
+    assert crm.find_or_create_contact.await_count == writes_before_invalid_inputs
+    assert crm.log_interaction.await_count == interactions_before_invalid_inputs
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_leads_intake.py
+++ b/tests/test_leads_intake.py
@@ -12,6 +12,7 @@ Covers the Review Contract in plans/PR-EOM-Lead-Intake.md:
 
 from __future__ import annotations
 
+import json
 import sys
 from unittest.mock import AsyncMock, MagicMock
 
@@ -609,6 +610,53 @@ def test_route_smoke_mounted_path_statuses():
         "/api/v1/leads/intake", json={"name": "Jane", "email": "jane@example.com"}
     )
     assert throttled.status_code == 429
+
+
+@pytest.mark.parametrize(
+    "address",
+    (
+        "\x00100 Main St",
+        "100\x00 Main St",
+        "100 Main St\x00",
+        "100\ud800 Main St",
+        "100 Main \udfffSt",
+    ),
+)
+def test_route_rejects_database_invalid_address_before_crm_write(address: str):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    import atlas_brain.api.leads as leads_mod
+
+    crm = _crm()
+
+    async def fake_count(email, phone):
+        return 0
+
+    async def fake_volume():
+        return 0
+
+    app = FastAPI()
+    app.include_router(leads_mod.router, prefix="/api/v1")
+    app.dependency_overrides[leads_mod._crm_dependency] = lambda: crm
+    app.dependency_overrides[leads_mod._email_dependency] = lambda: _email_provider()
+    app.dependency_overrides[leads_mod._email_history_dependency] = _email_history
+    app.dependency_overrides[leads_mod._daily_count_dependency] = lambda: fake_count
+    app.dependency_overrides[leads_mod._ack_volume_dependency] = lambda: fake_volume
+
+    response = TestClient(app).post(
+        "/api/v1/leads/intake",
+        content=json.dumps({
+            "name": "Jane",
+            "email": "jane@example.com",
+            "address": address,
+        }),
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert response.status_code == 422
+    crm.find_or_create_contact.assert_not_awaited()
+    crm.log_interaction.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_leads_intake.py
+++ b/tests/test_leads_intake.py
@@ -128,6 +128,32 @@ async def test_contact_stamped_with_eom_tenant_and_web_source():
     assert kwargs["preserve_existing"] is True
     assert kwargs["email"] == "jane@example.com"
     assert kwargs["phone"] == "2175550100"  # digits-only normalization
+    assert kwargs["address"] is None  # base payload submits no address
+
+
+@pytest.mark.asyncio
+async def test_address_forwarded_to_crm_and_recorded_on_interaction():
+    crm, provider = _crm(), _email_provider()
+    await _process_lead_intake(
+        _payload(address="207 Santa Fe Ave, Effingham, IL 62401"),
+        crm=crm,
+        email_provider=provider,
+    )
+    assert (
+        crm.find_or_create_contact.call_args.kwargs["address"]
+        == "207 Santa Fe Ave, Effingham, IL 62401"
+    )
+    assert (
+        crm.log_interaction.call_args.kwargs["metadata"]["submitted_address"]
+        == "207 Santa Fe Ave, Effingham, IL 62401"
+    )
+
+
+@pytest.mark.asyncio
+async def test_blank_address_collapses_to_none_on_create():
+    crm, provider = _crm(), _email_provider()
+    await _process_lead_intake(_payload(address="   "), crm=crm, email_provider=provider)
+    assert crm.find_or_create_contact.call_args.kwargs["address"] is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Plan: plans/PR-EOM-Lead-Intake-Address.md
Slice phase: Vertical slice
Ownership lane: eom-crm/lead-intake-address

Adds an optional `address` to the public lead-intake endpoint and persists it. The website lead forms + `script.js` now send an optional `address` (Effingham_Office_Maids_Website #140, merged); the intake endpoint dropped it because `LeadIntakeRequest` had no `address` field and `_process_lead_intake` hard-coded `address=None` in the CRM write.

## What this PR does
- `LeadIntakeRequest` gains optional `address` (default `""`, max_length 300).
- `_process_lead_intake` passes `address=payload.address.strip() or None` to the ingress (was `None`), and records the stripped value on the interaction metadata as `submitted_address` (mirrors `submitted_email`/`submitted_phone`, so it survives an existing-contact read-only resolve).
- The public request boundary rejects NUL-containing and non-UTF-8-encodable address text with `422` before any CRM write.
- Tests cover address forwarding, blank/whitespace collapse, base-payload compatibility, and a generated valid/invalid address class through the public route.

## Intentional
- One combined `address` string, not structured street/city/state/zip: the atomic EOM insert only has an `address` column, so structured fields would extend that insert. The operator chose a single field.
- No DB migration because `contacts.address` already exists and the ingress + atomic insert already thread `address`.
- Existing-contact address is not overwritten (preserve-existing); the submission is recorded on the interaction instead.

## AI reconciliation
- Include address in the interaction dedupe basis -- waived-out-of-scope: this additive capture slice does not change the shared daily interaction-dedupe contract; repeat same-day resubmission semantics require a separate CRM contract.
- Prove address persistence through the real adapter -- waived-out-of-scope: the new field uses the existing atomic adapter and SQL insert path; adding an address-specific environment-gated PostgreSQL fixture is test-harness expansion beyond this slice.
- Project the submitted address for returning leads -- waived-out-of-scope: this capture slice records `submitted_address` as interaction evidence but intentionally does not change the office review projection or calendar booking contract.
- Reject NUL bytes before persisting addresses -- fixed-in: 9b748352b/atlas_brain/api/leads.py/tests/test_leads_intake.py
- Replace fixed address fixtures with generated class proof -- fixed-in: 7fc52aa5b/tests/test_leads_intake.py

## Deferred
- Structured address (city/state/zip) if ever needed; that would extend the atomic EOM insert and the model.

## Parked hardening
- None.

## Cold diff reconstruction
- Changed: `atlas_brain/api/leads.py` adds `address`, passes the normalized value to CRM, records `submitted_address`, and rejects database-invalid address text before processing.
- Changed: `tests/test_leads_intake.py` proves forwarding, blank collapse, default behavior, generated valid-address admission, and zero-write `422` responses for generated database-invalid text at every insertion position.
- Added: `plans/PR-EOM-Lead-Intake-Address.md` as the canonical contract and verification record.
- Contract match: additive optional field + passthrough + persistence-boundary validation; no change to email-or-phone admission, honeypot, throttle, tenant/source stamping, or acknowledgement-email behavior.
- Gaps: none. No schema or migration is required because `contacts.address` and the CRM write path pre-exist.

## Verification
- `python -m pytest tests/test_leads_intake.py -q` -> **50 passed**
- `python -m py_compile atlas_brain/api/leads.py` -> passed
- Mutation-probed: reverting the passthrough to `address=None` fails `test_address_forwarded_to_crm_and_recorded_on_interaction`; malformed address cases assert `422` and zero CRM writes.

## Mechanical verification
- Command: `python -m pytest tests/test_leads_intake.py -q` - Result: pass (50 passed) - Environment: Office PC

## Diff size
| File | LOC |
|---|---:|
| `atlas_brain/api/leads.py` | 32 |
| `plans/PR-EOM-Lead-Intake-Address.md` | 165 |
| `tests/test_leads_intake.py` | 115 |
| **Total** | **312** |

<!-- atlas-open-pr-wrapper: v1 -->
