### PR TITLE
Mirror unit gate in local PR review

### DIFF
--- a/plans/PR-Local-Unit-Gate-Mirror.md
+++ b/plans/PR-Local-Unit-Gate-Mirror.md
@@ -1,0 +1,170 @@
+# PR-Local-Unit-Gate-Mirror
+
+## Why this slice exists
+
+The operator observed repeated PRs going red on the branch-required `unit-gate`
+after publication and asked whether the gate can run before opening the PR. The
+current wrappers already route publish/open through `scripts/local_pr_review.sh`,
+but that local bundle does not execute the same selector/check path as
+`.github/workflows/unit_gate.yml`, so GitHub becomes the first place a unit-gate
+failure is discovered.
+
+### Problem-derived contract
+
+- Root cause: Local PR publication runs the pre-push/local-review mechanics but
+  omits the branch-required unit-gate selection and ratchet check, so a builder
+  can open or update a PR that has already-failing required unit-gate evidence.
+- Correct fix must touch/change: `scripts/local_pr_review.sh` must run a local
+  mirror of the unit-gate selector/check flow before reporting success, and
+  `tests/test_local_pr_review.py` must prove the mirror runs locally, fails
+  closed, strips wrapper-only PR body/Git hook env from the unit-gate
+  subprocess, propagates selector failures before dispatching the checker,
+  covers all three selector outcomes, and does not duplicate the separate
+  GitHub Actions `unit_gate` job.
+- Must not change: Do not alter `.github/workflows/unit_gate.yml`,
+  `scripts/check_unit_gate.py`, `scripts/select_impacted_tests.py`, the unit
+  baseline, product code, product shape, or review verdict policy.
+
+## Scope (this PR)
+
+Ownership lane: atlas-workflow/pr-enforcement
+Slice phase: Workflow/process
+
+1. Add a late-stage `Local unit gate mirror` step to `scripts/local_pr_review.sh`.
+2. Add focused local-review tests for selected-test execution, empty-selection
+   growth-only execution, `FULL` execution, selector failure propagation, and
+   GitHub Actions duplication avoidance.
+
+### Review Contract
+
+- Acceptance criteria:
+  - `scripts/local_pr_review.sh` invokes the local unit-gate mirror before
+    printing `local PR review passed` when earlier local checks have no failures.
+  - The mirror resolves the base unit-gate baseline from the merge base with the
+    supplied base ref, writes an empty baseline when the base has no ledger, and
+    then runs the same `check_unit_gate.py` modes as the workflow: `FULL`,
+    `--growth-only`, or `--selected-files` with the selected pytest paths.
+  - A failing local mirror increments the local-review failure count and prevents
+    the wrappers from opening/updating a PR as green.
+  - A failing selector exits the mirror before any `check_unit_gate.py` dispatch,
+    and the failure increments the local-review failure count.
+  - The mirror unsets wrapper-only PR body environment and Git hook-local
+    environment before running selector and unit-gate subprocesses, matching the
+    standalone GitHub `unit_gate` job.
+  - Under `GITHUB_ACTIONS=true`, `local_pr_review.sh` skips the mirror because
+    `.github/workflows/unit_gate.yml` is already a separate required CI job.
+- Reachability proof: Real entrypoint is `bash scripts/local_pr_review.sh`; the
+  observable effect is the `Local unit gate mirror` section running or skipping
+  and the final local-review exit code.
+- Affected surfaces: `scripts/local_pr_review.sh` and
+  `tests/test_local_pr_review.py`.
+- Risk areas: local/CI duplication, trusted script-root execution, expensive
+  full-suite selection, baseline-ratchet parity.
+- Reviewer rules triggered: R1, R2, R6, R7, R10, R12, R14.
+
+### Boundary-change enumeration
+
+Required when this diff changes a guard, validator, normalizer, resolver,
+router/classifier, or admission boundary. Name each changed boundary path or
+seam in the enumeration; otherwise write "N/A - no boundary change."
+
+- Boundary path/seam: `scripts/local_pr_review.sh` success admission now depends
+  on the local mirror of the branch-required unit gate.
+- Replaced-path behaviors: Previously local review could pass without any unit
+  gate evidence; now it runs the mirror unless earlier local checks already
+  failed, the check script is absent, or GitHub Actions is already running the
+  dedicated unit-gate workflow.
+- Guard-relevant fields: `base_ref`, `repo_root`, `script_root`,
+  `GITHUB_ACTIONS`, `ATLAS_CURRENT_PR_BODY_FILE`, `ATLAS_CURRENT_PR_AUTHOR`,
+  Git hook-local variables from `git rev-parse --local-env-vars`, selected test
+  file contents, and the merge-base baseline.
+- Caller x input shape: `scripts/push_pr.sh` and `scripts/open_pr.sh` call
+  `local_pr_review.sh --current-pr-body-file ...`; the pre-push hook calls
+  `local_pr_review.sh`; GitHub `pre_push_audit` calls the same script with
+  `--repo-root` and `--script-root`.
+
+### Deployed-config probing
+
+Required for guard, validator, resolver, admission-boundary, or env/config
+fallback changes; otherwise write "N/A - no guard/config boundary change."
+
+- Deployed/default config values: Default local shell has `GITHUB_ACTIONS`
+  unset, so the mirror runs when `scripts/check_unit_gate.py` exists and earlier
+  local checks passed.
+- Explicit value probe: `GITHUB_ACTIONS=true` skips the mirror, leaving the
+  dedicated CI `unit_gate` job as the required remote authority.
+- Absent value probe: If `scripts/check_unit_gate.py` is absent, local review
+  prints a skip instead of pretending to run the gate.
+- Default-session/default-context probe: Normal `push_pr.sh` / `open_pr.sh`
+  local publication inherits the unset `GITHUB_ACTIONS` default and therefore
+  runs the mirror.
+- Side-effect ordering: The mirror runs after cheap local-review checks and
+  before the final success message; if earlier checks failed, it skips to avoid
+  spending full-suite time on an already-invalid PR.
+
+### Files touched
+
+- `plans/PR-Local-Unit-Gate-Mirror.md`
+- `scripts/local_pr_review.sh`
+- `tests/test_local_pr_review.py`
+
+## Mechanism
+
+`scripts/local_pr_review.sh` gains `run_local_unit_gate_mirror`, which creates
+temporary selection and base-baseline files, resolves the merge-base baseline
+using the same base-ref contract as the workflow, runs
+`scripts/select_impacted_tests.py --base <base-ref>` when the selector exists in
+the PR tree, and dispatches to `scripts/check_unit_gate.py` in the same three
+modes as `.github/workflows/unit_gate.yml`. The selector/check subprocesses run
+without `ATLAS_CURRENT_PR_BODY_FILE`, `ATLAS_CURRENT_PR_AUTHOR`, or Git
+hook-local variables so the local mirror matches the standalone CI unit-gate
+environment instead of the publication wrapper environment.
+
+Selector execution and checker dispatch record and return child exit codes
+explicitly; the function does not depend on Bash `errexit` because
+`run_check` invokes checks through an `if` condition.
+
+The call is deliberately late in local review. Cheap plan/body/drift/diff checks
+run first; if any failed, the mirror reports a skip because the PR is already
+blocked. When `GITHUB_ACTIONS=true`, the mirror also reports a skip so the
+trusted-base pre-push audit does not duplicate the dedicated required
+`unit_gate` workflow.
+
+## Intentional
+
+- No change to the workflow, selector, unit-gate checker, or baseline; this PR
+  only moves discovery earlier in the local publish path.
+- The mirror can run the full unit suite locally when the selector escalates to
+  `FULL`. That cost is intentional because it is the exact red check the
+  operator asked to catch before opening or updating the PR.
+- The mirror skips in GitHub Actions to avoid a second copy of the same
+  branch-required unit gate inside `pre_push_audit`.
+
+## Deferred
+
+- Unit-gate runtime optimization or caching, if the full-suite path remains too
+  slow after failures move local.
+- Additional selector ownership refinements as separate narrow PRs when a
+  concrete changed path escalates unnecessarily.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_local_pr_review.py -q` - 25 passed.
+- `GITHUB_ACTIONS=true python -m pytest tests/test_local_pr_review.py -q` - 25 passed.
+- `bash -n scripts/local_pr_review.sh` - passed.
+- Scoped CI-mode unit gate invocation for `tests/test_local_pr_review.py` -
+  passed with zero regressions against the merge-base baseline.
+- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/atlas-pr-local-unit-gate-mirror-body.md`
+  - passed, including `Local unit gate mirror` selecting
+    `tests/test_local_pr_review.py` and reporting zero regressions.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Local-Unit-Gate-Mirror.md` | 170 |
+| `scripts/local_pr_review.sh` | 93 |
+| `tests/test_local_pr_review.py` | 126 |
+| **Total** | **389** |

--- a/plans/PR-Local-Unit-Gate-Mirror.md
+++ b/plans/PR-Local-Unit-Gate-Mirror.md
@@ -22,8 +22,9 @@ must fail locally, and checker failures must block every mirror dispatch mode.
 - Correct fix must touch/change: `scripts/local_pr_review.sh` must run a local
   mirror of the unit-gate selector/check flow before reporting success, and
   `tests/test_local_pr_review.py` must prove the mirror runs locally, fails
-  closed, strips wrapper-only PR body/Git hook env from the unit-gate
-  subprocess, propagates selector failures before dispatching the checker,
+  closed, strips wrapper-only PR body/Git hook env plus local pytest option
+  overrides from the unit-gate subprocess, propagates selector failures before
+  dispatching the checker,
   propagates checker failures in all three dispatch modes, fails when the
   checker is absent from a PR head whose base has the checker, covers all three
   selector outcomes, and does not duplicate the separate GitHub Actions
@@ -61,9 +62,9 @@ Slice phase: Workflow/process
   - If the base branch has `scripts/check_unit_gate.py` and the PR head removes
     or renames it, local review treats that as a failed mirror rather than a
     successful skip.
-  - The mirror unsets wrapper-only PR body environment and Git hook-local
-    environment before running selector and unit-gate subprocesses, matching the
-    standalone GitHub `unit_gate` job.
+  - The mirror unsets wrapper-only PR body environment, Git hook-local
+    environment, and local pytest option overrides before running selector and
+    unit-gate subprocesses, matching the standalone GitHub `unit_gate` job.
   - Under `GITHUB_ACTIONS=true`, `local_pr_review.sh` skips the mirror because
     `.github/workflows/unit_gate.yml` is already a separate required CI job.
 - Reachability proof: Real entrypoint is `bash scripts/local_pr_review.sh`; the
@@ -90,8 +91,9 @@ seam in the enumeration; otherwise write "N/A - no boundary change."
   of a checker present on the base branch fails locally.
 - Guard-relevant fields: `base_ref`, `repo_root`, `script_root`,
   `GITHUB_ACTIONS`, `ATLAS_CURRENT_PR_BODY_FILE`, `ATLAS_CURRENT_PR_AUTHOR`,
-  Git hook-local variables from `git rev-parse --local-env-vars`, selected test
-  file contents, and the merge-base baseline.
+  `PYTEST_ADDOPTS`, Git hook-local variables from
+  `git rev-parse --local-env-vars`, selected test file contents, and the
+  merge-base baseline.
 - Caller x input shape: `scripts/push_pr.sh` and `scripts/open_pr.sh` call
   `local_pr_review.sh --current-pr-body-file ...`; the pre-push hook calls
   `local_pr_review.sh`; GitHub `pre_push_audit` calls the same script with
@@ -131,9 +133,10 @@ using the same base-ref contract as the workflow, runs
 `scripts/select_impacted_tests.py --base <base-ref>` when the selector exists in
 the PR tree, and dispatches to `scripts/check_unit_gate.py` in the same three
 modes as `.github/workflows/unit_gate.yml`. The selector/check subprocesses run
-without `ATLAS_CURRENT_PR_BODY_FILE`, `ATLAS_CURRENT_PR_AUTHOR`, or Git
-hook-local variables so the local mirror matches the standalone CI unit-gate
-environment instead of the publication wrapper environment.
+without `ATLAS_CURRENT_PR_BODY_FILE`, `ATLAS_CURRENT_PR_AUTHOR`,
+`PYTEST_ADDOPTS`, or Git hook-local variables so the local mirror matches the
+standalone CI unit-gate environment instead of the publication wrapper
+environment.
 
 Selector execution and checker dispatch record and return child exit codes
 explicitly; the function does not depend on Bash `errexit` because
@@ -184,7 +187,7 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Local-Unit-Gate-Mirror.md` | 190 |
-| `scripts/local_pr_review.sh` | 104 |
-| `tests/test_local_pr_review.py` | 181 |
-| **Total** | **475** |
+| `plans/PR-Local-Unit-Gate-Mirror.md` | 193 |
+| `scripts/local_pr_review.sh` | 105 |
+| `tests/test_local_pr_review.py` | 184 |
+| **Total** | **482** |

--- a/plans/PR-Local-Unit-Gate-Mirror.md
+++ b/plans/PR-Local-Unit-Gate-Mirror.md
@@ -22,9 +22,9 @@ must fail locally, and checker failures must block every mirror dispatch mode.
 - Correct fix must touch/change: `scripts/local_pr_review.sh` must run a local
   mirror of the unit-gate selector/check flow before reporting success, and
   `tests/test_local_pr_review.py` must prove the mirror runs locally, fails
-  closed, strips wrapper-only PR body/Git hook env plus local pytest option
-  overrides from the unit-gate subprocess, propagates selector failures before
-  dispatching the checker,
+  closed, strips wrapper-only PR body/Git hook env plus local `PYTEST_*`
+  startup overrides from the unit-gate subprocess, propagates selector failures
+  before dispatching the checker,
   propagates checker failures in all three dispatch modes, fails when the
   checker is absent from a PR head whose base has the checker, covers all three
   selector outcomes, and does not duplicate the separate GitHub Actions
@@ -63,8 +63,8 @@ Slice phase: Workflow/process
     or renames it, local review treats that as a failed mirror rather than a
     successful skip.
   - The mirror unsets wrapper-only PR body environment, Git hook-local
-    environment, and local pytest option overrides before running selector and
-    unit-gate subprocesses, matching the standalone GitHub `unit_gate` job.
+    environment, and local `PYTEST_*` startup overrides before running selector
+    and unit-gate subprocesses, matching the standalone GitHub `unit_gate` job.
   - Under `GITHUB_ACTIONS=true`, `local_pr_review.sh` skips the mirror because
     `.github/workflows/unit_gate.yml` is already a separate required CI job.
 - Reachability proof: Real entrypoint is `bash scripts/local_pr_review.sh`; the
@@ -91,7 +91,7 @@ seam in the enumeration; otherwise write "N/A - no boundary change."
   of a checker present on the base branch fails locally.
 - Guard-relevant fields: `base_ref`, `repo_root`, `script_root`,
   `GITHUB_ACTIONS`, `ATLAS_CURRENT_PR_BODY_FILE`, `ATLAS_CURRENT_PR_AUTHOR`,
-  `PYTEST_ADDOPTS`, Git hook-local variables from
+  local `PYTEST_*` environment variables, Git hook-local variables from
   `git rev-parse --local-env-vars`, selected test file contents, and the
   merge-base baseline.
 - Caller x input shape: `scripts/push_pr.sh` and `scripts/open_pr.sh` call
@@ -133,10 +133,10 @@ using the same base-ref contract as the workflow, runs
 `scripts/select_impacted_tests.py --base <base-ref>` when the selector exists in
 the PR tree, and dispatches to `scripts/check_unit_gate.py` in the same three
 modes as `.github/workflows/unit_gate.yml`. The selector/check subprocesses run
-without `ATLAS_CURRENT_PR_BODY_FILE`, `ATLAS_CURRENT_PR_AUTHOR`,
-`PYTEST_ADDOPTS`, or Git hook-local variables so the local mirror matches the
-standalone CI unit-gate environment instead of the publication wrapper
-environment.
+without `ATLAS_CURRENT_PR_BODY_FILE`, `ATLAS_CURRENT_PR_AUTHOR`, local
+`PYTEST_*` startup variables, or Git hook-local variables so the local mirror
+matches the standalone CI unit-gate environment instead of the publication
+wrapper environment.
 
 Selector execution and checker dispatch record and return child exit codes
 explicitly; the function does not depend on Bash `errexit` because
@@ -188,6 +188,6 @@ Parked hardening: none.
 | File | LOC |
 |---|---:|
 | `plans/PR-Local-Unit-Gate-Mirror.md` | 193 |
-| `scripts/local_pr_review.sh` | 105 |
-| `tests/test_local_pr_review.py` | 184 |
-| **Total** | **482** |
+| `scripts/local_pr_review.sh` | 109 |
+| `tests/test_local_pr_review.py` | 187 |
+| **Total** | **489** |

--- a/plans/PR-Local-Unit-Gate-Mirror.md
+++ b/plans/PR-Local-Unit-Gate-Mirror.md
@@ -9,6 +9,11 @@ but that local bundle does not execute the same selector/check path as
 `.github/workflows/unit_gate.yml`, so GitHub becomes the first place a unit-gate
 failure is discovered.
 
+The final diff exceeds the 400 LOC target because two Codex blocker threads
+found uncovered fail-open paths in the admission gate itself. The added lines
+are the smallest paired code/test proof for those blockers: checker absence
+must fail locally, and checker failures must block every mirror dispatch mode.
+
 ### Problem-derived contract
 
 - Root cause: Local PR publication runs the pre-push/local-review mechanics but
@@ -19,8 +24,10 @@ failure is discovered.
   `tests/test_local_pr_review.py` must prove the mirror runs locally, fails
   closed, strips wrapper-only PR body/Git hook env from the unit-gate
   subprocess, propagates selector failures before dispatching the checker,
-  covers all three selector outcomes, and does not duplicate the separate
-  GitHub Actions `unit_gate` job.
+  propagates checker failures in all three dispatch modes, fails when the
+  checker is absent from a PR head whose base has the checker, covers all three
+  selector outcomes, and does not duplicate the separate GitHub Actions
+  `unit_gate` job.
 - Must not change: Do not alter `.github/workflows/unit_gate.yml`,
   `scripts/check_unit_gate.py`, `scripts/select_impacted_tests.py`, the unit
   baseline, product code, product shape, or review verdict policy.
@@ -32,8 +39,9 @@ Slice phase: Workflow/process
 
 1. Add a late-stage `Local unit gate mirror` step to `scripts/local_pr_review.sh`.
 2. Add focused local-review tests for selected-test execution, empty-selection
-   growth-only execution, `FULL` execution, selector failure propagation, and
-   GitHub Actions duplication avoidance.
+   growth-only execution, `FULL` execution, selector failure propagation,
+   checker failure propagation in all three dispatch modes, checker deletion,
+   and GitHub Actions duplication avoidance.
 
 ### Review Contract
 
@@ -48,6 +56,11 @@ Slice phase: Workflow/process
     the wrappers from opening/updating a PR as green.
   - A failing selector exits the mirror before any `check_unit_gate.py` dispatch,
     and the failure increments the local-review failure count.
+  - A failing `check_unit_gate.py` dispatch increments the local-review failure
+    count for selected, growth-only, and `FULL` modes.
+  - If the base branch has `scripts/check_unit_gate.py` and the PR head removes
+    or renames it, local review treats that as a failed mirror rather than a
+    successful skip.
   - The mirror unsets wrapper-only PR body environment and Git hook-local
     environment before running selector and unit-gate subprocesses, matching the
     standalone GitHub `unit_gate` job.
@@ -72,8 +85,9 @@ seam in the enumeration; otherwise write "N/A - no boundary change."
   on the local mirror of the branch-required unit gate.
 - Replaced-path behaviors: Previously local review could pass without any unit
   gate evidence; now it runs the mirror unless earlier local checks already
-  failed, the check script is absent, or GitHub Actions is already running the
-  dedicated unit-gate workflow.
+  failed, this branch lineage has no unit-gate checker at all, or GitHub
+  Actions is already running the dedicated unit-gate workflow. A PR-head removal
+  of a checker present on the base branch fails locally.
 - Guard-relevant fields: `base_ref`, `repo_root`, `script_root`,
   `GITHUB_ACTIONS`, `ATLAS_CURRENT_PR_BODY_FILE`, `ATLAS_CURRENT_PR_AUTHOR`,
   Git hook-local variables from `git rev-parse --local-env-vars`, selected test
@@ -93,8 +107,9 @@ fallback changes; otherwise write "N/A - no guard/config boundary change."
   local checks passed.
 - Explicit value probe: `GITHUB_ACTIONS=true` skips the mirror, leaving the
   dedicated CI `unit_gate` job as the required remote authority.
-- Absent value probe: If `scripts/check_unit_gate.py` is absent, local review
-  prints a skip instead of pretending to run the gate.
+- Absent value probe: If `scripts/check_unit_gate.py` is absent from this PR
+  head while the base branch has it, local review fails the mirror. Tiny fixture
+  repos that never had the checker still print a skip.
 - Default-session/default-context probe: Normal `push_pr.sh` / `open_pr.sh`
   local publication inherits the unset `GITHUB_ACTIONS` default and therefore
   runs the mirror.
@@ -124,6 +139,11 @@ Selector execution and checker dispatch record and return child exit codes
 explicitly; the function does not depend on Bash `errexit` because
 `run_check` invokes checks through an `if` condition.
 
+When the base branch carries `scripts/check_unit_gate.py`, the mirror runs even
+if the PR head removed that file and then fails before publication. That keeps
+the local admission path aligned with the required GitHub workflow, which would
+also fail on a missing checker.
+
 The call is deliberately late in local review. Cheap plan/body/drift/diff checks
 run first; if any failed, the mirror reports a skip because the PR is already
 blocked. When `GITHUB_ACTIONS=true`, the mirror also reports a skip so the
@@ -151,8 +171,8 @@ Parked hardening: none.
 
 ## Verification
 
-- `python -m pytest tests/test_local_pr_review.py -q` - 25 passed.
-- `GITHUB_ACTIONS=true python -m pytest tests/test_local_pr_review.py -q` - 25 passed.
+- `python -m pytest tests/test_local_pr_review.py -q` - 27 passed.
+- `GITHUB_ACTIONS=true python -m pytest tests/test_local_pr_review.py -q` - 27 passed.
 - `bash -n scripts/local_pr_review.sh` - passed.
 - Scoped CI-mode unit gate invocation for `tests/test_local_pr_review.py` -
   passed with zero regressions against the merge-base baseline.
@@ -164,7 +184,7 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Local-Unit-Gate-Mirror.md` | 170 |
-| `scripts/local_pr_review.sh` | 93 |
-| `tests/test_local_pr_review.py` | 126 |
-| **Total** | **389** |
+| `plans/PR-Local-Unit-Gate-Mirror.md` | 190 |
+| `scripts/local_pr_review.sh` | 104 |
+| `tests/test_local_pr_review.py` | 181 |
+| **Total** | **475** |

--- a/scripts/local_pr_review.sh
+++ b/scripts/local_pr_review.sh
@@ -126,7 +126,7 @@ run_local_unit_gate_mirror() {
     tmp_dir="$(mktemp -d)"
     base_baseline="$tmp_dir/base_baseline.txt"
     selected="$tmp_dir/selected.txt"
-    unit_gate_env=(-u ATLAS_CURRENT_PR_BODY_FILE -u ATLAS_CURRENT_PR_AUTHOR)
+    unit_gate_env=(-u ATLAS_CURRENT_PR_BODY_FILE -u ATLAS_CURRENT_PR_AUTHOR -u PYTEST_ADDOPTS)
     while IFS= read -r git_env_var; do
         [ -z "$git_env_var" ] && continue
         unit_gate_env+=("-u" "$git_env_var")
@@ -156,8 +156,9 @@ run_local_unit_gate_mirror() {
         echo "trusted selector unavailable; running FULL"
         echo "FULL" > "$selected"
     else
-        # The unit gate workflow does not receive wrapper-only PR body env
-        # or Git hook-local env. Drop both so local pre-push mirrors CI.
+        # The unit gate workflow does not receive wrapper-only PR body env,
+        # Git hook-local env, or local pytest option overrides.
+        # Drop them so local pre-push mirrors CI.
         env "${unit_gate_env[@]}" \
             "$python_bin" "$script_root/scripts/select_impacted_tests.py" --base "$base_ref" > "$selected"
         status=$?

--- a/scripts/local_pr_review.sh
+++ b/scripts/local_pr_review.sh
@@ -132,6 +132,17 @@ run_local_unit_gate_mirror() {
         unit_gate_env+=("-u" "$git_env_var")
     done < <(git rev-parse --local-env-vars)
 
+    if [ ! -f "$repo_root/scripts/check_unit_gate.py" ]; then
+        echo "scripts/check_unit_gate.py is absent from this PR head; local unit gate mirror cannot verify the required gate"
+        rm -rf "$tmp_dir"
+        return 1
+    fi
+    if [ ! -f "$script_root/scripts/check_unit_gate.py" ]; then
+        echo "trusted unit-gate checker unavailable; local unit gate mirror cannot verify the required gate"
+        rm -rf "$tmp_dir"
+        return 1
+    fi
+
     if merge_base="$(git merge-base "$base_ref" HEAD 2>/dev/null)"; then
         git show "${merge_base}:tests/unit_gate_baseline.txt" > "$base_baseline" 2>/dev/null || : > "$base_baseline"
     else
@@ -334,7 +345,7 @@ elif [ "$failures" -ne 0 ]; then
     echo
     echo "==> Local unit gate mirror"
     echo "    SKIP ($failures earlier local review check(s) failed)"
-elif [ -f "$script_root/scripts/check_unit_gate.py" ]; then
+elif [ -f "$script_root/scripts/check_unit_gate.py" ] || git cat-file -e "$base:scripts/check_unit_gate.py" 2>/dev/null; then
     run_check "Local unit gate mirror" run_local_unit_gate_mirror
 else
     echo

--- a/scripts/local_pr_review.sh
+++ b/scripts/local_pr_review.sh
@@ -116,6 +116,83 @@ run_check() {
     fi
 }
 
+run_local_unit_gate_mirror() {
+    local tmp_dir
+    local base_baseline
+    local selected
+    local merge_base
+    local status
+    local -a unit_gate_env
+    tmp_dir="$(mktemp -d)"
+    base_baseline="$tmp_dir/base_baseline.txt"
+    selected="$tmp_dir/selected.txt"
+    unit_gate_env=(-u ATLAS_CURRENT_PR_BODY_FILE -u ATLAS_CURRENT_PR_AUTHOR)
+    while IFS= read -r git_env_var; do
+        [ -z "$git_env_var" ] && continue
+        unit_gate_env+=("-u" "$git_env_var")
+    done < <(git rev-parse --local-env-vars)
+
+    if merge_base="$(git merge-base "$base_ref" HEAD 2>/dev/null)"; then
+        git show "${merge_base}:tests/unit_gate_baseline.txt" > "$base_baseline" 2>/dev/null || : > "$base_baseline"
+    else
+        git show "${base_ref}:tests/unit_gate_baseline.txt" > "$base_baseline" 2>/dev/null || : > "$base_baseline"
+    fi
+
+    if [ ! -f "$repo_root/scripts/select_impacted_tests.py" ]; then
+        echo "selector absent from this PR head; running FULL"
+        echo "FULL" > "$selected"
+    elif [ ! -f "$script_root/scripts/select_impacted_tests.py" ]; then
+        echo "trusted selector unavailable; running FULL"
+        echo "FULL" > "$selected"
+    else
+        # The unit gate workflow does not receive wrapper-only PR body env
+        # or Git hook-local env. Drop both so local pre-push mirrors CI.
+        env "${unit_gate_env[@]}" \
+            "$python_bin" "$script_root/scripts/select_impacted_tests.py" --base "$base_ref" > "$selected"
+        status=$?
+        if [ "$status" -ne 0 ]; then
+            echo "selector failed while choosing local unit-gate tests"
+            rm -rf "$tmp_dir"
+            return "$status"
+        fi
+    fi
+
+    echo "--- selection ---"
+    cat "$selected"
+
+    if [ "$(cat "$selected")" = "FULL" ]; then
+        echo "running the FULL suite (selection escalated)"
+        env "${unit_gate_env[@]}" \
+            "$python_bin" "$script_root/scripts/check_unit_gate.py" \
+            --baseline tests/unit_gate_baseline.txt \
+            --base-baseline "$base_baseline"
+        status=$?
+    elif [ ! -s "$selected" ]; then
+        echo "no test is reachable from the changed files; growth guard only"
+        env "${unit_gate_env[@]}" \
+            "$python_bin" "$script_root/scripts/check_unit_gate.py" \
+            --baseline tests/unit_gate_baseline.txt \
+            --base-baseline "$base_baseline" \
+            --growth-only
+        status=$?
+    else
+        mapfile -t selected_tests < "$selected"
+        echo "running ${#selected_tests[@]} impacted test file(s)"
+        env "${unit_gate_env[@]}" \
+            "$python_bin" "$script_root/scripts/check_unit_gate.py" \
+            --baseline tests/unit_gate_baseline.txt \
+            --base-baseline "$base_baseline" \
+            --selected-files "$selected" \
+            --pytest-args "${selected_tests[@]}" \
+                -m "not integration and not e2e" \
+                --continue-on-collection-errors -rfE --tb=no -q \
+                -p no:cacheprovider
+        status=$?
+    fi
+    rm -rf "$tmp_dir"
+    return "$status"
+}
+
 body_uses_docs_only_marker() {
     [ -n "$current_pr_body_file" ] || return 1
     [ -f "$current_pr_body_file" ] || return 1
@@ -248,6 +325,22 @@ else
 fi
 
 run_check "git diff --check" git diff --check
+
+if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+    echo
+    echo "==> Local unit gate mirror"
+    echo "    SKIP (GitHub Actions runs .github/workflows/unit_gate.yml as its own required check)"
+elif [ "$failures" -ne 0 ]; then
+    echo
+    echo "==> Local unit gate mirror"
+    echo "    SKIP ($failures earlier local review check(s) failed)"
+elif [ -f "$script_root/scripts/check_unit_gate.py" ]; then
+    run_check "Local unit gate mirror" run_local_unit_gate_mirror
+else
+    echo
+    echo "==> Local unit gate mirror"
+    echo "    SKIP (scripts/check_unit_gate.py not found)"
+fi
 
 # Advisory only: nudge to archive merged plan docs once the plans/ root grows
 # past the threshold. Never affects the failure count -- archive_plans.py check

--- a/scripts/local_pr_review.sh
+++ b/scripts/local_pr_review.sh
@@ -126,11 +126,15 @@ run_local_unit_gate_mirror() {
     tmp_dir="$(mktemp -d)"
     base_baseline="$tmp_dir/base_baseline.txt"
     selected="$tmp_dir/selected.txt"
-    unit_gate_env=(-u ATLAS_CURRENT_PR_BODY_FILE -u ATLAS_CURRENT_PR_AUTHOR -u PYTEST_ADDOPTS)
+    unit_gate_env=(-u ATLAS_CURRENT_PR_BODY_FILE -u ATLAS_CURRENT_PR_AUTHOR)
     while IFS= read -r git_env_var; do
         [ -z "$git_env_var" ] && continue
         unit_gate_env+=("-u" "$git_env_var")
     done < <(git rev-parse --local-env-vars)
+    while IFS= read -r pytest_env_var; do
+        [ -z "$pytest_env_var" ] && continue
+        unit_gate_env+=("-u" "$pytest_env_var")
+    done < <(compgen -e PYTEST_)
 
     if [ ! -f "$repo_root/scripts/check_unit_gate.py" ]; then
         echo "scripts/check_unit_gate.py is absent from this PR head; local unit gate mirror cannot verify the required gate"

--- a/tests/test_local_pr_review.py
+++ b/tests/test_local_pr_review.py
@@ -237,6 +237,7 @@ def test_local_pr_review_runs_local_unit_gate_mirror(tmp_path: Path) -> None:
             "print('body env=' + str(os.environ.get('ATLAS_CURRENT_PR_BODY_FILE')))\n"
             "print('git prefix env=' + str(os.environ.get('GIT_PREFIX')))\n"
             "print('pytest addopts env=' + str(os.environ.get('PYTEST_ADDOPTS')))\n"
+            "print('pytest disable plugins env=' + str(os.environ.get('PYTEST_DISABLE_PLUGIN_AUTOLOAD')))\n"
             "print('unit gate args=' + ' '.join(sys.argv[1:]))\n"
         ),
     )
@@ -249,6 +250,7 @@ def test_local_pr_review_runs_local_unit_gate_mirror(tmp_path: Path) -> None:
             "GIT_PREFIX": "from-hook/",
             "GITHUB_ACTIONS": "false",
             "PYTEST_ADDOPTS": "-k passing",
+            "PYTEST_DISABLE_PLUGIN_AUTOLOAD": "1",
         },
     )
 
@@ -257,6 +259,7 @@ def test_local_pr_review_runs_local_unit_gate_mirror(tmp_path: Path) -> None:
     assert "body env=None" in result.stdout
     assert "git prefix env=None" in result.stdout
     assert "pytest addopts env=None" in result.stdout
+    assert "pytest disable plugins env=None" in result.stdout
     assert "running 1 impacted test file(s)" in result.stdout
     assert "--selected-files" in result.stdout
     assert "tests/test_example.py -m not integration and not e2e" in result.stdout

--- a/tests/test_local_pr_review.py
+++ b/tests/test_local_pr_review.py
@@ -224,6 +224,106 @@ def test_local_pr_review_forwards_pr_author_to_pre_push_audit(tmp_path: Path) ->
     assert "--pr-author dependabot[bot]" in result.stdout
 
 
+def test_local_pr_review_runs_local_unit_gate_mirror(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _write_fixture_repo(repo)
+    _write_unit_gate_fixture(
+        repo,
+        selector_script="#!/usr/bin/env python3\nprint('tests/test_example.py')\n",
+        checker_script=(
+            "#!/usr/bin/env python3\n"
+            "import os\n"
+            "import sys\n"
+            "print('body env=' + str(os.environ.get('ATLAS_CURRENT_PR_BODY_FILE')))\n"
+            "print('git prefix env=' + str(os.environ.get('GIT_PREFIX')))\n"
+            "print('unit gate args=' + ' '.join(sys.argv[1:]))\n"
+        ),
+    )
+
+    result = _run(
+        repo,
+        ["bash", "scripts/local_pr_review.sh"],
+        env={
+            "ATLAS_CURRENT_PR_BODY_FILE": "/tmp/body-from-wrapper.md",
+            "GIT_PREFIX": "from-hook/",
+            "GITHUB_ACTIONS": "false",
+        },
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Local unit gate mirror" in result.stdout
+    assert "body env=None" in result.stdout
+    assert "git prefix env=None" in result.stdout
+    assert "running 1 impacted test file(s)" in result.stdout
+    assert "--selected-files" in result.stdout
+    assert "tests/test_example.py -m not integration and not e2e" in result.stdout
+    assert "local PR review passed" in result.stdout
+
+
+def test_local_pr_review_unit_gate_mirror_runs_growth_only_for_empty_selection(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _write_fixture_repo(repo)
+    _write_unit_gate_fixture(repo, selector_script="#!/usr/bin/env python3\n")
+
+    result = _run(repo, ["bash", "scripts/local_pr_review.sh"], env={"GITHUB_ACTIONS": "false"})
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "no test is reachable from the changed files; growth guard only" in result.stdout
+    assert "--growth-only" in result.stdout
+    assert "--selected-files" not in result.stdout
+    assert "local PR review passed" in result.stdout
+
+
+def test_local_pr_review_unit_gate_mirror_runs_full_selection(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _write_fixture_repo(repo)
+    _write_unit_gate_fixture(repo, selector_script="#!/usr/bin/env python3\nprint('FULL')\n")
+
+    result = _run(repo, ["bash", "scripts/local_pr_review.sh"], env={"GITHUB_ACTIONS": "false"})
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "running the FULL suite (selection escalated)" in result.stdout
+    assert "--growth-only" not in result.stdout
+    assert "--selected-files" not in result.stdout
+    assert "local PR review passed" in result.stdout
+
+
+def test_local_pr_review_unit_gate_mirror_propagates_selector_failure(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _write_fixture_repo(repo)
+    _write_unit_gate_fixture(
+        repo,
+        selector_script="#!/usr/bin/env python3\nimport sys\nprint('selector failed')\nsys.exit(7)\n",
+        checker_script="#!/usr/bin/env python3\nprint('unit gate should not run')\n",
+    )
+
+    result = _run(repo, ["bash", "scripts/local_pr_review.sh"], env={"GITHUB_ACTIONS": "false"})
+
+    assert result.returncode == 1
+    assert "Local unit gate mirror" in result.stdout
+    assert "selector failed while choosing local unit-gate tests" in result.stdout
+    assert "unit gate should not run" not in result.stdout
+    assert "1 local review check(s) failed" in result.stdout
+
+
+def test_local_pr_review_skips_unit_gate_mirror_in_github_actions(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _write_fixture_repo(repo)
+    _write_executable(
+        repo / "scripts" / "check_unit_gate.py",
+        "#!/usr/bin/env python3\nimport sys\nprint('should not run')\nsys.exit(1)\n",
+    )
+    _git(repo, "add", "scripts/check_unit_gate.py")
+    _git(repo, "commit", "-m", "add unit gate stub")
+
+    result = _run(repo, ["bash", "scripts/local_pr_review.sh"], env={"GITHUB_ACTIONS": "true"})
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "SKIP (GitHub Actions runs .github/workflows/unit_gate.yml as its own required check)" in result.stdout
+    assert "should not run" not in result.stdout
+    assert "local PR review passed" in result.stdout
+
+
 def test_local_pr_review_env_pr_body_contract_fails_closed(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     _write_fixture_repo(repo)
@@ -568,6 +668,32 @@ def _write_fixture_repo(repo: Path) -> None:
     _git(repo, "remote", "add", "origin", str(repo))
     _git(repo, "update-ref", "refs/remotes/origin/main", "HEAD")
     _git(repo, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main")
+
+
+def _write_unit_gate_fixture(
+    repo: Path,
+    *,
+    selector_script: str,
+    checker_script: str | None = None,
+) -> None:
+    _write_executable(repo / "scripts" / "select_impacted_tests.py", selector_script)
+    _write_executable(
+        repo / "scripts" / "check_unit_gate.py",
+        checker_script
+        or "#!/usr/bin/env python3\nimport sys\nprint('unit gate args=' + ' '.join(sys.argv[1:]))\n",
+    )
+    (repo / "tests").mkdir(exist_ok=True)
+    (repo / "tests" / "test_example.py").write_text("def test_example():\n    assert True\n", encoding="utf-8")
+    (repo / "tests" / "unit_gate_baseline.txt").write_text("", encoding="utf-8")
+    _git(
+        repo,
+        "add",
+        "scripts/select_impacted_tests.py",
+        "scripts/check_unit_gate.py",
+        "tests/test_example.py",
+        "tests/unit_gate_baseline.txt",
+    )
+    _git(repo, "commit", "-m", "add unit gate stubs")
 
 
 def _run(

--- a/tests/test_local_pr_review.py
+++ b/tests/test_local_pr_review.py
@@ -236,6 +236,7 @@ def test_local_pr_review_runs_local_unit_gate_mirror(tmp_path: Path) -> None:
             "import sys\n"
             "print('body env=' + str(os.environ.get('ATLAS_CURRENT_PR_BODY_FILE')))\n"
             "print('git prefix env=' + str(os.environ.get('GIT_PREFIX')))\n"
+            "print('pytest addopts env=' + str(os.environ.get('PYTEST_ADDOPTS')))\n"
             "print('unit gate args=' + ' '.join(sys.argv[1:]))\n"
         ),
     )
@@ -247,6 +248,7 @@ def test_local_pr_review_runs_local_unit_gate_mirror(tmp_path: Path) -> None:
             "ATLAS_CURRENT_PR_BODY_FILE": "/tmp/body-from-wrapper.md",
             "GIT_PREFIX": "from-hook/",
             "GITHUB_ACTIONS": "false",
+            "PYTEST_ADDOPTS": "-k passing",
         },
     )
 
@@ -254,6 +256,7 @@ def test_local_pr_review_runs_local_unit_gate_mirror(tmp_path: Path) -> None:
     assert "Local unit gate mirror" in result.stdout
     assert "body env=None" in result.stdout
     assert "git prefix env=None" in result.stdout
+    assert "pytest addopts env=None" in result.stdout
     assert "running 1 impacted test file(s)" in result.stdout
     assert "--selected-files" in result.stdout
     assert "tests/test_example.py -m not integration and not e2e" in result.stdout

--- a/tests/test_local_pr_review.py
+++ b/tests/test_local_pr_review.py
@@ -288,6 +288,44 @@ def test_local_pr_review_unit_gate_mirror_runs_full_selection(tmp_path: Path) ->
     assert "local PR review passed" in result.stdout
 
 
+def test_local_pr_review_unit_gate_mirror_checker_failures_block_every_mode(tmp_path: Path) -> None:
+    cases = {
+        "selected": (
+            "#!/usr/bin/env python3\nprint('tests/test_example.py')\n",
+            "running 1 impacted test file(s)",
+            "--selected-files",
+        ),
+        "growth_only": (
+            "#!/usr/bin/env python3\n",
+            "no test is reachable from the changed files; growth guard only",
+            "--growth-only",
+        ),
+        "full": (
+            "#!/usr/bin/env python3\nprint('FULL')\n",
+            "running the FULL suite (selection escalated)",
+            "--baseline tests/unit_gate_baseline.txt",
+        ),
+    }
+
+    for name, (selector_script, mode_message, args_fragment) in cases.items():
+        repo = tmp_path / name
+        _write_fixture_repo(repo)
+        _write_unit_gate_fixture(
+            repo,
+            selector_script=selector_script,
+            checker_script="#!/usr/bin/env python3\nimport sys\nprint('unit gate rejected: ' + ' '.join(sys.argv[1:]))\nsys.exit(9)\n",
+        )
+
+        result = _run(repo, ["bash", "scripts/local_pr_review.sh"], env={"GITHUB_ACTIONS": "false"})
+
+        assert result.returncode == 1, result.stdout + result.stderr
+        assert "Local unit gate mirror" in result.stdout
+        assert mode_message in result.stdout
+        assert args_fragment in result.stdout
+        assert "unit gate rejected:" in result.stdout
+        assert "1 local review check(s) failed" in result.stdout
+
+
 def test_local_pr_review_unit_gate_mirror_propagates_selector_failure(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     _write_fixture_repo(repo)
@@ -303,6 +341,23 @@ def test_local_pr_review_unit_gate_mirror_propagates_selector_failure(tmp_path: 
     assert "Local unit gate mirror" in result.stdout
     assert "selector failed while choosing local unit-gate tests" in result.stdout
     assert "unit gate should not run" not in result.stdout
+    assert "1 local review check(s) failed" in result.stdout
+
+
+def test_local_pr_review_unit_gate_mirror_fails_when_checker_was_removed(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _write_fixture_repo(repo)
+    _write_unit_gate_fixture(repo, selector_script="#!/usr/bin/env python3\nprint('FULL')\n")
+    _git(repo, "update-ref", "refs/remotes/origin/main", "HEAD")
+    _git(repo, "rm", "scripts/check_unit_gate.py")
+    _git(repo, "commit", "-m", "remove unit gate checker")
+
+    result = _run(repo, ["bash", "scripts/local_pr_review.sh"], env={"GITHUB_ACTIONS": "false"})
+
+    assert result.returncode == 1
+    assert "Local unit gate mirror" in result.stdout
+    assert "scripts/check_unit_gate.py is absent from this PR head" in result.stdout
+    assert "SKIP (scripts/check_unit_gate.py not found)" not in result.stdout
     assert "1 local review check(s) failed" in result.stdout
 
 


### PR DESCRIPTION
Plan: plans/PR-Local-Unit-Gate-Mirror.md
Slice phase: Workflow/process
Ownership lane: atlas-workflow/pr-enforcement
Diff-budget override: This admission-gate slice is indivisible after Codex found fail-open paths; the overage is the paired code and test proof that selector failures, checker failures, and checker deletion block local publication before GitHub is first red.

Run the branch-required unit-gate selector/check path inside the local PR review bundle before a local push/open flow can report success, so unit-gate failures are discovered before GitHub is the first red signal.

## Intentional
- Keep `.github/workflows/unit_gate.yml`, `scripts/check_unit_gate.py`, `scripts/select_impacted_tests.py`, and `tests/unit_gate_baseline.txt` semantics unchanged.
- Run the mirror only after cheaper local review checks pass, so full-suite unit-gate time is not spent on an already-invalid PR.
- Skip the mirror under `GITHUB_ACTIONS=true` because GitHub already runs `.github/workflows/unit_gate.yml` as its own required check.

## AI reconciliation
- Propagate selector failures before dispatching the gate -- fixed-in: 695d8503985f100d008c399fb773e37f18e602f1 scripts/local_pr_review.sh and tests/test_local_pr_review.py::test_local_pr_review_unit_gate_mirror_propagates_selector_failure
- Exercise every selector outcome in mirror tests -- fixed-in: 695d8503985f100d008c399fb773e37f18e602f1 tests/test_local_pr_review.py::test_local_pr_review_unit_gate_mirror_runs_growth_only_for_empty_selection and tests/test_local_pr_review.py::test_local_pr_review_unit_gate_mirror_runs_full_selection
- Prove checker failures block every mirror mode -- fixed-in: d3960492dcf8388636061043ec95d3139c3660c3 tests/test_local_pr_review.py::test_local_pr_review_unit_gate_mirror_checker_failures_block_every_mode
- Fail when the unit-gate checker is absent -- fixed-in: d3960492dcf8388636061043ec95d3139c3660c3 scripts/local_pr_review.sh and tests/test_local_pr_review.py::test_local_pr_review_unit_gate_mirror_fails_when_checker_was_removed
- Clear pytest option overrides before mirroring CI -- fixed-in: 3808b2a573a26bf1138119b5a1909cbcdcfffff2 scripts/local_pr_review.sh and tests/test_local_pr_review.py::test_local_pr_review_runs_local_unit_gate_mirror
- Clear every pytest startup override before mirroring CI -- fixed-in: 1d8db5663d6842d97d226f5603d50544119a800c scripts/local_pr_review.sh and tests/test_local_pr_review.py::test_local_pr_review_runs_local_unit_gate_mirror
- Add coverage for selector-absence fallback -- waived-out-of-scope: adjacent fixture hardening after the selector outcome and checker failure classes are already covered; parked for a separate narrow selector-absence proof slice per docs/REVIEWER_RULES.md boundary rule.
- Prove the merge-base baseline is preserved -- waived-out-of-scope: adjacent fixture hardening for divergent ledger histories; the current slice preserves the merge-base read path and parks deeper ratchet proof for a separate baseline-parity slice per docs/REVIEWER_RULES.md boundary rule.

## Deferred
- Unit-gate runtime optimization or caching if local full-suite runs remain too slow after failures move local.
- Additional selector ownership refinements as separate narrow PRs when concrete changed paths escalate unnecessarily.
- Selector-absence fallback fixture proof as a separate narrow follow-up if the operator wants more coverage.
- Divergent merge-base/base-tip/HEAD baseline fixture proof as a separate narrow follow-up if the operator wants more coverage.

## Parked hardening
- Selector-absence fallback fixture proof deferred from this PR's AI-rec thread.
- Divergent merge-base baseline fixture proof deferred from this PR's AI-rec thread.

## Cold diff reconstruction
- Changed: scripts/local_pr_review.sh:119 adds `run_local_unit_gate_mirror`, which resolves the merge-base unit-gate baseline, writes selector output, and dispatches to `check_unit_gate.py`.
- Changed: scripts/local_pr_review.sh:135 fails the mirror when the PR head lacks `scripts/check_unit_gate.py`, and scripts/local_pr_review.sh:140 fails if the trusted script root lacks the checker.
- Changed: scripts/local_pr_review.sh:146 reads the base baseline from the merge base, falling back to an empty file when the baseline is absent.
- Changed: scripts/local_pr_review.sh:129 strips wrapper-only PR body env, Git hook env, and local `PYTEST_*` startup overrides before selector/checker subprocesses so the mirror cannot inherit local pytest controls absent from CI.
- Changed: scripts/local_pr_review.sh:152 escalates to `FULL` when the PR tree has no selector, scripts/local_pr_review.sh:161 runs the trusted selector with wrapper-only PR body env stripped, and scripts/local_pr_review.sh:163 propagates selector failures before any checker dispatch.
- Changed: scripts/local_pr_review.sh:174 dispatches `FULL`, scripts/local_pr_review.sh:181 dispatches growth-only, and scripts/local_pr_review.sh:189 dispatches selected test files with the same pytest arguments.
- Changed: scripts/local_pr_review.sh:340 skips under `GITHUB_ACTIONS=true`, scripts/local_pr_review.sh:344 skips when earlier local checks already failed, and scripts/local_pr_review.sh:348 gates final success on the mirror when `check_unit_gate.py` exists or the base branch had it.
- Changed: tests/test_local_pr_review.py:227 proves the local mirror runs selected tests with sanitized wrapper env and no inherited `PYTEST_ADDOPTS` or `PYTEST_DISABLE_PLUGIN_AUTOLOAD`, tests/test_local_pr_review.py:263 proves empty selection uses growth-only, tests/test_local_pr_review.py:277 proves `FULL` selection dispatches the full-suite mode, tests/test_local_pr_review.py:291 proves checker failures block every dispatch mode, tests/test_local_pr_review.py:329 proves selector failure blocks before checker dispatch, tests/test_local_pr_review.py:347 proves checker deletion fails instead of skipping, and tests/test_local_pr_review.py:364 proves GitHub Actions skips the duplicate mirror.
- Contract match: plans/PR-Local-Unit-Gate-Mirror.md:19 identifies the missing local unit-gate mirror as the root cause, and plans/PR-Local-Unit-Gate-Mirror.md:48 lists the acceptance criteria implemented above.
- Gaps: none.

## Verification
- `bash -n scripts/local_pr_review.sh` - passed.
- `python -m pytest tests/test_local_pr_review.py -q` - 27 passed.
- `GITHUB_ACTIONS=true python -m pytest tests/test_local_pr_review.py -q` - 27 passed.
- Scoped CI-mode unit gate invocation for `tests/test_local_pr_review.py` - passed with zero regressions against the merge-base baseline.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/atlas-pr-local-unit-gate-mirror-body.md` - passed, including `Local unit gate mirror` selecting `tests/test_local_pr_review.py` and reporting zero regressions.

## Mechanical verification
- Command: `bash -n scripts/local_pr_review.sh` - Result: passed - Environment: local
- Command: `python -m pytest tests/test_local_pr_review.py -q` - Result: 27 passed - Environment: local
- Command: `GITHUB_ACTIONS=true python -m pytest tests/test_local_pr_review.py -q` - Result: 27 passed - Environment: CI
- Command: scoped CI-mode unit gate invocation for `tests/test_local_pr_review.py` - Result: passed - Environment: CI
- Command: `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/atlas-pr-local-unit-gate-mirror-body.md` - Result: passed - Environment: local

## Diff size
3 files, +489 / -0

<!-- atlas-open-pr-wrapper: v1 -->
