### PR TITLE
EOM: persist approved invoice PDF artifacts

### DIFF
--- a/.github/workflows/atlas_invoicing_checks.yml
+++ b/.github/workflows/atlas_invoicing_checks.yml
@@ -31,6 +31,7 @@ on:
       - "atlas_brain/services/commercial_billing_candidates.py"
       - "atlas_brain/services/commercial_billing_runs.py"
       - "atlas_brain/services/commercial_billing_approvals.py"
+      - "atlas_brain/services/commercial_billing_invoice_pdfs.py"
       - "atlas_brain/services/invoice_pdf.py"
       # normalize_contact_email decides billing eligibility and the
       # address these routes return; a grammar change here must run
@@ -44,6 +45,7 @@ on:
       - "atlas_brain/storage/migrations/370_commercial_billing_runs.sql"
       - "atlas_brain/storage/migrations/371_eom_billing_delivery_preferences.sql"
       - "atlas_brain/storage/migrations/372_commercial_billing_candidate_approvals.sql"
+      - "atlas_brain/storage/migrations/373_commercial_billing_invoice_pdf_artifacts.sql"
       - "atlas_brain/storage/repositories/invoice.py"
       - "atlas_brain/templates/email/__init__.py"
       - "atlas_brain/templates/email/estimate_confirmation.py"
@@ -92,6 +94,7 @@ on:
       - "atlas_brain/services/commercial_billing_candidates.py"
       - "atlas_brain/services/commercial_billing_runs.py"
       - "atlas_brain/services/commercial_billing_approvals.py"
+      - "atlas_brain/services/commercial_billing_invoice_pdfs.py"
       - "atlas_brain/services/invoice_pdf.py"
       # normalize_contact_email decides billing eligibility and the
       # address these routes return; a grammar change here must run
@@ -105,6 +108,7 @@ on:
       - "atlas_brain/storage/migrations/370_commercial_billing_runs.sql"
       - "atlas_brain/storage/migrations/371_eom_billing_delivery_preferences.sql"
       - "atlas_brain/storage/migrations/372_commercial_billing_candidate_approvals.sql"
+      - "atlas_brain/storage/migrations/373_commercial_billing_invoice_pdf_artifacts.sql"
       - "atlas_brain/storage/repositories/invoice.py"
       - "atlas_brain/templates/email/__init__.py"
       - "atlas_brain/templates/email/estimate_confirmation.py"

--- a/atlas_brain/api/invoicing/receivables.py
+++ b/atlas_brain/api/invoicing/receivables.py
@@ -48,6 +48,15 @@ from ...services.commercial_billing_approvals import (
     CommercialBillingApprovalValidationError,
     get_commercial_billing_approval_service,
 )
+from ...services.commercial_billing_invoice_pdfs import (
+    CommercialBillingInvoicePDFConflictError,
+    CommercialBillingInvoicePDFNotFoundError,
+    CommercialBillingInvoicePDFRenderError,
+    CommercialBillingInvoicePDFService,
+    CommercialBillingInvoicePDFUnavailableError,
+    CommercialBillingInvoicePDFValidationError,
+    get_commercial_billing_invoice_pdf_service,
+)
 from ...services.eom_lead_ingress import EOM_BUSINESS_CONTEXT_ID
 from ...storage.exceptions import DatabaseUnavailableError
 from .auth import require_actor, require_receivables_api
@@ -292,6 +301,34 @@ async def _call_commercial_billing_approval(awaitable):
             detail={"code": exc.code, "message": str(exc)},
         ) from exc
     except CommercialBillingApprovalUnavailableError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail={"code": exc.code, "message": str(exc)},
+        ) from exc
+
+
+async def _call_commercial_billing_invoice_pdf(awaitable):
+    try:
+        return await awaitable
+    except CommercialBillingInvoicePDFValidationError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail={"code": exc.code, "message": str(exc)},
+        ) from exc
+    except CommercialBillingInvoicePDFNotFoundError as exc:
+        raise HTTPException(
+            status_code=404,
+            detail={"code": exc.code, "message": str(exc)},
+        ) from exc
+    except CommercialBillingInvoicePDFConflictError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={"code": exc.code, "message": str(exc)},
+        ) from exc
+    except (
+        CommercialBillingInvoicePDFRenderError,
+        CommercialBillingInvoicePDFUnavailableError,
+    ) as exc:
         raise HTTPException(
             status_code=503,
             detail={"code": exc.code, "message": str(exc)},
@@ -596,6 +633,28 @@ async def approve_commercial_billing_candidate(
             billing_run_id=billing_run_id,
             candidate_key=body.candidate_key,
             expected_source_fingerprint=body.expected_source_fingerprint,
+            idempotency_key=idempotency_key,
+            actor=actor,
+        )
+    )
+
+
+@router.post("/commercial-billing-approvals/{approval_id}/invoice-pdf", status_code=201)
+async def generate_commercial_billing_invoice_pdf(
+    approval_id: UUID,
+    actor: Annotated[str, Depends(require_actor)],
+    idempotency_key: Annotated[
+        str, Header(alias="Idempotency-Key", min_length=1, max_length=128)
+    ],
+    service: CommercialBillingInvoicePDFService = Depends(
+        get_commercial_billing_invoice_pdf_service
+    ),
+) -> dict:
+    """Create or reuse one durable PDF for an explicitly approved draft invoice."""
+
+    return await _call_commercial_billing_invoice_pdf(
+        service.generate_or_reuse(
+            approval_id=approval_id,
             idempotency_key=idempotency_key,
             actor=actor,
         )

--- a/atlas_brain/services/commercial_billing_invoice_pdfs.py
+++ b/atlas_brain/services/commercial_billing_invoice_pdfs.py
@@ -1,0 +1,592 @@
+"""Durable PDF artifacts for explicitly approved EOM commercial invoices.
+
+This service owns only one narrow transition: a linked commercial-billing
+approval's still-draft invoice becomes one immutable, database-retained PDF
+artifact.  It does not create an invoice, draft or send Gmail, mutate financial
+status, write a filesystem path, invoke CRM, or mark a service invoiced.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from typing import Any, Callable, Mapping, Optional
+from uuid import UUID, uuid4
+
+import asyncpg
+
+from .invoice_pdf import render_invoice_pdf
+from ..storage.database import DatabasePool, get_db_pool
+from ..storage.exceptions import DatabaseOperationError, DatabaseUnavailableError
+
+
+_ARTIFACT_KIND = "invoice_pdf"
+_ARTIFACT_SOURCE = "eom_admin"
+_CONTENT_TYPE = "application/pdf"
+_INVOICE_SOURCE = "eom_commercial_billing"
+_MAX_ARTIFACT_BYTES = 10 * 1024 * 1024
+_MAX_IDEMPOTENCY_KEY_LENGTH = 128
+_FINGERPRINT = re.compile(r"^[0-9a-f]{64}$")
+_DATABASE_UNAVAILABLE_ERRORS = (
+    DatabaseOperationError,
+    DatabaseUnavailableError,
+    asyncpg.PostgresConnectionError,
+    asyncpg.CannotConnectNowError,
+    asyncpg.TooManyConnectionsError,
+    asyncpg.AdminShutdownError,
+    asyncpg.CrashShutdownError,
+    asyncpg.UndefinedTableError,
+    asyncpg.UndefinedColumnError,
+    asyncpg.InvalidSchemaNameError,
+    asyncpg.InsufficientPrivilegeError,
+    asyncpg.InvalidAuthorizationSpecificationError,
+)
+
+
+class CommercialBillingInvoicePDFError(Exception):
+    code = "commercial_billing_invoice_pdf_error"
+
+
+class CommercialBillingInvoicePDFValidationError(CommercialBillingInvoicePDFError):
+    code = "invalid_commercial_billing_invoice_pdf"
+
+
+class CommercialBillingInvoicePDFNotFoundError(CommercialBillingInvoicePDFError):
+    code = "commercial_billing_approval_not_found"
+
+
+class CommercialBillingInvoicePDFConflictError(CommercialBillingInvoicePDFError):
+    code = "commercial_billing_invoice_pdf_conflict"
+
+
+class CommercialBillingInvoicePDFUnavailableError(CommercialBillingInvoicePDFError):
+    code = "commercial_billing_invoice_pdf_unavailable"
+
+
+class CommercialBillingInvoicePDFRenderError(CommercialBillingInvoicePDFError):
+    code = "commercial_billing_invoice_pdf_render_failed"
+
+
+@dataclass(frozen=True)
+class _ApprovedInvoice:
+    approval_id: UUID
+    invoice_id: UUID
+    invoice: dict[str, Any]
+    render_fingerprint: str
+
+
+def _text(value: Any) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _required_text(value: Any, field: str, *, limit: int = 256) -> str:
+    text = _text(value)
+    if text is None or not text.strip() or len(text.strip()) > limit:
+        raise CommercialBillingInvoicePDFConflictError(
+            f"Approved invoice {field} is invalid"
+        )
+    return text.strip()
+
+
+def _optional_text(value: Any, field: str, *, limit: int = 256) -> str | None:
+    if value is None:
+        return None
+    return _required_text(value, field, limit=limit)
+
+
+def _uuid(value: Any, field: str) -> UUID:
+    if isinstance(value, UUID):
+        return value
+    try:
+        return UUID(str(value))
+    except (TypeError, ValueError, AttributeError) as exc:
+        raise CommercialBillingInvoicePDFUnavailableError(
+            f"Commercial billing {field} is invalid"
+        ) from exc
+
+
+def _json_value(value: Any, field: str, expected_type: type) -> Any:
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise CommercialBillingInvoicePDFConflictError(
+                f"Approved invoice {field} is invalid"
+            ) from exc
+    if not isinstance(value, expected_type):
+        raise CommercialBillingInvoicePDFConflictError(
+            f"Approved invoice {field} is invalid"
+        )
+    return value
+
+
+def _exact_money(value: Any, field: str, *, positive: bool = False) -> Decimal:
+    try:
+        decimal = Decimal(str(value))
+    except (ArithmeticError, TypeError, ValueError) as exc:
+        raise CommercialBillingInvoicePDFConflictError(
+            f"Approved invoice {field} is invalid"
+        ) from exc
+    cents = decimal * Decimal(100)
+    if (
+        not decimal.is_finite()
+        or cents != cents.to_integral_value()
+        or (positive and decimal <= 0)
+    ):
+        raise CommercialBillingInvoicePDFConflictError(
+            f"Approved invoice {field} is invalid"
+        )
+    return decimal
+
+
+def _json_default(value: Any) -> str:
+    if isinstance(value, (date, datetime)):
+        return value.isoformat()
+    if isinstance(value, Decimal):
+        return format(value, "f")
+    if isinstance(value, UUID):
+        return str(value)
+    raise TypeError(f"Unsupported commercial billing PDF value: {type(value).__name__}")
+
+
+def _fingerprint(value: Mapping[str, Any]) -> str:
+    try:
+        encoded = json.dumps(
+            value,
+            default=_json_default,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise CommercialBillingInvoicePDFConflictError(
+            "Approved invoice render evidence is invalid"
+        ) from exc
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _validate_key(value: str, *, field: str, limit: int) -> str:
+    if not isinstance(value, str):
+        raise CommercialBillingInvoicePDFValidationError(f"{field} is required")
+    key = value.strip()
+    if not key or len(key) > limit:
+        raise CommercialBillingInvoicePDFValidationError(
+            f"{field} must contain 1 to {limit} characters"
+        )
+    return key
+
+
+def _render_snapshot(invoice: Mapping[str, Any]) -> dict[str, Any]:
+    """Derive the complete invoice field set read by ``render_invoice_pdf``.
+
+    Keeping this in one place means every later reuse compares the same
+    customer, line-item, money, date, note, metadata, and status values that
+    determine the generated document.
+    """
+
+    return {
+        "amount_due": invoice["amount_due"],
+        "contact_name": invoice["contact_name"],
+        "customer_address": invoice["customer_address"],
+        "customer_email": invoice["customer_email"],
+        "customer_name": invoice["customer_name"],
+        "customer_phone": invoice["customer_phone"],
+        "discount_amount": invoice["discount_amount"],
+        "due_date": invoice["due_date"],
+        "invoice_for": invoice["invoice_for"],
+        "invoice_number": invoice["invoice_number"],
+        "issue_date": invoice["issue_date"],
+        "line_items": invoice["line_items"],
+        "metadata": invoice["metadata"],
+        "notes": invoice["notes"],
+        "status": invoice["status"],
+        "subtotal": invoice["subtotal"],
+        "tax_amount": invoice["tax_amount"],
+        "total_amount": invoice["total_amount"],
+    }
+
+
+def _filename(invoice_number: str) -> str:
+    filename = f"{invoice_number}.pdf"
+    if len(filename) > 128:
+        raise CommercialBillingInvoicePDFConflictError(
+            "Approved invoice filename is invalid"
+        )
+    return filename
+
+
+class CommercialBillingInvoicePDFService:
+    """Create or reuse one immutable PDF artifact for an approved draft invoice."""
+
+    def __init__(
+        self,
+        *,
+        pool: Optional[DatabasePool] = None,
+        renderer: Callable[[dict[str, Any]], bytes] = render_invoice_pdf,
+        now: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
+    ) -> None:
+        self._configured_pool = pool
+        self._renderer = renderer
+        self._now = now
+
+    @property
+    def pool(self) -> DatabasePool:
+        pool = self._configured_pool or get_db_pool()
+        if not pool.is_initialized:
+            raise CommercialBillingInvoicePDFUnavailableError(
+                "Commercial billing database unavailable"
+            )
+        return pool
+
+    async def generate_or_reuse(
+        self,
+        *,
+        approval_id: UUID,
+        idempotency_key: str,
+        actor: str,
+    ) -> dict[str, Any]:
+        if not isinstance(approval_id, UUID):
+            raise CommercialBillingInvoicePDFValidationError("Approval id is invalid")
+        key = _validate_key(
+            idempotency_key,
+            field="Idempotency key",
+            limit=_MAX_IDEMPOTENCY_KEY_LENGTH,
+        )
+        requested_by = _required_text(actor, "authenticated actor", limit=128)
+        request_fingerprint = _fingerprint({"approvalId": str(approval_id)})
+        try:
+            async with self.pool.transaction() as conn:
+                await self._lock(conn, f"operation:{key}")
+                operation = await self._find_operation(conn, key)
+                if operation is not None:
+                    self._assert_operation(operation, request_fingerprint)
+                    return {
+                        "artifact": self._view(operation),
+                        "replayed": True,
+                        "reused": True,
+                    }
+
+                await self._lock(conn, f"approval:{approval_id}")
+                approved = await self._approved_invoice(conn, approval_id)
+                artifact = await self._find_artifact(conn, approval_id)
+                if artifact is not None:
+                    if artifact["render_fingerprint"] != approved.render_fingerprint:
+                        raise CommercialBillingInvoicePDFConflictError(
+                            "Approved invoice changed after PDF generation; resolve it before reuse"
+                        )
+                    await self._insert_operation(
+                        conn,
+                        artifact_id=_uuid(artifact["artifact_id"], "PDF artifact id"),
+                        idempotency_key=key,
+                        request_fingerprint=request_fingerprint,
+                        actor=requested_by,
+                    )
+                    return {
+                        "artifact": self._view(artifact),
+                        "replayed": False,
+                        "reused": True,
+                    }
+
+                pdf_bytes = self._render(approved.invoice)
+                artifact = await self._insert_artifact(
+                    conn,
+                    approved=approved,
+                    pdf_bytes=pdf_bytes,
+                    actor=requested_by,
+                )
+                await self._insert_operation(
+                    conn,
+                    artifact_id=_uuid(artifact["artifact_id"], "PDF artifact id"),
+                    idempotency_key=key,
+                    request_fingerprint=request_fingerprint,
+                    actor=requested_by,
+                )
+                return {
+                    "artifact": self._view(artifact),
+                    "replayed": False,
+                    "reused": False,
+                }
+        except CommercialBillingInvoicePDFError:
+            raise
+        except (asyncpg.UniqueViolationError, asyncpg.ForeignKeyViolationError) as exc:
+            raise CommercialBillingInvoicePDFConflictError(
+                "Commercial billing invoice PDF could not be reconciled"
+            ) from exc
+        except asyncpg.PostgresError as exc:
+            raise CommercialBillingInvoicePDFUnavailableError(
+                "Commercial billing database unavailable"
+            ) from exc
+        except _DATABASE_UNAVAILABLE_ERRORS as exc:
+            raise CommercialBillingInvoicePDFUnavailableError(
+                "Commercial billing database unavailable"
+            ) from exc
+
+    def _render(self, invoice: dict[str, Any]) -> bytes:
+        try:
+            value = self._renderer(invoice)
+        except Exception as exc:
+            raise CommercialBillingInvoicePDFRenderError(
+                "Approved invoice PDF could not be rendered; retry is safe"
+            ) from exc
+        if not isinstance(value, (bytes, bytearray)):
+            raise CommercialBillingInvoicePDFRenderError(
+                "Approved invoice PDF could not be rendered; retry is safe"
+            )
+        pdf_bytes = bytes(value)
+        if (
+            len(pdf_bytes) < 8
+            or len(pdf_bytes) > _MAX_ARTIFACT_BYTES
+            or not pdf_bytes.startswith(b"%PDF-")
+            or b"%%EOF" not in pdf_bytes[-1024:]
+        ):
+            raise CommercialBillingInvoicePDFRenderError(
+                "Approved invoice PDF could not be rendered; retry is safe"
+            )
+        return pdf_bytes
+
+    @staticmethod
+    async def _lock(conn: Any, scope: str) -> None:
+        await conn.fetchval(
+            "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+            f"commercial-billing-invoice-pdf:{scope}",
+        )
+
+    async def _approved_invoice(self, conn: Any, approval_id: UUID) -> _ApprovedInvoice:
+        row = await conn.fetchrow(
+            """
+            SELECT a.id AS approval_id, a.billing_run_id, a.candidate_key,
+                   a.source_fingerprint, a.state AS approval_state, a.invoice_id,
+                   i.id AS invoice_id, i.invoice_number, i.customer_name,
+                   i.customer_email, i.customer_phone, i.customer_address,
+                   i.line_items, i.subtotal, i.tax_amount, i.discount_amount,
+                   i.total_amount, i.amount_due, i.issue_date, i.due_date,
+                   i.status AS invoice_status, i.source AS invoice_source,
+                   i.notes, i.metadata, i.invoice_for, i.contact_name
+            FROM commercial_billing_candidate_approvals AS a
+            JOIN invoices AS i ON i.id = a.invoice_id
+            WHERE a.id = $1
+            """,
+            approval_id,
+        )
+        if row is None:
+            raise CommercialBillingInvoicePDFNotFoundError(
+                "Commercial billing approval not found"
+            )
+        approval_state = _required_text(row["approval_state"], "approval state", limit=32)
+        if approval_state != "invoice_created":
+            raise CommercialBillingInvoicePDFConflictError(
+                "Commercial billing approval is not ready for PDF generation"
+            )
+        source_fingerprint = _required_text(
+            row["source_fingerprint"], "source fingerprint", limit=64
+        )
+        if _FINGERPRINT.fullmatch(source_fingerprint) is None:
+            raise CommercialBillingInvoicePDFConflictError(
+                "Commercial billing approval evidence is invalid"
+            )
+        if _required_text(row["invoice_source"], "invoice source", limit=32) != _INVOICE_SOURCE:
+            raise CommercialBillingInvoicePDFConflictError(
+                "Approved invoice is not an EOM commercial billing invoice"
+            )
+        status = _required_text(row["invoice_status"], "invoice status", limit=32)
+        if status != "draft":
+            raise CommercialBillingInvoicePDFConflictError(
+                "Approved invoice is no longer a draft"
+            )
+
+        metadata = dict(_json_value(row["metadata"], "metadata", Mapping))
+        candidate_key = _required_text(row["candidate_key"], "candidate key", limit=512)
+        billing_run_id = _uuid(row["billing_run_id"], "billing run id")
+        if (
+            metadata.get("candidateKey") != candidate_key
+            or metadata.get("commercialBillingRunId") != str(billing_run_id)
+            or metadata.get("sourceFingerprint") != source_fingerprint
+        ):
+            raise CommercialBillingInvoicePDFConflictError(
+                "Approved invoice evidence no longer matches its approval"
+            )
+
+        invoice = {
+            "amount_due": _exact_money(row["amount_due"], "amount due"),
+            "contact_name": _optional_text(row["contact_name"], "contact name"),
+            "customer_address": _optional_text(row["customer_address"], "customer address"),
+            "customer_email": _optional_text(row["customer_email"], "customer email"),
+            "customer_name": _required_text(row["customer_name"], "customer name"),
+            "customer_phone": _optional_text(row["customer_phone"], "customer phone", limit=32),
+            "discount_amount": _exact_money(row["discount_amount"], "discount amount"),
+            "due_date": row["due_date"],
+            "invoice_for": _optional_text(row["invoice_for"], "invoice for"),
+            "invoice_number": _required_text(row["invoice_number"], "invoice number", limit=32),
+            "issue_date": row["issue_date"],
+            "line_items": _json_value(row["line_items"], "line items", list),
+            "metadata": metadata,
+            "notes": _optional_text(row["notes"], "notes", limit=10_000),
+            "status": status,
+            "subtotal": _exact_money(row["subtotal"], "subtotal"),
+            "tax_amount": _exact_money(row["tax_amount"], "tax amount"),
+            "total_amount": _exact_money(row["total_amount"], "total amount", positive=True),
+        }
+        return _ApprovedInvoice(
+            approval_id=_uuid(row["approval_id"], "approval id"),
+            invoice_id=_uuid(row["invoice_id"], "invoice id"),
+            invoice=invoice,
+            render_fingerprint=_fingerprint(_render_snapshot(invoice)),
+        )
+
+    @staticmethod
+    async def _find_operation(conn: Any, idempotency_key: str) -> Any | None:
+        row = await conn.fetchrow(
+            """
+            SELECT o.request_fingerprint AS operation_request_fingerprint,
+                   artifact.id AS artifact_id, artifact.approval_id,
+                   approval.invoice_id, artifact.artifact_kind, artifact.state,
+                   artifact.content_type, artifact.filename, artifact.byte_size,
+                   artifact.pdf_sha256, artifact.render_fingerprint,
+                   artifact.generated_by, artifact.generated_at
+            FROM commercial_billing_invoice_pdf_operations AS o
+            JOIN commercial_billing_invoice_pdf_artifacts AS artifact ON artifact.id = o.artifact_id
+            JOIN commercial_billing_candidate_approvals AS approval
+              ON approval.id = artifact.approval_id
+            WHERE o.source = $1 AND o.idempotency_key = $2
+            """,
+            _ARTIFACT_SOURCE,
+            idempotency_key,
+        )
+        return row
+
+    @staticmethod
+    async def _find_artifact(conn: Any, approval_id: UUID) -> Any | None:
+        return await conn.fetchrow(
+            """
+            SELECT artifact.id AS artifact_id, artifact.approval_id,
+                   approval.invoice_id, artifact.artifact_kind, artifact.state,
+                   artifact.content_type, artifact.filename, artifact.byte_size,
+                   artifact.pdf_sha256, artifact.render_fingerprint,
+                   artifact.generated_by, artifact.generated_at
+            FROM commercial_billing_invoice_pdf_artifacts AS artifact
+            JOIN commercial_billing_candidate_approvals AS approval
+              ON approval.id = artifact.approval_id
+            WHERE artifact.approval_id = $1
+            """,
+            approval_id,
+        )
+
+    @staticmethod
+    def _assert_operation(row: Any, request_fingerprint: str) -> None:
+        if row["operation_request_fingerprint"] != request_fingerprint:
+            raise CommercialBillingInvoicePDFConflictError(
+                "Idempotency key was already used with a different commercial billing approval"
+            )
+
+    async def _insert_artifact(
+        self,
+        conn: Any,
+        *,
+        approved: _ApprovedInvoice,
+        pdf_bytes: bytes,
+        actor: str,
+    ) -> Any:
+        now = self._now()
+        if not isinstance(now, datetime) or now.tzinfo is None:
+            raise CommercialBillingInvoicePDFUnavailableError(
+                "Commercial billing PDF clock is invalid"
+            )
+        row = await conn.fetchrow(
+            """
+            INSERT INTO commercial_billing_invoice_pdf_artifacts (
+                id, approval_id, artifact_kind, state, content_type,
+                filename, pdf_bytes, byte_size, pdf_sha256, render_fingerprint,
+                generated_by, generated_at, created_at
+            )
+            VALUES (
+                $1, $2, $3, 'ready', $4, $5, $6, $7, $8, $9, $10, $11, $11
+            )
+            RETURNING id AS artifact_id, approval_id, artifact_kind,
+                      state, content_type, filename, byte_size, pdf_sha256,
+                      render_fingerprint, generated_by, generated_at
+            """,
+            uuid4(),
+            approved.approval_id,
+            _ARTIFACT_KIND,
+            _CONTENT_TYPE,
+            _filename(_required_text(approved.invoice["invoice_number"], "invoice number", limit=32)),
+            pdf_bytes,
+            len(pdf_bytes),
+            hashlib.sha256(pdf_bytes).hexdigest(),
+            approved.render_fingerprint,
+            actor,
+            now,
+        )
+        if row is None:
+            raise CommercialBillingInvoicePDFUnavailableError(
+                "Commercial billing PDF artifact could not be reconciled"
+            )
+        return {**dict(row), "invoice_id": approved.invoice_id}
+
+    async def _insert_operation(
+        self,
+        conn: Any,
+        *,
+        artifact_id: UUID,
+        idempotency_key: str,
+        request_fingerprint: str,
+        actor: str,
+    ) -> None:
+        now = self._now()
+        if not isinstance(now, datetime) or now.tzinfo is None:
+            raise CommercialBillingInvoicePDFUnavailableError(
+                "Commercial billing PDF clock is invalid"
+            )
+        await conn.execute(
+            """
+            INSERT INTO commercial_billing_invoice_pdf_operations (
+                id, artifact_id, source, idempotency_key,
+                request_fingerprint, requested_by, requested_at, created_at
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $7)
+            """,
+            uuid4(),
+            artifact_id,
+            _ARTIFACT_SOURCE,
+            idempotency_key,
+            request_fingerprint,
+            actor,
+            now,
+        )
+
+    @staticmethod
+    def _view(row: Any) -> dict[str, Any]:
+        return {
+            "approvalId": str(row["approval_id"]),
+            "contentType": row["content_type"],
+            "filename": row["filename"],
+            "generatedAt": row["generated_at"].isoformat(),
+            "generatedBy": row["generated_by"],
+            "id": str(row["artifact_id"]),
+            "invoiceId": str(row["invoice_id"]),
+            "kind": row["artifact_kind"],
+            "renderFingerprint": row["render_fingerprint"],
+            "sha256": row["pdf_sha256"],
+            "sizeBytes": row["byte_size"],
+            "state": row["state"],
+        }
+
+
+def get_commercial_billing_invoice_pdf_service() -> CommercialBillingInvoicePDFService:
+    return CommercialBillingInvoicePDFService()
+
+
+__all__ = [
+    "CommercialBillingInvoicePDFConflictError",
+    "CommercialBillingInvoicePDFError",
+    "CommercialBillingInvoicePDFNotFoundError",
+    "CommercialBillingInvoicePDFRenderError",
+    "CommercialBillingInvoicePDFService",
+    "CommercialBillingInvoicePDFUnavailableError",
+    "CommercialBillingInvoicePDFValidationError",
+    "get_commercial_billing_invoice_pdf_service",
+]

--- a/atlas_brain/storage/migrations/373_commercial_billing_invoice_pdf_artifacts.sql
+++ b/atlas_brain/storage/migrations/373_commercial_billing_invoice_pdf_artifacts.sql
@@ -1,0 +1,65 @@
+-- Durable, immutable PDF artifacts for explicitly approved EOM commercial invoices.
+--
+-- This is additive.  It is intentionally separate from the financial approval
+-- transaction and from Gmail/Square delivery state: an artifact row means only
+-- that ATLAS retained one exact invoice PDF for a linked approved draft.
+--
+-- Rollback: stop the artifact route/service and retain the records.  Dropping
+-- PII-bearing invoice artifacts or their audit receipts is a separately
+-- authorized destructive retention action, never a mixed-version rollback.
+
+CREATE TABLE IF NOT EXISTS commercial_billing_invoice_pdf_artifacts (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    approval_id UUID NOT NULL UNIQUE
+        REFERENCES commercial_billing_candidate_approvals(id) ON DELETE RESTRICT,
+    artifact_kind VARCHAR(32) NOT NULL DEFAULT 'invoice_pdf',
+    state VARCHAR(32) NOT NULL DEFAULT 'ready',
+    content_type VARCHAR(128) NOT NULL DEFAULT 'application/pdf',
+    filename VARCHAR(128) NOT NULL,
+    pdf_bytes BYTEA NOT NULL,
+    byte_size INTEGER NOT NULL,
+    pdf_sha256 VARCHAR(64) NOT NULL,
+    render_fingerprint VARCHAR(64) NOT NULL,
+    generated_by VARCHAR(128) NOT NULL,
+    generated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT commercial_billing_invoice_pdf_artifacts_kind_check
+        CHECK (artifact_kind = 'invoice_pdf'),
+    CONSTRAINT commercial_billing_invoice_pdf_artifacts_state_check
+        CHECK (state = 'ready'),
+    CONSTRAINT commercial_billing_invoice_pdf_artifacts_content_type_check
+        CHECK (content_type = 'application/pdf'),
+    CONSTRAINT commercial_billing_invoice_pdf_artifacts_byte_size_check
+        CHECK (byte_size > 0 AND byte_size <= 10485760),
+    CONSTRAINT commercial_billing_invoice_pdf_artifacts_bytes_match_size_check
+        CHECK (octet_length(pdf_bytes) = byte_size),
+    CONSTRAINT commercial_billing_invoice_pdf_artifacts_sha256_check
+        CHECK (pdf_sha256 ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT commercial_billing_invoice_pdf_artifacts_render_fingerprint_check
+        CHECK (render_fingerprint ~ '^[0-9a-f]{64}$')
+);
+
+CREATE TABLE IF NOT EXISTS commercial_billing_invoice_pdf_operations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    artifact_id UUID NOT NULL
+        REFERENCES commercial_billing_invoice_pdf_artifacts(id) ON DELETE RESTRICT,
+    source VARCHAR(32) NOT NULL DEFAULT 'eom_admin',
+    idempotency_key VARCHAR(128) NOT NULL,
+    request_fingerprint VARCHAR(64) NOT NULL,
+    requested_by VARCHAR(128) NOT NULL,
+    requested_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT commercial_billing_invoice_pdf_operations_source_key
+        UNIQUE (source, idempotency_key),
+    CONSTRAINT commercial_billing_invoice_pdf_operations_request_fingerprint_check
+        CHECK (request_fingerprint ~ '^[0-9a-f]{64}$')
+);
+
+CREATE INDEX IF NOT EXISTS idx_commercial_billing_invoice_pdf_operations_artifact
+    ON commercial_billing_invoice_pdf_operations (artifact_id, requested_at DESC);
+
+COMMENT ON TABLE commercial_billing_invoice_pdf_artifacts IS
+    'One immutable ready PDF byte artifact per explicitly approved EOM commercial draft invoice; no delivery state.';
+
+COMMENT ON TABLE commercial_billing_invoice_pdf_operations IS
+    'Idempotent authenticated requests that created or reused approved commercial invoice PDF artifacts.';

--- a/plans/PR-EOM-Approved-Invoice-PDF-Artifact.md
+++ b/plans/PR-EOM-Approved-Invoice-PDF-Artifact.md
@@ -1,0 +1,268 @@
+# PR-EOM-Approved-Invoice-PDF-Artifact
+
+## Why this slice exists
+
+ATLAS PR #2381 deliberately stops after an explicit commercial-candidate
+approval creates one draft invoice.  It creates no PDF because the only current
+PDF callers are the legacy monthly/MCP flows, which combine disk writes with
+service markers, CRM activity, email, and/or sent state.  H-15 in the Billing &
+Payments deferred issue requires a durable, retry-safe PDF artifact before a
+later no-send Gmail-draft slice can attach one.
+
+Diff-budget override: The additive retention schema, transaction-locked exact
+byte writer, authenticated real route, and disposable-PostgreSQL
+render/failure/retry proof are one independently deployable provider behavior.
+Splitting them would publish either a PDF route without durable recovery or
+binary financial evidence without a safe authenticated operation boundary.
+
+### Problem-derived contract
+
+- Root cause: ATLAS has a pure in-memory `render_invoice_pdf()` renderer, but
+  no durable artifact identity or operation receipt for an invoice created by
+  an explicit commercial-billing approval.  Reusing the legacy callers would
+  introduce delivery and financial side effects into PDF generation.
+- Correct fix must touch/change: add one additive ATLAS artifact/operation
+  persistence contract, an exact approved-invoice PDF service, and an
+  authenticated receivables route.  It must lock/reconcile a request identity,
+  render only the linked EOM draft invoice, persist bytes plus immutable
+  render-input/hash evidence atomically, and expose only artifact metadata.
+  Tests must prove creation, unchanged replay, recovery after renderer or
+  transaction failure, same-approval reuse, changed-invoice rejection, and
+  route authentication.
+- Must not change: invoice content/branding, the existing renderer, legacy
+  MCP/monthly paths, invoice status, payment balances, billing-run candidate
+  evidence, Gmail drafts, email sending, CRM/service markers, Square state,
+  browser credentials, or any tracker/Website consumer.
+
+## Scope (this PR)
+
+Ownership lane: eom/billing-approved-gmail-drafts
+Slice phase: Vertical slice
+
+1. Add a durable `invoice_pdf` artifact with immutable SHA-256 and render-input
+   fingerprint, plus a separate idempotency/actor operation receipt keyed to
+   the already-approved invoice.
+2. Add `POST /receivables/commercial-billing-approvals/{approval_id}/invoice-pdf`.
+   The existing server-to-server token, actor header, and idempotency header are
+   required.  The response exposes metadata only; no PDF bytes or delivery
+   action cross the browser boundary.
+3. Generate a PDF only for the approval's `eom_commercial_billing` invoice
+   while it remains `draft`; replay returns the same artifact, and a fresh
+   request refuses a changed or non-draft invoice instead of silently attaching
+   stale money/customer data later.
+4. Keep failures recoverable: failed render or failed artifact/operation
+   insertion commits neither row, so the same key can retry; a committed
+   operation returns the original artifact without rendering again.
+
+### Review Contract
+
+- Acceptance criteria:
+  1. The service's advisory-lock transaction creates at most one artifact for
+     one approval, byte-hash/fingerprint evidence matches the renderer input,
+     and a same-key replay returns the original artifact without calling the
+     renderer again -- settled by
+     `tests/test_commercial_billing_approvals.py` service tests.
+  2. A failed renderer and an injected artifact/operation insert failure leave
+     no durable artifact or operation; retrying the identical request can
+     create exactly one ready artifact -- settled by the focused test and its
+     disposable PostgreSQL rollback assertion.
+  3. A new operation key may reuse an unchanged artifact without rerendering,
+     while changed render-input evidence or a non-draft invoice returns a
+     conflict before any artifact/operation insert -- settled by the focused
+     test's zero-write assertions.
+  4. The authenticated FastAPI route requires the existing bearer token,
+     `X-EOM-Actor`, and `Idempotency-Key`; the real full-application mount
+     (`atlas_brain.main.app -> /api/v1 -> receivables router`) invokes the
+     service and exposes artifact metadata only -- settled by the ASGI route
+     test with only the auth configuration and service dependency overridden.
+     The bounded idempotency-key validator is also checked against a
+     grammar-derived tokens/wrappers/families oracle without a database call.
+  5. The new service imports neither Gmail, email transport, the legacy monthly
+     task, CRM writer, nor service-marker writer, and it never updates invoice
+     status -- settled by the import/source contract test and SQL assertions.
+  6. The migration is additive, restricts one artifact to one approval (and
+     therefore its approval's unique invoice), keeps its references on
+     `ON DELETE RESTRICT`, and stores no
+     failed/delivery/sent state -- settled by migration contract and disposable
+     PostgreSQL tests.
+- Reachability proof: invoke the real mounted
+  `POST /api/v1/receivables/commercial-billing-approvals/{approval_id}/invoice-pdf`
+  route through `atlas_brain.main.app`; override only the existing receivables
+  auth configuration and PDF-service dependency, then assert the service
+  receives UUID, actor, and idempotency key and the response has no PDF-byte
+  field.
+- Affected surfaces: `atlas_brain/api/invoicing/receivables.py`, a new
+  `commercial_billing_invoice_pdfs` service, additive migration 373, the
+  existing `commercial_billing_candidate_approvals`/`invoices` tables, and the
+  existing explicit invoicing workflow test enrollment.
+- Risk areas: financial evidence linkage; exact cents/render input; durable
+  idempotency; partial transaction failures; non-draft/stale invoice reuse;
+  PII-bearing binary storage; auth; accidental delivery imports; additive
+  mixed-version deployment.
+- Reviewer rules triggered: R1, R2, R3, R4, R5, R6, R8, R10, R12, R13, R14.
+
+### Boundary-change enumeration
+
+- Boundary path/seam: authenticated receivables PDF-artifact route ->
+  `CommercialBillingInvoicePDFService.generate_or_reuse()` -> PostgreSQL
+  artifact/operation rows -> existing in-process renderer.
+- Replaced-path behaviors: none; legacy MCP/monthly file-write/send paths
+  remain callable and are deliberately not used.
+- Guard-relevant fields: approval UUID, idempotency key, authenticated actor,
+  exact approval/invoice linkage, `draft` status, renderer bytes, content hash,
+  and render-input fingerprint.
+- Caller x input shape: tracker is the future authenticated server caller;
+  this provider accepts UUID path identity plus bounded headers only.  Browser
+  clients do not receive ATLAS credentials or bytes.
+
+### Deployed-config probing
+
+N/A - no new environment/config fallback.  The artifact is PostgreSQL-owned
+instead of using the legacy configurable filesystem path, which avoids an
+unverified per-host storage dependency.  Deployment verification will use the
+existing protected route only with an unauthenticated rejection probe and a
+read-only schema/health check; it will not generate a real customer PDF.
+
+### Closure Declaration
+
+- **Approval/invoice state predicate — CLOSED / DERIVED:** allowed generation
+  membership is the existing approval row linked by foreign key to an invoice
+  whose source is `eom_commercial_billing` and whose status is exactly `draft`.
+  The service derives it from the joined database row rather than copying a
+  caller-provided vocabulary.  Any absent, mismatched, or non-draft member is
+  rejected before renderer or insert work because a stale or sent financial
+  artifact is costlier than a recoverable operator conflict.
+- **Artifact kind and MIME vocabulary — CLOSED / AUTHORED HERE:** this migration
+  creates only `invoice_pdf` / `application/pdf`; no unlisted artifact kind is
+  admitted.  The outside default is reject/no-write, preventing this PDF slice
+  from becoming a generic delivery state machine.
+- **Render-evidence field inventory — CLOSED / DERIVED:** the fingerprint is
+  built from precisely the invoice fields read by
+  `atlas_brain/services/invoice_pdf.py::render_invoice_pdf`; the service's
+  snapshot builder is the single derived choke point.  Any changed derived
+  fingerprint makes a fresh reuse request fail closed rather than silently
+  returning a PDF whose customer, line, total, date, or status no longer
+  matches ATLAS.
+- The renderer's bytes are in-process output, not an open user-input admission
+  classifier.  A bounded `%PDF-`/EOF/size sanity check only prevents persisting an
+  obviously invalid renderer result; it never chooses an external delivery
+  destination.  No trigger-A open-input classifier is introduced.
+
+### Files touched
+
+- `.github/workflows/atlas_invoicing_checks.yml`
+- `atlas_brain/api/invoicing/receivables.py`
+- `atlas_brain/services/commercial_billing_invoice_pdfs.py`
+- `atlas_brain/storage/migrations/373_commercial_billing_invoice_pdf_artifacts.sql`
+- `plans/PR-EOM-Approved-Invoice-PDF-Artifact.md`
+- `tests/test_commercial_billing_approvals.py`
+
+## Mechanism
+
+The service resolves the immutable approval-to-invoice foreign-key link inside
+one PostgreSQL transaction.  It takes an advisory lock for the idempotency key,
+then an approval lock.  A matching operation receipt returns its artifact;
+otherwise a matching artifact is reused only when the current derived render
+fingerprint still matches.  When no artifact exists, the service validates the
+draft invoice, invokes the existing exact-cent renderer inside the transaction,
+validates bounded PDF bytes, hashes them, inserts one immutable `BYTEA` row and
+one operation receipt, and returns metadata.
+
+The artifact and operation inserts share the same transaction.  Thus a database
+failure rolls both back, while an earlier renderer failure has no persistent
+effect and can be retried with the unchanged key.  Artifact bytes stay in the
+ATLAS financial database for future server-side Gmail attachment work; this
+slice adds neither a public download nor a delivery integration.
+
+### Execution model and invariant
+
+Every request executes in one PostgreSQL transaction.  It first takes a
+transaction-scoped advisory lock for its idempotency key and then one for the
+approval; PostgreSQL releases both locks on commit, rollback, cancellation, or
+connection loss.  The approval's unique artifact constraint is the durable
+backstop.  Across every interleaving admitted by those primitives, a committed
+approval has at most one artifact, each committed operation refers to that
+artifact, and a `(source, idempotency_key)` maps to exactly one approval
+fingerprint.  A crash or cancellation before commit leaves neither newly
+inserted row; after commit both rows are visible.  Same-key callers therefore
+replay one committed result, while concurrent different-key callers serialize
+on the approval and one reuses the finished artifact.  The real-PostgreSQL
+concurrency test holds the first renderer invocation inside its transaction,
+proves the second caller reaches and waits at the approval lock, then verifies
+one artifact, two receipts, and one render after release.
+
+## Intentional
+
+- PostgreSQL `BYTEA`, rather than the legacy `auto_invoice_save_path`, is the
+  durable artifact store: a per-worktree filesystem path cannot prove reuse or
+  survive provider cutovers, and it would not give a later Gmail writer one
+  audited source of attachment bytes.
+- A same-key replay returns its committed original even if someone later edits
+  the invoice; a new operation key detects that change and fails closed.  This
+  preserves idempotency while preventing a new delivery attempt from quietly
+  using obsolete financial content.
+- No status transition is added to `commercial_billing_candidate_approvals`.
+  The immutable artifact row is the PDF state; changing the approval lifecycle
+  now would entangle later Gmail, sent-mail, and Square recovery states.
+- Manual-Square draft invoices may have a PDF artifact because it is a private
+  ATLAS document action, not a delivery-channel inference.  This slice creates
+  no Square invoice/reference or sent state.
+
+## Deferred
+
+- H-15 / #2363: no-send Gmail draft identity, attachment recovery state,
+  verified sent-mail reconciliation, and manual Square sent action remain
+  separate provider slices.
+- An authenticated artifact download/read UI is deferred until the Website's
+  operator workflow has an accepted product-shape contract.  The future Gmail
+  provider can retrieve bytes server-side without exposing them to the browser.
+- Parking predicate: generic artifact formats, external object storage,
+  delivery-channel semantics, post-send correction workflows, and product PDF
+  redesign are parked by default.  They require another state machine or a
+  customer/operator-visible decision and are not needed to prove one durable
+  ATLAS PDF artifact.  Parked hardening: `HARDENING.md` "Isolate receivables
+  config failures from unrelated public routes" remains parked because it is a
+  pre-existing full-app startup-isolation concern, not an artifact behavior or
+  regression caused by this slice.
+
+## Verification
+
+- `python -m compileall -q atlas_brain/services/commercial_billing_invoice_pdfs.py
+  atlas_brain/api/invoicing/receivables.py tests/test_commercial_billing_approvals.py`
+  -- passed locally.
+- `python3.11 -m compileall -q atlas_brain/services/commercial_billing_invoice_pdfs.py
+  atlas_brain/api/invoicing/receivables.py tests/test_commercial_billing_approvals.py`
+  -- passed locally (workflow interpreter syntax check).
+- ruff check `atlas_brain/services/commercial_billing_invoice_pdfs.py`,
+  `atlas_brain/api/invoicing/receivables.py`, and
+  `tests/test_commercial_billing_approvals.py` -- passed locally.
+- `ATLAS_RECEIVABLES_TEST_DATABASE_URL=... python -m pytest -q
+  tests/test_commercial_billing_approvals.py` -- 78 passed using disposable
+  PostgreSQL 16 schemas; no live financial or email state was touched.
+- The exact three commands in `.github/workflows/atlas_invoicing_checks.yml`
+  passed locally: 2 approval-blocker tests (41 deselected), the nine-file
+  invoicing suite (exit 0), and the 43 MCP/OAuth surface tests.  The installed
+  local test stack is Python 3.13; the separate Python 3.11 compile check above
+  confirms source syntax but Python 3.11's pytest dependencies are not locally
+  installed.
+- `python scripts/maturity_sweep.py atlas_brain/api ...` with the workflow's
+  baseline and sensitive globs -- passed: `ratchet gate passed: no new
+  brittleness above baseline`.
+- Final local plan, diff-budget, reconciliation, and guard-closure checks passed
+  before push; the repository local-review wrapper remains the final pre-push
+  mechanical gate and records its receipt in the PR body.
+- Deployment: protected-route unauthenticated rejection plus read-only schema,
+  process cwd, and health checks only; no customer invoice, PDF, Gmail draft,
+  email, payment, or service marker will be created as a probe.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_invoicing_checks.yml` | 4 |
+| `atlas_brain/api/invoicing/receivables.py` | 59 |
+| `atlas_brain/services/commercial_billing_invoice_pdfs.py` | 592 |
+| `atlas_brain/storage/migrations/373_commercial_billing_invoice_pdf_artifacts.sql` | 65 |
+| `plans/PR-EOM-Approved-Invoice-PDF-Artifact.md` | 268 |
+| `tests/test_commercial_billing_approvals.py` | 576 |
+| **Total** | **1564** |

--- a/tests/test_commercial_billing_approvals.py
+++ b/tests/test_commercial_billing_approvals.py
@@ -2,14 +2,16 @@
 
 from __future__ import annotations
 
+import asyncio
 import ast
 import copy
 import hashlib
 import inspect
 import json
 import os
+import threading
 from contextlib import asynccontextmanager
-from datetime import date
+from datetime import date, datetime, timezone
 from decimal import Decimal
 from itertools import product
 from pathlib import Path
@@ -27,12 +29,59 @@ from atlas_brain.services.commercial_billing_approvals import (
     CommercialBillingApprovalUnavailableError,
     CommercialBillingApprovalValidationError,
 )
+from atlas_brain.services.commercial_billing_invoice_pdfs import (
+    CommercialBillingInvoicePDFConflictError,
+    CommercialBillingInvoicePDFRenderError,
+    CommercialBillingInvoicePDFService,
+    CommercialBillingInvoicePDFUnavailableError,
+    CommercialBillingInvoicePDFValidationError,
+    _validate_key,
+)
 
 
 def _fingerprint(value: object) -> str:
     return hashlib.sha256(
         json.dumps(value, sort_keys=True, separators=(",", ":"), allow_nan=False).encode()
     ).hexdigest()
+
+
+def _idempotency_key_oracle(value: object) -> bool:
+    """Specification-derived admission oracle for the bounded header key."""
+
+    return isinstance(value, str) and 1 <= len(value.strip()) <= 128
+
+
+def _idempotency_key_grammar_candidates():
+    """Generate tokens x wrappers x families rather than enumerating examples."""
+
+    for token, wrapper, family in product(
+        ("", "a", "a" * 128, "a" * 129, " "),
+        (
+            lambda value: value,
+            lambda value: [value],
+            lambda value: {"idempotency": value},
+            lambda value: (value,),
+        ),
+        (
+            lambda value: value,
+            lambda value: f" {value} ",
+            lambda value: f"\t{value}\n",
+        ),
+    ):
+        yield wrapper(family(token))
+
+
+@pytest.mark.parametrize("value", tuple(_idempotency_key_grammar_candidates()))
+def test_commercial_billing_invoice_pdfs_idempotency_key_matches_spec_derived_oracle(
+    value: object,
+):
+    """Every generated shape follows the key contract without a database call."""
+
+    if _idempotency_key_oracle(value):
+        assert _validate_key(value, field="Idempotency key", limit=128) == value.strip()
+    else:
+        with pytest.raises(CommercialBillingInvoicePDFValidationError):
+            _validate_key(value, field="Idempotency key", limit=128)
 
 
 def _candidate(
@@ -236,6 +285,7 @@ async def _approval_database():
             "047_invoice_extra_fields.sql",
             "370_commercial_billing_runs.sql",
             "372_commercial_billing_candidate_approvals.sql",
+            "373_commercial_billing_invoice_pdf_artifacts.sql",
         ):
             await connection.execute((migrations / name).read_text())
         yield connection, schema
@@ -540,6 +590,383 @@ async def test_real_postgres_rolls_back_the_invoice_when_approval_audit_insert_f
         ) == 0
 
 
+async def _create_approved_invoice(connection, schema: str) -> dict:
+    run_id, candidate = uuid4(), _candidate()
+    fingerprint = candidate["sourceFingerprint"]
+    await connection.execute(
+        "INSERT INTO contacts (id) VALUES ($1)",
+        UUID(candidate["customer"]["contactId"]),
+    )
+    await connection.execute(
+        """
+        INSERT INTO commercial_billing_runs (
+            id, billing_period, state, candidate_contract_version,
+            snapshot_fingerprint, source, idempotency_key,
+            request_fingerprint, created_by
+        ) VALUES ($1, '2026-03', 'draft', 2, $2, 'eom_admin', 'review-pdf', $2, 'Juan')
+        """,
+        run_id,
+        fingerprint,
+    )
+    await connection.execute(
+        """
+        INSERT INTO commercial_billing_run_candidates (
+            id, billing_run_id, candidate_key, source_fingerprint,
+            display_order, snapshot
+        ) VALUES ($1, $2, $3, $4, 0, $5::jsonb)
+        """,
+        uuid4(),
+        run_id,
+        candidate["candidateKey"],
+        fingerprint,
+        json.dumps(candidate),
+    )
+    result = await _service(
+        _SchemaPool(connection, schema), _CandidateService(candidate)
+    ).approve(
+        billing_run_id=run_id,
+        candidate_key=candidate["candidateKey"],
+        expected_source_fingerprint=fingerprint,
+        idempotency_key="approve-pdf",
+        actor="Juan",
+    )
+    return result["approval"]
+
+
+class _PDFRenderer:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+        self.failure: Exception | None = None
+        self.output = b"%PDF-1.7\nsynthetic commercial billing artifact\n%%EOF\n"
+
+    def __call__(self, invoice: dict) -> bytes:
+        self.calls.append(copy.deepcopy(invoice))
+        if self.failure is not None:
+            raise self.failure
+        return self.output
+
+
+class _BlockingPDFRenderer(_PDFRenderer):
+    """Hold one real service transaction while another caller reaches its lock."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.first_render_started = threading.Event()
+        self.release_first_render = threading.Event()
+        self._calls_lock = threading.Lock()
+
+    def __call__(self, invoice: dict) -> bytes:
+        with self._calls_lock:
+            call_number = len(self.calls) + 1
+            self.calls.append(copy.deepcopy(invoice))
+        if call_number == 1:
+            self.first_render_started.set()
+            if not self.release_first_render.wait(timeout=5):
+                raise RuntimeError("timed out waiting to release synthetic PDF render")
+        if self.failure is not None:
+            raise self.failure
+        return self.output
+
+
+class _IsolatedSchemaPool:
+    """Give concurrent service calls independent real PostgreSQL connections."""
+
+    def __init__(self, database_url: str, schema: str) -> None:
+        self.database_url = database_url
+        self.schema = schema
+
+    @property
+    def is_initialized(self) -> bool:
+        return True
+
+    @asynccontextmanager
+    async def transaction(self):
+        asyncpg = pytest.importorskip("asyncpg")
+        connection = await asyncpg.connect(self.database_url)
+        try:
+            await connection.execute(f'SET search_path TO "{self.schema}"')
+            async with connection.transaction():
+                yield connection
+        finally:
+            await connection.close()
+
+
+class _ApprovalLockObservingPDFService(CommercialBillingInvoicePDFService):
+    def __init__(self, *, approval_lock_started: threading.Event, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._approval_lock_started = approval_lock_started
+
+    async def _lock(self, conn, scope: str) -> None:
+        if scope.startswith("approval:"):
+            self._approval_lock_started.set()
+        await super()._lock(conn, scope)
+
+
+def _pdf_service(connection, schema: str, renderer: _PDFRenderer) -> CommercialBillingInvoicePDFService:
+    return CommercialBillingInvoicePDFService(
+        pool=_SchemaPool(connection, schema),
+        renderer=renderer,
+        now=lambda: datetime(2026, 4, 2, tzinfo=timezone.utc),
+    )
+
+
+@pytest.mark.asyncio
+async def test_real_postgres_pdf_artifact_is_immutable_idempotent_and_reusable():
+    async with _approval_database() as (connection, schema):
+        approval = await _create_approved_invoice(connection, schema)
+        renderer = _PDFRenderer()
+        service = _pdf_service(connection, schema, renderer)
+
+        created = await service.generate_or_reuse(
+            approval_id=UUID(approval["id"]), idempotency_key="pdf-1", actor="Juan"
+        )
+        replayed = await service.generate_or_reuse(
+            approval_id=UUID(approval["id"]), idempotency_key="pdf-1", actor="Juan"
+        )
+        reused = await service.generate_or_reuse(
+            approval_id=UUID(approval["id"]), idempotency_key="pdf-2", actor="Juan"
+        )
+
+        assert created["replayed"] is False
+        assert created["reused"] is False
+        assert created["artifact"]["state"] == "ready"
+        assert created["artifact"]["filename"] == "INV-2026-Mar-0001.pdf"
+        assert "pdfBytes" not in created["artifact"]
+        assert replayed == {**created, "replayed": True, "reused": True}
+        assert reused == {**created, "replayed": False, "reused": True}
+        assert len(renderer.calls) == 1
+
+        artifact = await connection.fetchrow(
+            "SELECT pdf_bytes, byte_size, pdf_sha256, render_fingerprint, generated_by "
+            "FROM commercial_billing_invoice_pdf_artifacts"
+        )
+        assert artifact["pdf_bytes"] == b"%PDF-1.7\nsynthetic commercial billing artifact\n%%EOF\n"
+        assert artifact["byte_size"] == len(artifact["pdf_bytes"])
+        assert artifact["pdf_sha256"] == hashlib.sha256(artifact["pdf_bytes"]).hexdigest()
+        assert artifact["render_fingerprint"] == created["artifact"]["renderFingerprint"]
+        assert artifact["generated_by"] == "Juan"
+        assert await connection.fetchval(
+            "SELECT COUNT(*) FROM commercial_billing_invoice_pdf_artifacts"
+        ) == 1
+        assert await connection.fetchval(
+            "SELECT COUNT(*) FROM commercial_billing_invoice_pdf_operations"
+        ) == 2
+
+
+@pytest.mark.asyncio
+async def test_real_postgres_pdf_artifact_serializes_concurrent_new_keys_per_approval():
+    """Every admitted distinct-key schedule creates one artifact and two receipts."""
+
+    async with _approval_database() as (connection, schema):
+        approval = await _create_approved_invoice(connection, schema)
+        approval_id = UUID(approval["id"])
+        database_url = os.environ["ATLAS_RECEIVABLES_TEST_DATABASE_URL"]
+        renderer = _BlockingPDFRenderer()
+        first_service = CommercialBillingInvoicePDFService(
+            pool=_IsolatedSchemaPool(database_url, schema),
+            renderer=renderer,
+            now=lambda: datetime(2026, 4, 2, tzinfo=timezone.utc),
+        )
+        second_approval_lock_started = threading.Event()
+        second_service = _ApprovalLockObservingPDFService(
+            pool=_IsolatedSchemaPool(database_url, schema),
+            renderer=renderer,
+            now=lambda: datetime(2026, 4, 2, tzinfo=timezone.utc),
+            approval_lock_started=second_approval_lock_started,
+        )
+
+        first = asyncio.create_task(
+            asyncio.to_thread(
+                lambda: asyncio.run(
+                    first_service.generate_or_reuse(
+                        approval_id=approval_id,
+                        idempotency_key="pdf-concurrent-1",
+                        actor="Juan",
+                    )
+                )
+            )
+        )
+        assert await asyncio.to_thread(renderer.first_render_started.wait, 2)
+        second = asyncio.create_task(
+            asyncio.to_thread(
+                lambda: asyncio.run(
+                    second_service.generate_or_reuse(
+                        approval_id=approval_id,
+                        idempotency_key="pdf-concurrent-2",
+                        actor="Juan",
+                    )
+                )
+            )
+        )
+        assert await asyncio.to_thread(second_approval_lock_started.wait, 2)
+        assert not second.done()
+
+        renderer.release_first_render.set()
+        first_result, second_result = await asyncio.gather(first, second)
+        assert {result["reused"] for result in (first_result, second_result)} == {False, True}
+        assert all(result["replayed"] is False for result in (first_result, second_result))
+        assert len(renderer.calls) == 1
+        assert await connection.fetchval(
+            "SELECT COUNT(*) FROM commercial_billing_invoice_pdf_artifacts"
+        ) == 1
+        assert await connection.fetchval(
+            "SELECT COUNT(*) FROM commercial_billing_invoice_pdf_operations"
+        ) == 2
+
+
+@pytest.mark.asyncio
+async def test_pdf_new_request_rejects_changed_or_non_draft_invoice_without_a_new_write():
+    async with _approval_database() as (connection, schema):
+        approval = await _create_approved_invoice(connection, schema)
+        renderer = _PDFRenderer()
+        service = _pdf_service(connection, schema, renderer)
+        created = await service.generate_or_reuse(
+            approval_id=UUID(approval["id"]), idempotency_key="pdf-change-1", actor="Juan"
+        )
+
+        await connection.execute(
+            "UPDATE invoices SET customer_name = 'Changed Office' WHERE id = $1",
+            UUID(approval["invoice"]["id"]),
+        )
+        with pytest.raises(CommercialBillingInvoicePDFConflictError):
+            await service.generate_or_reuse(
+                approval_id=UUID(approval["id"]),
+                idempotency_key="pdf-change-2",
+                actor="Juan",
+            )
+        replayed = await service.generate_or_reuse(
+            approval_id=UUID(approval["id"]),
+            idempotency_key="pdf-change-1",
+            actor="Juan",
+        )
+        assert replayed == {**created, "replayed": True, "reused": True}
+        assert len(renderer.calls) == 1
+        assert await connection.fetchval(
+            "SELECT COUNT(*) FROM commercial_billing_invoice_pdf_operations"
+        ) == 1
+
+    async with _approval_database() as (connection, schema):
+        approval = await _create_approved_invoice(connection, schema)
+        renderer = _PDFRenderer()
+        await connection.execute(
+            "UPDATE invoices SET status = 'sent' WHERE id = $1",
+            UUID(approval["invoice"]["id"]),
+        )
+        with pytest.raises(CommercialBillingInvoicePDFConflictError):
+            await _pdf_service(connection, schema, renderer).generate_or_reuse(
+                approval_id=UUID(approval["id"]),
+                idempotency_key="pdf-sent-1",
+                actor="Juan",
+            )
+        assert renderer.calls == []
+        assert await connection.fetchval(
+            "SELECT COUNT(*) FROM commercial_billing_invoice_pdf_artifacts"
+        ) == 0
+        assert await connection.fetchval(
+            "SELECT COUNT(*) FROM commercial_billing_invoice_pdf_operations"
+        ) == 0
+
+    async with _approval_database() as (connection, schema):
+        approval = await _create_approved_invoice(connection, schema)
+        renderer = _PDFRenderer()
+        await connection.execute(
+            "UPDATE invoices SET total_amount = 'NaN'::numeric WHERE id = $1",
+            UUID(approval["invoice"]["id"]),
+        )
+        with pytest.raises(CommercialBillingInvoicePDFConflictError):
+            await _pdf_service(connection, schema, renderer).generate_or_reuse(
+                approval_id=UUID(approval["id"]),
+                idempotency_key="pdf-nan-1",
+                actor="Juan",
+            )
+        assert renderer.calls == []
+        assert await connection.fetchval(
+            "SELECT COUNT(*) FROM commercial_billing_invoice_pdf_artifacts"
+        ) == 0
+        assert await connection.fetchval(
+            "SELECT COUNT(*) FROM commercial_billing_invoice_pdf_operations"
+        ) == 0
+
+
+@pytest.mark.asyncio
+async def test_pdf_render_and_operation_failures_leave_no_artifact_and_retry_safely():
+    async with _approval_database() as (connection, schema):
+        approval = await _create_approved_invoice(connection, schema)
+        renderer = _PDFRenderer()
+        renderer.failure = RuntimeError("synthetic renderer failure")
+        service = _pdf_service(connection, schema, renderer)
+
+        with pytest.raises(CommercialBillingInvoicePDFRenderError):
+            await service.generate_or_reuse(
+                approval_id=UUID(approval["id"]), idempotency_key="pdf-retry-1", actor="Juan"
+            )
+        assert await connection.fetchval(
+            "SELECT COUNT(*) FROM commercial_billing_invoice_pdf_artifacts"
+        ) == 0
+        assert await connection.fetchval(
+            "SELECT COUNT(*) FROM commercial_billing_invoice_pdf_operations"
+        ) == 0
+
+        renderer.failure = None
+        renderer.output = b"not a PDF"
+        with pytest.raises(CommercialBillingInvoicePDFRenderError):
+            await service.generate_or_reuse(
+                approval_id=UUID(approval["id"]), idempotency_key="pdf-retry-1", actor="Juan"
+            )
+        assert await connection.fetchval(
+            "SELECT COUNT(*) FROM commercial_billing_invoice_pdf_artifacts"
+        ) == 0
+        assert await connection.fetchval(
+            "SELECT COUNT(*) FROM commercial_billing_invoice_pdf_operations"
+        ) == 0
+
+        renderer.output = b"%PDF-1.7\nsynthetic commercial billing artifact\n%%EOF\n"
+        await connection.execute(
+            """
+            CREATE FUNCTION reject_commercial_billing_pdf_operation()
+            RETURNS trigger LANGUAGE plpgsql AS $$
+            BEGIN
+                RAISE EXCEPTION 'injected PDF operation failure';
+            END;
+            $$
+            """
+        )
+        await connection.execute(
+            """
+            CREATE TRIGGER reject_commercial_billing_pdf_operation_trigger
+            BEFORE INSERT ON commercial_billing_invoice_pdf_operations
+            FOR EACH ROW EXECUTE FUNCTION reject_commercial_billing_pdf_operation()
+            """
+        )
+        with pytest.raises(CommercialBillingInvoicePDFUnavailableError):
+            await service.generate_or_reuse(
+                approval_id=UUID(approval["id"]), idempotency_key="pdf-retry-1", actor="Juan"
+            )
+        assert await connection.fetchval(
+            "SELECT COUNT(*) FROM commercial_billing_invoice_pdf_artifacts"
+        ) == 0
+        assert await connection.fetchval(
+            "SELECT COUNT(*) FROM commercial_billing_invoice_pdf_operations"
+        ) == 0
+
+        await connection.execute(
+            "DROP TRIGGER reject_commercial_billing_pdf_operation_trigger "
+            "ON commercial_billing_invoice_pdf_operations"
+        )
+        await connection.execute("DROP FUNCTION reject_commercial_billing_pdf_operation()")
+        retried = await service.generate_or_reuse(
+            approval_id=UUID(approval["id"]), idempotency_key="pdf-retry-1", actor="Juan"
+        )
+        assert retried["replayed"] is False
+        assert retried["reused"] is False
+        assert await connection.fetchval(
+            "SELECT COUNT(*) FROM commercial_billing_invoice_pdf_artifacts"
+        ) == 1
+        assert await connection.fetchval(
+            "SELECT COUNT(*) FROM commercial_billing_invoice_pdf_operations"
+        ) == 1
+
+
 class _RouteService:
     def __init__(self) -> None:
         self.calls: list[dict] = []
@@ -549,7 +976,27 @@ class _RouteService:
         return {"approval": {"id": "approval-1"}, "replayed": False}
 
 
-def _route_app(service: _RouteService) -> tuple[FastAPI, str]:
+class _PDFRouteService:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def generate_or_reuse(self, **kwargs):
+        self.calls.append(kwargs)
+        return {
+            "artifact": {
+                "approvalId": str(kwargs["approval_id"]),
+                "id": "artifact-1",
+                "state": "ready",
+            },
+            "replayed": False,
+            "reused": False,
+        }
+
+
+def _route_app(
+    service: _RouteService,
+    pdf_service: _PDFRouteService | None = None,
+) -> tuple[FastAPI, str]:
     from atlas_brain.api.invoicing import auth as receivables_auth
     from atlas_brain.api.invoicing import receivables as routes
     from atlas_brain.eom_api.auth import generate_receivables_service_token
@@ -561,6 +1008,10 @@ def _route_app(service: _RouteService) -> tuple[FastAPI, str]:
         receivables_api_enabled=True, receivables_service_token="", receivables_service_token_sha256=generated.sha256,
     )
     app.dependency_overrides[routes.get_commercial_billing_approval_service] = lambda: service
+    if pdf_service is not None:
+        app.dependency_overrides[
+            routes.get_commercial_billing_invoice_pdf_service
+        ] = lambda: pdf_service
     return app, generated.token
 
 
@@ -579,6 +1030,60 @@ async def test_approval_route_requires_token_actor_fingerprint_and_idempotency_k
     assert service.calls == [{"billing_run_id": run_id, "candidate_key": body["candidate_key"], "expected_source_fingerprint": body["expected_source_fingerprint"], "idempotency_key": "route-1", "actor": "Juan"}]
 
 
+@pytest.mark.asyncio
+async def test_full_atlas_app_pdf_route_requires_token_actor_and_idempotency_without_returning_bytes():
+    """Exercise the live ``main.app -> /api/v1`` route registration chain."""
+
+    from atlas_brain.api.invoicing import auth as receivables_auth
+    from atlas_brain.api.invoicing import receivables as routes
+    from atlas_brain.eom_api.auth import generate_receivables_service_token
+    from atlas_brain.main import app
+
+    approval_id = uuid4()
+    service = _PDFRouteService()
+    generated = generate_receivables_service_token()
+    original_overrides = dict(app.dependency_overrides)
+    app.dependency_overrides[receivables_auth.get_receivables_api_config] = lambda: SimpleNamespace(
+        receivables_api_enabled=True,
+        receivables_service_token="",
+        receivables_service_token_sha256=generated.sha256,
+    )
+    app.dependency_overrides[routes.get_commercial_billing_invoice_pdf_service] = lambda: service
+    path = f"/api/v1/receivables/commercial-billing-approvals/{approval_id}/invoice-pdf"
+    headers = {"Authorization": f"Bearer {generated.token}"}
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            assert (await client.post(path)).status_code == 401
+            assert (await client.post(path, headers=headers)).status_code == 422
+            assert (
+                await client.post(
+                    path,
+                    headers={**headers, "Idempotency-Key": "route-pdf-1"},
+                )
+            ).status_code == 422
+            response = await client.post(
+                path,
+                headers={
+                    **headers,
+                    "Idempotency-Key": "route-pdf-1",
+                    "X-EOM-Actor": "Juan",
+                },
+            )
+    finally:
+        app.dependency_overrides.clear()
+        app.dependency_overrides.update(original_overrides)
+    assert response.status_code == 201
+    assert response.json()["artifact"] == {
+        "approvalId": str(approval_id), "id": "artifact-1", "state": "ready"
+    }
+    assert "pdf_bytes" not in response.text
+    assert service.calls == [
+        {"approval_id": approval_id, "idempotency_key": "route-pdf-1", "actor": "Juan"}
+    ]
+
+
 def test_approval_migration_is_additive_and_financially_restrictive():
     migration = (Path(__file__).parents[1] / "atlas_brain/storage/migrations/372_commercial_billing_candidate_approvals.sql").read_text()
     assert "CREATE TABLE IF NOT EXISTS commercial_billing_candidate_approvals" in migration
@@ -592,6 +1097,27 @@ def test_approval_migration_is_additive_and_financially_restrictive():
     assert "DROP TABLE" not in "\n".join(line for line in migration.splitlines() if not line.lstrip().startswith("--"))
 
 
+def test_pdf_artifact_migration_is_additive_and_financially_restrictive():
+    migration = (
+        Path(__file__).parents[1]
+        / "atlas_brain/storage/migrations/373_commercial_billing_invoice_pdf_artifacts.sql"
+    ).read_text()
+    assert "CREATE TABLE IF NOT EXISTS commercial_billing_invoice_pdf_artifacts" in migration
+    assert "CREATE TABLE IF NOT EXISTS commercial_billing_invoice_pdf_operations" in migration
+    assert migration.count("ON DELETE RESTRICT") == 2
+    assert "approval_id UUID NOT NULL UNIQUE" in migration
+    assert "invoice_id UUID" not in migration
+    assert "pdf_bytes BYTEA NOT NULL" in migration
+    assert "CHECK (state = 'ready')" in migration
+    assert "CHECK (octet_length(pdf_bytes) = byte_size)" in migration
+    assert "UNIQUE (source, idempotency_key)" in migration
+    executable = "\n".join(
+        line for line in migration.splitlines() if not line.lstrip().startswith("--")
+    )
+    assert "DROP TABLE" not in executable
+    assert not any(token in executable.lower() for token in ("gmail", "email", "sent_via"))
+
+
 def test_approval_service_does_not_import_delivery_or_legacy_monthly_writers():
     import atlas_brain.services.commercial_billing_approvals as approvals
 
@@ -601,11 +1127,57 @@ def test_approval_service_does_not_import_delivery_or_legacy_monthly_writers():
     assert "float(" not in inspect.getsource(approvals)
 
 
+def test_pdf_artifact_service_tracks_every_renderer_field_without_delivery_imports():
+    import atlas_brain.services.commercial_billing_invoice_pdfs as pdf_artifacts
+    from atlas_brain.services import invoice_pdf
+
+    renderer_fields = {
+        node.args[0].value
+        for node in ast.walk(ast.parse(inspect.getsource(invoice_pdf.render_invoice_pdf)))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "get"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "invoice"
+        and node.args
+        and isinstance(node.args[0], ast.Constant)
+        and isinstance(node.args[0].value, str)
+    }
+    snapshot = pdf_artifacts._render_snapshot(
+        {field: None for field in renderer_fields}
+    )
+    source = inspect.getsource(pdf_artifacts)
+    imports = {
+        alias.name
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    }
+    imports.update(
+        {
+            f"{node.module}.{alias.name}" if node.module else alias.name
+            for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.ImportFrom)
+            for alias in node.names
+        }
+    )
+    assert renderer_fields == set(snapshot)
+    assert not any(
+        fragment in imported
+        for fragment in {"gmail", "email_provider", "monthly_invoice_generation", "crm_provider"}
+        for imported in imports
+    )
+    assert "UPDATE invoices" not in source
+    assert "float(" not in source
+
+
 def test_invoicing_workflow_enrolls_the_approval_writer_and_contract():
     workflow = (Path(__file__).parents[1] / ".github/workflows/atlas_invoicing_checks.yml").read_text()
     for path in (
         "atlas_brain/services/commercial_billing_approvals.py",
         "atlas_brain/storage/migrations/372_commercial_billing_candidate_approvals.sql",
+        "atlas_brain/services/commercial_billing_invoice_pdfs.py",
+        "atlas_brain/storage/migrations/373_commercial_billing_invoice_pdf_artifacts.sql",
         "tests/test_commercial_billing_approvals.py",
     ):
         assert workflow.count(f'      - "{path}"') == 2


### PR DESCRIPTION
Plan: plans/PR-EOM-Approved-Invoice-PDF-Artifact.md
Slice phase: Vertical slice
Ownership lane: eom/billing-approved-gmail-drafts

ATLAS can now retain exactly one immutable PDF byte artifact for a draft invoice
created by an explicit commercial-billing approval. This is the narrow durable
provider foundation for a later no-send Gmail-draft slice; it does not create a
Gmail draft, send mail, mutate invoice status, write legacy PDF files, touch
CRM/service markers, or infer Square delivery.

## Intentional

- Store the artifact as ATLAS PostgreSQL `BYTEA`, not in the legacy configured
  filesystem path, so retry/reuse evidence survives provider cutovers and a
  later Gmail provider can retrieve attachment bytes without browser exposure.
- A same-key retry returns its original committed artifact even after a later
  invoice change; a fresh key refuses changed or non-draft evidence before any
  write. This preserves idempotency without silently reusing stale financial
  content.
- The immutable artifact is PDF state only. Gmail draft, sent-mail, Square
  reference, and delivery recovery remain separate state-machine slices.

## AI reconciliation

- no-findings

## Deferred

- H-15 / #2363: durable Gmail-draft identity and retries, verified sent-mail
  reconciliation, and the manual-Square sent action remain follow-on provider
  slices.
- An authenticated artifact download/UI waits for the Website operator workflow;
  future server-side Gmail attachment code can retrieve bytes without it.

## Parked hardening

- `HARDENING.md` "Isolate receivables config failures from unrelated public
  routes" remains parked: it is a pre-existing full-app startup-isolation
  concern, not an artifact behavior or regression introduced by this slice.

## Cold diff reconstruction

- Changed: `atlas_brain/storage/migrations/373_commercial_billing_invoice_pdf_artifacts.sql`
  adds additive, restrictive artifact and idempotency-receipt tables with one
  artifact per approval, exact byte-size/hash checks, and `ON DELETE RESTRICT`.
- Changed: `atlas_brain/services/commercial_billing_invoice_pdfs.py` uses one
  PostgreSQL transaction plus transaction-scoped advisory locks to validate the
  approval-linked draft invoice, derive renderer evidence, persist PDF bytes and
  operation receipt atomically, or safely replay/reuse a committed result.
- Changed: `atlas_brain/api/invoicing/receivables.py` exposes one existing-token
  protected route that returns metadata only and maps validation/not-found/
  conflict/retry-safe failure classes explicitly.
- Changed: `tests/test_commercial_billing_approvals.py` proves PostgreSQL
  creation, replay, different-key reuse, changed/sent/NaN rejection, malformed
  renderer output, transaction rollback/retry, concurrent different-key
  serialization, full-app route reachability, schema restrictions, renderer
  field coverage, and no delivery imports/status writes.
- Changed: `.github/workflows/atlas_invoicing_checks.yml` enrolls the new
  provider service and migration in both pull-request and main-path triggers.
- Changed: `plans/PR-EOM-Approved-Invoice-PDF-Artifact.md` records the review
  contract, execution model, deployment/rollback boundary, evidence, and the
  explicitly indivisible diff-budget decision.
- Contract match: every changed production path implements the durable artifact
  requirement; legacy MCP/monthly flows, invoice status, payment balances,
  Gmail/email, CRM/service markers, Square state, browser credentials, and PDF
  content remain untouched.
- Gaps: none found in the stated slice. No real customer record, email, Gmail
  draft, invoice send, payment, or service marker was exercised.

## Verification

- `python -m compileall -q atlas_brain/services/commercial_billing_invoice_pdfs.py atlas_brain/api/invoicing/receivables.py tests/test_commercial_billing_approvals.py` — passed.
- `python3.11 -m compileall -q atlas_brain/services/commercial_billing_invoice_pdfs.py atlas_brain/api/invoicing/receivables.py tests/test_commercial_billing_approvals.py` — passed.
- `ruff check atlas_brain/services/commercial_billing_invoice_pdfs.py atlas_brain/api/invoicing/receivables.py tests/test_commercial_billing_approvals.py` — passed.
- `ATLAS_RECEIVABLES_TEST_DATABASE_URL=... python -m pytest -q tests/test_commercial_billing_approvals.py` — 78 passed on disposable PostgreSQL 16 schemas.
- Exact local mirrors of `.github/workflows/atlas_invoicing_checks.yml` — 2 passed / 41 deselected for approval blockers; nine-file invoicing suite exit 0; 43 MCP/OAuth surface tests passed.
- `python scripts/maturity_sweep.py atlas_brain/api --tests-root tests --baseline tests/maturity_sweep/baseline_atlas_brain_api.json --min-score 8` with the workflow sensitive globs — passed: no new brittleness above baseline.
- `bash scripts/push_pr.sh /tmp/eom-approved-invoice-pdf-artifact-pr-body.md -u origin HEAD` — passed through the repository local review and full unit gate: 160 baseline failures, 0 regressions.

## Mechanical verification

- Command: `python scripts/sync_pr_plan.py --check plans/PR-EOM-Approved-Invoice-PDF-Artifact.md origin/main` - Result: passed - Environment: local
- Command: `git diff --check` - Result: passed - Environment: local
- Command: `python scripts/check_guard_class_closure.py --base origin/main --strict` - Result: passed - Environment: local
- Command: `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/eom-approved-invoice-pdf-artifact-pr-body.md` - Result: passed - Environment: local
- Skipped: Python 3.11 pytest execution - Reason: the local Python 3.11 interpreter has no pytest/runtime dependency environment; source compiled under 3.11 and the full local test stack ran under Python 3.13.

## Diff size

6 files, +1562 / -2

Diff-budget override: The additive retention schema, transaction-locked exact byte writer, authenticated real route, and disposable-PostgreSQL render/failure/retry proof are one independently deployable provider behavior. Splitting them would publish either a PDF route without durable recovery or binary financial evidence without a safe authenticated operation boundary.

<!-- atlas-open-pr-wrapper: v1 -->
