### PR TITLE
Make guard-class closure a local stop gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1200,6 +1200,13 @@ in `AGENTS.md`; the highlights:
 - **Codex review reconciliation:** fix confirmed in-scope Codex findings, group
   duplicates, waive out-of-scope/speculative/NIT-only findings in the PR body,
   and resolve GitHub threads only after code/body evidence addresses them.
+- **Guard-class closure is a mechanical stop.** For any review-fix PR or any
+  diff that changes a guard / validator / sanitizer / classifier / gate /
+  denylist / parser-admission rule, run
+  `python scripts/check_guard_class_closure.py --base origin/main --strict`
+  before another push. A finding means stop patching the cited instance: add
+  the class-level closure proof required by `docs/GUARD_CLASS_CLOSURE.md`, or
+  put `guard-class-closure: waived` in the PR body with the explicit rationale.
 - **Code for reconstruction review.** While building, follow
   `docs/CODING_FOR_RECONSTRUCTION_REVIEW.md`: start from the correct-fix shape,
   keep the diff self-explaining, test real behavior, and make the PR body a
@@ -1467,6 +1474,13 @@ Compose files for sub-services:
   is correct** -- the root near a symptom is often a consequence of something
   coded wrong further up; if you stop short of the true upstream root, name it
   and the follow-up rather than patch downstream. See `AGENTS.md` §3k.
+- **Guard-class closure before another patch**: when the fix touches a guard /
+  validator / sanitizer / classifier / gate / denylist / parser-admission rule,
+  `python scripts/check_guard_class_closure.py --base origin/main --strict` is
+  the local stop sign. If it reports a finding, do not add another token, regex,
+  example fixture, or downstream filter just to satisfy the visible review
+  thread; close the class per `docs/GUARD_CLASS_CLOSURE.md` or explicitly waive
+  with `guard-class-closure: waived` and a rationale in the PR body.
 - **ASCII Python**: `scripts/check_ascii_python.sh` is part of CI.
   Non-ASCII characters in `.py` files break the gate. Use ASCII-only
   identifiers and string literals.

--- a/plans/PR-Guard-Class-Closure-Claude-Contract.md
+++ b/plans/PR-Guard-Class-Closure-Claude-Contract.md
@@ -1,0 +1,240 @@
+# PR-Guard-Class-Closure-Claude-Contract
+
+## Why this slice exists
+
+The operator reported that `scripts/check_guard_class_closure.py` already exists
+but is not being followed by Claude Code sessions, so review-fix PRs can still
+patch the reviewer-cited symptom instead of closing the defect class. The
+checker is visible in an advisory GitHub workflow, but the read-first Claude
+contract does not name the exact command or the stop rule, and local PR review
+does not run the checker before push.
+
+This workflow/process slice makes the existing guard-class closure rule
+preventative for builders: CLAUDE.md must tell Claude when to run the checker
+and what a finding means, and `local_pr_review.sh` must run the checker in
+strict mode so an unclosed guard-shaped diff stops before push unless the
+existing waiver marker is present.
+
+Diff-budget override: the local-gate wiring exposed coupled review failures on
+the same guard-class closure boundary. The trusted-root execution fix,
+trusted-policy-root separation, strict detector strengthening, selector closure
+declaration, and red-path tests must land together so the new local stop gate is
+both enforced and truthful.
+
+### Problem-derived contract
+
+- Root cause: the repository has a guard-class closure detector, but the
+  builder-facing contract and local review bundle do not mechanically require
+  Claude Code sessions to use it before pushing review-fix or guard-shaped
+  changes. The result is a gap between the intended R13 discipline and the
+  commands builders actually run.
+- Correct fix must touch/change: add command-level CLAUDE.md guidance for
+  `scripts/check_guard_class_closure.py`; run that checker from
+  `scripts/local_pr_review.sh` with `--strict`; make the checker inspect the PR
+  worktree under trusted-base local review while loading ignore policy only from
+  the trusted script checkout; strengthen strict mode so existing guard body
+  edits, bare generative-looking syntax, fixture matrices, string-scoped product
+  costumes, or unused Hypothesis imports do not satisfy class closure; enroll the
+  checker/local-review surfaces in impacted-test selection; add tests proving
+  the strict local gate, waiver path, trusted-root path, and CLAUDE.md command
+  contract.
+- Must not change: do not rewrite the canonical guard-closure bar in
+  `docs/GUARD_CLASS_CLOSURE.md`; do not promote the remote GitHub workflow to
+  branch-required/trusted-base; do not change product behavior or
+  reviewer-rule semantics beyond making the existing builder gate visible and
+  strict locally.
+
+## Scope (this PR)
+
+Ownership lane: workflow/guard-class-closure-claude-contract
+Slice phase: Workflow/process
+Max files: 9
+
+1. Make Claude Code guidance name the guard-class closure checker, the command
+   to run, and the meaning of a finding.
+2. Make local PR review run `scripts/check_guard_class_closure.py --strict` so
+   guard-shaped diffs without class-level proof or waiver block before push.
+3. Make strict mode reject weak same-example parametrized fixture lists and
+   string-scoped product costumes while still allowing generative
+   product/Hypothesis evidence.
+4. Add focused tests and impacted-test enrollment for the local gate and
+   CLAUDE.md contract.
+
+### Review Contract
+
+- Acceptance criteria:
+  1. `CLAUDE.md` names `scripts/check_guard_class_closure.py`, gives the exact
+     `python scripts/check_guard_class_closure.py --base origin/main --strict`
+     command, and says a finding blocks another symptom patch unless the PR
+     adds class-level proof or carries the existing `guard-class-closure:
+     waived` marker with rationale.
+  2. `scripts/local_pr_review.sh` runs the guard-class closure checker with
+     `--strict` after the PR body is available and before the local unit mirror.
+  3. The checker honors `ATLAS_AUDIT_REPO_ROOT`, so trusted-base local review
+     inspects the materialized PR worktree rather than the trusted script
+     checkout.
+4. Strict mode rejects a bare `@pytest.mark.parametrize` fixture list,
+     literal-only `product(...)` matrices, string-scoped product costumes, and
+     unused Hypothesis imports, while accepting generative `itertools.product` /
+     Hypothesis evidence tied to the guard module with grammar axes and an
+     independent oracle marker.
+  5. A synthetic local-review fixture with a guard-shaped diff and no
+     property/generative test fails local review.
+  6. The same synthetic fixture passes when the PR body carries the existing
+     guard-class closure waiver marker.
+  7. Impacted-test selection maps `scripts/check_guard_class_closure.py` and
+     the CLAUDE.md contract check to focused tests.
+- Reachability proof: run `bash scripts/local_pr_review.sh` on this PR and the
+  focused pytest files; the observable effect is the local review output
+  including a strict guard-class closure gate before push.
+- Affected surfaces: `CLAUDE.md`, `scripts/check_guard_class_closure.py`,
+  `scripts/local_pr_review.sh`, `scripts/select_impacted_tests.py`, guard
+  checker tests, local-review tests, selector tests, and a CLAUDE contract test.
+- Risk areas: false-positive guard blocking, waiver handling, command drift in
+  CLAUDE.md, selector under-selection, and accidental remote workflow promotion.
+- Reviewer rules triggered: R1, R2, R10, R12, R13, R14.
+
+### Boundary-change enumeration
+
+Required when this diff changes a guard, validator, normalizer, resolver,
+router/classifier, or admission boundary. Name each changed boundary path or
+seam in the enumeration; otherwise write "N/A - no boundary change."
+
+- Boundary path/seam: local PR review admission for guard-shaped diffs.
+- Replaced-path behaviors: before this slice, `local_pr_review.sh` did not run
+  `scripts/check_guard_class_closure.py`; after this slice, it runs the checker
+  with `--strict` and fails on findings unless the existing waiver marker is in
+  the PR body.
+- Guard-relevant fields: changed Python files, added diff lines, co-changed
+  test files, `ATLAS_CURRENT_PR_BODY_FILE`, `guard-class-closure: waived`,
+  trusted ignore config, base ref, and `ATLAS_AUDIT_REPO_ROOT`.
+- Caller x input shape: `bash scripts/local_pr_review.sh --current-pr-body-file <body> [base-ref]`
+  before push/open.
+
+### Deployed-config probing
+
+Required for guard, validator, resolver, admission-boundary, or env/config
+fallback changes; otherwise write "N/A - no guard/config boundary change."
+
+- Deployed/default config values: N/A - local builder review gate, no deployed
+  configuration.
+- Explicit value probe: tests provide a PR body containing
+  `guard-class-closure: waived`, and tests prove PR-side ignore-config data
+  cannot override trusted ignore policy.
+- Absent value probe: tests provide the same guard-shaped diff with no waiver
+  and no property/generative test.
+- Default-session/default-context probe: `bash scripts/local_pr_review.sh` runs
+  the checker with its default `origin/main` base unless a base ref is supplied.
+- Side-effect ordering: guard-class closure runs before the local unit-gate
+  mirror so symptom patching blocks before expensive tests.
+
+### Closure declaration
+
+- Set-valued dependency: `scripts/select_impacted_tests.py`'s
+  `EXPLICIT_TEST_OWNERS` entries added by this slice.
+- Is the set closed or open? CLOSED for this slice: the membership is exactly
+  the two non-import-graph surfaces this PR changes and must unit-enroll
+  (`CLAUDE.md` and `scripts/check_guard_class_closure.py`).
+- Where does membership come from? ENUMERATED/AUTHORED HERE in the selector's
+  explicit owner map because these surfaces are not discoverable by the Python
+  import graph. The owning tests are the contract tests this PR adds or extends:
+  `tests/test_claude_guard_class_contract.py`,
+  `tests/test_check_guard_class_closure.py`, `tests/test_local_pr_review.py`,
+  and `tests/test_select_impacted_tests.py`.
+- What happens outside the set? Existing selector behavior remains unchanged:
+  unknown Python/global CI surfaces escalate to `FULL`, while regular
+  Markdown-only docs remain provably test-free unless explicitly mapped. This
+  slice explicitly maps `CLAUDE.md` because it is a read-first agent contract,
+  not ordinary prose.
+
+### Files touched
+
+- `CLAUDE.md`
+- `plans/PR-Guard-Class-Closure-Claude-Contract.md`
+- `scripts/check_guard_class_closure.py`
+- `scripts/local_pr_review.sh`
+- `scripts/select_impacted_tests.py`
+- `tests/test_check_guard_class_closure.py`
+- `tests/test_claude_guard_class_contract.py`
+- `tests/test_local_pr_review.py`
+- `tests/test_select_impacted_tests.py`
+
+## Mechanism
+
+Add a strict guard-class closure stage to `local_pr_review.sh`. It reuses the
+existing checker and passes the same PR body via `ATLAS_CURRENT_PR_BODY_FILE`
+that the checker already reads for waivers. The checker now separates its
+trusted policy root from the inspected Git root: `ATLAS_AUDIT_REPO_ROOT` points
+git diff commands at the PR worktree, while the optional guard-class closure
+ignore policy is loaded from the trusted script checkout when that config
+exists.
+
+Strengthen strict mode inside `scripts/check_guard_class_closure.py`: advisory
+mode still surfaces weak `@pytest.mark.parametrize` signals, but strict mode
+requires generator syntax, explicit grammar axes, an independent
+oracle/expected-verdict marker, a tie to the guard module, strict verdict-hunk
+detection for existing guard body edits, and non-literal axis fixtures. That
+prevents a single cited-example parametrized list, unused Hypothesis import,
+literal-only `product(...)` matrix, or string-scoped product costume from
+satisfying the new local stop gate.
+
+Add CLAUDE.md guidance in the PR workflow/root-cause area so Claude Code sees
+the exact command and the disposition rule before it starts another review-fix
+push. Add focused tests that prove the local review stage fails on an unclosed
+guard-shaped diff, passes with the existing waiver marker, and keeps CLAUDE.md
+from drifting back to vague prose.
+
+## Intentional
+
+- Keep the remote GitHub workflow advisory in this slice; trusted-base/required
+  promotion is a separate security and branch-protection change.
+- Reuse the existing waiver marker rather than creating a second disposition
+  vocabulary.
+- Keep advisory mode's heuristic scope; only strict mode gets the stronger
+  property/generative evidence bar.
+- The cross-layer caller hint on `tests/test_local_pr_review.py`'s private
+  `_write_fixture_repo` helper is test-only reuse. The helper's existing
+  behavior is preserved; it now also installs the guard checker so local-review
+  fixtures exercise the same gate this PR adds.
+- Cross-layer hints on `scan_diff` and `main` are same-name functions in
+  separate checker modules, not call sites of `scripts/check_guard_class_closure.py`;
+  the real guard-checker callers are its CLI and tests covered in this slice.
+
+## Deferred
+
+- Trusted-base remote promotion for `guard-class-closure-lint` after the
+  operator chooses to make the GitHub check required.
+- Broader set-valued dependency detection from
+  `docs/GUARD_CLASS_CLOSURE.md` trigger B.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_claude_guard_class_contract.py -q` - passed, 2
+  tests.
+- `python -m pytest tests/test_check_guard_class_closure.py -q` - passed, 30
+  tests.
+- `python -m pytest tests/test_local_pr_review.py -q` - passed, 31 tests.
+- `python -m pytest tests/test_select_impacted_tests.py tests/test_claude_guard_class_contract.py -q`
+  - passed, 68 tests.
+- `python -m pytest tests/test_check_guard_class_closure.py tests/test_local_pr_review.py tests/test_select_impacted_tests.py tests/test_claude_guard_class_contract.py -q`
+  - passed, 129 tests.
+- `python scripts/check_guard_class_closure.py --base origin/main --strict` -
+  passed.
+- Pending before push: refreshed plan/body audits and local PR review.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `CLAUDE.md` | 14 |
+| `plans/PR-Guard-Class-Closure-Claude-Contract.md` | 240 |
+| `scripts/check_guard_class_closure.py` | 93 |
+| `scripts/local_pr_review.sh` | 15 |
+| `scripts/select_impacted_tests.py` | 8 |
+| `tests/test_check_guard_class_closure.py` | 133 |
+| `tests/test_claude_guard_class_contract.py` | 23 |
+| `tests/test_local_pr_review.py` | 100 |
+| `tests/test_select_impacted_tests.py` | 9 |
+| **Total** | **635** |

--- a/scripts/check_guard_class_closure.py
+++ b/scripts/check_guard_class_closure.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
@@ -31,8 +32,9 @@ from pathlib import Path, PurePosixPath
 from typing import Iterable, Mapping, Sequence
 
 
-REPO_ROOT = Path(__file__).resolve().parent.parent
-CONFIG_PATH = REPO_ROOT / "scripts" / "guard_class_closure_config.json"
+TRUSTED_REPO_ROOT = Path(__file__).resolve().parent.parent
+INSPECTED_REPO_ROOT = Path(os.environ.get("ATLAS_AUDIT_REPO_ROOT", TRUSTED_REPO_ROOT)).resolve()
+CONFIG_PATH = TRUSTED_REPO_ROOT / "scripts" / "guard_class_closure_config.json"
 WAIVER_MARKER = "guard-class-closure: waived"
 
 # --- Guard-shape signals -----------------------------------------------------
@@ -80,11 +82,45 @@ _OPEN_INPUT_RE = re.compile(
 # A bare for-loop is NOT a property signal: a plain loop over a fixture list
 # is exactly the shape the lint exists to reject, and the old trailing-loop
 # alternative (no MULTILINE) was order-dependent noise in both directions.
-_PROPERTY_TEST_RE = re.compile(
+_ADVISORY_PROPERTY_TEST_RE = re.compile(
     r"@pytest\.mark\.parametrize"
     r"|itertools\.product|\bproduct\("
     r"|\bhypothesis\b|@given\b"
 )
+_STRICT_PROPERTY_TEST_RE = re.compile(
+    r"itertools\.product|\bproduct\("
+    r"|\bhypothesis\b|@given\b"
+)
+_STRICT_GENERATOR_RE = re.compile(r"itertools\.product|\bproduct\(|@given\b")
+_STRICT_ORACLE_RE = re.compile(
+    r"\b(?:[a-z0-9_]*oracle[a-z0-9_]*|expected|spec[-_ ]derived|contract[-_ ]derived|invariant)\b",
+    re.IGNORECASE,
+)
+_STRICT_AXIS_RE = re.compile(
+    r"\b(?P<axis>tokens?|values?|vocabular(?:y|ies)|containers?|wrappers?|famil(?:y|ies)|keys?)\b",
+    re.IGNORECASE,
+)
+_STRING_SCOPED_AXIS_ASSIGN_RE = re.compile(
+    r"(?m)^\+?\s*(?:tokens?|values?|containers?|wrappers?|famil(?:y|ies)|keys?|expected)"
+    r"\s*=\s*(?:"
+    r"\[[^\]\n]*(?:['\"]|True|False|\b\d+\b)[^\]\n]*\]"
+    r"|\([^\)\n]*(?:['\"]|True|False|\b\d+\b)[^\)\n]*\)"
+    r"|\{[^\}\n]*(?:['\"]|True|False|\b\d+\b)[^\}\n]*\}"
+    r"|['\"][^'\"]+['\"]|True|False|\d+"
+    r")\s*$",
+    re.IGNORECASE,
+)
+
+
+def _axis_category(raw: str) -> str:
+    value = raw.lower()
+    if value.startswith(("token", "value", "vocabular")):
+        return "token"
+    if value.startswith(("container", "wrapper")):
+        return "container"
+    if value.startswith(("famil", "key")):
+        return "key"
+    return value
 
 
 def _is_test_path(path: str) -> bool:
@@ -112,7 +148,7 @@ class Finding:
     reason: str
 
 
-def file_is_guard_shaped(path: str, added: str) -> bool:
+def file_is_guard_shaped(path: str, added: str, *, strict: bool = False) -> bool:
     """True if a non-test .py file's change looks like a guard over open input.
 
     Guard-shaped iff a guard path-name stem is present, OR the added lines show
@@ -126,16 +162,43 @@ def file_is_guard_shaped(path: str, added: str) -> bool:
     if any(stem in compact for stem in _GUARD_PATH_STEMS):
         return True
     has_verdict = _VERDICT_DEF_RE.search(added) is not None
+    if strict and has_verdict:
+        return True
     has_open_input = _OPEN_INPUT_RE.search(added) is not None
     return has_verdict and has_open_input
 
 
-def diff_has_property_test(test_added: Mapping[str, str]) -> bool:
+def diff_has_property_test(test_added: Mapping[str, str], *, strict: bool = False) -> bool:
     """True if any co-changed test file adds a property/generative test."""
-    return any(_PROPERTY_TEST_RE.search(added) for added in test_added.values())
+    if strict:
+        return any(strict_property_test_evidence(added) for added in test_added.values())
+    return any(_ADVISORY_PROPERTY_TEST_RE.search(added) for added in test_added.values())
 
 
-def guard_has_property_test(guard_path: str, test_added: Mapping[str, str]) -> bool:
+def strict_property_test_evidence(added: str) -> bool:
+    """True only for strict class-closure evidence, not generative-looking syntax.
+
+    Strict mode is a stop gate, so a product loop or Hypothesis import is not
+    enough by itself. The added test must show a generator, an independent oracle
+    / expected-verdict marker, and at least two grammar axes such as tokens,
+    containers/wrappers, or key families.
+    """
+    if _STRICT_GENERATOR_RE.search(added) is None:
+        return False
+    if _STRICT_ORACLE_RE.search(added) is None:
+        return False
+    if _STRING_SCOPED_AXIS_ASSIGN_RE.search(added) is not None:
+        return False
+    axes = {_axis_category(match.group("axis")) for match in _STRICT_AXIS_RE.finditer(added)}
+    return len(axes) >= 3
+
+
+def guard_has_property_test(
+    guard_path: str,
+    test_added: Mapping[str, str],
+    *,
+    strict: bool = False,
+) -> bool:
     """True if a property/generative test is tied to THIS guard.
 
     Evidence must both carry a property signal AND reference the guard's
@@ -144,7 +207,12 @@ def guard_has_property_test(guard_path: str, test_added: Mapping[str, str]) -> b
     """
     stem = PurePosixPath(guard_path).stem.lower()
     for test_path, added in test_added.items():
-        if not _PROPERTY_TEST_RE.search(added):
+        has_evidence = (
+            strict_property_test_evidence(added)
+            if strict
+            else _ADVISORY_PROPERTY_TEST_RE.search(added) is not None
+        )
+        if not has_evidence:
             continue
         if stem in test_path.lower() or stem in added.lower():
             return True
@@ -155,6 +223,7 @@ def scan_diff(
     added_by_file: Mapping[str, str],
     *,
     ignore_globs: Sequence[str] = (),
+    strict: bool = False,
 ) -> list[Finding]:
     """Pure core: given {path: added-lines}, return advisory findings.
 
@@ -169,11 +238,11 @@ def scan_diff(
             continue
         if any(PurePosixPath(path).match(glob) for glob in ignore_globs):
             continue
-        if not file_is_guard_shaped(path, added):
+        if not file_is_guard_shaped(path, added, strict=strict):
             continue
         # Evidence is per-guard: an unrelated property test in the same PR
         # must not suppress this guard's finding.
-        if guard_has_property_test(path, test_added):
+        if guard_has_property_test(path, test_added, strict=strict):
             continue
         findings.append(
             Finding(
@@ -194,7 +263,7 @@ def scan_diff(
 
 def _git(args: Sequence[str]) -> str:
     result = subprocess.run(
-        ["git", *args], cwd=REPO_ROOT, check=False, capture_output=True, text=True
+        ["git", *args], cwd=INSPECTED_REPO_ROOT, check=False, capture_output=True, text=True
     )
     if result.returncode != 0:
         raise SystemExit(f"git {' '.join(args)} failed: {result.stderr.strip()}")
@@ -245,7 +314,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     added_by_file = changed_added_lines(args.base)
-    findings = scan_diff(added_by_file, ignore_globs=load_ignore_globs())
+    findings = scan_diff(added_by_file, ignore_globs=load_ignore_globs(), strict=args.strict)
 
     print("guard class-closure lint (advisory)")
     print("-" * 60)

--- a/scripts/local_pr_review.sh
+++ b/scripts/local_pr_review.sh
@@ -346,6 +346,21 @@ if [ -n "$current_pr_body_file" ]; then
     fi
 fi
 
+if [ -f "$script_root/scripts/check_guard_class_closure.py" ]; then
+    guard_class_args=("$script_root/scripts/check_guard_class_closure.py" --base "$base_ref" --strict)
+    if [ -n "$current_pr_body_file" ]; then
+        run_check "Guard class-closure lint" env \
+            ATLAS_CURRENT_PR_BODY_FILE="$current_pr_body_file" \
+            "$python_bin" "${guard_class_args[@]}"
+    else
+        run_check "Guard class-closure lint" "$python_bin" "${guard_class_args[@]}"
+    fi
+else
+    echo
+    echo "==> Guard class-closure lint"
+    echo "    SKIP (scripts/check_guard_class_closure.py not found)"
+fi
+
 committed_plan_docs=$(
     git diff --name-only --diff-filter=AM "$base"...HEAD -- 'plans/PR-*.md' 2>/dev/null |
         sort -u |

--- a/scripts/select_impacted_tests.py
+++ b/scripts/select_impacted_tests.py
@@ -66,6 +66,9 @@ TEST_FREE_SUFFIXES = {".md"}
 # deliberately small and auditable: unknown workflows, registries, and scripts
 # still escalate to FULL.
 EXPLICIT_TEST_OWNERS: dict[str, tuple[str, ...]] = {
+    "CLAUDE.md": (
+        "tests/test_claude_guard_class_contract.py",
+    ),
     ".github/workflows/branch_protection_required_checks.yml": (
         "tests/test_security_guardrails_workflow.py",
     ),
@@ -125,6 +128,11 @@ EXPLICIT_TEST_OWNERS: dict[str, tuple[str, ...]] = {
     ),
     "scripts/check_ai_reconciliation_live.py": (
         "tests/test_check_ai_reconciliation_live.py",
+    ),
+    "scripts/check_guard_class_closure.py": (
+        "tests/test_check_guard_class_closure.py",
+        "tests/test_local_pr_review.py",
+        "tests/test_select_impacted_tests.py",
     ),
     "scripts/check_required_status_checks.py": (
         "tests/test_security_guardrails_workflow.py",

--- a/tests/test_check_guard_class_closure.py
+++ b/tests/test_check_guard_class_closure.py
@@ -44,6 +44,7 @@ def test_content_signals_both_required() -> None:
     # verdict only, no open-input inspection -> not guard-shaped
     verdict_only = "+def is_ready(count):\n+    return count > 0\n"
     assert not mod.file_is_guard_shaped("atlas_brain/services/foo.py", verdict_only)
+    assert mod.file_is_guard_shaped("atlas_brain/services/foo.py", verdict_only, strict=True)
 
     # open-input only, no verdict def -> not guard-shaped
     open_only = "+    if isinstance(value, dict):\n+        data = frozenset({'a', 'b'})\n"
@@ -71,6 +72,45 @@ def test_non_python_and_test_files_are_never_guard_shaped() -> None:
 )
 def test_property_test_signals_recognized(added: str) -> None:
     assert mod.diff_has_property_test({"tests/test_x.py": added})
+
+
+def test_strict_property_test_rejects_bare_parametrize_fixture() -> None:
+    weak = "+@pytest.mark.parametrize('v', ['kept private'])\n+def test_x(v): ...\n"
+    strong = (
+        "+    # grammar axes: tokens x containers x key families\n"
+        "+    contract_oracle = {'private': False, 'public': True}\n"
+        "+    for key, val in itertools.product(KEY_FAMILIES, TOKEN_VALUES):\n"
+        "+        assert guard(key, [val]) == contract_oracle[val]\n"
+    )
+
+    assert mod.diff_has_property_test({"tests/test_x.py": weak}) is True
+    assert mod.diff_has_property_test({"tests/test_x.py": weak}, strict=True) is False
+    assert mod.diff_has_property_test({"tests/test_x.py": strong}, strict=True) is True
+
+
+def test_strict_property_test_rejects_product_without_oracle_axes() -> None:
+    fixture_matrix = (
+        "+def test_support_ticket_privacy_matrix():\n"
+        "+    for value, flag in product(['kept private'], [0]):\n"
+        "+        assert support_ticket_privacy_guard(value) == flag\n"
+    )
+    unused_hypothesis = "+from hypothesis import given\n+def test_support_ticket_privacy_literal(): ...\n"
+
+    assert mod.diff_has_property_test({"tests/test_x.py": fixture_matrix}, strict=True) is False
+    assert mod.diff_has_property_test({"tests/test_x.py": unused_hypothesis}, strict=True) is False
+
+
+def test_strict_property_test_rejects_string_scoped_product_costume() -> None:
+    product_costume = (
+        "+tokens = ['kept private']\n"
+        "+containers = [False]\n"
+        "+expected = False\n"
+        "+def test_support_ticket_privacy_matrix():\n"
+        "+    for token, container in product(tokens, containers):\n"
+        "+        assert support_ticket_privacy_guard(token) == expected\n"
+    )
+
+    assert mod.diff_has_property_test({"tests/test_x.py": product_costume}, strict=True) is False
 
 
 def test_plain_fixture_list_is_not_a_property_test() -> None:
@@ -109,6 +149,36 @@ def test_guard_change_with_property_test_is_clean() -> None:
             "extracted_content_pipeline/support_ticket_privacy.py": GUARD_CHANGE,
             "tests/test_support_ticket_privacy_sweep.py": PROPERTY_TEST,
         }
+    )
+    assert findings == []
+
+
+def test_guard_change_with_weak_parametrize_stays_flagged_in_strict_mode() -> None:
+    findings = mod.scan_diff(
+        {
+            "extracted_content_pipeline/support_ticket_privacy.py": GUARD_CHANGE,
+            "tests/test_support_ticket_privacy_sweep.py": PROPERTY_TEST,
+        },
+        strict=True,
+    )
+    assert len(findings) == 1
+
+
+def test_guard_change_with_generative_product_is_clean_in_strict_mode() -> None:
+    product_test = (
+        "+import itertools\n"
+        "+# grammar axes: tokens x containers x key families\n"
+        "+SPEC_ORACLE = {'kept private': False, 'published': True}\n"
+        "+def test_support_ticket_privacy_matrix():\n"
+        "+    for key, value in itertools.product(KEY_FAMILIES, TOKEN_VALUES):\n"
+        "+        assert support_ticket_privacy_guard(key, [value]) == SPEC_ORACLE[value]\n"
+    )
+    findings = mod.scan_diff(
+        {
+            "extracted_content_pipeline/support_ticket_privacy.py": GUARD_CHANGE,
+            "tests/test_support_ticket_privacy_sweep.py": product_test,
+        },
+        strict=True,
     )
     assert findings == []
 
@@ -181,9 +251,70 @@ def test_unrelated_property_test_does_not_suppress_guard_finding() -> None:
 def test_stem_tied_property_test_suppresses_guard_finding() -> None:
     findings = mod.scan_diff({
         "pkg/privacy_guard.py": "+def is_private(v):\n+    return _verdict(v)\n",
-        "tests/test_privacy_guard.py": "+from hypothesis import given\n+@given(st.text())\n+def test_privacy_guard_closed(s): ...\n",
+        "tests/test_privacy_guard.py": (
+            "+from hypothesis import given\n"
+            "+@given(token=st.text(), key=st.sampled_from(KEY_FAMILIES))\n"
+            "+def test_privacy_guard_closed(token, key):\n"
+            "+    expected = contract_oracle(token)\n"
+            "+    assert privacy_guard(key, [token]) == expected\n"
+        ),
     })
     assert findings == []
+
+
+def test_strict_mode_requires_oracle_axes_for_guard_scan() -> None:
+    findings = mod.scan_diff(
+        {
+            "pkg/privacy_guard.py": "+def is_private(v):\n+    return _verdict(v)\n",
+            "tests/test_privacy_guard.py": (
+                "+def test_privacy_guard_cases():\n"
+                "+    for token, flag in product(['kept private'], [False]):\n"
+                "+        assert privacy_guard(token) == flag\n"
+            ),
+        },
+        strict=True,
+    )
+    assert [f.path for f in findings] == ["pkg/privacy_guard.py"]
+
+
+def test_strict_mode_flags_existing_guard_body_edit_without_open_input_token() -> None:
+    findings = mod.scan_diff(
+        {
+            "pkg/rules.py": (
+                "@@ -12,0 +13,1 @@ def validate_payload(value):\n"
+                "+    return value == 'kept private'\n"
+            )
+        },
+        strict=True,
+    )
+
+    assert [f.path for f in findings] == ["pkg/rules.py"]
+
+
+def test_ignore_config_stays_on_trusted_root_when_inspecting_pr_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    trusted = tmp_path / "trusted"
+    inspected = tmp_path / "pr"
+    (trusted / "scripts").mkdir(parents=True)
+    (inspected / "scripts").mkdir(parents=True)
+    (trusted / "scripts" / "guard_class_closure_config.json").write_text(
+        '{"ignore_globs": ["trusted_only.py"]}',
+        encoding="utf-8",
+    )
+    (inspected / "scripts" / "guard_class_closure_config.json").write_text(
+        '{"ignore_globs": ["**"]}',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(mod, "TRUSTED_REPO_ROOT", trusted)
+    monkeypatch.setattr(mod, "INSPECTED_REPO_ROOT", inspected)
+    monkeypatch.setattr(
+        mod,
+        "CONFIG_PATH",
+        mod.TRUSTED_REPO_ROOT / "scripts" / "guard_class_closure_config.json",
+    )
+
+    assert mod.load_ignore_globs() == ["trusted_only.py"]
 
 
 def test_async_guard_def_is_detected() -> None:

--- a/tests/test_claude_guard_class_contract.py
+++ b/tests/test_claude_guard_class_contract.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_claude_names_guard_class_closure_stop_command() -> None:
+    text = (REPO_ROOT / "CLAUDE.md").read_text(encoding="utf-8")
+
+    assert "Guard-class closure is a mechanical stop" in text
+    assert "python scripts/check_guard_class_closure.py --base origin/main --strict" in text
+    assert "docs/GUARD_CLASS_CLOSURE.md" in text
+    assert "guard-class-closure: waived" in text
+
+
+def test_claude_rejects_instance_patching_after_guard_finding() -> None:
+    text = (REPO_ROOT / "CLAUDE.md").read_text(encoding="utf-8")
+    normalized = " ".join(text.split())
+
+    assert "do not add another token, regex, example fixture, or downstream filter" in normalized
+    assert "close the class" in normalized

--- a/tests/test_local_pr_review.py
+++ b/tests/test_local_pr_review.py
@@ -170,6 +170,38 @@ def test_local_pr_review_runs_fix_loop_disposition_when_body_supplied(tmp_path: 
     assert "local PR review passed" in result.stdout
 
 
+def test_local_pr_review_blocks_unclosed_guard_class(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _write_fixture_repo(repo)
+    _add_guard_shaped_change(repo)
+
+    result = _run(repo, ["bash", "scripts/local_pr_review.sh"])
+
+    assert result.returncode == 1
+    assert "Guard class-closure lint" in result.stdout
+    assert "guard-shaped change over open input with no co-changed property/generative test" in result.stdout
+    assert "1 local review check(s) failed" in result.stdout
+
+
+def test_local_pr_review_allows_guard_class_waiver_from_pr_body(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _write_fixture_repo(repo)
+    _add_guard_shaped_change(repo)
+    body = tmp_path / "body.md"
+    body.write_text(
+        "guard-class-closure: waived\n\n"
+        "Reason: false-positive synthetic guard fixture for local review wiring.\n",
+        encoding="utf-8",
+    )
+
+    result = _run(repo, ["bash", "scripts/local_pr_review.sh", "--current-pr-body-file", str(body)])
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Guard class-closure lint" in result.stdout
+    assert "WAIVED: 'guard-class-closure: waived' present" in result.stdout
+    assert "local PR review passed" in result.stdout
+
+
 def test_local_pr_review_forwards_pr_author_to_body_contract(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     _write_fixture_repo(repo)
@@ -472,7 +504,11 @@ def test_local_pr_review_real_body_audit_honors_dependabot_exemption(
     repo = tmp_path / "repo"
     _write_fixture_repo(repo)
     body = tmp_path / "body.md"
-    body.write_text("Dependabot generated body without the Atlas plan contract.\n", encoding="utf-8")
+    body.write_text(
+        "Dependabot generated body without the Atlas plan contract.\n"
+        "guard-class-closure: waived\n",
+        encoding="utf-8",
+    )
     _write_executable(
         repo / "scripts" / "audit_pr_body.py",
         (REPO_ROOT / "scripts" / "audit_pr_body.py").read_text(encoding="utf-8"),
@@ -516,7 +552,11 @@ def test_local_pr_review_ai_reconciliation_honors_plain_dependabot_author(
     repo = tmp_path / "repo"
     _write_fixture_repo(repo)
     body = tmp_path / "body.md"
-    body.write_text("Dependabot generated body without Atlas reconciliation.\n", encoding="utf-8")
+    body.write_text(
+        "Dependabot generated body without Atlas reconciliation.\n"
+        "guard-class-closure: waived\n",
+        encoding="utf-8",
+    )
     _write_executable(
         repo / "scripts" / "audit_pr_body.py",
         (REPO_ROOT / "scripts" / "audit_pr_body.py").read_text(encoding="utf-8"),
@@ -661,6 +701,44 @@ def test_local_pr_review_trusted_script_root_does_not_execute_repo_scripts(tmp_p
     assert "repo pre-push should not run" not in result.stderr
 
 
+def test_local_pr_review_trusted_guard_checker_inspects_repo_root(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _write_fixture_repo(repo)
+    _add_guard_shaped_change(repo)
+
+    trusted = tmp_path / "trusted"
+    (trusted / "scripts").mkdir(parents=True)
+    _write_executable(
+        trusted / "scripts" / "local_pr_review.sh",
+        (REPO_ROOT / "scripts" / "local_pr_review.sh").read_text(encoding="utf-8"),
+    )
+    _write_executable(
+        trusted / "scripts" / "check_guard_class_closure.py",
+        (REPO_ROOT / "scripts" / "check_guard_class_closure.py").read_text(encoding="utf-8"),
+    )
+    _write_executable(
+        trusted / "scripts" / "pre_push_audit.sh",
+        "#!/usr/bin/env bash\nset -euo pipefail\necho trusted pre-push ok\n",
+    )
+
+    result = _run(
+        tmp_path,
+        [
+            "bash",
+            str(trusted / "scripts" / "local_pr_review.sh"),
+            "--repo-root",
+            str(repo),
+            "--script-root",
+            str(trusted),
+        ],
+    )
+
+    assert result.returncode == 1
+    assert "Guard class-closure lint" in result.stdout
+    assert "extracted_content_pipeline/support_ticket_privacy.py" in result.stdout
+    assert "guard-shaped change over open input" in result.stdout
+
+
 def test_local_pr_review_body_audit_inspects_repo_root_plan_with_trusted_scripts(
     tmp_path: Path,
 ) -> None:
@@ -770,6 +848,10 @@ def _write_fixture_repo(repo: Path) -> None:
         (REPO_ROOT / "scripts" / "local_pr_review.sh").read_text(encoding="utf-8"),
     )
     _write_executable(
+        repo / "scripts" / "check_guard_class_closure.py",
+        (REPO_ROOT / "scripts" / "check_guard_class_closure.py").read_text(encoding="utf-8"),
+    )
+    _write_executable(
         repo / "scripts" / "pre_push_audit.sh",
         "#!/usr/bin/env bash\nset -euo pipefail\necho pre-push ok\n",
     )
@@ -787,6 +869,20 @@ def _write_fixture_repo(repo: Path) -> None:
     _git(repo, "remote", "add", "origin", str(repo))
     _git(repo, "update-ref", "refs/remotes/origin/main", "HEAD")
     _git(repo, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main")
+
+
+def _add_guard_shaped_change(repo: Path) -> None:
+    guard = repo / "extracted_content_pipeline" / "support_ticket_privacy.py"
+    guard.parent.mkdir(parents=True, exist_ok=True)
+    guard.write_text(
+        "def is_private_marker(value):\n"
+        "    if isinstance(value, (str, dict)):\n"
+        "        return value.strip().lower() in {'not published'}\n"
+        "    return False\n",
+        encoding="utf-8",
+    )
+    _git(repo, "add", "extracted_content_pipeline/support_ticket_privacy.py")
+    _git(repo, "commit", "-m", "add guard-shaped symptom patch")
 
 
 def _write_unit_gate_fixture(

--- a/tests/test_select_impacted_tests.py
+++ b/tests/test_select_impacted_tests.py
@@ -138,6 +138,7 @@ def test_global_files_escalate_to_full(tmp_path, path):
 
 
 @pytest.mark.parametrize(("path", "owners"), [
+    ("CLAUDE.md", ["tests/test_claude_guard_class_contract.py"]),
     (
         ".github/workflows/branch_protection_required_checks.yml",
         ["tests/test_security_guardrails_workflow.py"],
@@ -216,6 +217,14 @@ def test_global_files_escalate_to_full(tmp_path, path):
     (
         "scripts/check_ai_reconciliation_live.py",
         ["tests/test_check_ai_reconciliation_live.py"],
+    ),
+    (
+        "scripts/check_guard_class_closure.py",
+        [
+            "tests/test_check_guard_class_closure.py",
+            "tests/test_local_pr_review.py",
+            "tests/test_select_impacted_tests.py",
+        ],
     ),
     (
         "scripts/check_required_status_checks.py",


### PR DESCRIPTION
Plan: plans/PR-Guard-Class-Closure-Claude-Contract.md
Slice phase: Workflow/process
Ownership lane: workflow/guard-class-closure-claude-contract

`scripts/check_guard_class_closure.py` existed, but Claude Code sessions were not mechanically directed to use it and local PR review did not run it, so review-fix PRs could keep patching cited instances while still getting local green. This slice makes the existing guard-class closure rule a local stop sign: CLAUDE.md names the exact strict command, `local_pr_review.sh` runs it before push, trusted-base execution inspects the PR worktree while keeping trusted ignore policy in the trusted checkout, and strict mode no longer accepts lone same-example parametrized fixtures, unused Hypothesis imports, or literal-only `product(...)` matrices as closure proof.

Diff-budget override: The local-gate wiring exposed coupled review failures on the same guard-class closure boundary. The trusted-root execution fix, trusted-policy-root separation, strict detector strengthening, selector closure declaration, and red-path tests must land together so the new local stop gate is both enforced and truthful.

## Intentional
- Keep the remote GitHub `guard-class-closure-lint` workflow advisory in this slice; trusted-base/required promotion is deferred.
- Reuse the existing `guard-class-closure: waived` marker instead of adding another waiver vocabulary.
- Keep advisory mode's heuristic scope; only strict mode gets the stronger property/generative evidence bar.
- Cross-layer caller hint disposition: `_write_fixture_repo` is a test-only helper; this slice preserves its fixture behavior and only adds the guard checker so local-review fixtures exercise the new gate.
- Cross-layer hints on `scan_diff` and `main` are same-name functions in separate checker modules, not call sites of `scripts/check_guard_class_closure.py`; the real guard-checker callers are its CLI and tests covered in this slice.

## AI reconciliation
- Point the strict checker at the PR worktree -- fixed-in: scripts/check_guard_class_closure.py honors `ATLAS_AUDIT_REPO_ROOT`; tests/test_local_pr_review.py proves trusted-base local review inspects the PR worktree.
- Declare closure for the explicit owner set -- fixed-in: plans/PR-Guard-Class-Closure-Claude-Contract.md adds the closure declaration for the `EXPLICIT_TEST_OWNERS` entries and scripts/select_impacted_tests.py keeps the mapped owners explicit.
- Strengthen the detector before making it strict -- fixed-in: scripts/check_guard_class_closure.py splits advisory vs strict property signals; tests/test_check_guard_class_closure.py proves weak parametrized fixtures fail strict mode and generative product evidence passes.
- Keep ignore policy in the trusted checkout -- fixed-in: scripts/check_guard_class_closure.py separates `TRUSTED_REPO_ROOT` from `INSPECTED_REPO_ROOT`; tests/test_check_guard_class_closure.py proves PR-side ignore config cannot override trusted policy.
- Require actual generative evidence in strict mode -- fixed-in: scripts/check_guard_class_closure.py requires generator syntax plus grammar axes plus oracle/expected-verdict evidence; tests/test_check_guard_class_closure.py proves literal-only product matrices and unused Hypothesis imports fail strict mode.
- Keep the heuristic detector advisory until it proves closure -- fixed-in: scripts/check_guard_class_closure.py makes strict mode treat verdict hunk headers as guard-shaped and rejects string-scoped axis fixtures; tests/test_check_guard_class_closure.py proves existing guard body edits and product-costume fixtures fail strict mode.

## Fix-loop disposition preflight
- Root Decision: Point the strict checker at the PR worktree
- Blocking Predicate: ci
- Disposition: fixed-in
- Allowed files: `CLAUDE.md`, `plans/PR-Guard-Class-Closure-Claude-Contract.md`, `scripts/check_guard_class_closure.py`, `scripts/local_pr_review.sh`, `scripts/select_impacted_tests.py`, `tests/test_check_guard_class_closure.py`, `tests/test_claude_guard_class_contract.py`, `tests/test_local_pr_review.py`, `tests/test_select_impacted_tests.py`
- Max files: 9
- Parked hardening: none

- Root Decision: Declare closure for the explicit owner set
- Blocking Predicate: contract
- Disposition: fixed-in
- Allowed files: `CLAUDE.md`, `plans/PR-Guard-Class-Closure-Claude-Contract.md`, `scripts/check_guard_class_closure.py`, `scripts/local_pr_review.sh`, `scripts/select_impacted_tests.py`, `tests/test_check_guard_class_closure.py`, `tests/test_claude_guard_class_contract.py`, `tests/test_local_pr_review.py`, `tests/test_select_impacted_tests.py`
- Max files: 9
- Parked hardening: none

- Root Decision: Strengthen the detector before making it strict
- Blocking Predicate: claimed-mechanism
- Disposition: fixed-in
- Allowed files: `CLAUDE.md`, `plans/PR-Guard-Class-Closure-Claude-Contract.md`, `scripts/check_guard_class_closure.py`, `scripts/local_pr_review.sh`, `scripts/select_impacted_tests.py`, `tests/test_check_guard_class_closure.py`, `tests/test_claude_guard_class_contract.py`, `tests/test_local_pr_review.py`, `tests/test_select_impacted_tests.py`
- Max files: 9
- Parked hardening: none

- Root Decision: Keep ignore policy in the trusted checkout
- Blocking Predicate: ci
- Disposition: fixed-in
- Allowed files: `CLAUDE.md`, `plans/PR-Guard-Class-Closure-Claude-Contract.md`, `scripts/check_guard_class_closure.py`, `scripts/local_pr_review.sh`, `scripts/select_impacted_tests.py`, `tests/test_check_guard_class_closure.py`, `tests/test_claude_guard_class_contract.py`, `tests/test_local_pr_review.py`, `tests/test_select_impacted_tests.py`
- Max files: 9
- Parked hardening: none

- Root Decision: Require actual generative evidence in strict mode
- Blocking Predicate: claimed-mechanism
- Disposition: fixed-in
- Allowed files: `CLAUDE.md`, `plans/PR-Guard-Class-Closure-Claude-Contract.md`, `scripts/check_guard_class_closure.py`, `scripts/local_pr_review.sh`, `scripts/select_impacted_tests.py`, `tests/test_check_guard_class_closure.py`, `tests/test_claude_guard_class_contract.py`, `tests/test_local_pr_review.py`, `tests/test_select_impacted_tests.py`
- Max files: 9
- Parked hardening: none

- Root Decision: Keep the heuristic detector advisory until it proves closure
- Blocking Predicate: claimed-mechanism
- Disposition: fixed-in
- Allowed files: `CLAUDE.md`, `plans/PR-Guard-Class-Closure-Claude-Contract.md`, `scripts/check_guard_class_closure.py`, `scripts/local_pr_review.sh`, `scripts/select_impacted_tests.py`, `tests/test_check_guard_class_closure.py`, `tests/test_claude_guard_class_contract.py`, `tests/test_local_pr_review.py`, `tests/test_select_impacted_tests.py`
- Max files: 9
- Parked hardening: none

## Deferred
- Trusted-base remote promotion for `guard-class-closure-lint` after operator approval.
- Broader set-valued dependency detection from `docs/GUARD_CLASS_CLOSURE.md` trigger B.

## Parked hardening
None.

## Cold diff reconstruction
- Changed: `CLAUDE.md:1203` adds a PR-workflow rule naming `python scripts/check_guard_class_closure.py --base origin/main --strict`, the stop condition, the canonical guard doc, and the existing waiver marker.
- Changed: `CLAUDE.md:1477` adds the same local stop sign to the root-cause checklist and explicitly rejects another token, regex, example fixture, or downstream filter when the checker reports a guard-class finding.
- Changed: `scripts/check_guard_class_closure.py` now resolves the inspected Git root from `ATLAS_AUDIT_REPO_ROOT`, so trusted-base local review checks the materialized PR worktree, while loading ignore policy from the trusted script checkout.
- Changed: `scripts/check_guard_class_closure.py` now keeps weak parametrized fixtures advisory-only and requires generator syntax, grammar axes, oracle/expected-verdict evidence, strict verdict-hunk detection, and non-literal axis fixtures in strict mode.
- Changed: `scripts/local_pr_review.sh` runs `scripts/check_guard_class_closure.py --base <base> --strict` and forwards `ATLAS_CURRENT_PR_BODY_FILE` so the existing waiver marker works with command-line PR bodies.
- Changed: `scripts/select_impacted_tests.py` maps `CLAUDE.md` to `tests/test_claude_guard_class_contract.py` and maps `scripts/check_guard_class_closure.py` to guard, local-review, and selector tests.
- Changed: `tests/test_local_pr_review.py` proves an unclosed guard-shaped diff blocks local review, the existing waiver marker permits the same synthetic diff, and trusted-base local review inspects the PR worktree.
- Changed: `tests/test_check_guard_class_closure.py` proves strict mode rejects weak parametrized fixture evidence, literal-only product matrices, string-scoped product costumes, and unused Hypothesis imports; accepts generative product evidence tied to the guard; detects existing guard body edits; and keeps PR-side ignore config from overriding trusted policy.
- Changed: `tests/test_claude_guard_class_contract.py` pins the CLAUDE.md command/waiver/canonical-doc contract and no-instance-patching stop language.
- Changed: `tests/test_select_impacted_tests.py` proves the selector enrolls the CLAUDE.md contract test and the guard checker tests.
- Contract match: all changed files trace to the planned CLAUDE command contract, strict local gate, trusted-root/trusted-policy correction, selector closure declaration, and focused fixture proof.
- Gaps: none.

## Verification
- `python -m pytest tests/test_claude_guard_class_contract.py -q` - passed, 2 tests.
- `python -m pytest tests/test_check_guard_class_closure.py -q` - passed, 30 tests.
- `python -m pytest tests/test_local_pr_review.py -q` - passed, 31 tests.
- `python -m pytest tests/test_select_impacted_tests.py tests/test_claude_guard_class_contract.py -q` - passed, 68 tests.
- `python -m pytest tests/test_check_guard_class_closure.py tests/test_local_pr_review.py tests/test_select_impacted_tests.py tests/test_claude_guard_class_contract.py -q` - passed, 129 tests.
- `python scripts/sync_pr_plan.py plans/PR-Guard-Class-Closure-Claude-Contract.md --check` - passed.
- `python scripts/audit_plan_doc.py plans/PR-Guard-Class-Closure-Claude-Contract.md` - passed.
- `python scripts/audit_plan_doc_files_touched.py plans/PR-Guard-Class-Closure-Claude-Contract.md origin/main` - passed.
- `python scripts/audit_plan_doc_diff_size.py plans/PR-Guard-Class-Closure-Claude-Contract.md origin/main` - passed.
- `python scripts/check_guard_class_closure.py --base origin/main --strict` - passed.
- `python scripts/select_impacted_tests.py --base origin/main` - selected `tests/test_check_guard_class_closure.py`, `tests/test_claude_guard_class_contract.py`, `tests/test_local_pr_review.py`, `tests/test_select_impacted_tests.py`.
- `bash -n scripts/local_pr_review.sh` - passed.
- `python -m py_compile scripts/check_guard_class_closure.py scripts/select_impacted_tests.py` - passed.
- `git diff --check origin/main...HEAD` - passed.

## Mechanical verification
- Command: `python -m pytest tests/test_check_guard_class_closure.py -q` - Result: 30 passed - Environment: local
- Command: `python -m pytest tests/test_check_guard_class_closure.py tests/test_local_pr_review.py tests/test_select_impacted_tests.py tests/test_claude_guard_class_contract.py -q` - Result: 129 passed - Environment: local
- Command: `python scripts/sync_pr_plan.py plans/PR-Guard-Class-Closure-Claude-Contract.md --check` - Result: pass - Environment: local
- Command: `python scripts/audit_plan_doc.py plans/PR-Guard-Class-Closure-Claude-Contract.md` - Result: pass - Environment: local
- Command: `python scripts/audit_plan_doc_files_touched.py plans/PR-Guard-Class-Closure-Claude-Contract.md origin/main` - Result: pass - Environment: local
- Command: `python scripts/audit_plan_doc_diff_size.py plans/PR-Guard-Class-Closure-Claude-Contract.md origin/main` - Result: pass - Environment: local
- Command: `python scripts/check_guard_class_closure.py --base origin/main --strict` - Result: pass - Environment: local
- Command: `python scripts/select_impacted_tests.py --base origin/main` - Result: pass - Environment: local
- Command: `bash -n scripts/local_pr_review.sh` - Result: pass - Environment: local
- Command: `python -m py_compile scripts/check_guard_class_closure.py scripts/select_impacted_tests.py` - Result: pass - Environment: local
- Command: `git diff --check origin/main...HEAD` - Result: pass - Environment: local

## Diff size
9 files, +620 / -15

<!-- atlas-open-pr-wrapper: v1 -->
