### PR TITLE
Align EOM demotion veto with import horizon

### DIFF
--- a/plans/PR-EOM-Calendar-Demotion-Veto.md
+++ b/plans/PR-EOM-Calendar-Demotion-Veto.md
@@ -57,8 +57,8 @@ Slice phase: production hardening
 - Risk areas: demotion safety window, cancellation precedence, calendar-provider
   query range, and avoiding accidental changes to import output or CRM write
   eligibility.
-- Reviewer rules triggered: R1 requirements match, R2 test evidence, R3 scope,
-  R7 data retention/customer state safety, R12 cross-repository issue linkage.
+- Reviewer rules triggered: R2 test evidence, R14 codebase verification and
+  boundary-probe for a guard-shaped change.
 
 ### Boundary-change enumeration
 

--- a/plans/PR-EOM-Calendar-Demotion-Veto.md
+++ b/plans/PR-EOM-Calendar-Demotion-Veto.md
@@ -1,0 +1,136 @@
+# PR-EOM-Calendar-Demotion-Veto
+
+## Why this slice exists
+
+Website issue canfieldjuan/Effingham_Office_Maids_Website#138 records a
+cross-repo defect in the Atlas EOM calendar/portal customer sync: calendar
+import can admit bookings up to twelve months ahead, but the portal-sync
+demotion veto only checks four months ahead.
+
+### Problem-derived contract
+
+- Root cause: the same future-booking horizon is encoded as separate literals in
+  two scripts. `scripts/import_eom_customers_live.py` imports future booking
+  customers through a twelve-month default window, while
+  `scripts/sync_eom_portal_customers.py` builds the calendar demotion veto
+  through a four-month default window. A customer imported from a booking five to
+  twelve months out can therefore be absent from the portal roster and also
+  absent from the demotion guard, so the "calendar vetoes demotion" owner rule is
+  shorter than the importer's own admitted future window.
+- Correct fix must touch/change: the importer must expose a single named default
+  for the forward booking-import horizon; the portal-sync demotion guard must
+  default to that importer-owned horizon instead of a shorter literal; regression
+  coverage must prove a booking beyond four months but within the importer
+  default produces guard keys and vetoes demotion.
+- Must not change: do not narrow the import horizon; do not widen the demotable
+  source set; do not change calendar parsing, cancellation precedence, portal
+  authentication, CRM contact matching, receipt behavior, or any EOM
+  acknowledgement/onboarding lanes.
+
+## Scope (this PR)
+
+Ownership lane: eom-calendar-demotion-veto
+Slice phase: production hardening
+
+1. Make the demotion-veto future window follow the importer default horizon.
+2. Add regression coverage for a far-future active calendar event that is beyond
+   the old four-month guard but inside the import horizon.
+
+### Review Contract
+
+- Acceptance criteria:
+  - The importer parser's `--months-forward` default is a named constant in
+    `scripts/import_eom_customers_live.py`, preserving the existing twelve-month
+    default.
+  - `fetch_calendar_guard_keys()` in `scripts/sync_eom_portal_customers.py`
+    defaults `months_forward` from that importer-owned constant, so the demotion
+    veto covers the same future window that default imports admit.
+  - `tests/test_sync_eom_portal_customers.py` proves an active booking roughly
+    ten months ahead emits a guard email and keeps the unmatched CRM contact
+    active; this is the old failure window because it is beyond four months and
+    within twelve months.
+- Reachability proof: `run()` calls `fetch_calendar_guard_keys()` before
+  `demote_unmatched()` in `scripts/sync_eom_portal_customers.py`; the regression
+  test exercises the real guard producer and `demote_unmatched()` path.
+- Affected surfaces: EOM live calendar import default constant; EOM portal-sync
+  demotion veto; sync regression tests.
+- Risk areas: demotion safety window, cancellation precedence, calendar-provider
+  query range, and avoiding accidental changes to import output or CRM write
+  eligibility.
+- Reviewer rules triggered: R1 requirements match, R2 test evidence, R3 scope,
+  R7 data retention/customer state safety, R12 cross-repository issue linkage.
+
+### Boundary-change enumeration
+
+Required when this diff changes a guard, validator, normalizer, resolver,
+router/classifier, or admission boundary. Name each changed boundary path or
+seam in the enumeration; otherwise write "N/A - no boundary change."
+
+- Boundary path/seam: calendar-active customer demotion veto in
+  `fetch_calendar_guard_keys()` -> `demote_unmatched()`.
+- Replaced-path behaviors: four-month default veto horizon is replaced by the
+  importer-owned default forward horizon.
+- Guard-relevant fields: calendar event start/end range, parsed email/phone/name
+  and address guard keys, CRM contact email/phone/name/address.
+- Caller x input shape: `run()` still calls `fetch_calendar_guard_keys()` with
+  no explicit override; tests may still pass explicit `months_forward` values.
+
+### Deployed-config probing
+
+Required for guard, validator, resolver, admission-boundary, or env/config
+fallback changes; otherwise write "N/A - no guard/config boundary change."
+
+- Deployed/default config values: no deployed environment value is changed; the
+  default script argument remains twelve months forward.
+- Explicit value probe: existing explicit `months_forward` callers continue to
+  override the default.
+- Absent value probe: the no-argument guard path now resolves to the importer
+  default.
+- Default-session/default-context probe: the regression test exercises the
+  no-argument guard call.
+- Side-effect ordering: unchanged; `run()` still obtains guard keys before any
+  demotion attempt and refuses demotion when guard construction fails.
+
+### Files touched
+
+- `plans/PR-EOM-Calendar-Demotion-Veto.md`
+- `scripts/import_eom_customers_live.py`
+- `scripts/sync_eom_portal_customers.py`
+- `tests/test_sync_eom_portal_customers.py`
+
+## Mechanism
+
+`import_eom_customers_live.py` names the default forward import horizon.
+`sync_eom_portal_customers.py` uses that value as the default forward guard
+horizon. The test's fake calendar provider filters returned events by the
+requested time window, then proves a ten-month-ahead active booking appears in
+guard keys and vetoes demotion.
+
+## Intentional
+
+- The import horizon stays twelve months; this slice does not narrow what the
+  calendar importer sees.
+- The demotable source set stays exactly as-is; this slice only changes how far
+  into booking calendars the existing veto looks.
+- No live calendar or CRM write is performed by verification.
+
+## Deferred
+
+None.
+
+Parked hardening: none.
+
+## Verification
+
+- `ATLAS_SESSION_STATE_FILE=SESSION_STATE.codex-eom-calendar-demotion-veto.local.md pytest -q tests/test_sync_eom_portal_customers.py` -- 54 passed.
+- `ATLAS_SESSION_STATE_FILE=SESSION_STATE.codex-eom-calendar-demotion-veto.local.md pytest -q tests/test_eom_live_calendar_import.py` -- 55 passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-EOM-Calendar-Demotion-Veto.md` | 136 |
+| `scripts/import_eom_customers_live.py` | 3 |
+| `scripts/sync_eom_portal_customers.py` | 5 |
+| `tests/test_sync_eom_portal_customers.py` | 19 |
+| **Total** | **163** |

--- a/plans/PR-EOM-Calendar-Demotion-Veto.md
+++ b/plans/PR-EOM-Calendar-Demotion-Veto.md
@@ -75,6 +75,25 @@ seam in the enumeration; otherwise write "N/A - no boundary change."
 - Caller x input shape: `run()` still calls `fetch_calendar_guard_keys()` with
   no explicit override; tests may still pass explicit `months_forward` values.
 
+### Closure declaration
+
+- Boundary inventory membership: CLOSED for this slice. The changed decision is
+  the future time window that feeds the existing demotion-veto guard; the
+  identity-key inventory remains the code-owned set already read by
+  `fetch_calendar_guard_keys()` and `on_calendar()`:
+  phone/email/address/name keys plus calendar event start/end/cancellation
+  state.
+- Membership source: DERIVED from the existing implementation at use time.
+  Calendar guard keys are emitted by `fetch_calendar_guard_keys()` from
+  `import_eom_customers_live` parsed records, and CRM row membership is consumed
+  by `on_calendar()`. This PR does not introduce an authored duplicate list of
+  customer identity channels.
+- Outside-set behavior: event dates outside the computed
+  `months_forward * 30` window produce no guard key and therefore do not veto
+  demotion. Calendar/CRM fields outside the existing identity-key set remain
+  non-participating, so they cannot silently widen the veto or demotable source
+  boundary.
+
 ### Deployed-config probing
 
 Required for guard, validator, resolver, admission-boundary, or env/config
@@ -118,6 +137,10 @@ guard keys and vetoes demotion.
 
 None.
 
+Parking predicate: this slice parks only hardening or polish that does not
+change whether default-import-horizon calendar bookings can veto portal-sync
+demotion and does not affect PR-shape, reconciliation, or CI gates.
+
 Parked hardening: none.
 
 ## Verification
@@ -129,8 +152,8 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `plans/PR-EOM-Calendar-Demotion-Veto.md` | 136 |
+| `plans/PR-EOM-Calendar-Demotion-Veto.md` | 159 |
 | `scripts/import_eom_customers_live.py` | 3 |
 | `scripts/sync_eom_portal_customers.py` | 5 |
-| `tests/test_sync_eom_portal_customers.py` | 19 |
-| **Total** | **163** |
+| `tests/test_sync_eom_portal_customers.py` | 32 |
+| **Total** | **199** |

--- a/plans/PR-EOM-Calendar-Demotion-Veto.md
+++ b/plans/PR-EOM-Calendar-Demotion-Veto.md
@@ -57,8 +57,8 @@ Slice phase: production hardening
 - Risk areas: demotion safety window, cancellation precedence, calendar-provider
   query range, and avoiding accidental changes to import output or CRM write
   eligibility.
-- Reviewer rules triggered: R2 test evidence, R14 codebase verification and
-  boundary-probe for a guard-shaped change.
+- Reviewer rules triggered: R2 test evidence, R13 guard-class closure, and R14
+  codebase verification/boundary-probe for a guard-shaped change.
 
 ### Boundary-change enumeration
 

--- a/scripts/import_eom_customers_live.py
+++ b/scripts/import_eom_customers_live.py
@@ -39,6 +39,7 @@ import import_calendar_contacts as ics  # noqa: E402  (reused extraction core)
 from eom_execution_receipt import EomExecutionReceipt, run_receipted  # noqa: E402
 
 EOM_CONTEXT_ID = "effingham_maids"
+DEFAULT_MONTHS_FORWARD = 12
 
 # The three booking calendars. Estimates is intentionally absent: it holds
 # leads, not customers, and the real-time intake endpoint owns leads now.
@@ -827,7 +828,7 @@ def main(argv=None):
         default="all",
     )
     parser.add_argument("--months-back", type=int, default=24)
-    parser.add_argument("--months-forward", type=int, default=12)
+    parser.add_argument("--months-forward", type=int, default=DEFAULT_MONTHS_FORWARD)
     parser.add_argument(
         "--receipt-dir",
         help="Private execution-receipt directory; required for live writes",

--- a/scripts/sync_eom_portal_customers.py
+++ b/scripts/sync_eom_portal_customers.py
@@ -560,7 +560,10 @@ async def sync_one(
     return outcome, contact_id
 
 
-async def fetch_calendar_guard_keys(months_back: int = 1, months_forward: int = 4):
+async def fetch_calendar_guard_keys(
+    months_back: int = 1,
+    months_forward: int = live.DEFAULT_MONTHS_FORWARD,
+):
     """Owner rule (2026-07-23): the CALENDAR VETOES DEMOTION. Live booking
     events (recent past through upcoming) yield phone/email/address/name keys;
     any demotion candidate matching one is a CURRENT customer regardless of

--- a/tests/test_sync_eom_portal_customers.py
+++ b/tests/test_sync_eom_portal_customers.py
@@ -806,6 +806,14 @@ def test_calendar_guard_uses_real_producer_for_email_and_cancellation(
         start=now,
         end=now + timedelta(hours=1),
     )
+    far_future = calendar_provider.CalendarEvent(
+        uid="far-future",
+        summary="Far Future Customer",
+        location="9 Future St, Effingham, IL",
+        description=" future@example.com ",
+        start=now + timedelta(days=300),
+        end=now + timedelta(days=300, hours=1),
+    )
     older = calendar_provider.CalendarEvent(
         uid="older",
         summary="Cancelled Customer",
@@ -829,11 +837,12 @@ def test_calendar_guard_uses_real_producer_for_email_and_cancellation(
 
         async def list_events(self, *, start, end, calendar_id):
             self.calls.append(calendar_id)
-            return {
-                "commercial@test": [active],
+            events = {
+                "commercial@test": [active, far_future],
                 "residential@test": [older],
                 "one-time@test": [cancellation],
             }[calendar_id]
+            return [event for event in events if start <= event.start <= end]
 
         async def aclose(self):
             type(self).closed = True
@@ -847,7 +856,7 @@ def test_calendar_guard_uses_real_producer_for_email_and_cancellation(
 
     keys = asyncio.run(fetch_calendar_guard_keys())
 
-    assert keys["emails"] == {"active@example.com"}
+    assert keys["emails"] == {"active@example.com", "future@example.com"}
     assert FakeGoogleCalendarProvider.calls == [
         "commercial@test", "residential@test", "one-time@test",
     ]
@@ -855,6 +864,8 @@ def test_calendar_guard_uses_real_producer_for_email_and_cancellation(
     pool = SyncPool(demotion_rows=[
         {"id": "active", "full_name": "Different CRM Name", "tags": [],
          "phone": None, "email": " ACTIVE@Example.COM ", "address": "X"},
+        {"id": "future", "full_name": "Future CRM Name", "tags": [],
+         "phone": None, "email": " future@example.com ", "address": "Future"},
         {"id": "cancelled", "full_name": "Former CRM Name", "tags": [],
          "phone": None, "email": "stale@example.com", "address": "Y"},
         {"id": "gone", "full_name": "Moved Away", "tags": [],
@@ -863,7 +874,7 @@ def test_calendar_guard_uses_real_producer_for_email_and_cancellation(
     demoted, eligible = asyncio.run(
         demote_unmatched(pool, set(), apply=True, guard_keys=keys))
 
-    assert (demoted, eligible) == (2, 3)
+    assert (demoted, eligible) == (2, 4)
     assert [contact_id for contact_id, _ in pool.updates] == [
         "cancelled", "gone",
     ]

--- a/tests/test_sync_eom_portal_customers.py
+++ b/tests/test_sync_eom_portal_customers.py
@@ -814,6 +814,14 @@ def test_calendar_guard_uses_real_producer_for_email_and_cancellation(
         start=now + timedelta(days=300),
         end=now + timedelta(days=300, hours=1),
     )
+    outside_future = calendar_provider.CalendarEvent(
+        uid="outside-future",
+        summary="Outside Horizon Customer",
+        location="10 Future St, Effingham, IL",
+        description=" outside@example.com ",
+        start=now + timedelta(days=361),
+        end=now + timedelta(days=361, hours=1),
+    )
     older = calendar_provider.CalendarEvent(
         uid="older",
         summary="Cancelled Customer",
@@ -838,7 +846,7 @@ def test_calendar_guard_uses_real_producer_for_email_and_cancellation(
         async def list_events(self, *, start, end, calendar_id):
             self.calls.append(calendar_id)
             events = {
-                "commercial@test": [active, far_future],
+                "commercial@test": [active, far_future, outside_future],
                 "residential@test": [older],
                 "one-time@test": [cancellation],
             }[calendar_id]
@@ -857,6 +865,7 @@ def test_calendar_guard_uses_real_producer_for_email_and_cancellation(
     keys = asyncio.run(fetch_calendar_guard_keys())
 
     assert keys["emails"] == {"active@example.com", "future@example.com"}
+    assert "outside@example.com" not in keys["emails"]
     assert FakeGoogleCalendarProvider.calls == [
         "commercial@test", "residential@test", "one-time@test",
     ]
@@ -866,6 +875,8 @@ def test_calendar_guard_uses_real_producer_for_email_and_cancellation(
          "phone": None, "email": " ACTIVE@Example.COM ", "address": "X"},
         {"id": "future", "full_name": "Future CRM Name", "tags": [],
          "phone": None, "email": " future@example.com ", "address": "Future"},
+        {"id": "outside", "full_name": "Outside Horizon", "tags": [],
+         "phone": None, "email": " outside@example.com ", "address": "Outside"},
         {"id": "cancelled", "full_name": "Former CRM Name", "tags": [],
          "phone": None, "email": "stale@example.com", "address": "Y"},
         {"id": "gone", "full_name": "Moved Away", "tags": [],
@@ -874,9 +885,9 @@ def test_calendar_guard_uses_real_producer_for_email_and_cancellation(
     demoted, eligible = asyncio.run(
         demote_unmatched(pool, set(), apply=True, guard_keys=keys))
 
-    assert (demoted, eligible) == (2, 4)
+    assert (demoted, eligible) == (3, 5)
     assert [contact_id for contact_id, _ in pool.updates] == [
-        "cancelled", "gone",
+        "outside", "cancelled", "gone",
     ]
     assert "email" in pool.queries[0][0]
 


### PR DESCRIPTION
Plan: plans/PR-EOM-Calendar-Demotion-Veto.md
Slice phase: production hardening
Ownership lane: eom-calendar-demotion-veto

Fixes canfieldjuan/Effingham_Office_Maids_Website#138 by making the EOM portal-sync calendar demotion veto use the same future booking horizon as the live calendar importer. The bug was a shorter guard default: the importer admitted bookings twelve months ahead, while demotion only checked four months ahead.

## Intentional
- The import horizon remains twelve months.
- The demotable source set remains unchanged.
- No live calendar, CRM, or production data mutation is part of this PR.

## AI reconciliation
- Declare the guard's actual triggered rules -- fixed-in: plans/PR-EOM-Calendar-Demotion-Veto.md Review Contract now lists R2 and R14 only for this guard-shaped change.
- Add the outside-horizon boundary case -- fixed-in: tests/test_sync_eom_portal_customers.py now includes a day-361 event that produces no guard key and does not veto demotion.
- Add the required closure declaration -- fixed-in: plans/PR-EOM-Calendar-Demotion-Veto.md now declares boundary inventory membership, source, and outside-set behavior.
- State the slice's parking predicate -- fixed-in: plans/PR-EOM-Calendar-Demotion-Veto.md now names the parked-finding predicate before `Parked hardening: none`.
- Add R13 to the triggered-rule declaration -- fixed-in: plans/PR-EOM-Calendar-Demotion-Veto.md now lists R2, R13, and R14 for the guard-shaped change with closure proof.

## Deferred
- None.

## Parked hardening
- None.

## Cold diff reconstruction

Confirmed gaps: None.

Contradicted: None.

Could-not-determine: None.

Diff reconstruction:
- `scripts/import_eom_customers_live.py:42` adds `DEFAULT_MONTHS_FORWARD = 12`; `scripts/import_eom_customers_live.py:831` uses that constant as the existing `--months-forward` parser default.
- `scripts/sync_eom_portal_customers.py:563-566` changes `fetch_calendar_guard_keys()` so the default forward guard window comes from `live.DEFAULT_MONTHS_FORWARD` instead of the old local literal.
- `tests/test_sync_eom_portal_customers.py:809-823` adds one active calendar event inside the new twelve-month horizon and one just outside it; `tests/test_sync_eom_portal_customers.py:846-853` makes the fake calendar provider filter by the requested range; `tests/test_sync_eom_portal_customers.py:865-892` proves the inside-horizon customer contributes a guard email and is kept, while the outside-horizon/cancelled/gone records are demoted.
- `plans/PR-EOM-Calendar-Demotion-Veto.md` records the pre-code contract, review contract, scope, and verification for this slice.

Contract comparison:
- The contract required preserving the twelve-month import horizon; `scripts/import_eom_customers_live.py:42` and `scripts/import_eom_customers_live.py:831` preserve it behind a named constant.
- The contract required the demotion veto to default to the importer-owned horizon; `scripts/sync_eom_portal_customers.py:563-566` does that.
- The contract required coverage of a booking beyond four months but within twelve months; `tests/test_sync_eom_portal_customers.py:809-815` and `tests/test_sync_eom_portal_customers.py:865-890` provide that proof. The follow-up review required the opposite boundary too; `tests/test_sync_eom_portal_customers.py:817-823` and `tests/test_sync_eom_portal_customers.py:867-890` prove a just-outside-horizon event does not veto demotion.
- The contract said not to change demotable sources, cancellation precedence, portal auth, CRM matching, receipt behavior, or acknowledgement/onboarding lanes; this diff does not touch those modules or surfaces.

Verification:
- `ATLAS_SESSION_STATE_FILE=SESSION_STATE.codex-eom-calendar-demotion-veto.local.md pytest -q tests/test_sync_eom_portal_customers.py` -- 54 passed.
- `ATLAS_SESSION_STATE_FILE=SESSION_STATE.codex-eom-calendar-demotion-veto.local.md pytest -q tests/test_eom_live_calendar_import.py` -- 55 passed.

## Verification
- `ATLAS_SESSION_STATE_FILE=SESSION_STATE.codex-eom-calendar-demotion-veto.local.md pytest -q tests/test_sync_eom_portal_customers.py` -- 54 passed.
- `ATLAS_SESSION_STATE_FILE=SESSION_STATE.codex-eom-calendar-demotion-veto.local.md pytest -q tests/test_eom_live_calendar_import.py` -- 55 passed.

## Mechanical verification
- Command: `ATLAS_SESSION_STATE_FILE=SESSION_STATE.codex-eom-calendar-demotion-veto.local.md pytest -q tests/test_sync_eom_portal_customers.py` - Result: pass - Environment: local
- Command: `ATLAS_SESSION_STATE_FILE=SESSION_STATE.codex-eom-calendar-demotion-veto.local.md pytest -q tests/test_eom_live_calendar_import.py` - Result: pass - Environment: local

## Diff size
4 files, +199 / -6

<!-- atlas-open-pr-wrapper: v1 -->
