### PR TITLE
EOM billing: add pure commercial candidate preview

### DIFF
--- a/.github/workflows/atlas_invoicing_checks.yml
+++ b/.github/workflows/atlas_invoicing_checks.yml
@@ -28,6 +28,7 @@ on:
       - "atlas_brain/main_eom.py"
       - "atlas_brain/services/__init__.py"
       - "atlas_brain/services/crm_provider.py"
+      - "atlas_brain/services/commercial_billing_candidates.py"
       # normalize_contact_email decides billing eligibility and the
       # address these routes return; a grammar change here must run
       # the billing proof.
@@ -46,6 +47,7 @@ on:
       - "tests/test_receivables.py"
       - "tests/test_eom_billing_recipients.py"
       - "tests/test_eom_payment_receipts.py"
+      - "tests/test_commercial_billing_candidates.py"
       - "tests/test_invoicing_readonly_mcp.py"
       - "tests/test_invoicing_readonly_oauth.py"
       - "tests/test_invoicing_draft_writer_mcp.py"
@@ -78,6 +80,7 @@ on:
       - "atlas_brain/main_eom.py"
       - "atlas_brain/services/__init__.py"
       - "atlas_brain/services/crm_provider.py"
+      - "atlas_brain/services/commercial_billing_candidates.py"
       # normalize_contact_email decides billing eligibility and the
       # address these routes return; a grammar change here must run
       # the billing proof.
@@ -96,6 +99,7 @@ on:
       - "tests/test_receivables.py"
       - "tests/test_eom_billing_recipients.py"
       - "tests/test_eom_payment_receipts.py"
+      - "tests/test_commercial_billing_candidates.py"
       - "tests/test_invoicing_readonly_mcp.py"
       - "tests/test_invoicing_readonly_oauth.py"
       - "tests/test_invoicing_draft_writer_mcp.py"
@@ -152,6 +156,7 @@ jobs:
             tests/test_receivables.py \
             tests/test_eom_billing_recipients.py \
             tests/test_eom_payment_receipts.py \
+            tests/test_commercial_billing_candidates.py \
             tests/test_invoice_repository.py \
             -q
 

--- a/atlas_brain/api/invoicing/receivables.py
+++ b/atlas_brain/api/invoicing/receivables.py
@@ -25,6 +25,12 @@ from ...services.receivables import (
     get_receivables_service,
 )
 from ...services.crm_provider import get_crm_provider
+from ...services.commercial_billing_candidates import (
+    CommercialBillingCandidateService,
+    CommercialBillingCandidatesUnavailableError,
+    CommercialBillingCandidatesValidationError,
+    get_commercial_billing_candidate_service,
+)
 from ...services.eom_lead_ingress import EOM_BUSINESS_CONTEXT_ID
 from ...storage.exceptions import DatabaseUnavailableError
 from .auth import require_actor, require_receivables_api
@@ -353,6 +359,34 @@ async def customer_ledger(
             offset=offset,
         )
     )
+
+
+@router.get("/commercial-billing-candidates")
+async def commercial_billing_candidates(
+    billing_period: str = Query(
+        ...,
+        min_length=7,
+        max_length=7,
+        pattern=r"^\d{4}-(0[1-9]|1[0-2])$",
+    ),
+    service: CommercialBillingCandidateService = Depends(
+        get_commercial_billing_candidate_service
+    ),
+) -> dict:
+    """Return a pure commercial billing preview; approval lives in a later slice."""
+
+    try:
+        return await service.preview(billing_period=billing_period)
+    except CommercialBillingCandidatesValidationError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail={"code": exc.code, "message": str(exc)},
+        ) from exc
+    except CommercialBillingCandidatesUnavailableError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail={"code": exc.code, "message": str(exc)},
+        ) from exc
 
 
 @router.put("/payments/{payment_id}/allocations")

--- a/atlas_brain/services/commercial_billing_candidates.py
+++ b/atlas_brain/services/commercial_billing_candidates.py
@@ -1,0 +1,996 @@
+"""Pure commercial billing-candidate generation for the EOM operator flow.
+
+This module is intentionally separate from ``monthly_invoice_generation``.
+That task performs invoice, PDF, service-marker, CRM, notification, and
+optional email writes even in its legacy review mode.  A candidate preview must
+be safe to regenerate before an operator explicitly approves any of those
+effects, so this service owns only source reads and deterministic projection.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from calendar import monthrange
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
+from typing import Any, Callable, Mapping, Optional, Protocol
+from uuid import UUID
+
+import asyncpg
+
+from ..storage.exceptions import DatabaseOperationError, DatabaseUnavailableError
+
+
+_CENT = Decimal("0.01")
+_TAX_RATE_QUANTUM = Decimal("0.0001")
+_MAX_CURRENCY = Decimal("9999999999.99")
+_PERIOD_PATTERN = re.compile(r"^(?P<year>[0-9]{4})-(?P<month>0[1-9]|1[0-2])$")
+_FINGERPRINT_VERSION = 1
+_CANDIDATE_CONTRACT_VERSION = 1
+
+RATE_LABEL_PER_VISIT = "Per Visit"
+RATE_LABEL_PER_MONTH = "Per Month"
+RATE_LABEL_PER_HOUR = "Per Hour"
+SUPPORTED_RATE_LABELS = frozenset(
+    {RATE_LABEL_PER_VISIT, RATE_LABEL_PER_MONTH, RATE_LABEL_PER_HOUR}
+)
+
+BILLING_CANDIDATE_BLOCKER_CODES = frozenset(
+    {
+        "ambiguous_calendar_service_match",
+        "customer_not_commercial",
+        "invalid_rate",
+        "invalid_rate_label",
+        "invalid_tax_rate",
+        "missing_billing_delivery_preference",
+        "missing_billing_email",
+        "missing_calendar_service_evidence",
+        "missing_canonical_customer",
+        "missing_hours",
+        "source_evidence_invalid",
+        "zero_or_invalid_total",
+    }
+)
+
+_SOURCE_UNAVAILABLE_ERRORS = (
+    DatabaseOperationError,
+    DatabaseUnavailableError,
+    asyncpg.PostgresConnectionError,
+    asyncpg.CannotConnectNowError,
+    asyncpg.TooManyConnectionsError,
+    asyncpg.AdminShutdownError,
+    asyncpg.CrashShutdownError,
+    asyncpg.UndefinedTableError,
+    asyncpg.UndefinedColumnError,
+    asyncpg.InvalidSchemaNameError,
+    asyncpg.InsufficientPrivilegeError,
+    asyncpg.InvalidAuthorizationSpecificationError,
+    OSError,
+    TimeoutError,
+)
+
+
+class CommercialBillingCandidatesError(Exception):
+    """Base error for the read-only commercial candidate contract."""
+
+    code = "commercial_billing_candidates_error"
+
+
+class CommercialBillingCandidatesValidationError(CommercialBillingCandidatesError):
+    """The requested candidate period is not a calendar month."""
+
+    code = "invalid_billing_period"
+
+
+class CommercialBillingCandidatesUnavailableError(CommercialBillingCandidatesError):
+    """A source of billing evidence cannot be read safely."""
+
+    code = "commercial_billing_candidates_unavailable"
+
+
+class _CustomerServiceRepository(Protocol):
+    async def list_active(self, auto_invoice_only: bool = False) -> list[dict]: ...
+
+
+class _CalendarProvider(Protocol):
+    async def list_events(
+        self,
+        start: datetime,
+        end: datetime,
+        calendar_id: Optional[str] = None,
+    ) -> list[Any]: ...
+
+
+class _CRMProvider(Protocol):
+    async def get_eom_payment_customer(
+        self,
+        contact_id: UUID,
+    ) -> dict[str, Any] | None: ...
+
+    async def get_billing_recipient(self, contact_id: UUID) -> dict[str, Any]: ...
+
+
+@dataclass(frozen=True)
+class _BillingPeriod:
+    label: str
+    start_date: date
+    end_date: date
+    calendar_start: datetime
+    calendar_end: datetime
+
+
+@dataclass(frozen=True)
+class _SourceService:
+    service_id: str
+    contact_id: UUID | None
+    service_name: str
+    rate_label: str
+    rate_value: Any
+    tax_rate_value: Any
+    calendar_keyword: str | None
+    service_calendar_id: str | None
+    source_index: int
+
+
+@dataclass(frozen=True)
+class _SourceEvent:
+    event_id: str
+    summary: str
+    source_date: date
+    start: str
+    end: str | None
+    calendar_id: str | None
+    location: str | None
+    status: str
+    all_day: bool
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "allDay": self.all_day,
+            "calendarId": self.calendar_id,
+            "end": self.end,
+            "eventId": self.event_id,
+            "location": self.location,
+            "sourceDate": self.source_date.isoformat(),
+            "start": self.start,
+            "status": self.status,
+            "summary": self.summary,
+        }
+
+
+def parse_billing_period(value: str) -> _BillingPeriod:
+    """Parse a strict YYYY-MM period before any provider read."""
+
+    if not isinstance(value, str):
+        raise CommercialBillingCandidatesValidationError(
+            "billing_period must use YYYY-MM"
+        )
+    match = _PERIOD_PATTERN.fullmatch(value)
+    if match is None:
+        raise CommercialBillingCandidatesValidationError(
+            "billing_period must use YYYY-MM"
+        )
+    year = int(match.group("year"))
+    month = int(match.group("month"))
+    try:
+        start_date = date(year, month, 1)
+    except ValueError as exc:
+        raise CommercialBillingCandidatesValidationError(
+            "billing_period must name a supported calendar month"
+        ) from exc
+    last_day = monthrange(year, month)[1]
+    end_date = date(year, month, last_day)
+    # Retain the legacy task's 30-hour fetch window. Event inclusion itself is
+    # decided by the event's calendar date below, not by this request bound.
+    calendar_start = datetime(year, month, 1, tzinfo=timezone.utc)
+    calendar_end = datetime(year, month, last_day, tzinfo=timezone.utc) + timedelta(
+        hours=30
+    )
+    return _BillingPeriod(
+        label=value,
+        start_date=start_date,
+        end_date=end_date,
+        calendar_start=calendar_start,
+        calendar_end=calendar_end,
+    )
+
+
+def _string_or_none(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _source_service(raw: Mapping[str, Any], source_index: int) -> _SourceService:
+    raw_service_id = _string_or_none(raw.get("id"))
+    service_id = raw_service_id or f"source-index:{source_index}"
+    contact_id: UUID | None
+    try:
+        contact_raw = raw.get("contact_id")
+        contact_id = UUID(str(contact_raw)) if contact_raw is not None else None
+    except (TypeError, ValueError, AttributeError):
+        contact_id = None
+    return _SourceService(
+        service_id=service_id,
+        contact_id=contact_id,
+        service_name=_string_or_none(raw.get("service_name")) or "Unnamed service",
+        rate_label=_string_or_none(raw.get("rate_label")) or "",
+        rate_value=raw.get("rate"),
+        tax_rate_value=raw.get("tax_rate", 0),
+        calendar_keyword=_string_or_none(raw.get("calendar_keyword")),
+        service_calendar_id=_string_or_none(raw.get("calendar_id")),
+        source_index=source_index,
+    )
+
+
+def _currency_cents(value: Any) -> int | None:
+    """Return a positive, persisted-money-compatible integer-cent value."""
+
+    try:
+        raw = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return None
+    if not raw.is_finite():
+        return None
+    try:
+        normalized = raw.quantize(_CENT)
+    except InvalidOperation:
+        return None
+    if raw != normalized or normalized <= 0 or normalized > _MAX_CURRENCY:
+        return None
+    return int(normalized * 100)
+
+
+def _tax_rate_basis_points(value: Any) -> int | None:
+    """Normalize a nonnegative NUMERIC(5,4) fractional rate to basis points."""
+
+    try:
+        raw = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return None
+    if not raw.is_finite():
+        return None
+    try:
+        normalized = raw.quantize(_TAX_RATE_QUANTUM)
+    except InvalidOperation:
+        return None
+    if raw != normalized or normalized < 0 or normalized > Decimal("1"):
+        return None
+    return int(normalized * 10_000)
+
+
+def _event_date(value: Any) -> date:
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    raise ValueError("calendar event start must be a date or datetime")
+
+
+def _iso_datetime_or_none(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, (date, datetime)):
+        return value.isoformat()
+    raise ValueError("calendar event time must be a date or datetime")
+
+
+def _source_event(raw: Any, *, selected_calendar_id: str | None) -> _SourceEvent:
+    source_date = _event_date(getattr(raw, "start", None))
+    event_id = _string_or_none(getattr(raw, "uid", None))
+    summary = _string_or_none(getattr(raw, "summary", None))
+    if event_id is None or summary is None:
+        raise ValueError("calendar event must have a UID and summary")
+    status = _string_or_none(getattr(raw, "status", None)) or ""
+    return _SourceEvent(
+        event_id=event_id,
+        summary=summary,
+        source_date=source_date,
+        start=_iso_datetime_or_none(getattr(raw, "start", None)) or "",
+        end=_iso_datetime_or_none(getattr(raw, "end", None)),
+        calendar_id=(
+            _string_or_none(getattr(raw, "calendar_id", None))
+            or selected_calendar_id
+        ),
+        location=_string_or_none(getattr(raw, "location", None)),
+        status=status,
+        all_day=bool(getattr(raw, "all_day", False)),
+    )
+
+
+def _blocker(
+    code: str,
+    message: str,
+    *,
+    service_id: str | None = None,
+    event_ids: list[str] | None = None,
+) -> dict[str, Any]:
+    if code not in BILLING_CANDIDATE_BLOCKER_CODES:
+        code = "source_evidence_invalid"
+        message = "Billing source evidence could not be normalized safely."
+    return {
+        "code": code,
+        "eventIds": sorted(set(event_ids or [])),
+        "message": message,
+        "serviceId": service_id,
+    }
+
+
+def _append_blocker(
+    blockers: list[dict[str, Any]],
+    seen: set[tuple[str, str | None, tuple[str, ...]]],
+    blocker: dict[str, Any],
+) -> None:
+    key = (
+        str(blocker["code"]),
+        blocker["serviceId"],
+        tuple(blocker["eventIds"]),
+    )
+    if key not in seen:
+        seen.add(key)
+        blockers.append(blocker)
+
+
+def _fingerprint(payload: Mapping[str, Any]) -> str:
+    canonical = json.dumps(
+        payload,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _amount_with_tax(subtotal_cents: int, tax_rate_basis_points: int) -> tuple[int, int]:
+    tax_cents = int(
+        (Decimal(subtotal_cents) * Decimal(tax_rate_basis_points) / Decimal(10_000))
+        .quantize(Decimal("1"), rounding=ROUND_HALF_UP)
+    )
+    return tax_cents, subtotal_cents + tax_cents
+
+
+def _line_item(
+    *,
+    service: _SourceService,
+    source_date: date,
+    quantity: int | None,
+    quantity_unit: str,
+    rate_cents: int | None,
+    event_ids: list[str],
+    locations: list[str],
+) -> dict[str, Any]:
+    amount_cents = (
+        quantity * rate_cents
+        if quantity is not None and rate_cents is not None
+        else None
+    )
+    return {
+        "amountCents": amount_cents,
+        "description": service.service_name,
+        "eventIds": sorted(set(event_ids)),
+        "locations": sorted(set(locations)),
+        "quantity": quantity,
+        "quantityUnit": quantity_unit,
+        "rateCents": rate_cents,
+        "serviceId": service.service_id,
+        "sourceDate": source_date.isoformat(),
+    }
+
+
+class CommercialBillingCandidateService:
+    """Project current commercial billing evidence without any financial write."""
+
+    def __init__(
+        self,
+        *,
+        customer_service_repository: _CustomerServiceRepository,
+        calendar_provider_loader: Callable[[], _CalendarProvider],
+        crm_provider_loader: Callable[[], _CRMProvider],
+        calendar_id: str | None,
+    ) -> None:
+        self._customer_service_repository = customer_service_repository
+        self._calendar_provider_loader = calendar_provider_loader
+        self._crm_provider_loader = crm_provider_loader
+        self._calendar_id = _string_or_none(calendar_id)
+
+    async def preview(self, *, billing_period: str) -> dict[str, Any]:
+        """Return a deterministic, non-persisted preview for one month."""
+
+        period = parse_billing_period(billing_period)
+        services = await self._list_active_services()
+        if not services:
+            return {
+                "billingPeriod": period.label,
+                "calendarId": self._calendar_id,
+                "candidates": [],
+                "contractVersion": _CANDIDATE_CONTRACT_VERSION,
+                "summary": {"blockedCandidateCount": 0, "candidateCount": 0},
+            }
+
+        events, malformed_event_count = await self._list_calendar_events(period)
+        return await self._build_preview(
+            period=period,
+            services=services,
+            events=events,
+            malformed_event_count=malformed_event_count,
+        )
+
+    async def _list_active_services(self) -> list[_SourceService]:
+        try:
+            rows = await self._customer_service_repository.list_active(
+                auto_invoice_only=True
+            )
+        except _SOURCE_UNAVAILABLE_ERRORS as exc:
+            raise CommercialBillingCandidatesUnavailableError(
+                "Commercial service evidence is unavailable"
+            ) from exc
+        if not isinstance(rows, list):
+            raise CommercialBillingCandidatesUnavailableError(
+                "Commercial service evidence is unavailable"
+            )
+        services: list[_SourceService] = []
+        for index, raw in enumerate(rows):
+            if not isinstance(raw, Mapping):
+                services.append(
+                    _SourceService(
+                        service_id=f"source-index:{index}",
+                        contact_id=None,
+                        service_name="Unnamed service",
+                        rate_label="",
+                        rate_value=None,
+                        tax_rate_value=None,
+                        calendar_keyword=None,
+                        service_calendar_id=None,
+                        source_index=index,
+                    )
+                )
+                continue
+            services.append(_source_service(raw, index))
+        return sorted(services, key=lambda item: (item.service_id, item.source_index))
+
+    async def _list_calendar_events(
+        self,
+        period: _BillingPeriod,
+    ) -> tuple[list[_SourceEvent], int]:
+        try:
+            provider = self._calendar_provider_loader()
+            rows = await provider.list_events(
+                period.calendar_start,
+                period.calendar_end,
+                calendar_id=self._calendar_id,
+            )
+        except (RuntimeError, *_SOURCE_UNAVAILABLE_ERRORS) as exc:
+            raise CommercialBillingCandidatesUnavailableError(
+                "Commercial calendar evidence is unavailable"
+            ) from exc
+        if not isinstance(rows, list):
+            raise CommercialBillingCandidatesUnavailableError(
+                "Commercial calendar evidence is unavailable"
+            )
+        events: list[_SourceEvent] = []
+        malformed_event_count = 0
+        for raw in rows:
+            if _string_or_none(getattr(raw, "status", None)) != "confirmed":
+                continue
+            try:
+                event = _source_event(raw, selected_calendar_id=self._calendar_id)
+            except (TypeError, ValueError, AttributeError):
+                # A malformed calendar row cannot be safely assigned. The
+                # candidate builder adds a visible blocker to each bundle.
+                malformed_event_count += 1
+                continue
+            if period.start_date <= event.source_date <= period.end_date:
+                events.append(event)
+        return (
+            sorted(
+                events,
+                key=lambda item: (
+                    item.source_date.isoformat(),
+                    item.start,
+                    item.event_id,
+                    item.summary,
+                ),
+            ),
+            malformed_event_count,
+        )
+
+    async def _build_preview(
+        self,
+        *,
+        period: _BillingPeriod,
+        services: list[_SourceService],
+        events: list[_SourceEvent],
+        malformed_event_count: int,
+    ) -> dict[str, Any]:
+        assignments, matches, collisions = self._assign_events(events, services)
+        bundles: dict[str, list[_SourceService]] = defaultdict(list)
+        for service in services:
+            bundle_key = (
+                str(service.contact_id)
+                if service.contact_id is not None
+                else f"unlinked:{service.service_id}"
+            )
+            bundles[bundle_key].append(service)
+
+        crm: _CRMProvider | None = None
+        candidates: list[dict[str, Any]] = []
+        for bundle_key in sorted(bundles):
+            bundle_services = sorted(
+                bundles[bundle_key], key=lambda item: (item.service_id, item.source_index)
+            )
+            contact_id = bundle_services[0].contact_id
+            customer: dict[str, Any] | None = None
+            recipient: dict[str, Any] | None = None
+            if contact_id is not None:
+                if crm is None:
+                    crm = self._load_crm_provider()
+                customer, recipient = await self._load_customer_evidence(crm, contact_id)
+            candidate = self._build_candidate(
+                period=period,
+                contact_id=contact_id,
+                services=bundle_services,
+                customer=customer,
+                recipient=recipient,
+                assignments=assignments,
+                matches=matches,
+                collisions=collisions,
+                malformed_event_count=malformed_event_count,
+            )
+            candidates.append(candidate)
+
+        candidates.sort(
+            key=lambda item: (
+                item["customer"]["contactId"] or "",
+                item["candidateKey"],
+            )
+        )
+        return {
+            "billingPeriod": period.label,
+            "calendarId": self._calendar_id,
+            "candidates": candidates,
+            "contractVersion": _CANDIDATE_CONTRACT_VERSION,
+            "summary": {
+                "blockedCandidateCount": sum(
+                    1 for candidate in candidates if candidate["blockers"]
+                ),
+                "candidateCount": len(candidates),
+            },
+        }
+
+    def _load_crm_provider(self) -> _CRMProvider:
+        try:
+            return self._crm_provider_loader()
+        except (RuntimeError, *_SOURCE_UNAVAILABLE_ERRORS) as exc:
+            raise CommercialBillingCandidatesUnavailableError(
+                "Canonical customer evidence is unavailable"
+            ) from exc
+
+    async def _load_customer_evidence(
+        self,
+        crm: _CRMProvider,
+        contact_id: UUID,
+    ) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+        try:
+            customer = await crm.get_eom_payment_customer(contact_id)
+            recipient = (
+                await crm.get_billing_recipient(contact_id)
+                if customer is not None
+                else None
+            )
+        except (RuntimeError, *_SOURCE_UNAVAILABLE_ERRORS) as exc:
+            raise CommercialBillingCandidatesUnavailableError(
+                "Canonical customer evidence is unavailable"
+            ) from exc
+        return customer, recipient
+
+    @staticmethod
+    def _assign_events(
+        events: list[_SourceEvent],
+        services: list[_SourceService],
+    ) -> tuple[
+        dict[str, list[_SourceEvent]],
+        dict[str, list[_SourceEvent]],
+        dict[str, list[dict[str, Any]]],
+    ]:
+        assignments: dict[str, list[_SourceEvent]] = defaultdict(list)
+        matches: dict[str, list[_SourceEvent]] = defaultdict(list)
+        collisions: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        for event in events:
+            summary = event.summary.casefold()
+            matchers = [
+                service
+                for service in services
+                if service.calendar_keyword
+                and service.calendar_keyword.casefold() in summary
+            ]
+            if not matchers:
+                continue
+            matchers.sort(
+                key=lambda service: (
+                    -len(service.calendar_keyword or ""),
+                    (service.calendar_keyword or "").casefold(),
+                    service.service_id,
+                )
+            )
+            for service in matchers:
+                matches[service.service_id].append(event)
+            assignments[matchers[0].service_id].append(event)
+            if len(matchers) > 1:
+                collision = {
+                    "eventId": event.event_id,
+                    "matchedServiceIds": [service.service_id for service in matchers],
+                    "resolution": (
+                        "alphabetical_tiebreak"
+                        if len(matchers[0].calendar_keyword or "")
+                        == len(matchers[1].calendar_keyword or "")
+                        else "longest_keyword"
+                    ),
+                    "selectedServiceId": matchers[0].service_id,
+                }
+                for service in matchers:
+                    collisions[service.service_id].append(collision)
+        return assignments, matches, collisions
+
+    def _build_candidate(
+        self,
+        *,
+        period: _BillingPeriod,
+        contact_id: UUID | None,
+        services: list[_SourceService],
+        customer: dict[str, Any] | None,
+        recipient: dict[str, Any] | None,
+        assignments: Mapping[str, list[_SourceEvent]],
+        matches: Mapping[str, list[_SourceEvent]],
+        collisions: Mapping[str, list[dict[str, Any]]],
+        malformed_event_count: int,
+    ) -> dict[str, Any]:
+        contact_text = str(contact_id) if contact_id is not None else None
+        candidate_key_contact = contact_text or f"unlinked:{services[0].service_id}"
+        blockers: list[dict[str, Any]] = []
+        seen_blockers: set[tuple[str, str | None, tuple[str, ...]]] = set()
+        incomplete_total = False
+
+        if malformed_event_count:
+            _append_blocker(
+                blockers,
+                seen_blockers,
+                _blocker(
+                    "source_evidence_invalid",
+                    "One or more confirmed calendar events could not be normalized safely.",
+                ),
+            )
+            incomplete_total = True
+
+        customer_type = _string_or_none((customer or {}).get("customer_type"))
+        customer_view = {
+            "contactId": contact_text,
+            "customerType": customer_type or "unknown",
+            "displayName": _string_or_none((customer or {}).get("customer_name")),
+        }
+        recipient_eligible = bool((recipient or {}).get("eligible"))
+        recipient_view = {
+            "contactId": contact_text,
+            "displayName": (
+                _string_or_none((recipient or {}).get("displayName"))
+                if recipient_eligible
+                else None
+            ),
+            "email": (
+                _string_or_none((recipient or {}).get("email"))
+                if recipient_eligible
+                else None
+            ),
+        }
+
+        if customer is None:
+            _append_blocker(
+                blockers,
+                seen_blockers,
+                _blocker(
+                    "missing_canonical_customer",
+                    "The service agreement has no active canonical EOM customer.",
+                ),
+            )
+        elif customer_type != "commercial":
+            _append_blocker(
+                blockers,
+                seen_blockers,
+                _blocker(
+                    "customer_not_commercial",
+                    "The canonical customer is not classified as commercial.",
+                ),
+            )
+        if customer is not None and not recipient_eligible:
+            recipient_reason = _string_or_none((recipient or {}).get("reason"))
+            if recipient_reason == "no_email":
+                _append_blocker(
+                    blockers,
+                    seen_blockers,
+                    _blocker(
+                        "missing_billing_email",
+                        "The canonical commercial customer has no valid billing email.",
+                    ),
+                )
+            else:
+                _append_blocker(
+                    blockers,
+                    seen_blockers,
+                    _blocker(
+                        "source_evidence_invalid",
+                        "Canonical customer and billing-recipient evidence disagree.",
+                    ),
+                )
+                incomplete_total = True
+        if customer_type == "commercial":
+            _append_blocker(
+                blockers,
+                seen_blockers,
+                _blocker(
+                    "missing_billing_delivery_preference",
+                    "No explicit billing delivery preference is recorded.",
+                ),
+            )
+
+        line_items: list[dict[str, Any]] = []
+        service_views: list[dict[str, Any]] = []
+        source_events: dict[str, _SourceEvent] = {}
+        rate_basis_points: list[int] = []
+        subtotal_cents = 0
+
+        for service in services:
+            rate_cents = _currency_cents(service.rate_value)
+            tax_basis_points = _tax_rate_basis_points(service.tax_rate_value)
+            service_views.append(
+                {
+                    "calendarId": service.service_calendar_id,
+                    "calendarKeyword": service.calendar_keyword,
+                    "rateCents": rate_cents,
+                    "rateLabel": service.rate_label or None,
+                    "serviceId": service.service_id,
+                    "serviceName": service.service_name,
+                    "taxRateBasisPoints": tax_basis_points,
+                }
+            )
+            matched_events = matches.get(service.service_id, [])
+            assigned_events = assignments.get(service.service_id, [])
+            for event in matched_events:
+                source_events[event.event_id] = event
+            for collision in collisions.get(service.service_id, []):
+                _append_blocker(
+                    blockers,
+                    seen_blockers,
+                    _blocker(
+                        "ambiguous_calendar_service_match",
+                        "A calendar event matches more than one service agreement.",
+                        service_id=service.service_id,
+                        event_ids=[collision["eventId"]],
+                    ),
+                )
+                incomplete_total = True
+            if service.contact_id is None:
+                _append_blocker(
+                    blockers,
+                    seen_blockers,
+                    _blocker(
+                        "missing_canonical_customer",
+                        "The service agreement is missing a canonical customer link.",
+                        service_id=service.service_id,
+                    ),
+                )
+                incomplete_total = True
+            if service.rate_label not in SUPPORTED_RATE_LABELS:
+                _append_blocker(
+                    blockers,
+                    seen_blockers,
+                    _blocker(
+                        "invalid_rate_label",
+                        "The service rate label is not supported for billing.",
+                        service_id=service.service_id,
+                    ),
+                )
+                incomplete_total = True
+                continue
+            if rate_cents is None:
+                _append_blocker(
+                    blockers,
+                    seen_blockers,
+                    _blocker(
+                        "invalid_rate",
+                        "The service rate must be a positive cent-precise amount.",
+                        service_id=service.service_id,
+                    ),
+                )
+                incomplete_total = True
+                continue
+            if tax_basis_points is None:
+                _append_blocker(
+                    blockers,
+                    seen_blockers,
+                    _blocker(
+                        "invalid_tax_rate",
+                        "The service tax rate must be a finite nonnegative rate.",
+                        service_id=service.service_id,
+                    ),
+                )
+                incomplete_total = True
+            else:
+                rate_basis_points.append(tax_basis_points)
+
+            if service.rate_label == RATE_LABEL_PER_MONTH:
+                item = _line_item(
+                    service=service,
+                    source_date=period.start_date,
+                    quantity=1,
+                    quantity_unit="month",
+                    rate_cents=rate_cents,
+                    event_ids=[],
+                    locations=[],
+                )
+                line_items.append(item)
+                subtotal_cents += item["amountCents"] or 0
+                continue
+
+            if not matched_events:
+                _append_blocker(
+                    blockers,
+                    seen_blockers,
+                    _blocker(
+                        "missing_calendar_service_evidence",
+                        "No confirmed calendar event matches this service in the billing period.",
+                        service_id=service.service_id,
+                    ),
+                )
+                incomplete_total = True
+                continue
+
+            if service.rate_label == RATE_LABEL_PER_HOUR:
+                by_date: dict[date, list[_SourceEvent]] = defaultdict(list)
+                for event in assigned_events:
+                    by_date[event.source_date].append(event)
+                for source_date, dated_events in sorted(by_date.items()):
+                    line_items.append(
+                        _line_item(
+                            service=service,
+                            source_date=source_date,
+                            quantity=None,
+                            quantity_unit="hour",
+                            rate_cents=rate_cents,
+                            event_ids=[event.event_id for event in dated_events],
+                            locations=[
+                                event.location
+                                for event in dated_events
+                                if event.location is not None
+                            ],
+                        )
+                    )
+                _append_blocker(
+                    blockers,
+                    seen_blockers,
+                    _blocker(
+                        "missing_hours",
+                        "Hours must be supplied before this service can be billed.",
+                        service_id=service.service_id,
+                        event_ids=[event.event_id for event in matched_events],
+                    ),
+                )
+                incomplete_total = True
+                continue
+
+            by_date: dict[date, list[_SourceEvent]] = defaultdict(list)
+            for event in assigned_events:
+                by_date[event.source_date].append(event)
+            for source_date, dated_events in sorted(by_date.items()):
+                item = _line_item(
+                    service=service,
+                    source_date=source_date,
+                    quantity=len(dated_events),
+                    quantity_unit="visit",
+                    rate_cents=rate_cents,
+                    event_ids=[event.event_id for event in dated_events],
+                    locations=[
+                        event.location
+                        for event in dated_events
+                        if event.location is not None
+                    ],
+                )
+                line_items.append(item)
+                subtotal_cents += item["amountCents"] or 0
+
+        line_items.sort(
+            key=lambda item: (
+                item["sourceDate"],
+                item["serviceId"],
+                item["eventIds"],
+            )
+        )
+        service_views.sort(key=lambda item: item["serviceId"])
+        source_event_views = [
+            source_events[event_id].as_dict()
+            for event_id in sorted(
+                source_events,
+                key=lambda event_id: (
+                    source_events[event_id].source_date.isoformat(),
+                    source_events[event_id].start,
+                    event_id,
+                ),
+            )
+        ]
+
+        tax_rate_basis_points = max(rate_basis_points) if rate_basis_points else 0
+        tax_cents: int | None
+        total_cents: int | None
+        if incomplete_total:
+            tax_cents = None
+            total_cents = None
+        else:
+            tax_cents, total_cents = _amount_with_tax(
+                subtotal_cents, tax_rate_basis_points
+            )
+        if total_cents is None or total_cents <= 0:
+            _append_blocker(
+                blockers,
+                seen_blockers,
+                _blocker(
+                    "zero_or_invalid_total",
+                    "The candidate total is zero or cannot be calculated from current evidence.",
+                ),
+            )
+        blockers.sort(
+            key=lambda blocker: (
+                blocker["code"],
+                blocker["serviceId"] or "",
+                blocker["eventIds"],
+            )
+        )
+        candidate = {
+            "billingPeriod": period.label,
+            "blockers": blockers,
+            "calendarId": self._calendar_id,
+            "candidateKey": f"commercial-billing:{candidate_key_contact}:{period.label}",
+            "customer": customer_view,
+            "deliveryMethod": None,
+            "fingerprintVersion": _FINGERPRINT_VERSION,
+            "lineItems": line_items,
+            "recipient": recipient_view,
+            "services": service_views,
+            "sourceEvents": source_event_views,
+            "subtotalCents": subtotal_cents,
+            "taxCents": tax_cents,
+            "taxRateBasisPoints": tax_rate_basis_points,
+            "totalCents": total_cents,
+        }
+        candidate["sourceFingerprint"] = _fingerprint(candidate)
+        return candidate
+
+
+def get_commercial_billing_candidate_service() -> CommercialBillingCandidateService:
+    """Construct the production read-only candidate service lazily per request."""
+
+    from ..config import settings
+    from ..storage.repositories.customer_service import get_customer_service_repo
+    from .calendar_provider import get_calendar_provider
+    from .crm_provider import get_crm_provider
+
+    return CommercialBillingCandidateService(
+        customer_service_repository=get_customer_service_repo(),
+        calendar_provider_loader=get_calendar_provider,
+        crm_provider_loader=get_crm_provider,
+        calendar_id=settings.invoicing.auto_invoice_calendar_id,
+    )
+
+
+__all__ = [
+    "BILLING_CANDIDATE_BLOCKER_CODES",
+    "CommercialBillingCandidateService",
+    "CommercialBillingCandidatesError",
+    "CommercialBillingCandidatesUnavailableError",
+    "CommercialBillingCandidatesValidationError",
+    "SUPPORTED_RATE_LABELS",
+    "get_commercial_billing_candidate_service",
+    "parse_billing_period",
+]

--- a/plans/PR-EOM-Commercial-Billing-Candidates.md
+++ b/plans/PR-EOM-Commercial-Billing-Candidates.md
@@ -1,0 +1,120 @@
+# PR-EOM-Commercial-Billing-Candidates
+
+## Why this slice exists
+
+The current monthly EOM invoice task combines calendar selection with invoice creation, PDF persistence, service-invoiced markers, CRM interaction logging, notifications, and optional mail. Its `review_mode` still creates invoice rows and PDFs, so it is not a safe candidate-review boundary for the Billing & Payments workspace. Coordinating issue #2362 requires a provider-first, side-effect-free candidate preview before the tracker or Website can expose commercial billing review.
+
+### Diff-budget justification
+
+This is above the repository's 400-LOC soft target because source normalization, fixed-cent calculation, collision/blocker projection, stable fingerprinting, and its failure/retry/staleness proof form one indivisible read contract. Splitting the route from that proof would either publish a dead internal generator or recreate the unsafe scheduler boundary. Financial persistence, approval, delivery preference, tracker proxy, and Website UI remain separate follow-up slices.
+
+### Problem-derived contract
+
+- Root cause: the only existing commercial billing computation is embedded in a writeful scheduler, which prevents an operator from inspecting source evidence and blockers before an invoice, PDF, Gmail draft, email, or invoiced marker exists.
+- Correct fix must touch/change: add one read-only candidate service that derives deterministic commercial candidates from active auto-invoice services, calendar events, and canonical CRM identity; expose it only through the deployed full receivables router; enroll a focused contract suite in the invoicing workflow.
+- Must not change: monthly scheduler behavior, invoice/payment/deposit/receipt/MCP/Gmail state, existing recipient semantics, customer-type definitions, database schema, the dormant slim EOM profile, or tracker/Website consumers.
+
+## Scope (this PR)
+
+Ownership lane: eom/billing-candidate-preview
+Slice phase: Vertical slice
+Max files: 5
+
+1. Add an authenticated GET preview that returns all active auto-invoice service bundles for one explicit month, including source events, line items, exact integer cents, explicit blockers, and a deterministic source fingerprint.
+2. Make preview computation structurally read-only: it may call only service, calendar, and canonical-CRM reads; it cannot create invoices/PDFs/drafts/mail, mark services invoiced, log CRM interactions, or notify.
+3. Treat unresolved source evidence as a blocker rather than a silent candidate selection: missing canonical customer/email/delivery preference, invalid rate/rate label, missing events/hours, zero/invalid total, non-commercial classification, and ambiguous keyword matches are visible in output.
+4. Keep the delivery method null and block it when no explicit preference exists; later durable billing-run and Square work owns the migration and approval behavior recorded as H-13 in #2363.
+
+### Review Contract
+
+- Acceptance criteria:
+  - An authenticated GET `/api/v1/receivables/commercial-billing-candidates?billing_period=YYYY-MM` reaches the active full receivables router and returns a bounded deterministic candidate response; a missing, malformed, or out-of-range period reaches no provider collaborator.
+  - A normal commercial Per Visit bundle groups confirmed calendar events by source date, exposes location/UID evidence, calculates cents with `Decimal(str(value))`, and carries a stable candidate key plus SHA-256 source fingerprint.
+  - Per Month has one monthly line without fabricated events; Per Hour is visibly blocked until hours are supplied; no-event, invalid-rate, invalid-rate-label, zero-total, missing canonical identity/email, missing delivery preference, non-commercial type, and ambiguous keyword inputs each emit their own blocking code.
+  - Equal source inputs produce byte-for-byte equivalent candidate content and fingerprint across retry; changing a rate, canonical recipient, service identity, or calendar event changes the fingerprint without performing a write.
+  - Route authorization rejects missing/wrong bearer credentials before the preview service is called, and calendar or canonical-CRM source unavailability maps to a stable 503 response without leaking the underlying exception; a recovered source permits a clean retry.
+  - Read-only fakes fail if any create/update/delete/PDF/Gmail/mail/CRM-interaction/notification method is reached; normal, failure, retry, stale-evidence, and recovery cases prove the public computation does not invoke them.
+  - The workflow-selected existing invoice validation tests pass unchanged and the scheduler has no diff, proving this route does not rewire the writeful scheduler or change its legacy behavior.
+  - Both pull-request and main-push workflow path filters and the local workflow-equivalent command enroll the new focused candidate suite.
+- Reachability proof: a FastAPI app including the actual `atlas_brain.api.invoicing.receivables.router` uses its production auth dependency and an explicit candidate-service dependency override; service tests inject read-only collaborators rather than replacing first-party globals.
+- Affected surfaces: `atlas_brain/services/commercial_billing_candidates.py`, the active full receivables router, invoice-check workflow enrollment, and the focused contract suite.
+- Risk areas: financial rounding, accidental effects, calendar ambiguity, canonical-customer disclosure, stale evidence, authorization, and deployment topology.
+- Reviewer rules triggered: R1, R2, R3, R5, R7, R8, R12, R14. R3 is satisfied by pure deterministic retry behavior; R8 has no idempotency write because this GET commits no financial or delivery state.
+
+### Boundary-change enumeration
+
+- Boundary path/seam: authenticated full-provider `GET /receivables/commercial-billing-candidates` to `CommercialBillingCandidateService.preview`.
+- Replaced-path behaviors: none; the old scheduler remains uncalled and unchanged. This is an additive route with no fallback to `monthly_invoice_generation.run`.
+- Guard-relevant fields: `billing_period` is strict `YYYY-MM`; calendar event status/date, service rate/rate label/keyword, canonical recipient/customer type, and output blocker/fingerprint fields are normalized at the new service boundary.
+- Caller x input shape: tracker will later call the GET with one query value; direct callers receive 401 before service access without the dedicated receivables bearer token, 422 for malformed query input, 503 for source availability failure, or a JSON preview result.
+
+### Deployed-config probing
+
+- Deployed/default config values: existing `settings.invoicing.auto_invoice_calendar_id` is read only as the current commercial-calendar selector; no feature flag, email setting, save path, or delivery credential is read.
+- Explicit value probe: a nonempty injected calendar ID is passed only to calendar `list_events` and becomes fingerprint evidence.
+- Absent value probe: an empty configured calendar ID becomes `None`, preserving existing provider default-calendar read semantics without selecting a delivery method.
+- Default-session/default-context probe: service and route tests construct explicit read-only collaborator/config values; no live provider, user session, financial row, Gmail account, or environment credential is touched.
+- Side-effect ordering: all service calls are reads. Candidate serialization/fingerprinting completes after those reads; no write or delivery operation exists before, during, or after it.
+
+### Closure declaration
+
+- Rate-label set: CLOSED and ENUMERATED from the current scheduler's documented branches: `Per Visit`, `Per Month`, and `Per Hour`. Unknown labels yield `invalid_rate_label` and no implicit Per Visit behavior.
+- Public blocker-code set: CLOSED and AUTHORED HERE by the candidate contract. A source condition outside its named set becomes `source_evidence_invalid`, remains blocking, and is preserved in the candidate's source evidence rather than being silently accepted.
+- Output ordering: CLOSED and deterministic: candidates by canonical contact UUID string, services by service UUID string, and source events by UTC start then UID.
+
+### Files touched
+
+- `.github/workflows/atlas_invoicing_checks.yml`
+- `atlas_brain/api/invoicing/receivables.py`
+- `atlas_brain/services/commercial_billing_candidates.py`
+- `plans/PR-EOM-Commercial-Billing-Candidates.md`
+- `tests/test_commercial_billing_candidates.py`
+
+## Mechanism
+
+`CommercialBillingCandidateService` accepts explicit read collaborators for active service agreements, calendar evidence, canonical customer/recipient lookups, and the configured commercial calendar ID. It parses the requested calendar month before any read, reads active auto-invoice agreements and confirmed in-period events, assigns matching events using the existing longest-keyword/alphabetical tie rule only for a deterministic preview, and records every multi-match as an approval blocker rather than concealing it.
+
+The service groups line items by canonical contact ID and preserves source dates, event IDs, summaries, calendar IDs, and locations. It converts every persisted numeric input through `Decimal(str(value))`, rejects nonfinite/non-cent data, performs all arithmetic in integer cents, and applies `ROUND_HALF_UP` exactly once when calculating tax cents. It returns no invoice-shaped database object: only a preview candidate with a candidate key, explicit line/evidence values, zero-or-more blocker objects, null delivery method, and a SHA-256 fingerprint of canonical JSON source evidence. The response is deterministic and can therefore be regenerated safely; it does not persist a run or pretend to approve a candidate.
+
+The active full router imports the service through an explicit dependency seam and maps only `CommercialBillingCandidatesUnavailableError` to a stable 503. It does not import the monthly task, invoice repository, PDF renderer, Gmail tooling, mail sender, notification client, or CRM interaction writer. The dormant `atlas_brain.eom_api.receivables` copy is deliberately unchanged: deployed evidence identifies the full `atlas_brain.api.invoicing.receivables` router as the active provider, and the new reusable service is API-independent. Any future slim-profile activation must mount the full contract or add its own compatibility proof; H-06 remains open in #2363.
+
+## Intentional
+
+- The preview is an additive read contract and is safe to deploy before tracker or Website consumers. It does not create a billing run, invoice, PDF, draft, sent state, payment, service marker, audit record, or email.
+- `deliveryMethod` is null and `missing_billing_delivery_preference` is blocking for every otherwise eligible commercial candidate because current code has no canonical delivery preference. Customer type never implies Gmail or Square.
+- Event locations are source evidence, not canonical service-site identity. A service-specific `calendar_id` remains evidence only; this slice preserves the current global-calendar selection rather than changing invoicing behavior.
+- Per-hour source events are retained but not assigned fabricated hours. Approval is blocked rather than estimating a total.
+- The existing invoice repository still has legacy float conversion. This new read-only candidate path uses exact cents but does not alter old invoice output; H-01 remains a prerequisite before an approval writer is enabled.
+
+## Deferred
+
+- H-13 in #2363: add an audited persisted delivery preference, manual Square reference capture, and canonical service/site/calendar identity before any candidate approval writer.
+- H-14 in #2363: repair the base-equal maturity-ratchet baseline omission for the existing receivables module and separately enroll receipt-template coverage; this slice does not accept or broaden that baseline.
+- #2362 next slices: durable billing-run persistence and staleness reconciliation; tracker proxy; Website review UI; explicit approval/invoice/PDF/Gmail draft recovery; sent-mail reconciliation; Square queue; operating documentation.
+- H-06 in #2363: evaluate the duplicated full/slim receivables route models before a provider-wide billing-run API expansion.
+
+Parked hardening: H-14 is recorded without changing its baseline in this PR. Financial writer hardening, schema migration, and delivery preference are deliberately deferred because the preview has no write path.
+
+## Verification
+
+- `python -m pytest tests/test_commercial_billing_candidates.py -q` — 11 passed (local; all collaborators are fakes, every address uses example.test, and calendar plus both canonical-CRM reader outage/recovery paths leave zero writes).
+- `ATLAS_RECEIVABLES_TEST_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:55441/atlas_receivables_test python -m pytest tests/test_monthly_invoice_generation.py -k "update_invoice_clears_needs_hours_when_line_items_are_billable or line_items_are_billable_requires_all_positive_quantities" -q` — 2 passed (isolated local PostgreSQL 16).
+- Same isolated database: the workflow's receivables/repository command with `tests/test_commercial_billing_candidates.py` enrolled — 231 passed, 1 unrelated torch/pynvml deprecation warning.
+- Same isolated database: the workflow's invoicing MCP/OAuth command — 43 passed.
+- `python -m ruff check atlas_brain/api/invoicing/receivables.py atlas_brain/services/commercial_billing_candidates.py tests/test_commercial_billing_candidates.py` — passed.
+- `python -m compileall -q atlas_brain/api/invoicing/receivables.py atlas_brain/services/commercial_billing_candidates.py` — passed.
+- `python scripts/sync_pr_plan.py plans/PR-EOM-Commercial-Billing-Candidates.md --check`, `git diff --check`, and `git diff --quiet origin/main -- atlas_brain/autonomous/tasks/monthly_invoice_generation.py` — passed.
+- Exact local maturity-ratchet checks found two failures that reproduce unchanged on the base revision: the missing API baseline entry for pre-existing receivables mocks and receipt-template coverage enrollment. H-14 records the evidence; neither failure is accepted or altered in this slice.
+- The broad legacy monthly-task suite was not run with `ATLAS_INVOICING_ENABLED=true`: doing so could select a configured non-test provider or datastore. The exact workflow-selected existing invoice tests passed against isolated PostgreSQL; this slice leaves the scheduler unchanged.
+- Repository local pre-push/review wrapper will run immediately before publication; GitHub-hosted statuses are observed but do not replace local acceptance evidence per the operator instruction.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_invoicing_checks.yml` | 5 |
+| `atlas_brain/api/invoicing/receivables.py` | 34 |
+| `atlas_brain/services/commercial_billing_candidates.py` | 996 |
+| `plans/PR-EOM-Commercial-Billing-Candidates.md` | 120 |
+| `tests/test_commercial_billing_candidates.py` | 742 |
+| **Total** | **1897** |

--- a/tests/test_commercial_billing_candidates.py
+++ b/tests/test_commercial_billing_candidates.py
@@ -1,0 +1,742 @@
+"""Contract tests for the side-effect-free EOM commercial billing preview."""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from datetime import datetime, timezone
+from decimal import Decimal
+from pathlib import Path
+from types import SimpleNamespace
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from atlas_brain.services.calendar_provider import CalendarEvent
+from atlas_brain.services.commercial_billing_candidates import (
+    CommercialBillingCandidateService,
+    CommercialBillingCandidatesUnavailableError,
+    CommercialBillingCandidatesValidationError,
+)
+
+
+class _ReadOnlyServiceRepository:
+    def __init__(self, rows: list[dict]) -> None:
+        self.rows = rows
+        self.calls: list[bool] = []
+        self.write_attempts = 0
+
+    async def list_active(self, auto_invoice_only: bool = False) -> list[dict]:
+        self.calls.append(auto_invoice_only)
+        return self.rows
+
+    async def mark_invoiced(self, *_args, **_kwargs) -> None:
+        self.write_attempts += 1
+        raise AssertionError("candidate preview must not mark a service invoiced")
+
+
+class _ReadOnlyCalendar:
+    def __init__(self, events: list[object], *, error: Exception | None = None) -> None:
+        self.events = events
+        self.error = error
+        self.calls: list[tuple[datetime, datetime, str | None]] = []
+        self.write_attempts = 0
+
+    async def list_events(
+        self,
+        start: datetime,
+        end: datetime,
+        calendar_id: str | None = None,
+    ) -> list[object]:
+        self.calls.append((start, end, calendar_id))
+        if self.error is not None:
+            raise self.error
+        return self.events
+
+    async def create_event(self, *_args, **_kwargs) -> None:
+        self.write_attempts += 1
+        raise AssertionError("candidate preview must not create calendar events")
+
+
+class _ReadOnlyCRM:
+    def __init__(
+        self,
+        customers: dict[UUID, dict | None],
+        recipients: dict[UUID, dict],
+        *,
+        customer_error: Exception | None = None,
+        recipient_error: Exception | None = None,
+    ) -> None:
+        self.customers = customers
+        self.recipients = recipients
+        self.customer_error = customer_error
+        self.recipient_error = recipient_error
+        self.customer_calls: list[UUID] = []
+        self.recipient_calls: list[UUID] = []
+        self.write_attempts = 0
+
+    async def get_eom_payment_customer(self, contact_id: UUID) -> dict | None:
+        self.customer_calls.append(contact_id)
+        if self.customer_error is not None:
+            raise self.customer_error
+        return self.customers.get(contact_id)
+
+    async def get_billing_recipient(self, contact_id: UUID) -> dict:
+        self.recipient_calls.append(contact_id)
+        if self.recipient_error is not None:
+            raise self.recipient_error
+        return self.recipients[contact_id]
+
+    async def log_interaction(self, *_args, **_kwargs) -> None:
+        self.write_attempts += 1
+        raise AssertionError("candidate preview must not log CRM interactions")
+
+
+def _service_row(
+    contact_id: UUID,
+    *,
+    service_id: UUID | None = None,
+    name: str = "Office cleaning",
+    rate: object = Decimal("48.25"),
+    rate_label: str = "Per Visit",
+    tax_rate: object = Decimal("0.0330"),
+    keyword: str = "Acme",
+    calendar_id: str | None = None,
+) -> dict:
+    return {
+        "id": service_id or uuid4(),
+        "contact_id": contact_id,
+        "service_name": name,
+        "rate": rate,
+        "rate_label": rate_label,
+        "tax_rate": tax_rate,
+        "calendar_keyword": keyword,
+        "calendar_id": calendar_id,
+    }
+
+
+def _customer(contact_id: UUID, *, customer_type: str = "commercial") -> dict:
+    return {
+        "contact_id": contact_id,
+        "customer_name": "Acme Office",
+        "customer_type": customer_type,
+        "recipient_email": "billing@example.test",
+    }
+
+
+def _recipient(contact_id: UUID, *, eligible: bool = True, reason: str | None = None) -> dict:
+    return {
+        "contactId": str(contact_id),
+        "displayName": "Acme Accounts Payable" if eligible else None,
+        "email": "billing@example.test" if eligible else None,
+        "eligible": eligible,
+        "reason": reason,
+    }
+
+
+def _event(
+    event_id: str,
+    day: int,
+    *,
+    summary: str = "Acme Office cleaning",
+    location: str | None = "100 Main St",
+    status: str = "confirmed",
+) -> CalendarEvent:
+    start = datetime(2026, 3, day, 16, 0, tzinfo=timezone.utc)
+    return CalendarEvent(
+        uid=event_id,
+        summary=summary,
+        start=start,
+        end=start.replace(hour=17),
+        calendar_id="commercial-calendar",
+        location=location,
+        status=status,
+    )
+
+
+def _candidate_service(
+    rows: list[dict],
+    events: list[object],
+    *,
+    customers: dict[UUID, dict | None] | None = None,
+    recipients: dict[UUID, dict] | None = None,
+    calendar_error: Exception | None = None,
+    crm_customer_error: Exception | None = None,
+    crm_recipient_error: Exception | None = None,
+) -> tuple[
+    CommercialBillingCandidateService,
+    _ReadOnlyServiceRepository,
+    _ReadOnlyCalendar,
+    _ReadOnlyCRM,
+]:
+    repository = _ReadOnlyServiceRepository(rows)
+    calendar = _ReadOnlyCalendar(events, error=calendar_error)
+    contact_ids = {
+        UUID(str(row["contact_id"]))
+        for row in rows
+        if row.get("contact_id") is not None
+    }
+    crm = _ReadOnlyCRM(
+        customers or {contact_id: _customer(contact_id) for contact_id in contact_ids},
+        recipients or {contact_id: _recipient(contact_id) for contact_id in contact_ids},
+        customer_error=crm_customer_error,
+        recipient_error=crm_recipient_error,
+    )
+    return (
+        CommercialBillingCandidateService(
+            customer_service_repository=repository,
+            calendar_provider_loader=lambda: calendar,
+            crm_provider_loader=lambda: crm,
+            calendar_id="commercial-calendar",
+        ),
+        repository,
+        calendar,
+        crm,
+    )
+
+
+@pytest.mark.asyncio
+async def test_per_visit_preview_is_exact_and_has_no_financial_or_delivery_effects():
+    contact_id = uuid4()
+    service, repository, calendar, crm = _candidate_service(
+        [_service_row(contact_id, rate=48.25)],
+        [_event("evt-2", 3), _event("evt-1", 3), _event("evt-3", 10)],
+    )
+
+    preview = await service.preview(billing_period="2026-03")
+
+    assert preview["billingPeriod"] == "2026-03"
+    assert preview["calendarId"] == "commercial-calendar"
+    assert preview["summary"] == {"blockedCandidateCount": 1, "candidateCount": 1}
+    candidate = preview["candidates"][0]
+    assert candidate["customer"] == {
+        "contactId": str(contact_id),
+        "customerType": "commercial",
+        "displayName": "Acme Office",
+    }
+    assert candidate["recipient"] == {
+        "contactId": str(contact_id),
+        "displayName": "Acme Accounts Payable",
+        "email": "billing@example.test",
+    }
+    assert candidate["deliveryMethod"] is None
+    assert candidate["subtotalCents"] == 14_475
+    assert candidate["taxRateBasisPoints"] == 330
+    assert candidate["taxCents"] == 478
+    assert candidate["totalCents"] == 14_953
+    assert candidate["lineItems"] == [
+        {
+            "amountCents": 9_650,
+            "description": "Office cleaning",
+            "eventIds": ["evt-1", "evt-2"],
+            "locations": ["100 Main St"],
+            "quantity": 2,
+            "quantityUnit": "visit",
+            "rateCents": 4_825,
+            "serviceId": str(repository.rows[0]["id"]),
+            "sourceDate": "2026-03-03",
+        },
+        {
+            "amountCents": 4_825,
+            "description": "Office cleaning",
+            "eventIds": ["evt-3"],
+            "locations": ["100 Main St"],
+            "quantity": 1,
+            "quantityUnit": "visit",
+            "rateCents": 4_825,
+            "serviceId": str(repository.rows[0]["id"]),
+            "sourceDate": "2026-03-10",
+        },
+    ]
+    assert candidate["blockers"] == [
+        {
+            "code": "missing_billing_delivery_preference",
+            "eventIds": [],
+            "message": "No explicit billing delivery preference is recorded.",
+            "serviceId": None,
+        }
+    ]
+    assert len(candidate["sourceFingerprint"]) == 64
+    assert repository.calls == [True]
+    assert calendar.calls[0][2] == "commercial-calendar"
+    assert crm.customer_calls == [contact_id]
+    assert crm.recipient_calls == [contact_id]
+    assert repository.write_attempts == calendar.write_attempts == crm.write_attempts == 0
+
+
+@pytest.mark.asyncio
+async def test_preview_retries_are_identical_and_source_changes_make_it_stale():
+    contact_id = uuid4()
+    row = _service_row(contact_id, rate=48.25)
+    service, repository, calendar, crm = _candidate_service(
+        [row], [_event("evt-1", 3)]
+    )
+
+    first = await service.preview(billing_period="2026-03")
+    second = await service.preview(billing_period="2026-03")
+    assert second == first
+
+    row["rate"] = Decimal("49.25")
+    changed_rate = await service.preview(billing_period="2026-03")
+    assert changed_rate["candidates"][0]["sourceFingerprint"] != first["candidates"][0]["sourceFingerprint"]
+
+    row["id"] = uuid4()
+    changed_service_identity = await service.preview(billing_period="2026-03")
+    assert (
+        changed_service_identity["candidates"][0]["sourceFingerprint"]
+        != changed_rate["candidates"][0]["sourceFingerprint"]
+    )
+
+    crm.recipients[contact_id] = {
+        **crm.recipients[contact_id],
+        "email": "new-ap@example.test",
+    }
+    changed_recipient = await service.preview(billing_period="2026-03")
+    assert (
+        changed_recipient["candidates"][0]["sourceFingerprint"]
+        != changed_service_identity["candidates"][0]["sourceFingerprint"]
+    )
+
+    calendar.events.append(_event("evt-2", 10, location="Second Site"))
+    changed_calendar = await service.preview(billing_period="2026-03")
+    assert (
+        changed_calendar["candidates"][0]["sourceFingerprint"]
+        != changed_recipient["candidates"][0]["sourceFingerprint"]
+    )
+    assert repository.write_attempts == calendar.write_attempts == crm.write_attempts == 0
+
+
+@pytest.mark.asyncio
+async def test_preview_surfaces_billing_blockers_without_creating_a_fake_invoice():
+    commercial = uuid4()
+    residential = uuid4()
+    rows = [
+        _service_row(
+            commercial,
+            name="Bad rate",
+            rate=Decimal("12.345"),
+            keyword="Bad rate",
+        ),
+        _service_row(
+            commercial,
+            name="Hourly",
+            rate_label="Per Hour",
+            keyword="Hours",
+        ),
+        _service_row(
+            commercial,
+            name="No calendar evidence",
+            keyword="Not found",
+        ),
+        _service_row(
+            commercial,
+            name="Unsupported rate label",
+            rate_label="Per Shift",
+            keyword="Unsupported",
+        ),
+        _service_row(
+            commercial,
+            name="Flat monthly service",
+            rate_label="Per Month",
+            keyword="Flat",
+        ),
+        _service_row(
+            residential,
+            name="Residential service",
+            rate_label="Per Month",
+            keyword="Residential",
+        ),
+    ]
+    customers = {
+        commercial: _customer(commercial),
+        residential: _customer(residential, customer_type="residential"),
+    }
+    recipients = {
+        commercial: _recipient(commercial, eligible=False, reason="no_email"),
+        residential: _recipient(residential),
+    }
+    service, repository, calendar, crm = _candidate_service(
+        rows,
+        [_event("evt-hours", 5, summary="Hours cleaning")],
+        customers=customers,
+        recipients=recipients,
+    )
+
+    preview = await service.preview(billing_period="2026-03")
+    commercial_candidate = next(
+        item
+        for item in preview["candidates"]
+        if item["customer"]["contactId"] == str(commercial)
+    )
+    assert {blocker["code"] for blocker in commercial_candidate["blockers"]} >= {
+        "invalid_rate",
+        "invalid_rate_label",
+        "missing_billing_delivery_preference",
+        "missing_billing_email",
+        "missing_calendar_service_evidence",
+        "missing_hours",
+        "zero_or_invalid_total",
+    }
+    assert commercial_candidate["totalCents"] is None
+    line_items = {
+        item["description"]: item for item in commercial_candidate["lineItems"]
+    }
+    assert line_items["Hourly"]["amountCents"] is None
+    assert (
+        line_items["Flat monthly service"]["quantity"],
+        line_items["Flat monthly service"]["quantityUnit"],
+        line_items["Flat monthly service"]["amountCents"],
+    ) == (1, "month", 4_825)
+
+    residential_candidate = next(
+        item
+        for item in preview["candidates"]
+        if item["customer"]["contactId"] == str(residential)
+    )
+    assert {blocker["code"] for blocker in residential_candidate["blockers"]} >= {
+        "customer_not_commercial"
+    }
+    assert residential_candidate["totalCents"] == 4_984
+    assert repository.write_attempts == calendar.write_attempts == crm.write_attempts == 0
+
+
+@pytest.mark.asyncio
+async def test_preview_blocks_ambiguous_keyword_matches_without_double_counting():
+    first_contact = uuid4()
+    second_contact = uuid4()
+    first_service = _service_row(
+        first_contact,
+        name="Acme",
+        rate=Decimal("10.00"),
+        keyword="Acme",
+    )
+    second_service = _service_row(
+        second_contact,
+        name="Acme Office",
+        rate=Decimal("20.00"),
+        keyword="Acme Office",
+    )
+    service, _, _, _ = _candidate_service(
+        [first_service, second_service],
+        [_event("evt-ambiguous", 7, summary="Acme Office cleaning")],
+    )
+
+    preview = await service.preview(billing_period="2026-03")
+    candidates = {item["customer"]["contactId"]: item for item in preview["candidates"]}
+    first = candidates[str(first_contact)]
+    second = candidates[str(second_contact)]
+    assert {blocker["code"] for blocker in first["blockers"]} >= {
+        "ambiguous_calendar_service_match",
+        "zero_or_invalid_total",
+    }
+    assert {blocker["code"] for blocker in second["blockers"]} >= {
+        "ambiguous_calendar_service_match"
+    }
+    assert first["lineItems"] == []
+    assert second["lineItems"][0]["amountCents"] == 2_000
+    assert second["totalCents"] is None
+    assert all(
+        source["eventId"] == "evt-ambiguous"
+        for candidate in (first, second)
+        for source in candidate["sourceEvents"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_preview_reports_missing_customer_and_malformed_calendar_evidence():
+    contact_id = uuid4()
+    row = _service_row(contact_id)
+    malformed = SimpleNamespace(
+        uid="",
+        summary="Acme Office cleaning",
+        start=datetime(2026, 3, 4, tzinfo=timezone.utc),
+        end=datetime(2026, 3, 4, 1, tzinfo=timezone.utc),
+        status="confirmed",
+    )
+    service, _, _, _ = _candidate_service(
+        [row],
+        [malformed],
+        customers={contact_id: None},
+        recipients={contact_id: _recipient(contact_id)},
+    )
+
+    candidate = (await service.preview(billing_period="2026-03"))["candidates"][0]
+    assert {blocker["code"] for blocker in candidate["blockers"]} >= {
+        "missing_canonical_customer",
+        "missing_calendar_service_evidence",
+        "source_evidence_invalid",
+        "zero_or_invalid_total",
+    }
+    assert candidate["recipient"] == {
+        "contactId": str(contact_id),
+        "displayName": None,
+        "email": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_invalid_period_and_source_outage_fail_without_a_write_or_partial_preview():
+    contact_id = uuid4()
+    service, repository, calendar, crm = _candidate_service(
+        [_service_row(contact_id)],
+        [_event("evt-1", 3)],
+    )
+
+    with pytest.raises(CommercialBillingCandidatesValidationError):
+        await service.preview(billing_period="2026-3")
+    assert repository.calls == []
+    assert calendar.calls == []
+    assert crm.customer_calls == []
+
+    unavailable_service, unavailable_repository, unavailable_calendar, unavailable_crm = (
+        _candidate_service(
+            [_service_row(contact_id)],
+            [],
+            calendar_error=OSError("calendar unavailable"),
+        )
+    )
+    with pytest.raises(CommercialBillingCandidatesUnavailableError):
+        await unavailable_service.preview(billing_period="2026-03")
+    assert unavailable_repository.calls == [True]
+    assert unavailable_calendar.calls
+    assert unavailable_crm.customer_calls == []
+    assert unavailable_repository.write_attempts == 0
+    assert unavailable_calendar.write_attempts == 0
+    assert unavailable_crm.write_attempts == 0
+
+    unavailable_calendar.error = None
+    recovered = await unavailable_service.preview(billing_period="2026-03")
+    assert recovered["summary"] == {"blockedCandidateCount": 1, "candidateCount": 1}
+
+    crm_unavailable_service, crm_unavailable_repository, crm_unavailable_calendar, crm_unavailable = (
+        _candidate_service(
+            [_service_row(contact_id)],
+            [_event("evt-1", 3)],
+            crm_customer_error=RuntimeError("canonical CRM unavailable"),
+        )
+    )
+    with pytest.raises(CommercialBillingCandidatesUnavailableError):
+        await crm_unavailable_service.preview(billing_period="2026-03")
+    assert crm_unavailable_repository.calls == [True]
+    assert crm_unavailable_calendar.calls
+    assert crm_unavailable.customer_calls == [contact_id]
+    assert crm_unavailable.recipient_calls == []
+    assert (
+        crm_unavailable_repository.write_attempts
+        == crm_unavailable_calendar.write_attempts
+        == crm_unavailable.write_attempts
+        == 0
+    )
+
+    crm_unavailable.customer_error = None
+    crm_recovered = await crm_unavailable_service.preview(billing_period="2026-03")
+    assert crm_recovered["summary"] == {
+        "blockedCandidateCount": 1,
+        "candidateCount": 1,
+    }
+
+    recipient_unavailable_service, recipient_unavailable_repository, recipient_unavailable_calendar, recipient_unavailable = (
+        _candidate_service(
+            [_service_row(contact_id)],
+            [_event("evt-1", 3)],
+            crm_recipient_error=RuntimeError("billing recipient unavailable"),
+        )
+    )
+    with pytest.raises(CommercialBillingCandidatesUnavailableError):
+        await recipient_unavailable_service.preview(billing_period="2026-03")
+    assert recipient_unavailable_repository.calls == [True]
+    assert recipient_unavailable_calendar.calls
+    assert recipient_unavailable.customer_calls == [contact_id]
+    assert recipient_unavailable.recipient_calls == [contact_id]
+    assert (
+        recipient_unavailable_repository.write_attempts
+        == recipient_unavailable_calendar.write_attempts
+        == recipient_unavailable.write_attempts
+        == 0
+    )
+
+    recipient_unavailable.recipient_error = None
+    recipient_recovered = await recipient_unavailable_service.preview(
+        billing_period="2026-03"
+    )
+    assert recipient_recovered["summary"] == {
+        "blockedCandidateCount": 1,
+        "candidateCount": 1,
+    }
+
+
+@pytest.mark.asyncio
+async def test_preview_passes_no_calendar_identifier_when_the_config_is_absent():
+    contact_id = uuid4()
+    repository = _ReadOnlyServiceRepository([_service_row(contact_id)])
+    calendar = _ReadOnlyCalendar([_event("evt-1", 3)])
+    crm = _ReadOnlyCRM({contact_id: _customer(contact_id)}, {contact_id: _recipient(contact_id)})
+    service = CommercialBillingCandidateService(
+        customer_service_repository=repository,
+        calendar_provider_loader=lambda: calendar,
+        crm_provider_loader=lambda: crm,
+        calendar_id="",
+    )
+
+    candidate = (await service.preview(billing_period="2026-03"))["candidates"][0]
+    assert calendar.calls[0][2] is None
+    assert candidate["calendarId"] is None
+
+    configured_service = CommercialBillingCandidateService(
+        customer_service_repository=repository,
+        calendar_provider_loader=lambda: calendar,
+        crm_provider_loader=lambda: crm,
+        calendar_id="second-commercial-calendar",
+    )
+    configured_candidate = (
+        await configured_service.preview(billing_period="2026-03")
+    )["candidates"][0]
+    assert configured_candidate["sourceFingerprint"] != candidate["sourceFingerprint"]
+
+
+def _route_app(service: object) -> tuple[FastAPI, str]:
+    from atlas_brain.api.invoicing import auth as receivables_auth
+    from atlas_brain.api.invoicing import receivables as routes
+    from atlas_brain.eom_api.auth import generate_receivables_service_token
+
+    generated = generate_receivables_service_token()
+    app = FastAPI()
+    app.include_router(routes.router)
+    app.dependency_overrides[receivables_auth.get_receivables_api_config] = lambda: (
+        SimpleNamespace(
+            receivables_api_enabled=True,
+            receivables_service_token="",
+            receivables_service_token_sha256=generated.sha256,
+        )
+    )
+    app.dependency_overrides[routes.get_commercial_billing_candidate_service] = (
+        lambda: service
+    )
+    return app, generated.token
+
+
+class _RoutePreviewService:
+    def __init__(self, *, error: Exception | None = None) -> None:
+        self.error = error
+        self.calls: list[str] = []
+
+    async def preview(self, *, billing_period: str) -> dict:
+        self.calls.append(billing_period)
+        if self.error is not None:
+            raise self.error
+        return {"billingPeriod": billing_period, "candidates": []}
+
+
+@pytest.mark.asyncio
+async def test_full_provider_route_authenticates_before_preview_and_validates_period():
+    service = _RoutePreviewService()
+    app, token = _route_app(service)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://receivables.test",
+    ) as client:
+        path = "/receivables/commercial-billing-candidates"
+        assert (await client.get(path)).status_code == 401
+        assert service.calls == []
+        headers = {"Authorization": f"Bearer {token}"}
+        assert (
+            await client.get(
+                path,
+                params={"billing_period": "2026-03"},
+                headers={"Authorization": "Bearer wrong-token"},
+            )
+        ).status_code == 401
+        assert service.calls == []
+        malformed = await client.get(
+            path,
+            params={"billing_period": "2026-3"},
+            headers=headers,
+        )
+        assert malformed.status_code == 422
+        assert service.calls == []
+        response = await client.get(
+            path,
+            params={"billing_period": "2026-03"},
+            headers=headers,
+        )
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {"billingPeriod": "2026-03", "candidates": []}
+    assert service.calls == ["2026-03"]
+
+
+@pytest.mark.asyncio
+async def test_full_provider_route_returns_stable_source_unavailable_response():
+    service = _RoutePreviewService(
+        error=CommercialBillingCandidatesUnavailableError("calendar evidence unavailable")
+    )
+    app, token = _route_app(service)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://receivables.test",
+    ) as client:
+        response = await client.get(
+            "/receivables/commercial-billing-candidates",
+            params={"billing_period": "2026-03"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 503
+    assert response.json() == {
+        "detail": {
+            "code": "commercial_billing_candidates_unavailable",
+            "message": "calendar evidence unavailable",
+        }
+    }
+    assert service.calls == ["2026-03"]
+
+
+def test_preview_service_does_not_import_the_writeful_scheduler_or_delivery_stack():
+    """A dependency-free source guard prevents accidental preview side effects."""
+
+    import atlas_brain.services.commercial_billing_candidates as candidates
+
+    imports = {
+        alias.name
+        for node in ast.walk(ast.parse(inspect.getsource(candidates)))
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    }
+    imports.update(
+        {
+            f"{node.module}.{alias.name}" if node.module else alias.name
+            for node in ast.walk(ast.parse(inspect.getsource(candidates)))
+            if isinstance(node, ast.ImportFrom)
+            for alias in node.names
+        }
+    )
+    forbidden_fragments = {
+        "monthly_invoice_generation",
+        "invoice_pdf",
+        "email_provider",
+        "gmail",
+        "notification",
+        "invoice",
+    }
+    assert not any(
+        fragment in imported
+        for fragment in forbidden_fragments
+        for imported in imports
+    )
+
+
+def test_invoicing_workflow_enrolls_the_candidate_contract_for_pr_and_main_push():
+    workflow = (
+        Path(__file__).resolve().parents[1]
+        / ".github"
+        / "workflows"
+        / "atlas_invoicing_checks.yml"
+    ).read_text(encoding="utf-8")
+
+    assert workflow.count('"atlas_brain/services/commercial_billing_candidates.py"') == 2
+    assert workflow.count('"tests/test_commercial_billing_candidates.py"') == 2
+    assert "tests/test_commercial_billing_candidates.py \\" in workflow


### PR DESCRIPTION
Plan: plans/PR-EOM-Commercial-Billing-Candidates.md
Slice phase: Vertical slice
Ownership lane: eom/billing-candidate-preview

The current monthly EOM invoicing task is not a candidate-review mechanism: it creates invoices, writes PDFs, marks services invoiced, logs CRM interactions, and can deliver email. This provider-first slice adds a separate authenticated, read-only commercial billing preview so later tracker and Website work can review source evidence before any financial or delivery action exists.

## Intentional

- The new endpoint is additive and deploys safely before consumers. It returns candidates, blockers, source evidence, exact integer cents, and a source fingerprint only; it creates no billing run, invoice, PDF, Gmail draft, email, payment, service marker, CRM interaction, or notification.
- Repeating the same request returns the same projection and fingerprint. A rate, service identity, recipient, selected calendar, or matching event change yields a different fingerprint; no retry can create money or delivery effects because the route has no write collaborator.
- Every commercial candidate is blocked with missing_billing_delivery_preference until a later explicit preference model chooses Gmail PDF, manual Square, or no-invoice/residential-receipt. Customer type never implies a delivery channel.
- Deployment order: deploy this Atlas provider revision first and verify the protected read endpoint. The next slice adds only the eom-timetracker proxy; Website review UI follows that deployed provider. No consumer is changed here.

## AI reconciliation

- no-findings

## Deferred

- H-13: durable delivery preference, manual Square reference, and canonical service/site/calendar identity are tracked in https://github.com/canfieldjuan/ATLAS/issues/2363#issuecomment-5279712636 and are required before an approval writer.
- H-14: the base-equal maturity-ratchet baseline/coverage omission is tracked in https://github.com/canfieldjuan/ATLAS/issues/2363#issuecomment-5280262602. This PR neither accepts nor changes that baseline.
- #2362 next slices own durable billing-run persistence, candidate reconciliation, tracker proxy, Website UI, approved invoice/PDF/Gmail-draft recovery, sent-mail reconciliation, Square queue, and operating documentation.
- H-06 remains open for duplicated full/slim receivables models before a broad billing-run API expansion.

## Parked hardening

- H-14 only: base-equal maturity baseline maintenance and receipt-template coverage are parked in #2363. The parking predicate is work outside the pure read boundary. Money-writer hardening and delivery-state persistence are not waived; they are intentionally deferred until approval behavior exists.

## Cold diff reconstruction

- Changed atlas_brain/services/commercial_billing_candidates.py:401-421 to parse the month before source reads and produce a non-persisted candidate response. Lines 573-589 classify both canonical CRM reader failures as unavailable; lines 639-968 derive source events, quantities, integer-cent totals, blockers, and a SHA-256 fingerprint; lines 972-984 wire only service/calendar/CRM read factories.
- Changed atlas_brain/api/invoicing/receivables.py:364-389 to expose the active full-provider authenticated GET, reject malformed periods, and map only source unavailability to a stable 503 response. It does not call monthly_invoice_generation.
- Changed .github/workflows/atlas_invoicing_checks.yml:31-50, 83-102, and 154-161 so both PR/main path filters and the local workflow-equivalent command include the candidate contract.
- Changed tests/test_commercial_billing_candidates.py:188-253, 257-299, 490-566, and 602-665 to prove normal exact cents, no-effect fakes, replay/staleness, calendar plus both canonical-CRM reader outage/recovery, configuration fallback, auth-before-service, malformed-request rejection, and 503 behavior. No test targets a live financial row, customer, Gmail account, or mail sender.
- Contract match: the old scheduler remains untouched, while the only new execution path is a protected GET into independently injected readers. Explicit blocked outputs preserve missing/ambiguous evidence instead of creating drafts as the old review mode does.
- Gaps: none in this pure preview scope. Persisted delivery preference/site identity is explicitly H-13; legacy invoice writer float conversion remains H-01 and is not used here; base-equal maturity maintenance is H-14.

## Verification

- Focused candidate contract: 11 passed locally, including calendar and both canonical-CRM reader outage/recovery paths with zero writes.
- Exact local equivalents of Atlas Invoicing Checks: 2 passed for existing invoice validation, 231 passed for receivables/repository/candidate coverage, and 43 passed for invoicing MCP/OAuth coverage, all against isolated local PostgreSQL 16. The only warning was the existing torch/pynvml deprecation warning.
- Ruff, compileall, plan synchronization, whitespace validation, and a no-diff assertion for the legacy monthly scheduler passed locally.
- The two local maturity-ratchet failures reproduce unchanged on the exact base revision: `receivables.py` has a missing baseline entry for seven pre-existing `get_crm_provider` mocks, and `payment_receipt.py` lacks enrolled coverage. H-14 records them; they are not a regression accepted by this diff.

## Mechanical verification

- Command: python -m pytest tests/test_commercial_billing_candidates.py -q - Result: 11 passed - Environment: local
- Command: ATLAS_RECEIVABLES_TEST_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:55441/atlas_receivables_test python -m pytest tests/test_monthly_invoice_generation.py -k "update_invoice_clears_needs_hours_when_line_items_are_billable or line_items_are_billable_requires_all_positive_quantities" -q - Result: 2 passed - Environment: local
- Command: ATLAS_RECEIVABLES_TEST_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:55441/atlas_receivables_test python -m pytest tests/test_eom_render_profile.py tests/test_receivables.py tests/test_eom_billing_recipients.py tests/test_eom_payment_receipts.py tests/test_commercial_billing_candidates.py tests/test_invoice_repository.py -q - Result: 231 passed - Environment: local
- Command: ATLAS_RECEIVABLES_TEST_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:55441/atlas_receivables_test python -m pytest tests/test_invoicing_readonly_mcp.py tests/test_invoicing_readonly_oauth.py tests/test_invoicing_draft_writer_mcp.py tests/test_invoicing_draft_writer_oauth.py -q - Result: 43 passed - Environment: local
- Command: python -m ruff check atlas_brain/api/invoicing/receivables.py atlas_brain/services/commercial_billing_candidates.py tests/test_commercial_billing_candidates.py - Result: passed - Environment: local
- Command: python -m compileall -q atlas_brain/api/invoicing/receivables.py atlas_brain/services/commercial_billing_candidates.py - Result: passed - Environment: local
- Command: python scripts/sync_pr_plan.py plans/PR-EOM-Commercial-Billing-Candidates.md --check; git diff --check; git diff --quiet origin/main -- atlas_brain/autonomous/tasks/monthly_invoice_generation.py - Result: passed - Environment: local
- Command: local atlas_brain/api and atlas_brain/templates maturity-ratchet commands against both the exact base and this head - Result: fail (the same two base-equal failures; candidate-route code adds no maturity finding; H-14) - Environment: local
- Skipped: broad legacy monthly task suite with ATLAS_INVOICING_ENABLED=true - Reason: it could select a configured non-test provider or datastore; the exact workflow-selected invoice regression passed against isolated PostgreSQL and the scheduler has no diff.

## Diff size

5 files, +1897 / -0. This exceeds the 400-LOC soft target because source normalization, blocker/fingerprint output, and finance-safe retry/failure proof are one read contract; the plan documents why splitting it would produce a dead generator or incomplete unsafe provider surface.

Diff-budget override: Source normalization, fixed-cent calculation, deterministic collision/blocker projection, source fingerprinting, and their normal/failure/retry/staleness proof are one indivisible read contract. Splitting this slice would publish either a dead internal generator or an unproven provider route, while every financial write, delivery preference, approval, and consumer remains in its own follow-up slice.

<!-- atlas-open-pr-wrapper: v1 -->
