### PR TITLE
EOM: approve commercial billing candidates into draft invoices

### DIFF
--- a/.github/workflows/atlas_invoicing_checks.yml
+++ b/.github/workflows/atlas_invoicing_checks.yml
@@ -30,6 +30,7 @@ on:
       - "atlas_brain/services/crm_provider.py"
       - "atlas_brain/services/commercial_billing_candidates.py"
       - "atlas_brain/services/commercial_billing_runs.py"
+      - "atlas_brain/services/commercial_billing_approvals.py"
       - "atlas_brain/services/invoice_pdf.py"
       # normalize_contact_email decides billing eligibility and the
       # address these routes return; a grammar change here must run
@@ -42,6 +43,7 @@ on:
       - "atlas_brain/storage/migrations/369_receivables_payment_receipt_outbox.sql"
       - "atlas_brain/storage/migrations/370_commercial_billing_runs.sql"
       - "atlas_brain/storage/migrations/371_eom_billing_delivery_preferences.sql"
+      - "atlas_brain/storage/migrations/372_commercial_billing_candidate_approvals.sql"
       - "atlas_brain/storage/repositories/invoice.py"
       - "atlas_brain/templates/email/__init__.py"
       - "atlas_brain/templates/email/estimate_confirmation.py"
@@ -54,6 +56,7 @@ on:
       - "tests/test_eom_payment_receipts.py"
       - "tests/test_commercial_billing_candidates.py"
       - "tests/test_commercial_billing_runs.py"
+      - "tests/test_commercial_billing_approvals.py"
       - "tests/test_invoicing_readonly_mcp.py"
       - "tests/test_invoicing_readonly_oauth.py"
       - "tests/test_invoicing_draft_writer_mcp.py"
@@ -88,6 +91,7 @@ on:
       - "atlas_brain/services/crm_provider.py"
       - "atlas_brain/services/commercial_billing_candidates.py"
       - "atlas_brain/services/commercial_billing_runs.py"
+      - "atlas_brain/services/commercial_billing_approvals.py"
       - "atlas_brain/services/invoice_pdf.py"
       # normalize_contact_email decides billing eligibility and the
       # address these routes return; a grammar change here must run
@@ -100,6 +104,7 @@ on:
       - "atlas_brain/storage/migrations/369_receivables_payment_receipt_outbox.sql"
       - "atlas_brain/storage/migrations/370_commercial_billing_runs.sql"
       - "atlas_brain/storage/migrations/371_eom_billing_delivery_preferences.sql"
+      - "atlas_brain/storage/migrations/372_commercial_billing_candidate_approvals.sql"
       - "atlas_brain/storage/repositories/invoice.py"
       - "atlas_brain/templates/email/__init__.py"
       - "atlas_brain/templates/email/estimate_confirmation.py"
@@ -112,6 +117,7 @@ on:
       - "tests/test_eom_payment_receipts.py"
       - "tests/test_commercial_billing_candidates.py"
       - "tests/test_commercial_billing_runs.py"
+      - "tests/test_commercial_billing_approvals.py"
       - "tests/test_invoicing_readonly_mcp.py"
       - "tests/test_invoicing_readonly_oauth.py"
       - "tests/test_invoicing_draft_writer_mcp.py"
@@ -170,6 +176,7 @@ jobs:
             tests/test_eom_payment_receipts.py \
             tests/test_commercial_billing_candidates.py \
             tests/test_commercial_billing_runs.py \
+            tests/test_commercial_billing_approvals.py \
             tests/test_invoice_repository.py \
             tests/test_invoice_pdf.py \
             -q

--- a/atlas_brain/api/invoicing/receivables.py
+++ b/atlas_brain/api/invoicing/receivables.py
@@ -39,6 +39,15 @@ from ...services.commercial_billing_runs import (
     CommercialBillingRunValidationError,
     get_commercial_billing_run_service,
 )
+from ...services.commercial_billing_approvals import (
+    CommercialBillingApprovalConflictError,
+    CommercialBillingApprovalNotFoundError,
+    CommercialBillingApprovalService,
+    CommercialBillingApprovalStaleError,
+    CommercialBillingApprovalUnavailableError,
+    CommercialBillingApprovalValidationError,
+    get_commercial_billing_approval_service,
+)
 from ...services.eom_lead_ingress import EOM_BUSINESS_CONTEXT_ID
 from ...storage.exceptions import DatabaseUnavailableError
 from .auth import require_actor, require_receivables_api
@@ -131,6 +140,15 @@ class CreateCommercialBillingRunRequest(BaseModel):
         min_length=7,
         max_length=7,
         pattern=r"^\d{4}-(0[1-9]|1[0-2])$",
+    )
+
+
+class ApproveCommercialBillingCandidateRequest(BaseModel):
+    candidate_key: str = Field(min_length=1, max_length=512)
+    expected_source_fingerprint: str = Field(
+        min_length=64,
+        max_length=64,
+        pattern=r"^[0-9a-f]{64}$",
     )
 
 
@@ -249,6 +267,31 @@ async def _call_commercial_billing_run(awaitable):
             detail={"code": exc.code, "message": str(exc)},
         ) from exc
     except CommercialBillingRunUnavailableError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail={"code": exc.code, "message": str(exc)},
+        ) from exc
+
+
+async def _call_commercial_billing_approval(awaitable):
+    try:
+        return await awaitable
+    except CommercialBillingApprovalValidationError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail={"code": exc.code, "message": str(exc)},
+        ) from exc
+    except CommercialBillingApprovalNotFoundError as exc:
+        raise HTTPException(
+            status_code=404,
+            detail={"code": exc.code, "message": str(exc)},
+        ) from exc
+    except (CommercialBillingApprovalConflictError, CommercialBillingApprovalStaleError) as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={"code": exc.code, "message": str(exc)},
+        ) from exc
+    except CommercialBillingApprovalUnavailableError as exc:
         raise HTTPException(
             status_code=503,
             detail={"code": exc.code, "message": str(exc)},
@@ -528,6 +571,31 @@ async def create_commercial_billing_run(
     return await _call_commercial_billing_run(
         service.create_run(
             billing_period=body.billing_period,
+            idempotency_key=idempotency_key,
+            actor=actor,
+        )
+    )
+
+
+@router.post("/commercial-billing-runs/{billing_run_id}/approvals", status_code=201)
+async def approve_commercial_billing_candidate(
+    billing_run_id: UUID,
+    body: ApproveCommercialBillingCandidateRequest,
+    actor: Annotated[str, Depends(require_actor)],
+    idempotency_key: Annotated[
+        str, Header(alias="Idempotency-Key", min_length=1, max_length=128)
+    ],
+    service: CommercialBillingApprovalService = Depends(
+        get_commercial_billing_approval_service
+    ),
+) -> dict:
+    """Create or reuse one draft invoice only after explicit candidate approval."""
+
+    return await _call_commercial_billing_approval(
+        service.approve(
+            billing_run_id=billing_run_id,
+            candidate_key=body.candidate_key,
+            expected_source_fingerprint=body.expected_source_fingerprint,
             idempotency_key=idempotency_key,
             actor=actor,
         )

--- a/atlas_brain/services/commercial_billing_approvals.py
+++ b/atlas_brain/services/commercial_billing_approvals.py
@@ -1,0 +1,636 @@
+"""Explicit, exact-cent approval of one retained commercial billing candidate.
+
+This is intentionally separate from the pure preview/run service and the
+legacy monthly task.  It creates only a draft ATLAS invoice plus durable
+approval evidence; it never creates a PDF, Gmail draft, email, CRM event, or
+service-invoiced marker.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from calendar import month_name
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
+from typing import Any, Callable, Mapping, Optional
+from uuid import UUID, uuid4
+
+import asyncpg
+
+from ..storage.database import DatabasePool, get_db_pool
+from ..storage.exceptions import DatabaseOperationError, DatabaseUnavailableError
+from .commercial_billing_candidates import (
+    CommercialBillingCandidateService,
+    CommercialBillingCandidatesUnavailableError,
+    CommercialBillingCandidatesValidationError,
+    get_commercial_billing_candidate_service,
+)
+from .eom_lead_ingress import EOM_BUSINESS_CONTEXT_ID
+
+
+_APPROVAL_SOURCE = "eom_admin"
+_INVOICE_SOURCE = "eom_commercial_billing"
+_FINGERPRINT = re.compile(r"^[0-9a-f]{64}$")
+_MAX_IDEMPOTENCY_KEY_LENGTH = 128
+_MAX_CANDIDATE_KEY_LENGTH = 512
+_MAX_INVOICE_CENTS = 999_999_999_999
+_DATABASE_UNAVAILABLE_ERRORS = (
+    DatabaseOperationError,
+    DatabaseUnavailableError,
+    asyncpg.PostgresConnectionError,
+    asyncpg.CannotConnectNowError,
+    asyncpg.TooManyConnectionsError,
+    asyncpg.AdminShutdownError,
+    asyncpg.CrashShutdownError,
+    asyncpg.UndefinedTableError,
+    asyncpg.UndefinedColumnError,
+    asyncpg.InvalidSchemaNameError,
+    asyncpg.InsufficientPrivilegeError,
+    asyncpg.InvalidAuthorizationSpecificationError,
+)
+
+
+class CommercialBillingApprovalError(Exception):
+    code = "commercial_billing_approval_error"
+
+
+class CommercialBillingApprovalValidationError(CommercialBillingApprovalError):
+    code = "invalid_commercial_billing_approval"
+
+
+class CommercialBillingApprovalNotFoundError(CommercialBillingApprovalError):
+    code = "commercial_billing_candidate_not_found"
+
+
+class CommercialBillingApprovalConflictError(CommercialBillingApprovalError):
+    code = "commercial_billing_approval_idempotency_conflict"
+
+
+class CommercialBillingApprovalStaleError(CommercialBillingApprovalError):
+    code = "stale_commercial_billing_candidate"
+
+
+class CommercialBillingApprovalUnavailableError(CommercialBillingApprovalError):
+    code = "commercial_billing_approvals_unavailable"
+
+
+@dataclass(frozen=True)
+class _InvoiceDraft:
+    billing_period: date
+    contact_id: UUID
+    customer_email: str | None
+    customer_name: str
+    due_date: date
+    invoice_for: str
+    issue_date: date
+    line_items: list[dict[str, Any]]
+    metadata: dict[str, Any]
+    source_ref: str
+    subtotal: Decimal
+    tax_amount: Decimal
+    tax_rate: Decimal
+    total: Decimal
+
+
+def _canonical_json(value: Any) -> str:
+    try:
+        return json.dumps(value, sort_keys=True, separators=(",", ":"), allow_nan=False)
+    except (TypeError, ValueError) as exc:
+        raise CommercialBillingApprovalValidationError(
+            "Commercial billing candidate evidence is invalid"
+        ) from exc
+
+
+def _fingerprint(value: Any) -> str:
+    return hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def _verified_candidate_fingerprint(snapshot: Mapping[str, Any]) -> str:
+    """Return the retained candidate fingerprint only when it covers its evidence."""
+
+    declared = snapshot.get("sourceFingerprint")
+    if not isinstance(declared, str) or _FINGERPRINT.fullmatch(declared) is None:
+        raise CommercialBillingApprovalUnavailableError(
+            "Commercial billing snapshot evidence is invalid"
+        )
+    evidence = dict(snapshot)
+    evidence.pop("sourceFingerprint", None)
+    try:
+        calculated = _fingerprint(evidence)
+    except CommercialBillingApprovalValidationError as exc:
+        raise CommercialBillingApprovalUnavailableError(
+            "Commercial billing snapshot evidence is invalid"
+        ) from exc
+    if calculated != declared:
+        raise CommercialBillingApprovalUnavailableError(
+            "Commercial billing snapshot evidence is invalid"
+        )
+    return declared
+
+
+def _text(value: Any) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _timestamp(value: Any) -> str:
+    return value.isoformat() if isinstance(value, datetime) else str(value)
+
+
+def _money(cents: int) -> Decimal:
+    return Decimal(cents) / Decimal(100)
+
+
+def _money_text(cents: int) -> str:
+    return f"{_money(cents):.2f}"
+
+
+def _cents(value: Any) -> int:
+    try:
+        decimal = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError) as exc:
+        raise CommercialBillingApprovalUnavailableError(
+            "Approved invoice money is invalid"
+        ) from exc
+    cents = decimal * Decimal(100)
+    if not cents.is_finite() or cents != cents.to_integral_value():
+        raise CommercialBillingApprovalUnavailableError("Approved invoice money is invalid")
+    return int(cents)
+
+
+def _json_object(value: Any) -> dict[str, Any]:
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise CommercialBillingApprovalUnavailableError(
+                "Commercial billing snapshot evidence is invalid"
+            ) from exc
+    if not isinstance(value, Mapping):
+        raise CommercialBillingApprovalUnavailableError(
+            "Commercial billing snapshot evidence is invalid"
+        )
+    return dict(value)
+
+
+def _required_text(value: Any, field: str, *, limit: int = 256) -> str:
+    text = _text(value)
+    if text is None or not text.strip() or len(text.strip()) > limit:
+        raise CommercialBillingApprovalValidationError(
+            f"Commercial billing candidate {field} is invalid"
+        )
+    return text.strip()
+
+
+def _validate_key(value: str, *, field: str, limit: int) -> str:
+    if not isinstance(value, str):
+        raise CommercialBillingApprovalValidationError(f"{field} is required")
+    key = value.strip()
+    if not key or len(key) > limit:
+        raise CommercialBillingApprovalValidationError(
+            f"{field} must contain 1 to {limit} characters"
+        )
+    return key
+
+
+def _source_ref(candidate_key: str, source_fingerprint: str) -> str:
+    digest = hashlib.sha256(f"{candidate_key}:{source_fingerprint}".encode()).hexdigest()
+    return f"eom-commercial-billing:{digest}"
+
+
+def _invoice_draft(
+    snapshot: Mapping[str, Any],
+    *,
+    billing_run_id: UUID,
+    expected_candidate_key: str,
+    expected_source_fingerprint: str,
+    actor: str,
+    due_days: int,
+    issue_date: date,
+) -> _InvoiceDraft:
+    if snapshot.get("blockers") != []:
+        raise CommercialBillingApprovalValidationError(
+            "Blocked commercial billing candidates cannot be approved"
+        )
+    if snapshot.get("sourceFingerprint") != expected_source_fingerprint:
+        raise CommercialBillingApprovalConflictError(
+            "The submitted source fingerprint does not match the reviewed candidate"
+        )
+    candidate_key = _validate_key(
+        snapshot.get("candidateKey"), field="Candidate key", limit=_MAX_CANDIDATE_KEY_LENGTH
+    )
+    if candidate_key != expected_candidate_key:
+        raise CommercialBillingApprovalUnavailableError(
+            "Commercial billing snapshot evidence is invalid"
+        )
+    customer = snapshot.get("customer")
+    if not isinstance(customer, Mapping) or customer.get("customerType") != "commercial":
+        raise CommercialBillingApprovalValidationError(
+            "Only canonical commercial customers can receive a commercial invoice"
+        )
+    try:
+        contact_id = UUID(_required_text(customer.get("contactId"), "customer contact"))
+    except ValueError as exc:
+        raise CommercialBillingApprovalValidationError(
+            "Commercial billing candidate customer contact is invalid"
+        ) from exc
+    customer_name = _required_text(customer.get("displayName"), "customer name")
+    delivery_method = snapshot.get("deliveryMethod")
+    if delivery_method not in {"gmail_pdf", "manual_square"}:
+        raise CommercialBillingApprovalValidationError(
+            "Commercial billing candidate delivery method cannot create an invoice"
+        )
+    customer_email = None
+    if delivery_method == "gmail_pdf":
+        recipient = snapshot.get("recipient")
+        if not isinstance(recipient, Mapping):
+            raise CommercialBillingApprovalValidationError(
+                "Commercial billing candidate billing recipient is invalid"
+            )
+        customer_email = _required_text(recipient.get("email"), "billing email")
+    if isinstance(due_days, bool) or not isinstance(due_days, int) or not 1 <= due_days <= 365:
+        raise CommercialBillingApprovalUnavailableError("Configured invoice due days are invalid")
+
+    period_text = _required_text(snapshot.get("billingPeriod"), "billing period", limit=7)
+    try:
+        period = date.fromisoformat(f"{period_text}-01")
+    except ValueError as exc:
+        raise CommercialBillingApprovalValidationError(
+            "Commercial billing candidate period is invalid"
+        ) from exc
+    lines = snapshot.get("lineItems")
+    if not isinstance(lines, list) or not lines:
+        raise CommercialBillingApprovalValidationError(
+            "Commercial billing candidate has no billable line items"
+        )
+    line_items: list[dict[str, Any]] = []
+    subtotal_cents = 0
+    names: list[str] = []
+    for line in lines:
+        if not isinstance(line, Mapping):
+            raise CommercialBillingApprovalValidationError(
+                "Commercial billing line item is invalid"
+            )
+        quantity = line.get("quantity")
+        rate_cents = line.get("rateCents")
+        amount_cents = line.get("amountCents")
+        if (
+            isinstance(quantity, bool)
+            or not isinstance(quantity, int)
+            or quantity <= 0
+            or isinstance(rate_cents, bool)
+            or not isinstance(rate_cents, int)
+            or rate_cents <= 0
+            or isinstance(amount_cents, bool)
+            or not isinstance(amount_cents, int)
+            or amount_cents != quantity * rate_cents
+            or amount_cents > _MAX_INVOICE_CENTS
+        ):
+            raise CommercialBillingApprovalValidationError(
+                "Commercial billing line-item cents are invalid"
+            )
+        description = _required_text(line.get("description"), "line-item description")
+        source_date = _required_text(line.get("sourceDate"), "line-item source date", limit=10)
+        try:
+            date.fromisoformat(source_date)
+        except ValueError as exc:
+            raise CommercialBillingApprovalValidationError(
+                "Commercial billing line-item source date is invalid"
+            ) from exc
+        subtotal_cents += amount_cents
+        if description not in names:
+            names.append(description)
+        line_items.append(
+            {
+                "amount": _money_text(amount_cents),
+                "date": source_date,
+                "description": description,
+                "quantity": quantity,
+                "unit_price": _money_text(rate_cents),
+            }
+        )
+    subtotal = snapshot.get("subtotalCents")
+    tax = snapshot.get("taxCents")
+    total = snapshot.get("totalCents")
+    basis_points = snapshot.get("taxRateBasisPoints")
+    if (
+        any(isinstance(value, bool) or not isinstance(value, int) for value in (subtotal, tax, total, basis_points))
+        or subtotal != subtotal_cents
+        or subtotal > _MAX_INVOICE_CENTS
+        or tax < 0
+        or total != subtotal + tax
+        or not 0 < total <= _MAX_INVOICE_CENTS
+        or not 0 <= basis_points <= 10_000
+        or tax != int(
+            (Decimal(subtotal) * Decimal(basis_points) / Decimal(10_000)).quantize(
+                Decimal("1"), rounding=ROUND_HALF_UP
+            )
+        )
+    ):
+        raise CommercialBillingApprovalValidationError(
+            "Commercial billing candidate totals are invalid"
+        )
+    return _InvoiceDraft(
+        billing_period=period,
+        contact_id=contact_id,
+        customer_email=customer_email,
+        customer_name=customer_name,
+        due_date=issue_date + timedelta(days=due_days),
+        invoice_for=f"{', '.join(names)} - {month_name[period.month]} {period.year}",
+        issue_date=issue_date,
+        line_items=line_items,
+        metadata={
+            "approvedBy": actor,
+            "candidateKey": candidate_key,
+            "commercialBillingRunId": str(billing_run_id),
+            "deliveryMethod": delivery_method,
+            "sourceFingerprint": expected_source_fingerprint,
+        },
+        source_ref=_source_ref(candidate_key, expected_source_fingerprint),
+        subtotal=_money(subtotal),
+        tax_amount=_money(tax),
+        tax_rate=Decimal(basis_points) / Decimal(10_000),
+        total=_money(total),
+    )
+
+
+class CommercialBillingApprovalService:
+    """Own one approved-candidate -> draft-invoice transaction."""
+
+    def __init__(
+        self,
+        *,
+        pool: Optional[DatabasePool] = None,
+        candidate_service_loader: Callable[[], CommercialBillingCandidateService] = (
+            get_commercial_billing_candidate_service
+        ),
+        due_days_loader: Callable[[], int] | None = None,
+        today: Callable[[], date] = date.today,
+    ) -> None:
+        self._configured_pool = pool
+        self._candidate_service_loader = candidate_service_loader
+        self._due_days_loader = due_days_loader or self._configured_due_days
+        self._today = today
+
+    @property
+    def pool(self) -> DatabasePool:
+        pool = self._configured_pool or get_db_pool()
+        if not pool.is_initialized:
+            raise CommercialBillingApprovalUnavailableError(
+                "Commercial billing database unavailable"
+            )
+        return pool
+
+    @staticmethod
+    def _configured_due_days() -> int:
+        from ..config import settings
+
+        return settings.invoicing.auto_invoice_due_days
+
+    async def approve(
+        self,
+        *,
+        billing_run_id: UUID,
+        candidate_key: str,
+        expected_source_fingerprint: str,
+        idempotency_key: str,
+        actor: str,
+    ) -> dict[str, Any]:
+        if not isinstance(billing_run_id, UUID):
+            raise CommercialBillingApprovalValidationError("Billing run id is invalid")
+        key = _validate_key(idempotency_key, field="Idempotency key", limit=_MAX_IDEMPOTENCY_KEY_LENGTH)
+        selected = _validate_key(candidate_key, field="Candidate key", limit=_MAX_CANDIDATE_KEY_LENGTH)
+        if (
+            not isinstance(expected_source_fingerprint, str)
+            or _FINGERPRINT.fullmatch(expected_source_fingerprint) is None
+        ):
+            raise CommercialBillingApprovalValidationError("Source fingerprint is invalid")
+        approved_by = _required_text(actor, "authenticated actor", limit=128)
+        request_fingerprint = _fingerprint(
+            {"billingRunId": str(billing_run_id), "candidateKey": selected, "sourceFingerprint": expected_source_fingerprint}
+        )
+        try:
+            async with self.pool.transaction() as conn:
+                await self._lock(conn, f"operation:{key}")
+                existing = await self._find_by_idempotency(conn, key)
+                if existing is not None:
+                    self._assert_request(existing, request_fingerprint)
+                    return {"approval": self._view(existing), "replayed": True}
+
+            stored = await self._stored_candidate(billing_run_id, selected)
+            snapshot = _json_object(stored["snapshot"])
+            if (
+                stored["source_fingerprint"] != _verified_candidate_fingerprint(snapshot)
+                or snapshot.get("billingPeriod") != stored["billing_period"]
+            ):
+                raise CommercialBillingApprovalUnavailableError(
+                    "Commercial billing snapshot evidence is invalid"
+                )
+            issue_date = self._today()
+            if isinstance(issue_date, datetime) or not isinstance(issue_date, date):
+                raise CommercialBillingApprovalUnavailableError("Invoice issue date is invalid")
+            draft = _invoice_draft(
+                snapshot,
+                billing_run_id=billing_run_id,
+                expected_candidate_key=selected,
+                expected_source_fingerprint=expected_source_fingerprint,
+                actor=approved_by,
+                due_days=self._due_days_loader(),
+                issue_date=issue_date,
+            )
+            await self._assert_current(stored["billing_period"], selected, expected_source_fingerprint)
+
+            async with self.pool.transaction() as conn:
+                await self._lock(conn, f"operation:{key}")
+                existing = await self._find_by_idempotency(conn, key)
+                if existing is not None:
+                    self._assert_request(existing, request_fingerprint)
+                    return {"approval": self._view(existing), "replayed": True}
+                await self._lock(conn, f"candidate:{selected}:{expected_source_fingerprint}")
+                existing = await self._find_by_candidate(conn, selected, expected_source_fingerprint)
+                if existing is not None:
+                    return {"approval": self._view(existing), "replayed": True}
+                invoice = await self._insert_invoice(conn, draft)
+                if invoice is None:
+                    raise CommercialBillingApprovalConflictError(
+                        "Invoice source reference already exists without approval evidence"
+                    )
+                await conn.fetchrow(
+                    """
+                    INSERT INTO commercial_billing_candidate_approvals (
+                        id, billing_run_id, candidate_key, source_fingerprint, source,
+                        idempotency_key, request_fingerprint, invoice_id, state,
+                        approved_by, approved_at, created_at, updated_at
+                    )
+                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'invoice_created', $9, $10, $10, $10)
+                    RETURNING id
+                    """,
+                    uuid4(), billing_run_id, selected, expected_source_fingerprint,
+                    _APPROVAL_SOURCE, key, request_fingerprint, invoice["id"], approved_by,
+                    datetime.now(timezone.utc),
+                )
+                created = await self._find_by_idempotency(conn, key)
+                if created is None:
+                    raise CommercialBillingApprovalUnavailableError(
+                        "Commercial billing approval could not be reconciled"
+                    )
+                return {"approval": self._view(created), "replayed": False}
+        except CommercialBillingApprovalError:
+            raise
+        except (asyncpg.UniqueViolationError, asyncpg.ForeignKeyViolationError) as exc:
+            raise CommercialBillingApprovalConflictError(
+                "Commercial billing approval could not be reconciled"
+            ) from exc
+        except (CommercialBillingCandidatesUnavailableError, CommercialBillingCandidatesValidationError) as exc:
+            raise CommercialBillingApprovalUnavailableError(
+                "Commercial billing candidate evidence is unavailable"
+            ) from exc
+        except asyncpg.PostgresError as exc:
+            raise CommercialBillingApprovalUnavailableError(
+                "Commercial billing database unavailable"
+            ) from exc
+        except _DATABASE_UNAVAILABLE_ERRORS as exc:
+            raise CommercialBillingApprovalUnavailableError(
+                "Commercial billing database unavailable"
+            ) from exc
+
+    async def _stored_candidate(self, billing_run_id: UUID, candidate_key: str) -> Any:
+        row = await self.pool.fetchrow(
+            """
+            SELECT run.billing_period, candidate.source_fingerprint, candidate.snapshot
+            FROM commercial_billing_runs AS run
+            JOIN commercial_billing_run_candidates AS candidate
+              ON candidate.billing_run_id = run.id
+            WHERE run.id = $1 AND candidate.candidate_key = $2
+            """,
+            billing_run_id, candidate_key,
+        )
+        if row is None:
+            raise CommercialBillingApprovalNotFoundError("Commercial billing candidate not found")
+        return row
+
+    async def _assert_current(self, period: str, candidate_key: str, fingerprint: str) -> None:
+        preview = await self._candidate_service_loader().preview(billing_period=period)
+        candidates = preview.get("candidates") if isinstance(preview, Mapping) else None
+        if not isinstance(candidates, list):
+            raise CommercialBillingApprovalUnavailableError(
+                "Commercial billing candidate evidence is invalid"
+            )
+        current = next(
+            (item for item in candidates if isinstance(item, Mapping) and item.get("candidateKey") == candidate_key),
+            None,
+        )
+        if current is None or _verified_candidate_fingerprint(current) != fingerprint:
+            raise CommercialBillingApprovalStaleError(
+                "Commercial billing candidate changed; regenerate and review it before approval"
+            )
+
+    @staticmethod
+    async def _lock(conn: Any, scope: str) -> None:
+        await conn.fetchval("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))", f"commercial-billing-approval:{scope}")
+
+    @staticmethod
+    async def _find_by_idempotency(conn: Any, key: str) -> Any | None:
+        return await conn.fetchrow(
+            """
+            SELECT a.id AS approval_id, a.billing_run_id, a.candidate_key,
+                   a.source_fingerprint, a.request_fingerprint, a.state,
+                   a.approved_by, a.approved_at, i.id AS invoice_id,
+                   i.invoice_number, i.status AS invoice_status, i.total_amount,
+                   i.issue_date, i.due_date, i.source_ref
+            FROM commercial_billing_candidate_approvals AS a
+            JOIN invoices AS i ON i.id = a.invoice_id
+            WHERE a.source = $1 AND a.idempotency_key = $2
+            """,
+            _APPROVAL_SOURCE, key,
+        )
+
+    @staticmethod
+    async def _find_by_candidate(conn: Any, candidate_key: str, fingerprint: str) -> Any | None:
+        return await conn.fetchrow(
+            """
+            SELECT a.id AS approval_id, a.billing_run_id, a.candidate_key,
+                   a.source_fingerprint, a.request_fingerprint, a.state,
+                   a.approved_by, a.approved_at, i.id AS invoice_id,
+                   i.invoice_number, i.status AS invoice_status, i.total_amount,
+                   i.issue_date, i.due_date, i.source_ref
+            FROM commercial_billing_candidate_approvals AS a
+            JOIN invoices AS i ON i.id = a.invoice_id
+            WHERE a.candidate_key = $1 AND a.source_fingerprint = $2
+            """,
+            candidate_key, fingerprint,
+        )
+
+    @staticmethod
+    def _assert_request(row: Any, request_fingerprint: str) -> None:
+        if row["request_fingerprint"] != request_fingerprint:
+            raise CommercialBillingApprovalConflictError(
+                "Idempotency key was already used with a different commercial billing candidate"
+            )
+
+    @staticmethod
+    async def _insert_invoice(conn: Any, draft: _InvoiceDraft) -> Any | None:
+        return await conn.fetchrow(
+            """
+            INSERT INTO invoices (
+                id, invoice_number, contact_id, customer_name, customer_email,
+                line_items, subtotal, tax_rate, tax_amount, discount_amount,
+                total_amount, issue_date, due_date, status, source, source_ref,
+                business_context_id, notes, metadata, invoice_for, created_at, updated_at
+            )
+            VALUES (
+                $1, 'INV-' || to_char($2::date, 'YYYY-Mon') || '-' || lpad(nextval('invoice_number_seq')::text, 4, '0'),
+                $3, $4, $5, $6::jsonb, $7, $8, $9, 0, $10, $11, $12, 'draft',
+                $13, $14, $15, $16, $17::jsonb, $18, $19, $19
+            )
+            ON CONFLICT (source, source_ref)
+                WHERE source = 'eom_commercial_billing' AND source_ref IS NOT NULL
+                DO NOTHING
+            RETURNING id
+            """,
+            uuid4(), draft.billing_period, draft.contact_id, draft.customer_name,
+            draft.customer_email, _canonical_json(draft.line_items), draft.subtotal,
+            draft.tax_rate, draft.tax_amount, draft.total, draft.issue_date,
+            draft.due_date, _INVOICE_SOURCE, draft.source_ref, EOM_BUSINESS_CONTEXT_ID,
+            f"Approved commercial billing candidate for {draft.billing_period:%Y-%m}.",
+            _canonical_json(draft.metadata), draft.invoice_for, datetime.now(timezone.utc),
+        )
+
+    @staticmethod
+    def _view(row: Any) -> dict[str, Any]:
+        return {
+            "approvedAt": _timestamp(row["approved_at"]),
+            "approvedBy": row["approved_by"],
+            "billingRunId": str(row["billing_run_id"]),
+            "candidateKey": row["candidate_key"],
+            "id": str(row["approval_id"]),
+            "invoice": {
+                "dueDate": str(row["due_date"]),
+                "id": str(row["invoice_id"]),
+                "invoiceNumber": row["invoice_number"],
+                "issueDate": str(row["issue_date"]),
+                "sourceRef": row["source_ref"],
+                "status": row["invoice_status"],
+                "totalCents": _cents(row["total_amount"]),
+            },
+            "sourceFingerprint": row["source_fingerprint"],
+            "state": row["state"],
+        }
+
+
+def get_commercial_billing_approval_service() -> CommercialBillingApprovalService:
+    return CommercialBillingApprovalService()
+
+
+__all__ = [
+    "CommercialBillingApprovalConflictError",
+    "CommercialBillingApprovalError",
+    "CommercialBillingApprovalNotFoundError",
+    "CommercialBillingApprovalService",
+    "CommercialBillingApprovalStaleError",
+    "CommercialBillingApprovalUnavailableError",
+    "CommercialBillingApprovalValidationError",
+    "get_commercial_billing_approval_service",
+]

--- a/atlas_brain/storage/migrations/372_commercial_billing_candidate_approvals.sql
+++ b/atlas_brain/storage/migrations/372_commercial_billing_candidate_approvals.sql
@@ -1,0 +1,58 @@
+-- Explicit approval evidence for one commercial billing candidate -> draft invoice.
+--
+-- This is additive. It neither changes retained review snapshots nor sends an
+-- invoice. A successful row proves one exact candidate became one draft ATLAS
+-- invoice; PDF/Gmail/Square delivery state belongs to later migrations.
+--
+-- Rollback: revert the reader/writer first and retain this financial audit
+-- evidence. Dropping either object is a separately authorized destructive
+-- operation, not a normal mixed-version rollback.
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_commercial_billing_run_candidates_exact_source
+    ON commercial_billing_run_candidates (
+        billing_run_id, candidate_key, source_fingerprint
+    );
+
+CREATE TABLE IF NOT EXISTS commercial_billing_candidate_approvals (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    billing_run_id UUID NOT NULL
+        REFERENCES commercial_billing_runs(id) ON DELETE RESTRICT,
+    candidate_key VARCHAR(512) NOT NULL,
+    source_fingerprint VARCHAR(64) NOT NULL,
+    source VARCHAR(32) NOT NULL DEFAULT 'eom_admin',
+    idempotency_key VARCHAR(128) NOT NULL,
+    request_fingerprint VARCHAR(64) NOT NULL,
+    invoice_id UUID NOT NULL REFERENCES invoices(id) ON DELETE RESTRICT,
+    state VARCHAR(32) NOT NULL DEFAULT 'invoice_created',
+    approved_by VARCHAR(128) NOT NULL,
+    approved_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT commercial_billing_candidate_approvals_fingerprint_check
+        CHECK (source_fingerprint ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT commercial_billing_candidate_approvals_request_fingerprint_check
+        CHECK (request_fingerprint ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT commercial_billing_candidate_approvals_state_check
+        CHECK (state = 'invoice_created'),
+    CONSTRAINT commercial_billing_candidate_approvals_source_key
+        UNIQUE (source, idempotency_key),
+    CONSTRAINT commercial_billing_candidate_approvals_candidate_fingerprint_key
+        UNIQUE (candidate_key, source_fingerprint),
+    CONSTRAINT commercial_billing_candidate_approvals_invoice_key
+        UNIQUE (invoice_id),
+    CONSTRAINT commercial_billing_candidate_approvals_snapshot_fkey
+        FOREIGN KEY (billing_run_id, candidate_key, source_fingerprint)
+        REFERENCES commercial_billing_run_candidates (
+            billing_run_id, candidate_key, source_fingerprint
+        ) ON DELETE RESTRICT
+);
+
+CREATE INDEX IF NOT EXISTS idx_commercial_billing_candidate_approvals_run
+    ON commercial_billing_candidate_approvals (billing_run_id, approved_at DESC);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_invoices_eom_commercial_billing_source_ref
+    ON invoices (source, source_ref)
+    WHERE source = 'eom_commercial_billing' AND source_ref IS NOT NULL;
+
+COMMENT ON TABLE commercial_billing_candidate_approvals IS
+    'One immutable approval audit row per exact commercial candidate fingerprint; creates a draft invoice only.';

--- a/plans/PR-EOM-Billing-Candidate-Approval-Invoices.md
+++ b/plans/PR-EOM-Billing-Candidate-Approval-Invoices.md
@@ -1,0 +1,204 @@
+# PR-EOM-Billing-Candidate-Approval-Invoices
+
+## Why this slice exists
+
+Coordinating issue #2362 requires an operator-reviewed commercial candidate to
+become an ATLAS financial invoice only after explicit approval. Current main
+can retain and reconcile the review snapshot, but it has no approval command.
+The legacy monthly task is not reusable: its review mode creates invoices and
+PDFs, marks services invoiced, records CRM interactions, and can send mail.
+
+This provider boundary exceeds the normal 400-line target because the
+additive migration, one atomic exact-cent writer, authenticated entrypoint,
+and isolated-PostgreSQL retry/rollback proof must deploy together. Splitting
+those pieces would either publish an unreachable ledger writer or leave a
+financial transaction without its schema invariant and failure evidence.
+
+### Problem-derived contract
+
+- Root cause: durable `commercial_billing_runs` rows remain immutable drafts,
+  while the only existing invoice writer accepts float-oriented legacy inputs
+  and the monthly task carries forbidden delivery and service-marker effects.
+- Correct fix must touch/change: add an additive approval/audit record and
+  source-scoped invoice idempotency constraint; add a separate exact-cent
+  approval service and authenticated receivables endpoint that consumes one
+  stored candidate only after current evidence matches its stored fingerprint.
+- Must not change: pure preview/run creation and reconciliation; legacy invoice
+  CRUD/MCP/monthly task behavior; payment, deposit, receipt, CRM, service
+  marker, Gmail, email, PDF, and invoice-sent behavior. An approved invoice
+  remains `draft` and no delivery artifact is created here.
+
+## Scope (this PR)
+
+Ownership lane: eom/billing-approved-gmail-drafts
+Slice phase: Vertical slice
+
+1. Approve one explicitly named, unblocked current candidate into one exact-cent
+   ATLAS draft invoice with a stable source reference and actor/audit record.
+2. Refuse stale, blocked, malformed, or UI-fingerprint-mismatched candidates
+   before any invoice write; retries and concurrent requests reuse the original
+   approval/invoice rather than duplicate financial records.
+3. Add focused service, route, migration, and compatibility tests. Gmail/PDF
+   artifact creation is intentionally deferred to the next provider slice.
+
+### Review Contract
+
+- Acceptance criteria: `tests/test_commercial_billing_approvals.py` proves an
+  eligible commercial snapshot produces a `draft` invoice whose stored money is
+  derived exclusively from integer cents; it proves same-key replay does not
+  regenerate source evidence or a second invoice; it proves stale/blocked/UI
+  mismatch failures attempt no insert; and it proves the route requires the
+  existing service token, actor, and idempotency key. The migration test proves
+  approval evidence and its invoice relation are restrictive and source scoped.
+- Reachability proof: `POST /api/v1/receivables/commercial-billing-runs/{id}/approvals`
+  reaches `CommercialBillingApprovalService.approve`; its observable result
+  contains the approval and draft invoice identity. Existing UI consumers do
+  not call the route until the tracker/UI proxy slice lands.
+- Affected surfaces: receivables provider API, a new approval service, invoice
+  table (additive source-specific unique index), approval audit table, focused
+  tests, and invoice-workflow enrollment.
+- Risk areas: stale-source race, duplicate invoices, integer-cent conversion,
+  malformed retained snapshots, direct/manual-Square invoice eligibility,
+  customer-facing invoice dates/copy, and accidental Gmail/service-marker work.
+- Reviewer rules triggered: R1, R2, R3, R4, R5, R8, R10, R13, R14.
+
+### Boundary-change enumeration
+
+Required when this diff changes a guard, validator, normalizer, resolver,
+router/classifier, or admission boundary. Name each changed boundary path or
+seam in the enumeration; otherwise write "N/A - no boundary change."
+
+- Boundary path/seam: approval admission verifies selected `candidateKey`,
+  stored `expectedSourceFingerprint`, a fresh candidate projection, blockers,
+  delivery method, canonical commercial identity, exact totals, and line-item
+  arithmetic before an invoice insert.
+- Replaced-path behaviors: the legacy monthly review path is not called. A new
+  source-scoped `eom_commercial_billing` invoice path returns only the durable
+  original approval on an unchanged retry.
+- Guard-relevant fields: run UUID, candidate key, expected source fingerprint,
+  idempotency key, actor, contact UUID, delivery method, line quantities/rates,
+  subtotal/tax/total cents, and configured due days.
+- Caller x input shape: route Pydantic validation bounds UI request strings;
+  service-level tests use stored JSON snapshots and adversarial values so a
+  direct caller cannot bypass the router's field grammar.
+
+### Closure Declaration
+
+- Retained candidate snapshot evidence is **OPEN**: it is producer-supplied
+  nested JSON, so its keys, text, and container shapes cannot be exhaustively
+  enumerated. Membership is **DERIVED** from the candidate service's canonical
+  full-snapshot SHA-256 at preview time and recomputed by the approval service
+  before it reads invoice fields. Any missing, malformed, or nonmatching
+  fingerprint defaults to the safe side—unavailable/rejected with no invoice
+  insert—because an unsealed snapshot could otherwise change money or customer
+  identity.
+- Invoice-capable delivery methods are **CLOSED** to `gmail_pdf` and
+  `manual_square`, enumerated from the canonical delivery-method vocabulary in
+  `EOMBillingDeliveryMethod`; every other value rejects before the writer,
+  because `no_invoice_residential_receipt` and unknown values cannot safely
+  create a commercial invoice.
+
+### Deployed-config probing
+
+Required for guard, validator, resolver, admission-boundary, or env/config
+fallback changes; otherwise write "N/A - no guard/config boundary change."
+
+- Deployed/default config values: reuse the established
+  `invoicing.auto_invoice_due_days` setting, whose default is 30 and whose
+  configuration validation allows only 1 through 365 days.
+- Explicit value probe: focused service tests inject a non-default due-days
+  value and assert the draft due date derives from it.
+- Absent value probe: this setting has a validated default; an invalid injected
+  value is rejected before the invoice insert.
+- Default-session/default-context probe: the route requires the existing
+  receivables token and `X-EOM-Actor`; an absent actor/token reaches no writer.
+- Side-effect ordering: idempotent existing approvals are returned before any
+  source read; new approvals validate current evidence before the one atomic
+  invoice-plus-approval transaction. No Gmail, email, PDF, CRM, or service
+  marker call is imported or reachable.
+
+### Files touched
+
+- `.github/workflows/atlas_invoicing_checks.yml`
+- `atlas_brain/api/invoicing/receivables.py`
+- `atlas_brain/services/commercial_billing_approvals.py`
+- `atlas_brain/storage/migrations/372_commercial_billing_candidate_approvals.sql`
+- `plans/PR-EOM-Billing-Candidate-Approval-Invoices.md`
+- `tests/test_commercial_billing_approvals.py`
+
+## Mechanism
+
+The service loads the immutable candidate snapshot, uses its fingerprint as the
+operator's explicit selection proof, and checks the current pure candidate
+projection before a first approval. It recomputes the retained fingerprint
+before consuming its fields, converts snapshot cents to Decimal only at the
+NUMERIC database boundary, and stores cent-renderable JSON strings for the
+draft invoice. Transaction-scoped locks cover the operation key and the
+run/candidate pair; a partial unique index on the new source reference backs
+the database invariant. The approval row and invoice are inserted atomically,
+so a transport retry returns the same invoice without duplicating money.
+
+## Intentional
+
+- One candidate per command is deliberate. It lets later UI batch orchestration
+  report a recoverable per-candidate result without turning one failed item into
+  an ambiguous multi-invoice transaction.
+- The established due-days setting is reused for invoice terms; no customer
+  billing preference is inferred from residential/commercial type.
+- The new invoice stays `draft`; this slice does not imply Gmail drafting,
+  sending, a Square-send action, or a service invoiced marker.
+
+## Deferred
+
+- Durable PDF artifact creation/reuse and per-candidate recovery state: #2362,
+  discovered while splitting this provider writer from forbidden legacy monthly
+  side effects; track under #2363.
+- Scoped no-send Gmail draft creation/recovery, sent-mail reconciliation, and
+  manual-Square sent-state action: #2362 subsequent provider slices.
+- Batch UI orchestration and tracker/website proxy adoption: #2362 after this
+  provider contract is deployed.
+
+Parking predicate: exact selected-candidate approval is the smallest safe
+financial writer. Legacy invoice repository float cleanup, broad invoice model
+refactors, and delivery work are parked because they do not block this proof.
+
+## Verification
+
+- `python -m pytest tests/test_commercial_billing_approvals.py` — 9 passed,
+  2 skipped when no disposable PostgreSQL URL is configured; it covers exact
+  cents, stale/blocked/malformed refusal, tamper refusal, retry, Square
+  eligibility, route authorization, migration shape, and delivery-import scan.
+- `ATLAS_RECEIVABLES_TEST_DATABASE_URL=... python -m pytest
+  tests/test_commercial_billing_approvals.py -q` — 11 passed against a local
+  disposable PostgreSQL 16 container, including duplicate reuse and an injected
+  approval-audit failure that rolls back the invoice. The container was removed
+  after the test; no production records were queried or changed by this test.
+- `python -m pytest tests/test_commercial_billing_approvals.py
+  tests/test_commercial_billing_runs.py tests/test_commercial_billing_candidates.py
+  tests/test_invoice_pdf.py tests/test_receivables.py tests/test_invoice_repository.py
+  tests/test_eom_billing_recipients.py tests/test_eom_payment_receipts.py -q`
+  — 186 passed, 28 environment-gated skips.
+- `python -m ruff check atlas_brain/services/commercial_billing_approvals.py
+  atlas_brain/api/invoicing/receivables.py tests/test_commercial_billing_approvals.py`
+  and `python -m compileall -q atlas_brain/services/commercial_billing_approvals.py
+  atlas_brain/api/invoicing/receivables.py` — passed.
+- `python scripts/maturity_sweep_file_lane.py --min-score 8 --baseline
+  tests/maturity_sweep/baseline_atlas_brain_api.json
+  atlas_brain/api/invoicing/receivables.py
+  atlas_brain/services/commercial_billing_approvals.py` — passed the ratchet;
+  the receiver's existing score of 28 is unchanged and the new service scored 0.
+- A read-only production-schema preflight counted zero existing
+  `eom_commercial_billing` source references and zero duplicate source-reference
+  groups before introducing the source-specific unique index.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_invoicing_checks.yml` | 7 |
+| `atlas_brain/api/invoicing/receivables.py` | 68 |
+| `atlas_brain/services/commercial_billing_approvals.py` | 636 |
+| `atlas_brain/storage/migrations/372_commercial_billing_candidate_approvals.sql` | 58 |
+| `plans/PR-EOM-Billing-Candidate-Approval-Invoices.md` | 204 |
+| `tests/test_commercial_billing_approvals.py` | 612 |
+| **Total** | **1585** |

--- a/tests/test_commercial_billing_approvals.py
+++ b/tests/test_commercial_billing_approvals.py
@@ -1,0 +1,612 @@
+"""Contract tests for explicit EOM commercial billing candidate approval."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import hashlib
+import inspect
+import json
+import os
+from contextlib import asynccontextmanager
+from datetime import date
+from decimal import Decimal
+from itertools import product
+from pathlib import Path
+from types import SimpleNamespace
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from atlas_brain.services.commercial_billing_approvals import (
+    CommercialBillingApprovalConflictError,
+    CommercialBillingApprovalService,
+    CommercialBillingApprovalStaleError,
+    CommercialBillingApprovalUnavailableError,
+    CommercialBillingApprovalValidationError,
+)
+
+
+def _fingerprint(value: object) -> str:
+    return hashlib.sha256(
+        json.dumps(value, sort_keys=True, separators=(",", ":"), allow_nan=False).encode()
+    ).hexdigest()
+
+
+def _candidate(
+    *,
+    blockers: list[dict] | None = None,
+    candidate_key: str = "commercial-billing:acme:2026-03",
+    description: str = "Office cleaning",
+    delivery_method: str = "gmail_pdf",
+    recipient_email: str | None = "billing@example.test",
+) -> dict:
+    candidate = {
+        "billingPeriod": "2026-03",
+        "blockers": blockers or [],
+        "candidateKey": candidate_key,
+        "customer": {
+            "contactId": "00000000-0000-0000-0000-000000000001",
+            "customerType": "commercial",
+            "displayName": "Acme Office",
+        },
+        "deliveryMethod": delivery_method,
+        "lineItems": [
+            {
+                "amountCents": 9650,
+                "description": description,
+                "quantity": 2,
+                "rateCents": 4825,
+                "sourceDate": "2026-03-03",
+            }
+        ],
+        "recipient": {"email": recipient_email},
+        "subtotalCents": 9650,
+        "taxCents": 0,
+        "taxRateBasisPoints": 0,
+        "totalCents": 9650,
+    }
+    candidate["sourceFingerprint"] = _fingerprint(candidate)
+    return candidate
+
+
+def _refresh_fingerprint(candidate: dict) -> str:
+    evidence = copy.deepcopy(candidate)
+    evidence.pop("sourceFingerprint", None)
+    candidate["sourceFingerprint"] = _fingerprint(evidence)
+    return candidate["sourceFingerprint"]
+
+
+def _tampered_snapshot(candidate: dict, family: str, value: object) -> dict:
+    tampered = copy.deepcopy(candidate)
+    if family == "customer":
+        tampered["customer"]["displayName"] = value
+    elif family == "recipient":
+        tampered["recipient"]["email"] = value
+    else:
+        assert family == "line_item"
+        tampered["lineItems"][0]["description"] = value
+    return tampered
+
+
+def _tamper_container(token: str, shape: str) -> object:
+    if shape == "scalar":
+        return token
+    if shape == "list":
+        return [token]
+    if shape == "wrapped":
+        return {"value": token}
+    assert shape == "nested"
+    return {"value": [token]}
+
+
+class _CandidateService:
+    def __init__(self, candidate: dict) -> None:
+        self.candidate = candidate
+        self.calls: list[str] = []
+
+    async def preview(self, *, billing_period: str) -> dict:
+        self.calls.append(billing_period)
+        return {"billingPeriod": billing_period, "candidates": [copy.deepcopy(self.candidate)]}
+
+
+class _MemoryConnection:
+    def __init__(self, candidate: dict, run_id: UUID) -> None:
+        self.candidate = candidate
+        self.run_id = run_id
+        self.invoices: dict[UUID, dict] = {}
+        self.approvals_by_key: dict[str, dict] = {}
+        self.approvals_by_candidate: dict[tuple[str, str], dict] = {}
+        self.insert_attempts = 0
+
+    async def fetchval(self, query, *_args):
+        assert "pg_advisory_xact_lock" in query
+        return None
+
+    async def fetchrow(self, query, *args):
+        if "FROM commercial_billing_runs AS run" in query:
+            if args == (self.run_id, self.candidate["candidateKey"]):
+                return {
+                    "billing_period": "2026-03",
+                    "source_fingerprint": self.candidate["sourceFingerprint"],
+                    "snapshot": copy.deepcopy(self.candidate),
+                }
+            return None
+        if "FROM commercial_billing_candidate_approvals AS a" in query:
+            if "a.source = $1" in query:
+                approval = self.approvals_by_key.get(args[1])
+            else:
+                approval = self.approvals_by_candidate.get((args[0], args[1]))
+            return self._view_row(approval) if approval else None
+        if "INSERT INTO invoices" in query:
+            self.insert_attempts += 1
+            invoice_id = args[0]
+            invoice = {
+                "id": invoice_id,
+                "invoice_number": "INV-2026-Mar-0001",
+                "status": "draft",
+                "total_amount": args[9],
+                "issue_date": args[10],
+                "due_date": args[11],
+                "source_ref": args[13],
+                "line_items": json.loads(args[5]),
+                "subtotal": args[6],
+                "tax_rate": args[7],
+                "tax_amount": args[8],
+                "metadata": json.loads(args[16]),
+            }
+            if any(item["source_ref"] == invoice["source_ref"] for item in self.invoices.values()):
+                return None
+            self.invoices[invoice_id] = invoice
+            return {"id": invoice_id}
+        if "INSERT INTO commercial_billing_candidate_approvals" in query:
+            approval = {
+                "approval_id": args[0], "billing_run_id": args[1], "candidate_key": args[2],
+                "source_fingerprint": args[3], "request_fingerprint": args[6],
+                "invoice_id": args[7], "state": "invoice_created", "approved_by": args[8],
+                "approved_at": args[9],
+            }
+            self.approvals_by_key[args[5]] = approval
+            self.approvals_by_candidate[(args[2], args[3])] = approval
+            return {"id": args[0]}
+        raise AssertionError(query)
+
+    def _view_row(self, approval: dict) -> dict:
+        invoice = self.invoices[approval["invoice_id"]]
+        return {
+            **approval,
+            "invoice_number": invoice["invoice_number"],
+            "invoice_status": invoice["status"],
+            "total_amount": invoice["total_amount"],
+            "issue_date": invoice["issue_date"],
+            "due_date": invoice["due_date"],
+            "source_ref": invoice["source_ref"],
+        }
+
+
+class _MemoryPool:
+    is_initialized = True
+
+    def __init__(self, candidate: dict, run_id: UUID) -> None:
+        self.conn = _MemoryConnection(candidate, run_id)
+
+    @asynccontextmanager
+    async def transaction(self):
+        yield self.conn
+
+    async def fetchrow(self, query, *args):
+        return await self.conn.fetchrow(query, *args)
+
+
+class _SchemaPool:
+    is_initialized = True
+
+    def __init__(self, connection, schema: str) -> None:
+        self.connection = connection
+        self.schema = schema
+
+    @asynccontextmanager
+    async def transaction(self):
+        async with self.connection.transaction():
+            await self.connection.execute(f'SET LOCAL search_path TO "{self.schema}"')
+            yield self.connection
+
+    async def fetchrow(self, query, *args):
+        async with self.connection.transaction():
+            await self.connection.execute(f'SET LOCAL search_path TO "{self.schema}"')
+            return await self.connection.fetchrow(query, *args)
+
+
+@asynccontextmanager
+async def _approval_database():
+    asyncpg = pytest.importorskip("asyncpg")
+    database_url = os.environ.get("ATLAS_RECEIVABLES_TEST_DATABASE_URL")
+    if not database_url:
+        pytest.skip("ATLAS_RECEIVABLES_TEST_DATABASE_URL not set")
+    schema, connection = f"commercial_approval_{uuid4().hex}", await asyncpg.connect(database_url)
+    migrations = Path(__file__).parents[1] / "atlas_brain/storage/migrations"
+    try:
+        await connection.execute(f'CREATE SCHEMA "{schema}"')
+        await connection.execute(f'SET search_path TO "{schema}"')
+        await connection.execute("CREATE TABLE contacts (id UUID PRIMARY KEY)")
+        for name in (
+            "045_invoices.sql",
+            "047_invoice_extra_fields.sql",
+            "370_commercial_billing_runs.sql",
+            "372_commercial_billing_candidate_approvals.sql",
+        ):
+            await connection.execute((migrations / name).read_text())
+        yield connection, schema
+    finally:
+        await connection.execute("SET search_path TO public")
+        await connection.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        await connection.close()
+
+
+def _service(pool: _MemoryPool, source: _CandidateService) -> CommercialBillingApprovalService:
+    return CommercialBillingApprovalService(
+        pool=pool,
+        candidate_service_loader=lambda: source,
+        due_days_loader=lambda: 14,
+        today=lambda: date(2026, 4, 2),
+    )
+
+
+@pytest.mark.asyncio
+async def test_approval_creates_one_exact_draft_and_same_key_replays_without_source_read():
+    run_id, candidate = uuid4(), _candidate()
+    fingerprint = candidate["sourceFingerprint"]
+    pool, source = _MemoryPool(candidate, run_id), _CandidateService(candidate)
+    service = _service(pool, source)
+
+    created = await service.approve(
+        billing_run_id=run_id, candidate_key=candidate["candidateKey"],
+        expected_source_fingerprint=fingerprint, idempotency_key="approve-acme-1", actor="Juan",
+    )
+
+    assert created["replayed"] is False
+    assert created["approval"]["state"] == "invoice_created"
+    assert created["approval"]["invoice"] == {
+        "dueDate": "2026-04-16", "id": created["approval"]["invoice"]["id"],
+        "invoiceNumber": "INV-2026-Mar-0001", "issueDate": "2026-04-02",
+        "sourceRef": created["approval"]["invoice"]["sourceRef"], "status": "draft",
+        "totalCents": 9650,
+    }
+    invoice = next(iter(pool.conn.invoices.values()))
+    assert invoice["subtotal"] == Decimal("96.50")
+    assert invoice["line_items"] == [{"amount": "96.50", "date": "2026-03-03", "description": "Office cleaning", "quantity": 2, "unit_price": "48.25"}]
+    assert source.calls == ["2026-03"]
+
+    source.candidate = _candidate(description="Changed cleaning")
+    replayed = await service.approve(
+        billing_run_id=run_id, candidate_key=candidate["candidateKey"],
+        expected_source_fingerprint=fingerprint, idempotency_key="approve-acme-1", actor="Juan",
+    )
+    assert replayed == {**created, "replayed": True}
+    assert len(pool.conn.invoices) == 1
+    assert source.calls == ["2026-03"]
+
+
+@pytest.mark.asyncio
+async def test_stale_or_blocked_candidate_never_attempts_an_invoice_insert():
+    run_id, candidate = uuid4(), _candidate()
+    fingerprint = candidate["sourceFingerprint"]
+    pool, source = _MemoryPool(candidate, run_id), _CandidateService(
+        _candidate(description="Changed cleaning")
+    )
+    service = _service(pool, source)
+
+    with pytest.raises(CommercialBillingApprovalStaleError):
+        await service.approve(
+            billing_run_id=run_id, candidate_key=candidate["candidateKey"],
+            expected_source_fingerprint=fingerprint, idempotency_key="stale-1", actor="Juan",
+        )
+    assert pool.conn.insert_attempts == 0
+
+    blocked = _candidate(blockers=[{"code": "missing_hours"}])
+    blocked_fingerprint = blocked["sourceFingerprint"]
+    blocked_pool, blocked_source = _MemoryPool(blocked, run_id), _CandidateService(blocked)
+    with pytest.raises(CommercialBillingApprovalValidationError):
+        await _service(blocked_pool, blocked_source).approve(
+            billing_run_id=run_id, candidate_key=blocked["candidateKey"],
+            expected_source_fingerprint=blocked_fingerprint, idempotency_key="blocked-1", actor="Juan",
+        )
+    assert blocked_pool.conn.insert_attempts == 0
+    assert blocked_source.calls == []
+
+    malformed = _candidate()
+    malformed["taxCents"], malformed["totalCents"] = 1, 9651
+    malformed_fingerprint = _refresh_fingerprint(malformed)
+    malformed_pool, malformed_source = _MemoryPool(malformed, run_id), _CandidateService(malformed)
+    with pytest.raises(CommercialBillingApprovalValidationError):
+        await _service(malformed_pool, malformed_source).approve(
+            billing_run_id=run_id, candidate_key=malformed["candidateKey"],
+            expected_source_fingerprint=malformed_fingerprint, idempotency_key="bad-totals-1", actor="Juan",
+        )
+    assert malformed_pool.conn.insert_attempts == 0
+    assert malformed_source.calls == []
+
+    mismatch_pool, mismatch_source = _MemoryPool(candidate, run_id), _CandidateService(candidate)
+    with pytest.raises(CommercialBillingApprovalConflictError):
+        await _service(mismatch_pool, mismatch_source).approve(
+            billing_run_id=run_id, candidate_key=candidate["candidateKey"],
+            expected_source_fingerprint=_fingerprint("b"), idempotency_key="mismatch-1", actor="Juan",
+        )
+    assert mismatch_pool.conn.insert_attempts == 0
+    assert mismatch_source.calls == []
+
+
+@pytest.mark.asyncio
+async def test_tampered_snapshot_fingerprint_never_reaches_current_source_or_invoice_insert():
+    run_id, candidate = uuid4(), _candidate()
+    tampered = copy.deepcopy(candidate)
+    tampered["customer"]["displayName"] = "Wrong customer"
+    pool, source = _MemoryPool(tampered, run_id), _CandidateService(candidate)
+
+    with pytest.raises(CommercialBillingApprovalUnavailableError):
+        await _service(pool, source).approve(
+            billing_run_id=run_id,
+            candidate_key=tampered["candidateKey"],
+            expected_source_fingerprint=tampered["sourceFingerprint"],
+            idempotency_key="tampered-snapshot-1",
+            actor="Juan",
+        )
+
+    assert pool.conn.insert_attempts == 0
+    assert source.calls == []
+
+
+@pytest.mark.asyncio
+async def test_snapshot_fingerprint_rejects_generated_tamper_tokens_containers_and_key_families():
+    """Spec-derived oracle: every unsealed snapshot alteration rejects before money moves.
+
+    Tokens x containers x key families cover scalar and JSON-wrapper shapes.
+    Representation parity requires every generated container to have the same
+    expected rejection; the oracle is independent of the writer because a
+    retained source fingerprint covers the entire candidate before field reads.
+    """
+
+    token_stems = ("changed", "recipient")
+    modifiers = ("", "-suffix", "-123")
+    container_shapes = ("scalar", "list", "wrapped", "nested")
+    key_families = ("customer", "recipient", "line_item")
+    expected_rejection = CommercialBillingApprovalUnavailableError
+
+    for token_stem, modifier, container_shape, key_family in product(
+        token_stems, modifiers, container_shapes, key_families
+    ):
+        candidate = _candidate()
+        tampered = _tampered_snapshot(
+            candidate,
+            key_family,
+            _tamper_container(f"{token_stem}{modifier}", container_shape),
+        )
+        pool, source = _MemoryPool(tampered, uuid4()), _CandidateService(candidate)
+
+        with pytest.raises(expected_rejection):
+            await _service(pool, source).approve(
+                billing_run_id=pool.conn.run_id,
+                candidate_key=tampered["candidateKey"],
+                expected_source_fingerprint=tampered["sourceFingerprint"],
+                idempotency_key=(
+                    f"tamper-{token_stem}-{modifier or 'base'}-"
+                    f"{container_shape}-{key_family}"
+                ),
+                actor="Juan",
+            )
+
+        assert pool.conn.insert_attempts == 0
+        assert source.calls == []
+
+
+@pytest.mark.asyncio
+async def test_manual_square_candidate_creates_draft_without_a_gmail_recipient():
+    run_id, candidate = uuid4(), _candidate(
+        delivery_method="manual_square", recipient_email=None
+    )
+    fingerprint = candidate["sourceFingerprint"]
+    pool, source = _MemoryPool(candidate, run_id), _CandidateService(candidate)
+
+    result = await _service(pool, source).approve(
+        billing_run_id=run_id, candidate_key=candidate["candidateKey"],
+        expected_source_fingerprint=fingerprint, idempotency_key="square-1", actor="Juan",
+    )
+
+    assert result["approval"]["invoice"]["status"] == "draft"
+    assert next(iter(pool.conn.invoices.values()))["metadata"]["deliveryMethod"] == "manual_square"
+
+
+@pytest.mark.asyncio
+async def test_real_postgres_approval_is_atomic_and_reuses_same_candidate_across_runs():
+    async with _approval_database() as (connection, schema):
+        run_id, second_run_id, candidate = uuid4(), uuid4(), _candidate()
+        fingerprint = candidate["sourceFingerprint"]
+        contact_id = UUID(candidate["customer"]["contactId"])
+        await connection.execute("INSERT INTO contacts (id) VALUES ($1)", contact_id)
+        for run, key in ((run_id, "review-1"), (second_run_id, "review-2")):
+            await connection.execute(
+                """
+                INSERT INTO commercial_billing_runs (
+                    id, billing_period, state, candidate_contract_version,
+                    snapshot_fingerprint, source, idempotency_key,
+                    request_fingerprint, created_by
+                ) VALUES ($1, '2026-03', 'draft', 2, $2, 'eom_admin', $3, $2, 'Juan')
+                """,
+                run, fingerprint, key,
+            )
+            await connection.execute(
+                """
+                INSERT INTO commercial_billing_run_candidates (
+                    id, billing_run_id, candidate_key, source_fingerprint,
+                    display_order, snapshot
+                ) VALUES ($1, $2, $3, $4, 0, $5::jsonb)
+                """,
+                uuid4(), run, candidate["candidateKey"], fingerprint, json.dumps(candidate),
+            )
+        source = _CandidateService(candidate)
+        service = _service(_SchemaPool(connection, schema), source)
+
+        created = await service.approve(
+            billing_run_id=run_id, candidate_key=candidate["candidateKey"],
+            expected_source_fingerprint=fingerprint, idempotency_key="approve-1", actor="Juan",
+        )
+        replayed = await service.approve(
+            billing_run_id=run_id, candidate_key=candidate["candidateKey"],
+            expected_source_fingerprint=fingerprint, idempotency_key="approve-1", actor="Juan",
+        )
+        reused = await service.approve(
+            billing_run_id=second_run_id, candidate_key=candidate["candidateKey"],
+            expected_source_fingerprint=fingerprint, idempotency_key="approve-2", actor="Juan",
+        )
+
+        assert created["replayed"] is False
+        assert replayed == {**created, "replayed": True}
+        assert reused == {**created, "replayed": True}
+        assert await connection.fetchval("SELECT COUNT(*) FROM invoices") == 1
+        assert await connection.fetchval("SELECT COUNT(*) FROM commercial_billing_candidate_approvals") == 1
+        invoice = await connection.fetchrow("SELECT status, total_amount, amount_due FROM invoices")
+        assert dict(invoice) == {"status": "draft", "total_amount": Decimal("96.50"), "amount_due": Decimal("96.50")}
+        assert source.calls == ["2026-03", "2026-03"]
+
+
+@pytest.mark.asyncio
+async def test_real_postgres_rolls_back_the_invoice_when_approval_audit_insert_fails():
+    async with _approval_database() as (connection, schema):
+        run_id, candidate = uuid4(), _candidate(
+            candidate_key="commercial-billing:rollback:2026-03",
+            description="Transactional approval test",
+        )
+        fingerprint = candidate["sourceFingerprint"]
+        await connection.execute(
+            "INSERT INTO contacts (id) VALUES ($1)",
+            UUID(candidate["customer"]["contactId"]),
+        )
+        await connection.execute(
+            """
+            INSERT INTO commercial_billing_runs (
+                id, billing_period, state, candidate_contract_version,
+                snapshot_fingerprint, source, idempotency_key,
+                request_fingerprint, created_by
+            ) VALUES ($1, '2026-03', 'draft', 2, $2, 'eom_admin', 'review-rollback', $2, 'Juan')
+            """,
+            run_id,
+            fingerprint,
+        )
+        await connection.execute(
+            """
+            INSERT INTO commercial_billing_run_candidates (
+                id, billing_run_id, candidate_key, source_fingerprint,
+                display_order, snapshot
+            ) VALUES ($1, $2, $3, $4, 0, $5::jsonb)
+            """,
+            uuid4(),
+            run_id,
+            candidate["candidateKey"],
+            fingerprint,
+            json.dumps(candidate),
+        )
+        await connection.execute(
+            """
+            CREATE FUNCTION reject_commercial_billing_approval()
+            RETURNS trigger LANGUAGE plpgsql AS $$
+            BEGIN
+                RAISE EXCEPTION 'injected approval-audit failure';
+            END;
+            $$
+            """
+        )
+        await connection.execute(
+            """
+            CREATE TRIGGER reject_commercial_billing_approval_trigger
+            BEFORE INSERT ON commercial_billing_candidate_approvals
+            FOR EACH ROW EXECUTE FUNCTION reject_commercial_billing_approval()
+            """
+        )
+
+        with pytest.raises(CommercialBillingApprovalUnavailableError):
+            await _service(_SchemaPool(connection, schema), _CandidateService(candidate)).approve(
+                billing_run_id=run_id,
+                candidate_key=candidate["candidateKey"],
+                expected_source_fingerprint=fingerprint,
+                idempotency_key="approve-rollback-1",
+                actor="Juan",
+            )
+
+        assert await connection.fetchval("SELECT COUNT(*) FROM invoices") == 0
+        assert await connection.fetchval(
+            "SELECT COUNT(*) FROM commercial_billing_candidate_approvals"
+        ) == 0
+
+
+class _RouteService:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def approve(self, **kwargs):
+        self.calls.append(kwargs)
+        return {"approval": {"id": "approval-1"}, "replayed": False}
+
+
+def _route_app(service: _RouteService) -> tuple[FastAPI, str]:
+    from atlas_brain.api.invoicing import auth as receivables_auth
+    from atlas_brain.api.invoicing import receivables as routes
+    from atlas_brain.eom_api.auth import generate_receivables_service_token
+
+    generated = generate_receivables_service_token()
+    app = FastAPI()
+    app.include_router(routes.router)
+    app.dependency_overrides[receivables_auth.get_receivables_api_config] = lambda: SimpleNamespace(
+        receivables_api_enabled=True, receivables_service_token="", receivables_service_token_sha256=generated.sha256,
+    )
+    app.dependency_overrides[routes.get_commercial_billing_approval_service] = lambda: service
+    return app, generated.token
+
+
+@pytest.mark.asyncio
+async def test_approval_route_requires_token_actor_fingerprint_and_idempotency_key():
+    service, run_id = _RouteService(), uuid4()
+    app, token = _route_app(service)
+    path = f"/receivables/commercial-billing-runs/{run_id}/approvals"
+    body = {"candidate_key": "commercial-billing:acme:2026-03", "expected_source_fingerprint": _fingerprint("a")}
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+        assert (await client.post(path, json=body)).status_code == 401
+        assert (await client.post(path, json=body, headers={"Authorization": f"Bearer {token}", "Idempotency-Key": "route-1"})).status_code == 422
+        assert (await client.post(path, json={**body, "expected_source_fingerprint": "bad"}, headers={"Authorization": f"Bearer {token}", "Idempotency-Key": "route-1", "X-EOM-Actor": "Juan"})).status_code == 422
+        response = await client.post(path, json=body, headers={"Authorization": f"Bearer {token}", "Idempotency-Key": "route-1", "X-EOM-Actor": "Juan"})
+    assert response.status_code == 201
+    assert service.calls == [{"billing_run_id": run_id, "candidate_key": body["candidate_key"], "expected_source_fingerprint": body["expected_source_fingerprint"], "idempotency_key": "route-1", "actor": "Juan"}]
+
+
+def test_approval_migration_is_additive_and_financially_restrictive():
+    migration = (Path(__file__).parents[1] / "atlas_brain/storage/migrations/372_commercial_billing_candidate_approvals.sql").read_text()
+    assert "CREATE TABLE IF NOT EXISTS commercial_billing_candidate_approvals" in migration
+    assert "ON DELETE RESTRICT" in migration
+    assert "UNIQUE (source, idempotency_key)" in migration
+    assert "UNIQUE (candidate_key, source_fingerprint)" in migration
+    assert "UNIQUE (invoice_id)" in migration
+    assert "idx_commercial_billing_run_candidates_exact_source" in migration
+    assert "commercial_billing_candidate_approvals_snapshot_fkey" in migration
+    assert "eom_commercial_billing" in migration
+    assert "DROP TABLE" not in "\n".join(line for line in migration.splitlines() if not line.lstrip().startswith("--"))
+
+
+def test_approval_service_does_not_import_delivery_or_legacy_monthly_writers():
+    import atlas_brain.services.commercial_billing_approvals as approvals
+
+    imports = {alias.name for node in ast.walk(ast.parse(inspect.getsource(approvals))) if isinstance(node, ast.Import) for alias in node.names}
+    imports.update({f"{node.module}.{alias.name}" if node.module else alias.name for node in ast.walk(ast.parse(inspect.getsource(approvals))) if isinstance(node, ast.ImportFrom) for alias in node.names})
+    assert not any(fragment in imported for fragment in {"gmail", "email_provider", "invoice_pdf", "monthly_invoice_generation", "mark_invoiced"} for imported in imports)
+    assert "float(" not in inspect.getsource(approvals)
+
+
+def test_invoicing_workflow_enrolls_the_approval_writer_and_contract():
+    workflow = (Path(__file__).parents[1] / ".github/workflows/atlas_invoicing_checks.yml").read_text()
+    for path in (
+        "atlas_brain/services/commercial_billing_approvals.py",
+        "atlas_brain/storage/migrations/372_commercial_billing_candidate_approvals.sql",
+        "tests/test_commercial_billing_approvals.py",
+    ):
+        assert workflow.count(f'      - "{path}"') == 2
+    assert "tests/test_commercial_billing_approvals.py \\" in workflow


### PR DESCRIPTION
Plan: plans/PR-EOM-Billing-Candidate-Approval-Invoices.md
Slice phase: Vertical slice
Ownership lane: eom/billing-approved-gmail-drafts

Add the ATLAS-only financial boundary for explicit approval of one retained,
current commercial billing candidate. The command creates or reuses exactly one
draft invoice plus restrictive approval evidence; it deliberately creates no
PDF, Gmail draft, email, sent state, Square delivery action, CRM event, or
service-invoiced marker.

## Intentional

- The service writes monetary values from integer cents through `Decimal`, not
  the legacy float-oriented repository writer.
- A current preview and a recomputed retained-snapshot fingerprint must agree
  before the one invoice-plus-approval transaction starts.
- The provider route is authenticated with the existing receivables token and
  actor header; tracker and Website adoption remain a later consumer slice.

## AI reconciliation

- no-findings

## Deferred

- Durable PDF artifact creation/reuse, Gmail draft recovery, sent-mail
  reconciliation, and manual-Square sent-state are tracked under #2362 and
  #2363.
- Tracker/Website batch orchestration is intentionally deferred until this
  provider contract is deployed.

## Parked hardening

- Legacy invoice-repository float cleanup is out of scope because this new
  writer is exact-cent and does not alter old consumers.

## Cold diff reconstruction

- Changed: `atlas_brain/services/commercial_billing_approvals.py` adds the
  source-fingerprinted, transactional candidate-to-draft writer and explicitly
  excludes delivery imports.
- Changed: `atlas_brain/storage/migrations/372_commercial_billing_candidate_approvals.sql`
  adds restrictive approval evidence, a source-scoped invoice reference
  invariant, and no destructive migration step.
- Changed: `atlas_brain/api/invoicing/receivables.py` exposes one authenticated
  `POST /api/v1/receivables/commercial-billing-runs/{id}/approvals` command.
- Changed: focused tests and invoice workflow enrollment prove normal, stale,
  tampered, retry, duplicate-reuse, authentication, and injected partial-failure
  behavior.
- Contract match: each changed runtime path is required by the plan's exact
  selected-candidate approval contract. Gaps: none.

## Verification

- Focused service/route/migration contract: 9 passed, 2 environment-gated
  skips locally; 11 passed against a disposable local PostgreSQL 16 container.
- Broader billing regression lane: 186 passed, 28 environment-gated skips.
- Static checks, compile, plan sync, and the API maturity ratchet pass locally.
- Read-only production-schema preflight found zero existing
  `eom_commercial_billing` source references and zero duplicate source-reference
  groups. No production financial record was changed.

## Mechanical verification

- Command: `python -m pytest tests/test_commercial_billing_approvals.py -q` - Result: 9 passed, 2 skipped - Environment: local
- Command: `ATLAS_RECEIVABLES_TEST_DATABASE_URL=... python -m pytest tests/test_commercial_billing_approvals.py -q` - Result: 11 passed - Environment: local
- Command: `python -m pytest tests/test_commercial_billing_approvals.py tests/test_commercial_billing_runs.py tests/test_commercial_billing_candidates.py tests/test_invoice_pdf.py tests/test_receivables.py tests/test_invoice_repository.py tests/test_eom_billing_recipients.py tests/test_eom_payment_receipts.py -q` - Result: 186 passed, 28 skipped - Environment: local
- Command: `python -m ruff check atlas_brain/services/commercial_billing_approvals.py atlas_brain/api/invoicing/receivables.py tests/test_commercial_billing_approvals.py` - Result: passed - Environment: local
- Command: `python scripts/maturity_sweep_file_lane.py --min-score 8 --baseline tests/maturity_sweep/baseline_atlas_brain_api.json atlas_brain/api/invoicing/receivables.py atlas_brain/services/commercial_billing_approvals.py` - Result: passed - Environment: local

## Diff size

6 files, +1585 / -0

Diff-budget override: The schema invariant, atomic exact-cent writer, authenticated route, and real PostgreSQL rollback/retry proof form one independently deployable provider behavior; splitting them would publish an unproved financial writer or a route without its durable invariant.

<!-- atlas-open-pr-wrapper: v1 -->
