### PR TITLE
Add a PR body update fast path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -524,10 +524,21 @@ rather than hand-formatting:
   open direct file paths. The shell redirect reads the file and `gh` receives
   the body on stdin. If the PR already exists, this wrapper updates only the
   body; use `gh pr edit` manually for title/base/label changes.
+- `bash scripts/update_pr_body.sh <pr-body-file>` — updates the body of the
+  already-open PR for the current branch when **only the PR body changed** after
+  the branch was already pushed/opened (for example AI reconciliation ledger,
+  verification receipt, deferred notes, or wrapper-marker repair). This helper
+  stamps the same hidden wrapper marker as `open_pr.sh`, runs the body,
+  AI-reconciliation, fix-loop disposition, live-reconciliation, ownership, and
+  head-identity checks that can be affected by a body-only edit, and publishes
+  through stdin. It intentionally does **not** run the full local review/unit
+  mirror; use `push_pr.sh` plus `open_pr.sh` when code or plan files changed.
 
 Flow: `bash scripts/new_pr_plan.sh` -> implement ->
 `python scripts/sync_pr_plan.py` -> `bash scripts/push_pr.sh` ->
 `bash scripts/open_pr.sh`.
+For body-only edits to an existing PR after that flow has already run, use
+`bash scripts/update_pr_body.sh` instead of raw `gh pr edit`.
 Do **not** run a separate manual `local_pr_review.sh` immediately before
 `push_pr.sh`; that duplicates the same mechanical bundle and burns context.
 Use manual local review for ad hoc triage or when you are not about to push.

--- a/plans/PR-Body-Update-Fast-Path.md
+++ b/plans/PR-Body-Update-Fast-Path.md
@@ -1,0 +1,165 @@
+# PR-Body-Update-Fast-Path
+
+## Why this slice exists
+
+PR #2329 exposed a workflow failure in the body-only fix loop. A manual
+`gh pr edit --body-file` update removed the hidden `open_pr.sh` wrapper marker,
+so the trusted `pr-body-contract` check failed even though the visible body
+looked valid. The compliant repair path, `scripts/open_pr.sh`, then reran the
+full local review and unit-gate mirror for a body-only reconciliation edit,
+which made the safe path expensive enough to discourage use.
+
+This workflow/process slice makes the body-only path cheap and still bounded:
+publish an existing PR body through a dedicated helper that stamps the wrapper
+marker, runs the body/reconciliation checks that can actually be affected by a
+body edit, verifies PR ownership/head identity, and leaves code/full-review
+checks to the push/open path.
+
+Diff-budget override: this workflow helper is indivisible in one PR because the
+script, AGENTS contract hook, impacted-test enrollment, and fake GitHub wrapper
+fixtures must ship together for the new path to be usable and reviewable.
+
+### Problem-derived contract
+
+- Root cause: Atlas has one approved PR-body mutation wrapper, but it is shaped
+  for PR create/update after code changes. For an existing PR body-only
+  reconciliation edit, the cheap path is raw `gh pr edit` and the safe path is a
+  full local-review replay. That incentive mismatch caused the missing wrapper
+  marker failure on #2329.
+- Correct fix must touch/change: add a focused existing-PR body update helper
+  that reuses the canonical body marker and body/reconciliation audits; document
+  when to use it; add wrapper tests proving it stamps full bodies, refuses
+  target-changing edits, verifies ownership/head identity, runs focused checks,
+  and does not call `local_pr_review.sh`.
+- Must not change: do not change PR body schema, live reconciliation semantics,
+  required GitHub checks, PR title/base/label editing, product behavior, or the
+  `open_pr.sh` create/update path for code-bearing pushes.
+
+## Scope (this PR)
+
+Ownership lane: workflow/pr-body-update-fast-path
+Slice phase: Workflow/process
+
+1. Add a dedicated helper for existing PR body-only updates.
+2. Document the helper as the required path when only the PR body changes after
+   a PR is already open.
+3. Add focused wrapper tests and impacted-test enrollment for the new helper.
+
+### Review Contract
+
+- Acceptance criteria:
+  1. `scripts/update_pr_body.sh` appends the same
+     `<!-- atlas-open-pr-wrapper: v1 -->` marker used by `scripts/open_pr.sh`
+     when a full human PR body lacks it, proved by
+     `tests/test_update_pr_body_wrapper.py::test_update_wrapper_stamps_full_body_before_publish`.
+  2. The helper runs focused body checks only: branch-name audit, PR-body audit,
+     AI reconciliation audit, fix-loop disposition preflight, optional live
+     reconciliation, and session ownership/head checks; it does not invoke
+     `scripts/local_pr_review.sh`, proved by
+     `tests/test_update_pr_body_wrapper.py::test_update_wrapper_does_not_run_full_local_review`.
+  3. The helper refuses create/target-changing/title/base/body argv edits and
+     only updates the existing PR for the current branch, proved by
+     `tests/test_update_pr_body_wrapper.py::test_update_wrapper_rejects_target_changing_args`.
+  4. The helper fails before mutation when the PR head reported by GitHub does
+     not match the reviewed local head, proved by
+     `tests/test_update_pr_body_wrapper.py::test_update_wrapper_rejects_head_drift_before_edit`.
+  5. `AGENTS.md` directs body-only PR updates through the helper while leaving
+     `open_pr.sh` as the create/body-update path after code changes.
+- Reachability proof: run the wrapper tests against a fake git/gh harness and
+  inspect the dry-run output showing the final mutation would be
+  `gh pr edit <number> --body-file -`.
+- Affected surfaces: `AGENTS.md`, `scripts/update_pr_body.sh`,
+  `scripts/select_impacted_tests.py`, and wrapper tests.
+- Risk areas: wrapper marker parity, ownership/head drift, accidental target
+  mutation, accidentally rerunning full local review, and live reconciliation
+  mismatch.
+- Reviewer rules triggered: R1, R2, R10, R12, R14.
+
+### Boundary-change enumeration
+
+Required when this diff changes a guard, validator, normalizer, resolver,
+router/classifier, or admission boundary. Name each changed boundary path or
+seam in the enumeration; otherwise write "N/A - no boundary change."
+
+- Boundary path/seam: existing PR body mutation command.
+- Replaced-path behaviors: raw `gh pr edit --body-file` is replaced for
+  body-only updates with a wrapper that stamps and audits the body before
+  mutation.
+- Guard-relevant fields: current branch, PR number, PR head SHA, PR base,
+  PR body marker, PR author, session state file, and body file hash.
+- Caller x input shape: shell invocation
+  `bash scripts/update_pr_body.sh <body-file>` on a branch with exactly one
+  open PR targeting `main`.
+
+### Deployed-config probing
+
+Required for guard, validator, resolver, admission-boundary, or env/config
+fallback changes; otherwise write "N/A - no guard/config boundary change."
+
+- Deployed/default config values: N/A - local GitHub CLI wrapper, no deployed
+  configuration or env fallback.
+- Explicit value probe: wrapper tests provide explicit PR/body/head fixtures.
+- Absent value probe: wrapper tests cover missing/invalid target-changing args
+  and head drift before mutation.
+- Default-session/default-context probe: session ownership guard is invoked
+  before mutation when PR metadata is known.
+- Side-effect ordering: body audit, ownership guard, and head verification all
+  run before the `gh pr edit` mutation.
+
+### Files touched
+
+- `AGENTS.md`
+- `plans/PR-Body-Update-Fast-Path.md`
+- `scripts/select_impacted_tests.py`
+- `scripts/update_pr_body.sh`
+- `tests/test_update_pr_body_wrapper.py`
+
+## Mechanism
+
+Add `scripts/update_pr_body.sh` for existing PR body-only updates. It prepares a
+temporary publish body with the same wrapper marker as `open_pr.sh`, validates
+the current branch name and PR body shape, runs AI/fix-loop reconciliation
+checks, discovers the existing current-branch PR, verifies ownership and head
+identity, optionally runs live reconciliation when `gh` can read the PR, and
+then publishes via `gh pr edit <number> --body-file -`.
+
+The helper is intentionally narrower than `open_pr.sh`: it never creates PRs,
+never changes title/base/labels/reviewers, and never runs
+`scripts/local_pr_review.sh`. Code changes still use the existing
+`push_pr.sh` -> `open_pr.sh` path.
+
+## Intentional
+
+- Keep this as a new narrow helper instead of weakening `open_pr.sh`; the create
+  path still needs full local review.
+- Keep live reconciliation semantics unchanged; this helper only calls the
+  existing checker before publishing body text.
+- Do not add automatic review-thread resolution; resolving remains an explicit
+  post-fix action after the body and code truth match.
+
+## Deferred
+
+- A generator that builds exact AI reconciliation root ledgers from live Codex
+  thread history.
+- A broader local-review scheduler that avoids duplicate full unit mirrors
+  across concurrent worktrees.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_update_pr_body_wrapper.py -q` - passed, 6 tests.
+- `python -m pytest tests/test_select_impacted_tests.py -q` - passed, 64 tests.
+- `bash -n scripts/update_pr_body.sh` - passed.
+- Pending before push: plan/body audits and local review wrapper.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `AGENTS.md` | 11 |
+| `plans/PR-Body-Update-Fast-Path.md` | 165 |
+| `scripts/select_impacted_tests.py` | 3 |
+| `scripts/update_pr_body.sh` | 235 |
+| `tests/test_update_pr_body_wrapper.py` | 283 |
+| **Total** | **697** |

--- a/scripts/select_impacted_tests.py
+++ b/scripts/select_impacted_tests.py
@@ -145,6 +145,9 @@ EXPLICIT_TEST_OWNERS: dict[str, tuple[str, ...]] = {
     "scripts/open_pr.sh": (
         "tests/test_open_pr_wrapper.py",
     ),
+    "scripts/update_pr_body.sh": (
+        "tests/test_update_pr_body_wrapper.py",
+    ),
     "scripts/pre_push_audit.sh": (
         "tests/test_pre_push_audit.py",
     ),

--- a/scripts/update_pr_body.sh
+++ b/scripts/update_pr_body.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# Update an existing PR body through the Atlas body-only fast path.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+python_bin="${PYTHON:-python3}"
+export GH_PROMPT_DISABLED=1
+
+usage() {
+    cat <<'EOF'
+Usage: bash scripts/update_pr_body.sh BODY_FILE
+
+Updates the existing GitHub PR for the current branch. This is for body-only
+edits after a PR is already open: AI reconciliation ledgers, verification
+receipts, deferred notes, and wrapper-marker repair. It validates the same body
+contract fields that a body-only edit can affect, verifies session ownership and
+PR head identity, and publishes through stdin.
+
+Use scripts/open_pr.sh for new PRs or after code changes.
+EOF
+}
+
+die() {
+    echo "update_pr_body.sh: $*" >&2
+    exit 2
+}
+
+if [ "$#" -lt 1 ] || [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+    usage
+    exit 2
+fi
+input_body_file="$1"
+shift
+[ "$#" -eq 0 ] || die "body-only updates do not accept PR create/edit args"
+[ -f "$input_body_file" ] || die "PR body file not found: $input_body_file"
+[ -z "${GH_REPO:-}" ] || die "refusing GH_REPO target override: $GH_REPO"
+
+open_pr_wrapper_marker="<!-- atlas-open-pr-wrapper: v1 -->"
+body_file="$input_body_file"
+temporary_body_file=""
+cleanup_body() {
+    [ -z "$temporary_body_file" ] || rm -f "$temporary_body_file"
+}
+trap cleanup_body EXIT
+
+body_uses_docs_only_marker() {
+    "$python_bin" - "$1" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+body = Path(sys.argv[1]).read_text(encoding="utf-8", errors="replace")
+first = next((line.strip() for line in body.splitlines() if line.strip()), "")
+raise SystemExit(0 if re.fullmatch(r"Docs-only:\s*true", first, re.IGNORECASE) else 1)
+PY
+}
+
+body_has_open_pr_wrapper_marker() {
+    grep -Fxq "$open_pr_wrapper_marker" "$1"
+}
+
+body_author_is_dependabot() {
+    local author_lc="${ATLAS_CURRENT_PR_AUTHOR:-}"
+    author_lc="${author_lc,,}"
+    [ "$author_lc" = "dependabot[bot]" ] || [ "$author_lc" = "app/dependabot" ] || [ "$author_lc" = "dependabot" ]
+}
+
+prepare_publish_body() {
+    if body_author_is_dependabot || body_uses_docs_only_marker "$input_body_file" || body_has_open_pr_wrapper_marker "$input_body_file"; then
+        body_file="$input_body_file"
+        return 0
+    fi
+    temporary_body_file="$(mktemp "${TMPDIR:-/tmp}/atlas-update-pr-body.XXXXXX")"
+    cp "$input_body_file" "$temporary_body_file"
+    printf '\n%s\n' "$open_pr_wrapper_marker" >> "$temporary_body_file"
+    body_file="$temporary_body_file"
+}
+
+body_hash() {
+    git hash-object "$body_file"
+}
+
+verify_body_hash() {
+    local expected="$1" current
+    current="$(body_hash)"
+    [ "$current" = "$expected" ] || die "PR body changed after review"
+}
+
+origin_repo_name() {
+    "$python_bin" - <<'PY'
+import re
+import subprocess
+
+url = subprocess.check_output(["git", "config", "--get", "remote.origin.url"], text=True).strip()
+patterns = (
+    r"^git@github\.com:(?P<repo>[^/]+/[^/]+?)(?:\.git)?$",
+    r"^ssh://git@github\.com/(?P<repo>[^/]+/[^/]+?)(?:\.git)?$",
+    r"^https://github\.com/(?P<repo>[^/]+/[^/]+?)(?:\.git)?$",
+)
+for pattern in patterns:
+    match = re.match(pattern, url)
+    if match:
+        print(match.group("repo"))
+        break
+else:
+    raise SystemExit(f"update_pr_body.sh: could not derive owner/repo from origin: {url}")
+PY
+}
+
+refresh_base_ref() {
+    echo "Refreshing origin/main before PR body audit..."
+    git fetch --quiet origin main || die "failed to refresh origin/main"
+}
+
+verify_published_head() {
+    local branch="$1" expected_sha="${2:-}" head_sha remote_sha
+    head_sha="$(git rev-parse HEAD)"
+    git fetch --quiet origin "refs/heads/$branch" || die "failed to refresh origin/$branch"
+    remote_sha="$(git rev-parse FETCH_HEAD 2>/dev/null)" || die "current branch is not published at origin/$branch"
+    if [ -n "$expected_sha" ] && [ "$head_sha" != "$expected_sha" ]; then
+        die "current HEAD changed after review: reviewed $expected_sha, now $head_sha"
+    fi
+    if [ -n "$expected_sha" ] && [ "$remote_sha" != "$expected_sha" ]; then
+        die "origin/$branch changed after review: reviewed $expected_sha, now $remote_sha"
+    fi
+    [ "$remote_sha" = "$head_sha" ] || die "origin/$branch is $remote_sha, current HEAD is $head_sha"
+    printf '%s\n' "$head_sha"
+}
+
+existing_pr_number_for_branch() {
+    local branch="$1" current_repo="$2" pr_json
+    pr_json="$(gh pr list --repo "$current_repo" --state open --head "$branch" --json number,headRefName,headRefOid,baseRefName,headRepository,isCrossRepository --limit 20)" || {
+        echo "update_pr_body.sh: failed to query existing PR for head branch $branch" >&2
+        exit 1
+    }
+    "$python_bin" - "$branch" "$current_repo" "$pr_json" <<'PY'
+import json
+import sys
+
+branch = sys.argv[1]
+current_repo = sys.argv[2].lower()
+items = [item for item in json.loads(sys.argv[3]) if item.get("headRefName") == branch]
+matches = []
+for item in items:
+    repo = ((item.get("headRepository") or {}).get("nameWithOwner") or "").lower()
+    if item.get("baseRefName") == "main" and repo == current_repo and not item.get("isCrossRepository"):
+        matches.append(item)
+if items and len(items) != len(matches):
+    raise SystemExit(f"update_pr_body.sh: found open PRs for head branch {branch} outside {current_repo}->main")
+if len(matches) != 1:
+    raise SystemExit(f"update_pr_body.sh: expected exactly one open PR for branch {branch}, found {len(matches)}")
+item = matches[0]
+print(f"{item['number']}\t{item.get('headRefOid', '')}")
+PY
+}
+
+snapshot_head_oid() {
+    local snapshot="$1"
+    if [ "$snapshot" = "${snapshot#*$'\t'}" ]; then
+        printf '\n'
+    else
+        printf '%s\n' "${snapshot#*$'\t'}"
+    fi
+}
+
+verify_pr_snapshot_head() {
+    local snapshot="$1" expected="$2" actual
+    actual="$(snapshot_head_oid "$snapshot")"
+    [ "$actual" = "$expected" ] || die "existing PR head does not match reviewed head: reviewed $expected, PR reports ${actual:-<missing>}"
+}
+
+guard_existing_pr_ownership() {
+    "$python_bin" scripts/check_session_pr_ownership.py \
+        --pr "$1" \
+        --branch "$2" \
+        --head-sha "$3"
+}
+
+run_body_audits() {
+    local checker_args=(--base-ref origin/main)
+    if [ -n "${ATLAS_CURRENT_PR_AUTHOR:-}" ]; then
+        checker_args+=(--pr-author "$ATLAS_CURRENT_PR_AUTHOR")
+    fi
+    if ! body_author_is_dependabot && ! body_uses_docs_only_marker "$body_file"; then
+        checker_args+=(--require-wrapper-marker)
+    fi
+    "$python_bin" scripts/audit_pr_body.py "${checker_args[@]}" "$body_file"
+    "$python_bin" scripts/audit_ai_reconciliation.py --current-pr-body-file "$body_file"
+    "$python_bin" scripts/audit_fix_loop_disposition.py --repo-root . --current-pr-body-file "$body_file" --base-ref origin/main
+}
+
+run_live_reconciliation() {
+    local repo="$1" pr_number="$2"
+    if [ "${ATLAS_UPDATE_PR_BODY_SKIP_LIVE:-}" = "1" ]; then
+        echo "live reconciliation: skipped by ATLAS_UPDATE_PR_BODY_SKIP_LIVE=1"
+        return 0
+    fi
+    "$python_bin" scripts/check_ai_reconciliation_live.py --repo "$repo" --pr "$pr_number" --body-file "$body_file"
+}
+
+acquire_mutation_lock() {
+    local lock_path
+    lock_path="$(git rev-parse --git-path update_pr_body_wrapper.lock)"
+    exec 9>"$lock_path"
+    flock -n 9 || die "another update_pr_body.sh mutation is already running in this checkout"
+}
+
+prepare_publish_body
+branch="$(git branch --show-current)"
+[ -n "$branch" ] || die "current checkout is detached; switch to a branch first"
+"$python_bin" scripts/check_pr_branch_name.py --branch "$branch" "$body_file"
+refresh_base_ref
+run_body_audits
+trusted_repo="$(origin_repo_name)"
+reviewed_head="$(verify_published_head "$branch")"
+existing_pr_snapshot="$(existing_pr_number_for_branch "$branch" "$trusted_repo")"
+existing_pr_number="${existing_pr_snapshot%%$'\t'*}"
+verify_pr_snapshot_head "$existing_pr_snapshot" "$reviewed_head"
+guard_existing_pr_ownership "$existing_pr_number" "$branch" "$reviewed_head"
+run_live_reconciliation "$trusted_repo" "$existing_pr_number"
+reviewed_body_hash="$(body_hash)"
+acquire_mutation_lock
+latest_snapshot="$(existing_pr_number_for_branch "$branch" "$trusted_repo")"
+[ "$latest_snapshot" = "$existing_pr_snapshot" ] || die "existing PR identity changed before mutation; rerun this wrapper"
+verify_pr_snapshot_head "$latest_snapshot" "$reviewed_head"
+verify_published_head "$branch" "$reviewed_head" >/dev/null
+verify_body_hash "$reviewed_body_hash"
+if [ "${ATLAS_UPDATE_PR_BODY_DRY_RUN:-}" = "1" ]; then
+    echo "DRY RUN: gh pr edit $existing_pr_number --repo $trusted_repo --body-file - < $body_file"
+    exit 0
+fi
+gh pr edit "$existing_pr_number" --repo "$trusted_repo" --body-file - < "$body_file"
+verify_published_head "$branch" "$reviewed_head" >/dev/null
+verify_body_hash "$reviewed_body_hash"

--- a/tests/test_update_pr_body_wrapper.py
+++ b/tests/test_update_pr_body_wrapper.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from shutil import copy2
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "update_pr_body.sh"
+OPEN_PR_WRAPPER_MARKER = "<!-- atlas-open-pr-wrapper: v1 -->"
+
+
+def test_update_wrapper_stamps_full_body_before_publish(tmp_path: Path) -> None:
+    repo, body, env, log, stdin_capture = _ready(tmp_path)
+
+    result = _run(repo, env, body)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert log.read_text(encoding="utf-8").strip() == "pr edit 17 --repo canfieldjuan/ATLAS --body-file -"
+    assert stdin_capture.read_text(encoding="utf-8") == _stamped_body(body)
+    assert OPEN_PR_WRAPPER_MARKER not in body.read_text(encoding="utf-8")
+
+
+def test_update_wrapper_does_not_run_full_local_review(tmp_path: Path) -> None:
+    repo, body, env, log, _ = _ready(tmp_path)
+
+    result = _run(repo, env, body)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert log.exists()
+    assert not (repo / "local-review.log").exists()
+
+
+def test_update_wrapper_runs_live_reconciliation_with_publish_body(tmp_path: Path) -> None:
+    repo, body, env, _, _ = _ready(tmp_path)
+
+    result = _run(repo, env, body)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    live_log = Path(env["LIVE_RECONCILIATION_LOG"]).read_text(encoding="utf-8")
+    assert "--repo canfieldjuan/ATLAS --pr 17 --body-file" in live_log
+    assert Path(env["LIVE_RECONCILIATION_BODY_CAPTURE"]).read_text(encoding="utf-8") == _stamped_body(body)
+
+
+def test_update_wrapper_rejects_target_changing_args(tmp_path: Path) -> None:
+    repo, body, env, log, stdin_capture = _ready(tmp_path)
+
+    result = _run(repo, env, body, "--title", "New title")
+
+    assert result.returncode == 2
+    assert "body-only updates do not accept PR create/edit args" in result.stderr
+    assert not log.exists()
+    assert not stdin_capture.exists()
+
+
+def test_update_wrapper_rejects_head_drift_before_edit(tmp_path: Path) -> None:
+    repo, body, env, log, stdin_capture = _ready(tmp_path)
+    stale_head = _git_output(repo, "rev-parse", "HEAD^")
+    env["GH_PR_LIST_JSON"] = (
+        f'[{{"number":17,"headRefName":"claude/pr-test","headRefOid":"{stale_head}",'
+        '"baseRefName":"main","headRepository":{"nameWithOwner":"canfieldjuan/ATLAS"},'
+        '"isCrossRepository":false}]'
+    )
+
+    result = _run(repo, env, body)
+
+    assert result.returncode == 2
+    assert "existing PR head does not match reviewed head" in result.stderr
+    assert not log.exists()
+    assert not stdin_capture.exists()
+
+
+def test_update_wrapper_ownership_guard_failure_blocks_before_edit(tmp_path: Path) -> None:
+    repo, body, env, log, stdin_capture = _ready(tmp_path)
+    env["OWNERSHIP_GUARD_EXIT"] = "23"
+
+    result = _run(repo, env, body)
+
+    assert result.returncode == 23
+    assert "fake ownership guard failed" in result.stderr
+    assert not log.exists()
+    assert not stdin_capture.exists()
+
+
+def _ready(tmp_path: Path) -> tuple[Path, Path, dict[str, str], Path, Path]:
+    repo = _write_fixture_repo(tmp_path)
+    body = _write_body(repo)
+    env, log, stdin_capture = _fake_gh_env(tmp_path)
+    return repo, body, env, log, stdin_capture
+
+
+def _run(repo: Path, env: dict[str, str], body: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", "scripts/update_pr_body.sh", str(body), *args],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _stamped_body(body: Path) -> str:
+    return body.read_text(encoding="utf-8") + f"\n{OPEN_PR_WRAPPER_MARKER}\n"
+
+
+def _write_fixture_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    scripts = repo / "scripts"
+    scripts.mkdir(parents=True)
+    for name in (
+        "update_pr_body.sh",
+        "audit_pr_body.py",
+        "audit_ai_reconciliation.py",
+        "audit_fix_loop_disposition.py",
+        "_pr_change_policy.py",
+        "check_pr_branch_name.py",
+    ):
+        copy2(REPO_ROOT / "scripts" / name, scripts / name)
+    (scripts / "check_session_pr_ownership.py").write_text(
+        """#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+import sys
+
+log = os.environ.get("OWNERSHIP_GUARD_LOG")
+if log:
+    with open(log, "a", encoding="utf-8") as handle:
+        handle.write(" ".join(sys.argv[1:]) + "\\n")
+exit_code = int(os.environ.get("OWNERSHIP_GUARD_EXIT", "0"))
+if exit_code:
+    print("fake ownership guard failed", file=sys.stderr)
+raise SystemExit(exit_code)
+""",
+        encoding="utf-8",
+    )
+    (scripts / "check_session_pr_ownership.py").chmod(0o755)
+    (scripts / "check_ai_reconciliation_live.py").write_text(
+        """#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+import sys
+
+log = os.environ["LIVE_RECONCILIATION_LOG"]
+with open(log, "a", encoding="utf-8") as handle:
+    handle.write(" ".join(sys.argv[1:]) + "\\n")
+if "--body-file" in sys.argv:
+    body_path = sys.argv[sys.argv.index("--body-file") + 1]
+    with open(body_path, "r", encoding="utf-8") as source:
+        body = source.read()
+    with open(os.environ["LIVE_RECONCILIATION_BODY_CAPTURE"], "w", encoding="utf-8") as target:
+        target.write(body)
+raise SystemExit(int(os.environ.get("LIVE_RECONCILIATION_EXIT", "0")))
+""",
+        encoding="utf-8",
+    )
+    (scripts / "check_ai_reconciliation_live.py").chmod(0o755)
+    (scripts / "local_pr_review.sh").write_text(
+        """#!/usr/bin/env bash
+printf 'local_pr_review called\\n' >> local-review.log
+exit 99
+""",
+        encoding="utf-8",
+    )
+    (scripts / "local_pr_review.sh").chmod(0o755)
+    subprocess.run(["git", "init", "--initial-branch", "main"], cwd=repo, check=True, capture_output=True, text=True)
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "base")
+    remote = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "--bare", str(remote)], check=True, capture_output=True, text=True)
+    _git(repo, "config", "url.git@github.com:canfieldjuan/ATLAS.git.insteadOf", str(remote))
+    _git(repo, "config", f"url.{remote}.insteadOf", "git@github.com:canfieldjuan/ATLAS.git")
+    _git(repo, "remote", "add", "origin", "git@github.com:canfieldjuan/ATLAS.git")
+    _git(repo, "push", "-q", "-u", "origin", "main")
+    _git(repo, "switch", "-c", "claude/pr-test")
+    return repo
+
+
+def _write_body(repo: Path) -> Path:
+    (repo / "plans").mkdir(exist_ok=True)
+    (repo / "plans" / "PR-Test.md").write_text("# Test plan\n", encoding="utf-8")
+    (repo / "scripts" / "example.py").write_text("print('changed')\n", encoding="utf-8")
+    _git(repo, "add", "plans/PR-Test.md", "scripts/example.py")
+    _git(repo, "commit", "-qm", "planned change")
+    _git(repo, "push", "-q", "-u", "origin", "HEAD")
+    body = repo.parent / "body.md"
+    body.write_text(_valid_body(), encoding="utf-8")
+    return body
+
+
+def _valid_body() -> str:
+    return "\n".join(
+        [
+            "Plan: plans/PR-Test.md",
+            "Slice phase: Workflow/process",
+            "Ownership lane: dev-workflow/process-gate-enrollment",
+            "",
+            "One-paragraph why.",
+            "",
+            "## Intentional",
+            "- a trade-off",
+            "",
+            "## AI reconciliation",
+            "- no-findings",
+            "",
+            "## Deferred",
+            "- a follow-up",
+            "",
+            "## Parked hardening",
+            "None.",
+            "",
+            "## Cold diff reconstruction",
+            "- Changed: scripts/example.sh:1 updates the wrapper.",
+            "- Contract match: traces to the body contract.",
+            "- Gaps: none.",
+            "",
+            "## Verification",
+            "- pytest passed",
+            "",
+            "## Mechanical verification",
+            "- Command: pytest tests/test_update_pr_body_wrapper.py - Result: passed - Environment: local",
+            "",
+            "## Diff size",
+            "2 files, +10 / -2",
+        ]
+    )
+
+
+def _fake_gh_env(tmp_path: Path) -> tuple[dict[str, str], Path, Path]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log = tmp_path / "gh-argv.txt"
+    stdin_capture = tmp_path / "gh-stdin.txt"
+    ownership_guard_log = tmp_path / "ownership-guard-argv.txt"
+    live_log = tmp_path / "live-reconciliation-argv.txt"
+    live_body_capture = tmp_path / "live-reconciliation-body.md"
+    gh = bin_dir / "gh"
+    gh.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+    if [ -n "${GH_PR_LIST_JSON:-}" ]; then
+        printf '%s\\n' "${GH_PR_LIST_JSON}"
+        exit 0
+    fi
+    current_branch="$(git branch --show-current)"
+    printf '[{"number":17,"headRefName":"%s","headRefOid":"%s","baseRefName":"main","headRepository":{"nameWithOwner":"canfieldjuan/ATLAS"},"isCrossRepository":false}]\\n' "$current_branch" "$(git rev-parse HEAD)"
+    exit 0
+fi
+printf '%s\\n' "$*" > "${GH_ARGV_LOG}"
+cat > "${GH_STDIN_CAPTURE}"
+""",
+        encoding="utf-8",
+    )
+    gh.chmod(0o755)
+    return {
+        **os.environ,
+        "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+        "GH_ARGV_LOG": str(log),
+        "GH_STDIN_CAPTURE": str(stdin_capture),
+        "OWNERSHIP_GUARD_LOG": str(ownership_guard_log),
+        "LIVE_RECONCILIATION_LOG": str(live_log),
+        "LIVE_RECONCILIATION_BODY_CAPTURE": str(live_body_capture),
+        "PYTHONDONTWRITEBYTECODE": "1",
+    }, log, stdin_capture
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-c", "user.email=t@example.com", "-c", "user.name=t", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _git_output(repo: Path, *args: str) -> str:
+    return subprocess.check_output(["git", *args], cwd=repo, text=True).strip()


### PR DESCRIPTION
Plan: plans/PR-Body-Update-Fast-Path.md
Slice phase: Workflow/process
Ownership lane: workflow/pr-body-update-fast-path

PR #2329 exposed that body-only reconciliation fixes had a bad choice: raw `gh pr edit` was cheap but missed Atlas wrapper invariants, while the compliant `open_pr.sh` repair replayed full local review and the unit mirror for a PR-body-only edit. This slice adds a bounded existing-PR body update helper that preserves the wrapper marker, runs only the checks a body edit can affect, verifies ownership/head identity, and leaves code-bearing updates on the existing push/open path.

Diff-budget override: Body-only wrapper, AGENTS contract hook, impacted-test enrollment, and fake GitHub wrapper fixtures must land together so the compliant path is usable and reviewable.

## Intentional
- Keep this as a narrow existing-PR body helper; `open_pr.sh` remains the create/update path after code changes.
- Keep live reconciliation semantics unchanged; this only calls the existing checker before publishing the reviewed body.
- Do not add automatic thread resolution; resolved state still follows the normal fixed/waived truth boundary.

## AI reconciliation
- no-findings

## Deferred
- Generate exact AI reconciliation ledgers from live Codex thread history.
- Build broader cross-worktree scheduling for repeated full local-review/unit mirrors.

## Parked hardening
None.

## Cold diff reconstruction
- Changed: `scripts/update_pr_body.sh:29` rejects missing/help usage and extra args, so the helper cannot be reused for title/base/target mutation.
- Changed: `scripts/update_pr_body.sh:69` prepares the publish body and appends `<!-- atlas-open-pr-wrapper: v1 -->` for full human PR bodies that lack it while leaving docs-only, dependabot, and already-stamped bodies alone.
- Changed: `scripts/update_pr_body.sh:111` refreshes `origin/main`; `scripts/update_pr_body.sh:180` runs branch/body/AI/fix-loop audits against the body that will be published.
- Changed: `scripts/update_pr_body.sh:116` verifies local and remote branch head identity; `scripts/update_pr_body.sh:131` discovers exactly one open same-repo current-branch PR targeting `main`; `scripts/update_pr_body.sh:173` runs session ownership before mutation.
- Changed: `scripts/update_pr_body.sh:193` runs live reconciliation with the publish body; `scripts/update_pr_body.sh:202` takes a mutation lock; `scripts/update_pr_body.sh:222` hashes the reviewed body; `scripts/update_pr_body.sh:233` publishes through `gh pr edit ... --body-file -`.
- Changed: `AGENTS.md:527` documents `scripts/update_pr_body.sh` as the required body-only path after a PR is already open, and `AGENTS.md:537` keeps the normal `new_pr_plan` -> `push_pr` -> `open_pr` flow for code-bearing updates.
- Changed: `scripts/select_impacted_tests.py:148` enrolls the new helper in impacted-test selection.
- Changed: `tests/test_update_pr_body_wrapper.py:14` proves marker stamping without mutating the source body; `tests/test_update_pr_body_wrapper.py:25` proves the helper does not call `local_pr_review.sh`; `tests/test_update_pr_body_wrapper.py:35` proves live reconciliation sees the publish body; `tests/test_update_pr_body_wrapper.py:46`, `tests/test_update_pr_body_wrapper.py:57`, and `tests/test_update_pr_body_wrapper.py:74` prove target-changing args, head drift, and ownership failures block before edit.
- Contract match: these changes trace to the plan's required focused body-only helper, AGENTS usage contract, impacted-test enrollment, and wrapper tests.
- Gaps: none.

## Verification
- `python -m pytest tests/test_update_pr_body_wrapper.py -q` - passed, 6 tests.
- `python -m pytest tests/test_select_impacted_tests.py -q` - passed, 64 tests.
- `python -m pytest tests/test_update_pr_body_wrapper.py tests/test_open_pr_wrapper.py tests/test_select_impacted_tests.py -q` - passed, 125 tests.
- `bash -n scripts/update_pr_body.sh` - passed.
- `python scripts/sync_pr_plan.py plans/PR-Body-Update-Fast-Path.md --check` - passed.
- `python scripts/audit_plan_doc_files_touched.py plans/PR-Body-Update-Fast-Path.md origin/main` - passed.
- `python scripts/audit_plan_doc_diff_size.py plans/PR-Body-Update-Fast-Path.md origin/main` - passed.
- `python scripts/audit_plan_doc.py plans/PR-Body-Update-Fast-Path.md` - passed.
- `git diff --check origin/main...HEAD` - passed.

## Mechanical verification
- Command: `python -m pytest tests/test_update_pr_body_wrapper.py -q` - Result: 6 passed - Environment: local
- Command: `python -m pytest tests/test_select_impacted_tests.py -q` - Result: 64 passed - Environment: local
- Command: `python -m pytest tests/test_update_pr_body_wrapper.py tests/test_open_pr_wrapper.py tests/test_select_impacted_tests.py -q` - Result: 125 passed - Environment: local
- Command: `bash -n scripts/update_pr_body.sh` - Result: pass - Environment: local
- Command: `python scripts/sync_pr_plan.py plans/PR-Body-Update-Fast-Path.md --check` - Result: pass - Environment: local
- Command: `python scripts/audit_plan_doc_files_touched.py plans/PR-Body-Update-Fast-Path.md origin/main` - Result: pass - Environment: local
- Command: `python scripts/audit_plan_doc_diff_size.py plans/PR-Body-Update-Fast-Path.md origin/main` - Result: pass - Environment: local
- Command: `python scripts/audit_plan_doc.py plans/PR-Body-Update-Fast-Path.md` - Result: pass - Environment: local
- Command: `git diff --check origin/main...HEAD` - Result: pass - Environment: local
- Command: `ATLAS_SESSION_STATE_FILE=SESSION_STATE.codex-pr-body-fast-path.local.md ATLAS_CURRENT_PR_BODY_FILE=/tmp/pr-body-update-fast-path.md bash scripts/local_pr_review.sh` - Result: pass - Environment: local

## Diff size
5 files, +697 / -0

<!-- atlas-open-pr-wrapper: v1 -->
