### PR TITLE
EOM billing: persist commercial review runs

### DIFF
--- a/.github/workflows/atlas_invoicing_checks.yml
+++ b/.github/workflows/atlas_invoicing_checks.yml
@@ -29,6 +29,7 @@ on:
       - "atlas_brain/services/__init__.py"
       - "atlas_brain/services/crm_provider.py"
       - "atlas_brain/services/commercial_billing_candidates.py"
+      - "atlas_brain/services/commercial_billing_runs.py"
       # normalize_contact_email decides billing eligibility and the
       # address these routes return; a grammar change here must run
       # the billing proof.
@@ -38,6 +39,7 @@ on:
       - "atlas_brain/storage/migrations/344_receivables_payments.sql"
       - "atlas_brain/storage/migrations/345_receivables_event_key_lookup.sql"
       - "atlas_brain/storage/migrations/369_receivables_payment_receipt_outbox.sql"
+      - "atlas_brain/storage/migrations/370_commercial_billing_runs.sql"
       - "atlas_brain/storage/repositories/invoice.py"
       - "atlas_brain/templates/email/__init__.py"
       - "atlas_brain/templates/email/estimate_confirmation.py"
@@ -48,6 +50,7 @@ on:
       - "tests/test_eom_billing_recipients.py"
       - "tests/test_eom_payment_receipts.py"
       - "tests/test_commercial_billing_candidates.py"
+      - "tests/test_commercial_billing_runs.py"
       - "tests/test_invoicing_readonly_mcp.py"
       - "tests/test_invoicing_readonly_oauth.py"
       - "tests/test_invoicing_draft_writer_mcp.py"
@@ -81,6 +84,7 @@ on:
       - "atlas_brain/services/__init__.py"
       - "atlas_brain/services/crm_provider.py"
       - "atlas_brain/services/commercial_billing_candidates.py"
+      - "atlas_brain/services/commercial_billing_runs.py"
       # normalize_contact_email decides billing eligibility and the
       # address these routes return; a grammar change here must run
       # the billing proof.
@@ -90,6 +94,7 @@ on:
       - "atlas_brain/storage/migrations/344_receivables_payments.sql"
       - "atlas_brain/storage/migrations/345_receivables_event_key_lookup.sql"
       - "atlas_brain/storage/migrations/369_receivables_payment_receipt_outbox.sql"
+      - "atlas_brain/storage/migrations/370_commercial_billing_runs.sql"
       - "atlas_brain/storage/repositories/invoice.py"
       - "atlas_brain/templates/email/__init__.py"
       - "atlas_brain/templates/email/estimate_confirmation.py"
@@ -100,6 +105,7 @@ on:
       - "tests/test_eom_billing_recipients.py"
       - "tests/test_eom_payment_receipts.py"
       - "tests/test_commercial_billing_candidates.py"
+      - "tests/test_commercial_billing_runs.py"
       - "tests/test_invoicing_readonly_mcp.py"
       - "tests/test_invoicing_readonly_oauth.py"
       - "tests/test_invoicing_draft_writer_mcp.py"
@@ -157,6 +163,7 @@ jobs:
             tests/test_eom_billing_recipients.py \
             tests/test_eom_payment_receipts.py \
             tests/test_commercial_billing_candidates.py \
+            tests/test_commercial_billing_runs.py \
             tests/test_invoice_repository.py \
             -q
 

--- a/atlas_brain/api/invoicing/receivables.py
+++ b/atlas_brain/api/invoicing/receivables.py
@@ -31,6 +31,14 @@ from ...services.commercial_billing_candidates import (
     CommercialBillingCandidatesValidationError,
     get_commercial_billing_candidate_service,
 )
+from ...services.commercial_billing_runs import (
+    CommercialBillingRunConflictError,
+    CommercialBillingRunNotFoundError,
+    CommercialBillingRunService,
+    CommercialBillingRunUnavailableError,
+    CommercialBillingRunValidationError,
+    get_commercial_billing_run_service,
+)
 from ...services.eom_lead_ingress import EOM_BUSINESS_CONTEXT_ID
 from ...storage.exceptions import DatabaseUnavailableError
 from .auth import require_actor, require_receivables_api
@@ -118,6 +126,14 @@ class CreateDepositBatchRequest(BaseModel):
     bank_reference: Optional[str] = Field(default=None, max_length=256)
 
 
+class CreateCommercialBillingRunRequest(BaseModel):
+    billing_period: str = Field(
+        min_length=7,
+        max_length=7,
+        pattern=r"^\d{4}-(0[1-9]|1[0-2])$",
+    )
+
+
 def _dollars(amount_cents: int) -> Decimal:
     return Decimal(amount_cents) / Decimal(100)
 
@@ -197,6 +213,41 @@ async def _call(awaitable):
         raise HTTPException(
             status_code=503,
             detail={"code": "database_unavailable", "message": message},
+        ) from exc
+
+
+async def _call_commercial_billing_run(awaitable):
+    try:
+        return await awaitable
+    except CommercialBillingCandidatesValidationError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail={"code": exc.code, "message": str(exc)},
+        ) from exc
+    except CommercialBillingCandidatesUnavailableError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail={"code": exc.code, "message": str(exc)},
+        ) from exc
+    except CommercialBillingRunValidationError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail={"code": exc.code, "message": str(exc)},
+        ) from exc
+    except CommercialBillingRunNotFoundError as exc:
+        raise HTTPException(
+            status_code=404,
+            detail={"code": exc.code, "message": str(exc)},
+        ) from exc
+    except CommercialBillingRunConflictError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={"code": exc.code, "message": str(exc)},
+        ) from exc
+    except CommercialBillingRunUnavailableError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail={"code": exc.code, "message": str(exc)},
         ) from exc
 
 
@@ -387,6 +438,64 @@ async def commercial_billing_candidates(
             status_code=503,
             detail={"code": exc.code, "message": str(exc)},
         ) from exc
+
+
+@router.post("/commercial-billing-runs", status_code=201)
+async def create_commercial_billing_run(
+    body: CreateCommercialBillingRunRequest,
+    actor: Annotated[str, Depends(require_actor)],
+    idempotency_key: Annotated[
+        str, Header(alias="Idempotency-Key", min_length=1, max_length=128)
+    ],
+    service: CommercialBillingRunService = Depends(get_commercial_billing_run_service),
+) -> dict:
+    """Persist immutable review evidence; explicit approval remains a later slice."""
+
+    return await _call_commercial_billing_run(
+        service.create_run(
+            billing_period=body.billing_period,
+            idempotency_key=idempotency_key,
+            actor=actor,
+        )
+    )
+
+
+@router.get("/commercial-billing-runs")
+async def list_commercial_billing_runs(
+    billing_period: Optional[str] = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+    service: CommercialBillingRunService = Depends(get_commercial_billing_run_service),
+) -> dict:
+    """List bounded durable review-run summaries without regenerating sources."""
+
+    return await _call_commercial_billing_run(
+        service.list_runs(
+            billing_period=billing_period,
+            limit=limit,
+            offset=offset,
+        )
+    )
+
+
+@router.get("/commercial-billing-runs/{billing_run_id}/reconciliation")
+async def reconcile_commercial_billing_run(
+    billing_run_id: UUID,
+    service: CommercialBillingRunService = Depends(get_commercial_billing_run_service),
+) -> dict:
+    """Compare durable evidence with fresh sources without writing either."""
+
+    return await _call_commercial_billing_run(service.reconcile_run(billing_run_id))
+
+
+@router.get("/commercial-billing-runs/{billing_run_id}")
+async def get_commercial_billing_run(
+    billing_run_id: UUID,
+    service: CommercialBillingRunService = Depends(get_commercial_billing_run_service),
+) -> dict:
+    """Return the immutable candidate snapshot retained for operator review."""
+
+    return await _call_commercial_billing_run(service.get_run(billing_run_id))
 
 
 @router.put("/payments/{payment_id}/allocations")

--- a/atlas_brain/services/commercial_billing_runs.py
+++ b/atlas_brain/services/commercial_billing_runs.py
@@ -1,0 +1,655 @@
+"""Durable, pre-approval EOM commercial billing-run snapshots.
+
+The companion candidate service is deliberately pure.  This service is the
+smallest separate write boundary that can retain the exact preview an operator
+reviewed and later prove whether its source evidence still matches.  It never
+creates invoices, PDFs, Gmail drafts, email, service markers, or sent state.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable, Mapping, Optional
+from uuid import UUID, uuid4
+
+import asyncpg
+
+from ..storage.database import DatabasePool, get_db_pool
+from ..storage.exceptions import DatabaseOperationError, DatabaseUnavailableError
+from .commercial_billing_candidates import (
+    CommercialBillingCandidateService,
+    CommercialBillingCandidatesUnavailableError,
+    CommercialBillingCandidatesValidationError,
+    get_commercial_billing_candidate_service,
+    parse_billing_period,
+)
+
+
+_RUN_SOURCE = "eom_admin"
+_MAX_IDEMPOTENCY_KEY_LENGTH = 128
+_MAX_CANDIDATE_KEY_LENGTH = 512
+_MAX_CANDIDATES = 500
+_FINGERPRINT_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+_DATABASE_UNAVAILABLE_ERRORS = (
+    DatabaseOperationError,
+    DatabaseUnavailableError,
+    asyncpg.PostgresConnectionError,
+    asyncpg.CannotConnectNowError,
+    asyncpg.TooManyConnectionsError,
+    asyncpg.AdminShutdownError,
+    asyncpg.CrashShutdownError,
+    asyncpg.UndefinedTableError,
+    asyncpg.UndefinedColumnError,
+    asyncpg.InvalidSchemaNameError,
+    asyncpg.InsufficientPrivilegeError,
+    asyncpg.InvalidAuthorizationSpecificationError,
+)
+
+
+class CommercialBillingRunError(Exception):
+    """Base error for the durable commercial billing-run contract."""
+
+    code = "commercial_billing_run_error"
+
+
+class CommercialBillingRunValidationError(CommercialBillingRunError):
+    """The request or generated preview cannot safely form a durable run."""
+
+    code = "invalid_commercial_billing_run"
+
+
+class CommercialBillingRunNotFoundError(CommercialBillingRunError):
+    """The requested durable review run does not exist."""
+
+    code = "commercial_billing_run_not_found"
+
+
+class CommercialBillingRunConflictError(CommercialBillingRunError):
+    """One operation key was reused with different durable intent."""
+
+    code = "commercial_billing_run_idempotency_conflict"
+
+
+class CommercialBillingRunUnavailableError(CommercialBillingRunError):
+    """The durable review store cannot safely serve this request."""
+
+    code = "commercial_billing_runs_unavailable"
+
+
+@dataclass(frozen=True)
+class _SnapshotCandidate:
+    candidate_key: str
+    source_fingerprint: str
+    snapshot: dict[str, Any]
+    display_order: int
+
+
+@dataclass(frozen=True)
+class _NormalizedPreview:
+    billing_period: str
+    contract_version: int
+    calendar_id: str | None
+    candidates: tuple[_SnapshotCandidate, ...]
+    snapshot_fingerprint: str
+
+
+def _canonical_json(value: Any) -> str:
+    try:
+        return json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        )
+    except (TypeError, ValueError) as exc:
+        raise CommercialBillingRunUnavailableError(
+            "Commercial billing candidate evidence is not JSON-safe"
+        ) from exc
+
+
+def _fingerprint(value: Any) -> str:
+    return hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def _json_object(value: Any) -> dict[str, Any]:
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise CommercialBillingRunUnavailableError(
+                "Commercial billing snapshot evidence is invalid"
+            ) from exc
+    if not isinstance(value, Mapping):
+        raise CommercialBillingRunUnavailableError(
+            "Commercial billing snapshot evidence is invalid"
+        )
+    try:
+        normalized = json.loads(_canonical_json(dict(value)))
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive boundary
+        raise CommercialBillingRunUnavailableError(
+            "Commercial billing snapshot evidence is invalid"
+        ) from exc
+    if not isinstance(normalized, dict):  # pragma: no cover - json object invariant
+        raise CommercialBillingRunUnavailableError(
+            "Commercial billing snapshot evidence is invalid"
+        )
+    return normalized
+
+
+def _text(value: Any) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _timestamp(value: Any) -> str:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
+
+def _validate_idempotency_key(value: str) -> str:
+    if not isinstance(value, str):
+        raise CommercialBillingRunValidationError("Idempotency key is required")
+    key = value.strip()
+    if not key or len(key) > _MAX_IDEMPOTENCY_KEY_LENGTH:
+        raise CommercialBillingRunValidationError(
+            "Idempotency key must contain 1 to 128 characters"
+        )
+    return key
+
+
+def _normalize_preview(preview: Any, *, billing_period: str) -> _NormalizedPreview:
+    if not isinstance(preview, Mapping):
+        raise CommercialBillingRunUnavailableError(
+            "Commercial billing candidate evidence is invalid"
+        )
+    if preview.get("billingPeriod") != billing_period:
+        raise CommercialBillingRunUnavailableError(
+            "Commercial billing candidate period does not match the requested run"
+        )
+    contract_version = preview.get("contractVersion")
+    if (
+        isinstance(contract_version, bool)
+        or not isinstance(contract_version, int)
+        or contract_version <= 0
+    ):
+        raise CommercialBillingRunUnavailableError(
+            "Commercial billing candidate contract version is invalid"
+        )
+    calendar_id = preview.get("calendarId")
+    if calendar_id is not None and not isinstance(calendar_id, str):
+        raise CommercialBillingRunUnavailableError(
+            "Commercial billing calendar evidence is invalid"
+        )
+    raw_candidates = preview.get("candidates")
+    if not isinstance(raw_candidates, list) or len(raw_candidates) > _MAX_CANDIDATES:
+        raise CommercialBillingRunUnavailableError(
+            "Commercial billing candidate evidence is invalid"
+        )
+
+    candidates: list[_SnapshotCandidate] = []
+    seen_keys: set[str] = set()
+    for display_order, raw_candidate in enumerate(raw_candidates):
+        snapshot = _json_object(raw_candidate)
+        candidate_key = _text(snapshot.get("candidateKey"))
+        source_fingerprint = _text(snapshot.get("sourceFingerprint"))
+        if (
+            candidate_key is None
+            or candidate_key != candidate_key.strip()
+            or not candidate_key
+            or len(candidate_key) > _MAX_CANDIDATE_KEY_LENGTH
+            or source_fingerprint is None
+            or _FINGERPRINT_PATTERN.fullmatch(source_fingerprint) is None
+            or snapshot.get("billingPeriod") != billing_period
+            or not isinstance(snapshot.get("blockers"), list)
+        ):
+            raise CommercialBillingRunUnavailableError(
+                "Commercial billing candidate evidence is invalid"
+            )
+        if candidate_key in seen_keys:
+            raise CommercialBillingRunUnavailableError(
+                "Commercial billing candidate keys must be unique"
+            )
+        seen_keys.add(candidate_key)
+        candidates.append(
+            _SnapshotCandidate(
+                candidate_key=candidate_key,
+                source_fingerprint=source_fingerprint,
+                snapshot=snapshot,
+                display_order=display_order,
+            )
+        )
+
+    snapshot_fingerprint = _fingerprint(
+        {
+            "billingPeriod": billing_period,
+            "calendarId": calendar_id,
+            "contractVersion": contract_version,
+            "candidates": [
+                {
+                    "candidateKey": candidate.candidate_key,
+                    "sourceFingerprint": candidate.source_fingerprint,
+                }
+                for candidate in sorted(candidates, key=lambda item: item.candidate_key)
+            ],
+        }
+    )
+    return _NormalizedPreview(
+        billing_period=billing_period,
+        contract_version=contract_version,
+        calendar_id=calendar_id,
+        candidates=tuple(candidates),
+        snapshot_fingerprint=snapshot_fingerprint,
+    )
+
+
+class CommercialBillingRunService:
+    """Own durable snapshots and read-only freshness reconciliation."""
+
+    def __init__(
+        self,
+        *,
+        pool: Optional[DatabasePool] = None,
+        candidate_service_loader: Callable[[], CommercialBillingCandidateService] = (
+            get_commercial_billing_candidate_service
+        ),
+    ) -> None:
+        self._configured_pool = pool
+        self._candidate_service_loader = candidate_service_loader
+
+    @property
+    def pool(self) -> DatabasePool:
+        pool = self._configured_pool or get_db_pool()
+        if not pool.is_initialized:
+            raise CommercialBillingRunUnavailableError("Commercial billing database unavailable")
+        return pool
+
+    async def create_run(
+        self,
+        *,
+        billing_period: str,
+        idempotency_key: str,
+        actor: str,
+    ) -> dict[str, Any]:
+        """Snapshot one pure preview; matching retries return the original run."""
+
+        period = parse_billing_period(billing_period).label
+        key = _validate_idempotency_key(idempotency_key)
+        actor_text = _text(actor)
+        if actor_text is None or not actor_text.strip() or len(actor_text) > 128:
+            raise CommercialBillingRunValidationError("Authenticated actor is required")
+        request_fingerprint = _fingerprint({"billingPeriod": period})
+
+        try:
+            async with self.pool.transaction() as conn:
+                await self._lock_operation_key(conn, key)
+                existing = await self._find_by_operation_key(conn, key)
+                if existing is not None:
+                    self._assert_request_fingerprint(existing, request_fingerprint)
+                    return {
+                        "billingRun": await self._run_view(conn, existing["id"]),
+                        "replayed": True,
+                    }
+
+            preview = await self._load_preview(period)
+
+            async with self.pool.transaction() as conn:
+                await self._lock_operation_key(conn, key)
+                existing = await self._find_by_operation_key(conn, key)
+                if existing is not None:
+                    self._assert_request_fingerprint(existing, request_fingerprint)
+                    return {
+                        "billingRun": await self._run_view(conn, existing["id"]),
+                        "replayed": True,
+                    }
+
+                run_id = uuid4()
+                now = datetime.now(timezone.utc)
+                created = await conn.fetchrow(
+                    """
+                    INSERT INTO commercial_billing_runs (
+                        id, billing_period, calendar_id, state,
+                        candidate_contract_version, snapshot_fingerprint, source,
+                        idempotency_key, request_fingerprint, created_by,
+                        created_at, updated_at
+                    )
+                    VALUES ($1, $2, $3, 'draft', $4, $5, $6, $7, $8, $9, $10, $10)
+                    ON CONFLICT (source, idempotency_key) DO NOTHING
+                    RETURNING id
+                    """,
+                    run_id,
+                    preview.billing_period,
+                    preview.calendar_id,
+                    preview.contract_version,
+                    preview.snapshot_fingerprint,
+                    _RUN_SOURCE,
+                    key,
+                    request_fingerprint,
+                    actor_text.strip(),
+                    now,
+                )
+                if created is None:
+                    existing = await self._find_by_operation_key(conn, key)
+                    if existing is None:
+                        raise CommercialBillingRunConflictError(
+                            "Billing-run idempotency conflict could not be reconciled"
+                        )
+                    self._assert_request_fingerprint(existing, request_fingerprint)
+                    return {
+                        "billingRun": await self._run_view(conn, existing["id"]),
+                        "replayed": True,
+                    }
+                for candidate in preview.candidates:
+                    await conn.execute(
+                        """
+                        INSERT INTO commercial_billing_run_candidates (
+                            id, billing_run_id, candidate_key, source_fingerprint,
+                            display_order, snapshot, created_at
+                        )
+                        VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7)
+                        """,
+                        uuid4(),
+                        run_id,
+                        candidate.candidate_key,
+                        candidate.source_fingerprint,
+                        candidate.display_order,
+                        _canonical_json(candidate.snapshot),
+                        now,
+                    )
+                return {
+                    "billingRun": await self._run_view(conn, run_id),
+                    "replayed": False,
+                }
+        except (
+            CommercialBillingRunError,
+            CommercialBillingCandidatesUnavailableError,
+            CommercialBillingCandidatesValidationError,
+        ):
+            raise
+        except _DATABASE_UNAVAILABLE_ERRORS as exc:
+            raise CommercialBillingRunUnavailableError(
+                "Commercial billing database unavailable"
+            ) from exc
+
+    async def list_runs(
+        self,
+        *,
+        billing_period: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> dict[str, Any]:
+        """Return a bounded list of durable draft-run summaries."""
+
+        period = (
+            parse_billing_period(billing_period).label
+            if billing_period is not None
+            else None
+        )
+        if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= 100:
+            raise CommercialBillingRunValidationError("limit must be between 1 and 100")
+        if isinstance(offset, bool) or not isinstance(offset, int) or offset < 0:
+            raise CommercialBillingRunValidationError("offset must be nonnegative")
+        try:
+            rows = await self.pool.fetch(
+                """
+                SELECT
+                    run.id,
+                    run.billing_period,
+                    run.calendar_id,
+                    run.state,
+                    run.candidate_contract_version,
+                    run.snapshot_fingerprint,
+                    run.created_by,
+                    run.created_at,
+                    run.updated_at,
+                    COUNT(candidate.id)::int AS candidate_count,
+                    COALESCE(
+                        SUM(
+                            CASE
+                                WHEN jsonb_array_length(candidate.snapshot -> 'blockers') > 0
+                                THEN 1 ELSE 0
+                            END
+                        ),
+                        0
+                    )::int AS blocked_candidate_count
+                FROM commercial_billing_runs AS run
+                LEFT JOIN commercial_billing_run_candidates AS candidate
+                    ON candidate.billing_run_id = run.id
+                WHERE ($1::varchar IS NULL OR run.billing_period = $1)
+                GROUP BY run.id
+                ORDER BY run.created_at DESC, run.id DESC
+                LIMIT $2 OFFSET $3
+                """,
+                period,
+                limit,
+                offset,
+            )
+            return {
+                "items": [self._run_summary(row) for row in rows],
+                "limit": limit,
+                "offset": offset,
+            }
+        except CommercialBillingRunError:
+            raise
+        except _DATABASE_UNAVAILABLE_ERRORS as exc:
+            raise CommercialBillingRunUnavailableError(
+                "Commercial billing database unavailable"
+            ) from exc
+
+    async def get_run(self, run_id: UUID) -> dict[str, Any]:
+        """Return one immutable snapshot with all stored candidate evidence."""
+
+        try:
+            return await self._run_view(self.pool, run_id)
+        except CommercialBillingRunError:
+            raise
+        except _DATABASE_UNAVAILABLE_ERRORS as exc:
+            raise CommercialBillingRunUnavailableError(
+                "Commercial billing database unavailable"
+            ) from exc
+
+    async def reconcile_run(self, run_id: UUID) -> dict[str, Any]:
+        """Compare stored evidence with a fresh pure preview without writing."""
+
+        try:
+            stored = await self._run_view(self.pool, run_id)
+            current = await self._load_preview(stored["billingPeriod"])
+        except (
+            CommercialBillingRunError,
+            CommercialBillingCandidatesUnavailableError,
+            CommercialBillingCandidatesValidationError,
+        ):
+            raise
+        except _DATABASE_UNAVAILABLE_ERRORS as exc:
+            raise CommercialBillingRunUnavailableError(
+                "Commercial billing database unavailable"
+            ) from exc
+
+        current_by_key = {
+            candidate.candidate_key: candidate for candidate in current.candidates
+        }
+        stored_by_key = {
+            candidate["candidateKey"]: candidate for candidate in stored["candidates"]
+        }
+        changes: list[dict[str, Any]] = []
+        for stored_candidate in stored["candidates"]:
+            candidate_key = stored_candidate["candidateKey"]
+            current_candidate = current_by_key.pop(candidate_key, None)
+            if current_candidate is None:
+                status = "missing"
+                current_fingerprint = None
+            elif current_candidate.source_fingerprint == stored_candidate["sourceFingerprint"]:
+                status = "unchanged"
+                current_fingerprint = current_candidate.source_fingerprint
+            else:
+                status = "changed"
+                current_fingerprint = current_candidate.source_fingerprint
+            changes.append(
+                {
+                    "candidateKey": candidate_key,
+                    "currentSourceFingerprint": current_fingerprint,
+                    "status": status,
+                    "storedSourceFingerprint": stored_candidate["sourceFingerprint"],
+                }
+            )
+        for candidate in current.candidates:
+            if candidate.candidate_key not in stored_by_key:
+                changes.append(
+                    {
+                        "candidateKey": candidate.candidate_key,
+                        "currentSourceFingerprint": candidate.source_fingerprint,
+                        "status": "new",
+                        "storedSourceFingerprint": None,
+                    }
+                )
+        is_stale = (
+            current.snapshot_fingerprint != stored["snapshotFingerprint"]
+            or any(change["status"] != "unchanged" for change in changes)
+        )
+        return {
+            "billingPeriod": stored["billingPeriod"],
+            "billingRunId": stored["id"],
+            "candidateChanges": changes,
+            "currentSnapshotFingerprint": current.snapshot_fingerprint,
+            "isStale": is_stale,
+            "snapshotFingerprint": stored["snapshotFingerprint"],
+        }
+
+    async def _load_preview(self, billing_period: str) -> _NormalizedPreview:
+        try:
+            candidate_service = self._candidate_service_loader()
+            preview = await candidate_service.preview(billing_period=billing_period)
+        except (CommercialBillingCandidatesUnavailableError, CommercialBillingCandidatesValidationError):
+            raise
+        except _DATABASE_UNAVAILABLE_ERRORS as exc:
+            raise CommercialBillingCandidatesUnavailableError(
+                "Commercial billing candidate evidence is unavailable"
+            ) from exc
+        except Exception as exc:
+            raise CommercialBillingRunUnavailableError(
+                "Commercial billing candidate evidence is unavailable"
+            ) from exc
+        return _normalize_preview(preview, billing_period=billing_period)
+
+    @staticmethod
+    async def _lock_operation_key(conn: Any, key: str) -> None:
+        await conn.fetchval(
+            "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+            f"commercial-billing-run-create:{_RUN_SOURCE}:{key}",
+        )
+
+    @staticmethod
+    async def _find_by_operation_key(conn: Any, key: str) -> Any | None:
+        return await conn.fetchrow(
+            """
+            SELECT id, request_fingerprint
+            FROM commercial_billing_runs
+            WHERE source = $1 AND idempotency_key = $2
+            FOR UPDATE
+            """,
+            _RUN_SOURCE,
+            key,
+        )
+
+    @staticmethod
+    def _assert_request_fingerprint(row: Any, expected: str) -> None:
+        if row["request_fingerprint"] != expected:
+            raise CommercialBillingRunConflictError(
+                "Idempotency key was already used with a different billing period"
+            )
+
+    async def _run_view(self, executor: Any, run_id: UUID) -> dict[str, Any]:
+        row = await executor.fetchrow(
+            """
+            SELECT
+                id,
+                billing_period,
+                calendar_id,
+                state,
+                candidate_contract_version,
+                snapshot_fingerprint,
+                created_by,
+                created_at,
+                updated_at
+            FROM commercial_billing_runs
+            WHERE id = $1
+            """,
+            run_id,
+        )
+        if row is None:
+            raise CommercialBillingRunNotFoundError("Commercial billing run not found")
+        candidate_rows = await executor.fetch(
+            """
+            SELECT candidate_key, source_fingerprint, display_order, snapshot
+            FROM commercial_billing_run_candidates
+            WHERE billing_run_id = $1
+            ORDER BY display_order ASC, candidate_key ASC
+            """,
+            run_id,
+        )
+        candidates = [_json_object(candidate["snapshot"]) for candidate in candidate_rows]
+        for candidate, row_candidate in zip(candidates, candidate_rows):
+            if (
+                candidate.get("candidateKey") != row_candidate["candidate_key"]
+                or candidate.get("sourceFingerprint")
+                != row_candidate["source_fingerprint"]
+            ):
+                raise CommercialBillingRunUnavailableError(
+                    "Commercial billing snapshot evidence is invalid"
+                )
+        return {
+            "billingPeriod": row["billing_period"],
+            "calendarId": row["calendar_id"],
+            "candidateContractVersion": row["candidate_contract_version"],
+            "candidates": candidates,
+            "createdAt": _timestamp(row["created_at"]),
+            "createdBy": row["created_by"],
+            "id": str(row["id"]),
+            "snapshotFingerprint": row["snapshot_fingerprint"],
+            "state": row["state"],
+            "summary": {
+                "blockedCandidateCount": sum(
+                    1 for candidate in candidates if candidate["blockers"]
+                ),
+                "candidateCount": len(candidates),
+            },
+            "updatedAt": _timestamp(row["updated_at"]),
+        }
+
+    @staticmethod
+    def _run_summary(row: Any) -> dict[str, Any]:
+        return {
+            "billingPeriod": row["billing_period"],
+            "calendarId": row["calendar_id"],
+            "candidateContractVersion": row["candidate_contract_version"],
+            "createdAt": _timestamp(row["created_at"]),
+            "createdBy": row["created_by"],
+            "id": str(row["id"]),
+            "snapshotFingerprint": row["snapshot_fingerprint"],
+            "state": row["state"],
+            "summary": {
+                "blockedCandidateCount": row["blocked_candidate_count"],
+                "candidateCount": row["candidate_count"],
+            },
+            "updatedAt": _timestamp(row["updated_at"]),
+        }
+
+
+def get_commercial_billing_run_service() -> CommercialBillingRunService:
+    """Build a fresh request service around the shared database pool."""
+
+    return CommercialBillingRunService()
+
+
+__all__ = [
+    "CommercialBillingRunConflictError",
+    "CommercialBillingRunError",
+    "CommercialBillingRunNotFoundError",
+    "CommercialBillingRunService",
+    "CommercialBillingRunUnavailableError",
+    "CommercialBillingRunValidationError",
+    "get_commercial_billing_run_service",
+]

--- a/atlas_brain/storage/migrations/370_commercial_billing_runs.sql
+++ b/atlas_brain/storage/migrations/370_commercial_billing_runs.sql
@@ -1,0 +1,79 @@
+-- Durable, pre-approval EOM commercial billing-review evidence.
+--
+-- This migration stores only the immutable preview Juan reviewed.  It creates
+-- no invoice, PDF, Gmail draft, sent state, service-invoiced marker, or email.
+-- The parent/child relationship is deliberately restrictive: review evidence
+-- must outlive application rollback and cannot be silently deleted by a later
+-- invoice or customer operation.
+--
+-- Rollback evidence:
+--   Revert application code first and retain these additive audit rows.
+--   A separately authorized destructive teardown, only after every reader and
+--   writer is removed, may run:
+--       DROP TABLE commercial_billing_run_candidates;
+--       DROP TABLE commercial_billing_runs;
+--   That is not an ordinary rollback: it destroys reviewed source evidence and
+--   breaks a mixed-version deployment.
+--
+-- Roll-forward safety:
+--   Existing candidate preview, payment, deposit, invoice, MCP, scheduler, PDF,
+--   Gmail, and mail paths do not reference these tables.  The new writer is an
+--   additive authenticated provider route and remains safe before tracker/UI
+--   consumers are deployed.
+
+CREATE TABLE IF NOT EXISTS commercial_billing_runs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    billing_period VARCHAR(7) NOT NULL,
+    calendar_id TEXT,
+    state VARCHAR(16) NOT NULL DEFAULT 'draft',
+    candidate_contract_version INTEGER NOT NULL,
+    snapshot_fingerprint VARCHAR(64) NOT NULL,
+    source VARCHAR(32) NOT NULL DEFAULT 'eom_admin',
+    idempotency_key VARCHAR(128) NOT NULL,
+    request_fingerprint VARCHAR(64) NOT NULL,
+    created_by VARCHAR(128) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT commercial_billing_runs_period_check
+        CHECK (billing_period ~ '^[0-9]{4}-(0[1-9]|1[0-2])$'),
+    CONSTRAINT commercial_billing_runs_state_check
+        CHECK (state = 'draft'),
+    CONSTRAINT commercial_billing_runs_contract_version_check
+        CHECK (candidate_contract_version > 0),
+    CONSTRAINT commercial_billing_runs_snapshot_fingerprint_check
+        CHECK (snapshot_fingerprint ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT commercial_billing_runs_request_fingerprint_check
+        CHECK (request_fingerprint ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT commercial_billing_runs_source_idempotency_key_key
+        UNIQUE (source, idempotency_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_commercial_billing_runs_period_created
+    ON commercial_billing_runs (billing_period, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS commercial_billing_run_candidates (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    billing_run_id UUID NOT NULL
+        REFERENCES commercial_billing_runs(id) ON DELETE RESTRICT,
+    candidate_key VARCHAR(512) NOT NULL,
+    source_fingerprint VARCHAR(64) NOT NULL,
+    display_order INTEGER NOT NULL,
+    snapshot JSONB NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT commercial_billing_run_candidates_source_fingerprint_check
+        CHECK (source_fingerprint ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT commercial_billing_run_candidates_display_order_check
+        CHECK (display_order >= 0),
+    CONSTRAINT commercial_billing_run_candidates_run_key_key
+        UNIQUE (billing_run_id, candidate_key),
+    CONSTRAINT commercial_billing_run_candidates_run_order_key
+        UNIQUE (billing_run_id, display_order)
+);
+
+CREATE INDEX IF NOT EXISTS idx_commercial_billing_run_candidates_run_order
+    ON commercial_billing_run_candidates (billing_run_id, display_order);
+
+COMMENT ON TABLE commercial_billing_runs IS
+    'Immutable EOM commercial billing-review snapshots. A draft run is not an invoice or delivery operation.';
+COMMENT ON TABLE commercial_billing_run_candidates IS
+    'Complete generated candidate evidence retained for stale-source reconciliation before approval.';

--- a/plans/PR-EOM-Billing-Run-Review.md
+++ b/plans/PR-EOM-Billing-Run-Review.md
@@ -1,0 +1,298 @@
+# PR-EOM-Billing-Run-Review
+
+## Why this slice exists
+
+The deployed commercial candidate route is intentionally a pure read: it
+returns current source evidence and a per-candidate SHA-256 fingerprint, but it
+does not preserve the preview Juan reviewed.  A later approval operation would
+therefore have no durable source snapshot to compare against, and could not
+prove that a service, rate, canonical customer, or calendar event changed after
+review.  Coordinating issue #2362 names stored candidates and source-fingerprint
+reconciliation as the next provider-first dependency after the deployed
+Website preview (#195).
+
+The current legacy monthly task is not a substitute.  Its review mode still
+creates an invoice, writes a PDF, marks services invoiced, logs CRM activity,
+and can notify or send (`atlas_brain/autonomous/tasks/monthly_invoice_generation.py:322-453`).
+The active full provider instead exposes the pure candidate seam at
+`atlas_brain/api/invoicing/receivables.py:364-389`, backed by
+`CommercialBillingCandidateService.preview`
+(`atlas_brain/services/commercial_billing_candidates.py:401-568`).
+
+### Problem-derived contract
+
+- Root cause: a transient candidate response cannot form an auditable review
+  boundary or later detect source drift; the only older monthly path is writeful
+  before an operator can review it.
+- Correct fix must touch/change: add additive ATLAS-owned draft-run and
+  immutable candidate-snapshot tables; add a focused provider service that
+  snapshots the already-pure generator result inside one database transaction;
+  add authenticated create/list/detail/reconciliation routes; enroll focused
+  unit, real-PostgreSQL, migration, route, retry, failure, and no-delivery tests
+  in the existing invoicing workflow.
+- Must not change: the pure candidate GET, the legacy monthly scheduler,
+  invoices, invoice balances, payment/receipt/deposit lifecycle, MCP tools,
+  Gmail, email transport, PDFs, service invoiced markers, tracker state, and
+  Website behavior.  This slice has no candidate editing, exclusion, selection,
+  approval, invoice, PDF, Gmail-draft, Square, or sent-mail writer.
+
+## Scope (this PR)
+
+Ownership lane: eom/billing-run-review
+Slice phase: Vertical slice
+
+1. Add an authenticated ATLAS-only `POST /receivables/commercial-billing-runs`
+   that takes an explicit billing period plus `Idempotency-Key`, invokes the
+   existing pure candidate service, and atomically persists one `draft` run and
+   immutable candidate snapshots with the authenticated actor, source evidence,
+   candidate fingerprint, contract version, and an aggregate snapshot
+   fingerprint.
+2. Add bounded authenticated list/detail reads and a read-only reconciliation
+   route.  Reconciliation regenerates the current pure preview and reports each
+   stored candidate as unchanged, changed, missing, or new, plus an overall
+   stale verdict; it writes nothing.
+3. Prove that an unchanged same-key retry returns the original run, a reused key
+   with another period conflicts, concurrent same-key creation has exactly one
+   run/snapshot set, source-reader failure leaves no draft rows, a later source
+   fingerprint/roster change is visible as stale, and neither route nor service
+   imports or calls invoice/PDF/Gmail/email/scheduler writers.
+
+### Review Contract
+
+- Acceptance criteria:
+  - `CommercialBillingRunService.create_run` records a server-generated,
+    deterministic snapshot only after the candidate generator returns a valid
+    preview; `tests/test_commercial_billing_runs.py` verifies the persisted
+    candidate JSON, per-candidate source fingerprint, aggregate fingerprint,
+    actor, exact cents, and source evidence through real PostgreSQL.
+  - `POST /receivables/commercial-billing-runs` is protected by the existing
+    service token and derives the actor with `require_actor`; its ASGI contract
+    test proves unauthenticated and malformed-period calls reach neither source
+    reader nor database writer, and a valid request produces the durable run.
+  - Equal `(source, Idempotency-Key)` calls serialize on a PostgreSQL advisory
+    transaction lock and a unique index, compare the canonical
+    `billing_period` request fingerprint, and return the original run.  The
+    execution invariant is: for every admitted scheduling interleaving, one key
+    can commit at most one parent run and one immutable snapshot per candidate;
+    a failed transaction commits neither.  Real-PostgreSQL retry/concurrency and
+    failure/recovery tests settle this R8 claim.
+  - `GET /receivables/commercial-billing-runs/{id}/reconciliation` consumes the
+    current pure generator result and compares the closed stored/current
+    candidate-key relation.  The focused tests prove changed source fingerprints,
+    removed snapshots, and new source candidates mark the run stale, while an
+    identical retry remains current and does not update any run row.
+  - The migration is additive, contains no backfill or destructive DDL, creates
+    its indexes before code relies on the tables, and documents rollback as
+    application rollback first while retaining audit evidence.  Migration and
+    workflow-enrollment tests prove the packaged SQL and local workflow cover it.
+  - AST/source guards prove the new service does not import the writeful monthly
+    scheduler, invoice repository, PDF renderer, Gmail, email provider,
+    notification sender, or CRM mutation surface; recording or reconciling a
+    run cannot create an invoice, PDF, draft, email, service marker, or sent
+    state.
+- Reachability proof: the active full application mounts the authenticated
+  `atlas_brain.api.invoicing.receivables` router under `/api/v1`; an ASGI test
+  includes that real router, uses the established hashed service-token
+  dependency, and observes create/detail/reconciliation output.  After merge,
+  the deployed route will be probed unauthenticated only (expected 401); no
+  production billing run or financial record will be created as a probe.
+- Affected surfaces: `atlas_brain/services/commercial_billing_runs.py`,
+  `atlas_brain/api/invoicing/receivables.py`, migration 370, the existing
+  invoicing workflow, its focused test file, and this plan.  The dormant slim
+  `eom_api.receivables` router remains unchanged because deployed evidence says
+  the full router is active and H-06 already tracks the duplicate-model decision.
+- Risk areas: protected-write authorization, source snapshot validity,
+  idempotent retry/cancellation, schema rollout, PostgreSQL isolation, stale
+  source evidence, bounded reads, nested snapshot JSON, and accidental financial
+  or delivery side effects.
+- Reviewer rules triggered: R1, R2, R3, R4, R5, R6, R7, R8, R10, R11, R12,
+  R13, and R14.  R9 is N/A: no browser surface changes.
+
+### Boundary-change enumeration
+
+- Boundary path/seam: authenticated `POST /receivables/commercial-billing-runs`
+  -> existing pure `CommercialBillingCandidateService.preview` -> transactional
+  run/snapshot persistence; authenticated list/detail/reconciliation reads use
+  the same token boundary.  The existing candidate GET and every legacy writer
+  remain separate.
+- Replaced-path behaviors: none.  This is additive; existing GET preview,
+  payment, invoice, MCP, scheduler, and Gmail callers keep their contracts.
+- Guard-relevant fields: JSON `billing_period`, `Idempotency-Key`, service-token
+  Authorization, server-derived `X-EOM-Actor`, route `run_id`, list `limit` and
+  `offset`, generated `candidateKey`, `sourceFingerprint`, and contract version.
+- Caller x input shape: tracker service caller with valid/invalid/missing bearer;
+  valid `YYYY-MM` and malformed period strings; nonempty/blank/overlong/reused
+  idempotency keys; known/unknown UUID run IDs; bounded/out-of-range list
+  pagination; generator outputs with empty, valid, duplicate-key, or invalid
+  fingerprint candidates.  Unrecognized or malformed input fails before a
+  financial/delivery write and before the candidate source is called where the
+  route/parser can decide it.
+
+### Deployed-config probing
+
+- Deployed/default config values: N/A - no new setting, flag, credential,
+  fallback, or environment variable is introduced.  The route reuses the
+  already-deployed receivables token/authentication and primary database pool.
+- Explicit value probe: post-deploy unauthenticated route probe must return 401;
+  it proves route registration and auth without creating a billing run.
+- Absent value probe: N/A - route configuration is the existing fail-closed
+  receivables configuration, not a new fallback.
+- Default-session/default-context probe: the create route records only the
+  authenticated actor supplied by `require_actor`; it never derives a customer,
+  delivery preference, or mailbox default.
+- Side-effect ordering: candidate generation completes before the one database
+  transaction.  The parent row and every candidate row commit together; source
+  failure or database rollback produces no run.  Reconciliation is read-only.
+
+### Closure declaration
+
+- Persisted run state is **CLOSED**, with the sole `draft` member authored in
+  migration 370 for this pre-approval slice.  The database check rejects any
+  other value, which is the safe side because approval/sending semantics have
+  not been implemented.
+- Reconciliation membership is **CLOSED** and **DERIVED** at comparison time
+  from the stored candidate-key map and the current pure-preview candidate-key
+  map.  The exhaustive relation emits only `unchanged`, `changed`, `missing`, or
+  `new`; a malformed generated candidate or duplicate key fails the read/run
+  instead of being silently treated as current.  This is the cheap/safe side:
+  refusing to claim freshness may require a retry, while accepting unknown
+  evidence could approve a stale invoice later.
+- `billing_period` is an **OPEN** string input whose valid grammar is
+  **DERIVED** from the existing `parse_billing_period` choke point.  Every
+  unmatched shape reaches its existing `invalid_billing_period` 422 before any
+  source reader or database mutation.  This plan does not duplicate a new
+  period regex/allowlist.
+
+### Files touched
+
+- `.github/workflows/atlas_invoicing_checks.yml`
+- `atlas_brain/api/invoicing/receivables.py`
+- `atlas_brain/services/commercial_billing_runs.py`
+- `atlas_brain/storage/migrations/370_commercial_billing_runs.sql`
+- `plans/PR-EOM-Billing-Run-Review.md`
+- `tests/test_commercial_billing_runs.py`
+
+## Mechanism
+
+`CommercialBillingRunService` owns the durable review boundary and accepts a
+pool plus an injected pure candidate service for tests.  It validates the period
+through the already-canonical parser before any source access, normalizes only
+the generator's `candidateKey`/SHA-256 fingerprint/JSON-safe snapshot contract,
+then computes a canonical aggregate fingerprint from the period, calendar,
+candidate contract version, and sorted candidate key/fingerprint pairs.
+
+The migration adds `commercial_billing_runs` and
+`commercial_billing_run_candidates`.  The parent records `draft`, period,
+calendar ID, generator contract version, aggregate fingerprint, request/idempotency
+fingerprints, actor, and timestamps.  Each child uses a `(billing_run_id,
+candidate_key)` uniqueness backstop and holds the complete immutable candidate
+JSON plus its original source fingerprint and display order.  This retains line
+items, cents, recipient, blockers, services, and calendar evidence without
+recomputing history.
+
+Creation uses PostgreSQL's existing transaction/advisory-lock component rather
+than a hand-rolled lease.  It serializes the operation key, locks/rechecks an
+existing parent row, and compares canonical request fingerprints.  A matching
+replay returns that row; a mismatched replay raises a named conflict.  Only an
+unseen key calls the pure generator, then starts one transaction that inserts the
+parent and every child together.  A unique index remains the storage backstop;
+the service re-reads a conflicting same-key row before returning or raising.
+The execution model is one database transaction per create, with PostgreSQL
+atomic commit/rollback and transaction-scoped advisory lock semantics; it makes
+the invariant in the Review Contract hold across all interleavings the database
+admits.  No external side effect occurs inside or after that transaction.
+
+List/detail are bounded repository reads.  Reconciliation loads the immutable
+run, invokes the same pure generator for its saved period, and performs a
+deterministic two-map comparison.  It never updates stored evidence or declares
+a missing current source candidate sent/approved.  A source outage returns a
+stable 503 so an unknown comparison cannot be reported as fresh.
+
+The router maps only the new domain validation/not-found/conflict/unavailable
+errors to stable 4xx/503 responses.  It reuses existing receivables token and
+actor dependencies, leaves the pure GET contract untouched, and imports no
+financial/delivery writer.
+
+## Intentional
+
+- A draft run is durable review evidence, not an invoice or financial lifecycle
+  mutation.  It is the smallest state allowed before explicit approval.
+- Multiple distinct operator operations may create separate draft runs for the
+  same billing period.  This slice guarantees same-key idempotency but does not
+  invent a global one-run-per-month policy; later explicit selection/approval
+  must own reconciliation and invoice-level idempotency.
+- Reconciliation reports that evidence changed but does not attempt an automatic
+  merge, candidate edit, exclusion, regeneration overwrite, or approval.  A
+  later operator review slice owns those business decisions.
+- The current missing delivery-preference blocker remains stored exactly as
+  projected.  Customer type does not infer Gmail or Square.
+- Full-provider deployment is the only active route evidence.  The slim EOM
+  profile and its migration closure stay untouched rather than creating another
+  unproven provider surface.
+
+## Deferred
+
+- #2362: tracker proxy and Website durable-review UI; permitted candidate edits,
+  explicit inclusion/exclusion, stale reconciliation/regeneration action, and
+  selected-candidate approval remain later slices.
+- #2362: idempotent invoice/PDF/Gmail-draft creation/recovery, sent-mail
+  reconciliation, manual Square queue, and operating documentation remain later
+  slices.
+- #2363 H-13: canonical persisted delivery preference, service/site identity,
+  and manual Square reference capture are required before an approval writer.
+- #2363 H-06: duplicate full/slim receivables model ownership remains parked;
+  this slice touches only the confirmed active full router.
+
+Parked hardening: unrelated legacy invoice float arithmetic, scheduler changes,
+generic billing preference schema, e-mail transport, migration-runner redesign,
+and full historical customer-ledger improvements remain out of scope.
+
+## Verification
+
+- Local workflow-equivalent evidence (2026-08-13): a disposable CPython 3.11
+  environment against an isolated local PostgreSQL schema ran the exact enrolled
+  approval-blocker command (2 passed), receivables/repository command (242
+  passed), and MCP/OAuth command (43 passed).  The focused billing-run plus
+  candidate command passed 22 tests.  `webrtcvad` alone could not compile in
+  this host's disposable environment because the host lacks Python 3.11 C
+  headers; it is unrelated to these test imports, no host package was changed,
+  and all workflow test groups themselves passed locally.
+- `python -m ruff check` and `python -m compileall -q` passed for every changed
+  Python/test file; `python scripts/sync_pr_plan.py
+  plans/PR-EOM-Billing-Run-Review.md --check`, `git diff --check`, migration,
+  route, retry/concurrency/recovery, workflow-enrollment, and static
+  no-writer-import assertions all passed.  The legacy scheduler, MCP surface,
+  and invoice repository have no diff from the inspected base.
+- Before push, `bash scripts/local_pr_review.sh --current-pr-body-file
+  tmp/PR_BODY_EOM_Billing_Run_Review.md origin/main` passed.  Its full local
+  unit-gate mirror reported 160 known failing/errored baseline nodes, zero
+  regressions, and zero newly passing nodes; every policy, plan, cross-layer,
+  reconciliation, closure, and baseline check passed.
+- Hosted Actions will be inspected but are not acceptance evidence under Juan's
+  explicit local-check instruction.  The known account-spending pre-step
+  failure remains H-11; no hosted failure will be reclassified as a source pass.
+- Before merge, perform thread-aware GraphQL inspection and address every
+  actionable thread on the published head.  A quota-exhaustion conversation note
+  with no requested change is recorded but not artificially resolved.
+- After merge, deploy ATLAS before any tracker consumer.  Verify the protected
+  route with an unauthenticated 401 only; do not create a live draft run, invoice,
+  PDF, Gmail draft, or email to prove deployment.
+
+This exceeds the 400-LOC soft target because durable source snapshots,
+transactional idempotency, storage rollback proof, source-fingerprint
+reconciliation, and the required real-entrypoint/real-PostgreSQL execution
+tests are one inseparable financial-review boundary.  Splitting the schema or
+route from its concurrency/recovery proof would publish an unsafe writer; the
+next tracker and Website consumers remain separate deployable slices.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_invoicing_checks.yml` | 7 |
+| `atlas_brain/api/invoicing/receivables.py` | 109 |
+| `atlas_brain/services/commercial_billing_runs.py` | 655 |
+| `atlas_brain/storage/migrations/370_commercial_billing_runs.sql` | 79 |
+| `plans/PR-EOM-Billing-Run-Review.md` | 298 |
+| `tests/test_commercial_billing_runs.py` | 727 |
+| **Total** | **1875** |

--- a/tests/test_commercial_billing_runs.py
+++ b/tests/test_commercial_billing_runs.py
@@ -1,0 +1,727 @@
+"""Contract tests for durable, pre-approval EOM commercial billing runs."""
+
+from __future__ import annotations
+
+import asyncio
+import ast
+import copy
+import inspect
+import json
+import os
+from contextlib import asynccontextmanager
+from itertools import product
+from pathlib import Path
+from types import SimpleNamespace
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from atlas_brain.services.commercial_billing_candidates import (
+    CommercialBillingCandidatesUnavailableError,
+    CommercialBillingCandidatesValidationError,
+)
+from atlas_brain.services.commercial_billing_runs import (
+    CommercialBillingRunConflictError,
+    CommercialBillingRunService,
+    CommercialBillingRunUnavailableError,
+    _normalize_preview,
+)
+
+
+def _fingerprint(letter: str) -> str:
+    return letter * 64
+
+
+def _candidate(
+    key: str,
+    fingerprint: str,
+    *,
+    blockers: list[dict] | None = None,
+    service_name: str = "Office cleaning",
+) -> dict:
+    return {
+        "billingPeriod": "2026-03",
+        "blockers": blockers or [],
+        "candidateKey": key,
+        "customer": {
+            "contactId": "00000000-0000-0000-0000-000000000001",
+            "customerType": "commercial",
+            "displayName": "Acme Office",
+        },
+        "deliveryMethod": None,
+        "lineItems": [
+            {
+                "amountCents": 9650,
+                "description": service_name,
+                "eventIds": ["event-1"],
+                "locations": ["100 Main St"],
+                "quantity": 2,
+                "quantityUnit": "visit",
+                "rateCents": 4825,
+                "serviceId": "service-1",
+                "sourceDate": "2026-03-03",
+            }
+        ],
+        "recipient": {
+            "contactId": "00000000-0000-0000-0000-000000000001",
+            "displayName": "Acme Accounts Payable",
+            "email": "billing@example.test",
+        },
+        "services": [
+            {
+                "calendarId": "commercial-calendar",
+                "calendarKeyword": "Acme",
+                "rateCents": 4825,
+                "rateLabel": "Per Visit",
+                "serviceId": "service-1",
+                "serviceName": service_name,
+                "taxRateBasisPoints": 0,
+            }
+        ],
+        "sourceEvents": [
+            {
+                "allDay": False,
+                "calendarId": "commercial-calendar",
+                "end": "2026-03-03T17:00:00+00:00",
+                "eventId": "event-1",
+                "location": "100 Main St",
+                "sourceDate": "2026-03-03",
+                "start": "2026-03-03T16:00:00+00:00",
+                "status": "confirmed",
+                "summary": "Acme Office cleaning",
+            }
+        ],
+        "sourceFingerprint": fingerprint,
+        "subtotalCents": 9650,
+        "taxCents": 0,
+        "taxRateBasisPoints": 0,
+        "totalCents": 9650,
+    }
+
+
+def _preview(*candidates: dict) -> dict:
+    return {
+        "billingPeriod": "2026-03",
+        "calendarId": "commercial-calendar",
+        "candidates": list(candidates),
+        "contractVersion": 1,
+        "summary": {
+            "blockedCandidateCount": sum(1 for candidate in candidates if candidate["blockers"]),
+            "candidateCount": len(candidates),
+        },
+    }
+
+
+class _CandidateService:
+    def __init__(self, preview: dict, *, error: Exception | None = None) -> None:
+        self.preview_payload = preview
+        self.error = error
+        self.calls: list[str] = []
+
+    async def preview(self, *, billing_period: str) -> dict:
+        self.calls.append(billing_period)
+        if self.error is not None:
+            raise self.error
+        return copy.deepcopy(self.preview_payload)
+
+
+class _BarrierCandidateService(_CandidateService):
+    def __init__(self, preview: dict) -> None:
+        super().__init__(preview)
+        self.two_calls_started = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def preview(self, *, billing_period: str) -> dict:
+        self.calls.append(billing_period)
+        if len(self.calls) >= 2:
+            self.two_calls_started.set()
+        await self.release.wait()
+        return copy.deepcopy(self.preview_payload)
+
+
+class _SchemaPool:
+    is_initialized = True
+
+    def __init__(self, conn, schema: str) -> None:
+        self.conn = conn
+        self.schema = schema
+
+    @asynccontextmanager
+    async def transaction(self):
+        async with self.conn.transaction():
+            await self.conn.execute(f'SET LOCAL search_path TO "{self.schema}"')
+            yield self.conn
+
+    async def fetch(self, query, *args):
+        async with self.conn.transaction():
+            await self.conn.execute(f'SET LOCAL search_path TO "{self.schema}"')
+            return await self.conn.fetch(query, *args)
+
+    async def fetchrow(self, query, *args):
+        async with self.conn.transaction():
+            await self.conn.execute(f'SET LOCAL search_path TO "{self.schema}"')
+            return await self.conn.fetchrow(query, *args)
+
+
+@asynccontextmanager
+async def _billing_run_database():
+    asyncpg = pytest.importorskip("asyncpg")
+    database_url = os.environ.get("ATLAS_RECEIVABLES_TEST_DATABASE_URL")
+    if not database_url:
+        pytest.skip("ATLAS_RECEIVABLES_TEST_DATABASE_URL not set")
+
+    schema = f"commercial_billing_runs_{uuid4().hex}"
+    conn = await asyncpg.connect(database_url)
+    migration = (
+        Path(__file__).parents[1]
+        / "atlas_brain/storage/migrations/370_commercial_billing_runs.sql"
+    ).read_text(encoding="utf-8")
+    try:
+        await conn.execute(f'CREATE SCHEMA "{schema}"')
+        await conn.execute(f'SET search_path TO "{schema}"')
+        await conn.execute(migration)
+        yield conn, schema, database_url
+    finally:
+        await conn.execute("SET search_path TO public")
+        await conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        await conn.close()
+
+
+def _service(pool, candidate_service: _CandidateService) -> CommercialBillingRunService:
+    return CommercialBillingRunService(
+        pool=pool,
+        candidate_service_loader=lambda: candidate_service,
+    )
+
+
+@pytest.mark.asyncio
+async def test_real_postgres_snapshot_is_immutable_and_same_key_replays_without_source_read():
+    async with _billing_run_database() as (conn, schema, _database_url):
+        candidate_service = _CandidateService(
+            _preview(
+                _candidate(
+                    "commercial-billing:acme:2026-03",
+                    _fingerprint("a"),
+                    blockers=[
+                        {
+                            "code": "missing_billing_delivery_preference",
+                            "eventIds": [],
+                            "message": "No explicit delivery preference.",
+                            "serviceId": None,
+                        }
+                    ],
+                )
+            )
+        )
+        service = _service(_SchemaPool(conn, schema), candidate_service)
+
+        created = await service.create_run(
+            billing_period="2026-03",
+            idempotency_key="billing-run-create-1",
+            actor="Juan Canfield",
+        )
+
+        assert created["replayed"] is False
+        run = created["billingRun"]
+        assert run["state"] == "draft"
+        assert run["createdBy"] == "Juan Canfield"
+        assert run["candidateContractVersion"] == 1
+        assert run["summary"] == {"blockedCandidateCount": 1, "candidateCount": 1}
+        assert run["candidates"][0]["lineItems"][0]["amountCents"] == 9650
+        assert run["candidates"][0]["sourceEvents"][0]["location"] == "100 Main St"
+        assert len(run["snapshotFingerprint"]) == 64
+        assert candidate_service.calls == ["2026-03"]
+
+        persisted = await conn.fetchrow(
+            """
+            SELECT
+                created_by, billing_period, calendar_id, state, snapshot_fingerprint
+            FROM commercial_billing_runs
+            """
+        )
+        assert dict(persisted) == {
+            "created_by": "Juan Canfield",
+            "billing_period": "2026-03",
+            "calendar_id": "commercial-calendar",
+            "state": "draft",
+            "snapshot_fingerprint": run["snapshotFingerprint"],
+        }
+        assert await conn.fetchval(
+            "SELECT COUNT(*) FROM commercial_billing_run_candidates"
+        ) == 1
+
+        candidate_service.error = AssertionError("retry must not regenerate sources")
+        replayed = await service.create_run(
+            billing_period="2026-03",
+            idempotency_key="billing-run-create-1",
+            actor="Juan Canfield",
+        )
+        assert replayed == {"billingRun": run, "replayed": True}
+        assert candidate_service.calls == ["2026-03"]
+
+        listed = await service.list_runs(billing_period="2026-03", limit=10)
+        assert listed["items"] == [
+            {
+                key: run[key]
+                for key in (
+                    "billingPeriod",
+                    "calendarId",
+                    "candidateContractVersion",
+                    "createdAt",
+                    "createdBy",
+                    "id",
+                    "snapshotFingerprint",
+                    "state",
+                    "summary",
+                    "updatedAt",
+                )
+            }
+        ]
+
+
+@pytest.mark.asyncio
+async def test_real_postgres_reconciliation_detects_changed_missing_and_new_evidence_without_write():
+    async with _billing_run_database() as (conn, schema, _database_url):
+        original = _preview(
+            _candidate("commercial-billing:alpha:2026-03", _fingerprint("a")),
+            _candidate("commercial-billing:bravo:2026-03", _fingerprint("b")),
+        )
+        candidate_service = _CandidateService(original)
+        service = _service(_SchemaPool(conn, schema), candidate_service)
+        created = await service.create_run(
+            billing_period="2026-03",
+            idempotency_key="billing-run-reconcile-1",
+            actor="Juan Canfield",
+        )
+        run = created["billingRun"]
+        before = await conn.fetchrow(
+            "SELECT updated_at FROM commercial_billing_runs WHERE id = $1",
+            UUID(run["id"]),
+        )
+
+        current = await service.reconcile_run(UUID(run["id"]))
+        assert current["isStale"] is False
+        assert [change["status"] for change in current["candidateChanges"]] == [
+            "unchanged",
+            "unchanged",
+        ]
+
+        candidate_service.preview_payload["calendarId"] = "replacement-calendar"
+        changed_calendar = await service.reconcile_run(UUID(run["id"]))
+        assert changed_calendar["isStale"] is True
+        assert [change["status"] for change in changed_calendar["candidateChanges"]] == [
+            "unchanged",
+            "unchanged",
+        ]
+
+        candidate_service.preview_payload = _preview(
+            _candidate("commercial-billing:alpha:2026-03", _fingerprint("c")),
+            _candidate("commercial-billing:charlie:2026-03", _fingerprint("d")),
+        )
+        stale = await service.reconcile_run(UUID(run["id"]))
+
+        assert stale["isStale"] is True
+        assert {
+            change["candidateKey"]: change["status"]
+            for change in stale["candidateChanges"]
+        } == {
+            "commercial-billing:alpha:2026-03": "changed",
+            "commercial-billing:bravo:2026-03": "missing",
+            "commercial-billing:charlie:2026-03": "new",
+        }
+        assert stale["snapshotFingerprint"] == run["snapshotFingerprint"]
+        assert stale["currentSnapshotFingerprint"] != run["snapshotFingerprint"]
+        after = await conn.fetchrow(
+            "SELECT updated_at FROM commercial_billing_runs WHERE id = $1",
+            UUID(run["id"]),
+        )
+        assert after["updated_at"] == before["updated_at"]
+        assert await conn.fetchval(
+            "SELECT COUNT(*) FROM commercial_billing_run_candidates"
+        ) == 2
+
+
+@pytest.mark.asyncio
+async def test_real_postgres_source_failure_rolls_back_then_retry_recovers():
+    async with _billing_run_database() as (conn, schema, _database_url):
+        candidate_service = _CandidateService(
+            _preview(_candidate("commercial-billing:acme:2026-03", _fingerprint("a"))),
+            error=CommercialBillingCandidatesUnavailableError("calendar unavailable"),
+        )
+        service = _service(_SchemaPool(conn, schema), candidate_service)
+
+        with pytest.raises(CommercialBillingCandidatesUnavailableError):
+            await service.create_run(
+                billing_period="2026-03",
+                idempotency_key="billing-run-source-retry-1",
+                actor="Juan Canfield",
+            )
+        assert await conn.fetchval("SELECT COUNT(*) FROM commercial_billing_runs") == 0
+        assert (
+            await conn.fetchval("SELECT COUNT(*) FROM commercial_billing_run_candidates")
+            == 0
+        )
+
+        candidate_service.error = None
+        recovered = await service.create_run(
+            billing_period="2026-03",
+            idempotency_key="billing-run-source-retry-1",
+            actor="Juan Canfield",
+        )
+        assert recovered["replayed"] is False
+        assert await conn.fetchval("SELECT COUNT(*) FROM commercial_billing_runs") == 1
+
+
+@pytest.mark.asyncio
+async def test_real_postgres_concurrent_same_key_creates_one_snapshot_set():
+    async with _billing_run_database() as (observer, schema, database_url):
+        asyncpg = pytest.importorskip("asyncpg")
+        first_conn = await asyncpg.connect(database_url)
+        second_conn = await asyncpg.connect(database_url)
+        await first_conn.execute(f'SET search_path TO "{schema}"')
+        await second_conn.execute(f'SET search_path TO "{schema}"')
+        candidate_service = _BarrierCandidateService(
+            _preview(
+                _candidate("commercial-billing:acme:2026-03", _fingerprint("a")),
+                _candidate("commercial-billing:bravo:2026-03", _fingerprint("b")),
+            )
+        )
+        try:
+            first = _service(_SchemaPool(first_conn, schema), candidate_service)
+            second = _service(_SchemaPool(second_conn, schema), candidate_service)
+            first_task = asyncio.create_task(
+                first.create_run(
+                    billing_period="2026-03",
+                    idempotency_key="billing-run-concurrent-1",
+                    actor="Juan Canfield",
+                )
+            )
+            second_task = asyncio.create_task(
+                second.create_run(
+                    billing_period="2026-03",
+                    idempotency_key="billing-run-concurrent-1",
+                    actor="Juan Canfield",
+                )
+            )
+            await asyncio.wait_for(candidate_service.two_calls_started.wait(), timeout=5)
+            candidate_service.release.set()
+            first_result, second_result = await asyncio.gather(first_task, second_task)
+        finally:
+            candidate_service.release.set()
+            await first_conn.close()
+            await second_conn.close()
+
+        assert {first_result["billingRun"]["id"], second_result["billingRun"]["id"]} == {
+            first_result["billingRun"]["id"]
+        }
+        assert {first_result["replayed"], second_result["replayed"]} == {False, True}
+        assert await observer.fetchval("SELECT COUNT(*) FROM commercial_billing_runs") == 1
+        assert (
+            await observer.fetchval(
+                "SELECT COUNT(*) FROM commercial_billing_run_candidates"
+            )
+            == 2
+        )
+
+
+@pytest.mark.asyncio
+async def test_same_key_with_another_period_conflicts_without_regenerating_sources():
+    async with _billing_run_database() as (conn, schema, _database_url):
+        candidate_service = _CandidateService(
+            _preview(_candidate("commercial-billing:acme:2026-03", _fingerprint("a")))
+        )
+        service = _service(_SchemaPool(conn, schema), candidate_service)
+        await service.create_run(
+            billing_period="2026-03",
+            idempotency_key="billing-run-period-conflict-1",
+            actor="Juan Canfield",
+        )
+        with pytest.raises(CommercialBillingRunConflictError):
+            await service.create_run(
+                billing_period="2026-04",
+                idempotency_key="billing-run-period-conflict-1",
+                actor="Juan Canfield",
+            )
+        assert candidate_service.calls == ["2026-03"]
+        assert await conn.fetchval("SELECT COUNT(*) FROM commercial_billing_runs") == 1
+
+
+class _NoStoredRunConnection:
+    def __init__(self) -> None:
+        self.transaction_count = 0
+        self.write_attempts = 0
+
+    async def fetchval(self, query, *_args):
+        assert "pg_advisory_xact_lock" in query
+        return None
+
+    async def fetchrow(self, query, *_args):
+        assert "FROM commercial_billing_runs" in query
+        return None
+
+    async def execute(self, *_args):
+        self.write_attempts += 1
+        raise AssertionError("invalid source evidence must not write a run")
+
+
+class _NoStoredRunPool:
+    is_initialized = True
+
+    def __init__(self) -> None:
+        self.conn = _NoStoredRunConnection()
+
+    @asynccontextmanager
+    async def transaction(self):
+        self.conn.transaction_count += 1
+        yield self.conn
+
+
+@pytest.mark.asyncio
+async def test_invalid_generated_evidence_fails_before_snapshot_write():
+    candidate_service = _CandidateService(
+        _preview(
+            _candidate("commercial-billing:duplicate:2026-03", _fingerprint("a")),
+            _candidate("commercial-billing:duplicate:2026-03", _fingerprint("b")),
+        )
+    )
+    pool = _NoStoredRunPool()
+    service = _service(pool, candidate_service)
+
+    with pytest.raises(CommercialBillingCandidatesValidationError):
+        await service.create_run(
+            billing_period="2026-3",
+            idempotency_key="billing-run-invalid-period-1",
+            actor="Juan Canfield",
+        )
+    assert candidate_service.calls == []
+    assert pool.conn.transaction_count == 0
+
+    with pytest.raises(CommercialBillingRunUnavailableError, match="keys must be unique"):
+        await service.create_run(
+            billing_period="2026-03",
+            idempotency_key="billing-run-duplicate-key-1",
+            actor="Juan Canfield",
+        )
+    assert candidate_service.calls == ["2026-03"]
+    assert pool.conn.transaction_count == 1
+    assert pool.conn.write_attempts == 0
+
+    invalid_money = _preview(
+        _candidate("commercial-billing:invalid-money:2026-03", _fingerprint("c"))
+    )
+    invalid_money["candidates"][0]["lineItems"][0]["amountCents"] = float("nan")
+    candidate_service.preview_payload = invalid_money
+    with pytest.raises(CommercialBillingRunUnavailableError, match="not JSON-safe"):
+        await service.create_run(
+            billing_period="2026-03",
+            idempotency_key="billing-run-invalid-money-1",
+            actor="Juan Canfield",
+        )
+    assert pool.conn.write_attempts == 0
+
+
+def test_generated_preview_admission_has_a_grammar_derived_oracle():
+    """Exercise every admitted token/container/family combination at the seam."""
+
+    tokens = "candidateKey sourceFingerprint blockers".split()
+    containers = "mapping json-object".split()
+    families = "accepted rejected".split()
+
+    for token, container, family in product(tokens, containers, families):
+        candidate = _candidate("commercial-billing:grammar:2026-03", _fingerprint("a"))
+        if family == "rejected":
+            if token == "candidateKey":
+                candidate[token] = " commercial-billing:grammar:2026-03"
+            elif token == "sourceFingerprint":
+                candidate[token] = _fingerprint("g")
+            else:
+                candidate[token] = {"not": "a list"}
+
+        raw_candidate = candidate if container == "mapping" else json.dumps(candidate)
+        preview = {
+            "billingPeriod": "2026-03",
+            "calendarId": "commercial-calendar",
+            "candidates": [raw_candidate],
+            "contractVersion": 1,
+        }
+        expected = family == "accepted"
+        try:
+            normalized = _normalize_preview(preview, billing_period="2026-03")
+        except CommercialBillingRunUnavailableError:
+            observed = False
+        else:
+            observed = True
+            assert normalized.candidates[0].candidate_key == candidate["candidateKey"]
+
+        assert observed is expected
+class _RouteRunService:
+    def __init__(self) -> None:
+        self.create_calls: list[tuple[str, str, str]] = []
+        self.get_calls: list[UUID] = []
+        self.reconcile_calls: list[UUID] = []
+
+    async def create_run(self, *, billing_period: str, idempotency_key: str, actor: str):
+        self.create_calls.append((billing_period, idempotency_key, actor))
+        if billing_period != "2026-03":
+            raise CommercialBillingCandidatesValidationError(
+                "billing_period must use YYYY-MM"
+            )
+        return {
+            "billingRun": {"id": "00000000-0000-0000-0000-000000000001"},
+            "replayed": False,
+        }
+
+    async def list_runs(self, *, billing_period, limit, offset):
+        return {"items": [], "limit": limit, "offset": offset}
+
+    async def get_run(self, run_id: UUID):
+        self.get_calls.append(run_id)
+        return {"id": str(run_id)}
+
+    async def reconcile_run(self, run_id: UUID):
+        self.reconcile_calls.append(run_id)
+        return {"billingRunId": str(run_id), "isStale": False}
+
+
+def _route_app(service: _RouteRunService) -> tuple[FastAPI, str]:
+    from atlas_brain.api.invoicing import auth as receivables_auth
+    from atlas_brain.api.invoicing import receivables as routes
+    from atlas_brain.eom_api.auth import generate_receivables_service_token
+
+    generated = generate_receivables_service_token()
+    app = FastAPI()
+    app.include_router(routes.router)
+    app.dependency_overrides[receivables_auth.get_receivables_api_config] = lambda: (
+        SimpleNamespace(
+            receivables_api_enabled=True,
+            receivables_service_token="",
+            receivables_service_token_sha256=generated.sha256,
+        )
+    )
+    app.dependency_overrides[routes.get_commercial_billing_run_service] = lambda: service
+    return app, generated.token
+
+
+@pytest.mark.asyncio
+async def test_full_provider_run_routes_authenticate_actor_and_expose_durable_reads():
+    service = _RouteRunService()
+    app, token = _route_app(service)
+    run_id = "00000000-0000-0000-0000-000000000001"
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://receivables.test",
+    ) as client:
+        path = "/receivables/commercial-billing-runs"
+        assert (await client.post(path, json={"billing_period": "2026-03"})).status_code == 401
+        assert service.create_calls == []
+
+        no_actor = await client.post(
+            path,
+            json={"billing_period": "2026-03"},
+            headers={"Authorization": f"Bearer {token}", "Idempotency-Key": "route-1"},
+        )
+        assert no_actor.status_code == 422
+        assert service.create_calls == []
+
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Idempotency-Key": "route-1",
+            "X-EOM-Actor": "Juan Canfield",
+        }
+        malformed = await client.post(
+            path,
+            json={"billing_period": "2026-3"},
+            headers=headers,
+        )
+        assert malformed.status_code == 422
+        assert service.create_calls == []
+
+        created = await client.post(
+            path,
+            json={"billing_period": "2026-03"},
+            headers=headers,
+        )
+        listed = await client.get(path, headers={"Authorization": f"Bearer {token}"})
+        detail = await client.get(
+            f"{path}/{run_id}", headers={"Authorization": f"Bearer {token}"}
+        )
+        reconciliation = await client.get(
+            f"{path}/{run_id}/reconciliation",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert created.status_code == 201
+    assert created.json()["replayed"] is False
+    assert listed.json() == {"items": [], "limit": 50, "offset": 0}
+    assert detail.json() == {"id": run_id}
+    assert reconciliation.json() == {"billingRunId": run_id, "isStale": False}
+    assert service.create_calls == [("2026-03", "route-1", "Juan Canfield")]
+    assert service.get_calls == [UUID(run_id)]
+    assert service.reconcile_calls == [UUID(run_id)]
+
+
+def test_billing_run_migration_is_additive_and_preserves_draft_evidence():
+    migration = (
+        Path(__file__).parents[1]
+        / "atlas_brain/storage/migrations/370_commercial_billing_runs.sql"
+    ).read_text(encoding="utf-8")
+
+    assert "CREATE TABLE IF NOT EXISTS commercial_billing_runs" in migration
+    assert "CREATE TABLE IF NOT EXISTS commercial_billing_run_candidates" in migration
+    assert "CHECK (state = 'draft')" in migration
+    assert "UNIQUE (source, idempotency_key)" in migration
+    assert "UNIQUE (billing_run_id, candidate_key)" in migration
+    assert "ON DELETE RESTRICT" in migration
+    assert "DROP TABLE" not in "\n".join(
+        line for line in migration.splitlines() if not line.lstrip().startswith("--")
+    )
+
+
+def test_billing_run_service_does_not_import_financial_or_delivery_writers():
+    import atlas_brain.services.commercial_billing_runs as billing_runs
+
+    imports = {
+        alias.name
+        for node in ast.walk(ast.parse(inspect.getsource(billing_runs)))
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    }
+    imports.update(
+        {
+            f"{node.module}.{alias.name}" if node.module else alias.name
+            for node in ast.walk(ast.parse(inspect.getsource(billing_runs)))
+            if isinstance(node, ast.ImportFrom)
+            for alias in node.names
+        }
+    )
+    forbidden_fragments = {
+        "monthly_invoice_generation",
+        "invoice_pdf",
+        "email_provider",
+        "gmail",
+        "notification",
+        "invoice",
+    }
+    assert not any(
+        fragment in imported
+        for fragment in forbidden_fragments
+        for imported in imports
+    )
+
+
+def test_invoicing_workflow_enrolls_billing_run_contract_for_pr_and_main_push():
+    workflow = (
+        Path(__file__).resolve().parents[1]
+        / ".github/workflows/atlas_invoicing_checks.yml"
+    ).read_text(encoding="utf-8")
+
+    for path in (
+        "atlas_brain/services/commercial_billing_runs.py",
+        "atlas_brain/storage/migrations/370_commercial_billing_runs.sql",
+        "tests/test_commercial_billing_runs.py",
+    ):
+        assert workflow.count(f'      - "{path}"') == 2
+    assert "tests/test_commercial_billing_runs.py \\" in workflow


### PR DESCRIPTION
Plan: plans/PR-EOM-Billing-Run-Review.md
Slice phase: Vertical slice
Ownership lane: eom/billing-run-review

This provider-first slice retains the exact commercial billing candidates Juan reviewed and can prove when that evidence goes stale, without creating any financial or delivery artifact. It is additive and safe to deploy before the tracker and Website consumers.

## Intentional

- Add a durable ATLAS `draft` billing-run snapshot plus immutable candidate evidence.
- Add authenticated, idempotent create and bounded list/detail/reconciliation reads on the active full receivables router.
- Reconciliation uses the existing pure candidate generator and reports unchanged, changed, missing, or new candidate evidence without writing.
- No invoice, PDF, Gmail draft, email, service-invoiced marker, candidate edit/exclusion, approval, Square action, or sent state is included.

## AI reconciliation

no-findings

## Deferred

- Tracker proxy and Website durable-review UI, candidate selection/exclusion/editing, explicit approval, invoice/PDF/Gmail-draft recovery, sent-mail reconciliation, and Square queue remain coordinated in #2362.
- Persisted delivery preference, service/site identity, and external Square reference capture remain #2363 H-13.
- Duplicate full/slim receivables ownership remains #2363 H-06; this PR touches only the confirmed active full provider.

## Parked hardening

- Legacy invoice float arithmetic, scheduler changes, generic billing-preference schema, email transport, migration-runner redesign, and historical-ledger improvements are intentionally outside this independently deployable review boundary.

## Cold diff reconstruction

- `370_commercial_billing_runs.sql` adds restrictive parent/child audit storage: only `draft` state, immutable JSON candidate evidence, fingerprints, actor, and additive indexes.
- `commercial_billing_runs.py` validates a pure preview, serializes same-key calls with a PostgreSQL advisory transaction lock plus unique constraint, atomically stores one snapshot, and only compares current source evidence during reconciliation.
- The active receivables router exposes the protected create/list/detail/reconciliation routes and maps named validation, unavailable, conflict, and not-found outcomes. Existing payment, invoice, MCP, candidate-preview, scheduler, PDF, Gmail, and mail paths have no diff.
- The test suite exercises real isolated PostgreSQL snapshot/retry/concurrency/failure/recovery behavior, ASGI auth/actor/period routes, migration safety, writer-import exclusion, and workflow enrollment.

## Verification

- Exact workflow test groups passed locally with a disposable Python 3.11 environment and isolated PostgreSQL schemas: approval blocker 2, receivables/repository 242, and MCP/OAuth 43. The focused billing-run plus candidate pair passed 22.
- The disposable host cannot compile unrelated `webrtcvad` because Python 3.11 C headers are absent; no host package or production setting was changed, and every enrolled workflow test group passed locally without importing it.
- `bash scripts/local_pr_review.sh` passed its policy and full local unit-gate mirror: 160 known baseline failures/errs, zero regressions, and zero newly passing nodes.
- Deployment order: merge and deploy ATLAS before its tracker consumer. The only production probe will be an unauthenticated 401 on the new protected route; it creates no run or financial/delivery artifact.

## Mechanical verification

- Command: `python -m pytest tests/test_monthly_invoice_generation.py -k 'update_invoice_clears_needs_hours_when_line_items_are_billable or line_items_are_billable_requires_all_positive_quantities' -q` - Result: 2 passed - Environment: local
- Command: `python -m pytest tests/test_eom_render_profile.py tests/test_receivables.py tests/test_eom_billing_recipients.py tests/test_eom_payment_receipts.py tests/test_commercial_billing_candidates.py tests/test_commercial_billing_runs.py tests/test_invoice_repository.py -q` - Result: 242 passed - Environment: local
- Command: `python -m pytest tests/test_invoicing_readonly_mcp.py tests/test_invoicing_readonly_oauth.py tests/test_invoicing_draft_writer_mcp.py tests/test_invoicing_draft_writer_oauth.py -q` - Result: 43 passed - Environment: local
- Command: `python -m pytest tests/test_commercial_billing_runs.py tests/test_commercial_billing_candidates.py -q` - Result: 22 passed - Environment: local
- Command: `python -m ruff check atlas_brain/services/commercial_billing_runs.py atlas_brain/api/invoicing/receivables.py tests/test_commercial_billing_runs.py` - Result: passed - Environment: local
- Command: `python -m compileall -q atlas_brain/services/commercial_billing_runs.py atlas_brain/api/invoicing/receivables.py tests/test_commercial_billing_runs.py` - Result: passed - Environment: local
- Command: `python scripts/sync_pr_plan.py plans/PR-EOM-Billing-Run-Review.md --check && git diff --check origin/main` - Result: passed - Environment: local
- Command: `bash scripts/local_pr_review.sh --current-pr-body-file tmp/PR_BODY_EOM_Billing_Run_Review.md origin/main` - Result: passed; known baseline 160, regressions 0 - Environment: local

## Diff size

- 6 files changed, 1,875 additions, 0 deletions. The size exceeds the 400-LOC soft target because atomic audit storage, idempotency/recovery, stale-source comparison, and real PostgreSQL/ASGI proof form one financial-review safety boundary; tracker and Website consumers remain separate slices.
- Diff-budget override: Durable snapshot storage, idempotent recovery, stale-source reconciliation, and real PostgreSQL/ASGI proof are an indivisible provider-first financial safety boundary; tracker and Website consumers remain separate deployable slices.

<!-- atlas-open-pr-wrapper: v1 -->
