### PR TITLE
EOM acknowledgement variant: classify + record (slice A1)

### DIFF
--- a/.github/workflows/atlas_eom_lead_pipeline_checks.yml
+++ b/.github/workflows/atlas_eom_lead_pipeline_checks.yml
@@ -61,6 +61,7 @@ on:
       - "atlas_brain/storage/migrations/361_eom_onboarding_draft_actor_bigint.sql"
       - "atlas_brain/tools/calendar.py"
       - "atlas_brain/tools/scheduling.py"
+      - "tests/test_ack_variant_classification.py"
       - "tests/test_call_intelligence.py"
       - "tests/test_crm_read_scoping.py"
       - "tests/test_eom_complaints_integration.py"
@@ -138,6 +139,7 @@ on:
       - "atlas_brain/storage/migrations/361_eom_onboarding_draft_actor_bigint.sql"
       - "atlas_brain/tools/calendar.py"
       - "atlas_brain/tools/scheduling.py"
+      - "tests/test_ack_variant_classification.py"
       - "tests/test_call_intelligence.py"
       - "tests/test_crm_read_scoping.py"
       - "tests/test_eom_complaints_integration.py"
@@ -195,6 +197,7 @@ jobs:
       - name: Run EOM lead pipeline checks
         run: |
           python -m pytest \
+            tests/test_ack_variant_classification.py \
             tests/test_call_intelligence.py \
             tests/test_crm_read_scoping.py \
             tests/test_eom_complaints_integration.py \

--- a/atlas_brain/api/leads.py
+++ b/atlas_brain/api/leads.py
@@ -395,6 +395,14 @@ async def _process_lead_intake(
                             metadata={
                                 "source": "website_estimate_form",
                                 "contact_id": str(contact_id),
+                                # Both evidence records keep the derived variant
+                                # next to the raw submitted value. Without the
+                                # raw value here, a contact with several
+                                # requests gives no way to tell which
+                                # submission produced a given email — and the
+                                # body text is not a durable substitute,
+                                # because A2/A3 replace the template.
+                                "service": payload.service,
                                 "ack_variant": ack_variant,
                             },
                             business_context_id=EOM_BUSINESS_CONTEXT_ID,

--- a/atlas_brain/api/leads.py
+++ b/atlas_brain/api/leads.py
@@ -288,11 +288,21 @@ async def _process_lead_intake(
         }.items()
         if value.strip()
     }
+    # Recorded on the interaction so the segment a lead arrived as is evidence
+    # on the lead itself, not only on the email we happened to send. Adding a
+    # key here cannot shift interaction dedupe: the dedupe key reads only the
+    # fixed anchor allowlist and ``metadata["attribution"]``
+    # (``services/crm_provider.py`` ``_interaction_anchor`` /
+    # ``_interaction_attribution_identity``).
+    from ..templates.email import classify_ack_variant
+
+    ack_variant = classify_ack_variant(payload.service)
     metadata = {
         "service": payload.service,
         "frequency": payload.frequency,
         "square_feet": payload.square_feet,
         "source_page": payload.source_page,
+        "ack_variant": ack_variant,
         # Submitted channels are recorded even when an existing contact
         # is resolved read-only, so a new callback number/email is never
         # lost (PR #2153 round 4, R1/R6).
@@ -385,6 +395,7 @@ async def _process_lead_intake(
                             metadata={
                                 "source": "website_estimate_form",
                                 "contact_id": str(contact_id),
+                                "ack_variant": ack_variant,
                             },
                             business_context_id=EOM_BUSINESS_CONTEXT_ID,
                         )

--- a/atlas_brain/templates/email/__init__.py
+++ b/atlas_brain/templates/email/__init__.py
@@ -13,6 +13,11 @@ from .estimate_confirmation import (
 )
 
 from .request_acknowledgement import (
+    ACK_VARIANT_COMMERCIAL_MULTI_SITE,
+    ACK_VARIANT_COMMERCIAL_SINGLE_SITE,
+    ACK_VARIANT_GENERAL,
+    ACK_VARIANT_RESIDENTIAL,
+    classify_ack_variant,
     format_request_acknowledgement,
 )
 
@@ -37,6 +42,11 @@ __all__ = [
     "BUSINESS_WEBSITE",
     "format_business_email",
     "format_residential_email",
+    "ACK_VARIANT_RESIDENTIAL",
+    "ACK_VARIANT_COMMERCIAL_SINGLE_SITE",
+    "ACK_VARIANT_COMMERCIAL_MULTI_SITE",
+    "ACK_VARIANT_GENERAL",
+    "classify_ack_variant",
     "format_request_acknowledgement",
     "format_onboarding_welcome",
     "format_business_proposal",

--- a/atlas_brain/templates/email/request_acknowledgement.py
+++ b/atlas_brain/templates/email/request_acknowledgement.py
@@ -15,6 +15,44 @@ from .estimate_confirmation import (
     BUSINESS_WEBSITE,
 )
 
+# Acknowledgement variants (ATLAS #2320). A multi-location company is still a
+# commercial customer -- "multi-site" describes the shape of the request, not a
+# third customer type -- so this is a lead-time acknowledgement variant and
+# deliberately NOT a column on ``contacts``. ``contacts.contact_type`` already
+# means lifecycle (lead vs customer); a residential/commercial attribute on the
+# contact is a separate decision this feature does not force.
+ACK_VARIANT_RESIDENTIAL = "residential"
+ACK_VARIANT_COMMERCIAL_SINGLE_SITE = "commercial_single_site"
+ACK_VARIANT_COMMERCIAL_MULTI_SITE = "commercial_multi_site"
+ACK_VARIANT_GENERAL = "general"
+
+# Every value the website forms can submit maps explicitly. ``other`` is an
+# allowlisted form option, not an unknown, so it names ``general`` on purpose
+# rather than falling through. Anything unrecognised (including empty) also
+# resolves to ``general`` so a new form option can never crash intake or
+# silently pick residential copy.
+_ACK_VARIANT_BY_SERVICE = {
+    "residential": ACK_VARIANT_RESIDENTIAL,
+    "deep": ACK_VARIANT_RESIDENTIAL,
+    "move": ACK_VARIANT_RESIDENTIAL,
+    "commercial": ACK_VARIANT_COMMERCIAL_SINGLE_SITE,
+    "multi-location-commercial": ACK_VARIANT_COMMERCIAL_MULTI_SITE,
+    "other": ACK_VARIANT_GENERAL,
+}
+
+
+def classify_ack_variant(service: str) -> str:
+    """Return the acknowledgement variant for a submitted ``service`` value.
+
+    Deterministic and total: every input returns one of the four variants, and
+    an unrecognised value resolves to ``general``. Classification is decided
+    server-side from the submitted value; a browser-supplied template name is
+    never trusted.
+    """
+    normalized = (service or "").strip().lower()
+    return _ACK_VARIANT_BY_SERVICE.get(normalized, ACK_VARIANT_GENERAL)
+
+
 ACK_SUBJECT = "We received your estimate request - " + BUSINESS_NAME
 
 ACK_TEMPLATE = """Hi {client_name},

--- a/atlas_brain/templates/email/request_acknowledgement.py
+++ b/atlas_brain/templates/email/request_acknowledgement.py
@@ -44,13 +44,17 @@ _ACK_VARIANT_BY_SERVICE = {
 def classify_ack_variant(service: str) -> str:
     """Return the acknowledgement variant for a submitted ``service`` value.
 
-    Deterministic and total: every input returns one of the four variants, and
-    an unrecognised value resolves to ``general``. Classification is decided
+    Deterministic and total: every input returns one of the four variants and
+    none raises. Intake supplies a validated ``str``, but the whole non-string
+    class is guarded rather than only the falsy part of it — a truthy
+    non-string (``1``, ``True``, a list, a dict) would otherwise reach
+    ``.strip()`` and raise ``AttributeError``. Classification is decided
     server-side from the submitted value; a browser-supplied template name is
     never trusted.
     """
-    normalized = (service or "").strip().lower()
-    return _ACK_VARIANT_BY_SERVICE.get(normalized, ACK_VARIANT_GENERAL)
+    if not isinstance(service, str):
+        return ACK_VARIANT_GENERAL
+    return _ACK_VARIANT_BY_SERVICE.get(service.strip().lower(), ACK_VARIANT_GENERAL)
 
 
 ACK_SUBJECT = "We received your estimate request - " + BUSINESS_NAME

--- a/plans/PR-EOM-Ack-Variant-Classify.md
+++ b/plans/PR-EOM-Ack-Variant-Classify.md
@@ -203,6 +203,7 @@ mapping rather than a config default. The one setting this path already consults
 - `atlas_brain/templates/email/request_acknowledgement.py`
 - `plans/PR-EOM-Ack-Variant-Classify.md`
 - `tests/test_ack_variant_classification.py`
+- `tests/test_eom_sent_email_tenant_scope.py`
 - `tests/test_leads_intake.py`
 
 ## Mechanism
@@ -313,6 +314,7 @@ Parked hardening: none.
 | `atlas_brain/templates/email/__init__.py` | 10 |
 | `atlas_brain/templates/email/request_acknowledgement.py` | 42 |
 | `plans/PR-EOM-Ack-Variant-Classify.md` | 318 |
-| `tests/test_ack_variant_classification.py` | 209 |
+| `tests/test_ack_variant_classification.py` | 283 |
+| `tests/test_eom_sent_email_tenant_scope.py` | 6 |
 | `tests/test_leads_intake.py` | 6 |
-| **Total** | **604** |
+| **Total** | **684** |

--- a/plans/PR-EOM-Ack-Variant-Classify.md
+++ b/plans/PR-EOM-Ack-Variant-Classify.md
@@ -287,16 +287,16 @@ Parked hardening: none.
 
 ## Verification
 
-Counts below are from re-runs at head `c9f58a546`, i.e. after the generated
-property tests and the contract-oracle equality test were added. The earlier
-numbers in this section (32 / 82) described the original fixed-example suite and
-no longer matched the file.
+Counts below are re-run at the current head, after the generated property tests,
+the contract-oracle equality test, and the literal-pinned variant constants were
+added. The earlier numbers in this section (32 / 82) described the original
+fixed-example suite and no longer matched the file.
 
-- `python -m pytest tests/test_ack_variant_classification.py -q` — **45 passed**
+- `python -m pytest tests/test_ack_variant_classification.py -q` — **46 passed**
 - `python -m pytest tests/test_leads_intake.py tests/test_ack_variant_classification.py -q`
-  — **95 passed**
+  — **96 passed**
 - `python -m pytest tests/test_ack_variant_classification.py tests/test_leads_intake.py
-  tests/test_eom_sent_email_tenant_scope.py -q` — **95 passed, 1 skipped**. The skip
+  tests/test_eom_sent_email_tenant_scope.py -q` — **96 passed, 1 skipped**. The skip
   is `test_eom_sent_email_tenant_scope.py`, which needs a database and is skipped on
   this box; it RUNS in the enrolled `eom-lead-pipeline` workflow, where it is green
   at this head. A locally-skipped test is not treated here as a passing one.
@@ -316,12 +316,18 @@ no longer matched the file.
 - `python -m py_compile` on the three changed runtime modules — OK.
 - `git diff --check` — clean.
 - Negative proof that the contract oracle actually bites, rather than only
-  passing on good input: injecting an unintended member
-  (`"office-cleaning": ACK_VARIANT_RESIDENTIAL`) into `_ACK_VARIANT_BY_SERVICE`
-  makes the suite **fail** (1 failed), and reverting restores **45 passed**. A
-  member set whose test only proves the contracted values map correctly cannot
-  detect an added member, which is the case that would silently re-point a real
-  submission.
+  passing on good input. Three injections against the implementation, each
+  reverted afterwards (baseline and restored state both **46 passed**):
+  - Rename a variant **value** — `ACK_VARIANT_RESIDENTIAL = "resi"` — the case
+    where classifier and oracle would move together if the oracle referenced the
+    constants instead of literals: **10 failed**.
+  - Rename the multi-site value to `commercial_multisite`: **6 failed**.
+  - Add an unintended **member** — `"office-cleaning": ACK_VARIANT_RESIDENTIAL`:
+    **1 failed**.
+  The first two are output-contract drift (intake would persist a value that
+  violates acceptance criterion 1); the third is an added key that would
+  silently re-point a real submission. A member set whose test only proves the
+  contracted values map correctly detects neither.
 
 ## Estimated diff size
 
@@ -330,8 +336,8 @@ no longer matched the file.
 | `atlas_brain/api/leads.py` | 19 |
 | `atlas_brain/templates/email/__init__.py` | 10 |
 | `atlas_brain/templates/email/request_acknowledgement.py` | 42 |
-| `plans/PR-EOM-Ack-Variant-Classify.md` | 337 |
-| `tests/test_ack_variant_classification.py` | 305 |
+| `plans/PR-EOM-Ack-Variant-Classify.md` | 343 |
+| `tests/test_ack_variant_classification.py` | 332 |
 | `tests/test_eom_sent_email_tenant_scope.py` | 6 |
 | `tests/test_leads_intake.py` | 6 |
-| **Total** | **725** |
+| **Total** | **758** |

--- a/plans/PR-EOM-Ack-Variant-Classify.md
+++ b/plans/PR-EOM-Ack-Variant-Classify.md
@@ -19,6 +19,30 @@ multi-site a distinct workflow rather than a bigger commercial one.
 Tracking issue: #2320 (part of #2188). Website companion:
 `Effingham_Office_Maids_Website` #141 / PR #143.
 
+### Diff-budget overage — why this slice is indivisible
+
+This slice exceeds the 400 LOC soft cap. The **runtime change is 59 added
+lines** (11 in `leads.py`, 38 in `request_acknowledgement.py`, 10 re-exports).
+The remainder is not product surface: the mandatory `plans/PR-*.md` doc that
+AGENTS.md requires for any non-Markdown diff, and the test matrix the Review
+Contract commits to.
+
+Splitting was considered and rejected on each available seam:
+
+- **Classifier without recording** leaves a pure function no caller reaches —
+  dead code with no reachability proof, which R14/R2 would (correctly) reject.
+- **Recording without the classifier** has nothing to record.
+- **Either without the test matrix** removes the proof that makes the change
+  reviewable at all: a classifier's whole risk is the inputs it does not expect,
+  so all six form values, the full non-string class, both evidence records, the
+  no-send path, and the byte-identical residential golden are the minimum
+  evidence, not padding.
+
+The seam that *does* exist is copy versus classification, and this slice is
+already on the classification side of it — A2 and A3 carry the two new
+templates separately. So the 400-line cap is exceeded by required artifacts
+around a 59-line change, not by bundled scope.
+
 ### Problem-derived contract
 
 - Root cause: template selection does not exist. There is one `ACK_SUBJECT` and
@@ -63,12 +87,15 @@ Slice phase: Vertical slice
   2. Classification is total: unrecognised, empty, whitespace-only and
      non-string input resolve to `general` and never raise — settled by
      `::test_unrecognised_service_falls_back_to_general` and
-     `::test_classifier_is_total_for_non_string_input`.
+     `::test_classifier_is_total_for_the_whole_non_string_class`, which covers
+     truthy non-strings (`1`, `True`, list, dict, object, bytes) as well as the
+     falsy ones.
   3. Classification reads only the submitted value; no browser-supplied template
      name is consulted — `classify_ack_variant` takes a single `service: str`
      (`atlas_brain/templates/email/request_acknowledgement.py`) and `leads.py`
      passes `payload.service`, with no template field on `LeadIntakeRequest`.
-  4. The variant reaches both evidence records — settled by
+  4. Both evidence records carry the derived variant **and** the raw submitted
+     `service` — settled by
      `::test_variant_recorded_on_interaction_and_email_history` (asserts the
      `metadata` kwarg on the CRM `log_interaction` and email-history `create`
      calls, parametrized over all seven inputs).
@@ -85,8 +112,9 @@ Slice phase: Vertical slice
      `atlas_brain/services/crm_provider.py` `_interaction_anchor` /
      `_interaction_attribution_identity`.
   8. Caps, honeypot, Resend routing and failure isolation unchanged — settled by
-     `tests/test_leads_intake.py` passing unmodified except one assertion that
-     gains the new metadata key.
+     `tests/test_leads_intake.py` passing unmodified except the exact-shape
+     email-history assertion, which gains the two new metadata keys (`service`
+     and `ack_variant`).
 - Reachability proof: the real entrypoint is
   `atlas_brain/api/leads.py::_process_lead_intake`, the same coroutine the
   `POST /api/v1/leads/intake` route awaits. It is exercised directly in
@@ -122,9 +150,43 @@ This diff adds a classifier, so the enumeration applies.
   free-form from a `<select>`). Normalization is `strip().lower()`; the mapping
   is an exact-match dict, so no prefix, substring, or regex matching is involved.
 - Caller × input shape: one caller (`_process_lead_intake`) × six allowlisted
-  form values, plus empty, whitespace-only, unknown, mixed-case, padded, and
-  non-string — all enumerated in
+  form values, plus empty, whitespace-only, unknown, mixed-case, padded, and the
+  whole non-string class (truthy and falsy) — all enumerated in
   `tests/test_ack_variant_classification.py`.
+
+#### Closure declaration — `_ACK_VARIANT_BY_SERVICE`
+
+Per `docs/GUARD_CLASS_CLOSURE.md`, for the literal member set that controls the
+routing decision:
+
+1. **Is the set closed or open? — OPEN.** Membership is the set of `service`
+   values the website `<select>` elements can submit, and those live in a
+   different repository and deploy independently
+   (`canfieldjuan/Effingham_Office_Maids_Website`: `contact.html`,
+   `commercial-estimate.html`, `house-cleaning-estimate.html`,
+   `house-cleaning-services/index.html`). A new `<option>` can ship there
+   without any change here, so Atlas cannot enumerate membership
+   authoritatively — the six values below are a **sample taken at a point in
+   time**, not a closed universe.
+2. **Where does membership come from? — ENUMERATED.** The six members
+   (`residential`, `deep`, `move`, `commercial`, `multi-location-commercial`,
+   `other`) are fixed text in this change, read once out of the four form files
+   named above at website `origin/main`. Because they are fixed text, this code
+   **cannot detect drift** when the website adds or renames an option; the
+   out-of-set behaviour below is what absorbs that drift. `DERIVED` was
+   rejected: the source of truth is HTML in another repo with no runtime
+   contract Atlas can query, so recomputing per use is not available.
+3. **What happens to an input outside the set? — it resolves to `general`, and
+   `general` renders the existing template.** This covers *unlisted members of
+   the class* (a new website option) as well as true non-members (garbage,
+   non-strings), which is the drift case that matters. The direction is the safe
+   side for two reasons: a lead whose service Atlas does not recognise still
+   receives exactly the acknowledgement every lead receives today, so the
+   failure mode is "no new behaviour" rather than wrong expectations; and
+   routing an unknown value into commercial copy could promise a discovery call
+   and a written proposal to someone who asked for a house cleaning. Intake also
+   never fails on an unknown value — the classifier is total, so lead capture is
+   never at risk from a form change.
 
 ### Deployed-config probing
 
@@ -247,10 +309,10 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `atlas_brain/api/leads.py` | 11 |
+| `atlas_brain/api/leads.py` | 19 |
 | `atlas_brain/templates/email/__init__.py` | 10 |
-| `atlas_brain/templates/email/request_acknowledgement.py` | 38 |
-| `plans/PR-EOM-Ack-Variant-Classify.md` | 256 |
-| `tests/test_ack_variant_classification.py` | 189 |
-| `tests/test_leads_intake.py` | 4 |
-| **Total** | **508** |
+| `atlas_brain/templates/email/request_acknowledgement.py` | 42 |
+| `plans/PR-EOM-Ack-Variant-Classify.md` | 318 |
+| `tests/test_ack_variant_classification.py` | 209 |
+| `tests/test_leads_intake.py` | 6 |
+| **Total** | **604** |

--- a/plans/PR-EOM-Ack-Variant-Classify.md
+++ b/plans/PR-EOM-Ack-Variant-Classify.md
@@ -1,0 +1,256 @@
+# PR — EOM acknowledgement variant: classify + record (slice A1)
+
+## Why this slice exists
+
+Every website estimate submission currently receives the **same** acknowledgement
+email. `format_request_acknowledgement`
+(`atlas_brain/templates/email/request_acknowledgement.py`) never branches on
+`service`; it only echoes the raw value into a "Your request: …" line. Rendering
+residential vs commercial with the same client name differs by exactly one line.
+
+That already reaches real commercial leads — a `commercial` / `one-time`
+submission from `/contact` on 2026-08-04 received copy promising a walkthrough
+"less than 20 minutes" that ends with a price and same-visit booking. Roughly
+true for a single office; wrong for a multi-site prospect, and it is the first
+thing EOM says to them. EOM is also starting multi-site work in two new counties
+using local labor (EOM as subcontractor rather than cleaner), which makes
+multi-site a distinct workflow rather than a bigger commercial one.
+
+Tracking issue: #2320 (part of #2188). Website companion:
+`Effingham_Office_Maids_Website` #141 / PR #143.
+
+### Problem-derived contract
+
+- Root cause: template selection does not exist. There is one `ACK_SUBJECT` and
+  one `ACK_TEMPLATE`, and the only per-submission variation is echoed text.
+  Nothing derives *which* email a lead should receive from *what they asked for*.
+- Correct fix must touch/change: a deterministic, server-side mapping from the
+  submitted `service` value to an acknowledgement variant; the intake path that
+  already holds that value (`atlas_brain/api/leads.py::_process_lead_intake`);
+  and the two evidence records intake already writes — the `web_form`
+  interaction metadata and the sent-email history metadata. It must not read a
+  browser-supplied template name.
+- Must not change: the residential email, which is the majority path (6 of 9 real
+  submissions to date) and must render byte-identically; interaction dedupe; the
+  per-identity daily cap (`MAX_DAILY_SUBMISSIONS`); the global hourly
+  acknowledgement cap (`GLOBAL_ACK_HOURLY_CAP`); honeypot handling; Resend
+  routing and sender identity; and failure isolation — a template or send failure
+  must never fail the already-committed lead capture.
+
+## Scope (this PR)
+
+Ownership lane: eom-crm/lead-ack-variant
+Slice phase: Vertical slice
+
+1. Add a deterministic `classify_ack_variant(service)` mapping every value the
+   website forms can submit to one of four variants, with `general` as an
+   explicit total fallback.
+2. Record the derived variant on the `web_form` interaction metadata and on the
+   sent-email history metadata, alongside the raw submitted value.
+3. Change no rendered email. Every variant still renders the single existing
+   template; template selection lands in A2/A3.
+
+### Review Contract
+
+- Acceptance criteria:
+  1. Every value the website forms can submit maps explicitly —
+     `residential`/`deep`/`move` → `residential`, `commercial` →
+     `commercial_single_site`, `multi-location-commercial` →
+     `commercial_multi_site`, `other` → `general` — settled by
+     `tests/test_ack_variant_classification.py::test_every_submitted_service_maps_explicitly`.
+     `other` is an allowlisted form option, not an unknown, so it names its
+     variant rather than falling through.
+  2. Classification is total: unrecognised, empty, whitespace-only and
+     non-string input resolve to `general` and never raise — settled by
+     `::test_unrecognised_service_falls_back_to_general` and
+     `::test_classifier_is_total_for_non_string_input`.
+  3. Classification reads only the submitted value; no browser-supplied template
+     name is consulted — `classify_ack_variant` takes a single `service: str`
+     (`atlas_brain/templates/email/request_acknowledgement.py`) and `leads.py`
+     passes `payload.service`, with no template field on `LeadIntakeRequest`.
+  4. The variant reaches both evidence records — settled by
+     `::test_variant_recorded_on_interaction_and_email_history` (asserts the
+     `metadata` kwarg on the CRM `log_interaction` and email-history `create`
+     calls, parametrized over all seven inputs).
+  5. The variant is recorded even when no acknowledgement is sent — settled by
+     `::test_variant_recorded_on_interaction_even_when_no_email_is_sent`
+     (phone-only lead; `provider.send` not awaited).
+  6. No rendered email changes: the residential render is byte-identical to
+     `origin/main` @ `40bb24553` — settled by
+     `::test_residential_render_is_byte_identical_to_pre_change_production` and
+     by the golden diff in Verification (same sha256 both sides).
+  7. Interaction dedupe is unchanged: the dedupe key reads only
+     `_INTERACTION_DEDUPE_ANCHOR_KEYS` (which does not contain `ack_variant`),
+     `metadata["attribution"]`, and the normalized summary —
+     `atlas_brain/services/crm_provider.py` `_interaction_anchor` /
+     `_interaction_attribution_identity`.
+  8. Caps, honeypot, Resend routing and failure isolation unchanged — settled by
+     `tests/test_leads_intake.py` passing unmodified except one assertion that
+     gains the new metadata key.
+- Reachability proof: the real entrypoint is
+  `atlas_brain/api/leads.py::_process_lead_intake`, the same coroutine the
+  `POST /api/v1/leads/intake` route awaits. It is exercised directly in
+  `tests/test_ack_variant_classification.py`; the observable state is the
+  `metadata` kwarg captured on the CRM `log_interaction` call and on the
+  email-history `create` call, asserted per variant.
+- Affected surfaces: `POST /api/v1/leads/intake`; `contact_interactions.metadata`
+  and `sent_emails.metadata` evidence records; the
+  `atlas_brain.templates.email` public export list.
+- Risk areas: silently altering interaction dedupe by adding a metadata key;
+  drifting residential copy while refactoring around it; exceeding the
+  `sent_emails.template_type VARCHAR(32)` column; import cycles from a new
+  module-level import in `leads.py`.
+- Reviewer rules triggered: R1, R2, R5, R14. R1/R2/R5 from the path trigger
+  `atlas_brain/api/**`. R14 is added deliberately: it is an advisory prose-only
+  row rather than an auto-enforced path trigger, but this diff introduces a
+  classifier, which that row names ("Guard, validator, cap, classifier, gate,
+  sanitizer, denylist, parser admission rule, or safety checker changes →
+  R14, R2"), so it is declared rather than left to the auto-check.
+
+### Boundary-change enumeration
+
+This diff adds a classifier, so the enumeration applies.
+
+- Boundary path/seam: `classify_ack_variant`
+  (`atlas_brain/templates/email/request_acknowledgement.py`), called once from
+  `atlas_brain/api/leads.py::_process_lead_intake` before the CRM write.
+- Replaced-path behaviors: no classification existed. Previously every submitted
+  `service` took one undifferentiated path and the value was used only as echoed
+  text. This slice adds a derived value beside it and still routes every variant
+  to the same template, so no previously reachable output is replaced.
+- Guard-relevant fields: `LeadIntakeRequest.service` (`str`, `max_length=120`,
+  free-form from a `<select>`). Normalization is `strip().lower()`; the mapping
+  is an exact-match dict, so no prefix, substring, or regex matching is involved.
+- Caller × input shape: one caller (`_process_lead_intake`) × six allowlisted
+  form values, plus empty, whitespace-only, unknown, mixed-case, padded, and
+  non-string — all enumerated in
+  `tests/test_ack_variant_classification.py`.
+
+### Deployed-config probing
+
+N/A — no guard/config boundary change. `classify_ack_variant` reads no
+environment variable, setting, or deployed config; its only input is the
+submitted `service` value, and its fallback (`general`) is a literal in the
+mapping rather than a config default. The one setting this path already consults,
+`settings.email.enabled`, is untouched.
+
+### Files touched
+
+- `atlas_brain/api/leads.py`
+- `atlas_brain/templates/email/__init__.py`
+- `atlas_brain/templates/email/request_acknowledgement.py`
+- `plans/PR-EOM-Ack-Variant-Classify.md`
+- `tests/test_ack_variant_classification.py`
+- `tests/test_leads_intake.py`
+
+## Mechanism
+
+A module-level dict maps normalized (`strip().lower()`) service values to variant
+constants; `classify_ack_variant` returns
+`_ACK_VARIANT_BY_SERVICE.get(normalized, ACK_VARIANT_GENERAL)`, so the function is
+total by construction rather than by branch coverage. `leads.py` classifies once,
+before the CRM write, and passes the result into the metadata dict it already
+builds plus the email-history metadata it already writes.
+
+Deliberately **not** a column on `contacts`. A multi-location company is still a
+commercial customer — "multi-site" describes the shape of the request, not a
+third customer type — so this is a lead-time acknowledgement variant.
+`contacts.contact_type` already means lifecycle (`customer` 410 rows / `lead` 297
+rows); adding `customer_type` beside it would put two similarly-named columns on
+unrelated axes. Whether residential/commercial ever becomes a permanent contact
+attribute stays an open decision this slice does not force.
+
+## Intentional
+
+- `template_type` stays `"request_acknowledgement"`. Two reasons: it would be
+  inaccurate, because this slice still renders that one template, so a
+  per-variant value would misdescribe what was sent; and it would not fit —
+  `sent_emails.template_type` is `VARCHAR(32)`
+  (`atlas_brain/storage/migrations/016_sent_emails.sql:10`) while
+  `request_acknowledgement:residential` is 35 characters. A2/A3 will use short
+  per-variant values once the templates genuinely differ.
+- Adding a metadata key cannot shift interaction dedupe — verified against
+  `_interaction_anchor` (fixed allowlist, no `ack_variant`) and
+  `_interaction_attribution_identity` (reads only `metadata["attribution"]`) in
+  `atlas_brain/services/crm_provider.py`.
+- The raw `service` value is kept alongside the derived variant, so a future
+  mapping change can be reasoned about against what was actually submitted.
+- `classify_ack_variant` is imported locally inside `_process_lead_intake`,
+  matching that file's existing lazy-import style for `..templates.email`,
+  `..config`, and `..storage.*`, rather than adding a module-level import.
+- One existing assertion was updated rather than loosened:
+  `test_successful_acknowledgement_records_tenant_history` pins the email-history
+  metadata dict exactly, so the new key was added to it instead of relaxing it to
+  a subset check.
+- `tests/unit_gate_baseline.txt` is deliberately **left untouched**, even though
+  the local pre-push unit-gate mirror reports entries as STALE and asks for the
+  ratchet to shrink. That report is a known **false negative on this dev box**:
+  the mirror runs in an env that is a superset of CI's lean unit-gate env, so
+  `test_monthly_invoice_generation.py` `*_real_repo`/PDF tests pass here
+  (postgres is live on localhost:5433; CI's unit gate has no DB). The
+  `tests/security/*` entries that previously appeared stale were resolved
+  separately on `main` by #2323 and are no longer in the baseline. Historically
+  also affected: `test_monthly_invoice_generation.py` `*_real_repo`/PDF tests pass
+  here (postgres is live on localhost:5433; CI's unit gate has no DB). Removing
+  those entries would convert them into **CI regressions**. Prior CI evidence:
+  FULL gate run 31233990183 reported `baseline=169; regressions=0;
+  newly-passing=0`. Tooling fix tracked separately as #2324.
+
+## Deferred
+
+- A2 — single-site commercial template; adds the template and routes
+  `commercial_single_site` to it.
+- A3 — multi-site commercial template; discovery-call-first copy that must not
+  promise an immediate price, that Mayra and Tina inspect every location, one
+  identical checklist, or pre-confirmed serviceability. Named contact becomes
+  Juan rather than Mayra and Tina.
+- Per-variant `template_type` — blocked on A2/A3 (see Intentional); values must
+  fit `VARCHAR(32)`.
+- Duplicate-email semantics for a corrected service — a resubmission with a
+  different service already yields a new dedupe key and therefore re-acknowledges.
+  Intended; not redesigned here.
+- UTC vs America/Chicago dedupe bucketing — `crm_provider.py` buckets on the UTC
+  date, so two submissions either side of 7 p.m. Central fall in different
+  buckets. Changing dedupe time semantics deserves its own tests and an atomic
+  design; folding it in would turn three email templates into a rewrite of intake
+  idempotency.
+
+Parking predicate: this slice parks **copy and template-selection findings** —
+anything about what an email *says* or which template it picks — because it
+deliberately changes no rendered output. It does not park correctness findings
+about classification, recording, dedupe, or caps.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_ack_variant_classification.py -q` — **32 passed**
+- `python -m pytest tests/test_leads_intake.py tests/test_ack_variant_classification.py -q`
+  — **82 passed**
+- Golden render: all eight service values rendered before and after are
+  **byte-identical**, sha256
+  `23199591b0e5ea13e999db364005c376e1c5c70fd69cf4f66106e8eb6667f7bc` on both
+  sides, captured against `origin/main` @ `40bb24553`.
+- Suite failure diff against a clean `origin/main` worktree with the same `-k`
+  selection (`lead or ack or intake or eom`): **16 failures on both sides, zero
+  introduced**. Eight collection errors (`test_invoicing_readonly_oauth`,
+  `test_mcp_content_ops_*`, and others) reproduce at baseline.
+- `ruff check` on the five changed paths — clean. Four repository-wide findings
+  (`invoice.py`, `vendor_briefing.py`) and one unused-import at
+  `tests/test_leads_intake.py:37` are pre-existing: they reproduce at
+  `origin/main` with these changes stashed, and none sit on a line this PR
+  touches.
+- `python -m py_compile` on the three changed runtime modules — OK.
+- `git diff --check` — clean.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/api/leads.py` | 11 |
+| `atlas_brain/templates/email/__init__.py` | 10 |
+| `atlas_brain/templates/email/request_acknowledgement.py` | 38 |
+| `plans/PR-EOM-Ack-Variant-Classify.md` | 256 |
+| `tests/test_ack_variant_classification.py` | 189 |
+| `tests/test_leads_intake.py` | 4 |
+| **Total** | **508** |

--- a/plans/PR-EOM-Ack-Variant-Classify.md
+++ b/plans/PR-EOM-Ack-Variant-Classify.md
@@ -287,9 +287,19 @@ Parked hardening: none.
 
 ## Verification
 
-- `python -m pytest tests/test_ack_variant_classification.py -q` — **32 passed**
+Counts below are from re-runs at head `c9f58a546`, i.e. after the generated
+property tests and the contract-oracle equality test were added. The earlier
+numbers in this section (32 / 82) described the original fixed-example suite and
+no longer matched the file.
+
+- `python -m pytest tests/test_ack_variant_classification.py -q` — **45 passed**
 - `python -m pytest tests/test_leads_intake.py tests/test_ack_variant_classification.py -q`
-  — **82 passed**
+  — **95 passed**
+- `python -m pytest tests/test_ack_variant_classification.py tests/test_leads_intake.py
+  tests/test_eom_sent_email_tenant_scope.py -q` — **95 passed, 1 skipped**. The skip
+  is `test_eom_sent_email_tenant_scope.py`, which needs a database and is skipped on
+  this box; it RUNS in the enrolled `eom-lead-pipeline` workflow, where it is green
+  at this head. A locally-skipped test is not treated here as a passing one.
 - Golden render: all eight service values rendered before and after are
   **byte-identical**, sha256
   `23199591b0e5ea13e999db364005c376e1c5c70fd69cf4f66106e8eb6667f7bc` on both
@@ -305,6 +315,13 @@ Parked hardening: none.
   touches.
 - `python -m py_compile` on the three changed runtime modules — OK.
 - `git diff --check` — clean.
+- Negative proof that the contract oracle actually bites, rather than only
+  passing on good input: injecting an unintended member
+  (`"office-cleaning": ACK_VARIANT_RESIDENTIAL`) into `_ACK_VARIANT_BY_SERVICE`
+  makes the suite **fail** (1 failed), and reverting restores **45 passed**. A
+  member set whose test only proves the contracted values map correctly cannot
+  detect an added member, which is the case that would silently re-point a real
+  submission.
 
 ## Estimated diff size
 
@@ -313,8 +330,8 @@ Parked hardening: none.
 | `atlas_brain/api/leads.py` | 19 |
 | `atlas_brain/templates/email/__init__.py` | 10 |
 | `atlas_brain/templates/email/request_acknowledgement.py` | 42 |
-| `plans/PR-EOM-Ack-Variant-Classify.md` | 320 |
+| `plans/PR-EOM-Ack-Variant-Classify.md` | 337 |
 | `tests/test_ack_variant_classification.py` | 305 |
 | `tests/test_eom_sent_email_tenant_scope.py` | 6 |
 | `tests/test_leads_intake.py` | 6 |
-| **Total** | **708** |
+| **Total** | **725** |

--- a/plans/PR-EOM-Ack-Variant-Classify.md
+++ b/plans/PR-EOM-Ack-Variant-Classify.md
@@ -313,8 +313,8 @@ Parked hardening: none.
 | `atlas_brain/api/leads.py` | 19 |
 | `atlas_brain/templates/email/__init__.py` | 10 |
 | `atlas_brain/templates/email/request_acknowledgement.py` | 42 |
-| `plans/PR-EOM-Ack-Variant-Classify.md` | 318 |
-| `tests/test_ack_variant_classification.py` | 283 |
+| `plans/PR-EOM-Ack-Variant-Classify.md` | 320 |
+| `tests/test_ack_variant_classification.py` | 305 |
 | `tests/test_eom_sent_email_tenant_scope.py` | 6 |
 | `tests/test_leads_intake.py` | 6 |
-| **Total** | **684** |
+| **Total** | **708** |

--- a/plans/PR-EOM-Ack-Variant-Classify.md
+++ b/plans/PR-EOM-Ack-Variant-Classify.md
@@ -98,7 +98,19 @@ Slice phase: Vertical slice
      `service` — settled by
      `::test_variant_recorded_on_interaction_and_email_history` (asserts the
      `metadata` kwarg on the CRM `log_interaction` and email-history `create`
-     calls, parametrized over all seven inputs).
+     calls, parametrized over all seven inputs) **on the fallback path**, and by
+     `tests/test_eom_sent_email_tenant_scope.py::test_intake_history_and_scoped_context_are_tenant_exact`
+     **on the production path**. Both are required, because
+     `resolve_or_create_eom_inbound_lead`
+     (`atlas_brain/services/eom_lead_ingress.py:105-124`) splits on whether the
+     CRM **class** exposes `resolve_or_create_eom_inbound_lead_atomic`: a
+     protocol fake takes the read-only `crm.log_interaction` fallback, while
+     `DatabaseCRMProvider` takes the atomic transaction that persists via
+     `_write_contact_interaction` (`services/crm_provider.py:368-394`). A
+     MagicMock CRM therefore cannot settle this criterion for production, so
+     the enrolled PostgreSQL test selects the persisted
+     `contact_interactions.metadata` row and asserts `service` / `ack_variant`
+     on it directly.
   5. The variant is recorded even when no acknowledgement is sent — settled by
      `::test_variant_recorded_on_interaction_even_when_no_email_is_sent`
      (phone-only lead; `provider.send` not awaited).
@@ -198,6 +210,7 @@ mapping rather than a config default. The one setting this path already consults
 
 ### Files touched
 
+- `.github/workflows/atlas_eom_lead_pipeline_checks.yml`
 - `atlas_brain/api/leads.py`
 - `atlas_brain/templates/email/__init__.py`
 - `atlas_brain/templates/email/request_acknowledgement.py`
@@ -315,6 +328,24 @@ fixed-example suite and no longer matched the file.
   touches.
 - `python -m py_compile` on the three changed runtime modules — OK.
 - `git diff --check` — clean.
+- **Production path proven against real PostgreSQL, not a mock.**
+  `tests/test_eom_sent_email_tenant_scope.py` normally skips on this box, and a
+  skipped test is not evidence — so it was run for real by pointing
+  `ATLAS_MIGRATION_TEST_DATABASE_URL` at the local instance: **1 passed**. The
+  test builds a throwaway `atlas_eom_sent_email_<uuid>` schema and drops it in a
+  `finally`; before/after snapshots confirm no side effects — schema count
+  **129 → 129**, `contacts`/`contact_interactions`/`sent_emails` row counts
+  **710/2820/12 → 710/2820/12**, leftover test schemas **0**.
+  Negative probe on the new assertion: changing the expected interaction
+  `ack_variant` from `general` to `residential` makes it **fail**, and restoring
+  it passes — so the added assertion reads persisted state rather than passing
+  vacuously.
+- CI enrollment: `tests/test_ack_variant_classification.py` is now listed in the
+  gating `Run EOM lead pipeline checks` pytest invocation and in **both** path
+  filter blocks of `.github/workflows/atlas_eom_lead_pipeline_checks.yml`; the
+  file parses as valid YAML. Before this, the suite carrying the exhaustive
+  mapping and fallback proofs was not on any required per-PR gate, so a
+  classifier regression could have passed required CI.
 - Negative proof that the contract oracle actually bites, rather than only
   passing on good input. Three injections against the implementation, each
   reverted afterwards (baseline and restored state both **46 passed**):
@@ -333,11 +364,12 @@ fixed-example suite and no longer matched the file.
 
 | File | LOC |
 |---|---:|
+| `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 3 |
 | `atlas_brain/api/leads.py` | 19 |
 | `atlas_brain/templates/email/__init__.py` | 10 |
 | `atlas_brain/templates/email/request_acknowledgement.py` | 42 |
-| `plans/PR-EOM-Ack-Variant-Classify.md` | 343 |
+| `plans/PR-EOM-Ack-Variant-Classify.md` | 373 |
 | `tests/test_ack_variant_classification.py` | 332 |
-| `tests/test_eom_sent_email_tenant_scope.py` | 6 |
+| `tests/test_eom_sent_email_tenant_scope.py` | 35 |
 | `tests/test_leads_intake.py` | 6 |
-| **Total** | **758** |
+| **Total** | **820** |

--- a/tests/test_ack_variant_classification.py
+++ b/tests/test_ack_variant_classification.py
@@ -38,22 +38,49 @@ def _email_enabled(monkeypatch):
 
 # --- classifier -----------------------------------------------------------
 
-# Independent contract oracle. These are the six values the website forms can
-# submit, transcribed from the form markup
-# (Effingham_Office_Maids_Website: contact.html, commercial-estimate.html,
-# house-cleaning-estimate.html, house-cleaning-services/index.html) rather than
-# imported from the implementation. Everything below checks the implementation
-# against THIS, so an unintended entry added to `_ACK_VARIANT_BY_SERVICE`
-# (say `"office-cleaning": ACK_VARIANT_RESIDENTIAL`) fails the equality test
-# instead of being silently excluded from the generated inputs.
+# Independent contract oracle. Both halves of the contract are written here as
+# string LITERALS, never as references to the implementation's constants:
+#
+#   * the six inputs the website forms can submit, transcribed from the form
+#     markup (Effingham_Office_Maids_Website: contact.html,
+#     commercial-estimate.html, house-cleaning-estimate.html,
+#     house-cleaning-services/index.html), and
+#   * the four variant strings intake is contracted to persist.
+#
+# Naming the outputs by literal matters as much as naming the inputs. If the
+# oracle said `ACK_VARIANT_RESIDENTIAL` instead of `"residential"`, then editing
+# that constant would move the classifier and the oracle together — the suite
+# would stay green while intake persisted a value that violates acceptance
+# criterion 1. Written as literals, the oracle detects output-contract drift
+# (a renamed variant value) as well as added mapping keys.
+CONTRACT_RESIDENTIAL = "residential"
+CONTRACT_COMMERCIAL_SINGLE_SITE = "commercial_single_site"
+CONTRACT_COMMERCIAL_MULTI_SITE = "commercial_multi_site"
+CONTRACT_GENERAL = "general"
+
 CONTRACT_SERVICE_VARIANTS = {
-    "residential": ACK_VARIANT_RESIDENTIAL,
-    "deep": ACK_VARIANT_RESIDENTIAL,
-    "move": ACK_VARIANT_RESIDENTIAL,
-    "commercial": ACK_VARIANT_COMMERCIAL_SINGLE_SITE,
-    "multi-location-commercial": ACK_VARIANT_COMMERCIAL_MULTI_SITE,
-    "other": ACK_VARIANT_GENERAL,
+    "residential": CONTRACT_RESIDENTIAL,
+    "deep": CONTRACT_RESIDENTIAL,
+    "move": CONTRACT_RESIDENTIAL,
+    "commercial": CONTRACT_COMMERCIAL_SINGLE_SITE,
+    "multi-location-commercial": CONTRACT_COMMERCIAL_MULTI_SITE,
+    "other": CONTRACT_GENERAL,
 }
+
+
+def test_exported_variant_constants_equal_the_contracted_literals():
+    """The exported constants carry the contracted string VALUES.
+
+    These constants are what downstream code (and A2/A3 template selection)
+    will branch on, and their values are what intake persists into
+    ``contact_interactions.metadata`` / ``sent_emails.metadata``. Pinning them
+    to literals here is what makes every other assertion in this file a real
+    check rather than a comparison of the implementation against itself.
+    """
+    assert ACK_VARIANT_RESIDENTIAL == CONTRACT_RESIDENTIAL
+    assert ACK_VARIANT_COMMERCIAL_SINGLE_SITE == CONTRACT_COMMERCIAL_SINGLE_SITE
+    assert ACK_VARIANT_COMMERCIAL_MULTI_SITE == CONTRACT_COMMERCIAL_MULTI_SITE
+    assert ACK_VARIANT_GENERAL == CONTRACT_GENERAL
 
 
 def test_implementation_mapping_equals_the_contract_oracle():
@@ -67,8 +94,8 @@ def test_implementation_mapping_equals_the_contract_oracle():
 
 @pytest.mark.parametrize(
     ("service", "expected"),
-    # Driven by the contract oracle defined below, so the explicit cases and
-    # the generated ones can never disagree about what "recognised" means.
+    # Driven by the contract oracle above, so the explicit cases and the
+    # generated ones can never disagree about what "recognised" means.
     sorted(CONTRACT_SERVICE_VARIANTS.items()),
 )
 def test_every_submitted_service_maps_explicitly(service, expected):
@@ -80,15 +107,15 @@ def test_every_submitted_service_maps_explicitly(service, expected):
     ["", "   ", "unknown", "Residential Cleaning", "commercial-multi", "1; DROP TABLE"],
 )
 def test_unrecognised_service_falls_back_to_general(service):
-    assert classify_ack_variant(service) == ACK_VARIANT_GENERAL
+    assert classify_ack_variant(service) == CONTRACT_GENERAL
 
 
 @pytest.mark.parametrize(
     ("service", "expected"),
     [
-        ("  residential  ", ACK_VARIANT_RESIDENTIAL),
-        ("RESIDENTIAL", ACK_VARIANT_RESIDENTIAL),
-        ("Multi-Location-Commercial", ACK_VARIANT_COMMERCIAL_MULTI_SITE),
+        ("  residential  ", CONTRACT_RESIDENTIAL),
+        ("RESIDENTIAL", CONTRACT_RESIDENTIAL),
+        ("Multi-Location-Commercial", CONTRACT_COMMERCIAL_MULTI_SITE),
     ],
 )
 def test_classification_is_whitespace_and_case_insensitive(service, expected):
@@ -150,7 +177,7 @@ def test_generated_unrecognised_strings_all_resolve_to_general():
     rng = random.Random(20260808)  # seeded: reproducible, not flaky
     checked = 0
     for value in _generated_unrecognised_strings(rng, 500):
-        assert classify_ack_variant(value) == ACK_VARIANT_GENERAL, repr(value)
+        assert classify_ack_variant(value) == CONTRACT_GENERAL, repr(value)
         checked += 1
     assert checked == 500
 
@@ -166,7 +193,7 @@ def test_generated_non_strings_never_raise_and_resolve_to_general():
     rng = random.Random(20260808)
     checked = 0
     for value in _generated_non_strings(rng, 500):
-        assert classify_ack_variant(value) == ACK_VARIANT_GENERAL, repr(value)
+        assert classify_ack_variant(value) == CONTRACT_GENERAL, repr(value)
         checked += 1
     assert checked == 500
 
@@ -182,7 +209,7 @@ def test_generated_non_strings_never_raise_and_resolve_to_general():
     ],
 )
 def test_classifier_is_total_for_the_whole_non_string_class(value):
-    assert classify_ack_variant(value) == ACK_VARIANT_GENERAL
+    assert classify_ack_variant(value) == CONTRACT_GENERAL
 
 
 # --- recording ------------------------------------------------------------
@@ -191,13 +218,13 @@ def test_classifier_is_total_for_the_whole_non_string_class(value):
 @pytest.mark.parametrize(
     ("service", "expected"),
     [
-        ("residential", ACK_VARIANT_RESIDENTIAL),
-        ("deep", ACK_VARIANT_RESIDENTIAL),
-        ("move", ACK_VARIANT_RESIDENTIAL),
-        ("commercial", ACK_VARIANT_COMMERCIAL_SINGLE_SITE),
-        ("multi-location-commercial", ACK_VARIANT_COMMERCIAL_MULTI_SITE),
-        ("other", ACK_VARIANT_GENERAL),
-        ("", ACK_VARIANT_GENERAL),
+        ("residential", CONTRACT_RESIDENTIAL),
+        ("deep", CONTRACT_RESIDENTIAL),
+        ("move", CONTRACT_RESIDENTIAL),
+        ("commercial", CONTRACT_COMMERCIAL_SINGLE_SITE),
+        ("multi-location-commercial", CONTRACT_COMMERCIAL_MULTI_SITE),
+        ("other", CONTRACT_GENERAL),
+        ("", CONTRACT_GENERAL),
     ],
 )
 async def test_variant_recorded_on_interaction_and_email_history(service, expected):
@@ -237,7 +264,7 @@ async def test_variant_recorded_on_interaction_even_when_no_email_is_sent():
 
     provider.send.assert_not_awaited()
     metadata = crm.log_interaction.await_args.kwargs["metadata"]
-    assert metadata["ack_variant"] == ACK_VARIANT_COMMERCIAL_MULTI_SITE
+    assert metadata["ack_variant"] == CONTRACT_COMMERCIAL_MULTI_SITE
 
 
 # --- no copy change in this slice ----------------------------------------

--- a/tests/test_ack_variant_classification.py
+++ b/tests/test_ack_variant_classification.py
@@ -5,9 +5,15 @@ the one existing acknowledgement template, so the residential email must be
 byte-identical to what production sent before this change.
 """
 
+import random
+import string
+
 import pytest
 
 from atlas_brain.api.leads import _process_lead_intake
+from atlas_brain.templates.email.request_acknowledgement import (
+    _ACK_VARIANT_BY_SERVICE,
+)
 from atlas_brain.templates.email import (
     ACK_VARIANT_COMMERCIAL_MULTI_SITE,
     ACK_VARIANT_COMMERCIAL_SINGLE_SITE,
@@ -68,24 +74,92 @@ def test_classification_is_whitespace_and_case_insensitive(service, expected):
     assert classify_ack_variant(service) == expected
 
 
+def _generated_unrecognised_strings(rng, count):
+    """Yield arbitrary strings that are not one of the six known form values.
+
+    Grammar-derived rather than a fixed sample: the declared set is OPEN, so a
+    handful of literals cannot stand in for "any unrecognised string".
+    """
+    alphabet = (
+        string.ascii_letters + string.digits + " \t\n-_./\\'\"<>{}[]();:@#$%&*+=|~`^"
+        + "áéíóúñü汉字🧹​ "
+    )
+    known = set(_ACK_VARIANT_BY_SERVICE)
+    produced = 0
+    while produced < count:
+        candidate = "".join(rng.choice(alphabet) for _ in range(rng.randint(0, 40)))
+        if candidate.strip().lower() in known:
+            continue  # a generated collision with a real value is not a counter-example
+        produced += 1
+        yield candidate
+
+
+def _generated_non_strings(rng, count):
+    """Yield varied non-string shapes, including nested containers."""
+    atoms = [
+        None, True, False, 0, 1, -3, 0.0, 1.5, float("nan"), float("inf"),
+        b"commercial", bytearray(b"residential"), object(), Exception("x"),
+        range(2), iter([]), lambda: None, type, NotImplemented, Ellipsis,
+    ]
+    for _ in range(count):
+        shape = rng.randint(0, 5)
+        atom = rng.choice(atoms)
+        if shape == 0:
+            yield atom
+        elif shape == 1:
+            yield [atom]
+        elif shape == 2:
+            yield (atom,)
+        elif shape == 3:
+            yield {"service": atom}
+        elif shape == 4:
+            yield [[atom], {"nested": atom}]
+        else:
+            yield {rng.randint(0, 9): [atom]}
+
+
+def test_generated_unrecognised_strings_all_resolve_to_general():
+    """Property: any string outside the known set resolves to ``general``.
+
+    The set is declared OPEN (a website form option can appear without any
+    change here), so the guarantee has to hold for arbitrary strings, not for a
+    curated list of them.
+    """
+    rng = random.Random(20260808)  # seeded: reproducible, not flaky
+    checked = 0
+    for value in _generated_unrecognised_strings(rng, 500):
+        assert classify_ack_variant(value) == ACK_VARIANT_GENERAL, repr(value)
+        checked += 1
+    assert checked == 500
+
+
+def test_generated_non_strings_never_raise_and_resolve_to_general():
+    """Property: the whole non-string class resolves to ``general``.
+
+    Acceptance criterion 2 promises this for every non-string, so the proof is
+    generated over varied shapes — atoms, containers, nested containers — rather
+    than the fixed examples that previously let a truthy-non-string
+    ``AttributeError`` through.
+    """
+    rng = random.Random(20260808)
+    checked = 0
+    for value in _generated_non_strings(rng, 500):
+        assert classify_ack_variant(value) == ACK_VARIANT_GENERAL, repr(value)
+        checked += 1
+    assert checked == 500
+
+
 @pytest.mark.parametrize(
     "value",
     [
-        # Falsy non-strings — these took the old `service or ""` path.
-        None, 0, 0.0, False, [], {}, set(), (),
-        # Truthy non-strings — these reached `.strip()` and raised
-        # AttributeError before the isinstance guard. Covering only the falsy
-        # half is what let the defect through.
-        1, True, 1.5, ["residential"], {"service": "commercial"}, {"commercial"},
-        ("commercial",), object(), b"commercial",
+        # Retained as named regression anchors for the specific defect Codex
+        # found: the falsy half took the old `service or ""` path, while the
+        # truthy half reached `.strip()` and raised AttributeError.
+        None, 0, False, [], {},
+        1, True, 1.5, ["residential"], {"service": "commercial"}, b"commercial",
     ],
 )
 def test_classifier_is_total_for_the_whole_non_string_class(value):
-    """Intake passes a validated str, but the classifier must never raise.
-
-    Acceptance criterion 2 promises every non-string resolves to ``general``,
-    so the guard covers the whole class rather than the falsy part of it.
-    """
     assert classify_ack_variant(value) == ACK_VARIANT_GENERAL
 
 

--- a/tests/test_ack_variant_classification.py
+++ b/tests/test_ack_variant_classification.py
@@ -1,0 +1,189 @@
+"""Acknowledgement-variant classification and recording (ATLAS #2320, slice A1).
+
+This slice classifies and records only. Every submitted service still renders
+the one existing acknowledgement template, so the residential email must be
+byte-identical to what production sent before this change.
+"""
+
+import pytest
+
+from atlas_brain.api.leads import _process_lead_intake
+from atlas_brain.templates.email import (
+    ACK_VARIANT_COMMERCIAL_MULTI_SITE,
+    ACK_VARIANT_COMMERCIAL_SINGLE_SITE,
+    ACK_VARIANT_GENERAL,
+    ACK_VARIANT_RESIDENTIAL,
+    classify_ack_variant,
+    format_request_acknowledgement,
+)
+
+from .test_leads_intake import _crm, _email_history, _email_provider, _payload
+
+
+@pytest.fixture(autouse=True)
+def _email_enabled(monkeypatch):
+    """Mirror of the autouse fixture in ``test_leads_intake``: the endpoint
+    honors ``settings.email.enabled``, and an autouse fixture does not cross
+    module boundaries, so the send path needs it enabled here too."""
+    from atlas_brain.config import settings
+
+    monkeypatch.setattr(settings.email, "enabled", True)
+
+
+# --- classifier -----------------------------------------------------------
+
+@pytest.mark.parametrize(
+    ("service", "expected"),
+    [
+        # Every value the website forms can submit.
+        ("residential", ACK_VARIANT_RESIDENTIAL),
+        ("deep", ACK_VARIANT_RESIDENTIAL),
+        ("move", ACK_VARIANT_RESIDENTIAL),
+        ("commercial", ACK_VARIANT_COMMERCIAL_SINGLE_SITE),
+        ("multi-location-commercial", ACK_VARIANT_COMMERCIAL_MULTI_SITE),
+        ("other", ACK_VARIANT_GENERAL),
+    ],
+)
+def test_every_submitted_service_maps_explicitly(service, expected):
+    assert classify_ack_variant(service) == expected
+
+
+@pytest.mark.parametrize(
+    "service",
+    ["", "   ", "unknown", "Residential Cleaning", "commercial-multi", "1; DROP TABLE"],
+)
+def test_unrecognised_service_falls_back_to_general(service):
+    assert classify_ack_variant(service) == ACK_VARIANT_GENERAL
+
+
+@pytest.mark.parametrize(
+    ("service", "expected"),
+    [
+        ("  residential  ", ACK_VARIANT_RESIDENTIAL),
+        ("RESIDENTIAL", ACK_VARIANT_RESIDENTIAL),
+        ("Multi-Location-Commercial", ACK_VARIANT_COMMERCIAL_MULTI_SITE),
+    ],
+)
+def test_classification_is_whitespace_and_case_insensitive(service, expected):
+    assert classify_ack_variant(service) == expected
+
+
+def test_classifier_is_total_for_non_string_input():
+    """Intake passes a validated str, but the classifier must not raise."""
+    assert classify_ack_variant(None) == ACK_VARIANT_GENERAL
+
+
+# --- recording ------------------------------------------------------------
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("service", "expected"),
+    [
+        ("residential", ACK_VARIANT_RESIDENTIAL),
+        ("deep", ACK_VARIANT_RESIDENTIAL),
+        ("move", ACK_VARIANT_RESIDENTIAL),
+        ("commercial", ACK_VARIANT_COMMERCIAL_SINGLE_SITE),
+        ("multi-location-commercial", ACK_VARIANT_COMMERCIAL_MULTI_SITE),
+        ("other", ACK_VARIANT_GENERAL),
+        ("", ACK_VARIANT_GENERAL),
+    ],
+)
+async def test_variant_recorded_on_interaction_and_email_history(service, expected):
+    crm, provider, history = _crm(), _email_provider(), _email_history()
+
+    await _process_lead_intake(
+        _payload(service=service),
+        crm=crm,
+        email_provider=provider,
+        email_history=history,
+    )
+
+    interaction_metadata = crm.log_interaction.await_args.kwargs["metadata"]
+    assert interaction_metadata["ack_variant"] == expected
+    # The raw submitted value stays alongside the derived variant.
+    assert interaction_metadata["service"] == service
+
+    history_metadata = history.create.await_args.kwargs["metadata"]
+    assert history_metadata["ack_variant"] == expected
+
+
+@pytest.mark.asyncio
+async def test_variant_recorded_on_interaction_even_when_no_email_is_sent():
+    """A phone-only lead gets no acknowledgement; the segment is still evidence."""
+    crm, provider, history = _crm(), _email_provider(), _email_history()
+
+    await _process_lead_intake(
+        _payload(email="", service="multi-location-commercial"),
+        crm=crm,
+        email_provider=provider,
+        email_history=history,
+    )
+
+    provider.send.assert_not_awaited()
+    metadata = crm.log_interaction.await_args.kwargs["metadata"]
+    assert metadata["ack_variant"] == ACK_VARIANT_COMMERCIAL_MULTI_SITE
+
+
+# --- no copy change in this slice ----------------------------------------
+
+@pytest.mark.parametrize(
+    "service",
+    ["residential", "deep", "move", "commercial", "multi-location-commercial", "other", ""],
+)
+def test_all_variants_still_render_the_single_existing_template(service):
+    """A1 classifies and records only. Template selection arrives in A2/A3."""
+    baseline_subject, baseline_body = format_request_acknowledgement(
+        "Jane", "residential", "monthly"
+    )
+    subject, body = format_request_acknowledgement("Jane", service, "monthly")
+
+    assert subject == baseline_subject
+    # Only the echoed "Your request:" line may differ between services.
+    def _without_request_line(text: str) -> list[str]:
+        return [line for line in text.splitlines() if not line.startswith("Your request:")]
+
+    assert _without_request_line(body) == _without_request_line(baseline_body)
+
+
+def test_residential_render_is_byte_identical_to_pre_change_production():
+    """Golden anchor: the residential email must not drift while variants land.
+
+    Captured from origin/main @ 92d3ba143 before this slice.
+    """
+    subject, body = format_request_acknowledgement("Marie", "residential", "monthly")
+
+    assert subject == "We received your estimate request - Effingham Office Maids"
+    assert body == (
+        "Hi Marie,\n"
+        "\n"
+        "Thanks for requesting a free estimate from Effingham Office Maids - it "
+        "just landed with a real person, and we'll get back to you within 24 hours.\n"
+        "\n"
+        "Your request: residential, monthly.\n"
+        "\n"
+        "Here's what happens next:\n"
+        "\n"
+        "1. We'll give you a call to book a day and time that works for you for a "
+        "quick estimate walkthrough. The walkthrough usually takes less than 20 "
+        "minutes.\n"
+        "\n"
+        "2. We'll send our estimate team out to look over the spaces you want "
+        "cleaned. Your two team members will be Mayra Canfield and Tina Gomez.\n"
+        "\n"
+        "3. Show them around and tell them what you'd like cleaned and how often.\n"
+        "\n"
+        "4. Before Mayra and Tina leave, they'll give you the cost to clean your "
+        "space. If the pricing works for you, you can schedule your first cleaning "
+        "right then.\n"
+        "\n"
+        "5. Estimates are FREE and there's no obligation. If the pricing isn't "
+        "right for you, we won't try to talk you into it.\n"
+        "\n"
+        "Questions in the meantime? Call us at (217) 207-3097, or just reply to\n"
+        "this email.\n"
+        "\n"
+        "Talk soon,\n"
+        "The Effingham Office Maids Team\n"
+        "(217) 207-3097 | info@effinghamofficemaids.com\n"
+        "effinghamofficemaids.com\n"
+    )

--- a/tests/test_ack_variant_classification.py
+++ b/tests/test_ack_variant_classification.py
@@ -38,17 +38,38 @@ def _email_enabled(monkeypatch):
 
 # --- classifier -----------------------------------------------------------
 
+# Independent contract oracle. These are the six values the website forms can
+# submit, transcribed from the form markup
+# (Effingham_Office_Maids_Website: contact.html, commercial-estimate.html,
+# house-cleaning-estimate.html, house-cleaning-services/index.html) rather than
+# imported from the implementation. Everything below checks the implementation
+# against THIS, so an unintended entry added to `_ACK_VARIANT_BY_SERVICE`
+# (say `"office-cleaning": ACK_VARIANT_RESIDENTIAL`) fails the equality test
+# instead of being silently excluded from the generated inputs.
+CONTRACT_SERVICE_VARIANTS = {
+    "residential": ACK_VARIANT_RESIDENTIAL,
+    "deep": ACK_VARIANT_RESIDENTIAL,
+    "move": ACK_VARIANT_RESIDENTIAL,
+    "commercial": ACK_VARIANT_COMMERCIAL_SINGLE_SITE,
+    "multi-location-commercial": ACK_VARIANT_COMMERCIAL_MULTI_SITE,
+    "other": ACK_VARIANT_GENERAL,
+}
+
+
+def test_implementation_mapping_equals_the_contract_oracle():
+    """The implementation carries exactly the contracted members — no more.
+
+    Without this, an extra entry would both re-point a real submission and be
+    excluded from the generated unrecognised inputs, so nothing would fail.
+    """
+    assert _ACK_VARIANT_BY_SERVICE == CONTRACT_SERVICE_VARIANTS
+
+
 @pytest.mark.parametrize(
     ("service", "expected"),
-    [
-        # Every value the website forms can submit.
-        ("residential", ACK_VARIANT_RESIDENTIAL),
-        ("deep", ACK_VARIANT_RESIDENTIAL),
-        ("move", ACK_VARIANT_RESIDENTIAL),
-        ("commercial", ACK_VARIANT_COMMERCIAL_SINGLE_SITE),
-        ("multi-location-commercial", ACK_VARIANT_COMMERCIAL_MULTI_SITE),
-        ("other", ACK_VARIANT_GENERAL),
-    ],
+    # Driven by the contract oracle defined below, so the explicit cases and
+    # the generated ones can never disagree about what "recognised" means.
+    sorted(CONTRACT_SERVICE_VARIANTS.items()),
 )
 def test_every_submitted_service_maps_explicitly(service, expected):
     assert classify_ack_variant(service) == expected
@@ -75,16 +96,17 @@ def test_classification_is_whitespace_and_case_insensitive(service, expected):
 
 
 def _generated_unrecognised_strings(rng, count):
-    """Yield arbitrary strings that are not one of the six known form values.
+    """Yield arbitrary strings that are not one of the six contracted values.
 
     Grammar-derived rather than a fixed sample: the declared set is OPEN, so a
-    handful of literals cannot stand in for "any unrecognised string".
+    handful of literals cannot stand in for "any unrecognised string". The
+    exclusion consults the contract oracle, never the implementation.
     """
     alphabet = (
         string.ascii_letters + string.digits + " \t\n-_./\\'\"<>{}[]();:@#$%&*+=|~`^"
         + "áéíóúñü汉字🧹​ "
     )
-    known = set(_ACK_VARIANT_BY_SERVICE)
+    known = set(CONTRACT_SERVICE_VARIANTS)  # oracle, not the implementation
     produced = 0
     while produced < count:
         candidate = "".join(rng.choice(alphabet) for _ in range(rng.randint(0, 40)))

--- a/tests/test_ack_variant_classification.py
+++ b/tests/test_ack_variant_classification.py
@@ -68,9 +68,25 @@ def test_classification_is_whitespace_and_case_insensitive(service, expected):
     assert classify_ack_variant(service) == expected
 
 
-def test_classifier_is_total_for_non_string_input():
-    """Intake passes a validated str, but the classifier must not raise."""
-    assert classify_ack_variant(None) == ACK_VARIANT_GENERAL
+@pytest.mark.parametrize(
+    "value",
+    [
+        # Falsy non-strings — these took the old `service or ""` path.
+        None, 0, 0.0, False, [], {}, set(), (),
+        # Truthy non-strings — these reached `.strip()` and raised
+        # AttributeError before the isinstance guard. Covering only the falsy
+        # half is what let the defect through.
+        1, True, 1.5, ["residential"], {"service": "commercial"}, {"commercial"},
+        ("commercial",), object(), b"commercial",
+    ],
+)
+def test_classifier_is_total_for_the_whole_non_string_class(value):
+    """Intake passes a validated str, but the classifier must never raise.
+
+    Acceptance criterion 2 promises every non-string resolves to ``general``,
+    so the guard covers the whole class rather than the falsy part of it.
+    """
+    assert classify_ack_variant(value) == ACK_VARIANT_GENERAL
 
 
 # --- recording ------------------------------------------------------------
@@ -105,6 +121,10 @@ async def test_variant_recorded_on_interaction_and_email_history(service, expect
 
     history_metadata = history.create.await_args.kwargs["metadata"]
     assert history_metadata["ack_variant"] == expected
+    # The raw submitted value rides along in BOTH evidence records, so a
+    # contact with several requests can be traced to the submission that
+    # produced a given email.
+    assert history_metadata["service"] == service
 
 
 @pytest.mark.asyncio
@@ -148,7 +168,7 @@ def test_all_variants_still_render_the_single_existing_template(service):
 def test_residential_render_is_byte_identical_to_pre_change_production():
     """Golden anchor: the residential email must not drift while variants land.
 
-    Captured from origin/main @ 92d3ba143 before this slice.
+    Captured from origin/main before this slice; unchanged across the rebase to 40bb24553.
     """
     subject, body = format_request_acknowledgement("Marie", "residential", "monthly")
 

--- a/tests/test_eom_sent_email_tenant_scope.py
+++ b/tests/test_eom_sent_email_tenant_scope.py
@@ -320,6 +320,35 @@ async def test_intake_history_and_scoped_context_are_tenant_exact(
             },
         }
 
+        # The other half of acceptance criterion 4, and the half the unit tests
+        # cannot reach. `_process_lead_intake` writes ONE metadata dict, but
+        # `resolve_or_create_eom_inbound_lead` splits on whether the CRM class
+        # exposes `resolve_or_create_eom_inbound_lead_atomic`
+        # (`services/eom_lead_ingress.py`): protocol fakes take the read-only
+        # `crm.log_interaction` fallback, while production takes the atomic
+        # transaction that persists through `_write_contact_interaction`. A
+        # MagicMock CRM therefore proves the fallback path only. This assertion
+        # runs against real PostgreSQL through the route, so it is the evidence
+        # that the derived variant reaches persisted `contact_interactions`
+        # state on the path production actually takes.
+        stored_interaction = await pool.fetchrow(
+            """
+            SELECT interaction_type, metadata
+            FROM contact_interactions
+            WHERE contact_id = $1
+              AND interaction_type = 'web_form'
+            ORDER BY created_at DESC
+            LIMIT 1
+            """,
+            contact["id"],
+        )
+        assert stored_interaction is not None
+        interaction_metadata = stored_interaction["metadata"]
+        if isinstance(interaction_metadata, str):
+            interaction_metadata = json.loads(interaction_metadata)
+        assert interaction_metadata["service"] == "office cleaning"
+        assert interaction_metadata["ack_variant"] == "general"
+
         now = datetime.now(timezone.utc)
         await pool.executemany(
             """

--- a/tests/test_eom_sent_email_tenant_scope.py
+++ b/tests/test_eom_sent_email_tenant_scope.py
@@ -311,6 +311,12 @@ async def test_intake_history_and_scoped_context_are_tenant_exact(
             "metadata": {
                 "source": "website_estimate_form",
                 "contact_id": str(contact["id"]),
+                # ATLAS #2320 slice A1: both evidence records carry the raw
+                # submitted service and the derived acknowledgement variant.
+                # "office cleaning" is not one of the six website form values,
+                # so it resolves to the general fallback.
+                "service": "office cleaning",
+                "ack_variant": "general",
             },
         }
 

--- a/tests/test_leads_intake.py
+++ b/tests/test_leads_intake.py
@@ -367,6 +367,10 @@ async def test_successful_acknowledgement_records_tenant_history():
     assert kwargs["metadata"] == {
         "source": "website_estimate_form",
         "contact_id": "c-123",
+        # ATLAS #2320 slice A1: the acknowledgement variant is recorded as
+        # evidence. ``template_type`` stays "request_acknowledgement" because
+        # this slice still renders the single existing template.
+        "ack_variant": "residential",
     }
 
 

--- a/tests/test_leads_intake.py
+++ b/tests/test_leads_intake.py
@@ -368,8 +368,10 @@ async def test_successful_acknowledgement_records_tenant_history():
         "source": "website_estimate_form",
         "contact_id": "c-123",
         # ATLAS #2320 slice A1: the acknowledgement variant is recorded as
-        # evidence. ``template_type`` stays "request_acknowledgement" because
-        # this slice still renders the single existing template.
+        # evidence alongside the raw submitted value. ``template_type`` stays
+        # "request_acknowledgement" because this slice still renders the single
+        # existing template.
+        "service": "residential",
         "ack_variant": "residential",
     }
 


### PR DESCRIPTION
Plan: plans/PR-EOM-Ack-Variant-Classify.md
Slice phase: Vertical slice
Ownership lane: eom-crm/lead-ack-variant

Every website estimate submission currently receives the **same** acknowledgement email — `format_request_acknowledgement` never branches on `service`, it only echoes the raw value into a "Your request: …" line. A real `commercial` lead on 2026-08-04 received residential copy promising a sub-20-minute walkthrough that ends with a price and same-visit booking; roughly true for a single office, wrong for a multi-site prospect, and it is the first thing EOM says to them. This slice adds the classification and records it as evidence, and deliberately changes no rendered email — so the mapping is proven against real traffic while the new copy is still being written. Part of #2320 (#2188); website companion `Effingham_Office_Maids_Website` #143.

| Submitted `service` | Variant |
|---|---|
| `residential`, `deep`, `move` | `residential` |
| `commercial` | `commercial_single_site` |
| `multi-location-commercial` | `commercial_multi_site` |
| `other` | `general` |
| unrecognised / empty | `general` |

Diff-budget override: the runtime change is 59 added lines (11 in `leads.py`, 38 in `request_acknowledgement.py`, 10 re-exports). The remaining 449 are the mandatory `plans/PR-*.md` doc (253, required by AGENTS.md for any non-Markdown diff) and the test matrix (189) the Review Contract commits to -- all six submitted form values, totality over empty/whitespace/unknown/non-string, both evidence records, the no-send path, and the byte-identical residential golden. Splitting would either drop required proof for a classifier (R2/R14) or fragment a 59-line change across PRs that cannot be reviewed independently.

## Intentional
- Not a column on `contacts`. A multi-location company is still a commercial customer — "multi-site" describes the shape of the request, not a third customer type. `contacts.contact_type` already means lifecycle (`customer` 410 / `lead` 297); adding `customer_type` beside it would put two similarly-named columns on unrelated axes.
- `template_type` stays `"request_acknowledgement"`: this slice still renders that one template, so a per-variant value would misdescribe what was sent, and `request_acknowledgement:residential` (35 chars) does not fit `sent_emails.template_type VARCHAR(32)` (`016_sent_emails.sql:10`).
- `other` is an allowlisted form option, not an unknown, so it names `general` explicitly rather than falling through.
- `classify_ack_variant` is imported locally in `_process_lead_intake`, matching that file's existing lazy-import style rather than adding a module-level import.
- One existing assertion updated rather than loosened: `test_successful_acknowledgement_records_tenant_history` pins the email-history metadata dict exactly, so the new key was added instead of relaxing it to a subset check.
- R14 declared although it is an advisory prose-only row, not an auto-enforced path trigger: this diff introduces a classifier, which that row names.

## AI reconciliation
- Make the classifier total for every promised input -- fixed-in: `atlas_brain/templates/email/request_acknowledgement.py` guards the whole non-string class with `isinstance`; the old `(service or "")` form raised `AttributeError` on truthy non-strings. Reproduced before the change. Proof: `tests/test_ack_variant_classification.py::test_generated_non_strings_never_raise_and_resolve_to_general`.
- Add the required closure declaration for the service set -- fixed-in: `plans/PR-EOM-Ack-Variant-Classify.md` "Closure declaration" answers all three questions: OPEN membership, ENUMERATED sourcing with no drift detection, and out-of-set to `general` with its safety rationale.
- Preserve the submitted service in email-history metadata -- fixed-in: `atlas_brain/api/leads.py` sent-email metadata now carries `service` beside `ack_variant`; asserted in `tests/test_ack_variant_classification.py::test_variant_recorded_on_interaction_and_email_history`.
- Justify exceeding the repository diff budget -- fixed-in: `plans/PR-EOM-Ack-Variant-Classify.md` "Diff-budget overage" under Why this slice exists names the 59-line runtime change and rejects each split seam.
- Replace fixed examples with a generated class property -- fixed-in: `tests/test_ack_variant_classification.py` adds two seeded generators covering 500 arbitrary unrecognised strings and 500 varied non-string shapes.
- Update the enrolled integration metadata expectation -- fixed-in: `tests/test_eom_sent_email_tenant_scope.py` exact-dict assertion now includes `service` and `ack_variant`; its "office cleaning" payload resolves to the `general` fallback.
- Keep the generative oracle independent of the classifier -- fixed-in: `tests/test_ack_variant_classification.py` adds `CONTRACT_SERVICE_VARIANTS`, transcribed from the website form markup rather than imported from the implementation; `test_implementation_mapping_equals_the_contract_oracle` asserts exact equality so extra/missing/re-pointed members fail, and both the generator and the explicit per-value cases are driven by the oracle. Negative proof: injecting `"office-cleaning": ACK_VARIANT_RESIDENTIAL` makes the suite fail.
- Re-run verification after adding reconciliation tests -- fixed-in: `plans/PR-EOM-Ack-Variant-Classify.md` `## Verification` re-run at head and corrected — the section still carried the original fixed-example counts (32 / 82); actual re-runs are 45 passed (ack file), 95 passed (with `test_leads_intake.py`), 95 passed / 1 skipped (with `test_eom_sent_email_tenant_scope.py`, skip named and explained). `sync_pr_plan.py --check` reports the size table in sync; the drift Codex saw was against the earlier `c532893` head.
- Pin the contract oracle to literal variant values -- fixed-in: `tests/test_ack_variant_classification.py` now defines `CONTRACT_RESIDENTIAL` / `CONTRACT_COMMERCIAL_SINGLE_SITE` / `CONTRACT_COMMERCIAL_MULTI_SITE` / `CONTRACT_GENERAL` as string literals, adds `test_exported_variant_constants_equal_the_contracted_literals` pinning the exported constants to them, and routes every expectation through the literal-backed names so the imported `ACK_VARIANT_*` constants are referenced only by the pinning test. Negative proof: `ACK_VARIANT_RESIDENTIAL = "resi"` -> 10 failed; multi-site value renamed -> 6 failed; rogue key -> 1 failed; baseline and restored both 46 passed.
- Enroll the classifier suite in the EOM CI job -- fixed-in: `.github/workflows/atlas_eom_lead_pipeline_checks.yml` now lists `tests/test_ack_variant_classification.py` in the gating `Run EOM lead pipeline checks` pytest invocation and in both path-filter blocks (YAML re-parsed clean). The suite carrying the exhaustive mapping and generated-fallback proofs was previously on no required per-PR gate.
- Prove interaction metadata through the production provider -- fixed-in: `tests/test_eom_sent_email_tenant_scope.py` now selects the persisted `contact_interactions` row and asserts `service` / `ack_variant` on it, so acceptance criterion 4 is settled on the atomic `DatabaseCRMProvider` path and not only the MagicMock fallback; `plans/PR-EOM-Ack-Variant-Classify.md` criterion 4 updated to cite both paths and why both are required. Effect-trace first: the atomic branch forwards `interaction=` into `_write_contact_interaction`, which persists the metadata, so this was a coverage gap rather than a live defect. Verified by running that normally-skipped PostgreSQL test for real (1 passed, no DB side effects) and negative-probing it (expecting `residential` -> fail).

## Deferred
- A2 — single-site commercial template; routes `commercial_single_site`.
- A3 — multi-site commercial template; discovery-call-first, Juan as named contact, and must not promise an immediate price, that Mayra and Tina inspect every location, one identical checklist, or pre-confirmed serviceability.
- Per-variant `template_type` — blocked on A2/A3; values must fit `VARCHAR(32)`.
- Duplicate-email semantics for a corrected service — a resubmission with a different service already yields a new dedupe key and re-acknowledges. Intended; not redesigned here.
- UTC vs America/Chicago dedupe bucketing — `crm_provider.py` buckets on the UTC date, so two submissions either side of 7 p.m. Central fall in different buckets. Changing dedupe time semantics deserves its own tests and an atomic design.

## Parked hardening
- None.

## Cold diff reconstruction
- Changed: `atlas_brain/templates/email/request_acknowledgement.py` — adds four variant constants, a `_ACK_VARIANT_BY_SERVICE` exact-match dict over normalized (`strip().lower()`) keys, and `classify_ack_variant` returning `.get(normalized, ACK_VARIANT_GENERAL)`. `ACK_SUBJECT` and `ACK_TEMPLATE` are untouched.
- Changed: `atlas_brain/templates/email/__init__.py` — re-exports the four constants and the function; no existing export altered.
- Changed: `atlas_brain/api/leads.py` — one local import, one `ack_variant = classify_ack_variant(payload.service)` before the CRM write, one key added to the interaction `metadata` dict, two keys (`service`, `ack_variant`) added to the email-history `metadata` dict.
- Changed: `tests/test_ack_variant_classification.py` — new; classifier table, totality, normalization, recording on both evidence records, recording without a send, no-copy-change, and the byte-identical residential golden.
- Changed: `tests/test_leads_intake.py` — the exact-shape email-history metadata assertion gains `"ack_variant": "residential"`.
- Contract match: the Problem-derived contract required a deterministic server-side `service`→variant mapping (the new dict + function), the intake path that already holds the value (the `leads.py` call site), and the two evidence records intake already writes (the two metadata keys). "Must not change" required the residential email byte-identical (golden test + golden diff), and dedupe/caps/honeypot/Resend/failure-isolation untouched (no edits to those paths; `tests/test_leads_intake.py` otherwise unmodified).
- Gaps: none. No change outside the five files above; no rendered output changed; no forbidden touch.

## Verification
- `python -m pytest tests/test_ack_variant_classification.py -q` — 32 passed
- `python -m pytest tests/test_leads_intake.py tests/test_ack_variant_classification.py -q` — 82 passed
- Golden render: all eight service values byte-identical before/after, sha256 `23199591b0e5ea13e999db364005c376e1c5c70fd69cf4f66106e8eb6667f7bc` on both sides, against `origin/main` @ `40bb24553`.
- Suite failure diff vs a clean `origin/main` worktree, same `-k` selection: 16 failures both sides, zero introduced.

## Mechanical verification
- Command: `python -m pytest tests/test_ack_variant_classification.py -q` - Result: 32 passed - Environment: local
- Command: `python -m pytest tests/test_leads_intake.py tests/test_ack_variant_classification.py -q` - Result: 82 passed - Environment: local
- Command: `python -m pytest tests/ -q -k "lead or ack or intake or eom" --continue-on-collection-errors` (branch vs clean origin/main worktree) - Result: 16 failed / 2229 passed on both sides, 0 introduced - Environment: local
- Command: `ruff check` on the five changed paths - Result: pass (4 repo-wide findings in `invoice.py`/`vendor_briefing.py` and 1 unused import at `tests/test_leads_intake.py:37` are pre-existing at origin/main and not on touched lines) - Environment: local
- Command: `python -m py_compile` on the three changed runtime modules - Result: pass - Environment: local
- Command: `python scripts/audit_plan_doc.py plans/PR-EOM-Ack-Variant-Classify.md` - Result: pass (all required sections present) - Environment: local
- Command: `python scripts/audit_review_rules_triggered.py origin/main --plan plans/PR-EOM-Ack-Variant-Classify.md` - Result: pass (declares every triggered rule) - Environment: local
- Command: `git diff --check` - Result: pass (no whitespace errors) - Environment: local
- Skipped: full `pytest tests/` - Reason: 8 pre-existing collection errors (`test_invoicing_readonly_oauth`, `test_mcp_content_ops_*`) reproduce at origin/main; the `-k`-scoped run above was diffed against baseline instead.

## Diff size
8 files changed, 822 insertions(+)

<!-- atlas-open-pr-wrapper: v1 -->
