### PR TITLE
EOM contact-link verification

### DIFF
--- a/.github/workflows/atlas_eom_lead_pipeline_checks.yml
+++ b/.github/workflows/atlas_eom_lead_pipeline_checks.yml
@@ -69,7 +69,7 @@ on:
       - "tests/test_crm_read_scoping.py"
       - "tests/test_eom_complaints_integration.py"
       - "tests/test_eom_contacts_api_tenant_scope.py"
-      - "tests/test_eom_known_contacts.py"
+      - "tests/test_eom_link_verification.py"
       - "tests/test_eom_lead_conversion.py"
       - "tests/test_eom_lead_conversion_integration.py"
       - "tests/test_eom_write_boundary_audit.py"
@@ -152,7 +152,7 @@ on:
       - "tests/test_crm_read_scoping.py"
       - "tests/test_eom_complaints_integration.py"
       - "tests/test_eom_contacts_api_tenant_scope.py"
-      - "tests/test_eom_known_contacts.py"
+      - "tests/test_eom_link_verification.py"
       - "tests/test_eom_lead_conversion.py"
       - "tests/test_eom_lead_conversion_integration.py"
       - "tests/test_eom_write_boundary_audit.py"
@@ -213,7 +213,7 @@ jobs:
             tests/test_crm_read_scoping.py \
             tests/test_eom_complaints_integration.py \
             tests/test_eom_contacts_api_tenant_scope.py \
-            tests/test_eom_known_contacts.py \
+            tests/test_eom_link_verification.py \
             tests/test_eom_lead_conversion.py \
             tests/test_eom_lead_conversion_integration.py \
             tests/test_eom_write_boundary_audit.py \

--- a/.github/workflows/atlas_eom_lead_pipeline_checks.yml
+++ b/.github/workflows/atlas_eom_lead_pipeline_checks.yml
@@ -69,6 +69,7 @@ on:
       - "tests/test_crm_read_scoping.py"
       - "tests/test_eom_complaints_integration.py"
       - "tests/test_eom_contacts_api_tenant_scope.py"
+      - "tests/test_eom_known_contacts.py"
       - "tests/test_eom_lead_conversion.py"
       - "tests/test_eom_lead_conversion_integration.py"
       - "tests/test_eom_write_boundary_audit.py"
@@ -151,6 +152,7 @@ on:
       - "tests/test_crm_read_scoping.py"
       - "tests/test_eom_complaints_integration.py"
       - "tests/test_eom_contacts_api_tenant_scope.py"
+      - "tests/test_eom_known_contacts.py"
       - "tests/test_eom_lead_conversion.py"
       - "tests/test_eom_lead_conversion_integration.py"
       - "tests/test_eom_write_boundary_audit.py"
@@ -211,6 +213,7 @@ jobs:
             tests/test_crm_read_scoping.py \
             tests/test_eom_complaints_integration.py \
             tests/test_eom_contacts_api_tenant_scope.py \
+            tests/test_eom_known_contacts.py \
             tests/test_eom_lead_conversion.py \
             tests/test_eom_lead_conversion_integration.py \
             tests/test_eom_write_boundary_audit.py \

--- a/atlas_brain/eom_api/funnel.py
+++ b/atlas_brain/eom_api/funnel.py
@@ -57,6 +57,11 @@ _RFC3339_DATETIME_PATTERN = re.compile(
 _MAX_SIGNED_BIGINT = 2**63 - 1
 _DEFAULT_LEAD_REVIEW_LIMIT = 100
 _MAX_LEAD_REVIEW_LIMIT = 200
+# Ids ride in the query string, so the cap is a URL-length budget rather than a
+# database one: 100 ids costs roughly 4.8 KB of `contact_id=<uuid>&`, comfortably
+# inside the 8 KB request line every proxy in front of this accepts. Callers with
+# more links to check page through them.
+_MAX_KNOWN_CONTACT_IDS = 100
 # Same conservative shape the public intake boundary accepts
 # (atlas_brain/api/leads.py), so an office-corrected recipient can never be
 # stricter or looser than an intake-submitted one.
@@ -235,6 +240,21 @@ class EOMLeadReviewResponse(BaseModel):
     # (Render) auto-deploy from main; Atlas deploys by hand, so callers
     # routinely run ahead of it. See ATLAS #2275 and website #112.
     capabilities: list[str] = Field(default_factory=list)
+
+
+class EOMKnownContactsResponse(BaseModel):
+    """Which of the submitted contact ids name a live EOM contact.
+
+    Deliberately id-only. A caller holding a stored contact id is asking
+    whether its link still resolves, and answering that needs no name, email,
+    or phone -- so none is disclosed.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    known_contact_ids: list[UUID] = Field(serialization_alias="knownContactIds")
+    checked: int
+    limit: Annotated[int, Field(ge=1, le=_MAX_KNOWN_CONTACT_IDS)]
 
 
 class EOMOnboardingDraftEditRequest(BaseModel):
@@ -422,6 +442,7 @@ _CAPABILITY_ROUTES: dict[str, tuple[str, str]] = {
         "POST",
         "/eom-funnel/onboarding-drafts/{draft_id}/confirm-sent",
     ),
+    "contact.link_verification": ("GET", "/eom-funnel/known-contacts"),
 }
 
 _served_capabilities_cache: tuple[str, ...] | None = None
@@ -588,6 +609,52 @@ async def list_eom_lead_review_items(
         has_more=has_more,
         next_cursor=next_cursor,
         capabilities=list(served_capabilities()),
+    )
+
+
+@router.get(
+    "/known-contacts",
+    response_model=EOMKnownContactsResponse,
+    dependencies=[Depends(require_eom_funnel_api)],
+)
+async def list_known_eom_contacts(
+    contact_id: Annotated[
+        list[UUID],
+        Query(min_length=1, max_length=_MAX_KNOWN_CONTACT_IDS),
+    ],
+    _actor: dict[str, object] = Depends(require_eom_funnel_actor),
+    crm: Any = Depends(_crm_dependency),
+) -> EOMKnownContactsResponse:
+    """Report which submitted contact ids still name a live EOM contact.
+
+    A system holding its own copy of a contact id -- the tracker's
+    ``customers.atlas_contact_id`` -- cannot tell a good link from a dangling
+    one on its own, so a link to a contact that no longer exists stays silent
+    until someone opens the record. This answers that question and nothing
+    else: an id comes back only when it names an ``effingham_maids`` contact.
+    Lifecycle is not part of the answer -- an archived or lost contact is still
+    a link that resolves.
+
+    An id that exists under a different tenant is reported the same way as one
+    that does not exist at all. The distinction would be more useful to the
+    caller and is deliberately withheld: this credential is scoped to EOM, and
+    confirming the existence of another tenant's contact would make this route
+    a cross-tenant existence oracle. Either answer means the same thing to the
+    caller anyway -- the link does not point at an EOM contact.
+
+    Reading this projection alters nothing.
+    """
+    requested = list(dict.fromkeys(contact_id))
+    known = await crm.list_known_eom_contact_ids(contact_ids=requested)
+    # Answer in terms of what was asked rather than echoing the provider's rows:
+    # an id the caller never submitted must never appear in the response, or the
+    # route would report a verdict the caller cannot attribute to a link it holds.
+    known_set = {UUID(str(value)) for value in known}
+    known_ids = [value for value in requested if value in known_set]
+    return EOMKnownContactsResponse(
+        known_contact_ids=known_ids,
+        checked=len(requested),
+        limit=_MAX_KNOWN_CONTACT_IDS,
     )
 
 

--- a/atlas_brain/services/crm_provider.py
+++ b/atlas_brain/services/crm_provider.py
@@ -20,7 +20,7 @@ import hashlib
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Mapping, Optional
+from typing import Any, Mapping, Optional, Sequence
 from uuid import UUID, uuid4
 
 logger = logging.getLogger("atlas.services.crm_provider")
@@ -1918,6 +1918,37 @@ class DatabaseCRMProvider:
             *params,
         )
         return [dict(row) for row in rows]
+
+    async def list_known_eom_contact_ids(
+        self,
+        *,
+        contact_ids: Sequence[UUID],
+    ) -> list[UUID]:
+        """Return the subset of ``contact_ids`` that name a live EOM contact.
+
+        Answers link verification for systems that store an Atlas contact id of
+        their own. Tenant scope is part of the answer, not a filter applied
+        afterwards: an id belonging to another business context is simply not
+        in the result, so no caller can use this to probe outside EOM.
+
+        Archived and lost contacts still count as known. The question is
+        whether the link resolves, and a link to a contact that was closed is
+        intact -- it is a dangling or cross-tenant id that means the write
+        boundary was bypassed.
+        """
+        if not contact_ids:
+            return []
+        pool = self._get_pool()
+        rows = await pool.fetch(
+            """
+            SELECT c.id
+            FROM contacts AS c
+            WHERE c.business_context_id = 'effingham_maids'
+              AND c.id = ANY($1::uuid[])
+            """,
+            list(contact_ids),
+        )
+        return [row["id"] for row in rows]
 
     @staticmethod
     def _eom_estimate_booking_metadata(

--- a/plans/PR-EOM-Contact-Link-Verification.md
+++ b/plans/PR-EOM-Contact-Link-Verification.md
@@ -35,6 +35,7 @@ anyway.
 
 Ownership lane: eom-crm/lead-funnel
 Slice phase: Vertical slice
+Max files: 5
 
 1. Add `GET /eom-funnel/known-contacts`: given up to 100 `contact_id` query
    values, return the subset that names a live `effingham_maids` contact, and
@@ -190,7 +191,7 @@ Parked hardening: none.
 - Neighbouring EOM suites for regression —
   `test_eom_funnel_capability_manifest.py`, `test_eom_lead_conversion.py`,
   `test_eom_contacts_api_tenant_scope.py`, `test_crm_read_scoping.py`,
-  `test_eom_known_contacts.py`: **495 passed**.
+  `test_eom_link_verification.py`: **495 passed**.
 
 ## Estimated diff size
 
@@ -199,6 +200,6 @@ Parked hardening: none.
 | `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 3 |
 | `atlas_brain/eom_api/funnel.py` | 67 |
 | `atlas_brain/services/crm_provider.py` | 33 |
-| `plans/PR-EOM-Contact-Link-Verification.md` | 204 |
-| `tests/test_eom_link_verification.py` | 342 |
-| **Total** | **649** |
+| `plans/PR-EOM-Contact-Link-Verification.md` | 205 |
+| `tests/test_eom_link_verification.py` | 388 |
+| **Total** | **696** |

--- a/plans/PR-EOM-Contact-Link-Verification.md
+++ b/plans/PR-EOM-Contact-Link-Verification.md
@@ -51,7 +51,7 @@ and depends on this deploying first.
 
 - Acceptance criteria:
   - A dangling id is reported unknown and a live id is reported known — settled by
-    `tests/test_eom_known_contacts.py::test_a_dangling_link_is_reported_as_unknown`
+    `tests/test_eom_link_verification.py::test_a_dangling_link_is_reported_as_unknown`
     and `::test_a_live_contact_is_not_reported_as_dangling`.
   - A contact in another business context is never reported known, proven against
     real PostgreSQL rather than a stub — settled by
@@ -121,7 +121,7 @@ EOM funnel reads already use.
 - `atlas_brain/eom_api/funnel.py`
 - `atlas_brain/services/crm_provider.py`
 - `plans/PR-EOM-Contact-Link-Verification.md`
-- `tests/test_eom_known_contacts.py`
+- `tests/test_eom_link_verification.py`
 
 ## Mechanism
 
@@ -179,7 +179,7 @@ Parked hardening: none.
 
 ## Verification
 
-- `tests/test_eom_known_contacts.py` — 14 tests, run against a throwaway
+- `tests/test_eom_link_verification.py` — 14 tests, run against a throwaway
   `postgres:16` with `ATLAS_MIGRATION_TEST_DATABASE_URL` set: **14 passed**.
 - Negative controls, both run and both failing as required before restore:
   removing the tenant predicate from the provider query fails
@@ -200,5 +200,5 @@ Parked hardening: none.
 | `atlas_brain/eom_api/funnel.py` | 67 |
 | `atlas_brain/services/crm_provider.py` | 33 |
 | `plans/PR-EOM-Contact-Link-Verification.md` | 204 |
-| `tests/test_eom_known_contacts.py` | 347 |
-| **Total** | **654** |
+| `tests/test_eom_link_verification.py` | 342 |
+| **Total** | **649** |

--- a/plans/PR-EOM-Contact-Link-Verification.md
+++ b/plans/PR-EOM-Contact-Link-Verification.md
@@ -92,8 +92,15 @@ and depends on this deploying first.
 - Risk areas: tenant leakage through an unscoped id lookup; disclosure beyond the
   id; unbounded id lists as a query-cost or URL-length vector; a capability that
   callers cannot discover; a new test file that silently never runs in CI.
-- Reviewer rules triggered: R1 (tenant scope), R2 (read-only boundary), R7
-  (input bounds), R9 (capability manifest), R14 (CI registration).
+- Reviewer rules triggered: R1 (requirements match), R2 (test evidence), R3
+  (security and authorization -- this route sits behind an explicit
+  authentication boundary and enforces tenant scope), R5 (backward
+  compatibility -- it adds a new request/response surface and a capability
+  manifest entry callers gate on), R7 (input bounds -- the 100-id cap and UUID
+  admission), R12 (deployment safety and CI enrollment -- the new test file is
+  enrolled in the EOM lead-pipeline workflow), R14 (verify against the
+  codebase). R9 is NOT triggered: it governs frontend behaviour, and an earlier
+  draft of this plan wrongly filed the capability manifest under it.
 
 ### Boundary-change enumeration
 
@@ -109,6 +116,37 @@ and depends on this deploying first.
   foreign-tenant id, duplicate ids, malformed id, empty list, 100 ids, 101 ids};
   unauthenticated caller and wrong-token caller x any id (both refused before the
   provider is reached).
+
+### Member-set closure: `_CAPABILITY_ROUTES`
+
+This PR adds `contact.link_verification` to `_CAPABILITY_ROUTES`, which is a
+decision-driving member set: callers gate control availability on the
+`capabilities` list the funnel returns, so membership decides what a caller will
+attempt.
+
+- **Open or closed:** CLOSED with respect to what a caller may rely on, and
+  append-only in practice. A capability name is a published contract; adding one
+  is additive and safe, renaming or removing one breaks callers that gate on it,
+  so removal requires a deprecation pass rather than an edit here.
+- **Where membership comes from:** the literal map in
+  `atlas_brain/eom_api/funnel.py`, intersected at runtime with the routes this
+  build actually registers (`served_capabilities()` reads `router.routes`). So a
+  name is served only if BOTH the map lists it and the route exists — the map
+  alone cannot advertise a capability this deployment does not serve. That
+  intersection is why the manifest is computed on first call rather than at
+  import: the decorators run later, and an import-time constant would silently
+  under-report.
+- **Unlisted routes:** a route with no entry in the map is simply never
+  advertised. It stays reachable to a caller that knows its path, so the map is
+  a discovery contract, not an authorization one — authorization is
+  `require_eom_funnel_api` + `require_eom_funnel_actor` on each route. Omission
+  degrades a caller to "cannot discover", never to "can call something it should
+  not".
+- **Drift policy:** a new EOM funnel route that callers must gate on adds its
+  name here in the same PR that adds the route. A route deliberately not
+  advertised (internal, or superseded) is left out and said so in its own plan.
+- **Enforced by:** `test_link_verification_is_advertised_in_the_capability_manifest`
+  fails if this entry is dropped while the route remains.
 
 ### Deployed-config probing
 
@@ -176,22 +214,36 @@ means the write boundary was bypassed.
   signal in the tracker audit that calls this route. Separate repo, separate PR,
   and it needs this deployed first. #167, #113 and #107 stay open until it lands.
 
+Parking predicate: hardening is parked when it protects a caller that does not
+exist yet, or an input shape this route cannot receive. Against that predicate,
+nothing is parked -- the only caller is the tracker consumer named above, and
+every input shape the route accepts (empty, over-cap, malformed, duplicate,
+cross-tenant, dangling) is covered by a test at this head.
+
 Parked hardening: none.
 
 ## Verification
 
-- `tests/test_eom_link_verification.py` — 14 tests, run against a throwaway
-  `postgres:16` with `ATLAS_MIGRATION_TEST_DATABASE_URL` set: **14 passed**.
+- `tests/test_eom_link_verification.py` — 15 tests, run against a throwaway
+  `postgres:16` with `ATLAS_MIGRATION_TEST_DATABASE_URL` set: **15 passed**.
+  Re-run at this head after adding the aggregate-reachability test; the earlier
+  14/495 receipt described the previous head and no longer substantiated it.
 - Negative controls, both run and both failing as required before restore:
   removing the tenant predicate from the provider query fails
   `test_tenant_scope_holds_against_real_postgres`; replacing the request-ordered
   intersection with `list(known_set)` fails
   `test_an_id_the_caller_never_submitted_is_never_returned`. Result: pass (each
-  control failed only its target test; restored source passes all 14).
+  control failed only its target test; restored source passes all 15).
 - Neighbouring EOM suites for regression —
   `test_eom_funnel_capability_manifest.py`, `test_eom_lead_conversion.py`,
   `test_eom_contacts_api_tenant_scope.py`, `test_crm_read_scoping.py`,
-  `test_eom_link_verification.py`: **495 passed**.
+  `test_eom_link_verification.py`: **496 passed**.
+- Reachability is proven on the deployed aggregate, not a harness:
+  `test_the_real_aggregate_serves_the_route_at_its_deployed_path` calls
+  `/api/v1/eom-funnel/known-contacts` on `atlas_brain.main.app`. Negative
+  control: replacing `router.include_router(eom_funnel_router)` with `pass`
+  fails ONLY that test (1 failed, 14 passed), which is the blind spot it
+  closes.
 
 ## Estimated diff size
 
@@ -200,6 +252,6 @@ Parked hardening: none.
 | `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 3 |
 | `atlas_brain/eom_api/funnel.py` | 67 |
 | `atlas_brain/services/crm_provider.py` | 33 |
-| `plans/PR-EOM-Contact-Link-Verification.md` | 205 |
+| `plans/PR-EOM-Contact-Link-Verification.md` | 257 |
 | `tests/test_eom_link_verification.py` | 388 |
-| **Total** | **696** |
+| **Total** | **748** |

--- a/plans/PR-EOM-Contact-Link-Verification.md
+++ b/plans/PR-EOM-Contact-Link-Verification.md
@@ -20,6 +20,35 @@ The tracker cannot ask. `_atlas_funnel_read` is hard-locked to `/eom-funnel/lead
 (`backend/time_tracker_api.py:3376`), and no Atlas route answers contact existence
 anyway.
 
+### Why this slice is indivisible above the 400-LOC budget
+
+The diff is 748 LOC. The application change inside it is 100 LOC across two
+files: one route in `atlas_brain/eom_api/funnel.py` and one read method in
+`atlas_brain/services/crm_provider.py`. The remaining ~648 are the tests that
+prove it and the plan doc this gate itself mandates.
+
+There is no split that leaves both halves reviewable:
+
+- **Route without tests** merges a tenant-scoped read boundary whose scoping is
+  unproven. Tenant scope is the one claim here that stub tests structurally
+  cannot settle — every stubbed test in the file passes identically against a
+  scoped and an unscoped query — so `test_tenant_scope_holds_against_real_
+  postgres` is the only evidence that the predicate is in the SQL rather than
+  only in the docstring. Merging that unproven is the precise failure this
+  slice exists to remove.
+- **Tests without the route** is not a slice; it is a red suite.
+- **Route plus a thinner suite** drops exactly the cases that make this a
+  boundary rather than a query: the both-sides cap, the empty-request refusal,
+  the caller-attribution filter, the unauthenticated and wrong-token paths, and
+  the aggregate-reachability proof. Each is one test and each closes a distinct
+  way the route could pass review while being wrong.
+- **The plan doc is not optional** — the PR gate rejects a non-Markdown diff
+  that does not add exactly one, so its ~250 lines cannot be split off at all.
+
+What could have been split, and was: the tracker-side consumer of this route is
+a separate PR in eom-timetracker, and the stale-reservation half of #167 already
+shipped independently as eom-timetracker #155/#156.
+
 ### Problem-derived contract
 
 - Root cause: no read boundary exists for "does this contact id still resolve to a
@@ -252,6 +281,6 @@ Parked hardening: none.
 | `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 3 |
 | `atlas_brain/eom_api/funnel.py` | 67 |
 | `atlas_brain/services/crm_provider.py` | 33 |
-| `plans/PR-EOM-Contact-Link-Verification.md` | 257 |
+| `plans/PR-EOM-Contact-Link-Verification.md` | 286 |
 | `tests/test_eom_link_verification.py` | 388 |
-| **Total** | **748** |
+| **Total** | **777** |

--- a/plans/PR-EOM-Contact-Link-Verification.md
+++ b/plans/PR-EOM-Contact-Link-Verification.md
@@ -1,0 +1,204 @@
+# PR-EOM-Contact-Link-Verification
+
+## Why this slice exists
+
+Website #167 is the tracker half of Slice 0F (write-boundary observability, #113).
+It was split out of ATLAS #2344 after three review rounds showed two of its signals
+could not be closed from inside ATLAS. The stale-reservation signal shipped in the
+tracker on its own. The remaining one is blocked here.
+
+The tracker stores its own copy of an Atlas contact id in
+`customers.atlas_contact_id`. A non-null value there proves nothing: it proves a
+write happened once, not that the contact still exists or that it was ever an EOM
+contact. Nothing on either side notices when that link stops resolving, so a
+customer whose Atlas contact is gone looks perfectly healthy in the tracker until
+someone opens the record by hand. That is the same silent-failure class Slice 0
+exists to close, and the reason the original defect survived long enough to need a
+backfill.
+
+The tracker cannot ask. `_atlas_funnel_read` is hard-locked to `/eom-funnel/leads`
+(`backend/time_tracker_api.py:3376`), and no Atlas route answers contact existence
+anyway.
+
+### Problem-derived contract
+
+- Root cause: no read boundary exists for "does this contact id still resolve to a
+  live EOM contact", so a system holding an Atlas contact id cannot validate it.
+- Correct fix must touch/change: a read-only EOM funnel route that takes contact
+  ids and returns which are known; a tenant-scoped provider query behind it; the
+  capability manifest, because callers gate on it; and the CI job's test list, or
+  the proof never runs.
+- Must not change: any write path, the funnel's auth model, the contacts schema,
+  or what the funnel discloses about a contact beyond its id.
+
+## Scope (this PR)
+
+Ownership lane: eom-crm/lead-funnel
+Slice phase: Vertical slice
+
+1. Add `GET /eom-funnel/known-contacts`: given up to 100 `contact_id` query
+   values, return the subset that names a live `effingham_maids` contact, and
+   nothing else about them.
+2. Add `DatabaseCRMProvider.list_known_eom_contact_ids`, tenant-scoped in the SQL
+   rather than filtered afterwards.
+3. Prove both directions, including a real-PostgreSQL proof that the tenant scope
+   is in the query and not just in the docstring.
+
+Not in this PR: the tracker-side consumer. It is a separate PR in eom-timetracker
+and depends on this deploying first.
+
+### Review Contract
+
+- Acceptance criteria:
+  - A dangling id is reported unknown and a live id is reported known — settled by
+    `tests/test_eom_known_contacts.py::test_a_dangling_link_is_reported_as_unknown`
+    and `::test_a_live_contact_is_not_reported_as_dangling`.
+  - A contact in another business context is never reported known, proven against
+    real PostgreSQL rather than a stub — settled by
+    `::test_tenant_scope_holds_against_real_postgres`, which seeds an
+    `effingham_maids` row beside a `churnsignals` row and asks for both.
+    Negative control run: removing `WHERE c.business_context_id =
+    'effingham_maids'` from the provider query fails this test.
+  - The response never contains an id the caller did not submit — settled by
+    `::test_an_id_the_caller_never_submitted_is_never_returned`, which stubs a
+    provider that returns an extra id. Negative control run: replacing the
+    request-ordered filter with `list(known_set)` fails this test.
+  - An empty request is rejected rather than answered "clean" — settled by
+    `::test_an_empty_check_is_rejected_rather_than_answered_clean` (422, provider
+    never called).
+  - The cap holds on both sides: 100 accepted, 101 rejected — settled by
+    `::test_exactly_the_cap_is_accepted` and `::test_the_cap_is_enforced_at_the_boundary`.
+  - A malformed id is rejected, not silently dropped — settled by
+    `::test_a_malformed_id_is_rejected_not_silently_dropped`.
+  - The route refuses unauthenticated and wrong-token callers without reaching the
+    provider — settled by `::test_the_route_refuses_an_unauthenticated_caller` and
+    `::test_a_wrong_service_token_is_refused`.
+  - The response body carries only `knownContactIds`, `checked`, `limit` — settled
+    by `::test_the_route_discloses_no_contact_data_beyond_the_id`.
+  - The capability is advertised, since callers gate on the manifest — settled by
+    `::test_link_verification_is_advertised_in_the_capability_manifest`.
+  - The new test file actually runs in CI — settled by
+    `.github/workflows/atlas_eom_lead_pipeline_checks.yml:216` (pytest argument)
+    plus lines 72 and 155 (both path-filter blocks, so a test-only edit still
+    triggers the job).
+- Reachability proof: real entrypoint is `GET /api/v1/eom-funnel/known-contacts`
+  on the aggregate app, behind `require_eom_funnel_api` +
+  `require_eom_funnel_actor` like every other funnel route. Observable effect is
+  the response body; the route performs no writes.
+- Affected surfaces: `atlas_brain/eom_api/funnel.py` (route, response model,
+  capability entry, cap constant), `atlas_brain/services/crm_provider.py` (one new
+  read method), the EOM lead-pipeline CI job.
+- Risk areas: tenant leakage through an unscoped id lookup; disclosure beyond the
+  id; unbounded id lists as a query-cost or URL-length vector; a capability that
+  callers cannot discover; a new test file that silently never runs in CI.
+- Reviewer rules triggered: R1 (tenant scope), R2 (read-only boundary), R7
+  (input bounds), R9 (capability manifest), R14 (CI registration).
+
+### Boundary-change enumeration
+
+- Boundary path/seam: `GET /eom-funnel/known-contacts` — a new admission boundary
+  over a list of contact ids.
+- Replaced-path behaviors: none. No existing route answered this question, so
+  nothing is replaced and no caller changes behavior.
+- Guard-relevant fields: `contact_id` (repeatable query param) — list length
+  (1..100), per-value UUID parseability, duplicates; and
+  `contacts.business_context_id`, which is part of the query rather than a filter
+  applied to its result.
+- Caller x input shape: authenticated tracker x {live id, dangling id,
+  foreign-tenant id, duplicate ids, malformed id, empty list, 100 ids, 101 ids};
+  unauthenticated caller and wrong-token caller x any id (both refused before the
+  provider is reached).
+
+### Deployed-config probing
+
+N/A - no guard/config boundary change. The route reads no environment or config
+value; the cap is a module constant and the tenant is the same literal the other
+EOM funnel reads already use.
+
+### Files touched
+
+- `.github/workflows/atlas_eom_lead_pipeline_checks.yml`
+- `atlas_brain/eom_api/funnel.py`
+- `atlas_brain/services/crm_provider.py`
+- `plans/PR-EOM-Contact-Link-Verification.md`
+- `tests/test_eom_known_contacts.py`
+
+## Mechanism
+
+The route takes `contact_id` as a repeatable query parameter, deduplicates while
+preserving submission order, and hands the list to
+`list_known_eom_contact_ids`. The provider runs a single
+`WHERE c.business_context_id = 'effingham_maids' AND c.id = ANY($1::uuid[])`, so
+tenant scope is part of what the query can return rather than a filter applied to
+its result — an unscoped variant would have to leak first and be cleaned up after.
+
+The route then answers in terms of what was asked: it intersects the provider's
+rows against the submitted ids and emits them in submission order. That is not
+belt-and-braces. Without it, a provider row the caller never submitted would
+appear in the response as a "known" verdict the caller cannot attribute to any
+link it holds.
+
+Ids ride in the query string, so the 100-id cap is a URL-length budget: 100 ids
+costs roughly 4.8 KB of `contact_id=<uuid>&`, inside the 8 KB request line proxies
+accept. Callers with more links page through them.
+
+Archived and lost contacts count as known. The question is whether the link
+resolves; a link to a closed contact is intact. Only a dangling or cross-tenant id
+means the write boundary was bypassed.
+
+## Intentional
+
+- **A cross-tenant id is reported exactly like a missing one.** Distinguishing
+  them would be more useful to the caller and is deliberately refused: this
+  credential is scoped to EOM, and confirming that some id exists under another
+  business context would make the route a cross-tenant existence oracle. Both
+  answers mean the same thing to the caller anyway — the link does not point at an
+  EOM contact.
+- **Id-only response.** A caller holding a stored contact id is asking whether its
+  link resolves; that needs no name, email, or phone, so none is disclosed. The
+  existing `/eom-funnel/leads` projection stays the only route that returns
+  identity fields.
+- **GET with repeated query params, not POST with a body.** The operation is a
+  read and the method should say so. The cost is the URL-length cap above, which
+  is the reason the cap exists at all.
+- **An empty id list is a 422, not an empty-and-clean 200.** A caller that
+  accidentally sends nothing must not read the answer as "every link is fine" —
+  that is the false-assurance failure this slice exists to remove.
+- **Rejected: a per-id `GET /eom-funnel/contacts/{id}`.** Simpler, but the tracker
+  would issue one request per customer to audit its links, which makes the audit
+  expensive enough to not run — and a monitor that does not run is the thing being
+  fixed.
+
+## Deferred
+
+- The tracker-side consumer (website #167's remaining half): a linkage-validity
+  signal in the tracker audit that calls this route. Separate repo, separate PR,
+  and it needs this deployed first. #167, #113 and #107 stay open until it lands.
+
+Parked hardening: none.
+
+## Verification
+
+- `tests/test_eom_known_contacts.py` — 14 tests, run against a throwaway
+  `postgres:16` with `ATLAS_MIGRATION_TEST_DATABASE_URL` set: **14 passed**.
+- Negative controls, both run and both failing as required before restore:
+  removing the tenant predicate from the provider query fails
+  `test_tenant_scope_holds_against_real_postgres`; replacing the request-ordered
+  intersection with `list(known_set)` fails
+  `test_an_id_the_caller_never_submitted_is_never_returned`. Result: pass (each
+  control failed only its target test; restored source passes all 14).
+- Neighbouring EOM suites for regression —
+  `test_eom_funnel_capability_manifest.py`, `test_eom_lead_conversion.py`,
+  `test_eom_contacts_api_tenant_scope.py`, `test_crm_read_scoping.py`,
+  `test_eom_known_contacts.py`: **495 passed**.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 3 |
+| `atlas_brain/eom_api/funnel.py` | 67 |
+| `atlas_brain/services/crm_provider.py` | 33 |
+| `plans/PR-EOM-Contact-Link-Verification.md` | 204 |
+| `tests/test_eom_known_contacts.py` | 347 |
+| **Total** | **654** |

--- a/tests/test_eom_known_contacts.py
+++ b/tests/test_eom_known_contacts.py
@@ -1,0 +1,347 @@
+"""HTTP boundary proof for EOM contact-link verification.
+
+The tracker stores its own copy of an Atlas contact id. Nothing on either side
+notices when that copy stops resolving, which is the silent write-boundary
+failure Slice 0 exists to close. These tests hold the route to answering that
+one question and no more: which submitted ids name a live EOM contact.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from atlas_brain.eom_api import funnel as funnel_mod
+from atlas_brain.eom_api import funnel_auth as auth_mod
+from atlas_brain.eom_api.config import EOMFunnelConfig
+
+ROOT = Path(__file__).resolve().parent.parent
+MIGRATIONS = ROOT / "atlas_brain" / "storage" / "migrations"
+DATABASE_URL_ENV = "ATLAS_MIGRATION_TEST_DATABASE_URL"
+TENANT = "effingham_maids"
+FOREIGN_TENANT = "churnsignals"
+
+_GENERATED_SERVICE_TOKEN = auth_mod.generate_eom_funnel_service_token()
+_SERVICE_TOKEN = _GENERATED_SERVICE_TOKEN.token
+_SERVICE_TOKEN_SHA256 = _GENERATED_SERVICE_TOKEN.sha256
+
+
+class _CRM:
+    """Stands in for the EOM tenant slice of the contacts table."""
+
+    def __init__(self, *, known: list[UUID] | None = None) -> None:
+        self.known = known or []
+        self.calls: list[list[UUID]] = []
+
+    async def list_known_eom_contact_ids(
+        self, *, contact_ids: list[UUID]
+    ) -> list[UUID]:
+        self.calls.append(list(contact_ids))
+        return [value for value in self.known if value in set(contact_ids)]
+
+
+def _app(crm: _CRM) -> FastAPI:
+    app = FastAPI()
+    app.include_router(funnel_mod.router)
+    app.dependency_overrides[funnel_mod._crm_dependency] = lambda: crm
+    app.dependency_overrides[auth_mod.get_eom_funnel_api_config] = lambda: (
+        EOMFunnelConfig(
+            api_enabled=True,
+            service_token_sha256=_SERVICE_TOKEN_SHA256,
+        )
+    )
+    return app
+
+
+def _headers(token: str = _SERVICE_TOKEN) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {token}",
+        "X-EOM-Actor": "Juan Canfield",
+        "X-EOM-Actor-ID": "1",
+    }
+
+
+async def _get(crm: _CRM, query: str, **kwargs: object) -> httpx.Response:
+    app = _app(crm)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        return await client.get(
+            f"/eom-funnel/known-contacts{query}",
+            headers=_headers(),
+            **kwargs,
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_dangling_link_is_reported_as_unknown():
+    """The signal that matters: a stored id that no longer resolves."""
+    live = uuid4()
+    dangling = uuid4()
+    crm = _CRM(known=[live])
+
+    response = await _get(crm, f"?contact_id={live}&contact_id={dangling}")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["knownContactIds"] == [str(live)]
+    assert str(dangling) not in body["knownContactIds"]
+    assert body["checked"] == 2
+
+
+@pytest.mark.asyncio
+async def test_a_live_contact_is_not_reported_as_dangling():
+    """The other direction -- a route that never confirms proves nothing."""
+    first = uuid4()
+    second = uuid4()
+    crm = _CRM(known=[first, second])
+
+    response = await _get(crm, f"?contact_id={first}&contact_id={second}")
+
+    assert response.status_code == 200
+    assert response.json()["knownContactIds"] == [str(first), str(second)]
+
+
+@pytest.mark.asyncio
+async def test_a_contact_in_another_tenant_is_not_known_here():
+    """Cross-tenant ids read exactly like missing ones, by design.
+
+    The provider is scoped to ``effingham_maids``, so an id from another
+    business context never reaches the route. Reporting it any other way would
+    turn an EOM-scoped credential into a cross-tenant existence oracle.
+    """
+    churnsignals_contact = uuid4()
+    crm = _CRM(known=[])
+
+    response = await _get(crm, f"?contact_id={churnsignals_contact}")
+
+    assert response.status_code == 200
+    assert response.json()["knownContactIds"] == []
+
+
+@pytest.mark.asyncio
+async def test_an_id_the_caller_never_submitted_is_never_returned():
+    """A verdict the caller cannot attribute to a link it holds is not an answer."""
+    asked = uuid4()
+    never_asked = uuid4()
+
+    class _LeakyCRM(_CRM):
+        async def list_known_eom_contact_ids(
+            self, *, contact_ids: list[UUID]
+        ) -> list[UUID]:
+            self.calls.append(list(contact_ids))
+            return [asked, never_asked]
+
+    response = await _get(_LeakyCRM(), f"?contact_id={asked}")
+
+    assert response.status_code == 200
+    assert response.json()["knownContactIds"] == [str(asked)]
+
+
+@pytest.mark.asyncio
+async def test_repeated_ids_are_asked_once_and_answered_once():
+    live = uuid4()
+    crm = _CRM(known=[live])
+
+    response = await _get(crm, f"?contact_id={live}&contact_id={live}")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "knownContactIds": [str(live)],
+        "checked": 1,
+        "limit": funnel_mod._MAX_KNOWN_CONTACT_IDS,
+    }
+    assert crm.calls == [[live]]
+
+
+@pytest.mark.asyncio
+async def test_an_empty_check_is_rejected_rather_than_answered_clean():
+    """An empty request must not read as 'every link is fine'."""
+    crm = _CRM(known=[])
+
+    response = await _get(crm, "")
+
+    assert response.status_code == 422
+    assert crm.calls == []
+
+
+@pytest.mark.asyncio
+async def test_the_cap_is_enforced_at_the_boundary():
+    crm = _CRM(known=[])
+    over = funnel_mod._MAX_KNOWN_CONTACT_IDS + 1
+    query = "?" + "&".join(f"contact_id={uuid4()}" for _ in range(over))
+
+    response = await _get(crm, query)
+
+    assert response.status_code == 422
+    assert crm.calls == []
+
+
+@pytest.mark.asyncio
+async def test_exactly_the_cap_is_accepted():
+    """max is allowed, max+1 is not -- the second side of the boundary."""
+    crm = _CRM(known=[])
+    ids = [uuid4() for _ in range(funnel_mod._MAX_KNOWN_CONTACT_IDS)]
+    query = "?" + "&".join(f"contact_id={value}" for value in ids)
+
+    response = await _get(crm, query)
+
+    assert response.status_code == 200
+    assert response.json()["checked"] == funnel_mod._MAX_KNOWN_CONTACT_IDS
+
+
+@pytest.mark.asyncio
+async def test_a_malformed_id_is_rejected_not_silently_dropped():
+    """Dropping an unparseable id would report it as neither known nor asked."""
+    crm = _CRM(known=[])
+
+    response = await _get(crm, f"?contact_id={uuid4()}&contact_id=not-a-uuid")
+
+    assert response.status_code == 422
+    assert crm.calls == []
+
+
+@pytest.mark.asyncio
+async def test_the_route_refuses_an_unauthenticated_caller():
+    crm = _CRM(known=[uuid4()])
+    app = _app(crm)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get(f"/eom-funnel/known-contacts?contact_id={uuid4()}")
+
+    assert response.status_code in (401, 403)
+    assert crm.calls == []
+
+
+@pytest.mark.asyncio
+async def test_a_wrong_service_token_is_refused():
+    crm = _CRM(known=[uuid4()])
+    app = _app(crm)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get(
+            f"/eom-funnel/known-contacts?contact_id={uuid4()}",
+            headers=_headers(token="wrong-token"),
+        )
+
+    assert response.status_code in (401, 403)
+    assert crm.calls == []
+
+
+@pytest.mark.asyncio
+async def test_the_route_discloses_no_contact_data_beyond_the_id():
+    """Callers get resolution, not a read of the CRM record."""
+    live = uuid4()
+    crm = _CRM(known=[live])
+
+    response = await _get(crm, f"?contact_id={live}")
+
+    assert set(response.json()) == {"knownContactIds", "checked", "limit"}
+
+
+def test_link_verification_is_advertised_in_the_capability_manifest():
+    """Callers gate on the manifest, so an unlisted route is an unusable one."""
+    assert "contact.link_verification" in funnel_mod.served_capabilities()
+
+
+@pytest.mark.asyncio
+async def test_tenant_scope_holds_against_real_postgres():
+    """The scope claim is only worth what the SQL does, so prove it there.
+
+    Every test above stubs the provider, which means none of them can tell a
+    tenant-scoped query from an unscoped one. This one seeds a real EOM contact
+    beside a real churnsignals contact and asks for both: an unscoped
+    ``WHERE c.id = ANY($1)`` would return the foreign row and fail here.
+    """
+    asyncpg = pytest.importorskip("asyncpg")
+    database_url = os.environ.get(DATABASE_URL_ENV)
+    if not database_url:
+        pytest.skip(f"{DATABASE_URL_ENV} is not configured")
+
+    from atlas_brain.services.crm_provider import DatabaseCRMProvider
+
+    schema = f"atlas_eom_known_contacts_{uuid.uuid4().hex}"
+    admin_conn = await asyncpg.connect(database_url)
+    pool = None
+    db_mod = None
+    original_db_pool = None
+    try:
+        await admin_conn.execute(f'CREATE SCHEMA "{schema}"')
+        await admin_conn.execute(f'SET search_path TO "{schema}", public')
+        # 035 backfills contacts from appointments and call transcripts, so the
+        # tables it reads have to exist even though this test only uses contacts.
+        for name in (
+            "001_initial_schema.sql",
+            "012_appointments.sql",
+            "030_call_transcripts.sql",
+            "035_contacts.sql",
+        ):
+            await admin_conn.execute((MIGRATIONS / name).read_text())
+
+        async def set_search_path(connection):
+            await connection.execute(f'SET search_path TO "{schema}", public')
+
+        pool = await asyncpg.create_pool(
+            database_url, min_size=1, max_size=2, setup=set_search_path
+        )
+
+        import atlas_brain.storage.database as db_mod
+
+        original_db_pool = db_mod._db_pool
+        db_mod._db_pool = _PoolAdapter(pool)
+
+        eom_row = await pool.fetchrow(
+            """
+            INSERT INTO contacts (full_name, business_context_id)
+            VALUES ('EOM Customer', $1) RETURNING id
+            """,
+            TENANT,
+        )
+        foreign_row = await pool.fetchrow(
+            """
+            INSERT INTO contacts (full_name, business_context_id)
+            VALUES ('Churnsignals Customer', $1) RETURNING id
+            """,
+            FOREIGN_TENANT,
+        )
+        deleted_id = uuid4()
+
+        known = await DatabaseCRMProvider().list_known_eom_contact_ids(
+            contact_ids=[eom_row["id"], foreign_row["id"], deleted_id]
+        )
+
+        assert eom_row["id"] in known, "a live EOM contact must resolve"
+        assert foreign_row["id"] not in known, (
+            "another tenant's contact must read exactly like a missing one"
+        )
+        assert deleted_id not in known
+    finally:
+        if db_mod is not None:
+            db_mod._db_pool = original_db_pool
+        if pool is not None:
+            await pool.close()
+        await admin_conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        await admin_conn.close()
+
+
+class _PoolAdapter:
+    def __init__(self, pool):
+        self._pool = pool
+        self.is_initialized = True
+
+    async def fetch(self, query, *args):
+        return await self._pool.fetch(query, *args)
+
+    async def fetchrow(self, query, *args):
+        return await self._pool.fetchrow(query, *args)
+
+    async def execute(self, query, *args):
+        return await self._pool.execute(query, *args)

--- a/tests/test_eom_link_verification.py
+++ b/tests/test_eom_link_verification.py
@@ -271,8 +271,6 @@ async def test_tenant_scope_holds_against_real_postgres():
     schema = f"atlas_eom_known_contacts_{uuid.uuid4().hex}"
     admin_conn = await asyncpg.connect(database_url)
     pool = None
-    db_mod = None
-    original_db_pool = None
     try:
         await admin_conn.execute(f'CREATE SCHEMA "{schema}"')
         await admin_conn.execute(f'SET search_path TO "{schema}", public')
@@ -292,11 +290,10 @@ async def test_tenant_scope_holds_against_real_postgres():
         pool = await asyncpg.create_pool(
             database_url, min_size=1, max_size=2, setup=set_search_path
         )
-
-        import atlas_brain.storage.database as db_mod
-
-        original_db_pool = db_mod._db_pool
-        db_mod._db_pool = _PoolAdapter(pool)
+        # Injected through the constructor, which exists for exactly this.
+        # Reaching into atlas_brain.storage.database._db_pool would test the
+        # same SQL while coupling this file to a private module attribute.
+        provider = DatabaseCRMProvider(pool=_PoolAdapter(pool))
 
         eom_row = await pool.fetchrow(
             """
@@ -314,7 +311,7 @@ async def test_tenant_scope_holds_against_real_postgres():
         )
         deleted_id = uuid4()
 
-        known = await DatabaseCRMProvider().list_known_eom_contact_ids(
+        known = await provider.list_known_eom_contact_ids(
             contact_ids=[eom_row["id"], foreign_row["id"], deleted_id]
         )
 
@@ -324,8 +321,6 @@ async def test_tenant_scope_holds_against_real_postgres():
         )
         assert deleted_id not in known
     finally:
-        if db_mod is not None:
-            db_mod._db_pool = original_db_pool
         if pool is not None:
             await pool.close()
         await admin_conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')

--- a/tests/test_eom_link_verification.py
+++ b/tests/test_eom_link_verification.py
@@ -253,6 +253,52 @@ def test_link_verification_is_advertised_in_the_capability_manifest():
 
 
 @pytest.mark.asyncio
+async def test_the_real_aggregate_serves_the_route_at_its_deployed_path():
+    """Prove reachability on the app that actually ships.
+
+    Every other test in this file mounts ``funnel_mod.router`` on a fresh
+    FastAPI instance, which proves the handler works but says nothing about
+    whether the deployed application mounts it. If the aggregate stopped
+    including the EOM funnel router, or mounted it under a different prefix,
+    all of them would stay green while the caller got a 404 from the one path
+    the review contract names. This calls the full deployed path instead.
+    """
+    from atlas_brain.main import app
+
+    live = uuid4()
+    dangling = uuid4()
+    crm = _CRM(known=[live])
+
+    original_overrides = dict(app.dependency_overrides)
+    app.dependency_overrides[funnel_mod._crm_dependency] = lambda: crm
+    app.dependency_overrides[auth_mod.get_eom_funnel_api_config] = lambda: (
+        EOMFunnelConfig(
+            api_enabled=True,
+            service_token_sha256=_SERVICE_TOKEN_SHA256,
+        )
+    )
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            response = await client.get(
+                "/api/v1/eom-funnel/known-contacts"
+                f"?contact_id={live}&contact_id={dangling}",
+                headers=_headers(),
+            )
+    finally:
+        app.dependency_overrides.clear()
+        app.dependency_overrides.update(original_overrides)
+
+    assert response.status_code == 200, (
+        "the deployed path must serve this route, not 404"
+    )
+    body = response.json()
+    assert body["knownContactIds"] == [str(live)]
+    assert str(dangling) not in body["knownContactIds"]
+
+
+@pytest.mark.asyncio
 async def test_tenant_scope_holds_against_real_postgres():
     """The scope claim is only worth what the SQL does, so prove it there.
 


### PR DESCRIPTION
Plan: plans/PR-EOM-Contact-Link-Verification.md
Slice phase: Vertical slice
Ownership lane: eom-crm/lead-funnel

Diff-budget override: the application change is 100 LOC across two files. The other 554 are the tests that prove it and the plan doc the PR gate itself mandates. Splitting the tests off would merge a tenant-scoped read boundary whose scoping is unproven — and the tenant claim is the one thing here that stub tests cannot settle, so the real-PostgreSQL test is the only evidence that the scope is in the query rather than only in the docstring. Merging that unproven is the exact failure this slice exists to remove.

The tracker stores its own copy of an Atlas contact id in
`customers.atlas_contact_id`. A non-null value there proves a write happened
once — not that the contact still exists, nor that it was ever an EOM contact.
Nothing on either side notices when that link stops resolving, so a customer
whose Atlas contact is gone looks perfectly healthy in the tracker until someone
opens the record by hand. That is the silent-failure class Slice 0 exists to
close, and the reason the original defect survived long enough to need a backfill
on 2026-08-09. The tracker cannot even ask today: `_atlas_funnel_read` is
hard-locked to `/eom-funnel/leads`, and no Atlas route answers contact existence.
This adds `GET /eom-funnel/known-contacts` — up to 100 contact ids in, the subset
naming a live `effingham_maids` contact out, and nothing else about them — which
unblocks the remaining half of Effingham_Office_Maids_Website#167, the tracker
half of Slice 0F that was split out of #2344.

## Intentional

- **A cross-tenant id reads exactly like a missing one.** Distinguishing them
  would be more useful to the caller and is deliberately refused: this credential
  is scoped to EOM, and confirming that some id exists under another business
  context would make the route a cross-tenant existence oracle. Both answers mean
  the same thing to the caller — the link does not point at an EOM contact.
- **Tenant scope lives in the query, not in a filter over its result.** An
  unscoped lookup cleaned up afterwards has to leak first to be corrected.
- **Id-only response.** A caller asking whether its stored id resolves needs no
  name, email, or phone, so none is disclosed. `/eom-funnel/leads` stays the only
  funnel route returning identity fields.
- **The route answers in terms of what was asked**, intersecting provider rows
  against the submitted ids. Without that, a row the caller never submitted would
  appear as a "known" verdict it cannot attribute to any link it holds.
- **An empty id list is 422, not an empty-and-clean 200.** A caller that
  accidentally sends nothing must not read the answer as "every link is fine" —
  that is precisely the false assurance this slice removes.
- **GET with repeated query params, not POST with a body.** The operation is a
  read and the method should say so. The cost is a URL-length budget, which is
  why the cap is 100: ~4.8 KB of `contact_id=<uuid>&`, inside the 8 KB request
  line proxies accept.
- **Archived and lost contacts count as known.** The question is whether the link
  resolves; a link to a closed contact is intact. Only a dangling or cross-tenant
  id means the write boundary was bypassed.
- **Rejected: per-id `GET /eom-funnel/contacts/{id}`.** Simpler, but the tracker
  would issue one request per customer to audit its links — expensive enough to
  not get run, and a monitor that does not run is the thing being fixed.

## AI reconciliation

- Exercise the production aggregate endpoint -- fixed-in: `tests/test_eom_link_verification.py` add a test that calls the deployed `/api/v1/eom-funnel/known-contacts` path on the real aggregate app.
- Refresh the verification receipt for this head -- fixed-in: `plans/PR-EOM-Contact-Link-Verification.md` re-run both stated commands at this head and record 15 passed and 496 passed.
- State the Deferred parking predicate -- fixed-in: `plans/PR-EOM-Contact-Link-Verification.md` name the class this slice parks by default before the none claim.
- Declare closure for the capability-map edit -- fixed-in: `plans/PR-EOM-Contact-Link-Verification.md` add a member-set closure declaration for `_CAPABILITY_ROUTES`.
- Correct the Review Contract rule set -- fixed-in: `plans/PR-EOM-Contact-Link-Verification.md` declare R3, R5 and R12 and drop the wrong R9.
- Justify the over-budget slice in Why -- fixed-in: `plans/PR-EOM-Contact-Link-Verification.md` add an indivisibility subsection under Why this slice exists.

## Fix-loop disposition preflight

- Root decision: Exercise the production aggregate endpoint
- Blocking predicate: contract
- Disposition: fixed-in
- Source Trace: a route the deployed app never mounts would still pass every test -> every test mounted `funnel_mod.router` on a fresh FastAPI instance in `tests/test_eom_link_verification.py`
- Upstream Files: `tests/test_eom_link_verification.py`
- Fix Strategy: upstream-root
- Allowed files: `.github/workflows/atlas_eom_lead_pipeline_checks.yml`, `atlas_brain/eom_api/funnel.py`, `atlas_brain/services/crm_provider.py`, `plans/PR-EOM-Contact-Link-Verification.md`, `tests/test_eom_link_verification.py`
- Max files: 5
- Parked hardening: none

- Root decision: Refresh the verification receipt for this head
- Blocking predicate: contract
- Disposition: fixed-in
- Source Trace: the plan's counts described the previous head -> Verification section reported 14/495 in `plans/PR-EOM-Contact-Link-Verification.md`
- Upstream Files: `plans/PR-EOM-Contact-Link-Verification.md`
- Fix Strategy: upstream-root
- Allowed files: `.github/workflows/atlas_eom_lead_pipeline_checks.yml`, `atlas_brain/eom_api/funnel.py`, `atlas_brain/services/crm_provider.py`, `plans/PR-EOM-Contact-Link-Verification.md`, `tests/test_eom_link_verification.py`
- Max files: 5
- Parked hardening: none

- Root decision: State the Deferred parking predicate
- Blocking predicate: contract
- Disposition: fixed-in
- Source Trace: an unqualified none claim names no class considered -> bare `Parked hardening: none.` in `plans/PR-EOM-Contact-Link-Verification.md`
- Upstream Files: `plans/PR-EOM-Contact-Link-Verification.md`
- Fix Strategy: upstream-root
- Allowed files: `.github/workflows/atlas_eom_lead_pipeline_checks.yml`, `atlas_brain/eom_api/funnel.py`, `atlas_brain/services/crm_provider.py`, `plans/PR-EOM-Contact-Link-Verification.md`, `tests/test_eom_link_verification.py`
- Max files: 5
- Parked hardening: none

- Root decision: Declare closure for the capability-map edit
- Blocking predicate: contract
- Disposition: fixed-in
- Source Trace: membership drift in a decision-driving set has no reviewable policy -> `_CAPABILITY_ROUTES` edited with no closure declaration in `plans/PR-EOM-Contact-Link-Verification.md`
- Upstream Files: `plans/PR-EOM-Contact-Link-Verification.md`
- Fix Strategy: upstream-root
- Allowed files: `.github/workflows/atlas_eom_lead_pipeline_checks.yml`, `atlas_brain/eom_api/funnel.py`, `atlas_brain/services/crm_provider.py`, `plans/PR-EOM-Contact-Link-Verification.md`, `tests/test_eom_link_verification.py`
- Max files: 5
- Parked hardening: none

- Root decision: Justify the over-budget slice in Why
- Blocking predicate: contract
- Disposition: fixed-in
- Source Trace: the budget exception was unvalidatable by a reviewer -> the override lived only in the PR body, not under Why this slice exists in `plans/PR-EOM-Contact-Link-Verification.md`
- Upstream Files: `plans/PR-EOM-Contact-Link-Verification.md`
- Fix Strategy: upstream-root
- Allowed files: `.github/workflows/atlas_eom_lead_pipeline_checks.yml`, `atlas_brain/eom_api/funnel.py`, `atlas_brain/services/crm_provider.py`, `plans/PR-EOM-Contact-Link-Verification.md`, `tests/test_eom_link_verification.py`
- Max files: 5
- Parked hardening: none

- Root decision: Correct the Review Contract rule set
- Blocking predicate: contract
- Disposition: fixed-in
- Source Trace: the scoped review gate never evaluated the security and deployment claims -> R9/R14 declared instead of R3/R5/R12 in `plans/PR-EOM-Contact-Link-Verification.md`
- Upstream Files: `plans/PR-EOM-Contact-Link-Verification.md`
- Fix Strategy: upstream-root
- Allowed files: `.github/workflows/atlas_eom_lead_pipeline_checks.yml`, `atlas_brain/eom_api/funnel.py`, `atlas_brain/services/crm_provider.py`, `plans/PR-EOM-Contact-Link-Verification.md`, `tests/test_eom_link_verification.py`
- Max files: 5
- Parked hardening: none

## Deferred

- The tracker-side consumer — a linkage-validity signal in the tracker's audit
  that calls this route. Separate repo, separate PR, and it needs this deployed
  first. Carried by Effingham_Office_Maids_Website#167; **#167, #113 and #107 stay
  open** until it lands.

## Parked hardening

None.

## Cold diff reconstruction

Read cold, the diff adds two files and modifies three.

1. `atlas_brain/eom_api/funnel.py` — adds `_MAX_KNOWN_CONTACT_IDS = 100`, the
   `EOMKnownContactsResponse` model (`knownContactIds`, `checked`, `limit`;
   `extra="forbid"`), a `contact.link_verification` entry in `_CAPABILITY_ROUTES`,
   and one `GET /known-contacts` handler behind the same
   `require_eom_funnel_api` + `require_eom_funnel_actor` pair as every other
   funnel route. The handler deduplicates the submitted ids preserving order,
   calls the provider, intersects the result against what was asked, and returns
   it. No writes, no other module touched.
2. `atlas_brain/services/crm_provider.py` — adds `Sequence` to the typing import
   and one `async def list_known_eom_contact_ids`, returning `[]` for an empty
   input and otherwise running a single `SELECT c.id FROM contacts AS c WHERE
   c.business_context_id = 'effingham_maids' AND c.id = ANY($1::uuid[])`. No
   other provider method changes.
3. `tests/test_eom_link_verification.py` — 15 tests: both directions of resolution,
   cross-tenant, caller attribution, duplicates, empty, cap at 100 and 101,
   malformed id, unauthenticated, wrong token, response-shape, capability
   manifest, and one asyncpg test applying the real migrations into a temp schema.
4. `.github/workflows/atlas_eom_lead_pipeline_checks.yml` — three added lines: the
   file in the pytest arguments, and in both path-filter blocks.
5. `plans/PR-EOM-Contact-Link-Verification.md` — the plan doc.

No migration, no schema change, no write path.

## Verification

- The tenant claim is the one that needed a real database. Every other test in
  the file stubs the provider, so **none of them can tell a tenant-scoped query
  from an unscoped one** — a suite of stub tests would have been false assurance
  on exactly the claim that matters most.
  `test_tenant_scope_holds_against_real_postgres` applies the real migrations
  into a throwaway schema, seeds an `effingham_maids` row beside a `churnsignals`
  row, and asks for both plus a never-inserted id.
- **Two negative controls, both run, both restored from a backup copy taken
  first** (an earlier arc lost an uncommitted edit to a careless `git checkout`):
  - Deleting `WHERE c.business_context_id = 'effingham_maids'` from the provider
    query fails `test_tenant_scope_holds_against_real_postgres`, and only it.
  - Replacing the request-ordered intersection with `list(known_set)` fails
    `test_an_id_the_caller_never_submitted_is_never_returned`, and only it.
  - Restored source passes 15/15 in both cases.
- Both sides of the cap are asserted (100 accepted, 101 rejected), and both
  refusal paths assert the provider was never reached, so a guard that failed
  open would fail the test rather than pass it quietly.
- The new test file is registered in CI in all three places it has to be — the
  pytest arguments and both path-filter blocks — so a test-only edit still
  triggers the job. An unregistered test file is a proof that never runs.
- Neighbouring EOM suites run for regression, including the capability manifest
  test, since this PR adds a manifest entry.
- **Reachability is proven on the app that ships, not a test harness.** Codex was
  right that every original test mounted the router on a fresh FastAPI instance,
  so all of them would have stayed green if the aggregate stopped mounting the
  route and the deployed path 404'd. `test_the_real_aggregate_serves_the_route_at_
  its_deployed_path` calls `/api/v1/eom-funnel/known-contacts` on
  `atlas_brain.main.app`. Its negative control is the precise one: replacing
  `router.include_router(eom_funnel_router)` with `pass` fails **only** that test
  — 1 failed, 14 passed — which is exactly the blind spot it closes.

## Mechanical verification

- Command: `python -m pytest tests/test_eom_link_verification.py -q` with `ATLAS_MIGRATION_TEST_DATABASE_URL` on a throwaway postgres:16 - Result: pass (15 passed) - Environment: local
- Command: `python -m pytest tests/test_eom_funnel_capability_manifest.py tests/test_eom_lead_conversion.py tests/test_eom_contacts_api_tenant_scope.py tests/test_crm_read_scoping.py tests/test_eom_link_verification.py -q` - Result: pass (496 passed) - Environment: local
- Command: negative control — remove the tenant predicate from `list_known_eom_contact_ids`, re-run the file - Result: pass (control behaved as required: 1 failed, 13 passed; the failure was `test_tenant_scope_holds_against_real_postgres` and only it; restored source 15 passed) - Environment: local
- Command: negative control — replace the request-ordered intersection with `list(known_set)`, re-run the file - Result: pass (control behaved as required: 1 failed, 13 passed; the failure was `test_an_id_the_caller_never_submitted_is_never_returned` and only it; restored source 15 passed) - Environment: local
- Command: negative control — replace `router.include_router(eom_funnel_router)` with `pass` in `atlas_brain/api/__init__.py`, re-run the file - Result: pass (control behaved as required: 1 failed, 14 passed; the failure was `test_the_real_aggregate_serves_the_route_at_its_deployed_path` and only it; restored source 15 passed) - Environment: local
- Command: read-only run of the endpoint's exact predicate against the live `atlas` database, submitting 2 EOM contact ids + the 1 real `churnsignals` contact id + 1 nonexistent id - Result: pass (returned 2 — the EOM pair only; the foreign-tenant and nonexistent ids were both excluded, against live data of 711 `effingham_maids` and 1 `churnsignals` contacts) - Environment: local

## Diff size

| File | LOC |
|---|---:|
| `tests/test_eom_link_verification.py` | 347 |
| `plans/PR-EOM-Contact-Link-Verification.md` | 206 |
| `atlas_brain/eom_api/funnel.py` | 67 |
| `atlas_brain/services/crm_provider.py` | 33 |
| `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 3 |
| **Total** | **656** |


<!-- atlas-open-pr-wrapper: v1 -->
