### PR TITLE
EOM invoicing MCP: stage payment response projection

### DIFF
--- a/atlas_brain/mcp/invoicing_server.py
+++ b/atlas_brain/mcp/invoicing_server.py
@@ -553,7 +553,14 @@ async def _record_customer_payment_with_service(
             recorded_by="atlas-invoicing-mcp",
             source="invoicing_mcp",
         )
-        return json.dumps({"success": True, "payment": payment}, default=str)
+        # Keep the long-lived MCP payment response stable while EOM adds its
+        # provider-only check metadata in a later, separately deployed slice.
+        mcp_payment = {
+            key: value
+            for key, value in payment.items()
+            if key not in {"check_date", "received_through"}
+        }
+        return json.dumps({"success": True, "payment": mcp_payment}, default=str)
     except Exception as exc:
         logger.warning("record_customer_payment rejected: %s", exc)
         return json.dumps({"success": False, "error": str(exc)})

--- a/plans/PR-EOM-MCP-Payment-Projection.md
+++ b/plans/PR-EOM-MCP-Payment-Projection.md
@@ -1,0 +1,151 @@
+# PR-EOM-MCP-Payment-Projection
+
+## Why this slice exists
+
+The first attempt to add optional EOM check metadata (closed PR #2368) exposed
+a deployment-order defect: the payment record is selected with `cp.*`, while
+the long-lived invoicing MCP serializes its service result as its established
+response contract. Read-only runtime inspection confirms that
+`atlas-invoicing-mcp.service` is a separate long-lived process from the full
+receivables provider (`atlas-api.service`). Applying the new database columns
+before every MCP process runs a projection would therefore change MCP responses
+during a mixed-version rollout.
+
+This is the required first stage recorded in Billing & Payments coordination
+#2362. It deliberately ships no schema, route, or payment-model change. Once
+deployed and the MCP service has been restarted and verified, the next provider
+slice can safely add the durable check metadata with readiness and real-entrypoint
+coverage.
+
+The local Unit Gate prerequisite #2369 merged as `12808da63` before this branch
+was rebased. Its actual selector now escalates this staging diff to the full
+suite because four reached OAuth/MCP tests are recorded as bare file-level
+collection failures; the entries remain untouched because only full-suite
+collection can prove them resolved.
+
+### Problem-derived contract
+
+- Root cause: `_record_customer_payment_with_service` serializes the entire
+  canonical payment view. Because that view uses `cp.*`, a future additive
+  `customer_payments` column reaches legacy MCP clients unless the MCP boundary
+  explicitly owns its response projection before the schema changes.
+- Correct fix must touch/change: create the projection at the MCP response
+  boundary and add a direct helper regression that supplies the future EOM-only
+  fields from a fake canonical service result, then proves the published JSON
+  excludes exactly those fields while preserving all other payment data.
+- Must not change: the database schema, migrations, payment validation,
+  idempotency, allocation, deposit/clearing/return/void lifecycle, MCP input
+  schema, persisted financial rows, Gmail, full/slim EOM routes, tracker, and
+  Website behavior, or the local unit-gate baseline.
+
+## Scope (this PR)
+
+Ownership lane: eom/billing-payments
+Slice phase: Vertical slice
+Max files: 3
+
+1. Project the future EOM-only `check_date` and `received_through` keys from
+   the successful `record_customer_payment` MCP response without changing the
+   canonical payment view or its stored financial record.
+2. Prove the projection against the real service-helper serialization seam with
+   a fake service result containing both fields and ordinary payment/allocations
+   data.
+3. Publish the narrow prerequisite for deployment before the separate metadata
+   migration slice; the PR body and #2362 state the mandatory restart/verify
+   handoff.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] A successful `record_customer_payment` helper response excludes
+    `check_date` and `received_through` when a canonical service result includes
+    them; settled by
+    `tests/test_receivables.py::test_mcp_payment_response_projects_future_eom_check_metadata`.
+  - [ ] The same response retains ordinary canonical payment fields and nested
+    allocations unchanged; settled by the same regression's exact JSON
+    assertions.
+  - [ ] The projection occurs after the canonical service completes, so it
+    cannot change creation, idempotency, or allocation inputs; settled by the
+    call-argument assertions in the same regression and
+    `atlas_brain/mcp/invoicing_server.py::_record_customer_payment_with_service`.
+  - [ ] No migration, EOM route, payment model, or receivables service code is
+    changed in this prerequisite; settled by the three-file diff enumeration.
+- Reachability proof: the test invokes the same private service helper reached
+  by the registered `record_customer_payment` MCP tool, verifies its JSON
+  output, and uses a fake service only to supply a future row shape that cannot
+  exist before the later migration.
+- Affected surfaces: the stable invoicing MCP payment response boundary and
+  its regression coverage.
+- Risk areas: backward-compatible MCP output, mixed-version provider/MCP
+  deployment, and accidental change to a financial write path.
+- Reviewer rules triggered: R1, R2, R5, R8, R14.
+
+### Boundary-change enumeration
+
+N/A - no admission, identity, routing, or validation boundary changes. The
+existing MCP output is projected after a successful canonical service result.
+
+### Deployed-config probing
+
+N/A - no environment/config fallback changes. The deployment handoff is an
+operational prerequisite, not a code-level configuration decision.
+
+### Files touched
+
+- `atlas_brain/mcp/invoicing_server.py`
+- `plans/PR-EOM-MCP-Payment-Projection.md`
+- `tests/test_receivables.py`
+
+## Mechanism
+
+After `ReceivablesService.create_payment` returns, the MCP helper builds a
+shallow response dictionary that omits only `check_date` and
+`received_through`; it then serializes the projected dictionary with the
+existing JSON encoder. The canonical service still receives exactly the same
+arguments and persists exactly the same financial record. The direct regression
+uses valid helper inputs and a service fake that returns a representative
+payment/allocations view plus both future fields, proving this older MCP binary
+will remain response-compatible after a later schema expansion.
+
+## Intentional
+
+- The projection lists only the two approved future EOM check-metadata fields;
+  it is not a broad or speculative filtering layer that could hide legitimate
+  existing MCP payment fields.
+- This slice contains no migration. It must be deployed and the standalone
+  invoicing MCP service restarted/verified before the metadata schema PR is
+  allowed to deploy.
+- The fake service is intentional: the prerequisite must prove handling of a
+  row shape that does not yet exist in production, without creating a test or
+  production financial record.
+
+## Deferred
+
+- After verified MCP-projection deployment, add migration 368, optional EOM
+  request fields, legacy fingerprint compatibility, route readiness gating, and
+  authenticated full/slim ASGI proof in the next provider slice (#2362).
+- Receipt delivery, customer ledger/history, billing-run previews, Gmail-draft
+  recovery, sent-mail reconciliation, and Square queue remain planned Billing &
+  Payments slices (#2362); nonessential hardening remains #2363.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_receivables.py -q -k "mcp_payment_response_projects_future_eom_check_metadata"` — 1 passed, 73 deselected.
+- `python -m pytest tests/test_receivables.py -q` — 66 passed, 8 skipped;
+  skipped isolated-PostgreSQL cases require an explicit local test URL and are
+  unrelated to this non-schema projection.
+- `python -m py_compile atlas_brain/mcp/invoicing_server.py tests/test_receivables.py` and targeted `ruff check ... --ignore F841` — passed; the MCP module's ignored F841 bindings pre-date this diff.
+- `python scripts/select_impacted_tests.py --base origin/main` — `FULL`, naming
+  exactly the four pre-existing OAuth/MCP file-level collection baselines after
+  merged #2369. The managed full local gate is the final acceptance evidence.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/mcp/invoicing_server.py` | 9 |
+| `plans/PR-EOM-MCP-Payment-Projection.md` | 151 |
+| `tests/test_receivables.py` | 66 |
+| **Total** | **226** |

--- a/plans/PR-EOM-MCP-Payment-Projection.md
+++ b/plans/PR-EOM-MCP-Payment-Projection.md
@@ -54,6 +54,29 @@ Max files: 3
    migration slice; the PR body and #2362 state the mandatory restart/verify
    handoff.
 
+### Closure declaration: legacy MCP EOM-metadata projection
+
+The exclusion set at `invoicing_server.py:558-562` is **CLOSED** for this
+prerequisite: its complete membership is `check_date` and
+`received_through`, the two names approved for #2362's next provider schema
+surface, migration 368's optional `customer_payments.check_date DATE` and
+`customer_payments.received_through VARCHAR(128)`. No other new payment
+metadata column is approved by that next slice; any later column requires its
+own compatibility/deployment decision rather than silently joining this set.
+
+Membership is **ENUMERATED** from that staged schema contract because migration
+368 intentionally does not exist in this prerequisite; deriving the set from a
+database schema would defeat the purpose of keeping an older long-lived MCP
+binary response-compatible during the later rollout. This one declaration
+governs both the response filter and the future-row fixture in its regression.
+
+For every key outside the set, the projection **preserves** the canonical value.
+That is the deliberate compatibility default: dropping an unrecognized field
+could hide an established MCP payment value, while an unapproved future field
+is deployment-contract drift that must be reviewed by its own later slice. The
+regression includes such an unapproved future key to prove the default instead
+of treating the two approved exclusions as a broad response sanitizer.
+
 ### Review Contract
 
 - Acceptance criteria:
@@ -64,6 +87,10 @@ Max files: 3
   - [ ] The same response retains ordinary canonical payment fields and nested
     allocations unchanged; settled by the same regression's exact JSON
     assertions.
+  - [ ] The closed, enumerated exclusion set is limited to the two migration
+    368 EOM metadata names; any other service-result key is preserved, settled
+    by the closure declaration above and the regression's unapproved-future-key
+    assertion.
   - [ ] The projection occurs after the canonical service completes, so it
     cannot change creation, idempotency, or allocation inputs; settled by the
     call-argument assertions in the same regression and
@@ -78,7 +105,7 @@ Max files: 3
   its regression coverage.
 - Risk areas: backward-compatible MCP output, mixed-version provider/MCP
   deployment, and accidental change to a financial write path.
-- Reviewer rules triggered: R1, R2, R5, R8, R14.
+- Reviewer rules triggered: R1, R2, R5, R8, R13, R14.
 
 ### Boundary-change enumeration
 
@@ -99,19 +126,21 @@ operational prerequisite, not a code-level configuration decision.
 ## Mechanism
 
 After `ReceivablesService.create_payment` returns, the MCP helper builds a
-shallow response dictionary that omits only `check_date` and
-`received_through`; it then serializes the projected dictionary with the
-existing JSON encoder. The canonical service still receives exactly the same
-arguments and persists exactly the same financial record. The direct regression
-uses valid helper inputs and a service fake that returns a representative
-payment/allocations view plus both future fields, proving this older MCP binary
-will remain response-compatible after a later schema expansion.
+shallow response dictionary that omits only the closed migration-368
+`check_date`/`received_through` pair; it then serializes the projected dictionary
+with the existing JSON encoder. The canonical service still receives exactly the
+same arguments and persists exactly the same financial record. The direct
+regression uses valid helper inputs and a service fake that returns a
+representative payment/allocations view, both approved future fields, and one
+unapproved future key. It proves this older MCP binary remains response-compatible
+after the approved schema expansion without becoming a broad sanitizer.
 
 ## Intentional
 
-- The projection lists only the two approved future EOM check-metadata fields;
-  it is not a broad or speculative filtering layer that could hide legitimate
-  existing MCP payment fields.
+- The projection lists only the closed, approved migration-368 EOM
+  check-metadata pair; unlisted keys deliberately remain visible rather than
+  silently broadening a filtering layer that could hide legitimate MCP payment
+  fields.
 - This slice contains no migration. It must be deployed and the standalone
   invoicing MCP service restarted/verified before the metadata schema PR is
   allowed to deploy.
@@ -146,6 +175,6 @@ Parked hardening: none.
 | File | LOC |
 |---|---:|
 | `atlas_brain/mcp/invoicing_server.py` | 9 |
-| `plans/PR-EOM-MCP-Payment-Projection.md` | 151 |
-| `tests/test_receivables.py` | 66 |
-| **Total** | **226** |
+| `plans/PR-EOM-MCP-Payment-Projection.md` | 180 |
+| `tests/test_receivables.py` | 68 |
+| **Total** | **257** |

--- a/tests/test_receivables.py
+++ b/tests/test_receivables.py
@@ -2674,6 +2674,72 @@ async def test_real_postgres_http_and_mcp_entrypoints_use_supported_dependencies
         await conn.close()
 
 
+@pytest.mark.asyncio
+async def test_mcp_payment_response_projects_future_eom_check_metadata():
+    from atlas_brain.mcp import invoicing_server
+
+    contact_id = uuid4()
+    invoice_id = uuid4()
+    canonical_payment = {
+        "id": "payment-1",
+        "contact_id": str(contact_id),
+        "payer_name": "Residential Customer",
+        "total_amount_cents": 12_500,
+        "payment_method": "check",
+        "status": "received",
+        "allocations": [{"invoice_id": str(invoice_id), "amount_cents": 12_500}],
+        "check_date": "2026-08-10",
+        "received_through": "mail",
+    }
+
+    class _FutureMetadataService:
+        def __init__(self) -> None:
+            self.kwargs = None
+
+        async def create_payment(self, **kwargs):
+            self.kwargs = kwargs
+            return canonical_payment
+
+    service = _FutureMetadataService()
+    result = json.loads(
+        await invoicing_server._record_customer_payment_with_service(
+            service=service,
+            contact_id=str(contact_id),
+            payer_name="Residential Customer",
+            total_amount_cents=12_500,
+            payment_method="check",
+            allocations=[{"invoice_id": str(invoice_id), "amount_cents": 12_500}],
+            idempotency_key="mcp-projection-1",
+            reference="1001",
+            notes="Received in mail",
+            payment_date="2026-08-12",
+        )
+    )
+
+    assert result == {
+        "success": True,
+        "payment": {
+            "id": "payment-1",
+            "contact_id": str(contact_id),
+            "payer_name": "Residential Customer",
+            "total_amount_cents": 12_500,
+            "payment_method": "check",
+            "status": "received",
+            "allocations": [
+                {"invoice_id": str(invoice_id), "amount_cents": 12_500}
+            ],
+        },
+    }
+    assert service.kwargs["contact_id"] == contact_id
+    assert service.kwargs["total_amount"] == Decimal("125")
+    assert service.kwargs["received_date"] == date(2026, 8, 12)
+    assert service.kwargs["allocations"] == [
+        {"invoice_id": invoice_id, "amount": Decimal("125")}
+    ]
+    assert service.kwargs["reference"] == "1001"
+    assert service.kwargs["notes"] == "Received in mail"
+
+
 def test_full_invoicing_mcp_http_refuses_to_start_without_strong_auth():
     from atlas_brain.mcp import invoicing_server
     from atlas_brain.mcp.auth import BearerAuthMiddleware

--- a/tests/test_receivables.py
+++ b/tests/test_receivables.py
@@ -2690,6 +2690,7 @@ async def test_mcp_payment_response_projects_future_eom_check_metadata():
         "allocations": [{"invoice_id": str(invoice_id), "amount_cents": 12_500}],
         "check_date": "2026-08-10",
         "received_through": "mail",
+        "unapproved_future_field": "preserved-by-legacy-mcp",
     }
 
     class _FutureMetadataService:
@@ -2728,6 +2729,7 @@ async def test_mcp_payment_response_projects_future_eom_check_metadata():
             "allocations": [
                 {"invoice_id": str(invoice_id), "amount_cents": 12_500}
             ],
+            "unapproved_future_field": "preserved-by-legacy-mcp",
         },
     }
     assert service.kwargs["contact_id"] == contact_id


### PR DESCRIPTION
Plan: plans/PR-EOM-MCP-Payment-Projection.md
Slice phase: Vertical slice
Ownership lane: eom/billing-payments

This is the deployment-safe prerequisite discovered while reviewing closed PR
#2368: keep the existing Invoicing MCP payment response stable before adding
durable EOM check metadata to the database. It changes neither a payment nor a
schema; it only establishes the response projection that must be deployed and
verified first.

### Problem

The canonical payment view selects `cp.*`, and the long-lived Invoicing MCP
serializes that result unchanged. A schema-first rollout would let an old MCP
process expose future EOM-only check metadata to current MCP clients.

### Current behavior

`record_customer_payment` passes the whole successful canonical payment result
through its JSON response. The provider API and MCP service are independently
long-lived, so deploying them is not an atomic binary swap.

### Slice contract

- Exclude exactly `check_date` and `received_through` from successful MCP
  payment responses if a future canonical row includes them.
- Preserve every other response value and every input passed to the canonical
  create-payment service.
- Declare that exclusion set as CLOSED and ENUMERATED from #2362's migration
  368 check-metadata surface, and prove the intended preserve-by-default
  behavior with an unapproved future key.
- Do not add a migration, request field, financial write behavior, or route.

### Implementation

- Add the shallow projection immediately after the canonical service returns.
- Add a regression with a valid fake future-row shape, exact JSON output,
  preservation of an unapproved future key, and service-call argument
  assertions.

### Deployment order

1. Merge this prerequisite.
2. Deploy the Invoicing MCP binary and restart every long-lived MCP instance.
3. Verify the running MCP process is on the projection commit.
4. Only then merge/deploy the metadata migration, mutation-readiness gate, and
   authenticated full/slim EOM entrypoint coverage in the next provider PR.

### Tests

The new regression invokes the real MCP service helper with valid input and a
future canonical result. It proves both EOM-only keys are absent from JSON while
ordinary payment values, allocations, and canonical service arguments remain
unchanged. No database, email, or financial record is created.

### Failure/retry behavior

There is no new failure or retry state: the projection occurs after the existing
canonical operation has completed and does not alter its write, idempotency, or
error paths. The later migration is deliberately blocked on deployment of this
binary.

## Intentional

- The closed, migration-368 field set is exact and approved, not a broad
  response sanitizer; every unlisted key deliberately remains visible.
- This is a separate deployable slice because live inspection proved that the
  MCP and provider processes are distinct and long-lived.
- The prior combined migration PR #2368 was closed without merge; no financial
  or schema change from it reached production.
- The local Unit Gate prerequisite #2369 merged as `12808da63` before this
  branch rebased; its selector now takes the full-suite path for this staged
  diff instead of falsely demanding removal of file-level collection debt.

## AI reconciliation

- Declare closure for the MCP field set -- fixed-in: 309cbe1c9fc5a38dade7b516ede2dac0a456a5b0 `plans/PR-EOM-MCP-Payment-Projection.md` and `tests/test_receivables.py` state the CLOSED/ENUMERATED/preserve-default contract and prove an unlisted key remains visible.

## Fix-loop disposition preflight

- Root decision: Declare closure for the MCP field set
- Source trace: future `customer_payments` metadata -> literal legacy-MCP exclusion set -> undeclared membership/default -> mixed-version response ambiguity
- Upstream files: `plans/PR-EOM-MCP-Payment-Projection.md`, `tests/test_receivables.py`
- Fix strategy: upstream-root
- Blocking predicate: back-compat
- Disposition: fixed-in
- Allowed files: `atlas_brain/mcp/invoicing_server.py`, `plans/PR-EOM-MCP-Payment-Projection.md`, `tests/test_receivables.py`
- Max files: 3
- Parked hardening: none

## Deferred

- Migration 368, EOM request models, legacy fingerprint compatibility, mutation
  readiness gating, and authenticated full/slim ASGI tests follow only after
  this deployed projection (#2362).
- Receipt delivery, ledger/history, billing-run preview, Gmail-draft recovery,
  sent-mail reconciliation, and Square queue remain their planned slices (#2362);
  nonessential hardening remains #2363.

## Parked hardening

- None.

## Cold diff reconstruction

- Changed: `atlas_brain/mcp/invoicing_server.py:556` projects two EOM-only
  fields after the canonical create call; `tests/test_receivables.py:2677`
  supplies a future payment view and proves exact output, unlisted-key
  preservation, and call preservation; `plans/PR-EOM-MCP-Payment-Projection.md:57`
  binds the closed field set to migration 368 and records the deployment-order
  root cause and handoff.
- Contract match: every changed path maps to the explicit MCP compatibility
  prerequisite or its reachability proof. The diff does not touch migrations,
  payment models, services, routes, lifecycle logic, or the unit-gate baseline.
- Gaps: none. Real MCP restart/version verification is a post-merge deployment
  action and the mandatory admission criterion for the next provider slice.

## Verification

- Local targeted projection regression: 1 passed, 73 deselected.
- Local receivables suite: 66 passed, 8 isolated-PostgreSQL skips.
- Local syntax, targeted Ruff, whitespace, and plan synchronization passed.
- Local selector after merged #2369: `FULL`, naming exactly the four existing
  OAuth/MCP file-level collection baselines. The managed full local gate is the
  acceptance gate for this slice per operator direction; on this review-response
  head it reported 160 current failures against the 160-entry baseline, with
  zero regressions and zero stale entries.

## Mechanical verification

- Command: `python -m pytest tests/test_receivables.py -q -k "mcp_payment_response_projects_future_eom_check_metadata"` - Result: 1 passed - Environment: local
- Command: `python -m pytest tests/test_receivables.py -q` - Result: 66 passed, 8 skipped - Environment: local
- Command: `python -m py_compile atlas_brain/mcp/invoicing_server.py tests/test_receivables.py && ruff check atlas_brain/mcp/invoicing_server.py tests/test_receivables.py --ignore F841 && git diff --check && python scripts/sync_pr_plan.py --check plans/PR-EOM-MCP-Payment-Projection.md` - Result: passed - Environment: local
- Command: `python scripts/select_impacted_tests.py --base origin/main` - Result: passed; `FULL` named four file-level baselines - Environment: local
- Command: `ATLAS_SESSION_STATE_FILE=SESSION_STATE.codex-eom-mcp-payment-projection.local.md bash scripts/local_pr_review.sh --current-pr-body-file /tmp/atlas-eom-mcp-payment-projection-pr-body.md` - Result: passed; full unit gate baseline 160, regressions 0, stale entries 0 - Environment: local

## Diff size

3 files, +256 / -1 (257 LOC).

<!-- atlas-open-pr-wrapper: v1 -->
