### PR TITLE
EOM receivables: queue residential receipt outbox

### DIFF
--- a/.github/workflows/atlas_invoicing_checks.yml
+++ b/.github/workflows/atlas_invoicing_checks.yml
@@ -36,13 +36,16 @@ on:
       - "atlas_brain/services/receivables.py"
       - "atlas_brain/storage/migrations/344_receivables_payments.sql"
       - "atlas_brain/storage/migrations/345_receivables_event_key_lookup.sql"
+      - "atlas_brain/storage/migrations/369_receivables_payment_receipt_outbox.sql"
       - "atlas_brain/storage/repositories/invoice.py"
       - "atlas_brain/templates/email/__init__.py"
       - "atlas_brain/templates/email/estimate_confirmation.py"
+      - "atlas_brain/templates/email/payment_receipt.py"
       - "tests/test_monthly_invoice_generation.py"
       - "tests/test_invoice_repository.py"
       - "tests/test_receivables.py"
       - "tests/test_eom_billing_recipients.py"
+      - "tests/test_eom_payment_receipts.py"
       - "tests/test_invoicing_readonly_mcp.py"
       - "tests/test_invoicing_readonly_oauth.py"
       - "tests/test_invoicing_draft_writer_mcp.py"
@@ -83,13 +86,16 @@ on:
       - "atlas_brain/services/receivables.py"
       - "atlas_brain/storage/migrations/344_receivables_payments.sql"
       - "atlas_brain/storage/migrations/345_receivables_event_key_lookup.sql"
+      - "atlas_brain/storage/migrations/369_receivables_payment_receipt_outbox.sql"
       - "atlas_brain/storage/repositories/invoice.py"
       - "atlas_brain/templates/email/__init__.py"
       - "atlas_brain/templates/email/estimate_confirmation.py"
+      - "atlas_brain/templates/email/payment_receipt.py"
       - "tests/test_monthly_invoice_generation.py"
       - "tests/test_invoice_repository.py"
       - "tests/test_receivables.py"
       - "tests/test_eom_billing_recipients.py"
+      - "tests/test_eom_payment_receipts.py"
       - "tests/test_invoicing_readonly_mcp.py"
       - "tests/test_invoicing_readonly_oauth.py"
       - "tests/test_invoicing_draft_writer_mcp.py"
@@ -145,6 +151,7 @@ jobs:
             tests/test_eom_render_profile.py \
             tests/test_receivables.py \
             tests/test_eom_billing_recipients.py \
+            tests/test_eom_payment_receipts.py \
             tests/test_invoice_repository.py \
             -q
 

--- a/atlas_brain/api/invoicing/receivables.py
+++ b/atlas_brain/api/invoicing/receivables.py
@@ -37,6 +37,13 @@ _DATABASE_UNAVAILABLE_ERRORS = (
     asyncpg.AdminShutdownError,
     asyncpg.CrashShutdownError,
 )
+_CANONICAL_CUSTOMER_UNAVAILABLE_ERRORS = _DATABASE_UNAVAILABLE_ERRORS + (
+    asyncpg.UndefinedTableError,
+    asyncpg.UndefinedColumnError,
+    asyncpg.InvalidSchemaNameError,
+    asyncpg.InsufficientPrivilegeError,
+    asyncpg.InvalidAuthorizationSpecificationError,
+)
 _UNAVAILABLE_INTERFACE_PREFIXES = (
     "connection is closed",
     "pool is closed",
@@ -134,6 +141,20 @@ def _is_database_unavailable_error(exc: Exception) -> bool:
     if isinstance(exc, (ConnectionError, TimeoutError, socket.gaierror)):
         return True
     return isinstance(exc, OSError) and exc.errno in _NETWORK_UNAVAILABLE_ERRNOS
+
+
+def _is_canonical_customer_unavailable_error(exc: Exception) -> bool:
+    """Classify canonical-CRM schema and connection failures for payment reads.
+
+    The payment route has a recovery path for a same-key replay when the
+    canonical customer read is unavailable.  A partially migrated or
+    permission-denied canonical CRM must therefore take that same controlled
+    path rather than escaping as an HTTP 500 before the ledger can reconcile
+    the existing payment.
+    """
+    return _is_database_unavailable_error(exc) or isinstance(
+        exc, _CANONICAL_CUSTOMER_UNAVAILABLE_ERRORS
+    )
 
 
 async def _call(awaitable):
@@ -255,7 +276,7 @@ async def create_payment(
                 ),
             )
     except Exception as exc:
-        if not _is_database_unavailable_error(exc):
+        if not _is_canonical_customer_unavailable_error(exc):
             raise
         canonical_failure = HTTPException(
             status_code=503,

--- a/atlas_brain/api/invoicing/receivables.py
+++ b/atlas_brain/api/invoicing/receivables.py
@@ -17,11 +17,14 @@ from ...services.receivables import (
     ReceivablesConflictError,
     ReceivablesError,
     ReceivablesNotFoundError,
+    ReceivablesReceiptContextRequiredError,
     ReceivablesSchemaUnavailableError,
     ReceivablesService,
     ReceivablesValidationError,
+    PaymentReceiptRecipient,
     get_receivables_service,
 )
+from ...services.crm_provider import get_crm_provider
 from ...services.eom_lead_ingress import EOM_BUSINESS_CONTEXT_ID
 from ...storage.exceptions import DatabaseUnavailableError
 from .auth import require_actor, require_receivables_api
@@ -174,7 +177,7 @@ async def _call(awaitable):
 async def ready() -> dict:
     service = get_receivables_service()
     try:
-        schema_ready = await service.is_ready()
+        schema_ready = await service.is_receipt_delivery_ready()
     except Exception as exc:
         raise HTTPException(
             status_code=503, detail="Receivables database unavailable"
@@ -218,24 +221,76 @@ async def create_payment(
     ],
     service: ReceivablesService = Depends(get_receivables_service),
 ) -> dict:
-    return await _call(
-        service.create_payment(
-            contact_id=body.contact_id,
-            payer_name=body.payer_name,
-            total_amount=_dollars(body.total_amount_cents),
-            payment_method=body.payment_method,
-            received_date=body.received_date,
-            check_date=body.check_date,
-            received_through=body.received_through,
-            reference=body.reference,
-            notes=body.notes,
-            allocations=_allocations(body.allocations),
-            recorded_by=actor,
-            idempotency_key=idempotency_key,
-            allow_unapplied=True,
-            unapplied_contact_context_id=EOM_BUSINESS_CONTEXT_ID,
+    """Record a payment from the deployed full EOM provider route.
+
+    The full application owns both the receivables ledger and canonical CRM
+    contacts through its primary database.  Resolve a narrow active-customer
+    snapshot before a new write, but defer a missing/unavailable CRM result to
+    the service's idempotency lookup so an unchanged retry can recover a
+    previously committed payment.
+    """
+    receipt_recipient: PaymentReceiptRecipient | None = None
+    canonical_failure: HTTPException | None = None
+    try:
+        customer = await get_crm_provider().get_eom_payment_customer(
+            body.contact_id
         )
-    )
+        if customer is None:
+            canonical_failure = HTTPException(
+                status_code=404,
+                detail={
+                    "code": "not_found",
+                    "message": "Customer not found",
+                },
+            )
+        else:
+            receipt_recipient = PaymentReceiptRecipient(
+                contact_id=UUID(str(customer["contact_id"])),
+                customer_name=str(customer["customer_name"]),
+                customer_type=str(customer["customer_type"]),
+                recipient_email=(
+                    str(customer["recipient_email"])
+                    if customer["recipient_email"] is not None
+                    else None
+                ),
+            )
+    except Exception as exc:
+        if not _is_database_unavailable_error(exc):
+            raise
+        canonical_failure = HTTPException(
+            status_code=503,
+            detail={
+                "code": "canonical_customer_unavailable",
+                "message": "Canonical EOM customer data is unavailable",
+            },
+        )
+
+    async def _write_payment() -> dict:
+        try:
+            return await service.create_payment(
+                contact_id=body.contact_id,
+                payer_name=body.payer_name,
+                total_amount=_dollars(body.total_amount_cents),
+                payment_method=body.payment_method,
+                received_date=body.received_date,
+                check_date=body.check_date,
+                received_through=body.received_through,
+                reference=body.reference,
+                notes=body.notes,
+                allocations=_allocations(body.allocations),
+                recorded_by=actor,
+                idempotency_key=idempotency_key,
+                allow_unapplied=True,
+                unapplied_contact_context_id=EOM_BUSINESS_CONTEXT_ID,
+                receipt_recipient=receipt_recipient,
+                require_receipt_recipient=True,
+            )
+        except ReceivablesReceiptContextRequiredError:
+            if canonical_failure is not None:
+                raise canonical_failure
+            raise
+
+    return await _call(_write_payment())
 
 
 @router.get("/payments")

--- a/atlas_brain/eom_api/receivables.py
+++ b/atlas_brain/eom_api/receivables.py
@@ -38,6 +38,13 @@ _DATABASE_UNAVAILABLE_ERRORS = (
     asyncpg.AdminShutdownError,
     asyncpg.CrashShutdownError,
 )
+_CANONICAL_CUSTOMER_UNAVAILABLE_ERRORS = _DATABASE_UNAVAILABLE_ERRORS + (
+    asyncpg.UndefinedTableError,
+    asyncpg.UndefinedColumnError,
+    asyncpg.InvalidSchemaNameError,
+    asyncpg.InsufficientPrivilegeError,
+    asyncpg.InvalidAuthorizationSpecificationError,
+)
 _UNAVAILABLE_INTERFACE_PREFIXES = (
     "connection is closed",
     "pool is closed",
@@ -137,6 +144,18 @@ def _is_database_unavailable_error(exc: Exception) -> bool:
     return isinstance(exc, OSError) and exc.errno in _NETWORK_UNAVAILABLE_ERRNOS
 
 
+def _is_canonical_customer_unavailable_error(exc: Exception) -> bool:
+    """Classify canonical-CRM schema and connection failures for payment reads.
+
+    A same-key retry may recover through the ledger when canonical data is
+    unavailable, but a missing customer column/table or denied read must not
+    escape this HTTP boundary as a 500 before that recovery decision runs.
+    """
+    return _is_database_unavailable_error(exc) or isinstance(
+        exc, _CANONICAL_CUSTOMER_UNAVAILABLE_ERRORS
+    )
+
+
 async def _call(awaitable):
     try:
         return await awaitable
@@ -189,23 +208,24 @@ async def ready() -> dict:
     # -- the pool that owns canonical EOM contacts -- so readiness off the
     # global receivables database alone is not the whole answer.
     #
-    # Two different states, deliberately not collapsed:
-    #
-    #   unconfigured -- no funnel DSN. This is a SUPPORTED deployment: a
-    #     profile running receivables without billing recipients. Failing
-    #     readiness here would take the whole invoicing service out over a
-    #     capability it does not use, which is worse than the gap. Reported,
-    #     not fatal.
-    #
-    #   unavailable -- a DSN IS configured and the pool cannot serve the two
-    #     queries: the pool never came up, or the database is reachable but
-    #     partially migrated. That is a real misconfiguration, and an
-    #     initialized pool alone does not rule it out -- it proves a
-    #     connection opened, not that `contacts` has the columns both queries
-    #     name. This one fails readiness.
-    pool = get_eom_funnel_db_pool()
+    # Receipt-aware payment creation requires this second database for every
+    # new payment.  A profile without its canonical-contact DSN is therefore
+    # not ready to serve the enabled receivables payment surface.
     if not funnel_settings.db_connection_string.strip():
-        return {"status": "ready", "billingRecipients": "unconfigured"}
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "code": "billing_recipients_unavailable",
+                "message": (
+                    "The canonical EOM contact database is not configured; set "
+                    "ATLAS_EOM_FUNNEL_DB_CONNECTION_STRING to use billing "
+                    "recipients."
+                ),
+            },
+        )
+    # A configured pool may still be partially migrated or lack permissions;
+    # initialization alone only proves that a connection opened.
+    pool = get_eom_funnel_db_pool()
     schema_ready = False
     if pool.is_initialized:
         try:
@@ -370,7 +390,7 @@ async def create_payment(
     except HTTPException as exc:
         canonical_failure = exc
     except Exception as exc:
-        if not _is_database_unavailable_error(exc):
+        if not _is_canonical_customer_unavailable_error(exc):
             raise
         canonical_failure = HTTPException(
             status_code=503,

--- a/atlas_brain/eom_api/receivables.py
+++ b/atlas_brain/eom_api/receivables.py
@@ -17,9 +17,11 @@ from ..services.receivables import (
     ReceivablesConflictError,
     ReceivablesError,
     ReceivablesNotFoundError,
+    ReceivablesReceiptContextRequiredError,
     ReceivablesSchemaUnavailableError,
     ReceivablesService,
     ReceivablesValidationError,
+    PaymentReceiptRecipient,
     get_receivables_service,
 )
 from ..services.eom_lead_ingress import EOM_BUSINESS_CONTEXT_ID
@@ -176,16 +178,16 @@ async def _call(awaitable):
 async def ready() -> dict:
     service = get_receivables_service()
     try:
-        schema_ready = await service.is_ready()
+        schema_ready = await service.is_receipt_delivery_ready()
     except Exception as exc:
         raise HTTPException(
             status_code=503, detail="Receivables database unavailable"
         ) from exc
     if not schema_ready:
         raise HTTPException(status_code=503, detail="Receivables schema unavailable")
-    # The billing-recipient routes read a SECOND database -- the pool that owns
-    # canonical EOM contacts -- so readiness off the global receivables
-    # database alone is not the whole answer.
+    # The billing-recipient and payment-receipt routes read a SECOND database
+    # -- the pool that owns canonical EOM contacts -- so readiness off the
+    # global receivables database alone is not the whole answer.
     #
     # Two different states, deliberately not collapsed:
     #
@@ -329,26 +331,81 @@ async def create_payment(
     idempotency_key: Annotated[
         str, Header(alias="Idempotency-Key", min_length=1, max_length=128)
     ],
+    request: Request,
     service: ReceivablesService = Depends(get_receivables_service),
 ) -> dict:
-    return await _call(
-        service.create_payment(
-            contact_id=body.contact_id,
-            payer_name=body.payer_name,
-            total_amount=_dollars(body.total_amount_cents),
-            payment_method=body.payment_method,
-            received_date=body.received_date,
-            check_date=body.check_date,
-            received_through=body.received_through,
-            reference=body.reference,
-            notes=body.notes,
-            allocations=_allocations(body.allocations),
-            recorded_by=actor,
-            idempotency_key=idempotency_key,
-            allow_unapplied=True,
-            unapplied_contact_context_id=EOM_BUSINESS_CONTEXT_ID,
+    """Record a payment with a canonical snapshot for receipt enqueueing.
+
+    The canonical read happens before the ledger write because the deployed
+    canonical CRM and receivables pools are separate.  A missing/unavailable
+    canonical customer cannot create a new EOM payment, but the service checks
+    its existing idempotency key first so an unchanged retry still recovers the
+    original payment after a later contact edit or CRM outage.
+    """
+    receipt_recipient: PaymentReceiptRecipient | None = None
+    canonical_failure: HTTPException | None = None
+    require_receipt_recipient = True
+    try:
+        crm = _billing_crm_dependency(request)
+        customer = await crm.get_eom_payment_customer(body.contact_id)
+        if customer is None:
+            canonical_failure = HTTPException(
+                status_code=404,
+                detail={
+                    "code": "not_found",
+                    "message": "Customer not found",
+                },
+            )
+        else:
+            receipt_recipient = PaymentReceiptRecipient(
+                contact_id=UUID(str(customer["contact_id"])),
+                customer_name=str(customer["customer_name"]),
+                customer_type=str(customer["customer_type"]),
+                recipient_email=(
+                    str(customer["recipient_email"])
+                    if customer["recipient_email"] is not None
+                    else None
+                ),
+            )
+    except HTTPException as exc:
+        canonical_failure = exc
+    except Exception as exc:
+        if not _is_database_unavailable_error(exc):
+            raise
+        canonical_failure = HTTPException(
+            status_code=503,
+            detail={
+                "code": "canonical_customer_unavailable",
+                "message": "Canonical EOM customer data is unavailable",
+            },
         )
-    )
+
+    async def _write_payment() -> dict:
+        try:
+            return await service.create_payment(
+                contact_id=body.contact_id,
+                payer_name=body.payer_name,
+                total_amount=_dollars(body.total_amount_cents),
+                payment_method=body.payment_method,
+                received_date=body.received_date,
+                check_date=body.check_date,
+                received_through=body.received_through,
+                reference=body.reference,
+                notes=body.notes,
+                allocations=_allocations(body.allocations),
+                recorded_by=actor,
+                idempotency_key=idempotency_key,
+                allow_unapplied=True,
+                unapplied_contact_context_id=EOM_BUSINESS_CONTEXT_ID,
+                receipt_recipient=receipt_recipient,
+                require_receipt_recipient=require_receipt_recipient,
+            )
+        except ReceivablesReceiptContextRequiredError:
+            if canonical_failure is not None:
+                raise canonical_failure
+            raise
+
+    return await _call(_write_payment())
 
 
 @router.get("/payments")

--- a/atlas_brain/main_eom.py
+++ b/atlas_brain/main_eom.py
@@ -103,6 +103,7 @@ EOM_RECEIVABLES_READINESS_MIGRATIONS: tuple[str, ...] = (
     "344_receivables_payments",
     "345_receivables_event_key_lookup",
     "368_receivables_payment_check_metadata",
+    "369_receivables_payment_receipt_outbox",
 )
 
 

--- a/atlas_brain/services/crm_provider.py
+++ b/atlas_brain/services/crm_provider.py
@@ -2157,19 +2157,58 @@ class DatabaseCRMProvider:
         results.sort(key=lambda item: (item["displayName"] or "", item["contactId"]))
         return results
 
+    async def get_eom_payment_customer(
+        self, contact_id: UUID
+    ) -> dict[str, Any] | None:
+        """Return the canonical active customer snapshot for an EOM payment.
+
+        This is intentionally not the public billing-recipient projection.  A
+        residential payment remains valid without an email address, so it must
+        carry the active-customer identity and classified type while preserving
+        a normalized email-or-``None`` outcome for the ledger receipt outbox.
+        The query is tenant-scoped and admits only active account records.
+        """
+        from .eom_crm_mutations import normalize_contact_email
+        from .eom_lead_ingress import EOM_BUSINESS_CONTEXT_ID
+
+        row = await self._get_pool().fetchrow(
+            """
+            SELECT id, full_name, customer_type,
+                   btrim(COALESCE(email, ''), $3) AS email
+            FROM contacts
+            WHERE id = $1
+              AND business_context_id = $2
+              AND status = $4
+              AND contact_type = $5
+            """,
+            contact_id,
+            EOM_BUSINESS_CONTEXT_ID,
+            BILLING_RECIPIENT_BLANK_CHARS,
+            BILLING_RECIPIENT_ELIGIBLE_STATUS,
+            BILLING_RECIPIENT_ELIGIBLE_CONTACT_TYPE,
+        )
+        if row is None:
+            return None
+        return {
+            "contact_id": row["id"],
+            "customer_name": str(row["full_name"] or "").strip() or "Customer",
+            "customer_type": str(row["customer_type"] or "unknown"),
+            "recipient_email": normalize_contact_email(row["email"]),
+        }
+
     async def billing_recipients_schema_ready(self) -> bool:
-        """True when both billing-recipient queries could actually run.
+        """True when the billing-recipient and payment-customer reads work.
 
         An initialized pool only proves a connection opened. A configured but
         partially migrated database passes that check and then fails every
         recipient read with an undefined column, so readiness has to name the
-        columns the two queries depend on. LIMIT 0 validates them without
-        reading a row.
+        columns the queries depend on. LIMIT 0 validates them without reading
+        a row.
         """
         try:
             await self._get_pool().fetch(
                 """
-                SELECT id, full_name, email, status, contact_type,
+                SELECT id, full_name, email, status, contact_type, customer_type,
                        business_context_id
                 FROM contacts
                 LIMIT 0

--- a/atlas_brain/services/receivables.py
+++ b/atlas_brain/services/receivables.py
@@ -11,12 +11,15 @@ from decimal import Decimal, InvalidOperation
 from typing import Any, Iterable, Optional
 from uuid import UUID, uuid4
 
+from ..templates.email.payment_receipt import render_residential_payment_receipt
 from ..storage.database import DatabasePool, get_db_pool
 from ..storage.exceptions import DatabaseUnavailableError
 
 ACTIVE_PAYMENT_STATUSES = ("legacy", "received", "deposited", "cleared")
 OPEN_INVOICE_STATUSES = ("sent", "partial", "overdue")
 API_PAYMENT_METHODS = ("check", "ach", "square")
+EOM_CUSTOMER_TYPES = ("residential", "commercial", "unknown")
+RESIDENTIAL_CUSTOMER_TYPE = "residential"
 _CENT = Decimal("0.01")
 _MAX_DATABASE_MONEY = Decimal("9999999999.99")
 _RECEIVABLES_REQUIRED_COLUMNS = {
@@ -222,6 +225,69 @@ _RECEIVABLES_REQUIRED_INDEXES = (
     ),
 )
 
+# Receipt delivery is a capability layered onto the existing ledger.  It is
+# deliberately NOT part of the legacy receivables readiness set: full Atlas
+# and MCP callers must remain able to use the established payment lifecycle
+# while an EOM-only outbox migration rolls out.  The receipt-aware full and
+# slim EOM routes require this additive set explicitly.
+_RECEIPT_DELIVERY_REQUIRED_COLUMNS = {
+    "payment_receipt_deliveries": (
+        "id",
+        "payment_id",
+        "contact_id",
+        "receipt_number",
+        "recipient_email",
+        "delivery_status",
+        "skip_reason",
+        "subject",
+        "body",
+        "created_at",
+        "updated_at",
+    ),
+}
+_RECEIPT_DELIVERY_REQUIRED_INDEXES = (
+    (
+        "payment_receipt_deliveries",
+        "payment_receipt_deliveries_pkey",
+        True,
+        ("id",),
+        None,
+        "p",
+    ),
+    (
+        "payment_receipt_deliveries",
+        "payment_receipt_deliveries_payment_id_key",
+        True,
+        ("payment_id",),
+        None,
+        "u",
+    ),
+    (
+        "payment_receipt_deliveries",
+        "payment_receipt_deliveries_receipt_number_key",
+        True,
+        ("receipt_number",),
+        None,
+        "u",
+    ),
+    (
+        "payment_receipt_deliveries",
+        "idx_payment_receipt_deliveries_contact_created",
+        False,
+        ("contact_id", "created_at"),
+        None,
+        None,
+    ),
+    (
+        "payment_receipt_deliveries",
+        "idx_payment_receipt_deliveries_status_created",
+        False,
+        ("delivery_status", "created_at"),
+        None,
+        None,
+    ),
+)
+
 
 @dataclass(frozen=True)
 class PaymentCreationOutcome:
@@ -229,6 +295,16 @@ class PaymentCreationOutcome:
 
     payment: dict[str, Any]
     replayed: bool
+
+
+@dataclass(frozen=True)
+class PaymentReceiptRecipient:
+    """Canonical customer snapshot used only by receipt-aware EOM routes."""
+
+    contact_id: UUID
+    customer_name: str
+    customer_type: str
+    recipient_email: Optional[str]
 
 
 class ReceivablesError(Exception):
@@ -251,6 +327,12 @@ class ReceivablesConflictError(ReceivablesError):
 
 class ReceivablesSchemaUnavailableError(ReceivablesError):
     code = "schema_unavailable"
+
+
+class ReceivablesReceiptContextRequiredError(ReceivablesError):
+    """An EOM route could not prove a new payment's canonical customer."""
+
+    code = "canonical_customer_unavailable"
 
 
 def money(value: Any) -> Decimal:
@@ -332,10 +414,37 @@ class ReceivablesService:
         return pool
 
     async def is_ready(self) -> bool:
-        """Return whether every required ledger column and index is usable."""
+        """Return whether the established receivables ledger is usable.
+
+        This remains the compatibility readiness probe for full Atlas and MCP
+        callers.  Receipt delivery is an EOM-only additive capability and is
+        checked by :meth:`is_receipt_delivery_ready` instead.
+        """
+        return await self._schema_objects_ready(
+            required_columns=_RECEIVABLES_REQUIRED_COLUMNS,
+            required_indexes=_RECEIVABLES_REQUIRED_INDEXES,
+        )
+
+    async def is_receipt_delivery_ready(self) -> bool:
+        """Return whether the ledger and residential receipt outbox are usable."""
+        return (
+            await self.is_ready()
+            and await self._schema_objects_ready(
+                required_columns=_RECEIPT_DELIVERY_REQUIRED_COLUMNS,
+                required_indexes=_RECEIPT_DELIVERY_REQUIRED_INDEXES,
+            )
+        )
+
+    async def _schema_objects_ready(
+        self,
+        *,
+        required_columns: dict[str, tuple[str, ...]],
+        required_indexes: tuple[tuple[Any, ...], ...],
+    ) -> bool:
+        """Probe one closed schema contract without broadening another one."""
         required = [
             (table_name, column_name)
-            for table_name, columns in _RECEIVABLES_REQUIRED_COLUMNS.items()
+            for table_name, columns in required_columns.items()
             for column_name in columns
         ]
         columns_ready = bool(
@@ -396,7 +505,7 @@ class ReceivablesService:
             """,
             [
                 index_name
-                for _table_name, index_name, *_rest in _RECEIVABLES_REQUIRED_INDEXES
+                for _table_name, index_name, *_rest in required_indexes
             ],
         )
         actual_indexes = {
@@ -429,7 +538,7 @@ class ReceivablesService:
                 key_columns,
                 predicate,
                 constraint_type,
-            ) in _RECEIVABLES_REQUIRED_INDEXES
+            ) in required_indexes
         )
 
     async def list_open_invoices(
@@ -511,6 +620,8 @@ class ReceivablesService:
         enforce_api_methods: bool = True,
         allow_unapplied: bool = False,
         unapplied_contact_context_id: Optional[str] = None,
+        receipt_recipient: Optional[PaymentReceiptRecipient] = None,
+        require_receipt_recipient: bool = False,
     ) -> dict[str, Any]:
         """Create one receipt and all of its allocations atomically."""
         outcome = await self.create_payment_with_outcome(
@@ -531,6 +642,8 @@ class ReceivablesService:
             enforce_api_methods=enforce_api_methods,
             allow_unapplied=allow_unapplied,
             unapplied_contact_context_id=unapplied_contact_context_id,
+            receipt_recipient=receipt_recipient,
+            require_receipt_recipient=require_receipt_recipient,
         )
         return outcome.payment
 
@@ -554,6 +667,8 @@ class ReceivablesService:
         enforce_api_methods: bool = True,
         allow_unapplied: bool = False,
         unapplied_contact_context_id: Optional[str] = None,
+        receipt_recipient: Optional[PaymentReceiptRecipient] = None,
+        require_receipt_recipient: bool = False,
     ) -> PaymentCreationOutcome:
         """Create a receipt and report whether this call replayed its first write."""
         total = money(total_amount)
@@ -578,6 +693,20 @@ class ReceivablesService:
             raise ReceivablesValidationError(
                 "Unapplied payments require a canonical customer context"
             )
+        self._assert_receipt_recipient_invariant(
+            contact_id=contact_id,
+            receipt_recipient=receipt_recipient,
+        )
+        # A replay whose canonical CRM read is unavailable must still return
+        # its financial payment during a mixed migration rollout.  Do not
+        # query the EOM-only outbox merely because the caller *requires* a
+        # canonical context for a new payment: it may be a legacy payment
+        # created before migration 369.  A supplied residential snapshot is
+        # the only case that asks the response projection to read the outbox.
+        include_receipt_delivery = bool(
+            receipt_recipient is not None
+            and receipt_recipient.customer_type == RESIDENTIAL_CUSTOMER_TYPE
+        )
 
         normalized = self._normalize_allocations(
             allocations, allow_empty=allow_unapplied
@@ -642,8 +771,30 @@ class ReceivablesService:
             if existing:
                 self._assert_idempotent(existing, fingerprint)
                 return PaymentCreationOutcome(
-                    payment=await self._payment_view(conn, existing["id"]),
+                    payment=await self._payment_view(
+                        conn,
+                        existing["id"],
+                        include_receipt_delivery=include_receipt_delivery,
+                    ),
                     replayed=True,
+                )
+            if require_receipt_recipient and receipt_recipient is None:
+                # This check follows the first idempotency lookup on purpose:
+                # an unchanged retry must recover its original payment even if
+                # the canonical CRM contact has been edited or is unavailable
+                # after the original commit.  A new payment still fails before
+                # any financial row is inserted when an EOM route lacks an
+                # authoritative customer snapshot.
+                raise ReceivablesReceiptContextRequiredError(
+                    "Canonical customer data is required for a new EOM payment"
+                )
+            if (
+                receipt_recipient is not None
+                and receipt_recipient.customer_type == RESIDENTIAL_CUSTOMER_TYPE
+                and not await self.is_receipt_delivery_ready()
+            ):
+                raise ReceivablesSchemaUnavailableError(
+                    "Receivables schema unavailable for payment receipt delivery"
                 )
             await self._assert_event_key_available(
                 conn, key=key, fingerprint=fingerprint
@@ -672,7 +823,11 @@ class ReceivablesService:
             if existing:
                 self._assert_idempotent(existing, fingerprint)
                 return PaymentCreationOutcome(
-                    payment=await self._payment_view(conn, existing["id"]),
+                    payment=await self._payment_view(
+                        conn,
+                        existing["id"],
+                        include_receipt_delivery=include_receipt_delivery,
+                    ),
                     replayed=True,
                 )
 
@@ -775,11 +930,30 @@ class ReceivablesService:
                     )
                 self._assert_idempotent(existing, fingerprint)
                 return PaymentCreationOutcome(
-                    payment=await self._payment_view(conn, existing["id"]),
+                    payment=await self._payment_view(
+                        conn,
+                        existing["id"],
+                        include_receipt_delivery=include_receipt_delivery,
+                    ),
                     replayed=True,
                 )
 
             now = datetime.now(timezone.utc)
+            if (
+                receipt_recipient is not None
+                and receipt_recipient.customer_type == RESIDENTIAL_CUSTOMER_TYPE
+            ):
+                await self._enqueue_residential_payment_receipt(
+                    conn,
+                    payment_id=payment_id,
+                    receipt_recipient=receipt_recipient,
+                    payer_name=payer,
+                    total_amount=total,
+                    payment_method=method,
+                    reference=payload["reference"],
+                    received_date=received_date,
+                    created_at=now,
+                )
             for allocation in normalized:
                 await conn.execute(
                     """
@@ -818,7 +992,11 @@ class ReceivablesService:
                 conn, [item["invoice_id"] for item in normalized]
             )
             return PaymentCreationOutcome(
-                payment=await self._payment_view(conn, payment_id),
+                payment=await self._payment_view(
+                    conn,
+                    payment_id,
+                    include_receipt_delivery=include_receipt_delivery,
+                ),
                 replayed=False,
             )
 
@@ -1389,6 +1567,86 @@ class ReceivablesService:
             await self._recalculate_invoices(conn, [invoice_id])
 
     @staticmethod
+    def _assert_receipt_recipient_invariant(
+        *,
+        contact_id: Optional[UUID],
+        receipt_recipient: Optional[PaymentReceiptRecipient],
+    ) -> None:
+        """Reject malformed internal receipt context before a new write.
+
+        The public HTTP body never carries these fields: EOM routes resolve
+        them from their canonical CRM provider.  This defensive check keeps a
+        future direct caller from attaching one customer's receipt metadata to
+        another customer's payment.
+        """
+        if receipt_recipient is None:
+            return
+        if not isinstance(receipt_recipient, PaymentReceiptRecipient):
+            raise ReceivablesValidationError("Receipt customer context is invalid")
+        if contact_id is None or receipt_recipient.contact_id != contact_id:
+            raise ReceivablesValidationError(
+                "Receipt customer context must match the payment customer"
+            )
+        if receipt_recipient.customer_type not in EOM_CUSTOMER_TYPES:
+            raise ReceivablesValidationError("Receipt customer type is invalid")
+        if not receipt_recipient.customer_name.strip():
+            raise ReceivablesValidationError("Receipt customer name is required")
+        if receipt_recipient.recipient_email is not None:
+            from .eom_crm_mutations import normalize_contact_email
+
+            if (
+                normalize_contact_email(receipt_recipient.recipient_email)
+                != receipt_recipient.recipient_email
+            ):
+                raise ReceivablesValidationError("Receipt email is invalid")
+
+    @staticmethod
+    async def _enqueue_residential_payment_receipt(
+        conn: Any,
+        *,
+        payment_id: UUID,
+        receipt_recipient: PaymentReceiptRecipient,
+        payer_name: str,
+        total_amount: Decimal,
+        payment_method: str,
+        reference: Optional[str],
+        received_date: date,
+        created_at: datetime,
+    ) -> None:
+        """Persist one non-sending receipt record in the payment transaction."""
+        receipt_number, subject, body = render_residential_payment_receipt(
+            payment_id=payment_id,
+            customer_name=receipt_recipient.customer_name.strip(),
+            payer_name=payer_name,
+            total_amount=total_amount,
+            payment_method=payment_method,
+            reference=reference,
+            received_date=received_date,
+        )
+        recipient_email = receipt_recipient.recipient_email
+        status = "pending" if recipient_email else "skipped"
+        skip_reason = None if recipient_email else "no_email"
+        await conn.execute(
+            """
+            INSERT INTO payment_receipt_deliveries (
+                id, payment_id, contact_id, receipt_number, recipient_email,
+                delivery_status, skip_reason, subject, body, created_at, updated_at
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $10)
+            """,
+            uuid4(),
+            payment_id,
+            receipt_recipient.contact_id,
+            receipt_number,
+            recipient_email,
+            status,
+            skip_reason,
+            subject,
+            body,
+            created_at,
+        )
+
+    @staticmethod
     def _normalize_allocations(
         allocations: list[dict[str, Any]],
         *,
@@ -1630,7 +1888,13 @@ class ReceivablesService:
             datetime.now(timezone.utc),
         )
 
-    async def _payment_view(self, conn: Any, payment_id: UUID) -> dict[str, Any]:
+    async def _payment_view(
+        self,
+        conn: Any,
+        payment_id: UUID,
+        *,
+        include_receipt_delivery: bool = False,
+    ) -> dict[str, Any]:
         row = await conn.fetchrow(
             """
             SELECT cp.*, pdi.batch_id
@@ -1655,11 +1919,39 @@ class ReceivablesService:
             """,
             payment_id,
         )
-        return self._compose_payment(row, allocations)
+        receipt_delivery = None
+        if include_receipt_delivery:
+            receipt_delivery = await conn.fetchrow(
+                """
+                SELECT receipt_number, recipient_email,
+                       delivery_status AS status, skip_reason
+                FROM payment_receipt_deliveries
+                WHERE payment_id = $1
+                """,
+                payment_id,
+            )
+        return self._compose_payment(
+            row,
+            allocations,
+            receipt_delivery=receipt_delivery,
+            include_receipt_delivery=include_receipt_delivery,
+        )
 
     @staticmethod
-    def _compose_payment(row: Any, allocations: list[Any]) -> dict[str, Any]:
+    def _compose_payment(
+        row: Any,
+        allocations: list[Any],
+        *,
+        receipt_delivery: Optional[Any] = None,
+        include_receipt_delivery: bool = False,
+    ) -> dict[str, Any]:
         result = _serialize_row(row)
+        if include_receipt_delivery:
+            result["receipt_delivery"] = (
+                _serialize_row(receipt_delivery)
+                if receipt_delivery is not None
+                else None
+            )
         allocation_views = [_serialize_row(item) for item in allocations]
         active_allocated = Decimal("0")
         is_active = row["status"] in ACTIVE_PAYMENT_STATUSES

--- a/atlas_brain/services/receivables.py
+++ b/atlas_brain/services/receivables.py
@@ -413,7 +413,7 @@ class ReceivablesService:
             raise DatabaseUnavailableError("receivables ledger")
         return pool
 
-    async def is_ready(self) -> bool:
+    async def is_ready(self, conn: Any | None = None) -> bool:
         """Return whether the established receivables ledger is usable.
 
         This remains the compatibility readiness probe for full Atlas and MCP
@@ -421,15 +421,17 @@ class ReceivablesService:
         checked by :meth:`is_receipt_delivery_ready` instead.
         """
         return await self._schema_objects_ready(
+            conn,
             required_columns=_RECEIVABLES_REQUIRED_COLUMNS,
             required_indexes=_RECEIVABLES_REQUIRED_INDEXES,
         )
 
-    async def is_receipt_delivery_ready(self) -> bool:
+    async def is_receipt_delivery_ready(self, conn: Any | None = None) -> bool:
         """Return whether the ledger and residential receipt outbox are usable."""
         return (
-            await self.is_ready()
+            await self.is_ready(conn)
             and await self._schema_objects_ready(
+                conn,
                 required_columns=_RECEIPT_DELIVERY_REQUIRED_COLUMNS,
                 required_indexes=_RECEIPT_DELIVERY_REQUIRED_INDEXES,
             )
@@ -437,18 +439,20 @@ class ReceivablesService:
 
     async def _schema_objects_ready(
         self,
+        conn: Any | None = None,
         *,
         required_columns: dict[str, tuple[str, ...]],
         required_indexes: tuple[tuple[Any, ...], ...],
     ) -> bool:
         """Probe one closed schema contract without broadening another one."""
+        executor = conn if conn is not None else self.pool
         required = [
             (table_name, column_name)
             for table_name, columns in required_columns.items()
             for column_name in columns
         ]
         columns_ready = bool(
-            await self.pool.fetchval(
+            await executor.fetchval(
                 """
                 SELECT NOT EXISTS (
                     SELECT 1
@@ -470,7 +474,7 @@ class ReceivablesService:
         if not columns_ready:
             return False
 
-        index_rows = await self.pool.fetch(
+        index_rows = await executor.fetch(
             """
             SELECT
                 table_class.relname AS table_name,
@@ -697,13 +701,7 @@ class ReceivablesService:
             contact_id=contact_id,
             receipt_recipient=receipt_recipient,
         )
-        # A replay whose canonical CRM read is unavailable must still return
-        # its financial payment during a mixed migration rollout.  Do not
-        # query the EOM-only outbox merely because the caller *requires* a
-        # canonical context for a new payment: it may be a legacy payment
-        # created before migration 369.  A supplied residential snapshot is
-        # the only case that asks the response projection to read the outbox.
-        include_receipt_delivery = bool(
+        is_residential_receipt = bool(
             receipt_recipient is not None
             and receipt_recipient.customer_type == RESIDENTIAL_CUSTOMER_TYPE
         )
@@ -774,7 +772,13 @@ class ReceivablesService:
                     payment=await self._payment_view(
                         conn,
                         existing["id"],
-                        include_receipt_delivery=include_receipt_delivery,
+                        include_receipt_delivery=(
+                            await self._has_replay_receipt_delivery(
+                                conn,
+                                payment_id=existing["id"],
+                                require_receipt_recipient=require_receipt_recipient,
+                            )
+                        ),
                     ),
                     replayed=True,
                 )
@@ -788,10 +792,8 @@ class ReceivablesService:
                 raise ReceivablesReceiptContextRequiredError(
                     "Canonical customer data is required for a new EOM payment"
                 )
-            if (
-                receipt_recipient is not None
-                and receipt_recipient.customer_type == RESIDENTIAL_CUSTOMER_TYPE
-                and not await self.is_receipt_delivery_ready()
+            if is_residential_receipt and not await self.is_receipt_delivery_ready(
+                conn
             ):
                 raise ReceivablesSchemaUnavailableError(
                     "Receivables schema unavailable for payment receipt delivery"
@@ -826,7 +828,13 @@ class ReceivablesService:
                     payment=await self._payment_view(
                         conn,
                         existing["id"],
-                        include_receipt_delivery=include_receipt_delivery,
+                        include_receipt_delivery=(
+                            await self._has_replay_receipt_delivery(
+                                conn,
+                                payment_id=existing["id"],
+                                require_receipt_recipient=require_receipt_recipient,
+                            )
+                        ),
                     ),
                     replayed=True,
                 )
@@ -933,7 +941,13 @@ class ReceivablesService:
                     payment=await self._payment_view(
                         conn,
                         existing["id"],
-                        include_receipt_delivery=include_receipt_delivery,
+                        include_receipt_delivery=(
+                            await self._has_replay_receipt_delivery(
+                                conn,
+                                payment_id=existing["id"],
+                                require_receipt_recipient=require_receipt_recipient,
+                            )
+                        ),
                     ),
                     replayed=True,
                 )
@@ -995,7 +1009,7 @@ class ReceivablesService:
                 payment=await self._payment_view(
                     conn,
                     payment_id,
-                    include_receipt_delivery=include_receipt_delivery,
+                    include_receipt_delivery=is_residential_receipt,
                 ),
                 replayed=False,
             )
@@ -1935,6 +1949,39 @@ class ReceivablesService:
             allocations,
             receipt_delivery=receipt_delivery,
             include_receipt_delivery=include_receipt_delivery,
+        )
+
+    async def _has_replay_receipt_delivery(
+        self,
+        conn: Any,
+        *,
+        payment_id: UUID,
+        require_receipt_recipient: bool,
+    ) -> bool:
+        """Read a receipt projection only when an EOM replay can prove it exists.
+
+        The original receipt is immutable payment evidence, whereas the CRM
+        customer type is mutable.  An unchanged retry must therefore derive
+        its projection from the committed outbox row.  The held transaction
+        connection performs the readiness/catalog probe so this path never
+        tries to acquire a second pool connection.  A pre-369 ledger simply
+        returns no projection without querying its missing outbox table.
+        """
+        if not require_receipt_recipient:
+            return False
+        if not await self.is_receipt_delivery_ready(conn):
+            return False
+        return bool(
+            await conn.fetchval(
+                """
+                SELECT EXISTS (
+                    SELECT 1
+                    FROM payment_receipt_deliveries
+                    WHERE payment_id = $1
+                )
+                """,
+                payment_id,
+            )
         )
 
     @staticmethod

--- a/atlas_brain/storage/migrations/369_receivables_payment_receipt_outbox.sql
+++ b/atlas_brain/storage/migrations/369_receivables_payment_receipt_outbox.sql
@@ -1,0 +1,68 @@
+-- Durable, non-sending receipt-delivery evidence for residential payments.
+--
+-- This belongs beside customer_payments in the receivables ledger, not in a
+-- mail provider or the separate canonical-CRM pool.  A payment and its receipt
+-- enqueue must commit or roll back together; transport delivery happens later,
+-- outside that financial transaction.
+--
+-- One row per payment is the idempotency anchor.  A retry of the same payment
+-- returns the original payment before this INSERT is reachable, and this UNIQUE
+-- constraint remains the database backstop if a future writer is wrong.
+--
+-- Delivery state is deliberately closed.  This migration writes no sent-mail
+-- evidence: a future sender must move pending/failed rows only after an
+-- explicit claim and verifiable transport result.  `skipped/no_email` records
+-- that the payment is valid but its canonical customer had no usable address;
+-- it must never be mistaken for a send failure or an unrecorded payment.
+--
+-- Rollback evidence:
+--   Revert application code first and retain this additive evidence table.
+--   A separately authorized destructive teardown, only after no deployed
+--   reader/writer remains, may run:
+--       DROP TABLE payment_receipt_deliveries;
+--   Never use that as an ordinary rollback: it destroys payment-receipt audit
+--   evidence and breaks a mixed-version deployment that reads delivery status.
+--
+-- Roll-forward safety:
+--   Existing payment, allocation, deposit, clearing, return, void, and MCP
+--   paths do not reference this table until the receipt-aware EOM release is
+--   deployed.  The table is purely additive and has no trigger on legacy
+--   financial rows.
+
+CREATE TABLE IF NOT EXISTS payment_receipt_deliveries (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    payment_id UUID NOT NULL REFERENCES customer_payments(id) ON DELETE RESTRICT,
+    contact_id UUID NOT NULL REFERENCES contacts(id) ON DELETE RESTRICT,
+    receipt_number VARCHAR(64) NOT NULL UNIQUE,
+    recipient_email VARCHAR(256),
+    delivery_status VARCHAR(16) NOT NULL
+        CHECK (delivery_status IN ('pending', 'sent', 'failed', 'skipped')),
+    skip_reason VARCHAR(32),
+    subject VARCHAR(500) NOT NULL,
+    body TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT payment_receipt_deliveries_payment_id_key UNIQUE (payment_id),
+    CONSTRAINT chk_payment_receipt_deliveries_delivery_shape CHECK (
+        (
+            delivery_status = 'skipped'
+            AND recipient_email IS NULL
+            AND skip_reason = 'no_email'
+        )
+        OR
+        (
+            delivery_status IN ('pending', 'sent', 'failed')
+            AND recipient_email IS NOT NULL
+            AND skip_reason IS NULL
+        )
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_payment_receipt_deliveries_contact_created
+    ON payment_receipt_deliveries (contact_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_payment_receipt_deliveries_status_created
+    ON payment_receipt_deliveries (delivery_status, created_at ASC);
+
+COMMENT ON TABLE payment_receipt_deliveries IS
+    'One durable non-sending residential payment receipt outbox row per customer payment; pending/sent/failed/skipped tracks delivery separately from financial lifecycle.';

--- a/atlas_brain/templates/email/payment_receipt.py
+++ b/atlas_brain/templates/email/payment_receipt.py
@@ -1,0 +1,67 @@
+"""Deterministic plain-text payment receipt for Effingham Office Maids."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from uuid import UUID
+
+from .invoice import (
+    BUSINESS_ADDRESS,
+    BUSINESS_EMAIL,
+    BUSINESS_NAME,
+    BUSINESS_PHONE,
+    BUSINESS_WEBSITE,
+)
+
+_PAYMENT_METHOD_LABELS = {
+    "check": "Check",
+    "ach": "ACH",
+    "square": "Square",
+}
+
+
+def receipt_number_for_payment(payment_id: UUID) -> str:
+    """Return the stable receipt number for one persisted payment."""
+    return f"EOM-RCP-{payment_id}"
+
+
+def render_residential_payment_receipt(
+    *,
+    payment_id: UUID,
+    customer_name: str,
+    payer_name: str,
+    total_amount: Decimal,
+    payment_method: str,
+    reference: str | None,
+    received_date: date,
+) -> tuple[str, str, str]:
+    """Render the immutable receipt number, subject, and plain-text body."""
+    receipt_number = receipt_number_for_payment(payment_id)
+    method = _PAYMENT_METHOD_LABELS[payment_method]
+    reference_label = "Check number" if payment_method == "check" else "Reference"
+    reference_value = reference or "Not provided"
+    check_status = (
+        "\nWe have received your check. It has not yet cleared.\n"
+        if payment_method == "check"
+        else ""
+    )
+    subject = f"Payment received — receipt {receipt_number}"
+    body = (
+        f"Thank you. {BUSINESS_NAME} has received your payment.\n\n"
+        f"Customer: {customer_name}\n"
+        f"Payer: {payer_name}\n"
+        f"Receipt number: {receipt_number}\n"
+        f"Amount received: ${total_amount:.2f}\n"
+        f"Payment method: {method}\n"
+        f"{reference_label}: {reference_value}\n"
+        f"Date received: {received_date.strftime('%B')} {received_date.day}, "
+        f"{received_date.year}\n"
+        f"{check_status}\n"
+        f"Questions? Contact {BUSINESS_NAME}\n"
+        f"{BUSINESS_ADDRESS}\n"
+        f"{BUSINESS_PHONE}\n"
+        f"{BUSINESS_EMAIL}\n"
+        f"{BUSINESS_WEBSITE}\n"
+    )
+    return receipt_number, subject, body

--- a/plans/PR-EOM-Residential-Receipt-Outbox.md
+++ b/plans/PR-EOM-Residential-Receipt-Outbox.md
@@ -1,0 +1,145 @@
+# PR-EOM-Residential-Receipt-Outbox
+
+## Why this slice exists
+
+Billing & Payments coordination issue [#2362](https://github.com/canfieldjuan/ATLAS/issues/2362) requires a residential payment to commit even when email cannot be delivered, while retaining one durable, retry-safe receipt-delivery record.  The current receivables transaction persists a payment, allocations, and a payment event, but has no receipt number, receipt email snapshot, or delivery status.  The current Gmail and Resend send abstractions also do not accept a caller-owned idempotency key, so calling either transport from the payment transaction would make an uncertain HTTP failure indistinguishable from a duplicate customer email.
+
+### Problem-derived contract
+
+- Root cause: the financial payment transaction has no durable, payment-keyed receipt outbox; neither the deployed full EOM route nor the slim EOM profile resolves customer type/email from its authoritative CRM before committing a payment.  The user-required draft-PR workflow also leaked its one-shot draft-consent environment variable into local verification, invalidating the wrapper's own no-consent safety fixtures.
+- Correct fix must touch/change: add an additive ledger-side receipt-outbox table and readiness migration; have both EOM payment routes obtain an active canonical customer snapshot from their respective CRM boundary; atomically create one residential receipt record with the payment; render stable receipt contents and expose a minimal delivery projection; test transaction/replay/no-email/failure-before-write behavior; consume draft consent after argv admission before invoking local verification.
+- Must not change: payment amounts, allocations, idempotency fingerprints, check/deposit/clearing/return/void lifecycle, generic MCP invoicing behavior, Gmail/Resend transport behavior, or any real customer email delivery.
+
+## Scope (this PR)
+
+Ownership lane: eom/billing-receipts
+Slice phase: Vertical slice
+Max files: 15
+
+1. `POST /api/v1/receivables/payments` on both the deployed full EOM application and the slim EOM profile will read the active canonical EOM customer before the financial write.  A residential snapshot creates exactly one payment-keyed receipt record in the same ledger transaction: `pending` with a canonical email, or `skipped` with `no_email` when no usable canonical email exists.  Commercial and unknown customers receive no residential receipt record.
+2. A payment created with a canonical residential snapshot will add a
+   receipt-delivery projection containing receipt number, recipient, and
+   status.  The payment itself remains valid and committed when the email is
+   absent; this slice deliberately queues only and never calls Gmail or
+   Resend.  A retry whose current CRM snapshot is unavailable still returns an
+   old financial payment without querying an outbox that may not yet exist.
+3. The receipt template will be deterministic from the persisted payment/customer snapshot, include the requested customer/payer/number/amount/method/reference/received date/EOM contact details, and state only that a check was received, never cleared.
+4. The full migration runner and the slim EOM startup migration list will install the new additive schema before either receipt-aware route is reachable.  A missing outbox schema makes the new residential receipt path fail closed before it can create a payment; generic service/MCP callers that do not opt into receipt context retain their existing behavior.
+5. The existing `scripts/open_pr.sh` draft-consent check remains mandatory at argv admission, but its consent value is removed from the child local-review environment.  This preserves draft authorization while allowing the local suite to independently prove that unauthorised draft flags fail closed.
+
+### Review Contract
+
+- Acceptance criteria:
+  - `ReceivablesService.create_payment_with_outcome` inserts the payment, event, allocations, and (when a residential context is supplied) one receipt delivery in one database transaction; a same-key replay returns the original payment and cannot insert a second receipt -- settled by `tests/test_receivables.py` unit and local-Postgres transaction tests.
+  - A canonical active residential customer with a valid email yields a `pending` delivery whose persisted subject/body/receipt number contain the payment facts and check-received wording; no-email yields `skipped/no_email` while the payment still exists -- settled by focused service/template tests.
+  - The deployed full and slim `POST /api/v1/receivables/payments` routes resolve the active canonical customer before invoking the ledger and return a controlled failure without a ledger write when that canonical read is unavailable or refuses the contact -- settled by full direct-route and slim ASGI tests with recording service/CRM doubles, plus isolated PostgreSQL HTTP entrypoint coverage.
+  - `EOM_RECEIVABLES_READINESS_MIGRATIONS` includes the receipt-outbox migration and a fresh, isolated local PostgreSQL schema reaches receivables readiness; removal of the outbox relation is detected only for receipt-enabled use -- settled by `tests/test_receivables.py::test_eom_receivables_readiness_migration_set_builds_ready_schema` and focused readiness tests.
+  - This slice has no path to Gmail, Resend, a real customer address, or a transport call; the next send/retry slice must introduce an idempotent transport/reconciliation contract -- settled by diff review and focused test doubles.
+  - A user-authorized `--draft` remains accepted by `scripts/open_pr.sh`, while its final local review sees no draft-consent value and therefore cannot mutate the wrapper's no-consent safety fixture behavior -- settled by `tests/test_open_pr_wrapper.py::test_open_pr_consumes_draft_consent_before_local_review`.
+- Reachability proof: authenticated full and slim EOM `POST /api/v1/receivables/payments` are exercised through direct/ASGI tests; the isolated full HTTP entrypoint produces a returned receipt-delivery projection and one persisted row in the isolated ledger schema.
+- Affected surfaces: full and slim EOM receivables routes, canonical CRM customer projection, receivables service/payment response, full migration runner and EOM startup migration tuple, receipt template, draft-PR local-review environment boundary, isolated migration/service/API tests.
+- Risk areas: money transaction atomicity, duplicate retries, active-canonical-customer admission, full-primary versus slim-canonical-pool preflight ordering, email/privacy exposure, migration rollout, generic MCP compatibility, customer-visible receipt wording, draft-consent leakage into child verification.
+- Reviewer rules triggered: R1, R2, R3, R4, R5, R6, R8, R10, R11, R12, R14.
+
+### Boundary-change enumeration
+
+Closure declaration: CLOSED.  Customer classification remains the existing database-enforced `residential|commercial|unknown` set in migration 366 / `EOM_CUSTOMER_TYPES`; this PR only recognizes the exact `residential` member for the new receipt path and safely treats every other admitted member as no residential receipt.  Receipt-delivery status is a new database-enforced closed set: `pending|sent|failed|skipped`; this slice writes only `pending` and `skipped`.
+
+- Boundary path/seam: deployed full and slim `POST /api/v1/receivables/payments` gain a canonical CRM preflight and pass an internal receipt context to the ledger; `DatabaseCRMProvider` gains a narrow active-customer payment projection.
+- Replaced-path behaviors: none.  The request body and payment fingerprint remain unchanged; full Atlas/MCP callers do not supply a receipt context and keep their existing route behavior.
+- Guard-relevant fields: canonical `id`, `business_context_id`, `contact_type`, `status`, `customer_type`, `full_name`, and normalized `email`; ledger `payment_id` and receipt `delivery_status`.
+- Caller x input shape: existing authenticated full and slim callers x every valid payment body retain the same body contract.  The canonical read must return an active `effingham_maids` customer; a nonmatching/missing/unavailable canonical contact fails before the payment transaction.  Only `customer_type == residential` receives an outbox row; blank/malformed email becomes `skipped/no_email` rather than an email attempt.
+
+### Deployed-config probing
+
+- Deployed/default config values: the deployed full application reads canonical customer identity through its initialized primary CRM provider; the slim profile continues to use the existing `ATLAS_EOM_FUNNEL_DB_CONNECTION_STRING` path guarded by `ATLAS_EOM_CANONICAL_CRM_DATABASE_CONFIRMED`.  Ledger schema setup uses the full migration runner and the existing EOM migration startup switch.
+- Explicit value probe: route tests provide a configured recording canonical CRM provider and prove its normalized residential/no-email outputs control the receipt row.
+- Absent value probe: route tests prove an unavailable canonical CRM dependency answers a controlled error before `create_payment` is invoked; the receipt-enabled ledger path rejects a missing outbox relation before writing.
+- Default-session/default-context probe: generic service/MCP tests preserve a `receipt_recipient=None` payment path and do not require canonical CRM configuration; both receipt-aware EOM HTTP routes require canonical context only for a new payment and still recover a same-key replay.
+- Side-effect ordering: canonical snapshot read first; ledger payment/event/outbox row atomically commit second; transport send is intentionally absent and therefore cannot precede or roll back financial state.
+
+### Files touched
+
+- `.github/workflows/atlas_invoicing_checks.yml`
+- `atlas_brain/api/invoicing/receivables.py`
+- `atlas_brain/eom_api/receivables.py`
+- `atlas_brain/main_eom.py`
+- `atlas_brain/services/crm_provider.py`
+- `atlas_brain/services/receivables.py`
+- `atlas_brain/storage/migrations/369_receivables_payment_receipt_outbox.sql`
+- `atlas_brain/templates/email/payment_receipt.py`
+- `plans/PR-EOM-Residential-Receipt-Outbox.md`
+- `scripts/open_pr.sh`
+- `tests/test_eom_billing_recipients.py`
+- `tests/test_eom_payment_receipts.py`
+- `tests/test_eom_render_profile.py`
+- `tests/test_open_pr_wrapper.py`
+- `tests/test_receivables.py`
+
+## Mechanism
+
+The deployed full route reads the narrow active-customer projection through its primary `DatabaseCRMProvider`; the slim route reads the same projection through its separately configured canonical CRM pool.  Each passes a typed internal snapshot to `ReceivablesService`; no client body can supply classification or recipient data.  The service creates the payment exactly as it does today, then—in the same transaction and only on the first successful payment insert—creates one `payment_receipt_deliveries` row keyed uniquely by `payment_id`.  The random payment UUID anchors a deterministic `EOM-RCP-<payment-id>` receipt number; the stored subject/body are rendered once from that snapshot and the immutable payment facts.
+
+The row is `pending` only when the canonical email normalizes successfully.  Otherwise it is `skipped` with `no_email`; no email transport is invoked.  Payment idempotency is checked and locked before any new payment/outbox insert, so same-key retries return the prior financial payment and delivery projection.  The outbox is deliberately separate from Gmail: a later slice will claim delivery, send outside the transaction with a transport idempotency/reconciliation strategy, then transition to `sent` or `failed` without creating a new payment.
+
+The receipt table is additive and is not placed in the canonical CRM database: it is financial lifecycle evidence owned by the receivables ledger.  Canonical identity is a read-before-write preflight: the full route uses the primary CRM provider and the slim profile uses its separate canonical pool.  Failure to obtain that snapshot fails closed before a new ledger transaction while an unchanged retry can still recover its already committed payment.  The stored snapshot makes the committed receipt deterministic even if the contact later changes.
+
+`open_pr.sh` validates draft consent before any network or Git side effect, then invokes its final local review with that one-shot consent removed.  The consent remains required to reach the draft create mutation, while a child test process cannot inherit approval for its own independent admission checks.
+
+## Intentional
+
+- No Gmail draft/send, Resend send, background worker, automatic retry, or browser UI is added.  The current sender API cannot prove an uncertain send was unique, and a receipt delivery failure must never roll back a payment.
+- `commercial` and `unknown` customer types produce no residential receipt delivery rather than a guessed recipient or a fake invoice.
+- The deployed full EOM HTTP route intentionally becomes receipt-aware because it has the authoritative primary CRM dependency; generic service and MCP callers receive no new implicit receipt behavior because they do not pass receipt context.  This preserves existing MCP callers while the website/tracker path gains the durable provider capability.
+- Receipt number uses the full persisted payment UUID rather than a mutable/sequence-based display counter, making retries deterministic without adding a counter race or a destructive reset procedure.
+- The small workflow correction is limited to draft-consent environment hygiene because the user-required draft path could not otherwise complete its mandatory local test gate; it does not relax consent, alter GitHub mutation targets, or change financial behavior.
+
+## Deferred
+
+- Slice 5 follow-up: tracker and Website show the canonical recipient before submit and display receipt status/retry controls.
+- Slice 5/9 follow-up: an explicit, idempotent send/reconciliation worker transitions pending/failed rows without duplicate email and records delivery evidence.
+- Customer-ledger slice: paginate/search/filter receipt delivery status alongside payments.
+
+Parking predicate: this PR parks unrelated billing-run, invoice/PDF/Gmail-draft, Square, generic email-provider, and presentation hardening unless it directly violates the atomic receipt-outbox contract above.  Parked hardening: none.
+
+## Verification
+
+- Passed locally: `ruff check --ignore E402` and `python -m compileall` on every
+  changed Python file; `git diff --check`; guard-class closure with a documented
+  closed-schema heuristic waiver; plan
+  audit and sync/check.  `main_eom.py` retains its pre-existing E402 bootstrap
+  import ordering, so the changed-file lint uses the repository's established
+  E402 exclusion rather than changing unrelated startup structure.
+- Passed locally: receipt-focused service/route coverage, plus isolated
+  PostgreSQL migration/readiness/rollback/recovery/mixed-rollout coverage.
+- Passed locally: the exact invoicing CI selections -- 2
+  monthly approval-blocker tests; 213 EOM/receivables/billing-recipient/
+  receipt/repository tests against a disposable local PostgreSQL 16 container;
+  and 43 MCP/OAuth regression tests.  No production payment, invoice, Gmail
+  draft, or customer email was created.
+- Passed locally: `tests/test_open_pr_wrapper.py` including the draft-consent
+  child-environment regression.
+- Pending before push: the repository local PR-contract bundle run by
+  `scripts/push_pr.sh`; hosted GitHub checks will not be manually dispatched
+  or rerun because local verification is the requested acceptance gate.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_invoicing_checks.yml` | 7 |
+| `atlas_brain/api/invoicing/receivables.py` | 91 |
+| `atlas_brain/eom_api/receivables.py` | 99 |
+| `atlas_brain/main_eom.py` | 1 |
+| `atlas_brain/services/crm_provider.py` | 47 |
+| `atlas_brain/services/receivables.py` | 314 |
+| `atlas_brain/storage/migrations/369_receivables_payment_receipt_outbox.sql` | 68 |
+| `atlas_brain/templates/email/payment_receipt.py` | 67 |
+| `plans/PR-EOM-Residential-Receipt-Outbox.md` | 145 |
+| `scripts/open_pr.sh` | 6 |
+| `tests/test_eom_billing_recipients.py` | 6 |
+| `tests/test_eom_payment_receipts.py` | 395 |
+| `tests/test_eom_render_profile.py` | 10 |
+| `tests/test_open_pr_wrapper.py` | 24 |
+| `tests/test_receivables.py` | 682 |
+| **Total** | **1962** |

--- a/plans/PR-EOM-Residential-Receipt-Outbox.md
+++ b/plans/PR-EOM-Residential-Receipt-Outbox.md
@@ -4,6 +4,13 @@
 
 Billing & Payments coordination issue [#2362](https://github.com/canfieldjuan/ATLAS/issues/2362) requires a residential payment to commit even when email cannot be delivered, while retaining one durable, retry-safe receipt-delivery record.  The current receivables transaction persists a payment, allocations, and a payment event, but has no receipt number, receipt email snapshot, or delivery status.  The current Gmail and Resend send abstractions also do not accept a caller-owned idempotency key, so calling either transport from the payment transaction would make an uncertain HTTP failure indistinguishable from a duplicate customer email.
 
+This diff intentionally exceeds the 400-line soft budget because the migration,
+canonical-customer preflight in both supported HTTP profiles, atomic ledger
+write, readiness admission, and rollback/replay proof are one financial
+transaction contract.  Splitting them would either ship no usable receipt
+behavior or expose a receipt-aware payment route without durable recovery
+evidence.
+
 ### Problem-derived contract
 
 - Root cause: the financial payment transaction has no durable, payment-keyed receipt outbox; neither the deployed full EOM route nor the slim EOM profile resolves customer type/email from its authoritative CRM before committing a payment.  The user-required draft-PR workflow also leaked its one-shot draft-consent environment variable into local verification, invalidating the wrapper's own no-consent safety fixtures.
@@ -32,7 +39,9 @@ Max files: 15
 - Acceptance criteria:
   - `ReceivablesService.create_payment_with_outcome` inserts the payment, event, allocations, and (when a residential context is supplied) one receipt delivery in one database transaction; a same-key replay returns the original payment and cannot insert a second receipt -- settled by `tests/test_receivables.py` unit and local-Postgres transaction tests.
   - A canonical active residential customer with a valid email yields a `pending` delivery whose persisted subject/body/receipt number contain the payment facts and check-received wording; no-email yields `skipped/no_email` while the payment still exists -- settled by focused service/template tests.
-  - The deployed full and slim `POST /api/v1/receivables/payments` routes resolve the active canonical customer before invoking the ledger and return a controlled failure without a ledger write when that canonical read is unavailable or refuses the contact -- settled by full direct-route and slim ASGI tests with recording service/CRM doubles, plus isolated PostgreSQL HTTP entrypoint coverage.
+  - The deployed full and slim `POST /api/v1/receivables/payments` routes resolve the active canonical customer before invoking the ledger and return a controlled failure without a ledger write when that canonical read is unavailable, schema-incompatible, permission-denied, or refuses the contact -- settled by full direct-route and slim ASGI tests with recording service/CRM doubles, plus isolated PostgreSQL HTTP entrypoint coverage.
+  - A slim receipt-aware profile without its canonical-contact DSN reports `billing_recipients_unavailable` from readiness; a configured but unreachable, partially migrated, or unauthorized canonical CRM follows the same controlled readiness admission -- settled by real-profile and focused readiness tests.
+  - A same-key EOM retry derives its receipt projection from the committed outbox row, not the mutable current customer classification; the receipt readiness probe uses the already-held ledger transaction connection, so a max-one/saturated pool cannot deadlock itself -- settled by reclassification and held-connection service tests.
   - `EOM_RECEIVABLES_READINESS_MIGRATIONS` includes the receipt-outbox migration and a fresh, isolated local PostgreSQL schema reaches receivables readiness; removal of the outbox relation is detected only for receipt-enabled use -- settled by `tests/test_receivables.py::test_eom_receivables_readiness_migration_set_builds_ready_schema` and focused readiness tests.
   - This slice has no path to Gmail, Resend, a real customer address, or a transport call; the next send/retry slice must introduce an idempotent transport/reconciliation contract -- settled by diff review and focused test doubles.
   - A user-authorized `--draft` remains accepted by `scripts/open_pr.sh`, while its final local review sees no draft-consent value and therefore cannot mutate the wrapper's no-consent safety fixture behavior -- settled by `tests/test_open_pr_wrapper.py::test_open_pr_consumes_draft_consent_before_local_review`.
@@ -113,7 +122,7 @@ Parking predicate: this PR parks unrelated billing-run, invoice/PDF/Gmail-draft,
 - Passed locally: receipt-focused service/route coverage, plus isolated
   PostgreSQL migration/readiness/rollback/recovery/mixed-rollout coverage.
 - Passed locally: the exact invoicing CI selections -- 2
-  monthly approval-blocker tests; 213 EOM/receivables/billing-recipient/
+  monthly approval-blocker tests; 217 EOM/receivables/billing-recipient/
   receipt/repository tests against a disposable local PostgreSQL 16 container;
   and 43 MCP/OAuth regression tests.  No production payment, invoice, Gmail
   draft, or customer email was created.
@@ -128,18 +137,18 @@ Parking predicate: this PR parks unrelated billing-run, invoice/PDF/Gmail-draft,
 | File | LOC |
 |---|---:|
 | `.github/workflows/atlas_invoicing_checks.yml` | 7 |
-| `atlas_brain/api/invoicing/receivables.py` | 91 |
-| `atlas_brain/eom_api/receivables.py` | 99 |
+| `atlas_brain/api/invoicing/receivables.py` | 112 |
+| `atlas_brain/eom_api/receivables.py` | 151 |
 | `atlas_brain/main_eom.py` | 1 |
 | `atlas_brain/services/crm_provider.py` | 47 |
-| `atlas_brain/services/receivables.py` | 314 |
+| `atlas_brain/services/receivables.py` | 367 |
 | `atlas_brain/storage/migrations/369_receivables_payment_receipt_outbox.sql` | 68 |
 | `atlas_brain/templates/email/payment_receipt.py` | 67 |
-| `plans/PR-EOM-Residential-Receipt-Outbox.md` | 145 |
+| `plans/PR-EOM-Residential-Receipt-Outbox.md` | 154 |
 | `scripts/open_pr.sh` | 6 |
-| `tests/test_eom_billing_recipients.py` | 6 |
-| `tests/test_eom_payment_receipts.py` | 395 |
-| `tests/test_eom_render_profile.py` | 10 |
+| `tests/test_eom_billing_recipients.py` | 34 |
+| `tests/test_eom_payment_receipts.py` | 450 |
+| `tests/test_eom_render_profile.py` | 58 |
 | `tests/test_open_pr_wrapper.py` | 24 |
-| `tests/test_receivables.py` | 682 |
-| **Total** | **1962** |
+| `tests/test_receivables.py` | 812 |
+| **Total** | **2358** |

--- a/scripts/open_pr.sh
+++ b/scripts/open_pr.sh
@@ -331,7 +331,11 @@ require_pr_branch_name() {
 
 run_final_local_review() {
     echo "Running final local PR review before GitHub mutation..."
-    ATLAS_CURRENT_PR_BODY_FILE="$body_file" \
+    # Draft consent is consumed during argv admission. Do not leak it into the
+    # local unit suite: its own draft-admission fixtures must exercise the
+    # default no-consent case, independent of this outer PR's authorized mode.
+    env -u ATLAS_OPEN_PR_DRAFT_CONSENT \
+        ATLAS_CURRENT_PR_BODY_FILE="$body_file" \
         bash scripts/local_pr_review.sh --current-pr-body-file "$body_file"
 }
 

--- a/tests/test_eom_billing_recipients.py
+++ b/tests/test_eom_billing_recipients.py
@@ -529,6 +529,9 @@ class _ReadyService:
     async def is_ready(self):
         return True
 
+    async def is_receipt_delivery_ready(self):
+        return True
+
 
 receivables.get_receivables_service = lambda: _ReadyService()
 if main_eom.app.dependency_overrides:
@@ -697,6 +700,9 @@ async def test_readiness_separates_unconfigured_from_unavailable(
 
     class _ReadyService:
         async def is_ready(self):
+            return True
+
+        async def is_receipt_delivery_ready(self):
             return True
 
     monkeypatch.setattr(routes, "get_receivables_service", lambda: _ReadyService())

--- a/tests/test_eom_billing_recipients.py
+++ b/tests/test_eom_billing_recipients.py
@@ -551,7 +551,8 @@ print(json.dumps({
     "listed_status": listed.status_code,
     "listed_code": listed.json().get("detail", {}).get("code"),
     "detail_status": detail.status_code,
-    "ready_billing": ready.json().get("billingRecipients"),
+    "ready_status": ready.status_code,
+    "ready_code": ready.json().get("detail", {}).get("code"),
     "dependency_overrides": len(main_eom.app.dependency_overrides),
 }))
 """
@@ -583,9 +584,10 @@ print(json.dumps({
         "listed_status": 503,
         "listed_code": "billing_recipients_unavailable",
         "detail_status": 503,
-        # Readiness says so too, rather than reporting a healthy service whose
-        # every recipient read fails.
-        "ready_billing": "unconfigured",
+        # Receipt-aware payment creation needs this database for every new
+        # payment, so readiness must make that unusable deployment explicit.
+        "ready_status": 503,
+        "ready_code": "billing_recipients_unavailable",
         "dependency_overrides": 0,
     }, observed
 
@@ -659,11 +661,10 @@ def test_admission_holds_over_the_whole_configuration_grammar(monkeypatch):
 @pytest.mark.parametrize(
     "dsn, initialized, schema_ok, expect_status, expect_label",
     [
-        # Deliberately absent: a supported profile that never calls these
-        # routes. Failing readiness would take invoicing out over a capability
-        # it does not use.
-        ("", False, False, 200, "unconfigured"),
-        ("   ", False, False, 200, "unconfigured"),
+        # Receipt-aware payment creation needs the canonical CRM for every
+        # new payment, so an absent DSN is unavailable rather than healthy.
+        ("", False, False, 503, None),
+        ("   ", False, False, 503, None),
         # Configured and working.
         ("postgresql://h/d", True, True, 200, "ready"),
         # Configured and NOT working -- the two ways that happens.
@@ -674,11 +675,12 @@ def test_admission_holds_over_the_whole_configuration_grammar(monkeypatch):
 async def test_readiness_separates_unconfigured_from_unavailable(
     monkeypatch, dsn, initialized, schema_ok, expect_status, expect_label,
 ):
-    """An initialized pool is not the same claim as a usable one.
+    """A configured pool is not the same claim as a usable payment dependency.
 
-    `is_initialized` proves a connection opened. A reachable but partially
-    migrated database passes it and then fails every recipient read on an
-    undefined column, so readiness has to probe the columns both queries name.
+    A blank DSN, an unopened pool, and a reachable-but-partially-migrated pool
+    all make receipt-aware payment creation unavailable. `is_initialized`
+    proves only that a connection opened, not that both payment customer reads
+    can run against the canonical CRM schema.
     """
     from fastapi import HTTPException
 

--- a/tests/test_eom_payment_receipts.py
+++ b/tests/test_eom_payment_receipts.py
@@ -1,0 +1,395 @@
+"""HTTP and canonical-CRM boundary tests for residential payment receipts."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from atlas_brain.eom_api import auth as receivables_auth
+from atlas_brain.eom_api import receivables as routes
+from atlas_brain.services.crm_provider import DatabaseCRMProvider
+from atlas_brain.services.receivables import ReceivablesReceiptContextRequiredError
+from atlas_brain.storage.exceptions import DatabaseUnavailableError
+
+
+class _CanonicalPool:
+    def __init__(self, *, initialized: bool) -> None:
+        self.is_initialized = initialized
+
+
+class _CRM:
+    def __init__(self, customer: dict | None) -> None:
+        self.customer = customer
+        self.calls: list[UUID] = []
+
+    async def get_eom_payment_customer(self, contact_id: UUID) -> dict | None:
+        self.calls.append(contact_id)
+        return self.customer
+
+
+class _PaymentService:
+    def __init__(self, *, replay_payment: dict | None = None) -> None:
+        self.replay_payment = replay_payment
+        self.calls: list[dict] = []
+        self.ledger_writes = 0
+
+    async def create_payment(self, **kwargs):
+        self.calls.append(kwargs)
+        if kwargs["receipt_recipient"] is None:
+            if self.replay_payment is not None:
+                return self.replay_payment
+            raise ReceivablesReceiptContextRequiredError(
+                "Canonical customer data is required for a new EOM payment"
+            )
+        self.ledger_writes += 1
+        recipient_email = kwargs["receipt_recipient"].recipient_email
+        return {
+            "id": "payment-1",
+            "status": "received",
+            "receipt_delivery": {
+                "receipt_number": "EOM-RCP-payment-1",
+                "recipient_email": recipient_email,
+                "status": "pending" if recipient_email else "skipped",
+                "skip_reason": None if recipient_email else "no_email",
+            },
+        }
+
+
+def _app(crm: _CRM, service: _PaymentService) -> tuple[FastAPI, str]:
+    generated = receivables_auth.generate_receivables_service_token()
+    app = FastAPI()
+    app.include_router(routes.router)
+    app.state.eom_funnel_crm_provider = lambda: crm
+    app.dependency_overrides[receivables_auth.get_receivables_api_config] = (
+        lambda: SimpleNamespace(
+            receivables_api_enabled=True,
+            receivables_service_token="",
+            receivables_service_token_sha256=generated.sha256,
+        )
+    )
+    app.dependency_overrides[routes.get_receivables_service] = lambda: service
+    return app, generated.token
+
+
+def _headers(token: str, *, key: str = "payment-receipt-http-1") -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {token}",
+        "X-EOM-Actor": "Juan Canfield",
+        "Idempotency-Key": key,
+    }
+
+
+def _body(contact_id: UUID) -> dict:
+    return {
+        "contact_id": str(contact_id),
+        "payer_name": "Riley Customer",
+        "total_amount_cents": 12_500,
+        "payment_method": "check",
+        "received_date": "2026-08-12",
+        "reference": "1042",
+    }
+
+
+@pytest.mark.asyncio
+async def test_full_payment_route_uses_canonical_residential_snapshot(monkeypatch):
+    from atlas_brain.api.invoicing import receivables as full_routes
+
+    contact_id = uuid4()
+    crm = _CRM(
+        {
+            "contact_id": contact_id,
+            "customer_name": "Riley Customer",
+            "customer_type": "residential",
+            "recipient_email": "riley@example.test",
+        }
+    )
+    service = _PaymentService()
+    monkeypatch.setattr(full_routes, "get_crm_provider", lambda: crm)
+
+    result = await full_routes.create_payment(
+        full_routes.CreatePaymentRequest.model_validate(_body(contact_id)),
+        actor="Juan Canfield",
+        idempotency_key="full-payment-receipt-http-1",
+        service=service,
+    )
+
+    assert result["receipt_delivery"]["recipient_email"] == "riley@example.test"
+    assert crm.calls == [contact_id]
+    assert service.ledger_writes == 1
+    assert service.calls[0]["require_receipt_recipient"] is True
+    assert service.calls[0]["receipt_recipient"].customer_type == "residential"
+
+
+@pytest.mark.asyncio
+async def test_full_payment_route_refuses_new_missing_customer_but_recovers_replay(
+    monkeypatch,
+):
+    from fastapi import HTTPException
+
+    from atlas_brain.api.invoicing import receivables as full_routes
+
+    contact_id = uuid4()
+    body = full_routes.CreatePaymentRequest.model_validate(_body(contact_id))
+    missing_service = _PaymentService()
+    monkeypatch.setattr(full_routes, "get_crm_provider", lambda: _CRM(None))
+
+    with pytest.raises(HTTPException) as excinfo:
+        await full_routes.create_payment(
+            body,
+            actor="Juan Canfield",
+            idempotency_key="full-payment-receipt-missing-1",
+            service=missing_service,
+        )
+    assert excinfo.value.status_code == 404
+    assert missing_service.ledger_writes == 0
+
+    class _UnavailableCRM:
+        async def get_eom_payment_customer(self, _contact_id):
+            raise DatabaseUnavailableError("canonical CRM")
+
+    replay_service = _PaymentService(
+        replay_payment={"id": "existing-full-payment", "status": "received"}
+    )
+    monkeypatch.setattr(full_routes, "get_crm_provider", lambda: _UnavailableCRM())
+    replay = await full_routes.create_payment(
+        body,
+        actor="Juan Canfield",
+        idempotency_key="full-payment-receipt-replay-1",
+        service=replay_service,
+    )
+    assert replay == {"id": "existing-full-payment", "status": "received"}
+    assert replay_service.ledger_writes == 0
+    assert replay_service.calls[0]["receipt_recipient"] is None
+    assert replay_service.calls[0]["require_receipt_recipient"] is True
+
+
+@pytest.mark.asyncio
+async def test_slim_payment_route_passes_only_canonical_residential_snapshot(
+    monkeypatch,
+):
+    contact_id = uuid4()
+    crm = _CRM(
+        {
+            "contact_id": contact_id,
+            "customer_name": "Riley Customer",
+            "customer_type": "residential",
+            "recipient_email": "riley@example.test",
+        }
+    )
+    service = _PaymentService()
+    app, token = _app(crm, service)
+    monkeypatch.setattr(
+        routes, "get_eom_funnel_db_pool", lambda: _CanonicalPool(initialized=True)
+    )
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://receivables.test"
+    ) as client:
+        response = await client.post(
+            "/receivables/payments",
+            headers=_headers(token),
+            json=_body(contact_id),
+        )
+
+    assert response.status_code == 201, response.text
+    assert response.json()["receipt_delivery"]["recipient_email"] == "riley@example.test"
+    assert crm.calls == [contact_id]
+    assert service.ledger_writes == 1
+    [call] = service.calls
+    snapshot = call["receipt_recipient"]
+    assert snapshot.contact_id == contact_id
+    assert snapshot.customer_type == "residential"
+    assert snapshot.recipient_email == "riley@example.test"
+    assert call["require_receipt_recipient"] is True
+    assert call["recorded_by"] == "Juan Canfield"
+    assert "customer_type" not in _body(contact_id)
+
+
+@pytest.mark.asyncio
+async def test_slim_payment_route_refuses_new_payment_without_canonical_customer(
+    monkeypatch,
+):
+    contact_id = uuid4()
+    crm = _CRM(None)
+    service = _PaymentService()
+    app, token = _app(crm, service)
+    monkeypatch.setattr(
+        routes, "get_eom_funnel_db_pool", lambda: _CanonicalPool(initialized=True)
+    )
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://receivables.test"
+    ) as client:
+        response = await client.post(
+            "/receivables/payments",
+            headers=_headers(token),
+            json=_body(contact_id),
+        )
+
+    assert response.status_code == 404, response.text
+    assert response.json()["detail"]["code"] == "not_found"
+    assert crm.calls == [contact_id]
+    assert service.ledger_writes == 0
+    assert service.calls[0]["receipt_recipient"] is None
+    assert service.calls[0]["require_receipt_recipient"] is True
+
+
+@pytest.mark.asyncio
+async def test_slim_payment_route_allows_residential_customer_without_email(
+    monkeypatch,
+):
+    contact_id = uuid4()
+    crm = _CRM(
+        {
+            "contact_id": contact_id,
+            "customer_name": "No Email Customer",
+            "customer_type": "residential",
+            "recipient_email": None,
+        }
+    )
+    service = _PaymentService()
+    app, token = _app(crm, service)
+    monkeypatch.setattr(
+        routes, "get_eom_funnel_db_pool", lambda: _CanonicalPool(initialized=True)
+    )
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://receivables.test"
+    ) as client:
+        response = await client.post(
+            "/receivables/payments",
+            headers=_headers(token),
+            json=_body(contact_id),
+        )
+
+    assert response.status_code == 201, response.text
+    assert response.json()["receipt_delivery"] == {
+        "receipt_number": "EOM-RCP-payment-1",
+        "recipient_email": None,
+        "status": "skipped",
+        "skip_reason": "no_email",
+    }
+    assert service.ledger_writes == 1
+    assert service.calls[0]["receipt_recipient"].recipient_email is None
+
+
+@pytest.mark.asyncio
+async def test_slim_payment_retry_recovers_original_when_canonical_pool_is_unavailable(
+    monkeypatch,
+):
+    contact_id = uuid4()
+    crm = _CRM(None)
+    service = _PaymentService(
+        replay_payment={
+            "id": "existing-payment",
+            "status": "received",
+            "receipt_delivery": {
+                "receipt_number": "EOM-RCP-existing-payment",
+                "recipient_email": "riley@example.test",
+                "status": "pending",
+                "skip_reason": None,
+            },
+        }
+    )
+    app, token = _app(crm, service)
+    monkeypatch.setattr(
+        routes, "get_eom_funnel_db_pool", lambda: _CanonicalPool(initialized=False)
+    )
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://receivables.test"
+    ) as client:
+        response = await client.post(
+            "/receivables/payments",
+            headers=_headers(token, key="existing-payment-key"),
+            json=_body(contact_id),
+        )
+
+    assert response.status_code == 201, response.text
+    assert response.json()["id"] == "existing-payment"
+    assert crm.calls == []
+    assert service.ledger_writes == 0
+    assert service.calls[0]["receipt_recipient"] is None
+    assert service.calls[0]["require_receipt_recipient"] is True
+
+
+@pytest.mark.asyncio
+async def test_slim_payment_route_returns_controlled_unavailable_for_new_payment(
+    monkeypatch,
+):
+    contact_id = uuid4()
+    crm = _CRM(None)
+    service = _PaymentService()
+    app, token = _app(crm, service)
+    monkeypatch.setattr(
+        routes, "get_eom_funnel_db_pool", lambda: _CanonicalPool(initialized=False)
+    )
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://receivables.test"
+    ) as client:
+        response = await client.post(
+            "/receivables/payments",
+            headers=_headers(token),
+            json=_body(contact_id),
+        )
+
+    assert response.status_code == 503, response.text
+    assert response.json()["detail"]["code"] == "billing_recipients_unavailable"
+    assert service.ledger_writes == 0
+
+
+@pytest.mark.asyncio
+async def test_canonical_payment_customer_is_tenant_scoped_and_normalizes_email():
+    contact_id = uuid4()
+
+    class _Pool:
+        def __init__(self) -> None:
+            self.query = ""
+            self.args = ()
+
+        async def fetchrow(self, query, *args):
+            self.query = query
+            self.args = args
+            return {
+                "id": contact_id,
+                "full_name": "  Riley Customer  ",
+                "customer_type": "residential",
+                "email": "  RILEY@Example.TEST  ",
+            }
+
+    pool = _Pool()
+    customer = await DatabaseCRMProvider(pool=pool).get_eom_payment_customer(
+        contact_id
+    )
+
+    assert customer == {
+        "contact_id": contact_id,
+        "customer_name": "Riley Customer",
+        "customer_type": "residential",
+        "recipient_email": "riley@example.test",
+    }
+    assert "business_context_id = $2" in pool.query
+    assert "status = $4" in pool.query
+    assert "contact_type = $5" in pool.query
+    assert pool.args[0] == contact_id
+    assert pool.args[1] == "effingham_maids"
+
+
+@pytest.mark.asyncio
+async def test_billing_recipient_readiness_requires_customer_type_column():
+    class _Pool:
+        def __init__(self) -> None:
+            self.query = ""
+
+        async def fetch(self, query):
+            self.query = query
+            return []
+
+    pool = _Pool()
+    assert await DatabaseCRMProvider(pool=pool).billing_recipients_schema_ready()
+    assert "customer_type" in pool.query

--- a/tests/test_eom_payment_receipts.py
+++ b/tests/test_eom_payment_receipts.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 from types import SimpleNamespace
 from uuid import UUID, uuid4
 
+import asyncpg
 import httpx
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 
 from atlas_brain.eom_api import auth as receivables_auth
 from atlas_brain.eom_api import receivables as routes
@@ -168,6 +169,32 @@ async def test_full_payment_route_refuses_new_missing_customer_but_recovers_repl
 
 
 @pytest.mark.asyncio
+async def test_full_payment_route_translates_canonical_schema_failure(monkeypatch):
+    from atlas_brain.api.invoicing import receivables as full_routes
+
+    class _SchemaBrokenCRM:
+        async def get_eom_payment_customer(self, _contact_id):
+            raise asyncpg.UndefinedColumnError("customer_type")
+
+    contact_id = uuid4()
+    service = _PaymentService()
+    monkeypatch.setattr(full_routes, "get_crm_provider", lambda: _SchemaBrokenCRM())
+
+    with pytest.raises(HTTPException) as excinfo:
+        await full_routes.create_payment(
+            full_routes.CreatePaymentRequest.model_validate(_body(contact_id)),
+            actor="Juan Canfield",
+            idempotency_key="full-payment-canonical-schema-1",
+            service=service,
+        )
+
+    assert excinfo.value.status_code == 503
+    assert excinfo.value.detail["code"] == "canonical_customer_unavailable"
+    assert service.ledger_writes == 0
+    assert service.calls[0]["receipt_recipient"] is None
+
+
+@pytest.mark.asyncio
 async def test_slim_payment_route_passes_only_canonical_residential_snapshot(
     monkeypatch,
 ):
@@ -236,6 +263,34 @@ async def test_slim_payment_route_refuses_new_payment_without_canonical_customer
     assert service.ledger_writes == 0
     assert service.calls[0]["receipt_recipient"] is None
     assert service.calls[0]["require_receipt_recipient"] is True
+
+
+@pytest.mark.asyncio
+async def test_slim_payment_route_translates_canonical_schema_failure(monkeypatch):
+    class _SchemaBrokenCRM:
+        async def get_eom_payment_customer(self, _contact_id):
+            raise asyncpg.UndefinedColumnError("customer_type")
+
+    contact_id = uuid4()
+    service = _PaymentService()
+    app, token = _app(_SchemaBrokenCRM(), service)
+    monkeypatch.setattr(
+        routes, "get_eom_funnel_db_pool", lambda: _CanonicalPool(initialized=True)
+    )
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://receivables.test"
+    ) as client:
+        response = await client.post(
+            "/receivables/payments",
+            headers=_headers(token, key="slim-payment-canonical-schema-1"),
+            json=_body(contact_id),
+        )
+
+    assert response.status_code == 503, response.text
+    assert response.json()["detail"]["code"] == "canonical_customer_unavailable"
+    assert service.ledger_writes == 0
+    assert service.calls[0]["receipt_recipient"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_eom_render_profile.py
+++ b/tests/test_eom_render_profile.py
@@ -104,6 +104,33 @@ def _sha256_ascii(value: str) -> str:
     return hashlib.sha256(value.encode("ascii")).hexdigest()
 
 
+def _configure_billing_recipient_readiness(monkeypatch, receivables) -> None:
+    """Make authentication-only readiness tests satisfy the payment dependency."""
+
+    class _CanonicalPool:
+        is_initialized = True
+
+    class _CanonicalCRM:
+        async def billing_recipients_schema_ready(self):
+            return True
+
+    monkeypatch.setattr(
+        receivables.funnel_settings,
+        "db_connection_string",
+        "postgresql://canonical.test/eom",
+    )
+    monkeypatch.setattr(
+        receivables,
+        "get_eom_funnel_db_pool",
+        lambda: _CanonicalPool(),
+    )
+    monkeypatch.setattr(
+        receivables,
+        "get_eom_funnel_crm_provider",
+        lambda: _CanonicalCRM(),
+    )
+
+
 def _route_paths_for_app_expr(app_expr: str) -> str:
     return f"""
 def _route_paths(app):
@@ -1370,6 +1397,7 @@ def test_eom_receivables_bearer_admission_matches_generated_token_grammar(
         "get_receivables_service",
         lambda: _ReadyService(),
     )
+    _configure_billing_recipient_readiness(monkeypatch, receivables)
 
     token_prefixes = (
         _GENERATED_RECEIVABLES_TOKEN_PREFIX,
@@ -1501,6 +1529,7 @@ def test_eom_receivables_ready_route_is_fail_closed(monkeypatch):
         "get_receivables_service",
         lambda: _ReadyService(),
     )
+    _configure_billing_recipient_readiness(monkeypatch, receivables)
 
     client = TestClient(app)
     assert client.get("/receivables/ready").status_code == 401
@@ -1986,11 +2015,20 @@ print(json.dumps({
     assert result.returncode == 0, result.stderr
     observed = json.loads(result.stdout.strip().splitlines()[-1])
     assert observed == {
-        "status_code": 200,
-        # Readiness now also reports the SECOND database the billing-recipient
-        # routes read. This profile configures no funnel DSN, so that pool is
-        # deliberately unconfigured while the service itself is ready.
-        "body": {"status": "ready", "billingRecipients": "unconfigured"},
+        "status_code": 503,
+        # A receipt-aware payment route cannot accept a new payment without
+        # its canonical-contact database, so an unconfigured profile must
+        # advertise that operationally rather than report readiness.
+        "body": {
+            "detail": {
+                "code": "billing_recipients_unavailable",
+                "message": (
+                    "The canonical EOM contact database is not configured; set "
+                    "ATLAS_EOM_FUNNEL_DB_CONNECTION_STRING to use billing "
+                    "recipients."
+                ),
+            }
+        },
         "env_projected_enabled": True,
         "env_projected_digest": True,
         "dependency_overrides": 0,

--- a/tests/test_eom_render_profile.py
+++ b/tests/test_eom_render_profile.py
@@ -489,6 +489,7 @@ def test_eom_startup_migrations_are_curated_for_receivables_readiness():
         "344_receivables_payments",
         "345_receivables_event_key_lookup",
         "368_receivables_payment_check_metadata",
+        "369_receivables_payment_receipt_outbox",
     )
     assert not any(
         migration.startswith(("066_", "068_", "074_", "076_", "083_", "095_"))
@@ -1347,6 +1348,9 @@ def test_eom_receivables_bearer_admission_matches_generated_token_grammar(
         async def is_ready(self):
             return True
 
+        async def is_receipt_delivery_ready(self):
+            return True
+
     app = FastAPI()
     app.include_router(receivables.router)
     runtime_config = {
@@ -1478,6 +1482,9 @@ def test_eom_receivables_ready_route_is_fail_closed(monkeypatch):
 
     class _ReadyService:
         async def is_ready(self):
+            return True
+
+        async def is_receipt_delivery_ready(self):
             return True
 
     app = FastAPI()
@@ -1926,6 +1933,9 @@ from atlas_brain.eom_api import receivables
 
 class _ReadyService:
     async def is_ready(self):
+        return True
+
+    async def is_receipt_delivery_ready(self):
         return True
 
 

--- a/tests/test_open_pr_wrapper.py
+++ b/tests/test_open_pr_wrapper.py
@@ -183,6 +183,30 @@ def test_open_pr_forwards_draft_assignment_when_operator_consent_flag_is_set(tmp
     assert stdin_capture.read_text(encoding="utf-8") == _stamped_body(body)
 
 
+def test_open_pr_consumes_draft_consent_before_local_review(tmp_path: Path) -> None:
+    repo, body, env, log, stdin_capture = _ready(tmp_path, view_exit=1)
+    env["ATLAS_OPEN_PR_DRAFT_CONSENT"] = "1"
+    local_review = repo / "scripts" / "local_pr_review.sh"
+    local_review.write_text(
+        local_review.read_text(encoding="utf-8").replace(
+            'exit "${LOCAL_REVIEW_EXIT:-0}"',
+            "printf '%s\\n' \"${ATLAS_OPEN_PR_DRAFT_CONSENT:-}\" "
+            "> local-review-draft-consent.log\n"
+            'exit "${LOCAL_REVIEW_EXIT:-0}"',
+        ),
+        encoding="utf-8",
+    )
+
+    result = _run(repo, env, body, "--draft", "--title", "Draft wrapper")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert (repo / "local-review-draft-consent.log").read_text(
+        encoding="utf-8"
+    ) == "\n"
+    assert log.read_text(encoding="utf-8").strip().startswith("pr create --draft")
+    assert stdin_capture.read_text(encoding="utf-8") == _stamped_body(body)
+
+
 def test_open_pr_allows_value_shorthand_containing_d_without_consent(tmp_path: Path) -> None:
     # -t takes a value, so the attached text (even containing 'd') is a title,
     # not a shorthand cluster that enables draft mode.

--- a/tests/test_receivables.py
+++ b/tests/test_receivables.py
@@ -156,12 +156,51 @@ class _CreatePaymentConnection:
             }
         raise AssertionError(f"Unexpected fetchrow query: {query}")
 
-    async def fetchval(self, query: str, *_args):
-        assert "pg_advisory_xact_lock" in query
-        return None
+    async def fetchval(self, query: str, *args):
+        if "pg_advisory_xact_lock" in query:
+            return None
+        if "information_schema.columns" in query:
+            return True
+        if "FROM payment_receipt_deliveries" in query:
+            return args[0] in self.receipt_deliveries
+        raise AssertionError(f"Unexpected fetchval query: {query}")
 
     async def fetch(self, query: str, *args):
         self.fetches.append((query, args))
+        if "FROM pg_index AS index_state" in query:
+            required_indexes = {
+                index_name: (
+                    table_name,
+                    is_unique,
+                    key_columns,
+                    predicate,
+                    constraint_type,
+                )
+                for (
+                    table_name,
+                    index_name,
+                    is_unique,
+                    key_columns,
+                    predicate,
+                    constraint_type,
+                ) in (
+                    *_RECEIVABLES_REQUIRED_INDEXES,
+                    *_RECEIPT_DELIVERY_REQUIRED_INDEXES,
+                )
+            }
+            return [
+                {
+                    "index_name": index_name,
+                    "table_name": required_indexes[index_name][0],
+                    "is_unique": required_indexes[index_name][1],
+                    "key_columns": list(required_indexes[index_name][2]),
+                    "predicate": required_indexes[index_name][3],
+                    "constraint_type": required_indexes[index_name][4],
+                    "is_valid": True,
+                    "is_ready": True,
+                }
+                for index_name in args[0]
+            ]
         if "FROM invoices" in query and "ORDER BY id FOR UPDATE" in query:
             selected = {str(item) for item in args[0]}
             return [row for row in self.invoices if str(row["id"]) in selected]
@@ -339,7 +378,7 @@ async def test_residential_payment_enqueues_one_pending_receipt_without_sending(
     pool = _CreatePaymentPool([], [contact_id])
     service = ReceivablesService(pool)
 
-    async def ready() -> bool:
+    async def ready(_conn=None) -> bool:
         return True
 
     service.is_receipt_delivery_ready = ready
@@ -396,12 +435,97 @@ async def test_residential_payment_enqueues_one_pending_receipt_without_sending(
 
 
 @pytest.mark.asyncio
+async def test_residential_receipt_readiness_uses_held_transaction_connection():
+    """Receipt readiness must not check out another pooled connection mid-write."""
+    contact_id = uuid4()
+    pool = _CreatePaymentPool([], [contact_id])
+
+    result = await ReceivablesService(pool).create_payment_with_outcome(
+        contact_id=contact_id,
+        payer_name="Held Connection Customer",
+        total_amount=Decimal("50.00"),
+        payment_method="check",
+        received_date=date(2026, 8, 12),
+        allocations=[],
+        idempotency_key="receipt-readiness-held-connection-1",
+        recorded_by="Juan Canfield",
+        allow_unapplied=True,
+        unapplied_contact_context_id="effingham_maids",
+        receipt_recipient=PaymentReceiptRecipient(
+            contact_id=contact_id,
+            customer_name="Held Connection Customer",
+            customer_type="residential",
+            recipient_email="held-connection@example.test",
+        ),
+        require_receipt_recipient=True,
+    )
+
+    assert result.replayed is False
+    assert result.payment["receipt_delivery"]["status"] == "pending"
+    # _CreatePaymentPool intentionally has no direct fetch/fetchval methods.
+    # Success therefore proves the readiness catalogs used the held `conn`.
+    assert pool.transaction_count == 1
+
+
+@pytest.mark.asyncio
+async def test_residential_replay_uses_persisted_receipt_after_reclassification():
+    contact_id = uuid4()
+    pool = _CreatePaymentPool([], [contact_id])
+    service = ReceivablesService(pool)
+
+    async def ready(_conn=None) -> bool:
+        return True
+
+    service.is_receipt_delivery_ready = ready
+    create_args = {
+        "contact_id": contact_id,
+        "payer_name": "Reclassified Customer",
+        "total_amount": Decimal("50.00"),
+        "payment_method": "ach",
+        "received_date": date(2026, 8, 12),
+        "allocations": [],
+        "idempotency_key": "residential-reclassification-replay-1",
+        "recorded_by": "Juan Canfield",
+        "allow_unapplied": True,
+        "unapplied_contact_context_id": "effingham_maids",
+        "require_receipt_recipient": True,
+    }
+    original = await service.create_payment_with_outcome(
+        **{
+            **create_args,
+            "receipt_recipient": PaymentReceiptRecipient(
+                contact_id=contact_id,
+                customer_name="Reclassified Customer",
+                customer_type="residential",
+                recipient_email="reclassified@example.test",
+            ),
+        }
+    )
+    replay = await service.create_payment_with_outcome(
+        **{
+            **create_args,
+            "receipt_recipient": PaymentReceiptRecipient(
+                contact_id=contact_id,
+                customer_name="Reclassified Customer",
+                customer_type="commercial",
+                recipient_email="billing@example.test",
+            ),
+        }
+    )
+
+    assert replay.replayed is True
+    assert replay.payment["id"] == original.payment["id"]
+    assert replay.payment["receipt_delivery"] == original.payment["receipt_delivery"]
+    assert len(pool.conn.receipt_deliveries) == 1
+
+
+@pytest.mark.asyncio
 async def test_residential_payment_without_email_is_skipped_but_financially_valid():
     contact_id = uuid4()
     pool = _CreatePaymentPool([], [contact_id])
     service = ReceivablesService(pool)
 
-    async def ready() -> bool:
+    async def ready(_conn=None) -> bool:
         return True
 
     service.is_receipt_delivery_ready = ready
@@ -500,7 +624,7 @@ async def test_canonical_receipt_context_is_required_only_for_a_new_eom_payment(
     pool = _CreatePaymentPool([], [contact_id])
     service = ReceivablesService(pool)
 
-    async def ready() -> bool:
+    async def ready(_conn=None) -> bool:
         return True
 
     service.is_receipt_delivery_ready = ready

--- a/tests/test_receivables.py
+++ b/tests/test_receivables.py
@@ -23,14 +23,17 @@ from atlas_brain.api.invoicing import actions
 from atlas_brain.api.invoicing import auth as receivables_auth
 from atlas_brain.eom_api import auth as eom_receivables_auth
 from atlas_brain.services.receivables import (
+    _RECEIPT_DELIVERY_REQUIRED_INDEXES,
     _RECEIVABLES_REQUIRED_COLUMNS,
     _RECEIVABLES_REQUIRED_INDEXES,
     ReceivablesConflictError,
     ReceivablesError,
     ReceivablesNotFoundError,
+    ReceivablesReceiptContextRequiredError,
     ReceivablesSchemaUnavailableError,
     ReceivablesService,
     ReceivablesValidationError,
+    PaymentReceiptRecipient,
     money,
     request_fingerprint,
 )
@@ -62,6 +65,7 @@ class _CreatePaymentConnection:
         self.parent_fingerprint_index: int | None = None
         self.parent_has_check_metadata = False
         self.parent_insert_count = 0
+        self.receipt_deliveries: dict[UUID, dict] = {}
         self.allocations: list[dict] = []
         self.fetches: list[tuple[str, tuple]] = []
         self.executions: list[tuple[str, tuple]] = []
@@ -140,6 +144,16 @@ class _CreatePaymentConnection:
                     }
                 )
             return payment
+        if "FROM payment_receipt_deliveries" in query:
+            stored = self.receipt_deliveries.get(args[0])
+            if stored is None:
+                return None
+            return {
+                "receipt_number": stored["receipt_number"],
+                "recipient_email": stored["recipient_email"],
+                "status": stored["delivery_status"],
+                "skip_reason": stored["skip_reason"],
+            }
         raise AssertionError(f"Unexpected fetchrow query: {query}")
 
     async def fetchval(self, query: str, *_args):
@@ -170,6 +184,19 @@ class _CreatePaymentConnection:
                     "reversal_reason": None,
                 }
             )
+        if "INSERT INTO payment_receipt_deliveries" in query:
+            self.receipt_deliveries[args[1]] = {
+                "id": args[0],
+                "payment_id": args[1],
+                "contact_id": args[2],
+                "receipt_number": args[3],
+                "recipient_email": args[4],
+                "delivery_status": args[5],
+                "skip_reason": args[6],
+                "subject": args[7],
+                "body": args[8],
+                "created_at": args[9],
+            }
         return "OK"
 
 
@@ -304,6 +331,214 @@ async def test_create_payment_records_unapplied_receipt_and_replays_without_invo
     ]
     assert len(events) == 1
     assert json.loads(events[0][10]) == {"allocated_amount": "0"}
+
+
+@pytest.mark.asyncio
+async def test_residential_payment_enqueues_one_pending_receipt_without_sending():
+    contact_id = uuid4()
+    pool = _CreatePaymentPool([], [contact_id])
+    service = ReceivablesService(pool)
+
+    async def ready() -> bool:
+        return True
+
+    service.is_receipt_delivery_ready = ready
+    create_args = {
+        "contact_id": contact_id,
+        "payer_name": "Jordan Customer",
+        "total_amount": Decimal("125.00"),
+        "payment_method": "check",
+        "received_date": date(2026, 8, 12),
+        "reference": "1042",
+        "allocations": [],
+        "idempotency_key": "residential-receipt-payment-1",
+        "recorded_by": "Juan Canfield",
+        "allow_unapplied": True,
+        "unapplied_contact_context_id": "effingham_maids",
+        "receipt_recipient": PaymentReceiptRecipient(
+            contact_id=contact_id,
+            customer_name="Jordan Customer",
+            customer_type="residential",
+            recipient_email="jordan@example.test",
+        ),
+        "require_receipt_recipient": True,
+    }
+
+    first = await service.create_payment_with_outcome(**create_args)
+    replay = await service.create_payment_with_outcome(**create_args)
+
+    assert first.replayed is False
+    assert replay.replayed is True
+    assert first.payment["id"] == replay.payment["id"]
+    receipt = first.payment["receipt_delivery"]
+    assert receipt == {
+        "receipt_number": f"EOM-RCP-{first.payment['id']}",
+        "recipient_email": "jordan@example.test",
+        "status": "pending",
+        "skip_reason": None,
+    }
+    assert len(pool.conn.receipt_deliveries) == 1
+    stored = next(iter(pool.conn.receipt_deliveries.values()))
+    assert stored["subject"] == (
+        f"Payment received — receipt EOM-RCP-{first.payment['id']}"
+    )
+    assert "Customer: Jordan Customer" in stored["body"]
+    assert "Payer: Jordan Customer" in stored["body"]
+    assert "Amount received: $125.00" in stored["body"]
+    assert "Payment method: Check" in stored["body"]
+    assert "Check number: 1042" in stored["body"]
+    assert "Date received: August 12, 2026" in stored["body"]
+    assert "We have received your check. It has not yet cleared." in stored["body"]
+    assert not any(
+        "Gmail" in query or "Resend" in query
+        for query, _args in pool.conn.executions
+    )
+
+
+@pytest.mark.asyncio
+async def test_residential_payment_without_email_is_skipped_but_financially_valid():
+    contact_id = uuid4()
+    pool = _CreatePaymentPool([], [contact_id])
+    service = ReceivablesService(pool)
+
+    async def ready() -> bool:
+        return True
+
+    service.is_receipt_delivery_ready = ready
+    result = await service.create_payment_with_outcome(
+        contact_id=contact_id,
+        payer_name="No Email Customer",
+        total_amount=Decimal("50.00"),
+        payment_method="ach",
+        received_date=date(2026, 8, 12),
+        allocations=[],
+        idempotency_key="residential-receipt-no-email-1",
+        recorded_by="Juan Canfield",
+        allow_unapplied=True,
+        unapplied_contact_context_id="effingham_maids",
+        receipt_recipient=PaymentReceiptRecipient(
+            contact_id=contact_id,
+            customer_name="No Email Customer",
+            customer_type="residential",
+            recipient_email=None,
+        ),
+        require_receipt_recipient=True,
+    )
+
+    assert result.payment["status"] == "cleared"
+    assert result.payment["receipt_delivery"]["status"] == "skipped"
+    assert result.payment["receipt_delivery"]["skip_reason"] == "no_email"
+    assert result.payment["receipt_delivery"]["recipient_email"] is None
+    assert pool.conn.parent_insert_count == 1
+    assert len(pool.conn.receipt_deliveries) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("customer_type", ("commercial", "unknown"))
+async def test_non_residential_payment_has_no_residential_receipt_delivery(
+    customer_type,
+):
+    contact_id = uuid4()
+    pool = _CreatePaymentPool([], [contact_id])
+    service = ReceivablesService(pool)
+    result = await service.create_payment_with_outcome(
+        contact_id=contact_id,
+        payer_name="Commercial Customer",
+        total_amount=Decimal("50.00"),
+        payment_method="ach",
+        received_date=date(2026, 8, 12),
+        allocations=[],
+        idempotency_key=f"{customer_type}-no-residential-receipt-1",
+        recorded_by="Juan Canfield",
+        allow_unapplied=True,
+        unapplied_contact_context_id="effingham_maids",
+        receipt_recipient=PaymentReceiptRecipient(
+            contact_id=contact_id,
+            customer_name="Commercial Customer",
+            customer_type=customer_type,
+            recipient_email="billing@example.test",
+        ),
+        require_receipt_recipient=True,
+    )
+
+    assert result.payment["status"] == "cleared"
+    assert "receipt_delivery" not in result.payment
+    assert pool.conn.receipt_deliveries == {}
+
+
+@pytest.mark.asyncio
+async def test_receipt_context_rejects_noncanonical_email_before_payment_write():
+    contact_id = uuid4()
+    pool = _CreatePaymentPool([], [contact_id])
+    with pytest.raises(ReceivablesValidationError, match="Receipt email is invalid"):
+        await ReceivablesService(pool).create_payment_with_outcome(
+            contact_id=contact_id,
+            payer_name="Residential Customer",
+            total_amount=Decimal("50.00"),
+            payment_method="ach",
+            received_date=date(2026, 8, 12),
+            allocations=[],
+            idempotency_key="invalid-receipt-email-1",
+            allow_unapplied=True,
+            unapplied_contact_context_id="effingham_maids",
+            receipt_recipient=PaymentReceiptRecipient(
+                contact_id=contact_id,
+                customer_name="Residential Customer",
+                customer_type="residential",
+                recipient_email="not-an-email",
+            ),
+            require_receipt_recipient=True,
+        )
+
+    assert pool.transaction_count == 0
+    assert pool.conn.parent_insert_count == 0
+
+
+@pytest.mark.asyncio
+async def test_canonical_receipt_context_is_required_only_for_a_new_eom_payment():
+    contact_id = uuid4()
+    pool = _CreatePaymentPool([], [contact_id])
+    service = ReceivablesService(pool)
+
+    async def ready() -> bool:
+        return True
+
+    service.is_receipt_delivery_ready = ready
+    create_args = {
+        "contact_id": contact_id,
+        "payer_name": "Replay Customer",
+        "total_amount": Decimal("50.00"),
+        "payment_method": "ach",
+        "received_date": date(2026, 8, 12),
+        "allocations": [],
+        "idempotency_key": "residential-receipt-replay-1",
+        "recorded_by": "Juan Canfield",
+        "allow_unapplied": True,
+        "unapplied_contact_context_id": "effingham_maids",
+        "require_receipt_recipient": True,
+    }
+    with pytest.raises(ReceivablesReceiptContextRequiredError):
+        await service.create_payment_with_outcome(**create_args)
+    assert pool.conn.parent_insert_count == 0
+
+    first = await service.create_payment_with_outcome(
+        **{
+            **create_args,
+            "receipt_recipient": PaymentReceiptRecipient(
+                contact_id=contact_id,
+                customer_name="Replay Customer",
+                customer_type="residential",
+                recipient_email="replay@example.test",
+            ),
+        }
+    )
+    replay = await service.create_payment_with_outcome(**create_args)
+
+    assert first.replayed is False
+    assert replay.replayed is True
+    assert replay.payment["id"] == first.payment["id"]
+    assert pool.conn.parent_insert_count == 1
+    assert len(pool.conn.receipt_deliveries) == 1
 
 
 @pytest.mark.asyncio
@@ -964,11 +1199,17 @@ def _workflow_event_paths(workflow: str, event_name: str) -> tuple[str, ...]:
     )
 
 
-def test_followup_receivables_migration_is_enrolled_in_invoicing_ci():
+@pytest.mark.parametrize(
+    "migration_path",
+    (
+        "atlas_brain/storage/migrations/345_receivables_event_key_lookup.sql",
+        "atlas_brain/storage/migrations/369_receivables_payment_receipt_outbox.sql",
+    ),
+)
+def test_receivables_migrations_are_enrolled_in_invoicing_ci(migration_path):
     workflow = (
         Path(__file__).parents[1] / ".github/workflows/atlas_invoicing_checks.yml"
     ).read_text(encoding="utf-8")
-    migration_path = "atlas_brain/storage/migrations/345_receivables_event_key_lookup.sql"
     entry = f'      - "{migration_path}"\n'
 
     assert migration_path in _workflow_event_paths(workflow, "pull_request")
@@ -990,6 +1231,17 @@ def test_followup_receivables_migration_is_enrolled_in_invoicing_ci():
     assert migration_path not in _workflow_event_paths(
         misplaced_under_branches, "push"
     )
+
+
+def test_payment_receipt_route_tests_are_enrolled_in_invoicing_ci():
+    workflow = (
+        Path(__file__).parents[1] / ".github/workflows/atlas_invoicing_checks.yml"
+    ).read_text(encoding="utf-8")
+    test_path = "tests/test_eom_payment_receipts.py"
+
+    assert test_path in _workflow_event_paths(workflow, "pull_request")
+    assert test_path in _workflow_event_paths(workflow, "push")
+    assert f"            {test_path} \\\n" in workflow
 
 
 class _SingleConnectionPool:
@@ -1084,7 +1336,11 @@ async def _create_pre_receivables_schema(conn, schema: str) -> None:
     await conn.execute(invoice_migration)
 
 
-def _receivables_migration_sql(*, include_check_metadata: bool = True) -> str:
+def _receivables_migration_sql(
+    *,
+    include_check_metadata: bool = True,
+    include_receipt_outbox: bool = True,
+) -> str:
     migrations = Path(__file__).parents[1] / "atlas_brain/storage/migrations"
     filenames = [
         "344_receivables_payments.sql",
@@ -1092,6 +1348,8 @@ def _receivables_migration_sql(*, include_check_metadata: bool = True) -> str:
     ]
     if include_check_metadata:
         filenames.append("368_receivables_payment_check_metadata.sql")
+    if include_receipt_outbox:
+        filenames.append("369_receivables_payment_receipt_outbox.sql")
     return "\n".join(
         (migrations / filename).read_text(encoding="utf-8")
         for filename in filenames
@@ -1174,6 +1432,7 @@ def test_eom_readiness_migration_set_is_closed_over_receivables_dependencies():
     )
 
     assert set(_RECEIVABLES_REQUIRED_COLUMNS) <= created_tables
+    assert "payment_receipt_deliveries" in created_tables
     assert positions["012_appointments"] < positions["035_contacts"]
     assert positions["035_contacts"] < positions["045_invoices"]
     assert positions["045_invoices"] < positions["344_receivables_payments"]
@@ -1184,6 +1443,10 @@ def test_eom_readiness_migration_set_is_closed_over_receivables_dependencies():
     assert (
         positions["345_receivables_event_key_lookup"]
         < positions["368_receivables_payment_check_metadata"]
+    )
+    assert (
+        positions["368_receivables_payment_check_metadata"]
+        < positions["369_receivables_payment_receipt_outbox"]
     )
     assert "ALTER TABLE appointments" in _packaged_migration_sql("035_contacts")
     assert "REFERENCES contacts(id)" in _packaged_migration_sql("045_invoices")
@@ -1196,6 +1459,12 @@ def test_eom_readiness_migration_set_is_closed_over_receivables_dependencies():
     assert "ADD COLUMN IF NOT EXISTS check_date DATE" in _packaged_migration_sql(
         "368_receivables_payment_check_metadata"
     )
+    receipt_outbox_sql = _packaged_migration_sql(
+        "369_receivables_payment_receipt_outbox"
+    )
+    assert "CREATE TABLE IF NOT EXISTS payment_receipt_deliveries" in receipt_outbox_sql
+    assert "UNIQUE (payment_id)" in receipt_outbox_sql
+    assert "'pending', 'sent', 'failed', 'skipped'" in receipt_outbox_sql
 
 
 @pytest.mark.asyncio
@@ -1238,6 +1507,7 @@ async def test_eom_receivables_readiness_migration_set_builds_ready_schema():
         )
         service = ReceivablesService(_SingleConnectionPool(conn, schema))
         assert await service.is_ready() is True
+        assert await service.is_receipt_delivery_ready() is True
         expected_foreign_keys = {
             ("appointments", ("contact_id",), "contacts", ("id",), "n"),
             ("contact_interactions", ("contact_id",), "contacts", ("id",), "c"),
@@ -1266,6 +1536,20 @@ async def test_eom_receivables_readiness_migration_set_builds_ready_schema():
                 "r",
             ),
             ("payment_events", ("payment_id",), "customer_payments", ("id",), "r"),
+            (
+                "payment_receipt_deliveries",
+                ("payment_id",),
+                "customer_payments",
+                ("id",),
+                "r",
+            ),
+            (
+                "payment_receipt_deliveries",
+                ("contact_id",),
+                "contacts",
+                ("id",),
+                "r",
+            ),
         }
         assert expected_foreign_keys <= await _schema_foreign_key_relationships(
             conn,
@@ -1288,6 +1572,7 @@ async def test_eom_receivables_readiness_migration_set_builds_ready_schema():
             )
         } == applied_names
         assert await service.is_ready() is True
+        assert await service.is_receipt_delivery_ready() is True
         for column, definition in (
             ("check_date", "DATE"),
             ("received_through", "VARCHAR(128)"),
@@ -1300,6 +1585,14 @@ async def test_eom_receivables_readiness_migration_set_builds_ready_schema():
                 f"ALTER TABLE customer_payments ADD COLUMN {column} {definition}"
             )
             assert await service.is_ready() is True
+            assert await service.is_receipt_delivery_ready() is True
+
+        await conn.execute("DROP TABLE payment_receipt_deliveries")
+        # The global/full-MCP readiness contract deliberately remains intact:
+        # it has no outbox writer.  The slim EOM receipt capability alone must
+        # fail closed until its additive migration is restored.
+        assert await service.is_ready() is True
+        assert await service.is_receipt_delivery_ready() is False
     finally:
         await conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
         await conn.close()
@@ -1375,6 +1668,60 @@ async def test_check_metadata_schema_gate_preserves_legacy_payment_creation(
 
 
 @pytest.mark.asyncio
+async def test_receipt_required_replay_recovers_legacy_payment_without_outbox_schema():
+    """A CRM outage cannot turn a valid old payment retry into a table error."""
+    asyncpg = pytest.importorskip("asyncpg")
+    database_url = os.environ.get("ATLAS_RECEIVABLES_TEST_DATABASE_URL")
+    if not database_url:
+        pytest.skip("ATLAS_RECEIVABLES_TEST_DATABASE_URL not set")
+
+    schema = f"receivables_receipt_legacy_replay_{uuid4().hex}"
+    conn = await asyncpg.connect(database_url)
+    try:
+        await _create_pre_receivables_schema(conn, schema)
+        await conn.execute(_receivables_migration_sql(include_receipt_outbox=False))
+        contact_id = uuid4()
+        await conn.execute(
+            "INSERT INTO contacts (id, business_context_id) "
+            "VALUES ($1, 'effingham_maids')",
+            contact_id,
+        )
+        service = ReceivablesService(_SingleConnectionPool(conn, schema))
+        create_args = {
+            "contact_id": contact_id,
+            "payer_name": "Residential Customer",
+            "total_amount": Decimal("125.00"),
+            "payment_method": "check",
+            "received_date": date(2026, 8, 12),
+            "allocations": [],
+            "idempotency_key": "legacy-payment-replay-without-outbox-1",
+            "recorded_by": "Juan Canfield",
+            "allow_unapplied": True,
+            "unapplied_contact_context_id": "effingham_maids",
+        }
+        original = await service.create_payment_with_outcome(**create_args)
+        replay = await service.create_payment_with_outcome(
+            **{**create_args, "require_receipt_recipient": True}
+        )
+
+        assert original.replayed is False
+        assert replay.replayed is True
+        assert replay.payment["id"] == original.payment["id"]
+        assert "receipt_delivery" not in replay.payment
+        assert (
+            await conn.fetchval(
+                "SELECT COUNT(*) FROM customer_payments "
+                "WHERE idempotency_key = 'legacy-payment-replay-without-outbox-1'"
+            )
+            == 1
+        )
+    finally:
+        await conn.execute("SET search_path TO public")
+        await conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        await conn.close()
+
+
+@pytest.mark.asyncio
 async def test_real_migration_backfills_and_adopts_late_rolling_writer_checks():
     asyncpg = pytest.importorskip("asyncpg")
     database_url = os.environ.get("ATLAS_RECEIVABLES_TEST_DATABASE_URL")
@@ -1428,9 +1775,15 @@ async def test_real_migration_backfills_and_adopts_late_rolling_writer_checks():
         created_tables = set(
             re.findall(r"CREATE TABLE IF NOT EXISTS ([a-z_]+)", migration_sql)
         )
-        assert set(_RECEIVABLES_REQUIRED_COLUMNS) == created_tables | {
-            "invoice_payments"
-        }
+        # The receipt outbox is an EOM-only additive capability.  It is
+        # intentionally absent from the legacy/full-MCP readiness set, so a
+        # mixed rollout cannot make established financial entrypoints claim
+        # their schema is incomplete solely because the EOM outbox has not
+        # reached that database yet.
+        assert set(_RECEIVABLES_REQUIRED_COLUMNS) == (
+            created_tables - {"payment_receipt_deliveries"}
+        ) | {"invoice_payments"}
+        assert "payment_receipt_deliveries" in created_tables
 
         for table_name, required_columns in _RECEIVABLES_REQUIRED_COLUMNS.items():
             actual_columns = {
@@ -1546,7 +1899,14 @@ async def test_real_migration_backfills_and_adopts_late_rolling_writer_checks():
             index_name
             for _table_name, index_name, *_rest in _RECEIVABLES_REQUIRED_INDEXES
         }
-        assert required_index_names == migration_index_names
+        receipt_delivery_index_names = {
+            index_name
+            for _table_name, index_name, *_rest in _RECEIPT_DELIVERY_REQUIRED_INDEXES
+        }
+        assert (
+            required_index_names | receipt_delivery_index_names
+            == migration_index_names
+        )
         for index_name in sorted(required_index_names):
             transaction = conn.transaction()
             await transaction.start()
@@ -1563,6 +1923,24 @@ async def test_real_migration_backfills_and_adopts_late_rolling_writer_checks():
             finally:
                 await transaction.rollback()
             assert await service.is_ready() is True
+
+        for index_name in sorted(receipt_delivery_index_names):
+            transaction = conn.transaction()
+            await transaction.start()
+            try:
+                if index_name in constraint_indexes:
+                    table_name = constraint_indexes[index_name]
+                    await conn.execute(
+                        f'ALTER TABLE "{table_name}" '
+                        f'DROP CONSTRAINT "{index_name}" CASCADE'
+                    )
+                else:
+                    await conn.execute(f'DROP INDEX "{index_name}"')
+                assert await service.is_ready() is True
+                assert await service.is_receipt_delivery_ready() is False
+            finally:
+                await transaction.rollback()
+            assert await service.is_receipt_delivery_ready() is True
 
         await conn.execute(
             "ALTER TABLE payment_deposit_batches "
@@ -1988,6 +2366,113 @@ async def test_real_postgres_receivables_lifecycle_and_concurrent_replays():
         await observer.execute("SET search_path TO public")
         await observer.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
         await observer.close()
+
+
+@pytest.mark.asyncio
+async def test_real_postgres_receipt_outbox_failure_rolls_back_new_payment():
+    """The receipt enqueue is financial-transaction work, never an email send.
+
+    An injected outbox write failure must leave no payment, event, or orphaned
+    delivery row behind.  Retrying after the transient failure clears must
+    produce exactly one complete payment/outbox pair under the same key.
+    """
+    asyncpg = pytest.importorskip("asyncpg")
+    database_url = os.environ.get("ATLAS_RECEIVABLES_TEST_DATABASE_URL")
+    if not database_url:
+        pytest.skip("ATLAS_RECEIVABLES_TEST_DATABASE_URL not set")
+
+    schema = f"receivables_receipt_outbox_atomicity_{uuid4().hex}"
+    conn = await asyncpg.connect(database_url)
+    try:
+        await _create_pre_receivables_schema(conn, schema)
+        await conn.execute(_receivables_migration_sql())
+        contact_id = uuid4()
+        await conn.execute(
+            "INSERT INTO contacts (id, business_context_id) "
+            "VALUES ($1, 'effingham_maids')",
+            contact_id,
+        )
+        await conn.execute(
+            """
+            CREATE FUNCTION fail_payment_receipt_enqueue()
+            RETURNS trigger
+            LANGUAGE plpgsql
+            AS $$
+            BEGIN
+                RAISE EXCEPTION 'injected receipt outbox failure';
+            END;
+            $$;
+
+            CREATE TRIGGER receipt_outbox_failure
+            BEFORE INSERT ON payment_receipt_deliveries
+            FOR EACH ROW EXECUTE FUNCTION fail_payment_receipt_enqueue();
+            """
+        )
+        service = ReceivablesService(_SingleConnectionPool(conn, schema))
+        create_args = {
+            "contact_id": contact_id,
+            "payer_name": "Residential Customer",
+            "total_amount": Decimal("125.00"),
+            "payment_method": "check",
+            "received_date": date(2026, 8, 12),
+            "reference": "1042",
+            "allocations": [],
+            "idempotency_key": "receipt-outbox-atomicity-1",
+            "recorded_by": "Juan Canfield",
+            "allow_unapplied": True,
+            "unapplied_contact_context_id": "effingham_maids",
+            "receipt_recipient": PaymentReceiptRecipient(
+                contact_id=contact_id,
+                customer_name="Residential Customer",
+                customer_type="residential",
+                recipient_email="residential@example.test",
+            ),
+            "require_receipt_recipient": True,
+        }
+
+        with pytest.raises(asyncpg.PostgresError, match="injected receipt outbox"):
+            await service.create_payment_with_outcome(**create_args)
+
+        assert (
+            await conn.fetchval(
+                "SELECT COUNT(*) FROM customer_payments "
+                "WHERE idempotency_key = 'receipt-outbox-atomicity-1'"
+            )
+            == 0
+        )
+        assert (
+            await conn.fetchval(
+                "SELECT COUNT(*) FROM payment_events "
+                "WHERE idempotency_key = 'receipt-outbox-atomicity-1'"
+            )
+            == 0
+        )
+        assert (
+            await conn.fetchval("SELECT COUNT(*) FROM payment_receipt_deliveries")
+            == 0
+        )
+
+        await conn.execute(
+            "DROP TRIGGER receipt_outbox_failure ON payment_receipt_deliveries"
+        )
+        recovered = await service.create_payment_with_outcome(**create_args)
+        assert recovered.replayed is False
+        assert recovered.payment["receipt_delivery"]["status"] == "pending"
+        assert (
+            await conn.fetchval(
+                "SELECT COUNT(*) FROM customer_payments "
+                "WHERE idempotency_key = 'receipt-outbox-atomicity-1'"
+            )
+            == 1
+        )
+        assert (
+            await conn.fetchval("SELECT COUNT(*) FROM payment_receipt_deliveries")
+            == 1
+        )
+    finally:
+        await conn.execute("SET search_path TO public")
+        await conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        await conn.close()
 
 
 @pytest.mark.asyncio
@@ -2634,7 +3119,9 @@ async def test_singular_mcp_rejects_invalid_key_before_repository_access(
 
 
 @pytest.mark.asyncio
-async def test_real_postgres_http_and_mcp_entrypoints_use_supported_dependencies():
+async def test_real_postgres_http_and_mcp_entrypoints_use_supported_dependencies(
+    monkeypatch,
+):
     asyncpg = pytest.importorskip("asyncpg")
     database_url = os.environ.get("ATLAS_RECEIVABLES_TEST_DATABASE_URL")
     if not database_url:
@@ -2737,6 +3224,49 @@ async def test_real_postgres_http_and_mcp_entrypoints_use_supported_dependencies
         slim_app.dependency_overrides[
             eom_routes.get_receivables_service
         ] = lambda: service
+
+        class _CanonicalPool:
+            is_initialized = True
+
+        class _SlimPaymentCRM:
+            async def get_eom_payment_customer(self, requested_contact_id):
+                if requested_contact_id != unapplied_contact_id:
+                    return None
+                return {
+                    "contact_id": unapplied_contact_id,
+                    "customer_name": "Residential Customer",
+                    "customer_type": "residential",
+                    "recipient_email": "residential@example.test",
+                }
+
+        class _FullPaymentCRM:
+            async def get_eom_payment_customer(self, requested_contact_id):
+                if requested_contact_id == contact_id:
+                    return {
+                        "contact_id": contact_id,
+                        "customer_name": "Acme",
+                        "customer_type": "commercial",
+                        "recipient_email": "billing@example.test",
+                    }
+                if requested_contact_id == unapplied_contact_id:
+                    return {
+                        "contact_id": unapplied_contact_id,
+                        "customer_name": "Residential Customer",
+                        "customer_type": "residential",
+                        "recipient_email": "residential@example.test",
+                    }
+                return None
+
+        monkeypatch.setattr(routes, "get_crm_provider", lambda: _FullPaymentCRM())
+        monkeypatch.setattr(
+            eom_routes, "get_eom_funnel_db_pool", lambda: _CanonicalPool()
+        )
+        monkeypatch.setattr(
+            slim_app.state,
+            "eom_funnel_crm_provider",
+            lambda: _SlimPaymentCRM(),
+            raising=False,
+        )
         body = {
             "contact_id": str(contact_id),
             "payer_name": "Acme",
@@ -2821,6 +3351,15 @@ async def test_real_postgres_http_and_mcp_entrypoints_use_supported_dependencies
                     },
                     json=slim_unapplied_body,
                 )
+                slim_unapplied_replay = await client.post(
+                    "/api/v1/receivables/payments",
+                    headers={
+                        "Authorization": f"Bearer {generated.token}",
+                        "X-EOM-Actor": "Juan Canfield",
+                        "Idempotency-Key": "slim-http-unapplied-payment-1",
+                    },
+                    json=slim_unapplied_body,
+                )
 
             assert response.status_code == 201
             assert response.json()["status"] == "received"
@@ -2851,6 +3390,12 @@ async def test_real_postgres_http_and_mcp_entrypoints_use_supported_dependencies
             assert unapplied_payment["received_through"] == "Mail"
             assert unapplied_payment["allocated_amount_cents"] == 0
             assert unapplied_payment["unapplied_amount_cents"] == 12_500
+            assert unapplied_payment["receipt_delivery"] == {
+                "receipt_number": f"EOM-RCP-{unapplied_payment['id']}",
+                "recipient_email": "residential@example.test",
+                "status": "pending",
+                "skip_reason": None,
+            }
             stored_check_metadata = await conn.fetchrow(
                 """
                 SELECT check_date, received_through
@@ -2860,7 +3405,29 @@ async def test_real_postgres_http_and_mcp_entrypoints_use_supported_dependencies
             )
             assert stored_check_metadata["check_date"] == date(2026, 8, 10)
             assert stored_check_metadata["received_through"] == "Mail"
+            full_receipt_delivery = await conn.fetchrow(
+                """
+                SELECT receipt_number, recipient_email, delivery_status, skip_reason
+                FROM payment_receipt_deliveries
+                WHERE payment_id = (
+                    SELECT id
+                    FROM customer_payments
+                    WHERE idempotency_key = 'http-unapplied-payment-1'
+                )
+                """
+            )
+            assert dict(full_receipt_delivery) == {
+                "receipt_number": f"EOM-RCP-{unapplied_payment['id']}",
+                "recipient_email": "residential@example.test",
+                "delivery_status": "pending",
+                "skip_reason": None,
+            }
             assert slim_unapplied_response.status_code == 201
+            assert slim_unapplied_replay.status_code == 201
+            assert (
+                slim_unapplied_replay.json()["id"]
+                == slim_unapplied_response.json()["id"]
+            )
             assert slim_unapplied_response.json()["check_date"] == "2026-08-11"
             assert (
                 slim_unapplied_response.json()["received_through"]
@@ -2876,6 +3443,39 @@ async def test_real_postgres_http_and_mcp_entrypoints_use_supported_dependencies
             assert stored_slim_check_metadata["check_date"] == date(2026, 8, 11)
             assert stored_slim_check_metadata["received_through"] == "Employee handoff"
             assert stored_slim_check_metadata["recorded_by"] == "Juan Canfield"
+            receipt_delivery = await conn.fetchrow(
+                """
+                SELECT receipt_number, recipient_email, delivery_status, skip_reason
+                FROM payment_receipt_deliveries
+                WHERE payment_id = (
+                    SELECT id
+                    FROM customer_payments
+                    WHERE idempotency_key = 'slim-http-unapplied-payment-1'
+                )
+                """
+            )
+            assert dict(receipt_delivery) == {
+                "receipt_number": (
+                    f"EOM-RCP-{slim_unapplied_response.json()['id']}"
+                ),
+                "recipient_email": "residential@example.test",
+                "delivery_status": "pending",
+                "skip_reason": None,
+            }
+            assert (
+                await conn.fetchval(
+                    """
+                    SELECT COUNT(*)
+                    FROM payment_receipt_deliveries
+                    WHERE payment_id = (
+                        SELECT id
+                        FROM customer_payments
+                        WHERE idempotency_key = 'slim-http-unapplied-payment-1'
+                    )
+                    """
+                )
+                == 1
+            )
             assert (
                 await conn.fetchval(
                     "SELECT COUNT(*) FROM invoice_payments ip "
@@ -3163,7 +3763,8 @@ def test_payment_http_models_preserve_optional_check_metadata():
 
 
 @pytest.mark.asyncio
-async def test_payment_routes_forward_omitted_allocations_as_empty_list():
+async def test_payment_routes_forward_omitted_allocations_as_empty_list(monkeypatch):
+    from atlas_brain.api.invoicing import receivables as full_routes
     from atlas_brain.api.invoicing.receivables import (
         CreatePaymentRequest as FullCreatePaymentRequest,
     )
@@ -3171,6 +3772,7 @@ async def test_payment_routes_forward_omitted_allocations_as_empty_list():
     from atlas_brain.eom_api.receivables import (
         CreatePaymentRequest as EOMCreatePaymentRequest,
     )
+    from atlas_brain.eom_api import receivables as eom_routes
     from atlas_brain.eom_api.receivables import create_payment as eom_create_payment
 
     class _RecordingService:
@@ -3180,6 +3782,17 @@ async def test_payment_routes_forward_omitted_allocations_as_empty_list():
         async def create_payment(self, **kwargs):
             self.kwargs = kwargs
             return {"id": "payment-1"}
+
+    class _CRM:
+        async def get_eom_payment_customer(self, contact_id):
+            return {
+                "contact_id": contact_id,
+                "customer_name": "Residential Customer",
+                "customer_type": "residential",
+                "recipient_email": "residential@example.test",
+            }
+
+    monkeypatch.setattr(full_routes, "get_crm_provider", lambda: _CRM())
 
     for request_model, create_route in (
         (FullCreatePaymentRequest, full_create_payment),
@@ -3197,12 +3810,25 @@ async def test_payment_routes_forward_omitted_allocations_as_empty_list():
         )
         service = _RecordingService()
 
-        result = await create_route(
-            body,
-            actor="Juan Canfield",
-            idempotency_key="route-unapplied-payment-1",
-            service=service,
-        )
+        route_args = {
+            "actor": "Juan Canfield",
+            "idempotency_key": "route-unapplied-payment-1",
+            "service": service,
+        }
+        if create_route is eom_create_payment:
+            class _CanonicalPool:
+                is_initialized = True
+
+            monkeypatch.setattr(
+                eom_routes, "get_eom_funnel_db_pool", lambda: _CanonicalPool()
+            )
+            route_args["request"] = SimpleNamespace(
+                app=SimpleNamespace(
+                    state=SimpleNamespace(eom_funnel_crm_provider=lambda: _CRM())
+                )
+            )
+
+        result = await create_route(body, **route_args)
 
         assert result == {"id": "payment-1"}
         assert service.kwargs["allocations"] == []
@@ -3212,6 +3838,8 @@ async def test_payment_routes_forward_omitted_allocations_as_empty_list():
         assert service.kwargs["idempotency_key"] == "route-unapplied-payment-1"
         assert service.kwargs["check_date"] is None
         assert service.kwargs["received_through"] is None
+        assert service.kwargs["require_receipt_recipient"] is True
+        assert service.kwargs["receipt_recipient"].contact_id == body.contact_id
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
@@ -3223,6 +3851,7 @@ async def test_payment_routes_forward_omitted_allocations_as_empty_list():
 )
 async def test_full_and_slim_payment_entrypoints_reject_check_metadata_when_schema_is_unready(
     check_metadata,
+    monkeypatch,
 ):
     from atlas_brain import main, main_eom
     from atlas_brain.api.invoicing import auth as full_auth
@@ -3250,6 +3879,29 @@ async def test_full_and_slim_payment_entrypoints_reject_check_metadata_when_sche
         "X-EOM-Actor": "Juan Canfield",
         "Idempotency-Key": "asgi-unready-check-metadata-1",
     }
+
+    class _CanonicalPool:
+        is_initialized = True
+
+    class _CRM:
+        async def get_eom_payment_customer(self, contact_id):
+            return {
+                "contact_id": contact_id,
+                "customer_name": "Residential Customer",
+                "customer_type": "residential",
+                "recipient_email": "residential@example.test",
+            }
+
+    monkeypatch.setattr(full_routes, "get_crm_provider", lambda: _CRM())
+    monkeypatch.setattr(
+        slim_routes, "get_eom_funnel_db_pool", lambda: _CanonicalPool()
+    )
+    monkeypatch.setattr(
+        main_eom.app.state,
+        "eom_funnel_crm_provider",
+        lambda: _CRM(),
+        raising=False,
+    )
 
     for app, config_dependency, service_dependency in (
         (main.app, full_auth.get_receivables_api_config, full_routes.get_receivables_service),


### PR DESCRIPTION
Plan: plans/PR-EOM-Residential-Receipt-Outbox.md
Slice phase: Vertical slice
Ownership lane: eom/billing-receipts

Residential EOM payments had no durable receipt-delivery record, and the deployed full provider route had not resolved canonical classification before committing a payment. This slice queues an atomic, non-sending receipt outbox record without changing money, allocations, or existing MCP behavior.

## Intentional

- Add one payment-keyed outbox row with deterministic receipt content and a pending or skipped status; no Gmail, Resend, browser UI, or transport call is introduced.
- Make the deployed full EOM route and the slim EOM profile obtain a canonical active-customer snapshot before a new write while allowing an unchanged idempotency retry to return its existing payment.
- Keep generic service/MCP callers on the established no-receipt-context behavior; the full EOM HTTP route is intentionally receipt-aware because it owns the canonical primary CRM dependency.
- Deploy this provider first; tracker and Website presentation/sending work remain later additive consumers.
- guard-class-closure: waived — the strict heuristic sees the changed closed schema-readiness probe as an open-input guard. The plan declares its migration/index inventory CLOSED and derives its verification from PostgreSQL catalogs; no free-text or producer-supplied safety admission rule changed.
- Consume authorized draft consent before final local review so its no-consent wrapper fixtures retain their own fail-closed coverage; this fixes the locally observed 15-test false regression without relaxing draft authorization.

## AI reconciliation

- Fail readiness when the canonical CRM is absent -- fixed-in: ef94432c5 atlas_brain/eom_api/receivables.py, tests/test_eom_render_profile.py
- Preserve persisted receipt projections across replays -- fixed-in: ef94432c5 atlas_brain/services/receivables.py, tests/test_receivables.py
- Run receipt readiness checks on the held connection -- fixed-in: ef94432c5 atlas_brain/services/receivables.py, tests/test_receivables.py
- Translate canonical schema failures into controlled responses -- fixed-in: ef94432c5 atlas_brain/api/invoicing/receivables.py, atlas_brain/eom_api/receivables.py, tests/test_eom_payment_receipts.py
- Justify the oversized slice in the required section -- fixed-in: ef94432c5 plans/PR-EOM-Residential-Receipt-Outbox.md

## Fix-loop disposition preflight

- Root decision: Fail readiness when the canonical CRM is absent
- Source trace: PRRT_kwDOQ5Uhrs6Y1ii1 -> eom_api/receivables.py ready -> billing recipient admission
- Upstream files: atlas_brain/eom_api/receivables.py
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: .github/workflows/atlas_invoicing_checks.yml, atlas_brain/api/invoicing/receivables.py, atlas_brain/eom_api/receivables.py, atlas_brain/main_eom.py, atlas_brain/services/crm_provider.py, atlas_brain/services/receivables.py, atlas_brain/storage/migrations/369_receivables_payment_receipt_outbox.sql, atlas_brain/templates/email/payment_receipt.py, plans/PR-EOM-Residential-Receipt-Outbox.md, scripts/open_pr.sh, tests/test_eom_billing_recipients.py, tests/test_eom_payment_receipts.py, tests/test_eom_render_profile.py, tests/test_open_pr_wrapper.py, tests/test_receivables.py
- Max files: 15
- Parked hardening: #2363 H-07

- Root decision: Preserve persisted receipt projections across replays
- Source trace: PRRT_kwDOQ5Uhrs6Y1ii6 -> services/receivables.py create_payment_with_outcome -> replay payment view
- Upstream files: atlas_brain/services/receivables.py
- Fix strategy: upstream-root
- Blocking predicate: money
- Disposition: fixed-in
- Allowed files: .github/workflows/atlas_invoicing_checks.yml, atlas_brain/api/invoicing/receivables.py, atlas_brain/eom_api/receivables.py, atlas_brain/main_eom.py, atlas_brain/services/crm_provider.py, atlas_brain/services/receivables.py, atlas_brain/storage/migrations/369_receivables_payment_receipt_outbox.sql, atlas_brain/templates/email/payment_receipt.py, plans/PR-EOM-Residential-Receipt-Outbox.md, scripts/open_pr.sh, tests/test_eom_billing_recipients.py, tests/test_eom_payment_receipts.py, tests/test_eom_render_profile.py, tests/test_open_pr_wrapper.py, tests/test_receivables.py
- Max files: 15
- Parked hardening: #2363 H-07

- Root decision: Run receipt readiness checks on the held connection
- Source trace: PRRT_kwDOQ5Uhrs6Y1ii8 -> services/receivables.py create_payment_with_outcome -> receipt readiness probe
- Upstream files: atlas_brain/services/receivables.py
- Fix strategy: upstream-root
- Blocking predicate: performance
- Disposition: fixed-in
- Allowed files: .github/workflows/atlas_invoicing_checks.yml, atlas_brain/api/invoicing/receivables.py, atlas_brain/eom_api/receivables.py, atlas_brain/main_eom.py, atlas_brain/services/crm_provider.py, atlas_brain/services/receivables.py, atlas_brain/storage/migrations/369_receivables_payment_receipt_outbox.sql, atlas_brain/templates/email/payment_receipt.py, plans/PR-EOM-Residential-Receipt-Outbox.md, scripts/open_pr.sh, tests/test_eom_billing_recipients.py, tests/test_eom_payment_receipts.py, tests/test_eom_render_profile.py, tests/test_open_pr_wrapper.py, tests/test_receivables.py
- Max files: 15
- Parked hardening: #2363 H-07

- Root decision: Translate canonical schema failures into controlled responses
- Source trace: PRRT_kwDOQ5Uhrs6Y1ijD -> full/slim canonical customer read -> HTTP exception classifier
- Upstream files: atlas_brain/api/invoicing/receivables.py, atlas_brain/eom_api/receivables.py
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: .github/workflows/atlas_invoicing_checks.yml, atlas_brain/api/invoicing/receivables.py, atlas_brain/eom_api/receivables.py, atlas_brain/main_eom.py, atlas_brain/services/crm_provider.py, atlas_brain/services/receivables.py, atlas_brain/storage/migrations/369_receivables_payment_receipt_outbox.sql, atlas_brain/templates/email/payment_receipt.py, plans/PR-EOM-Residential-Receipt-Outbox.md, scripts/open_pr.sh, tests/test_eom_billing_recipients.py, tests/test_eom_payment_receipts.py, tests/test_eom_render_profile.py, tests/test_open_pr_wrapper.py, tests/test_receivables.py
- Max files: 15
- Parked hardening: #2363 H-07

- Root decision: Justify the oversized slice in the required section
- Source trace: PRRT_kwDOQ5Uhrs6Y1ijI -> plans/PR-EOM-Residential-Receipt-Outbox.md Why -> diff-budget review policy
- Upstream files: plans/PR-EOM-Residential-Receipt-Outbox.md
- Fix strategy: upstream-root
- Blocking predicate: ci
- Disposition: fixed-in
- Allowed files: .github/workflows/atlas_invoicing_checks.yml, atlas_brain/api/invoicing/receivables.py, atlas_brain/eom_api/receivables.py, atlas_brain/main_eom.py, atlas_brain/services/crm_provider.py, atlas_brain/services/receivables.py, atlas_brain/storage/migrations/369_receivables_payment_receipt_outbox.sql, atlas_brain/templates/email/payment_receipt.py, plans/PR-EOM-Residential-Receipt-Outbox.md, scripts/open_pr.sh, tests/test_eom_billing_recipients.py, tests/test_eom_payment_receipts.py, tests/test_eom_render_profile.py, tests/test_open_pr_wrapper.py, tests/test_receivables.py
- Max files: 15
- Parked hardening: #2363 H-07

## Deferred

- Tracker/Website recipient preview, receipt-status display, and email retry controls remain in the next EOM Billing & Payments slices.
- A sender/reconciliation worker must claim pending/failed rows, use a verifiable idempotency strategy, and never roll back a committed payment.
- Customer-ledger search/filter/export of receipt status and all billing-run, Gmail-draft, sent-mail, and Square queue work stay in the coordinating plan.

## Parked hardening

- None.

## Cold diff reconstruction

- Changed: additive receipt-outbox migration and deterministic template; full/slim canonical CRM preflight; ledger atomic enqueue/readiness/projection; migration and HTTP/replay/rollback tests; local workflow enrollment.
- Contract match: a residential payment atomically gains exactly one pending/skipped receipt row, a receipt-send failure is impossible in this slice because no sender exists, and a same-key retry cannot write a second payment or receipt.
- Deployment order: ATLAS provider migration/release first, then tracker/Website consumers; generic MCP payment paths remain compatible during mixed rollout.
- Gaps: no customer email was sent, no production financial data was mutated, and delivery reconciliation is deliberately deferred.

## Verification

- The exact local equivalent of the invoicing workflow passed against disposable PostgreSQL 16: 2 monthly blocker tests, 217 provider/ledger tests, and 43 MCP/OAuth tests.
- Isolated PostgreSQL coverage proves the active full HTTP route persists a pending receipt row, preserves an unchanged retry, and rolls back the payment if enqueue fails; slim-profile parity is covered separately.
- The draft-PR wrapper regression passes locally: authorized `--draft` is forwarded, but final local review does not inherit the one-shot consent environment variable.
- The guarded local PR gate passed its full baseline-aware unit suite: 160 failing/errored nodes exactly matched the accepted baseline, with 0 regressions and 0 newly passing nodes.
- No hosted check was manually dispatched or re-run: the operator explicitly requested local GitHub-equivalent checks as the acceptance gate.

## Mechanical verification

- Command: `ruff check --ignore E402 atlas_brain/api/invoicing/receivables.py atlas_brain/eom_api/receivables.py atlas_brain/main_eom.py atlas_brain/services/crm_provider.py atlas_brain/services/receivables.py atlas_brain/templates/email/payment_receipt.py tests/test_eom_billing_recipients.py tests/test_eom_payment_receipts.py tests/test_eom_render_profile.py tests/test_receivables.py` - Result: passed - Environment: local
- Command: `python -m compileall -q atlas_brain/api/invoicing/receivables.py atlas_brain/eom_api/receivables.py atlas_brain/main_eom.py atlas_brain/services/crm_provider.py atlas_brain/services/receivables.py atlas_brain/templates/email/payment_receipt.py tests/test_eom_billing_recipients.py tests/test_eom_payment_receipts.py tests/test_eom_render_profile.py tests/test_receivables.py` - Result: passed - Environment: local
- Command: `python -m pytest -q tests/test_eom_render_profile.py tests/test_receivables.py tests/test_eom_billing_recipients.py tests/test_eom_payment_receipts.py tests/test_invoice_repository.py` with disposable PostgreSQL 16 - Result: 217 passed - Environment: local
- Command: `python -m pytest tests/test_monthly_invoice_generation.py -k 'update_invoice_clears_needs_hours_when_line_items_are_billable or line_items_are_billable_requires_all_positive_quantities' -q` - Result: 2 passed - Environment: local
- Command: `python -m pytest tests/test_invoicing_readonly_mcp.py tests/test_invoicing_readonly_oauth.py tests/test_invoicing_draft_writer_mcp.py tests/test_invoicing_draft_writer_oauth.py -q` - Result: 43 passed - Environment: local
- Command: `python -m pytest -q tests/test_migrations_runner.py -k 'migration or receivables'` - Result: 30 passed, 1 skipped - Environment: local
- Command: `bash -n scripts/open_pr.sh && python -m pytest -q tests/test_open_pr_wrapper.py` - Result: 56 passed - Environment: local
- Command: `ATLAS_CURRENT_PR_BODY_FILE=tmp/pr_body_eom_receipt_outbox.md python scripts/check_guard_class_closure.py --base origin/main --strict` - Result: passed with the documented closed-schema inventory waiver - Environment: local
- Command: `python scripts/audit_plan_doc_files_touched.py plans/PR-EOM-Residential-Receipt-Outbox.md origin/main && python scripts/audit_plan_code_consistency.py --base-ref origin/main plans/PR-EOM-Residential-Receipt-Outbox.md && python scripts/audit_review_rules_triggered.py origin/main --plan plans/PR-EOM-Residential-Receipt-Outbox.md` - Result: passed - Environment: local
- Command: `python scripts/sync_pr_plan.py --check plans/PR-EOM-Residential-Receipt-Outbox.md origin/main` - Result: passed - Environment: local
- Command: `git diff --check` - Result: passed - Environment: local
- Command: `ATLAS_SESSION_STATE_FILE=SESSION_STATE.codex-eom-receipt-outbox.local.md bash scripts/push_pr.sh tmp/pr_body_eom_receipt_outbox.md -u origin HEAD` - Result: passed; full local unit gate baseline=160, regressions=0; published ef94432c5 - Environment: local
- Skipped: hosted GitHub Actions dispatch or re-run - Reason: operator requested local GitHub-equivalent checks instead.

## Diff size

Diff-budget override: The outbox migration, canonical-customer preflight, atomic ledger write, readiness probe, and rollback/replay coverage are one financial transaction contract; splitting them would either ship no usable receipt behavior or activate a receipt-aware payment route without its durable recovery proof.

15 files, +2248/-110 lines (2,358 total). The full active router is included with the slim profile because deployment inspection proved tracker production targets the full route; omitting it would ship an unreachable receipt capability. Workflow enrollment and the narrow local-wrapper repair are included because they are required to prove the provider transaction contract locally.

<!-- atlas-open-pr-wrapper: v1 -->
