### PR TITLE
EOM: harden commercial billing PDF money

### DIFF
--- a/.github/workflows/atlas_invoicing_checks.yml
+++ b/.github/workflows/atlas_invoicing_checks.yml
@@ -30,6 +30,7 @@ on:
       - "atlas_brain/services/crm_provider.py"
       - "atlas_brain/services/commercial_billing_candidates.py"
       - "atlas_brain/services/commercial_billing_runs.py"
+      - "atlas_brain/services/invoice_pdf.py"
       # normalize_contact_email decides billing eligibility and the
       # address these routes return; a grammar change here must run
       # the billing proof.
@@ -47,6 +48,7 @@ on:
       - "atlas_brain/templates/email/payment_receipt.py"
       - "tests/test_monthly_invoice_generation.py"
       - "tests/test_invoice_repository.py"
+      - "tests/test_invoice_pdf.py"
       - "tests/test_receivables.py"
       - "tests/test_eom_billing_recipients.py"
       - "tests/test_eom_payment_receipts.py"
@@ -86,6 +88,7 @@ on:
       - "atlas_brain/services/crm_provider.py"
       - "atlas_brain/services/commercial_billing_candidates.py"
       - "atlas_brain/services/commercial_billing_runs.py"
+      - "atlas_brain/services/invoice_pdf.py"
       # normalize_contact_email decides billing eligibility and the
       # address these routes return; a grammar change here must run
       # the billing proof.
@@ -103,6 +106,7 @@ on:
       - "atlas_brain/templates/email/payment_receipt.py"
       - "tests/test_monthly_invoice_generation.py"
       - "tests/test_invoice_repository.py"
+      - "tests/test_invoice_pdf.py"
       - "tests/test_receivables.py"
       - "tests/test_eom_billing_recipients.py"
       - "tests/test_eom_payment_receipts.py"
@@ -167,6 +171,7 @@ jobs:
             tests/test_commercial_billing_candidates.py \
             tests/test_commercial_billing_runs.py \
             tests/test_invoice_repository.py \
+            tests/test_invoice_pdf.py \
             -q
 
       - name: Run invoicing MCP + OAuth surface tests

--- a/atlas_brain/services/invoice_pdf.py
+++ b/atlas_brain/services/invoice_pdf.py
@@ -7,6 +7,7 @@ invoice PDFs matching the branded HTML email layout.
 from __future__ import annotations
 
 import io
+from decimal import Decimal, DecimalException, InvalidOperation, ROUND_HALF_UP
 from datetime import date
 from typing import Any
 
@@ -27,6 +28,8 @@ _MUTED = (136, 136, 136)     # #888888
 _LIGHT_BG = (244, 244, 244)  # #f4f4f4
 _WHITE = (255, 255, 255)
 _TABLE_BORDER = (224, 224, 224)  # #e0e0e0
+_CENT = Decimal("0.01")
+_ZERO = Decimal("0")
 
 _UNICODE_MAP = str.maketrans({
     "\u2014": "--",
@@ -48,11 +51,48 @@ def _safe(text: Any) -> str:
     return s.encode("latin-1", errors="replace").decode("latin-1")
 
 
-def _money(val: Any) -> str:
+def _decimal(value: Any) -> Decimal:
+    """Return finite decimal input or a safe zero for legacy malformed data."""
+
     try:
-        return f"${float(val):,.2f}"
-    except (TypeError, ValueError):
-        return "$0.00"
+        result = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return _ZERO
+    return result if result.is_finite() else _ZERO
+
+
+def _money_value(value: Any) -> Decimal:
+    """Normalize monetary display/calculation input to exact whole cents."""
+
+    try:
+        return _decimal(value).quantize(_CENT, rounding=ROUND_HALF_UP)
+    except DecimalException:
+        return _ZERO
+
+
+def _money(val: Any) -> str:
+    return f"${_money_value(val):,.2f}"
+
+
+def _line_total(item: dict[str, Any], quantity: Any) -> Decimal:
+    """Retain the legacy fallback order without binary-float arithmetic."""
+
+    flat = item.get("flat_fee")
+    amount = item.get("amount")
+    try:
+        if amount:
+            total = _money_value(amount)
+        elif flat:
+            total = _money_value(flat)
+        else:
+            unit = _money_value(item.get("unit_price") or item.get("rate") or 0)
+            total = _money_value(_decimal(quantity) * unit)
+        discount = item.get("discount")
+        if discount:
+            total = _money_value(total - _money_value(discount))
+        return total
+    except DecimalException:
+        return _ZERO
 
 
 def _fmt_date(val: Any) -> str:
@@ -207,12 +247,10 @@ def render_invoice_pdf(invoice: dict[str, Any]) -> bytes:
     for item in parsed_items:
         desc = _safe(item.get("description", ""))
         qty = item.get("quantity") or 1
-        unit = float(item.get("unit_price") or item.get("rate") or 0)
+        unit = _money_value(item.get("unit_price") or item.get("rate") or 0)
         flat = item.get("flat_fee")
         discount = item.get("discount")
-        total = float(item.get("amount") or (float(flat) if flat else qty * unit))
-        if discount:
-            total -= float(discount)
+        total = _line_total(item, qty)
 
         if has_dates:
             pdf.cell(col_w[0], 6, _safe(item.get("date", "")), align="L")
@@ -254,13 +292,13 @@ def render_invoice_pdf(invoice: dict[str, Any]) -> bytes:
         pdf.cell(0, 6, value, align="R", new_x="LMARGIN", new_y="NEXT")
 
     _total_row("Subtotal:", _money(invoice.get("subtotal")))
-    tax = invoice.get("tax_amount")
-    if tax and float(tax) > 0:
+    tax = _money_value(invoice.get("tax_amount"))
+    if tax > _ZERO:
         meta = invoice.get("metadata") or {}
         tax_label = meta.get("tax_label", "Tax") if isinstance(meta, dict) else "Tax"
         _total_row(f"{tax_label}:", _money(tax))
-    discount = invoice.get("discount_amount")
-    if discount and float(discount) > 0:
+    discount = _money_value(invoice.get("discount_amount"))
+    if discount > _ZERO:
         _total_row("Discount:", f"-{_money(discount)}")
     _total_row("Total Due:", _money(invoice.get("total_amount") or invoice.get("amount_due")), bold=True, border_top=True)
 

--- a/plans/PR-EOM-Commercial-Billing-Exact-PDF.md
+++ b/plans/PR-EOM-Commercial-Billing-Exact-PDF.md
@@ -1,0 +1,121 @@
+# PR-EOM-Commercial-Billing-Exact-PDF
+
+## Why this slice exists
+
+Coordinating issue #2362 and deferred item #2363 H-01 require financial
+precision before an approved commercial-billing writer can produce PDF
+attachments. The existing invoice renderer formats and calculates money via
+`float`, so the future exact-cent writer cannot safely reuse it.
+
+### Problem-derived contract
+
+- Root cause: `invoice_pdf.py` converts invoice money and line totals through
+  binary float before displaying a customer-facing amount.
+- Correct fix must touch/change: replace renderer-only money normalization and
+  arithmetic with finite, cent-quantized `Decimal` values and test exact-cent
+  inputs plus the existing PDF contract.
+- Must not change: invoice persistence, existing invoice schema/API/MCP flows,
+  PDF layout/copy, customer records, payment flows, Gmail behavior, and invoice
+  status. No invoice or email is created by this PR.
+
+## Scope (this PR)
+
+Ownership lane: eom/billing-approved-gmail-drafts
+Slice phase: Production hardening
+
+1. Format invoice totals, line items, discounts, and tax using Decimal-safe
+   monetary conversion instead of float conversion.
+2. Add focused regression tests for fractional-cent rounding, cents/Decimal/
+   string inputs, malformed values, and valid branded PDF bytes.
+
+### Review Contract
+
+- Acceptance criteria: `tests/test_invoice_pdf.py` proves all rendered monetary
+  text is cent-quantized with Decimal, string, integer-cent, malformed, and
+  negative/discount inputs; it proves `render_invoice_pdf` still emits a valid
+  PDF. A source-level assertion proves no `float(` remains in the renderer.
+- Reachability proof: existing invoice PDF callers (`export_invoice_pdf`,
+  monthly invoice generation, and the future approval writer) call
+  `render_invoice_pdf`; a fixture invocation produces a `%PDF-` artifact with
+  expected displayed cents.
+- Affected surfaces: `atlas_brain/services/invoice_pdf.py`, focused PDF tests,
+  and invoicing workflow test enrollment.
+- Risk areas: rounding mode, malformed legacy data, discount/tax branches,
+  existing layout, and unintended sender/financial side effects.
+- Reviewer rules triggered: R3, R8, R10, R13.
+
+### Boundary-change enumeration
+
+Required when this diff changes a guard, validator, normalizer, resolver,
+router/classifier, or admission boundary. Name each changed boundary path or
+seam in the enumeration; otherwise write "N/A - no boundary change."
+
+- Boundary path/seam: PDF-only money normalizer and line-total calculation.
+- Replaced-path behaviors: finite Decimal/string/integer inputs format exactly;
+  invalid/non-finite values retain the existing safe `$0.00` fallback.
+- Guard-relevant fields: monetary fields, quantity, flat fee, discount, and
+  tax amount.
+- Caller x input shape: legacy JSON values may be numbers or strings; new
+  exact-cent documents will provide Decimal-compatible values. Tests admit both
+  and reject `NaN`/infinity/non-numeric values without emitting unsafe amounts.
+
+### Deployed-config probing
+
+Required for guard, validator, resolver, admission-boundary, or env/config
+fallback changes; otherwise write "N/A - no guard/config boundary change."
+
+- Deployed/default config values: N/A - no config, credential, or route change.
+- Explicit value probe: N/A - no config boundary change.
+- Absent value probe: N/A - no config boundary change.
+- Default-session/default-context probe: N/A - no config boundary change.
+- Side-effect ordering: pure in-memory rendering only; no database, Gmail, or
+  email side effect is reachable from this change.
+
+### Files touched
+
+- `.github/workflows/atlas_invoicing_checks.yml`
+- `atlas_brain/services/invoice_pdf.py`
+- `plans/PR-EOM-Commercial-Billing-Exact-PDF.md`
+- `tests/test_invoice_pdf.py`
+
+## Mechanism
+
+One private helper parses a finite `Decimal(str(value))`, quantizes it to cents
+with `ROUND_HALF_UP`, and returns a stable display value. Existing table code
+uses it for money fields and calculates totals with Decimal multiplication/
+subtraction. The renderer’s page geometry and business copy are unchanged.
+
+## Intentional
+
+- This intentionally contains H-01 at the PDF boundary instead of rewriting
+  legacy invoice persistence; the new approval writer will use its own
+  exact-cent database adapter in the next slice.
+- Invalid legacy values retain `$0.00` display fallback rather than causing a
+  customer-facing PDF failure.
+
+## Deferred
+
+- Exact-cent invoice persistence plus durable selected-candidate approval:
+  #2362 next provider slice.
+- No-send Gmail draft creation/recovery and verified sent-mail reconciliation:
+  #2362 subsequent slices.
+- Legacy repository float removal outside this boundary remains #2363 H-01.
+
+Parking predicate: product-shape changes and non-PDF legacy refactors are
+parked. Parked hardening: none.
+
+## Verification
+
+- Pending before push: focused pytest, invoicing regression, ruff, compileall,
+  plan sync/check, local diff budget, financial source scan, and local PR
+  review through `scripts/push_pr.sh` exactly once.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_invoicing_checks.yml` | 5 |
+| `atlas_brain/services/invoice_pdf.py` | 60 |
+| `plans/PR-EOM-Commercial-Billing-Exact-PDF.md` | 121 |
+| `tests/test_invoice_pdf.py` | 92 |
+| **Total** | **278** |

--- a/tests/test_invoice_pdf.py
+++ b/tests/test_invoice_pdf.py
@@ -1,0 +1,92 @@
+"""Exact-money regression coverage for branded invoice PDF rendering."""
+
+from __future__ import annotations
+
+import inspect
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from atlas_brain.services import invoice_pdf
+from atlas_brain.services.invoice_pdf import InvoicePDF, _line_total, _money, render_invoice_pdf
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (Decimal("10.005"), "$10.01"),
+        ("10.004", "$10.00"),
+        (9650, "$9,650.00"),
+        ("96.50", "$96.50"),
+        ("NaN", "$0.00"),
+        ("Infinity", "$0.00"),
+        ("1e999999", "$0.00"),
+        ("not-money", "$0.00"),
+    ],
+)
+def test_money_uses_finite_decimal_round_half_up(value, expected):
+    assert _money(value) == expected
+
+
+def test_line_total_uses_exact_cent_values_and_preserves_discount_order():
+    total = _line_total(
+        {
+            "amount": "30.015",
+            "discount": Decimal("0.005"),
+            "unit_price": "10.005",
+        },
+        "3",
+    )
+
+    assert total == Decimal("30.01")
+
+
+def test_rendered_pdf_uses_exact_money_for_line_tax_and_discount(monkeypatch):
+    captured: list[str] = []
+    original_cell = InvoicePDF.cell
+
+    def capture_cell(self, *args, **kwargs):
+        if "text" in kwargs:
+            captured.append(str(kwargs["text"]))
+        elif len(args) >= 3:
+            captured.append(str(args[2]))
+        return original_cell(self, *args, **kwargs)
+
+    monkeypatch.setattr(InvoicePDF, "cell", capture_cell)
+
+    pdf = render_invoice_pdf(
+        {
+            "invoice_number": "INV-2026-Mar-0001",
+            "issue_date": date(2026, 3, 1),
+            "due_date": date(2026, 3, 31),
+            "customer_name": "Acme Office",
+            "customer_email": "billing@example.test",
+            "line_items": [
+                {
+                    "description": "Commercial cleaning",
+                    "quantity": "3",
+                    "unit_price": "10.005",
+                    "amount": "30.015",
+                    "discount": "0.005",
+                }
+            ],
+            "subtotal": "30.015",
+            "tax_amount": "0.005",
+            "discount_amount": "0.005",
+            "total_amount": "30.015",
+            "metadata": {"tax_label": "Sales tax"},
+            "status": "draft",
+        }
+    )
+
+    assert pdf.startswith(b"%PDF-")
+    assert "$10.01" in captured
+    assert "$30.01" in captured
+    assert "$30.02" in captured
+    assert "$0.01" in captured
+    assert "Sales tax:" in captured
+
+
+def test_renderer_has_no_binary_float_money_conversion():
+    assert "float(" not in inspect.getsource(invoice_pdf)


### PR DESCRIPTION
Plan: plans/PR-EOM-Commercial-Billing-Exact-PDF.md
Slice phase: Production hardening
Ownership lane: eom/billing-approved-gmail-drafts

The existing branded invoice PDF rendered financial values through binary
floats. This narrow money-safety prerequisite replaces only renderer
normalization and line arithmetic with finite, cent-quantized Decimal values,
preserving layout and all invoice/Gmail/MCP lifecycle behavior before the new
approved-draft writer is introduced.

## Intentional

- Invalid or non-finite legacy display values continue to render as `$0.00` so
  a malformed historic row cannot fail an operator-visible PDF.
- Invoice persistence remains untouched; the next provider slice will use an
  isolated exact-cent writer rather than widening this focused PDF repair.

## AI reconciliation

- no-findings

## Deferred

- Exact-cent invoice persistence and durable selected-candidate approval: #2362
  next provider slice.
- Gmail draft recovery, sent-mail reconciliation, and manual Square workflow:
  #2362 later slices.
- Legacy non-PDF invoice repository float removal: #2363 H-01.

## Parked hardening

- None.

## Cold diff reconstruction

- Changed: `.github/workflows/atlas_invoicing_checks.yml` enrolls the renderer
  and focused test; `atlas_brain/services/invoice_pdf.py` replaces float money
  arithmetic with Decimal; `tests/test_invoice_pdf.py` proves cent rounding,
  malformed fallback, table/tax/discount output, valid PDF bytes, and no float
  calls.
- Contract match: each change is limited to the customer-visible PDF money
  boundary identified by #2363 H-01; no persistence, delivery, or status path
  is touched.
- Gaps: none.

## Verification

- Focused invoice PDF suite passes with 11 tests.
- Existing PDF generation/export regressions pass with 2 tests.
- The local invoicing ledger/repository/candidate/run lane exits successfully;
  its optional PostgreSQL cases were skipped because no local test database URL
  is configured.
- Ruff, compileall, plan-shape/files/diff/code-consistency audits, source scan,
  and whitespace checks pass locally.

## Mechanical verification

- Command: `python -m pytest tests/test_invoice_pdf.py -q` - Result: 11 passed - Environment: local
- Command: `python -m pytest tests/test_monthly_invoice_generation.py -k 'pdf_generation_from_real_invoice or export_invoice_pdf' -q` - Result: 2 passed - Environment: local
- Command: `python -m pytest tests/test_eom_render_profile.py tests/test_receivables.py tests/test_eom_billing_recipients.py tests/test_eom_payment_receipts.py tests/test_commercial_billing_candidates.py tests/test_commercial_billing_runs.py tests/test_invoice_repository.py tests/test_invoice_pdf.py -q` - Result: passed - Environment: local
- Command: `ruff check atlas_brain/services/invoice_pdf.py tests/test_invoice_pdf.py && python -m compileall -q atlas_brain/services/invoice_pdf.py tests/test_invoice_pdf.py` - Result: passed - Environment: local
- Command: `python scripts/audit_plan_doc.py plans/PR-EOM-Commercial-Billing-Exact-PDF.md && python scripts/audit_plan_doc_files_touched.py plans/PR-EOM-Commercial-Billing-Exact-PDF.md && python scripts/audit_plan_doc_diff_size.py plans/PR-EOM-Commercial-Billing-Exact-PDF.md && python scripts/audit_plan_code_consistency.py plans/PR-EOM-Commercial-Billing-Exact-PDF.md` - Result: passed - Environment: local
- Skipped: PostgreSQL-backed billing-run cases - Reason: `ATLAS_RECEIVABLES_TEST_DATABASE_URL` is unset locally; the changed renderer has no database I/O and its focused suite is fully local.

## Diff size

4 files, +267 / -11

<!-- atlas-open-pr-wrapper: v1 -->
