### PR TITLE
BREAKING EOM: require payment references at receivables boundary

### DIFF
--- a/atlas_brain/api/invoicing/receivables.py
+++ b/atlas_brain/api/invoicing/receivables.py
@@ -11,7 +11,7 @@ from uuid import UUID
 
 import asyncpg
 from fastapi import APIRouter, Depends, Header, HTTPException, Query
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from ...services.receivables import (
     ReceivablesConflictError,
@@ -151,9 +151,23 @@ class CreatePaymentRequest(BaseModel):
     received_date: date
     check_date: Optional[date] = None
     received_through: Optional[str] = Field(default=None, max_length=128)
-    reference: Optional[str] = Field(default=None, max_length=256)
+    reference: str = Field(min_length=1, max_length=256)
     notes: Optional[str] = None
     allocations: list[AllocationRequest] = Field(default_factory=list, max_length=100)
+
+    @field_validator("reference", mode="before")
+    @classmethod
+    def reference_must_identify_receipt(cls, value: Any) -> str:
+        if not isinstance(value, str):
+            raise ValueError(
+                "check number, ACH confirmation, or Square transaction ID is required"
+            )
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError(
+                "check number, ACH confirmation, or Square transaction ID is required"
+            )
+        return normalized
 
 
 class AdjustAllocationsRequest(BaseModel):

--- a/atlas_brain/eom_api/receivables.py
+++ b/atlas_brain/eom_api/receivables.py
@@ -11,7 +11,7 @@ from uuid import UUID
 
 import asyncpg
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from ..services.receivables import (
     ReceivablesConflictError,
@@ -93,9 +93,23 @@ class CreatePaymentRequest(BaseModel):
     received_date: date
     check_date: Optional[date] = None
     received_through: Optional[str] = Field(default=None, max_length=128)
-    reference: Optional[str] = Field(default=None, max_length=256)
+    reference: str = Field(min_length=1, max_length=256)
     notes: Optional[str] = None
     allocations: list[AllocationRequest] = Field(default_factory=list, max_length=100)
+
+    @field_validator("reference", mode="before")
+    @classmethod
+    def reference_must_identify_receipt(cls, value: Any) -> str:
+        if not isinstance(value, str):
+            raise ValueError(
+                "check number, ACH confirmation, or Square transaction ID is required"
+            )
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError(
+                "check number, ACH confirmation, or Square transaction ID is required"
+            )
+        return normalized
 
 
 class AdjustAllocationsRequest(BaseModel):

--- a/plans/PR-EOM-Payment-Reference-Admission.md
+++ b/plans/PR-EOM-Payment-Reference-Admission.md
@@ -1,0 +1,203 @@
+# PR-EOM-Payment-Reference-Admission
+
+## Why this slice exists
+
+The Billing & Payments functional contract requires a check number for checks
+and a confirmation or transaction ID for ACH and Square. H-07 in the
+[Billing & Payments hardening ledger #2363](https://github.com/canfieldjuan/ATLAS/issues/2363)
+confirmed that both active EOM payment HTTP models still admit a missing
+`reference`, even though the deployed tracker and Website already reject it.
+This closes that provider-side admission gap before any financial service,
+receipt outbox, or allocation writer runs.
+
+**BREAKING (EOM private API only):** a direct EOM receivables caller that omits
+or sends a blank `reference` will now receive HTTP 422. The current tracker and
+Website already send a trimmed nonblank value for every admitted method. The
+legacy invoicing MCP payment contract remains unchanged.
+
+### Problem-derived contract
+
+- Root cause: the EOM-specific HTTP request boundary accepts an optional
+  receipt identifier, so a direct authenticated request can persist a check,
+  ACH, or Square payment with no required reference despite the operator
+  contract and current consumer validation. The general receivables service is
+  not the root cause: it also supports the separately preserved legacy MCP
+  payment surface.
+- Correct fix must touch/change: both parallel EOM request models must require
+  a string reference and normalize/reject blank input before their route
+  functions can call `ReceivablesService`; route-level ASGI tests must prove
+  the full and slim entrypoints return 422 without invoking their service;
+  model tests must cover all three admitted payment methods and the MCP
+  compatibility test must prove its optional reference remains optional.
+- Must not change: the `ReceivablesService` method signature and financial
+  transaction/idempotency behavior; customer, allocation, receipt-outbox,
+  deposit, clearing, Gmail, PDF, and Square lifecycle writers; legacy MCP
+  request/response behavior; tracker and Website contracts; migrations and
+  customer-facing copy.
+
+## Scope (this PR)
+
+Ownership lane: eom/billing-payments
+Slice phase: Functional validation
+
+Max files: 4
+
+1. Require and trim one nonblank payment reference at the active full and slim
+   EOM receivables HTTP request models for each existing `check`, `ach`, and
+   `square` payment method.
+2. Reject absent, null, whitespace-only, non-string, and over-length references
+   with FastAPI/Pydantic validation before the route calls a financial service.
+3. Preserve valid current EOM requests and the separate legacy MCP optional
+   reference contract; add focused regression/reachability evidence.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] The active full and slim `POST /api/v1/receivables/payments` entrypoints
+    return 422 for every admitted method when `reference` is absent, null, or
+    blank, and their injected `create_payment` service records zero calls;
+    settled by the new ASGI reachability test in `tests/test_receivables.py`.
+  - [ ] Both `CreatePaymentRequest` models accept a nonblank check number, ACH
+    confirmation, or Square transaction ID, trim surrounding whitespace, and
+    reject non-string or 257-character values; settled by the parametrized
+    model-contract test in `tests/test_receivables.py`.
+  - [ ] Existing valid EOM route forwarding and unchanged-key payment retry
+    behavior retain a nonblank reference; settled by the focused receivables
+    route/retry regression tests.
+  - [ ] The legacy `record_customer_payment` MCP tool still admits an omitted
+    reference and forwards `None` to its service, settled by a focused MCP
+    compatibility test in `tests/test_receivables.py`.
+- Reachability proof: real full `main.app` and slim `main_eom.app` ASGI
+  requests exercise the protected payment route with valid auth and assert the
+  422 response plus zero service calls; no financial database or external
+  delivery operation occurs.
+- Affected surfaces: full and slim EOM FastAPI request models, their existing
+  protected payment routes, EOM tracker/Website callers, and the legacy MCP
+  compatibility seam.
+- Risk areas: money-record admission, direct mixed-version caller behavior,
+  validation ordering before mutation, duplicate full/slim model drift,
+  idempotency preservation, and legacy MCP compatibility.
+- Reviewer rules triggered: R1, R2, R3, R5, R6, R8, R10, R12, R13, R14.
+
+### Boundary-change enumeration
+
+This is a closed request-admission boundary. The relevant payment-method set is
+**CLOSED**: `check`, `ach`, and `square` are the current `Literal` values in
+each active model. Its membership is **ENUMERATED** by the existing full and
+slim API models while H-06 tracks their later shared-schema extraction. An
+out-of-set method receives Pydantic validation rejection; for every in-set
+method, a non-string, absent, null, blank, or over-length reference is rejected
+before the endpoint calls a service. The safe financial default is rejection:
+the cost of an incomplete receipt identifier is a persistently ambiguous
+financial record, while a caller can correct and resubmit before any write.
+
+- Boundary path/seam: full
+  `atlas_brain/api/invoicing/receivables.py::CreatePaymentRequest` and slim
+  `atlas_brain/eom_api/receivables.py::CreatePaymentRequest`, both consumed by
+  their existing `POST /api/v1/receivables/payments` routes.
+- Replaced-path behaviors: optional/missing/blank `reference` previously bound
+  to `None` or an empty string and could enter `ReceivablesService`; this PR
+  replaces only that admission with a 422. Valid nonblank references continue
+  to route unchanged except for whitespace trimming.
+- Guard-relevant fields: `payment_method` selects the closed allowed method
+  set; `reference` supplies the required receipt identifier. Customer,
+  allocation, amount, dates, actor, and idempotency key retain their existing
+  independent validation and are not part of this decision.
+- Caller x input shape: deployed tracker requests a validated trimmed string
+  for each method; the Website validates a nonblank form value before proxying;
+  direct EOM callers with missing/null/blank/non-string/over-length references
+  receive 422 and make zero writes; legacy invoicing MCP bypasses these EOM
+  models and keeps its optional reference contract.
+
+### Deployed-config probing
+
+- Deployed/default config values: the active full ATLAS service currently has
+  the receivables API enabled (read-only `/api/v1/receivables/ready` proof at
+  the deployed `fde6e16f` revision). There is no reference-related environment
+  default or config fallback, and this PR changes none.
+- Explicit value probe: a valid trimmed reference reaches the existing model
+  and route-forwarding behavior for each closed method, demonstrated by the
+  focused model and route tests.
+- Absent value probe: absent, null, empty, and whitespace-only references are
+  ASGI-posted to both protected routes and return 422.
+- Default-session/default-context probe: there is no reference default and no
+  customer/actor fallback involved in this decision; the ASGI test uses a valid
+  service token and actor only to prove rejection happens at body admission.
+- Side-effect ordering: Pydantic body validation rejects the request before
+  either route function can resolve canonical customer data or call
+  `create_payment`; the injected service's zero call count is the observable
+  proof.
+
+### Files touched
+
+- `atlas_brain/api/invoicing/receivables.py`
+- `atlas_brain/eom_api/receivables.py`
+- `plans/PR-EOM-Payment-Reference-Admission.md`
+- `tests/test_receivables.py`
+
+## Mechanism
+
+Each parallel EOM `CreatePaymentRequest` changes `reference` from optional to
+required and uses the same small field validator: accept only a string, strip
+it, then reject an empty normalized value. The existing closed payment-method
+literal remains unchanged. Because FastAPI constructs the request model before
+entering the endpoint function, an invalid body returns 422 before any canonical
+customer lookup, service call, receipt-outbox attempt, payment write,
+allocation, or idempotency lookup.
+
+The general `ReceivablesService` stays permissive because legacy invoicing MCP
+tools deliberately call it directly with an optional reference. Tests use the
+real ASGI router with only auth/service dependencies faked, then separately
+assert the existing MCP helper continues to forward `None`.
+
+## Intentional
+
+- This is a provider-only EOM API admission change. Current tracker and Website
+  clients are already compliant, so they need no companion deployment; deploy
+  ATLAS first and retain their existing behavior.
+- The validation is deliberately not method-format-specific: ATLAS requires an
+  identifying value but does not invent a regex for bank or Square identifiers
+  it does not own.
+- The two validators remain small mirrored code. Extracting a shared schema is
+  existing H-06 work and would widen this financial admission slice.
+- The legacy MCP `record_customer_payment` reference remains optional. Tightening
+  the shared service would break that established surface and is not required to
+  close the EOM route gap.
+- No migration, financial correction, test payment, Gmail call, receipt email,
+  or production-record mutation is used for verification.
+
+## Deferred
+
+- H-06 / #2363: consolidate the duplicate full and slim request schemas behind
+  one shared contract after the financial admission behavior is stable.
+- H-15 / #2363: explicit Gmail missing-draft replacement and scheduled
+  observation remain separate delivery-state work.
+- Stronger bank- or processor-specific reference formatting and duplicate-ID
+  policy are not inferred here; they require an operator-owned business rule
+  and are not necessary to require a receipt identifier.
+
+Parking predicate: broader service/MCP policy changes, reference semantic
+formatting, migrations, delivery behavior, and refactors are parked unless the
+new EOM admission boundary cannot safely reject before financial mutation.
+
+Parked hardening: none.
+
+## Verification
+
+- `git diff --check` — passed.
+- `/home/juan-canfield/Desktop/Atlas/.venv/bin/python -m pytest -q tests/test_receivables.py -k 'payment_http_models or payment_routes_forward_omitted_allocations or full_and_slim_payment_entrypoints_reject_invalid_reference_before_service or legacy_mcp_customer_payment_keeps_reference_optional or multi_invoice_mcp_is_registered_with_bounded_strict_schema'` — 23 passed.
+- `ATLAS_RECEIVABLES_TEST_DATABASE_URL=<local test database> /home/juan-canfield/Desktop/Atlas/.venv/bin/python -m pytest -q tests/test_receivables.py` — 118 passed.
+- `/home/juan-canfield/Desktop/Atlas/.venv/bin/python -m pytest -q tests/test_eom_payment_receipts.py` — 11 passed.
+- Scoped Ruff lint for the two route modules and receivables test file — passed.
+- `/home/juan-canfield/Desktop/Atlas/.venv/bin/python -m py_compile atlas_brain/api/invoicing/receivables.py atlas_brain/eom_api/receivables.py tests/test_receivables.py` — passed.
+- Pending before push: repository `scripts/local_pr_review.sh`, the guarded full unit baseline, maturity matrix, and current-head AI reconciliation. Hosted Actions are diagnostic only per the operator's local-check direction; their known pre-step allocation failure remains H-11, not acceptance evidence.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/api/invoicing/receivables.py` | 18 |
+| `atlas_brain/eom_api/receivables.py` | 18 |
+| `plans/PR-EOM-Payment-Reference-Admission.md` | 203 |
+| `tests/test_receivables.py` | 156 |
+| **Total** | **395** |

--- a/tests/test_receivables.py
+++ b/tests/test_receivables.py
@@ -3886,6 +3886,7 @@ async def test_real_postgres_http_and_mcp_entrypoints_use_supported_dependencies
             "total_amount_cents": 20_000,
             "payment_method": "check",
             "received_date": "2026-07-16",
+            "reference": "HTTP-1001",
             "allocations": [
                 {"invoice_id": str(invoice_ids[0]), "amount_cents": 12_500},
                 {"invoice_id": str(invoice_ids[1]), "amount_cents": 5_000},
@@ -4346,6 +4347,42 @@ async def test_mcp_payment_response_projects_future_eom_check_metadata():
     assert service.kwargs["notes"] == "Received in mail"
 
 
+@pytest.mark.asyncio
+async def test_legacy_mcp_customer_payment_keeps_reference_optional():
+    from atlas_brain.mcp import invoicing_server
+
+    contact_id = uuid4()
+    invoice_id = uuid4()
+
+    class _LegacyMCPService:
+        def __init__(self) -> None:
+            self.kwargs = None
+
+        async def create_payment(self, **kwargs):
+            self.kwargs = kwargs
+            return {"id": "legacy-mcp-payment", "status": "received"}
+
+    service = _LegacyMCPService()
+    result = json.loads(
+        await invoicing_server._record_customer_payment_with_service(
+            service=service,
+            contact_id=str(contact_id),
+            payer_name="Legacy Customer",
+            total_amount_cents=12_500,
+            payment_method="check",
+            allocations=[{"invoice_id": str(invoice_id), "amount_cents": 12_500}],
+            idempotency_key="legacy-mcp-optional-reference-1",
+        )
+    )
+
+    assert result == {
+        "success": True,
+        "payment": {"id": "legacy-mcp-payment", "status": "received"},
+    }
+    assert service.kwargs["reference"] is None
+    assert service.kwargs["source"] == "invoicing_mcp"
+
+
 def test_full_invoicing_mcp_http_refuses_to_start_without_strong_auth():
     from atlas_brain.mcp import invoicing_server
     from atlas_brain.mcp.auth import BearerAuthMiddleware
@@ -4415,6 +4452,36 @@ def test_payment_http_models_reject_coercive_cent_values():
                     ],
                 }
             )
+
+
+@pytest.mark.parametrize("payment_method", ("check", "ach", "square"))
+def test_eom_payment_http_models_require_trimmed_reference(payment_method):
+    from atlas_brain.api.invoicing.receivables import CreatePaymentRequest
+    from atlas_brain.eom_api.receivables import (
+        CreatePaymentRequest as EOMCreatePaymentRequest,
+    )
+
+    base = {
+        "contact_id": str(uuid4()),
+        "payer_name": "Receipt Customer",
+        "total_amount_cents": 12_500,
+        "payment_method": payment_method,
+        "received_date": "2026-08-15",
+        "reference": "  receipt-reference-1001  ",
+    }
+    invalid_references = (None, "", " \t ", 1001, False, {}, [], "x" * 257)
+
+    for request_model in (CreatePaymentRequest, EOMCreatePaymentRequest):
+        assert request_model.model_validate(base).reference == "receipt-reference-1001"
+
+        with pytest.raises(ValueError):
+            request_model.model_validate(
+                {key: value for key, value in base.items() if key != "reference"}
+            )
+
+        for reference in invalid_references:
+            with pytest.raises(ValueError):
+                request_model.model_validate({**base, "reference": reference})
 
 
 def test_payment_http_models_preserve_optional_check_metadata():
@@ -4534,6 +4601,7 @@ async def test_payment_routes_forward_omitted_allocations_as_empty_list(monkeypa
         assert service.kwargs["idempotency_key"] == "route-unapplied-payment-1"
         assert service.kwargs["check_date"] is None
         assert service.kwargs["received_through"] is None
+        assert service.kwargs["reference"] == "1001"
         assert service.kwargs["require_receipt_recipient"] is True
         assert service.kwargs["receipt_recipient"].contact_id == body.contact_id
 
@@ -4638,6 +4706,93 @@ async def test_full_and_slim_payment_entrypoints_reject_check_metadata_when_sche
             app.dependency_overrides.update(original_overrides)
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("payment_method", ("check", "ach", "square"))
+@pytest.mark.parametrize(
+    "reference_body",
+    (
+        {},
+        {"reference": None},
+        {"reference": ""},
+        {"reference": " \t "},
+        {"reference": 1001},
+    ),
+)
+async def test_full_and_slim_payment_entrypoints_reject_invalid_reference_before_service(
+    payment_method,
+    reference_body,
+):
+    from atlas_brain import main, main_eom
+    from atlas_brain.api.invoicing import auth as full_auth
+    from atlas_brain.api.invoicing import receivables as full_routes
+    from atlas_brain.eom_api import auth as slim_auth
+    from atlas_brain.eom_api import receivables as slim_routes
+
+    generated = eom_receivables_auth.generate_receivables_service_token()
+    config = SimpleNamespace(
+        receivables_api_enabled=True,
+        receivables_service_token="",
+        receivables_service_token_sha256=generated.sha256,
+    )
+    body = {
+        "contact_id": str(uuid4()),
+        "payer_name": "Receipt Customer",
+        "total_amount_cents": 12_500,
+        "payment_method": payment_method,
+        "received_date": "2026-08-15",
+        **reference_body,
+    }
+    headers = {
+        "Authorization": f"Bearer {generated.token}",
+        "X-EOM-Actor": "Juan Canfield",
+        "Idempotency-Key": "invalid-reference-before-service-1",
+    }
+
+    class _NoPaymentWriteService:
+        def __init__(self) -> None:
+            self.calls: list[dict] = []
+
+        async def create_payment(self, **kwargs):
+            self.calls.append(kwargs)
+            raise AssertionError("invalid payment reference must not reach service")
+
+    for app, config_dependency, service_dependency in (
+        (
+            main.app,
+            full_auth.get_receivables_api_config,
+            full_routes.get_receivables_service,
+        ),
+        (
+            main_eom.app,
+            slim_auth.get_receivables_api_config,
+            slim_routes.get_receivables_service,
+        ),
+    ):
+        service = _NoPaymentWriteService()
+        original_overrides = app.dependency_overrides.copy()
+        app.dependency_overrides[config_dependency] = lambda: config
+        app.dependency_overrides[service_dependency] = lambda: service
+        try:
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app),
+                base_url="http://receivables.test",
+            ) as client:
+                response = await client.post(
+                    "/api/v1/receivables/payments",
+                    headers=headers,
+                    json=body,
+                )
+
+            assert response.status_code == 422, response.text
+            assert any(
+                error["loc"][-1] == "reference" for error in response.json()["detail"]
+            )
+            assert service.calls == []
+        finally:
+            app.dependency_overrides.clear()
+            app.dependency_overrides.update(original_overrides)
+
+
 def test_multi_invoice_mcp_is_registered_with_bounded_strict_schema():
     probe = r'''
 import asyncio
@@ -4659,6 +4814,7 @@ async def main():
     assert properties["allocations"]["maxItems"] == 100
     assert properties["payer_name"]["maxLength"] == 256
     assert properties["idempotency_key"]["maxLength"] == 128
+    assert "reference" not in matching[0].inputSchema.get("required", [])
 
     singular = [tool for tool in tools if tool.name == "record_payment"]
     assert len(singular) == 1


### PR DESCRIPTION
Plan: plans/PR-EOM-Payment-Reference-Admission.md
Slice phase: Functional validation
Ownership lane: eom/billing-payments

H-07 found that ATLAS's two active EOM payment HTTP models permit an absent
receipt reference even though the current tracker and Website require one. This
provider-first slice makes that private EOM API contract explicit: every check,
ACH, and Square request needs a trimmed nonblank reference before the route can
call its payment service. It does not alter the legacy invoicing MCP surface.

Problem: an authenticated direct EOM API request can currently create a payment
without the check number, ACH confirmation, or Square transaction ID required
to identify it.

Current behavior: the full and slim `CreatePaymentRequest` types declare
`reference` optional; `ReceivablesService` then normalizes a missing value to
`None`. The service deliberately remains broader because legacy MCP tools call
it directly with an optional reference.

Slice contract: both active EOM routes reject missing/null/blank/non-string
references with 422 before `create_payment`; valid values are trimmed; valid
route/retry behavior and MCP's optional-reference behavior stay unchanged.

Implementation: both parallel models now use the same small Pydantic field
validator. The changed test suite exercises real full/slim ASGI routes with a
valid bearer/actor and a no-write service seam, model admission for all three
methods, normal forwarding, and the legacy MCP schema/helper.

Deployment order: ATLAS only. Current tracker main `0cbcdaf` and Website main
`c357afb` already require a nonblank reference, so this tightening is safe to
deploy ahead of unchanged consumers. A direct older EOM caller without a
reference receives the intended 422 before any financial write.

Failure and retry behavior: validation failure happens before service payment
creation, receipt outbox, allocation, or idempotency work; the ASGI test asserts
zero service calls. Existing valid idempotency keys continue through the
unchanged service path. No Gmail, PDF, Square API, email send, migration, or
production financial mutation is part of this slice.

## Intentional

- The EOM private API behavior change is explicitly breaking for invalid direct
  callers only; current tracker/Website clients are compatible.
- No method-specific identifier regex or duplicate-ID policy is invented.
- The small mirrored validators preserve full/slim parity; H-06 retains the
  later shared-schema extraction.
- Legacy MCP keeps optional `reference`; changing the general service would
  expand this slice and break its established contract.

## AI reconciliation

- no-findings

## Deferred

- H-06 / #2363: extract the parallel full/slim request schema later.
- H-15 / #2363: explicit missing-Gmail-draft replacement and scheduled
  observation remain separate delivery work.
- Payment-processor-specific reference formats and duplicate-ID policy require
  a separate operator-derived business rule.

## Parked hardening

- None. The parking predicate is broader service/MCP policy, semantic format
  enforcement, migrations, delivery behavior, and refactors; none is required
  for this pre-write admission boundary.

## Cold diff reconstruction

- Changed: `atlas_brain/api/invoicing/receivables.py` and
  `atlas_brain/eom_api/receivables.py` make `reference` required and normalize
  nonblank strings at the only EOM payment request models. `tests/test_receivables.py`
  adds full/slim ASGI zero-service-call proof, all-method model coverage,
  forwarding coverage, and MCP compatibility coverage. The plan records the
  closed method set, caller shapes, no-config default, and deployment proof.
- Contract match: model validation prevents an incomplete reference from
  reaching the financial writer; the full/slim tests cover the mirrored active
  entrypoints; the MCP test proves the intentionally excluded caller remains
  compatible.
- Gaps: none found in the current diff. No service, migration, lifecycle,
  delivery, consumer, or customer-facing files changed.

## Verification

- Focused receivables selection: 23 passed.
- Full `tests/test_receivables.py` against the local receivables database: 118 passed.
- `tests/test_eom_payment_receipts.py`: 11 passed.
- Changed-file Ruff, `py_compile`, and `git diff --check`: passed.
- Repository `local_pr_review.sh` passed through `scripts/push_pr.sh`; its unit gate selected the full suite and completed before the wrapper published the exact head `3255b5d1`.

## Mechanical verification

- Command: `git diff --check` - Result: passed - Environment: local
- Command: `ruff check atlas_brain/api/invoicing/receivables.py atlas_brain/eom_api/receivables.py tests/test_receivables.py` - Result: passed - Environment: local
- Command: `/home/juan-canfield/Desktop/Atlas/.venv/bin/python -m pytest -q tests/test_receivables.py` - Result: 118 passed - Environment: local
- Command: `/home/juan-canfield/Desktop/Atlas/.venv/bin/python -m pytest -q tests/test_eom_payment_receipts.py` - Result: 11 passed - Environment: local
- Command: `PYTHON=/home/juan-canfield/Desktop/Atlas/.venv/bin/python ATLAS_CURRENT_PR_AUTHOR=canfieldjuan bash scripts/push_pr.sh .tmp/eom-payment-reference-pr-body.tmp -u origin HEAD` - Result: passed; local review and full unit-baseline gate completed before publishing `3255b5d1` - Environment: local
- Skipped: hosted GitHub Actions - Reason: the operator directed local acceptance; the known hosted pre-step runner-allocation failure is H-11 external state, not a code result.

## Diff size

4 files, +391 / -4 at `3255b5d1b8cb9486454119e066c33480b344a2b2`.

<!-- atlas-open-pr-wrapper: v1 -->
