### PR TITLE
D5 (#128): retire the legacy ICS importer behind a deprecation error

### DIFF
--- a/plans/PR-D5-Retire-Legacy-ICS.md
+++ b/plans/PR-D5-Retire-Legacy-ICS.md
@@ -1,0 +1,145 @@
+# PR-D5-Retire-Legacy-ICS
+
+## Why this slice exists
+
+Website #128 (D5), the last 0D child: `scripts/import_calendar_contacts.py` is a
+strictly-worse duplicate of the live importer and can be run by accident.
+
+### Problem-derived contract
+
+- **Root cause.** The legacy importer writes through `crm_provider.create_contact`,
+  which resolves an existing contact on **phone then email only, never address**
+  (provider docstring: "returning an existing one if phone or email already
+  matches. Dedup order: phone first, then email."). So an **address-only** record
+  (no phone, no email) can never match an existing contact and is **re-created on
+  every run** -- the documented rerun-duplicate defect. The replacement
+  `scripts/import_eom_customers_live.py` added an address pre-resolver
+  (`import_one`); the legacy script did not. Repairing the legacy one means
+  maintaining two importers where the older is strictly worse.
+- **Correct fix touches.** Retire the legacy script's **runnable command** behind a
+  deprecation error naming the replacement -- WITHOUT breaking the module's
+  importability, because the replacement does `import import_calendar_contacts as
+  ics` (`import_eom_customers_live.py:38`) and reuses its `parse_ics` /
+  `CustomerRecord` extraction core. Pin the defect by test **first**, or retiring
+  the CLI makes the defect unobservable and its evidence is lost.
+- **Must NOT change.** `import_records` / `parse_ics` / `dedup_across_calendars` /
+  `CustomerRecord` (kept intact and importable); the replacement importer; the
+  `"business_context_id": "effingham_maids"` line (`test_tenant_stamping` reads
+  it); the defect itself (retire, do not repair). No deletion.
+
+### Operator gate (satisfied)
+
+#128 blocks on operator confirmation that no workflow depends on the ICS path.
+**Received 2026-08-08:** Juan confirmed he does not run the manual
+`python scripts/import_calendar_contacts.py` command, after I traced the ops-tab
+Schedule import to a separate live Google Calendar path
+(`service-schedule.js` -> `/admin/google-calendar/*`) with zero `.ics` references
+in the portal, the schedule JS, or the tracker backend. Nothing automated invokes
+the legacy script; its only code reference is the replacement's library reuse.
+
+## Scope (this PR)
+
+Ownership lane: eom-crm/lead-funnel
+Slice phase: production hardening
+
+1. `scripts/import_calendar_contacts.py`: the `if __name__ == "__main__"` entry
+   raises `SystemExit` with a deprecation message naming the replacement, instead
+   of `asyncio.run(main())`. A `RETIRED` banner is added to the module docstring.
+   Nothing else in the module changes.
+2. `tests/test_calendar_import_rerun.py`: pin the rerun-duplicate defect (address-
+   only duplicates; a phone-bearing record does not) and pin that the module stays
+   importable as a library.
+
+### Files touched
+
+- `scripts/import_calendar_contacts.py`
+- `tests/test_calendar_import_rerun.py`
+- `plans/PR-D5-Retire-Legacy-ICS.md`
+
+### Review Contract
+
+1. Running the script exits with a clear, non-silent deprecation error that names
+   `scripts/import_eom_customers_live.py`.
+2. The module remains importable: `import import_calendar_contacts` succeeds and
+   `parse_ics` / `CustomerRecord` / `import_records` are still present, so the
+   replacement importer's `import ... as ics` reuse is unaffected.
+3. The defect is pinned by test BEFORE retirement: an address-only record
+   duplicates on re-run; a phone-bearing record does not (the contrast proves the
+   claim is class-specific, not a blanket "import_records is broken").
+4. No behavior change to any path that is not the ICS importer's runnable command.
+   `import_records`, `parse_ics`, dedup, and the tenant stamp are byte-unchanged.
+
+Affected surfaces: the `__main__` entry only (one call swapped for a raise) plus a
+docstring banner. No provider change, no schema change, no change to the
+replacement importer.
+
+Risk areas: (a) breaking the library reuse -> probed by
+`test_module_stays_importable_as_a_library` and a live `import
+import_eom_customers_live` check; (b) losing the defect evidence -> probed by the
+two rerun tests, which exercise the real `import_records` against a faithful
+phone/email-only provider stub.
+
+- Reviewer rules triggered: R1, R14. (R1: retire the dup-generating path at its
+  root -- the runnable entry -- rather than patching a symptom, and pin the root
+  defect by test first. R14: reviewer verdict discipline.)
+
+**boundary-probe:** both sides -- the runnable command refuses (exit 1), while the
+importable-library path still works (`parse_ics`/`CustomerRecord` present).
+
+**Mutation-probe (run, not asserted):** the pin test exercises the real
+`import_records`; a stub that (wrongly) resolved on address would make
+`test_address_only_record_duplicates_on_rerun` fail, so the test is bound to the
+real defect, not the stub's convenience.
+
+## Mechanism
+
+One entry-point swap (`asyncio.run(main())` -> `raise SystemExit(...)`) plus a
+docstring banner. The library surface is untouched.
+
+## Intentional
+
+- **Retire, do not repair.** #128 is explicit: the legacy path is strictly worse
+  than the replacement, so repairing it would mean maintaining two importers.
+- **CLI-only, not import-time.** The replacement reuses this module as a library,
+  so the deprecation must fire on execution (`__main__`), never on import -- an
+  import-time raise would break the dominant live importer.
+- **Deprecation, not deletion.** The runnable path is recoverable by reverting one
+  commit; the module and its extraction core stay in place.
+- **Pin before retire.** Once `__main__` raises, the duplicate behavior is
+  unobservable by execution; the test preserves the evidence it existed.
+
+## Deferred
+
+- Fixing the legacy `import_records` to resolve by address -- explicitly out of
+  scope (the replacement already does this; the legacy path is being retired, not
+  repaired).
+- Routing the live importer through the canonical boundary -- separate concern,
+  tracked as website #142 (the D3 remainder).
+
+Parked hardening: none.
+
+## Verification
+
+```
+$ python -m pytest tests/test_calendar_import_rerun.py -q
+3 passed
+
+$ python scripts/import_calendar_contacts.py --dry-run
+scripts/import_calendar_contacts.py is retired: ... (exit 1)
+
+$ python -c "import sys; sys.path.insert(0,'scripts'); import import_eom_customers_live"
+(imports OK -- library reuse intact)
+```
+
+`tests/test_tenant_stamping.py`, `tests/test_contact_write_boundary.py`, and
+`tests/test_eom_live_calendar_import.py` (which imports the legacy module) all
+stay green.
+
+## Estimated diff size
+
+| File | LOC (added) |
+|---|---:|
+| `scripts/import_calendar_contacts.py` | 22 |
+| `tests/test_calendar_import_rerun.py` | 133 |
+| `plans/PR-D5-Retire-Legacy-ICS.md` | 145 |
+| **Total** | **300** |

--- a/plans/PR-D5-Retire-Legacy-ICS.md
+++ b/plans/PR-D5-Retire-Legacy-ICS.md
@@ -79,17 +79,26 @@ import_eom_customers_live` check; (b) losing the defect evidence -> probed by th
 two rerun tests, which exercise the real `import_records` against a faithful
 phone/email-only provider stub.
 
-- Reviewer rules triggered: R1, R14. (R1: retire the dup-generating path at its
-  root -- the runnable entry -- rather than patching a symptom, and pin the root
-  defect by test first. R14: reviewer verdict discipline.)
+- Reviewer rules triggered: R1, R2, R14. (R1: retire the dup-generating path at
+  its root -- the runnable entry -- rather than patching a symptom, and pin the
+  root defect by test first. R2: the `__main__` retirement is a gate change; its
+  behavior is proven by an *executing* subprocess test
+  (`test_running_the_script_as_a_command_is_retired`) asserting the nonzero exit
+  and the replacement name, and boundary-probed on both sides. R14: reviewer
+  verdict discipline.)
 
-**boundary-probe:** both sides -- the runnable command refuses (exit 1), while the
+**boundary-probe:** both sides -- the runnable command refuses (subprocess test
+asserts exit != 0 + deprecation message naming the replacement), while the
 importable-library path still works (`parse_ics`/`CustomerRecord` present).
 
-**Mutation-probe (run, not asserted):** the pin test exercises the real
-`import_records`; a stub that (wrongly) resolved on address would make
-`test_address_only_record_duplicates_on_rerun` fail, so the test is bound to the
-real defect, not the stub's convenience.
+**Mutation-probe (run, not asserted):**
+1. Reverting the `__main__` guard to `asyncio.run(main())` makes
+   `test_running_the_script_as_a_command_is_retired` fail (the command runs main()
+   and exits without the deprecation message) -- so the test is bound to the
+   actual retirement behavior, not just the guard's presence.
+2. The pin test exercises the real `import_records`; a stub that (wrongly)
+   resolved on address would make `test_address_only_record_duplicates_on_rerun`
+   fail, so it is bound to the real defect, not the stub's convenience.
 
 ## Mechanism
 
@@ -122,10 +131,11 @@ Parked hardening: none.
 
 ```
 $ python -m pytest tests/test_calendar_import_rerun.py -q
-3 passed
+4 passed        # 2 rerun (defect) + library-importable + executing-CLI-retired
 
 $ python scripts/import_calendar_contacts.py --dry-run
 scripts/import_calendar_contacts.py is retired: ... (exit 1)
+# now also asserted by test_running_the_script_as_a_command_is_retired
 
 $ python -c "import sys; sys.path.insert(0,'scripts'); import import_eom_customers_live"
 (imports OK -- library reuse intact)
@@ -140,6 +150,6 @@ stay green.
 | File | LOC (added) |
 |---|---:|
 | `scripts/import_calendar_contacts.py` | 22 |
-| `tests/test_calendar_import_rerun.py` | 133 |
-| `plans/PR-D5-Retire-Legacy-ICS.md` | 145 |
-| **Total** | **300** |
+| `tests/test_calendar_import_rerun.py` | 163 |
+| `plans/PR-D5-Retire-Legacy-ICS.md` | 155 |
+| **Total** | **340** |

--- a/scripts/import_calendar_contacts.py
+++ b/scripts/import_calendar_contacts.py
@@ -1,4 +1,12 @@
 """
+RETIRED (website #128 / D5) -- do not run. Running this script now exits with a
+deprecation error. It duplicated address-only records on every re-run because the
+CRM provider resolves on phone/email only, never address. Use
+scripts/import_eom_customers_live.py instead (it resolves by address and reads
+live Google Calendar). This module stays importable as a library -- its parse_ics
+and CustomerRecord are reused by the replacement -- so only the runnable command
+is retired.
+
 Import customer contacts from Google Calendar ICS exports.
 
 Parses all 4 Effingham Office Maids calendars, deduplicates by address
@@ -636,4 +644,17 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    # RETIRED (website #128 / D5). This importer duplicated address-only records on
+    # every re-run because the CRM provider resolves on phone/email only, never
+    # address (defect pinned in tests/test_calendar_import_rerun.py). The runnable
+    # command is retired behind this error, NOT deleted: the module's parse_ics /
+    # CustomerRecord / import_records stay importable, and
+    # scripts/import_eom_customers_live.py imports this module as its extraction
+    # core. To restore the runnable path, revert this commit (re-enable the
+    # asyncio.run(main()) below).
+    raise SystemExit(
+        "scripts/import_calendar_contacts.py is retired: it duplicated address-only "
+        "records on every re-run. Use scripts/import_eom_customers_live.py instead "
+        "(it resolves by address and reads live Google Calendar)."
+    )
+    # asyncio.run(main())

--- a/tests/test_calendar_import_rerun.py
+++ b/tests/test_calendar_import_rerun.py
@@ -18,6 +18,7 @@ script's behavior, not the stub's.
 
 from __future__ import annotations
 
+import subprocess
 import sys
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
@@ -131,3 +132,32 @@ def test_module_stays_importable_as_a_library():
     assert hasattr(ics, "parse_ics")
     assert hasattr(ics, "CustomerRecord")
     assert hasattr(ics, "import_records")
+
+
+def test_running_the_script_as_a_command_is_retired():
+    """Review Contract criterion 1, executed: running the script as a command must
+    exit nonzero with a deprecation message that names the replacement.
+
+    This is the ONLY test that exercises the changed behavior end-to-end -- the
+    others call import_records directly or inspect symbols, so they would all still
+    pass if the guard were removed, moved to import time, returned success, or
+    stopped naming the replacement. Run it as a real subprocess so the assertion is
+    bound to the actual `__main__` exit, not an in-process re-import.
+    """
+    script = REPO / "scripts" / "import_calendar_contacts.py"
+    result = subprocess.run(
+        [sys.executable, str(script), "--dry-run"],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO),
+    )
+    assert result.returncode != 0, (
+        f"the retired CLI must exit nonzero; got {result.returncode}\n"
+        f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+    )
+    combined = (result.stdout + result.stderr).lower()
+    assert "retired" in combined, f"missing deprecation wording; got {combined!r}"
+    assert "import_eom_customers_live" in combined, (
+        "the deprecation must name scripts/import_eom_customers_live.py as the "
+        f"replacement; got {combined!r}"
+    )

--- a/tests/test_calendar_import_rerun.py
+++ b/tests/test_calendar_import_rerun.py
@@ -1,0 +1,133 @@
+"""Pin the legacy ICS importer's rerun-duplicate defect before retiring it.
+
+D5 / website #128. `scripts/import_calendar_contacts.py` writes through
+`crm_provider.create_contact`, which resolves an existing contact on PHONE then
+EMAIL only -- never address (see the provider docstring: "returning an existing
+one if phone or email already matches. Dedup order: phone first, then email").
+So an address-only record (no phone, no email) can never match an existing
+contact and is re-created on every run. The replacement
+`scripts/import_eom_customers_live.py` added an address pre-resolver; the legacy
+script did not.
+
+Retiring the runnable script (its `__main__` now raises) makes this defect
+unobservable by execution, so this test documents that it existed and pins the
+exact class it affected. The stub CRM is a faithful model of the real provider's
+contract -- match on phone/email, not address -- so the duplication here is the
+script's behavior, not the stub's.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+
+# crm_provider imports asyncpg at module load; stub it so monkeypatching the real
+# get_crm_provider attribute does not require a live driver (mirrors
+# tests/test_crm_read_scoping.py).
+_asyncpg = MagicMock()
+_asyncpg_exc = MagicMock()
+_asyncpg_exc.UndefinedTableError = type("UndefinedTableError", (Exception,), {})
+_asyncpg.exceptions = _asyncpg_exc
+sys.modules.setdefault("asyncpg", _asyncpg)
+sys.modules.setdefault("asyncpg.exceptions", _asyncpg_exc)
+
+import import_calendar_contacts as ics  # noqa: E402
+
+
+class _PhoneEmailOnlyCRM:
+    """Faithful model of crm_provider.create_contact: resolve on phone then email,
+    never address. A match returns created_at != updated_at (an update); a miss
+    creates a fresh id with created_at == updated_at (import_records reads exactly
+    that to count created-vs-updated)."""
+
+    def __init__(self):
+        self._by_phone: dict[str, str] = {}
+        self._by_email: dict[str, str] = {}
+        self.created: list[tuple[str, str]] = []  # (id, address)
+        self._n = 0
+        self.log_interaction = AsyncMock(return_value={"id": "i"})
+
+    async def create_contact(self, data):
+        phone = data.get("phone")
+        email = (data.get("email") or "").lower() or None
+        existing = None
+        if phone and phone in self._by_phone:
+            existing = self._by_phone[phone]
+        elif email and email in self._by_email:
+            existing = self._by_email[email]
+        if existing is not None:
+            return {"id": existing, "created_at": "t0", "updated_at": "t1"}
+        self._n += 1
+        cid = f"c{self._n}"
+        if phone:
+            self._by_phone[phone] = cid
+        if email:
+            self._by_email[email] = cid
+        self.created.append((cid, data.get("address")))
+        return {"id": cid, "created_at": "t0", "updated_at": "t0"}
+
+
+def _record(**kw):
+    base = dict(
+        name="Test Cust",
+        address="123 Main St",
+        contact_type="customer",
+        source_calendar="residential",
+        event_count=1,
+    )
+    base.update(kw)
+    return ics.CustomerRecord(**base)
+
+
+@pytest.fixture
+def stub_crm(monkeypatch):
+    crm = _PhoneEmailOnlyCRM()
+    monkeypatch.setattr(
+        "atlas_brain.services.crm_provider.get_crm_provider", lambda: crm
+    )
+    return crm
+
+
+@pytest.mark.asyncio
+async def test_address_only_record_duplicates_on_rerun(stub_crm):
+    """DEFECT PIN: an address-only record is re-created on every run."""
+    rec = _record(name="Address Only", address="500 Oak Ave")  # no phone, no email
+
+    await ics.import_records([rec], dry_run=False)
+    await ics.import_records([rec], dry_run=False)  # re-run, same record
+
+    same_address = [cid for cid, addr in stub_crm.created if addr == "500 Oak Ave"]
+    assert len(same_address) == 2, (
+        "the legacy importer duplicates address-only records on re-run because the "
+        "provider resolves only on phone/email; two runs produced "
+        f"{len(same_address)} contacts for one address"
+    )
+
+
+@pytest.mark.asyncio
+async def test_phone_bearing_record_does_not_duplicate_on_rerun(stub_crm):
+    """Contrast: a record carrying a phone resolves on re-run, so it does NOT
+    duplicate. This proves the defect is specific to the address-only class, not
+    `import_records` in general -- otherwise retiring it would be over-claiming."""
+    rec = _record(name="Has Phone", address="600 Elm St", phone="618-555-0100")
+
+    await ics.import_records([rec], dry_run=False)
+    await ics.import_records([rec], dry_run=False)
+
+    same_address = [cid for cid, addr in stub_crm.created if addr == "600 Elm St"]
+    assert len(same_address) == 1, "a phone-bearing record must resolve on re-run"
+
+
+def test_module_stays_importable_as_a_library():
+    """The retirement is CLI-only: import_eom_customers_live.py does
+    `import import_calendar_contacts as ics` and reuses this extraction core, so
+    the module must remain importable even though its `__main__` now refuses."""
+    assert hasattr(ics, "parse_ics")
+    assert hasattr(ics, "CustomerRecord")
+    assert hasattr(ics, "import_records")


### PR DESCRIPTION
Plan: plans/PR-D5-Retire-Legacy-ICS.md
Slice phase: production hardening
Ownership lane: eom-crm/lead-funnel

Website #128 (D5), the last 0D child: retire the legacy ICS importer
`scripts/import_calendar_contacts.py` behind a deprecation error.

## Root cause
The legacy importer writes through `crm_provider.create_contact`, which resolves an existing contact on **phone then email only, never address** ("returning an existing one if phone or email already matches. Dedup order: phone first, then email"). So an **address-only** record (no phone, no email) can never match and is **re-created on every run** — the documented rerun-duplicate defect. The replacement `scripts/import_eom_customers_live.py` added an address pre-resolver; the legacy script did not. Repairing it means maintaining two importers where the older is strictly worse.

## Operator gate (satisfied)
#128 blocks on operator confirmation that no workflow depends on the ICS path. **Received 2026-08-08:** Juan confirmed he does not run the manual `python scripts/import_calendar_contacts.py` command, after I traced the ops-tab Schedule import to a **separate** live Google Calendar path (`service-schedule.js` → `/admin/google-calendar/*`) — zero `.ics` references in the portal, the schedule JS, or the tracker backend. Nothing automated invokes the legacy script.

## What changed
- `scripts/import_calendar_contacts.py`: the `if __name__ == "__main__"` entry now `raise`s `SystemExit` with a deprecation message naming `scripts/import_eom_customers_live.py`, instead of `asyncio.run(main())`; a `RETIRED` banner is added to the module docstring. **Nothing else in the module changes.**
- `tests/test_calendar_import_rerun.py` (new): pins the defect before retiring it.

## Intentional
- **Retire, do not repair** — the legacy path is strictly worse than the replacement.
- **CLI-only, not import-time** — the replacement does `import import_calendar_contacts as ics` (`import_eom_customers_live.py:38`) and reuses `parse_ics`/`CustomerRecord`, so an import-time raise would break the dominant live importer. The guard fires only on execution.
- **Deprecation, not deletion** — recoverable by reverting one commit; the module and its extraction core stay in place.
- **Pin before retire** — once `__main__` raises, the duplicate behavior is unobservable, so the test preserves the evidence it existed.

## Backward compatibility
No API/schema/wire change. The only behavior change is that **running the script** now exits with a deprecation error (intended). Importing the module is byte-for-byte unaffected — `parse_ics`/`CustomerRecord`/`import_records` are unchanged and still exported.

## Explicit non-scope (verified by diff)
`import_records`, `parse_ics`, `dedup_across_calendars`, `CustomerRecord`, and the `"business_context_id": "effingham_maids"` line are untouched. No provider change, no schema change, no change to the replacement importer, no fix of the defect.

## AI reconciliation
- Add a regression test for the retired CLI — fixed-in: tests/test_calendar_import_rerun.py adds test_running_the_script_as_a_command_is_retired, a subprocess test that runs the script as a command and asserts a nonzero exit plus a deprecation message naming import_eom_customers_live. It is the only test bound to the changed behavior end-to-end (the rerun tests call import_records; the importability test inspects symbols). Mutation-probed: reverting the __main__ guard to asyncio.run(main()) makes it fail. R2 is now declared in the plan's triggered rules.

## Deferred
- Fixing legacy `import_records` to resolve by address — out of scope (the replacement already does this; the legacy path is being retired, not repaired).
- Routing the live importer through the canonical boundary — separate concern, tracked as website #142 (the D3 remainder).

## Parked hardening
- None.

## Cold diff reconstruction
- Changed: `scripts/import_calendar_contacts.py` — `__main__` swapped from `asyncio.run(main())` to a `SystemExit` deprecation naming the replacement; docstring `RETIRED` banner. Library surface unchanged (1 logic line replaced).
- Added: `tests/test_calendar_import_rerun.py` — two rerun tests (address-only duplicates; phone-bearing does not) against a faithful phone/email-only provider stub, an importable-as-a-library assertion, and an executing subprocess test asserting the CLI exits nonzero with the deprecation message.
- Added: `plans/PR-D5-Retire-Legacy-ICS.md`.
- Contract match: the only behavior change is the runnable command refusing; every non-scope symbol is byte-unchanged.
- Gaps: none.

## Verification
- `pytest tests/test_calendar_import_rerun.py` → **4 passed** (defect pinned + library-importable + executing CLI-retired).
- `python scripts/import_calendar_contacts.py --dry-run` → exits **1** with the deprecation message (raises before any DB/calendar logic); now also asserted by `test_running_the_script_as_a_command_is_retired`.
- `python -c "import import_eom_customers_live"` → imports OK (library reuse intact).
- `tests/test_tenant_stamping.py` + `tests/test_contact_write_boundary.py` + `tests/test_eom_live_calendar_import.py` → green (138 passed together).
- `check_contact_write_boundary.py` → exit 0 (44 writes, no new site; the docstring banner is prose, not a write).

## Mechanical verification
- Command: `python -m pytest tests/test_calendar_import_rerun.py -q` - Result: pass (4 passed) - Environment: Office PC

## Diff size
| File | LOC (added) |
|---|---:|
| `scripts/import_calendar_contacts.py` | 22 |
| `tests/test_calendar_import_rerun.py` | 163 |
| `plans/PR-D5-Retire-Legacy-ICS.md` | 155 |
| **Total** | **340** |

<!-- atlas-open-pr-wrapper: v1 -->
