### PR TITLE
EOM: reconcile commercial Gmail sent mail

### DIFF
--- a/.github/workflows/atlas_invoicing_checks.yml
+++ b/.github/workflows/atlas_invoicing_checks.yml
@@ -33,6 +33,7 @@ on:
       - "atlas_brain/services/commercial_billing_approvals.py"
       - "atlas_brain/services/commercial_billing_invoice_pdfs.py"
       - "atlas_brain/services/commercial_billing_invoice_gmail_drafts.py"
+      - "atlas_brain/services/commercial_billing_invoice_gmail_sent_reconciliation.py"
       - "atlas_brain/services/invoice_pdf.py"
       - "atlas_brain/tools/gmail.py"
       # normalize_contact_email decides billing eligibility and the
@@ -49,6 +50,7 @@ on:
       - "atlas_brain/storage/migrations/372_commercial_billing_candidate_approvals.sql"
       - "atlas_brain/storage/migrations/373_commercial_billing_invoice_pdf_artifacts.sql"
       - "atlas_brain/storage/migrations/374_commercial_billing_invoice_gmail_drafts.sql"
+      - "atlas_brain/storage/migrations/375_commercial_billing_invoice_gmail_sent_reconciliation.sql"
       - "atlas_brain/storage/repositories/invoice.py"
       - "atlas_brain/templates/email/__init__.py"
       - "atlas_brain/templates/email/estimate_confirmation.py"
@@ -100,6 +102,7 @@ on:
       - "atlas_brain/services/commercial_billing_approvals.py"
       - "atlas_brain/services/commercial_billing_invoice_pdfs.py"
       - "atlas_brain/services/commercial_billing_invoice_gmail_drafts.py"
+      - "atlas_brain/services/commercial_billing_invoice_gmail_sent_reconciliation.py"
       - "atlas_brain/services/invoice_pdf.py"
       - "atlas_brain/tools/gmail.py"
       # normalize_contact_email decides billing eligibility and the
@@ -116,6 +119,7 @@ on:
       - "atlas_brain/storage/migrations/372_commercial_billing_candidate_approvals.sql"
       - "atlas_brain/storage/migrations/373_commercial_billing_invoice_pdf_artifacts.sql"
       - "atlas_brain/storage/migrations/374_commercial_billing_invoice_gmail_drafts.sql"
+      - "atlas_brain/storage/migrations/375_commercial_billing_invoice_gmail_sent_reconciliation.sql"
       - "atlas_brain/storage/repositories/invoice.py"
       - "atlas_brain/templates/email/__init__.py"
       - "atlas_brain/templates/email/estimate_confirmation.py"

--- a/atlas_brain/api/invoicing/receivables.py
+++ b/atlas_brain/api/invoicing/receivables.py
@@ -66,6 +66,14 @@ from ...services.commercial_billing_invoice_gmail_drafts import (
     CommercialBillingGmailDraftValidationError,
     get_commercial_billing_invoice_gmail_draft_service,
 )
+from ...services.commercial_billing_invoice_gmail_sent_reconciliation import (
+    CommercialBillingGmailSentReconciliationConflictError,
+    CommercialBillingGmailSentReconciliationNotFoundError,
+    CommercialBillingGmailSentReconciliationUnavailableError,
+    CommercialBillingGmailSentReconciliationValidationError,
+    CommercialBillingInvoiceGmailSentReconciliationService,
+    get_commercial_billing_invoice_gmail_sent_reconciliation_service,
+)
 from ...services.eom_lead_ingress import EOM_BUSINESS_CONTEXT_ID
 from ...storage.exceptions import DatabaseUnavailableError
 from .auth import require_actor, require_receivables_api
@@ -378,6 +386,41 @@ async def _call_commercial_billing_gmail_draft(awaitable):
             detail={
                 "code": "commercial_billing_gmail_draft_unavailable",
                 "message": "Commercial billing Gmail draft database unavailable",
+            },
+        ) from exc
+
+
+async def _call_commercial_billing_gmail_sent_reconciliation(awaitable):
+    try:
+        return await awaitable
+    except CommercialBillingGmailSentReconciliationValidationError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail={"code": exc.code, "message": str(exc)},
+        ) from exc
+    except CommercialBillingGmailSentReconciliationNotFoundError as exc:
+        raise HTTPException(
+            status_code=404,
+            detail={"code": exc.code, "message": str(exc)},
+        ) from exc
+    except CommercialBillingGmailSentReconciliationConflictError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={"code": exc.code, "message": str(exc)},
+        ) from exc
+    except CommercialBillingGmailSentReconciliationUnavailableError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail={"code": exc.code, "message": str(exc)},
+        ) from exc
+    except Exception as exc:
+        if not _is_database_unavailable_error(exc):
+            raise
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "code": "commercial_billing_gmail_sent_reconciliation_unavailable",
+                "message": "Commercial billing Gmail sent reconciliation database unavailable",
             },
         ) from exc
 
@@ -723,6 +766,28 @@ async def create_commercial_billing_invoice_gmail_draft(
 
     return await _call_commercial_billing_gmail_draft(
         service.create_or_reuse(
+            approval_id=approval_id,
+            idempotency_key=idempotency_key,
+            actor=actor,
+        )
+    )
+
+
+@router.post("/commercial-billing-approvals/{approval_id}/gmail-draft/reconcile")
+async def reconcile_commercial_billing_invoice_gmail_draft_sent_mail(
+    approval_id: UUID,
+    actor: Annotated[str, Depends(require_actor)],
+    idempotency_key: Annotated[
+        str, Header(alias="Idempotency-Key", min_length=1, max_length=128)
+    ],
+    service: CommercialBillingInvoiceGmailSentReconciliationService = Depends(
+        get_commercial_billing_invoice_gmail_sent_reconciliation_service
+    ),
+) -> dict:
+    """Reconcile a manually sent Gmail draft from verifiable Sent-mail evidence."""
+
+    return await _call_commercial_billing_gmail_sent_reconciliation(
+        service.reconcile(
             approval_id=approval_id,
             idempotency_key=idempotency_key,
             actor=actor,

--- a/atlas_brain/services/commercial_billing_invoice_gmail_sent_reconciliation.py
+++ b/atlas_brain/services/commercial_billing_invoice_gmail_sent_reconciliation.py
@@ -1,0 +1,1100 @@
+"""Proof-gated Sent-mail reconciliation for EOM commercial Gmail drafts.
+
+The earlier Gmail-draft slice persists only a no-send draft identity.  Gmail
+replaces that draft with a different message when an operator sends it, so this
+service searches Sent mail by the durable RFC Message-ID and marks the linked
+ATLAS invoice sent only after it verifies the mailbox evidence.  A disappeared
+draft without that proof is explicitly retained as missing, never inferred sent.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable, Mapping, Optional, Protocol
+from uuid import UUID, uuid4
+
+import asyncpg
+
+from ..storage.database import DatabasePool, get_db_pool
+from ..storage.exceptions import DatabaseOperationError, DatabaseUnavailableError
+from ..tools.gmail import (
+    GmailSentMessageLookupError,
+    get_gmail_transport,
+)
+
+
+_DELIVERY_METHOD = "gmail_pdf"
+_DRAFT_SOURCE = "eom_admin"
+_INVOICE_SOURCE = "eom_commercial_billing"
+_MAX_ACTOR_LENGTH = 128
+_MAX_GMAIL_ID_LENGTH = 256
+_MAX_IDEMPOTENCY_KEY_LENGTH = 128
+_MAX_RFC_MESSAGE_ID_LENGTH = 320
+_OPERATION_STATES = frozenset({"pending", "completed"})
+_OUTCOME_STATES = frozenset({"draft_present", "draft_missing", "sent_confirmed"})
+_RECONCILIATION_STATES = frozenset(
+    {"not_reconciled", "draft_present", "draft_missing", "sent_confirmed"}
+)
+_POST_SEND_INVOICE_STATUSES = frozenset(
+    {"sent", "partial", "overdue", "paid", "void"}
+)
+_DATABASE_UNAVAILABLE_ERRORS = (
+    DatabaseOperationError,
+    DatabaseUnavailableError,
+    asyncpg.PostgresConnectionError,
+    asyncpg.CannotConnectNowError,
+    asyncpg.TooManyConnectionsError,
+    asyncpg.AdminShutdownError,
+    asyncpg.CrashShutdownError,
+    asyncpg.UndefinedTableError,
+    asyncpg.UndefinedColumnError,
+    asyncpg.InvalidSchemaNameError,
+    asyncpg.InsufficientPrivilegeError,
+    asyncpg.InvalidAuthorizationSpecificationError,
+)
+
+_RECORD_SELECT = """
+    SELECT draft.id AS draft_id, draft.approval_id, draft.state AS draft_state,
+           draft.rfc_message_id, draft.reconciliation_state,
+           draft.gmail_draft_id, draft.gmail_message_id, draft.gmail_thread_id,
+           draft.gmail_sent_message_id, draft.gmail_sent_thread_id,
+           draft.gmail_sent_at, draft.sent_reconciled_by,
+           draft.sent_reconciled_at, draft.last_reconciled_by,
+           draft.last_reconciled_at, draft.draft_missing_by,
+           draft.draft_missing_at,
+           approval.state AS approval_state,
+           approval.invoice_id AS approval_invoice_id,
+           invoice.id AS invoice_id, invoice.status AS invoice_status,
+           invoice.sent_at AS invoice_sent_at, invoice.sent_via AS invoice_sent_via,
+           invoice.source AS invoice_source, invoice.metadata AS invoice_metadata
+    FROM commercial_billing_invoice_gmail_drafts AS draft
+    JOIN commercial_billing_candidate_approvals AS approval
+      ON approval.id = draft.approval_id
+    JOIN invoices AS invoice ON invoice.id = approval.invoice_id
+"""
+
+_OPERATION_RECORD_SELECT = """
+    SELECT operation.id AS operation_id,
+           operation.request_fingerprint AS operation_request_fingerprint,
+           operation.state AS operation_state,
+           operation.outcome_state AS operation_outcome_state,
+           draft.id AS draft_id, draft.approval_id, draft.state AS draft_state,
+           draft.rfc_message_id, draft.reconciliation_state,
+           draft.gmail_draft_id, draft.gmail_message_id, draft.gmail_thread_id,
+           draft.gmail_sent_message_id, draft.gmail_sent_thread_id,
+           draft.gmail_sent_at, draft.sent_reconciled_by,
+           draft.sent_reconciled_at, draft.last_reconciled_by,
+           draft.last_reconciled_at, draft.draft_missing_by,
+           draft.draft_missing_at,
+           approval.state AS approval_state,
+           approval.invoice_id AS approval_invoice_id,
+           invoice.id AS invoice_id, invoice.status AS invoice_status,
+           invoice.sent_at AS invoice_sent_at, invoice.sent_via AS invoice_sent_via,
+           invoice.source AS invoice_source, invoice.metadata AS invoice_metadata
+    FROM commercial_billing_gmail_sent_reconciliation_operations AS operation
+    JOIN commercial_billing_invoice_gmail_drafts AS draft
+      ON draft.id = operation.gmail_draft_record_id
+    JOIN commercial_billing_candidate_approvals AS approval
+      ON approval.id = draft.approval_id
+    JOIN invoices AS invoice ON invoice.id = approval.invoice_id
+"""
+
+
+class CommercialBillingGmailSentReconciliationError(Exception):
+    code = "commercial_billing_gmail_sent_reconciliation_error"
+
+
+class CommercialBillingGmailSentReconciliationValidationError(
+    CommercialBillingGmailSentReconciliationError
+):
+    code = "invalid_commercial_billing_gmail_sent_reconciliation"
+
+
+class CommercialBillingGmailSentReconciliationNotFoundError(
+    CommercialBillingGmailSentReconciliationError
+):
+    code = "commercial_billing_gmail_draft_not_found"
+
+
+class CommercialBillingGmailSentReconciliationConflictError(
+    CommercialBillingGmailSentReconciliationError
+):
+    code = "commercial_billing_gmail_sent_reconciliation_conflict"
+
+
+class CommercialBillingGmailSentReconciliationUnavailableError(
+    CommercialBillingGmailSentReconciliationError
+):
+    code = "commercial_billing_gmail_sent_reconciliation_unavailable"
+
+
+class _GmailSentReconciliationGateway(Protocol):
+    async def find_draft_by_rfc_message_id(
+        self, rfc_message_id: str
+    ) -> dict[str, Any] | None: ...
+
+    async def find_sent_message_by_rfc_message_id(
+        self, rfc_message_id: str
+    ) -> dict[str, Any] | None: ...
+
+
+@dataclass(frozen=True)
+class _Context:
+    approval_id: UUID
+    draft_id: UUID
+    draft_state: str
+    invoice_id: UUID
+    invoice_sent_at: datetime | None
+    invoice_sent_via: str | None
+    invoice_status: str
+    reconciliation_state: str
+    rfc_message_id: str
+
+
+@dataclass(frozen=True)
+class _PreparedReconciliation:
+    context: _Context
+    operation: Mapping[str, Any]
+    record: Mapping[str, Any]
+    replayed: bool
+    action: str
+
+
+@dataclass(frozen=True)
+class _SentProof:
+    gmail_message_id: str
+    gmail_sent_at: datetime
+    gmail_thread_id: str
+
+
+@dataclass(frozen=True)
+class _LookupOutcome:
+    state: str
+    proof: _SentProof | None = None
+
+
+def _request_text(value: Any, field: str, *, limit: int) -> str:
+    if not isinstance(value, str):
+        raise CommercialBillingGmailSentReconciliationValidationError(
+            f"{field} is required"
+        )
+    text = value.strip()
+    if (
+        not text
+        or len(text) > limit
+        or "\r" in text
+        or "\n" in text
+        or "\x00" in text
+    ):
+        raise CommercialBillingGmailSentReconciliationValidationError(
+            f"{field} must contain 1 to {limit} safe characters"
+        )
+    return text
+
+
+def _stored_text(value: Any, field: str, *, limit: int) -> str:
+    if not isinstance(value, str):
+        raise CommercialBillingGmailSentReconciliationConflictError(
+            f"Commercial billing Gmail reconciliation {field} is invalid"
+        )
+    text = value.strip()
+    if (
+        not text
+        or len(text) > limit
+        or "\r" in text
+        or "\n" in text
+        or "\x00" in text
+    ):
+        raise CommercialBillingGmailSentReconciliationConflictError(
+            f"Commercial billing Gmail reconciliation {field} is invalid"
+        )
+    return text
+
+
+def _uuid(value: Any, field: str) -> UUID:
+    if isinstance(value, UUID):
+        return value
+    try:
+        return UUID(str(value))
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise CommercialBillingGmailSentReconciliationUnavailableError(
+            f"Commercial billing Gmail reconciliation {field} is invalid"
+        ) from exc
+
+
+def _fingerprint(value: Mapping[str, Any]) -> str:
+    try:
+        encoded = json.dumps(
+            value, sort_keys=True, separators=(",", ":"), allow_nan=False
+        ).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise CommercialBillingGmailSentReconciliationValidationError(
+            "Commercial billing Gmail reconciliation request is invalid"
+        ) from exc
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _mapping(value: Any, field: str) -> Mapping[str, Any]:
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise CommercialBillingGmailSentReconciliationConflictError(
+                f"Commercial billing Gmail reconciliation {field} is invalid"
+            ) from exc
+    if not isinstance(value, Mapping):
+        raise CommercialBillingGmailSentReconciliationConflictError(
+            f"Commercial billing Gmail reconciliation {field} is invalid"
+        )
+    return value
+
+
+def _state(value: Any) -> str:
+    state = _stored_text(value, "state", limit=32)
+    if state not in _RECONCILIATION_STATES:
+        raise CommercialBillingGmailSentReconciliationConflictError(
+            "Commercial billing Gmail reconciliation state is invalid"
+        )
+    return state
+
+
+def _operation_state(value: Any) -> str:
+    state = _stored_text(value, "operation state", limit=32)
+    if state not in _OPERATION_STATES:
+        raise CommercialBillingGmailSentReconciliationConflictError(
+            "Commercial billing Gmail reconciliation operation state is invalid"
+        )
+    return state
+
+
+def _external_id(value: Any, field: str) -> str:
+    return _stored_text(value, field, limit=_MAX_GMAIL_ID_LENGTH)
+
+
+def _rfc_message_id(value: Any) -> str:
+    message_id = _stored_text(value, "RFC Message-ID", limit=_MAX_RFC_MESSAGE_ID_LENGTH)
+    if (
+        len(message_id) < 5
+        or not message_id.startswith("<")
+        or not message_id.endswith(">")
+        or message_id.count("@") != 1
+        or any(character.isspace() for character in message_id)
+    ):
+        raise CommercialBillingGmailSentReconciliationConflictError(
+            "Commercial billing Gmail reconciliation RFC Message-ID is invalid"
+        )
+    return message_id
+
+
+def _timestamp(value: Any, field: str) -> datetime:
+    if not isinstance(value, datetime) or value.tzinfo is None:
+        raise CommercialBillingGmailSentReconciliationUnavailableError(
+            f"Commercial billing Gmail reconciliation {field} is invalid"
+        )
+    return value
+
+
+def _optional_timestamp(value: Any, field: str) -> datetime | None:
+    return None if value is None else _timestamp(value, field)
+
+
+def _sent_timestamp(value: Any) -> datetime:
+    if (
+        not isinstance(value, str)
+        or not value
+        or value != value.strip()
+        or not value.isascii()
+        or not value.isdecimal()
+    ):
+        raise CommercialBillingGmailSentReconciliationConflictError(
+            "Gmail sent-message timestamp is invalid"
+        )
+    try:
+        milliseconds = int(value)
+        if milliseconds <= 0:
+            raise ValueError("must be positive")
+        seconds, remainder = divmod(milliseconds, 1000)
+        return datetime.fromtimestamp(seconds, tz=timezone.utc) + timedelta(
+            milliseconds=remainder
+        )
+    except (OverflowError, OSError, ValueError) as exc:
+        raise CommercialBillingGmailSentReconciliationConflictError(
+            "Gmail sent-message timestamp is invalid"
+        ) from exc
+
+
+def _exact_header(headers: Any, name: str, expected: str) -> None:
+    if not isinstance(headers, list):
+        raise CommercialBillingGmailSentReconciliationConflictError(
+            "Gmail sent-message headers are invalid"
+        )
+    values: list[str] = []
+    for header in headers:
+        if not isinstance(header, Mapping):
+            raise CommercialBillingGmailSentReconciliationConflictError(
+                "Gmail sent-message headers are invalid"
+            )
+        raw_name = header.get("name")
+        raw_value = header.get("value")
+        if (
+            not isinstance(raw_name, str)
+            or not isinstance(raw_value, str)
+            or "\r" in raw_name
+            or "\n" in raw_name
+            or "\x00" in raw_name
+            or "\r" in raw_value
+            or "\n" in raw_value
+            or "\x00" in raw_value
+        ):
+            raise CommercialBillingGmailSentReconciliationConflictError(
+                "Gmail sent-message headers are invalid"
+            )
+        if raw_name.casefold() == name.casefold():
+            values.append(raw_value)
+    if len(values) != 1 or values != [expected]:
+        raise CommercialBillingGmailSentReconciliationConflictError(
+            "Gmail sent-message does not match its approved invoice identity"
+        )
+
+
+class CommercialBillingInvoiceGmailSentReconciliationService:
+    """Reconcile one manually sent Gmail draft without sending another email."""
+
+    def __init__(
+        self,
+        *,
+        pool: Optional[DatabasePool] = None,
+        gateway_loader: Callable[[], _GmailSentReconciliationGateway] = get_gmail_transport,
+        now: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
+    ) -> None:
+        self._configured_pool = pool
+        self._gateway_loader = gateway_loader
+        self._now = now
+
+    @property
+    def pool(self) -> DatabasePool:
+        pool = self._configured_pool or get_db_pool()
+        if not pool.is_initialized:
+            raise CommercialBillingGmailSentReconciliationUnavailableError(
+                "Commercial billing database unavailable"
+            )
+        return pool
+
+    async def reconcile(
+        self,
+        *,
+        approval_id: UUID,
+        idempotency_key: str,
+        actor: str,
+    ) -> dict[str, Any]:
+        """Record one proof-gated reconciliation or a non-financial observation."""
+
+        if not isinstance(approval_id, UUID):
+            raise CommercialBillingGmailSentReconciliationValidationError(
+                "Approval id is invalid"
+            )
+        key = _request_text(
+            idempotency_key, "Idempotency key", limit=_MAX_IDEMPOTENCY_KEY_LENGTH
+        )
+        requested_by = _request_text(actor, "authenticated actor", limit=_MAX_ACTOR_LENGTH)
+        fingerprint = _fingerprint({"approvalId": str(approval_id)})
+        try:
+            prepared = await self._prepare(
+                approval_id=approval_id,
+                idempotency_key=key,
+                request_fingerprint=fingerprint,
+                actor=requested_by,
+            )
+            if prepared.action == "return":
+                return self._result(
+                    prepared.record,
+                    outcome_state=_stored_text(
+                        prepared.operation.get("operation_outcome_state"),
+                        "operation outcome",
+                        limit=32,
+                    ),
+                    replayed=prepared.replayed,
+                    reused=True,
+                )
+            if prepared.action != "lookup":
+                raise CommercialBillingGmailSentReconciliationConflictError(
+                    "Commercial billing Gmail reconciliation action is invalid"
+                )
+            outcome = await self._lookup(prepared.context)
+            return await self._finalize(
+                prepared=prepared,
+                outcome=outcome,
+                actor=requested_by,
+            )
+        except CommercialBillingGmailSentReconciliationError:
+            raise
+        except (asyncpg.UniqueViolationError, asyncpg.ForeignKeyViolationError) as exc:
+            raise CommercialBillingGmailSentReconciliationConflictError(
+                "Commercial billing Gmail reconciliation could not be reconciled"
+            ) from exc
+        except asyncpg.PostgresError as exc:
+            raise CommercialBillingGmailSentReconciliationUnavailableError(
+                "Commercial billing database unavailable"
+            ) from exc
+        except _DATABASE_UNAVAILABLE_ERRORS as exc:
+            raise CommercialBillingGmailSentReconciliationUnavailableError(
+                "Commercial billing database unavailable"
+            ) from exc
+
+    async def _prepare(
+        self,
+        *,
+        approval_id: UUID,
+        idempotency_key: str,
+        request_fingerprint: str,
+        actor: str,
+    ) -> _PreparedReconciliation:
+        async with self.pool.transaction() as conn:
+            await self._lock_operation(conn, idempotency_key)
+            operation = await self._find_operation_by_key(conn, idempotency_key)
+            if operation is not None:
+                self._assert_operation(operation, approval_id, request_fingerprint)
+                context = self._context(operation)
+                await self._lock_approval(conn, context.approval_id)
+                operation = await self._find_operation_by_key(conn, idempotency_key)
+                if operation is None:
+                    raise CommercialBillingGmailSentReconciliationUnavailableError(
+                        "Commercial billing Gmail reconciliation operation is unavailable"
+                    )
+                context = self._context(operation)
+                if _operation_state(operation["operation_state"]) == "completed":
+                    return _PreparedReconciliation(
+                        context=context,
+                        operation=operation,
+                        record=operation,
+                        replayed=True,
+                        action="return",
+                    )
+                if context.reconciliation_state == "sent_confirmed":
+                    self._assert_confirmed_financial_state(context)
+                    operation = await self._complete_operation(
+                        conn,
+                        operation_id=_uuid(operation["operation_id"], "operation id"),
+                        outcome_state="sent_confirmed",
+                        now=self._now_timestamp(),
+                    )
+                    return _PreparedReconciliation(
+                        context=context,
+                        operation=operation,
+                        record=operation,
+                        replayed=True,
+                        action="return",
+                    )
+                self._assert_reconcilable(context)
+                return _PreparedReconciliation(
+                    context=context,
+                    operation=operation,
+                    record=operation,
+                    replayed=True,
+                    action="lookup",
+                )
+
+            await self._lock_approval(conn, approval_id)
+            record = await self._find_record_for_approval(conn, approval_id)
+            if record is None:
+                raise CommercialBillingGmailSentReconciliationNotFoundError(
+                    "Commercial billing Gmail draft not found"
+                )
+            context = self._context(record)
+            operation = await self._insert_operation(
+                conn,
+                draft_id=context.draft_id,
+                idempotency_key=idempotency_key,
+                request_fingerprint=request_fingerprint,
+                actor=actor,
+                now=self._now_timestamp(),
+            )
+            if context.reconciliation_state == "sent_confirmed":
+                self._assert_confirmed_financial_state(context)
+                operation = await self._complete_operation(
+                    conn,
+                    operation_id=_uuid(operation["operation_id"], "operation id"),
+                    outcome_state="sent_confirmed",
+                    now=self._now_timestamp(),
+                )
+                return _PreparedReconciliation(
+                    context=context,
+                    operation=operation,
+                    record=record,
+                    replayed=False,
+                    action="return",
+                )
+            self._assert_reconcilable(context)
+            return _PreparedReconciliation(
+                context=context,
+                operation=operation,
+                record=record,
+                replayed=False,
+                action="lookup",
+            )
+
+    async def _lookup(self, context: _Context) -> _LookupOutcome:
+        try:
+            gateway = self._gateway_loader()
+            sent_message = await gateway.find_sent_message_by_rfc_message_id(
+                context.rfc_message_id
+            )
+        except GmailSentMessageLookupError as exc:
+            if exc.retryable:
+                raise CommercialBillingGmailSentReconciliationUnavailableError(
+                    "Gmail Sent-mail lookup is unavailable; retry is safe"
+                ) from exc
+            raise CommercialBillingGmailSentReconciliationConflictError(
+                "Gmail Sent-mail evidence is ambiguous or invalid"
+            ) from exc
+        except Exception as exc:
+            raise CommercialBillingGmailSentReconciliationUnavailableError(
+                "Gmail Sent-mail lookup is unavailable; retry is safe"
+            ) from exc
+        if sent_message is not None:
+            return _LookupOutcome(
+                state="sent_confirmed",
+                proof=self._sent_proof(sent_message, context),
+            )
+
+        try:
+            draft = await gateway.find_draft_by_rfc_message_id(context.rfc_message_id)
+        except Exception as exc:
+            raise CommercialBillingGmailSentReconciliationUnavailableError(
+                "Gmail draft lookup is unavailable; retry is safe"
+            ) from exc
+        return _LookupOutcome(
+            state="draft_present" if draft is not None else "draft_missing"
+        )
+
+    async def _finalize(
+        self,
+        *,
+        prepared: _PreparedReconciliation,
+        outcome: _LookupOutcome,
+        actor: str,
+    ) -> dict[str, Any]:
+        now = self._now_timestamp()
+        async with self.pool.transaction() as conn:
+            await self._lock_approval(conn, prepared.context.approval_id)
+            record = await self._find_record_for_id(conn, prepared.context.draft_id)
+            if record is None:
+                raise CommercialBillingGmailSentReconciliationUnavailableError(
+                    "Commercial billing Gmail draft is unavailable"
+                )
+            context = self._context(record)
+            operation = await self._find_operation_by_id(
+                conn, _uuid(prepared.operation["operation_id"], "operation id")
+            )
+            if operation is None:
+                raise CommercialBillingGmailSentReconciliationUnavailableError(
+                    "Commercial billing Gmail reconciliation operation is unavailable"
+                )
+            operation_state = _operation_state(operation["operation_state"])
+            if operation_state == "completed":
+                return self._result(
+                    record,
+                    outcome_state=_stored_text(
+                        operation["operation_outcome_state"],
+                        "operation outcome",
+                        limit=32,
+                    ),
+                    replayed=True,
+                    reused=True,
+                )
+            if context.reconciliation_state == "sent_confirmed":
+                self._assert_confirmed_financial_state(context)
+                operation = await self._complete_operation(
+                    conn,
+                    operation_id=_uuid(operation["operation_id"], "operation id"),
+                    outcome_state="sent_confirmed",
+                    now=now,
+                )
+                return self._result(
+                    record,
+                    outcome_state=_stored_text(
+                        operation["operation_outcome_state"],
+                        "operation outcome",
+                        limit=32,
+                    ),
+                    replayed=prepared.replayed,
+                    reused=True,
+                )
+
+            self._assert_reconcilable(context)
+            if outcome.state == "sent_confirmed":
+                if outcome.proof is None:
+                    raise CommercialBillingGmailSentReconciliationConflictError(
+                        "Gmail sent-mail proof is invalid"
+                    )
+                record = await self._confirm_sent(
+                    conn,
+                    context=context,
+                    proof=outcome.proof,
+                    actor=actor,
+                    now=now,
+                )
+            elif outcome.state in {"draft_present", "draft_missing"}:
+                record = await self._record_nonfinancial_outcome(
+                    conn,
+                    context=context,
+                    outcome_state=outcome.state,
+                    actor=actor,
+                    now=now,
+                )
+            else:
+                raise CommercialBillingGmailSentReconciliationConflictError(
+                    "Commercial billing Gmail reconciliation outcome is invalid"
+                )
+            operation = await self._complete_operation(
+                conn,
+                operation_id=_uuid(operation["operation_id"], "operation id"),
+                outcome_state=outcome.state,
+                now=now,
+            )
+            return self._result(
+                record,
+                outcome_state=_stored_text(
+                    operation["operation_outcome_state"],
+                    "operation outcome",
+                    limit=32,
+                ),
+                replayed=prepared.replayed,
+                reused=False,
+            )
+
+    @staticmethod
+    async def _lock_operation(conn: Any, idempotency_key: str) -> None:
+        await conn.fetchval(
+            "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+            f"commercial-billing-gmail-sent-reconciliation:operation:{idempotency_key}",
+        )
+
+    @staticmethod
+    async def _lock_approval(conn: Any, approval_id: UUID) -> None:
+        """Share the original draft service's approval lock across both flows."""
+
+        await conn.fetchval(
+            "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+            f"commercial-billing-invoice-gmail-draft:approval:{approval_id}",
+        )
+
+    @staticmethod
+    async def _find_record_for_approval(conn: Any, approval_id: UUID) -> Any | None:
+        row = await conn.fetchrow(
+            _RECORD_SELECT + " WHERE draft.approval_id = $1",
+            approval_id,
+        )
+        return dict(row) if row is not None else None
+
+    @staticmethod
+    async def _find_record_for_id(conn: Any, draft_id: UUID) -> Any | None:
+        row = await conn.fetchrow(
+            _RECORD_SELECT + " WHERE draft.id = $1",
+            draft_id,
+        )
+        return dict(row) if row is not None else None
+
+    @staticmethod
+    async def _find_operation_by_key(conn: Any, idempotency_key: str) -> Any | None:
+        row = await conn.fetchrow(
+            _OPERATION_RECORD_SELECT
+            + " WHERE operation.source = $1 AND operation.idempotency_key = $2",
+            _DRAFT_SOURCE,
+            idempotency_key,
+        )
+        return dict(row) if row is not None else None
+
+    @staticmethod
+    async def _find_operation_by_id(conn: Any, operation_id: UUID) -> Any | None:
+        row = await conn.fetchrow(
+            """
+            SELECT id AS operation_id, state AS operation_state,
+                   outcome_state AS operation_outcome_state
+            FROM commercial_billing_gmail_sent_reconciliation_operations
+            WHERE id = $1
+            """,
+            operation_id,
+        )
+        return dict(row) if row is not None else None
+
+    @staticmethod
+    async def _insert_operation(
+        conn: Any,
+        *,
+        draft_id: UUID,
+        idempotency_key: str,
+        request_fingerprint: str,
+        actor: str,
+        now: datetime,
+    ) -> Any:
+        row = await conn.fetchrow(
+            """
+            INSERT INTO commercial_billing_gmail_sent_reconciliation_operations (
+                id, gmail_draft_record_id, source, idempotency_key,
+                request_fingerprint, requested_by, requested_at, created_at
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $7)
+            RETURNING id AS operation_id, state AS operation_state,
+                      outcome_state AS operation_outcome_state
+            """,
+            uuid4(),
+            draft_id,
+            _DRAFT_SOURCE,
+            idempotency_key,
+            request_fingerprint,
+            actor,
+            now,
+        )
+        if row is None:
+            raise CommercialBillingGmailSentReconciliationUnavailableError(
+                "Commercial billing Gmail reconciliation operation could not be recorded"
+            )
+        return dict(row)
+
+    @staticmethod
+    async def _complete_operation(
+        conn: Any,
+        *,
+        operation_id: UUID,
+        outcome_state: str,
+        now: datetime,
+    ) -> Any:
+        if outcome_state not in _OUTCOME_STATES:
+            raise CommercialBillingGmailSentReconciliationConflictError(
+                "Commercial billing Gmail reconciliation outcome is invalid"
+            )
+        row = await conn.fetchrow(
+            """
+            UPDATE commercial_billing_gmail_sent_reconciliation_operations
+               SET state = 'completed', outcome_state = $2, completed_at = $3
+             WHERE id = $1 AND state = 'pending'
+            RETURNING id AS operation_id, state AS operation_state,
+                      outcome_state AS operation_outcome_state
+            """,
+            operation_id,
+            outcome_state,
+            now,
+        )
+        if row is not None:
+            return dict(row)
+        existing = await CommercialBillingInvoiceGmailSentReconciliationService._find_operation_by_id(
+            conn, operation_id
+        )
+        if existing is not None and _operation_state(existing["operation_state"]) == "completed":
+            return existing
+        raise CommercialBillingGmailSentReconciliationConflictError(
+            "Commercial billing Gmail reconciliation operation could not be completed"
+        )
+
+    async def _confirm_sent(
+        self,
+        conn: Any,
+        *,
+        context: _Context,
+        proof: _SentProof,
+        actor: str,
+        now: datetime,
+    ) -> Mapping[str, Any]:
+        invoice = await conn.fetchrow(
+            "SELECT id, status, source FROM invoices WHERE id = $1 FOR UPDATE",
+            context.invoice_id,
+        )
+        if invoice is None:
+            raise CommercialBillingGmailSentReconciliationNotFoundError(
+                "Commercial billing invoice not found"
+            )
+        if _stored_text(invoice["source"], "invoice source", limit=32) != _INVOICE_SOURCE:
+            raise CommercialBillingGmailSentReconciliationConflictError(
+                "Commercial billing invoice is not eligible for Gmail reconciliation"
+            )
+        if _stored_text(invoice["status"], "invoice status", limit=32) != "draft":
+            raise CommercialBillingGmailSentReconciliationConflictError(
+                "Commercial billing invoice changed outside Gmail sent-mail reconciliation"
+            )
+        updated_invoice = await conn.fetchrow(
+            """
+            UPDATE invoices
+               SET status = 'sent', sent_at = $2, sent_via = 'gmail', updated_at = $3
+             WHERE id = $1 AND status = 'draft'
+            RETURNING id
+            """,
+            context.invoice_id,
+            proof.gmail_sent_at,
+            now,
+        )
+        if updated_invoice is None:
+            raise CommercialBillingGmailSentReconciliationConflictError(
+                "Commercial billing invoice changed outside Gmail sent-mail reconciliation"
+            )
+        row = await conn.fetchrow(
+            """
+            UPDATE commercial_billing_invoice_gmail_drafts
+               SET reconciliation_state = 'sent_confirmed',
+                   gmail_sent_message_id = $2, gmail_sent_thread_id = $3,
+                   gmail_sent_at = $4, sent_reconciled_by = $5,
+                   sent_reconciled_at = $6, last_reconciled_by = $5,
+                   last_reconciled_at = $6
+             WHERE id = $1 AND state = 'draft_created'
+               AND reconciliation_state <> 'sent_confirmed'
+            RETURNING id
+            """,
+            context.draft_id,
+            proof.gmail_message_id,
+            proof.gmail_thread_id,
+            proof.gmail_sent_at,
+            actor,
+            now,
+        )
+        if row is None:
+            raise CommercialBillingGmailSentReconciliationConflictError(
+                "Commercial billing Gmail reconciliation changed concurrently"
+            )
+        return await self._record_with_context(conn, context.draft_id)
+
+    async def _record_nonfinancial_outcome(
+        self,
+        conn: Any,
+        *,
+        context: _Context,
+        outcome_state: str,
+        actor: str,
+        now: datetime,
+    ) -> Mapping[str, Any]:
+        row = await conn.fetchrow(
+            """
+            UPDATE commercial_billing_invoice_gmail_drafts
+               SET reconciliation_state = $2::varchar, last_reconciled_by = $3,
+                   last_reconciled_at = $4,
+                   draft_missing_by = CASE
+                       WHEN $2::varchar = 'draft_missing' THEN $3
+                       ELSE draft_missing_by
+                   END,
+                   draft_missing_at = CASE
+                       WHEN $2::varchar = 'draft_missing' THEN $4
+                       ELSE draft_missing_at
+                   END
+             WHERE id = $1 AND state = 'draft_created'
+               AND reconciliation_state <> 'sent_confirmed'
+            RETURNING id
+            """,
+            context.draft_id,
+            outcome_state,
+            actor,
+            now,
+        )
+        if row is None:
+            raise CommercialBillingGmailSentReconciliationConflictError(
+                "Commercial billing Gmail reconciliation changed concurrently"
+            )
+        return await self._record_with_context(conn, context.draft_id)
+
+    @staticmethod
+    async def _record_with_context(conn: Any, draft_id: UUID) -> Mapping[str, Any]:
+        context_row = await CommercialBillingInvoiceGmailSentReconciliationService._find_record_for_id(
+            conn, draft_id
+        )
+        if context_row is None:
+            raise CommercialBillingGmailSentReconciliationUnavailableError(
+                "Commercial billing Gmail draft is unavailable"
+            )
+        return context_row
+
+    @staticmethod
+    def _assert_operation(
+        operation: Mapping[str, Any], approval_id: UUID, request_fingerprint: str
+    ) -> None:
+        if operation.get("operation_request_fingerprint") != request_fingerprint:
+            raise CommercialBillingGmailSentReconciliationConflictError(
+                "Idempotency key was already used with a different commercial billing approval"
+            )
+        if _uuid(operation.get("approval_id"), "approval id") != approval_id:
+            raise CommercialBillingGmailSentReconciliationConflictError(
+                "Idempotency key was already used with a different commercial billing approval"
+            )
+
+    @staticmethod
+    def _context(record: Mapping[str, Any]) -> _Context:
+        approval_id = _uuid(record.get("approval_id"), "approval id")
+        invoice_id = _uuid(record.get("invoice_id"), "invoice id")
+        if _uuid(record.get("approval_invoice_id"), "approval invoice id") != invoice_id:
+            raise CommercialBillingGmailSentReconciliationConflictError(
+                "Commercial billing approval no longer matches its invoice"
+            )
+        if _stored_text(record.get("approval_state"), "approval state", limit=32) != "invoice_created":
+            raise CommercialBillingGmailSentReconciliationConflictError(
+                "Commercial billing approval is not ready for Gmail reconciliation"
+            )
+        if _stored_text(record.get("invoice_source"), "invoice source", limit=32) != _INVOICE_SOURCE:
+            raise CommercialBillingGmailSentReconciliationConflictError(
+                "Commercial billing invoice is not eligible for Gmail reconciliation"
+            )
+        metadata = _mapping(record.get("invoice_metadata"), "invoice metadata")
+        if metadata.get("deliveryMethod") != _DELIVERY_METHOD:
+            raise CommercialBillingGmailSentReconciliationConflictError(
+                "Commercial billing invoice is not configured for Gmail PDF delivery"
+            )
+        return _Context(
+            approval_id=approval_id,
+            draft_id=_uuid(record.get("draft_id"), "draft id"),
+            draft_state=_stored_text(record.get("draft_state"), "draft state", limit=32),
+            invoice_id=invoice_id,
+            invoice_sent_at=_optional_timestamp(
+                record.get("invoice_sent_at"), "invoice sent timestamp"
+            ),
+            invoice_sent_via=(
+                None
+                if record.get("invoice_sent_via") is None
+                else _stored_text(record.get("invoice_sent_via"), "invoice sent via", limit=32)
+            ),
+            invoice_status=_stored_text(record.get("invoice_status"), "invoice status", limit=32),
+            reconciliation_state=_state(record.get("reconciliation_state")),
+            rfc_message_id=_rfc_message_id(record.get("rfc_message_id")),
+        )
+
+    @staticmethod
+    def _assert_reconcilable(context: _Context) -> None:
+        if context.draft_state != "draft_created":
+            raise CommercialBillingGmailSentReconciliationConflictError(
+                "Commercial billing Gmail draft is not ready for sent-mail reconciliation"
+            )
+        if context.invoice_status != "draft":
+            raise CommercialBillingGmailSentReconciliationConflictError(
+                "Commercial billing invoice changed outside Gmail sent-mail reconciliation"
+            )
+
+    @staticmethod
+    def _assert_confirmed_financial_state(context: _Context) -> None:
+        if context.invoice_status not in _POST_SEND_INVOICE_STATUSES:
+            raise CommercialBillingGmailSentReconciliationConflictError(
+                "Confirmed Gmail sent-mail evidence no longer matches invoice lifecycle"
+            )
+        if context.invoice_sent_via != "gmail" or context.invoice_sent_at is None:
+            raise CommercialBillingGmailSentReconciliationConflictError(
+                "Confirmed Gmail sent-mail evidence no longer matches invoice lifecycle"
+            )
+
+    @staticmethod
+    def _sent_proof(value: Any, context: _Context) -> _SentProof:
+        if not isinstance(value, Mapping):
+            raise CommercialBillingGmailSentReconciliationConflictError(
+                "Gmail sent-message evidence is invalid"
+            )
+        labels = value.get("labelIds")
+        if (
+            not isinstance(labels, list)
+            or not all(isinstance(label, str) and label for label in labels)
+            or "SENT" not in labels
+        ):
+            raise CommercialBillingGmailSentReconciliationConflictError(
+                "Gmail sent-message is not verifiably in Sent mail"
+            )
+        headers = value.get("headers")
+        _exact_header(headers, "Message-ID", context.rfc_message_id)
+        _exact_header(
+            headers,
+            "X-Atlas-Commercial-Billing-Approval",
+            str(context.approval_id),
+        )
+        _exact_header(
+            headers,
+            "X-Atlas-Commercial-Billing-Invoice",
+            str(context.invoice_id),
+        )
+        return _SentProof(
+            gmail_message_id=_external_id(value.get("id"), "sent message id"),
+            gmail_thread_id=_external_id(value.get("threadId"), "sent thread id"),
+            gmail_sent_at=_sent_timestamp(value.get("internalDate")),
+        )
+
+    def _now_timestamp(self) -> datetime:
+        return _timestamp(self._now(), "clock")
+
+    @staticmethod
+    def _view(record: Mapping[str, Any]) -> dict[str, Any]:
+        state = _state(record.get("reconciliation_state"))
+        result = {
+            "approvalId": str(_uuid(record.get("approval_id"), "approval id")),
+            "draftId": str(_uuid(record.get("draft_id"), "draft id")),
+            "invoiceId": str(_uuid(record.get("invoice_id"), "invoice id")),
+            "state": state,
+            "rfcMessageId": _rfc_message_id(record.get("rfc_message_id")),
+            "gmailDraftId": record.get("gmail_draft_id"),
+            "gmailMessageId": record.get("gmail_message_id"),
+            "gmailThreadId": record.get("gmail_thread_id"),
+            "gmailSentMessageId": record.get("gmail_sent_message_id"),
+            "gmailSentThreadId": record.get("gmail_sent_thread_id"),
+            "gmailSentAt": CommercialBillingInvoiceGmailSentReconciliationService._iso_optional(
+                record.get("gmail_sent_at"), "Gmail sent timestamp"
+            ),
+            "sentReconciledAt": CommercialBillingInvoiceGmailSentReconciliationService._iso_optional(
+                record.get("sent_reconciled_at"), "sent reconciliation timestamp"
+            ),
+            "sentReconciledBy": record.get("sent_reconciled_by"),
+            "lastReconciledAt": CommercialBillingInvoiceGmailSentReconciliationService._iso_optional(
+                record.get("last_reconciled_at"), "last reconciliation timestamp"
+            ),
+            "lastReconciledBy": record.get("last_reconciled_by"),
+            "draftMissingAt": CommercialBillingInvoiceGmailSentReconciliationService._iso_optional(
+                record.get("draft_missing_at"), "draft missing timestamp"
+            ),
+            "draftMissingBy": record.get("draft_missing_by"),
+            "recoveryAction": {
+                "draft_present": "wait_for_operator_send",
+                "draft_missing": "review_missing_draft",
+                "not_reconciled": "reconcile_sent_mail",
+                "sent_confirmed": "none",
+            }[state],
+        }
+        if state == "sent_confirmed":
+            _external_id(result["gmailSentMessageId"], "sent message id")
+            _external_id(result["gmailSentThreadId"], "sent thread id")
+            _stored_text(result["sentReconciledBy"], "sent reconciliation actor", limit=128)
+            if result["gmailSentAt"] is None or result["sentReconciledAt"] is None:
+                raise CommercialBillingGmailSentReconciliationUnavailableError(
+                    "Commercial billing Gmail sent reconciliation timestamps are invalid"
+                )
+        return result
+
+    @staticmethod
+    def _iso_optional(value: Any, field: str) -> str | None:
+        return None if value is None else _timestamp(value, field).isoformat()
+
+    @classmethod
+    def _result(
+        cls,
+        record: Mapping[str, Any],
+        *,
+        outcome_state: str,
+        replayed: bool,
+        reused: bool,
+    ) -> dict[str, Any]:
+        if outcome_state not in _OUTCOME_STATES:
+            raise CommercialBillingGmailSentReconciliationConflictError(
+                "Commercial billing Gmail reconciliation outcome is invalid"
+            )
+        return {
+            "outcome": outcome_state,
+            "reconciliation": cls._view(record),
+            "replayed": replayed,
+            "reused": reused,
+        }
+
+
+def get_commercial_billing_invoice_gmail_sent_reconciliation_service(
+) -> CommercialBillingInvoiceGmailSentReconciliationService:
+    return CommercialBillingInvoiceGmailSentReconciliationService()
+
+
+__all__ = [
+    "CommercialBillingGmailSentReconciliationConflictError",
+    "CommercialBillingGmailSentReconciliationError",
+    "CommercialBillingGmailSentReconciliationNotFoundError",
+    "CommercialBillingGmailSentReconciliationUnavailableError",
+    "CommercialBillingGmailSentReconciliationValidationError",
+    "CommercialBillingInvoiceGmailSentReconciliationService",
+    "get_commercial_billing_invoice_gmail_sent_reconciliation_service",
+]

--- a/atlas_brain/storage/migrations/375_commercial_billing_invoice_gmail_sent_reconciliation.sql
+++ b/atlas_brain/storage/migrations/375_commercial_billing_invoice_gmail_sent_reconciliation.sql
@@ -1,0 +1,120 @@
+-- Durable sent-mail reconciliation for a manually sent EOM commercial Gmail draft.
+--
+-- Gmail deletes a draft when an operator sends it and returns a different sent
+-- message identity.  The durable draft record therefore retains the stable RFC
+-- Message-ID and stores only a verified Sent-mail outcome.  A missing draft is
+-- explicitly distinguishable from a confirmed sent message.  The service, not
+-- this migration, performs the proof-gated invoice lifecycle update inside the
+-- same PostgreSQL transaction that records the confirmation.
+--
+-- Rollback: stop the reconciliation route/service and retain these audit rows.
+-- Removing sent-mail identities or reconciliation evidence is a separately
+-- authorized destructive retention action, never a mixed-version rollback.
+
+ALTER TABLE commercial_billing_invoice_gmail_drafts
+    ADD COLUMN IF NOT EXISTS reconciliation_state VARCHAR(32)
+        NOT NULL DEFAULT 'not_reconciled',
+    ADD COLUMN IF NOT EXISTS gmail_sent_message_id VARCHAR(256),
+    ADD COLUMN IF NOT EXISTS gmail_sent_thread_id VARCHAR(256),
+    ADD COLUMN IF NOT EXISTS gmail_sent_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS sent_reconciled_by VARCHAR(128),
+    ADD COLUMN IF NOT EXISTS sent_reconciled_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS last_reconciled_by VARCHAR(128),
+    ADD COLUMN IF NOT EXISTS last_reconciled_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS draft_missing_by VARCHAR(128),
+    ADD COLUMN IF NOT EXISTS draft_missing_at TIMESTAMPTZ;
+
+ALTER TABLE commercial_billing_invoice_gmail_drafts
+    ADD CONSTRAINT commercial_billing_invoice_gmail_drafts_reconciliation_state_check
+        CHECK (
+            reconciliation_state IN (
+                'not_reconciled', 'draft_present', 'draft_missing', 'sent_confirmed'
+            )
+        ),
+    ADD CONSTRAINT commercial_billing_invoice_gmail_drafts_sent_identity_check
+        CHECK (
+            (
+                gmail_sent_message_id IS NULL
+                AND gmail_sent_thread_id IS NULL
+                AND gmail_sent_at IS NULL
+                AND sent_reconciled_by IS NULL
+                AND sent_reconciled_at IS NULL
+            )
+            OR (
+                length(btrim(COALESCE(gmail_sent_message_id, ''))) > 0
+                AND length(btrim(COALESCE(gmail_sent_thread_id, ''))) > 0
+                AND gmail_sent_at IS NOT NULL
+                AND length(btrim(COALESCE(sent_reconciled_by, ''))) > 0
+                AND sent_reconciled_at IS NOT NULL
+            )
+        ),
+    ADD CONSTRAINT commercial_billing_invoice_gmail_drafts_sent_state_check
+        CHECK (
+            reconciliation_state = 'sent_confirmed'
+            OR (
+                gmail_sent_message_id IS NULL
+                AND gmail_sent_thread_id IS NULL
+                AND gmail_sent_at IS NULL
+                AND sent_reconciled_by IS NULL
+                AND sent_reconciled_at IS NULL
+            )
+        ),
+    ADD CONSTRAINT commercial_billing_invoice_gmail_drafts_reconciled_attempt_check
+        CHECK (
+            (last_reconciled_by IS NULL AND last_reconciled_at IS NULL)
+            OR (
+                length(btrim(COALESCE(last_reconciled_by, ''))) > 0
+                AND last_reconciled_at IS NOT NULL
+            )
+        ),
+    ADD CONSTRAINT commercial_billing_invoice_gmail_drafts_missing_draft_check
+        CHECK (
+            (draft_missing_by IS NULL AND draft_missing_at IS NULL)
+            OR (
+                length(btrim(COALESCE(draft_missing_by, ''))) > 0
+                AND draft_missing_at IS NOT NULL
+            )
+        );
+
+CREATE TABLE IF NOT EXISTS commercial_billing_gmail_sent_reconciliation_operations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    gmail_draft_record_id UUID NOT NULL
+        REFERENCES commercial_billing_invoice_gmail_drafts(id) ON DELETE RESTRICT,
+    source VARCHAR(32) NOT NULL DEFAULT 'eom_admin',
+    idempotency_key VARCHAR(128) NOT NULL,
+    request_fingerprint VARCHAR(64) NOT NULL,
+    state VARCHAR(32) NOT NULL DEFAULT 'pending',
+    outcome_state VARCHAR(32),
+    requested_by VARCHAR(128) NOT NULL,
+    requested_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    completed_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT cb_gmail_sent_recon_ops_source_key
+        UNIQUE (source, idempotency_key),
+    CONSTRAINT cb_gmail_sent_recon_ops_fingerprint_check
+        CHECK (request_fingerprint ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT cb_gmail_sent_recon_ops_actor_check
+        CHECK (length(btrim(requested_by)) > 0),
+    CONSTRAINT cb_gmail_sent_recon_ops_state_check
+        CHECK (state IN ('pending', 'completed')),
+    CONSTRAINT cb_gmail_sent_recon_ops_outcome_check
+        CHECK (
+            (state = 'pending' AND outcome_state IS NULL AND completed_at IS NULL)
+            OR (
+                state = 'completed'
+                AND outcome_state IN ('draft_present', 'draft_missing', 'sent_confirmed')
+                AND completed_at IS NOT NULL
+            )
+        )
+);
+
+CREATE INDEX IF NOT EXISTS idx_cb_gmail_sent_recon_ops_record
+    ON commercial_billing_gmail_sent_reconciliation_operations (
+        gmail_draft_record_id, requested_at DESC
+    );
+
+COMMENT ON COLUMN commercial_billing_invoice_gmail_drafts.reconciliation_state IS
+    'Observed Gmail delivery proof state; draft_missing is not sent and sent_confirmed requires metadata proof.';
+
+COMMENT ON TABLE commercial_billing_gmail_sent_reconciliation_operations IS
+    'Idempotent authenticated Sent-mail reconciliation requests for one durable commercial Gmail draft.';

--- a/atlas_brain/tools/gmail.py
+++ b/atlas_brain/tools/gmail.py
@@ -24,6 +24,7 @@ logger = logging.getLogger("atlas.tools.gmail")
 GMAIL_API_BASE = "https://gmail.googleapis.com/gmail/v1"
 TOKEN_URL = "https://oauth2.googleapis.com/token"
 _MAX_GMAIL_DRAFT_LOOKUP_PAGES = 20
+_MAX_GMAIL_SENT_LOOKUP_PAGES = 20
 _MAX_GMAIL_RFC_MESSAGE_ID_LENGTH = 320
 _MAX_GMAIL_EXTRA_HEADER_VALUE_LENGTH = 998
 _EXTRA_HEADER_NAME = re.compile(r"^(?:Message-ID|X-[A-Za-z0-9-]{1,72})$")
@@ -41,6 +42,14 @@ _PROTECTED_HEADER_NAMES = frozenset(
 
 class GmailDraftLookupError(RuntimeError):
     """A Gmail draft lookup cannot safely name one external draft."""
+
+
+class GmailSentMessageLookupError(RuntimeError):
+    """A Gmail Sent lookup cannot safely name one external message."""
+
+    def __init__(self, message: str, *, retryable: bool = False) -> None:
+        super().__init__(message)
+        self.retryable = retryable
 
 
 class GmailDraftCreateError(RuntimeError):
@@ -98,6 +107,25 @@ def _rfc_message_id(value: str) -> str:
     ):
         raise GmailDraftLookupError("Gmail draft RFC Message-ID is invalid")
     return value
+
+
+def _gmail_message_identifier(value: Any, field: str) -> str:
+    if not isinstance(value, str):
+        raise GmailSentMessageLookupError(
+            f"Gmail sent-message {field} is invalid"
+        )
+    normalized = value.strip()
+    if (
+        not normalized
+        or len(normalized) > 256
+        or "\r" in normalized
+        or "\n" in normalized
+        or "\x00" in normalized
+    ):
+        raise GmailSentMessageLookupError(
+            f"Gmail sent-message {field} is invalid"
+        )
+    return normalized
 
 
 class GmailTransport:
@@ -462,6 +490,189 @@ class GmailTransport:
             page_token = next_page
 
         raise GmailDraftLookupError("Gmail draft lookup exceeded its page bound")
+
+    async def find_sent_message_by_rfc_message_id(
+        self,
+        rfc_message_id: str,
+    ) -> dict[str, Any] | None:
+        """Return one metadata-verified Sent message for a stable Message-ID.
+
+        The Gmail list API returns only resource identifiers, so every candidate
+        is fetched with ``format=metadata`` before this transport reports it.
+        The caller remains responsible for comparing its business-specific
+        namespaced headers; this generic transport only establishes one bounded,
+        read-only mailbox result that has Gmail's ``SENT`` label.
+        """
+
+        try:
+            message_id = _rfc_message_id(rfc_message_id)
+        except GmailDraftLookupError as exc:
+            raise GmailSentMessageLookupError(
+                "Gmail sent-message RFC Message-ID is invalid"
+            ) from exc
+        token = await self._get_access_token()
+        client = await self._ensure_client()
+        page_token: str | None = None
+        seen_page_tokens: set[str] = set()
+        matches: list[dict[str, Any]] = []
+
+        for _ in range(_MAX_GMAIL_SENT_LOOKUP_PAGES):
+            params: dict[str, Any] = {
+                "q": f"rfc822msgid:{message_id}",
+                "labelIds": "SENT",
+                "maxResults": 100,
+            }
+            if page_token is not None:
+                params["pageToken"] = page_token
+            response = await client.get(
+                f"{GMAIL_API_BASE}/users/me/messages",
+                params=params,
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            if response.status_code == 403:
+                raise GmailSentMessageLookupError(
+                    "Gmail sent-message lookup permission denied. Re-run setup with gmail.modify scope: "
+                    "python scripts/setup_google_oauth.py",
+                    retryable=True,
+                )
+            response.raise_for_status()
+            payload = response.json()
+            if not isinstance(payload, dict):
+                raise GmailSentMessageLookupError(
+                    "Gmail sent-message lookup response is invalid"
+                )
+            messages = payload.get("messages", [])
+            if not isinstance(messages, list):
+                raise GmailSentMessageLookupError(
+                    "Gmail sent-message lookup response is invalid"
+                )
+            for message in messages:
+                if not isinstance(message, dict):
+                    raise GmailSentMessageLookupError(
+                        "Gmail sent-message lookup response is invalid"
+                    )
+                candidate_id = _gmail_message_identifier(
+                    message.get("id"), "id"
+                )
+                candidate_thread_id = _gmail_message_identifier(
+                    message.get("threadId"), "thread ID"
+                )
+                metadata = await self._get_sent_message_metadata(
+                    client=client,
+                    token=token,
+                    message_id=candidate_id,
+                )
+                if metadata["id"] != candidate_id or metadata["threadId"] != candidate_thread_id:
+                    raise GmailSentMessageLookupError(
+                        "Gmail sent-message lookup identity is inconsistent"
+                    )
+                matches.append(metadata)
+                if len(matches) > 1:
+                    raise GmailSentMessageLookupError(
+                        "Gmail sent-message lookup found multiple matching messages"
+                    )
+
+            next_page = payload.get("nextPageToken")
+            if next_page is None:
+                return next(iter(matches), None)
+            if not isinstance(next_page, str) or not next_page:
+                raise GmailSentMessageLookupError(
+                    "Gmail sent-message lookup pagination is invalid"
+                )
+            if next_page in seen_page_tokens:
+                raise GmailSentMessageLookupError(
+                    "Gmail sent-message lookup pagination is invalid"
+                )
+            seen_page_tokens.add(next_page)
+            page_token = next_page
+
+        raise GmailSentMessageLookupError(
+            "Gmail sent-message lookup exceeded its page bound"
+        )
+
+    @staticmethod
+    async def _get_sent_message_metadata(
+        *,
+        client: httpx.AsyncClient,
+        token: str,
+        message_id: str,
+    ) -> dict[str, Any]:
+        response = await client.get(
+            f"{GMAIL_API_BASE}/users/me/messages/{message_id}",
+            params=[
+                ("format", "metadata"),
+                ("metadataHeaders", "Message-ID"),
+                ("metadataHeaders", "X-Atlas-Commercial-Billing-Approval"),
+                ("metadataHeaders", "X-Atlas-Commercial-Billing-Invoice"),
+            ],
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        if response.status_code == 403:
+            raise GmailSentMessageLookupError(
+                "Gmail sent-message lookup permission denied. Re-run setup with gmail.modify scope: "
+                "python scripts/setup_google_oauth.py",
+                retryable=True,
+            )
+        response.raise_for_status()
+        payload = response.json()
+        if not isinstance(payload, dict):
+            raise GmailSentMessageLookupError("Gmail sent-message metadata is invalid")
+        normalized_id = _gmail_message_identifier(payload.get("id"), "id")
+        normalized_thread_id = _gmail_message_identifier(
+            payload.get("threadId"), "thread ID"
+        )
+        labels = payload.get("labelIds")
+        if (
+            not isinstance(labels, list)
+            or not all(isinstance(label, str) and label for label in labels)
+            or "SENT" not in labels
+        ):
+            raise GmailSentMessageLookupError(
+                "Gmail sent-message metadata is not in Sent mail"
+            )
+        internal_date = payload.get("internalDate")
+        if not isinstance(internal_date, str) or not internal_date:
+            raise GmailSentMessageLookupError(
+                "Gmail sent-message metadata is missing its timestamp"
+            )
+        message_payload = payload.get("payload")
+        if not isinstance(message_payload, dict):
+            raise GmailSentMessageLookupError("Gmail sent-message metadata is invalid")
+        headers = message_payload.get("headers")
+        if not isinstance(headers, list):
+            raise GmailSentMessageLookupError("Gmail sent-message metadata is invalid")
+        normalized_headers: list[dict[str, str]] = []
+        for header in headers:
+            if not isinstance(header, dict):
+                raise GmailSentMessageLookupError(
+                    "Gmail sent-message metadata is invalid"
+                )
+            name = header.get("name")
+            value = header.get("value")
+            if (
+                not isinstance(name, str)
+                or not name
+                or len(name) > 128
+                or "\r" in name
+                or "\n" in name
+                or "\x00" in name
+                or not isinstance(value, str)
+                or len(value) > _MAX_GMAIL_EXTRA_HEADER_VALUE_LENGTH
+                or "\r" in value
+                or "\n" in value
+                or "\x00" in value
+            ):
+                raise GmailSentMessageLookupError(
+                    "Gmail sent-message metadata is invalid"
+                )
+            normalized_headers.append({"name": name, "value": value})
+        return {
+            "id": normalized_id,
+            "threadId": normalized_thread_id,
+            "labelIds": list(labels),
+            "internalDate": internal_date,
+            "headers": normalized_headers,
+        }
 
     async def modify_thread(
         self,

--- a/plans/PR-EOM-Commercial-Invoice-Sent-Reconciliation.md
+++ b/plans/PR-EOM-Commercial-Invoice-Sent-Reconciliation.md
@@ -1,0 +1,221 @@
+# PR-EOM-Commercial-Invoice-Sent-Reconciliation
+
+## Why this slice exists
+
+The Billing & Payments workspace requires an ATLAS invoice to become sent only
+after a manually sent Gmail draft has verifiable sent-mail evidence.  Provider
+slice #2383 deliberately creates only a no-send Gmail draft and leaves the
+invoice in `draft`; its durable row cannot be interpreted as delivery.  The
+legacy `/invoicing/{id}/send` path marks an invoice sent before it attempts an
+email, so it is not a safe reconciliation path.  This slice closes that gap
+without sending mail or changing the draft-creation behavior.
+
+Diff-budget override: the additive proof/outcome migration, bounded Gmail
+metadata reader, durable idempotency state machine, authenticated route, and
+real-PostgreSQL failure/concurrency proof are one financial-lifecycle boundary.
+Splitting them would either let a provider write happen without durable recovery
+evidence or ship a route that cannot safely prove or persist the required state.
+
+### Problem-derived contract
+
+- Root cause: the durable Gmail-draft state proves only intent and a draft
+  identity; it has no proof-gated transition from the Gmail Sent mailbox to
+  the ATLAS invoice lifecycle.  Reusing the legacy send route would invert the
+  required ordering by recording `sent` before external delivery is known.
+- Correct fix must touch/change: add an additive ATLAS migration for durable
+  reconciliation outcome/idempotency evidence; add a read-only Gmail Sent
+  lookup that verifies the stable message and invoice/approval headers; add a
+  transactional service that updates the draft reconciliation record and the
+  still-draft invoice together only after that evidence; expose the service
+  through the existing authenticated receivables boundary; and prove normal,
+  missing, malformed, retry, concurrent, and route-auth paths with a real
+  temporary PostgreSQL schema and mocked Gmail transport.
+- Must not change: no Gmail send, draft create, PDF create, invoice creation,
+  payment/allocation, CRM/service evidence, Square workflow, customer-facing
+  email/PDF copy, MCP behavior, or browser credentials.  The legacy automatic
+  send route remains untouched and is not a dependency of this slice.
+
+## Scope (this PR)
+
+Ownership lane: eom/billing-sent-reconciliation
+Slice phase: Vertical slice
+
+1. Add `POST /api/v1/receivables/commercial-billing-approvals/{approval_id}/gmail-draft/reconcile`, protected by the existing receivables token,
+   authenticated actor, and idempotency-key contract.
+2. Reconcile only a durable, `draft_created` Gmail-PDF draft.  The service
+   searches Gmail Sent mail by its stable RFC Message-ID, requires the `SENT`
+   label, the expected Message-ID and namespaced approval/invoice headers, and
+   a valid Gmail internal timestamp before marking the linked still-draft
+   invoice sent via Gmail.
+3. When Sent evidence is absent, record `draft_present` or `draft_missing`
+   after a read-only draft lookup.  Neither result changes financial state; an
+   ambiguous, malformed, or unavailable Gmail response fails closed.
+4. Persist each reconciliation request and outcome.  An unchanged completed
+   retry returns its original outcome without another Gmail lookup; a retry
+   after a read failure remains safe because the Gmail operation was read-only.
+5. Prove the route and service with no live Gmail/customer operation.  Tests
+   cover the invoice transition, exact retry, missing/deleted draft,
+   malformed/ambiguous sent proof, unchanged financial state on failures, and
+   concurrent reconciliation requests.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] An authenticated request to the real receivables route reaches the
+    reconciliation service with its approval UUID, actor, and idempotency key;
+    `tests/test_commercial_billing_gmail_drafts.py::test_full_atlas_app_gmail_sent_reconciliation_route_requires_existing_auth` settles it.
+  - [ ] A Gmail message carrying the stable Message-ID, `SENT` label, matching
+    approval/invoice headers, and valid Gmail `internalDate` atomically stores
+    final Gmail identifiers/actor/time and changes only the linked draft invoice
+    from `draft` to `sent` via `gmail`; the real-PostgreSQL happy-path test
+    settles it.
+  - [ ] Missing/draft-present/ambiguous/malformed/unavailable Gmail outcomes
+    do not mark the invoice sent; the named real-PostgreSQL and mocked-transport
+    tests settle each outcome.
+  - [ ] A completed request replay returns its durable outcome without another
+    Gmail lookup, while two fresh concurrent requests cannot produce more than
+    one invoice lifecycle transition; the idempotency and concurrency tests
+    settle the admitted interleavings.
+  - [ ] The Gmail adapter uses only `users.messages.list` and
+    `users.messages.get` for Sent reconciliation, never `messages.send`; the
+    transport test settles the no-send boundary.
+- Reachability proof: the full Atlas ASGI app test invokes the real
+  `/api/v1/receivables/.../gmail-draft/reconcile` route under existing bearer
+  and actor dependencies and observes the service result without exposing PDF
+  bytes or contacting Gmail.
+- Affected surfaces: receivables authenticated API; ATLAS invoices and durable
+  Gmail-draft reconciliation records; Gmail OAuth transport read boundary;
+  migration runner; invoicing workflow test enrollment.
+- Risk areas: financial lifecycle truth, Gmail evidence ambiguity, replay,
+  concurrent operator requests, migration compatibility, authorization, and
+  inadvertent email send.
+- Reviewer rules triggered: R1, R2, R3, R4, R5, R6, R8, R10, R12, R14.
+
+### Boundary-change enumeration
+
+The changed seam resolves one external Gmail mailbox result into an ATLAS
+financial lifecycle transition.  It is deliberately finite and fails closed.
+
+- Boundary path/seam: `CommercialBillingInvoiceGmailSentReconciliationService`
+  decides whether one approved Gmail draft has proof that authorizes the invoice
+  status transition.
+- Replaced-path behaviors: no provider route previously reconciled a manually
+  sent Gmail draft; the invoice remained draft.  The legacy send route remains
+  outside this boundary because it sends/marks before email delivery.
+- Guard-relevant fields: approval UUID; durable draft state; draft RFC
+  Message-ID; expected approval/invoice IDs; Gmail message ID/thread ID,
+  `SENT` label, metadata headers, and internal timestamp; current linked
+  invoice status; actor and idempotency key.
+- Caller x input shape:
+  - Existing authenticated manager + exact single sent proof + linked draft
+    invoice -> persist proof and mark sent.
+  - Existing authenticated manager + no sent proof + retained draft -> persist
+    `draft_present`, leave invoice draft.
+  - Existing authenticated manager + no sent proof + missing draft -> persist
+    `draft_missing`, leave invoice draft and expose recovery state.
+  - Missing/creating/recovery-required draft, invalid/multiple/mismatched Gmail
+    result, pre-sent invoice, or unavailable mailbox -> conflict/unavailable;
+    no invoice transition.
+  - Same idempotency key + completed result -> replay that result; fresh keys
+    serialize final state under the approval lock.
+
+### Deployed-config probing
+
+N/A - no environment/config fallback changes.  Existing Gmail OAuth and
+receivables authorization configuration are reused.  The migration records
+intent/outcomes before/after only read-only Gmail requests; the invoice write is
+inside the final evidence-confirming PostgreSQL transaction.
+
+### Files touched
+
+- `.github/workflows/atlas_invoicing_checks.yml`
+- `atlas_brain/api/invoicing/receivables.py`
+- `atlas_brain/services/commercial_billing_invoice_gmail_sent_reconciliation.py`
+- `atlas_brain/storage/migrations/375_commercial_billing_invoice_gmail_sent_reconciliation.sql`
+- `atlas_brain/tools/gmail.py`
+- `plans/PR-EOM-Commercial-Invoice-Sent-Reconciliation.md`
+- `tests/test_commercial_billing_gmail_drafts.py`
+
+## Mechanism
+
+The draft service's deterministic RFC Message-ID and namespaced approval and
+invoice headers are the stable external identity.  The Gmail transport performs
+a bounded `messages.list` search restricted to `SENT`, then fetches metadata
+for a unique candidate.  The service validates all expected fields rather than
+treating a missing draft as delivery proof.
+
+The service uses PostgreSQL, not a client cache, as the execution component.
+It first stores an idempotency operation under the existing per-approval draft
+advisory lock.  It releases that transaction before the read-only Gmail calls.
+Its final transaction reacquires the same lock and locks the linked invoice:
+only an exact proof can write the Gmail final identifiers and change a still
+draft invoice to `sent`; every non-proof outcome persists a recovery-visible
+observation and leaves invoice state unchanged.  Completed same-key operations
+replay their stored outcome.  Fresh-key requests may perform concurrent
+read-only lookup, but their final transitions serialize on the approval lock,
+and a confirmed sent state cannot be downgraded by a stale observation.
+
+The execution model admits process failure before or after either transaction,
+network failure during Gmail reads, same-key retry, fresh-key concurrent retry,
+and a concurrent draft create/recovery.  Gmail reads have no financial or
+delivery side effect; the durable operation makes every later attempt either
+return the completed outcome or re-query safely.  The shared approval lock
+prevents a reconciliation from interpreting a still-creating draft as missing,
+and the final invoice row lock prevents any interleaving from overwriting an
+already-confirmed financial lifecycle transition.  The model assumes Gmail's
+metadata API is the evidence source; an unavailable, malformed, zero-match, or
+multi-match response never authorizes `sent`.
+
+## Intentional
+
+- Gmail's `messages.send`, draft creation, PDF generation, and browser-facing
+  PDF bytes are absent from this slice.  Gmail remains a delivery system; ATLAS
+  retains the financial lifecycle state and audit actor/time.
+- A deleted/missing Gmail draft is stored as `draft_missing`, not inferred sent.
+  The response exposes that recovery state for a later Website view; it does
+  not automatically create a replacement draft because an operator must first
+  resolve any mailbox-indexing or manual-delivery ambiguity.
+- The transition accepts only an invoice still in `draft`, the same state that
+  created the approved artifact and Gmail draft.  A legacy/out-of-band status
+  update conflicts rather than silently rewriting financial history.
+- This is a new delivery/lifecycle slice, not a modification of the legacy
+  `/invoicing/{id}/send` behavior or a new customer-visible email/PDF design.
+
+## Deferred
+
+- Website Sent-mail recovery view and an explicit, audited replacement-draft
+  operator action after `draft_missing` are deferred to the Billing & Payments
+  UI/recovery follow-up and will be linked to #2363 from this slice.
+- Manual Square invoice queue/reference recording, Gmail sent-mail polling or
+  webhook scheduling, and cross-repository tracker/Website consumers remain
+  deferred to their already-tracked Billing & Payments slices (#2363).
+
+Parked hardening: none.
+
+## Verification
+
+- Temporary-PostgreSQL Gmail draft/reconciliation suite: `86 passed`.
+- Local `Atlas Invoicing Checks` mirror: approval blockers `2 passed`;
+  ledger/PDF/billing suite `428 passed`; MCP/OAuth surface `43 passed`.
+- Migration runner regression: `30 passed, 1 skipped`.
+- `ruff`, Python compilation, `git diff --check`, and the new sent-mail service
+  maturity lane passed with zero service findings.
+- Final local PR review passed: body contract, diff-budget override,
+  AI-reconciliation record, plan/code consistency, guard closure, and the
+  locally escalated full unit gate. Its `160` failing/error nodes matched the
+  trusted baseline exactly (zero regressions and zero newly-passing nodes).
+- No test contacted Gmail or altered a live financial record; the database
+  tests created and dropped only temporary local schemas.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_invoicing_checks.yml` | 4 |
+| `atlas_brain/api/invoicing/receivables.py` | 65 |
+| `atlas_brain/services/commercial_billing_invoice_gmail_sent_reconciliation.py` | 1100 |
+| `atlas_brain/storage/migrations/375_commercial_billing_invoice_gmail_sent_reconciliation.sql` | 120 |
+| `atlas_brain/tools/gmail.py` | 211 |
+| `plans/PR-EOM-Commercial-Invoice-Sent-Reconciliation.md` | 221 |
+| `tests/test_commercial_billing_gmail_drafts.py` | 549 |
+| **Total** | **2270** |

--- a/tests/test_commercial_billing_gmail_drafts.py
+++ b/tests/test_commercial_billing_gmail_drafts.py
@@ -29,12 +29,18 @@ from atlas_brain.services.commercial_billing_invoice_gmail_drafts import (
     CommercialBillingInvoiceGmailDraftService,
     _request_text,
 )
+from atlas_brain.services.commercial_billing_invoice_gmail_sent_reconciliation import (
+    CommercialBillingGmailSentReconciliationConflictError,
+    CommercialBillingGmailSentReconciliationUnavailableError,
+    CommercialBillingInvoiceGmailSentReconciliationService,
+)
 from atlas_brain.services.commercial_billing_invoice_pdfs import (
     CommercialBillingInvoicePDFService,
 )
 from atlas_brain.tools.gmail import (
     GmailDraftCreateError,
     GmailDraftLookupError,
+    GmailSentMessageLookupError,
     GmailTransport,
 )
 
@@ -99,8 +105,11 @@ class _RecordingGateway:
     def __init__(self) -> None:
         self.create_calls: list[dict] = []
         self.lookup_calls: list[str] = []
+        self.sent_lookup_calls: list[str] = []
         self.drafts: dict[str, dict] = {}
+        self.sent_messages: dict[str, dict] = {}
         self.create_error: Exception | None = None
+        self.sent_lookup_error: Exception | None = None
         self.create_then_raise = False
 
     async def create_draft(self, **kwargs) -> dict:
@@ -126,6 +135,42 @@ class _RecordingGateway:
         result = self.drafts.get(rfc_message_id)
         return json.loads(json.dumps(result)) if result is not None else None
 
+    async def find_sent_message_by_rfc_message_id(
+        self, rfc_message_id: str
+    ) -> dict | None:
+        self.sent_lookup_calls.append(rfc_message_id)
+        if self.sent_lookup_error is not None:
+            raise self.sent_lookup_error
+        result = self.sent_messages.get(rfc_message_id)
+        return json.loads(json.dumps(result)) if result is not None else None
+
+    def record_sent(
+        self,
+        *,
+        rfc_message_id: str,
+        approval_id,
+        invoice_id,
+        internal_date: str = "1775088000123",
+    ) -> None:
+        self.drafts.pop(rfc_message_id, None)
+        self.sent_messages[rfc_message_id] = {
+            "id": "sent-message-1",
+            "threadId": "sent-thread-1",
+            "labelIds": ["SENT"],
+            "internalDate": internal_date,
+            "headers": [
+                {"name": "Message-ID", "value": rfc_message_id},
+                {
+                    "name": "X-Atlas-Commercial-Billing-Approval",
+                    "value": str(approval_id),
+                },
+                {
+                    "name": "X-Atlas-Commercial-Billing-Invoice",
+                    "value": str(invoice_id),
+                },
+            ],
+        }
+
 
 class _BlockingGateway(_RecordingGateway):
     def __init__(self) -> None:
@@ -144,6 +189,23 @@ class _BlockingGateway(_RecordingGateway):
         }
         self.drafts[message_id] = result
         return result
+
+
+class _BlockingSentGateway(_RecordingGateway):
+    def __init__(self) -> None:
+        super().__init__()
+        self.sent_lookup_started = asyncio.Event()
+        self.release_first_lookup = asyncio.Event()
+
+    async def find_sent_message_by_rfc_message_id(
+        self, rfc_message_id: str
+    ) -> dict | None:
+        self.sent_lookup_calls.append(rfc_message_id)
+        if len(self.sent_lookup_calls) == 1:
+            self.sent_lookup_started.set()
+            await self.release_first_lookup.wait()
+        result = self.sent_messages.get(rfc_message_id)
+        return json.loads(json.dumps(result)) if result is not None else None
 
 
 @asynccontextmanager
@@ -166,6 +228,7 @@ async def _gmail_draft_database():
             "372_commercial_billing_candidate_approvals.sql",
             "373_commercial_billing_invoice_pdf_artifacts.sql",
             "374_commercial_billing_invoice_gmail_drafts.sql",
+            "375_commercial_billing_invoice_gmail_sent_reconciliation.sql",
         ):
             await connection.execute((migrations / name).read_text())
         yield connection, schema
@@ -314,6 +377,17 @@ def _service(connection, schema: str, gateway: _RecordingGateway):
     )
 
 
+def _sent_reconciliation_service(
+    connection, schema: str, gateway: _RecordingGateway
+):
+    now = datetime(2026, 4, 2, tzinfo=timezone.utc)
+    return CommercialBillingInvoiceGmailSentReconciliationService(
+        pool=_SchemaPool(connection, schema),
+        gateway_loader=lambda: gateway,
+        now=lambda: now,
+    )
+
+
 @pytest.mark.asyncio
 async def test_real_postgres_creates_one_no_send_draft_and_reuses_it_idempotently():
     async with _gmail_draft_database() as (connection, schema):
@@ -371,6 +445,272 @@ async def test_real_postgres_creates_one_no_send_draft_and_reuses_it_idempotentl
             "SELECT status, sent_at, sent_via FROM invoices WHERE id = $1", seed["invoice_id"]
         )
         assert dict(invoice) == {"status": "draft", "sent_at": None, "sent_via": None}
+
+
+@pytest.mark.asyncio
+async def test_real_postgres_reconciles_verifiable_sent_mail_once_and_replays_it():
+    async with _gmail_draft_database() as (connection, schema):
+        seed = await _seed_approved_invoice(connection, schema)
+        gateway = _RecordingGateway()
+        draft = await _service(connection, schema, gateway).create_or_reuse(
+            approval_id=seed["approval_id"], idempotency_key="gmail-for-sent", actor="Juan"
+        )
+        rfc_message_id = draft["draft"]["rfcMessageId"]
+        gateway.record_sent(
+            rfc_message_id=rfc_message_id,
+            approval_id=seed["approval_id"],
+            invoice_id=seed["invoice_id"],
+        )
+        service = _sent_reconciliation_service(connection, schema, gateway)
+
+        reconciled = await service.reconcile(
+            approval_id=seed["approval_id"], idempotency_key="sent-reconcile-1", actor="Juan"
+        )
+        replayed = await service.reconcile(
+            approval_id=seed["approval_id"], idempotency_key="sent-reconcile-1", actor="Mayra"
+        )
+
+        assert reconciled["outcome"] == "sent_confirmed"
+        assert reconciled["replayed"] is False
+        assert reconciled["reused"] is False
+        assert reconciled["reconciliation"]["state"] == "sent_confirmed"
+        assert reconciled["reconciliation"]["gmailSentMessageId"] == "sent-message-1"
+        assert reconciled["reconciliation"]["gmailSentThreadId"] == "sent-thread-1"
+        assert reconciled["reconciliation"]["sentReconciledBy"] == "Juan"
+        assert reconciled["reconciliation"]["recoveryAction"] == "none"
+        assert replayed["outcome"] == "sent_confirmed"
+        assert replayed["replayed"] is True
+        assert replayed["reused"] is True
+        assert len(gateway.sent_lookup_calls) == 1
+        assert gateway.lookup_calls == []
+
+        invoice = await connection.fetchrow(
+            "SELECT status, sent_at, sent_via FROM invoices WHERE id = $1", seed["invoice_id"]
+        )
+        assert invoice["status"] == "sent"
+        assert invoice["sent_via"] == "gmail"
+        assert invoice["sent_at"] == datetime.fromtimestamp(
+            1775088000, tz=timezone.utc
+        ).replace(microsecond=123000)
+        assert await connection.fetchval(
+            "SELECT COUNT(*) FROM commercial_billing_gmail_sent_reconciliation_operations"
+        ) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("remove_draft", "expected_state", "expected_recovery_action"),
+    (
+        (False, "draft_present", "wait_for_operator_send"),
+        (True, "draft_missing", "review_missing_draft"),
+    ),
+)
+async def test_sent_reconciliation_retains_nonfinancial_draft_observations(
+    remove_draft: bool, expected_state: str, expected_recovery_action: str
+):
+    async with _gmail_draft_database() as (connection, schema):
+        seed = await _seed_approved_invoice(connection, schema)
+        gateway = _RecordingGateway()
+        draft = await _service(connection, schema, gateway).create_or_reuse(
+            approval_id=seed["approval_id"], idempotency_key="gmail-observation", actor="Juan"
+        )
+        if remove_draft:
+            gateway.drafts.pop(draft["draft"]["rfcMessageId"])
+
+        result = await _sent_reconciliation_service(connection, schema, gateway).reconcile(
+            approval_id=seed["approval_id"],
+            idempotency_key=f"sent-observation-{expected_state}",
+            actor="Mayra",
+        )
+
+        assert result["outcome"] == expected_state
+        assert result["reconciliation"]["state"] == expected_state
+        assert result["reconciliation"]["recoveryAction"] == expected_recovery_action
+        assert result["reconciliation"]["gmailSentMessageId"] is None
+        if remove_draft:
+            assert result["reconciliation"]["draftMissingAt"] is not None
+        else:
+            assert result["reconciliation"]["draftMissingAt"] is None
+        invoice = await connection.fetchrow(
+            "SELECT status, sent_at, sent_via FROM invoices WHERE id = $1", seed["invoice_id"]
+        )
+        assert dict(invoice) == {"status": "draft", "sent_at": None, "sent_via": None}
+
+
+@pytest.mark.asyncio
+async def test_sent_reconciliation_rejects_mismatched_or_ambiguous_evidence_without_financial_write():
+    async with _gmail_draft_database() as (connection, schema):
+        seed = await _seed_approved_invoice(connection, schema)
+        gateway = _RecordingGateway()
+        draft = await _service(connection, schema, gateway).create_or_reuse(
+            approval_id=seed["approval_id"], idempotency_key="gmail-bad-sent", actor="Juan"
+        )
+        rfc_message_id = draft["draft"]["rfcMessageId"]
+        gateway.record_sent(
+            rfc_message_id=rfc_message_id,
+            approval_id=seed["approval_id"],
+            invoice_id=uuid4(),
+        )
+        service = _sent_reconciliation_service(connection, schema, gateway)
+
+        with pytest.raises(CommercialBillingGmailSentReconciliationConflictError):
+            await service.reconcile(
+                approval_id=seed["approval_id"],
+                idempotency_key="sent-mismatched", actor="Juan"
+            )
+        gateway.sent_lookup_error = GmailSentMessageLookupError(
+            "synthetic multiple sent messages"
+        )
+        with pytest.raises(CommercialBillingGmailSentReconciliationConflictError):
+            await service.reconcile(
+                approval_id=seed["approval_id"],
+                idempotency_key="sent-ambiguous", actor="Juan"
+            )
+
+        invoice = await connection.fetchrow(
+            "SELECT status, sent_at, sent_via FROM invoices WHERE id = $1", seed["invoice_id"]
+        )
+        assert dict(invoice) == {"status": "draft", "sent_at": None, "sent_via": None}
+        assert await connection.fetchval(
+            "SELECT COUNT(*) FROM commercial_billing_gmail_sent_reconciliation_operations "
+            "WHERE state = 'completed'"
+        ) == 0
+
+
+@pytest.mark.asyncio
+async def test_sent_reconciliation_retries_a_read_failure_with_the_same_key():
+    async with _gmail_draft_database() as (connection, schema):
+        seed = await _seed_approved_invoice(connection, schema)
+        gateway = _RecordingGateway()
+        draft = await _service(connection, schema, gateway).create_or_reuse(
+            approval_id=seed["approval_id"], idempotency_key="gmail-retry-sent", actor="Juan"
+        )
+        gateway.sent_lookup_error = RuntimeError("synthetic Gmail timeout")
+        service = _sent_reconciliation_service(connection, schema, gateway)
+
+        with pytest.raises(CommercialBillingGmailSentReconciliationUnavailableError):
+            await service.reconcile(
+                approval_id=seed["approval_id"], idempotency_key="sent-retry", actor="Juan"
+            )
+        gateway.sent_lookup_error = None
+        gateway.record_sent(
+            rfc_message_id=draft["draft"]["rfcMessageId"],
+            approval_id=seed["approval_id"],
+            invoice_id=seed["invoice_id"],
+        )
+
+        result = await service.reconcile(
+            approval_id=seed["approval_id"], idempotency_key="sent-retry", actor="Juan"
+        )
+        assert result["outcome"] == "sent_confirmed"
+        assert result["replayed"] is True
+        assert len(gateway.sent_lookup_calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_concurrent_sent_reconciliation_requests_have_one_financial_transition():
+    async with _gmail_draft_database() as (connection, schema):
+        seed = await _seed_approved_invoice(connection, schema)
+        gateway = _BlockingSentGateway()
+        draft = await _service(connection, schema, gateway).create_or_reuse(
+            approval_id=seed["approval_id"], idempotency_key="gmail-concurrent-sent", actor="Juan"
+        )
+        gateway.record_sent(
+            rfc_message_id=draft["draft"]["rfcMessageId"],
+            approval_id=seed["approval_id"],
+            invoice_id=seed["invoice_id"],
+        )
+        await connection.execute(
+            "CREATE TABLE invoice_status_changes (old_status text, new_status text)"
+        )
+        await connection.execute(
+            """
+            CREATE FUNCTION capture_invoice_status_change()
+            RETURNS trigger LANGUAGE plpgsql AS $$
+            BEGIN
+                IF OLD.status IS DISTINCT FROM NEW.status THEN
+                    INSERT INTO invoice_status_changes (old_status, new_status)
+                    VALUES (OLD.status, NEW.status);
+                END IF;
+                RETURN NEW;
+            END;
+            $$
+            """
+        )
+        await connection.execute(
+            """
+            CREATE TRIGGER capture_invoice_status_change_trigger
+            BEFORE UPDATE ON invoices
+            FOR EACH ROW EXECUTE FUNCTION capture_invoice_status_change()
+            """
+        )
+        service = _sent_reconciliation_service(connection, schema, gateway)
+        first = asyncio.create_task(
+            service.reconcile(
+                approval_id=seed["approval_id"], idempotency_key="sent-concurrent-1", actor="Juan"
+            )
+        )
+        await asyncio.wait_for(gateway.sent_lookup_started.wait(), timeout=2)
+        second = await service.reconcile(
+            approval_id=seed["approval_id"], idempotency_key="sent-concurrent-2", actor="Mayra"
+        )
+        gateway.release_first_lookup.set()
+        first_result = await first
+
+        assert first_result["outcome"] == "sent_confirmed"
+        assert second["outcome"] == "sent_confirmed"
+        assert len(gateway.create_calls) == 1
+        assert len(gateway.sent_lookup_calls) == 2
+        assert await connection.fetchval(
+            "SELECT COUNT(*) FROM invoice_status_changes "
+            "WHERE old_status = 'draft' AND new_status = 'sent'"
+        ) == 1
+
+
+@pytest.mark.asyncio
+async def test_sent_reconciliation_rejects_a_stale_invoice_after_gmail_lookup():
+    async with _gmail_draft_database() as (connection, schema):
+        seed = await _seed_approved_invoice(connection, schema)
+        gateway = _BlockingSentGateway()
+        draft = await _service(connection, schema, gateway).create_or_reuse(
+            approval_id=seed["approval_id"],
+            idempotency_key="gmail-stale-sent",
+            actor="Juan",
+        )
+        gateway.record_sent(
+            rfc_message_id=draft["draft"]["rfcMessageId"],
+            approval_id=seed["approval_id"],
+            invoice_id=seed["invoice_id"],
+        )
+        reconciliation = _sent_reconciliation_service(connection, schema, gateway)
+        task = asyncio.create_task(
+            reconciliation.reconcile(
+                approval_id=seed["approval_id"],
+                idempotency_key="sent-stale",
+                actor="Juan",
+            )
+        )
+        await asyncio.wait_for(gateway.sent_lookup_started.wait(), timeout=2)
+        await connection.execute(
+            "UPDATE invoices SET status = 'void' WHERE id = $1", seed["invoice_id"]
+        )
+        gateway.release_first_lookup.set()
+
+        with pytest.raises(CommercialBillingGmailSentReconciliationConflictError):
+            await task
+
+        invoice = await connection.fetchrow(
+            "SELECT status, sent_at, sent_via FROM invoices WHERE id = $1",
+            seed["invoice_id"],
+        )
+        assert dict(invoice) == {"status": "void", "sent_at": None, "sent_via": None}
+        assert await connection.fetchval(
+            "SELECT reconciliation_state FROM commercial_billing_invoice_gmail_drafts"
+        ) == "not_reconciled"
+        assert await connection.fetchval(
+            "SELECT COUNT(*) FROM commercial_billing_gmail_sent_reconciliation_operations "
+            "WHERE state = 'completed'"
+        ) == 0
 
 
 @pytest.mark.asyncio
@@ -652,6 +992,112 @@ async def test_gmail_transport_looks_up_exact_rfc_message_id_and_rejects_ambigui
         await transport.close()
 
 
+@pytest.mark.asyncio
+async def test_gmail_transport_reads_one_sent_message_with_metadata_and_never_sends():
+    requests: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.path.endswith("/users/me/messages"):
+            return httpx.Response(
+                200,
+                json={"messages": [{"id": "sent-1", "threadId": "thread-1"}]},
+            )
+        if request.url.path.endswith("/users/me/messages/sent-1"):
+            return httpx.Response(
+                200,
+                json={
+                    "id": "sent-1",
+                    "threadId": "thread-1",
+                    "labelIds": ["SENT"],
+                    "internalDate": "1775088000123",
+                    "payload": {
+                        "headers": [
+                            {"name": "Message-ID", "value": "<stable@example.test>"},
+                            {
+                                "name": "X-Atlas-Commercial-Billing-Approval",
+                                "value": "approval-1",
+                            },
+                            {
+                                "name": "X-Atlas-Commercial-Billing-Invoice",
+                                "value": "invoice-1",
+                            },
+                        ]
+                    },
+                },
+            )
+        return httpx.Response(404)
+
+    transport = GmailTransport()
+    transport._access_token = "token"
+    transport._token_expires = time.time() + 600
+    transport._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        found = await transport.find_sent_message_by_rfc_message_id(
+            "<stable@example.test>"
+        )
+    finally:
+        await transport.close()
+
+    assert found == {
+        "id": "sent-1",
+        "threadId": "thread-1",
+        "labelIds": ["SENT"],
+        "internalDate": "1775088000123",
+        "headers": [
+            {"name": "Message-ID", "value": "<stable@example.test>"},
+            {"name": "X-Atlas-Commercial-Billing-Approval", "value": "approval-1"},
+            {"name": "X-Atlas-Commercial-Billing-Invoice", "value": "invoice-1"},
+        ],
+    }
+    assert [request.method for request in requests] == ["GET", "GET"]
+    assert "/messages/send" not in " ".join(request.url.path for request in requests)
+    search = requests[0]
+    assert search.url.params["q"] == "rfc822msgid:<stable@example.test>"
+    assert search.url.params["labelIds"] == "SENT"
+    metadata_headers = requests[1].url.params.get_list("metadataHeaders")
+    assert metadata_headers == [
+        "Message-ID",
+        "X-Atlas-Commercial-Billing-Approval",
+        "X-Atlas-Commercial-Billing-Invoice",
+    ]
+
+    async def ambiguous_handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/users/me/messages"):
+            return httpx.Response(
+                200,
+                json={
+                    "messages": [
+                        {"id": "sent-1", "threadId": "thread-1"},
+                        {"id": "sent-2", "threadId": "thread-2"},
+                    ]
+                },
+            )
+        message_id = request.url.path.rsplit("/", maxsplit=1)[-1]
+        return httpx.Response(
+            200,
+            json={
+                "id": message_id,
+                "threadId": f"thread-{message_id[-1]}",
+                "labelIds": ["SENT"],
+                "internalDate": "1775088000123",
+                "payload": {"headers": []},
+            },
+        )
+
+    transport = GmailTransport()
+    transport._access_token = "token"
+    transport._token_expires = time.time() + 600
+    transport._client = httpx.AsyncClient(
+        transport=httpx.MockTransport(ambiguous_handler)
+    )
+    try:
+        with pytest.raises(GmailSentMessageLookupError, match="multiple"):
+            await transport.find_sent_message_by_rfc_message_id("<stable@example.test>")
+    finally:
+        await transport.close()
+
+
 class _RouteService:
     def __init__(self) -> None:
         self.calls: list[dict] = []
@@ -663,6 +1109,23 @@ class _RouteService:
                 "approvalId": str(kwargs["approval_id"]),
                 "id": "draft-record-1",
                 "state": "draft_created",
+            },
+            "replayed": False,
+            "reused": False,
+        }
+
+
+class _SentReconciliationRouteService:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def reconcile(self, **kwargs) -> dict:
+        self.calls.append(kwargs)
+        return {
+            "outcome": "draft_missing",
+            "reconciliation": {
+                "approvalId": str(kwargs["approval_id"]),
+                "state": "draft_missing",
             },
             "replayed": False,
             "reused": False,
@@ -726,6 +1189,61 @@ async def test_full_atlas_app_gmail_draft_route_requires_existing_auth_and_never
     ]
 
 
+@pytest.mark.asyncio
+async def test_full_atlas_app_gmail_sent_reconciliation_route_requires_existing_auth():
+    from atlas_brain.api.invoicing import auth as receivables_auth
+    from atlas_brain.api.invoicing import receivables as routes
+    from atlas_brain.eom_api.auth import generate_receivables_service_token
+    from atlas_brain.main import app
+
+    approval_id = uuid4()
+    service = _SentReconciliationRouteService()
+    generated = generate_receivables_service_token()
+    original_overrides = dict(app.dependency_overrides)
+    app.dependency_overrides[receivables_auth.get_receivables_api_config] = lambda: SimpleNamespace(
+        receivables_api_enabled=True,
+        receivables_service_token="",
+        receivables_service_token_sha256=generated.sha256,
+    )
+    app.dependency_overrides[
+        routes.get_commercial_billing_invoice_gmail_sent_reconciliation_service
+    ] = lambda: service
+    path = (
+        "/api/v1/receivables/commercial-billing-approvals/"
+        f"{approval_id}/gmail-draft/reconcile"
+    )
+    headers = {"Authorization": f"Bearer {generated.token}"}
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            assert (await client.post(path)).status_code == 401
+            assert (await client.post(path, headers=headers)).status_code == 422
+            assert (
+                await client.post(
+                    path,
+                    headers={**headers, "Idempotency-Key": "route-sent-1"},
+                )
+            ).status_code == 422
+            response = await client.post(
+                path,
+                headers={
+                    **headers,
+                    "Idempotency-Key": "route-sent-1",
+                    "X-EOM-Actor": "Juan",
+                },
+            )
+    finally:
+        app.dependency_overrides.clear()
+        app.dependency_overrides.update(original_overrides)
+
+    assert response.status_code == 200
+    assert response.json()["outcome"] == "draft_missing"
+    assert service.calls == [
+        {"approval_id": approval_id, "idempotency_key": "route-sent-1", "actor": "Juan"}
+    ]
+
+
 def test_gmail_draft_migration_is_additive_and_never_encodes_sent_state():
     migration = (
         Path(__file__).parents[1]
@@ -744,6 +1262,23 @@ def test_gmail_draft_migration_is_additive_and_never_encodes_sent_state():
     assert "sent_at" not in executable
     assert "UPDATE invoices" not in executable
     assert "DROP TABLE" not in executable
+
+
+def test_gmail_sent_reconciliation_migration_is_additive_and_never_marks_an_invoice_sent():
+    migration = (
+        Path(__file__).parents[1]
+        / "atlas_brain/storage/migrations/375_commercial_billing_invoice_gmail_sent_reconciliation.sql"
+    ).read_text()
+    executable = "\n".join(
+        line for line in migration.splitlines() if not line.lstrip().startswith("--")
+    )
+    assert "ADD COLUMN IF NOT EXISTS reconciliation_state" in migration
+    assert "CREATE TABLE IF NOT EXISTS commercial_billing_gmail_sent_reconciliation_operations" in migration
+    assert "UNIQUE (source, idempotency_key)" in migration
+    assert "'draft_present', 'draft_missing', 'sent_confirmed'" in migration
+    assert "UPDATE invoices" not in executable
+    assert "DROP TABLE" not in executable
+    assert "DROP COLUMN" not in executable
 
 
 def test_gmail_draft_service_imports_no_sender_or_financial_state_writer():
@@ -779,11 +1314,25 @@ def test_gmail_draft_service_imports_no_sender_or_financial_state_writer():
     assert "float(" not in source
 
 
+def test_gmail_sent_reconciliation_service_only_reads_gmail_and_writes_after_proof():
+    import atlas_brain.services.commercial_billing_invoice_gmail_sent_reconciliation as reconciliation
+
+    source = inspect.getsource(reconciliation)
+    assert "find_sent_message_by_rfc_message_id" in source
+    assert "find_draft_by_rfc_message_id" in source
+    assert "create_draft" not in source
+    assert ".send(" not in source
+    assert "UPDATE invoices" in source
+    assert "float(" not in source
+
+
 def test_invoicing_workflow_enrolls_the_gmail_draft_surface_and_contract():
     workflow = (Path(__file__).parents[1] / ".github/workflows/atlas_invoicing_checks.yml").read_text()
     for path in (
         "atlas_brain/services/commercial_billing_invoice_gmail_drafts.py",
+        "atlas_brain/services/commercial_billing_invoice_gmail_sent_reconciliation.py",
         "atlas_brain/storage/migrations/374_commercial_billing_invoice_gmail_drafts.sql",
+        "atlas_brain/storage/migrations/375_commercial_billing_invoice_gmail_sent_reconciliation.sql",
         "atlas_brain/tools/gmail.py",
         "tests/test_commercial_billing_gmail_drafts.py",
     ):


### PR DESCRIPTION
Plan: plans/PR-EOM-Commercial-Invoice-Sent-Reconciliation.md
Slice phase: Vertical slice
Ownership lane: eom/billing-sent-reconciliation

ATLAS has a durable no-send Gmail draft after approval, but a manually sent
draft must not mark its invoice sent merely because the draft disappears. This
provider slice uses the draft's stable RFC Message-ID and namespaced headers to
record only verified Gmail Sent-mail evidence, then atomically update the
linked still-draft invoice.

Diff-budget override: The additive proof/outcome migration, bounded Gmail metadata reader, durable idempotency state machine, authenticated route, and real-PostgreSQL failure/concurrency proof are one financial-lifecycle boundary; splitting them would either let a provider write happen without durable recovery evidence or ship a route that cannot safely prove or persist the required state.

## Intentional

- Gmail calls are read-only `messages.list` and `messages.get`; this slice does
  not create a draft, create a PDF, send an email, or expose Gmail credentials.
- A draft absent from Gmail without matching Sent-mail proof persists
  `draft_missing`; it is never inferred to be sent.
- The invoice update accepts only the existing approved Gmail-PDF draft while
  its linked invoice remains `draft`; stale or ambiguous state conflicts.

## AI reconciliation

- no-findings

## Deferred

- #2363 H-15: Website recovery UI and an explicit, audited replacement-draft
  action after a `draft_missing` observation.
- #2363 H-15: mailbox polling/webhook scheduling and manual Square invoice
  queue/reference recording remain later Billing & Payments slices.

## Parked hardening

- None. This slice owns the provider proof boundary; it does not choose a
  customer-visible recovery design or delivery channel.

## Cold diff reconstruction

- Changed: `375_commercial_billing_invoice_gmail_sent_reconciliation.sql:14`
  adds only durable evidence/outcome columns and an idempotency table; it never
  updates invoices or deletes historical data.
- Changed: `gmail.py:494` performs bounded, exact, read-only Gmail Sent search
  and metadata fetch. `commercial_billing_invoice_gmail_sent_reconciliation.py:386`
  verifies all headers/labels/timestamps before its final atomic invoice write.
- Changed: `receivables.py:777` exposes the service through the existing
  authenticated receivables boundary. `tests/test_commercial_billing_gmail_drafts.py:451`
  proves normal, missing, malformed, retry, concurrency, stale-session,
  transport, and mounted-route behavior.
- Contract match: every production change is required to turn only verified
  Sent-mail evidence into the financial lifecycle transition; no changed path
  sends mail or uses Gmail as the ledger.
- Gaps: none found in the cold reconstruction.

## Verification

- Isolated temporary-PostgreSQL Gmail-draft/reconciliation suite: `86 passed`.
- Local mirror of Atlas Invoicing Checks: approval blockers `2 passed`,
  ledger/PDF/billing suite `428 passed`, MCP/OAuth surface `43 passed`.
- Migration-runner regression: `30 passed, 1 skipped`.
- Changed-path `ruff`, Python compilation, `git diff --check`, and the new
  service maturity ratchet all pass. No test contacted Gmail or modified a live
  financial record.

## Mechanical verification

- Command: `python scripts/sync_pr_plan.py --check plans/PR-EOM-Commercial-Invoice-Sent-Reconciliation.md origin/main` - Result: pass - Environment: local
- Command: local Atlas Invoicing Checks mirror - Result: pass (2 + 428 + 43 passed) - Environment: local
- Command: `python scripts/maturity_sweep_file_lane.py atlas_brain/services/commercial_billing_invoice_gmail_sent_reconciliation.py --tests-root tests --min-score 8` - Result: pass; zero findings - Environment: local
- Command: `python -m ruff check ... && python -m py_compile ... && git diff --check` - Result: pass - Environment: local
- Skipped: GitHub Actions - Reason: Juan requested the corresponding checks run locally.

## Diff size

7 files, +2270 / -0

<!-- atlas-open-pr-wrapper: v1 -->
