### PR TITLE
EOM: durable approved commercial Gmail drafts

### DIFF
--- a/.github/workflows/atlas_invoicing_checks.yml
+++ b/.github/workflows/atlas_invoicing_checks.yml
@@ -32,7 +32,9 @@ on:
       - "atlas_brain/services/commercial_billing_runs.py"
       - "atlas_brain/services/commercial_billing_approvals.py"
       - "atlas_brain/services/commercial_billing_invoice_pdfs.py"
+      - "atlas_brain/services/commercial_billing_invoice_gmail_drafts.py"
       - "atlas_brain/services/invoice_pdf.py"
+      - "atlas_brain/tools/gmail.py"
       # normalize_contact_email decides billing eligibility and the
       # address these routes return; a grammar change here must run
       # the billing proof.
@@ -46,6 +48,7 @@ on:
       - "atlas_brain/storage/migrations/371_eom_billing_delivery_preferences.sql"
       - "atlas_brain/storage/migrations/372_commercial_billing_candidate_approvals.sql"
       - "atlas_brain/storage/migrations/373_commercial_billing_invoice_pdf_artifacts.sql"
+      - "atlas_brain/storage/migrations/374_commercial_billing_invoice_gmail_drafts.sql"
       - "atlas_brain/storage/repositories/invoice.py"
       - "atlas_brain/templates/email/__init__.py"
       - "atlas_brain/templates/email/estimate_confirmation.py"
@@ -59,6 +62,7 @@ on:
       - "tests/test_commercial_billing_candidates.py"
       - "tests/test_commercial_billing_runs.py"
       - "tests/test_commercial_billing_approvals.py"
+      - "tests/test_commercial_billing_gmail_drafts.py"
       - "tests/test_invoicing_readonly_mcp.py"
       - "tests/test_invoicing_readonly_oauth.py"
       - "tests/test_invoicing_draft_writer_mcp.py"
@@ -95,7 +99,9 @@ on:
       - "atlas_brain/services/commercial_billing_runs.py"
       - "atlas_brain/services/commercial_billing_approvals.py"
       - "atlas_brain/services/commercial_billing_invoice_pdfs.py"
+      - "atlas_brain/services/commercial_billing_invoice_gmail_drafts.py"
       - "atlas_brain/services/invoice_pdf.py"
+      - "atlas_brain/tools/gmail.py"
       # normalize_contact_email decides billing eligibility and the
       # address these routes return; a grammar change here must run
       # the billing proof.
@@ -109,6 +115,7 @@ on:
       - "atlas_brain/storage/migrations/371_eom_billing_delivery_preferences.sql"
       - "atlas_brain/storage/migrations/372_commercial_billing_candidate_approvals.sql"
       - "atlas_brain/storage/migrations/373_commercial_billing_invoice_pdf_artifacts.sql"
+      - "atlas_brain/storage/migrations/374_commercial_billing_invoice_gmail_drafts.sql"
       - "atlas_brain/storage/repositories/invoice.py"
       - "atlas_brain/templates/email/__init__.py"
       - "atlas_brain/templates/email/estimate_confirmation.py"
@@ -122,6 +129,7 @@ on:
       - "tests/test_commercial_billing_candidates.py"
       - "tests/test_commercial_billing_runs.py"
       - "tests/test_commercial_billing_approvals.py"
+      - "tests/test_commercial_billing_gmail_drafts.py"
       - "tests/test_invoicing_readonly_mcp.py"
       - "tests/test_invoicing_readonly_oauth.py"
       - "tests/test_invoicing_draft_writer_mcp.py"
@@ -181,6 +189,7 @@ jobs:
             tests/test_commercial_billing_candidates.py \
             tests/test_commercial_billing_runs.py \
             tests/test_commercial_billing_approvals.py \
+            tests/test_commercial_billing_gmail_drafts.py \
             tests/test_invoice_repository.py \
             tests/test_invoice_pdf.py \
             -q

--- a/atlas_brain/api/invoicing/receivables.py
+++ b/atlas_brain/api/invoicing/receivables.py
@@ -57,6 +57,15 @@ from ...services.commercial_billing_invoice_pdfs import (
     CommercialBillingInvoicePDFValidationError,
     get_commercial_billing_invoice_pdf_service,
 )
+from ...services.commercial_billing_invoice_gmail_drafts import (
+    CommercialBillingGmailDraftConflictError,
+    CommercialBillingGmailDraftNotFoundError,
+    CommercialBillingGmailDraftRecoveryRequiredError,
+    CommercialBillingInvoiceGmailDraftService,
+    CommercialBillingGmailDraftUnavailableError,
+    CommercialBillingGmailDraftValidationError,
+    get_commercial_billing_invoice_gmail_draft_service,
+)
 from ...services.eom_lead_ingress import EOM_BUSINESS_CONTEXT_ID
 from ...storage.exceptions import DatabaseUnavailableError
 from .auth import require_actor, require_receivables_api
@@ -332,6 +341,44 @@ async def _call_commercial_billing_invoice_pdf(awaitable):
         raise HTTPException(
             status_code=503,
             detail={"code": exc.code, "message": str(exc)},
+        ) from exc
+
+
+async def _call_commercial_billing_gmail_draft(awaitable):
+    try:
+        return await awaitable
+    except CommercialBillingGmailDraftValidationError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail={"code": exc.code, "message": str(exc)},
+        ) from exc
+    except CommercialBillingGmailDraftNotFoundError as exc:
+        raise HTTPException(
+            status_code=404,
+            detail={"code": exc.code, "message": str(exc)},
+        ) from exc
+    except (
+        CommercialBillingGmailDraftConflictError,
+        CommercialBillingGmailDraftRecoveryRequiredError,
+    ) as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={"code": exc.code, "message": str(exc)},
+        ) from exc
+    except CommercialBillingGmailDraftUnavailableError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail={"code": exc.code, "message": str(exc)},
+        ) from exc
+    except Exception as exc:
+        if not _is_database_unavailable_error(exc):
+            raise
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "code": "commercial_billing_gmail_draft_unavailable",
+                "message": "Commercial billing Gmail draft database unavailable",
+            },
         ) from exc
 
 
@@ -654,6 +701,28 @@ async def generate_commercial_billing_invoice_pdf(
 
     return await _call_commercial_billing_invoice_pdf(
         service.generate_or_reuse(
+            approval_id=approval_id,
+            idempotency_key=idempotency_key,
+            actor=actor,
+        )
+    )
+
+
+@router.post("/commercial-billing-approvals/{approval_id}/gmail-draft", status_code=201)
+async def create_commercial_billing_invoice_gmail_draft(
+    approval_id: UUID,
+    actor: Annotated[str, Depends(require_actor)],
+    idempotency_key: Annotated[
+        str, Header(alias="Idempotency-Key", min_length=1, max_length=128)
+    ],
+    service: CommercialBillingInvoiceGmailDraftService = Depends(
+        get_commercial_billing_invoice_gmail_draft_service
+    ),
+) -> dict:
+    """Create, recover, or reuse one no-send Gmail draft for an approval PDF."""
+
+    return await _call_commercial_billing_gmail_draft(
+        service.create_or_reuse(
             approval_id=approval_id,
             idempotency_key=idempotency_key,
             actor=actor,

--- a/atlas_brain/services/commercial_billing_invoice_gmail_drafts.py
+++ b/atlas_brain/services/commercial_billing_invoice_gmail_drafts.py
@@ -1,0 +1,984 @@
+"""Durable no-send Gmail drafts for approved EOM commercial invoices.
+
+This service is the delivery boundary after an explicit commercial-billing
+approval and its immutable PDF artifact already exist.  It creates or recovers
+one Gmail *draft* only; it does not send mail, change an invoice status, write
+CRM/service evidence, or invoke Square.  Gmail has no caller-provided draft
+idempotency key, so an intent plus stable RFC Message-ID is committed before
+the external call.  An uncertain create is recovered by lookup, never retried
+as another create.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
+from typing import Any, Callable, Mapping, Optional, Protocol
+from uuid import UUID, uuid4
+
+import asyncpg
+
+from ..storage.database import DatabasePool, get_db_pool
+from ..storage.exceptions import DatabaseOperationError, DatabaseUnavailableError
+from ..templates.email.invoice import BUSINESS_NAME, render_invoice_html, render_invoice_text
+from ..tools.gmail import (
+    GmailDraftCreateError,
+    get_gmail_transport,
+)
+from .commercial_billing_invoice_pdfs import (
+    CommercialBillingInvoicePDFConflictError,
+    CommercialBillingInvoicePDFError,
+    CommercialBillingInvoicePDFNotFoundError,
+    CommercialBillingInvoicePDFService,
+    CommercialBillingInvoicePDFUnavailableError,
+    CommercialBillingInvoicePDFValidationError,
+    ReadyCommercialBillingInvoicePDFArtifact,
+)
+from .eom_crm_mutations import normalize_contact_email
+
+
+logger = logging.getLogger("atlas.services.commercial_billing_invoice_gmail_drafts")
+
+_DRAFT_SOURCE = "eom_admin"
+_DELIVERY_METHOD = "gmail_pdf"
+_MAX_IDEMPOTENCY_KEY_LENGTH = 128
+_MAX_ACTOR_LENGTH = 128
+_MAX_GMAIL_ID_LENGTH = 256
+_DRAFT_STATES = frozenset(
+    {"creating", "retryable", "recovery_required", "draft_created"}
+)
+_DATABASE_UNAVAILABLE_ERRORS = (
+    DatabaseOperationError,
+    DatabaseUnavailableError,
+    asyncpg.PostgresConnectionError,
+    asyncpg.CannotConnectNowError,
+    asyncpg.TooManyConnectionsError,
+    asyncpg.AdminShutdownError,
+    asyncpg.CrashShutdownError,
+    asyncpg.UndefinedTableError,
+    asyncpg.UndefinedColumnError,
+    asyncpg.InvalidSchemaNameError,
+    asyncpg.InsufficientPrivilegeError,
+    asyncpg.InvalidAuthorizationSpecificationError,
+)
+
+
+class CommercialBillingGmailDraftError(Exception):
+    code = "commercial_billing_gmail_draft_error"
+
+
+class CommercialBillingGmailDraftValidationError(CommercialBillingGmailDraftError):
+    code = "invalid_commercial_billing_gmail_draft"
+
+
+class CommercialBillingGmailDraftNotFoundError(CommercialBillingGmailDraftError):
+    code = "commercial_billing_gmail_draft_not_found"
+
+
+class CommercialBillingGmailDraftConflictError(CommercialBillingGmailDraftError):
+    code = "commercial_billing_gmail_draft_conflict"
+
+
+class CommercialBillingGmailDraftUnavailableError(CommercialBillingGmailDraftError):
+    code = "commercial_billing_gmail_draft_unavailable"
+
+
+class CommercialBillingGmailDraftRecoveryRequiredError(CommercialBillingGmailDraftError):
+    code = "commercial_billing_gmail_draft_recovery_required"
+
+
+class _GmailDraftGateway(Protocol):
+    async def create_draft(
+        self,
+        *,
+        to: list[str],
+        subject: str,
+        body: str,
+        attachments: list[dict[str, Any]],
+        html: str,
+        headers: Mapping[str, str],
+    ) -> dict[str, Any]: ...
+
+    async def find_draft_by_rfc_message_id(
+        self,
+        rfc_message_id: str,
+    ) -> dict[str, Any] | None: ...
+
+
+@dataclass(frozen=True)
+class _DraftContext:
+    artifact: ReadyCommercialBillingInvoicePDFArtifact
+    body: str
+    html: str
+    recipient_email: str
+    rfc_message_id: str
+    subject: str
+
+
+@dataclass(frozen=True)
+class _PreparedDraft:
+    context: _DraftContext | None
+    record: Mapping[str, Any]
+    replayed: bool
+    action: str
+
+
+def _request_text(value: Any, field: str, *, limit: int) -> str:
+    if not isinstance(value, str):
+        raise CommercialBillingGmailDraftValidationError(f"{field} is required")
+    text = value.strip()
+    if not text or len(text) > limit:
+        raise CommercialBillingGmailDraftValidationError(
+            f"{field} must contain 1 to {limit} characters"
+        )
+    return text
+
+
+def _stored_text(value: Any, field: str, *, limit: int) -> str:
+    if not isinstance(value, str):
+        raise CommercialBillingGmailDraftConflictError(
+            f"Commercial billing Gmail draft {field} is invalid"
+        )
+    text = value.strip()
+    if not text or len(text) > limit:
+        raise CommercialBillingGmailDraftConflictError(
+            f"Commercial billing Gmail draft {field} is invalid"
+        )
+    return text
+
+
+def _uuid(value: Any, field: str) -> UUID:
+    if isinstance(value, UUID):
+        return value
+    try:
+        return UUID(str(value))
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise CommercialBillingGmailDraftUnavailableError(
+            f"Commercial billing Gmail draft {field} is invalid"
+        ) from exc
+
+
+def _fingerprint(value: Mapping[str, Any]) -> str:
+    try:
+        encoded = json.dumps(
+            value, sort_keys=True, separators=(",", ":"), allow_nan=False
+        ).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise CommercialBillingGmailDraftValidationError(
+            "Commercial billing Gmail request is invalid"
+        ) from exc
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _rfc_message_id(approval_id: UUID) -> str:
+    """One stable mailbox-search identity per immutable approval record."""
+
+    return (
+        f"<atlas-eom-commercial-billing-{approval_id}"
+        "@effinghamofficemaids.com>"
+    )
+
+
+def _subject(invoice: Mapping[str, Any]) -> str:
+    invoice_number = _stored_text(
+        invoice.get("invoice_number"), "invoice number", limit=32
+    )
+    try:
+        total = Decimal(str(invoice.get("total_amount")))
+    except (InvalidOperation, TypeError, ValueError) as exc:
+        raise CommercialBillingGmailDraftConflictError(
+            "Approved invoice total is invalid"
+        ) from exc
+    cents = total * Decimal(100)
+    if not total.is_finite() or cents != cents.to_integral_value() or total <= 0:
+        raise CommercialBillingGmailDraftConflictError(
+            "Approved invoice total is invalid"
+        )
+    subject = f"Invoice {invoice_number} - {BUSINESS_NAME} - ${total:,.2f}"
+    if len(subject) > 512 or "\r" in subject or "\n" in subject:
+        raise CommercialBillingGmailDraftConflictError(
+            "Approved invoice email subject is invalid"
+        )
+    return subject
+
+
+def _gateway_identity(value: Any) -> dict[str, str]:
+    if not isinstance(value, Mapping):
+        raise CommercialBillingGmailDraftRecoveryRequiredError(
+            "Gmail draft response is invalid; recover it by its Message-ID"
+        )
+    message = value.get("message")
+    if not isinstance(message, Mapping):
+        raise CommercialBillingGmailDraftRecoveryRequiredError(
+            "Gmail draft response is invalid; recover it by its Message-ID"
+        )
+    fields = {
+        "gmail_draft_id": value.get("id"),
+        "gmail_message_id": message.get("id"),
+        "gmail_thread_id": message.get("threadId"),
+    }
+    result: dict[str, str] = {}
+    for field, raw in fields.items():
+        if not isinstance(raw, str):
+            raise CommercialBillingGmailDraftRecoveryRequiredError(
+                "Gmail draft response is invalid; recover it by its Message-ID"
+            )
+        normalized = raw.strip()
+        if (
+            not normalized
+            or len(normalized) > _MAX_GMAIL_ID_LENGTH
+            or "\r" in normalized
+            or "\n" in normalized
+            or "\x00" in normalized
+        ):
+            raise CommercialBillingGmailDraftRecoveryRequiredError(
+                "Gmail draft response is invalid; recover it by its Message-ID"
+            )
+        result[field] = normalized
+    return result
+
+
+class CommercialBillingInvoiceGmailDraftService:
+    """Create, recover, or reuse one no-send Gmail draft per approval/PDF."""
+
+    def __init__(
+        self,
+        *,
+        pool: Optional[DatabasePool] = None,
+        pdf_service: CommercialBillingInvoicePDFService | None = None,
+        gateway_loader: Callable[[], _GmailDraftGateway] = get_gmail_transport,
+        now: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
+    ) -> None:
+        self._configured_pool = pool
+        self._configured_pdf_service = pdf_service
+        self._gateway_loader = gateway_loader
+        self._now = now
+
+    @property
+    def pool(self) -> DatabasePool:
+        pool = self._configured_pool or get_db_pool()
+        if not pool.is_initialized:
+            raise CommercialBillingGmailDraftUnavailableError(
+                "Commercial billing database unavailable"
+            )
+        return pool
+
+    @property
+    def pdf_service(self) -> CommercialBillingInvoicePDFService:
+        return self._configured_pdf_service or CommercialBillingInvoicePDFService(
+            pool=self.pool
+        )
+
+    async def create_or_reuse(
+        self,
+        *,
+        approval_id: UUID,
+        idempotency_key: str,
+        actor: str,
+    ) -> dict[str, Any]:
+        """Create one Gmail draft, or recover/reuse its durable identity.
+
+        The external call is intentionally outside PostgreSQL transactions.  A
+        precommitted ``creating`` record is enough to make every later caller
+        reconcile the same RFC Message-ID before another create could occur.
+        """
+
+        if not isinstance(approval_id, UUID):
+            raise CommercialBillingGmailDraftValidationError("Approval id is invalid")
+        key = _request_text(
+            idempotency_key,
+            "Idempotency key",
+            limit=_MAX_IDEMPOTENCY_KEY_LENGTH,
+        )
+        requested_by = _request_text(actor, "authenticated actor", limit=_MAX_ACTOR_LENGTH)
+        request_fingerprint = _fingerprint({"approvalId": str(approval_id)})
+        try:
+            prepared = await self._prepare(
+                approval_id=approval_id,
+                idempotency_key=key,
+                request_fingerprint=request_fingerprint,
+                actor=requested_by,
+            )
+            if prepared.action == "return":
+                return {
+                    "draft": self._view(prepared.record),
+                    "replayed": prepared.replayed,
+                    "reused": True,
+                }
+            if prepared.action == "lookup":
+                return await self._recover(
+                    prepared=prepared,
+                    actor=requested_by,
+                )
+            if prepared.action != "create" or prepared.context is None:
+                raise CommercialBillingGmailDraftConflictError(
+                    "Commercial billing Gmail draft action is invalid"
+                )
+            return await self._create(
+                prepared=prepared,
+                actor=requested_by,
+            )
+        except CommercialBillingGmailDraftError:
+            raise
+        except CommercialBillingInvoicePDFValidationError as exc:
+            raise CommercialBillingGmailDraftValidationError(str(exc)) from exc
+        except CommercialBillingInvoicePDFNotFoundError as exc:
+            raise CommercialBillingGmailDraftNotFoundError(str(exc)) from exc
+        except CommercialBillingInvoicePDFConflictError as exc:
+            raise CommercialBillingGmailDraftConflictError(str(exc)) from exc
+        except CommercialBillingInvoicePDFUnavailableError as exc:
+            raise CommercialBillingGmailDraftUnavailableError(str(exc)) from exc
+        except CommercialBillingInvoicePDFError as exc:
+            raise CommercialBillingGmailDraftUnavailableError(str(exc)) from exc
+        except (asyncpg.UniqueViolationError, asyncpg.ForeignKeyViolationError) as exc:
+            raise CommercialBillingGmailDraftConflictError(
+                "Commercial billing Gmail draft could not be reconciled"
+            ) from exc
+        except asyncpg.PostgresError as exc:
+            raise CommercialBillingGmailDraftUnavailableError(
+                "Commercial billing database unavailable"
+            ) from exc
+        except _DATABASE_UNAVAILABLE_ERRORS as exc:
+            raise CommercialBillingGmailDraftUnavailableError(
+                "Commercial billing database unavailable"
+            ) from exc
+
+    async def _prepare(
+        self,
+        *,
+        approval_id: UUID,
+        idempotency_key: str,
+        request_fingerprint: str,
+        actor: str,
+    ) -> _PreparedDraft:
+        async with self.pool.transaction() as conn:
+            await self._lock(conn, f"operation:{idempotency_key}")
+            operation = await self._find_operation(conn, idempotency_key)
+            if operation is not None:
+                self._assert_operation(operation, approval_id, request_fingerprint)
+                state = self._state(operation)
+                if state == "draft_created":
+                    return _PreparedDraft(
+                        context=None,
+                        record=operation,
+                        replayed=True,
+                        action="return",
+                    )
+                await self._lock(conn, f"approval:{approval_id}")
+                if state == "retryable":
+                    context = await self._current_context(conn, approval_id)
+                    self._assert_context(operation, context)
+                    claimed = await self._claim_retryable(
+                        conn, _uuid(operation["id"], "record id"), actor
+                    )
+                    return _PreparedDraft(
+                        context=context,
+                        record=claimed,
+                        replayed=True,
+                        action="create",
+                    )
+                return _PreparedDraft(
+                    context=None,
+                    record=operation,
+                    replayed=True,
+                    action="lookup",
+                )
+
+            await self._lock(conn, f"approval:{approval_id}")
+            context = await self._current_context(conn, approval_id)
+            record = await self._find_record_for_approval(conn, approval_id)
+            if record is None:
+                record = await self._insert_record(conn, context, actor)
+                await self._insert_operation(
+                    conn,
+                    record_id=_uuid(record["id"], "record id"),
+                    idempotency_key=idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    actor=actor,
+                )
+                return _PreparedDraft(
+                    context=context,
+                    record=record,
+                    replayed=False,
+                    action="create",
+                )
+
+            self._assert_context(record, context)
+            await self._insert_operation(
+                conn,
+                record_id=_uuid(record["id"], "record id"),
+                idempotency_key=idempotency_key,
+                request_fingerprint=request_fingerprint,
+                actor=actor,
+            )
+            state = self._state(record)
+            if state == "draft_created":
+                return _PreparedDraft(
+                    context=None,
+                    record=record,
+                    replayed=False,
+                    action="return",
+                )
+            if state == "retryable":
+                claimed = await self._claim_retryable(
+                    conn, _uuid(record["id"], "record id"), actor
+                )
+                return _PreparedDraft(
+                    context=context,
+                    record=claimed,
+                    replayed=False,
+                    action="create",
+                )
+            return _PreparedDraft(
+                context=None,
+                record=record,
+                replayed=False,
+                action="lookup",
+            )
+
+    async def _create(
+        self,
+        *,
+        prepared: _PreparedDraft,
+        actor: str,
+    ) -> dict[str, Any]:
+        if prepared.context is None:
+            raise CommercialBillingGmailDraftConflictError(
+                "Commercial billing Gmail draft create context is invalid"
+            )
+        record_id = _uuid(prepared.record["id"], "record id")
+        try:
+            gateway = self._gateway_loader()
+        except Exception as exc:
+            await self._best_effort_transition(record_id, "retryable", actor)
+            raise CommercialBillingGmailDraftUnavailableError(
+                "Gmail draft transport is unavailable; retry is safe"
+            ) from exc
+        try:
+            result = await gateway.create_draft(
+                to=[prepared.context.recipient_email],
+                subject=prepared.context.subject,
+                body=prepared.context.body,
+                html=prepared.context.html,
+                attachments=[
+                    {
+                        "filename": prepared.context.artifact.filename,
+                        "content": base64.b64encode(
+                            prepared.context.artifact.pdf_bytes
+                        ).decode("ascii"),
+                    }
+                ],
+                headers={
+                    "Message-ID": prepared.context.rfc_message_id,
+                    "X-Atlas-Commercial-Billing-Approval": str(
+                        prepared.context.artifact.approval_id
+                    ),
+                    "X-Atlas-Commercial-Billing-Invoice": str(
+                        prepared.context.artifact.invoice_id
+                    ),
+                },
+            )
+        except GmailDraftCreateError as exc:
+            if exc.definitely_not_created:
+                await self._best_effort_transition(record_id, "retryable", actor)
+                raise CommercialBillingGmailDraftUnavailableError(
+                    "Gmail draft creation failed before acceptance; retry is safe"
+                ) from exc
+            await self._best_effort_transition(record_id, "recovery_required", actor)
+            raise CommercialBillingGmailDraftRecoveryRequiredError(
+                "Gmail draft creation outcome is uncertain; recover it by its Message-ID"
+            ) from exc
+        except Exception as exc:
+            await self._best_effort_transition(record_id, "recovery_required", actor)
+            raise CommercialBillingGmailDraftRecoveryRequiredError(
+                "Gmail draft creation outcome is uncertain; recover it by its Message-ID"
+            ) from exc
+
+        try:
+            identity = _gateway_identity(result)
+        except CommercialBillingGmailDraftRecoveryRequiredError as exc:
+            await self._best_effort_transition(record_id, "recovery_required", actor)
+            raise exc
+        try:
+            confirmed = await self._confirm_draft(record_id, identity, actor)
+        except CommercialBillingGmailDraftError:
+            raise
+        except Exception as exc:
+            await self._best_effort_transition(record_id, "recovery_required", actor)
+            raise CommercialBillingGmailDraftRecoveryRequiredError(
+                "Gmail draft may exist but confirmation failed; recover it by its Message-ID"
+            ) from exc
+        return {
+            "draft": self._view(confirmed),
+            "replayed": prepared.replayed,
+            "reused": False,
+        }
+
+    async def _recover(
+        self,
+        *,
+        prepared: _PreparedDraft,
+        actor: str,
+    ) -> dict[str, Any]:
+        record_id = _uuid(prepared.record["id"], "record id")
+        rfc_message_id = _stored_text(
+            prepared.record["rfc_message_id"], "RFC Message-ID", limit=320
+        )
+        try:
+            gateway = self._gateway_loader()
+            result = await gateway.find_draft_by_rfc_message_id(rfc_message_id)
+        except Exception as exc:
+            await self._best_effort_transition(record_id, "recovery_required", actor)
+            raise CommercialBillingGmailDraftRecoveryRequiredError(
+                "Gmail draft lookup failed; recover it by its Message-ID"
+            ) from exc
+        if result is None:
+            await self._best_effort_transition(record_id, "recovery_required", actor)
+            raise CommercialBillingGmailDraftRecoveryRequiredError(
+                "Gmail draft was not found; it may be missing or require reconciliation"
+            )
+        try:
+            identity = _gateway_identity(result)
+        except CommercialBillingGmailDraftRecoveryRequiredError as exc:
+            await self._best_effort_transition(record_id, "recovery_required", actor)
+            raise exc
+        try:
+            confirmed = await self._confirm_draft(record_id, identity, actor)
+        except CommercialBillingGmailDraftError:
+            raise
+        except Exception as exc:
+            await self._best_effort_transition(record_id, "recovery_required", actor)
+            raise CommercialBillingGmailDraftRecoveryRequiredError(
+                "Gmail draft was found but could not be confirmed; retry recovery"
+            ) from exc
+        return {
+            "draft": self._view(confirmed),
+            "replayed": prepared.replayed,
+            "reused": True,
+        }
+
+    async def _current_context(
+        self,
+        conn: Any,
+        approval_id: UUID,
+    ) -> _DraftContext:
+        artifact = await self.pdf_service.load_ready_artifact_for_delivery(
+            conn=conn,
+            approval_id=approval_id,
+        )
+        metadata = artifact.invoice.get("metadata")
+        if (
+            not isinstance(metadata, Mapping)
+            or metadata.get("deliveryMethod") != _DELIVERY_METHOD
+        ):
+            raise CommercialBillingGmailDraftConflictError(
+                "Approved invoice is not configured for Gmail PDF delivery"
+            )
+        recipient_email = normalize_contact_email(
+            artifact.invoice.get("customer_email")
+        )
+        if recipient_email is None:
+            raise CommercialBillingGmailDraftConflictError(
+                "Approved invoice billing recipient is invalid"
+            )
+        try:
+            body = render_invoice_text(artifact.invoice)
+            html = render_invoice_html(artifact.invoice)
+        except Exception as exc:
+            raise CommercialBillingGmailDraftUnavailableError(
+                "Approved invoice email could not be rendered"
+            ) from exc
+        if (
+            not isinstance(body, str)
+            or not body.strip()
+            or not isinstance(html, str)
+            or not html.strip()
+        ):
+            raise CommercialBillingGmailDraftUnavailableError(
+                "Approved invoice email could not be rendered"
+            )
+        return _DraftContext(
+            artifact=artifact,
+            body=body,
+            html=html,
+            recipient_email=recipient_email,
+            rfc_message_id=_rfc_message_id(artifact.approval_id),
+            subject=_subject(artifact.invoice),
+        )
+
+    @staticmethod
+    async def _lock(conn: Any, scope: str) -> None:
+        await conn.fetchval(
+            "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+            f"commercial-billing-invoice-gmail-draft:{scope}",
+        )
+
+    @staticmethod
+    async def _find_operation(conn: Any, idempotency_key: str) -> Any | None:
+        row = await conn.fetchrow(
+            """
+            SELECT operation.request_fingerprint AS operation_request_fingerprint,
+                   draft.id, draft.approval_id, draft.artifact_id, draft.state,
+                   draft.recipient_email, draft.subject, draft.rfc_message_id,
+                   draft.gmail_draft_id, draft.gmail_message_id,
+                   draft.gmail_thread_id, draft.created_by, draft.created_at,
+                   draft.last_attempt_by, draft.last_attempt_at,
+                   draft.draft_created_at, draft.recovery_required_at,
+                   approval.invoice_id
+            FROM commercial_billing_invoice_gmail_draft_operations AS operation
+            JOIN commercial_billing_invoice_gmail_drafts AS draft
+              ON draft.id = operation.gmail_draft_record_id
+            JOIN commercial_billing_candidate_approvals AS approval
+              ON approval.id = draft.approval_id
+            WHERE operation.source = $1 AND operation.idempotency_key = $2
+            """,
+            _DRAFT_SOURCE,
+            idempotency_key,
+        )
+        return dict(row) if row is not None else None
+
+    @staticmethod
+    async def _find_record_for_approval(conn: Any, approval_id: UUID) -> Any | None:
+        row = await conn.fetchrow(
+            """
+            SELECT draft.id, draft.approval_id, draft.artifact_id, draft.state,
+                   draft.recipient_email, draft.subject, draft.rfc_message_id,
+                   draft.gmail_draft_id, draft.gmail_message_id,
+                   draft.gmail_thread_id, draft.created_by, draft.created_at,
+                   draft.last_attempt_by, draft.last_attempt_at,
+                   draft.draft_created_at, draft.recovery_required_at,
+                   approval.invoice_id
+            FROM commercial_billing_invoice_gmail_drafts AS draft
+            JOIN commercial_billing_candidate_approvals AS approval
+              ON approval.id = draft.approval_id
+            WHERE draft.approval_id = $1
+            """,
+            approval_id,
+        )
+        return dict(row) if row is not None else None
+
+    async def _insert_record(
+        self,
+        conn: Any,
+        context: _DraftContext,
+        actor: str,
+    ) -> Any:
+        now = self._timestamp()
+        row = await conn.fetchrow(
+            """
+            INSERT INTO commercial_billing_invoice_gmail_drafts (
+                id, approval_id, artifact_id, state, recipient_email, subject,
+                rfc_message_id, created_by, created_at, last_attempt_by,
+                last_attempt_at
+            )
+            VALUES ($1, $2, $3, 'creating', $4, $5, $6, $7, $8, $7, $8)
+            RETURNING id, approval_id, artifact_id, state, recipient_email,
+                      subject, rfc_message_id, gmail_draft_id, gmail_message_id,
+                      gmail_thread_id, created_by, created_at, last_attempt_by,
+                      last_attempt_at, draft_created_at, recovery_required_at
+            """,
+            uuid4(),
+            context.artifact.approval_id,
+            context.artifact.artifact_id,
+            context.recipient_email,
+            context.subject,
+            context.rfc_message_id,
+            actor,
+            now,
+        )
+        if row is None:
+            raise CommercialBillingGmailDraftUnavailableError(
+                "Commercial billing Gmail draft intent could not be reconciled"
+            )
+        return {**dict(row), "invoice_id": context.artifact.invoice_id}
+
+    async def _insert_operation(
+        self,
+        conn: Any,
+        *,
+        record_id: UUID,
+        idempotency_key: str,
+        request_fingerprint: str,
+        actor: str,
+    ) -> None:
+        now = self._timestamp()
+        await conn.execute(
+            """
+            INSERT INTO commercial_billing_invoice_gmail_draft_operations (
+                id, gmail_draft_record_id, source, idempotency_key,
+                request_fingerprint, requested_by, requested_at, created_at
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $7)
+            """,
+            uuid4(),
+            record_id,
+            _DRAFT_SOURCE,
+            idempotency_key,
+            request_fingerprint,
+            actor,
+            now,
+        )
+
+    async def _claim_retryable(self, conn: Any, record_id: UUID, actor: str) -> Any:
+        now = self._timestamp()
+        row = await conn.fetchrow(
+            """
+            UPDATE commercial_billing_invoice_gmail_drafts
+               SET state = 'creating', last_attempt_by = $2, last_attempt_at = $3,
+                   recovery_required_at = NULL
+             WHERE id = $1 AND state = 'retryable'
+            RETURNING id, approval_id, artifact_id, state, recipient_email,
+                      subject, rfc_message_id, gmail_draft_id, gmail_message_id,
+                      gmail_thread_id, created_by, created_at, last_attempt_by,
+                      last_attempt_at, draft_created_at, recovery_required_at
+            """,
+            record_id,
+            actor,
+            now,
+        )
+        if row is None:
+            raise CommercialBillingGmailDraftConflictError(
+                "Commercial billing Gmail draft retry could not be claimed"
+            )
+        return dict(row)
+
+    async def _confirm_draft(
+        self,
+        record_id: UUID,
+        identity: Mapping[str, str],
+        actor: str,
+    ) -> Any:
+        now = self._timestamp()
+        async with self.pool.transaction() as conn:
+            record = await self._find_record_for_id(conn, record_id)
+            if record is None:
+                raise CommercialBillingGmailDraftUnavailableError(
+                    "Commercial billing Gmail draft intent is unavailable"
+                )
+            approval_id = _uuid(record["approval_id"], "approval id")
+            await self._lock(conn, f"approval:{approval_id}")
+            record = await self._find_record_for_id(conn, record_id)
+            if record is None:
+                raise CommercialBillingGmailDraftUnavailableError(
+                    "Commercial billing Gmail draft intent is unavailable"
+                )
+            state = self._state(record)
+            if state == "draft_created":
+                if all(record[field] == identity[field] for field in identity):
+                    return record
+                raise CommercialBillingGmailDraftConflictError(
+                    "Commercial billing Gmail draft identity conflicts with a prior result"
+                )
+            row = await conn.fetchrow(
+                """
+                UPDATE commercial_billing_invoice_gmail_drafts
+                   SET state = 'draft_created', gmail_draft_id = $2,
+                       gmail_message_id = $3, gmail_thread_id = $4,
+                       last_attempt_by = $5, last_attempt_at = $6,
+                       draft_created_at = $6, recovery_required_at = NULL
+                 WHERE id = $1 AND state IN ('creating', 'retryable', 'recovery_required')
+                RETURNING id, approval_id, artifact_id, state, recipient_email,
+                          subject, rfc_message_id, gmail_draft_id, gmail_message_id,
+                          gmail_thread_id, created_by, created_at, last_attempt_by,
+                          last_attempt_at, draft_created_at, recovery_required_at
+                """,
+                record_id,
+                identity["gmail_draft_id"],
+                identity["gmail_message_id"],
+                identity["gmail_thread_id"],
+                actor,
+                now,
+            )
+            if row is None:
+                raise CommercialBillingGmailDraftConflictError(
+                    "Commercial billing Gmail draft could not be confirmed"
+                )
+            return {**dict(row), "invoice_id": record["invoice_id"]}
+
+    @staticmethod
+    async def _find_record_for_id(conn: Any, record_id: UUID) -> Any | None:
+        row = await conn.fetchrow(
+            """
+            SELECT draft.id, draft.approval_id, draft.artifact_id, draft.state,
+                   draft.recipient_email, draft.subject, draft.rfc_message_id,
+                   draft.gmail_draft_id, draft.gmail_message_id,
+                   draft.gmail_thread_id, draft.created_by, draft.created_at,
+                   draft.last_attempt_by, draft.last_attempt_at,
+                   draft.draft_created_at, draft.recovery_required_at,
+                   approval.invoice_id
+            FROM commercial_billing_invoice_gmail_drafts AS draft
+            JOIN commercial_billing_candidate_approvals AS approval
+              ON approval.id = draft.approval_id
+            WHERE draft.id = $1
+            """,
+            record_id,
+        )
+        return dict(row) if row is not None else None
+
+    async def _best_effort_transition(
+        self,
+        record_id: UUID,
+        state: str,
+        actor: str,
+    ) -> None:
+        """Record recovery evidence without masking the original transport error."""
+
+        try:
+            now = self._timestamp()
+            async with self.pool.transaction() as conn:
+                record = await self._find_record_for_id(conn, record_id)
+                if record is None or self._state(record) == "draft_created":
+                    return
+                approval_id = _uuid(record["approval_id"], "approval id")
+                await self._lock(conn, f"approval:{approval_id}")
+                if state == "retryable":
+                    await conn.execute(
+                        """
+                        UPDATE commercial_billing_invoice_gmail_drafts
+                           SET state = 'retryable', last_attempt_by = $2,
+                               last_attempt_at = $3, recovery_required_at = NULL
+                         WHERE id = $1 AND state = 'creating'
+                        """,
+                        record_id,
+                        actor,
+                        now,
+                    )
+                elif state == "recovery_required":
+                    await conn.execute(
+                        """
+                        UPDATE commercial_billing_invoice_gmail_drafts
+                           SET state = 'recovery_required', last_attempt_by = $2,
+                               last_attempt_at = $3, recovery_required_at = $3
+                         WHERE id = $1
+                           AND state IN ('creating', 'retryable', 'recovery_required')
+                        """,
+                        record_id,
+                        actor,
+                        now,
+                    )
+                else:
+                    raise CommercialBillingGmailDraftConflictError(
+                        "Commercial billing Gmail draft recovery state is invalid"
+                    )
+        except Exception:
+            logger.warning(
+                "Commercial billing Gmail draft %s could not record %s recovery state",
+                record_id,
+                state,
+                exc_info=True,
+            )
+
+    @staticmethod
+    def _assert_operation(
+        operation: Mapping[str, Any],
+        approval_id: UUID,
+        request_fingerprint: str,
+    ) -> None:
+        if operation.get("operation_request_fingerprint") != request_fingerprint:
+            raise CommercialBillingGmailDraftConflictError(
+                "Idempotency key was already used with a different commercial billing approval"
+            )
+        if _uuid(operation.get("approval_id"), "approval id") != approval_id:
+            raise CommercialBillingGmailDraftConflictError(
+                "Idempotency key was already used with a different commercial billing approval"
+            )
+
+    @staticmethod
+    def _assert_context(record: Mapping[str, Any], context: _DraftContext) -> None:
+        expected = {
+            "approval_id": context.artifact.approval_id,
+            "artifact_id": context.artifact.artifact_id,
+            "recipient_email": context.recipient_email,
+            "subject": context.subject,
+            "rfc_message_id": context.rfc_message_id,
+        }
+        for field, value in expected.items():
+            if record.get(field) != value:
+                raise CommercialBillingGmailDraftConflictError(
+                    "Commercial billing Gmail draft intent no longer matches its approval PDF"
+                )
+
+    @staticmethod
+    def _state(record: Mapping[str, Any]) -> str:
+        state = _stored_text(record.get("state"), "state", limit=32)
+        if state not in _DRAFT_STATES:
+            raise CommercialBillingGmailDraftConflictError(
+                "Commercial billing Gmail draft state is invalid"
+            )
+        return state
+
+    def _timestamp(self) -> datetime:
+        value = self._now()
+        if not isinstance(value, datetime) or value.tzinfo is None:
+            raise CommercialBillingGmailDraftUnavailableError(
+                "Commercial billing Gmail draft clock is invalid"
+            )
+        return value
+
+    @staticmethod
+    def _view(record: Mapping[str, Any]) -> dict[str, Any]:
+        state = CommercialBillingInvoiceGmailDraftService._state(record)
+        created_at = record.get("created_at")
+        last_attempt_at = record.get("last_attempt_at")
+        if not isinstance(created_at, datetime) or not isinstance(last_attempt_at, datetime):
+            raise CommercialBillingGmailDraftUnavailableError(
+                "Commercial billing Gmail draft timestamps are invalid"
+            )
+        result = {
+            "approvalId": str(_uuid(record.get("approval_id"), "approval id")),
+            "artifactId": str(_uuid(record.get("artifact_id"), "artifact id")),
+            "createdAt": created_at.isoformat(),
+            "createdBy": _stored_text(record.get("created_by"), "creator", limit=128),
+            "gmailDraftId": record.get("gmail_draft_id"),
+            "gmailMessageId": record.get("gmail_message_id"),
+            "gmailThreadId": record.get("gmail_thread_id"),
+            "id": str(_uuid(record.get("id"), "record id")),
+            "invoiceId": str(_uuid(record.get("invoice_id"), "invoice id")),
+            "lastAttemptAt": last_attempt_at.isoformat(),
+            "lastAttemptBy": _stored_text(
+                record.get("last_attempt_by"), "last attempt actor", limit=128
+            ),
+            "recipientEmail": _stored_text(
+                record.get("recipient_email"), "recipient", limit=256
+            ),
+            "rfcMessageId": _stored_text(
+                record.get("rfc_message_id"), "RFC Message-ID", limit=320
+            ),
+            "state": state,
+            "subject": _stored_text(record.get("subject"), "subject", limit=512),
+        }
+        for field, key in (
+            ("draft_created_at", "draftCreatedAt"),
+            ("recovery_required_at", "recoveryRequiredAt"),
+        ):
+            value = record.get(field)
+            if value is not None:
+                if not isinstance(value, datetime):
+                    raise CommercialBillingGmailDraftUnavailableError(
+                        "Commercial billing Gmail draft timestamps are invalid"
+                    )
+                result[key] = value.isoformat()
+            else:
+                result[key] = None
+        return result
+
+
+def get_commercial_billing_invoice_gmail_draft_service() -> CommercialBillingInvoiceGmailDraftService:
+    return CommercialBillingInvoiceGmailDraftService()
+
+
+__all__ = [
+    "CommercialBillingGmailDraftConflictError",
+    "CommercialBillingGmailDraftError",
+    "CommercialBillingGmailDraftNotFoundError",
+    "CommercialBillingGmailDraftRecoveryRequiredError",
+    "CommercialBillingGmailDraftUnavailableError",
+    "CommercialBillingGmailDraftValidationError",
+    "CommercialBillingInvoiceGmailDraftService",
+    "get_commercial_billing_invoice_gmail_draft_service",
+]

--- a/atlas_brain/services/commercial_billing_invoice_pdfs.py
+++ b/atlas_brain/services/commercial_billing_invoice_pdfs.py
@@ -79,6 +79,27 @@ class _ApprovedInvoice:
     render_fingerprint: str
 
 
+@dataclass(frozen=True)
+class ReadyCommercialBillingInvoicePDFArtifact:
+    """One verified stored artifact for a server-side delivery transition.
+
+    The raw bytes intentionally remain an internal service result.  Public
+    receivables routes continue to expose metadata only; a later server-side
+    delivery service may attach the verified bytes without exposing them to a
+    browser or trusting a caller-supplied file.
+    """
+
+    approval_id: UUID
+    artifact_id: UUID
+    invoice_id: UUID
+    content_type: str
+    filename: str
+    pdf_bytes: bytes
+    pdf_sha256: str
+    render_fingerprint: str
+    invoice: dict[str, Any]
+
+
 def _text(value: Any) -> str | None:
     return value if isinstance(value, str) else None
 
@@ -325,6 +346,80 @@ class CommercialBillingInvoicePDFService:
                 "Commercial billing database unavailable"
             ) from exc
 
+    async def load_ready_artifact_for_delivery(
+        self,
+        *,
+        conn: Any,
+        approval_id: UUID,
+    ) -> ReadyCommercialBillingInvoicePDFArtifact:
+        """Read one unchanged ready artifact for a server-side delivery step.
+
+        The caller owns the surrounding transaction and approval lock.  Keeping
+        the read inside that transaction makes the approval/invoice evidence,
+        immutable artifact fingerprint, and eventual external-delivery intent
+        one preflight decision rather than a read-then-write race.  This method
+        never renders, inserts, updates, or exposes bytes through a route.
+        """
+
+        if not isinstance(approval_id, UUID):
+            raise CommercialBillingInvoicePDFValidationError("Approval id is invalid")
+        approved = await self._approved_invoice(conn, approval_id)
+        artifact = await self._find_artifact_with_bytes(conn, approval_id)
+        if artifact is None:
+            raise CommercialBillingInvoicePDFConflictError(
+                "Approved invoice PDF has not been generated"
+            )
+        if artifact["render_fingerprint"] != approved.render_fingerprint:
+            raise CommercialBillingInvoicePDFConflictError(
+                "Approved invoice changed after PDF generation; resolve it before delivery"
+            )
+        artifact_kind = _required_text(artifact["artifact_kind"], "PDF artifact kind", limit=32)
+        state = _required_text(artifact["state"], "PDF artifact state", limit=32)
+        content_type = _required_text(
+            artifact["content_type"], "PDF artifact content type", limit=128
+        )
+        filename = _required_text(artifact["filename"], "PDF artifact filename", limit=128)
+        sha256 = _required_text(artifact["pdf_sha256"], "PDF artifact hash", limit=64)
+        if (
+            artifact_kind != _ARTIFACT_KIND
+            or state != "ready"
+            or content_type != _CONTENT_TYPE
+            or _FINGERPRINT.fullmatch(sha256) is None
+        ):
+            raise CommercialBillingInvoicePDFConflictError(
+                "Approved invoice PDF artifact is invalid"
+            )
+        raw_bytes = artifact["pdf_bytes"]
+        if not isinstance(raw_bytes, (bytes, bytearray, memoryview)):
+            raise CommercialBillingInvoicePDFConflictError(
+                "Approved invoice PDF artifact is invalid"
+            )
+        pdf_bytes = bytes(raw_bytes)
+        size = artifact["byte_size"]
+        if (
+            not isinstance(size, int)
+            or size != len(pdf_bytes)
+            or len(pdf_bytes) < 8
+            or len(pdf_bytes) > _MAX_ARTIFACT_BYTES
+            or not pdf_bytes.startswith(b"%PDF-")
+            or b"%%EOF" not in pdf_bytes[-1024:]
+            or hashlib.sha256(pdf_bytes).hexdigest() != sha256
+        ):
+            raise CommercialBillingInvoicePDFConflictError(
+                "Approved invoice PDF artifact is invalid"
+            )
+        return ReadyCommercialBillingInvoicePDFArtifact(
+            approval_id=approved.approval_id,
+            artifact_id=_uuid(artifact["artifact_id"], "PDF artifact id"),
+            invoice_id=approved.invoice_id,
+            content_type=content_type,
+            filename=filename,
+            pdf_bytes=pdf_bytes,
+            pdf_sha256=sha256,
+            render_fingerprint=approved.render_fingerprint,
+            invoice=approved.invoice,
+        )
+
     def _render(self, invoice: dict[str, Any]) -> bytes:
         try:
             value = self._renderer(invoice)
@@ -476,6 +571,24 @@ class CommercialBillingInvoicePDFService:
         )
 
     @staticmethod
+    async def _find_artifact_with_bytes(conn: Any, approval_id: UUID) -> Any | None:
+        return await conn.fetchrow(
+            """
+            SELECT artifact.id AS artifact_id, artifact.approval_id,
+                   approval.invoice_id, artifact.artifact_kind, artifact.state,
+                   artifact.content_type, artifact.filename, artifact.pdf_bytes,
+                   artifact.byte_size, artifact.pdf_sha256,
+                   artifact.render_fingerprint, artifact.generated_by,
+                   artifact.generated_at
+            FROM commercial_billing_invoice_pdf_artifacts AS artifact
+            JOIN commercial_billing_candidate_approvals AS approval
+              ON approval.id = artifact.approval_id
+            WHERE artifact.approval_id = $1
+            """,
+            approval_id,
+        )
+
+    @staticmethod
     def _assert_operation(row: Any, request_fingerprint: str) -> None:
         if row["operation_request_fingerprint"] != request_fingerprint:
             raise CommercialBillingInvoicePDFConflictError(
@@ -588,5 +701,6 @@ __all__ = [
     "CommercialBillingInvoicePDFService",
     "CommercialBillingInvoicePDFUnavailableError",
     "CommercialBillingInvoicePDFValidationError",
+    "ReadyCommercialBillingInvoicePDFArtifact",
     "get_commercial_billing_invoice_pdf_service",
 ]

--- a/atlas_brain/storage/migrations/374_commercial_billing_invoice_gmail_drafts.sql
+++ b/atlas_brain/storage/migrations/374_commercial_billing_invoice_gmail_drafts.sql
@@ -1,0 +1,110 @@
+-- Durable no-send Gmail draft identity for explicitly approved EOM invoices.
+--
+-- This is deliberately a delivery-audit state machine, not invoice financial
+-- state.  A row means ATLAS has a persisted intent or Gmail draft identity for
+-- one already-approved invoice PDF.  It does not mean Gmail sent anything and
+-- it never updates invoices, receivables, payments, or service evidence.
+--
+-- The intent row is committed before the Gmail API call.  Its deterministic
+-- RFC Message-ID lets a later retry query Gmail's Drafts mailbox when the API
+-- outcome was uncertain, rather than issue a second create request.  A row in
+-- ``recovery_required`` is deliberately retained evidence; it cannot be
+-- interpreted as sent and it is not silently retried.
+--
+-- Rollback: stop the route/service and retain these delivery/audit records.
+-- Dropping rows that describe customer recipient/draft identity is a separately
+-- authorized destructive retention action, never a mixed-version rollback.
+
+CREATE TABLE IF NOT EXISTS commercial_billing_invoice_gmail_drafts (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    approval_id UUID NOT NULL UNIQUE
+        REFERENCES commercial_billing_candidate_approvals(id) ON DELETE RESTRICT,
+    artifact_id UUID NOT NULL UNIQUE
+        REFERENCES commercial_billing_invoice_pdf_artifacts(id) ON DELETE RESTRICT,
+    state VARCHAR(32) NOT NULL DEFAULT 'creating',
+    recipient_email VARCHAR(256) NOT NULL,
+    subject VARCHAR(512) NOT NULL,
+    rfc_message_id VARCHAR(320) NOT NULL UNIQUE,
+    gmail_draft_id VARCHAR(256),
+    gmail_message_id VARCHAR(256),
+    gmail_thread_id VARCHAR(256),
+    created_by VARCHAR(128) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_attempt_by VARCHAR(128) NOT NULL,
+    last_attempt_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    draft_created_at TIMESTAMPTZ,
+    recovery_required_at TIMESTAMPTZ,
+    CONSTRAINT commercial_billing_invoice_gmail_drafts_state_check
+        CHECK (state IN ('creating', 'retryable', 'recovery_required', 'draft_created')),
+    CONSTRAINT commercial_billing_invoice_gmail_drafts_recipient_check
+        CHECK (length(btrim(recipient_email)) > 0),
+    CONSTRAINT commercial_billing_invoice_gmail_drafts_subject_check
+        CHECK (length(btrim(subject)) > 0),
+    CONSTRAINT commercial_billing_invoice_gmail_drafts_rfc_message_id_check
+        CHECK (
+            rfc_message_id ~ '^<[^[:space:]<>]+@[^[:space:]<>]+>$'
+            AND length(btrim(rfc_message_id)) = length(rfc_message_id)
+        ),
+    CONSTRAINT commercial_billing_invoice_gmail_drafts_actor_check
+        CHECK (
+            length(btrim(created_by)) > 0
+            AND length(btrim(last_attempt_by)) > 0
+        ),
+    CONSTRAINT commercial_billing_invoice_gmail_drafts_external_identity_check
+        CHECK (
+            (
+                gmail_draft_id IS NULL
+                AND gmail_message_id IS NULL
+                AND gmail_thread_id IS NULL
+            )
+            OR (
+                length(btrim(COALESCE(gmail_draft_id, ''))) > 0
+                AND length(btrim(COALESCE(gmail_message_id, ''))) > 0
+                AND length(btrim(COALESCE(gmail_thread_id, ''))) > 0
+            )
+        ),
+    CONSTRAINT commercial_billing_invoice_gmail_drafts_completed_state_check
+        CHECK (
+            state <> 'draft_created'
+            OR (
+                gmail_draft_id IS NOT NULL
+                AND gmail_message_id IS NOT NULL
+                AND gmail_thread_id IS NOT NULL
+                AND draft_created_at IS NOT NULL
+            )
+        ),
+    CONSTRAINT commercial_billing_invoice_gmail_drafts_recovery_timestamp_check
+        CHECK (
+            state = 'recovery_required'
+            OR recovery_required_at IS NULL
+        )
+);
+
+CREATE TABLE IF NOT EXISTS commercial_billing_invoice_gmail_draft_operations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    gmail_draft_record_id UUID NOT NULL
+        REFERENCES commercial_billing_invoice_gmail_drafts(id) ON DELETE RESTRICT,
+    source VARCHAR(32) NOT NULL DEFAULT 'eom_admin',
+    idempotency_key VARCHAR(128) NOT NULL,
+    request_fingerprint VARCHAR(64) NOT NULL,
+    requested_by VARCHAR(128) NOT NULL,
+    requested_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT commercial_billing_invoice_gmail_draft_operations_source_key
+        UNIQUE (source, idempotency_key),
+    CONSTRAINT commercial_billing_invoice_gmail_draft_operations_request_fingerprint_check
+        CHECK (request_fingerprint ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT commercial_billing_invoice_gmail_draft_operations_actor_check
+        CHECK (length(btrim(requested_by)) > 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_commercial_billing_invoice_gmail_draft_operations_record
+    ON commercial_billing_invoice_gmail_draft_operations (
+        gmail_draft_record_id, requested_at DESC
+    );
+
+COMMENT ON TABLE commercial_billing_invoice_gmail_drafts IS
+    'One no-send Gmail draft intent/identity per approved EOM commercial invoice PDF; never invoice sent state.';
+
+COMMENT ON TABLE commercial_billing_invoice_gmail_draft_operations IS
+    'Idempotent authenticated requests that create, recover, or reuse one commercial Gmail draft identity.';

--- a/atlas_brain/tools/gmail.py
+++ b/atlas_brain/tools/gmail.py
@@ -8,11 +8,12 @@ when gmail_send_enabled is True.
 
 import base64
 import logging
+import re
 import time
 from email.mime.base import MIMEBase
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-from typing import Any
+from typing import Any, Mapping
 
 import httpx
 
@@ -22,6 +23,81 @@ logger = logging.getLogger("atlas.tools.gmail")
 
 GMAIL_API_BASE = "https://gmail.googleapis.com/gmail/v1"
 TOKEN_URL = "https://oauth2.googleapis.com/token"
+_MAX_GMAIL_DRAFT_LOOKUP_PAGES = 20
+_MAX_GMAIL_RFC_MESSAGE_ID_LENGTH = 320
+_MAX_GMAIL_EXTRA_HEADER_VALUE_LENGTH = 998
+_EXTRA_HEADER_NAME = re.compile(r"^(?:Message-ID|X-[A-Za-z0-9-]{1,72})$")
+_PROTECTED_HEADER_NAMES = frozenset(
+    {
+        "bcc",
+        "cc",
+        "from",
+        "reply-to",
+        "subject",
+        "to",
+    }
+)
+
+
+class GmailDraftLookupError(RuntimeError):
+    """A Gmail draft lookup cannot safely name one external draft."""
+
+
+class GmailDraftCreateError(RuntimeError):
+    """A Gmail draft create failed with known or uncertain delivery state."""
+
+    def __init__(self, message: str, *, definitely_not_created: bool) -> None:
+        super().__init__(message)
+        self.definitely_not_created = definitely_not_created
+
+
+def _extra_headers(headers: Mapping[str, str] | None) -> dict[str, str]:
+    """Accept the narrow immutable headers a server-side draft may add.
+
+    Gmail's raw-message API accepts arbitrary message headers.  This transport
+    is shared, so only Message-ID and namespaced X- headers are admitted here;
+    recipients and normal mail headers remain explicit method arguments.  A
+    newline would permit header injection into the raw MIME message.
+    """
+
+    if headers is None:
+        return {}
+    if not isinstance(headers, Mapping):
+        raise ValueError("Gmail draft headers must be a mapping")
+    result: dict[str, str] = {}
+    for name, value in headers.items():
+        if not isinstance(name, str) or not _EXTRA_HEADER_NAME.fullmatch(name):
+            raise ValueError("Gmail draft header name is invalid")
+        if name.casefold() in _PROTECTED_HEADER_NAMES:
+            raise ValueError("Gmail draft header name is invalid")
+        if (
+            not isinstance(value, str)
+            or not value
+            or len(value) > _MAX_GMAIL_EXTRA_HEADER_VALUE_LENGTH
+            or "\r" in value
+            or "\n" in value
+            or "\x00" in value
+        ):
+            raise ValueError("Gmail draft header value is invalid")
+        result[name] = value
+    return result
+
+
+def _rfc_message_id(value: str) -> str:
+    if (
+        not isinstance(value, str)
+        or len(value) > _MAX_GMAIL_RFC_MESSAGE_ID_LENGTH
+        or len(value) < 5
+        or "\r" in value
+        or "\n" in value
+        or "\x00" in value
+        or not value.startswith("<")
+        or not value.endswith(">")
+        or value.count("@") != 1
+        or any(char.isspace() for char in value)
+    ):
+        raise GmailDraftLookupError("Gmail draft RFC Message-ID is invalid")
+    return value
 
 
 class GmailTransport:
@@ -206,6 +282,7 @@ class GmailTransport:
         reply_to: str | None = None,
         attachments: list[dict[str, Any]] | None = None,
         html: str | None = None,
+        headers: Mapping[str, str] | None = None,
     ) -> dict[str, Any]:
         """Create a Gmail draft (NOT sent) under the authenticated account.
 
@@ -213,6 +290,13 @@ class GmailTransport:
         Gmail draft resource: {"id": draft_id, "message": {"id", "threadId"}}.
         The user can review and send the draft from their Gmail UI.
         """
+        try:
+            validated_headers = _extra_headers(headers)
+        except ValueError as exc:
+            raise GmailDraftCreateError(
+                "Gmail draft headers are invalid", definitely_not_created=True
+            ) from exc
+
         if attachments:
             msg = MIMEMultipart("mixed")
             if html:
@@ -232,6 +316,8 @@ class GmailTransport:
             msg["Bcc"] = ", ".join(bcc)
         if reply_to:
             msg["Reply-To"] = reply_to
+        for name, value in validated_headers.items():
+            msg[name] = value
 
         if attachments:
             for att in attachments:
@@ -247,20 +333,41 @@ class GmailTransport:
 
         raw_b64 = base64.urlsafe_b64encode(msg.as_bytes()).decode("ascii")
 
-        token = await self._get_access_token()
+        try:
+            token = await self._get_access_token()
+        except Exception as exc:
+            raise GmailDraftCreateError(
+                "Gmail draft authentication failed", definitely_not_created=True
+            ) from exc
         client = await self._ensure_client()
-        response = await client.post(
-            f"{GMAIL_API_BASE}/users/me/drafts",
-            json={"message": {"raw": raw_b64}},
-            headers={"Authorization": f"Bearer {token}"},
-        )
+        try:
+            response = await client.post(
+                f"{GMAIL_API_BASE}/users/me/drafts",
+                json={"message": {"raw": raw_b64}},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        except Exception:
+            # A transport exception can happen after Gmail accepted the bytes.
+            # Preserve it as uncertain so the caller reconciles by Message-ID
+            # rather than submitting another create request.
+            raise
 
         if response.status_code == 403:
-            raise RuntimeError(
+            raise GmailDraftCreateError(
                 "Gmail draft permission denied. Re-run setup with gmail.modify scope: "
-                "python scripts/setup_google_oauth.py"
+                "python scripts/setup_google_oauth.py",
+                definitely_not_created=True,
             )
-        response.raise_for_status()
+        try:
+            response.raise_for_status()
+        except Exception as exc:
+            status_code = getattr(response, "status_code", 0)
+            raise GmailDraftCreateError(
+                "Gmail draft creation was rejected"
+                if 400 <= status_code < 500
+                else "Gmail draft creation outcome is unknown",
+                definitely_not_created=400 <= status_code < 500,
+            ) from exc
 
         result = response.json()
         logger.info(
@@ -270,6 +377,91 @@ class GmailTransport:
             subject[:50],
         )
         return result
+
+    async def find_draft_by_rfc_message_id(
+        self,
+        rfc_message_id: str,
+    ) -> dict[str, Any] | None:
+        """Return the one Gmail draft with a stable RFC Message-ID, if present.
+
+        Gmail's documented ``users.drafts.list`` search supports
+        ``rfc822msgid:<...>`` and returns the draft resource's own id plus its
+        message/thread ids.  Searching is intentionally read-only: a caller
+        recovering an uncertain create may inspect this identity before deciding
+        whether another draft create would be safe.
+        """
+
+        message_id = _rfc_message_id(rfc_message_id)
+        token = await self._get_access_token()
+        client = await self._ensure_client()
+        page_token: str | None = None
+        seen_page_tokens: set[str] = set()
+        matches: list[dict[str, Any]] = []
+
+        for _ in range(_MAX_GMAIL_DRAFT_LOOKUP_PAGES):
+            params: dict[str, Any] = {
+                "q": f"rfc822msgid:{message_id}",
+                "maxResults": 100,
+            }
+            if page_token is not None:
+                params["pageToken"] = page_token
+            response = await client.get(
+                f"{GMAIL_API_BASE}/users/me/drafts",
+                params=params,
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            if response.status_code == 403:
+                raise GmailDraftLookupError(
+                    "Gmail draft lookup permission denied. Re-run setup with gmail.modify scope: "
+                    "python scripts/setup_google_oauth.py"
+                )
+            response.raise_for_status()
+            payload = response.json()
+            if not isinstance(payload, dict):
+                raise GmailDraftLookupError("Gmail draft lookup response is invalid")
+            drafts = payload.get("drafts", [])
+            if not isinstance(drafts, list):
+                raise GmailDraftLookupError("Gmail draft lookup response is invalid")
+            for draft in drafts:
+                if not isinstance(draft, dict):
+                    raise GmailDraftLookupError("Gmail draft lookup response is invalid")
+                draft_id = draft.get("id")
+                message = draft.get("message")
+                if (
+                    not isinstance(draft_id, str)
+                    or not draft_id.strip()
+                    or not isinstance(message, dict)
+                    or not isinstance(message.get("id"), str)
+                    or not message["id"].strip()
+                    or not isinstance(message.get("threadId"), str)
+                    or not message["threadId"].strip()
+                ):
+                    raise GmailDraftLookupError("Gmail draft lookup response is invalid")
+                matches.append(
+                    {
+                        "id": draft_id.strip(),
+                        "message": {
+                            "id": message["id"].strip(),
+                            "threadId": message["threadId"].strip(),
+                        },
+                    }
+                )
+                if len(matches) > 1:
+                    raise GmailDraftLookupError(
+                        "Gmail draft lookup found multiple matching drafts"
+                    )
+
+            next_page = payload.get("nextPageToken")
+            if next_page is None:
+                return next(iter(matches), None)
+            if not isinstance(next_page, str) or not next_page:
+                raise GmailDraftLookupError("Gmail draft lookup response is invalid")
+            if next_page in seen_page_tokens:
+                raise GmailDraftLookupError("Gmail draft lookup pagination is invalid")
+            seen_page_tokens.add(next_page)
+            page_token = next_page
+
+        raise GmailDraftLookupError("Gmail draft lookup exceeded its page bound")
 
     async def modify_thread(
         self,

--- a/plans/PR-EOM-Commercial-Invoice-Gmail-Drafts.md
+++ b/plans/PR-EOM-Commercial-Invoice-Gmail-Drafts.md
@@ -1,0 +1,291 @@
+# PR-EOM-Commercial-Invoice-Gmail-Drafts
+
+## Why this slice exists
+
+The Billing & Payments coordinating issue #2362 and H-15 in #2363 require a
+website-initiated commercial invoice to become a Gmail draft only after an
+explicit commercial-billing approval.  PR #2381 creates the exact draft ATLAS
+invoice and PR #2382 retains one exact PDF artifact, but neither persists a
+Gmail draft identity or can recover an uncertain Gmail API result.  The legacy
+MCP and invoice action paths combine sending/marking-sent with delivery, so
+they cannot be used by the operator workspace.
+
+Diff-budget override: the additive draft/operation persistence, existing
+Gmail API recovery lookup, authenticated provider route, and disposable
+PostgreSQL failure/concurrency proof are one deployable no-send behavior.
+Splitting them would either call Gmail without durable recovery evidence or
+publish a durable state machine that cannot safely create/reconcile its
+external draft.
+
+### Problem-derived contract
+
+- Root cause: ATLAS has a `GmailTransport.create_draft()` API primitive, but
+  it has no durable link to an explicit EOM commercial approval/PDF artifact,
+  no idempotent operation receipt, no stable message identity to find a draft
+  after a process/database failure, and no guard against the legacy
+  send/mark-sent paths.
+- Correct fix must touch/change: add an additive ATLAS Gmail-draft/operation
+  persistence contract, a no-send draft service that only accepts the
+  approval's unchanged `gmail_pdf` draft invoice plus its ready retained PDF,
+  and an authenticated receivables route.  It must persist intent before
+  external work, attach the retained bytes, store Gmail draft/message/thread
+  identifiers only after a successful response or lookup, and use a stable
+  RFC Message-ID to reconcile an uncertain outcome without a second create.
+  Tests must cover normal creation, same-key and new-key reuse, transport
+  failure, database-confirm failure, recovery lookup, stale/non-Gmail/Square
+  rejection, concurrent callers, route auth, and the actual Gmail query shape.
+- Must not change: invoice amount/status/sent state, payment balances,
+  candidate/run evidence, the immutable PDF artifact, Gmail sending, the
+  existing MCP/manual invoice flows, CRM/service markers, Square execution,
+  browser credential exposure, invoice/PDF/email product copy, or tracker and
+  Website consumers.
+
+## Scope (this PR)
+
+Ownership lane: eom/billing-approved-gmail-drafts
+Slice phase: Vertical slice
+
+1. Add one durable no-send Gmail draft operation for an already-approved
+   `gmail_pdf` commercial invoice that already has its immutable PDF artifact.
+   Persist the Gmail draft/message/thread identity, recipient/subject evidence,
+   actor and idempotency receipts, but never update invoice financial state.
+2. Extend only the existing Gmail draft transport with a stable RFC Message-ID
+   search and safe deterministic headers, then add the authenticated provider
+   route and tests that prove normal/retry/failure/recovery/concurrency behavior
+   without contacting a real mailbox.
+
+### Review Contract
+
+- Acceptance criteria:
+  1. The service creates one `draft_created` Gmail draft for an explicitly
+     approved, still-draft `gmail_pdf` invoice with a ready unchanged PDF
+     artifact; it uses the existing invoice template and attaches the retained
+     bytes, then returns durable draft/message/thread identifiers without
+     changing any invoice status -- settled by the focused disposable
+     PostgreSQL service tests and source assertions.
+  2. A matching idempotency key returns the original operation result, while a
+     fresh key for the same completed approval records a second receipt and
+     reuses the same Gmail draft without another transport call; a key reused
+     for another approval fails before a write -- settled by the focused tests.
+  3. Intent and operation evidence are committed before the Gmail call.  If
+     transport acceptance succeeds but final database confirmation fails, a
+     retry searches Gmail by its exact persisted RFC Message-ID and stores the
+     found draft rather than calling create again; an ambiguous or missing
+     result remains visible `recovery_required`, never inferred sent -- settled
+     by the fake-gateway and disposable PostgreSQL failure tests.
+  4. The execution model serializes every operation request on its key and
+     every approval on its durable draft row.  Across admitted interleavings,
+     an approval links to at most one persisted Gmail draft identity, and a
+     caller that sees another request's `creating` state may lookup/recover but
+     cannot issue a second Gmail create -- settled by the real PostgreSQL
+     concurrency test plus the service's transaction/transition code.
+  5. Non-`gmail_pdf`, missing/invalid recipient, missing/mismatched artifact,
+     changed PDF evidence, and non-draft/sent invoice inputs fail before a
+     Gmail create or draft/operation insert.  Delivery eligibility comes from
+     the approval invoice's retained metadata and canonical recipient
+     normalizer, not a new caller-provided channel -- settled by negative
+     zero-write tests.
+  6. The authenticated full application route requires the existing bearer
+     token, `X-EOM-Actor`, and `Idempotency-Key`; it reaches the service through
+     `atlas_brain.main.app -> /api/v1 -> receivables`, returns draft metadata
+     only, and does not expose PDF bytes or credentials -- settled by an ASGI
+     full-mount test.
+  7. The Gmail transport's draft lookup calls the documented
+     `users/me/drafts` search with `q=rfc822msgid:<stable-id>`, recognizes zero
+     or exactly one result, and rejects malformed/ambiguous responses; the
+     tests fake only HTTP at this third-party seam.  No test authenticates to
+     Gmail or creates a real customer draft.
+- Reachability proof: invoke the real mounted
+  `POST /api/v1/receivables/commercial-billing-approvals/{approval_id}/gmail-draft`
+  route through `atlas_brain.main.app`; override only the existing receivables
+  auth configuration and Gmail-draft-service dependency, then assert UUID,
+  actor, and idempotency key reach the service and no attachment bytes occur in
+  the response.
+- Affected surfaces: `atlas_brain/api/invoicing/receivables.py`, a new
+  `commercial_billing_invoice_gmail_drafts` service, the existing PDF artifact
+  reader, the existing Gmail transport, additive migration 374, the explicit
+  invoicing workflow enrollment, and focused service/transport/route tests.
+- Risk areas: external exactly-once boundary; invoice/PDF staleness; customer
+  recipient and attachment PII; mailbox recovery; no-send financial lifecycle;
+  concurrent retries; migration/rollback; auth; legacy compatibility.
+- Reviewer rules triggered: R1, R2, R3, R4, R5, R6, R8, R10, R12, R13, R14.
+
+### Boundary-change enumeration
+
+Required when this diff changes a guard, validator, normalizer, resolver,
+router/classifier, or admission boundary. Name each changed boundary path or
+seam in the enumeration; otherwise write "N/A - no boundary change."
+
+- Boundary path/seam: authenticated receivables Gmail-draft route -> durable
+  Gmail-draft service -> PostgreSQL intent/operation rows -> existing
+  GmailTransport `drafts.create` / `drafts.list` third-party seam.
+- Replaced-path behaviors: none; legacy MCP and invoice action
+  send/approve-and-send behaviors stay callable but are deliberately not
+  imported by this service.
+- Guard-relevant fields: approval UUID, idempotency key, authenticated actor,
+  linked invoice/approval/artifact identities, artifact hash/fingerprint,
+  `draft` invoice status, retained `deliveryMethod`, canonical recipient,
+  RFC Message-ID, Gmail draft/message/thread identifiers, and the closed draft
+  state vocabulary.
+- Caller x input shape: future tracker is the authenticated server caller;
+  this provider accepts a UUID path identity and bounded headers only.  The
+  browser receives no ATLAS/Gmail credentials or PDF bytes.
+
+### Deployed-config probing
+
+Required for guard, validator, resolver, admission-boundary, or env/config
+fallback changes; otherwise write "N/A - no guard/config boundary change."
+
+- Deployed/default config values: existing Gmail OAuth credentials and
+  `gmail.modify` scope remain the only transport configuration; this slice
+  introduces no new environment variable or fallback sender.
+- Explicit value probe: the default transport is injected in tests and is not
+  invoked by deployment/route auth probes; fake transport tests cover valid
+  create and lookup responses.
+- Absent value probe: a configured transport failure leaves `retryable` or
+  `recovery_required` evidence, never a sent invoice or a second create.
+- Default-session/default-context probe: no production Gmail call occurs in
+  tests or deployment verification; the protected route is checked only with
+  no credentials to prove rejection.
+- Side-effect ordering: one transaction persists a `creating` intent plus
+  operation receipt before any Gmail call; final `draft_created` confirmation
+  happens only after response/lookup validation.  Uncertain outcomes must
+  reconcile by the persisted RFC identity before any new create is allowed.
+
+### Closure Declaration
+
+- **Delivery-method predicate — CLOSED / DERIVED:** only the existing exact
+  `gmail_pdf` value retained in the approval invoice's metadata is admitted.
+  `manual_square` and every other/missing value fail before any draft row or
+  Gmail call; the service does not accept a delivery-channel argument.
+- **Draft-state vocabulary — CLOSED / AUTHORED HERE:** `creating`,
+  `retryable`, `recovery_required`, and `draft_created` are the only persisted
+  states.  The durable row is a delivery-state record, not invoice state; no
+  state means sent.
+- **External result identity — CLOSED / DERIVED:** the service derives one
+  RFC Message-ID from the immutable approval UUID and writes it before the
+  first external call.  It accepts only exactly one Gmail Draft list result
+  carrying nonblank draft/message/thread IDs; zero results are not treated as
+  sent and more than one is ambiguous/recovery-required.
+- **Recipient admission — CLOSED / DERIVED:** the recipient is the retained
+  invoice email, normalized by the canonical EOM contact-email normalizer
+  already used by candidate selection.  No route body can choose or override a
+  customer address.  An absent/invalid result is a no-write conflict.
+- The route idempotency key is bounded by the existing strict 1--128-character
+  header schema and service validator.  It is not a free-text classifier;
+  grammar-derived admission tests cover strings, padding, boundaries, and
+  non-string container shapes.
+
+### Files touched
+
+- `.github/workflows/atlas_invoicing_checks.yml`
+- `atlas_brain/api/invoicing/receivables.py`
+- `atlas_brain/services/commercial_billing_invoice_gmail_drafts.py`
+- `atlas_brain/services/commercial_billing_invoice_pdfs.py`
+- `atlas_brain/storage/migrations/374_commercial_billing_invoice_gmail_drafts.sql`
+- `atlas_brain/tools/gmail.py`
+- `plans/PR-EOM-Commercial-Invoice-Gmail-Drafts.md`
+- `tests/test_commercial_billing_gmail_drafts.py`
+
+## Mechanism
+
+The Gmail-draft service first uses the PDF artifact service's server-only read
+boundary to validate the approval-to-draft-invoice link, current render
+fingerprint, retained PDF bytes/hash, and invoice metadata.  It rejects an
+unapproved, changed, sent, missing-PDF, non-Gmail, or invalid-recipient state
+without contacting Gmail.
+
+It then opens a short PostgreSQL transaction: lock the idempotency key, lock
+the approval, insert/reuse one draft intent and one operation receipt, and
+commit.  The intent has a deterministic RFC Message-ID and frozen recipient /
+subject metadata.  Gmail work occurs outside that transaction.  A successful
+`create_draft` response is validated and confirmed in a second short
+transaction.  If confirmation fails or transport returns an uncertain result,
+the next same-key request performs only `drafts.list` by that Message-ID; it
+stores the one found draft or leaves explicit recovery evidence rather than
+creating another draft.  Definite pre-create/rejection failures move to the
+safe `retryable` state; ambiguous/missing recovery results do not.
+
+The email body/HTML comes from the existing EOM invoice template and the
+attachment is the already-retained `BYTEA`, so this slice adds neither new
+customer-facing copy nor a filesystem dependency.  The service invokes only
+the Gmail draft API.  It never invokes `send`, an email provider, CRM, Square,
+or an invoice-status writer.
+
+### Execution model and invariant
+
+The first and confirmation transitions use transaction-scoped PostgreSQL
+advisory locks: operation key before approval, released at commit/rollback.
+The draft row's unique approval/artifact foreign keys are the durable backstop.
+No transaction spans a Gmail HTTP call.  Across every admitted interleaving,
+one approval can own one Gmail-draft intent and at most one confirmed Gmail
+draft identity; every idempotency key maps to that intent's fixed approval
+fingerprint.  Only the caller that changes `retryable` to `creating` may call
+`create_draft`; callers observing `creating` or `recovery_required` may only
+look up the stable RFC identity.  A crash after Gmail acceptance but before
+confirmation therefore becomes a lookup/recovery operation rather than a
+second-create operation.  A deleted/missing draft remains recovery evidence;
+it is never sent.
+
+## Intentional
+
+- The service requires an existing retained PDF rather than calling the PDF
+  writer itself.  This keeps PDF creation and external Gmail delivery as two
+  independently retryable provider transitions and avoids generating a PDF for
+  a rejected Square candidate.
+- The existing EOM invoice template is reused; this accepted workspace
+  behavior does not silently redesign customer email content.
+- An uncertain Gmail call is not automatically retried.  Gmail's create API
+  has no caller-provided idempotency key, so a second create could duplicate a
+  draft.  The stable Message-ID lookup is the visible recovery path.
+- The generic transport gains a draft lookup and safe extra-header support,
+  not any send behavior.  Its documented Draft list query can return an
+  external draft ID and message/thread IDs without treating Gmail as the
+  financial ledger.
+- No sent-mail reconciliation occurs here.  A Gmail draft can disappear when
+  sent or deleted; deciding between those outcomes is a separate H-15 slice.
+
+## Deferred
+
+- H-15 / #2363: verifiable sent-mail reconciliation, final sent message ID /
+  timestamp, deleted-draft classification, and recovery actions after an
+  unresolved `recovery_required` state remain separate slices.
+- H-15 / #2363: Manual Square queue, external Square invoice reference, and
+  explicit audited `sent via Square` action remain separate provider/UI work.
+- Tracker proxy and Website review/recovery UI remain dependent consumer
+  slices after this provider contract deploys.
+- Parking predicate: new delivery channels, Gmail mailbox background sweeps,
+  invoice/email redesign, manual-reconciliation UX, generic artifact download,
+  and sender/credential redesign are parked by default because they introduce
+  a new state machine or product decision beyond one no-send draft creation.
+  Parked hardening: none.
+
+## Verification
+
+- Completed locally against the isolated `atlas_receivables_test` PostgreSQL
+  container: `python -m pytest -q tests/test_commercial_billing_gmail_drafts.py`
+  — 75 passed (the route uses ASGI plus a fake dependency; no Gmail account or
+  live financial record is contacted).
+- Completed local `Atlas Invoicing Checks` equivalents: 2 approval blockers,
+  417 receivables/PDF/billing regressions, and 43 MCP/OAuth regressions passed.
+- Completed: targeted ruff, Python source compilation, and `git diff --check`.
+- Completed: maturity-sweep unit suite (86 passed) and API/storage/Gmail
+  ratchets; the Gmail ratchet passes without a baseline update, and the new
+  state-machine service has no maturity findings after replacing runtime
+  assertions with explicit conflict handling.
+- Pending before push: final plan/body/diff-budget/AI-reconciliation/guard
+  closure checks and one local PR-review wrapper run.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_invoicing_checks.yml` | 9 |
+| `atlas_brain/api/invoicing/receivables.py` | 69 |
+| `atlas_brain/services/commercial_billing_invoice_gmail_drafts.py` | 984 |
+| `atlas_brain/services/commercial_billing_invoice_pdfs.py` | 114 |
+| `atlas_brain/storage/migrations/374_commercial_billing_invoice_gmail_drafts.sql` | 110 |
+| `atlas_brain/tools/gmail.py` | 212 |
+| `plans/PR-EOM-Commercial-Invoice-Gmail-Drafts.md` | 291 |
+| `tests/test_commercial_billing_gmail_drafts.py` | 791 |
+| **Total** | **2580** |

--- a/tests/test_commercial_billing_gmail_drafts.py
+++ b/tests/test_commercial_billing_gmail_drafts.py
@@ -1,0 +1,791 @@
+"""Contract tests for durable, no-send EOM commercial Gmail invoice drafts."""
+
+from __future__ import annotations
+
+import asyncio
+import ast
+import base64
+import hashlib
+import inspect
+import json
+import os
+import time
+from contextlib import asynccontextmanager
+from datetime import date, datetime, timezone
+from email import message_from_bytes
+from itertools import product
+from pathlib import Path
+from types import SimpleNamespace
+from uuid import uuid4
+
+import httpx
+import pytest
+
+from atlas_brain.services.commercial_billing_invoice_gmail_drafts import (
+    CommercialBillingGmailDraftConflictError,
+    CommercialBillingGmailDraftRecoveryRequiredError,
+    CommercialBillingGmailDraftUnavailableError,
+    CommercialBillingGmailDraftValidationError,
+    CommercialBillingInvoiceGmailDraftService,
+    _request_text,
+)
+from atlas_brain.services.commercial_billing_invoice_pdfs import (
+    CommercialBillingInvoicePDFService,
+)
+from atlas_brain.tools.gmail import (
+    GmailDraftCreateError,
+    GmailDraftLookupError,
+    GmailTransport,
+)
+
+
+def _fingerprint(value: object) -> str:
+    return hashlib.sha256(
+        json.dumps(value, sort_keys=True, separators=(",", ":"), allow_nan=False).encode()
+    ).hexdigest()
+
+
+def _idempotency_key_oracle(value: object) -> bool:
+    return isinstance(value, str) and 1 <= len(value.strip()) <= 128
+
+
+def _idempotency_key_grammar_candidates():
+    for token, wrapper, padding in product(
+        ("", "a", "a" * 128, "a" * 129, " "),
+        (
+            lambda value: value,
+            lambda value: [value],
+            lambda value: {"key": value},
+            lambda value: (value,),
+        ),
+        (lambda value: value, lambda value: f" {value} ", lambda value: f"\t{value}\n"),
+    ):
+        yield wrapper(padding(token))
+
+
+@pytest.mark.parametrize("value", tuple(_idempotency_key_grammar_candidates()))
+def test_gmail_draft_idempotency_key_matches_the_spec_derived_oracle(value: object):
+    if _idempotency_key_oracle(value):
+        assert _request_text(value, "Idempotency key", limit=128) == value.strip()
+    else:
+        with pytest.raises(CommercialBillingGmailDraftValidationError):
+            _request_text(value, "Idempotency key", limit=128)
+
+
+class _SchemaPool:
+    is_initialized = True
+
+    def __init__(self, connection, schema: str) -> None:
+        self.connection = connection
+        self.schema = schema
+
+    @asynccontextmanager
+    async def transaction(self):
+        async with self.connection.transaction():
+            await self.connection.execute(f'SET LOCAL search_path TO "{self.schema}"')
+            yield self.connection
+
+
+class _PDFRenderer:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def __call__(self, invoice: dict) -> bytes:
+        self.calls.append(str(invoice["invoice_number"]))
+        return b"%PDF-1.7\nsynthetic commercial billing artifact\n%%EOF\n"
+
+
+class _RecordingGateway:
+    def __init__(self) -> None:
+        self.create_calls: list[dict] = []
+        self.lookup_calls: list[str] = []
+        self.drafts: dict[str, dict] = {}
+        self.create_error: Exception | None = None
+        self.create_then_raise = False
+
+    async def create_draft(self, **kwargs) -> dict:
+        self.create_calls.append(kwargs)
+        message_id = kwargs["headers"]["Message-ID"]
+        result = {
+            "id": f"draft-{len(self.create_calls)}",
+            "message": {
+                "id": f"message-{len(self.create_calls)}",
+                "threadId": f"thread-{len(self.create_calls)}",
+            },
+        }
+        if self.create_then_raise:
+            self.drafts[message_id] = result
+            raise RuntimeError("synthetic uncertain Gmail timeout")
+        if self.create_error is not None:
+            raise self.create_error
+        self.drafts[message_id] = result
+        return result
+
+    async def find_draft_by_rfc_message_id(self, rfc_message_id: str) -> dict | None:
+        self.lookup_calls.append(rfc_message_id)
+        result = self.drafts.get(rfc_message_id)
+        return json.loads(json.dumps(result)) if result is not None else None
+
+
+class _BlockingGateway(_RecordingGateway):
+    def __init__(self) -> None:
+        super().__init__()
+        self.create_started = asyncio.Event()
+        self.release_create = asyncio.Event()
+
+    async def create_draft(self, **kwargs) -> dict:
+        self.create_calls.append(kwargs)
+        self.create_started.set()
+        await self.release_create.wait()
+        message_id = kwargs["headers"]["Message-ID"]
+        result = {
+            "id": "draft-1",
+            "message": {"id": "message-1", "threadId": "thread-1"},
+        }
+        self.drafts[message_id] = result
+        return result
+
+
+@asynccontextmanager
+async def _gmail_draft_database():
+    asyncpg = pytest.importorskip("asyncpg")
+    database_url = os.environ.get("ATLAS_RECEIVABLES_TEST_DATABASE_URL")
+    if not database_url:
+        pytest.skip("ATLAS_RECEIVABLES_TEST_DATABASE_URL not set")
+    schema = f"commercial_gmail_draft_{uuid4().hex}"
+    connection = await asyncpg.connect(database_url)
+    migrations = Path(__file__).parents[1] / "atlas_brain/storage/migrations"
+    try:
+        await connection.execute(f'CREATE SCHEMA "{schema}"')
+        await connection.execute(f'SET search_path TO "{schema}"')
+        await connection.execute("CREATE TABLE contacts (id UUID PRIMARY KEY)")
+        for name in (
+            "045_invoices.sql",
+            "047_invoice_extra_fields.sql",
+            "370_commercial_billing_runs.sql",
+            "372_commercial_billing_candidate_approvals.sql",
+            "373_commercial_billing_invoice_pdf_artifacts.sql",
+            "374_commercial_billing_invoice_gmail_drafts.sql",
+        ):
+            await connection.execute((migrations / name).read_text())
+        yield connection, schema
+    finally:
+        await connection.execute("SET search_path TO public")
+        await connection.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        await connection.close()
+
+
+async def _seed_approved_invoice(
+    connection,
+    schema: str,
+    *,
+    delivery_method: str = "gmail_pdf",
+    customer_email: str = "billing@example.test",
+    with_artifact: bool = True,
+) -> dict:
+    contact_id, run_id, candidate_id, approval_id, invoice_id = (
+        uuid4(),
+        uuid4(),
+        uuid4(),
+        uuid4(),
+        uuid4(),
+    )
+    candidate_key = f"commercial-billing:acme:{approval_id}"
+    source_fingerprint = _fingerprint({"approval": str(approval_id)})
+    request_fingerprint = _fingerprint({"seed": str(approval_id)})
+    now = datetime(2026, 4, 2, tzinfo=timezone.utc)
+    await connection.execute("INSERT INTO contacts (id) VALUES ($1)", contact_id)
+    await connection.execute(
+        """
+        INSERT INTO commercial_billing_runs (
+            id, billing_period, state, candidate_contract_version,
+            snapshot_fingerprint, source, idempotency_key, request_fingerprint,
+            created_by, created_at, updated_at
+        )
+        VALUES ($1, '2026-03', 'draft', 1, $2, 'eom_admin', $3, $4, 'Juan', $5, $5)
+        """,
+        run_id,
+        source_fingerprint,
+        f"run-{approval_id}",
+        request_fingerprint,
+        now,
+    )
+    await connection.execute(
+        """
+        INSERT INTO commercial_billing_run_candidates (
+            id, billing_run_id, candidate_key, source_fingerprint,
+            display_order, snapshot, created_at
+        )
+        VALUES ($1, $2, $3, $4, 0, '{}'::jsonb, $5)
+        """,
+        candidate_id,
+        run_id,
+        candidate_key,
+        source_fingerprint,
+        now,
+    )
+    metadata = {
+        "candidateKey": candidate_key,
+        "commercialBillingRunId": str(run_id),
+        "deliveryMethod": delivery_method,
+        "sourceFingerprint": source_fingerprint,
+    }
+    await connection.execute(
+        """
+        INSERT INTO invoices (
+            id, invoice_number, contact_id, customer_name, customer_email,
+            line_items, subtotal, tax_rate, tax_amount, discount_amount,
+            total_amount, issue_date, due_date, status, source, source_ref,
+            business_context_id, notes, metadata, invoice_for, contact_name,
+            created_at, updated_at
+        )
+        VALUES (
+            $1, $2, $3, 'Acme Office', $4, $5::jsonb, 96.50, 0, 0, 0,
+            96.50, $6, $7, 'draft', 'eom_commercial_billing', $8,
+            'effingham_maids', 'Approved commercial billing candidate', $9::jsonb,
+            'Office cleaning - March 2026', 'Billing Contact', $10, $10
+        )
+        """,
+        invoice_id,
+        f"INV-2026-Mar-{str(approval_id).replace('-', '')[:4]}",
+        contact_id,
+        customer_email,
+        json.dumps(
+            [
+                {
+                    "amount": 96.50,
+                    "description": "Office cleaning",
+                    "quantity": 2,
+                    "unit_price": 48.25,
+                }
+            ]
+        ),
+        date(2026, 4, 2),
+        date(2026, 4, 16),
+        f"approval:{approval_id}",
+        json.dumps(metadata),
+        now,
+    )
+    await connection.execute(
+        """
+        INSERT INTO commercial_billing_candidate_approvals (
+            id, billing_run_id, candidate_key, source_fingerprint, source,
+            idempotency_key, request_fingerprint, invoice_id, state,
+            approved_by, approved_at, created_at, updated_at
+        )
+        VALUES ($1, $2, $3, $4, 'eom_admin', $5, $6, $7, 'invoice_created',
+                'Juan', $8, $8, $8)
+        """,
+        approval_id,
+        run_id,
+        candidate_key,
+        source_fingerprint,
+        f"approval-{approval_id}",
+        request_fingerprint,
+        invoice_id,
+        now,
+    )
+    renderer = _PDFRenderer()
+    if with_artifact:
+        await CommercialBillingInvoicePDFService(
+            pool=_SchemaPool(connection, schema),
+            renderer=renderer,
+            now=lambda: now,
+        ).generate_or_reuse(
+            approval_id=approval_id,
+            idempotency_key=f"pdf-{approval_id}",
+            actor="Juan",
+        )
+    return {
+        "approval_id": approval_id,
+        "invoice_id": invoice_id,
+        "renderer": renderer,
+    }
+
+
+def _service(connection, schema: str, gateway: _RecordingGateway):
+    now = datetime(2026, 4, 2, tzinfo=timezone.utc)
+    pool = _SchemaPool(connection, schema)
+    return CommercialBillingInvoiceGmailDraftService(
+        pool=pool,
+        pdf_service=CommercialBillingInvoicePDFService(pool=pool, now=lambda: now),
+        gateway_loader=lambda: gateway,
+        now=lambda: now,
+    )
+
+
+@pytest.mark.asyncio
+async def test_real_postgres_creates_one_no_send_draft_and_reuses_it_idempotently():
+    async with _gmail_draft_database() as (connection, schema):
+        seed = await _seed_approved_invoice(connection, schema)
+        gateway = _RecordingGateway()
+        service = _service(connection, schema, gateway)
+
+        created = await service.create_or_reuse(
+            approval_id=seed["approval_id"], idempotency_key="gmail-1", actor="Juan"
+        )
+        replayed = await service.create_or_reuse(
+            approval_id=seed["approval_id"], idempotency_key="gmail-1", actor="Mayra"
+        )
+        reused = await service.create_or_reuse(
+            approval_id=seed["approval_id"], idempotency_key="gmail-2", actor="Mayra"
+        )
+
+        assert created["replayed"] is False
+        assert created["reused"] is False
+        assert created["draft"]["state"] == "draft_created"
+        assert created["draft"]["gmailDraftId"] == "draft-1"
+        assert created["draft"]["recipientEmail"] == "billing@example.test"
+        assert created["draft"]["subject"].startswith("Invoice INV-2026-Mar-")
+        assert created["draft"]["rfcMessageId"].startswith(
+            "<atlas-eom-commercial-billing-"
+        )
+        assert replayed["replayed"] is True
+        assert replayed["reused"] is True
+        assert reused["replayed"] is False
+        assert reused["reused"] is True
+        assert len(gateway.create_calls) == 1
+        assert gateway.lookup_calls == []
+
+        call = gateway.create_calls[0]
+        assert call["headers"]["Message-ID"] == created["draft"]["rfcMessageId"]
+        assert call["headers"]["X-Atlas-Commercial-Billing-Approval"] == str(
+            seed["approval_id"]
+        )
+        assert call["headers"]["X-Atlas-Commercial-Billing-Invoice"] == str(
+            seed["invoice_id"]
+        )
+        attachment = call["attachments"][0]
+        assert attachment["filename"].endswith(".pdf")
+        assert base64.b64decode(attachment["content"]).startswith(b"%PDF-")
+        assert call["body"]
+        assert call["html"]
+
+        assert await connection.fetchval(
+            "SELECT COUNT(*) FROM commercial_billing_invoice_gmail_drafts"
+        ) == 1
+        assert await connection.fetchval(
+            "SELECT COUNT(*) FROM commercial_billing_invoice_gmail_draft_operations"
+        ) == 2
+        invoice = await connection.fetchrow(
+            "SELECT status, sent_at, sent_via FROM invoices WHERE id = $1", seed["invoice_id"]
+        )
+        assert dict(invoice) == {"status": "draft", "sent_at": None, "sent_via": None}
+
+
+@pytest.mark.asyncio
+async def test_definite_gmail_rejection_stays_retryable_and_same_key_can_create_once():
+    async with _gmail_draft_database() as (connection, schema):
+        seed = await _seed_approved_invoice(connection, schema)
+        gateway = _RecordingGateway()
+        gateway.create_error = GmailDraftCreateError(
+            "synthetic rejected request", definitely_not_created=True
+        )
+        service = _service(connection, schema, gateway)
+
+        with pytest.raises(CommercialBillingGmailDraftUnavailableError):
+            await service.create_or_reuse(
+                approval_id=seed["approval_id"], idempotency_key="gmail-retry", actor="Juan"
+            )
+        assert await connection.fetchval(
+            "SELECT state FROM commercial_billing_invoice_gmail_drafts"
+        ) == "retryable"
+        gateway.create_error = None
+
+        created = await service.create_or_reuse(
+            approval_id=seed["approval_id"], idempotency_key="gmail-retry", actor="Juan"
+        )
+        assert created["replayed"] is True
+        assert created["reused"] is False
+        assert created["draft"]["state"] == "draft_created"
+        assert len(gateway.create_calls) == 2
+        assert await connection.fetchval(
+            "SELECT COUNT(*) FROM commercial_billing_invoice_gmail_drafts"
+        ) == 1
+        assert await connection.fetchval(
+            "SELECT COUNT(*) FROM commercial_billing_invoice_gmail_draft_operations"
+        ) == 1
+
+
+@pytest.mark.asyncio
+async def test_gmail_acceptance_with_database_confirm_failure_recovers_by_message_id():
+    async with _gmail_draft_database() as (connection, schema):
+        seed = await _seed_approved_invoice(connection, schema)
+        gateway = _RecordingGateway()
+        service = _service(connection, schema, gateway)
+        await connection.execute(
+            """
+            CREATE FUNCTION reject_gmail_draft_confirmation()
+            RETURNS trigger LANGUAGE plpgsql AS $$
+            BEGIN
+                IF NEW.state = 'draft_created' THEN
+                    RAISE EXCEPTION 'synthetic confirmation failure';
+                END IF;
+                RETURN NEW;
+            END;
+            $$
+            """
+        )
+        await connection.execute(
+            """
+            CREATE TRIGGER reject_gmail_draft_confirmation_trigger
+            BEFORE UPDATE ON commercial_billing_invoice_gmail_drafts
+            FOR EACH ROW EXECUTE FUNCTION reject_gmail_draft_confirmation()
+            """
+        )
+        with pytest.raises(CommercialBillingGmailDraftRecoveryRequiredError):
+            await service.create_or_reuse(
+                approval_id=seed["approval_id"], idempotency_key="gmail-confirm", actor="Juan"
+            )
+        assert len(gateway.create_calls) == 1
+        assert await connection.fetchval(
+            "SELECT state FROM commercial_billing_invoice_gmail_drafts"
+        ) == "recovery_required"
+        await connection.execute(
+            "DROP TRIGGER reject_gmail_draft_confirmation_trigger "
+            "ON commercial_billing_invoice_gmail_drafts"
+        )
+        await connection.execute("DROP FUNCTION reject_gmail_draft_confirmation()")
+
+        recovered = await service.create_or_reuse(
+            approval_id=seed["approval_id"], idempotency_key="gmail-confirm", actor="Juan"
+        )
+        assert recovered["replayed"] is True
+        assert recovered["reused"] is True
+        assert recovered["draft"]["state"] == "draft_created"
+        assert len(gateway.create_calls) == 1
+        assert len(gateway.lookup_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_concurrent_fresh_keys_never_issue_a_second_gmail_create():
+    async with _gmail_draft_database() as (connection, schema):
+        seed = await _seed_approved_invoice(connection, schema)
+        gateway = _BlockingGateway()
+        service = _service(connection, schema, gateway)
+        first = asyncio.create_task(
+            service.create_or_reuse(
+                approval_id=seed["approval_id"], idempotency_key="gmail-concurrent-1", actor="Juan"
+            )
+        )
+        await asyncio.wait_for(gateway.create_started.wait(), timeout=2)
+        with pytest.raises(CommercialBillingGmailDraftRecoveryRequiredError):
+            await service.create_or_reuse(
+                approval_id=seed["approval_id"], idempotency_key="gmail-concurrent-2", actor="Mayra"
+            )
+        assert len(gateway.create_calls) == 1
+        assert len(gateway.lookup_calls) == 1
+        gateway.release_create.set()
+        completed = await first
+        assert completed["draft"]["state"] == "draft_created"
+        assert await connection.fetchval(
+            "SELECT COUNT(*) FROM commercial_billing_invoice_gmail_drafts"
+        ) == 1
+        assert await connection.fetchval(
+            "SELECT COUNT(*) FROM commercial_billing_invoice_gmail_draft_operations"
+        ) == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("delivery_method", "customer_email", "with_artifact"),
+    (
+        ("manual_square", "billing@example.test", True),
+        ("gmail_pdf", "not-an-email", True),
+        ("gmail_pdf", "billing@example.test", False),
+    ),
+)
+async def test_ineligible_or_missing_pdf_draft_inputs_leave_zero_gmail_writes(
+    delivery_method: str,
+    customer_email: str,
+    with_artifact: bool,
+):
+    async with _gmail_draft_database() as (connection, schema):
+        seed = await _seed_approved_invoice(
+            connection,
+            schema,
+            delivery_method=delivery_method,
+            customer_email=customer_email,
+            with_artifact=with_artifact,
+        )
+        gateway = _RecordingGateway()
+        with pytest.raises(CommercialBillingGmailDraftConflictError):
+            await _service(connection, schema, gateway).create_or_reuse(
+                approval_id=seed["approval_id"], idempotency_key="gmail-invalid", actor="Juan"
+            )
+        assert gateway.create_calls == []
+        assert gateway.lookup_calls == []
+        assert await connection.fetchval(
+            "SELECT COUNT(*) FROM commercial_billing_invoice_gmail_drafts"
+        ) == 0
+        assert await connection.fetchval(
+            "SELECT COUNT(*) FROM commercial_billing_invoice_gmail_draft_operations"
+        ) == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mutation", ("sent", "changed_after_pdf"))
+async def test_sent_or_changed_invoice_rejects_new_draft_before_gmail_or_operation_write(
+    mutation: str,
+):
+    async with _gmail_draft_database() as (connection, schema):
+        seed = await _seed_approved_invoice(connection, schema)
+        if mutation == "sent":
+            await connection.execute(
+                "UPDATE invoices SET status = 'sent' WHERE id = $1",
+                seed["invoice_id"],
+            )
+        else:
+            await connection.execute(
+                "UPDATE invoices SET notes = 'Changed after PDF generation' WHERE id = $1",
+                seed["invoice_id"],
+            )
+        gateway = _RecordingGateway()
+        with pytest.raises(CommercialBillingGmailDraftConflictError):
+            await _service(connection, schema, gateway).create_or_reuse(
+                approval_id=seed["approval_id"], idempotency_key="gmail-sent", actor="Juan"
+            )
+        assert gateway.create_calls == []
+        assert await connection.fetchval(
+            "SELECT COUNT(*) FROM commercial_billing_invoice_gmail_drafts"
+        ) == 0
+        assert await connection.fetchval(
+            "SELECT COUNT(*) FROM commercial_billing_invoice_gmail_draft_operations"
+        ) == 0
+
+
+@pytest.mark.asyncio
+async def test_gmail_transport_draft_create_uses_only_drafts_endpoint_and_safe_headers():
+    requests: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={"id": "draft-1", "message": {"id": "message-1", "threadId": "thread-1"}},
+        )
+
+    transport = GmailTransport()
+    transport._access_token = "token"
+    transport._token_expires = time.time() + 600
+    transport._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        result = await transport.create_draft(
+            to=["billing@example.test"],
+            subject="Invoice INV-1",
+            body="Body",
+            headers={
+                "Message-ID": "<atlas-eom-commercial-billing-1@example.test>",
+                "X-Atlas-Commercial-Billing-Approval": "approval-1",
+            },
+        )
+    finally:
+        await transport.close()
+
+    assert result["id"] == "draft-1"
+    assert len(requests) == 1
+    request = requests[0]
+    assert request.method == "POST"
+    assert request.url.path.endswith("/users/me/drafts")
+    assert "/messages/send" not in request.url.path
+    payload = json.loads(request.content)
+    raw = payload["message"]["raw"]
+    raw_bytes = base64.urlsafe_b64decode(raw + "=" * (-len(raw) % 4))
+    message = message_from_bytes(raw_bytes)
+    assert message["Message-ID"] == "<atlas-eom-commercial-billing-1@example.test>"
+    assert message["X-Atlas-Commercial-Billing-Approval"] == "approval-1"
+
+
+@pytest.mark.asyncio
+async def test_gmail_transport_looks_up_exact_rfc_message_id_and_rejects_ambiguity():
+    requests: list[httpx.Request] = []
+
+    async def one_match(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "drafts": [
+                    {
+                        "id": "draft-1",
+                        "message": {"id": "message-1", "threadId": "thread-1"},
+                    }
+                ]
+            },
+        )
+
+    transport = GmailTransport()
+    transport._access_token = "token"
+    transport._token_expires = time.time() + 600
+    transport._client = httpx.AsyncClient(transport=httpx.MockTransport(one_match))
+    try:
+        found = await transport.find_draft_by_rfc_message_id("<stable@example.test>")
+    finally:
+        await transport.close()
+    assert found == {
+        "id": "draft-1",
+        "message": {"id": "message-1", "threadId": "thread-1"},
+    }
+    assert requests[0].method == "GET"
+    assert requests[0].url.path.endswith("/users/me/drafts")
+    assert requests[0].url.params["q"] == "rfc822msgid:<stable@example.test>"
+
+    async def ambiguous(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "drafts": [
+                    {"id": "draft-1", "message": {"id": "m-1", "threadId": "t-1"}},
+                    {"id": "draft-2", "message": {"id": "m-2", "threadId": "t-2"}},
+                ]
+            },
+        )
+
+    transport = GmailTransport()
+    transport._access_token = "token"
+    transport._token_expires = time.time() + 600
+    transport._client = httpx.AsyncClient(transport=httpx.MockTransport(ambiguous))
+    try:
+        with pytest.raises(GmailDraftLookupError, match="multiple"):
+            await transport.find_draft_by_rfc_message_id("<stable@example.test>")
+    finally:
+        await transport.close()
+
+
+class _RouteService:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def create_or_reuse(self, **kwargs) -> dict:
+        self.calls.append(kwargs)
+        return {
+            "draft": {
+                "approvalId": str(kwargs["approval_id"]),
+                "id": "draft-record-1",
+                "state": "draft_created",
+            },
+            "replayed": False,
+            "reused": False,
+        }
+
+
+@pytest.mark.asyncio
+async def test_full_atlas_app_gmail_draft_route_requires_existing_auth_and_never_returns_pdf_bytes():
+    from atlas_brain.api.invoicing import auth as receivables_auth
+    from atlas_brain.api.invoicing import receivables as routes
+    from atlas_brain.eom_api.auth import generate_receivables_service_token
+    from atlas_brain.main import app
+
+    approval_id = uuid4()
+    service = _RouteService()
+    generated = generate_receivables_service_token()
+    original_overrides = dict(app.dependency_overrides)
+    app.dependency_overrides[receivables_auth.get_receivables_api_config] = lambda: SimpleNamespace(
+        receivables_api_enabled=True,
+        receivables_service_token="",
+        receivables_service_token_sha256=generated.sha256,
+    )
+    app.dependency_overrides[
+        routes.get_commercial_billing_invoice_gmail_draft_service
+    ] = lambda: service
+    path = f"/api/v1/receivables/commercial-billing-approvals/{approval_id}/gmail-draft"
+    headers = {"Authorization": f"Bearer {generated.token}"}
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            assert (await client.post(path)).status_code == 401
+            assert (await client.post(path, headers=headers)).status_code == 422
+            assert (
+                await client.post(
+                    path,
+                    headers={**headers, "Idempotency-Key": "route-gmail-1"},
+                )
+            ).status_code == 422
+            response = await client.post(
+                path,
+                headers={
+                    **headers,
+                    "Idempotency-Key": "route-gmail-1",
+                    "X-EOM-Actor": "Juan",
+                },
+            )
+    finally:
+        app.dependency_overrides.clear()
+        app.dependency_overrides.update(original_overrides)
+    assert response.status_code == 201
+    assert response.json()["draft"] == {
+        "approvalId": str(approval_id),
+        "id": "draft-record-1",
+        "state": "draft_created",
+    }
+    assert "pdf_bytes" not in response.text
+    assert "pdfBytes" not in response.text
+    assert service.calls == [
+        {"approval_id": approval_id, "idempotency_key": "route-gmail-1", "actor": "Juan"}
+    ]
+
+
+def test_gmail_draft_migration_is_additive_and_never_encodes_sent_state():
+    migration = (
+        Path(__file__).parents[1]
+        / "atlas_brain/storage/migrations/374_commercial_billing_invoice_gmail_drafts.sql"
+    ).read_text()
+    executable = "\n".join(
+        line for line in migration.splitlines() if not line.lstrip().startswith("--")
+    )
+    assert "CREATE TABLE IF NOT EXISTS commercial_billing_invoice_gmail_drafts" in migration
+    assert "CREATE TABLE IF NOT EXISTS commercial_billing_invoice_gmail_draft_operations" in migration
+    assert migration.count("ON DELETE RESTRICT") == 3
+    assert "approval_id UUID NOT NULL UNIQUE" in migration
+    assert "artifact_id UUID NOT NULL UNIQUE" in migration
+    assert "UNIQUE (source, idempotency_key)" in migration
+    assert "'creating', 'retryable', 'recovery_required', 'draft_created'" in migration
+    assert "sent_at" not in executable
+    assert "UPDATE invoices" not in executable
+    assert "DROP TABLE" not in executable
+
+
+def test_gmail_draft_service_imports_no_sender_or_financial_state_writer():
+    import atlas_brain.services.commercial_billing_invoice_gmail_drafts as drafts
+
+    source = inspect.getsource(drafts)
+    imports = {
+        alias.name
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    }
+    imports.update(
+        {
+            f"{node.module}.{alias.name}" if node.module else alias.name
+            for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.ImportFrom)
+            for alias in node.names
+        }
+    )
+    assert not any(
+        fragment in imported
+        for fragment in {
+            "email_provider",
+            "invoicing_server",
+            "monthly_invoice_generation",
+            "crm_provider",
+        }
+        for imported in imports
+    )
+    assert "UPDATE invoices" not in source
+    assert ".send(" not in source
+    assert "float(" not in source
+
+
+def test_invoicing_workflow_enrolls_the_gmail_draft_surface_and_contract():
+    workflow = (Path(__file__).parents[1] / ".github/workflows/atlas_invoicing_checks.yml").read_text()
+    for path in (
+        "atlas_brain/services/commercial_billing_invoice_gmail_drafts.py",
+        "atlas_brain/storage/migrations/374_commercial_billing_invoice_gmail_drafts.sql",
+        "atlas_brain/tools/gmail.py",
+        "tests/test_commercial_billing_gmail_drafts.py",
+    ):
+        assert workflow.count(f'      - "{path}"') == 2
+    assert "tests/test_commercial_billing_gmail_drafts.py \\" in workflow


### PR DESCRIPTION
Plan: plans/PR-EOM-Commercial-Invoice-Gmail-Drafts.md
Slice phase: Vertical slice
Ownership lane: eom/billing-approved-gmail-drafts

An explicitly approved EOM commercial invoice already has a durable, exact PDF
artifact, but ATLAS cannot yet create or recover one Gmail draft without
reusing legacy send/mark-sent paths. This provider-only slice persists a
no-send Gmail draft intent before the external call, then either confirms or
recovers that exact draft by a stable RFC Message-ID.

Diff-budget override: The migration, durable state machine, Gmail lookup, authenticated route, and failure/concurrency proof are indivisible because any split either contacts Gmail without recovery evidence or ships an inert contract.

## Intentional

- This calls only Gmail Drafts create/list endpoints; it never sends, marks an
  invoice sent, alters receivables, changes CRM evidence, or executes Square.
- Gmail bytes come only from the already-retained immutable PDF artifact; no
  browser route exposes PDF bytes or credentials.
- An uncertain create is recovered only by its persisted Message-ID. A missing
  or ambiguous draft remains `recovery_required`, never inferred sent.

## AI reconciliation

- no-findings

## Deferred

- #2363 H-15: sent-mail reconciliation, final sent-message evidence, deleted
  draft classification, and operator recovery UX.
- #2363 H-15: manual Square invoice queue/reference and audited sent-via-Square
  action.
- Dependent eom-timetracker proxy and Website review/recovery UI after this
  provider contract is deployed.

## Parked hardening

- None. New delivery channels, background mailbox sweeps, generic PDF download,
  and customer-email redesign are outside this one no-send provider transition.

## Cold diff reconstruction

- Changed: `374_commercial_billing_invoice_gmail_drafts.sql:17` adds one
  approval/artifact-bound draft state record and idempotency receipts with no
  invoice sent state; `commercial_billing_invoice_gmail_drafts.py:351` commits
  intent before Gmail and `:444` creates/reconciles only that intent.
- Changed: `commercial_billing_invoice_pdfs.py:349` provides the service-only
  retained-PDF read; `tools/gmail.py:274` adds safe immutable headers and
  `:378` the exact Drafts lookup; `receivables.py:711` exposes the existing-auth
  provider route only.
- Changed: `test_commercial_billing_gmail_drafts.py:317` proves reuse,
  rejection, confirmation failure recovery, concurrent callers, zero-write
  rejection, real mounted auth, and Gmail endpoint/query shape. The invoicing
  workflow explicitly enrolls that proof.
- Contract match: each changed production surface is necessary for the
  precommitted no-send draft/recovery boundary; no changed path sends email,
  changes invoice financial state, or provides browser credentials/PDF bytes.
- Gaps: none found in cold reconstruction.

## Verification

- Isolated PostgreSQL focused service/transport/route proof: `75 passed`.
- Local mirror of `Atlas Invoicing Checks`: approval blockers `2 passed`,
  ledger/PDF/billing suite `417 passed`, MCP/OAuth surface `43 passed`.
- `ruff`, source compilation, and `git diff --check` pass. No test contacted
  Gmail or a live financial database.
- The repository local PR-review wrapper and escalated full unit gate pass;
  its 160 failing/error nodes exactly match the trusted baseline (zero
  regressions and zero newly-passing baseline nodes).
- Maturity sweep unit suite: `86 passed`; changed API, storage, and Gmail
  transport ratchets pass without a baseline update. The new state-machine
  service has no maturity findings after explicit non-assert state guards.

## Mechanical verification

- Command: `python scripts/sync_pr_plan.py --check plans/PR-EOM-Commercial-Invoice-Gmail-Drafts.md origin/main` - Result: pass - Environment: local
- Command: local Atlas Invoicing Checks mirror - Result: 462 passed - Environment: local
- Command: maturity-sweep unit/API/storage/Gmail checks - Result: 86 passed - Environment: local
- Command: `python -m ruff check ... && python -m compileall ... && git diff --check` - Result: pass - Environment: local
- Command: `bash scripts/push_pr.sh /tmp/eom-commercial-invoice-gmail-drafts-pr-body.md -u origin HEAD` - Result: pass - Environment: local

## Diff size

8 files, +2570 / -10.

<!-- atlas-open-pr-wrapper: v1 -->
