### PR TITLE
EOM ack: commercial and multi-site acknowledgement templates (#2320 A2/A3)

### DIFF
--- a/.github/workflows/atlas_eom_lead_pipeline_checks.yml
+++ b/.github/workflows/atlas_eom_lead_pipeline_checks.yml
@@ -30,6 +30,7 @@ on:
       - "atlas_brain/templates/email/__init__.py"
       - "atlas_brain/templates/email/estimate_confirmation.py"
       - "atlas_brain/templates/email/onboarding_welcome.py"
+      - "atlas_brain/templates/email/request_acknowledgement.py"
       - "atlas_brain/eom_api/config.py"
       - "atlas_brain/eom_api/auth.py"
       - "atlas_brain/eom_api/funnel.py"
@@ -61,6 +62,7 @@ on:
       - "atlas_brain/storage/migrations/361_eom_onboarding_draft_actor_bigint.sql"
       - "atlas_brain/tools/calendar.py"
       - "atlas_brain/tools/scheduling.py"
+      - "tests/test_ack_commercial_templates.py"
       - "tests/test_ack_variant_classification.py"
       - "tests/test_call_intelligence.py"
       - "tests/test_crm_read_scoping.py"
@@ -108,6 +110,7 @@ on:
       - "atlas_brain/templates/email/__init__.py"
       - "atlas_brain/templates/email/estimate_confirmation.py"
       - "atlas_brain/templates/email/onboarding_welcome.py"
+      - "atlas_brain/templates/email/request_acknowledgement.py"
       - "atlas_brain/eom_api/config.py"
       - "atlas_brain/eom_api/auth.py"
       - "atlas_brain/eom_api/funnel.py"
@@ -139,6 +142,7 @@ on:
       - "atlas_brain/storage/migrations/361_eom_onboarding_draft_actor_bigint.sql"
       - "atlas_brain/tools/calendar.py"
       - "atlas_brain/tools/scheduling.py"
+      - "tests/test_ack_commercial_templates.py"
       - "tests/test_ack_variant_classification.py"
       - "tests/test_call_intelligence.py"
       - "tests/test_crm_read_scoping.py"
@@ -197,6 +201,7 @@ jobs:
       - name: Run EOM lead pipeline checks
         run: |
           python -m pytest \
+            tests/test_ack_commercial_templates.py \
             tests/test_ack_variant_classification.py \
             tests/test_call_intelligence.py \
             tests/test_crm_read_scoping.py \

--- a/atlas_brain/templates/email/request_acknowledgement.py
+++ b/atlas_brain/templates/email/request_acknowledgement.py
@@ -90,6 +90,108 @@ The {business_name} Team
 """
 
 
+COMMERCIAL_SINGLE_SITE_TEMPLATE = """Hi {client_name},
+
+Thank you for requesting a free estimate from {business_name}
+
+My name is Juan Canfield and I'll be giving you a call shortly.
+
+{request_line}Here's what happens next:
+
+1. I will give you a call within 24 hours to ask a few questions about \
+your facility and to set up a time and day for a walk-through.
+
+2. We'll walk the space with you when you have some free time available. \
+We have a flexible schedule for walk-throughs and estimates.
+
+3. Tell us what areas are the most important to you. Which areas need the \
+most attention, anything that needs special handling, and how often you \
+want us on site.
+
+4. After the walk-through, we'll put together an estimate covering the \
+scope of work plus any details covered in the walk-through and email it to \
+you for review.
+
+5. Estimates are FREE and there is no obligation. If we're not the right \
+fit, we won't try to talk you into it.
+
+If you have any questions in the meantime call me at {business_phone}, or
+just reply to this email.
+
+Talk soon,
+Juan Canfield
+{business_name}
+{business_phone} | {business_email}
+{business_website}
+"""
+
+COMMERCIAL_MULTI_SITE_TEMPLATE = """Hi {client_name},
+
+Thank you for requesting a free estimate from {business_name}
+
+My name is Juan Canfield and I'll be giving you a call shortly.
+
+{request_line}Multi-location work takes a little more planning than a \
+single building, so here's what happens next:
+
+1. I will give you a call within 24 hours. That first call is to \
+understand the whole picture before we put any numbers to it.
+
+2. We'll go through your locations together - where they are, how they \
+differ from each other, and who we'd be working with at each one. Some \
+sites need more attention than others, and we'd rather know that up front.
+
+3. From there we'll work out which locations need a walk-through. Not \
+every site always does - it depends on how similar they are.
+
+4. Once we understand the locations and the schedules you need, we'll put \
+together a scope for each one and email you an estimate for review.
+
+5. Estimates are FREE and there is no obligation. If we're not the right \
+fit, we won't try to talk you into it.
+
+If you have any questions in the meantime call me at {business_phone}, or
+just reply to this email.
+
+Talk soon,
+Juan Canfield
+{business_name}
+{business_phone} | {business_email}
+{business_website}
+"""
+
+# "custom" is a real website form option, but it is a placeholder for "we'll
+# work it out on the call" rather than a cadence that can be read back in a
+# sentence -- "a custom commercial cleaning" does not parse as English. It is
+# therefore dropped exactly like a blank frequency, and the request line falls
+# back to its cadence-free wording.
+_UNSPOKEN_FREQUENCIES = frozenset({"custom"})
+
+
+def _spoken_frequency(frequency: str) -> str:
+    """Return the frequency only when it reads naturally inside a sentence."""
+    cleaned = frequency.strip()
+    if cleaned.lower() in _UNSPOKEN_FREQUENCIES:
+        return ""
+    return cleaned
+
+
+def _commercial_request_line(frequency: str, *, multi_site: bool) -> str:
+    """Echo the submitted cadence back in the commercial voice.
+
+    The residential template keeps its raw ``service, frequency`` echo
+    unchanged (operator decision, 2026-08-09: leave residential as is). The
+    commercial variants speak the cadence in a sentence instead, so the value
+    has to be one that reads naturally after "a".
+    """
+    spoken = _spoken_frequency(frequency)
+    if multi_site:
+        detail = f"{spoken} cleaning" if spoken else "cleaning"
+        return f"You requested {detail} for multiple locations.\n\n"
+    detail = f"a {spoken} commercial cleaning" if spoken else "a commercial cleaning"
+    return f"You requested {detail}.\n\n"
+
+
 def format_request_acknowledgement(
     client_name: str,
     service: str = "",
@@ -97,12 +199,34 @@ def format_request_acknowledgement(
 ) -> tuple[str, str]:
     """Render (subject, body) for the request acknowledgement.
 
+    The variant is derived here from ``service`` rather than accepted as an
+    argument, so the email a lead receives and the ``ack_variant`` intake
+    records cannot disagree: both call ``classify_ack_variant`` on the same
+    submitted value. Callers keep the existing signature.
+
     ``service``/``frequency`` echo the form selections back when present so
     the lead sees their request was captured accurately; both are optional.
     """
-    details = ", ".join(part for part in (service.strip(), frequency.strip()) if part)
-    request_line = f"Your request: {details}.\n\n" if details else ""
-    body = ACK_TEMPLATE.format(
+    variant = classify_ack_variant(service)
+
+    if variant == ACK_VARIANT_COMMERCIAL_SINGLE_SITE:
+        template = COMMERCIAL_SINGLE_SITE_TEMPLATE
+        request_line = _commercial_request_line(frequency, multi_site=False)
+    elif variant == ACK_VARIANT_COMMERCIAL_MULTI_SITE:
+        template = COMMERCIAL_MULTI_SITE_TEMPLATE
+        request_line = _commercial_request_line(frequency, multi_site=True)
+    else:
+        # residential AND general. `general` covers the form's "Other" option
+        # and anything unrecognised, where the request is not known to be
+        # commercial -- so it keeps exactly the copy those leads receive
+        # today rather than being pointed at unapproved wording.
+        template = ACK_TEMPLATE
+        details = ", ".join(
+            part for part in (service.strip(), frequency.strip()) if part
+        )
+        request_line = f"Your request: {details}.\n\n" if details else ""
+
+    body = template.format(
         client_name=client_name.strip() or "there",
         business_name=BUSINESS_NAME,
         business_phone=BUSINESS_PHONE,

--- a/atlas_brain/templates/email/request_acknowledgement.py
+++ b/atlas_brain/templates/email/request_acknowledgement.py
@@ -8,6 +8,9 @@ clock promises beyond "within 24 hours", "estimate" never "quote", sell the
 team (separate areas at once) without per-size time claims.
 """
 
+from collections.abc import Callable
+from typing import NamedTuple
+
 from .estimate_confirmation import (
     BUSINESS_EMAIL,
     BUSINESS_NAME,
@@ -144,8 +147,9 @@ sites need more attention than others, and we'd rather know that up front.
 3. From there we'll work out which locations need a walk-through. Not \
 every site always does - it depends on how similar they are.
 
-4. Once we understand the locations and the schedules you need, we'll put \
-together a scope and email you an estimate for review.
+4. Once we understand the locations and the schedules you need, and we've \
+confirmed what we can cover, we'll put together a scope and email you an \
+estimate for review.
 
 5. Estimates are FREE and there is no obligation. If we're not the right \
 fit, we won't try to talk you into it.
@@ -172,35 +176,81 @@ Juan Canfield
 # free-text value, falls back to the cadence-free wording.
 #
 # Every member is consonant-initial, so the fixed article "a" is always
-# correct; `test_every_speakable_frequency_takes_the_article_a` enforces that
+# correct; `test_every_speakable_frequency_is_reviewed_for_the_article_a` enforces that
 # for any future member.
 SPEAKABLE_FREQUENCIES = frozenset(
     {"daily", "weekly", "bi-weekly", "monthly", "one-time"}
 )
 
-# The canonical template-selection surface: every acknowledgement variant maps
-# to exactly one template body. This is the single source of membership for
-# "which templates does this module route to", so the copy guards in
+
+class AckRoute(NamedTuple):
+    """Everything variant-specific about rendering one acknowledgement.
+
+    Body and request-line style travel together deliberately. They were briefly
+    two independent structures -- a template map plus a separate set of
+    "commercial" variants -- and that split had a real failure mode: adding a
+    third commercial variant to the template map but forgetting the set would
+    render the commercial BODY with the residential "Your request: <raw>" echo,
+    bypassing the cadence allowlist while every router and inventory test
+    stayed green. One tuple per variant makes that state unrepresentable.
+    """
+
+    template: str
+    request_line: Callable[[str, str], str]
+
+
+def _raw_echo_request_line(service: str, frequency: str) -> str:
+    """Residential/general: echo the submitted values verbatim, unchanged.
+
+    Frozen copy -- operator decision 2026-08-09, "leave it as is".
+    """
+    service = service if isinstance(service, str) else ""
+    frequency = frequency if isinstance(frequency, str) else ""
+    details = ", ".join(part for part in (service.strip(), frequency.strip()) if part)
+    return f"Your request: {details}.\n\n" if details else ""
+
+
+def _single_site_request_line(service: str, frequency: str) -> str:
+    return _commercial_request_line(frequency, multi_site=False)
+
+
+def _multi_site_request_line(service: str, frequency: str) -> str:
+    return _commercial_request_line(frequency, multi_site=True)
+
+
+# The canonical rendering surface: every acknowledgement variant maps to
+# exactly one (body, request-line style) pair. This is the single source of
+# membership for "what does this module route to", so the copy guards in
 # `tests/test_ack_commercial_templates.py` derive their inventory from it
 # rather than maintaining a parallel hand-written list that could silently fall
 # behind and let a new template bypass the dollar/terminology/turnaround
 # checks. `test_every_module_template_is_routed` fails closed if a
-# `*_TEMPLATE` constant is added here without being routed.
+# `*_TEMPLATE` constant is added without being routed, and
+# `test_every_variant_is_routed_to_a_template` fails if a variant is not.
 #
 # `general` shares the residential body on purpose: it covers the form's
 # "Other" option and anything unrecognised, which are not known to be
 # commercial, so those leads keep the copy they already receive.
-ACK_TEMPLATE_BY_VARIANT = {
-    ACK_VARIANT_RESIDENTIAL: ACK_TEMPLATE,
-    ACK_VARIANT_GENERAL: ACK_TEMPLATE,
-    ACK_VARIANT_COMMERCIAL_SINGLE_SITE: COMMERCIAL_SINGLE_SITE_TEMPLATE,
-    ACK_VARIANT_COMMERCIAL_MULTI_SITE: COMMERCIAL_MULTI_SITE_TEMPLATE,
+ACK_ROUTE_BY_VARIANT: dict[str, AckRoute] = {
+    ACK_VARIANT_RESIDENTIAL: AckRoute(ACK_TEMPLATE, _raw_echo_request_line),
+    ACK_VARIANT_GENERAL: AckRoute(ACK_TEMPLATE, _raw_echo_request_line),
+    ACK_VARIANT_COMMERCIAL_SINGLE_SITE: AckRoute(
+        COMMERCIAL_SINGLE_SITE_TEMPLATE, _single_site_request_line
+    ),
+    ACK_VARIANT_COMMERCIAL_MULTI_SITE: AckRoute(
+        COMMERCIAL_MULTI_SITE_TEMPLATE, _multi_site_request_line
+    ),
 }
 
-# The variants whose copy speaks the cadence in a sentence rather than echoing
-# the raw "Your request: …" line.
+# Derived views, never independently maintained. Kept as names because callers
+# and tests read them, but they cannot drift from the routing table above.
+ACK_TEMPLATE_BY_VARIANT = {
+    variant: route.template for variant, route in ACK_ROUTE_BY_VARIANT.items()
+}
 COMMERCIAL_ACK_VARIANTS = frozenset(
-    {ACK_VARIANT_COMMERCIAL_SINGLE_SITE, ACK_VARIANT_COMMERCIAL_MULTI_SITE}
+    variant
+    for variant, route in ACK_ROUTE_BY_VARIANT.items()
+    if route.request_line is not _raw_echo_request_line
 )
 
 
@@ -244,21 +294,13 @@ def format_request_acknowledgement(
     the lead sees their request was captured accurately; both are optional.
     """
     variant = classify_ack_variant(service)
-    template = ACK_TEMPLATE_BY_VARIANT.get(variant, ACK_TEMPLATE)
-
-    if variant in COMMERCIAL_ACK_VARIANTS:
-        request_line = _commercial_request_line(
-            frequency, multi_site=variant == ACK_VARIANT_COMMERCIAL_MULTI_SITE
-        )
-    else:
-        # residential AND general. `general` covers the form's "Other" option
-        # and anything unrecognised, where the request is not known to be
-        # commercial -- so it keeps exactly the copy those leads receive
-        # today rather than being pointed at unapproved wording.
-        details = ", ".join(
-            part for part in (service.strip(), frequency.strip()) if part
-        )
-        request_line = f"Your request: {details}.\n\n" if details else ""
+    # One lookup decides BOTH the body and how the request is echoed, so a
+    # variant can never get a commercial body with the residential echo.
+    # `general` is the fallback because a variant that is not known to be
+    # commercial must keep the copy those leads receive today.
+    route = ACK_ROUTE_BY_VARIANT.get(variant, ACK_ROUTE_BY_VARIANT[ACK_VARIANT_GENERAL])
+    template = route.template
+    request_line = route.request_line(service, frequency)
 
     body = template.format(
         client_name=client_name.strip() or "there",

--- a/atlas_brain/templates/email/request_acknowledgement.py
+++ b/atlas_brain/templates/email/request_acknowledgement.py
@@ -145,7 +145,7 @@ sites need more attention than others, and we'd rather know that up front.
 every site always does - it depends on how similar they are.
 
 4. Once we understand the locations and the schedules you need, we'll put \
-together a scope for each one and email you an estimate for review.
+together a scope and email you an estimate for review.
 
 5. Estimates are FREE and there is no obligation. If we're not the right \
 fit, we won't try to talk you into it.
@@ -160,20 +160,56 @@ Juan Canfield
 {business_website}
 """
 
-# "custom" is a real website form option, but it is a placeholder for "we'll
-# work it out on the call" rather than a cadence that can be read back in a
-# sentence -- "a custom commercial cleaning" does not parse as English. It is
-# therefore dropped exactly like a blank frequency, and the request line falls
-# back to its cadence-free wording.
-_UNSPOKEN_FREQUENCIES = frozenset({"custom"})
+# Cadence values that may be spoken inside a sentence, as an ALLOWLIST.
+#
+# This deliberately fails closed. `frequency` is free text server-side --
+# `leads.py` declares `Field(default="", max_length=120)` -- so a denylist of
+# known-bad values does not hold: `frequency="every other week"` would render
+# "You requested a every other week commercial cleaning", which is broken
+# English in customer-facing copy. Only these values are interpolated after
+# "a"; everything else, including the website's own `custom` option (a
+# placeholder for "we'll work it out on the call", not a cadence) and any
+# free-text value, falls back to the cadence-free wording.
+#
+# Every member is consonant-initial, so the fixed article "a" is always
+# correct; `test_every_speakable_frequency_takes_the_article_a` enforces that
+# for any future member.
+SPEAKABLE_FREQUENCIES = frozenset(
+    {"daily", "weekly", "bi-weekly", "monthly", "one-time"}
+)
+
+# The canonical template-selection surface: every acknowledgement variant maps
+# to exactly one template body. This is the single source of membership for
+# "which templates does this module route to", so the copy guards in
+# `tests/test_ack_commercial_templates.py` derive their inventory from it
+# rather than maintaining a parallel hand-written list that could silently fall
+# behind and let a new template bypass the dollar/terminology/turnaround
+# checks. `test_every_module_template_is_routed` fails closed if a
+# `*_TEMPLATE` constant is added here without being routed.
+#
+# `general` shares the residential body on purpose: it covers the form's
+# "Other" option and anything unrecognised, which are not known to be
+# commercial, so those leads keep the copy they already receive.
+ACK_TEMPLATE_BY_VARIANT = {
+    ACK_VARIANT_RESIDENTIAL: ACK_TEMPLATE,
+    ACK_VARIANT_GENERAL: ACK_TEMPLATE,
+    ACK_VARIANT_COMMERCIAL_SINGLE_SITE: COMMERCIAL_SINGLE_SITE_TEMPLATE,
+    ACK_VARIANT_COMMERCIAL_MULTI_SITE: COMMERCIAL_MULTI_SITE_TEMPLATE,
+}
+
+# The variants whose copy speaks the cadence in a sentence rather than echoing
+# the raw "Your request: …" line.
+COMMERCIAL_ACK_VARIANTS = frozenset(
+    {ACK_VARIANT_COMMERCIAL_SINGLE_SITE, ACK_VARIANT_COMMERCIAL_MULTI_SITE}
+)
 
 
 def _spoken_frequency(frequency: str) -> str:
     """Return the frequency only when it reads naturally inside a sentence."""
-    cleaned = frequency.strip()
-    if cleaned.lower() in _UNSPOKEN_FREQUENCIES:
+    if not isinstance(frequency, str):
         return ""
-    return cleaned
+    cleaned = frequency.strip()
+    return cleaned.lower() if cleaned.lower() in SPEAKABLE_FREQUENCIES else ""
 
 
 def _commercial_request_line(frequency: str, *, multi_site: bool) -> str:
@@ -208,19 +244,17 @@ def format_request_acknowledgement(
     the lead sees their request was captured accurately; both are optional.
     """
     variant = classify_ack_variant(service)
+    template = ACK_TEMPLATE_BY_VARIANT.get(variant, ACK_TEMPLATE)
 
-    if variant == ACK_VARIANT_COMMERCIAL_SINGLE_SITE:
-        template = COMMERCIAL_SINGLE_SITE_TEMPLATE
-        request_line = _commercial_request_line(frequency, multi_site=False)
-    elif variant == ACK_VARIANT_COMMERCIAL_MULTI_SITE:
-        template = COMMERCIAL_MULTI_SITE_TEMPLATE
-        request_line = _commercial_request_line(frequency, multi_site=True)
+    if variant in COMMERCIAL_ACK_VARIANTS:
+        request_line = _commercial_request_line(
+            frequency, multi_site=variant == ACK_VARIANT_COMMERCIAL_MULTI_SITE
+        )
     else:
         # residential AND general. `general` covers the form's "Other" option
         # and anything unrecognised, where the request is not known to be
         # commercial -- so it keeps exactly the copy those leads receive
         # today rather than being pointed at unapproved wording.
-        template = ACK_TEMPLATE
         details = ", ".join(
             part for part in (service.strip(), frequency.strip()) if part
         )

--- a/plans/PR-EOM-Ack-Commercial-Copy.md
+++ b/plans/PR-EOM-Ack-Commercial-Copy.md
@@ -66,6 +66,7 @@ the other half of that split, not a bundle.
 
 Ownership lane: eom-crm/lead-ack-variant
 Slice phase: Vertical slice
+Max files: 5
 
 1. Add `COMMERCIAL_SINGLE_SITE_TEMPLATE` and `COMMERCIAL_MULTI_SITE_TEMPLATE`,
    both operator-authored.
@@ -352,7 +353,7 @@ All counts re-run at this head.
 |---|---:|
 | `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 5 |
 | `atlas_brain/templates/email/request_acknowledgement.py` | 164 |
-| `plans/PR-EOM-Ack-Commercial-Copy.md` | 358 |
+| `plans/PR-EOM-Ack-Commercial-Copy.md` | 359 |
 | `tests/test_ack_commercial_templates.py` | 441 |
 | `tests/test_ack_variant_classification.py` | 45 |
-| **Total** | **1013** |
+| **Total** | **1014** |

--- a/plans/PR-EOM-Ack-Commercial-Copy.md
+++ b/plans/PR-EOM-Ack-Commercial-Copy.md
@@ -17,6 +17,32 @@ This slice is the copy change A1 built the plumbing for: `commercial` and
 
 Tracking issue: #2320 (part of #2188). Predecessor: #2328.
 
+### Diff-budget overage — why this slice is indivisible
+
+This slice exceeds the 400 LOC soft cap. The runtime change is one module: two
+operator-authored template bodies plus the selection table and the cadence
+helpers. The remainder is the mandatory `plans/PR-*.md` doc that AGENTS.md
+requires for any non-Markdown diff, and the test matrix the Review Contract
+commits to.
+
+Splitting was considered and rejected on each available seam:
+
+- **Templates without selection** ships two constants nothing routes to — dead
+  copy with no reachability proof, which R14/R2 would correctly reject.
+- **Selection without templates** has nothing to select between.
+- **One commercial variant at a time** leaves the other still sending
+  residential copy to real leads, which is the live defect this slice exists to
+  stop. Both variants are reachable from the same form today.
+- **Either without the test matrix** removes the proof that makes a
+  customer-facing copy change reviewable: the copy guardrails (no dollar
+  figures, "estimate" never "quote", the 24-hour promise scoped to first
+  contact), the frozen residential anchor, and the free-text cadence
+  fail-closed behaviour are the minimum evidence, not padding.
+
+The seam that did exist — classification versus copy — is exactly where #2320
+was already split, and A1 (#2328) took the classification side. This slice is
+the other half of that split, not a bundle.
+
 ### Problem-derived contract
 
 - Root cause: `format_request_acknowledgement` selected no template. There was
@@ -67,12 +93,16 @@ Slice phase: Vertical slice
      structurally, not by convention: `format_request_acknowledgement` calls
      `classify_ack_variant(service)` itself rather than accepting a
      caller-supplied variant that could drift from the one intake records.
-  4. Every website frequency option renders well-formed English, including the
-     `custom` option and a blank — settled by
-     `::test_single_site_speaks_every_spoken_frequency`,
+  4. The cadence echo is well-formed for ANY submitted value, not just the
+     form's options. `frequency` is free text server-side, so an allowlist
+     decides what may be spoken and everything else falls back to cadence-free
+     wording — settled by `::test_single_site_speaks_every_spoken_frequency`,
      `::test_multi_site_speaks_every_spoken_frequency`,
-     `::test_unspoken_frequency_falls_back_to_cadence_free_wording` and
-     `::test_commercial_copy_never_double_spaces_or_dangles_the_cadence`.
+     `::test_implementation_allowlist_equals_the_contract`,
+     `::test_every_speakable_frequency_is_reviewed_for_the_article_a`,
+     `::test_unspeakable_frequency_falls_back_to_cadence_free_wording`,
+     `::test_commercial_copy_never_double_spaces_or_dangles_the_cadence` and
+     `::test_non_string_frequency_never_raises`.
   5. Residential and `general` are unchanged — settled by
      `tests/test_ack_variant_classification.py::test_residential_and_general_still_render_the_original_template`
      and the byte-identical anchor
@@ -87,8 +117,15 @@ Slice phase: Vertical slice
      `::test_only_approved_sentences_promise_24_hours` (an exact whitelist; see
      Mechanism for why it is not a keyword rule) and
      `::test_estimate_delivery_is_never_inside_the_24_hour_window`.
-  8. The multi-site email makes none of the promises #2320 forbids — settled by
+  8. The multi-site email makes none of the promises #2320 forbids, including
+     promising a scope for every submitted location before serviceability is
+     established — settled by
      `::test_multi_site_makes_none_of_the_promises_it_must_not_make`.
+  10. The copy guards cannot be bypassed by adding a template or a variant —
+     settled by `::test_the_guard_inventory_is_derived_from_the_router_not_hand_written`,
+     `::test_every_module_template_is_routed`,
+     `::test_every_variant_is_routed_to_a_template` and
+     `::test_the_24_hour_whitelist_covers_every_routed_variant`.
   9. The commercial body is what intake actually sends and stores, not merely
      what the renderer returns — settled by
      `::test_intake_sends_the_commercial_body_for_commercial_services`, which
@@ -146,6 +183,45 @@ Closure declaration for the variant set consumed here:
    production today, which is the safe direction: the failure mode of the
    `else` is "unchanged behaviour", never "a business-specific promise sent to
    someone whose request was not identified as commercial".
+
+Closure declaration for the **cadence** set (`SPEAKABLE_FREQUENCIES`):
+
+1. **Closed or open? — CLOSED**, and this is the fix for a real defect found in
+   review. `frequency` is free text server-side (`leads.py`
+   `Field(default="", max_length=120)`), so the first implementation's denylist
+   (exclude `custom`, speak everything else) admitted arbitrary input:
+   `frequency="every other week"` rendered "You requested a **every other
+   week** commercial cleaning" into a customer-facing email.
+2. **Where does membership come from? — ENUMERATED**, from the website form's
+   own options, and pinned to literals by
+   `tests/test_ack_commercial_templates.py::test_implementation_allowlist_equals_the_contract`.
+   Article correctness is a second, separately reviewed list
+   (`ARTICLE_A_FREQUENCIES`) because English article choice follows sound, not
+   spelling — "a one-time cleaning" is correct — so no heuristic can decide it.
+3. **Out-of-set behaviour — FAIL CLOSED to the cadence-free wording.** Any
+   value outside the allowlist, including the form's own `custom`, blanks and
+   non-strings, renders "You requested a commercial cleaning." Proved over
+   free-text and injection-shaped inputs by
+   `::test_unspeakable_frequency_falls_back_to_cadence_free_wording`.
+
+Closure declaration for the **guard-inventory** sets (`ALL_TEMPLATES`,
+`APPROVED_24_HOUR_SENTENCES`):
+
+1. **Closed or open? — CLOSED**, bounded by the routing table
+   `ACK_TEMPLATE_BY_VARIANT`.
+2. **Where does membership come from? — DERIVED**, not hand-written.
+   `ALL_TEMPLATES` is computed from `ACK_TEMPLATE_BY_VARIANT.values()`, and
+   `APPROVED_24_HOUR_SENTENCES` is keyed by variant with
+   `::test_the_24_hour_whitelist_covers_every_routed_variant` asserting its
+   keys equal the routing table's. A hand-maintained list could fall behind and
+   let a new template bypass the dollar / terminology / turnaround guards while
+   the suite stayed green.
+3. **Out-of-set behaviour — FAIL CLOSED in both directions.**
+   `::test_every_module_template_is_routed` fails if a `*_TEMPLATE` constant
+   exists in the module but is not routed (so it cannot escape the guards), and
+   `::test_every_variant_is_routed_to_a_template` fails if a variant has no
+   template. Verified by injection: adding an unrouted `ORPHAN_TEMPLATE`
+   containing a dollar figure and the word "quote" fails the suite.
 
 ### Deployed-config probing
 
@@ -235,12 +311,12 @@ Parked hardening: none.
 
 All counts re-run at this head.
 
-- `python -m pytest tests/test_ack_commercial_templates.py -q` — **51 passed**
+- `python -m pytest tests/test_ack_commercial_templates.py -q` — **83 passed**
 - `python -m pytest tests/test_ack_commercial_templates.py
-  tests/test_ack_variant_classification.py -q` — **97 passed**
+  tests/test_ack_variant_classification.py -q` — **129 passed**
 - `python -m pytest tests/test_ack_commercial_templates.py
   tests/test_ack_variant_classification.py tests/test_leads_intake.py
-  tests/test_eom_sent_email_tenant_scope.py -q` — **181 passed, 1 skipped**
+  tests/test_eom_sent_email_tenant_scope.py -q` — **213 passed, 1 skipped**
   (the skip is the PostgreSQL test, run separately below).
 - **The PostgreSQL route test was RUN, not skipped** — a skipped test is not
   evidence. Pointing `ATLAS_MIGRATION_TEST_DATABASE_URL` at the local instance:
@@ -275,8 +351,8 @@ All counts re-run at this head.
 | File | LOC |
 |---|---:|
 | `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 5 |
-| `atlas_brain/templates/email/request_acknowledgement.py` | 130 |
-| `plans/PR-EOM-Ack-Commercial-Copy.md` | 271 |
-| `tests/test_ack_commercial_templates.py` | 306 |
+| `atlas_brain/templates/email/request_acknowledgement.py` | 164 |
+| `plans/PR-EOM-Ack-Commercial-Copy.md` | 358 |
+| `tests/test_ack_commercial_templates.py` | 441 |
 | `tests/test_ack_variant_classification.py` | 45 |
-| **Total** | **757** |
+| **Total** | **1013** |

--- a/plans/PR-EOM-Ack-Commercial-Copy.md
+++ b/plans/PR-EOM-Ack-Commercial-Copy.md
@@ -1,0 +1,282 @@
+# PR-EOM-Ack-Commercial-Copy
+
+## Why this slice exists
+
+A1 (#2328, merged `8d67520f4`) classified every submission into an
+acknowledgement variant and recorded it on both evidence records, but
+deliberately changed **no** email — every variant still rendered the one
+residential template. So the defect that motivated #2320 is still live in
+production today: a `commercial` lead receives copy promising that Mayra and
+Tina will do a walkthrough in "less than 20 minutes", give a price before they
+leave, and that the lead can "schedule your first cleaning right then". Roughly
+true for a house; wrong for a facility, and wrong in a way the recipient can
+see. It is the first thing EOM says to a commercial prospect.
+
+This slice is the copy change A1 built the plumbing for: `commercial` and
+`multi-location-commercial` render their own templates.
+
+Tracking issue: #2320 (part of #2188). Predecessor: #2328.
+
+### Problem-derived contract
+
+- Root cause: `format_request_acknowledgement` selected no template. There was
+  one `ACK_TEMPLATE`, and the only per-submission variation was an echoed
+  "Your request: …" line. A1 added the variant but did not consume it.
+- Correct fix must touch/change: template selection inside
+  `format_request_acknowledgement`, driven by the variant A1 already derives;
+  two new template bodies carrying the commercial workflow (facility
+  walk-through scheduled by Juan, written estimate after the walk-through, and
+  for multi-site a discovery call before any numbers).
+- Must not change: the residential email, which is frozen by operator decision
+  (2026-08-09, "leave it as is") and must stay byte-identical; the `general`
+  fallback, which covers the form's "Other" option and anything unrecognised
+  and is therefore not known to be commercial; `ACK_SUBJECT`; `template_type`;
+  the recorded `ack_variant`; interaction dedupe; the per-identity daily cap
+  (`MAX_DAILY_SUBMISSIONS`); the global hourly cap (`GLOBAL_ACK_HOURLY_CAP`);
+  honeypot handling; Resend routing and sender identity; and failure isolation
+  — a template or send failure must never fail the already-committed capture.
+
+## Scope (this PR)
+
+Ownership lane: eom-crm/lead-ack-variant
+Slice phase: Vertical slice
+
+1. Add `COMMERCIAL_SINGLE_SITE_TEMPLATE` and `COMMERCIAL_MULTI_SITE_TEMPLATE`,
+   both operator-authored.
+2. Select the template inside `format_request_acknowledgement` from the variant
+   it derives itself via `classify_ack_variant`, so the email sent and the
+   `ack_variant` recorded cannot disagree.
+3. Speak the submitted cadence in the commercial voice, dropping cadence values
+   that cannot be spoken in a sentence.
+4. Leave residential and `general` byte-identical.
+5. Close the A1 CI-enrollment gap for this surface (see Intentional).
+
+### Review Contract
+
+- Acceptance criteria:
+  1. `commercial` renders the single-site template and
+     `multi-location-commercial` renders the multi-site template — settled by
+     `tests/test_ack_commercial_templates.py::test_single_site_commercial_renders_the_single_site_template`
+     and `::test_multi_site_commercial_renders_the_multi_site_template`.
+  2. Neither commercial email carries the residential promises that were wrong
+     for a business (`Mayra Canfield and Tina Gomez`, `less than 20 minutes`,
+     `schedule your first cleaning right then`) — settled by
+     `tests/test_ack_variant_classification.py::test_commercial_services_render_their_own_template`.
+  3. The rendered variant always equals the recorded variant — settled by
+     `::test_rendering_agrees_with_the_recorded_variant`. Guaranteed
+     structurally, not by convention: `format_request_acknowledgement` calls
+     `classify_ack_variant(service)` itself rather than accepting a
+     caller-supplied variant that could drift from the one intake records.
+  4. Every website frequency option renders well-formed English, including the
+     `custom` option and a blank — settled by
+     `::test_single_site_speaks_every_spoken_frequency`,
+     `::test_multi_site_speaks_every_spoken_frequency`,
+     `::test_unspoken_frequency_falls_back_to_cadence_free_wording` and
+     `::test_commercial_copy_never_double_spaces_or_dangles_the_cadence`.
+  5. Residential and `general` are unchanged — settled by
+     `tests/test_ack_variant_classification.py::test_residential_and_general_still_render_the_original_template`
+     and the byte-identical anchor
+     `::test_residential_render_is_byte_identical_to_pre_change_production`,
+     plus the golden diff in Verification.
+  6. Operator copy guardrails hold in all three templates: no dollar figures,
+     "estimate" never "quote" — settled by
+     `::test_no_template_contains_a_dollar_figure` and
+     `::test_no_template_says_quote`.
+  7. "Within 24 hours" promises initial contact only, never walkthrough
+     completion or estimate delivery — settled by
+     `::test_only_approved_sentences_promise_24_hours` (an exact whitelist; see
+     Mechanism for why it is not a keyword rule) and
+     `::test_estimate_delivery_is_never_inside_the_24_hour_window`.
+  8. The multi-site email makes none of the promises #2320 forbids — settled by
+     `::test_multi_site_makes_none_of_the_promises_it_must_not_make`.
+  9. The commercial body is what intake actually sends and stores, not merely
+     what the renderer returns — settled by
+     `::test_intake_sends_the_commercial_body_for_commercial_services`, which
+     asserts the `body` kwarg handed to the email provider and that the stored
+     copy equals the sent copy.
+- Reachability proof: the entrypoint is
+  `atlas_brain/api/leads.py::_process_lead_intake`, the coroutine
+  `POST /api/v1/leads/intake` awaits. The observable state is the `body` kwarg
+  captured on the email provider `send` call and on the email-history `create`
+  call, asserted per variant.
+- Affected surfaces: the acknowledgement email body for `commercial` and
+  `multi-location-commercial` submissions (customer-visible); the
+  `atlas_brain.templates.email.request_acknowledgement` module exports; the
+  EOM lead-pipeline workflow trigger set.
+- Risk areas: drifting residential copy while editing the module around it;
+  a cadence value that renders broken English; the rendered variant diverging
+  from the recorded one; copy guardrail regressions (dollar figures, "quote",
+  over-promised turnaround).
+- Reviewer rules triggered: R1, R2, R5, R14. R1/R2/R5 from the path trigger
+  `atlas_brain/api/**`. R14 declared deliberately: the template selection is a
+  router-classifier consuming a closed variant set.
+
+### Boundary-change enumeration
+
+The seam is template selection inside `format_request_acknowledgement`: one
+unconditional `ACK_TEMPLATE` becomes a three-way branch on the derived variant.
+
+- Replaced-path behaviour: previously every variant rendered `ACK_TEMPLATE`.
+  Now `commercial` → `COMMERCIAL_SINGLE_SITE_TEMPLATE`,
+  `multi-location-commercial` → `COMMERCIAL_MULTI_SITE_TEMPLATE`, and
+  everything else (`residential`, `deep`, `move`, `other`, unrecognised, empty,
+  non-string) → `ACK_TEMPLATE`, unchanged.
+- Guard-relevant fields: `service` (selects the template, via
+  `classify_ack_variant`) and `frequency` (selects the spoken cadence).
+- Caller × input shape: one caller,
+  `leads.py::_process_lead_intake`, passing `payload.service` and
+  `payload.frequency`. Both are free-text server-side (`max_length` 120), so
+  the branch is total over arbitrary strings and over the non-string class,
+  inherited from A1's `classify_ack_variant`.
+
+Closure declaration for the variant set consumed here:
+
+1. **Is the set closed or open? — CLOSED.** The four `ACK_VARIANT_*` values are
+   the complete output range of `classify_ack_variant`, which A1 proved total:
+   every input, including non-strings, returns one of exactly four values.
+2. **Where does membership come from? — ENUMERATED**, in
+   `atlas_brain/templates/email/request_acknowledgement.py`, and pinned to
+   literals by
+   `tests/test_ack_variant_classification.py::test_exported_variant_constants_equal_the_contracted_literals`
+   and `::test_implementation_mapping_equals_the_contract_oracle`.
+3. **Out-of-set behaviour and its safety rationale — fall through to
+   `ACK_TEMPLATE`.** The branch uses `if / elif / else` with `else` covering
+   everything non-commercial, so a fifth variant added later cannot reach a
+   commercial template by accident. It renders the copy those leads receive in
+   production today, which is the safe direction: the failure mode of the
+   `else` is "unchanged behaviour", never "a business-specific promise sent to
+   someone whose request was not identified as commercial".
+
+### Deployed-config probing
+
+N/A - this slice reads no environment variable, feature flag or deployed
+config. Template selection is a pure function of the submitted `service` and
+`frequency`. The one pre-existing gate on this path, `settings.email.enabled`,
+is untouched and still decides only whether any acknowledgement is sent.
+
+### Files touched
+
+- `.github/workflows/atlas_eom_lead_pipeline_checks.yml`
+- `atlas_brain/templates/email/request_acknowledgement.py`
+- `plans/PR-EOM-Ack-Commercial-Copy.md`
+- `tests/test_ack_commercial_templates.py`
+- `tests/test_ack_variant_classification.py`
+
+## Mechanism
+
+`format_request_acknowledgement` derives the variant itself —
+`classify_ack_variant(service)` — rather than taking one from its caller. Intake
+computes `ack_variant` separately for the evidence records, so accepting a
+caller-supplied variant would create two independent derivations that could
+drift; deriving it here means the email sent and the variant recorded are the
+same computation on the same input.
+
+The cadence is echoed differently per variant. Residential keeps its raw
+`"Your request: <service>, <frequency>."` line untouched. The commercial
+variants speak it in a sentence — "You requested a weekly commercial cleaning."
+— which requires a value that reads naturally after "a". `custom` is a real
+website option but a placeholder for "we'll work it out on the call", and "a
+custom commercial cleaning" does not parse, so it is dropped exactly like a
+blank frequency via `_UNSPOKEN_FREQUENCIES`.
+
+The "within 24 hours" guard is an **exact whitelist of approved sentences**,
+not a keyword rule, and that is deliberate. The obvious keyword rule — no line
+containing "24 hours" may also contain "estimate" — cannot distinguish
+"requesting a free estimate … within 24 hours" (correct: it names what was
+requested) from "we'll send the estimate within 24 hours" (a promise EOM cannot
+keep). A guard that flags correct copy gets relaxed until it means nothing. The
+whitelist instead fails on **any** edit to a 24-hour sentence and asks a human
+to re-approve it, which is the review this actually needs.
+
+## Intentional
+
+- **The residential email is frozen.** Operator decision 2026-08-09: friendly
+  echo-line labels are *not* extended to residential — "leave it as is". The
+  byte-identical anchor from A1 therefore stops being a migration aid and
+  becomes a permanent contract: any future diff to that copy is a regression.
+- **`general` keeps the current copy.** `other` and unrecognised values are not
+  known to be commercial, so pointing them at commercial copy would be a
+  downgrade. A dedicated neutral "Other" email is copy work, not plumbing — the
+  classifier already separates them.
+- **`template_type` stays `"request_acknowledgement"` for every variant.** A1
+  deferred "per-variant `template_type`"; this slice closes that as **won't
+  do**. `ack_variant` already rides in `sent_emails.metadata` and is proven
+  against real PostgreSQL, so a per-variant `template_type` would duplicate it
+  while splitting the column into pre-change and post-change values and
+  creating a backfill obligation for zero new information.
+- **`ACK_SUBJECT` is shared across all variants** (operator-approved). One less
+  moving part, and the subject is not what carries the workflow difference.
+- **CI enrollment fixed for this surface.** `tests/test_ack_commercial_templates.py`
+  is added to the gating `Run EOM lead pipeline checks` invocation and to both
+  path-filter blocks. Separately,
+  `atlas_brain/templates/email/request_acknowledgement.py` was **not** a path
+  trigger at all — though both sibling template modules were — so a change to
+  the acknowledgement copy alone did not fire the workflow. It is added now.
+  This is the same class of gap Codex found on #2328, fixed proactively.
+
+## Deferred
+
+Parking predicate: deferred items are non-blocking because none of them changes
+what a lead receives in this slice; each is either unreachable today or a
+separate copy decision that needs operator input.
+
+- A dedicated `general` / "Other" template. Needs operator-authored copy. Today
+  those leads keep exactly the email they already get, so there is no
+  regression to hold this slice for.
+- UTC-vs-Central dedupe bucketing (inherited from A1). The dedupe key buckets on
+  the UTC date, so 6:55pm and 7:05pm Central fall in different buckets.
+  Unchanged here; changing dedupe time semantics deserves its own tests.
+- A corrected service *inside the same variant* may still send a second email.
+  Documented in #2320, unchanged.
+
+Parked hardening: none.
+
+## Verification
+
+All counts re-run at this head.
+
+- `python -m pytest tests/test_ack_commercial_templates.py -q` — **51 passed**
+- `python -m pytest tests/test_ack_commercial_templates.py
+  tests/test_ack_variant_classification.py -q` — **97 passed**
+- `python -m pytest tests/test_ack_commercial_templates.py
+  tests/test_ack_variant_classification.py tests/test_leads_intake.py
+  tests/test_eom_sent_email_tenant_scope.py -q` — **181 passed, 1 skipped**
+  (the skip is the PostgreSQL test, run separately below).
+- **The PostgreSQL route test was RUN, not skipped** — a skipped test is not
+  evidence. Pointing `ATLAS_MIGRATION_TEST_DATABASE_URL` at the local instance:
+  **1 passed**. It builds a throwaway `atlas_eom_sent_email_<uuid>` schema and
+  drops it in a `finally`; before/after snapshots taken around this run are
+  identical — schema count **129 → 129**, `contacts`/`contact_interactions`/
+  `sent_emails` **712/2821/12 → 712/2821/12**.
+- Golden render diff against A1's captured baseline, over all eight
+  (name, service, frequency) combinations: the six residential/general rows are
+  **byte-identical** (per-row sha256 equal on both sides); only the two
+  commercial rows differ, which is this slice's entire intended effect.
+- **Negative probes — each guard was made to fail, then restored** (baseline and
+  restored state both **97 passed**). A guard only shown to pass on good input
+  is not evidence it bites:
+  | Injected defect | Result |
+  |---|---|
+  | multi-site copy says "every location" | 1 failed |
+  | dollar figure added to commercial copy | 2 failed |
+  | "quote" used instead of "estimate" | 1 failed |
+  | 24-hour promise attached to estimate delivery | 1 failed |
+  | commercial copy names Mayra instead of Juan | 2 failed |
+  | commercial silently falls back to `ACK_TEMPLATE` | 6 failed |
+  | residential copy edited (the frozen path) | 2 failed |
+- `ruff check` on the changed module and both changed test files — clean.
+- `python -m py_compile` on the changed runtime module — OK.
+- `git diff --check` — clean.
+- `.github/workflows/atlas_eom_lead_pipeline_checks.yml` re-parsed with
+  `yaml.safe_load` after both edits — valid.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 5 |
+| `atlas_brain/templates/email/request_acknowledgement.py` | 130 |
+| `plans/PR-EOM-Ack-Commercial-Copy.md` | 271 |
+| `tests/test_ack_commercial_templates.py` | 306 |
+| `tests/test_ack_variant_classification.py` | 45 |
+| **Total** | **757** |

--- a/plans/PR-EOM-Ack-Commercial-Copy.md
+++ b/plans/PR-EOM-Ack-Commercial-Copy.md
@@ -124,16 +124,16 @@ Max files: 5
      area is not told an estimate is coming — settled by
      `::test_multi_site_makes_none_of_the_promises_it_must_not_make`, which
      asserts both the absent promises and the present condition.
-  10. The copy guards cannot be bypassed by adding a template or a variant —
-     settled by `::test_the_guard_inventory_is_derived_from_the_router_not_hand_written`,
-     `::test_every_module_template_is_routed`,
-     `::test_every_variant_is_routed_to_a_template` and
-     `::test_the_24_hour_whitelist_covers_every_routed_variant`.
   9. The commercial body is what intake actually sends and stores, not merely
      what the renderer returns — settled by
      `::test_intake_sends_the_commercial_body_for_commercial_services`, which
      asserts the `body` kwarg handed to the email provider and that the stored
      copy equals the sent copy.
+  10. The copy guards cannot be bypassed by adding a template or a variant —
+     settled by `::test_the_guard_inventory_is_derived_from_the_router_not_hand_written`,
+     `::test_every_module_template_is_routed`,
+     `::test_every_variant_is_routed_to_a_template` and
+     `::test_the_24_hour_whitelist_covers_every_routed_variant`.
 - Reachability proof: the entrypoint is
   `atlas_brain/api/leads.py::_process_lead_intake`, the coroutine
   `POST /api/v1/leads/intake` awaits. The observable state is the `body` kwarg
@@ -271,13 +271,28 @@ caller-supplied variant would create two independent derivations that could
 drift; deriving it here means the email sent and the variant recorded are the
 same computation on the same input.
 
-The cadence is echoed differently per variant. Residential keeps its raw
-`"Your request: <service>, <frequency>."` line untouched. The commercial
-variants speak it in a sentence — "You requested a weekly commercial cleaning."
-— which requires a value that reads naturally after "a". `custom` is a real
-website option but a placeholder for "we'll work it out on the call", and "a
-custom commercial cleaning" does not parse, so it is dropped exactly like a
-blank frequency via `_UNSPOKEN_FREQUENCIES`.
+Template body and cadence style are selected by a **single lookup** in
+`ACK_ROUTE_BY_VARIANT`, which maps each variant to one
+`AckRoute(template, request_line)`. Residential and `general` route to the raw
+`"Your request: <service>, <frequency>."` echo, unchanged; the two commercial
+variants route to their own body and to the spoken-cadence builder.
+`ACK_TEMPLATE_BY_VARIANT` and `COMMERCIAL_ACK_VARIANTS` are derived views of
+that table rather than independently maintained structures — an earlier
+revision kept them separate, and that split allowed a commercial body to be
+paired with the residential echo (see the rendering-route closure declaration).
+
+The cadence itself is filtered by an **allowlist**, `SPEAKABLE_FREQUENCIES` =
+`{daily, weekly, bi-weekly, monthly, one-time}`, and fails closed. An earlier
+revision used a denylist that excluded only `custom` and spoke everything else;
+because `frequency` is free text server-side (`leads.py`
+`Field(default="", max_length=120)`), that admitted arbitrary input and rendered
+"You requested **a every other week** commercial cleaning" into a customer-facing
+email. Any value outside the allowlist — the website's own `custom` option,
+blanks, free text, non-strings — now falls back to the cadence-free wording
+("You requested a commercial cleaning."). Article correctness is a second,
+separately reviewed list (`ARTICLE_A_FREQUENCIES`) because English article
+choice follows sound rather than spelling: "a one-time cleaning" is correct
+despite the leading vowel letter, so no spelling heuristic can decide it.
 
 The "within 24 hours" guard is an **exact whitelist of approved sentences**,
 not a keyword rule, and that is deliberate. The obvious keyword rule — no line
@@ -376,7 +391,7 @@ All counts re-run at this head.
 |---|---:|
 | `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 5 |
 | `atlas_brain/templates/email/request_acknowledgement.py` | 206 |
-| `plans/PR-EOM-Ack-Commercial-Copy.md` | 382 |
+| `plans/PR-EOM-Ack-Commercial-Copy.md` | 397 |
 | `tests/test_ack_commercial_templates.py` | 494 |
 | `tests/test_ack_variant_classification.py` | 45 |
-| **Total** | **1132** |
+| **Total** | **1147** |

--- a/plans/PR-EOM-Ack-Commercial-Copy.md
+++ b/plans/PR-EOM-Ack-Commercial-Copy.md
@@ -118,10 +118,12 @@ Max files: 5
      `::test_only_approved_sentences_promise_24_hours` (an exact whitelist; see
      Mechanism for why it is not a keyword rule) and
      `::test_estimate_delivery_is_never_inside_the_24_hour_window`.
-  8. The multi-site email makes none of the promises #2320 forbids, including
-     promising a scope for every submitted location before serviceability is
-     established — settled by
-     `::test_multi_site_makes_none_of_the_promises_it_must_not_make`.
+  8. The multi-site email makes none of the promises #2320 forbids. The scope
+     and estimate are CONDITIONAL on confirming coverage ("and we've confirmed
+     what we can cover"), so a prospect whose sites are all outside the service
+     area is not told an estimate is coming — settled by
+     `::test_multi_site_makes_none_of_the_promises_it_must_not_make`, which
+     asserts both the absent promises and the present condition.
   10. The copy guards cannot be bypassed by adding a template or a variant —
      settled by `::test_the_guard_inventory_is_derived_from_the_router_not_hand_written`,
      `::test_every_module_template_is_routed`,
@@ -204,6 +206,27 @@ Closure declaration for the **cadence** set (`SPEAKABLE_FREQUENCIES`):
    non-strings, renders "You requested a commercial cleaning." Proved over
    free-text and injection-shaped inputs by
    `::test_unspeakable_frequency_falls_back_to_cadence_free_wording`.
+
+Closure declaration for the **rendering-route** table (`ACK_ROUTE_BY_VARIANT`):
+
+1. **Closed or open? — CLOSED**, one `AckRoute(template, request_line)` per
+   acknowledgement variant.
+2. **Where does membership come from? — ENUMERATED** here, and it is the ONLY
+   variant-keyed decision surface. `ACK_TEMPLATE_BY_VARIANT` and
+   `COMMERCIAL_ACK_VARIANTS` are now DERIVED views of it rather than
+   independently maintained structures. They briefly were independent, and that
+   split had a real failure mode found in review: a variant added to the
+   template map but omitted from the commercial set would render the commercial
+   BODY with the residential raw `Your request: <service>, <frequency>` echo,
+   bypassing the cadence allowlist while every router and inventory test stayed
+   green. Pairing body and request-line style in one tuple makes that state
+   unrepresentable.
+3. **Out-of-set behaviour — fall back to the `general` route**, which is the
+   residential body and the raw echo, i.e. exactly today's behaviour. Enforced
+   by `::test_cadence_style_is_bound_to_the_router_not_an_independent_set` and
+   `::test_every_routed_variant_renders_its_own_cadence_style`; verified by
+   injection (pointing the multi-site route at the residential echo fails 45
+   nodes).
 
 Closure declaration for the **guard-inventory** sets (`ALL_TEMPLATES`,
 `APPROVED_24_HOUR_SENTENCES`):
@@ -312,12 +335,12 @@ Parked hardening: none.
 
 All counts re-run at this head.
 
-- `python -m pytest tests/test_ack_commercial_templates.py -q` — **83 passed**
+- `python -m pytest tests/test_ack_commercial_templates.py -q` — **85 passed**
 - `python -m pytest tests/test_ack_commercial_templates.py
-  tests/test_ack_variant_classification.py -q` — **129 passed**
+  tests/test_ack_variant_classification.py -q` — **131 passed**
 - `python -m pytest tests/test_ack_commercial_templates.py
   tests/test_ack_variant_classification.py tests/test_leads_intake.py
-  tests/test_eom_sent_email_tenant_scope.py -q` — **213 passed, 1 skipped**
+  tests/test_eom_sent_email_tenant_scope.py -q` — **215 passed, 1 skipped**
   (the skip is the PostgreSQL test, run separately below).
 - **The PostgreSQL route test was RUN, not skipped** — a skipped test is not
   evidence. Pointing `ATLAS_MIGRATION_TEST_DATABASE_URL` at the local instance:
@@ -352,8 +375,8 @@ All counts re-run at this head.
 | File | LOC |
 |---|---:|
 | `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 5 |
-| `atlas_brain/templates/email/request_acknowledgement.py` | 164 |
-| `plans/PR-EOM-Ack-Commercial-Copy.md` | 359 |
-| `tests/test_ack_commercial_templates.py` | 441 |
+| `atlas_brain/templates/email/request_acknowledgement.py` | 206 |
+| `plans/PR-EOM-Ack-Commercial-Copy.md` | 382 |
+| `tests/test_ack_commercial_templates.py` | 494 |
 | `tests/test_ack_variant_classification.py` | 45 |
-| **Total** | **1014** |
+| **Total** | **1132** |

--- a/tests/test_ack_commercial_templates.py
+++ b/tests/test_ack_commercial_templates.py
@@ -291,6 +291,11 @@ def test_multi_site_makes_none_of_the_promises_it_must_not_make():
     # site before coverage has been established (Codex #2340 R1).
     assert "for each one" not in body.lower()
     assert "for each of" not in body.lower()
+    # The scope/estimate outcome must be CONDITIONAL on confirming coverage,
+    # not merely silent about it: a prospect whose sites are all outside the
+    # service area must not be told an estimate is coming (Codex #2340 R1,
+    # round 2). Operator-approved wording, 2026-08-09.
+    assert "confirmed what we can cover" in body
 
 
 # Every sentence in which any variant may promise "24 hours", approved
@@ -439,3 +444,51 @@ async def test_intake_still_sends_the_original_copy_for_residential():
     sent_body = provider.send.await_args.kwargs["body"]
     assert "Mayra Canfield and Tina Gomez" in sent_body
     assert "Juan Canfield" not in sent_body
+
+
+# --- routing-surface closure (Codex #2340 R13) ----------------------------
+
+
+def test_cadence_style_is_bound_to_the_router_not_an_independent_set():
+    """A variant cannot get a commercial body with the residential echo.
+
+    The template and the request-line style live in ONE `AckRoute` tuple per
+    variant, so the state Codex described -- routed to a commercial template
+    but omitted from a separate "commercial variants" set, echoing raw
+    service/frequency text and bypassing the cadence allowlist -- is not
+    representable. `COMMERCIAL_ACK_VARIANTS` is derived, not maintained.
+    """
+    from atlas_brain.templates.email.request_acknowledgement import (
+        ACK_ROUTE_BY_VARIANT,
+        COMMERCIAL_ACK_VARIANTS,
+    )
+
+    assert set(ACK_TEMPLATE_BY_VARIANT) == set(ACK_ROUTE_BY_VARIANT)
+    for variant, route in ACK_ROUTE_BY_VARIANT.items():
+        commercial_body = route.template in {
+            COMMERCIAL_SINGLE_SITE_TEMPLATE,
+            COMMERCIAL_MULTI_SITE_TEMPLATE,
+        }
+        assert commercial_body == (variant in COMMERCIAL_ACK_VARIANTS), variant
+
+
+def test_every_routed_variant_renders_its_own_cadence_style():
+    """Rendered proof, not just structural: no commercial body carries the
+    residential raw echo, and no residential body carries the spoken cadence."""
+    from atlas_brain.templates.email.request_acknowledgement import (
+        ACK_ROUTE_BY_VARIANT,
+    )
+
+    for variant in ACK_ROUTE_BY_VARIANT:
+        _, body = format_request_acknowledgement(
+            "Acme", SERVICE_FOR_VARIANT[variant], "weekly"
+        )
+        if variant in (
+            ACK_VARIANT_COMMERCIAL_SINGLE_SITE,
+            ACK_VARIANT_COMMERCIAL_MULTI_SITE,
+        ):
+            assert "You requested" in body, variant
+            assert "Your request:" not in body, variant
+        else:
+            assert "Your request:" in body, variant
+            assert "You requested" not in body, variant

--- a/tests/test_ack_commercial_templates.py
+++ b/tests/test_ack_commercial_templates.py
@@ -1,0 +1,306 @@
+"""Commercial acknowledgement copy (ATLAS #2320, slices A2 + A3).
+
+A1 classified and recorded without changing any email. This slice is the copy
+change: `commercial` and `multi-location-commercial` now render their own
+templates. The residential email stays frozen — operator decision 2026-08-09,
+"leave it as is" — so the byte-identical anchor from A1 has to keep holding.
+"""
+
+import re
+
+import pytest
+
+from atlas_brain.api.leads import _process_lead_intake
+from atlas_brain.templates.email import (
+    ACK_VARIANT_COMMERCIAL_MULTI_SITE,
+    ACK_VARIANT_COMMERCIAL_SINGLE_SITE,
+    classify_ack_variant,
+    format_request_acknowledgement,
+)
+from atlas_brain.templates.email.request_acknowledgement import (
+    ACK_TEMPLATE,
+    COMMERCIAL_MULTI_SITE_TEMPLATE,
+    COMMERCIAL_SINGLE_SITE_TEMPLATE,
+)
+
+from .test_leads_intake import _crm, _email_history, _email_provider, _payload
+
+
+@pytest.fixture(autouse=True)
+def _email_enabled(monkeypatch):
+    """`test_leads_intake`'s autouse fixture does not cross module boundaries."""
+    from atlas_brain.config import settings
+
+    monkeypatch.setattr(settings.email, "enabled", True)
+
+
+# The website form's own frequency options, transcribed from the markup
+# (Effingham_Office_Maids_Website: contact.html, commercial-estimate.html)
+# rather than read from the implementation. `frequency` is a free-text field
+# server-side (`leads.py` `Field(default="", max_length=120)`), so these are
+# what real submissions carry, not what the API constrains.
+FORM_FREQUENCIES = ("daily", "weekly", "bi-weekly", "monthly", "one-time", "custom")
+
+# "custom" is a placeholder for "we'll work it out on the call", not a cadence
+# that can be spoken in a sentence.
+UNSPOKEN_FREQUENCIES = ("custom",)
+SPOKEN_FREQUENCIES = tuple(f for f in FORM_FREQUENCIES if f not in UNSPOKEN_FREQUENCIES)
+
+
+# --- template selection ---------------------------------------------------
+
+
+def test_single_site_commercial_renders_the_single_site_template():
+    _, body = format_request_acknowledgement("Gretchen", "commercial", "one-time")
+    assert "set up a time and day for a walk-through" in body
+    assert "for multiple locations" not in body
+
+
+def test_multi_site_commercial_renders_the_multi_site_template():
+    _, body = format_request_acknowledgement(
+        "Acme", "multi-location-commercial", "weekly"
+    )
+    assert "Multi-location work takes a little more planning" in body
+    assert "set up a time and day for a walk-through" not in body
+
+
+def test_the_two_commercial_templates_are_not_the_same_copy():
+    _, single = format_request_acknowledgement("Acme", "commercial", "weekly")
+    _, multi = format_request_acknowledgement(
+        "Acme", "multi-location-commercial", "weekly"
+    )
+    assert single != multi
+
+
+@pytest.mark.parametrize(
+    ("service", "expected_variant"),
+    [
+        ("commercial", ACK_VARIANT_COMMERCIAL_SINGLE_SITE),
+        ("Commercial", ACK_VARIANT_COMMERCIAL_SINGLE_SITE),
+        ("  MULTI-LOCATION-COMMERCIAL  ", ACK_VARIANT_COMMERCIAL_MULTI_SITE),
+    ],
+)
+def test_rendering_agrees_with_the_recorded_variant(service, expected_variant):
+    """The email sent and the `ack_variant` recorded cannot disagree.
+
+    `format_request_acknowledgement` derives the variant from `service` with
+    the same `classify_ack_variant` intake uses, rather than accepting a
+    caller-supplied variant that could drift from the recorded one.
+    """
+    assert classify_ack_variant(service) == expected_variant
+    _, body = format_request_acknowledgement("Acme", service, "weekly")
+    expected_marker = {
+        ACK_VARIANT_COMMERCIAL_SINGLE_SITE: "set up a time and day for a walk-through",
+        ACK_VARIANT_COMMERCIAL_MULTI_SITE: "Multi-location work takes a little more",
+    }[expected_variant]
+    assert expected_marker in body
+
+
+# --- the echoed cadence ---------------------------------------------------
+
+
+@pytest.mark.parametrize("frequency", SPOKEN_FREQUENCIES)
+def test_single_site_speaks_every_spoken_frequency(frequency):
+    _, body = format_request_acknowledgement("Gretchen", "commercial", frequency)
+    assert f"You requested a {frequency} commercial cleaning." in body
+
+
+@pytest.mark.parametrize("frequency", SPOKEN_FREQUENCIES)
+def test_multi_site_speaks_every_spoken_frequency(frequency):
+    _, body = format_request_acknowledgement(
+        "Acme", "multi-location-commercial", frequency
+    )
+    assert f"You requested {frequency} cleaning for multiple locations." in body
+
+
+@pytest.mark.parametrize("frequency", ["", "   ", "custom", "CUSTOM", "  Custom  "])
+def test_unspoken_frequency_falls_back_to_cadence_free_wording(frequency):
+    """A blank or `custom` cadence must not produce broken English.
+
+    "You requested a custom commercial cleaning" does not parse, so `custom`
+    is dropped exactly like a blank value.
+    """
+    _, single = format_request_acknowledgement("Gretchen", "commercial", frequency)
+    assert "You requested a commercial cleaning." in single
+
+    _, multi = format_request_acknowledgement(
+        "Acme", "multi-location-commercial", frequency
+    )
+    assert "You requested cleaning for multiple locations." in multi
+
+
+@pytest.mark.parametrize("frequency", FORM_FREQUENCIES + ("", "   "))
+def test_commercial_copy_never_double_spaces_or_dangles_the_cadence(frequency):
+    """Whatever the cadence, the sentence stays well-formed."""
+    for service in ("commercial", "multi-location-commercial"):
+        _, body = format_request_acknowledgement("Acme", service, frequency)
+        line = next(
+            line for line in body.splitlines() if line.startswith("You requested")
+        )
+        assert "  " not in line, line
+        assert line.endswith("."), line
+        assert " ." not in line, line
+
+
+# --- copy guardrails, as executable checks --------------------------------
+
+ALL_TEMPLATES = (
+    ACK_TEMPLATE,
+    COMMERCIAL_SINGLE_SITE_TEMPLATE,
+    COMMERCIAL_MULTI_SITE_TEMPLATE,
+)
+
+
+@pytest.mark.parametrize("template", ALL_TEMPLATES)
+def test_no_template_contains_a_dollar_figure(template):
+    """Operator copy guardrail: no dollar figures in public copy, ever."""
+    assert re.search(r"\$\s*\d", template) is None
+
+
+@pytest.mark.parametrize("template", ALL_TEMPLATES)
+def test_no_template_says_quote(template):
+    """Operator copy guardrail: it is an "estimate", never a "quote"."""
+    assert re.search(r"\bquotes?\b", template, re.IGNORECASE) is None
+
+
+@pytest.mark.parametrize(
+    "template", (COMMERCIAL_SINGLE_SITE_TEMPLATE, COMMERCIAL_MULTI_SITE_TEMPLATE)
+)
+def test_commercial_templates_name_juan_not_the_residential_estimate_team(template):
+    assert "Juan Canfield" in template
+    assert "Mayra" not in template
+    assert "Tina" not in template
+
+
+def test_multi_site_makes_none_of_the_promises_it_must_not_make():
+    """The multi-site email must not carry single-building promises.
+
+    Spec (issue #2320): no immediate price at the first visit, no claim that
+    the estimate team personally inspects every location, no implication of one
+    identical checklist for every building.
+    """
+    body = COMMERCIAL_MULTI_SITE_TEMPLATE
+    assert "right then" not in body
+    assert "before they leave" not in body.lower()
+    assert "every location" not in body.lower()
+    assert "each location" not in body.lower()
+
+
+# Every sentence in which any variant may promise "24 hours", approved
+# verbatim. "Within 24 hours" is the INITIAL-RESPONSE promise only: it must
+# never attach to walkthrough completion or estimate delivery.
+#
+# This is an exact whitelist rather than a keyword rule on purpose. A rule like
+# "no line containing '24 hours' may also contain 'estimate'" cannot tell
+# "requesting a free estimate ... within 24 hours" (fine — that names what was
+# requested) from "we'll send the estimate within 24 hours" (a promise EOM
+# cannot keep). A keyword guard that flags correct copy gets relaxed until it
+# means nothing; an exact list fails on ANY edit to a 24-hour sentence and asks
+# a human to re-approve it, which is the actual review this needs.
+APPROVED_24_HOUR_SENTENCES = {
+    "residential": [
+        "Thanks for requesting a free estimate from Effingham Office Maids - it "
+        "just landed with a real person, and we'll get back to you within 24 hours."
+    ],
+    "commercial": [
+        "1. I will give you a call within 24 hours to ask a few questions about "
+        "your facility and to set up a time and day for a walk-through."
+    ],
+    "multi-location-commercial": [
+        "1. I will give you a call within 24 hours. That first call is to "
+        "understand the whole picture before we put any numbers to it."
+    ],
+}
+
+
+@pytest.mark.parametrize("service", sorted(APPROVED_24_HOUR_SENTENCES))
+def test_only_approved_sentences_promise_24_hours(service):
+    _, body = format_request_acknowledgement("Acme", service, "weekly")
+    promised = [line for line in body.splitlines() if "24 hours" in line]
+    assert promised == APPROVED_24_HOUR_SENTENCES[service]
+
+
+@pytest.mark.parametrize("service", sorted(APPROVED_24_HOUR_SENTENCES))
+def test_estimate_delivery_is_never_inside_the_24_hour_window(service):
+    """The estimate is promised after the walkthrough, never within 24 hours.
+
+    Checked as an ordering property rather than a keyword: the sentence that
+    delivers the estimate must be a different sentence from the one that
+    promises 24 hours.
+    """
+    _, body = format_request_acknowledgement("Acme", service, "weekly")
+    delivery_lines = [
+        line
+        for line in body.splitlines()
+        if re.search(r"\bemail it to you\b|\bemail you an estimate\b", line)
+    ]
+    for line in delivery_lines:
+        assert "24 hours" not in line
+
+
+@pytest.mark.parametrize("service", ["commercial", "multi-location-commercial"])
+def test_rendered_commercial_body_has_no_unfilled_placeholders(service):
+    _, body = format_request_acknowledgement("Acme", service, "weekly")
+    assert "{" not in body
+    assert "}" not in body
+    assert "Acme" in body
+    assert "(217) 207-3097" in body
+    assert "info@effinghamofficemaids.com" in body
+
+
+@pytest.mark.parametrize("service", ["commercial", "multi-location-commercial"])
+def test_missing_client_name_still_renders_a_greeting(service):
+    _, body = format_request_acknowledgement("   ", service, "weekly")
+    assert body.startswith("Hi there,")
+
+
+# --- through intake -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("service", "marker"),
+    [
+        ("commercial", "set up a time and day for a walk-through"),
+        ("multi-location-commercial", "Multi-location work takes a little more"),
+    ],
+)
+async def test_intake_sends_the_commercial_body_for_commercial_services(service, marker):
+    """The real intake coroutine sends the commercial copy, not just the renderer.
+
+    A template can be correct while the send path still passes the wrong
+    arguments, so this asserts the body actually handed to the provider.
+    """
+    crm, provider, history = _crm(), _email_provider(), _email_history()
+
+    await _process_lead_intake(
+        _payload(service=service, frequency="weekly"),
+        crm=crm,
+        email_provider=provider,
+        email_history=history,
+    )
+
+    provider.send.assert_awaited()
+    sent_body = provider.send.await_args.kwargs["body"]
+    assert marker in sent_body
+    assert "Mayra Canfield and Tina Gomez" not in sent_body
+
+    # The stored copy must be the copy that was sent.
+    assert history.create.await_args.kwargs["body"] == sent_body
+
+
+@pytest.mark.asyncio
+async def test_intake_still_sends_the_original_copy_for_residential():
+    """The frozen path, asserted through intake rather than only the renderer."""
+    crm, provider, history = _crm(), _email_provider(), _email_history()
+
+    await _process_lead_intake(
+        _payload(service="residential", frequency="monthly"),
+        crm=crm,
+        email_provider=provider,
+        email_history=history,
+    )
+
+    sent_body = provider.send.await_args.kwargs["body"]
+    assert "Mayra Canfield and Tina Gomez" in sent_body
+    assert "Juan Canfield" not in sent_body

--- a/tests/test_ack_commercial_templates.py
+++ b/tests/test_ack_commercial_templates.py
@@ -14,13 +14,18 @@ from atlas_brain.api.leads import _process_lead_intake
 from atlas_brain.templates.email import (
     ACK_VARIANT_COMMERCIAL_MULTI_SITE,
     ACK_VARIANT_COMMERCIAL_SINGLE_SITE,
+    ACK_VARIANT_GENERAL,
+    ACK_VARIANT_RESIDENTIAL,
     classify_ack_variant,
     format_request_acknowledgement,
+    request_acknowledgement,
 )
 from atlas_brain.templates.email.request_acknowledgement import (
     ACK_TEMPLATE,
+    ACK_TEMPLATE_BY_VARIANT,
     COMMERCIAL_MULTI_SITE_TEMPLATE,
     COMMERCIAL_SINGLE_SITE_TEMPLATE,
+    SPEAKABLE_FREQUENCIES,
 )
 
 from .test_leads_intake import _crm, _email_history, _email_provider, _payload
@@ -38,13 +43,57 @@ def _email_enabled(monkeypatch):
 # (Effingham_Office_Maids_Website: contact.html, commercial-estimate.html)
 # rather than read from the implementation. `frequency` is a free-text field
 # server-side (`leads.py` `Field(default="", max_length=120)`), so these are
-# what real submissions carry, not what the API constrains.
+# what the form offers, NOT what the API constrains -- any string up to 120
+# characters can arrive.
 FORM_FREQUENCIES = ("daily", "weekly", "bi-weekly", "monthly", "one-time", "custom")
 
-# "custom" is a placeholder for "we'll work it out on the call", not a cadence
-# that can be spoken in a sentence.
-UNSPOKEN_FREQUENCIES = ("custom",)
-SPOKEN_FREQUENCIES = tuple(f for f in FORM_FREQUENCIES if f not in UNSPOKEN_FREQUENCIES)
+# The contracted allowlist, written here as literals rather than imported, so
+# the tests check the implementation against the contract instead of against
+# itself.
+CONTRACT_SPEAKABLE = frozenset({"daily", "weekly", "bi-weekly", "monthly", "one-time"})
+SPOKEN_FREQUENCIES = tuple(sorted(CONTRACT_SPEAKABLE))
+
+# Everything the form can offer that is NOT speakable, plus free-text values
+# that no form offers but intake accepts.
+UNSPEAKABLE_INPUTS = (
+    "",
+    "   ",
+    "custom",
+    "CUSTOM",
+    "  Custom  ",
+    "every other week",
+    "twice a month",
+    "as needed",
+    "whenever you can fit us in",
+    "2x/week",
+    "<script>alert(1)</script>",
+    "x" * 120,
+)
+
+
+def test_implementation_allowlist_equals_the_contract():
+    """The speakable set is exactly the contracted one -- no more, no less.
+
+    An extra member would be interpolated into customer copy without any test
+    proving it reads correctly; a missing one would silently drop a real
+    cadence from the email.
+    """
+    assert set(SPEAKABLE_FREQUENCIES) == CONTRACT_SPEAKABLE
+
+
+# Members reviewed and confirmed to read correctly after the hardcoded "a".
+# English article choice follows SOUND, not spelling: "a one-time cleaning" is
+# correct despite the leading vowel letter, while "an hour" is correct despite
+# the leading consonant. A spelling heuristic therefore cannot decide this, so
+# this is an explicit reviewed list -- a new member (say "annual") fails here
+# and forces someone to check whether the sentence needs "an".
+ARTICLE_A_FREQUENCIES = frozenset(
+    {"daily", "weekly", "bi-weekly", "monthly", "one-time"}
+)
+
+
+def test_every_speakable_frequency_is_reviewed_for_the_article_a():
+    assert set(SPEAKABLE_FREQUENCIES) == ARTICLE_A_FREQUENCIES
 
 
 # --- template selection ---------------------------------------------------
@@ -113,15 +162,18 @@ def test_multi_site_speaks_every_spoken_frequency(frequency):
     assert f"You requested {frequency} cleaning for multiple locations." in body
 
 
-@pytest.mark.parametrize("frequency", ["", "   ", "custom", "CUSTOM", "  Custom  "])
-def test_unspoken_frequency_falls_back_to_cadence_free_wording(frequency):
-    """A blank or `custom` cadence must not produce broken English.
+@pytest.mark.parametrize("frequency", UNSPEAKABLE_INPUTS)
+def test_unspeakable_frequency_falls_back_to_cadence_free_wording(frequency):
+    """Anything outside the allowlist must not reach customer copy.
 
-    "You requested a custom commercial cleaning" does not parse, so `custom`
-    is dropped exactly like a blank value.
+    `frequency` is free text server-side, so this fails CLOSED: a denylist
+    would let `"every other week"` through and render "You requested a every
+    other week commercial cleaning", which is broken English in an email a
+    lead actually reads.
     """
     _, single = format_request_acknowledgement("Gretchen", "commercial", frequency)
     assert "You requested a commercial cleaning." in single
+    assert frequency.strip() not in single or not frequency.strip()
 
     _, multi = format_request_acknowledgement(
         "Acme", "multi-location-commercial", frequency
@@ -129,9 +181,9 @@ def test_unspoken_frequency_falls_back_to_cadence_free_wording(frequency):
     assert "You requested cleaning for multiple locations." in multi
 
 
-@pytest.mark.parametrize("frequency", FORM_FREQUENCIES + ("", "   "))
+@pytest.mark.parametrize("frequency", FORM_FREQUENCIES + UNSPEAKABLE_INPUTS)
 def test_commercial_copy_never_double_spaces_or_dangles_the_cadence(frequency):
-    """Whatever the cadence, the sentence stays well-formed."""
+    """Whatever arrives in the field, the sentence stays well-formed."""
     for service in ("commercial", "multi-location-commercial"):
         _, body = format_request_acknowledgement("Acme", service, frequency)
         line = next(
@@ -140,15 +192,66 @@ def test_commercial_copy_never_double_spaces_or_dangles_the_cadence(frequency):
         assert "  " not in line, line
         assert line.endswith("."), line
         assert " ." not in line, line
+        assert " a  " not in line, line
+
+
+@pytest.mark.parametrize("frequency", [None, 0, True, [], {}, 1.5, object()])
+def test_non_string_frequency_never_raises(frequency):
+    """Defence in depth, mirroring A1's totality guarantee for `service`."""
+    for service in ("commercial", "multi-location-commercial"):
+        _, body = format_request_acknowledgement("Acme", service, frequency)
+        assert "You requested" in body
 
 
 # --- copy guardrails, as executable checks --------------------------------
 
-ALL_TEMPLATES = (
-    ACK_TEMPLATE,
-    COMMERCIAL_SINGLE_SITE_TEMPLATE,
-    COMMERCIAL_MULTI_SITE_TEMPLATE,
-)
+# Derived from the canonical selection surface, never hand-maintained. A
+# parallel hand-written list would let a template added to the router escape
+# the dollar / terminology / turnaround guards while this suite stayed green.
+# `test_every_module_template_is_routed` closes the other direction: a
+# `*_TEMPLATE` constant that exists but is not routed also fails.
+ALL_TEMPLATES = tuple(dict.fromkeys(ACK_TEMPLATE_BY_VARIANT.values()))
+
+
+def test_the_guard_inventory_is_derived_from_the_router_not_hand_written():
+    """Every routed template is covered by the copy guards below."""
+    assert set(ALL_TEMPLATES) == set(ACK_TEMPLATE_BY_VARIANT.values())
+    assert ACK_TEMPLATE in ALL_TEMPLATES
+    assert COMMERCIAL_SINGLE_SITE_TEMPLATE in ALL_TEMPLATES
+    assert COMMERCIAL_MULTI_SITE_TEMPLATE in ALL_TEMPLATES
+
+
+def test_every_module_template_is_routed():
+    """A template constant that exists but is unrouted fails closed.
+
+    Without this, adding `SOME_NEW_TEMPLATE` to the module and forgetting to
+    route it would leave it unguarded and unnoticed: the guards iterate the
+    router, so an unrouted body is invisible to them.
+    """
+    module_templates = {
+        name: value
+        for name, value in vars(request_acknowledgement).items()
+        if name.endswith("_TEMPLATE") and isinstance(value, str)
+    }
+    assert module_templates, "no *_TEMPLATE constants found -- test is not looking"
+    unrouted = {
+        name
+        for name, value in module_templates.items()
+        if value not in set(ACK_TEMPLATE_BY_VARIANT.values())
+    }
+    assert unrouted == set(), f"template constants not routed by variant: {unrouted}"
+
+
+def test_every_variant_is_routed_to_a_template():
+    """The other side of the same closure: no variant may be unrouted."""
+    from atlas_brain.templates.email.request_acknowledgement import (
+        _ACK_VARIANT_BY_SERVICE,
+    )
+
+    assert set(ACK_TEMPLATE_BY_VARIANT) == set(_ACK_VARIANT_BY_SERVICE.values()) | {
+        ACK_VARIANT_COMMERCIAL_SINGLE_SITE,
+        ACK_VARIANT_COMMERCIAL_MULTI_SITE,
+    }
 
 
 @pytest.mark.parametrize("template", ALL_TEMPLATES)
@@ -184,6 +287,10 @@ def test_multi_site_makes_none_of_the_promises_it_must_not_make():
     assert "before they leave" not in body.lower()
     assert "every location" not in body.lower()
     assert "each location" not in body.lower()
+    # A scope promised "for each one" commits EOM to serving every submitted
+    # site before coverage has been established (Codex #2340 R1).
+    assert "for each one" not in body.lower()
+    assert "for each of" not in body.lower()
 
 
 # Every sentence in which any variant may promise "24 hours", approved
@@ -198,37 +305,65 @@ def test_multi_site_makes_none_of_the_promises_it_must_not_make():
 # means nothing; an exact list fails on ANY edit to a 24-hour sentence and asks
 # a human to re-approve it, which is the actual review this needs.
 APPROVED_24_HOUR_SENTENCES = {
-    "residential": [
+    ACK_VARIANT_RESIDENTIAL: [
         "Thanks for requesting a free estimate from Effingham Office Maids - it "
         "just landed with a real person, and we'll get back to you within 24 hours."
     ],
-    "commercial": [
+    ACK_VARIANT_GENERAL: [
+        "Thanks for requesting a free estimate from Effingham Office Maids - it "
+        "just landed with a real person, and we'll get back to you within 24 hours."
+    ],
+    ACK_VARIANT_COMMERCIAL_SINGLE_SITE: [
         "1. I will give you a call within 24 hours to ask a few questions about "
         "your facility and to set up a time and day for a walk-through."
     ],
-    "multi-location-commercial": [
+    ACK_VARIANT_COMMERCIAL_MULTI_SITE: [
         "1. I will give you a call within 24 hours. That first call is to "
         "understand the whole picture before we put any numbers to it."
     ],
 }
 
+# One representative service per variant, so the whitelist can be exercised
+# through the real rendering path rather than against the raw constants.
+SERVICE_FOR_VARIANT = {
+    ACK_VARIANT_RESIDENTIAL: "residential",
+    ACK_VARIANT_GENERAL: "other",
+    ACK_VARIANT_COMMERCIAL_SINGLE_SITE: "commercial",
+    ACK_VARIANT_COMMERCIAL_MULTI_SITE: "multi-location-commercial",
+}
 
-@pytest.mark.parametrize("service", sorted(APPROVED_24_HOUR_SENTENCES))
-def test_only_approved_sentences_promise_24_hours(service):
-    _, body = format_request_acknowledgement("Acme", service, "weekly")
+
+def test_the_24_hour_whitelist_covers_every_routed_variant():
+    """Closure: a new variant cannot slip past the turnaround guard.
+
+    Keyed by variant rather than by service precisely so that adding a route
+    to `ACK_TEMPLATE_BY_VARIANT` without approving its 24-hour wording fails
+    here instead of shipping an unreviewed promise.
+    """
+    assert set(APPROVED_24_HOUR_SENTENCES) == set(ACK_TEMPLATE_BY_VARIANT)
+    assert set(SERVICE_FOR_VARIANT) == set(ACK_TEMPLATE_BY_VARIANT)
+
+
+@pytest.mark.parametrize("variant", sorted(APPROVED_24_HOUR_SENTENCES))
+def test_only_approved_sentences_promise_24_hours(variant):
+    _, body = format_request_acknowledgement(
+        "Acme", SERVICE_FOR_VARIANT[variant], "weekly"
+    )
     promised = [line for line in body.splitlines() if "24 hours" in line]
-    assert promised == APPROVED_24_HOUR_SENTENCES[service]
+    assert promised == APPROVED_24_HOUR_SENTENCES[variant]
 
 
-@pytest.mark.parametrize("service", sorted(APPROVED_24_HOUR_SENTENCES))
-def test_estimate_delivery_is_never_inside_the_24_hour_window(service):
+@pytest.mark.parametrize("variant", sorted(APPROVED_24_HOUR_SENTENCES))
+def test_estimate_delivery_is_never_inside_the_24_hour_window(variant):
     """The estimate is promised after the walkthrough, never within 24 hours.
 
     Checked as an ordering property rather than a keyword: the sentence that
     delivers the estimate must be a different sentence from the one that
     promises 24 hours.
     """
-    _, body = format_request_acknowledgement("Acme", service, "weekly")
+    _, body = format_request_acknowledgement(
+        "Acme", SERVICE_FOR_VARIANT[variant], "weekly"
+    )
     delivery_lines = [
         line
         for line in body.splitlines()

--- a/tests/test_ack_variant_classification.py
+++ b/tests/test_ack_variant_classification.py
@@ -267,25 +267,54 @@ async def test_variant_recorded_on_interaction_even_when_no_email_is_sent():
     assert metadata["ack_variant"] == CONTRACT_COMMERCIAL_MULTI_SITE
 
 
-# --- no copy change in this slice ----------------------------------------
+# --- which template each variant renders ---------------------------------
 
-@pytest.mark.parametrize(
-    "service",
-    ["residential", "deep", "move", "commercial", "multi-location-commercial", "other", ""],
-)
-def test_all_variants_still_render_the_single_existing_template(service):
-    """A1 classifies and records only. Template selection arrives in A2/A3."""
+# A1's `test_all_variants_still_render_the_single_existing_template` asserted
+# that classification changed no copy. A2/A3 is precisely the slice that makes
+# that false for the two commercial variants, so it is replaced here rather
+# than relaxed: the residential/general half of the guarantee is kept intact
+# and the commercial half is inverted into a positive assertion.
+
+
+@pytest.mark.parametrize("service", ["residential", "deep", "move", "other", ""])
+def test_residential_and_general_still_render_the_original_template(service):
+    """Everything not known to be commercial keeps the copy it gets today.
+
+    `other` and unrecognised values classify as `general`. Those leads are not
+    known to be businesses, so they keep the existing template rather than
+    being pointed at the commercial copy.
+    """
     baseline_subject, baseline_body = format_request_acknowledgement(
         "Jane", "residential", "monthly"
     )
     subject, body = format_request_acknowledgement("Jane", service, "monthly")
 
     assert subject == baseline_subject
-    # Only the echoed "Your request:" line may differ between services.
+    # Only the echoed "Your request:" line may differ between these services.
     def _without_request_line(text: str) -> list[str]:
         return [line for line in text.splitlines() if not line.startswith("Your request:")]
 
     assert _without_request_line(body) == _without_request_line(baseline_body)
+
+
+@pytest.mark.parametrize(
+    ("service", "marker"),
+    [
+        ("commercial", "set up a time and day for a walk-through"),
+        ("multi-location-commercial", "for multiple locations"),
+    ],
+)
+def test_commercial_services_render_their_own_template(service, marker):
+    """The two commercial variants no longer render the residential copy."""
+    _, residential_body = format_request_acknowledgement("Jane", "residential", "monthly")
+    _, body = format_request_acknowledgement("Jane", service, "weekly")
+
+    assert marker in body
+    assert body != residential_body
+    # The specific residential promises that were wrong for a business.
+    assert "Mayra Canfield and Tina Gomez" not in body
+    assert "less than 20 minutes" not in body
+    assert "schedule your first cleaning right then" not in body
 
 
 def test_residential_render_is_byte_identical_to_pre_change_production():


### PR DESCRIPTION
Plan: plans/PR-EOM-Ack-Commercial-Copy.md
Slice phase: Vertical slice
Ownership lane: eom-crm/lead-ack-variant

A1 (#2328) classified every submission into an acknowledgement variant and recorded it on both evidence records, but deliberately changed no email — so the defect #2320 was opened for is still live in production: a `commercial` lead receives residential copy promising that Mayra and Tina will walk the space in "less than 20 minutes", give a price before they leave, and that the lead can schedule the first cleaning that day. Roughly true for a house, wrong for a facility, and it is the first thing EOM says to a commercial prospect. This slice is the copy change A1 built the plumbing for.

Diff-budget override: indivisible. The runtime change is 130 lines in one module (two operator-authored template bodies plus a three-way selection branch). The remainder is the mandatory plan doc and the test matrix the Review Contract commits to. Splitting copy from selection leaves either unreachable templates or a branch with nothing to select; splitting the two templates ships one commercial variant while the other keeps sending wrong copy.

## Intentional

- The residential email is frozen (operator decision 2026-08-09, "leave it as is"). A1's byte-identical anchor stops being a migration aid and becomes a permanent contract.
- `general` keeps today's copy. `other` and unrecognised values are not known to be commercial, so pointing them at commercial copy would be a downgrade; a neutral "Other" email is copy work, deferred.
- `template_type` stays `"request_acknowledgement"` for every variant. This closes A1's "per-variant template_type" deferral as **won't do**: `ack_variant` already rides in `sent_emails.metadata` and is proven against real PostgreSQL, so a per-variant value would duplicate it while splitting the column into pre/post values and creating a backfill obligation for zero new information.
- `ACK_SUBJECT` is shared across variants (operator-approved).
- `format_request_acknowledgement` derives the variant itself instead of taking one from its caller, so the email sent and the variant recorded cannot drift.
- The "within 24 hours" guard is an exact whitelist of approved sentences, not a keyword rule. A keyword rule cannot distinguish "requesting a free estimate … within 24 hours" (correct) from "we'll send the estimate within 24 hours" (a promise EOM cannot keep), and a guard that flags correct copy gets relaxed until it means nothing.
- CI enrollment fixed for this surface: the new test file is added to the gating pytest invocation and both path-filter blocks, and `request_acknowledgement.py` — which was not a path trigger at all, though both sibling template modules were — is added. Same class of gap Codex found on #2328, fixed proactively.

## AI reconciliation

- Fail closed on unrecognized cadence text -- fixed-in: `atlas_brain/templates/email/request_acknowledgement.py` replaces the `custom`-only denylist with the `SPEAKABLE_FREQUENCIES` allowlist ({daily, weekly, bi-weekly, monthly, one-time}); every other value, including free text like `"every other week"`, injection-shaped strings and non-strings, falls back to the cadence-free wording. Proved by `tests/test_ack_commercial_templates.py::test_unspeakable_frequency_falls_back_to_cadence_free_wording` and negative-probed (reverting to pass-through -> 10 failed).
- Make the multi-site estimate conditional on serviceability -- fixed-in: `atlas_brain/templates/email/request_acknowledgement.py` multi-site step 4 narrowed from "a scope for each one" to "a scope", removing the promise to serve every submitted location; `::test_multi_site_makes_none_of_the_promises_it_must_not_make` now asserts the omitted case. The coverage caveat the operator deliberately removed is NOT re-added; this is the minimal edit that drops the promise.
- Declare the inventories that drive the copy guards -- fixed-in: `atlas_brain/templates/email/request_acknowledgement.py` adds `ACK_TEMPLATE_BY_VARIANT` as the canonical routing table and `tests/test_ack_commercial_templates.py` derives `ALL_TEMPLATES` from it and re-keys `APPROVED_24_HOUR_SENTENCES` by variant; closure is enforced in both directions by `::test_every_module_template_is_routed` and `::test_every_variant_is_routed_to_a_template`, with the declaration recorded in the plan's Boundary-change enumeration. Negative-probed with an unrouted `ORPHAN_TEMPLATE` carrying a dollar figure and "quote" -> 1 failed.
- Justify and synchronize the over-budget plan -- fixed-in: `plans/PR-EOM-Ack-Commercial-Copy.md` gains `### Diff-budget overage — why this slice is indivisible` under `## Why this slice exists` with each rejected seam, and `scripts/sync_pr_plan.py --check` now reports "plan already in sync".

- Condition the multi-site estimate on serviceability -- fixed-in: `atlas_brain/templates/email/request_acknowledgement.py` multi-site step 4 is now conditional — "and we've confirmed what we can cover" — so a prospect whose locations are all outside the service area is not told an estimate is coming; round 1's removal of "for each one" alone was insufficient and Codex was right. `tests/test_ack_commercial_templates.py::test_multi_site_makes_none_of_the_promises_it_must_not_make` asserts the condition is present, not only that the forbidden promises are absent. Operator-approved wording (chosen over restoring the removed paragraph or waiving).
- Bind commercial cadence routing to the canonical variant map -- fixed-in: `atlas_brain/templates/email/request_acknowledgement.py` replaces the independent `COMMERCIAL_ACK_VARIANTS` set with a single `ACK_ROUTE_BY_VARIANT` mapping each variant to one `AckRoute(template, request_line)`; `ACK_TEMPLATE_BY_VARIANT` and `COMMERCIAL_ACK_VARIANTS` are now derived views, so a commercial body paired with the residential raw echo is unrepresentable. Closure declared in the plan and enforced by `::test_cadence_style_is_bound_to_the_router_not_an_independent_set` and `::test_every_routed_variant_renders_its_own_cadence_style`; negative-probed (pointing the multi-site route at the residential echo -> 45 failed).

- Update the plan to describe the cadence allowlist -- fixed-in: `plans/PR-EOM-Ack-Commercial-Copy.md` `## Mechanism` rewritten to describe the implemented design — single-lookup selection via `ACK_ROUTE_BY_VARIANT` with `ACK_TEMPLATE_BY_VARIANT`/`COMMERCIAL_ACK_VARIANTS` as derived views, and the `SPEAKABLE_FREQUENCIES` allowlist with its fail-closed rationale — replacing the stale `_UNSPOKEN_FREQUENCIES` denylist description (that symbol no longer exists; 0 occurrences in plan and code). Also ran a mechanical symbol-citation check: 37 identifier-shaped tokens cited, 3 not in code and all three legitimate.

## Fix-loop disposition preflight

- Root decision: Fail closed on unrecognized cadence text
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `atlas_brain/templates/email/request_acknowledgement.py`, `tests/test_ack_commercial_templates.py`, `tests/test_ack_variant_classification.py`, `plans/PR-EOM-Ack-Commercial-Copy.md`, `.github/workflows/atlas_eom_lead_pipeline_checks.yml`
- Max files: 5
- Parked hardening: none — the allowlist is the complete fix; no follow-up is deferred.

- Root decision: Make the multi-site estimate conditional on serviceability
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `atlas_brain/templates/email/request_acknowledgement.py`, `tests/test_ack_commercial_templates.py`, `tests/test_ack_variant_classification.py`, `plans/PR-EOM-Ack-Commercial-Copy.md`, `.github/workflows/atlas_eom_lead_pipeline_checks.yml`
- Max files: 5
- Parked hardening: none — an explicit coverage caveat is an operator copy decision, tracked in #2320, not deferred engineering.

- Root decision: Declare the inventories that drive the copy guards
- Blocking predicate: claimed-mechanism
- Disposition: fixed-in
- Allowed files: `atlas_brain/templates/email/request_acknowledgement.py`, `tests/test_ack_commercial_templates.py`, `tests/test_ack_variant_classification.py`, `plans/PR-EOM-Ack-Commercial-Copy.md`, `.github/workflows/atlas_eom_lead_pipeline_checks.yml`
- Max files: 5
- Parked hardening: none — closure is enforced in both directions by tests in this PR.

- Root decision: Justify and synchronize the over-budget plan
- Blocking predicate: ci
- Disposition: fixed-in
- Allowed files: `atlas_brain/templates/email/request_acknowledgement.py`, `tests/test_ack_commercial_templates.py`, `tests/test_ack_variant_classification.py`, `plans/PR-EOM-Ack-Commercial-Copy.md`, `.github/workflows/atlas_eom_lead_pipeline_checks.yml`
- Max files: 5
- Parked hardening: none — the plan is regenerated by `scripts/sync_pr_plan.py`.

- Root decision: Condition the multi-site estimate on serviceability
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `atlas_brain/templates/email/request_acknowledgement.py`, `tests/test_ack_commercial_templates.py`, `tests/test_ack_variant_classification.py`, `plans/PR-EOM-Ack-Commercial-Copy.md`, `.github/workflows/atlas_eom_lead_pipeline_checks.yml`
- Max files: 5
- Parked hardening: none — the condition is operator-approved final wording.

- Root decision: Bind commercial cadence routing to the canonical variant map
- Blocking predicate: claimed-mechanism
- Disposition: fixed-in
- Allowed files: `atlas_brain/templates/email/request_acknowledgement.py`, `tests/test_ack_commercial_templates.py`, `tests/test_ack_variant_classification.py`, `plans/PR-EOM-Ack-Commercial-Copy.md`, `.github/workflows/atlas_eom_lead_pipeline_checks.yml`
- Max files: 5
- Parked hardening: none — the bad state is unrepresentable after this change.

- Root decision: Update the plan to describe the cadence allowlist
- Blocking predicate: claimed-mechanism
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-Ack-Commercial-Copy.md`
- Max files: 5
- Parked hardening: none — documentation now matches the implementation.

## Deferred

- A dedicated `general` / "Other" template — needs operator-authored copy; those leads keep exactly the email they get today, so nothing regresses.
- UTC-vs-Central dedupe bucketing (inherited from A1), unchanged here.
- A corrected service inside the same variant may still send a second email; documented in #2320, unchanged.

Parking predicate: none of these changes what a lead receives in this slice; each is either unreachable today or a separate copy decision needing operator input.

## Parked hardening

none

## Cold diff reconstruction

Changed: `request_acknowledgement.py` gains two template constants and a three-way selection branch keyed on `classify_ack_variant(service)`, plus `_spoken_frequency`/`_commercial_request_line` helpers that drop cadence values which cannot be spoken in a sentence. `tests/test_ack_commercial_templates.py` is new (51 nodes). `tests/test_ack_variant_classification.py` replaces A1's "no copy changed" assertion with a residential/general-only version plus a positive commercial assertion. The workflow gains three path-filter entries and one pytest entry.

Contract match: the diff matches the plan's Problem-derived contract — selection is added inside `format_request_acknowledgement`, driven by the already-derived variant, and the must-not-change list (residential copy, `general`, `ACK_SUBJECT`, `template_type`, `ack_variant`, dedupe, caps, honeypot, routing, failure isolation) is untouched.

Gaps: none between diff, plan and this description. The one behaviour the description does not carry in its title is the workflow-trigger fix, called out under Intentional because it changes which PRs this gate runs on.

## Verification

- `python -m pytest tests/test_ack_commercial_templates.py -q` — 51 passed
- `python -m pytest tests/test_ack_commercial_templates.py tests/test_ack_variant_classification.py -q` — 97 passed
- `python -m pytest` over the four affected files — 181 passed, 1 skipped
- The normally-skipped PostgreSQL route test was RUN against a real database — 1 passed, with before/after snapshots identical (schemas 129 → 129; contacts/interactions/sent_emails 712/2821/12 unchanged)
- Golden diff vs A1's baseline: six residential/general rows byte-identical by per-row sha256; only the two commercial rows differ
- Seven negative probes, each injected then restored (baseline and restored both 97 passed)

## Mechanical verification

- Command: python -m pytest tests/test_ack_commercial_templates.py -q - Result: pass (51 passed) - Environment: local
- Command: python -m pytest tests/test_ack_commercial_templates.py tests/test_ack_variant_classification.py -q - Result: pass (97 passed) - Environment: local
- Command: python -m pytest tests/test_ack_commercial_templates.py tests/test_ack_variant_classification.py tests/test_leads_intake.py tests/test_eom_sent_email_tenant_scope.py -q - Result: pass (181 passed, 1 skipped) - Environment: local
- Command: ATLAS_MIGRATION_TEST_DATABASE_URL=... python -m pytest tests/test_eom_sent_email_tenant_scope.py -q - Result: pass (1 passed) - Environment: local
- Command: ruff check atlas_brain/templates/email/request_acknowledgement.py tests/test_ack_commercial_templates.py tests/test_ack_variant_classification.py - Result: pass (All checks passed) - Environment: local
- Command: python -m py_compile atlas_brain/templates/email/request_acknowledgement.py - Result: pass (no output) - Environment: local
- Command: git diff --check - Result: pass (clean) - Environment: local
- Command: python -c "import yaml; yaml.safe_load(open('.github/workflows/atlas_eom_lead_pipeline_checks.yml'))" - Result: pass (valid YAML) - Environment: local
- Command: python scripts/audit_plan_doc.py plans/PR-EOM-Ack-Commercial-Copy.md - Result: pass (exit 0) - Environment: local
- Command: python scripts/audit_review_rules_triggered.py origin/main --plan plans/PR-EOM-Ack-Commercial-Copy.md - Result: pass (exit 0) - Environment: local

## Diff size
5 files changed, 1136 insertions(+), 11 deletions(-)

<!-- atlas-open-pr-wrapper: v1 -->
