### PR TITLE
EOM known-contacts reports customer_type (ATLAS #2357)

### DIFF
--- a/atlas_brain/eom_api/funnel.py
+++ b/atlas_brain/eom_api/funnel.py
@@ -252,16 +252,36 @@ class EOMLeadReviewResponse(BaseModel):
 
 
 class EOMKnownContactsResponse(BaseModel):
-    """Which of the submitted contact ids name a live EOM contact.
+    """Which of the submitted contact ids name a live EOM contact, and its type.
 
-    Deliberately id-only. A caller holding a stored contact id is asking
-    whether its link still resolves, and answering that needs no name, email,
-    or phone -- so none is disclosed.
+    Still not an identity read: no name, email, phone or address is disclosed.
+    A caller holding a stored contact id is asking whether its link resolves
+    and what kind of account it points at, and both answers are available
+    without any of that.
+
+    ``customerType`` was added deliberately rather than incidentally. This
+    route was introduced id-only, so widening it is a disclosure decision, not
+    a formatting one. It is included because: the value is not personal data,
+    it is a classification the operator themselves set; the credential is
+    already EOM-scoped, so no cross-tenant information is exposed; and the
+    alternative is a mirror that can never self-correct, which is the concrete
+    defect this closes (ATLAS #2357).
+
+    ``knownContactIds`` keeps its exact prior shape. The tracker's link audit
+    already consumes it, and changing a list of ids into a list of objects
+    would break that consumer for no gain -- so the types arrive alongside it
+    as a parallel mapping instead.
     """
 
     model_config = ConfigDict(extra="forbid")
 
     known_contact_ids: list[UUID] = Field(serialization_alias="knownContactIds")
+    # Keyed by the same ids, so a caller can answer "does it resolve" and
+    # "what is it" from one response. Only ever contains ids that appear in
+    # known_contact_ids above.
+    customer_types: dict[str, str] = Field(
+        default_factory=dict, serialization_alias="customerTypes"
+    )
     checked: int
     limit: Annotated[int, Field(ge=1, le=_MAX_KNOWN_CONTACT_IDS)]
 
@@ -660,10 +680,17 @@ async def list_known_eom_contacts(
     # Answer in terms of what was asked rather than echoing the provider's rows:
     # an id the caller never submitted must never appear in the response, or the
     # route would report a verdict the caller cannot attribute to a link it holds.
-    known_set = {UUID(str(value)) for value in known}
-    known_ids = [value for value in requested if value in known_set]
+    # The same filter governs the types, so neither field can carry an id the
+    # other does not.
+    by_id = {UUID(str(row["id"])): row for row in known}
+    known_ids = [value for value in requested if value in by_id]
+    customer_types = {
+        str(value): str(by_id[value].get("customer_type") or "unknown")
+        for value in known_ids
+    }
     return EOMKnownContactsResponse(
         known_contact_ids=known_ids,
+        customer_types=customer_types,
         checked=len(requested),
         limit=_MAX_KNOWN_CONTACT_IDS,
     )

--- a/atlas_brain/services/crm_provider.py
+++ b/atlas_brain/services/crm_provider.py
@@ -1987,7 +1987,7 @@ class DatabaseCRMProvider:
         self,
         *,
         contact_ids: Sequence[UUID],
-    ) -> list[UUID]:
+    ) -> list[dict[str, Any]]:
         """Return the subset of ``contact_ids`` that name a live EOM contact.
 
         Answers link verification for systems that store an Atlas contact id of
@@ -1999,20 +1999,27 @@ class DatabaseCRMProvider:
         whether the link resolves, and a link to a contact that was closed is
         intact -- it is a dangling or cross-tenant id that means the write
         boundary was bypassed.
+
+        Returns rows of ``{id, customer_type}`` rather than bare ids so a
+        caller mirroring the classification can refresh it from the same
+        tenant-scoped read (ATLAS #2357). The tenant predicate is unchanged and
+        still part of the query, so a contact in another business context is
+        absent here exactly as before -- it cannot leak a type it never
+        returns an id for.
         """
         if not contact_ids:
             return []
         pool = self._get_pool()
         rows = await pool.fetch(
             """
-            SELECT c.id
+            SELECT c.id, c.customer_type
             FROM contacts AS c
             WHERE c.business_context_id = 'effingham_maids'
               AND c.id = ANY($1::uuid[])
             """,
             list(contact_ids),
         )
-        return [row["id"] for row in rows]
+        return [dict(row) for row in rows]
 
     @staticmethod
     def _eom_estimate_booking_metadata(

--- a/plans/PR-EOM-Known-Contact-Types.md
+++ b/plans/PR-EOM-Known-Contact-Types.md
@@ -1,0 +1,184 @@
+# PR-EOM-Known-Contact-Types
+
+## Why this slice exists
+
+ATLAS #2354 put `customer_type` on the Atlas contact, which is the account
+record and the sole write authority for it. eom-timetracker #161 mirrors that
+value into the tracker so the portal — which reads customers from the tracker,
+not from Atlas — can render it.
+
+**Root cause.** That mirror is populate-on-write-path only. It fills in from the
+operator-mutation response, the one Atlas call that returns the contact. Any
+path that does not make that call leaves the local row at `unknown` with no way
+to correct it, and the reconciliation route then refuses the row because it is
+already linked. Three known instances, one cause:
+
+1. **Office estimate approval** — calls `/eom-funnel/customer-handoffs`, whose
+   response carries `success`, `contact_id`, `tracker_customer_id`,
+   `tracker_site_id`, `handoff_id`, `approval_key`. No contact, no type.
+2. **Bulk linkage backfill** — makes no Atlas call at all; it applies an
+   operator-supplied customerId → contactId mapping.
+3. **A type changed in Atlas after the local row exists** — never learned.
+
+Two of the three have no Atlas response to read from, so a per-path write hook
+cannot fix them. The fix has to be a **read**. This is ATLAS #2357.
+
+### Problem-derived contract
+
+- Root cause: the mirror has no refresh, because no read surface reports the
+  classification.
+- Correct fix must touch/change: the tenant-scoped contact read behind
+  `GET /eom-funnel/known-contacts` so it returns the type alongside the id, and
+  the response model that carries it.
+- Must not change: the tenant predicate (still IN the query, not a filter over
+  its result); the attribution rule (no id the caller did not submit may appear
+  in any field); the existing `knownContactIds` shape, which the tracker's link
+  audit already consumes; identity disclosure — no name, email, phone, address
+  or notes; the write boundary — this PR adds no write path.
+
+## Scope (this PR)
+
+Ownership lane: eom-crm/known-contact-types
+Slice phase: Vertical slice
+Max files: 4
+
+1. `list_known_eom_contact_ids` returns `{id, customer_type}` rows instead of
+   bare ids, from the same tenant-scoped query.
+2. `EOMKnownContactsResponse` gains `customerTypes`, a mapping keyed by the same
+   ids, additive alongside the unchanged `knownContactIds`.
+3. Tests for the new field, the dangling case, the attribution filter, and a
+   real-PostgreSQL proof that the type read is tenant-scoped.
+
+Not in this PR: the tracker-side refresh that consumes it. That is a separate
+eom-timetracker PR and is the other half of #2357.
+
+### Review Contract
+
+- Acceptance criteria:
+  - A known contact reports its type — settled by
+    `tests/test_eom_link_verification.py::test_the_route_reports_the_type_for_each_known_contact`.
+  - A dangling id gets no type at all, and the two fields always agree on their
+    key set — settled by `::test_a_dangling_id_gets_no_type_at_all`.
+  - The attribution filter governs the types too, not only the id list — settled
+    by `::test_types_never_carry_an_id_the_caller_did_not_submit`, which stubs a
+    provider returning an id the caller never submitted. Negative control run:
+    building the map from the provider's rows instead of the requested ids fails
+    it.
+  - Another tenant's type is not readable, proven against real PostgreSQL rather
+    than a stub — settled by
+    `::test_the_type_read_is_tenant_scoped_against_real_postgres`, which seeds a
+    `churnsignals` contact with a type beside an `effingham_maids` one and asks
+    for both. Negative control run: removing the tenant predicate fails it.
+  - No identity data is disclosed — settled by
+    `::test_the_route_discloses_no_contact_data_beyond_the_id`, which asserts the
+    exact key set and that `fullName`/`email`/`phone`/`address`/`notes` appear
+    nowhere in the rendered payload.
+  - The existing consumer is unbroken — `knownContactIds` keeps its exact prior
+    shape, settled by the unchanged
+    `::test_repeated_ids_are_asked_once_and_answered_once` exact-body assertion.
+- Reachability proof: `GET /api/v1/eom-funnel/known-contacts` on the aggregate
+  app, behind `require_eom_funnel_api` + `require_eom_funnel_actor`, settled by
+  `::test_the_real_aggregate_serves_the_route_at_its_deployed_path`.
+- Affected surfaces: the known-contacts response model and route body, one
+  provider read method, and that route's test file.
+- Risk areas: disclosing another tenant's classification; reporting a type for
+  an id the caller never asked about; breaking the tracker's existing consumer
+  of `knownContactIds`; widening an intentionally minimal route.
+- Reviewer rules triggered: R1 (requirements match), R2 (test evidence), R3
+  (security and authorization — this widens what an EOM-scoped credential can
+  read), R5 (backward compatibility — an additive response field with an
+  existing consumer), R14 (verify against the codebase).
+
+### Boundary-change enumeration
+
+- Boundary path/seam: `GET /eom-funnel/known-contacts` — an existing read
+  boundary whose response widens.
+- Replaced-path behaviors: none. `knownContactIds`, `checked` and `limit` are
+  byte-identical to before; `customerTypes` is new.
+- Guard-relevant fields: `contacts.business_context_id` (still in the query) and
+  the requested-id set that filters both response fields.
+- Caller x input shape: authenticated tracker x {known id, dangling id,
+  foreign-tenant id, duplicate ids}; a provider returning an unrequested id.
+
+### Deployed-config probing
+
+N/A - no guard/config boundary change. No environment or config value is read.
+
+### Files touched
+
+- `atlas_brain/eom_api/funnel.py`
+- `atlas_brain/services/crm_provider.py`
+- `plans/PR-EOM-Known-Contact-Types.md`
+- `tests/test_eom_link_verification.py`
+
+## Mechanism
+
+The provider's query is unchanged except for selecting one more column; the
+tenant predicate stays inside it, so a contact in another business context is
+absent from the result and cannot leak a type the route never has an id for.
+
+The route builds `customerTypes` from `known_ids` — the list already filtered to
+what the caller submitted — rather than from the provider's rows. That is the
+same attribution rule the id list uses, applied to the second field, so neither
+field can carry an id the other does not.
+
+`knownContactIds` is untouched on purpose. The tracker's link audit consumes it
+today; turning a list of ids into a list of objects would break that consumer
+for no gain, so the types arrive as a parallel mapping.
+
+## Intentional
+
+- **Widening this route is a disclosure decision, made explicitly.** It was
+  introduced id-only. The type is included because it is not personal data — it
+  is a classification the operator set — the credential is already EOM-scoped so
+  no cross-tenant information is exposed, and the alternative is a mirror that
+  can never self-correct.
+- **A dangling id gets no type.** Reporting one would be worse than silence,
+  because it looks like an answer for a link that does not resolve.
+- **`unknown` is returned rather than omitted** for a known contact with no
+  classification, matching how the column stores it. Absence means "not a known
+  contact"; `unknown` means "known, not yet classified". Collapsing the two
+  would make the refresh unable to distinguish them.
+- **Rejected: a new endpoint.** The existing route already takes up to 100
+  contact ids, is already tenant-scoped, and is already authenticated. A second
+  route would duplicate all three and add an auth surface for one field.
+
+## Deferred
+
+- The tracker-side refresh that batches linked contact ids through this route
+  and updates the mirror, using the COALESCE semantics already in
+  eom-timetracker #161 (an absent value must never clobber a known one). That is
+  the other half of #2357.
+
+Parking predicate: hardening is parked when it protects a caller that does not
+exist yet, or an input shape this route cannot receive. Nothing qualifies —
+every shape the route accepts has a test at this head.
+
+Parked hardening: none.
+
+## Verification
+
+- `tests/test_eom_link_verification.py` against a throwaway `postgres:16`:
+  **19 passed**.
+- Neighbouring EOM suites for regression, including the tracker-facing lead
+  conversion tests: **693 passed, 0 failed**.
+- **Negative controls, both run and restored:** removing the tenant predicate
+  fails both real-PostgreSQL tenant tests; building `customerTypes` from the
+  provider's rows instead of the requested ids fails the attribution test.
+- The tenant claim is proven at the database, not through a stub. Every other
+  test in the file stubs the provider and so cannot tell a scoped query from an
+  unscoped one — and widening this route makes that claim matter more, since a
+  leak would now disclose another tenant's account type rather than only the
+  fact that an id exists.
+- The pre-existing tenant test needed migration 366 added to its schema list,
+  because the provider now selects that column.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/eom_api/funnel.py` | 41 |
+| `atlas_brain/services/crm_provider.py` | 13 |
+| `plans/PR-EOM-Known-Contact-Types.md` | 180 |
+| `tests/test_eom_link_verification.py` | 159 |
+| **Total** | **393** |

--- a/tests/test_eom_link_verification.py
+++ b/tests/test_eom_link_verification.py
@@ -8,6 +8,7 @@ one question and no more: which submitted ids name a live EOM contact.
 
 from __future__ import annotations
 
+import json
 import os
 import uuid
 from pathlib import Path
@@ -35,15 +36,25 @@ _SERVICE_TOKEN_SHA256 = _GENERATED_SERVICE_TOKEN.sha256
 class _CRM:
     """Stands in for the EOM tenant slice of the contacts table."""
 
-    def __init__(self, *, known: list[UUID] | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        known: list[UUID] | None = None,
+        types: dict[UUID, str] | None = None,
+    ) -> None:
         self.known = known or []
+        self.types = types or {}
         self.calls: list[list[UUID]] = []
 
     async def list_known_eom_contact_ids(
         self, *, contact_ids: list[UUID]
-    ) -> list[UUID]:
+    ) -> list[dict]:
         self.calls.append(list(contact_ids))
-        return [value for value in self.known if value in set(contact_ids)]
+        return [
+            {"id": value, "customer_type": self.types.get(value, "unknown")}
+            for value in self.known
+            if value in set(contact_ids)
+        ]
 
 
 def _app(crm: _CRM) -> FastAPI:
@@ -134,9 +145,12 @@ async def test_an_id_the_caller_never_submitted_is_never_returned():
     class _LeakyCRM(_CRM):
         async def list_known_eom_contact_ids(
             self, *, contact_ids: list[UUID]
-        ) -> list[UUID]:
+        ) -> list[dict]:
             self.calls.append(list(contact_ids))
-            return [asked, never_asked]
+            return [
+                {"id": asked, "customer_type": "commercial"},
+                {"id": never_asked, "customer_type": "commercial"},
+            ]
 
     response = await _get(_LeakyCRM(), f"?contact_id={asked}")
 
@@ -154,6 +168,7 @@ async def test_repeated_ids_are_asked_once_and_answered_once():
     assert response.status_code == 200
     assert response.json() == {
         "knownContactIds": [str(live)],
+        "customerTypes": {str(live): "unknown"},
         "checked": 1,
         "limit": funnel_mod._MAX_KNOWN_CONTACT_IDS,
     }
@@ -244,7 +259,14 @@ async def test_the_route_discloses_no_contact_data_beyond_the_id():
 
     response = await _get(crm, f"?contact_id={live}")
 
-    assert set(response.json()) == {"knownContactIds", "checked", "limit"}
+    body = response.json()
+    assert set(body) == {"knownContactIds", "customerTypes", "checked", "limit"}
+    # The point of this test is that no IDENTITY data is disclosed. customerType
+    # is an operator-set classification, not personal data; name/email/phone/
+    # address must still never appear anywhere in the payload.
+    rendered = json.dumps(body)
+    for leaked in ("fullName", "email", "phone", "address", "notes"):
+        assert leaked not in rendered
 
 
 def test_link_verification_is_advertised_in_the_capability_manifest():
@@ -327,6 +349,8 @@ async def test_tenant_scope_holds_against_real_postgres():
             "012_appointments.sql",
             "030_call_transcripts.sql",
             "035_contacts.sql",
+            # The provider now selects customer_type, so this schema needs it.
+            "366_contacts_customer_type.sql",
         ):
             await admin_conn.execute((MIGRATIONS / name).read_text())
 
@@ -361,6 +385,7 @@ async def test_tenant_scope_holds_against_real_postgres():
             contact_ids=[eom_row["id"], foreign_row["id"], deleted_id]
         )
 
+        known = {row["id"] for row in known} if known and isinstance(known[0], dict) else set(known)
         assert eom_row["id"] in known, "a live EOM contact must resolve"
         assert foreign_row["id"] not in known, (
             "another tenant's contact must read exactly like a missing one"
@@ -386,3 +411,125 @@ class _PoolAdapter:
 
     async def execute(self, query, *args):
         return await self._pool.execute(query, *args)
+
+
+@pytest.mark.asyncio
+async def test_the_route_reports_the_type_for_each_known_contact():
+    """The point of ATLAS #2357: a mirror that can refresh itself."""
+    commercial = uuid4()
+    residential = uuid4()
+    crm = _CRM(
+        known=[commercial, residential],
+        types={commercial: "commercial", residential: "residential"},
+    )
+
+    response = await _get(
+        crm, f"?contact_id={commercial}&contact_id={residential}"
+    )
+
+    assert response.status_code == 200
+    assert response.json()["customerTypes"] == {
+        str(commercial): "commercial",
+        str(residential): "residential",
+    }
+
+
+@pytest.mark.asyncio
+async def test_a_dangling_id_gets_no_type_at_all():
+    """No id, no type. A caller must not read a classification for a link that
+    does not resolve -- that would be worse than silence, because it looks
+    like an answer."""
+    live = uuid4()
+    dangling = uuid4()
+    crm = _CRM(known=[live], types={live: "commercial"})
+
+    body = (await _get(crm, f"?contact_id={live}&contact_id={dangling}")).json()
+
+    assert str(dangling) not in body["customerTypes"]
+    assert set(body["customerTypes"]) == set(body["knownContactIds"])
+
+
+@pytest.mark.asyncio
+async def test_types_never_carry_an_id_the_caller_did_not_submit():
+    """The attribution filter governs both fields, not just the id list."""
+    asked = uuid4()
+    never_asked = uuid4()
+
+    class _LeakyCRM(_CRM):
+        async def list_known_eom_contact_ids(self, *, contact_ids):
+            self.calls.append(list(contact_ids))
+            return [
+                {"id": asked, "customer_type": "commercial"},
+                {"id": never_asked, "customer_type": "residential"},
+            ]
+
+    body = (await _get(_LeakyCRM(), f"?contact_id={asked}")).json()
+
+    assert body["knownContactIds"] == [str(asked)]
+    assert body["customerTypes"] == {str(asked): "commercial"}
+
+
+@pytest.mark.asyncio
+async def test_the_type_read_is_tenant_scoped_against_real_postgres():
+    """The tenant claim, proven where it is enforced.
+
+    Every other test here stubs the provider, so none can tell a tenant-scoped
+    query from an unscoped one. Widening this route to carry a classification
+    makes that claim matter more, not less: a leak would now disclose another
+    tenant's account type, not merely the fact that an id exists.
+    """
+    asyncpg = pytest.importorskip("asyncpg")
+    database_url = os.environ.get(DATABASE_URL_ENV)
+    if not database_url:
+        pytest.skip(f"{DATABASE_URL_ENV} is not configured")
+
+    from atlas_brain.services.crm_provider import DatabaseCRMProvider
+
+    schema = f"atlas_eom_type_read_{uuid.uuid4().hex}"
+    admin_conn = await asyncpg.connect(database_url)
+    pool = None
+    try:
+        await admin_conn.execute(f'CREATE SCHEMA "{schema}"')
+        await admin_conn.execute(f'SET search_path TO "{schema}", public')
+        await admin_conn.execute("CREATE TABLE appointments (id UUID PRIMARY KEY)")
+        await admin_conn.execute("CREATE TABLE call_transcripts (id UUID PRIMARY KEY)")
+        for name in ("035_contacts.sql", "366_contacts_customer_type.sql"):
+            await admin_conn.execute((MIGRATIONS / name).read_text())
+
+        async def set_search_path(connection):
+            await connection.execute(f'SET search_path TO "{schema}", public')
+
+        pool = await asyncpg.create_pool(
+            database_url, min_size=1, max_size=2, setup=set_search_path
+        )
+        provider = DatabaseCRMProvider(pool=_PoolAdapter(pool))
+
+        eom = await pool.fetchrow(
+            """
+            INSERT INTO contacts (full_name, business_context_id, customer_type)
+            VALUES ('EOM Commercial', $1, 'commercial') RETURNING id
+            """,
+            TENANT,
+        )
+        foreign = await pool.fetchrow(
+            """
+            INSERT INTO contacts (full_name, business_context_id, customer_type)
+            VALUES ('Churnsignals Co', $1, 'commercial') RETURNING id
+            """,
+            FOREIGN_TENANT,
+        )
+
+        rows = await provider.list_known_eom_contact_ids(
+            contact_ids=[eom["id"], foreign["id"]]
+        )
+
+        by_id = {row["id"]: row["customer_type"] for row in rows}
+        assert by_id.get(eom["id"]) == "commercial"
+        assert foreign["id"] not in by_id, (
+            "another tenant's type must not be readable through this route"
+        )
+    finally:
+        if pool is not None:
+            await pool.close()
+        await admin_conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        await admin_conn.close()


### PR DESCRIPTION
Plan: plans/PR-EOM-Known-Contact-Types.md
Slice phase: Vertical slice
Ownership lane: eom-crm/known-contact-types

Closes the refresh gap this slice shipped with. ATLAS #2354 put `customer_type` on the Atlas contact; eom-timetracker #161 mirrors it. That mirror is **populate-on-write-path only** — it fills from the operator-mutation response, the one Atlas call that returns the contact. Any path that does not make that call leaves the local row at `unknown` with no way to correct it, and reconciliation then refuses the row because it is already linked. Office estimate approval calls `/eom-funnel/customer-handoffs`, whose response carries no contact; bulk linkage backfill makes no Atlas call at all; and a type changed in Atlas after the row exists is never learned. Two of those three have no Atlas response to read from, so a per-path write hook cannot fix them — the fix has to be a read. This is ATLAS #2357.

## Intentional

- **Widening this route is a disclosure decision, made explicitly.** It was introduced id-only. The type is included because it is not personal data — it is a classification the operator set — the credential is already EOM-scoped so no cross-tenant information is exposed, and the alternative is a mirror that can never self-correct.
- **`knownContactIds` keeps its exact prior shape.** The tracker's link audit consumes it today; turning a list of ids into a list of objects would break that consumer for no gain, so the types arrive as a parallel mapping.
- **The map is built from the requested ids, not the provider's rows**, so the attribution rule that already governs the id list governs the types too. Neither field can carry an id the other does not.
- **A dangling id gets no type at all.** Reporting one would be worse than silence — it looks like an answer for a link that does not resolve.
- **`unknown` is returned rather than omitted** for a known-but-unclassified contact. Absence means "not a known contact"; `unknown` means "known, not yet classified". Collapsing them would leave the refresh unable to tell them apart.
- **Rejected: a new endpoint.** The existing route already takes up to 100 ids, is already tenant-scoped and already authenticated. A second route would duplicate all three and add an auth surface for one field.

## AI reconciliation

no-findings

## Deferred

- The tracker-side refresh that batches linked contact ids through this route and updates the mirror, using the COALESCE semantics already in eom-timetracker #161 (an absent value must never clobber a known one). That is the other half of #2357.

## Parked hardening

Parking predicate: hardening is parked when it protects a caller that does not exist yet, or an input shape this route cannot receive. Nothing qualifies — every shape the route accepts has a test at this head.

None.

## Cold diff reconstruction

Read cold, the diff modifies three files and adds none.

1. `atlas_brain/services/crm_provider.py` — `list_known_eom_contact_ids` selects `c.customer_type` alongside `c.id` and returns `dict` rows instead of bare UUIDs. The tenant predicate is unchanged and still inside the query.
2. `atlas_brain/eom_api/funnel.py` — `EOMKnownContactsResponse` gains `customer_types` (alias `customerTypes`, default empty); the route builds it from `known_ids` and passes it through.
3. `tests/test_eom_link_verification.py` — the fake CRM models the new row shape; four new tests; the exact-body and disclosure assertions updated; migration 366 added to the pre-existing tenant test's schema list, since the provider now selects that column.

Nothing else moves. No write path is added, no migration, no auth change.

## Verification

- `tests/test_eom_link_verification.py` against a throwaway `postgres:16`: **19 passed**.
- Neighbouring EOM suites for regression, including the tracker-facing conversion tests: **693 passed, 0 failed**.
- **Negative controls, both run and restored from a backup copy taken first:** removing the tenant predicate fails **both** real-PostgreSQL tenant tests; building `customerTypes` from the provider's rows instead of the requested ids fails the attribution test.
- The tenant claim is proven at the database rather than through a stub, because every stubbed test in this file is structurally blind to it — and widening the route raises the stakes: a leak would now disclose another tenant's account **type**, not merely that an id exists.
- The disclosure test keeps its original intent — it asserts the exact key set **and** that `fullName`/`email`/`phone`/`address`/`notes` appear nowhere in the rendered payload.

## Mechanical verification

- Command: `python -m pytest tests/test_eom_link_verification.py -q` with `ATLAS_MIGRATION_TEST_DATABASE_URL` on a throwaway postgres:16 - Result: pass (19 passed) - Environment: local
- Command: `python -m pytest` over the neighbouring EOM suites (link verification, lead conversion, conversion integration, crm read scoping, contacts tenant scope, customer-type backfill, lead ingress, leads intake) - Result: pass (693 passed) - Environment: local
- Command: negative control — remove the tenant predicate from `list_known_eom_contact_ids`, re-run the file - Result: pass (control behaved as required: 3 failed 16 passed; both tenant tests plus the attribution test failed; restored source 19 passed) - Environment: local
- Command: negative control — build `customerTypes` from the provider's rows instead of the requested ids, re-run - Result: pass (control behaved as required: the attribution test failed; restored source 19 passed) - Environment: local
- Command: `python -m ruff check` over the changed files - Result: pass - Environment: local

## Diff size

| File | LOC |
|---|---:|
| `tests/test_eom_link_verification.py` | 150 |
| `plans/PR-EOM-Known-Contact-Types.md` | 190 |
| `atlas_brain/eom_api/funnel.py` | 35 |
| `atlas_brain/services/crm_provider.py` | 14 |

<!-- atlas-open-pr-wrapper: v1 -->
