### PR TITLE
EOM receivables: persist optional check metadata

### DIFF
--- a/atlas_brain/api/invoicing/receivables.py
+++ b/atlas_brain/api/invoicing/receivables.py
@@ -17,6 +17,7 @@ from ...services.receivables import (
     ReceivablesConflictError,
     ReceivablesError,
     ReceivablesNotFoundError,
+    ReceivablesSchemaUnavailableError,
     ReceivablesService,
     ReceivablesValidationError,
     get_receivables_service,
@@ -79,6 +80,8 @@ class CreatePaymentRequest(BaseModel):
     total_amount_cents: PositiveCents
     payment_method: Literal["check", "ach", "square"]
     received_date: date
+    check_date: Optional[date] = None
+    received_through: Optional[str] = Field(default=None, max_length=128)
     reference: Optional[str] = Field(default=None, max_length=256)
     notes: Optional[str] = None
     allocations: list[AllocationRequest] = Field(default_factory=list, max_length=100)
@@ -133,6 +136,10 @@ def _is_database_unavailable_error(exc: Exception) -> bool:
 async def _call(awaitable):
     try:
         return await awaitable
+    except ReceivablesSchemaUnavailableError as exc:
+        raise HTTPException(
+            status_code=503, detail={"code": exc.code, "message": str(exc)}
+        ) from exc
     except ReceivablesValidationError as exc:
         raise HTTPException(
             status_code=422, detail={"code": exc.code, "message": str(exc)}
@@ -218,6 +225,8 @@ async def create_payment(
             total_amount=_dollars(body.total_amount_cents),
             payment_method=body.payment_method,
             received_date=body.received_date,
+            check_date=body.check_date,
+            received_through=body.received_through,
             reference=body.reference,
             notes=body.notes,
             allocations=_allocations(body.allocations),

--- a/atlas_brain/eom_api/receivables.py
+++ b/atlas_brain/eom_api/receivables.py
@@ -17,6 +17,7 @@ from ..services.receivables import (
     ReceivablesConflictError,
     ReceivablesError,
     ReceivablesNotFoundError,
+    ReceivablesSchemaUnavailableError,
     ReceivablesService,
     ReceivablesValidationError,
     get_receivables_service,
@@ -81,6 +82,8 @@ class CreatePaymentRequest(BaseModel):
     total_amount_cents: PositiveCents
     payment_method: Literal["check", "ach", "square"]
     received_date: date
+    check_date: Optional[date] = None
+    received_through: Optional[str] = Field(default=None, max_length=128)
     reference: Optional[str] = Field(default=None, max_length=256)
     notes: Optional[str] = None
     allocations: list[AllocationRequest] = Field(default_factory=list, max_length=100)
@@ -135,6 +138,10 @@ def _is_database_unavailable_error(exc: Exception) -> bool:
 async def _call(awaitable):
     try:
         return await awaitable
+    except ReceivablesSchemaUnavailableError as exc:
+        raise HTTPException(
+            status_code=503, detail={"code": exc.code, "message": str(exc)}
+        ) from exc
     except ReceivablesValidationError as exc:
         raise HTTPException(
             status_code=422, detail={"code": exc.code, "message": str(exc)}
@@ -331,6 +338,8 @@ async def create_payment(
             total_amount=_dollars(body.total_amount_cents),
             payment_method=body.payment_method,
             received_date=body.received_date,
+            check_date=body.check_date,
+            received_through=body.received_through,
             reference=body.reference,
             notes=body.notes,
             allocations=_allocations(body.allocations),

--- a/atlas_brain/main_eom.py
+++ b/atlas_brain/main_eom.py
@@ -102,6 +102,7 @@ EOM_RECEIVABLES_READINESS_MIGRATIONS: tuple[str, ...] = (
     "045_invoices",
     "344_receivables_payments",
     "345_receivables_event_key_lookup",
+    "368_receivables_payment_check_metadata",
 )
 
 

--- a/atlas_brain/services/receivables.py
+++ b/atlas_brain/services/receivables.py
@@ -28,6 +28,8 @@ _RECEIVABLES_REQUIRED_COLUMNS = {
         "payment_method",
         "reference",
         "received_date",
+        "check_date",
+        "received_through",
         "status",
         "source",
         "idempotency_key",
@@ -245,6 +247,10 @@ class ReceivablesNotFoundError(ReceivablesError):
 
 class ReceivablesConflictError(ReceivablesError):
     code = "conflict"
+
+
+class ReceivablesSchemaUnavailableError(ReceivablesError):
+    code = "schema_unavailable"
 
 
 def money(value: Any) -> Decimal:
@@ -493,6 +499,8 @@ class ReceivablesService:
         total_amount: Decimal,
         payment_method: str,
         received_date: date,
+        check_date: Optional[date] = None,
+        received_through: Optional[str] = None,
         allocations: list[dict[str, Any]],
         idempotency_key: str,
         reference: Optional[str] = None,
@@ -511,6 +519,8 @@ class ReceivablesService:
             total_amount=total_amount,
             payment_method=payment_method,
             received_date=received_date,
+            check_date=check_date,
+            received_through=received_through,
             allocations=allocations,
             idempotency_key=idempotency_key,
             reference=reference,
@@ -532,6 +542,8 @@ class ReceivablesService:
         total_amount: Decimal,
         payment_method: str,
         received_date: date,
+        check_date: Optional[date] = None,
+        received_through: Optional[str] = None,
         allocations: list[dict[str, Any]],
         idempotency_key: str,
         reference: Optional[str] = None,
@@ -576,6 +588,19 @@ class ReceivablesService:
                 "Allocated amount cannot exceed the payment total"
             )
         initial_status = "received" if method == "check" else "cleared"
+        raw_received_through = received_through or ""
+        if len(raw_received_through) > 128:
+            raise ReceivablesValidationError(
+                "Received through must contain at most 128 characters"
+            )
+        normalized_received_through = raw_received_through.strip() or None
+        has_check_metadata = (
+            check_date is not None or normalized_received_through is not None
+        )
+        if has_check_metadata and method != "check":
+            raise ReceivablesValidationError(
+                "Check metadata requires a check payment method"
+            )
         payload = {
             "contact_id": contact_id,
             "payer_name": payer,
@@ -586,6 +611,17 @@ class ReceivablesService:
             "reference": (reference or "").strip() or None,
             "notes": (notes or "").strip() or None,
         }
+        if has_check_metadata:
+            if not await self.is_ready():
+                raise ReceivablesSchemaUnavailableError(
+                    "Receivables schema unavailable for check metadata"
+                )
+            payload.update(
+                {
+                    "check_date": check_date,
+                    "received_through": normalized_received_through,
+                }
+            )
         fingerprint = request_fingerprint(payload)
 
         async with self.pool.transaction() as conn:
@@ -649,41 +685,81 @@ class ReceivablesService:
                     )
 
             payment_id = uuid4()
-            payment_row = await conn.fetchrow(
-                """
-                INSERT INTO customer_payments (
-                    id, contact_id, payer_name, total_amount, payment_method,
-                    reference, received_date, status, source, idempotency_key,
-                    request_fingerprint, notes, recorded_by, cleared_at,
-                    metadata, created_at, updated_at
+            if has_check_metadata:
+                payment_row = await conn.fetchrow(
+                    """
+                    INSERT INTO customer_payments (
+                        id, contact_id, payer_name, total_amount, payment_method,
+                        reference, received_date, check_date, received_through,
+                        status, source, idempotency_key, request_fingerprint,
+                        notes, recorded_by, cleared_at, metadata, created_at,
+                        updated_at
+                    )
+                    VALUES (
+                        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12,
+                        $13, $14, $15, CASE WHEN $10::varchar = 'cleared'
+                            THEN $16::timestamptz ELSE NULL END,
+                        $17::jsonb, $16, $16
+                    )
+                    ON CONFLICT (source, idempotency_key)
+                        WHERE idempotency_key IS NOT NULL
+                    DO NOTHING
+                    RETURNING id
+                    """,
+                    payment_id,
+                    contact_id,
+                    payer,
+                    total,
+                    method,
+                    payload["reference"],
+                    received_date,
+                    payload["check_date"],
+                    payload["received_through"],
+                    initial_status,
+                    source,
+                    key,
+                    fingerprint,
+                    payload["notes"],
+                    recorded_by,
+                    datetime.now(timezone.utc),
+                    json.dumps(metadata or {}),
                 )
-                VALUES (
-                    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12,
-                    $13, CASE WHEN $8::varchar = 'cleared'
-                        THEN $14::timestamptz ELSE NULL END,
-                    $15::jsonb, $14, $14
+            else:
+                payment_row = await conn.fetchrow(
+                    """
+                    INSERT INTO customer_payments (
+                        id, contact_id, payer_name, total_amount, payment_method,
+                        reference, received_date, status, source, idempotency_key,
+                        request_fingerprint, notes, recorded_by, cleared_at,
+                        metadata, created_at, updated_at
+                    )
+                    VALUES (
+                        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12,
+                        $13, CASE WHEN $8::varchar = 'cleared'
+                            THEN $14::timestamptz ELSE NULL END,
+                        $15::jsonb, $14, $14
+                    )
+                    ON CONFLICT (source, idempotency_key)
+                        WHERE idempotency_key IS NOT NULL
+                    DO NOTHING
+                    RETURNING id
+                    """,
+                    payment_id,
+                    contact_id,
+                    payer,
+                    total,
+                    method,
+                    payload["reference"],
+                    received_date,
+                    initial_status,
+                    source,
+                    key,
+                    fingerprint,
+                    payload["notes"],
+                    recorded_by,
+                    datetime.now(timezone.utc),
+                    json.dumps(metadata or {}),
                 )
-                ON CONFLICT (source, idempotency_key)
-                    WHERE idempotency_key IS NOT NULL
-                DO NOTHING
-                RETURNING id
-                """,
-                payment_id,
-                contact_id,
-                payer,
-                total,
-                method,
-                payload["reference"],
-                received_date,
-                initial_status,
-                source,
-                key,
-                fingerprint,
-                payload["notes"],
-                recorded_by,
-                datetime.now(timezone.utc),
-                json.dumps(metadata or {}),
-            )
             if not payment_row:
                 existing = await conn.fetchrow(
                     """

--- a/atlas_brain/storage/migrations/368_receivables_payment_check_metadata.sql
+++ b/atlas_brain/storage/migrations/368_receivables_payment_check_metadata.sql
@@ -1,0 +1,5 @@
+-- Optional operational details recorded with a customer payment.
+-- Nullable additions preserve every legacy and already-recorded payment.
+ALTER TABLE customer_payments
+    ADD COLUMN IF NOT EXISTS check_date DATE,
+    ADD COLUMN IF NOT EXISTS received_through VARCHAR(128);

--- a/plans/PR-EOM-Payment-Check-Metadata-V2.md
+++ b/plans/PR-EOM-Payment-Check-Metadata-V2.md
@@ -1,0 +1,242 @@
+# PR-EOM-Payment-Check-Metadata-V2
+
+Issue: #2362
+
+## Why this slice exists
+
+The Billing & Payments workspace needs ATLAS to retain an optional check date
+and received-through detail (for example mail, employee handoff, or customer
+delivery) with the canonical payment. The deployed provider currently accepts
+only a received date, reference, notes, and allocations. Browser or tracker
+state cannot be the financial source of truth for these details, and later
+receipt delivery must be able to reconstruct the record faithfully.
+
+The closed precursor PR #2368 cannot be reused: it was based on an older main
+and bundled the MCP response projection now separately merged as #2370. Current
+main also proves an additional rollout risk: `atlas_brain.main` logs a full
+migration failure and keeps serving, while the payment service would otherwise
+issue a new-column insert. This rebuilt provider-first slice closes that actual
+root cause before a tracker or Website consumer can send the new fields.
+
+This cohesive migration/contract slice is expected to exceed the 400-LOC soft
+target because the money-safety boundary needs both full and slim ASGI proofs,
+an isolated real-Postgres migration proof, compatibility/retry coverage, and
+the paired EOM startup inventory assertion. Splitting those artifacts would
+permit an unproven partial provider rollout.
+
+### Problem-derived contract
+
+- Root cause: `customer_payments`, the two active EOM payment request models,
+  and `ReceivablesService` do not own the check-date/received-through data.
+  Moreover, a provider binary can remain online after a full-app migration
+  failure, so an unconditional new-column insert would turn a valid legacy
+  payment into a schema error during a mixed rollout.
+- Correct fix must touch/change: add nullable `check_date DATE` and
+  `received_through VARCHAR(128)` columns in one additive migration; append it
+  to the slim EOM readiness migration closure; add the two optional request
+  fields to both provider models and forward them through both routes; make the
+  service normalize and fingerprint supplied metadata, preserve the legacy
+  payload/insert when neither field is materially supplied, and fail a
+  metadata-bearing request before its transaction when canonical readiness is
+  false; prove that behavior through full and slim ASGI entrypoints plus an
+  isolated real-Postgres schema.
+- Must not change: required payment fields; check received/deposited/cleared,
+  return, void, allocation, customer-identity, money, actor, or retry
+  semantics; existing MCP request/response behavior (including #2370's
+  projection); tracker/Website behavior; receipt-email delivery; billing
+  recipients; and any production records or configuration.
+
+## Scope (this PR)
+
+Ownership lane: eom/billing-payments
+Slice phase: Vertical slice
+Max files: 8
+
+1. Accept and persist optional check-only `check_date` and `received_through`
+   through the current full and slim EOM payment-create APIs; reject those
+   fields for ACH and Square before a transaction.
+2. Keep a no-metadata request byte-for-byte equivalent at the service intent
+   level: its legacy fingerprint and legacy-column insert remain usable before
+   migration 368, while any material metadata request is rejected with a 503
+   before financial writes if readiness is false.
+3. Add and enroll the nullable migration in the EOM readiness closure, then
+   prove migration idempotency, ready/not-ready detection, idempotency replay,
+   and both active ASGI entrypoints locally.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] Both `atlas_brain.api.invoicing.receivables.CreatePaymentRequest` and
+    `atlas_brain.eom_api.receivables.CreatePaymentRequest` accept omitted,
+    valid, and 128-character `received_through` values, and reject malformed
+    dates and 129-character values; settled by
+    `tests/test_receivables.py::test_payment_http_models_preserve_optional_check_metadata`.
+  - [ ] `ReceivablesService.create_payment_with_outcome` normalizes and
+    persists supplied metadata, replays an unchanged request, and conflicts on
+    a changed material metadata value without a second payment event; check
+    metadata on ACH or Square is rejected before a transaction; settled by
+    `tests/test_receivables.py::test_create_payment_persists_optional_check_metadata_in_payment_intent`
+    and `tests/test_receivables.py::test_create_payment_rejects_check_metadata_for_non_check_methods`.
+  - [ ] A legacy request that omits both values retains its old fingerprint and
+    old insert shape, and can commit in a pre-368 isolated schema; settled by
+    `tests/test_receivables.py::test_create_payment_without_check_metadata_preserves_legacy_intent`
+    and `tests/test_receivables.py::test_check_metadata_schema_gate_preserves_legacy_payment_creation`.
+  - [ ] A supplied check date or nonblank received-through value observes the
+    canonical readiness gate before a transaction and returns a 503/no-write
+    result when migration 368 is absent; settled by
+    `tests/test_receivables.py::test_full_and_slim_payment_entrypoints_reject_check_metadata_when_schema_is_unready`.
+  - [ ] A full authenticated and a slim authenticated
+    `POST /api/v1/receivables/payments` request each forward approved metadata
+    to the canonical service; settled by
+    `tests/test_receivables.py::test_real_postgres_http_and_mcp_entrypoints_use_supported_dependencies`.
+  - [ ] Applying the closed slim migration set, including migration 368, makes
+    `ReceivablesService.is_ready()` true; removing either new column makes it
+    false; settled by
+    `tests/test_receivables.py::test_eom_receivables_readiness_migration_set_builds_ready_schema`
+    and `tests/test_eom_render_profile.py::test_eom_startup_migrations_are_curated_for_receivables_readiness`.
+- Reachability proof: authenticated ASGI requests through `main.app` and
+  `main_eom.app` observe a canonical service result or a 503 before a
+  transaction. The successful full path additionally persists normalized data
+  in an isolated local Postgres schema. No production payment, invoice, or
+  email is created.
+- Affected surfaces: full and slim EOM payment API contracts; canonical
+  receivables persistence/retry/readiness; slim migration startup inventory;
+  isolated database and ASGI regression tests.
+- Risk areas: financial-record truthfulness, idempotency/retry safety,
+  migration compatibility, full-versus-slim route parity, and incremental
+  provider deployment.
+- Reviewer rules triggered: R1, R2, R3, R4, R5, R6, R8, R10, R12, R14.
+
+### Boundary-change enumeration
+
+- Boundary path/seam: full `atlas_brain.api.invoicing.receivables` and slim
+  `atlas_brain.eom_api.receivables` `POST /receivables/payments` request
+  bodies, then `ReceivablesService.create_payment_with_outcome`.
+- Replaced-path behaviors: an omitted or blank-normalized metadata pair keeps
+  the legacy request fingerprint and legacy insert; a material `check_date` or
+  `received_through` joins the payment intent and new-column insert only after
+  the canonical readiness decision succeeds.
+- Guard-relevant fields: `check_date` and `received_through`; all existing
+  payment fields remain inputs to the unchanged validation and fingerprint.
+- Caller x input shape:
+  - full and slim HTTP callers omitting both fields preserve legacy behavior;
+  - full and slim HTTP check callers supplying a date, nonblank route text, or
+    both receive the canonical payment result only when schema-ready;
+  - ACH and Square callers supplying either material check field receive a
+    validation error before a transaction; blank route text normalizes to
+    absent metadata and preserves the legacy path;
+  - blank route text normalizes to absent metadata and follows the legacy path;
+  - direct legacy MCP/service callers omit these parameters and retain their
+    current behavior; no MCP input contract is added here.
+- Closure declaration for the metadata-field inventory: the field set is
+  **CLOSED** and **ENUMERATED** by migration
+  `368_receivables_payment_check_metadata.sql` and the two paired HTTP models.
+  Unlisted request fields neither affect the fingerprint nor reach the insert;
+  omitted/blank values take the backward-compatible legacy path, while the two
+  recognized material values fail closed on unavailable schema before any
+  financial write. This direction is safer because it preserves valid legacy
+  payments but never pretends a new detail was recorded when its columns are
+  missing.
+- Closure declaration for `EOM_RECEIVABLES_READINESS_MIGRATIONS`: the curated
+  migration set is **CLOSED** and **ENUMERATED** from the required receivables
+  tables, columns, indexes, and SQL prerequisites used by
+  `ReceivablesService.is_ready()`. Migrations outside it intentionally do not
+  run in the slim profile; a future receivables schema dependency must update
+  this tuple and its ready-schema test in the same slice. Incompleteness fails
+  the metadata mutation rather than creating a partial record.
+
+### Deployed-config probing
+
+N/A - this changes no environment/config fallback. The deployment-sensitive
+decision is database schema readiness and is probed with a ready schema,
+pre-368 schema, and blank/absent metadata inputs before any transaction.
+
+### Files touched
+
+- `atlas_brain/api/invoicing/receivables.py`
+- `atlas_brain/eom_api/receivables.py`
+- `atlas_brain/main_eom.py`
+- `atlas_brain/services/receivables.py`
+- `atlas_brain/storage/migrations/368_receivables_payment_check_metadata.sql`
+- `plans/PR-EOM-Payment-Check-Metadata-V2.md`
+- `tests/test_eom_render_profile.py`
+- `tests/test_receivables.py`
+
+## Mechanism
+
+Migration 368 only adds nullable fields, so existing rows and old binaries are
+valid. The service normalizes `received_through` once. If neither new value is
+material, it constructs the exact legacy intent and executes the legacy insert.
+Material check metadata is valid only for check payments; ACH and Square fail
+validation before a transaction. For a material check request, the service
+first calls the established complete `is_ready()` check; a false or unavailable
+answer becomes a typed schema unavailable response before a payment transaction
+begins. A ready request adds the normalized values to its fingerprint and uses
+the extended insert. Thus an unchanged retry returns the original payment and a
+changed check detail is an idempotency conflict rather than a second
+receipt/allocation.
+
+The full app may log a failed best-effort migration and continue; the
+metadata-specific service gate makes that state observable and safe. The slim
+profile's curated migration tuple gains 368, so its normal startup path applies
+the additive prerequisite. A code rollback is safe because older code ignores
+the nullable columns; no rollback drops customer-payment history or columns.
+
+## Intentional
+
+- `received_through` remains bounded operator-entered text, not a speculative
+  enum: the approved requirements give examples but no canonical taxonomy.
+- These fields are check-specific. A material value is rejected for ACH and
+  Square before a transaction so ATLAS never records a false check detail;
+  blank route text remains backward-compatible absent metadata.
+- The metadata schema gate is in the canonical service, not duplicated as
+  route-specific business logic, so both full and slim HTTP routes and any
+  future direct caller receive the same fail-closed rule.
+- The already-merged MCP response projection remains untouched. MCP callers do
+  not receive a new request field in this slice.
+
+## Deferred
+
+- eom-timetracker and Website consumption of these fields follow only after the
+  provider migration is deployed (#2362).
+- Receipt numbers, deterministic receipt composition, outbox state, retry, and
+  no-email recovery remain the dedicated residential receipt-outbox slices
+  tracked in #2362 and #2363.
+- Customer ledger search, commercial billing candidates, Gmail draft recovery,
+  sent-mail reconciliation, and manual Square queue behavior remain later
+  Billing & Payments slices (#2362).
+
+Parking predicate: customer-facing receipt composition/delivery, payment-search
+ergonomics, billing-run behavior, and metadata taxonomy/polish that do not
+block durable provider storage, legacy replay, or fail-closed metadata writes
+are parked in #2363.
+
+Parked hardening: none.
+
+## Verification
+
+- Passed locally: `ruff check` on all changed Python files; `compileall` on
+  all changed Python files; `git diff --check`; plan sync/check; and strict
+  `check_guard_class_closure.py`.
+- Passed locally: focused model/service/ASGI coverage (10 passed) and isolated
+  PostgreSQL migration/readiness/entrypoint coverage (4 passed).
+- Passed locally: the invoicing workflow selection -- 2 monthly-invoice tests,
+  194 EOM/receivables/billing-recipient/repository tests, and 43 MCP
+  regression tests. No production payment, invoice, or email was created.
+- Pending before push: the repository local PR gate. Hosted GitHub checks are
+  not manually dispatched or rerun; the operator requested equivalent checks
+  be run locally.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/api/invoicing/receivables.py` | 9 |
+| `atlas_brain/eom_api/receivables.py` | 9 |
+| `atlas_brain/main_eom.py` | 1 |
+| `atlas_brain/services/receivables.py` | 142 |
+| `atlas_brain/storage/migrations/368_receivables_payment_check_metadata.sql` | 5 |
+| `plans/PR-EOM-Payment-Check-Metadata-V2.md` | 242 |
+| `tests/test_eom_render_profile.py` | 1 |
+| `tests/test_receivables.py` | 455 |
+| **Total** | **864** |

--- a/tests/test_eom_render_profile.py
+++ b/tests/test_eom_render_profile.py
@@ -488,6 +488,7 @@ def test_eom_startup_migrations_are_curated_for_receivables_readiness():
         "045_invoices",
         "344_receivables_payments",
         "345_receivables_event_key_lookup",
+        "368_receivables_payment_check_metadata",
     )
     assert not any(
         migration.startswith(("066_", "068_", "074_", "076_", "083_", "095_"))

--- a/tests/test_receivables.py
+++ b/tests/test_receivables.py
@@ -28,9 +28,11 @@ from atlas_brain.services.receivables import (
     ReceivablesConflictError,
     ReceivablesError,
     ReceivablesNotFoundError,
+    ReceivablesSchemaUnavailableError,
     ReceivablesService,
     ReceivablesValidationError,
     money,
+    request_fingerprint,
 )
 from atlas_brain.storage.exceptions import DatabaseUnavailableError
 
@@ -57,6 +59,8 @@ class _CreatePaymentConnection:
         self.contact_lock_count = 0
         self.contact_queries: list[str] = []
         self.parent_args = None
+        self.parent_fingerprint_index: int | None = None
+        self.parent_has_check_metadata = False
         self.parent_insert_count = 0
         self.allocations: list[dict] = []
         self.fetches: list[tuple[str, tuple]] = []
@@ -67,7 +71,9 @@ class _CreatePaymentConnection:
             if self.parent_args is not None:
                 return {
                     "id": self.parent_args[0],
-                    "request_fingerprint": self.parent_args[10],
+                    "request_fingerprint": self.parent_args[
+                        self.parent_fingerprint_index
+                    ],
                 }
             return None
         if "FROM contacts" in query:
@@ -88,11 +94,17 @@ class _CreatePaymentConnection:
         if "INSERT INTO customer_payments" in query:
             self.parent_insert_count += 1
             self.parent_args = args
+            self.parent_has_check_metadata = (
+                "check_date, received_through" in query
+            )
+            self.parent_fingerprint_index = (
+                12 if self.parent_has_check_metadata else 10
+            )
             return {"id": args[0]}
         if "SELECT cp.*, pdi.batch_id" in query:
             assert self.parent_args is not None
             parent = self.parent_args
-            return {
+            payment = {
                 "id": parent[0],
                 "contact_id": parent[1],
                 "payer_name": parent[2],
@@ -100,15 +112,34 @@ class _CreatePaymentConnection:
                 "payment_method": parent[4],
                 "reference": parent[5],
                 "received_date": parent[6],
-                "status": parent[7],
-                "source": parent[8],
-                "idempotency_key": parent[9],
-                "request_fingerprint": parent[10],
-                "notes": parent[11],
-                "recorded_by": parent[12],
                 "metadata": {},
                 "batch_id": None,
             }
+            if self.parent_has_check_metadata:
+                payment.update(
+                    {
+                        "check_date": parent[7],
+                        "received_through": parent[8],
+                        "status": parent[9],
+                        "source": parent[10],
+                        "idempotency_key": parent[11],
+                        "request_fingerprint": parent[12],
+                        "notes": parent[13],
+                        "recorded_by": parent[14],
+                    }
+                )
+            else:
+                payment.update(
+                    {
+                        "status": parent[7],
+                        "source": parent[8],
+                        "idempotency_key": parent[9],
+                        "request_fingerprint": parent[10],
+                        "notes": parent[11],
+                        "recorded_by": parent[12],
+                    }
+                )
+            return payment
         raise AssertionError(f"Unexpected fetchrow query: {query}")
 
     async def fetchval(self, query: str, *_args):
@@ -273,6 +304,132 @@ async def test_create_payment_records_unapplied_receipt_and_replays_without_invo
     ]
     assert len(events) == 1
     assert json.loads(events[0][10]) == {"allocated_amount": "0"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("received_through", (None, "  "))
+async def test_create_payment_without_check_metadata_preserves_legacy_intent(
+    received_through,
+):
+    contact_id = uuid4()
+    pool = _CreatePaymentPool([], [contact_id])
+    service = ReceivablesService(pool)
+    create_args = {
+        "contact_id": contact_id,
+        "payer_name": "Residential Customer",
+        "total_amount": Decimal("125.00"),
+        "payment_method": "check",
+        "received_date": date(2026, 8, 12),
+        "received_through": received_through,
+        "allocations": [],
+        "idempotency_key": "legacy-payment-intent-1",
+        "recorded_by": "Juan Canfield",
+        "allow_unapplied": True,
+        "unapplied_contact_context_id": "effingham_maids",
+    }
+
+    result = await service.create_payment_with_outcome(**create_args)
+
+    assert result.replayed is False
+    assert pool.conn.parent_has_check_metadata is False
+    assert pool.conn.parent_args[10] == request_fingerprint(
+        {
+            "contact_id": contact_id,
+            "payer_name": "Residential Customer",
+            "total_amount": Decimal("125.00"),
+            "payment_method": "check",
+            "received_date": date(2026, 8, 12),
+            "allocations": [],
+            "reference": None,
+            "notes": None,
+        }
+    )
+
+    with pytest.raises(ReceivablesValidationError, match="at most 128"):
+        await service.create_payment_with_outcome(
+            **{**create_args, "received_through": "x" * 129}
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_payment_persists_optional_check_metadata_in_payment_intent():
+    contact_id = uuid4()
+    pool = _CreatePaymentPool([], [contact_id])
+    service = ReceivablesService(pool)
+
+    async def ready() -> bool:
+        return True
+
+    service.is_ready = ready
+    create_args = {
+        "contact_id": contact_id,
+        "payer_name": "Residential Customer",
+        "total_amount": Decimal("125.00"),
+        "payment_method": "check",
+        "received_date": date(2026, 8, 12),
+        "check_date": date(2026, 8, 10),
+        "received_through": " Mail ",
+        "allocations": [],
+        "idempotency_key": "unapplied-payment-check-metadata-1",
+        "recorded_by": "Juan Canfield",
+        "allow_unapplied": True,
+        "unapplied_contact_context_id": "effingham_maids",
+    }
+
+    first = await service.create_payment_with_outcome(**create_args)
+    replay = await service.create_payment_with_outcome(**create_args)
+
+    assert first.replayed is False
+    assert replay.replayed is True
+    assert first.payment["id"] == replay.payment["id"]
+    assert first.payment["check_date"] == date(2026, 8, 10)
+    assert first.payment["received_through"] == "Mail"
+    for changed_field, changed_value in (
+        ("check_date", date(2026, 8, 11)),
+        ("received_through", "Employee handoff"),
+    ):
+        with pytest.raises(ReceivablesConflictError, match="different request"):
+            await service.create_payment_with_outcome(
+                **{**create_args, changed_field: changed_value}
+            )
+
+    assert pool.conn.parent_insert_count == 1
+    assert len(
+        [
+            query
+            for query, _args in pool.conn.executions
+            if "INSERT INTO payment_events" in query
+        ]
+    ) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("payment_method", ("ach", "square"))
+async def test_create_payment_rejects_check_metadata_for_non_check_methods(
+    payment_method,
+):
+    contact_id = uuid4()
+    pool = _CreatePaymentPool([], [contact_id])
+
+    with pytest.raises(
+        ReceivablesValidationError,
+        match="Check metadata requires a check payment method",
+    ):
+        await ReceivablesService(pool).create_payment(
+            contact_id=contact_id,
+            payer_name="Residential Customer",
+            total_amount=Decimal("125.00"),
+            payment_method=payment_method,
+            received_date=date(2026, 8, 12),
+            check_date=date(2026, 8, 10),
+            allocations=[],
+            idempotency_key=f"{payment_method}-check-metadata",
+            allow_unapplied=True,
+            unapplied_contact_context_id="effingham_maids",
+        )
+
+    assert pool.transaction_count == 0
+    assert pool.conn.parent_args is None
 
 
 @pytest.mark.asyncio
@@ -927,14 +1084,17 @@ async def _create_pre_receivables_schema(conn, schema: str) -> None:
     await conn.execute(invoice_migration)
 
 
-def _receivables_migration_sql() -> str:
+def _receivables_migration_sql(*, include_check_metadata: bool = True) -> str:
     migrations = Path(__file__).parents[1] / "atlas_brain/storage/migrations"
+    filenames = [
+        "344_receivables_payments.sql",
+        "345_receivables_event_key_lookup.sql",
+    ]
+    if include_check_metadata:
+        filenames.append("368_receivables_payment_check_metadata.sql")
     return "\n".join(
         (migrations / filename).read_text(encoding="utf-8")
-        for filename in (
-            "344_receivables_payments.sql",
-            "345_receivables_event_key_lookup.sql",
-        )
+        for filename in filenames
     )
 
 
@@ -1021,6 +1181,10 @@ def test_eom_readiness_migration_set_is_closed_over_receivables_dependencies():
         positions["344_receivables_payments"]
         < positions["345_receivables_event_key_lookup"]
     )
+    assert (
+        positions["345_receivables_event_key_lookup"]
+        < positions["368_receivables_payment_check_metadata"]
+    )
     assert "ALTER TABLE appointments" in _packaged_migration_sql("035_contacts")
     assert "REFERENCES contacts(id)" in _packaged_migration_sql("045_invoices")
     assert "ALTER TABLE invoice_payments" in _packaged_migration_sql(
@@ -1028,6 +1192,9 @@ def test_eom_readiness_migration_set_is_closed_over_receivables_dependencies():
     )
     assert "ON payment_events(idempotency_key)" in _packaged_migration_sql(
         "345_receivables_event_key_lookup"
+    )
+    assert "ADD COLUMN IF NOT EXISTS check_date DATE" in _packaged_migration_sql(
+        "368_receivables_payment_check_metadata"
     )
 
 
@@ -1121,6 +1288,87 @@ async def test_eom_receivables_readiness_migration_set_builds_ready_schema():
             )
         } == applied_names
         assert await service.is_ready() is True
+        for column, definition in (
+            ("check_date", "DATE"),
+            ("received_through", "VARCHAR(128)"),
+        ):
+            await conn.execute(
+                f"ALTER TABLE customer_payments DROP COLUMN {column}"
+            )
+            assert await service.is_ready() is False
+            await conn.execute(
+                f"ALTER TABLE customer_payments ADD COLUMN {column} {definition}"
+            )
+            assert await service.is_ready() is True
+    finally:
+        await conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        await conn.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "check_metadata",
+    (
+        {"check_date": date(2026, 8, 10)},
+        {"received_through": "Mail"},
+    ),
+)
+async def test_check_metadata_schema_gate_preserves_legacy_payment_creation(
+    check_metadata,
+):
+    asyncpg = pytest.importorskip("asyncpg")
+    database_url = os.environ.get("ATLAS_RECEIVABLES_TEST_DATABASE_URL")
+    if not database_url:
+        pytest.skip("ATLAS_RECEIVABLES_TEST_DATABASE_URL not set")
+
+    schema = f"receivables_check_metadata_gate_{uuid4().hex}"
+    conn = await asyncpg.connect(database_url)
+    try:
+        await _create_pre_receivables_schema(conn, schema)
+        await conn.execute(_receivables_migration_sql(include_check_metadata=False))
+        contact_id = uuid4()
+        await conn.execute(
+            "INSERT INTO contacts (id, business_context_id) "
+            "VALUES ($1, 'effingham_maids')",
+            contact_id,
+        )
+        service = ReceivablesService(_SingleConnectionPool(conn, schema))
+
+        assert await service.is_ready() is False
+        legacy_payment = await service.create_payment(
+            contact_id=contact_id,
+            payer_name="Residential Customer",
+            total_amount=Decimal("125.00"),
+            payment_method="check",
+            received_date=date(2026, 8, 12),
+            allocations=[],
+            idempotency_key="pre-368-legacy-payment",
+            recorded_by="Juan Canfield",
+            allow_unapplied=True,
+            unapplied_contact_context_id="effingham_maids",
+        )
+        assert legacy_payment["status"] == "received"
+
+        with pytest.raises(
+            ReceivablesSchemaUnavailableError,
+            match="schema unavailable for check metadata",
+        ):
+            await service.create_payment(
+                contact_id=contact_id,
+                payer_name="Residential Customer",
+                total_amount=Decimal("125.00"),
+                payment_method="check",
+                received_date=date(2026, 8, 12),
+                allocations=[],
+                idempotency_key="pre-368-check-metadata-payment",
+                recorded_by="Juan Canfield",
+                allow_unapplied=True,
+                unapplied_contact_context_id="effingham_maids",
+                **check_metadata,
+            )
+
+        assert await conn.fetchval("SELECT COUNT(*) FROM customer_payments") == 1
+        assert await conn.fetchval("SELECT COUNT(*) FROM payment_events") == 1
     finally:
         await conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
         await conn.close()
@@ -2392,8 +2640,9 @@ async def test_real_postgres_http_and_mcp_entrypoints_use_supported_dependencies
     if not database_url:
         pytest.skip("ATLAS_RECEIVABLES_TEST_DATABASE_URL not set")
 
-    from atlas_brain import main
+    from atlas_brain import main, main_eom
     from atlas_brain.api.invoicing import receivables as routes
+    from atlas_brain.eom_api import receivables as eom_routes
     from atlas_brain.mcp import invoicing_server
     from atlas_brain.storage.repositories.invoice import InvoiceRepository
 
@@ -2480,6 +2729,14 @@ async def test_real_postgres_http_and_mcp_entrypoints_use_supported_dependencies
             lambda: config
         )
         app.dependency_overrides[routes.get_receivables_service] = lambda: service
+        slim_app = main_eom.app
+        original_slim_dependency_overrides = slim_app.dependency_overrides.copy()
+        slim_app.dependency_overrides[
+            eom_receivables_auth.get_receivables_api_config
+        ] = lambda: config
+        slim_app.dependency_overrides[
+            eom_routes.get_receivables_service
+        ] = lambda: service
         body = {
             "contact_id": str(contact_id),
             "payer_name": "Acme",
@@ -2497,7 +2754,14 @@ async def test_real_postgres_http_and_mcp_entrypoints_use_supported_dependencies
             "total_amount_cents": 12_500,
             "payment_method": "check",
             "received_date": "2026-08-12",
+            "check_date": "2026-08-10",
+            "received_through": " Mail ",
             "reference": "1001",
+        }
+        slim_unapplied_body = {
+            **unapplied_body,
+            "check_date": "2026-08-11",
+            "received_through": "Employee handoff",
         }
 
         try:
@@ -2543,6 +2807,21 @@ async def test_real_postgres_http_and_mcp_entrypoints_use_supported_dependencies
                     json=unapplied_body,
                 )
 
+            slim_transport = httpx.ASGITransport(app=slim_app)
+            async with httpx.AsyncClient(
+                transport=slim_transport,
+                base_url="http://receivables.test",
+            ) as client:
+                slim_unapplied_response = await client.post(
+                    "/api/v1/receivables/payments",
+                    headers={
+                        "Authorization": f"Bearer {generated.token}",
+                        "X-EOM-Actor": "Juan Canfield",
+                        "Idempotency-Key": "slim-http-unapplied-payment-1",
+                    },
+                    json=slim_unapplied_body,
+                )
+
             assert response.status_code == 201
             assert response.json()["status"] == "received"
             http_payment = await conn.fetchrow("""
@@ -2568,8 +2847,35 @@ async def test_real_postgres_http_and_mcp_entrypoints_use_supported_dependencies
             unapplied_payment = unapplied_response.json()
             assert unapplied_replay.json()["id"] == unapplied_payment["id"]
             assert unapplied_payment["status"] == "received"
+            assert unapplied_payment["check_date"] == "2026-08-10"
+            assert unapplied_payment["received_through"] == "Mail"
             assert unapplied_payment["allocated_amount_cents"] == 0
             assert unapplied_payment["unapplied_amount_cents"] == 12_500
+            stored_check_metadata = await conn.fetchrow(
+                """
+                SELECT check_date, received_through
+                FROM customer_payments
+                WHERE idempotency_key = 'http-unapplied-payment-1'
+                """
+            )
+            assert stored_check_metadata["check_date"] == date(2026, 8, 10)
+            assert stored_check_metadata["received_through"] == "Mail"
+            assert slim_unapplied_response.status_code == 201
+            assert slim_unapplied_response.json()["check_date"] == "2026-08-11"
+            assert (
+                slim_unapplied_response.json()["received_through"]
+                == "Employee handoff"
+            )
+            stored_slim_check_metadata = await conn.fetchrow(
+                """
+                SELECT check_date, received_through, recorded_by
+                FROM customer_payments
+                WHERE idempotency_key = 'slim-http-unapplied-payment-1'
+                """
+            )
+            assert stored_slim_check_metadata["check_date"] == date(2026, 8, 11)
+            assert stored_slim_check_metadata["received_through"] == "Employee handoff"
+            assert stored_slim_check_metadata["recorded_by"] == "Juan Canfield"
             assert (
                 await conn.fetchval(
                     "SELECT COUNT(*) FROM invoice_payments ip "
@@ -2590,6 +2896,8 @@ async def test_real_postgres_http_and_mcp_entrypoints_use_supported_dependencies
         finally:
             app.dependency_overrides.clear()
             app.dependency_overrides.update(original_dependency_overrides)
+            slim_app.dependency_overrides.clear()
+            slim_app.dependency_overrides.update(original_slim_dependency_overrides)
 
         crm_calls = []
 
@@ -2813,6 +3121,47 @@ def test_payment_http_models_reject_coercive_cent_values():
             )
 
 
+def test_payment_http_models_preserve_optional_check_metadata():
+    from atlas_brain.api.invoicing.receivables import CreatePaymentRequest
+    from atlas_brain.eom_api.receivables import (
+        CreatePaymentRequest as EOMCreatePaymentRequest,
+    )
+
+    base = {
+        "contact_id": str(uuid4()),
+        "payer_name": "Residential Customer",
+        "total_amount_cents": 12_500,
+        "payment_method": "check",
+        "received_date": "2026-08-12",
+        "reference": "1001",
+    }
+    for request_model in (CreatePaymentRequest, EOMCreatePaymentRequest):
+        omitted = request_model.model_validate(base)
+        assert omitted.check_date is None
+        assert omitted.received_through is None
+
+        with_metadata = request_model.model_validate(
+            {
+                **base,
+                "check_date": "2026-08-10",
+                "received_through": "Mail",
+            }
+        )
+        assert with_metadata.check_date == date(2026, 8, 10)
+        assert with_metadata.received_through == "Mail"
+        assert (
+            request_model.model_validate(
+                {**base, "received_through": "x" * 128}
+            ).received_through
+            == "x" * 128
+        )
+
+        with pytest.raises(ValueError):
+            request_model.model_validate({**base, "check_date": "not-a-date"})
+        with pytest.raises(ValueError):
+            request_model.model_validate({**base, "received_through": "x" * 129})
+
+
 @pytest.mark.asyncio
 async def test_payment_routes_forward_omitted_allocations_as_empty_list():
     from atlas_brain.api.invoicing.receivables import (
@@ -2861,6 +3210,84 @@ async def test_payment_routes_forward_omitted_allocations_as_empty_list():
         assert service.kwargs["unapplied_contact_context_id"] == "effingham_maids"
         assert service.kwargs["recorded_by"] == "Juan Canfield"
         assert service.kwargs["idempotency_key"] == "route-unapplied-payment-1"
+        assert service.kwargs["check_date"] is None
+        assert service.kwargs["received_through"] is None
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "check_metadata",
+    (
+        {"check_date": "2026-08-10"},
+        {"received_through": "Mail"},
+    ),
+)
+async def test_full_and_slim_payment_entrypoints_reject_check_metadata_when_schema_is_unready(
+    check_metadata,
+):
+    from atlas_brain import main, main_eom
+    from atlas_brain.api.invoicing import auth as full_auth
+    from atlas_brain.api.invoicing import receivables as full_routes
+    from atlas_brain.eom_api import auth as slim_auth
+    from atlas_brain.eom_api import receivables as slim_routes
+
+    generated = eom_receivables_auth.generate_receivables_service_token()
+    config = SimpleNamespace(
+        receivables_api_enabled=True,
+        receivables_service_token="",
+        receivables_service_token_sha256=generated.sha256,
+    )
+    body = {
+        "contact_id": str(uuid4()),
+        "payer_name": "Residential Customer",
+        "total_amount_cents": 12_500,
+        "payment_method": "check",
+        "received_date": "2026-08-12",
+        "reference": "1001",
+        **check_metadata,
+    }
+    headers = {
+        "Authorization": f"Bearer {generated.token}",
+        "X-EOM-Actor": "Juan Canfield",
+        "Idempotency-Key": "asgi-unready-check-metadata-1",
+    }
+
+    for app, config_dependency, service_dependency in (
+        (main.app, full_auth.get_receivables_api_config, full_routes.get_receivables_service),
+        (
+            main_eom.app,
+            slim_auth.get_receivables_api_config,
+            slim_routes.get_receivables_service,
+        ),
+    ):
+        service = ReceivablesService()
+        readiness_calls = 0
+
+        async def unready() -> bool:
+            nonlocal readiness_calls
+            readiness_calls += 1
+            return False
+
+        service.is_ready = unready
+        original_overrides = app.dependency_overrides.copy()
+        app.dependency_overrides[config_dependency] = lambda: config
+        app.dependency_overrides[service_dependency] = lambda: service
+        try:
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(
+                transport=transport,
+                base_url="http://receivables.test",
+            ) as client:
+                response = await client.post(
+                    "/api/v1/receivables/payments",
+                    headers=headers,
+                    json=body,
+                )
+            assert response.status_code == 503
+            assert response.json()["detail"]["code"] == "schema_unavailable"
+            assert readiness_calls == 1
+        finally:
+            app.dependency_overrides.clear()
+            app.dependency_overrides.update(original_overrides)
 
 
 def test_multi_invoice_mcp_is_registered_with_bounded_strict_schema():


### PR DESCRIPTION
Plan: plans/PR-EOM-Payment-Check-Metadata-V2.md
Slice phase: Vertical slice
Ownership lane: eom/billing-payments

ATLAS needs to retain optional check date and received-through details as
canonical payment data without turning a mixed migration rollout into a failed
or duplicated financial write. This provider-first slice adds nullable storage
and paired full/slim API forwarding, preserves the exact legacy intent and SQL
shape when metadata is absent, and fails a material check-metadata request
before its transaction when the complete receivables schema is unavailable.

Diff-budget override: The paired provider models/routes, canonical readiness gate, legacy/retry behavior, and isolated real-PostgreSQL proofs must land together; splitting them would leave a partial financial rollout unproven.

## Intentional

- Material check metadata is valid only for check payments; ACH/Square reject
  it before a transaction so ATLAS cannot record a false check detail.
- Blank `received_through` normalizes to absent metadata and uses the legacy
  payload and insert; MCP input behavior remains unchanged.
- The schema gate lives in `ReceivablesService`, not route-specific code, so
  both full and slim provider paths share the same safety result.

## AI reconciliation

- no-findings

## Deferred

- Tracker/Website consumption, receipt outbox, customer ledger, commercial
  billing runs, Gmail recovery, and Square queue work remain in #2362 / #2363.

## Parked hardening

- None.

## Cold diff reconstruction

- Changed: `atlas_brain/services/receivables.py:591` normalizes and validates
  check-only metadata, readiness-gates it at `:615`, and selects the extended
  insert at `:688` without changing the legacy insert; paired full/slim routes
  accept and forward the fields at `atlas_brain/api/invoicing/receivables.py:83`
  and `atlas_brain/eom_api/receivables.py:85`.
- Changed: migration `368_receivables_payment_check_metadata.sql:1` adds only
  nullable columns and `atlas_brain/main_eom.py:105` enrolls it in the curated
  slim readiness set; `tests/test_receivables.py:311`, `:408`, `:1202`,
  `:1316`, `:2637`, `:3124`, and `:3224` prove legacy, validation, migration,
  real-ASGI, retry, and unavailable-schema behavior.
- Contract match: each changed production path directly supports durable
  check-record truth, idempotent retries, or safe provider-first deployment.
- Gaps: none.

## Verification

- Passed locally: changed-file Ruff, Python compilation, whitespace check,
  plan sync/check, and strict guard-class closure.
- Passed locally: 10 focused model/service/ASGI tests and 4 isolated PostgreSQL
  migration/readiness/entrypoint tests.
- Passed locally: workflow-equivalent selections -- 2 monthly-invoice tests,
  194 EOM/receivables/billing-recipient/repository tests, and 43 MCP
  regression tests. No production records, Gmail drafts, or emails were used.

## Mechanical verification

- Command: `ruff check <changed Python files> --ignore E402` - Result: pass - Environment: local
- Command: `python -m compileall -q <changed Python files>` - Result: pass - Environment: local
- Command: `python -m pytest tests/test_eom_render_profile.py tests/test_receivables.py tests/test_eom_billing_recipients.py tests/test_invoice_repository.py -q` with isolated local PostgreSQL - Result: 194 passed - Environment: local
- Command: `python -m pytest tests/test_monthly_invoice_generation.py -k '<workflow selection>' -q` - Result: 2 passed - Environment: local
- Command: `python -m pytest tests/test_invoicing_readonly_mcp.py tests/test_invoicing_readonly_oauth.py tests/test_invoicing_draft_writer_mcp.py tests/test_invoicing_draft_writer_oauth.py -q` - Result: 43 passed - Environment: local
- Command: `python scripts/check_guard_class_closure.py --base origin/main --strict` - Result: pass - Environment: local
- Command: `bash scripts/push_pr.sh <body> -u origin HEAD` - Result: pass; full unit gate matched 160 known failures with 0 regressions - Environment: local
- Skipped: manual hosted GitHub check dispatch/rerun - Reason: requested local checks are the primary acceptance evidence.
- Skipped: browser verification - Reason: this is a provider-only slice with no visible UI.

## Diff size

8 files, +817 / -47

<!-- atlas-open-pr-wrapper: v1 -->
