### PR TITLE
Fix unit-gate file-level baseline selection

### DIFF
--- a/plans/PR-Unit-Gate-File-Baseline-Escalation.md
+++ b/plans/PR-Unit-Gate-File-Baseline-Escalation.md
@@ -1,0 +1,159 @@
+# PR-Unit-Gate-File-Baseline-Escalation
+
+## Why this slice exists
+
+The staged EOM Invoicing MCP payment-response compatibility slice cannot pass
+the repository's local Unit Gate as currently implemented. Its selector reaches
+four OAuth/MCP test modules that are recorded as bare file-level baseline
+failures. Those modules pass when executed in isolation, so the scoped ratchet
+demands that their baseline entries be removed. The same gate's required full
+suite then proves that all four still fail during collection because legacy
+tests install a fake `mcp` package in `sys.modules` before OAuth imports run.
+
+The root cause is selector unsoundness: a scoped pass can establish a test-file
+result, but it cannot establish that a bare file-level full-suite collection
+failure is fixed. The selector must therefore choose the full suite whenever
+its otherwise-scoped result includes an exact bare test-file baseline entry.
+This hardening slice is justified because it blocks the current Billing &
+Payments vertical prerequisite without weakening its financial contract.
+
+### Problem-derived contract
+
+- Root cause: a selected bare file-level baseline entry represents a known
+  full-suite collection failure, yet the scoped gate treats its isolated pass
+  as evidence that the entry is stale.
+- Correct fix must touch/change: the impacted-test selector must inspect exact
+  bare test-file entries in the committed baseline after it derives a scoped
+  selection, then return `FULL` for an overlap.
+- Must not change: the payment projection, financial behavior, known-failure
+  baseline contents, unit-gate regression/growth predicate, test selection for
+  exact node-level baseline entries, deployment configuration, or hosted test
+  execution.
+
+## Scope (this PR)
+
+Ownership lane: developer-experience/ci
+Slice phase: production hardening
+Max files: 3
+
+1. Escalate a scoped selector result to `FULL` when it includes a test path
+   listed as a bare file-level known failure in `tests/unit_gate_baseline.txt`.
+2. Prove the admission boundary with a fixture whose selected file has a bare
+   baseline entry and a just-outside fixture whose baseline entry names a single
+   test node in that same file.
+3. Unblock the staged EOM MCP payment-response projection without accepting a
+   weaker unit-gate baseline or changing financial code.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] A selected fixture test file with a matching bare baseline line returns
+    `FULL`; settled by
+    `tests/test_select_impacted_tests.py::test_selected_file_level_baseline_escalates_to_full`.
+  - [ ] A selected fixture test file with only a named test-node baseline entry
+    stays scoped; settled by
+    `tests/test_select_impacted_tests.py::test_node_level_baseline_does_not_escalate_to_full`.
+  - [ ] The selector never changes the baseline and preserves its existing
+    unresolvable-input `FULL` behavior; settled by the changed-file diff and
+    the existing selector fixture suite.
+  - [ ] The EOM staging branch's changed paths select `FULL` after this
+    prerequisite merges; settled by the local selector command recorded in
+    this plan's Verification section.
+- Reachability proof: the production selector CLI and the local pre-push mirror
+  both consume `scripts/select_impacted_tests.py`; the fixtures call its real
+  `select` function and the staging branch later exercises the same CLI before
+  its local full-suite gate.
+- Affected surfaces: local/hosted unit-gate test selection and the Billing &
+  Payments MCP-projection prerequisite's acceptance path.
+- Risk areas: false-green scoped tests, unnecessary full-suite escalation, and
+  inadvertent baseline or financial behavior changes.
+- Reviewer rules triggered: R1, R2, R5, R10, R12, R14.
+
+### Boundary-change enumeration
+
+- Admitted to `FULL`: a selected test path exactly equal to a non-comment,
+  bare Python-file baseline entry.
+- Not admitted to `FULL` by this rule: a baseline entry containing `::`, a
+  baseline path outside the selected test set, blank/comment lines, and an
+  absent baseline file.
+
+### Guard class-closure declaration
+
+- **OPEN:** baseline rows and selector-produced test paths are open text/path
+  inputs; their membership cannot be exhaustively listed in this PR.
+- **DERIVED:** each selector invocation derives the candidate set from the
+  committed `tests/unit_gate_baseline.txt` with the existing bare-path grammar,
+  then intersects it with the selector's derived impacted-test set.
+- **DEFAULTED:** unrecognized, commented, blank, node-level, or unselected
+  rows retain normal scoped selection because they are not a recorded
+  full-suite collection failure. An unreadable baseline instead defaults to
+  `FULL`, the safe direction because it prevents a false-green scope at the
+  cost of only a local full-suite run.
+- The property proof generates baseline line family × selected-path membership
+  × whitespace wrapper and compares the result to a specification-derived
+  oracle; it does not rely on a list of reported MCP/OAuth paths.
+
+### Deployed-config probing
+
+N/A - this is deterministic repository-local test selection; it does not read
+credentials, feature flags, services, or deployed configuration.
+
+### Files touched
+
+- `plans/PR-Unit-Gate-File-Baseline-Escalation.md`
+- `scripts/select_impacted_tests.py`
+- `tests/test_select_impacted_tests.py`
+
+## Mechanism
+
+After the selector derives its ordinary set of impacted test files, it reads
+only bare test-file entries from the committed unit-gate baseline. An exact
+intersection escalates to `FULL` with an explanatory stderr message. The
+existing full-run ratchet remains authoritative for baseline shrink proof; the
+scoped path still catches new failures and remains fast for node-level debt.
+
+## Intentional
+
+- This does not repair every legacy module-level `sys.modules` fake. Those
+  fakes are the underlying test-debt class, but changing them would broaden an
+  infrastructure prerequisite into unrelated test rewrites.
+- Escalating the affected selection costs one full local suite, which is the
+  necessary proof because the baseline itself records a full-suite-only
+  collection failure.
+- A bare file-level baseline is intentionally treated differently from a
+  node-level baseline: the former denotes a collection failure before a test
+  node exists.
+
+## Deferred
+
+- The legacy process-global MCP fake cleanup is recorded in Billing & Payments
+  Hardening & Deferred #2363, discovered by the EOM MCP-projection staging
+  slice. This PR parks only that unrelated rewrite class; it fixes the
+  selector's immediate false verdict.
+- After this merges, rebase and rerun the staged EOM MCP payment-response
+  projection before proceeding to its deployment/restart handoff (#2362).
+
+Parked hardening: legacy MCP collection-fake cleanup (#2363).
+
+## Verification
+
+- `python -m py_compile scripts/select_impacted_tests.py
+  tests/test_select_impacted_tests.py` — passed.
+- `python -m pytest tests/test_select_impacted_tests.py -q` — 70 passed.
+- `python scripts/select_impacted_tests.py --changed-file
+  /tmp/eom-mcp-payment-projection-changed-files.txt --repo
+  /home/juan-canfield/Desktop/Atlas-worktrees/eom-mcp-payment-projection` —
+  `FULL`, naming exactly the four file-level MCP/OAuth baseline entries.
+- `ruff check scripts/select_impacted_tests.py tests/test_select_impacted_tests.py
+  --ignore F841` and `git diff --check` — passed.
+- Managed `scripts/push_pr.sh` local gate remains the final acceptance evidence;
+  no GitHub-hosted check is used as acceptance evidence.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Unit-Gate-File-Baseline-Escalation.md` | 159 |
+| `scripts/select_impacted_tests.py` | 63 |
+| `tests/test_select_impacted_tests.py` | 75 |
+| **Total** | **297** |

--- a/scripts/select_impacted_tests.py
+++ b/scripts/select_impacted_tests.py
@@ -6,7 +6,7 @@ re-pays for a guarantee `repo_wide_unit_backstop` already holds daily. This
 picks the tests a change can actually reach, so a push pays for its own blast
 radius instead of the repo's.
 
-Soundness rests on three properties, in order of how much they matter:
+Soundness rests on four properties, in order of how much they matter:
 
 1. **Transitive, not one-hop.** Reachability is computed over the whole
    first-party import graph, so `tests/test_a.py -> helpers -> changed_module`
@@ -21,6 +21,10 @@ Soundness rests on three properties, in order of how much they matter:
 3. **Empty is only for provably test-free changes.** An empty selection means
    every changed file was mapped and none of them is reachable from any test
    (documentation, plans). It is not the fallback for "I could not tell".
+4. **Bare file-level baseline entries require the full suite.** A collection
+   failure recorded as a bare test-file path can pass in isolation while still
+   failing in the full collection order, so scoped execution cannot prove that
+   entry stale.
 
 Output: newline-separated test paths on stdout, or the single token ``FULL``.
 
@@ -212,6 +216,56 @@ def is_provably_test_free_path(path: Path) -> bool:
     return path.suffix in TEST_FREE_SUFFIXES
 
 
+def bare_file_level_baseline_paths(repo: Path) -> set[str] | None:
+    """Return bare test-file baseline entries, or ``None`` when unreadable.
+
+    The Unit Gate's baseline records a collection failure as a bare test path,
+    unlike a normal failing test node that contains ``::``. A scoped run cannot
+    reliably prove that a collection failure disappears under the full suite's
+    import order, so callers must escalate when one of these paths is selected.
+    """
+    baseline = repo / "tests" / "unit_gate_baseline.txt"
+    if not baseline.exists():
+        return set()
+    try:
+        lines = baseline.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError):
+        print(
+            "select_impacted_tests: cannot read unit-gate baseline; "
+            "escalating to FULL",
+            file=sys.stderr,
+        )
+        return None
+    return {
+        line
+        for raw in lines
+        if (line := raw.strip())
+        and not line.startswith("#")
+        and line.startswith("tests/")
+        and line.endswith(".py")
+        and "::" not in line
+    }
+
+
+def requires_full_suite_for_file_level_baseline(
+    selected: set[str], repo: Path
+) -> bool:
+    """True when selected tests overlap a full-suite-only collection baseline."""
+    baseline_paths = bare_file_level_baseline_paths(repo)
+    if baseline_paths is None:
+        return True
+    overlap = sorted(selected & baseline_paths)
+    if not overlap:
+        return False
+    print(
+        "select_impacted_tests: selected file-level unit-gate baseline entry "
+        "requires full-suite collection; escalating to FULL: "
+        + ", ".join(overlap),
+        file=sys.stderr,
+    )
+    return True
+
+
 def is_conftest_module(name: str) -> bool:
     """True for any ``tests/.../conftest.py`` module name."""
     return name == "tests.conftest" or name.endswith(".conftest")
@@ -395,6 +449,8 @@ def select(changed: list[str], repo: Path) -> list[str] | str:
         graph_changed.append(path)
 
     if not graph_changed:
+        if requires_full_suite_for_file_level_baseline(owned_tests, repo):
+            return FULL
         return sorted(owned_tests)
 
     reverse, unparseable = build_reverse_graph(repo)
@@ -409,7 +465,10 @@ def select(changed: list[str], repo: Path) -> list[str] | str:
     result = impacted_tests(graph_changed, reverse, repo)
     if result == FULL:
         return FULL
-    return sorted(result | owned_tests)
+    selected = result | owned_tests
+    if requires_full_suite_for_file_level_baseline(selected, repo):
+        return FULL
+    return sorted(selected)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/test_select_impacted_tests.py
+++ b/tests/test_select_impacted_tests.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import ast
 import importlib.util
+import itertools
 from pathlib import Path
 
 import pytest
@@ -118,6 +119,80 @@ def test_unrelated_module_is_not_selected(tmp_path):
         "tests/test_other.py": "from atlas_brain.other import Y\n",
     })
     assert sel.select(["atlas_brain/svc.py"], repo) == []
+
+
+def test_selected_file_level_baseline_escalates_to_full(tmp_path):
+    """Collection-order baseline debt cannot be declared fixed in isolation."""
+    repo = _mkrepo(tmp_path, {
+        "atlas_brain/__init__.py": "",
+        "atlas_brain/svc.py": "VALUE = 1\n",
+        "tests/test_svc.py": "from atlas_brain.svc import VALUE\n",
+        "tests/unit_gate_baseline.txt": "tests/test_svc.py\n",
+    })
+
+    assert sel.select(["atlas_brain/svc.py"], repo) == sel.FULL
+
+
+def test_node_level_baseline_does_not_escalate_to_full(tmp_path):
+    """A named test node is not the full-suite collection-failure boundary."""
+    repo = _mkrepo(tmp_path, {
+        "atlas_brain/__init__.py": "",
+        "atlas_brain/svc.py": "VALUE = 1\n",
+        "tests/test_svc.py": "from atlas_brain.svc import VALUE\n",
+        "tests/unit_gate_baseline.txt": "tests/test_svc.py::test_known\n",
+    })
+
+    assert sel.select(["atlas_brain/svc.py"], repo) == ["tests/test_svc.py"]
+
+
+def test_unselected_file_level_baseline_does_not_escalate_to_full(tmp_path):
+    """Only the exact selected collection-failure path requires full scope."""
+    repo = _mkrepo(tmp_path, {
+        "atlas_brain/__init__.py": "",
+        "atlas_brain/svc.py": "VALUE = 1\n",
+        "tests/test_svc.py": "from atlas_brain.svc import VALUE\n",
+        "tests/unit_gate_baseline.txt": "tests/test_other.py\n",
+    })
+
+    assert sel.select(["atlas_brain/svc.py"], repo) == ["tests/test_svc.py"]
+
+
+def test_file_level_baseline_escalation_is_grammar_closed(tmp_path):
+    """Generate parser grammar axes, not a fixture list of reported files."""
+    baseline = tmp_path / "tests" / "unit_gate_baseline.txt"
+    baseline.parent.mkdir()
+    selected_path = "tests/test_selected.py"
+    other_path = "tests/test_other.py"
+
+    # Grammar axes: baseline line values x whitespace wrappers x selected key families.
+    line_forms = ("bare", "node", "comment", "source", "non_python", "blank")
+    candidate_paths = (selected_path, other_path)
+    selected_sets = (
+        frozenset({selected_path}),
+        frozenset({other_path}),
+        frozenset({selected_path, other_path}),
+    )
+    presentation_forms = ("", "  ", "\t")
+    contract_oracle = {"bare": True, "node": False, "comment": False,
+                       "source": False, "non_python": False, "blank": False}
+
+    for line_form, candidate_path, selected, wrapper in itertools.product(
+        line_forms, candidate_paths, selected_sets, presentation_forms
+    ):
+        core = {
+            "bare": candidate_path,
+            "node": f"{candidate_path}::test_known",
+            "comment": f"# {candidate_path}",
+            "source": "atlas_brain/service.py",
+            "non_python": candidate_path.removesuffix(".py") + ".txt",
+            "blank": "",
+        }[line_form]
+        baseline.write_text(f"{wrapper}{core}{wrapper}\n", encoding="utf-8")
+
+        expected_full = contract_oracle[line_form] and candidate_path in selected
+        assert sel.requires_full_suite_for_file_level_baseline(
+            set(selected), tmp_path
+        ) is expected_full
 
 
 # --- escalation: unresolvable input must never yield an empty selection -----


### PR DESCRIPTION
Plan: plans/PR-Unit-Gate-File-Baseline-Escalation.md
Slice phase: production hardening
Ownership lane: developer-experience/ci

This prerequisite fixes a real local/hosted Unit Gate contradiction discovered
while staging EOM Billing & Payments MCP compatibility work: a bare file-level
collection failure can pass in an isolated selected run but still fail during
the full suite's import order. The selector now escalates exactly that overlap
to the full suite, preserving the existing ratchet rather than changing its
baseline or weakening the financial slice.

### Problem

The impacted-test selector scoped four invoicing OAuth/MCP files. Their bare
file-level baseline entries were reported stale because the selected files pass
in isolation, yet the full suite proves they still fail when legacy tests place
a fake `mcp` package in `sys.modules` during collection.

### Current behavior

The scoped gate and the full gate give incompatible required outcomes for the
same four existing baseline entries. A Billing & Payments PR touching the
invoicing MCP path therefore cannot publish without either falsely deleting
known failures or bypassing its local gate.

### Slice contract

- Escalate to `FULL` only when an exact selected test path is a bare file-level
  entry in the committed unit-gate baseline.
- Keep node-level entries, baseline entries outside the selection, regression
  detection, baseline-growth rejection, and financial behavior unchanged.
- Prove the admitted boundary and two just-outside cases with real selector
  fixtures.

### Implementation

- Read bare `tests/...` file entries from the existing baseline after ordinary
  impact selection.
- Return `FULL` with an explanatory diagnostic only for their exact
  intersection with the selected set.
- Add selector fixtures for matching file-level, named node-level, and
  unselected file-level baseline entries.

### Deployment order

1. Merge this independent gate-correctness prerequisite.
2. Rebase the staged EOM Invoicing MCP response-projection branch.
3. Run its local gate, which now executes the truthful full-suite path before
   that financial compatibility PR is opened.

### Tests

`tests/test_select_impacted_tests.py` passes 70 local tests. The real selector,
executed from this branch against the actual staged EOM MCP diff, reports
`FULL` and names exactly the four pre-existing file-level MCP/OAuth entries.
No database, financial record, email, credential, or live service is touched.

### Failure/retry behavior

Selection is deterministic and fail-closed: an unreadable baseline also returns
`FULL`. There is no transaction, retry state, or customer-visible behavior.

## Intentional

- Full-suite escalation is intentionally more expensive for the narrow
  collection-failure condition; only a full suite can prove that debt changed.
- This does not rewrite legacy global MCP test fakes. That broader test-debt
  cleanup is deferred separately.

## AI reconciliation

- no-findings

## Deferred

- Legacy global MCP test-fake cleanup remains Billing & Payments Hardening &
  Deferred #2363, discovered by the staged MCP response-projection slice.
- The EOM MCP response projection resumes immediately after this prerequisite
  merges (#2362).

## Parked hardening

- Legacy global MCP test-fake cleanup (#2363).

## Cold diff reconstruction

- Changed: `scripts/select_impacted_tests.py:216` derives bare file-level
  baseline paths and escalates only their selected intersection; 
  `tests/test_select_impacted_tests.py:123` proves the admitted boundary plus
  node-level and outside-selection counterexamples; 
  `plans/PR-Unit-Gate-File-Baseline-Escalation.md:1` records the exact gate
  contradiction and dependency handoff.
- Contract match: each changed path belongs to selector correctness, its
  adversarial proof, or the required narrow plan. No baseline, workflow,
  payment, service, route, or deployment configuration changes.
- Gaps: none. The full local gate is the final acceptance command for this
  prerequisite; the actual financial slice remains unmodified on its own
  branch.

## Verification

- Local syntax: passed.
- Local selector fixtures: 70 passed.
- Local Ruff and whitespace checks: passed.
- Real staging-diff selector: `FULL`, with exactly four named file-level
  entries.
- Managed local PR gate: pending; it is the acceptance gate and replaces a
  manual hosted-check run per operator direction.

## Mechanical verification

- Command: `python -m py_compile scripts/select_impacted_tests.py tests/test_select_impacted_tests.py && python -m pytest tests/test_select_impacted_tests.py -q && ruff check scripts/select_impacted_tests.py tests/test_select_impacted_tests.py --ignore F841 && git diff --check` - Result: 70 passed - Environment: local
- Command: `python scripts/select_impacted_tests.py --changed-file /tmp/eom-mcp-payment-projection-changed-files.txt --repo /home/juan-canfield/Desktop/Atlas-worktrees/eom-mcp-payment-projection` - Result: passed; `FULL` named exact four file-level entries - Environment: local

## Diff size

3 files, +295 / -2 (297 LOC).

<!-- atlas-open-pr-wrapper: v1 -->
