### PR TITLE
EOM receivables: allow unapplied customer payments

### DIFF
--- a/atlas_brain/api/invoicing/receivables.py
+++ b/atlas_brain/api/invoicing/receivables.py
@@ -21,6 +21,7 @@ from ...services.receivables import (
     ReceivablesValidationError,
     get_receivables_service,
 )
+from ...services.eom_lead_ingress import EOM_BUSINESS_CONTEXT_ID
 from ...storage.exceptions import DatabaseUnavailableError
 from .auth import require_actor, require_receivables_api
 
@@ -222,6 +223,8 @@ async def create_payment(
             allocations=_allocations(body.allocations),
             recorded_by=actor,
             idempotency_key=idempotency_key,
+            allow_unapplied=True,
+            unapplied_contact_context_id=EOM_BUSINESS_CONTEXT_ID,
         )
     )
 

--- a/atlas_brain/api/invoicing/receivables.py
+++ b/atlas_brain/api/invoicing/receivables.py
@@ -80,7 +80,7 @@ class CreatePaymentRequest(BaseModel):
     received_date: date
     reference: Optional[str] = Field(default=None, max_length=256)
     notes: Optional[str] = None
-    allocations: list[AllocationRequest] = Field(min_length=1, max_length=100)
+    allocations: list[AllocationRequest] = Field(default_factory=list, max_length=100)
 
 
 class AdjustAllocationsRequest(BaseModel):

--- a/atlas_brain/eom_api/receivables.py
+++ b/atlas_brain/eom_api/receivables.py
@@ -80,7 +80,7 @@ class CreatePaymentRequest(BaseModel):
     received_date: date
     reference: Optional[str] = Field(default=None, max_length=256)
     notes: Optional[str] = None
-    allocations: list[AllocationRequest] = Field(min_length=1, max_length=100)
+    allocations: list[AllocationRequest] = Field(default_factory=list, max_length=100)
 
 
 class AdjustAllocationsRequest(BaseModel):

--- a/atlas_brain/eom_api/receivables.py
+++ b/atlas_brain/eom_api/receivables.py
@@ -21,6 +21,7 @@ from ..services.receivables import (
     ReceivablesValidationError,
     get_receivables_service,
 )
+from ..services.eom_lead_ingress import EOM_BUSINESS_CONTEXT_ID
 from ..storage.exceptions import DatabaseUnavailableError
 from .auth import require_actor, require_receivables_api
 
@@ -222,6 +223,8 @@ async def create_payment(
             allocations=_allocations(body.allocations),
             recorded_by=actor,
             idempotency_key=idempotency_key,
+            allow_unapplied=True,
+            unapplied_contact_context_id=EOM_BUSINESS_CONTEXT_ID,
         )
     )
 

--- a/atlas_brain/services/receivables.py
+++ b/atlas_brain/services/receivables.py
@@ -557,7 +557,7 @@ class ReceivablesService:
                 "Idempotency key must contain 1 to 128 characters"
             )
 
-        normalized = self._normalize_allocations(allocations)
+        normalized = self._normalize_allocations(allocations, allow_empty=True)
         allocated_total = sum((item["amount"] for item in normalized), Decimal("0"))
         if allocated_total > total:
             raise ReceivablesValidationError(
@@ -1302,8 +1302,12 @@ class ReceivablesService:
     @staticmethod
     def _normalize_allocations(
         allocations: list[dict[str, Any]],
+        *,
+        allow_empty: bool = False,
     ) -> list[dict[str, Any]]:
         if not allocations:
+            if allow_empty and allocations == []:
+                return []
             raise ReceivablesValidationError(
                 "At least one invoice allocation is required"
             )
@@ -1338,6 +1342,23 @@ class ReceivablesService:
     ) -> list[Any]:
         allocated_ids = {item["invoice_id"] for item in allocations}
         invoice_ids = sorted(allocated_ids.union(additional_invoice_ids or []), key=str)
+        if not invoice_ids:
+            if contact_id is None:
+                raise ReceivablesValidationError(
+                    "A customer is required when a payment has no invoice allocations"
+                )
+            contact = await conn.fetchrow(
+                """
+                SELECT id
+                FROM contacts
+                WHERE id = $1
+                FOR KEY SHARE
+                """,
+                contact_id,
+            )
+            if not contact:
+                raise ReceivablesNotFoundError("Customer not found")
+            return []
         rows = await conn.fetch(
             """
             SELECT id, invoice_number, contact_id, status, amount_due

--- a/atlas_brain/services/receivables.py
+++ b/atlas_brain/services/receivables.py
@@ -501,6 +501,8 @@ class ReceivablesService:
         source: str = "eom_admin",
         metadata: Optional[dict[str, Any]] = None,
         enforce_api_methods: bool = True,
+        allow_unapplied: bool = False,
+        unapplied_contact_context_id: Optional[str] = None,
     ) -> dict[str, Any]:
         """Create one receipt and all of its allocations atomically."""
         outcome = await self.create_payment_with_outcome(
@@ -517,6 +519,8 @@ class ReceivablesService:
             source=source,
             metadata=metadata,
             enforce_api_methods=enforce_api_methods,
+            allow_unapplied=allow_unapplied,
+            unapplied_contact_context_id=unapplied_contact_context_id,
         )
         return outcome.payment
 
@@ -536,6 +540,8 @@ class ReceivablesService:
         source: str = "eom_admin",
         metadata: Optional[dict[str, Any]] = None,
         enforce_api_methods: bool = True,
+        allow_unapplied: bool = False,
+        unapplied_contact_context_id: Optional[str] = None,
     ) -> PaymentCreationOutcome:
         """Create a receipt and report whether this call replayed its first write."""
         total = money(total_amount)
@@ -556,8 +562,14 @@ class ReceivablesService:
             raise ReceivablesValidationError(
                 "Idempotency key must contain 1 to 128 characters"
             )
+        if allow_unapplied and not unapplied_contact_context_id:
+            raise ReceivablesValidationError(
+                "Unapplied payments require a canonical customer context"
+            )
 
-        normalized = self._normalize_allocations(allocations, allow_empty=True)
+        normalized = self._normalize_allocations(
+            allocations, allow_empty=allow_unapplied
+        )
         allocated_total = sum((item["amount"] for item in normalized), Decimal("0"))
         if allocated_total > total:
             raise ReceivablesValidationError(
@@ -605,6 +617,7 @@ class ReceivablesService:
                 conn,
                 contact_id=contact_id,
                 allocations=normalized,
+                unapplied_contact_context_id=unapplied_contact_context_id,
             )
             # A same-key create can arrive while the first transaction is still
             # holding these invoice locks. Reconcile again after the wait, before
@@ -1339,6 +1352,7 @@ class ReceivablesService:
         allocations: list[dict[str, Any]],
         current_allocations: Optional[dict[str, Decimal]] = None,
         additional_invoice_ids: Optional[Iterable[UUID]] = None,
+        unapplied_contact_context_id: Optional[str] = None,
     ) -> list[Any]:
         allocated_ids = {item["invoice_id"] for item in allocations}
         invoice_ids = sorted(allocated_ids.union(additional_invoice_ids or []), key=str)
@@ -1352,9 +1366,14 @@ class ReceivablesService:
                 SELECT id
                 FROM contacts
                 WHERE id = $1
+                  AND business_context_id = $2
+                  AND contact_type = 'customer'
+                  AND status = 'active'
+                  AND lead_stage IS NULL
                 FOR KEY SHARE
                 """,
                 contact_id,
+                unapplied_contact_context_id,
             )
             if not contact:
                 raise ReceivablesNotFoundError("Customer not found")

--- a/atlas_brain/services/receivables.py
+++ b/atlas_brain/services/receivables.py
@@ -1369,7 +1369,6 @@ class ReceivablesService:
                   AND business_context_id = $2
                   AND contact_type = 'customer'
                   AND status = 'active'
-                  AND lead_stage IS NULL
                 FOR KEY SHARE
                 """,
                 contact_id,

--- a/atlas_brain/services/receivables.py
+++ b/atlas_brain/services/receivables.py
@@ -1369,7 +1369,7 @@ class ReceivablesService:
                   AND business_context_id = $2
                   AND contact_type = 'customer'
                   AND status = 'active'
-                FOR KEY SHARE
+                FOR SHARE
                 """,
                 contact_id,
                 unapplied_contact_context_id,

--- a/plans/PR-EOM-Receivables-Unapplied-Payments.md
+++ b/plans/PR-EOM-Receivables-Unapplied-Payments.md
@@ -6,6 +6,14 @@ Issue: #2362
 
 ATLAS must record an EOM canonical-customer payment without an invoice; provider models/service otherwise require an allocation.
 
+The 782-LOC diff exceeds the 400-LOC target because 640 LOC are inseparable
+regression and real-entrypoint proof for this one transactional admission seam:
+empty-allocation creation, idempotent replay, tenant/customer eligibility,
+concurrent archival, and the mounted API all protect the same financial write.
+Splitting that evidence into a later PR would deploy the widened payment boundary
+without the proof that makes it safe; the production-code delta remains limited to
+the two route models and the receivables service.
+
 ### Problem-derived contract
 
 - Root cause: initial creation and the shared normalizer required at least one allocation.
@@ -72,12 +80,25 @@ through the transaction.
 
 ## Deferred
 
-- #2362 later slices; #2363 H-01/H-06 remain separate. No schema or UI expansion here.
+Parking predicate: park any new work that does not change initial EOM
+allocation-free payment admission, its required financial-safety proof, or this
+provider slice's independent deployability.
+
+Parked hardening: #2363 H-01 (legacy invoice float-money audit) and H-06
+(full/slim provider-model structural deduplication). #2362 owns later tracker,
+Website, receipts, ledger, billing, Gmail, sent-mail, and Square slices. No
+schema or UI expansion belongs here.
 
 ## Verification
 
-- Focused/optional Postgres concurrency and ineligible-customer boundaries,
-  EOM profile, ruff, diff/plan and full gates; no live financial write.
+- `pytest -q tests/test_receivables.py`: 65 passed, 8 skipped. The optional
+  PostgreSQL cases require `ATLAS_RECEIVABLES_TEST_DATABASE_URL`; absent it,
+  they skip without accessing live financial data.
+- `pytest -q tests/test_eom_render_profile.py --disable-warnings`: 61 passed.
+- Command: ruff check atlas_brain/api/invoicing/receivables.py atlas_brain/eom_api/receivables.py atlas_brain/services/receivables.py tests/test_receivables.py. Result: passed.
+- `python scripts/sync_pr_plan.py --check plans/PR-EOM-Receivables-Unapplied-Payments.md origin/main`, `python scripts/audit_plan_doc.py plans/PR-EOM-Receivables-Unapplied-Payments.md`, `python scripts/audit_plan_code_consistency.py --base-ref origin/main plans/PR-EOM-Receivables-Unapplied-Payments.md`, `python scripts/check_boundary_change_enumeration.py --base origin/main --strict`, and `python scripts/check_deployed_config_probing.py --base origin/main --strict`: passed.
+- The required `scripts/push_pr.sh` local review gate passed and its impacted
+  test selector conservatively ran the full unit suite; no live financial write.
 
 ## Estimated diff size
 
@@ -86,6 +107,6 @@ through the transaction.
 | `atlas_brain/api/invoicing/receivables.py` | 5 |
 | `atlas_brain/eom_api/receivables.py` | 5 |
 | `atlas_brain/services/receivables.py` | 41 |
-| `plans/PR-EOM-Receivables-Unapplied-Payments.md` | 91 |
+| `plans/PR-EOM-Receivables-Unapplied-Payments.md` | 112 |
 | `tests/test_receivables.py` | 640 |
-| **Total** | **782** |
+| **Total** | **803** |

--- a/plans/PR-EOM-Receivables-Unapplied-Payments.md
+++ b/plans/PR-EOM-Receivables-Unapplied-Payments.md
@@ -1,0 +1,151 @@
+# PR-EOM-Receivables-Unapplied-Payments
+
+Issue: #2362
+
+## Why this slice exists
+
+Billing & Payments must record a payment for a canonical customer who has no
+invoice, such as a residential customer. ATLAS currently requires an invoice
+allocation at both its private EOM API and service layer. The allocation also
+acts as the current proof that a supplied customer exists.
+
+This first provider slice is additive and safe before tracker or website
+consumers change.
+
+### Problem-derived contract
+
+- Root cause: CreatePaymentRequest and _normalize_allocations reject [], even
+  though customer_payments, its event, its idempotency fingerprint, and its
+  payment view already represent an unapplied payment.
+- Correct fix must change only initial creation: admit missing/empty
+  allocations, validate and key-share lock the canonical contact, skip invoice
+  work for no invoice IDs, and preserve the existing fingerprint/replay path.
+- Must not change: adjustment/MCP allocation requirements, nonempty allocation
+  validation, invoice locks/recalculation, payment status/method behavior,
+  checks/deposits/returns/voids, migration/schema, Gmail, or UI behavior.
+
+## Scope (this PR)
+
+Ownership lane: eom/receivables
+Slice phase: Vertical slice
+
+1. Allow POST /api/v1/receivables/payments to omit allocations or send [].
+2. Atomically create an unapplied payment/event for an existing canonical
+   contact without querying, allocating to, or recalculating an invoice.
+3. Keep same-key retries deduplicated and leave all non-create allocation
+   boundaries strict.
+
+### Review Contract
+
+- Acceptance criteria: the EOM request model accepts missing/empty allocations;
+  a valid empty request yields one received check payment, zero allocated cents,
+  full unapplied cents, one event, and no invoice writes; unknown contacts fail
+  before a parent/event insert; an unchanged retry returns its original ID and
+  does not add a payment/event; default normalization and adjustments still
+  reject []; legacy invoicing/MCP request behavior remains allocation-required.
+- Reachability proof: the production create-payment route converts
+  body.allocations and calls ReceivablesService.create_payment. Focused tests
+  invoke the real model/route function, the service transaction, and an
+  optional real-Postgres concurrent replay path.
+- Affected surfaces: private EOM create request, payment creation normalizer,
+  zero-invoice contact validation, and receivables tests.
+- Risk areas: broad relaxation of adjustment admission, unknown contact,
+  invoice balance mutation, retry duplication, and lifecycle regression.
+- Reviewer rules triggered: R1, R3, R4, R5, R8, R11, R12, R14.
+
+### Boundary-change enumeration
+
+- Boundary path/seam: CreatePaymentRequest.allocations at POST /payments.
+- Replaced-path behaviors: create changes one-to-100 rows to omitted/zero-to-100;
+  AdjustAllocationsRequest remains one-to-100.
+- Guard-relevant fields: allocations, invoice_id, amount_cents,
+  total_amount_cents, contact_id, and Idempotency-Key.
+- Caller x input shape: a valid EOM create caller sends no allocations or [];
+  nonempty rows still require UUID plus strict positive cents.
+- Boundary path/seam: _normalize_allocations(..., allow_empty=True) called only
+  from create_payment_with_outcome, plus its no-invoice contact lookup.
+- Replaced-path behaviors: exact [] is permitted only for initial creation,
+  key-share locks an existing contacts.id, then returns no invoice rows to lock.
+- Guard-relevant fields: exact list cardinality, contact ID, amount, source,
+  and idempotency key.
+- Caller x input shape: [] with an existing contact proceeds; absent/unknown
+  contact and malformed/non-list/row shapes reject; default normalizer callers
+  remain one-or-more.
+- Closure declaration: allocation cardinality is CLOSED and DERIVED from
+  CreatePaymentRequest plus create_payment_with_outcome: omitted, [], or the
+  existing one-to-100 valid rows. Row contents are OPEN but retain UUID,
+  positive exact-decimal, no-duplicate, and total-not-exceeded grammar.
+  API_PAYMENT_METHODS, statuses, events, invoice states, and default
+  normalizer callers are unchanged CLOSED sets.
+
+### Deployed-config probing
+
+- Deployed/default config values: no config, flag, credential, or migration is
+  changed; repo-owned render.eom.yaml keeps the EOM receivables API disabled by
+  default, while live Atlas values are unavailable through read-only access.
+- Explicit value probe: tests use [] plus an inserted canonical contact and
+  prove one payment/event with no invoice side effect.
+- Absent value probe: the request-model test omits allocations and proves [].
+- Default-session/default-context probe: isolated model, route, and fake-pool
+  tests read no environment or credentials.
+- Side-effect ordering: validation and fingerprinting precede the transaction;
+  idempotency locks/existing-row checks precede a key-share contact lookup;
+  only then can the parent and one payment event insert. A same-key replay
+  returns before a second insert.
+
+### Files touched
+
+- `atlas_brain/eom_api/receivables.py`
+- `atlas_brain/services/receivables.py`
+- `plans/PR-EOM-Receivables-Unapplied-Payments.md`
+- `tests/test_receivables.py`
+
+## Mechanism
+
+The EOM request model defaults allocations to []. Only initial creation passes
+allow_empty=True to the existing normalizer; all other callers retain its
+strict default. With no invoice IDs, the service key-share locks contacts.id
+and raises the domain not-found error if it is absent, then skips invoice
+locking/allocation/recalculation. Existing Decimal amounts, parent insert,
+payment event, fingerprint, and replay logic are unchanged.
+
+## Intentional
+
+- No migration is needed: customer_payments is already separate from
+  invoice_payments and supports unapplied totals.
+- The private EOM route remains the new UI provider; legacy invoicing/MCP
+  stays allocation-required and unchanged for backwards compatibility.
+- Customer selection, check metadata, receipts, tracker proxy, and website UI
+  belong to later #2362 slices. Payment validity does not infer customer type.
+
+## Deferred
+
+- #2362 Slice 2 tracker proxy; Slice 3 customer-wide website payment entry;
+  later receipt, ledger, billing preview/review, Gmail, sent-mail, and Square
+  slices.
+- #2363 H-01 legacy invoice float-money audit remains separate.
+
+Parking predicate: do not add customer fields, delivery, invoices, UI, or a
+schema migration without a later provider-backed slice contract.
+
+Parked hardening: #2363 H-01 only.
+
+## Verification
+
+- pytest -q tests/test_receivables.py: focused tests pass locally; the
+  real-Postgres concurrent-replay test is skipped only when
+  ATLAS_RECEIVABLES_TEST_DATABASE_URL is absent.
+- ruff check on all three changed Python files, git diff --check, plan sync,
+  and plan-sync check pass locally.
+- Cold reconstruction is recorded in the final PR body; publish through
+  push_pr.sh exactly once with that audited body.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/eom_api/receivables.py` | 2 |
+| `atlas_brain/services/receivables.py` | 23 |
+| `plans/PR-EOM-Receivables-Unapplied-Payments.md` | 151 |
+| `tests/test_receivables.py` | 198 |
+| **Total** | **374** |

--- a/plans/PR-EOM-Receivables-Unapplied-Payments.md
+++ b/plans/PR-EOM-Receivables-Unapplied-Payments.md
@@ -137,12 +137,12 @@ insert, payment event, fingerprint, and replay logic are unchanged.
 - #2362 Slice 2 tracker proxy; Slice 3 customer-wide website payment entry;
   later receipt, ledger, billing preview/review, Gmail, sent-mail, and Square
   slices.
-- #2363 H-01 legacy invoice float-money audit remains separate.
+- #2363 H-01 legacy invoice float-money audit and H-06 duplicate-provider refactor remain separate.
 
 Parking predicate: do not add customer fields, delivery, invoices, UI, or a
 schema migration without a later provider-backed slice contract.
 
-Parked hardening: #2363 H-01 only.
+Parked hardening: #2363 H-01 and H-06.
 
 ## Verification
 

--- a/plans/PR-EOM-Receivables-Unapplied-Payments.md
+++ b/plans/PR-EOM-Receivables-Unapplied-Payments.md
@@ -26,7 +26,8 @@ Admit missing/empty allocations only through two EOM routes, create an active ca
 - Default service callers, adjustments, and legacy MCP/invoice callers remain strict;
   only both EOM routes explicitly opt into `allow_unapplied`.
 - Reachability: tracker targets Funnel full `main:app`; full/slim routes have parity.
-  No flag, migration, credential, UI, or email changes.
+  The no-invoice query uses the slim profile's contact fields only: EOM context,
+  customer type, and active status. No flag, migration, credential, UI, or email changes.
 - Reviewer rules triggered: R1, R2, R3, R4, R5, R8, R11, R12, R14; R2 tests both cardinalities and R3 scopes zero-allocation lookup to active `effingham_maids` customers.
 - R8: same-key transactions take global-event then source/key advisory locks; winner
   inserts one parent/event, waiter rechecks and returns matching original (or conflicts).
@@ -36,7 +37,7 @@ Admit missing/empty allocations only through two EOM routes, create an active ca
 
 - Only POST create widens `allocations` to omitted/[] or existing one-to-100 rows;
   adjustments/non-routed callers remain one-to-100. No-invoice creation key-share locks
-  an active EOM customer with no lead stage, then skips invoice locks/recalculation.
+  an active EOM customer by context/type/status, then skips invoice locks/recalculation.
 
 ### Deployed-config probing
 
@@ -57,6 +58,9 @@ Routes pass the EOM context into a default-strict service; only an active canoni
 ## Intentional
 
 - Provider-only, additive behavior; no schema, UI, receipt, Gmail, or live financial-data operation.
+- The slim profile does not own lead-pipeline migrations, so this payment boundary
+  deliberately does not query lead-pipeline columns; `contact_type='customer'`
+  is the customer-versus-lead eligibility boundary.
 
 ## Deferred
 
@@ -72,7 +76,7 @@ Routes pass the EOM context into a default-strict service; only an active canoni
 |---|---:|
 | `atlas_brain/api/invoicing/receivables.py` | 5 |
 | `atlas_brain/eom_api/receivables.py` | 5 |
-| `atlas_brain/services/receivables.py` | 42 |
-| `plans/PR-EOM-Receivables-Unapplied-Payments.md` | 78 |
-| `tests/test_receivables.py` | 286 |
-| **Total** | **416** |
+| `atlas_brain/services/receivables.py` | 41 |
+| `plans/PR-EOM-Receivables-Unapplied-Payments.md` | 82 |
+| `tests/test_receivables.py` | 291 |
+| **Total** | **424** |

--- a/plans/PR-EOM-Receivables-Unapplied-Payments.md
+++ b/plans/PR-EOM-Receivables-Unapplied-Payments.md
@@ -26,17 +26,21 @@ Admit missing/empty allocations only through two EOM routes, create an active ca
 - Default service callers, adjustments, and legacy MCP/invoice callers remain strict;
   only both EOM routes explicitly opt into `allow_unapplied`.
 - Reachability: tracker targets Funnel full `main:app`; full/slim routes have parity.
+  An authenticated request through that mounted route covers omitted allocations.
   The no-invoice query uses the slim profile's contact fields only: EOM context,
   customer type, and active status. No flag, migration, credential, UI, or email changes.
 - Reviewer rules triggered: R1, R2, R3, R4, R5, R8, R11, R12, R14; R2 tests both cardinalities and R3 scopes zero-allocation lookup to active `effingham_maids` customers.
 - R8: same-key transactions take global-event then source/key advisory locks; winner
   inserts one parent/event, waiter rechecks and returns matching original (or conflicts).
-  Real-Postgres gather samples this; locks plus parent idempotency index carry invariant.
+  On the no-invoice path, `FOR SHARE` holds the active canonical-customer
+  eligibility predicate until the payment commits, so an archive/update cannot
+  race that validation. Real-Postgres samples both behaviors; locks plus the
+  parent idempotency index carry the invariant.
 
 ### Boundary-change enumeration
 
 - Only POST create widens `allocations` to omitted/[] or existing one-to-100 rows;
-  adjustments/non-routed callers remain one-to-100. No-invoice creation key-share locks
+  adjustments/non-routed callers remain one-to-100. No-invoice creation share-locks
   an active EOM customer by context/type/status, then skips invoice locks/recalculation.
 
 ### Deployed-config probing
@@ -53,7 +57,9 @@ Admit missing/empty allocations only through two EOM routes, create an active ca
 
 ## Mechanism
 
-Routes pass the EOM context into a default-strict service; only an active canonical customer can take the zero-allocation branch.
+Routes pass the EOM context into a default-strict service; only an active canonical
+customer can take the zero-allocation branch, and that eligibility remains locked
+through the transaction.
 
 ## Intentional
 
@@ -77,6 +83,6 @@ Routes pass the EOM context into a default-strict service; only an active canoni
 | `atlas_brain/api/invoicing/receivables.py` | 5 |
 | `atlas_brain/eom_api/receivables.py` | 5 |
 | `atlas_brain/services/receivables.py` | 41 |
-| `plans/PR-EOM-Receivables-Unapplied-Payments.md` | 82 |
-| `tests/test_receivables.py` | 291 |
-| **Total** | **424** |
+| `plans/PR-EOM-Receivables-Unapplied-Payments.md` | 88 |
+| `tests/test_receivables.py` | 575 |
+| **Total** | **714** |

--- a/plans/PR-EOM-Receivables-Unapplied-Payments.md
+++ b/plans/PR-EOM-Receivables-Unapplied-Payments.md
@@ -23,6 +23,8 @@ Admit missing/empty allocations only through two EOM routes, create an active ca
 ### Review Contract
 
 - Acceptance: EOM route accepts omitted/[]; active EOM customer gets one payment/event, zero allocated cents, full unapplied cents, no invoice writes; unknown/foreign/lead/inactive contacts fail before insert.
+- Real-Postgres evidence exercises foreign, lead, and inactive rows through the
+  production SQL and proves each leaves no payment or event.
 - Default service callers, adjustments, and legacy MCP/invoice callers remain strict;
   only both EOM routes explicitly opt into `allow_unapplied`.
 - Reachability: tracker targets Funnel full `main:app`; full/slim routes have parity.
@@ -74,7 +76,8 @@ through the transaction.
 
 ## Verification
 
-- Focused/optional Postgres concurrency, EOM profile, ruff, diff/plan and full gates; no live financial write.
+- Focused/optional Postgres concurrency and ineligible-customer boundaries,
+  EOM profile, ruff, diff/plan and full gates; no live financial write.
 
 ## Estimated diff size
 
@@ -83,6 +86,6 @@ through the transaction.
 | `atlas_brain/api/invoicing/receivables.py` | 5 |
 | `atlas_brain/eom_api/receivables.py` | 5 |
 | `atlas_brain/services/receivables.py` | 41 |
-| `plans/PR-EOM-Receivables-Unapplied-Payments.md` | 88 |
-| `tests/test_receivables.py` | 575 |
-| **Total** | **714** |
+| `plans/PR-EOM-Receivables-Unapplied-Payments.md` | 91 |
+| `tests/test_receivables.py` | 640 |
+| **Total** | **782** |

--- a/plans/PR-EOM-Receivables-Unapplied-Payments.md
+++ b/plans/PR-EOM-Receivables-Unapplied-Payments.md
@@ -4,27 +4,13 @@ Issue: #2362
 
 ## Why this slice exists
 
-Billing & Payments must record a payment for a canonical customer who has no
-invoice, such as a residential customer. ATLAS currently requires an invoice
-allocation at both versioned provider request models and the shared service layer.
-The allocation also acts as the current proof that a supplied customer exists.
-
-This first provider slice is additive and safe before tracker or website
-consumers change.
+ATLAS must record an EOM canonical-customer payment without an invoice; provider models/service otherwise require an allocation.
 
 ### Problem-derived contract
 
-- Root cause: the full `main:app` provider used by the deployed tracker and
-  the slim EOM provider each have a CreatePaymentRequest that rejects [], and
-  _normalize_allocations rejects it too, even though customer_payments, its
-  event, its idempotency fingerprint, and its payment view already represent
-  an unapplied payment.
-- Correct fix must change only initial creation: admit missing/empty
-  allocations, validate and key-share lock the canonical contact, skip invoice
-  work for no invoice IDs, and preserve the existing fingerprint/replay path.
-- Must not change: adjustment/MCP allocation requirements, nonempty allocation
-  validation, invoice locks/recalculation, payment status/method behavior,
-  checks/deposits/returns/voids, migration/schema, Gmail, or UI behavior.
+- Root cause: initial creation and the shared normalizer required at least one allocation.
+- Correct fix: keep the default guard while allowing only contextual EOM creation.
+- Must not change: adjustments, MCP, invoice lifecycle, migrations, email, or UI.
 
 ## Scope (this PR)
 
@@ -32,78 +18,29 @@ Ownership lane: eom/receivables
 Slice phase: Vertical slice
 Max files: 5
 
-1. Allow both POST /api/v1/receivables/payments provider implementations to
-   omit allocations or send [].
-2. Atomically create an unapplied payment/event for an existing canonical
-   contact without querying, allocating to, or recalculating an invoice.
-3. Keep same-key retries deduplicated and leave all non-create allocation
-   boundaries strict.
+Admit missing/empty allocations only through two EOM routes, create an active canonical customer's payment/event without invoice work, and preserve legacy contracts.
 
 ### Review Contract
 
-- Acceptance criteria: both provider request models accept missing/empty
-  allocations; a valid empty request yields one received check payment, zero
-  allocated cents, full unapplied cents, one event, and no invoice writes;
-  unknown contacts fail before a parent/event insert; an unchanged retry
-  returns its original ID and does not add a payment/event; default
-  normalization and adjustments still reject []; legacy invoicing/MCP request
-  behavior remains allocation-required.
-- Reachability proof: the deployed tracker has a configured server-only token
-  and its base URL matches the live Atlas Funnel, which proxies `/api` to the
-  full `main:app`; that app includes `api.invoicing.receivables`. Both full and
-  slim create-payment functions convert body.allocations and call
-  ReceivablesService.create_payment. Focused tests invoke both real
-  model/route functions, the service transaction, and an optional real-Postgres
-  concurrent replay path.
-- Affected surfaces: full and slim EOM create requests, payment creation
-  normalizer, zero-invoice contact validation, and receivables tests.
-- Risk areas: broad relaxation of adjustment admission, unknown contact,
-  invoice balance mutation, retry duplication, and lifecycle regression.
-- Reviewer rules triggered: R1, R2, R3, R4, R5, R8, R11, R12, R14.
+- Acceptance: EOM route accepts omitted/[]; active EOM customer gets one payment/event, zero allocated cents, full unapplied cents, no invoice writes; unknown/foreign/lead/inactive contacts fail before insert.
+- Default service callers, adjustments, and legacy MCP/invoice callers remain strict;
+  only both EOM routes explicitly opt into `allow_unapplied`.
+- Reachability: tracker targets Funnel full `main:app`; full/slim routes have parity.
+  No flag, migration, credential, UI, or email changes.
+- Reviewer rules triggered: R1, R2, R3, R4, R5, R8, R11, R12, R14; R2 tests both cardinalities and R3 scopes zero-allocation lookup to active `effingham_maids` customers.
+- R8: same-key transactions take global-event then source/key advisory locks; winner
+  inserts one parent/event, waiter rechecks and returns matching original (or conflicts).
+  Real-Postgres gather samples this; locks plus parent idempotency index carry invariant.
 
 ### Boundary-change enumeration
 
-- Boundary path/seam: CreatePaymentRequest.allocations at POST /payments in
-  the full `main:app` and slim EOM provider routers.
-- Replaced-path behaviors: create changes one-to-100 rows to omitted/zero-to-100;
-  AdjustAllocationsRequest remains one-to-100.
-- Guard-relevant fields: allocations, invoice_id, amount_cents,
-  total_amount_cents, contact_id, and Idempotency-Key.
-- Caller x input shape: a valid EOM create caller sends no allocations or [];
-  nonempty rows still require UUID plus strict positive cents.
-- Boundary path/seam: _normalize_allocations(..., allow_empty=True) called only
-  from create_payment_with_outcome, plus its no-invoice contact lookup.
-- Replaced-path behaviors: exact [] is permitted only for initial creation,
-  key-share locks an existing contacts.id, then returns no invoice rows to lock.
-- Guard-relevant fields: exact list cardinality, contact ID, amount, source,
-  and idempotency key.
-- Caller x input shape: [] with an existing contact proceeds; absent/unknown
-  contact and malformed/non-list/row shapes reject; default normalizer callers
-  remain one-or-more.
-- Closure declaration: allocation cardinality is CLOSED and DERIVED from
-  CreatePaymentRequest plus create_payment_with_outcome: omitted, [], or the
-  existing one-to-100 valid rows. Row contents are OPEN but retain UUID,
-  positive exact-decimal, no-duplicate, and total-not-exceeded grammar.
-  API_PAYMENT_METHODS, statuses, events, invoice states, and default
-  normalizer callers are unchanged CLOSED sets.
+- Only POST create widens `allocations` to omitted/[] or existing one-to-100 rows;
+  adjustments/non-routed callers remain one-to-100. No-invoice creation key-share locks
+  an active EOM customer with no lead stage, then skips invoice locks/recalculation.
 
 ### Deployed-config probing
 
-- Deployed/default config values: no config, flag, credential, or migration is
-  changed. The live `atlas-api.service` runs full `main:app` with
-  ATLAS_INVOICING_RECEIVABLES_API_ENABLED=true and a masked present token;
-  the deployed tracker has a masked present service token and a base URL that
-  matches that service's Funnel `/api/v1` route. Repo-owned render.eom.yaml
-  remains an undeployed slim-service candidate with receivables disabled.
-- Explicit value probe: tests use [] plus an inserted canonical contact and
-  prove one payment/event with no invoice side effect.
-- Absent value probe: the request-model test omits allocations and proves [].
-- Default-session/default-context probe: isolated model, route, and fake-pool
-  tests read no environment or credentials.
-- Side-effect ordering: validation and fingerprinting precede the transaction;
-  idempotency locks/existing-row checks precede a key-share contact lookup;
-  only then can the parent and one payment event insert. A same-key replay
-  returns before a second insert.
+- Read-only evidence: full `main:app` is live, tracker targets Funnel `/api/v1`, and slim Render remains an undeployed disabled candidate.
 
 ### Files touched
 
@@ -115,52 +52,27 @@ Max files: 5
 
 ## Mechanism
 
-Both provider request models default allocations to []. Only initial creation
-passes allow_empty=True to the existing normalizer; all other callers retain
-its strict default. With no invoice IDs, the service key-share locks
-contacts.id and raises the domain not-found error if it is absent, then skips
-invoice locking/allocation/recalculation. Existing Decimal amounts, parent
-insert, payment event, fingerprint, and replay logic are unchanged.
+Routes pass the EOM context into a default-strict service; only an active canonical customer can take the zero-allocation branch.
 
 ## Intentional
 
-- No migration is needed: customer_payments is already separate from
-  invoice_payments and supports unapplied totals.
-- The full live provider and the slim future EOM provider remain behaviorally
-  equivalent; legacy invoicing/MCP stays allocation-required and unchanged for
-  backwards compatibility.
-- Customer selection, check metadata, receipts, tracker proxy, and website UI
-  belong to later #2362 slices. Payment validity does not infer customer type.
+- Provider-only, additive behavior; no schema, UI, receipt, Gmail, or live financial-data operation.
 
 ## Deferred
 
-- #2362 Slice 2 tracker proxy; Slice 3 customer-wide website payment entry;
-  later receipt, ledger, billing preview/review, Gmail, sent-mail, and Square
-  slices.
-- #2363 H-01 legacy invoice float-money audit and H-06 duplicate-provider refactor remain separate.
-
-Parking predicate: do not add customer fields, delivery, invoices, UI, or a
-schema migration without a later provider-backed slice contract.
-
-Parked hardening: #2363 H-01 and H-06.
+- #2362 later slices; #2363 H-01/H-06 remain separate. No schema or UI expansion here.
 
 ## Verification
 
-- pytest -q tests/test_receivables.py: focused tests pass locally; the
-  real-Postgres concurrent-replay test is skipped only when
-  ATLAS_RECEIVABLES_TEST_DATABASE_URL is absent.
-- ruff check on all four changed Python files, git diff --check, plan sync,
-  and plan-sync check pass locally.
-- Cold reconstruction is recorded in the final PR body; publish through
-  push_pr.sh exactly once with that audited body.
+- Focused/optional Postgres concurrency, EOM profile, ruff, diff/plan and full gates; no live financial write.
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
-| `atlas_brain/api/invoicing/receivables.py` | 2 |
-| `atlas_brain/eom_api/receivables.py` | 2 |
-| `atlas_brain/services/receivables.py` | 23 |
-| `plans/PR-EOM-Receivables-Unapplied-Payments.md` | 166 |
-| `tests/test_receivables.py` | 206 |
-| **Total** | **399** |
+| `atlas_brain/api/invoicing/receivables.py` | 5 |
+| `atlas_brain/eom_api/receivables.py` | 5 |
+| `atlas_brain/services/receivables.py` | 42 |
+| `plans/PR-EOM-Receivables-Unapplied-Payments.md` | 78 |
+| `tests/test_receivables.py` | 286 |
+| **Total** | **416** |

--- a/plans/PR-EOM-Receivables-Unapplied-Payments.md
+++ b/plans/PR-EOM-Receivables-Unapplied-Payments.md
@@ -6,17 +6,19 @@ Issue: #2362
 
 Billing & Payments must record a payment for a canonical customer who has no
 invoice, such as a residential customer. ATLAS currently requires an invoice
-allocation at both its private EOM API and service layer. The allocation also
-acts as the current proof that a supplied customer exists.
+allocation at both versioned provider request models and the shared service layer.
+The allocation also acts as the current proof that a supplied customer exists.
 
 This first provider slice is additive and safe before tracker or website
 consumers change.
 
 ### Problem-derived contract
 
-- Root cause: CreatePaymentRequest and _normalize_allocations reject [], even
-  though customer_payments, its event, its idempotency fingerprint, and its
-  payment view already represent an unapplied payment.
+- Root cause: the full `main:app` provider used by the deployed tracker and
+  the slim EOM provider each have a CreatePaymentRequest that rejects [], and
+  _normalize_allocations rejects it too, even though customer_payments, its
+  event, its idempotency fingerprint, and its payment view already represent
+  an unapplied payment.
 - Correct fix must change only initial creation: admit missing/empty
   allocations, validate and key-share lock the canonical contact, skip invoice
   work for no invoice IDs, and preserve the existing fingerprint/replay path.
@@ -28,8 +30,10 @@ consumers change.
 
 Ownership lane: eom/receivables
 Slice phase: Vertical slice
+Max files: 5
 
-1. Allow POST /api/v1/receivables/payments to omit allocations or send [].
+1. Allow both POST /api/v1/receivables/payments provider implementations to
+   omit allocations or send [].
 2. Atomically create an unapplied payment/event for an existing canonical
    contact without querying, allocating to, or recalculating an invoice.
 3. Keep same-key retries deduplicated and leave all non-create allocation
@@ -37,25 +41,30 @@ Slice phase: Vertical slice
 
 ### Review Contract
 
-- Acceptance criteria: the EOM request model accepts missing/empty allocations;
-  a valid empty request yields one received check payment, zero allocated cents,
-  full unapplied cents, one event, and no invoice writes; unknown contacts fail
-  before a parent/event insert; an unchanged retry returns its original ID and
-  does not add a payment/event; default normalization and adjustments still
-  reject []; legacy invoicing/MCP request behavior remains allocation-required.
-- Reachability proof: the production create-payment route converts
-  body.allocations and calls ReceivablesService.create_payment. Focused tests
-  invoke the real model/route function, the service transaction, and an
-  optional real-Postgres concurrent replay path.
-- Affected surfaces: private EOM create request, payment creation normalizer,
-  zero-invoice contact validation, and receivables tests.
+- Acceptance criteria: both provider request models accept missing/empty
+  allocations; a valid empty request yields one received check payment, zero
+  allocated cents, full unapplied cents, one event, and no invoice writes;
+  unknown contacts fail before a parent/event insert; an unchanged retry
+  returns its original ID and does not add a payment/event; default
+  normalization and adjustments still reject []; legacy invoicing/MCP request
+  behavior remains allocation-required.
+- Reachability proof: the deployed tracker has a configured server-only token
+  and its base URL matches the live Atlas Funnel, which proxies `/api` to the
+  full `main:app`; that app includes `api.invoicing.receivables`. Both full and
+  slim create-payment functions convert body.allocations and call
+  ReceivablesService.create_payment. Focused tests invoke both real
+  model/route functions, the service transaction, and an optional real-Postgres
+  concurrent replay path.
+- Affected surfaces: full and slim EOM create requests, payment creation
+  normalizer, zero-invoice contact validation, and receivables tests.
 - Risk areas: broad relaxation of adjustment admission, unknown contact,
   invoice balance mutation, retry duplication, and lifecycle regression.
-- Reviewer rules triggered: R1, R3, R4, R5, R8, R11, R12, R14.
+- Reviewer rules triggered: R1, R2, R3, R4, R5, R8, R11, R12, R14.
 
 ### Boundary-change enumeration
 
-- Boundary path/seam: CreatePaymentRequest.allocations at POST /payments.
+- Boundary path/seam: CreatePaymentRequest.allocations at POST /payments in
+  the full `main:app` and slim EOM provider routers.
 - Replaced-path behaviors: create changes one-to-100 rows to omitted/zero-to-100;
   AdjustAllocationsRequest remains one-to-100.
 - Guard-relevant fields: allocations, invoice_id, amount_cents,
@@ -81,8 +90,11 @@ Slice phase: Vertical slice
 ### Deployed-config probing
 
 - Deployed/default config values: no config, flag, credential, or migration is
-  changed; repo-owned render.eom.yaml keeps the EOM receivables API disabled by
-  default, while live Atlas values are unavailable through read-only access.
+  changed. The live `atlas-api.service` runs full `main:app` with
+  ATLAS_INVOICING_RECEIVABLES_API_ENABLED=true and a masked present token;
+  the deployed tracker has a masked present service token and a base URL that
+  matches that service's Funnel `/api/v1` route. Repo-owned render.eom.yaml
+  remains an undeployed slim-service candidate with receivables disabled.
 - Explicit value probe: tests use [] plus an inserted canonical contact and
   prove one payment/event with no invoice side effect.
 - Absent value probe: the request-model test omits allocations and proves [].
@@ -95,6 +107,7 @@ Slice phase: Vertical slice
 
 ### Files touched
 
+- `atlas_brain/api/invoicing/receivables.py`
 - `atlas_brain/eom_api/receivables.py`
 - `atlas_brain/services/receivables.py`
 - `plans/PR-EOM-Receivables-Unapplied-Payments.md`
@@ -102,19 +115,20 @@ Slice phase: Vertical slice
 
 ## Mechanism
 
-The EOM request model defaults allocations to []. Only initial creation passes
-allow_empty=True to the existing normalizer; all other callers retain its
-strict default. With no invoice IDs, the service key-share locks contacts.id
-and raises the domain not-found error if it is absent, then skips invoice
-locking/allocation/recalculation. Existing Decimal amounts, parent insert,
-payment event, fingerprint, and replay logic are unchanged.
+Both provider request models default allocations to []. Only initial creation
+passes allow_empty=True to the existing normalizer; all other callers retain
+its strict default. With no invoice IDs, the service key-share locks
+contacts.id and raises the domain not-found error if it is absent, then skips
+invoice locking/allocation/recalculation. Existing Decimal amounts, parent
+insert, payment event, fingerprint, and replay logic are unchanged.
 
 ## Intentional
 
 - No migration is needed: customer_payments is already separate from
   invoice_payments and supports unapplied totals.
-- The private EOM route remains the new UI provider; legacy invoicing/MCP
-  stays allocation-required and unchanged for backwards compatibility.
+- The full live provider and the slim future EOM provider remain behaviorally
+  equivalent; legacy invoicing/MCP stays allocation-required and unchanged for
+  backwards compatibility.
 - Customer selection, check metadata, receipts, tracker proxy, and website UI
   belong to later #2362 slices. Payment validity does not infer customer type.
 
@@ -135,7 +149,7 @@ Parked hardening: #2363 H-01 only.
 - pytest -q tests/test_receivables.py: focused tests pass locally; the
   real-Postgres concurrent-replay test is skipped only when
   ATLAS_RECEIVABLES_TEST_DATABASE_URL is absent.
-- ruff check on all three changed Python files, git diff --check, plan sync,
+- ruff check on all four changed Python files, git diff --check, plan sync,
   and plan-sync check pass locally.
 - Cold reconstruction is recorded in the final PR body; publish through
   push_pr.sh exactly once with that audited body.
@@ -144,8 +158,9 @@ Parked hardening: #2363 H-01 only.
 
 | File | LOC |
 |---|---:|
+| `atlas_brain/api/invoicing/receivables.py` | 2 |
 | `atlas_brain/eom_api/receivables.py` | 2 |
 | `atlas_brain/services/receivables.py` | 23 |
-| `plans/PR-EOM-Receivables-Unapplied-Payments.md` | 151 |
-| `tests/test_receivables.py` | 198 |
-| **Total** | **374** |
+| `plans/PR-EOM-Receivables-Unapplied-Payments.md` | 166 |
+| `tests/test_receivables.py` | 206 |
+| **Total** | **399** |

--- a/tests/test_receivables.py
+++ b/tests/test_receivables.py
@@ -1845,6 +1845,71 @@ async def test_real_postgres_unapplied_payment_holds_customer_eligibility_lock()
 
 
 @pytest.mark.asyncio
+async def test_real_postgres_unapplied_payment_rejects_ineligible_customer_rows():
+    asyncpg = pytest.importorskip("asyncpg")
+    database_url = os.environ.get("ATLAS_RECEIVABLES_TEST_DATABASE_URL")
+    if not database_url:
+        pytest.skip("ATLAS_RECEIVABLES_TEST_DATABASE_URL not set")
+
+    schema = f"receivables_ineligible_customer_{uuid4().hex}"
+    observer = await asyncpg.connect(database_url)
+    payment_conn = await asyncpg.connect(database_url)
+    try:
+        await _create_pre_receivables_schema(observer, schema)
+        await observer.execute(_receivables_migration_sql())
+        cases = (
+            ("foreign", "other_business", "customer", "active"),
+            ("lead", "effingham_maids", "lead", "active"),
+            ("inactive", "effingham_maids", "customer", "inactive"),
+        )
+        contacts = [(uuid4(), *case[1:]) for case in cases]
+        await observer.executemany(
+            """
+            INSERT INTO contacts (id, business_context_id, contact_type, status)
+            VALUES ($1, $2, $3, $4)
+            """,
+            contacts,
+        )
+        service = ReceivablesService(_SingleConnectionPool(payment_conn, schema))
+
+        for (label, *_), (contact_id, *_contact) in zip(cases, contacts):
+            key = f"e2e-unapplied-ineligible-{label}"
+            with pytest.raises(ReceivablesNotFoundError, match="Customer not found"):
+                await service.create_payment(
+                    contact_id=contact_id,
+                    payer_name="Residential Customer",
+                    total_amount=Decimal("125"),
+                    payment_method="check",
+                    received_date=date.today(),
+                    allocations=[],
+                    idempotency_key=key,
+                    allow_unapplied=True,
+                    unapplied_contact_context_id="effingham_maids",
+                )
+            assert (
+                await observer.fetchval(
+                    "SELECT COUNT(*) FROM customer_payments "
+                    "WHERE idempotency_key = $1",
+                    key,
+                )
+                == 0
+            )
+            assert (
+                await observer.fetchval(
+                    "SELECT COUNT(*) FROM payment_events "
+                    "WHERE idempotency_key = $1",
+                    key,
+                )
+                == 0
+            )
+    finally:
+        await payment_conn.close()
+        await observer.execute("SET search_path TO public")
+        await observer.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        await observer.close()
+
+
+@pytest.mark.asyncio
 async def test_return_waits_for_concurrent_create_before_balance_snapshot():
     """A return cannot overwrite a concurrently-created active allocation."""
     asyncpg = pytest.importorskip("asyncpg")

--- a/tests/test_receivables.py
+++ b/tests/test_receivables.py
@@ -259,6 +259,8 @@ async def test_create_payment_records_unapplied_receipt_and_replays_without_invo
     assert pool.conn.parent_insert_count == 1
     assert pool.conn.contact_lock_count == 1
     assert all("lead_stage" not in query for query in pool.conn.contact_queries)
+    assert all("FOR SHARE" in query for query in pool.conn.contact_queries)
+    assert all("FOR KEY SHARE" not in query for query in pool.conn.contact_queries)
     assert not any("FROM invoices" in query for query, _args in pool.conn.fetches)
     assert not any(
         "INSERT INTO invoice_payments" in query or "WITH totals AS" in query
@@ -860,6 +862,40 @@ class _SingleConnectionPool:
         async with self.conn.transaction():
             await self.conn.execute(f'SET LOCAL search_path TO "{self.schema}"')
             return await self.conn.fetchval(query, *args)
+
+
+class _PauseAfterContactLockConnection:
+    def __init__(self, conn, contact_locked, release_contact_lock) -> None:
+        self._conn = conn
+        self._contact_locked = contact_locked
+        self._release_contact_lock = release_contact_lock
+
+    async def fetchrow(self, query, *args):
+        row = await self._conn.fetchrow(query, *args)
+        if "FROM contacts" in query:
+            self._contact_locked.set()
+            await self._release_contact_lock.wait()
+        return row
+
+    def __getattr__(self, name):
+        return getattr(self._conn, name)
+
+
+class _PauseAfterContactLockPool(_SingleConnectionPool):
+    def __init__(self, conn, schema, contact_locked, release_contact_lock) -> None:
+        super().__init__(conn, schema)
+        self._contact_locked = contact_locked
+        self._release_contact_lock = release_contact_lock
+
+    @asynccontextmanager
+    async def transaction(self):
+        async with self.conn.transaction():
+            await self.conn.execute(f'SET LOCAL search_path TO "{self.schema}"')
+            yield _PauseAfterContactLockConnection(
+                self.conn,
+                self._contact_locked,
+                self._release_contact_lock,
+            )
 
 
 class _MigrationConnectionPool:
@@ -1707,6 +1743,108 @@ async def test_real_postgres_receivables_lifecycle_and_concurrent_replays():
 
 
 @pytest.mark.asyncio
+async def test_real_postgres_unapplied_payment_holds_customer_eligibility_lock():
+    asyncpg = pytest.importorskip("asyncpg")
+    database_url = os.environ.get("ATLAS_RECEIVABLES_TEST_DATABASE_URL")
+    if not database_url:
+        pytest.skip("ATLAS_RECEIVABLES_TEST_DATABASE_URL not set")
+
+    schema = f"receivables_customer_lock_{uuid4().hex}"
+    observer = await asyncpg.connect(database_url)
+    payment_conn = await asyncpg.connect(database_url)
+    archive_conn = await asyncpg.connect(database_url)
+    contact_locked = asyncio.Event()
+    release_contact_lock = asyncio.Event()
+    payment_task = None
+    archive_task = None
+    try:
+        await _create_pre_receivables_schema(observer, schema)
+        await observer.execute(_receivables_migration_sql())
+        contact_id = uuid4()
+        await observer.execute(
+            "INSERT INTO contacts (id, business_context_id) "
+            "VALUES ($1, 'effingham_maids')",
+            contact_id,
+        )
+        service = ReceivablesService(
+            _PauseAfterContactLockPool(
+                payment_conn,
+                schema,
+                contact_locked,
+                release_contact_lock,
+            )
+        )
+        payment_task = asyncio.create_task(
+            service.create_payment(
+                contact_id=contact_id,
+                payer_name="Residential Customer",
+                total_amount=Decimal("125"),
+                payment_method="check",
+                received_date=date.today(),
+                allocations=[],
+                idempotency_key="e2e-unapplied-customer-lock",
+                allow_unapplied=True,
+                unapplied_contact_context_id="effingham_maids",
+            )
+        )
+        await asyncio.wait_for(contact_locked.wait(), timeout=3)
+
+        async with archive_conn.transaction():
+            await archive_conn.execute(f'SET LOCAL search_path TO "{schema}"')
+            archive_task = asyncio.create_task(
+                archive_conn.execute(
+                    "UPDATE contacts SET status = 'inactive' WHERE id = $1",
+                    contact_id,
+                )
+            )
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(asyncio.shield(archive_task), timeout=0.2)
+            assert (
+                await observer.fetchval(
+                    "SELECT status FROM contacts WHERE id = $1", contact_id
+                )
+                == "active"
+            )
+
+            release_contact_lock.set()
+            payment = await asyncio.wait_for(payment_task, timeout=3)
+            payment_task = None
+            assert payment["status"] == "received"
+            assert payment["allocated_amount_cents"] == 0
+            assert payment["unapplied_amount_cents"] == 12_500
+            assert await asyncio.wait_for(archive_task, timeout=3) == "UPDATE 1"
+            archive_task = None
+
+        assert (
+            await observer.fetchval(
+                "SELECT status FROM contacts WHERE id = $1", contact_id
+            )
+            == "inactive"
+        )
+        assert (
+            await observer.fetchval(
+                "SELECT COUNT(*) FROM invoice_payments WHERE payment_id = $1",
+                UUID(payment["id"]),
+            )
+            == 0
+        )
+    finally:
+        release_contact_lock.set()
+        pending_tasks = [
+            task for task in (payment_task, archive_task) if task is not None
+        ]
+        for task in pending_tasks:
+            task.cancel()
+        if pending_tasks:
+            await asyncio.gather(*pending_tasks, return_exceptions=True)
+        await payment_conn.close()
+        await archive_conn.close()
+        await observer.execute("SET search_path TO public")
+        await observer.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        await observer.close()
+
+
+@pytest.mark.asyncio
 async def test_return_waits_for_concurrent_create_before_balance_snapshot():
     """A return cannot overwrite a concurrently-created active allocation."""
     asyncpg = pytest.importorskip("asyncpg")
@@ -2189,6 +2327,7 @@ async def test_real_postgres_http_and_mcp_entrypoints_use_supported_dependencies
     if not database_url:
         pytest.skip("ATLAS_RECEIVABLES_TEST_DATABASE_URL not set")
 
+    from atlas_brain import main
     from atlas_brain.api.invoicing import receivables as routes
     from atlas_brain.mcp import invoicing_server
     from atlas_brain.storage.repositories.invoice import InvoiceRepository
@@ -2213,6 +2352,13 @@ async def test_real_postgres_http_and_mcp_entrypoints_use_supported_dependencies
                 (invoice_ids[1], "INV-HTTP-2", contact_id),
                 (invoice_ids[2], "INV-MCP-1", contact_id),
             ],
+        )
+
+        unapplied_contact_id = uuid4()
+        await conn.execute(
+            "INSERT INTO contacts (id, business_context_id) "
+            "VALUES ($1, 'effingham_maids')",
+            unapplied_contact_id,
         )
 
         allocation_contact_id = uuid4()
@@ -2263,8 +2409,8 @@ async def test_real_postgres_http_and_mcp_entrypoints_use_supported_dependencies
             receivables_service_token="",
             receivables_service_token_sha256=generated.sha256,
         )
-        app = FastAPI()
-        app.include_router(routes.router)
+        app = main.app
+        original_dependency_overrides = app.dependency_overrides.copy()
         app.dependency_overrides[receivables_auth.get_receivables_api_config] = (
             lambda: config
         )
@@ -2280,45 +2426,105 @@ async def test_real_postgres_http_and_mcp_entrypoints_use_supported_dependencies
                 {"invoice_id": str(invoice_ids[1]), "amount_cents": 5_000},
             ],
         }
+        unapplied_body = {
+            "contact_id": str(unapplied_contact_id),
+            "payer_name": "Residential Customer",
+            "total_amount_cents": 12_500,
+            "payment_method": "check",
+            "received_date": "2026-08-12",
+            "reference": "1001",
+        }
 
-        transport = httpx.ASGITransport(app=app)
-        async with httpx.AsyncClient(
-            transport=transport,
-            base_url="http://receivables.test",
-        ) as client:
-            unauthorized = await client.post("/receivables/payments", json=body)
-            assert unauthorized.status_code == 401
-            assert await conn.fetchval("SELECT COUNT(*) FROM customer_payments") == 0
+        try:
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(
+                transport=transport,
+                base_url="http://receivables.test",
+            ) as client:
+                unauthorized = await client.post(
+                    "/api/v1/receivables/payments", json=body
+                )
+                assert unauthorized.status_code == 401
+                assert (
+                    await conn.fetchval("SELECT COUNT(*) FROM customer_payments")
+                    == 0
+                )
 
-            response = await client.post(
-                "/receivables/payments",
-                headers={
-                    "Authorization": f"Bearer {generated.token}",
-                    "X-EOM-Actor": "Juan Canfield",
-                    "Idempotency-Key": "http-payment-1",
-                },
-                json=body,
+                response = await client.post(
+                    "/api/v1/receivables/payments",
+                    headers={
+                        "Authorization": f"Bearer {generated.token}",
+                        "X-EOM-Actor": "Juan Canfield",
+                        "Idempotency-Key": "http-payment-1",
+                    },
+                    json=body,
+                )
+                unapplied_response = await client.post(
+                    "/api/v1/receivables/payments",
+                    headers={
+                        "Authorization": f"Bearer {generated.token}",
+                        "X-EOM-Actor": "Juan Canfield",
+                        "Idempotency-Key": "http-unapplied-payment-1",
+                    },
+                    json=unapplied_body,
+                )
+                unapplied_replay = await client.post(
+                    "/api/v1/receivables/payments",
+                    headers={
+                        "Authorization": f"Bearer {generated.token}",
+                        "X-EOM-Actor": "Juan Canfield",
+                        "Idempotency-Key": "http-unapplied-payment-1",
+                    },
+                    json=unapplied_body,
+                )
+
+            assert response.status_code == 201
+            assert response.json()["status"] == "received"
+            http_payment = await conn.fetchrow("""
+                SELECT idempotency_key, total_amount, recorded_by
+                FROM customer_payments
+                WHERE source = 'eom_admin' AND idempotency_key = 'http-payment-1'
+                """)
+            assert http_payment["total_amount"] == Decimal("200.00")
+            assert http_payment["recorded_by"] == "Juan Canfield"
+            http_allocations = await conn.fetch("""
+                SELECT amount FROM invoice_payments ip
+                JOIN customer_payments cp ON cp.id = ip.payment_id
+                WHERE cp.idempotency_key = 'http-payment-1'
+                ORDER BY amount DESC
+                """)
+            assert [row["amount"] for row in http_allocations] == [
+                Decimal("125.00"),
+                Decimal("50.00"),
+            ]
+
+            assert unapplied_response.status_code == 201
+            assert unapplied_replay.status_code == 201
+            unapplied_payment = unapplied_response.json()
+            assert unapplied_replay.json()["id"] == unapplied_payment["id"]
+            assert unapplied_payment["status"] == "received"
+            assert unapplied_payment["allocated_amount_cents"] == 0
+            assert unapplied_payment["unapplied_amount_cents"] == 12_500
+            assert (
+                await conn.fetchval(
+                    "SELECT COUNT(*) FROM invoice_payments ip "
+                    "JOIN customer_payments cp ON cp.id = ip.payment_id "
+                    "WHERE cp.idempotency_key = 'http-unapplied-payment-1'"
+                )
+                == 0
             )
-
-        assert response.status_code == 201
-        assert response.json()["status"] == "received"
-        http_payment = await conn.fetchrow("""
-            SELECT idempotency_key, total_amount, recorded_by
-            FROM customer_payments
-            WHERE source = 'eom_admin' AND idempotency_key = 'http-payment-1'
-            """)
-        assert http_payment["total_amount"] == Decimal("200.00")
-        assert http_payment["recorded_by"] == "Juan Canfield"
-        http_allocations = await conn.fetch("""
-            SELECT amount FROM invoice_payments ip
-            JOIN customer_payments cp ON cp.id = ip.payment_id
-            WHERE cp.idempotency_key = 'http-payment-1'
-            ORDER BY amount DESC
-            """)
-        assert [row["amount"] for row in http_allocations] == [
-            Decimal("125.00"),
-            Decimal("50.00"),
-        ]
+            assert (
+                await conn.fetchval(
+                    "SELECT COUNT(*) FROM payment_events pe "
+                    "JOIN customer_payments cp ON cp.id = pe.payment_id "
+                    "WHERE cp.idempotency_key = 'http-unapplied-payment-1' "
+                    "AND pe.event_type = 'payment_recorded'"
+                )
+                == 1
+            )
+        finally:
+            app.dependency_overrides.clear()
+            app.dependency_overrides.update(original_dependency_overrides)
 
         crm_calls = []
 

--- a/tests/test_receivables.py
+++ b/tests/test_receivables.py
@@ -48,7 +48,6 @@ class _CreatePaymentConnection:
                 "business_context_id": "effingham_maids",
                 "contact_type": "customer",
                 "status": "active",
-                "lead_stage": None,
             }
             for contact_id in contact_ids or []
         }
@@ -56,6 +55,7 @@ class _CreatePaymentConnection:
             {contact["id"]: contact for contact in contact_rows or []}
         )
         self.contact_lock_count = 0
+        self.contact_queries: list[str] = []
         self.parent_args = None
         self.parent_insert_count = 0
         self.allocations: list[dict] = []
@@ -72,6 +72,7 @@ class _CreatePaymentConnection:
             return None
         if "FROM contacts" in query:
             self.contact_lock_count += 1
+            self.contact_queries.append(query)
             contact = self.contacts.get(args[0])
             if not contact:
                 return None
@@ -79,7 +80,6 @@ class _CreatePaymentConnection:
                 contact.get("business_context_id") != args[1]
                 or contact.get("contact_type") != "customer"
                 or contact.get("status") != "active"
-                or contact.get("lead_stage") is not None
             ):
                 return None
             return {"id": args[0]}
@@ -258,6 +258,7 @@ async def test_create_payment_records_unapplied_receipt_and_replays_without_invo
     assert pool.transaction_count == 2
     assert pool.conn.parent_insert_count == 1
     assert pool.conn.contact_lock_count == 1
+    assert all("lead_stage" not in query for query in pool.conn.contact_queries)
     assert not any("FROM invoices" in query for query, _args in pool.conn.fetches)
     assert not any(
         "INSERT INTO invoice_payments" in query or "WITH totals AS" in query
@@ -321,7 +322,7 @@ async def test_create_unapplied_payment_rejects_ineligible_eom_contacts_before_i
     contact_id = uuid4()
     pool = _CreatePaymentPool(
         [],
-        contact_rows=[{"id": contact_id, "lead_stage": None, **contact}],
+        contact_rows=[{"id": contact_id, **contact}],
     )
 
     with pytest.raises(ReceivablesNotFoundError, match="Customer not found"):
@@ -879,7 +880,11 @@ class _MigrationConnectionPool:
 async def _create_pre_receivables_schema(conn, schema: str) -> None:
     await conn.execute(f'CREATE SCHEMA "{schema}"')
     await conn.execute(f'SET search_path TO "{schema}"')
-    await conn.execute("CREATE TABLE contacts (id uuid PRIMARY KEY, business_context_id VARCHAR(64), contact_type VARCHAR(32) NOT NULL DEFAULT 'customer', status VARCHAR(32) NOT NULL DEFAULT 'active', lead_stage VARCHAR(32))")
+    await conn.execute(
+        "CREATE TABLE contacts (id uuid PRIMARY KEY, business_context_id VARCHAR(64), "
+        "contact_type VARCHAR(32) NOT NULL DEFAULT 'customer', "
+        "status VARCHAR(32) NOT NULL DEFAULT 'active')"
+    )
     invoice_migration = (
         Path(__file__).parents[1] / "atlas_brain/storage/migrations/045_invoices.sql"
     ).read_text(encoding="utf-8")

--- a/tests/test_receivables.py
+++ b/tests/test_receivables.py
@@ -2366,16 +2366,14 @@ def test_payment_http_models_reject_coercive_cent_values():
         "allocations": [{"invoice_id": str(uuid4()), "amount_cents": 100}],
     }
     assert CreatePaymentRequest.model_validate(base).total_amount_cents == 100
-    assert (
-        EOMCreatePaymentRequest.model_validate(
-            {key: value for key, value in base.items() if key != "allocations"}
-        ).allocations
-        == []
-    )
-    assert (
-        EOMCreatePaymentRequest.model_validate({**base, "allocations": []}).allocations
-        == []
-    )
+    for request_model in (CreatePaymentRequest, EOMCreatePaymentRequest):
+        assert (
+            request_model.model_validate(
+                {key: value for key, value in base.items() if key != "allocations"}
+            ).allocations
+            == []
+        )
+        assert request_model.model_validate({**base, "allocations": []}).allocations == []
     with pytest.raises(ValueError):
         AdjustAllocationsRequest.model_validate(
             {"allocations": [], "reason": "Cannot leave adjustment empty"}
@@ -2396,9 +2394,15 @@ def test_payment_http_models_reject_coercive_cent_values():
 
 
 @pytest.mark.asyncio
-async def test_eom_payment_route_forwards_omitted_allocations_as_empty_list():
-    from atlas_brain.eom_api.receivables import CreatePaymentRequest
-    from atlas_brain.eom_api.receivables import create_payment
+async def test_payment_routes_forward_omitted_allocations_as_empty_list():
+    from atlas_brain.api.invoicing.receivables import (
+        CreatePaymentRequest as FullCreatePaymentRequest,
+    )
+    from atlas_brain.api.invoicing.receivables import create_payment as full_create_payment
+    from atlas_brain.eom_api.receivables import (
+        CreatePaymentRequest as EOMCreatePaymentRequest,
+    )
+    from atlas_brain.eom_api.receivables import create_payment as eom_create_payment
 
     class _RecordingService:
         def __init__(self) -> None:
@@ -2408,29 +2412,33 @@ async def test_eom_payment_route_forwards_omitted_allocations_as_empty_list():
             self.kwargs = kwargs
             return {"id": "payment-1"}
 
-    body = CreatePaymentRequest.model_validate(
-        {
-            "contact_id": str(uuid4()),
-            "payer_name": "Residential Customer",
-            "total_amount_cents": 12_500,
-            "payment_method": "check",
-            "received_date": "2026-08-12",
-            "reference": "1001",
-        }
-    )
-    service = _RecordingService()
+    for request_model, create_route in (
+        (FullCreatePaymentRequest, full_create_payment),
+        (EOMCreatePaymentRequest, eom_create_payment),
+    ):
+        body = request_model.model_validate(
+            {
+                "contact_id": str(uuid4()),
+                "payer_name": "Residential Customer",
+                "total_amount_cents": 12_500,
+                "payment_method": "check",
+                "received_date": "2026-08-12",
+                "reference": "1001",
+            }
+        )
+        service = _RecordingService()
 
-    result = await create_payment(
-        body,
-        actor="Juan Canfield",
-        idempotency_key="route-unapplied-payment-1",
-        service=service,
-    )
+        result = await create_route(
+            body,
+            actor="Juan Canfield",
+            idempotency_key="route-unapplied-payment-1",
+            service=service,
+        )
 
-    assert result == {"id": "payment-1"}
-    assert service.kwargs["allocations"] == []
-    assert service.kwargs["recorded_by"] == "Juan Canfield"
-    assert service.kwargs["idempotency_key"] == "route-unapplied-payment-1"
+        assert result == {"id": "payment-1"}
+        assert service.kwargs["allocations"] == []
+        assert service.kwargs["recorded_by"] == "Juan Canfield"
+        assert service.kwargs["idempotency_key"] == "route-unapplied-payment-1"
 
 
 def test_multi_invoice_mcp_is_registered_with_bounded_strict_schema():

--- a/tests/test_receivables.py
+++ b/tests/test_receivables.py
@@ -36,18 +36,33 @@ from atlas_brain.storage.exceptions import DatabaseUnavailableError
 
 
 class _CreatePaymentConnection:
-    def __init__(self, invoices: list[dict]) -> None:
+    def __init__(
+        self, invoices: list[dict], contact_ids: list[UUID] | None = None
+    ) -> None:
         self.invoices = invoices
+        self.contact_ids = set(contact_ids or [])
+        self.contact_lock_count = 0
         self.parent_args = None
+        self.parent_insert_count = 0
         self.allocations: list[dict] = []
+        self.fetches: list[tuple[str, tuple]] = []
         self.executions: list[tuple[str, tuple]] = []
 
     async def fetchrow(self, query: str, *args):
         if "WHERE source = $1 AND idempotency_key = $2" in query:
+            if self.parent_args is not None:
+                return {
+                    "id": self.parent_args[0],
+                    "request_fingerprint": self.parent_args[10],
+                }
             return None
+        if "FROM contacts" in query:
+            self.contact_lock_count += 1
+            return {"id": args[0]} if args[0] in self.contact_ids else None
         if "FROM payment_events" in query:
             return None
         if "INSERT INTO customer_payments" in query:
+            self.parent_insert_count += 1
             self.parent_args = args
             return {"id": args[0]}
         if "SELECT cp.*, pdi.batch_id" in query:
@@ -77,6 +92,7 @@ class _CreatePaymentConnection:
         return None
 
     async def fetch(self, query: str, *args):
+        self.fetches.append((query, args))
         if "FROM invoices" in query and "ORDER BY id FOR UPDATE" in query:
             selected = {str(item) for item in args[0]}
             return [row for row in self.invoices if str(row["id"]) in selected]
@@ -105,8 +121,10 @@ class _CreatePaymentConnection:
 class _CreatePaymentPool:
     is_initialized = True
 
-    def __init__(self, invoices: list[dict]) -> None:
-        self.conn = _CreatePaymentConnection(invoices)
+    def __init__(
+        self, invoices: list[dict], contact_ids: list[UUID] | None = None
+    ) -> None:
+        self.conn = _CreatePaymentConnection(invoices, contact_ids)
         self.transaction_count = 0
 
     @asynccontextmanager
@@ -180,6 +198,71 @@ async def test_create_payment_records_multi_invoice_receipt_in_one_transaction()
         if "INSERT INTO payment_events" in query
     )
     assert event[8] == "payment-create-1"
+
+
+@pytest.mark.asyncio
+async def test_create_payment_records_unapplied_receipt_and_replays_without_invoice_side_effects():
+    contact_id = uuid4()
+    pool = _CreatePaymentPool([], [contact_id])
+    service = ReceivablesService(pool)
+    create_args = {
+        "contact_id": contact_id,
+        "payer_name": "Residential Customer",
+        "total_amount": Decimal("125.00"),
+        "payment_method": "check",
+        "received_date": date(2026, 8, 12),
+        "allocations": [],
+        "idempotency_key": "unapplied-payment-create-1",
+        "recorded_by": "Juan Canfield",
+    }
+
+    first = await service.create_payment_with_outcome(**create_args)
+    replay = await service.create_payment_with_outcome(**create_args)
+
+    assert first.replayed is False
+    assert replay.replayed is True
+    assert first.payment["id"] == replay.payment["id"]
+    assert first.payment["status"] == "received"
+    assert first.payment["allocated_amount_cents"] == 0
+    assert first.payment["unapplied_amount_cents"] == 12_500
+    assert first.payment["allocations"] == []
+    assert pool.transaction_count == 2
+    assert pool.conn.parent_insert_count == 1
+    assert pool.conn.contact_lock_count == 1
+    assert not any("FROM invoices" in query for query, _args in pool.conn.fetches)
+    assert not any(
+        "INSERT INTO invoice_payments" in query or "WITH totals AS" in query
+        for query, _args in pool.conn.executions
+    )
+    events = [
+        args
+        for query, args in pool.conn.executions
+        if "INSERT INTO payment_events" in query
+    ]
+    assert len(events) == 1
+    assert json.loads(events[0][10]) == {"allocated_amount": "0"}
+
+
+@pytest.mark.asyncio
+async def test_create_unapplied_payment_requires_existing_customer_before_insert():
+    pool = _CreatePaymentPool([])
+
+    with pytest.raises(ReceivablesNotFoundError, match="Customer not found"):
+        await ReceivablesService(pool).create_payment(
+            contact_id=uuid4(),
+            payer_name="Residential Customer",
+            total_amount=Decimal("125.00"),
+            payment_method="check",
+            received_date=date(2026, 8, 12),
+            allocations=[],
+            idempotency_key="unapplied-payment-unknown-customer",
+        )
+
+    assert pool.transaction_count == 1
+    assert pool.conn.contact_lock_count == 1
+    assert pool.conn.parent_args is None
+    assert not pool.conn.executions
+    assert not any("FROM invoices" in query for query, _args in pool.conn.fetches)
 
 
 @pytest.mark.asyncio
@@ -290,6 +373,14 @@ def test_money_rejects_nan_and_duplicate_invoice_allocations():
                 {"invoice_id": invoice_id, "amount": "2.00"},
             ]
         )
+
+
+def test_empty_allocations_require_explicit_initial_creation_opt_in():
+    assert ReceivablesService._normalize_allocations([], allow_empty=True) == []
+    with pytest.raises(ReceivablesValidationError, match="At least one"):
+        ReceivablesService._normalize_allocations([])
+    with pytest.raises(ReceivablesValidationError, match="At least one"):
+        ReceivablesService._normalize_allocations(None, allow_empty=True)
 
 
 def test_idempotency_key_reuse_with_different_request_conflicts():
@@ -1165,8 +1256,53 @@ async def test_real_postgres_receivables_lifecycle_and_concurrent_replays():
                 (invoice_ids[3], "INV-E2E-4", contact_id, Decimal("10")),
             ],
         )
+        unapplied_contact_id = uuid4()
+        await observer.execute(
+            "INSERT INTO contacts (id) VALUES ($1)", unapplied_contact_id
+        )
         service_a = ReceivablesService(_SingleConnectionPool(conn_a, schema))
         service_b = ReceivablesService(_SingleConnectionPool(conn_b, schema))
+        unapplied_args = {
+            "contact_id": unapplied_contact_id,
+            "payer_name": "Residential Customer",
+            "total_amount": Decimal("125"),
+            "payment_method": "check",
+            "received_date": date.today(),
+            "allocations": [],
+            "idempotency_key": "e2e-unapplied-payment-create",
+        }
+        unapplied_outcomes = await asyncio.gather(
+            service_a.create_payment_with_outcome(**unapplied_args),
+            service_b.create_payment_with_outcome(**unapplied_args),
+        )
+        assert sorted(outcome.replayed for outcome in unapplied_outcomes) == [
+            False,
+            True,
+        ]
+        unapplied_first, unapplied_replay = (
+            outcome.payment for outcome in unapplied_outcomes
+        )
+        assert unapplied_first["id"] == unapplied_replay["id"]
+        assert unapplied_first["status"] == "received"
+        assert unapplied_first["allocated_amount_cents"] == 0
+        assert unapplied_first["unapplied_amount_cents"] == 12_500
+        assert (
+            await observer.fetchval(
+                """
+                SELECT COUNT(*)
+                FROM customer_payments
+                WHERE idempotency_key = 'e2e-unapplied-payment-create'
+                """
+            )
+            == 1
+        )
+        assert (
+            await observer.fetchval(
+                "SELECT COUNT(*) FROM invoice_payments WHERE payment_id = $1",
+                UUID(unapplied_first["id"]),
+            )
+            == 0
+        )
         create_args = {
             "contact_id": contact_id,
             "payer_name": "Acme",
@@ -2215,6 +2351,10 @@ def test_full_invoicing_mcp_http_refuses_to_start_without_strong_auth():
 
 def test_payment_http_models_reject_coercive_cent_values():
     from atlas_brain.api.invoicing.receivables import CreatePaymentRequest
+    from atlas_brain.eom_api.receivables import AdjustAllocationsRequest
+    from atlas_brain.eom_api.receivables import (
+        CreatePaymentRequest as EOMCreatePaymentRequest,
+    )
 
     base = {
         "contact_id": str(uuid4()),
@@ -2226,6 +2366,20 @@ def test_payment_http_models_reject_coercive_cent_values():
         "allocations": [{"invoice_id": str(uuid4()), "amount_cents": 100}],
     }
     assert CreatePaymentRequest.model_validate(base).total_amount_cents == 100
+    assert (
+        EOMCreatePaymentRequest.model_validate(
+            {key: value for key, value in base.items() if key != "allocations"}
+        ).allocations
+        == []
+    )
+    assert (
+        EOMCreatePaymentRequest.model_validate({**base, "allocations": []}).allocations
+        == []
+    )
+    with pytest.raises(ValueError):
+        AdjustAllocationsRequest.model_validate(
+            {"allocations": [], "reason": "Cannot leave adjustment empty"}
+        )
 
     for invalid in (True, False, 100.0, 100.5, "100", 0, -1):
         with pytest.raises(ValueError):
@@ -2239,6 +2393,44 @@ def test_payment_http_models_reject_coercive_cent_values():
                     ],
                 }
             )
+
+
+@pytest.mark.asyncio
+async def test_eom_payment_route_forwards_omitted_allocations_as_empty_list():
+    from atlas_brain.eom_api.receivables import CreatePaymentRequest
+    from atlas_brain.eom_api.receivables import create_payment
+
+    class _RecordingService:
+        def __init__(self) -> None:
+            self.kwargs = None
+
+        async def create_payment(self, **kwargs):
+            self.kwargs = kwargs
+            return {"id": "payment-1"}
+
+    body = CreatePaymentRequest.model_validate(
+        {
+            "contact_id": str(uuid4()),
+            "payer_name": "Residential Customer",
+            "total_amount_cents": 12_500,
+            "payment_method": "check",
+            "received_date": "2026-08-12",
+            "reference": "1001",
+        }
+    )
+    service = _RecordingService()
+
+    result = await create_payment(
+        body,
+        actor="Juan Canfield",
+        idempotency_key="route-unapplied-payment-1",
+        service=service,
+    )
+
+    assert result == {"id": "payment-1"}
+    assert service.kwargs["allocations"] == []
+    assert service.kwargs["recorded_by"] == "Juan Canfield"
+    assert service.kwargs["idempotency_key"] == "route-unapplied-payment-1"
 
 
 def test_multi_invoice_mcp_is_registered_with_bounded_strict_schema():

--- a/tests/test_receivables.py
+++ b/tests/test_receivables.py
@@ -37,10 +37,24 @@ from atlas_brain.storage.exceptions import DatabaseUnavailableError
 
 class _CreatePaymentConnection:
     def __init__(
-        self, invoices: list[dict], contact_ids: list[UUID] | None = None
+        self,
+        invoices: list[dict],
+        contact_ids: list[UUID] | None = None,
+        contact_rows: list[dict] | None = None,
     ) -> None:
         self.invoices = invoices
-        self.contact_ids = set(contact_ids or [])
+        self.contacts = {
+            contact_id: {
+                "business_context_id": "effingham_maids",
+                "contact_type": "customer",
+                "status": "active",
+                "lead_stage": None,
+            }
+            for contact_id in contact_ids or []
+        }
+        self.contacts.update(
+            {contact["id"]: contact for contact in contact_rows or []}
+        )
         self.contact_lock_count = 0
         self.parent_args = None
         self.parent_insert_count = 0
@@ -58,7 +72,17 @@ class _CreatePaymentConnection:
             return None
         if "FROM contacts" in query:
             self.contact_lock_count += 1
-            return {"id": args[0]} if args[0] in self.contact_ids else None
+            contact = self.contacts.get(args[0])
+            if not contact:
+                return None
+            if args[1] is not None and (
+                contact.get("business_context_id") != args[1]
+                or contact.get("contact_type") != "customer"
+                or contact.get("status") != "active"
+                or contact.get("lead_stage") is not None
+            ):
+                return None
+            return {"id": args[0]}
         if "FROM payment_events" in query:
             return None
         if "INSERT INTO customer_payments" in query:
@@ -122,9 +146,12 @@ class _CreatePaymentPool:
     is_initialized = True
 
     def __init__(
-        self, invoices: list[dict], contact_ids: list[UUID] | None = None
+        self,
+        invoices: list[dict],
+        contact_ids: list[UUID] | None = None,
+        contact_rows: list[dict] | None = None,
     ) -> None:
-        self.conn = _CreatePaymentConnection(invoices, contact_ids)
+        self.conn = _CreatePaymentConnection(invoices, contact_ids, contact_rows)
         self.transaction_count = 0
 
     @asynccontextmanager
@@ -214,6 +241,8 @@ async def test_create_payment_records_unapplied_receipt_and_replays_without_invo
         "allocations": [],
         "idempotency_key": "unapplied-payment-create-1",
         "recorded_by": "Juan Canfield",
+        "allow_unapplied": True,
+        "unapplied_contact_context_id": "effingham_maids",
     }
 
     first = await service.create_payment_with_outcome(**create_args)
@@ -244,18 +273,30 @@ async def test_create_payment_records_unapplied_receipt_and_replays_without_invo
 
 
 @pytest.mark.asyncio
-async def test_create_unapplied_payment_requires_existing_customer_before_insert():
+async def test_create_unapplied_payment_requires_opt_in_and_existing_customer_before_insert():
     pool = _CreatePaymentPool([])
+    create_args = {
+        "contact_id": uuid4(),
+        "payer_name": "Residential Customer",
+        "total_amount": Decimal("125.00"),
+        "payment_method": "check",
+        "received_date": date(2026, 8, 12),
+        "allocations": [],
+        "idempotency_key": "unapplied-payment-unknown-customer",
+    }
 
+    with pytest.raises(ReceivablesValidationError, match="At least one"):
+        await ReceivablesService(pool).create_payment(**create_args)
+    with pytest.raises(ReceivablesValidationError, match="canonical customer context"):
+        await ReceivablesService(pool).create_payment(
+            **create_args, allow_unapplied=True
+        )
+    assert pool.transaction_count == 0
     with pytest.raises(ReceivablesNotFoundError, match="Customer not found"):
         await ReceivablesService(pool).create_payment(
-            contact_id=uuid4(),
-            payer_name="Residential Customer",
-            total_amount=Decimal("125.00"),
-            payment_method="check",
-            received_date=date(2026, 8, 12),
-            allocations=[],
-            idempotency_key="unapplied-payment-unknown-customer",
+            **create_args,
+            allow_unapplied=True,
+            unapplied_contact_context_id="effingham_maids",
         )
 
     assert pool.transaction_count == 1
@@ -263,6 +304,41 @@ async def test_create_unapplied_payment_requires_existing_customer_before_insert
     assert pool.conn.parent_args is None
     assert not pool.conn.executions
     assert not any("FROM invoices" in query for query, _args in pool.conn.fetches)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "contact",
+    [
+        {"business_context_id": "other", "contact_type": "customer", "status": "active"},
+        {"business_context_id": "effingham_maids", "contact_type": "lead", "status": "active"},
+        {"business_context_id": "effingham_maids", "contact_type": "customer", "status": "inactive"},
+    ],
+)
+async def test_create_unapplied_payment_rejects_ineligible_eom_contacts_before_insert(
+    contact,
+):
+    contact_id = uuid4()
+    pool = _CreatePaymentPool(
+        [],
+        contact_rows=[{"id": contact_id, "lead_stage": None, **contact}],
+    )
+
+    with pytest.raises(ReceivablesNotFoundError, match="Customer not found"):
+        await ReceivablesService(pool).create_payment(
+            contact_id=contact_id,
+            payer_name="Residential Customer",
+            total_amount=Decimal("125.00"),
+            payment_method="check",
+            received_date=date(2026, 8, 12),
+            allocations=[],
+            idempotency_key="unapplied-payment-ineligible-customer",
+            allow_unapplied=True,
+            unapplied_contact_context_id="effingham_maids",
+        )
+
+    assert pool.conn.parent_args is None
+    assert pool.conn.contact_lock_count == 1
 
 
 @pytest.mark.asyncio
@@ -803,7 +879,7 @@ class _MigrationConnectionPool:
 async def _create_pre_receivables_schema(conn, schema: str) -> None:
     await conn.execute(f'CREATE SCHEMA "{schema}"')
     await conn.execute(f'SET search_path TO "{schema}"')
-    await conn.execute("CREATE TABLE contacts (id uuid PRIMARY KEY)")
+    await conn.execute("CREATE TABLE contacts (id uuid PRIMARY KEY, business_context_id VARCHAR(64), contact_type VARCHAR(32) NOT NULL DEFAULT 'customer', status VARCHAR(32) NOT NULL DEFAULT 'active', lead_stage VARCHAR(32))")
     invoice_migration = (
         Path(__file__).parents[1] / "atlas_brain/storage/migrations/045_invoices.sql"
     ).read_text(encoding="utf-8")
@@ -1257,9 +1333,7 @@ async def test_real_postgres_receivables_lifecycle_and_concurrent_replays():
             ],
         )
         unapplied_contact_id = uuid4()
-        await observer.execute(
-            "INSERT INTO contacts (id) VALUES ($1)", unapplied_contact_id
-        )
+        await observer.execute("INSERT INTO contacts (id, business_context_id) VALUES ($1, 'effingham_maids')", unapplied_contact_id)
         service_a = ReceivablesService(_SingleConnectionPool(conn_a, schema))
         service_b = ReceivablesService(_SingleConnectionPool(conn_b, schema))
         unapplied_args = {
@@ -1270,6 +1344,8 @@ async def test_real_postgres_receivables_lifecycle_and_concurrent_replays():
             "received_date": date.today(),
             "allocations": [],
             "idempotency_key": "e2e-unapplied-payment-create",
+            "allow_unapplied": True,
+            "unapplied_contact_context_id": "effingham_maids",
         }
         unapplied_outcomes = await asyncio.gather(
             service_a.create_payment_with_outcome(**unapplied_args),
@@ -2437,6 +2513,8 @@ async def test_payment_routes_forward_omitted_allocations_as_empty_list():
 
         assert result == {"id": "payment-1"}
         assert service.kwargs["allocations"] == []
+        assert service.kwargs["allow_unapplied"] is True
+        assert service.kwargs["unapplied_contact_context_id"] == "effingham_maids"
         assert service.kwargs["recorded_by"] == "Juan Canfield"
         assert service.kwargs["idempotency_key"] == "route-unapplied-payment-1"
 


### PR DESCRIPTION
Plan: plans/PR-EOM-Receivables-Unapplied-Payments.md
Slice phase: Vertical slice
Ownership lane: eom/receivables

ATLAS must allow the EOM portal to record a real payment for an active canonical customer who has no invoice, without weakening legacy allocation-only consumers or introducing a second ledger.

## Problem

Both versioned EOM provider models and the shared service rejected omitted or empty allocations, so a residential payment could not exist without a fake invoice.

## Current behavior

The deployed full provider and the dormant slim provider now accept an empty initial allocation only through their EOM routes. The customer lock uses only the slim profile's tenant, customer-type, and active-status columns; other service callers, allocation adjustments, and the invoicing MCP remain allocation-required.

## Slice contract

One active `effingham_maids` customer can receive an atomic unapplied payment/event. The request is idempotent, does not write allocations or invoice balances, and rejects unknown, foreign, lead, and inactive contacts before any financial insert.

## Implementation

- Both EOM create routes explicitly opt into `allow_unapplied` and pass the EOM tenant context.
- The service keeps its default allocation guard, requires a canonical context for the opt-in, and `FOR SHARE` locks an eligible active customer without a lead-pipeline-column dependency until the payment transaction commits; Decimal amounts, lifecycle state, and replay behavior remain unchanged.
- Focused tests prove both provider routes, no-invoice side effects, same-key replay, real-Postgres foreign/lead/inactive rejection, a slim-shaped contacts table without `lead_stage`, the authenticated mounted full-app route, and the contact-archive interlock.

## Deployment order

Deploy this ATLAS provider slice first. The tracker and Website retain their existing behavior until their later backward-compatible slices are merged and deployed.

## Failure and retry behavior

Validation happens before inserts. A same-key matching retry returns the original payment; a changed request conflicts. A rejected/missing/ineligible customer leaves no payment or event, and no email or live customer operation is involved.

## Tests

Focused receivables tests, EOM Render-profile tests, ruff, plan/diff checks, and the repository local PR gate run before publication. The optional real-Postgres HTTP, concurrency, and ineligible-row cases remain safely skipped without their dedicated test database.

## Intentional

- This is provider-only: no migration, email, receipt, UI, Gmail, or live financial-data operation.
- The adjustment, deposit, clearing, return, void, and MCP contracts remain unchanged.
- The slim provider does not need a lead-pipeline migration for this payment boundary; `contact_type='customer'` is the lead/customer eligibility discriminator.

## AI reconciliation

- Add R2 to the changed-path rule declaration: fixed-in: 801155e and plans/PR-EOM-Receivables-Unapplied-Payments.md
- Restrict unapplied payments to eligible EOM customers: fixed-in: 801155e and atlas_brain/services/receivables.py
- State the concurrent replay execution model: fixed-in: 801155e and plans/PR-EOM-Receivables-Unapplied-Payments.md
- Restrict empty-allocation admission to explicit EOM routes: fixed-in: 801155e and atlas_brain/services/receivables.py
- Enroll the lead-stage migration for the slim profile: not-applicable: `atlas_brain/services/receivables.py` deliberately uses only context, contact-type, and active-status fields shared by both provider schemas, so this payment boundary needs no `lead_stage` migration.
- Exercise omission through the mounted HTTP route: fixed-in: 3c241917 and tests/test_receivables.py
- Lock contact eligibility against concurrent changes: fixed-in: 3c241917 and atlas_brain/services/receivables.py
- Prove eligibility against real PostgreSQL: fixed-in: 6ff7917 and tests/test_receivables.py
- Add the diff-budget justification: fixed-in: f9f0373 and plans/PR-EOM-Receivables-Unapplied-Payments.md
- Record reproducible verification in the plan: fixed-in: f9f0373 and plans/PR-EOM-Receivables-Unapplied-Payments.md
- State the slice parking predicate: fixed-in: f9f0373 and plans/PR-EOM-Receivables-Unapplied-Payments.md
- All findings fixed or waived: Yes.

## Fix-loop disposition preflight

- Root decision: Add R2 to the changed-path rule declaration
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: atlas_brain/api/invoicing/receivables.py, atlas_brain/eom_api/receivables.py, atlas_brain/services/receivables.py, plans/PR-EOM-Receivables-Unapplied-Payments.md, tests/test_receivables.py
- Max files: 5
- Parked hardening: #2363 H-01 and H-06
- Source trace: Codex R2 finding -> plans/PR-EOM-Receivables-Unapplied-Payments.md
- Upstream files: plans/PR-EOM-Receivables-Unapplied-Payments.md
- Fix strategy: upstream-root

- Root decision: Restrict unapplied payments to eligible EOM customers
- Blocking predicate: money
- Disposition: fixed-in
- Allowed files: atlas_brain/api/invoicing/receivables.py, atlas_brain/eom_api/receivables.py, atlas_brain/services/receivables.py, plans/PR-EOM-Receivables-Unapplied-Payments.md, tests/test_receivables.py
- Max files: 5
- Parked hardening: #2363 H-01 and H-06
- Source trace: EOM route context -> atlas_brain/services/receivables.py
- Upstream files: atlas_brain/services/receivables.py, tests/test_receivables.py
- Fix strategy: upstream-root

- Root decision: State the concurrent replay execution model
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: atlas_brain/api/invoicing/receivables.py, atlas_brain/eom_api/receivables.py, atlas_brain/services/receivables.py, plans/PR-EOM-Receivables-Unapplied-Payments.md, tests/test_receivables.py
- Max files: 5
- Parked hardening: #2363 H-01 and H-06
- Source trace: receipt replay locks -> plans/PR-EOM-Receivables-Unapplied-Payments.md
- Upstream files: plans/PR-EOM-Receivables-Unapplied-Payments.md
- Fix strategy: upstream-root

- Root decision: Restrict empty-allocation admission to explicit EOM routes
- Blocking predicate: back-compat
- Disposition: fixed-in
- Allowed files: atlas_brain/api/invoicing/receivables.py, atlas_brain/eom_api/receivables.py, atlas_brain/services/receivables.py, plans/PR-EOM-Receivables-Unapplied-Payments.md, tests/test_receivables.py
- Max files: 5
- Parked hardening: #2363 H-01 and H-06
- Source trace: generic service caller -> atlas_brain/services/receivables.py
- Upstream files: atlas_brain/services/receivables.py, atlas_brain/api/invoicing/receivables.py, atlas_brain/eom_api/receivables.py
- Fix strategy: upstream-root

- Root decision: Enroll the lead-stage migration for the slim profile
- Blocking predicate: back-compat
- Disposition: not-applicable
- Allowed files: atlas_brain/api/invoicing/receivables.py, atlas_brain/eom_api/receivables.py, atlas_brain/services/receivables.py, plans/PR-EOM-Receivables-Unapplied-Payments.md, tests/test_receivables.py
- Max files: 5
- Parked hardening: #2363 H-01 and H-06
- Source trace: slim migration profile -> atlas_brain/services/receivables.py
- Upstream files: atlas_brain/services/receivables.py, tests/test_receivables.py
- Fix strategy: upstream-root

- Root decision: Exercise omission through the mounted HTTP route
- Blocking predicate: money
- Disposition: fixed-in
- Allowed files: atlas_brain/api/invoicing/receivables.py, atlas_brain/eom_api/receivables.py, atlas_brain/services/receivables.py, plans/PR-EOM-Receivables-Unapplied-Payments.md, tests/test_receivables.py
- Max files: 5
- Parked hardening: #2363 H-01 and H-06
- Source trace: direct route-model test -> tests/test_receivables.py
- Upstream files: tests/test_receivables.py
- Fix strategy: upstream-root

- Root decision: Lock contact eligibility against concurrent changes
- Blocking predicate: money
- Disposition: fixed-in
- Allowed files: atlas_brain/api/invoicing/receivables.py, atlas_brain/eom_api/receivables.py, atlas_brain/services/receivables.py, plans/PR-EOM-Receivables-Unapplied-Payments.md, tests/test_receivables.py
- Max files: 5
- Parked hardening: #2363 H-01 and H-06
- Source trace: customer archive update -> atlas_brain/services/receivables.py
- Upstream files: atlas_brain/services/receivables.py, tests/test_receivables.py
- Fix strategy: upstream-root

- Root decision: Prove eligibility against real PostgreSQL
- Blocking predicate: money
- Disposition: fixed-in
- Allowed files: atlas_brain/api/invoicing/receivables.py, atlas_brain/eom_api/receivables.py, atlas_brain/services/receivables.py, plans/PR-EOM-Receivables-Unapplied-Payments.md, tests/test_receivables.py
- Max files: 5
- Parked hardening: #2363 H-01 and H-06
- Source trace: SQL-blind ineligible-contact fake -> tests/test_receivables.py
- Upstream files: tests/test_receivables.py
- Fix strategy: upstream-root

- Root decision: Add the diff-budget justification
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: atlas_brain/api/invoicing/receivables.py, atlas_brain/eom_api/receivables.py, atlas_brain/services/receivables.py, plans/PR-EOM-Receivables-Unapplied-Payments.md, tests/test_receivables.py
- Max files: 5
- Parked hardening: #2363 H-01 and H-06
- Source trace: plan size table -> plans/PR-EOM-Receivables-Unapplied-Payments.md
- Upstream files: plans/PR-EOM-Receivables-Unapplied-Payments.md
- Fix strategy: upstream-root

- Root decision: Record reproducible verification in the plan
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: atlas_brain/api/invoicing/receivables.py, atlas_brain/eom_api/receivables.py, atlas_brain/services/receivables.py, plans/PR-EOM-Receivables-Unapplied-Payments.md, tests/test_receivables.py
- Max files: 5
- Parked hardening: #2363 H-01 and H-06
- Source trace: plan verification section -> plans/PR-EOM-Receivables-Unapplied-Payments.md
- Upstream files: plans/PR-EOM-Receivables-Unapplied-Payments.md
- Fix strategy: upstream-root

- Root decision: State the slice parking predicate
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: atlas_brain/api/invoicing/receivables.py, atlas_brain/eom_api/receivables.py, atlas_brain/services/receivables.py, plans/PR-EOM-Receivables-Unapplied-Payments.md, tests/test_receivables.py
- Max files: 5
- Parked hardening: #2363 H-01 and H-06
- Source trace: plan deferred section -> plans/PR-EOM-Receivables-Unapplied-Payments.md
- Upstream files: plans/PR-EOM-Receivables-Unapplied-Payments.md
- Fix strategy: upstream-root

## Deferred

- Parking predicate: park new work that does not change allocation-free EOM payment
  admission, its required financial-safety proof, or this provider slice's
  independent deployability.
- #2362: tracker proxy, website entry, receipts, ledger, commercial billing, Gmail draft, sent-mail, and Square slices.

## Parked hardening

- #2363 H-01: legacy invoice float-money audit; H-06: full/slim provider-model structural deduplication. Neither belongs in this behavioral slice or satisfies the parking predicate.

## Cold diff reconstruction

- `atlas_brain/api/invoicing/receivables.py:76` / `:205` and `atlas_brain/eom_api/receivables.py:76` / `:205` change only initial create request admission and forward the explicit EOM-only opt-in.
- `atlas_brain/services/receivables.py:565` / `:1364` keeps default allocation rejection, makes empty allocation an explicit contextual capability, and share-locks the canonical active EOM customer using fields owned by both provider profiles until the payment commits.
- `tests/test_receivables.py:1746` / `:1847` / `:2388` covers positive, retry, opt-in, real-Postgres tenant/type/status rejection, full/slim parity, an absent `lead_stage` column, authenticated allocation omission through mounted `main.app`, and optional real-Postgres archive interlocking.
- `plans/PR-EOM-Receivables-Unapplied-Payments.md:5` / `:81` / `:92` explains why the proof-heavy 803-LOC slice is indivisible, records its parking predicate, and carries reproducible verification receipts; it does not add product behavior.

## Verification

- `pytest -q tests/test_receivables.py`: 65 passed, 8 skipped; skipped database cases require `ATLAS_RECEIVABLES_TEST_DATABASE_URL` and never use live financial data.
- `pytest -q tests/test_eom_render_profile.py`: 61 passed.
- `ruff check`, plan sync/check, boundary/config probes, and diff checks passed locally. A masked authenticated readiness GET against the live full provider returned ready without a financial mutation.

## Mechanical verification

- Command: pytest -q tests/test_receivables.py - Result: 65 passed, 8 skipped - Environment: local
- Command: pytest -q tests/test_eom_render_profile.py - Result: 61 passed - Environment: local
- Command: ruff check atlas_brain/api/invoicing/receivables.py atlas_brain/eom_api/receivables.py atlas_brain/services/receivables.py tests/test_receivables.py - Result: passed - Environment: local
- Command: python scripts/sync_pr_plan.py --check plans/PR-EOM-Receivables-Unapplied-Payments.md origin/main - Result: passed - Environment: local
- Command: python scripts/check_boundary_change_enumeration.py --strict - Result: passed - Environment: local
- Command: python scripts/check_deployed_config_probing.py --strict - Result: passed - Environment: local
- Command: authenticated GET /api/v1/receivables/ready - Result: passed (status ready) - Environment: Office PC
- Skipped: real-Postgres receivables concurrency execution | Reason: dedicated test database is absent; no live financial data is used for automated tests.

## Diff size

Diff-budget override: This proof-heavy 757-added-line slice is indivisible because the EOM-only admission change, mounted-route and idempotency proof, real-Postgres eligibility checks, and archive-lock interlock jointly protect one live money boundary; splitting them would deploy that boundary without its required safety evidence.

803 LOC across five files; the review corrections add tenant/opt-in, slim-profile, mounted-route, customer-eligibility, and proof/plan-contract evidence, not new product scope.

<!-- atlas-open-pr-wrapper: v1 -->
