### PR TITLE
EOM receivables: add customer ledger history contract

### DIFF
--- a/atlas_brain/api/invoicing/receivables.py
+++ b/atlas_brain/api/invoicing/receivables.py
@@ -328,6 +328,33 @@ async def list_payments(
     )
 
 
+@router.get("/customers/{contact_id}/ledger")
+async def customer_ledger(
+    contact_id: UUID,
+    payment_status: Optional[str] = Query(default=None, max_length=16),
+    payment_method: Optional[str] = Query(default=None, max_length=32),
+    search: Optional[str] = Query(default=None, max_length=256),
+    from_date: Optional[date] = Query(default=None),
+    to_date: Optional[date] = Query(default=None),
+    limit: int = Query(default=100, ge=1, le=200),
+    offset: int = Query(default=0, ge=0, le=10000),
+    service: ReceivablesService = Depends(get_receivables_service),
+) -> dict:
+    """Return one bounded, receipt-aware financial ledger page for a customer."""
+    return await _call(
+        service.list_customer_ledger(
+            contact_id=contact_id,
+            payment_status=payment_status,
+            payment_method=payment_method,
+            search=search,
+            from_date=from_date,
+            to_date=to_date,
+            limit=limit,
+            offset=offset,
+        )
+    )
+
+
 @router.put("/payments/{payment_id}/allocations")
 async def adjust_allocations(
     payment_id: UUID,

--- a/atlas_brain/api/invoicing/receivables.py
+++ b/atlas_brain/api/invoicing/receivables.py
@@ -337,7 +337,7 @@ async def customer_ledger(
     from_date: Optional[date] = Query(default=None),
     to_date: Optional[date] = Query(default=None),
     limit: int = Query(default=100, ge=1, le=200),
-    offset: int = Query(default=0, ge=0, le=10000),
+    offset: int = Query(default=0, ge=0),
     service: ReceivablesService = Depends(get_receivables_service),
 ) -> dict:
     """Return one bounded, receipt-aware financial ledger page for a customer."""

--- a/atlas_brain/eom_api/receivables.py
+++ b/atlas_brain/eom_api/receivables.py
@@ -451,7 +451,7 @@ async def customer_ledger(
     from_date: Optional[date] = Query(default=None),
     to_date: Optional[date] = Query(default=None),
     limit: int = Query(default=100, ge=1, le=200),
-    offset: int = Query(default=0, ge=0, le=10000),
+    offset: int = Query(default=0, ge=0),
     service: ReceivablesService = Depends(get_receivables_service),
 ) -> dict:
     """Return one bounded, receipt-aware financial ledger page for a customer."""

--- a/atlas_brain/eom_api/receivables.py
+++ b/atlas_brain/eom_api/receivables.py
@@ -442,6 +442,33 @@ async def list_payments(
     )
 
 
+@router.get("/customers/{contact_id}/ledger")
+async def customer_ledger(
+    contact_id: UUID,
+    payment_status: Optional[str] = Query(default=None, max_length=16),
+    payment_method: Optional[str] = Query(default=None, max_length=32),
+    search: Optional[str] = Query(default=None, max_length=256),
+    from_date: Optional[date] = Query(default=None),
+    to_date: Optional[date] = Query(default=None),
+    limit: int = Query(default=100, ge=1, le=200),
+    offset: int = Query(default=0, ge=0, le=10000),
+    service: ReceivablesService = Depends(get_receivables_service),
+) -> dict:
+    """Return one bounded, receipt-aware financial ledger page for a customer."""
+    return await _call(
+        service.list_customer_ledger(
+            contact_id=contact_id,
+            payment_status=payment_status,
+            payment_method=payment_method,
+            search=search,
+            from_date=from_date,
+            to_date=to_date,
+            limit=limit,
+            offset=offset,
+        )
+    )
+
+
 @router.put("/payments/{payment_id}/allocations")
 async def adjust_allocations(
     payment_id: UUID,

--- a/atlas_brain/services/receivables.py
+++ b/atlas_brain/services/receivables.py
@@ -336,8 +336,8 @@ class ReceivablesReceiptContextRequiredError(ReceivablesError):
     code = "canonical_customer_unavailable"
 
 
-def money(value: Any) -> Decimal:
-    """Normalize a value to finite, two-decimal currency."""
+def _currency(value: Any, *, max_abs: Optional[Decimal]) -> Decimal:
+    """Normalize finite, cent-precise currency with an optional magnitude cap."""
     try:
         raw = Decimal(str(value))
     except (InvalidOperation, TypeError, ValueError) as exc:
@@ -350,14 +350,34 @@ def money(value: Any) -> Decimal:
         raise ReceivablesValidationError("Amount must be valid currency") from exc
     if raw != normalized:
         raise ReceivablesValidationError("Amount must use cent precision")
-    if abs(normalized) > _MAX_DATABASE_MONEY:
+    if max_abs is not None and abs(normalized) > max_abs:
         raise ReceivablesValidationError("Amount exceeds the supported currency range")
     return normalized
+
+
+def money(value: Any) -> Decimal:
+    """Normalize a persisted money value to finite, two-decimal currency."""
+    return _currency(value, max_abs=_MAX_DATABASE_MONEY)
 
 
 def cents(value: Any) -> int:
     """Convert a database currency value to integer cents."""
     return int(money(value) * 100)
+
+
+def aggregate_cents(value: Any) -> int:
+    """Convert a finite, cent-precise aggregate without a per-row storage cap."""
+    return int(_currency(value, max_abs=None) * 100)
+
+
+def _literal_ilike_pattern(value: str) -> str:
+    """Build a literal substring pattern for ledger ILIKE predicates."""
+    escaped = (
+        value.replace("\\", "\\\\")
+        .replace("%", "\\%")
+        .replace("_", "\\_")
+    )
+    return f"%{escaped}%"
 
 
 def _jsonable(value: Any) -> Any:
@@ -1084,7 +1104,9 @@ class ReceivablesService:
         normalized_method = payment_method.strip() if payment_method is not None else None
         page_size = max(1, min(limit, 200))
         page_offset = max(0, offset)
-        search_pattern = f"%{normalized_search}%" if normalized_search else None
+        search_pattern = (
+            _literal_ilike_pattern(normalized_search) if normalized_search else None
+        )
 
         async with self.pool.transaction() as conn:
             await conn.execute(
@@ -1109,8 +1131,8 @@ class ReceivablesService:
                       AND ($5::varchar IS NULL AND $6::varchar IS NULL)
                       AND (
                           $4::text IS NULL
-                          OR i.invoice_number ILIKE $4
-                          OR i.customer_name ILIKE $4
+                          OR i.invoice_number ILIKE $4 ESCAPE E'\\\\'
+                          OR i.customer_name ILIKE $4 ESCAPE E'\\\\'
                       )
 
                     UNION ALL
@@ -1127,13 +1149,13 @@ class ReceivablesService:
                       AND ($6::varchar IS NULL OR cp.payment_method = $6)
                       AND (
                           $4::text IS NULL
-                          OR cp.payer_name ILIKE $4
-                          OR cp.reference ILIKE $4
+                          OR cp.payer_name ILIKE $4 ESCAPE E'\\\\'
+                          OR cp.reference ILIKE $4 ESCAPE E'\\\\'
                           OR EXISTS (
                               SELECT 1
                               FROM payment_receipt_deliveries prd
                               WHERE prd.payment_id = cp.id
-                                AND prd.receipt_number ILIKE $4
+                                AND prd.receipt_number ILIKE $4 ESCAPE E'\\\\'
                           )
                           OR EXISTS (
                               SELECT 1
@@ -1141,8 +1163,8 @@ class ReceivablesService:
                               JOIN invoices i ON i.id = ip.invoice_id
                               WHERE ip.payment_id = cp.id
                                 AND (
-                                    i.invoice_number ILIKE $4
-                                    OR i.customer_name ILIKE $4
+                                    i.invoice_number ILIKE $4 ESCAPE E'\\\\'
+                                    OR i.customer_name ILIKE $4 ESCAPE E'\\\\'
                                 )
                           )
                       )
@@ -1274,10 +1296,10 @@ class ReceivablesService:
                 page_offset + page_size if len(entry_rows) > page_size else None
             ),
             "balances": {
-                "open_invoice_balance_cents": cents(
+                "open_invoice_balance_cents": aggregate_cents(
                     balance_row["open_invoice_balance"]
                 ),
-                "unapplied_payment_balance_cents": cents(
+                "unapplied_payment_balance_cents": aggregate_cents(
                     balance_row["unapplied_payment_balance"]
                 ),
             },

--- a/atlas_brain/services/receivables.py
+++ b/atlas_brain/services/receivables.py
@@ -22,6 +22,7 @@ EOM_CUSTOMER_TYPES = ("residential", "commercial", "unknown")
 RESIDENTIAL_CUSTOMER_TYPE = "residential"
 _CENT = Decimal("0.01")
 _MAX_DATABASE_MONEY = Decimal("9999999999.99")
+_LEDGER_ALLOCATION_HISTORY_LIMIT = 100
 _RECEIVABLES_REQUIRED_COLUMNS = {
     "customer_payments": (
         "id",
@@ -1075,8 +1076,12 @@ class ReceivablesService:
             )
 
         normalized_search = (search or "").strip() or None
-        normalized_status = (payment_status or "").strip() or None
-        normalized_method = (payment_method or "").strip() or None
+        if payment_status is not None and not payment_status.strip():
+            raise ReceivablesValidationError("Payment status cannot be blank")
+        if payment_method is not None and not payment_method.strip():
+            raise ReceivablesValidationError("Payment method cannot be blank")
+        normalized_status = payment_status.strip() if payment_status is not None else None
+        normalized_method = payment_method.strip() if payment_method is not None else None
         page_size = max(1, min(limit, 200))
         page_offset = max(0, offset)
         search_pattern = f"%{normalized_search}%" if normalized_search else None
@@ -1144,7 +1149,10 @@ class ReceivablesService:
                 )
                 SELECT entry_type, entry_id, created_at, occurred_date
                 FROM ledger_entries
-                ORDER BY created_at DESC, entry_type DESC, entry_id DESC
+                ORDER BY occurred_date DESC NULLS LAST,
+                         created_at DESC,
+                         entry_type DESC,
+                         entry_id DESC
                 LIMIT $7 OFFSET $8
                 """,
                 contact_id,
@@ -1182,6 +1190,7 @@ class ReceivablesService:
                     conn,
                     payment_rows,
                     include_receipt_delivery=True,
+                    allocation_history_limit=_LEDGER_ALLOCATION_HISTORY_LIMIT,
                 )
             }
             invoice_rows = (
@@ -1204,11 +1213,16 @@ class ReceivablesService:
             }
             balance_row = await conn.fetchrow(
                 """
-                WITH applied_by_payment AS (
+                WITH customer_payments_in_scope AS (
+                    SELECT cp.id, cp.total_amount, cp.status
+                    FROM customer_payments cp
+                    WHERE cp.contact_id = $1
+                ),
+                applied_by_payment AS (
                     SELECT ip.payment_id, COALESCE(SUM(ip.amount), 0) AS allocated_amount
                     FROM invoice_payments ip
-                    WHERE ip.payment_id IS NOT NULL
-                      AND ip.reversed_at IS NULL
+                    JOIN customer_payments_in_scope cp ON cp.id = ip.payment_id
+                    WHERE ip.reversed_at IS NULL
                     GROUP BY ip.payment_id
                 ),
                 invoice_balance AS (
@@ -1222,10 +1236,9 @@ class ReceivablesService:
                         SUM(cp.total_amount - COALESCE(abp.allocated_amount, 0)),
                         0
                     ) AS unapplied_payment_balance
-                    FROM customer_payments cp
+                    FROM customer_payments_in_scope cp
                     LEFT JOIN applied_by_payment abp ON abp.payment_id = cp.id
-                    WHERE cp.contact_id = $1
-                      AND cp.status = ANY($2::varchar[])
+                    WHERE cp.status = ANY($2::varchar[])
                 )
                 SELECT invoice_balance.open_invoice_balance,
                        unapplied_balance.unapplied_payment_balance
@@ -2158,29 +2171,95 @@ class ReceivablesService:
         rows: list[Any],
         *,
         include_receipt_delivery: bool = False,
+        allocation_history_limit: Optional[int] = None,
     ) -> list[dict[str, Any]]:
         """Hydrate payment list rows without changing their requested order."""
         if not rows:
             return []
         payment_ids = [row["id"] for row in rows]
-        allocation_rows = await executor.fetch(
-            """
-            SELECT ip.payment_id, ip.id, ip.invoice_id, i.invoice_number,
-                   ip.amount, ip.payment_date, ip.payment_method, ip.reference,
-                   ip.notes, ip.recorded_by, ip.created_at, ip.metadata,
-                   ip.reversed_at, ip.reversal_reason
-            FROM invoice_payments ip
-            JOIN invoices i ON i.id = ip.invoice_id
-            WHERE ip.payment_id = ANY($1::uuid[])
-            ORDER BY i.due_date, i.invoice_number, ip.created_at
-            """,
-            payment_ids,
-        )
+        if allocation_history_limit is None:
+            allocation_rows = await executor.fetch(
+                """
+                SELECT ip.payment_id, ip.id, ip.invoice_id, i.invoice_number,
+                       ip.amount, ip.payment_date, ip.payment_method, ip.reference,
+                       ip.notes, ip.recorded_by, ip.created_at, ip.metadata,
+                       ip.reversed_at, ip.reversal_reason
+                FROM invoice_payments ip
+                JOIN invoices i ON i.id = ip.invoice_id
+                WHERE ip.payment_id = ANY($1::uuid[])
+                ORDER BY i.due_date, i.invoice_number, ip.created_at
+                """,
+                payment_ids,
+            )
+        else:
+            if allocation_history_limit < 1:
+                raise ValueError("allocation_history_limit must be positive")
+            allocation_rows = await executor.fetch(
+                """
+                WITH allocation_totals AS (
+                    SELECT ip.payment_id,
+                           COALESCE(SUM(ip.amount) FILTER (
+                               WHERE ip.reversed_at IS NULL
+                           ), 0) AS active_allocated_amount,
+                           COUNT(*) AS allocation_history_count
+                    FROM invoice_payments ip
+                    WHERE ip.payment_id = ANY($1::uuid[])
+                    GROUP BY ip.payment_id
+                ),
+                ranked_allocations AS (
+                    SELECT ip.payment_id, ip.id, ip.invoice_id, i.invoice_number,
+                           ip.amount, ip.payment_date, ip.payment_method,
+                           ip.reference, ip.notes, ip.recorded_by, ip.created_at,
+                           ip.metadata, ip.reversed_at, ip.reversal_reason,
+                           ROW_NUMBER() OVER (
+                               PARTITION BY ip.payment_id
+                               ORDER BY (ip.reversed_at IS NULL) DESC,
+                                        i.due_date,
+                                        i.invoice_number,
+                                        ip.created_at,
+                                        ip.id
+                           ) AS allocation_rank
+                    FROM invoice_payments ip
+                    JOIN invoices i ON i.id = ip.invoice_id
+                    WHERE ip.payment_id = ANY($1::uuid[])
+                )
+                SELECT ranked_allocations.payment_id,
+                       ranked_allocations.id,
+                       ranked_allocations.invoice_id,
+                       ranked_allocations.invoice_number,
+                       ranked_allocations.amount,
+                       ranked_allocations.payment_date,
+                       ranked_allocations.payment_method,
+                       ranked_allocations.reference,
+                       ranked_allocations.notes,
+                       ranked_allocations.recorded_by,
+                       ranked_allocations.created_at,
+                       ranked_allocations.metadata,
+                       ranked_allocations.reversed_at,
+                       ranked_allocations.reversal_reason,
+                       allocation_totals.active_allocated_amount,
+                       allocation_totals.allocation_history_count
+                FROM ranked_allocations
+                JOIN allocation_totals
+                  ON allocation_totals.payment_id = ranked_allocations.payment_id
+                WHERE ranked_allocations.allocation_rank <= $2
+                ORDER BY ranked_allocations.payment_id, ranked_allocations.allocation_rank
+                """,
+                payment_ids,
+                allocation_history_limit,
+            )
         allocations_by_payment: dict[str, list[Any]] = {
             str(payment_id): [] for payment_id in payment_ids
         }
+        allocation_summaries_by_payment: dict[str, dict[str, Any]] = {}
         for allocation in allocation_rows:
-            allocations_by_payment[str(allocation["payment_id"])].append(allocation)
+            payment_id = str(allocation["payment_id"])
+            allocations_by_payment[payment_id].append(allocation)
+            if allocation_history_limit is not None:
+                allocation_summaries_by_payment[payment_id] = {
+                    "active_allocated_amount": allocation["active_allocated_amount"],
+                    "allocation_history_count": allocation["allocation_history_count"],
+                }
 
         receipt_by_payment: dict[str, dict[str, Any]] = {}
         if include_receipt_delivery:
@@ -2203,15 +2282,33 @@ class ReceivablesService:
                 for receipt in receipt_rows
             }
 
-        return [
-            self._compose_payment(
-                row,
-                allocations_by_payment.get(str(row["id"]), []),
-                receipt_delivery=receipt_by_payment.get(str(row["id"])),
-                include_receipt_delivery=include_receipt_delivery,
+        payment_views: list[dict[str, Any]] = []
+        for row in rows:
+            payment_id = str(row["id"])
+            allocation_summary = allocation_summaries_by_payment.get(payment_id)
+            payment_views.append(
+                self._compose_payment(
+                    row,
+                    allocations_by_payment.get(payment_id, []),
+                    receipt_delivery=receipt_by_payment.get(payment_id),
+                    include_receipt_delivery=include_receipt_delivery,
+                    active_allocated_amount=(
+                        allocation_summary["active_allocated_amount"]
+                        if allocation_summary is not None
+                        else Decimal("0")
+                        if allocation_history_limit is not None
+                        else None
+                    ),
+                    allocation_history_count=(
+                        int(allocation_summary["allocation_history_count"])
+                        if allocation_summary is not None
+                        else 0
+                        if allocation_history_limit is not None
+                        else None
+                    ),
+                )
             )
-            for row in rows
-        ]
+        return payment_views
 
     async def _has_replay_receipt_delivery(
         self,
@@ -2253,6 +2350,8 @@ class ReceivablesService:
         *,
         receipt_delivery: Optional[Any] = None,
         include_receipt_delivery: bool = False,
+        active_allocated_amount: Optional[Decimal] = None,
+        allocation_history_count: Optional[int] = None,
     ) -> dict[str, Any]:
         result = _serialize_row(row)
         if include_receipt_delivery:
@@ -2261,10 +2360,17 @@ class ReceivablesService:
                 if receipt_delivery is not None
                 else None
             )
-        allocation_views = [_serialize_row(item) for item in allocations]
+        allocation_views = []
+        for allocation in allocations:
+            view = _serialize_row(allocation)
+            view.pop("active_allocated_amount", None)
+            view.pop("allocation_history_count", None)
+            allocation_views.append(view)
         active_allocated = Decimal("0")
         is_active = row["status"] in ACTIVE_PAYMENT_STATUSES
-        if is_active:
+        if is_active and active_allocated_amount is not None:
+            active_allocated = money(active_allocated_amount)
+        elif is_active:
             active_allocated = sum(
                 (
                     money(item["amount"])
@@ -2284,6 +2390,11 @@ class ReceivablesService:
         for view in allocation_views:
             view["amount_cents"] = cents(view["amount"])
         result["allocations"] = allocation_views
+        if allocation_history_count is not None:
+            result["allocation_history_count"] = allocation_history_count
+            result["allocations_truncated"] = (
+                allocation_history_count > len(allocation_views)
+            )
         return result
 
     @staticmethod

--- a/atlas_brain/services/receivables.py
+++ b/atlas_brain/services/receivables.py
@@ -1048,26 +1048,227 @@ class ReceivablesService:
         )
         if not rows:
             return []
-        payment_ids = [row["id"] for row in rows]
-        allocation_rows = await self.pool.fetch(
-            """
-            SELECT ip.payment_id, ip.id, ip.invoice_id, i.invoice_number,
-                   ip.amount, ip.payment_date, ip.payment_method, ip.reference,
-                   ip.notes, ip.recorded_by, ip.created_at, ip.metadata,
-                   ip.reversed_at, ip.reversal_reason
-            FROM invoice_payments ip
-            JOIN invoices i ON i.id = ip.invoice_id
-            WHERE ip.payment_id = ANY($1::uuid[])
-            ORDER BY i.due_date, i.invoice_number, ip.created_at
-            """,
-            payment_ids,
-        )
-        grouped: dict[str, list[Any]] = {str(item): [] for item in payment_ids}
-        for allocation in allocation_rows:
-            grouped[str(allocation["payment_id"])].append(allocation)
-        return [
-            self._compose_payment(row, grouped.get(str(row["id"]), [])) for row in rows
-        ]
+        return await self._payment_views_for_rows(self.pool, rows)
+
+    async def list_customer_ledger(
+        self,
+        *,
+        contact_id: UUID,
+        payment_status: Optional[str] = None,
+        payment_method: Optional[str] = None,
+        search: Optional[str] = None,
+        from_date: Optional[date] = None,
+        to_date: Optional[date] = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> dict[str, Any]:
+        """Return one bounded, receipt-aware ledger page for a customer.
+
+        Entries are a current financial snapshot, not a reconstructed historical
+        balance.  Invoices do not yet have an immutable lifecycle-event stream,
+        so the response names current invoice and unapplied-payment balances
+        explicitly instead of inferring a running balance from mutable rows.
+        """
+        if from_date is not None and to_date is not None and from_date > to_date:
+            raise ReceivablesValidationError(
+                "Ledger start date cannot be after end date"
+            )
+
+        normalized_search = (search or "").strip() or None
+        normalized_status = (payment_status or "").strip() or None
+        normalized_method = (payment_method or "").strip() or None
+        page_size = max(1, min(limit, 200))
+        page_offset = max(0, offset)
+        search_pattern = f"%{normalized_search}%" if normalized_search else None
+
+        async with self.pool.transaction() as conn:
+            await conn.execute(
+                "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY"
+            )
+            if not await self.is_receipt_delivery_ready(conn):
+                raise ReceivablesSchemaUnavailableError(
+                    "Receivables schema unavailable for customer ledger"
+                )
+
+            entry_rows = await conn.fetch(
+                """
+                WITH ledger_entries AS (
+                    SELECT 'invoice'::text AS entry_type,
+                           i.id AS entry_id,
+                           i.created_at,
+                           i.issue_date AS occurred_date
+                    FROM invoices i
+                    WHERE i.contact_id = $1
+                      AND ($2::date IS NULL OR i.issue_date >= $2)
+                      AND ($3::date IS NULL OR i.issue_date <= $3)
+                      AND ($5::varchar IS NULL AND $6::varchar IS NULL)
+                      AND (
+                          $4::text IS NULL
+                          OR i.invoice_number ILIKE $4
+                          OR i.customer_name ILIKE $4
+                      )
+
+                    UNION ALL
+
+                    SELECT 'payment'::text AS entry_type,
+                           cp.id AS entry_id,
+                           cp.created_at,
+                           cp.received_date AS occurred_date
+                    FROM customer_payments cp
+                    WHERE cp.contact_id = $1
+                      AND ($2::date IS NULL OR cp.received_date >= $2)
+                      AND ($3::date IS NULL OR cp.received_date <= $3)
+                      AND ($5::varchar IS NULL OR cp.status = $5)
+                      AND ($6::varchar IS NULL OR cp.payment_method = $6)
+                      AND (
+                          $4::text IS NULL
+                          OR cp.payer_name ILIKE $4
+                          OR cp.reference ILIKE $4
+                          OR EXISTS (
+                              SELECT 1
+                              FROM payment_receipt_deliveries prd
+                              WHERE prd.payment_id = cp.id
+                                AND prd.receipt_number ILIKE $4
+                          )
+                          OR EXISTS (
+                              SELECT 1
+                              FROM invoice_payments ip
+                              JOIN invoices i ON i.id = ip.invoice_id
+                              WHERE ip.payment_id = cp.id
+                                AND (
+                                    i.invoice_number ILIKE $4
+                                    OR i.customer_name ILIKE $4
+                                )
+                          )
+                      )
+                )
+                SELECT entry_type, entry_id, created_at, occurred_date
+                FROM ledger_entries
+                ORDER BY created_at DESC, entry_type DESC, entry_id DESC
+                LIMIT $7 OFFSET $8
+                """,
+                contact_id,
+                from_date,
+                to_date,
+                search_pattern,
+                normalized_status,
+                normalized_method,
+                page_size + 1,
+                page_offset,
+            )
+            page_rows = entry_rows[:page_size]
+            payment_ids = [
+                row["entry_id"] for row in page_rows if row["entry_type"] == "payment"
+            ]
+            invoice_ids = [
+                row["entry_id"] for row in page_rows if row["entry_type"] == "invoice"
+            ]
+            payment_rows = (
+                await conn.fetch(
+                    """
+                SELECT cp.*, pdi.batch_id
+                FROM customer_payments cp
+                LEFT JOIN payment_deposit_items pdi ON pdi.payment_id = cp.id
+                WHERE cp.id = ANY($1::uuid[])
+                """,
+                    payment_ids,
+                )
+                if payment_ids
+                else []
+            )
+            payment_views = {
+                view["id"]: view
+                for view in await self._payment_views_for_rows(
+                    conn,
+                    payment_rows,
+                    include_receipt_delivery=True,
+                )
+            }
+            invoice_rows = (
+                await conn.fetch(
+                    """
+                SELECT id, invoice_number, contact_id, customer_name, issue_date,
+                       due_date, status, total_amount, amount_paid, amount_due,
+                       sent_at, paid_at, voided_at, void_reason, source, source_ref,
+                       created_at, updated_at
+                FROM invoices
+                WHERE id = ANY($1::uuid[])
+                """,
+                    invoice_ids,
+                )
+                if invoice_ids
+                else []
+            )
+            invoice_views = {
+                view["id"]: view for view in map(self._invoice_view, invoice_rows)
+            }
+            balance_row = await conn.fetchrow(
+                """
+                WITH applied_by_payment AS (
+                    SELECT ip.payment_id, COALESCE(SUM(ip.amount), 0) AS allocated_amount
+                    FROM invoice_payments ip
+                    WHERE ip.payment_id IS NOT NULL
+                      AND ip.reversed_at IS NULL
+                    GROUP BY ip.payment_id
+                ),
+                invoice_balance AS (
+                    SELECT COALESCE(SUM(i.amount_due), 0) AS open_invoice_balance
+                    FROM invoices i
+                    WHERE i.contact_id = $1
+                      AND i.status NOT IN ('draft', 'void')
+                ),
+                unapplied_balance AS (
+                    SELECT COALESCE(
+                        SUM(cp.total_amount - COALESCE(abp.allocated_amount, 0)),
+                        0
+                    ) AS unapplied_payment_balance
+                    FROM customer_payments cp
+                    LEFT JOIN applied_by_payment abp ON abp.payment_id = cp.id
+                    WHERE cp.contact_id = $1
+                      AND cp.status = ANY($2::varchar[])
+                )
+                SELECT invoice_balance.open_invoice_balance,
+                       unapplied_balance.unapplied_payment_balance
+                FROM invoice_balance
+                CROSS JOIN unapplied_balance
+                """,
+                contact_id,
+                list(ACTIVE_PAYMENT_STATUSES),
+            )
+
+        entries: list[dict[str, Any]] = []
+        for row in page_rows:
+            entry_id = str(row["entry_id"])
+            entry_type = row["entry_type"]
+            entries.append(
+                {
+                    "entry_type": entry_type,
+                    "entry_id": entry_id,
+                    "created_at": row["created_at"],
+                    "occurred_date": row["occurred_date"],
+                    entry_type: (
+                        payment_views[entry_id]
+                        if entry_type == "payment"
+                        else invoice_views[entry_id]
+                    ),
+                }
+            )
+
+        return {
+            "contact_id": str(contact_id),
+            "entries": entries,
+            "next_offset": (
+                page_offset + page_size if len(entry_rows) > page_size else None
+            ),
+            "balances": {
+                "open_invoice_balance_cents": cents(
+                    balance_row["open_invoice_balance"]
+                ),
+                "unapplied_payment_balance_cents": cents(
+                    balance_row["unapplied_payment_balance"]
+                ),
+            },
+        }
 
     async def adjust_allocations(
         self,
@@ -1950,6 +2151,67 @@ class ReceivablesService:
             receipt_delivery=receipt_delivery,
             include_receipt_delivery=include_receipt_delivery,
         )
+
+    async def _payment_views_for_rows(
+        self,
+        executor: Any,
+        rows: list[Any],
+        *,
+        include_receipt_delivery: bool = False,
+    ) -> list[dict[str, Any]]:
+        """Hydrate payment list rows without changing their requested order."""
+        if not rows:
+            return []
+        payment_ids = [row["id"] for row in rows]
+        allocation_rows = await executor.fetch(
+            """
+            SELECT ip.payment_id, ip.id, ip.invoice_id, i.invoice_number,
+                   ip.amount, ip.payment_date, ip.payment_method, ip.reference,
+                   ip.notes, ip.recorded_by, ip.created_at, ip.metadata,
+                   ip.reversed_at, ip.reversal_reason
+            FROM invoice_payments ip
+            JOIN invoices i ON i.id = ip.invoice_id
+            WHERE ip.payment_id = ANY($1::uuid[])
+            ORDER BY i.due_date, i.invoice_number, ip.created_at
+            """,
+            payment_ids,
+        )
+        allocations_by_payment: dict[str, list[Any]] = {
+            str(payment_id): [] for payment_id in payment_ids
+        }
+        for allocation in allocation_rows:
+            allocations_by_payment[str(allocation["payment_id"])].append(allocation)
+
+        receipt_by_payment: dict[str, dict[str, Any]] = {}
+        if include_receipt_delivery:
+            receipt_rows = await executor.fetch(
+                """
+                SELECT payment_id, receipt_number, recipient_email,
+                       delivery_status AS status, skip_reason
+                FROM payment_receipt_deliveries
+                WHERE payment_id = ANY($1::uuid[])
+                """,
+                payment_ids,
+            )
+            receipt_by_payment = {
+                str(receipt["payment_id"]): {
+                    "receipt_number": receipt["receipt_number"],
+                    "recipient_email": receipt["recipient_email"],
+                    "status": receipt["status"],
+                    "skip_reason": receipt["skip_reason"],
+                }
+                for receipt in receipt_rows
+            }
+
+        return [
+            self._compose_payment(
+                row,
+                allocations_by_payment.get(str(row["id"]), []),
+                receipt_delivery=receipt_by_payment.get(str(row["id"])),
+                include_receipt_delivery=include_receipt_delivery,
+            )
+            for row in rows
+        ]
 
     async def _has_replay_receipt_delivery(
         self,

--- a/plans/PR-EOM-Customer-Ledger-History.md
+++ b/plans/PR-EOM-Customer-Ledger-History.md
@@ -1,0 +1,257 @@
+# PR-EOM-Customer-Ledger-History
+
+## Why this slice exists
+
+The Billing & Payments coordinating issue (#2362) needs a safe ATLAS read
+contract before tracker and website can show a customer ledger. The existing
+`GET /receivables/payments` endpoint only returns payment rows and only searches
+payer name/reference; it has no invoice timeline, receipt-delivery projection,
+or authoritative per-customer balance snapshot
+(`atlas_brain/services/receivables.py:1017-1070`).
+
+This slice closes that provider gap without changing the established mutation
+paths. It follows the deployed receipt-outbox slice #2372 and is intentionally
+read-only, so ATLAS remains the financial source of truth and the tracker can
+later proxy one canonical query rather than inventing a second ledger.
+
+### Problem-derived contract
+
+- Root cause: ATLAS stores invoice state, customer payments, allocations,
+  payment lifecycle state, deposit linkage, and receipt-outbox state, but its
+  EOM HTTP read surface exposes only a payment-list projection. A portal cannot
+  truthfully assemble customer history from that partial projection without
+  becoming a parallel financial reporter.
+- Correct fix must touch/change: add one bounded, customer-scoped query on
+  `ReceivablesService`; expose the same authenticated route from full and slim
+  EOM providers; prove the result through a real local PostgreSQL schema and
+  both ASGI entrypoints.
+- Must not change: no payment/invoice/deposit/return/void/retry write behavior,
+  no invoice schema migration, no MCP tool behavior, no Gmail/receipt transport,
+  no canonical-CRM lookup or new customer-facing UI/product wording, and no
+  financial records outside isolated local test schemas.
+
+## Scope (this PR)
+
+Ownership lane: eom/customer-ledger
+Slice phase: vertical slice
+
+1. Add `GET /receivables/customers/{contact_id}/ledger` to both the full and
+   slim authenticated EOM provider routes. The additive response contains a
+   bounded, deterministic combined timeline of invoice and payment entries;
+   payment entries include allocations, unapplied cents, deposit/clearing
+   state, return/void reasons, and receipt-delivery state.
+2. Support the existing finance-safe query shapes: optional case-insensitive
+   search over
+   payer, payment reference (including check/Square references), receipt number,
+   allocated invoice number, and invoice customer/name; optional payment
+   status/method and date-range filters; `limit` 1..200 and nonnegative
+   `offset`. Payment-only filters return payment entries only. The unfiltered
+   balance snapshot remains current ATLAS state, never a filter-dependent or
+   reconstructed historical balance.
+3. Return `open_invoice_balance_cents` and
+   `unapplied_payment_balance_cents` as current source-of-truth snapshots.
+   Do not call either a historical running balance: immutable invoice lifecycle
+   evidence is tracked as H-08 in #2363.
+4. Require the already-deployed receipt-outbox schema for this new receipt-aware
+   read contract and map an unavailable schema through the existing controlled
+   receivables error boundary. Existing payment-list and mutation routes remain
+   unchanged.
+5. Prove normal, filtered, paginated, retry/repeated-read, unavailable-schema,
+   and both-provider HTTP behavior locally without sending email or modifying
+   any non-test financial data.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] `ReceivablesService.list_customer_ledger` returns only the requested
+    customer's deterministic invoice/payment entries, each payment with
+    allocations, active-unapplied cents, deposit/clearing state, reversal
+    reason/state, and receipt-delivery projection; settled by the real
+    PostgreSQL service test in `tests/test_receivables.py`.
+  - [ ] A case-insensitive payer, check/Square reference, receipt number, or invoice
+    number search, payment status/method filter, date range, and bounded page
+    return only matching entries; settled by the same service test, including
+    an unrelated customer's rows.
+  - [ ] `open_invoice_balance_cents` and
+    `unapplied_payment_balance_cents` reflect current persisted invoice/payment
+    state in integer cents; settled by the service test. The response does not
+    claim a historical running balance.
+  - [ ] A repeated/stale read and a rejected inverted date range create no
+    payment, allocation, invoice, receipt, event, or email side effect;
+    settled by before/after counts and the validation test.
+  - [ ] The full and slim service-authenticated ASGI routes reach the same
+    service contract, while an unavailable receipt-aware schema is reported by
+    the existing `ReceivablesSchemaUnavailableError` boundary; settled by
+    `tests/test_receivables.py`.
+  - [ ] Existing `GET /receivables/payments` response semantics, all financial
+    mutation routes, and MCP payment behavior remain backward-compatible and
+    pass the focused receivables/MCP regression suite.
+- Reachability proof: authenticated `GET /api/v1/receivables/customers/<uuid>/ledger`
+  through both `atlas_brain.main.app` and `atlas_brain.main_eom.app` returns a
+  bounded JSON ledger from a real local PostgreSQL service; no external email
+  or financial system is contacted.
+- Affected surfaces: receivables service; full and slim EOM HTTP routers;
+  service-token authorization (existing dependency); receipt-outbox schema;
+  local PostgreSQL/ASGI tests.
+- Risk areas: financial-data truthfulness, backward compatibility, read-path
+  pagination, schema availability, receipt privacy, no-write/retry behavior,
+  performance/bounded loading.
+- Reviewer rules triggered: R1, R2, R3, R4, R5, R6, R7, R8, R12, R14.
+
+### Closure declaration
+
+- Ledger entry type is **CLOSED** and **DERIVED** from the two owned source
+  branches in the service query: `invoices` derives `invoice`; and
+  `customer_payments` derives `payment`. No caller supplies an entry type, so
+  an unlisted value cannot enter the response; rows outside those financial
+  sources are omitted rather than guessed.
+- Payment status and method are not locally enumerated policy sets. They are
+  stored financial values compared exactly when a caller supplies a filter;
+  an unknown value takes the safe read-only default of matching no payment
+  rows. Existing lifecycle writers remain their canonical validators.
+
+### Boundary-change enumeration
+
+The new authenticated route is an additive read admission boundary. It does not
+replace an existing route or widen an existing authorization dependency.
+
+- Boundary path/seam: full and slim
+  `GET /receivables/customers/{contact_id}/ledger` query parsing before
+  `ReceivablesService.list_customer_ledger`. FastAPI rejects zero/out-of-range
+  page limits before service invocation; the real ASGI test exercises that
+  admission failure as well as the authenticated success path.
+- Replaced-path behaviors: none; existing `GET /receivables/payments` retains
+  its list/offset/query semantics and all mutations retain their current
+  entrypoints.
+- Guard-relevant fields: service token (existing router dependency), canonical
+  UUID path `contact_id`, optional `search`, `payment_status`,
+  `payment_method`, `from_date`, `to_date`, `limit`, and `offset`. FastAPI
+  rejects non-UUID dates/limits; the service rejects an inverted date interval;
+  unknown historical status/method values safely yield no matching payment rows.
+- Caller x input shape:
+  - full provider + valid token + valid contact/filter page -> ledger envelope;
+  - slim provider + valid token + valid contact/filter page -> same envelope;
+  - either provider + absent/invalid token -> existing auth failure before the
+    service; malformed UUID/date/limit -> FastAPI 422; inverted dates ->
+    controlled domain 422; receipt schema unavailable -> controlled 503;
+  - repeated/stale valid GET -> fresh read only, no financial mutation.
+
+### Deployed-config probing
+
+No new environment/config fallback is introduced. Existing
+`ATLAS_INVOICING_RECEIVABLES_API_ENABLED` and digest-only service-token
+configuration gate both routes through `require_receivables_api`.
+
+- Deployed/default config values: provider deployment already reports the
+  receipt-aware receivables route ready; the slice adds no setting.
+- Explicit value probe: local ASGI tests use a generated configured digest and
+  matching bearer token.
+- Absent value probe: existing auth regression tests retain the disabled/missing
+  token failures; this slice does not bypass the router dependency.
+- Default-session/default-context probe: no session/context fallback exists;
+  `contact_id` is required by the path and unknown rows produce an empty ledger.
+- Side-effect ordering: all filter/schema validation occurs before read queries;
+  the read contract contains no write, queue, mail, or external call.
+
+### Files touched
+
+- `atlas_brain/api/invoicing/receivables.py`
+- `atlas_brain/eom_api/receivables.py`
+- `atlas_brain/services/receivables.py`
+- `plans/PR-EOM-Customer-Ledger-History.md`
+- `tests/test_receivables.py`
+
+## Mechanism
+
+`ReceivablesService` starts one `REPEATABLE READ, READ ONLY` transaction,
+requires its receipt-aware schema capability inside that snapshot, then builds
+one combined SQL page from invoices and customer payments constrained by the
+requested `contact_id`. The union selects only identifiers plus stable ordering
+fields; the service hydrates invoice rows and payment rows in bounded set
+queries, groups allocations, and reads the one-to-one receipt outbox rows. The
+page, nested details, and summary therefore reflect one committed database
+snapshot; a concurrent commit falls entirely before or after the read. It
+returns nested entry objects so invoice and payment field names cannot be
+confused.
+
+Payment references are intentionally the common check/Square reference source;
+receipt numbers are queried from the durable outbox; allocated invoice numbers
+are queried through `invoice_payments`. Current balance snapshot values use the
+existing `invoices.amount_due` and active customer-payment allocations, then
+convert exact `Decimal` values to integer cents at the service boundary. No
+float is used for new financial calculations.
+
+The route handlers only pass validated path/query fields into the service and
+reuse `_call` for controlled domain/schema/database failures. They do not call
+canonical CRM, Gmail, MCP, or any mutation.
+
+## Intentional
+
+- The new route is customer-scoped rather than a global free-text ledger scan.
+  Canonical customer discovery belongs at the tracker boundary; requiring the
+  selected ATLAS contact preserves the existing customer-payment index and
+  avoids turning a read endpoint into an unbounded cross-customer report.
+- Offset pagination is retained for consistency with existing receivables list
+  clients. It is read-only: a stale page can be refreshed but can never create,
+  allocate, email, deposit, clear, return, or void money.
+- The response exposes a current balance snapshot, not a historical running
+  balance. The invoices table has mutable state but no immutable invoice event
+  history; inventing one from present-day values would be false financial
+  evidence.
+- No new migration is needed: all queried payment, allocation, deposit, and
+  receipt-outbox data is owned by deployed additive migrations 344/368/369.
+- The slice exceeds the normal 400-line soft target because one safe provider
+  contract needs its bounded snapshot query and shared payment hydrator, plus a
+  real PostgreSQL lifecycle fixture and mounted full/slim ASGI proof. Splitting
+  that proof from the contract would weaken the financial no-write and
+  entrypoint evidence rather than create an independently deployable slice.
+
+## Deferred
+
+- H-08 / #2363: add an immutable invoice financial-event basis before the UI
+  uses the phrase "historical running balance." Discovered and linked from this
+  slice in #2362.
+- Tracker slice: proxy this contract and combine it with canonical active
+  customer search; ATLAS deliberately does not create another CRM reader here.
+- Website slice: render ledger filters, CSV export from this canonical query,
+  accessibility states, and recovery copy.
+- Receipt sender slice: transition pending/failed delivery outbox rows only
+  after verified transport; this query merely shows the current outbox state.
+
+Parking predicate: park unrelated reporting redesign, global search/index
+hardening, historical event-model work, and UI/product-copy choices unless they
+block this provider read contract or prove a financial truthfulness/safety risk.
+
+Parked hardening: H-08 is tracked in #2363 because historical balance wording
+would otherwise overstate what mutable invoice rows can prove.
+
+## Verification
+
+- Passed locally (no GitHub Actions acceptance required by the operator):
+  - `ATLAS_RECEIVABLES_TEST_DATABASE_URL=... python -m pytest -q
+    tests/test_receivables.py tests/test_eom_payment_receipts.py
+    tests/test_eom_billing_recipients.py tests/test_invoice_repository.py` —
+    157 passed; the real PostgreSQL test creates only an isolated temporary
+    schema and proves receipt/status/search/filter/page/repeated-read/schema
+    failure/no-write behavior plus full/slim mounted ASGI reachability.
+  - `ATLAS_RECEIVABLES_TEST_DATABASE_URL=... python -m pytest -q
+    tests/test_invoicing_readonly_mcp.py tests/test_invoicing_draft_writer_mcp.py`
+    — 22 passed, preserving existing MCP behavior.
+  - `python -m compileall -q` for each changed Python file; `ruff check` for
+    those files; and `bash scripts/check_ascii_python.sh` — passed.
+- Before publication, `scripts/push_pr.sh` will run the repository's single
+  local PR-review/unit-gate mirror with the same reviewed PR body; its result
+  is recorded in the PR and coordinating issue. No real email, external
+  financial record, Gmail draft, or production schema is contacted by these
+  tests.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/api/invoicing/receivables.py` | 27 |
+| `atlas_brain/eom_api/receivables.py` | 27 |
+| `atlas_brain/services/receivables.py` | 302 |
+| `plans/PR-EOM-Customer-Ledger-History.md` | 257 |
+| `tests/test_receivables.py` | 293 |
+| **Total** | **906** |

--- a/plans/PR-EOM-Customer-Ledger-History.md
+++ b/plans/PR-EOM-Customer-Ledger-History.md
@@ -24,9 +24,12 @@ later proxy one canonical query rather than inventing a second ledger.
 - Review-fix root cause: the first ledger projection ordered a financial
   history by ingestion time, reused an unrestricted legacy nested-allocation
   hydrator, aggregated allocations outside the selected customer, and left
-  continuation/filter/search-isolation boundaries without direct proof. Those
-  choices can misstate chronology, make a returned page URL invalid, or make a
-  bounded ledger response grow with unrelated/history rows.
+  continuation/filter/search-isolation boundaries without direct proof. It also
+  applied a single persisted-row money cap to multi-row balance aggregates and
+  interpreted literal ledger search text as SQL wildcard syntax. Those choices
+  can misstate chronology, make a returned page URL invalid, reject valid
+  balances, broaden a finance search, or make a bounded response grow with
+  unrelated/history rows.
 - Correct fix must touch/change: add one bounded, customer-scoped query on
   `ReceivablesService`; expose the same authenticated route from full and slim
   EOM providers; prove the result through a real local PostgreSQL schema and
@@ -49,28 +52,32 @@ Max files: 5
    deposit/clearing state, return/void reasons, receipt-delivery state, exact
    active allocation/unapplied cents, and at most 100 active-first allocation
    history rows with `allocation_history_count` and `allocations_truncated`.
-2. Support the existing finance-safe query shapes: optional case-insensitive
-   search over
+2. Support the existing finance-safe query shapes: optional case-insensitive,
+   literal-substring search over
    payer, payment reference (including check/Square references), receipt number,
    allocated invoice number, and invoice customer/name; optional nonblank
    payment status/method and date-range filters; `limit` 1..200 and nonnegative
-   `offset`. Every generated `next_offset` remains routable through both
-   handlers. Payment-only filters return payment entries only. The unfiltered
-   balance snapshot remains current ATLAS state, never a filter-dependent or
-   reconstructed historical balance.
+   `offset`. It escapes SQL `ILIKE` `%`, `_`, and escape characters. Every
+   generated `next_offset` remains routable through both handlers. Payment-only
+   filters return payment entries only. The unfiltered balance snapshot remains
+   current ATLAS state, never a filter-dependent or reconstructed historical
+   balance.
 3. Return `open_invoice_balance_cents` and
-   `unapplied_payment_balance_cents` as current source-of-truth snapshots.
-   Do not call either a historical running balance: immutable invoice lifecycle
-   evidence is tracked as H-08 in #2363.
+   `unapplied_payment_balance_cents` as exact current source-of-truth snapshots,
+   including a valid multi-row aggregate above one persisted `NUMERIC(12,2)`
+   value. Do not call either a historical running balance: immutable invoice
+   lifecycle evidence is tracked as H-08 in #2363.
 4. Require the already-deployed receipt-outbox schema for this new receipt-aware
    read contract and map an unavailable schema through the existing controlled
    receivables error boundary. Existing payment-list and mutation routes remain
    unchanged.
-5. Prove chronological/backdated ordering, payer/check/Square/receipt/invoice
-   search, payment-side customer isolation, bounded nested allocation history
-   with exact totals, filtered/paginated/retry/repeated-read behavior,
-   unavailable schema, and both-provider HTTP admission locally without sending
-   email or modifying any non-test financial data.
+5. Prove chronological/backdated ordering; literal payer/check/Square/receipt/
+   invoice search including SQL wildcard and escape characters; payment-side
+   customer isolation; bounded nested allocation history with exact totals;
+   aggregates beyond one persisted-row money cap; filtered/paginated/
+   retry/repeated-read behavior; unavailable schema; and both-provider HTTP
+   admission locally without sending email or modifying any non-test financial
+   data.
 
 ### Review Contract
 
@@ -83,16 +90,18 @@ Max files: 5
     deposit/clearing state, reversal reason/state, and receipt-delivery
     projection; settled by the real PostgreSQL service test in
     `tests/test_receivables.py`.
-  - [ ] A case-insensitive payer, check/Square reference, receipt number, or
-    invoice number search, payment status/method filter, date range, and
-    bounded page return only matching entries. Blank supplied payment filters
-    are controlled validation errors, a generated continuation remains an
-    admitted handler input, and an unrelated customer's invoice **and payment**
-    never appear; settled by the service and both mounted-ASGI tests.
+  - [ ] A case-insensitive literal payer, check/Square reference, receipt
+    number, or invoice-number substring search, payment status/method filter,
+    date range, and bounded page return only matching entries. SQL `%`, `_`,
+    and escape characters remain literal search text. Blank supplied payment
+    filters are controlled validation errors, a generated continuation remains
+    an admitted handler input, and an unrelated customer's invoice **and
+    payment** never appear; settled by the service and both mounted-ASGI tests.
   - [ ] `open_invoice_balance_cents` and
     `unapplied_payment_balance_cents` reflect current persisted invoice/payment
-    state in integer cents; settled by the service test. The response does not
-    claim a historical running balance.
+    state in exact integer cents even when a valid aggregate exceeds the maximum
+    persisted amount for one row; settled by the service test. The response does
+    not claim a historical running balance.
   - [ ] A repeated/stale read and a rejected inverted date range create no
     payment, allocation, invoice, receipt, event, or email side effect;
     settled by before/after counts and the validation test.
@@ -202,10 +211,12 @@ confused.
 
 Payment references are intentionally the common check/Square reference source;
 receipt numbers are queried from the durable outbox; allocated invoice numbers
-are queried through `invoice_payments`. Current balance snapshot values use the
-existing `invoices.amount_due` and active customer-payment allocations, then
-convert exact `Decimal` values to integer cents at the service boundary. No
-float is used for new financial calculations.
+are queried through `invoice_payments`. The ledger escapes `ILIKE` syntax and
+uses an explicit escape character, so these are literal substring searches.
+Current balance snapshot values use the existing `invoices.amount_due` and
+active customer-payment allocations, then convert finite, cent-precise
+`Decimal` aggregates to integer cents without applying the maximum for a single
+persisted row. No float is used for new financial calculations.
 
 The route handlers only pass validated path/query fields into the service and
 reuse `_call` for controlled domain/schema/database failures. They do not call
@@ -226,6 +237,13 @@ canonical CRM, Gmail, MCP, or any mutation.
   active totals remain authoritative; `allocation_history_count` and
   `allocations_truncated` make omitted historical rows explicit. Existing
   `GET /receivables/payments` keeps its full legacy allocation shape.
+- The ledger treats search input as literal text rather than a caller-supplied
+  `ILIKE` expression. This preserves expected receipt/reference lookup behavior
+  and prevents `%`, `_`, or a backslash from widening or changing a search.
+- A persisted invoice/payment remains limited to its database money range, but
+  a read-only balance sum is not: several valid rows can exceed one row's
+  `NUMERIC(12,2)` maximum. Aggregate conversion preserves finite cent precision
+  without weakening any mutation-time range guard.
 - The response exposes a current balance snapshot, not a historical running
   balance. The invoices table has mutable state but no immutable invoice event
   history; inventing one from present-day values would be false financial
@@ -279,10 +297,11 @@ evidence, while a cursor would be a separate read contract.
   - `ATLAS_RECEIVABLES_TEST_DATABASE_URL=... python -m pytest -q
     tests/test_receivables.py tests/test_eom_payment_receipts.py
     tests/test_eom_billing_recipients.py tests/test_invoice_repository.py` —
-    158 passed; the real PostgreSQL test creates only an isolated temporary
+    159 passed; the real PostgreSQL test creates only an isolated temporary
     schema and proves receipt/status/search/filter/page/repeated-read/schema
-    failure/no-write behavior, chronological ordering, payment-side isolation,
-    allocation-history bounds, and full/slim mounted ASGI reachability.
+    failure/no-write behavior, chronological ordering, literal wildcard/escape
+    search, payment-side isolation, aggregate values beyond one row's money
+    cap, allocation-history bounds, and full/slim mounted ASGI reachability.
   - `ATLAS_RECEIVABLES_TEST_DATABASE_URL=... python -m pytest -q
     tests/test_invoicing_readonly_mcp.py tests/test_invoicing_draft_writer_mcp.py`
     — 22 passed, preserving existing MCP behavior.
@@ -300,7 +319,7 @@ evidence, while a cursor would be a separate read contract.
 |---|---:|
 | `atlas_brain/api/invoicing/receivables.py` | 27 |
 | `atlas_brain/eom_api/receivables.py` | 27 |
-| `atlas_brain/services/receivables.py` | 417 |
-| `plans/PR-EOM-Customer-Ledger-History.md` | 306 |
-| `tests/test_receivables.py` | 496 |
-| **Total** | **1273** |
+| `atlas_brain/services/receivables.py` | 443 |
+| `plans/PR-EOM-Customer-Ledger-History.md` | 325 |
+| `tests/test_receivables.py` | 576 |
+| **Total** | **1398** |

--- a/plans/PR-EOM-Customer-Ledger-History.md
+++ b/plans/PR-EOM-Customer-Ledger-History.md
@@ -34,6 +34,7 @@ later proxy one canonical query rather than inventing a second ledger.
 
 Ownership lane: eom/customer-ledger
 Slice phase: vertical slice
+Max files: 5
 
 1. Add `GET /receivables/customers/{contact_id}/ledger` to both the full and
    slim authenticated EOM provider routes. The additive response contains a
@@ -211,6 +212,13 @@ canonical CRM, Gmail, MCP, or any mutation.
 - H-08 / #2363: add an immutable invoice financial-event basis before the UI
   uses the phrase "historical running balance." Discovered and linked from this
   slice in #2362.
+- H-09 / #2363: `origin/main` maturity baselines omit existing
+  `atlas_brain/api/invoicing/receivables.py` and
+  `atlas_brain/templates/email/payment_receipt.py` evidence. The exact sweep
+  fails identically on the base, so this finance-safe read slice must not mask
+  it with an unrelated baseline rewrite. The follow-up must add direct
+  test-discovery evidence and/or make an intentional targeted baseline-refresh
+  decision. Discovered by #2373 and linked from #2362.
 - Tracker slice: proxy this contract and combine it with canonical active
   customer search; ATLAS deliberately does not create another CRM reader here.
 - Website slice: render ledger filters, CSV export from this canonical query,
@@ -223,7 +231,9 @@ hardening, historical event-model work, and UI/product-copy choices unless they
 block this provider read contract or prove a financial truthfulness/safety risk.
 
 Parked hardening: H-08 is tracked in #2363 because historical balance wording
-would otherwise overstate what mutable invoice rows can prove.
+would otherwise overstate what mutable invoice rows can prove. H-09 is also
+parked in #2363 because the maturity baseline/test-discovery defect predates
+this slice and needs a dedicated coverage decision.
 
 ## Verification
 
@@ -252,6 +262,6 @@ would otherwise overstate what mutable invoice rows can prove.
 | `atlas_brain/api/invoicing/receivables.py` | 27 |
 | `atlas_brain/eom_api/receivables.py` | 27 |
 | `atlas_brain/services/receivables.py` | 302 |
-| `plans/PR-EOM-Customer-Ledger-History.md` | 257 |
+| `plans/PR-EOM-Customer-Ledger-History.md` | 267 |
 | `tests/test_receivables.py` | 293 |
-| **Total** | **906** |
+| **Total** | **916** |

--- a/plans/PR-EOM-Customer-Ledger-History.md
+++ b/plans/PR-EOM-Customer-Ledger-History.md
@@ -21,6 +21,12 @@ later proxy one canonical query rather than inventing a second ledger.
   EOM HTTP read surface exposes only a payment-list projection. A portal cannot
   truthfully assemble customer history from that partial projection without
   becoming a parallel financial reporter.
+- Review-fix root cause: the first ledger projection ordered a financial
+  history by ingestion time, reused an unrestricted legacy nested-allocation
+  hydrator, aggregated allocations outside the selected customer, and left
+  continuation/filter/search-isolation boundaries without direct proof. Those
+  choices can misstate chronology, make a returned page URL invalid, or make a
+  bounded ledger response grow with unrelated/history rows.
 - Correct fix must touch/change: add one bounded, customer-scoped query on
   `ReceivablesService`; expose the same authenticated route from full and slim
   EOM providers; prove the result through a real local PostgreSQL schema and
@@ -38,15 +44,18 @@ Max files: 5
 
 1. Add `GET /receivables/customers/{contact_id}/ledger` to both the full and
    slim authenticated EOM provider routes. The additive response contains a
-   bounded, deterministic combined timeline of invoice and payment entries;
-   payment entries include allocations, unapplied cents, deposit/clearing
-   state, return/void reasons, and receipt-delivery state.
+   bounded, deterministic combined timeline ordered by financial
+   `occurred_date` before stable ingestion/type/ID ties. Payment entries include
+   deposit/clearing state, return/void reasons, receipt-delivery state, exact
+   active allocation/unapplied cents, and at most 100 active-first allocation
+   history rows with `allocation_history_count` and `allocations_truncated`.
 2. Support the existing finance-safe query shapes: optional case-insensitive
    search over
    payer, payment reference (including check/Square references), receipt number,
-   allocated invoice number, and invoice customer/name; optional payment
-   status/method and date-range filters; `limit` 1..200 and nonnegative
-   `offset`. Payment-only filters return payment entries only. The unfiltered
+   allocated invoice number, and invoice customer/name; optional nonblank
+   payment status/method and date-range filters; `limit` 1..200 and nonnegative
+   `offset`. Every generated `next_offset` remains routable through both
+   handlers. Payment-only filters return payment entries only. The unfiltered
    balance snapshot remains current ATLAS state, never a filter-dependent or
    reconstructed historical balance.
 3. Return `open_invoice_balance_cents` and
@@ -57,22 +66,29 @@ Max files: 5
    read contract and map an unavailable schema through the existing controlled
    receivables error boundary. Existing payment-list and mutation routes remain
    unchanged.
-5. Prove normal, filtered, paginated, retry/repeated-read, unavailable-schema,
-   and both-provider HTTP behavior locally without sending email or modifying
-   any non-test financial data.
+5. Prove chronological/backdated ordering, payer/check/Square/receipt/invoice
+   search, payment-side customer isolation, bounded nested allocation history
+   with exact totals, filtered/paginated/retry/repeated-read behavior,
+   unavailable schema, and both-provider HTTP admission locally without sending
+   email or modifying any non-test financial data.
 
 ### Review Contract
 
 - Acceptance criteria:
   - [ ] `ReceivablesService.list_customer_ledger` returns only the requested
-    customer's deterministic invoice/payment entries, each payment with
-    allocations, active-unapplied cents, deposit/clearing state, reversal
-    reason/state, and receipt-delivery projection; settled by the real
-    PostgreSQL service test in `tests/test_receivables.py`.
-  - [ ] A case-insensitive payer, check/Square reference, receipt number, or invoice
-    number search, payment status/method filter, date range, and bounded page
-    return only matching entries; settled by the same service test, including
-    an unrelated customer's rows.
+    customer's deterministic invoice/payment entries in descending
+    `occurred_date` order, then stable ingestion/type/ID ties. Each payment
+    includes exact active allocation/unapplied cents, a bounded active-first
+    allocation-history projection with explicit truncation/count metadata,
+    deposit/clearing state, reversal reason/state, and receipt-delivery
+    projection; settled by the real PostgreSQL service test in
+    `tests/test_receivables.py`.
+  - [ ] A case-insensitive payer, check/Square reference, receipt number, or
+    invoice number search, payment status/method filter, date range, and
+    bounded page return only matching entries. Blank supplied payment filters
+    are controlled validation errors, a generated continuation remains an
+    admitted handler input, and an unrelated customer's invoice **and payment**
+    never appear; settled by the service and both mounted-ASGI tests.
   - [ ] `open_invoice_balance_cents` and
     `unapplied_payment_balance_cents` reflect current persisted invoice/payment
     state in integer cents; settled by the service test. The response does not
@@ -108,8 +124,9 @@ Max files: 5
   sources are omitted rather than guessed.
 - Payment status and method are not locally enumerated policy sets. They are
   stored financial values compared exactly when a caller supplies a filter;
-  an unknown value takes the safe read-only default of matching no payment
-  rows. Existing lifecycle writers remain their canonical validators.
+  an unknown nonblank value takes the safe read-only default of matching no
+  payment rows, while a blank supplied value is rejected. Existing lifecycle
+  writers remain their canonical validators.
 
 ### Boundary-change enumeration
 
@@ -127,8 +144,10 @@ replace an existing route or widen an existing authorization dependency.
 - Guard-relevant fields: service token (existing router dependency), canonical
   UUID path `contact_id`, optional `search`, `payment_status`,
   `payment_method`, `from_date`, `to_date`, `limit`, and `offset`. FastAPI
-  rejects non-UUID dates/limits; the service rejects an inverted date interval;
-  unknown historical status/method values safely yield no matching payment rows.
+  rejects malformed UUID/date/limit inputs; the service rejects an inverted
+  date interval and blank supplied payment filters; unknown nonblank historical
+  status/method values safely yield no matching payment rows. No fixed handler
+  offset cap can invalidate a service-generated continuation.
 - Caller x input shape:
   - full provider + valid token + valid contact/filter page -> ledger envelope;
   - slim provider + valid token + valid contact/filter page -> same envelope;
@@ -167,10 +186,16 @@ configuration gate both routes through `require_receivables_api`.
 `ReceivablesService` starts one `REPEATABLE READ, READ ONLY` transaction,
 requires its receipt-aware schema capability inside that snapshot, then builds
 one combined SQL page from invoices and customer payments constrained by the
-requested `contact_id`. The union selects only identifiers plus stable ordering
-fields; the service hydrates invoice rows and payment rows in bounded set
-queries, groups allocations, and reads the one-to-one receipt outbox rows. The
-page, nested details, and summary therefore reflect one committed database
+requested `contact_id`. The union orders first by financial `occurred_date`,
+then uses creation/type/ID only as deterministic ties. The service hydrates
+invoice rows and payment rows in bounded set queries, scopes the balance
+allocation aggregate to that customer, and reads the one-to-one receipt outbox
+rows. Ledger hydration uses a dedicated active-first allocation-history cap:
+it transfers at most 100 allocation rows per payment while separately deriving
+the exact active total and history count for the selected payment IDs. The
+legacy payment-list projection retains its existing full-history shape.
+
+The page, nested details, and summary therefore reflect one committed database
 snapshot; a concurrent commit falls entirely before or after the read. It
 returns nested entry objects so invoice and payment field names cannot be
 confused.
@@ -193,8 +218,14 @@ canonical CRM, Gmail, MCP, or any mutation.
   selected ATLAS contact preserves the existing customer-payment index and
   avoids turning a read endpoint into an unbounded cross-customer report.
 - Offset pagination is retained for consistency with existing receivables list
-  clients. It is read-only: a stale page can be refreshed but can never create,
-  allocate, email, deposit, clear, return, or void money.
+  clients. It has no artificial handler maximum, so a returned `next_offset`
+  is always routable. It is read-only: a stale page can be refreshed but can
+  never create, allocate, email, deposit, clear, return, or void money.
+- The ledger's nested `allocations` list is intentionally a bounded,
+  active-first history projection rather than an unbounded response. Exact
+  active totals remain authoritative; `allocation_history_count` and
+  `allocations_truncated` make omitted historical rows explicit. Existing
+  `GET /receivables/payments` keeps its full legacy allocation shape.
 - The response exposes a current balance snapshot, not a historical running
   balance. The invoices table has mutable state but no immutable invoice event
   history; inventing one from present-day values would be false financial
@@ -219,6 +250,11 @@ canonical CRM, Gmail, MCP, or any mutation.
   it with an unrelated baseline rewrite. The follow-up must add direct
   test-discovery evidence and/or make an intentional targeted baseline-refresh
   decision. Discovered by #2373 and linked from #2362.
+- H-10 / #2363: add a customer-scoped, per-payment allocation-history detail
+  cursor before an operator needs to inspect more than the ledger's bounded
+  100-row projection. The current ledger exposes exact count/truncation rather
+  than silently dropping history; this follow-up is discovered by #2373 and
+  must preserve the existing immutable reversal evidence.
 - Tracker slice: proxy this contract and combine it with canonical active
   customer search; ATLAS deliberately does not create another CRM reader here.
 - Website slice: render ledger filters, CSV export from this canonical query,
@@ -233,7 +269,9 @@ block this provider read contract or prove a financial truthfulness/safety risk.
 Parked hardening: H-08 is tracked in #2363 because historical balance wording
 would otherwise overstate what mutable invoice rows can prove. H-09 is also
 parked in #2363 because the maturity baseline/test-discovery defect predates
-this slice and needs a dedicated coverage decision.
+this slice and needs a dedicated coverage decision. H-10 is parked in #2363
+because the current bounded projection provides explicit count/truncation
+evidence, while a cursor would be a separate read contract.
 
 ## Verification
 
@@ -241,9 +279,10 @@ this slice and needs a dedicated coverage decision.
   - `ATLAS_RECEIVABLES_TEST_DATABASE_URL=... python -m pytest -q
     tests/test_receivables.py tests/test_eom_payment_receipts.py
     tests/test_eom_billing_recipients.py tests/test_invoice_repository.py` —
-    157 passed; the real PostgreSQL test creates only an isolated temporary
+    158 passed; the real PostgreSQL test creates only an isolated temporary
     schema and proves receipt/status/search/filter/page/repeated-read/schema
-    failure/no-write behavior plus full/slim mounted ASGI reachability.
+    failure/no-write behavior, chronological ordering, payment-side isolation,
+    allocation-history bounds, and full/slim mounted ASGI reachability.
   - `ATLAS_RECEIVABLES_TEST_DATABASE_URL=... python -m pytest -q
     tests/test_invoicing_readonly_mcp.py tests/test_invoicing_draft_writer_mcp.py`
     — 22 passed, preserving existing MCP behavior.
@@ -261,7 +300,7 @@ this slice and needs a dedicated coverage decision.
 |---|---:|
 | `atlas_brain/api/invoicing/receivables.py` | 27 |
 | `atlas_brain/eom_api/receivables.py` | 27 |
-| `atlas_brain/services/receivables.py` | 302 |
-| `plans/PR-EOM-Customer-Ledger-History.md` | 267 |
-| `tests/test_receivables.py` | 293 |
-| **Total** | **916** |
+| `atlas_brain/services/receivables.py` | 417 |
+| `plans/PR-EOM-Customer-Ledger-History.md` | 306 |
+| `tests/test_receivables.py` | 496 |
+| **Total** | **1273** |

--- a/tests/test_receivables.py
+++ b/tests/test_receivables.py
@@ -2093,6 +2093,242 @@ async def test_real_migration_backfills_and_adopts_late_rolling_writer_checks():
 
 
 @pytest.mark.asyncio
+async def test_real_postgres_customer_ledger_is_bounded_receipt_aware_and_read_only():
+    asyncpg = pytest.importorskip("asyncpg")
+    database_url = os.environ.get("ATLAS_RECEIVABLES_TEST_DATABASE_URL")
+    if not database_url:
+        pytest.skip("ATLAS_RECEIVABLES_TEST_DATABASE_URL not set")
+
+    schema = f"receivables_customer_ledger_{uuid4().hex}"
+    conn = await asyncpg.connect(database_url)
+    try:
+        await _create_pre_receivables_schema(conn, schema)
+        await conn.execute(_receivables_migration_sql())
+        contact_id, other_contact_id = uuid4(), uuid4()
+        invoice_a, invoice_b, other_invoice = uuid4(), uuid4(), uuid4()
+        await conn.executemany(
+            "INSERT INTO contacts (id, business_context_id) VALUES ($1, 'effingham_maids')",
+            [(contact_id,), (other_contact_id,)],
+        )
+        await conn.executemany(
+            """
+            INSERT INTO invoices (
+                id, invoice_number, contact_id, customer_name, total_amount,
+                issue_date, due_date, status
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, 'sent')
+            """,
+            [
+                (
+                    invoice_a,
+                    "INV-LEDGER-ALPHA",
+                    contact_id,
+                    "Ledger Customer",
+                    Decimal("200.00"),
+                    date(2026, 8, 1),
+                    date(2026, 8, 31),
+                ),
+                (
+                    invoice_b,
+                    "INV-LEDGER-BRAVO",
+                    contact_id,
+                    "Ledger Customer",
+                    Decimal("100.00"),
+                    date(2026, 8, 2),
+                    date(2026, 9, 1),
+                ),
+                (
+                    other_invoice,
+                    "INV-OTHER-CUSTOMER",
+                    other_contact_id,
+                    "Other Customer",
+                    Decimal("400.00"),
+                    date(2026, 8, 3),
+                    date(2026, 9, 2),
+                ),
+            ],
+        )
+        service = ReceivablesService(_SingleConnectionPool(conn, schema))
+
+        check = await service.create_payment(
+            contact_id=contact_id,
+            payer_name="Ledger Check Payer",
+            total_amount=Decimal("80.00"),
+            payment_method="check",
+            received_date=date(2026, 8, 10),
+            allocations=[{"invoice_id": invoice_a, "amount": Decimal("50.00")}],
+            reference="CHECK-1042",
+            idempotency_key="customer-ledger-check-1",
+            recorded_by="Ledger test",
+            allow_unapplied=True,
+            unapplied_contact_context_id="effingham_maids",
+            receipt_recipient=PaymentReceiptRecipient(
+                contact_id=contact_id,
+                customer_name="Ledger Customer",
+                customer_type="residential",
+                recipient_email="ledger@example.test",
+            ),
+            require_receipt_recipient=True,
+        )
+        batch = await service.create_deposit_batch(
+            payment_ids=[UUID(check["id"])],
+            deposit_date=date(2026, 8, 11),
+            bank_reference="ledger-deposit-1",
+            actor="Ledger test",
+            idempotency_key="customer-ledger-deposit-1",
+        )
+        await service.clear_deposit_batch(
+            batch_id=UUID(batch["id"]),
+            actor="Ledger test",
+            idempotency_key="customer-ledger-clear-1",
+        )
+        returned = await service.create_payment(
+            contact_id=contact_id,
+            payer_name="Ledger ACH Payer",
+            total_amount=Decimal("30.00"),
+            payment_method="ach",
+            received_date=date(2026, 8, 11),
+            allocations=[{"invoice_id": invoice_a, "amount": Decimal("30.00")}],
+            reference="ACH-LEDGER-1",
+            idempotency_key="customer-ledger-ach-1",
+            recorded_by="Ledger test",
+        )
+        await service.return_payment(
+            payment_id=UUID(returned["id"]),
+            reason="NSF",
+            actor="Ledger test",
+            idempotency_key="customer-ledger-return-1",
+        )
+        square = await service.create_payment(
+            contact_id=contact_id,
+            payer_name="Ledger Square Payer",
+            total_amount=Decimal("20.00"),
+            payment_method="square",
+            received_date=date(2026, 8, 12),
+            allocations=[],
+            reference="square-txn-9001",
+            idempotency_key="customer-ledger-square-1",
+            recorded_by="Ledger test",
+            allow_unapplied=True,
+            unapplied_contact_context_id="effingham_maids",
+        )
+        before = {
+            table: await conn.fetchval(f"SELECT COUNT(*) FROM {table}")
+            for table in (
+                "customer_payments",
+                "invoice_payments",
+                "payment_receipt_deliveries",
+                "payment_events",
+            )
+        }
+
+        receipt_number = check["receipt_delivery"]["receipt_number"]
+        receipt_search = await service.list_customer_ledger(
+            contact_id=contact_id,
+            search=receipt_number,
+        )
+        [receipt_entry] = receipt_search["entries"]
+        assert receipt_entry["entry_type"] == "payment"
+        assert receipt_entry["payment"]["id"] == check["id"]
+        assert receipt_entry["payment"]["status"] == "cleared"
+        assert receipt_entry["payment"]["batch_id"] == batch["id"]
+        assert receipt_entry["payment"]["receipt_delivery"] == {
+            "receipt_number": receipt_number,
+            "recipient_email": "ledger@example.test",
+            "status": "pending",
+            "skip_reason": None,
+        }
+        assert receipt_search["balances"] == {
+            "open_invoice_balance_cents": 25_000,
+            "unapplied_payment_balance_cents": 5_000,
+        }
+
+        invoice_search = await service.list_customer_ledger(
+            contact_id=contact_id,
+            search="INV-LEDGER-ALPHA",
+        )
+        assert {entry["entry_type"] for entry in invoice_search["entries"]} == {
+            "invoice",
+            "payment",
+        }
+        assert all(
+            entry["entry_id"] != str(other_invoice)
+            for entry in invoice_search["entries"]
+        )
+        assert {
+            entry["payment"]["id"]
+            for entry in invoice_search["entries"]
+            if entry["entry_type"] == "payment"
+        } == {
+            check["id"],
+            returned["id"],
+        }
+
+        returned_only = await service.list_customer_ledger(
+            contact_id=contact_id,
+            payment_status="returned",
+        )
+        assert len(returned_only["entries"]) == 1
+        returned_entry = returned_only["entries"][0]
+        assert returned_entry["entry_type"] == "payment"
+        assert returned_entry["entry_id"] == returned["id"]
+        assert returned_entry["payment"]["return_reason"] == "NSF"
+        assert returned_entry["payment"]["unapplied_amount_cents"] == 0
+
+        square_only = await service.list_customer_ledger(
+            contact_id=contact_id,
+            payment_method="square",
+            search="square-txn-9001",
+            from_date=date(2026, 8, 12),
+            to_date=date(2026, 8, 12),
+        )
+        assert [entry["payment"]["id"] for entry in square_only["entries"]] == [
+            square["id"]
+        ]
+
+        first_page = await service.list_customer_ledger(
+            contact_id=contact_id,
+            limit=1,
+        )
+        second_page = await service.list_customer_ledger(
+            contact_id=contact_id,
+            limit=1,
+            offset=first_page["next_offset"],
+        )
+        assert first_page["next_offset"] == 1
+        assert (
+            second_page["entries"][0]["entry_id"]
+            != first_page["entries"][0]["entry_id"]
+        )
+        assert receipt_search == await service.list_customer_ledger(
+            contact_id=contact_id,
+            search=receipt_number,
+        )
+        assert before == {
+            table: await conn.fetchval(f"SELECT COUNT(*) FROM {table}")
+            for table in before
+        }
+
+        with pytest.raises(ReceivablesValidationError, match="start date"):
+            await service.list_customer_ledger(
+                contact_id=contact_id,
+                from_date=date(2026, 8, 13),
+                to_date=date(2026, 8, 12),
+            )
+        assert before == {
+            table: await conn.fetchval(f"SELECT COUNT(*) FROM {table}")
+            for table in before
+        }
+
+        await conn.execute("DROP TABLE payment_receipt_deliveries")
+        with pytest.raises(ReceivablesSchemaUnavailableError, match="customer ledger"):
+            await service.list_customer_ledger(contact_id=contact_id)
+    finally:
+        await conn.execute("SET search_path TO public")
+        await conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        await conn.close()
+
+
+@pytest.mark.asyncio
 async def test_real_postgres_receivables_lifecycle_and_concurrent_replays():
     asyncpg = pytest.importorskip("asyncpg")
     database_url = os.environ.get("ATLAS_RECEIVABLES_TEST_DATABASE_URL")
@@ -3484,6 +3720,63 @@ async def test_real_postgres_http_and_mcp_entrypoints_use_supported_dependencies
                     },
                     json=slim_unapplied_body,
                 )
+
+            before_ledger_reads = await conn.fetchval(
+                "SELECT COUNT(*) FROM customer_payments"
+            )
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app),
+                base_url="http://receivables.test",
+            ) as client:
+                unauthenticated_ledger = await client.get(
+                    f"/api/v1/receivables/customers/{contact_id}/ledger"
+                )
+                invalid_ledger_limit = await client.get(
+                    f"/api/v1/receivables/customers/{contact_id}/ledger",
+                    headers={"Authorization": f"Bearer {generated.token}"},
+                    params={"limit": 0},
+                )
+                full_ledger = await client.get(
+                    f"/api/v1/receivables/customers/{contact_id}/ledger",
+                    headers={"Authorization": f"Bearer {generated.token}"},
+                )
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=slim_app),
+                base_url="http://receivables.test",
+            ) as client:
+                slim_ledger = await client.get(
+                    f"/api/v1/receivables/customers/{unapplied_contact_id}/ledger",
+                    headers={"Authorization": f"Bearer {generated.token}"},
+                )
+
+            assert unauthenticated_ledger.status_code == 401
+            assert invalid_ledger_limit.status_code == 422
+            assert full_ledger.status_code == 200, full_ledger.text
+            full_ledger_payload = full_ledger.json()
+            assert full_ledger_payload["contact_id"] == str(contact_id)
+            assert any(
+                entry["entry_type"] == "invoice"
+                and entry["invoice"]["invoice_number"] == "INV-HTTP-1"
+                for entry in full_ledger_payload["entries"]
+            )
+            assert any(
+                entry["entry_type"] == "payment"
+                and entry["payment"]["id"] == response.json()["id"]
+                for entry in full_ledger_payload["entries"]
+            )
+            assert slim_ledger.status_code == 200, slim_ledger.text
+            slim_ledger_payload = slim_ledger.json()
+            assert slim_ledger_payload["contact_id"] == str(unapplied_contact_id)
+            assert (
+                slim_ledger_payload["entries"][0]["payment"]["receipt_delivery"][
+                    "status"
+                ]
+                == "pending"
+            )
+            assert (
+                await conn.fetchval("SELECT COUNT(*) FROM customer_payments")
+                == before_ledger_reads
+            )
 
             assert response.status_code == 201
             assert response.json()["status"] == "received"

--- a/tests/test_receivables.py
+++ b/tests/test_receivables.py
@@ -8,7 +8,7 @@ import re
 import subprocess
 import sys
 from contextlib import asynccontextmanager
-from datetime import date
+from datetime import date, datetime, timezone
 from decimal import Decimal
 from pathlib import Path
 from types import SimpleNamespace
@@ -2211,6 +2211,30 @@ async def test_real_postgres_customer_ledger_is_bounded_receipt_aware_and_read_o
             allow_unapplied=True,
             unapplied_contact_context_id="effingham_maids",
         )
+        other_payment = await service.create_payment(
+            contact_id=other_contact_id,
+            payer_name="Other Ledger Payer",
+            total_amount=Decimal("40.00"),
+            payment_method="check",
+            received_date=date(2026, 8, 12),
+            allocations=[{"invoice_id": other_invoice, "amount": Decimal("40.00")}],
+            reference="OTHER-CHECK-1042",
+            idempotency_key="customer-ledger-other-payment-1",
+            recorded_by="Ledger test",
+        )
+        backdated = await service.create_payment(
+            contact_id=contact_id,
+            payer_name="Ledger Backdated Payer",
+            total_amount=Decimal("10.00"),
+            payment_method="ach",
+            received_date=date(2026, 7, 31),
+            allocations=[],
+            reference="BACKDATED-ACH-1",
+            idempotency_key="customer-ledger-backdated-payment-1",
+            recorded_by="Ledger test",
+            allow_unapplied=True,
+            unapplied_contact_context_id="effingham_maids",
+        )
         before = {
             table: await conn.fetchval(f"SELECT COUNT(*) FROM {table}")
             for table in (
@@ -2239,12 +2263,52 @@ async def test_real_postgres_customer_ledger_is_bounded_receipt_aware_and_read_o
         }
         assert receipt_search["balances"] == {
             "open_invoice_balance_cents": 25_000,
-            "unapplied_payment_balance_cents": 5_000,
+            "unapplied_payment_balance_cents": 6_000,
         }
+
+        payer_search = await service.list_customer_ledger(
+            contact_id=contact_id,
+            search="ledger check payer",
+        )
+        assert [entry["payment"]["id"] for entry in payer_search["entries"]] == [
+            check["id"]
+        ]
+        check_reference_search = await service.list_customer_ledger(
+            contact_id=contact_id,
+            search="check-1042",
+        )
+        assert [
+            entry["payment"]["id"]
+            for entry in check_reference_search["entries"]
+        ] == [check["id"]]
+        receipt_casefold_search = await service.list_customer_ledger(
+            contact_id=contact_id,
+            search=receipt_number.lower(),
+        )
+        assert [
+            entry["payment"]["id"]
+            for entry in receipt_casefold_search["entries"]
+        ] == [check["id"]]
+        other_payment_search = await service.list_customer_ledger(
+            contact_id=contact_id,
+            search="other ledger payer",
+        )
+        assert other_payment_search["entries"] == []
+        full_customer_ledger = await service.list_customer_ledger(
+            contact_id=contact_id,
+        )
+        assert other_payment["id"] not in {
+            entry["entry_id"] for entry in full_customer_ledger["entries"]
+        }
+        assert [entry["occurred_date"] for entry in full_customer_ledger["entries"]] == sorted(
+            (entry["occurred_date"] for entry in full_customer_ledger["entries"]),
+            reverse=True,
+        )
+        assert full_customer_ledger["entries"][-1]["payment"]["id"] == backdated["id"]
 
         invoice_search = await service.list_customer_ledger(
             contact_id=contact_id,
-            search="INV-LEDGER-ALPHA",
+            search="inv-ledger-alpha",
         )
         assert {entry["entry_type"] for entry in invoice_search["entries"]} == {
             "invoice",
@@ -2277,13 +2341,24 @@ async def test_real_postgres_customer_ledger_is_bounded_receipt_aware_and_read_o
         square_only = await service.list_customer_ledger(
             contact_id=contact_id,
             payment_method="square",
-            search="square-txn-9001",
+            search="SQUARE-TXN-9001",
             from_date=date(2026, 8, 12),
             to_date=date(2026, 8, 12),
         )
         assert [entry["payment"]["id"] for entry in square_only["entries"]] == [
             square["id"]
         ]
+
+        with pytest.raises(ReceivablesValidationError, match="status cannot be blank"):
+            await service.list_customer_ledger(
+                contact_id=contact_id,
+                payment_status="   ",
+            )
+        with pytest.raises(ReceivablesValidationError, match="method cannot be blank"):
+            await service.list_customer_ledger(
+                contact_id=contact_id,
+                payment_method="\t",
+            )
 
         first_page = await service.list_customer_ledger(
             contact_id=contact_id,
@@ -2322,6 +2397,106 @@ async def test_real_postgres_customer_ledger_is_bounded_receipt_aware_and_read_o
         await conn.execute("DROP TABLE payment_receipt_deliveries")
         with pytest.raises(ReceivablesSchemaUnavailableError, match="customer ledger"):
             await service.list_customer_ledger(contact_id=contact_id)
+    finally:
+        await conn.execute("SET search_path TO public")
+        await conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_real_postgres_customer_ledger_bounds_allocation_history_and_preserves_active_total():
+    asyncpg = pytest.importorskip("asyncpg")
+    database_url = os.environ.get("ATLAS_RECEIVABLES_TEST_DATABASE_URL")
+    if not database_url:
+        pytest.skip("ATLAS_RECEIVABLES_TEST_DATABASE_URL not set")
+
+    schema = f"receivables_ledger_allocation_history_{uuid4().hex}"
+    conn = await asyncpg.connect(database_url)
+    try:
+        await _create_pre_receivables_schema(conn, schema)
+        await conn.execute(_receivables_migration_sql())
+        contact_id, invoice_id, payment_id = uuid4(), uuid4(), uuid4()
+        await conn.execute(
+            "INSERT INTO contacts (id, business_context_id) VALUES ($1, 'effingham_maids')",
+            contact_id,
+        )
+        await conn.execute(
+            """
+            INSERT INTO invoices (
+                id, invoice_number, contact_id, customer_name, total_amount,
+                issue_date, due_date, status
+            ) VALUES ($1, 'INV-ALLOCATION-HISTORY', $2, 'History Customer', 200,
+                      DATE '2026-08-01', DATE '2026-08-31', 'sent')
+            """,
+            invoice_id,
+            contact_id,
+        )
+        await conn.execute(
+            """
+            INSERT INTO customer_payments (
+                id, contact_id, payer_name, total_amount, payment_method,
+                received_date, status, source, idempotency_key,
+                request_fingerprint, recorded_by
+            ) VALUES ($1, $2, 'Allocation History Payer', 100, 'ach',
+                      DATE '2026-08-12', 'received', 'test',
+                      'allocation-history-payment', 'allocation-history-fingerprint',
+                      'Ledger test')
+            """,
+            payment_id,
+            contact_id,
+        )
+        historical_at = datetime(2026, 8, 12, tzinfo=timezone.utc)
+        history_rows = [
+            (
+                uuid4(),
+                invoice_id,
+                payment_id,
+                Decimal("1.00"),
+                date(2026, 8, 12),
+                "ach",
+                "ALLOCATION-HISTORY",
+                "historical adjustment",
+                "Ledger test",
+                historical_at if index else None,
+                "replaced allocation" if index else None,
+            )
+            for index in range(101)
+        ]
+        await conn.executemany(
+            """
+            INSERT INTO invoice_payments (
+                id, invoice_id, payment_id, amount, payment_date,
+                payment_method, reference, notes, recorded_by, reversed_at,
+                reversal_reason
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+            """,
+            history_rows,
+        )
+        service = ReceivablesService(_SingleConnectionPool(conn, schema))
+
+        ledger = await service.list_customer_ledger(
+            contact_id=contact_id,
+            payment_method="ach",
+        )
+
+        [entry] = ledger["entries"]
+        payment = entry["payment"]
+        assert payment["id"] == str(payment_id)
+        assert payment["allocated_amount_cents"] == 100
+        assert payment["unapplied_amount_cents"] == 9_900
+        assert payment["allocation_history_count"] == 101
+        assert payment["allocations_truncated"] is True
+        assert len(payment["allocations"]) == 100
+        assert payment["allocations"][0]["reversed_at"] is None
+        assert all(
+            "active_allocated_amount" not in allocation
+            and "allocation_history_count" not in allocation
+            for allocation in payment["allocations"]
+        )
+        assert all(
+            allocation["reversed_at"] is not None
+            for allocation in payment["allocations"][1:]
+        )
     finally:
         await conn.execute("SET search_path TO public")
         await conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
@@ -3736,6 +3911,16 @@ async def test_real_postgres_http_and_mcp_entrypoints_use_supported_dependencies
                     headers={"Authorization": f"Bearer {generated.token}"},
                     params={"limit": 0},
                 )
+                blank_ledger_status = await client.get(
+                    f"/api/v1/receivables/customers/{contact_id}/ledger",
+                    headers={"Authorization": f"Bearer {generated.token}"},
+                    params={"payment_status": "   "},
+                )
+                routable_large_offset = await client.get(
+                    f"/api/v1/receivables/customers/{contact_id}/ledger",
+                    headers={"Authorization": f"Bearer {generated.token}"},
+                    params={"offset": 10_001},
+                )
                 full_ledger = await client.get(
                     f"/api/v1/receivables/customers/{contact_id}/ledger",
                     headers={"Authorization": f"Bearer {generated.token}"},
@@ -3748,9 +3933,22 @@ async def test_real_postgres_http_and_mcp_entrypoints_use_supported_dependencies
                     f"/api/v1/receivables/customers/{unapplied_contact_id}/ledger",
                     headers={"Authorization": f"Bearer {generated.token}"},
                 )
+                slim_blank_ledger_method = await client.get(
+                    f"/api/v1/receivables/customers/{unapplied_contact_id}/ledger",
+                    headers={"Authorization": f"Bearer {generated.token}"},
+                    params={"payment_method": "\t"},
+                )
+                slim_routable_large_offset = await client.get(
+                    f"/api/v1/receivables/customers/{unapplied_contact_id}/ledger",
+                    headers={"Authorization": f"Bearer {generated.token}"},
+                    params={"offset": 10_001},
+                )
 
             assert unauthenticated_ledger.status_code == 401
             assert invalid_ledger_limit.status_code == 422
+            assert blank_ledger_status.status_code == 422
+            assert routable_large_offset.status_code == 200
+            assert routable_large_offset.json()["entries"] == []
             assert full_ledger.status_code == 200, full_ledger.text
             full_ledger_payload = full_ledger.json()
             assert full_ledger_payload["contact_id"] == str(contact_id)
@@ -3765,6 +3963,9 @@ async def test_real_postgres_http_and_mcp_entrypoints_use_supported_dependencies
                 for entry in full_ledger_payload["entries"]
             )
             assert slim_ledger.status_code == 200, slim_ledger.text
+            assert slim_blank_ledger_method.status_code == 422
+            assert slim_routable_large_offset.status_code == 200
+            assert slim_routable_large_offset.json()["entries"] == []
             slim_ledger_payload = slim_ledger.json()
             assert slim_ledger_payload["contact_id"] == str(unapplied_contact_id)
             assert (

--- a/tests/test_receivables.py
+++ b/tests/test_receivables.py
@@ -34,6 +34,7 @@ from atlas_brain.services.receivables import (
     ReceivablesService,
     ReceivablesValidationError,
     PaymentReceiptRecipient,
+    aggregate_cents,
     money,
     request_fingerprint,
 )
@@ -954,11 +955,14 @@ async def test_open_invoice_feed_orders_due_date_before_customer_name():
     )
 
 
-def test_money_rejects_nan_and_duplicate_invoice_allocations():
+def test_money_and_aggregate_cents_preserve_currency_validation():
     with pytest.raises(ReceivablesValidationError, match="finite"):
         money("NaN")
     with pytest.raises(ReceivablesValidationError, match="cent precision"):
         money("10.005")
+    with pytest.raises(ReceivablesValidationError, match="finite"):
+        aggregate_cents("NaN")
+    assert aggregate_cents("10000000000.00") == 1_000_000_000_000
 
     invoice_id = uuid4()
     with pytest.raises(ReceivablesValidationError, match="only appear once"):
@@ -2156,7 +2160,7 @@ async def test_real_postgres_customer_ledger_is_bounded_receipt_aware_and_read_o
             payment_method="check",
             received_date=date(2026, 8, 10),
             allocations=[{"invoice_id": invoice_a, "amount": Decimal("50.00")}],
-            reference="CHECK-1042",
+            reference="CHECK_1042",
             idempotency_key="customer-ledger-check-1",
             recorded_by="Ledger test",
             allow_unapplied=True,
@@ -2188,7 +2192,7 @@ async def test_real_postgres_customer_ledger_is_bounded_receipt_aware_and_read_o
             payment_method="ach",
             received_date=date(2026, 8, 11),
             allocations=[{"invoice_id": invoice_a, "amount": Decimal("30.00")}],
-            reference="ACH-LEDGER-1",
+            reference="SQUAREXTXN-9001",
             idempotency_key="customer-ledger-ach-1",
             recorded_by="Ledger test",
         )
@@ -2205,7 +2209,7 @@ async def test_real_postgres_customer_ledger_is_bounded_receipt_aware_and_read_o
             payment_method="square",
             received_date=date(2026, 8, 12),
             allocations=[],
-            reference="square-txn-9001",
+            reference="SQUARE%TXN-9001",
             idempotency_key="customer-ledger-square-1",
             recorded_by="Ledger test",
             allow_unapplied=True,
@@ -2224,12 +2228,12 @@ async def test_real_postgres_customer_ledger_is_bounded_receipt_aware_and_read_o
         )
         backdated = await service.create_payment(
             contact_id=contact_id,
-            payer_name="Ledger Backdated Payer",
+            payer_name=r"Ledger\Backdated Payer",
             total_amount=Decimal("10.00"),
             payment_method="ach",
             received_date=date(2026, 7, 31),
             allocations=[],
-            reference="BACKDATED-ACH-1",
+            reference="CHECKX1042",
             idempotency_key="customer-ledger-backdated-payment-1",
             recorded_by="Ledger test",
             allow_unapplied=True,
@@ -2275,12 +2279,28 @@ async def test_real_postgres_customer_ledger_is_bounded_receipt_aware_and_read_o
         ]
         check_reference_search = await service.list_customer_ledger(
             contact_id=contact_id,
-            search="check-1042",
+            search="check_1042",
         )
         assert [
             entry["payment"]["id"]
             for entry in check_reference_search["entries"]
         ] == [check["id"]]
+        percent_reference_search = await service.list_customer_ledger(
+            contact_id=contact_id,
+            search="square%txn-9001",
+        )
+        assert [
+            entry["payment"]["id"]
+            for entry in percent_reference_search["entries"]
+        ] == [square["id"]]
+        backslash_payer_search = await service.list_customer_ledger(
+            contact_id=contact_id,
+            search=r"ledger\backdated payer",
+        )
+        assert [
+            entry["payment"]["id"]
+            for entry in backslash_payer_search["entries"]
+        ] == [backdated["id"]]
         receipt_casefold_search = await service.list_customer_ledger(
             contact_id=contact_id,
             search=receipt_number.lower(),
@@ -2341,7 +2361,7 @@ async def test_real_postgres_customer_ledger_is_bounded_receipt_aware_and_read_o
         square_only = await service.list_customer_ledger(
             contact_id=contact_id,
             payment_method="square",
-            search="SQUARE-TXN-9001",
+            search="SQUARE%TXN-9001",
             from_date=date(2026, 8, 12),
             to_date=date(2026, 8, 12),
         )
@@ -2497,6 +2517,64 @@ async def test_real_postgres_customer_ledger_bounds_allocation_history_and_prese
             allocation["reversed_at"] is not None
             for allocation in payment["allocations"][1:]
         )
+    finally:
+        await conn.execute("SET search_path TO public")
+        await conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_real_postgres_customer_ledger_aggregate_balances_exceed_one_row_money_cap():
+    asyncpg = pytest.importorskip("asyncpg")
+    database_url = os.environ.get("ATLAS_RECEIVABLES_TEST_DATABASE_URL")
+    if not database_url:
+        pytest.skip("ATLAS_RECEIVABLES_TEST_DATABASE_URL not set")
+
+    schema = f"receivables_ledger_aggregate_{uuid4().hex}"
+    conn = await asyncpg.connect(database_url)
+    try:
+        await _create_pre_receivables_schema(conn, schema)
+        await conn.execute(_receivables_migration_sql())
+        contact_id = uuid4()
+        await conn.execute(
+            "INSERT INTO contacts (id, business_context_id) VALUES ($1, 'effingham_maids')",
+            contact_id,
+        )
+        amount = Decimal("5000000000.00")
+        await conn.executemany(
+            """
+            INSERT INTO invoices (
+                id, invoice_number, contact_id, customer_name, total_amount,
+                issue_date, due_date, status
+            ) VALUES ($1, $2, $3, 'Aggregate Customer', $4,
+                      DATE '2026-08-01', DATE '2026-08-31', 'sent')
+            """,
+            [
+                (uuid4(), "INV-LEDGER-AGGREGATE-A", contact_id, amount),
+                (uuid4(), "INV-LEDGER-AGGREGATE-B", contact_id, amount),
+            ],
+        )
+        await conn.executemany(
+            """
+            INSERT INTO customer_payments (
+                id, contact_id, payer_name, total_amount, payment_method,
+                received_date, status, source
+            ) VALUES ($1, $2, $3, $4, 'ach', DATE '2026-08-02', 'received', 'test')
+            """,
+            [
+                (uuid4(), contact_id, "Aggregate Payer A", amount),
+                (uuid4(), contact_id, "Aggregate Payer B", amount),
+            ],
+        )
+
+        ledger = await ReceivablesService(
+            _SingleConnectionPool(conn, schema)
+        ).list_customer_ledger(contact_id=contact_id)
+
+        assert ledger["balances"] == {
+            "open_invoice_balance_cents": 1_000_000_000_000,
+            "unapplied_payment_balance_cents": 1_000_000_000_000,
+        }
     finally:
         await conn.execute("SET search_path TO public")
         await conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')


### PR DESCRIPTION
Plan: plans/PR-EOM-Customer-Ledger-History.md
Slice phase: vertical slice
Ownership lane: eom/customer-ledger

ATLAS now has one authenticated, customer-scoped, receipt-aware ledger-read contract for the Billing & Payments workspace. It is additive and read-only: tracker can later proxy this canonical query without becoming a second financial ledger, while the website gets no direct ATLAS or Gmail access.

## Intentional

- The route is customer-scoped rather than a global free-text report. Canonical customer discovery remains the tracker boundary, which keeps this query bounded and avoids another CRM reader in ATLAS.
- The response names `open_invoice_balance_cents` and `unapplied_payment_balance_cents` as current snapshots. It deliberately does not claim an historical running balance because the invoice table has mutable state but no immutable invoice-event stream.
- Payment status/method filters show payment entries only; unfiltered responses combine invoices and payments. Offset pagination is read-only and cannot create, allocate, email, deposit, clear, return, or void money.
- Literal ledger search text is escaped before `ILIKE`, and balance aggregates retain exact cents without applying the maximum valid amount for one persisted row. Neither behavior changes the mutation-time row-range guard.
- The 1398-LOC total exceeds the soft target because the atomic provider contract needs its bounded snapshot query/shared payment projection plus real-PostgreSQL lifecycle and mounted-ASGI proof. Separating the evidence would weaken financial no-write and reachability assurance.
- Diff-budget override: The bounded ledger service and shared hydration are inseparable from the real PostgreSQL lifecycle and mounted full/slim ASGI proof needed to establish financial no-write, retry, and route reachability safety.

## AI reconciliation

- Sort ledger entries by occurrence date -- fixed-in: `atlas_brain/services/receivables.py` orders the union by financial occurrence before deterministic ties; `tests/test_receivables.py` proves a newly entered backdated payment is chronologically last.
- Keep returned pagination offsets routable -- fixed-in: `atlas_brain/api/invoicing/receivables.py`, `atlas_brain/eom_api/receivables.py`, and `tests/test_receivables.py` admit offset 10,001 through both mounted routes.
- Scope allocation aggregation to the requested customer -- fixed-in: `atlas_brain/services/receivables.py` derives the aggregate from a customer-scoped payment CTE; `tests/test_receivables.py` exercises an unrelated customer's allocated payment without exposing it or its balance to the requested ledger.
- Add the missing ledger search and isolation cases -- fixed-in: `tests/test_receivables.py` proves case-insensitive payer/check/Square/receipt/invoice searches and excludes an unrelated customer's payment as well as invoice.
- Reject blank payment filters instead of dropping them -- fixed-in: `atlas_brain/services/receivables.py` rejects supplied blank values; `tests/test_receivables.py` proves service and full/slim mounted-route 422 behavior.
- Bound nested allocation history on ledger pages -- fixed-in: `atlas_brain/services/receivables.py` uses a 100-row active-first projection with exact active totals, count, and truncation metadata; `tests/test_receivables.py` proves 101 historical rows cannot expand the response or change the active total.
- Allow aggregate balances beyond the per-row money cap -- fixed-in: `atlas_brain/services/receivables.py` converts finite, cent-precise balance sums without the persisted-row magnitude cap while retaining that cap for mutations and row projections; `tests/test_receivables.py` proves two valid $5B rows return exact $10B invoice and unapplied balances.
- Escape wildcard characters in ledger searches -- fixed-in: `atlas_brain/services/receivables.py` escapes `%`, `_`, and backslash and declares the same SQL escape character at every ledger `ILIKE` predicate; `tests/test_receivables.py` proves literal check/Square/backslash search behavior against same-customer wildcard collisions.

## Fix-loop disposition preflight

- Root decision: Sort ledger entries by occurrence date
- Blocking predicate: contract
- Disposition: fixed-in
- Source trace: backdated financial record -> combined ledger ordering -> `atlas_brain/services/receivables.py`
- Upstream files: `atlas_brain/services/receivables.py`, `tests/test_receivables.py`
- Fix strategy: upstream-root
- Allowed files: `atlas_brain/services/receivables.py`, `tests/test_receivables.py`, `plans/PR-EOM-Customer-Ledger-History.md`
- Max files: 5
- Parked hardening: H-10 / #2363

- Root decision: Allow aggregate balances beyond the per-row money cap
- Blocking predicate: contract
- Disposition: fixed-in
- Source trace: valid persisted amounts -> customer balance aggregate -> integer-cent response -> `atlas_brain/services/receivables.py`
- Upstream files: `atlas_brain/services/receivables.py`, `tests/test_receivables.py`
- Fix strategy: upstream-root
- Allowed files: `atlas_brain/services/receivables.py`, `tests/test_receivables.py`, `plans/PR-EOM-Customer-Ledger-History.md`
- Max files: 5
- Parked hardening: H-10 / #2363

- Root decision: Escape wildcard characters in ledger searches
- Blocking predicate: contract
- Disposition: fixed-in
- Source trace: literal customer-ledger query -> parameterized ILIKE pattern -> `atlas_brain/services/receivables.py`
- Upstream files: `atlas_brain/services/receivables.py`, `tests/test_receivables.py`
- Fix strategy: upstream-root
- Allowed files: `atlas_brain/services/receivables.py`, `tests/test_receivables.py`, `plans/PR-EOM-Customer-Ledger-History.md`
- Max files: 5
- Parked hardening: H-10 / #2363

- Root decision: Keep returned pagination offsets routable
- Blocking predicate: contract
- Disposition: fixed-in
- Source trace: generated next offset -> handler query admission -> `atlas_brain/api/invoicing/receivables.py` and `atlas_brain/eom_api/receivables.py`
- Upstream files: `atlas_brain/api/invoicing/receivables.py`, `atlas_brain/eom_api/receivables.py`, `tests/test_receivables.py`
- Fix strategy: upstream-root
- Allowed files: `atlas_brain/api/invoicing/receivables.py`, `atlas_brain/eom_api/receivables.py`, `tests/test_receivables.py`, `plans/PR-EOM-Customer-Ledger-History.md`
- Max files: 5
- Parked hardening: H-10 / #2363

- Root decision: Scope allocation aggregation to the requested customer
- Blocking predicate: performance
- Disposition: fixed-in
- Source trace: global allocation aggregate -> ledger balance query -> `atlas_brain/services/receivables.py`
- Upstream files: `atlas_brain/services/receivables.py`, `tests/test_receivables.py`
- Fix strategy: upstream-root
- Allowed files: `atlas_brain/services/receivables.py`, `tests/test_receivables.py`, `plans/PR-EOM-Customer-Ledger-History.md`
- Max files: 5
- Parked hardening: H-10 / #2363

- Root decision: Add the missing ledger search and isolation cases
- Blocking predicate: contract
- Disposition: fixed-in
- Source trace: unproven new search branches -> real PostgreSQL ledger fixture -> `tests/test_receivables.py`
- Upstream files: `tests/test_receivables.py`
- Fix strategy: upstream-root
- Allowed files: `atlas_brain/services/receivables.py`, `tests/test_receivables.py`, `plans/PR-EOM-Customer-Ledger-History.md`
- Max files: 5
- Parked hardening: H-10 / #2363

- Root decision: Reject blank payment filters instead of dropping them
- Blocking predicate: contract
- Disposition: fixed-in
- Source trace: supplied blank filter -> service normalization -> `atlas_brain/services/receivables.py`
- Upstream files: `atlas_brain/services/receivables.py`, `atlas_brain/api/invoicing/receivables.py`, `atlas_brain/eom_api/receivables.py`, `tests/test_receivables.py`
- Fix strategy: upstream-root
- Allowed files: `atlas_brain/services/receivables.py`, `atlas_brain/api/invoicing/receivables.py`, `atlas_brain/eom_api/receivables.py`, `tests/test_receivables.py`, `plans/PR-EOM-Customer-Ledger-History.md`
- Max files: 5
- Parked hardening: H-10 / #2363

- Root decision: Bound nested allocation history on ledger pages
- Blocking predicate: performance
- Disposition: fixed-in
- Source trace: unbounded legacy hydration -> ledger payment projection -> `atlas_brain/services/receivables.py`
- Upstream files: `atlas_brain/services/receivables.py`, `tests/test_receivables.py`
- Fix strategy: upstream-root
- Allowed files: `atlas_brain/services/receivables.py`, `tests/test_receivables.py`, `plans/PR-EOM-Customer-Ledger-History.md`
- Max files: 5
- Parked hardening: H-10 / #2363

## Deferred

- H-08 / #2363: add immutable invoice financial events before any UI calls a sequence a historical running balance.
- H-09 / #2363: the exact API/template maturity sweeps fail identically on the branch and detached `origin/main` because their baselines omit existing `atlas_brain/api/invoicing/receivables.py` and `atlas_brain/templates/email/payment_receipt.py` evidence. Do not mask that unrelated baseline/test-discovery debt in this ledger slice; #2363 owns a direct-test-discovery and/or targeted-baseline decision. Discovered by #2373 and linked from #2362.
- H-10 / #2363: the bounded active-first ledger allocation projection exposes exact count/truncation but does not add a separate per-payment history cursor. That cursor is a future customer-scoped read contract, discovered by #2373.
- Tracker proxy plus canonical active-customer search; website ledger rendering/CSV/accessibility states; and receipt-outbox delivery transitions remain subsequent independently deployable slices.

## Parked hardening

- Global search/index redesign, immutable invoice-event backfill, UI/product-copy decisions, the pre-existing H-09 maturity baseline/test-discovery debt, and H-10 allocation-history cursor design are intentionally parked in #2363 unless they prove a current financial truthfulness or safety defect in this provider read contract.

## Cold diff reconstruction

Gaps: none found after reconstructing the committed diff against the problem-derived contract.

- `atlas_brain/services/receivables.py:339-380` keeps the row-level money range guard while adding exact aggregate conversion and literal-`ILIKE` escaping. `:1075-1306` adds the customer-scoped ledger service. It uses one `REPEATABLE READ, READ ONLY` transaction, rejects supplied blank payment filters, orders the bounded invoice/payment union by financial occurrence date, scopes balance allocations to the selected customer, hydrates each entry and receipt status from that same snapshot, and returns exact integer-cent current balances. This implements the provider-owned financial read boundary without mutations or external calls.
- `atlas_brain/services/receivables.py:2168-2398` extracts the existing list-payment allocation projection into a reusable helper. The ledger-only branch caps nested allocation history at 100 active-first rows while returning exact active totals and explicit count/truncation metadata; `list_payments` retains its current full-history query/response shape.
- `atlas_brain/api/invoicing/receivables.py:331-355` and `atlas_brain/eom_api/receivables.py:445-469` add matching full/slim authenticated routes using injected `ReceivablesService`, so mounted ASGI dependency overrides and production route wiring reach the same service contract. Neither route calls CRM, Gmail, MCP, nor a financial mutation.
- `tests/test_receivables.py:2100`, `:2427`, `:2527`, and `:3735` create payments/deposits/clearing/return/receipt state only in temporary local schemas and prove backdated chronology; literal payer/check/Square/receipt/invoice searches including `%`, `_`, and backslash; customer-payment isolation; filters; pages; bounded nested allocation history with exact active totals; multi-row aggregates beyond a persisted-row money cap; repeated reads; unavailable schema behavior; before/after no-write counts; both mounted entrypoints; blank-filter errors; routable offset 10,001; auth rejection; invalid pagination rejection; and no read-side payment creation.
- No migration, write route, Gmail sender, MCP tool, customer identity source, or external financial system changes in this diff. The only compatibility-sensitive refactor is the payment-list hydration extraction, covered by the focused receivables and MCP regressions.

## Verification

- Focused real PostgreSQL financial regression: 159 passed across receivables, receipt-outbox, billing-recipient, and invoice-repository tests. The schema is temporary/local; no production financial rows or email are touched.
- Existing MCP invoice/draft behavior: 22 passed.
- Python compilation, Ruff, and ASCII policy passed for the changed surface.
- The required repository local PR-review/unit-gate mirror passed through both `scripts/push_pr.sh` and the final `scripts/open_pr.sh` wrapper for published head `1bfc62401`; its selector escalated to the full non-integration/non-e2e suite because a collection-scoped fixture is reachable. Both runs reported the existing 160-node baseline with zero regressions. Per operator direction, those local results—not hosted GitHub checks—are the acceptance evidence.
- Local live reconciliation against #2373 passed after all eight scoped Codex findings were fixed, replied to with `1bfc62401` source/test evidence, and resolved. The connector’s usage-limit comment is informational only and did not create a review finding or thread.
- The local maturity-sweep command was also reproduced against the branch and a detached `origin/main`; both fail on the same API/template baseline omissions. That is recorded as pre-existing H-09 in #2363, not treated as local acceptance evidence or fixed by widening this financial slice.

## Mechanical verification

- Command: `ATLAS_RECEIVABLES_TEST_DATABASE_URL=<local-test-db> python -m pytest -q tests/test_receivables.py tests/test_eom_payment_receipts.py tests/test_eom_billing_recipients.py tests/test_invoice_repository.py` - Result: 159 passed - Environment: local
- Command: `ATLAS_RECEIVABLES_TEST_DATABASE_URL=<local-test-db> python -m pytest -q tests/test_invoicing_readonly_mcp.py tests/test_invoicing_draft_writer_mcp.py` - Result: 22 passed - Environment: local
- Command: `python -m compileall -q atlas_brain/services/receivables.py atlas_brain/api/invoicing/receivables.py atlas_brain/eom_api/receivables.py tests/test_receivables.py && ruff check atlas_brain/services/receivables.py atlas_brain/api/invoicing/receivables.py atlas_brain/eom_api/receivables.py tests/test_receivables.py && bash scripts/check_ascii_python.sh` - Result: passed - Environment: local
- Command: `python scripts/sync_pr_plan.py plans/PR-EOM-Customer-Ledger-History.md origin/main --check && git diff --check` - Result: passed - Environment: local
- Command: `bash scripts/push_pr.sh tmp/pr_body_eom_customer_ledger.md -u origin HEAD` - Result: passed for published head 1bfc62401; full unit gate baseline=160, regressions=0 - Environment: local
- Command: `bash scripts/open_pr.sh tmp/pr_body_eom_customer_ledger.md` - Result: passed for published head 1bfc62401; full unit gate baseline=160, regressions=0 - Environment: local
- Command: `python scripts/check_ai_reconciliation_live.py --repo canfieldjuan/ATLAS --pr 2373` - Result: passed — no open scoped Codex review threads remain after eight evidence-backed replies/resolutions - Environment: local

## Diff size

5 files, +1372 / -26 (1398 LOC).

<!-- atlas-open-pr-wrapper: v1 -->
