### PR TITLE
Isolate tests from global git config to stop pre-push recursion

### DIFF
--- a/plans/PR-Test-Git-Hermetic-Isolation.md
+++ b/plans/PR-Test-Git-Hermetic-Isolation.md
@@ -1,0 +1,315 @@
+# PR-Test-Git-Hermetic-Isolation
+
+## Why this slice exists
+
+`core.hooksPath` set in the developer's **global** git config applies to every
+repository on the machine, including the throwaway repos the test suite builds
+under `/tmp`. When a gated test pushed inside one of those repos, the managed
+pre-push hook fired, ran `scripts/local_pr_review.sh`, which ran
+`scripts/check_unit_gate.py` → `pytest`, whose tests push again — re-entering the
+same hook. The recursion is unbounded and nests one process chain per cycle.
+
+Observed live: **56,192 tasks** (`/proc/loadavg`), load average **38.09**, and
+**59 Gi of 61 Gi** RAM consumed with swap fully exhausted. The machine was
+minutes from unusable.
+
+The hook already carried a guard, `ATLAS_SKIP_LOCAL_PR_REVIEW`, but
+`run_local_unit_gate_mirror` did not set it for the unit-gate child. A normal
+developer shell does not carry that guard, so the child that performed the
+recursing push reached the managed hook with no skip signal.
+
+This slice is over the 400 LOC target because the safety change crosses the
+suite-wide pytest environment, the local unit-gate mirror, hook-behavior tests
+that must opt back in, and failing-first regression coverage for both
+file-backed and command-scope Git config. Splitting any of those surfaces would
+leave one side of the recursion path unproven.
+
+### Problem-derived contract
+
+A test must never execute the developer's git hooks or read their git config,
+regardless of machine state — and the unit gate must not hand its child an
+environment that can re-enter the hook. Neither may be achieved by disabling
+hooks generally: tests that assert managed-hook behavior must keep working.
+
+## Scope (this PR)
+
+Ownership lane: local-pr-review-tooling
+Slice phase: production hardening
+Max files: 6
+
+- `tests/conftest.py`: point `GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM` at
+  `os.devnull` at import time, so no user or system git config — including
+  `core.hooksPath` — reaches any test. Clear command-scope Git config injection
+  variables (`GIT_CONFIG_COUNT`, `GIT_CONFIG_PARAMETERS`, and numbered
+  `GIT_CONFIG_KEY_*`/`GIT_CONFIG_VALUE_*` entries) for the same reason. Clear
+  `GIT_TEMPLATE_DIR` because it can copy hook files into repos during
+  `git init`. Supply a git identity via `GIT_AUTHOR_*`/`GIT_COMMITTER_*` to
+  compensate, and preserve any ambient `ATLAS_SKIP_LOCAL_PR_REVIEW` so the unit
+  gate's guard survives into pytest.
+- `scripts/local_pr_review.sh`: add `ATLAS_SKIP_LOCAL_PR_REVIEW=1` to
+  `unit_gate_env_values`, so the guard survives into pytest and any push it
+  performs.
+- `tests/test_local_pr_review.py`: eleven regression tests, covering both sides
+  of the guard, guard preservation, inherited file-backed Git config, inherited
+  command-scope Git config, inherited Git template hooks, and a real pytest
+  launch.
+- `tests/test_install_local_pr_hook.py`, `tests/test_push_pr_wrapper.py`:
+  autouse fixtures clearing the guard for the modules that assert the hook runs.
+
+### Review Contract
+
+**Acceptance criteria** (check one by one):
+
+1. A `core.hooksPath` configured in user/system git config does not fire inside
+   a repo built by a test — proven by `test_tests_do_not_inherit_a_global_hooks_path`,
+   `test_inherited_git_config_global_is_cleared_during_real_pytest_launch`, and
+   `test_inherited_git_config_system_is_cleared_during_real_pytest_launch`.
+2. A `core.hooksPath` injected through command-scope Git config environment
+   variables does not fire inside a repo built by a test — proven by
+   `test_command_scope_hooks_path_is_cleared_during_real_pytest_launch`.
+3. A `pre-push` hook inherited through `GIT_TEMPLATE_DIR` is not copied into a
+   repo built by a test — proven by
+   `test_inherited_git_template_dir_is_cleared_during_real_pytest_launch`.
+4. The same hook still fires when a caller opts back in, so the isolation is
+   what suppresses it — `test_global_hooks_path_still_fires_when_not_isolated`.
+5. `scripts/local_pr_review.sh` hands `ATLAS_SKIP_LOCAL_PR_REVIEW=1` to the unit
+   gate, asserted against an ambient `0` so only the script can satisfy it —
+   `test_local_pr_review_unit_gate_mirror_sets_recursion_guard`.
+6. That guard survives a real `pytest` launch and conftest import, not just a
+   stub that prints its environment —
+   `test_recursion_guard_survives_a_real_pytest_launch`.
+7. Tests that assert the managed hook *runs* still pass with the guard ambient,
+   as the unit gate invokes them — `test_install_local_pr_hook.py` and
+   `test_push_pr_wrapper.py`, both ambient states.
+8. Git identity still resolves with user/system config neutralized, for the six
+   committing test files that set none locally.
+
+**Affected surfaces**
+
+- `tests/conftest.py` — suite-wide process environment for every pytest run,
+  local and CI. Highest-blast-radius file in the diff.
+- `scripts/local_pr_review.sh` — the local unit-gate mirror, invoked by the
+  managed pre-push hook.
+- `tests/test_install_local_pr_hook.py`, `tests/test_push_pr_wrapper.py` —
+  module-scoped env fixtures only; no assertion or production path changed.
+- No `atlas_brain/` runtime, migration, workflow, billing, or public contract
+  surface is touched, so no reachability proof is owed.
+
+**Risk areas**
+
+- Neutralizing global git config removes `user.name`/`user.email`; a fixture
+  that commits without a local identity would break. Compensated by
+  `GIT_AUTHOR_*`/`GIT_COMMITTER_*` and verified against the six files that rely
+  on it.
+- Preserving the guard makes the managed hook skip for the tests that assert it
+  runs. Handled by clearing it in those two modules via autouse fixtures rather
+  than dropping it globally, so every other test stays protected.
+- `conftest.py` changes cannot be validated by running the edited files alone;
+  the first revision of this PR passed its targeted runs and still regressed 10
+  tests under the real gate.
+
+**Triggered reviewer rules**
+
+- **R2 (test evidence)** — the diff is predominantly tests, and both guards
+  carry a failure-direction case, per `AGENTS.md` 3h/3i.
+- **R11 (dependencies and config)** — `conftest.py` changes env/config
+  resolution for the whole suite.
+- **R12 (deployment safety and CI enrollment)** — `local_pr_review.sh` is the
+  local mirror of the CI unit gate; both must stay in step.
+- **R10 (maintainability)** — hook-behavior control moves from ambient
+  environment to explicit per-module fixtures.
+- **R14 (verify against the codebase)** — universal.
+
+### Files touched
+
+- `plans/PR-Test-Git-Hermetic-Isolation.md`
+- `scripts/local_pr_review.sh`
+- `tests/conftest.py`
+- `tests/test_install_local_pr_hook.py`
+- `tests/test_local_pr_review.py`
+- `tests/test_push_pr_wrapper.py`
+
+### Boundary-change enumeration
+No module or ownership boundary changes. No new imports, callers, or public
+surfaces. `conftest.py` gains only process-environment assignments in the
+existing import-time block; `local_pr_review.sh` gains one array entry.
+
+### Git config closure declaration
+
+The file-backed Git config override set is **closed** for this slice:
+`GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM` are the complete file-backed
+environment controls and are assigned to `os.devnull`. The canonical source is
+`tests/conftest.py`.
+
+The command-scope Git config injection set is also **closed** for this slice.
+The canonical exact-name source is
+`tests/conftest.py::_GIT_CONFIG_INJECTION_ENV_NAMES`
+(`GIT_CONFIG_COUNT`, `GIT_CONFIG_PARAMETERS`). The canonical prefix source is
+`tests/conftest.py::_GIT_CONFIG_INJECTION_ENV_PREFIXES`
+(`GIT_CONFIG_KEY_`, `GIT_CONFIG_VALUE_`) for Git's numbered key/value pairs.
+
+Unlisted `GIT_CONFIG_*` variables are not treated as Git config-injection
+controls by this PR and remain unchanged. If Git adds or documents another
+environment variable that injects config into commands, that is a future slice
+only after a failing proof or a newly observed recurrence. The implementation is
+bound to those constants, and the regression tests exercise the file-backed
+source (`GIT_CONFIG_GLOBAL`, `GIT_CONFIG_SYSTEM`) plus the command-scope
+exact/prefix source (`GIT_CONFIG_COUNT`, `GIT_CONFIG_KEY_0`,
+`GIT_CONFIG_VALUE_0`, `GIT_CONFIG_PARAMETERS`) through real nested pytest
+launches.
+
+The hook-producing Git template environment set is **closed** for this slice:
+`GIT_TEMPLATE_DIR` is the complete inherited template-directory control this PR
+handles. It is not a Git config variable, so it is documented separately from
+the `GIT_CONFIG_*` closure above. Unlisted template/config-path mechanisms are
+future work only after a failing proof or newly observed recurrence.
+
+### Deployed-config probing
+No deployed-config, env, secret, or blueprint changes. `GIT_CONFIG_GLOBAL` and
+`GIT_CONFIG_SYSTEM` are set only inside the pytest process and its children.
+
+## Mechanism
+
+Git resolves `core.hooksPath` from the full config stack, so a value in the
+user's global config applies to a repo created seconds earlier by `git init` in
+`/tmp`. Pointing `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` at `/dev/null` makes git
+read no user or system config at all, which removes the vector structurally
+rather than blacklisting one key.
+
+That also removes `user.name`/`user.email`. Most git fixtures set an identity
+locally, but six committing test files do not
+(`test_check_ai_reconciliation_live`, `test_check_seam_convergence`,
+`test_getapp_parser`, `test_pr_watcher`, `test_security_guardrails_workflow`,
+`test_watch_owned_pr`), so identity is supplied via environment variables, which
+apply with no config file present.
+
+For the second layer, `unit_gate_env_values` is passed to all three
+`check_unit_gate.py` invocations, and `check_unit_gate.py:336` calls
+`subprocess.run` with no `env=`, so the value inherits cleanly through to pytest
+and any git it spawns.
+
+Git can also receive command-scope config from inherited environment variables:
+the closed exact-name set (`GIT_CONFIG_COUNT`, `GIT_CONFIG_PARAMETERS`) and the
+closed numbered key/value prefix set (`GIT_CONFIG_KEY_*`,
+`GIT_CONFIG_VALUE_*`). Conftest clears those names through the canonical
+constants before tests run, so a `core.hooksPath` injected that way cannot reach
+a throwaway repo created by pytest.
+
+Git templates are a third hook-producing path: `GIT_TEMPLATE_DIR` can cause
+plain `git init` to copy an executable `hooks/pre-push` into a fixture repo
+before the first push. Conftest clears that variable at import time, and the
+nested-pytest regression launches with a hook-bearing template directory to
+prove the inner fixture repo does not copy or run it.
+
+## Intentional
+
+- `conftest.py` **preserves** `ATLAS_SKIP_LOCAL_PR_REVIEW` rather than dropping
+  it, so the guard the unit gate supplies survives into pytest. Both
+  `scripts/push_pr.sh:80` and the installed hook branch on that variable, so ten
+  tests that assert the hook *runs* would see it skip; those two modules clear
+  it with an autouse fixture instead. Dropping it suite-wide — the first
+  revision of this PR — traded protection for every test to accommodate ten, and
+  left the recursion's own crossing point (checker → pytest) unguarded.
+- The guard is asserted through a **real pytest launch**
+  (`test_recursion_guard_survives_a_real_pytest_launch`), not only against a
+  stub checker that prints its environment. The stub never imports conftest, so
+  it cannot observe whether conftest preserves or deletes the value — the exact
+  step where the first revision went wrong.
+- Identity vars use `setdefault`, so a fixture can still override them; the
+  `GIT_CONFIG_*` vars are assigned unconditionally because hermetic git is a
+  guarantee, not a default a stale environment may override.
+
+## Deferred
+
+- Future PR: machine-local temp-repo hook hard-stop. Unlock condition: the
+  repo-managed pytest isolation in this PR fails to prevent a recurrence, or
+  the operator explicitly wants belt-and-suspenders protection outside repo
+  content. Parking predicate: `~/.claude/hooks/git/pre-push` is machine-local
+  configuration, not repo content, and the current repo tests now prove
+  inherited file-backed and command-scope hook config is neutralized before a
+  test push.
+- Future refactor: consolidate duplicated git fixture helpers
+  (`_write_fixture_repo`, `_git`). Unlock condition: #2341 has landed and an
+  adjacent PR needs shared fixture-helper edits. Parking predicate: helper
+  consolidation is maintenance cleanup, not required to stop the recursion or
+  prove the hermetic Git-config boundary.
+- Parked hardening: none.
+
+## Verification
+
+- The two new failing-first tests were confirmed red against `origin/main`:
+  the isolation test failed with `global pre-push hook ran inside a test repo`,
+  reproducing the incident inside a test. The control passed on `main`, proving
+  the mechanism is real before any fix.
+- After the change: all file-backed and command-scope hook isolation tests pass.
+- The first attempt at the guard regressed **10 tests** in the full unit gate
+  (8 in `test_install_local_pr_hook.py`, 2 in `test_push_pr_wrapper.py`), all
+  asserting the managed hook runs. Caught by running the real gate, not just
+  the edited files. Round 1 keeps the guard and clears it per module instead;
+  the trio passes in **both** ambient states — **68 passed** with
+  `ATLAS_SKIP_LOCAL_PR_REVIEW=1` set, as the unit gate invokes them, and
+  **68 passed** without it.
+- Blast-site files (`test_local_pr_review.py`, `test_open_pr_wrapper.py`,
+  `test_push_pr_wrapper.py`): **109 passed**.
+- Identity regression, the six files that commit without a local identity:
+  `pytest tests/test_check_ai_reconciliation_live.py tests/test_check_seam_convergence.py tests/test_getapp_parser.py tests/test_pr_watcher.py tests/test_security_guardrails_workflow.py tests/test_watch_owned_pr.py`
+  -- **282 passed**.
+- Full git-touching sweep, 33 test modules plus the `tests/conftest.py`
+  blast-site imported by each run:
+  `pytest tests/test_audit_cross_layer_callers.py tests/test_audit_fix_loop_disposition.py tests/test_audit_plan_code_consistency.py tests/test_audit_plan_doc_diff_size.py tests/test_audit_plan_doc_files_touched.py tests/test_audit_pr_body.py tests/test_audit_pr_plan_presence.py tests/test_audit_pr_session_drift.py tests/test_check_ai_reconciliation_live.py tests/test_check_boundary_change_enumeration.py tests/test_check_deployed_config_probing.py tests/test_check_guard_class_closure.py tests/test_codex_issue_queue.py tests/test_content_factory_copy_verification.py tests/test_content_factory_runner.py tests/test_content_factory_store.py tests/test_detect_retired_failure_modes.py tests/test_docs_no_raw_deflection_request_ids.py tests/test_install_local_pr_hook.py tests/test_leads_intake.py tests/test_local_pr_review.py tests/test_new_pr_plan.py tests/test_open_pr_wrapper.py tests/test_plan_admission_workflow.py tests/test_pr_watcher.py tests/test_pre_push_audit.py tests/test_pre_push_audit_workflow.py tests/test_push_pr_wrapper.py tests/test_security_policy_docs.py tests/test_session_lane_workflow.py tests/test_sync_pr_plan.py tests/test_unit_gate_selector_fallback.py tests/test_update_pr_body_wrapper.py`
+  -- **1,828 passed**.
+- Current focused review-fix verification:
+  `pytest tests/test_local_pr_review.py -k "recursion_guard or global_hooks_path or command_scope_hooks_path or inherited_git_config or git_template_dir" -q`
+  -- **11 passed, 31 deselected**;
+  `ATLAS_SKIP_LOCAL_PR_REVIEW=1 pytest tests/test_install_local_pr_hook.py tests/test_push_pr_wrapper.py -q`
+  -- **32 passed**; and
+  `pytest tests/test_local_pr_review.py tests/test_install_local_pr_hook.py tests/test_push_pr_wrapper.py -q`
+  -- **74 passed**.
+- Process-count sampled across the runs stayed flat (2,445 → 2,468), i.e. the
+  recursion cannot re-enter.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Test-Git-Hermetic-Isolation.md` | 315 |
+| `scripts/local_pr_review.sh` | 3 |
+| `tests/conftest.py` | 42 |
+| `tests/test_install_local_pr_hook.py` | 14 |
+| `tests/test_local_pr_review.py` | 283 |
+| `tests/test_push_pr_wrapper.py` | 13 |
+| **Total** | **670** |
+
+## Cold diff reconstruction
+
+- `tests/conftest.py`: after the existing `ATLAS_DB_*` `setdefault` block, assign
+  `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` to `os.devnull`, declare the closed
+  exact-name and prefix constants for command-scope Git config injection, clear
+  those variables, clear `GIT_TEMPLATE_DIR`, `setdefault` the four
+  `GIT_AUTHOR_*`/`GIT_COMMITTER_*` vars, and
+  `os.environ.setdefault("ATLAS_SKIP_LOCAL_PR_REVIEW", "1")` with a comment
+  naming the two modules that clear it locally.
+- `scripts/local_pr_review.sh`: add `ATLAS_SKIP_LOCAL_PR_REVIEW=1` as the first
+  entry of `unit_gate_env_values`, with a comment naming the recursion.
+- `tests/test_local_pr_review.py`: add
+  `test_local_pr_review_unit_gate_mirror_sets_recursion_guard` (checker prints
+  the var, ambient set to `0`),
+  `test_tests_do_not_inherit_a_global_hooks_path` (fake `HOME` with a
+  hooksPath-setting gitconfig; marker must not appear; push succeeds), and
+  `test_global_hooks_path_still_fires_when_not_isolated` (same setup, explicit
+  `GIT_CONFIG_GLOBAL`; marker must appear; push fails), and
+  `test_conftest_preserves_the_recursion_guard` plus
+  `test_recursion_guard_survives_a_real_pytest_launch`, which spawns a real
+  pytest so conftest is genuinely imported.
+- `test_command_scope_hooks_path_is_cleared_during_real_pytest_launch`, which
+  launches pytest with both `GIT_CONFIG_COUNT` numbered `core.hooksPath` entries
+  and `GIT_CONFIG_PARAMETERS` injected, then proves a push inside the inner test
+  does not run the hook.
+- `test_inherited_git_config_global_is_cleared_during_real_pytest_launch` and
+  `test_inherited_git_config_system_is_cleared_during_real_pytest_launch`, which
+  launch nested pytest processes with each inherited file-backed config variable
+  pointing at a hook-bearing file and prove conftest overwrites them before the
+  inner push.
+- `test_inherited_git_template_dir_is_cleared_during_real_pytest_launch`, which
+  launches nested pytest with a hook-bearing template directory and proves
+  conftest clears it before the inner fixture repo is initialized and pushed.

--- a/scripts/local_pr_review.sh
+++ b/scripts/local_pr_review.sh
@@ -129,6 +129,9 @@ run_local_unit_gate_mirror() {
     selected="$tmp_dir/selected.txt"
     unit_gate_env=(-u ATLAS_CURRENT_PR_BODY_FILE -u ATLAS_CURRENT_PR_AUTHOR)
     unit_gate_env_values=(
+        # A push performed by a gated test would otherwise re-enter the
+        # pre-push hook, which re-runs this script, which pushes again.
+        ATLAS_SKIP_LOCAL_PR_REVIEW=1
         ATLAS_DB_CONNECTION_STRING=
         ATLAS_DB_HOST=127.0.0.1
         ATLAS_DB_PORT=1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,48 @@ os.environ.setdefault("ATLAS_DB_DATABASE", "atlas")
 os.environ.setdefault("ATLAS_DB_USER", "atlas")
 os.environ.setdefault("ATLAS_DB_PASSWORD", "atlas_dev_password")
 
+# Tests must never inherit the developer's git configuration. A global
+# core.hooksPath made the pre-push hook fire inside the throwaway repos tests
+# build, and that hook re-ran this suite, which pushed again -- unbounded
+# recursion that exhausted system memory. Assigned, not setdefault: hermetic
+# git is a guarantee, not a default a stale environment can override.
+os.environ["GIT_CONFIG_GLOBAL"] = os.devnull
+os.environ["GIT_CONFIG_SYSTEM"] = os.devnull
+# Closed source for env-delivered Git config controls. Exact names are the
+# complete non-numbered set this slice handles; prefixes cover Git's numbered
+# key/value pairs. Other GIT_CONFIG_* names stay unchanged unless a future proof
+# shows Git treats them as config injection.
+_GIT_CONFIG_INJECTION_ENV_NAMES = ("GIT_CONFIG_COUNT", "GIT_CONFIG_PARAMETERS")
+_GIT_CONFIG_INJECTION_ENV_PREFIXES = ("GIT_CONFIG_KEY_", "GIT_CONFIG_VALUE_")
+for name in list(os.environ):
+    if (
+        name in _GIT_CONFIG_INJECTION_ENV_NAMES
+        or name.startswith(_GIT_CONFIG_INJECTION_ENV_PREFIXES)
+    ):
+        os.environ.pop(name, None)
+
+# GIT_TEMPLATE_DIR is not config, but it can install a developer hook into every
+# fixture repo created by plain git init. Clear it with the inherited config
+# controls so throwaway repos cannot copy hook state before their first push.
+os.environ.pop("GIT_TEMPLATE_DIR", None)
+
+# Keep the recursion guard scripts/local_pr_review.sh exports into the unit
+# gate. A test that pushes into a repo carrying a managed pre-push hook would
+# otherwise re-enter review -> unit gate -> pytest and exhaust the machine, so
+# the guard is preserved by default rather than dropped suite-wide. The handful
+# of tests that assert the hook *runs* clear it per module (see
+# tests/test_install_local_pr_hook.py and tests/test_push_pr_wrapper.py), which
+# keeps every other test protected.
+os.environ.setdefault("ATLAS_SKIP_LOCAL_PR_REVIEW", "1")
+
+# Neutralizing global config also drops user.name/user.email. Most git fixtures
+# set an identity locally, but not all of them do, so supply one via env -- it
+# applies with no config file at all. setdefault so a fixture can still override.
+os.environ.setdefault("GIT_AUTHOR_NAME", "Atlas Test")
+os.environ.setdefault("GIT_AUTHOR_EMAIL", "test@example.invalid")
+os.environ.setdefault("GIT_COMMITTER_NAME", "Atlas Test")
+os.environ.setdefault("GIT_COMMITTER_EMAIL", "test@example.invalid")
+
 # The unit backstop installs asyncpg, so load the real driver before test module
 # collection. This prevents legacy import-time sys.modules.setdefault("asyncpg",
 # MagicMock()) helpers from poisoning later DB-fixture tests.

--- a/tests/test_install_local_pr_hook.py
+++ b/tests/test_install_local_pr_hook.py
@@ -6,7 +6,21 @@ import stat
 import subprocess
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(autouse=True)
+def _review_guard_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """These tests assert the installed hook RUNS the review.
+
+    conftest preserves ATLAS_SKIP_LOCAL_PR_REVIEW so a pushing test cannot
+    re-enter the review -> unit gate -> pytest cycle, but that same value makes
+    the hook under test skip. Clear it for this module only; the test that
+    exercises the skip path passes it explicitly, which still wins.
+    """
+    monkeypatch.delenv("ATLAS_SKIP_LOCAL_PR_REVIEW", raising=False)
 
 
 def test_installs_managed_pre_push_hook(tmp_path):

--- a/tests/test_local_pr_review.py
+++ b/tests/test_local_pr_review.py
@@ -6,6 +6,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -803,6 +805,287 @@ def test_local_pr_review_skips_plans_advisory_when_absent(tmp_path: Path) -> Non
 
     assert result.returncode == 0, result.stdout + result.stderr
     assert "SKIP (scripts/archive_plans.py not found)" in result.stdout
+
+
+def test_local_pr_review_unit_gate_mirror_sets_recursion_guard(tmp_path: Path) -> None:
+    """The unit gate must run with ATLAS_SKIP_LOCAL_PR_REVIEW=1.
+
+    Without it, a push performed by a test inside the gated suite re-enters
+    the pre-push hook, which re-runs this script, which pushes again.
+    """
+    repo = tmp_path / "repo"
+    _write_fixture_repo(repo)
+    _write_unit_gate_fixture(
+        repo,
+        selector_script="#!/usr/bin/env python3\nprint('tests/test_example.py')\n",
+        checker_script=(
+            "#!/usr/bin/env python3\n"
+            "import os\n"
+            "print('skip local pr review env=' + str(os.environ.get('ATLAS_SKIP_LOCAL_PR_REVIEW')))\n"
+        ),
+    )
+
+    result = _run(
+        repo,
+        ["bash", "scripts/local_pr_review.sh"],
+        # Ambient "0" so a passing assertion can only come from the script
+        # setting the guard itself, never from an inherited value.
+        env={"GITHUB_ACTIONS": "false", "ATLAS_SKIP_LOCAL_PR_REVIEW": "0"},
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "skip local pr review env=1" in result.stdout.splitlines()
+
+
+def test_conftest_preserves_the_recursion_guard() -> None:
+    """conftest must keep ATLAS_SKIP_LOCAL_PR_REVIEW set for the suite.
+
+    Dropping it would let a test that pushes into a repo with a managed
+    pre-push hook re-enter review -> unit gate -> pytest.
+    """
+    assert os.environ.get("ATLAS_SKIP_LOCAL_PR_REVIEW") == "1"
+
+
+def test_recursion_guard_survives_a_real_pytest_launch() -> None:
+    """Cover the checker -> pytest path, not just a stub that prints its env.
+
+    scripts/check_unit_gate.py launches pytest, which imports conftest. This
+    asserts the guard supplied by scripts/local_pr_review.sh is still set once
+    that import has happened -- the step a stub checker cannot exercise.
+    """
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "tests/test_local_pr_review.py::test_conftest_preserves_the_recursion_guard",
+            "-p",
+            "no:cacheprovider",
+            "-q",
+            "--no-header",
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "ATLAS_SKIP_LOCAL_PR_REVIEW": "1"},
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+@pytest.mark.parametrize(
+    ("inherited_env", "marker_name"),
+    [
+        (
+            {
+                "GIT_CONFIG_COUNT": "1",
+                "GIT_CONFIG_KEY_0": "core.hooksPath",
+                "GIT_CONFIG_VALUE_0": "{hooks_dir}",
+            },
+            "command-scope-count-hook-ran.txt",
+        ),
+        (
+            {"GIT_CONFIG_PARAMETERS": "'core.hooksPath={hooks_dir}'"},
+            "command-scope-parameters-hook-ran.txt",
+        ),
+    ],
+)
+def test_command_scope_hooks_path_is_cleared_during_real_pytest_launch(
+    tmp_path: Path,
+    inherited_env: dict[str, str],
+    marker_name: str,
+) -> None:
+    """Cover Git's env-injected config, not only file-backed global config."""
+    _assert_inherited_hooks_path_is_cleared_by_inner_pytest(
+        tmp_path,
+        inherited_env,
+        marker_name=marker_name,
+    )
+
+
+def test_inherited_git_config_global_is_cleared_during_real_pytest_launch(tmp_path: Path) -> None:
+    """An inherited GIT_CONFIG_GLOBAL file must not reach test repos."""
+    config = tmp_path / "global.gitconfig"
+    _assert_inherited_hooks_path_is_cleared_by_inner_pytest(
+        tmp_path,
+        {"GIT_CONFIG_GLOBAL": str(config)},
+        config_path=config,
+        marker_name="global-env-hook-ran.txt",
+    )
+
+
+def test_inherited_git_config_system_is_cleared_during_real_pytest_launch(tmp_path: Path) -> None:
+    """An inherited GIT_CONFIG_SYSTEM file must not reach test repos."""
+    config = tmp_path / "system.gitconfig"
+    _assert_inherited_hooks_path_is_cleared_by_inner_pytest(
+        tmp_path,
+        {"GIT_CONFIG_SYSTEM": str(config)},
+        config_path=config,
+        marker_name="system-env-hook-ran.txt",
+    )
+
+
+def test_inherited_git_template_dir_is_cleared_during_real_pytest_launch(tmp_path: Path) -> None:
+    """An inherited Git template hook must not be copied into test repos."""
+    template_dir = tmp_path / "git-template"
+    hooks_dir = template_dir / "hooks"
+    hooks_dir.mkdir(parents=True)
+    marker = tmp_path / "template-hook-ran.txt"
+    _write_executable(
+        hooks_dir / "pre-push",
+        f"#!/usr/bin/env bash\necho ran > {marker}\nexit 1\n",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "tests/test_local_pr_review.py::test_tests_do_not_inherit_command_scope_hooks_path",
+            "-p",
+            "no:cacheprovider",
+            "-q",
+            "--no-header",
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "ATLAS_SKIP_LOCAL_PR_REVIEW": "1",
+            "GIT_TEMPLATE_DIR": str(template_dir),
+        },
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert not marker.exists(), "inherited Git template hook ran inside pytest"
+
+
+def _assert_inherited_hooks_path_is_cleared_by_inner_pytest(
+    tmp_path: Path,
+    inherited_env: dict[str, str],
+    *,
+    marker_name: str,
+    config_path: Path | None = None,
+) -> None:
+    hooks_dir = tmp_path / "command-scope-hooks"
+    hooks_dir.mkdir()
+    marker = tmp_path / marker_name
+    _write_executable(
+        hooks_dir / "pre-push",
+        f"#!/usr/bin/env bash\necho ran > {marker}\nexit 1\n",
+    )
+    if config_path is not None:
+        config_path.write_text(f"[core]\n\thooksPath = {hooks_dir}\n", encoding="utf-8")
+    resolved_env = {
+        name: value.replace("{hooks_dir}", str(hooks_dir))
+        for name, value in inherited_env.items()
+    }
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "tests/test_local_pr_review.py::test_tests_do_not_inherit_command_scope_hooks_path",
+            "-p",
+            "no:cacheprovider",
+            "-q",
+            "--no-header",
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "ATLAS_SKIP_LOCAL_PR_REVIEW": "1",
+            **resolved_env,
+        },
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert not marker.exists(), "inherited pre-push hook ran inside pytest"
+
+
+def test_tests_do_not_inherit_command_scope_hooks_path(tmp_path: Path) -> None:
+    """A GIT_CONFIG_COUNT-injected hook must not reach test repos."""
+    repo = tmp_path / "repo"
+    _write_fixture_repo(repo)
+
+    result = _run(
+        repo,
+        ["git", "push", "-q", "origin", "HEAD:refs/heads/probe"],
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_tests_do_not_inherit_a_global_hooks_path(tmp_path: Path) -> None:
+    """A globally configured hook must not fire inside a test's repo.
+
+    This reproduces the incident: core.hooksPath set in the user's global
+    config fired the pre-push hook inside throwaway test repos.
+    """
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    hooks_dir = tmp_path / "global-hooks"
+    hooks_dir.mkdir()
+    marker = tmp_path / "hook-ran.txt"
+    _write_executable(
+        hooks_dir / "pre-push",
+        f"#!/usr/bin/env bash\necho ran > {marker}\nexit 1\n",
+    )
+    (fake_home / ".gitconfig").write_text(
+        f"[core]\n\thooksPath = {hooks_dir}\n", encoding="utf-8"
+    )
+
+    repo = tmp_path / "repo"
+    _write_fixture_repo(repo)
+
+    result = _run(
+        repo,
+        ["git", "push", "-q", "origin", "HEAD:refs/heads/probe"],
+        env={"HOME": str(fake_home)},
+    )
+
+    assert not marker.exists(), "global pre-push hook ran inside a test repo"
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_global_hooks_path_still_fires_when_not_isolated(tmp_path: Path) -> None:
+    """Second side of the guard: the isolation is what suppresses the hook.
+
+    Opting back in must still run it -- otherwise the test above could pass
+    for an unrelated reason and we would have proved nothing.
+    """
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    hooks_dir = tmp_path / "global-hooks"
+    hooks_dir.mkdir()
+    marker = tmp_path / "hook-ran.txt"
+    _write_executable(
+        hooks_dir / "pre-push",
+        f"#!/usr/bin/env bash\necho ran > {marker}\nexit 1\n",
+    )
+    global_config = fake_home / ".gitconfig"
+    global_config.write_text(
+        f"[core]\n\thooksPath = {hooks_dir}\n", encoding="utf-8"
+    )
+
+    repo = tmp_path / "repo"
+    _write_fixture_repo(repo)
+
+    result = _run(
+        repo,
+        ["git", "push", "-q", "origin", "HEAD:refs/heads/probe"],
+        env={"HOME": str(fake_home), "GIT_CONFIG_GLOBAL": str(global_config)},
+    )
+
+    assert marker.exists(), "hook did not run even when explicitly opted in"
+    assert result.returncode != 0
 
 
 def _valid_pr_body(plan: str) -> str:

--- a/tests/test_push_pr_wrapper.py
+++ b/tests/test_push_pr_wrapper.py
@@ -5,8 +5,21 @@ import subprocess
 from pathlib import Path
 from shutil import copy2, which
 
+import pytest
+
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(autouse=True)
+def _review_guard_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """push_pr.sh:80 branches on ATLAS_SKIP_LOCAL_PR_REVIEW.
+
+    conftest preserves that guard so a pushing test cannot re-enter the
+    review -> unit gate -> pytest cycle, but it would make the managed hook
+    look absent to these tests. Clear it for this module only.
+    """
+    monkeypatch.delenv("ATLAS_SKIP_LOCAL_PR_REVIEW", raising=False)
 SCRIPT = REPO_ROOT / "scripts" / "push_pr.sh"
 AUDIT_SCRIPT = REPO_ROOT / "scripts" / "audit_pr_body.py"
 AI_RECONCILIATION_SCRIPT = REPO_ROOT / "scripts" / "audit_ai_reconciliation.py"


### PR DESCRIPTION
Plan: plans/PR-Test-Git-Hermetic-Isolation.md
Slice phase: production hardening
Ownership lane: local-pr-review-tooling

`core.hooksPath` set in a developer's **global** git config applies to every
repository on the machine, including the throwaway repos the suite builds under
`/tmp`. When a gated test pushed inside one of those repos, the managed pre-push
hook fired, ran `scripts/local_pr_review.sh` → `scripts/check_unit_gate.py` →
`pytest`, whose tests push again — re-entering the same hook.

Observed live before this fix: **56,192 tasks** (`/proc/loadavg`), load average
**38.09**, **59 Gi of 61 Gi** RAM consumed and swap fully exhausted.

The hook already had a guard, `ATLAS_SKIP_LOCAL_PR_REVIEW`, but
`run_local_unit_gate_mirror` did not set it for the unit-gate child. A normal
developer shell does not carry that guard, so the child that performed the
recursing push reached the managed hook with no skip signal.

Diff-budget override: this slice is genuinely indivisible because the recursion
fix crosses the suite-wide pytest environment, the local unit-gate mirror, the
hook-behavior tests that must opt back in, and failing-first coverage for both
file-backed and command-scope Git config inheritance.

## Intentional

- `conftest.py` **preserves** `ATLAS_SKIP_LOCAL_PR_REVIEW` so the guard the unit
  gate supplies survives into pytest. `scripts/push_pr.sh:80` and the installed
  hook both branch on it, so the ten tests that assert the hook *runs* clear it
  with a per-module autouse fixture instead. Dropping it suite-wide — this PR's
  first revision — traded protection for every test to accommodate ten, and left
  the recursion's own crossing point (checker → pytest) unguarded.
- `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` are assigned unconditionally rather
  than via `setdefault`: hermetic git is a guarantee, not a default a stale
  environment may override. The identity vars use `setdefault` so fixtures can
  still override them. Command-scope Git config injection variables are cleared
  too, because Git honors those even when file-backed config is pointed at
  `/dev/null`.
- Fixed at the config layer rather than by blacklisting `core.hooksPath`, so any
  other hostile inherited git setting is closed off by the same change.

## AI reconciliation

- Preserve the recursion guard through pytest -- fixed-in: `tests/conftest.py`, `tests/test_local_pr_review.py`, `tests/test_install_local_pr_hook.py`, `tests/test_push_pr_wrapper.py`
- Complete the review contract before admission -- fixed-in: `plans/PR-Test-Git-Hermetic-Isolation.md`
- Clear command-scope Git config from pytest -- fixed-in: `tests/conftest.py`, `tests/test_local_pr_review.py`
- Sync and justify the over-budget plan -- fixed-in: `plans/PR-Test-Git-Hermetic-Isolation.md`
- Declare closure for the Git-config variable set -- fixed-in: `tests/conftest.py`, `plans/PR-Test-Git-Hermetic-Isolation.md`, `tests/test_local_pr_review.py`
- Complete the Deferred hardening disposition -- fixed-in: `plans/PR-Test-Git-Hermetic-Isolation.md`
- Exercise inherited file-backed config variables -- fixed-in: `tests/test_local_pr_review.py`
- Synchronize the canonical commit reconstruction -- fixed-in: `plans/PR-Test-Git-Hermetic-Isolation.md`, canonical squash commit for this head
- Record reproducible sweep commands -- fixed-in: `plans/PR-Test-Git-Hermetic-Isolation.md`, `tmp/pr-body-test-git-hermetic-isolation.md`
- Test the GIT_CONFIG_PARAMETERS injection path -- fixed-in: `tests/test_local_pr_review.py`
- Correct the stated recursion root cause -- fixed-in: `plans/PR-Test-Git-Hermetic-Isolation.md`, `tmp/pr-body-test-git-hermetic-isolation.md`
- Synchronize the canonical commit message with this diff -- fixed-in: canonical squash commit for this head, `plans/PR-Test-Git-Hermetic-Isolation.md`, `tmp/pr-body-test-git-hermetic-isolation.md`
- Clear inherited Git templates before fixture initialization -- fixed-in: `tests/conftest.py`, `tests/test_local_pr_review.py`, `plans/PR-Test-Git-Hermetic-Isolation.md`
- Synchronize the canonical commit with the 608-line diff -- fixed-in: canonical squash commit superseded by current 670-line head, `plans/PR-Test-Git-Hermetic-Isolation.md`, `tmp/pr-body-test-git-hermetic-isolation.md`
- Synchronize the canonical commit with the 670-line diff -- fixed-in: canonical squash commit for this head, `plans/PR-Test-Git-Hermetic-Isolation.md`, `tmp/pr-body-test-git-hermetic-isolation.md`
- Synchronize the canonical message with the 670-line tree -- waived-duplicate: current head `381d5cb579b855059ddf9ee7538c40e43b1c7928` already records eleven focused regressions and `6 files, +670/-0`; duplicate of the resolved 670-line canonical-message disposition above.

## Fix-loop disposition preflight

- Root decision: Preserve the recursion guard through pytest
- Source trace: Codex conftest guard claim -> conftest import could delete the unit-gate guard -> pytest now preserves ATLAS_SKIP_LOCAL_PR_REVIEW and hook-run tests opt in per module
- Upstream files: tests/conftest.py, tests/test_local_pr_review.py
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: tests/conftest.py, tests/test_local_pr_review.py, tests/test_install_local_pr_hook.py, tests/test_push_pr_wrapper.py, scripts/local_pr_review.sh, plans/PR-Test-Git-Hermetic-Isolation.md
- Max files: 6
- Parked hardening: none
- Root decision: Complete the review contract before admission
- Source trace: Codex review-contract claim -> plan lacked required affected-surface/risk/rule declarations -> Review Contract now enumerates acceptance criteria affected surfaces risk areas and triggered rules
- Upstream files: plans/PR-Test-Git-Hermetic-Isolation.md
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: plans/PR-Test-Git-Hermetic-Isolation.md
- Max files: 6
- Parked hardening: none
- Root decision: Clear command-scope Git config from pytest
- Source trace: Codex command-scope Git config claim -> file-backed config isolation did not clear inherited GIT_CONFIG_COUNT entries -> conftest clears command-scope config variables before test git commands run
- Upstream files: tests/conftest.py, tests/test_local_pr_review.py
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: tests/conftest.py, tests/test_local_pr_review.py, plans/PR-Test-Git-Hermetic-Isolation.md
- Max files: 6
- Parked hardening: none
- Root decision: Sync and justify the over-budget plan
- Source trace: Codex diff-budget claim -> plan/body underreported the actual PR size and omitted the override marker -> plan table is synced and body states the indivisible over-budget reason
- Upstream files: plans/PR-Test-Git-Hermetic-Isolation.md
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: plans/PR-Test-Git-Hermetic-Isolation.md
- Max files: 6
- Parked hardening: none
- Root decision: Declare closure for the Git-config variable set
- Source trace: Codex closure claim -> conftest used an enumerated Git config-injection list without declaring closed/open behavior -> conftest now exposes exact/prefix constants and the plan declares the closed set plus fallback for unlisted variables
- Upstream files: tests/conftest.py, plans/PR-Test-Git-Hermetic-Isolation.md
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: tests/conftest.py, tests/test_local_pr_review.py, plans/PR-Test-Git-Hermetic-Isolation.md
- Max files: 6
- Parked hardening: none
- Root decision: Complete the Deferred hardening disposition
- Source trace: Codex deferred-disposition claim -> Deferred listed ideas without parking predicates or unlock conditions -> Deferred now names future PR/refactor unlock conditions and says Parked hardening: none
- Upstream files: plans/PR-Test-Git-Hermetic-Isolation.md
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: plans/PR-Test-Git-Hermetic-Isolation.md
- Max files: 6
- Parked hardening: none
- Root decision: Exercise inherited file-backed config variables
- Source trace: Codex file-backed config claim -> HOME-only test did not prove inherited GIT_CONFIG_GLOBAL/SYSTEM are overwritten -> nested pytest regressions now launch with each variable pointing at a hook-bearing file
- Upstream files: tests/test_local_pr_review.py
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: tests/test_local_pr_review.py
- Max files: 6
- Parked hardening: none
- Root decision: Synchronize the canonical commit reconstruction
- Source trace: Codex canonical-message claim -> branch history still described the superseded first attempt -> this update will squash to a canonical commit message that matches the final head and PR body
- Upstream files: plans/PR-Test-Git-Hermetic-Isolation.md
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: plans/PR-Test-Git-Hermetic-Isolation.md, tmp/pr-body-test-git-hermetic-isolation.md
- Max files: 6
- Parked hardening: none
- Root decision: Record reproducible sweep commands
- Source trace: Codex verification claim -> plan/body reported broad pass counts without complete command arguments -> plan/body now include the exact identity and git-touching pytest invocations
- Upstream files: plans/PR-Test-Git-Hermetic-Isolation.md, tmp/pr-body-test-git-hermetic-isolation.md
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: plans/PR-Test-Git-Hermetic-Isolation.md, tmp/pr-body-test-git-hermetic-isolation.md
- Max files: 6
- Parked hardening: none
- Root decision: Test the GIT_CONFIG_PARAMETERS injection path
- Source trace: Codex parameters-coverage claim -> command-scope test covered GIT_CONFIG_COUNT key/value injection but not GIT_CONFIG_PARAMETERS -> the nested pytest proof is parameterized across both mechanisms
- Upstream files: tests/test_local_pr_review.py
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: tests/test_local_pr_review.py, plans/PR-Test-Git-Hermetic-Isolation.md
- Max files: 6
- Parked hardening: none
- Root decision: Correct the stated recursion root cause
- Source trace: Codex root-cause claim -> plan/body said local review stripped ATLAS_SKIP_LOCAL_PR_REVIEW even though local_pr_review.sh only omitted setting it for the child -> root-cause text now matches scripts/local_pr_review.sh
- Upstream files: plans/PR-Test-Git-Hermetic-Isolation.md
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: plans/PR-Test-Git-Hermetic-Isolation.md, tmp/pr-body-test-git-hermetic-isolation.md
- Max files: 6
- Parked hardening: none
- Root decision: Synchronize the canonical commit message with this diff
- Source trace: Codex canonical-message claim -> final commit message must match the current head after the GIT_CONFIG_PARAMETERS and root-cause edits -> the amended commit message will record 10 focused regressions and the synced diff budget
- Upstream files: plans/PR-Test-Git-Hermetic-Isolation.md
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: plans/PR-Test-Git-Hermetic-Isolation.md, tests/test_local_pr_review.py, tmp/pr-body-test-git-hermetic-isolation.md
- Max files: 6
- Parked hardening: none
- Root decision: Clear inherited Git templates before fixture initialization
- Source trace: Codex template-inheritance claim -> file-backed and command-scope config isolation did not clear GIT_TEMPLATE_DIR, which can copy hooks during git init -> conftest clears GIT_TEMPLATE_DIR and nested pytest proves a template pre-push hook does not run
- Upstream files: tests/conftest.py, tests/test_local_pr_review.py
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: tests/conftest.py, tests/test_local_pr_review.py, plans/PR-Test-Git-Hermetic-Isolation.md
- Max files: 6
- Parked hardening: none
- Root decision: Synchronize the canonical commit with the 608-line diff
- Source trace: Codex canonical-message claim -> the intermediate 608-line head needed an exact canonical-message disposition -> superseded by the current amended head whose canonical commit records the synced 670-line diff
- Upstream files: plans/PR-Test-Git-Hermetic-Isolation.md
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: plans/PR-Test-Git-Hermetic-Isolation.md, tmp/pr-body-test-git-hermetic-isolation.md
- Max files: 6
- Parked hardening: none
- Root decision: Synchronize the canonical commit with the 670-line diff
- Source trace: Codex canonical-message claim -> the final commit message must match the current head after the template fix -> the amended commit message will record 11 focused regressions and the synced diff budget
- Upstream files: plans/PR-Test-Git-Hermetic-Isolation.md
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: plans/PR-Test-Git-Hermetic-Isolation.md, tests/conftest.py, tests/test_local_pr_review.py, tmp/pr-body-test-git-hermetic-isolation.md
- Max files: 6
- Parked hardening: none
- Root decision: Synchronize the canonical message with the 670-line tree
- Source trace: Codex canonical-message claim -> current head already records eleven focused regressions and 6 files +670/-0 -> duplicate of the already-resolved 670-line canonical-message disposition
- Upstream files: plans/PR-Test-Git-Hermetic-Isolation.md
- Fix strategy: upstream-root
- Blocking predicate: not-blocking
- Disposition: waived-duplicate
- Allowed files: plans/PR-Test-Git-Hermetic-Isolation.md, tmp/pr-body-test-git-hermetic-isolation.md
- Max files: 6
- Parked hardening: none

## Deferred

- Future PR: machine-local temp-repo hook hard-stop. Unlock condition: the
  repo-managed pytest isolation in this PR fails to prevent a recurrence, or
  the operator explicitly wants belt-and-suspenders protection outside repo
  content. Parking predicate: `~/.claude/hooks/git/pre-push` is machine-local
  configuration, not repo content, and the current repo tests now prove inherited
  file-backed and command-scope hook config is neutralized before a test push.
- Future refactor: consolidate duplicated git fixture helpers
  (`_write_fixture_repo`, `_git`). Unlock condition: #2341 has landed and an
  adjacent PR needs shared fixture-helper edits. Parking predicate: helper
  consolidation is maintenance cleanup, not required to stop the recursion or
  prove the hermetic Git-config boundary.

## Parked hardening

None.

## Cold diff reconstruction

Read cold, the diff does four things:

1. `tests/conftest.py` — after the existing `ATLAS_DB_*` `setdefault` block,
   assigns `GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM` to `os.devnull`, clears
   command-scope Git config injection variables through the closed exact/prefix
   constants, records that unlisted `GIT_CONFIG_*` variables are out of this
   slice unless a future proof shows Git treats them as config injection, clears
   `GIT_TEMPLATE_DIR`,
   `setdefault`s
   `GIT_AUTHOR_NAME/EMAIL` and `GIT_COMMITTER_NAME/EMAIL`, and `setdefault`s
   `ATLAS_SKIP_LOCAL_PR_REVIEW=1` so the unit gate's guard survives into pytest.
2. `scripts/local_pr_review.sh` — adds `ATLAS_SKIP_LOCAL_PR_REVIEW=1` as the
   first entry of `unit_gate_env_values`. That array reaches all three
   `check_unit_gate.py` invocations, and `check_unit_gate.py:336` calls
   `subprocess.run` with no `env=`, so it inherits through to pytest.
3. `tests/test_local_pr_review.py` — adds eleven tests: the unit gate must expose
   the guard to its checker (ambient value set to `0` so a pass can only come
   from the script); a globally configured hooksPath must not fire inside a test
   repo; it must still fire when explicitly opted back in; conftest must preserve
   the guard; and that must hold through a real `pytest` launch, which a stub
   checker cannot exercise.
   It also covers command-scope `GIT_CONFIG_COUNT` / `GIT_CONFIG_KEY_*` /
   `GIT_CONFIG_VALUE_*` and `GIT_CONFIG_PARAMETERS` hook injection plus
   inherited `GIT_CONFIG_GLOBAL`, `GIT_CONFIG_SYSTEM`, and `GIT_TEMPLATE_DIR`
   hooks through real nested pytest launches.
4. `tests/test_install_local_pr_hook.py`, `tests/test_push_pr_wrapper.py` — an
   autouse fixture clears the guard for those modules only, so they still
   exercise the hook while every other test keeps it.

No production code path changes. The only non-test change is one environment
entry in the local review script.

## Verification

- Both new guard tests were confirmed **red against `origin/main`** first. The
  isolation test failed with `global pre-push hook ran inside a test repo`,
  reproducing the incident inside a test.
- The control test passed on `main` before any fix, proving the hook mechanism is
  real — so the isolation test cannot pass for an unrelated reason.
- Identity compensation was verified against the six test files that commit
  without setting a local identity, which is exactly what neutralizing global
  config would otherwise break.
- Because a `conftest.py` change has suite-wide blast radius, all 34
  git-touching test files were run, not only the three edited paths.
- The first attempt regressed **10 tests** under the real unit gate (8 in
  `test_install_local_pr_hook.py`, 2 in `test_push_pr_wrapper.py`), all asserting
  the managed hook runs. Running only the edited files would have missed this;
  the full gate caught it. Round 1 resolves it by keeping the guard and
  clearing it per module, so those files pass with the guard ambient — exactly
  how the unit gate invokes them — and with it absent.
- Process count was sampled across the runs and stayed flat (2,445 → 2,507),
  i.e. the recursion cannot re-enter.

## Mechanical verification

- Command: `pytest tests/test_local_pr_review.py -k "recursion_guard or global_hooks_path"` on unfixed origin/main - Result: fail (2 failed, 1 passed — intended red) - Environment: local
- Command: `pytest tests/test_local_pr_review.py -k "recursion_guard or global_hooks_path"` - Result: pass (3 passed) - Environment: local
- Command: `pytest tests/test_local_pr_review.py tests/test_open_pr_wrapper.py tests/test_push_pr_wrapper.py` - Result: pass (109 passed) - Environment: local
- Command: `pytest tests/test_check_ai_reconciliation_live.py tests/test_check_seam_convergence.py tests/test_getapp_parser.py tests/test_pr_watcher.py tests/test_security_guardrails_workflow.py tests/test_watch_owned_pr.py` - Result: pass (282 passed) - Environment: local
- Command: `pytest tests/test_audit_cross_layer_callers.py tests/test_audit_fix_loop_disposition.py tests/test_audit_plan_code_consistency.py tests/test_audit_plan_doc_diff_size.py tests/test_audit_plan_doc_files_touched.py tests/test_audit_pr_body.py tests/test_audit_pr_plan_presence.py tests/test_audit_pr_session_drift.py tests/test_check_ai_reconciliation_live.py tests/test_check_boundary_change_enumeration.py tests/test_check_deployed_config_probing.py tests/test_check_guard_class_closure.py tests/test_codex_issue_queue.py tests/test_content_factory_copy_verification.py tests/test_content_factory_runner.py tests/test_content_factory_store.py tests/test_detect_retired_failure_modes.py tests/test_docs_no_raw_deflection_request_ids.py tests/test_install_local_pr_hook.py tests/test_leads_intake.py tests/test_local_pr_review.py tests/test_new_pr_plan.py tests/test_open_pr_wrapper.py tests/test_plan_admission_workflow.py tests/test_pr_watcher.py tests/test_pre_push_audit.py tests/test_pre_push_audit_workflow.py tests/test_push_pr_wrapper.py tests/test_security_policy_docs.py tests/test_session_lane_workflow.py tests/test_sync_pr_plan.py tests/test_unit_gate_selector_fallback.py tests/test_update_pr_body_wrapper.py` - Result: pass (1828 passed) - Environment: local
- Command: `ATLAS_SKIP_LOCAL_PR_REVIEW=1 pytest tests/test_install_local_pr_hook.py tests/test_push_pr_wrapper.py` - Result: pass (32 passed) - Environment: local
- Command: `bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr-body-test-git-hermetic-isolation.md` - Result: fail on first attempt (unit gate: regressions=10), then re-run after the conftest fix - Environment: local
- Command: `ATLAS_SKIP_LOCAL_PR_REVIEW=1 pytest tests/test_local_pr_review.py tests/test_install_local_pr_hook.py tests/test_push_pr_wrapper.py` (round 1) - Result: pass (68 passed) - Environment: local
- Command: `pytest tests/test_local_pr_review.py tests/test_install_local_pr_hook.py tests/test_push_pr_wrapper.py` (round 1, no ambient guard) - Result: pass (68 passed) - Environment: local
- Command: `pytest tests/test_local_pr_review.py -k "recursion_guard or global_hooks_path or command_scope_hooks_path or inherited_git_config or git_template_dir" -q` - Result: pass (11 passed, 31 deselected) - Environment: local
- Command: `ATLAS_SKIP_LOCAL_PR_REVIEW=1 pytest tests/test_install_local_pr_hook.py tests/test_push_pr_wrapper.py -q` - Result: pass (32 passed) - Environment: local
- Command: `pytest tests/test_local_pr_review.py tests/test_install_local_pr_hook.py tests/test_push_pr_wrapper.py -q` - Result: pass (74 passed) - Environment: local
- Command: `bash -n scripts/local_pr_review.sh` - Result: pass - Environment: local

## Diff size

Diff-budget override: this slice is genuinely indivisible because the recursion
fix crosses the suite-wide pytest environment, the local unit-gate mirror, the
hook-behavior tests that must opt back in, and failing-first coverage for both
file-backed and command-scope Git config inheritance.

6 files, 670 LOC. The synced plan table carries the exact per-file diff.

<!-- atlas-open-pr-wrapper: v1 -->
