### PR TITLE
EOM: add audited commercial billing candidate overrides

### DIFF
--- a/.github/workflows/atlas_invoicing_checks.yml
+++ b/.github/workflows/atlas_invoicing_checks.yml
@@ -31,6 +31,7 @@ on:
       - "atlas_brain/services/crm_provider.py"
       - "atlas_brain/services/commercial_billing_candidates.py"
       - "atlas_brain/services/commercial_billing_runs.py"
+      - "atlas_brain/services/commercial_billing_candidate_overrides.py"
       - "atlas_brain/services/commercial_billing_approvals.py"
       - "atlas_brain/services/commercial_billing_invoice_pdfs.py"
       - "atlas_brain/services/commercial_billing_invoice_gmail_drafts.py"
@@ -60,6 +61,7 @@ on:
       - "atlas_brain/storage/migrations/377_commercial_billing_gmail_draft_replacements.sql"
       - "atlas_brain/storage/migrations/380_commercial_billing_candidate_review_decisions.sql"
       - "atlas_brain/storage/migrations/381_commercial_billing_candidate_review_decisions_recovery.sql"
+      - "atlas_brain/storage/migrations/382_commercial_billing_candidate_overrides.sql"
       - "atlas_brain/storage/repositories/invoice.py"
       - "atlas_brain/templates/email/__init__.py"
       - "atlas_brain/templates/email/estimate_confirmation.py"
@@ -73,6 +75,7 @@ on:
       - "tests/test_residential_payment_receipt_delivery.py"
       - "tests/test_commercial_billing_candidates.py"
       - "tests/test_commercial_billing_runs.py"
+      - "tests/test_commercial_billing_candidate_overrides.py"
       - "tests/test_commercial_billing_approvals.py"
       - "tests/test_commercial_billing_gmail_drafts.py"
       - "tests/test_commercial_billing_manual_square_invoices.py"
@@ -111,6 +114,7 @@ on:
       - "atlas_brain/services/crm_provider.py"
       - "atlas_brain/services/commercial_billing_candidates.py"
       - "atlas_brain/services/commercial_billing_runs.py"
+      - "atlas_brain/services/commercial_billing_candidate_overrides.py"
       - "atlas_brain/services/commercial_billing_approvals.py"
       - "atlas_brain/services/commercial_billing_invoice_pdfs.py"
       - "atlas_brain/services/commercial_billing_invoice_gmail_drafts.py"
@@ -140,6 +144,7 @@ on:
       - "atlas_brain/storage/migrations/377_commercial_billing_gmail_draft_replacements.sql"
       - "atlas_brain/storage/migrations/380_commercial_billing_candidate_review_decisions.sql"
       - "atlas_brain/storage/migrations/381_commercial_billing_candidate_review_decisions_recovery.sql"
+      - "atlas_brain/storage/migrations/382_commercial_billing_candidate_overrides.sql"
       - "atlas_brain/storage/repositories/invoice.py"
       - "atlas_brain/templates/email/__init__.py"
       - "atlas_brain/templates/email/estimate_confirmation.py"
@@ -153,6 +158,7 @@ on:
       - "tests/test_residential_payment_receipt_delivery.py"
       - "tests/test_commercial_billing_candidates.py"
       - "tests/test_commercial_billing_runs.py"
+      - "tests/test_commercial_billing_candidate_overrides.py"
       - "tests/test_commercial_billing_approvals.py"
       - "tests/test_commercial_billing_gmail_drafts.py"
       - "tests/test_commercial_billing_manual_square_invoices.py"
@@ -214,6 +220,7 @@ jobs:
             tests/test_eom_payment_receipts.py \
             tests/test_residential_payment_receipt_delivery.py \
             tests/test_commercial_billing_candidates.py \
+            tests/test_commercial_billing_candidate_overrides.py \
             tests/test_commercial_billing_runs.py \
             tests/test_commercial_billing_approvals.py \
             tests/test_commercial_billing_gmail_drafts.py \

--- a/atlas_brain/api/invoicing/receivables.py
+++ b/atlas_brain/api/invoicing/receivables.py
@@ -202,8 +202,16 @@ class CreateCommercialBillingRunRequest(BaseModel):
 
 
 class ApproveCommercialBillingCandidateRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     candidate_key: str = Field(min_length=1, max_length=512)
     expected_source_fingerprint: str = Field(
+        min_length=64,
+        max_length=64,
+        pattern=r"^[0-9a-f]{64}$",
+    )
+    expected_review_fingerprint: Optional[str] = Field(
+        default=None,
         min_length=64,
         max_length=64,
         pattern=r"^[0-9a-f]{64}$",
@@ -218,12 +226,81 @@ class SetCommercialBillingCandidateReviewDecisionRequest(BaseModel):
         max_length=64,
         pattern=r"^[0-9a-f]{64}$",
     )
+    expected_review_fingerprint: Optional[str] = Field(
+        default=None,
+        min_length=64,
+        max_length=64,
+        pattern=r"^[0-9a-f]{64}$",
+    )
     decision: Literal["included", "excluded"]
     reason: str = Field(min_length=1, max_length=1000)
 
     @field_validator("reason", mode="before")
     @classmethod
     def normalize_reason_before_length_validation(cls, value: Any) -> Any:
+        return value.strip() if isinstance(value, str) else value
+
+
+class CommercialBillingCandidateLineOverrideRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    line_key: str = Field(min_length=64, max_length=64, pattern=r"^[0-9a-f]{64}$")
+    description: Optional[str] = Field(default=None, min_length=1, max_length=512)
+    rate_cents: Optional[int] = Field(
+        default=None, strict=True, gt=0, le=999_999_999_999
+    )
+    quantity: Optional[int] = Field(
+        default=None, strict=True, gt=0, le=999_999_999_999
+    )
+    quantity_minutes: Optional[int] = Field(
+        default=None, strict=True, gt=0, le=999_999_999_999
+    )
+
+
+class CommercialBillingCandidateAdjustmentRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    kind: Literal["credit", "charge"]
+    description: str = Field(min_length=1, max_length=512)
+    amount_cents: int = Field(strict=True, gt=0, le=999_999_999_999)
+
+
+class CommercialBillingCandidateRecipientOverrideRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    display_name: Optional[str] = Field(default=None, min_length=1, max_length=256)
+    email: str = Field(min_length=3, max_length=256)
+
+
+class SetCommercialBillingCandidateOverrideRequest(BaseModel):
+    """One full, run-only effective-candidate revision; no source data is edited."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    expected_source_fingerprint: str = Field(
+        min_length=64, max_length=64, pattern=r"^[0-9a-f]{64}$"
+    )
+    expected_override_revision: int = Field(strict=True, ge=0)
+    reason_code: Literal[
+        "one_time_service_variation",
+        "partial_or_missed_service",
+        "approved_pricing_exception",
+        "customer_credit",
+        "additional_charge",
+        "source_correction_pending",
+        "billing_delivery_exception",
+    ]
+    reason: str = Field(min_length=1, max_length=1000)
+    line_overrides: list[CommercialBillingCandidateLineOverrideRequest] = Field(
+        default_factory=list, max_length=500
+    )
+    adjustment: Optional[CommercialBillingCandidateAdjustmentRequest] = None
+    recipient: Optional[CommercialBillingCandidateRecipientOverrideRequest] = None
+    delivery_method: Optional[Literal["gmail_pdf", "manual_square"]] = None
+
+    @field_validator("reason", mode="before")
+    @classmethod
+    def normalize_override_reason_before_length_validation(cls, value: Any) -> Any:
         return value.strip() if isinstance(value, str) else value
 
 
@@ -891,11 +968,81 @@ async def approve_commercial_billing_candidate(
 ) -> dict:
     """Create or reuse one draft invoice only after explicit candidate approval."""
 
-    return await _call_commercial_billing_approval(
-        service.approve(
+    request = {
+        "billing_run_id": billing_run_id,
+        "candidate_key": body.candidate_key,
+        "expected_source_fingerprint": body.expected_source_fingerprint,
+        "idempotency_key": idempotency_key,
+        "actor": actor,
+    }
+    if body.expected_review_fingerprint is not None:
+        request["expected_review_fingerprint"] = body.expected_review_fingerprint
+    return await _call_commercial_billing_approval(service.approve(**request))
+
+
+@router.post(
+    "/commercial-billing-runs/{billing_run_id}/candidates/{candidate_key}/override",
+    status_code=201,
+)
+async def set_commercial_billing_candidate_override(
+    billing_run_id: UUID,
+    candidate_key: str,
+    body: SetCommercialBillingCandidateOverrideRequest,
+    actor: Annotated[str, Depends(require_actor)],
+    idempotency_key: Annotated[
+        str, Header(alias="Idempotency-Key", min_length=1, max_length=128)
+    ],
+    service: CommercialBillingRunService = Depends(get_commercial_billing_run_service),
+) -> dict:
+    """Append one audited candidate revision without financial or delivery work."""
+
+    line_overrides = [
+        {
+            **{"lineKey": item.line_key},
+            **({"description": item.description} if item.description is not None else {}),
+            **({"rateCents": item.rate_cents} if item.rate_cents is not None else {}),
+            **({"quantity": item.quantity} if item.quantity is not None else {}),
+            **(
+                {"quantityMinutes": item.quantity_minutes}
+                if item.quantity_minutes is not None
+                else {}
+            ),
+        }
+        for item in body.line_overrides
+    ]
+    adjustment = (
+        {
+            "kind": body.adjustment.kind,
+            "description": body.adjustment.description,
+            "amountCents": body.adjustment.amount_cents,
+        }
+        if body.adjustment is not None
+        else None
+    )
+    recipient = (
+        {
+            **(
+                {"displayName": body.recipient.display_name}
+                if body.recipient.display_name is not None
+                else {}
+            ),
+            "email": body.recipient.email,
+        }
+        if body.recipient is not None
+        else None
+    )
+    return await _call_commercial_billing_run(
+        service.set_candidate_override(
             billing_run_id=billing_run_id,
-            candidate_key=body.candidate_key,
+            candidate_key=candidate_key,
             expected_source_fingerprint=body.expected_source_fingerprint,
+            expected_override_revision=body.expected_override_revision,
+            reason_code=body.reason_code,
+            reason=body.reason,
+            line_overrides=line_overrides,
+            adjustment=adjustment,
+            recipient=recipient,
+            delivery_method=body.delivery_method,
             idempotency_key=idempotency_key,
             actor=actor,
         )
@@ -917,16 +1064,19 @@ async def set_commercial_billing_candidate_review_decision(
 ) -> dict:
     """Append an audited include/exclude review decision without delivery work."""
 
+    request = {
+        "billing_run_id": billing_run_id,
+        "candidate_key": candidate_key,
+        "expected_source_fingerprint": body.expected_source_fingerprint,
+        "decision": body.decision,
+        "reason": body.reason,
+        "idempotency_key": idempotency_key,
+        "actor": actor,
+    }
+    if body.expected_review_fingerprint is not None:
+        request["expected_review_fingerprint"] = body.expected_review_fingerprint
     return await _call_commercial_billing_run(
-        service.set_candidate_review_decision(
-            billing_run_id=billing_run_id,
-            candidate_key=candidate_key,
-            expected_source_fingerprint=body.expected_source_fingerprint,
-            decision=body.decision,
-            reason=body.reason,
-            idempotency_key=idempotency_key,
-            actor=actor,
-        )
+        service.set_candidate_review_decision(**request)
     )
 
 

--- a/atlas_brain/main.py
+++ b/atlas_brain/main.py
@@ -45,7 +45,7 @@ _SECURITY_CONTACT_URL = "https://github.com/canfieldjuan/ATLAS/security/advisori
 _SECURITY_POLICY_URL = "https://github.com/canfieldjuan/ATLAS/blob/main/SECURITY.md"
 _SECURITY_TXT_MAX_AGE_DAYS = 180
 _COMMERCIAL_BILLING_REVIEW_RECOVERY_MIGRATION = (
-    "381_commercial_billing_candidate_review_decisions_recovery"
+    "382_commercial_billing_candidate_overrides"
 )
 
 
@@ -316,7 +316,7 @@ async def _start_asr_server() -> subprocess.Popen | None:
 
 
 async def _commercial_billing_review_recovery_is_recorded(pool: object) -> bool:
-    """Return whether the recovery migration is durably present in the ledger."""
+    """Return whether the current review-safety migration is durably recorded."""
     try:
         return bool(
             await pool.fetchval(

--- a/atlas_brain/services/commercial_billing_approvals.py
+++ b/atlas_brain/services/commercial_billing_approvals.py
@@ -32,6 +32,11 @@ from .commercial_billing_runs import (
     lock_commercial_billing_candidate_identity,
     lock_commercial_billing_run_candidate,
 )
+from .commercial_billing_candidate_overrides import (
+    CommercialBillingCandidateOverrideValidationError,
+    MAX_INVOICE_LINE_DESCRIPTION_LENGTH,
+    override_review_fingerprint,
+)
 from .eom_lead_ingress import EOM_BUSINESS_CONTEXT_ID
 
 
@@ -139,6 +144,17 @@ def _text(value: Any) -> str | None:
     return value if isinstance(value, str) else None
 
 
+def _row_value(row: Any, key: str, default: Any = None) -> Any:
+    if row is None:
+        return default
+    if isinstance(row, Mapping):
+        return row.get(key, default)
+    try:
+        return row[key]
+    except (KeyError, IndexError):
+        return default
+
+
 def _timestamp(value: Any) -> str:
     return value.isoformat() if isinstance(value, datetime) else str(value)
 
@@ -199,8 +215,8 @@ def _validate_key(value: str, *, field: str, limit: int) -> str:
     return key
 
 
-def _source_ref(candidate_key: str, source_fingerprint: str) -> str:
-    digest = hashlib.sha256(f"{candidate_key}:{source_fingerprint}".encode()).hexdigest()
+def _source_ref(candidate_key: str, review_fingerprint: str) -> str:
+    digest = hashlib.sha256(f"{candidate_key}:{review_fingerprint}".encode()).hexdigest()
     return f"eom-commercial-billing:{digest}"
 
 
@@ -210,6 +226,7 @@ def _invoice_draft(
     billing_run_id: UUID,
     expected_candidate_key: str,
     expected_source_fingerprint: str,
+    expected_review_fingerprint: str,
     actor: str,
     due_days: int,
     issue_date: date,
@@ -277,25 +294,12 @@ def _invoice_draft(
             raise CommercialBillingApprovalValidationError(
                 "Commercial billing line item is invalid"
             )
-        quantity = line.get("quantity")
-        rate_cents = line.get("rateCents")
         amount_cents = line.get("amountCents")
-        if (
-            isinstance(quantity, bool)
-            or not isinstance(quantity, int)
-            or quantity <= 0
-            or isinstance(rate_cents, bool)
-            or not isinstance(rate_cents, int)
-            or rate_cents <= 0
-            or isinstance(amount_cents, bool)
-            or not isinstance(amount_cents, int)
-            or amount_cents != quantity * rate_cents
-            or amount_cents > _MAX_INVOICE_CENTS
-        ):
-            raise CommercialBillingApprovalValidationError(
-                "Commercial billing line-item cents are invalid"
-            )
-        description = _required_text(line.get("description"), "line-item description")
+        description = _required_text(
+            line.get("description"),
+            "line-item description",
+            limit=MAX_INVOICE_LINE_DESCRIPTION_LENGTH,
+        )
         source_date = _required_text(line.get("sourceDate"), "line-item source date", limit=10)
         try:
             date.fromisoformat(source_date)
@@ -303,6 +307,72 @@ def _invoice_draft(
             raise CommercialBillingApprovalValidationError(
                 "Commercial billing line-item source date is invalid"
             ) from exc
+        if line.get("kind") == "adjustment":
+            if (
+                isinstance(amount_cents, bool)
+                or not isinstance(amount_cents, int)
+                or amount_cents == 0
+                or abs(amount_cents) > _MAX_INVOICE_CENTS
+            ):
+                raise CommercialBillingApprovalValidationError(
+                    "Commercial billing adjustment cents are invalid"
+                )
+            subtotal_cents += amount_cents
+            if description not in names:
+                names.append(description)
+            line_items.append(
+                {
+                    "amount": _money_text(amount_cents),
+                    "date": source_date,
+                    "description": description,
+                    "quantity": 1,
+                    "unit_price": _money_text(amount_cents),
+                }
+            )
+            continue
+        quantity = line.get("quantity")
+        rate_cents = line.get("rateCents")
+        quantity_unit = line.get("quantityUnit")
+        if quantity_unit == "hour":
+            minutes = line.get("quantityMinutes")
+            if (
+                isinstance(minutes, bool)
+                or not isinstance(minutes, int)
+                or minutes <= 0
+                or isinstance(rate_cents, bool)
+                or not isinstance(rate_cents, int)
+                or rate_cents <= 0
+                or isinstance(amount_cents, bool)
+                or not isinstance(amount_cents, int)
+                or amount_cents
+                != int(
+                    (Decimal(rate_cents) * Decimal(minutes) / Decimal(60)).quantize(
+                        Decimal("1"), rounding=ROUND_HALF_UP
+                    )
+                )
+                or amount_cents > _MAX_INVOICE_CENTS
+            ):
+                raise CommercialBillingApprovalValidationError(
+                    "Commercial billing hourly line-item cents are invalid"
+                )
+            quantity_for_invoice = f"{(Decimal(minutes) / Decimal(60)):.4f}".rstrip("0").rstrip(".")
+        else:
+            quantity_for_invoice = quantity
+            if (
+                isinstance(quantity, bool)
+                or not isinstance(quantity, int)
+                or quantity <= 0
+                or isinstance(rate_cents, bool)
+                or not isinstance(rate_cents, int)
+                or rate_cents <= 0
+                or isinstance(amount_cents, bool)
+                or not isinstance(amount_cents, int)
+                or amount_cents != quantity * rate_cents
+                or amount_cents > _MAX_INVOICE_CENTS
+            ):
+                raise CommercialBillingApprovalValidationError(
+                    "Commercial billing line-item cents are invalid"
+                )
         subtotal_cents += amount_cents
         if description not in names:
             names.append(description)
@@ -311,7 +381,7 @@ def _invoice_draft(
                 "amount": _money_text(amount_cents),
                 "date": source_date,
                 "description": description,
-                "quantity": quantity,
+                "quantity": quantity_for_invoice,
                 "unit_price": _money_text(rate_cents),
             }
         )
@@ -348,11 +418,13 @@ def _invoice_draft(
         metadata={
             "approvedBy": actor,
             "candidateKey": candidate_key,
+            "commercialBillingExactLineAmounts": True,
             "commercialBillingRunId": str(billing_run_id),
             "deliveryMethod": delivery_method,
+            "reviewFingerprint": expected_review_fingerprint,
             "sourceFingerprint": expected_source_fingerprint,
         },
-        source_ref=_source_ref(candidate_key, expected_source_fingerprint),
+        source_ref=_source_ref(candidate_key, expected_review_fingerprint),
         subtotal=_money(subtotal),
         tax_amount=_money(tax),
         tax_rate=Decimal(basis_points) / Decimal(10_000),
@@ -401,6 +473,7 @@ class CommercialBillingApprovalService:
         expected_source_fingerprint: str,
         idempotency_key: str,
         actor: str,
+        expected_review_fingerprint: str | None = None,
     ) -> dict[str, Any]:
         if not isinstance(billing_run_id, UUID):
             raise CommercialBillingApprovalValidationError("Billing run id is invalid")
@@ -411,26 +484,59 @@ class CommercialBillingApprovalService:
             or _FINGERPRINT.fullmatch(expected_source_fingerprint) is None
         ):
             raise CommercialBillingApprovalValidationError("Source fingerprint is invalid")
+        if expected_review_fingerprint is None:
+            submitted_review_fingerprint = expected_source_fingerprint
+        elif isinstance(expected_review_fingerprint, str) and _FINGERPRINT.fullmatch(
+            expected_review_fingerprint
+        ) is not None:
+            submitted_review_fingerprint = expected_review_fingerprint
+        else:
+            raise CommercialBillingApprovalValidationError("Review fingerprint is invalid")
         approved_by = _required_text(actor, "authenticated actor", limit=128)
         request_fingerprint = _fingerprint(
-            {"billingRunId": str(billing_run_id), "candidateKey": selected, "sourceFingerprint": expected_source_fingerprint}
+            {
+                "billingRunId": str(billing_run_id),
+                "candidateKey": selected,
+                "reviewFingerprint": submitted_review_fingerprint,
+                "sourceFingerprint": expected_source_fingerprint,
+            }
+        )
+        legacy_request_fingerprint = (
+            _fingerprint(
+                {
+                    "billingRunId": str(billing_run_id),
+                    "candidateKey": selected,
+                    "sourceFingerprint": expected_source_fingerprint,
+                }
+            )
+            if submitted_review_fingerprint == expected_source_fingerprint
+            else None
         )
         try:
             async with self.pool.transaction() as conn:
                 await self._lock(conn, f"operation:{key}")
                 existing = await self._find_by_idempotency(conn, key)
                 if existing is not None:
-                    self._assert_request(existing, request_fingerprint)
+                    self._assert_request(
+                        existing, request_fingerprint, legacy_request_fingerprint
+                    )
                     return {"approval": self._view(existing), "replayed": True}
 
             stored = await self._stored_candidate(billing_run_id, selected)
-            snapshot = _json_object(stored["snapshot"])
+            source_snapshot = _json_object(stored["snapshot"])
             if (
-                stored["source_fingerprint"] != _verified_candidate_fingerprint(snapshot)
-                or snapshot.get("billingPeriod") != stored["billing_period"]
+                stored["source_fingerprint"] != _verified_candidate_fingerprint(source_snapshot)
+                or source_snapshot.get("billingPeriod") != stored["billing_period"]
             ):
                 raise CommercialBillingApprovalUnavailableError(
                     "Commercial billing snapshot evidence is invalid"
+                )
+            snapshot, actual_review_fingerprint = self._effective_snapshot(
+                billing_run_id, stored, source_snapshot
+            )
+            if actual_review_fingerprint != submitted_review_fingerprint:
+                raise CommercialBillingApprovalConflictError(
+                    "Commercial billing candidate review identity changed before approval"
                 )
             issue_date = self._today()
             if isinstance(issue_date, datetime) or not isinstance(issue_date, date):
@@ -440,6 +546,7 @@ class CommercialBillingApprovalService:
                 billing_run_id=billing_run_id,
                 expected_candidate_key=selected,
                 expected_source_fingerprint=expected_source_fingerprint,
+                expected_review_fingerprint=submitted_review_fingerprint,
                 actor=approved_by,
                 due_days=self._due_days_loader(),
                 issue_date=issue_date,
@@ -450,7 +557,9 @@ class CommercialBillingApprovalService:
                 await self._lock(conn, f"operation:{key}")
                 existing = await self._find_by_idempotency(conn, key)
                 if existing is not None:
-                    self._assert_request(existing, request_fingerprint)
+                    self._assert_request(
+                        existing, request_fingerprint, legacy_request_fingerprint
+                    )
                     return {"approval": self._view(existing), "replayed": True}
                 await lock_commercial_billing_candidate_identity(
                     conn,
@@ -470,11 +579,42 @@ class CommercialBillingApprovalService:
                     raise CommercialBillingApprovalConflictError(
                         "Commercial billing candidate fingerprint changed before approval"
                     )
+                locked_source_snapshot = _json_object(locked_candidate["snapshot"])
+                if (
+                    locked_candidate["source_fingerprint"]
+                    != _verified_candidate_fingerprint(locked_source_snapshot)
+                ):
+                    raise CommercialBillingApprovalUnavailableError(
+                        "Commercial billing snapshot evidence is invalid"
+                    )
+                locked_override = await self._latest_override(
+                    conn,
+                    billing_run_id=billing_run_id,
+                    candidate_key=selected,
+                    source_fingerprint=expected_source_fingerprint,
+                )
+                _, locked_review_fingerprint = self._effective_snapshot(
+                    billing_run_id,
+                    {**dict(locked_candidate), **({"override": locked_override} if locked_override else {})},
+                    locked_source_snapshot,
+                )
+                if locked_review_fingerprint != submitted_review_fingerprint:
+                    raise CommercialBillingApprovalConflictError(
+                        "Commercial billing candidate review identity changed before approval"
+                    )
                 review_decision = await self._latest_review_decision(
                     conn,
                     candidate_key=selected,
                     source_fingerprint=expected_source_fingerprint,
+                    review_fingerprint=submitted_review_fingerprint,
                 )
+                if (
+                    submitted_review_fingerprint != expected_source_fingerprint
+                    and (review_decision is None or review_decision["decision"] != "included")
+                ):
+                    raise CommercialBillingApprovalConflictError(
+                        "Commercial billing candidate override requires an explicit include decision"
+                    )
                 if review_decision is not None and review_decision["decision"] == "excluded":
                     raise CommercialBillingApprovalConflictError(
                         "Commercial billing candidate is excluded; include it before approval"
@@ -490,16 +630,16 @@ class CommercialBillingApprovalService:
                 await conn.fetchrow(
                     """
                     INSERT INTO commercial_billing_candidate_approvals (
-                        id, billing_run_id, candidate_key, source_fingerprint, source,
+                        id, billing_run_id, candidate_key, source_fingerprint, review_fingerprint, source,
                         idempotency_key, request_fingerprint, invoice_id, state,
                         approved_by, approved_at, created_at, updated_at
                     )
-                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'invoice_created', $9, $10, $10, $10)
+                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'invoice_created', $10, $11, $11, $11)
                     RETURNING id
                     """,
                     uuid4(), billing_run_id, selected, expected_source_fingerprint,
-                    _APPROVAL_SOURCE, key, request_fingerprint, invoice["id"], approved_by,
-                    datetime.now(timezone.utc),
+                    submitted_review_fingerprint, _APPROVAL_SOURCE, key,
+                    request_fingerprint, invoice["id"], approved_by, datetime.now(timezone.utc),
                 )
                 created = await self._find_by_idempotency(conn, key)
                 if created is None:
@@ -529,10 +669,23 @@ class CommercialBillingApprovalService:
     async def _stored_candidate(self, billing_run_id: UUID, candidate_key: str) -> Any:
         row = await self.pool.fetchrow(
             """
-            SELECT run.billing_period, candidate.source_fingerprint, candidate.snapshot
+            SELECT run.billing_period, candidate.source_fingerprint, candidate.snapshot,
+                   override.id AS override_id,
+                   override.revision AS override_revision,
+                   override.review_fingerprint AS override_review_fingerprint,
+                   override.effective_snapshot AS override_effective_snapshot
             FROM commercial_billing_runs AS run
             JOIN commercial_billing_run_candidates AS candidate
               ON candidate.billing_run_id = run.id
+            LEFT JOIN LATERAL (
+                SELECT id, revision, review_fingerprint, effective_snapshot
+                FROM commercial_billing_candidate_overrides AS candidate_override
+                WHERE candidate_override.billing_run_id = candidate.billing_run_id
+                  AND candidate_override.candidate_key = candidate.candidate_key
+                  AND candidate_override.source_fingerprint = candidate.source_fingerprint
+                ORDER BY candidate_override.revision DESC
+                LIMIT 1
+            ) AS override ON TRUE
             WHERE run.id = $1 AND candidate.candidate_key = $2
             """,
             billing_run_id, candidate_key,
@@ -540,6 +693,73 @@ class CommercialBillingApprovalService:
         if row is None:
             raise CommercialBillingApprovalNotFoundError("Commercial billing candidate not found")
         return row
+
+    @staticmethod
+    def _effective_snapshot(
+        billing_run_id: UUID, stored: Any, source_snapshot: Mapping[str, Any]
+    ) -> tuple[dict[str, Any], str]:
+        if not isinstance(billing_run_id, UUID):
+            raise CommercialBillingApprovalUnavailableError(
+                "Commercial billing run identity is invalid"
+            )
+        source_fingerprint = _row_value(stored, "source_fingerprint")
+        if not isinstance(source_fingerprint, str):
+            raise CommercialBillingApprovalUnavailableError(
+                "Commercial billing snapshot evidence is invalid"
+            )
+        override = _row_value(stored, "override")
+        if override is None and _row_value(stored, "override_id") is not None:
+            override = {
+                "revision": _row_value(stored, "override_revision"),
+                "review_fingerprint": _row_value(stored, "override_review_fingerprint"),
+                "effective_snapshot": _row_value(stored, "override_effective_snapshot"),
+            }
+        if override is None:
+            return dict(source_snapshot), source_fingerprint
+        effective = _json_object(_row_value(override, "effective_snapshot"))
+        if effective.get("sourceFingerprint") != source_fingerprint:
+            raise CommercialBillingApprovalUnavailableError(
+                "Commercial billing override evidence is invalid"
+            )
+        try:
+            expected = override_review_fingerprint(
+                billing_run_id,
+                source_fingerprint,
+                _row_value(override, "revision"),
+                effective,
+            )
+        except CommercialBillingCandidateOverrideValidationError as exc:
+            raise CommercialBillingApprovalUnavailableError(
+                "Commercial billing override evidence is invalid"
+            ) from exc
+        if _row_value(override, "review_fingerprint") != expected:
+            raise CommercialBillingApprovalUnavailableError(
+                "Commercial billing override evidence is invalid"
+            )
+        return effective, expected
+
+    @staticmethod
+    async def _latest_override(
+        conn: Any,
+        *,
+        billing_run_id: UUID,
+        candidate_key: str,
+        source_fingerprint: str,
+    ) -> Any | None:
+        return await conn.fetchrow(
+            """
+            SELECT id, revision, review_fingerprint, effective_snapshot
+            FROM commercial_billing_candidate_overrides
+            WHERE billing_run_id = $1
+              AND candidate_key = $2
+              AND source_fingerprint = $3
+            ORDER BY revision DESC
+            LIMIT 1
+            """,
+            billing_run_id,
+            candidate_key,
+            source_fingerprint,
+        )
 
     async def _assert_current(self, period: str, candidate_key: str, fingerprint: str) -> None:
         preview = await self._candidate_service_loader().preview(billing_period=period)
@@ -563,6 +783,7 @@ class CommercialBillingApprovalService:
         *,
         candidate_key: str,
         source_fingerprint: str,
+        review_fingerprint: str,
     ) -> Any | None:
         return await conn.fetchrow(
             """
@@ -570,11 +791,13 @@ class CommercialBillingApprovalService:
             FROM commercial_billing_candidate_review_decisions
             WHERE candidate_key = $1
               AND source_fingerprint = $2
+              AND review_fingerprint = $3
             ORDER BY revision DESC
             LIMIT 1
             """,
             candidate_key,
             source_fingerprint,
+            review_fingerprint,
         )
 
     @staticmethod
@@ -586,7 +809,7 @@ class CommercialBillingApprovalService:
         return await conn.fetchrow(
             """
             SELECT a.id AS approval_id, a.billing_run_id, a.candidate_key,
-                   a.source_fingerprint, a.request_fingerprint, a.state,
+                   a.source_fingerprint, a.review_fingerprint, a.request_fingerprint, a.state,
                    a.approved_by, a.approved_at, i.id AS invoice_id,
                    i.invoice_number, i.status AS invoice_status, i.total_amount,
                    i.issue_date, i.due_date, i.source_ref
@@ -602,7 +825,7 @@ class CommercialBillingApprovalService:
         return await conn.fetchrow(
             """
             SELECT a.id AS approval_id, a.billing_run_id, a.candidate_key,
-                   a.source_fingerprint, a.request_fingerprint, a.state,
+                   a.source_fingerprint, a.review_fingerprint, a.request_fingerprint, a.state,
                    a.approved_by, a.approved_at, i.id AS invoice_id,
                    i.invoice_number, i.status AS invoice_status, i.total_amount,
                    i.issue_date, i.due_date, i.source_ref
@@ -614,8 +837,13 @@ class CommercialBillingApprovalService:
         )
 
     @staticmethod
-    def _assert_request(row: Any, request_fingerprint: str) -> None:
-        if row["request_fingerprint"] != request_fingerprint:
+    def _assert_request(
+        row: Any, request_fingerprint: str, legacy_request_fingerprint: str | None = None
+    ) -> None:
+        if row["request_fingerprint"] not in {
+            request_fingerprint,
+            legacy_request_fingerprint,
+        }:
             raise CommercialBillingApprovalConflictError(
                 "Idempotency key was already used with a different commercial billing candidate"
             )
@@ -666,6 +894,9 @@ class CommercialBillingApprovalService:
                 "totalCents": _cents(row["total_amount"]),
             },
             "sourceFingerprint": row["source_fingerprint"],
+            "reviewFingerprint": _row_value(
+                row, "review_fingerprint", row["source_fingerprint"]
+            ),
             "state": row["state"],
         }
 

--- a/atlas_brain/services/commercial_billing_candidate_overrides.py
+++ b/atlas_brain/services/commercial_billing_candidate_overrides.py
@@ -1,0 +1,632 @@
+"""Pure, exact-cent projections for one-run EOM billing candidate overrides.
+
+The durable writer lives in :mod:`commercial_billing_runs`; this module has no
+database or delivery dependency so the same strict projection is used by the
+writer, run reader, and approval boundary.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from decimal import Decimal, ROUND_HALF_UP
+from typing import Any, Mapping
+from uuid import UUID
+
+from .eom_crm_mutations import normalize_contact_email
+
+MAX_ADJUSTMENT_CENTS = 999_999_999_999
+MAX_INVOICE_LINE_DESCRIPTION_LENGTH = 256
+MAX_NOTE_LENGTH = 1000
+MAX_RATE_CENTS = 999_999_999_999
+MAX_RECIPIENT_NAME_LENGTH = 256
+MAX_LINE_OVERRIDES = 500
+OVERRIDE_REASON_CODES = frozenset(
+    {
+        "one_time_service_variation",
+        "partial_or_missed_service",
+        "approved_pricing_exception",
+        "customer_credit",
+        "additional_charge",
+        "source_correction_pending",
+        "billing_delivery_exception",
+    }
+)
+OVERRIDE_DELIVERY_METHODS = frozenset({"gmail_pdf", "manual_square"})
+
+
+class CommercialBillingCandidateOverrideValidationError(ValueError):
+    """An override is malformed or would make billing evidence unsafe."""
+
+
+def canonical_json(value: Any) -> str:
+    try:
+        return json.dumps(value, sort_keys=True, separators=(",", ":"), allow_nan=False)
+    except (TypeError, ValueError) as exc:
+        raise CommercialBillingCandidateOverrideValidationError(
+            "Commercial billing override evidence is not JSON-safe"
+        ) from exc
+
+
+def fingerprint(value: Any) -> str:
+    return hashlib.sha256(canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def _required_text(value: Any, field: str, limit: int) -> str:
+    if not isinstance(value, str):
+        raise CommercialBillingCandidateOverrideValidationError(f"{field} is required")
+    normalized = value.strip()
+    if not normalized or len(normalized) > limit or "\x00" in normalized:
+        raise CommercialBillingCandidateOverrideValidationError(
+            f"{field} must contain 1 to {limit} safe characters"
+        )
+    return normalized
+
+
+def _optional_text(value: Any, field: str, limit: int) -> str | None:
+    if value is None:
+        return None
+    return _required_text(value, field, limit)
+
+
+def _positive_int(value: Any, field: str, maximum: int) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not 1 <= value <= maximum
+    ):
+        raise CommercialBillingCandidateOverrideValidationError(
+            f"{field} must be an integer between 1 and {maximum}"
+        )
+    return value
+
+
+def _line_key(
+    candidate_key: str, source_fingerprint: str, index: int, line: Mapping[str, Any]
+) -> str:
+    return fingerprint(
+        {
+            "candidateKey": candidate_key,
+            "sourceFingerprint": source_fingerprint,
+            "index": index,
+            "line": dict(line),
+        }
+    )
+
+
+def decorate_line_keys(snapshot: Mapping[str, Any]) -> dict[str, Any]:
+    """Return an operator view with server-derived stable source-line keys."""
+
+    candidate = deepcopy(dict(snapshot))
+    candidate_key = candidate.get("candidateKey")
+    source_fingerprint = candidate.get("sourceFingerprint")
+    lines = candidate.get("lineItems")
+    if not isinstance(candidate_key, str) or not isinstance(source_fingerprint, str):
+        raise CommercialBillingCandidateOverrideValidationError(
+            "Commercial billing candidate identity is invalid"
+        )
+    if not isinstance(lines, list):
+        raise CommercialBillingCandidateOverrideValidationError(
+            "Commercial billing candidate line items are invalid"
+        )
+    decorated: list[dict[str, Any]] = []
+    for index, raw_line in enumerate(lines):
+        if not isinstance(raw_line, Mapping):
+            raise CommercialBillingCandidateOverrideValidationError(
+                "Commercial billing candidate line item is invalid"
+            )
+        line = deepcopy(dict(raw_line))
+        line["lineKey"] = _line_key(candidate_key, source_fingerprint, index, raw_line)
+        decorated.append(line)
+    candidate["lineItems"] = decorated
+    return candidate
+
+
+def decorate_effective_line_keys(
+    source_snapshot: Mapping[str, Any], effective_snapshot: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Expose effective lines with the immutable source-line keys they revise.
+
+    An effective line's description/rate/quantity may differ from the source,
+    so deriving its key from the effective value would make a second revision
+    target disappear. Adjustment lines are intentionally not line-editable.
+    """
+
+    source = decorate_line_keys(source_snapshot)
+    effective = deepcopy(dict(effective_snapshot))
+    if effective.get("candidateKey") != source.get("candidateKey") or effective.get(
+        "sourceFingerprint"
+    ) != source.get("sourceFingerprint"):
+        raise CommercialBillingCandidateOverrideValidationError(
+            "Commercial billing effective candidate identity is invalid"
+        )
+    source_lines = source["lineItems"]
+    effective_lines = effective.get("lineItems")
+    if not isinstance(effective_lines, list) or len(effective_lines) < len(
+        source_lines
+    ):
+        raise CommercialBillingCandidateOverrideValidationError(
+            "Commercial billing effective candidate line items are invalid"
+        )
+    decorated: list[dict[str, Any]] = []
+    for index, source_line in enumerate(source_lines):
+        raw_effective_line = effective_lines[index]
+        if not isinstance(raw_effective_line, Mapping):
+            raise CommercialBillingCandidateOverrideValidationError(
+                "Commercial billing effective candidate line item is invalid"
+            )
+        line = deepcopy(dict(raw_effective_line))
+        line["lineKey"] = source_line["lineKey"]
+        decorated.append(line)
+    for raw_effective_line in effective_lines[len(source_lines) :]:
+        if (
+            not isinstance(raw_effective_line, Mapping)
+            or raw_effective_line.get("kind") != "adjustment"
+        ):
+            raise CommercialBillingCandidateOverrideValidationError(
+                "Commercial billing effective candidate line items are invalid"
+            )
+        line = deepcopy(dict(raw_effective_line))
+        line.pop("lineKey", None)
+        decorated.append(line)
+    effective["lineItems"] = decorated
+    return effective
+
+
+def _source_line_unit(line: Mapping[str, Any]) -> str:
+    unit = line.get("quantityUnit")
+    return unit if isinstance(unit, str) and unit else "unit"
+
+
+def _hour_text(minutes: int) -> str:
+    hours = Decimal(minutes) / Decimal(60)
+    text = f"{hours:.4f}".rstrip("0").rstrip(".")
+    return text or "0"
+
+
+def _hour_amount(rate_cents: int, minutes: int) -> int:
+    return int(
+        (Decimal(rate_cents) * Decimal(minutes) / Decimal(60)).quantize(
+            Decimal("1"), rounding=ROUND_HALF_UP
+        )
+    )
+
+
+def _tax_amount(subtotal_cents: int, tax_rate_basis_points: int) -> int:
+    return int(
+        (
+            Decimal(subtotal_cents) * Decimal(tax_rate_basis_points) / Decimal(10_000)
+        ).quantize(Decimal("1"), rounding=ROUND_HALF_UP)
+    )
+
+
+def _valid_source_rate(value: Any) -> int | None:
+    return (
+        value
+        if isinstance(value, int) and not isinstance(value, bool) and value > 0
+        else None
+    )
+
+
+def _valid_source_quantity(value: Any) -> int | None:
+    return (
+        value
+        if isinstance(value, int) and not isinstance(value, bool) and value > 0
+        else None
+    )
+
+
+def _line_override_map(
+    source_snapshot: Mapping[str, Any], raw_overrides: Any
+) -> dict[str, dict[str, Any]]:
+    if raw_overrides is None:
+        return {}
+    if not isinstance(raw_overrides, list) or len(raw_overrides) > MAX_LINE_OVERRIDES:
+        raise CommercialBillingCandidateOverrideValidationError(
+            "Line overrides must be a bounded list"
+        )
+    source = decorate_line_keys(source_snapshot)
+    admitted = {line["lineKey"]: line for line in source["lineItems"]}
+    normalized: dict[str, dict[str, Any]] = {}
+    for item in raw_overrides:
+        if not isinstance(item, Mapping):
+            raise CommercialBillingCandidateOverrideValidationError(
+                "Line override is invalid"
+            )
+        unknown = set(item) - {
+            "lineKey",
+            "description",
+            "rateCents",
+            "quantity",
+            "quantityMinutes",
+        }
+        if unknown:
+            raise CommercialBillingCandidateOverrideValidationError(
+                "Line override contains unsupported fields"
+            )
+        key = _required_text(item.get("lineKey"), "Line key", 64)
+        line = admitted.get(key)
+        if line is None or key in normalized:
+            raise CommercialBillingCandidateOverrideValidationError(
+                "Line override target is invalid"
+            )
+        unit = _source_line_unit(line)
+        has_quantity = "quantity" in item
+        has_minutes = "quantityMinutes" in item
+        if unit == "hour" and has_quantity:
+            raise CommercialBillingCandidateOverrideValidationError(
+                "Hourly line overrides use whole quantityMinutes"
+            )
+        if unit != "hour" and has_minutes:
+            raise CommercialBillingCandidateOverrideValidationError(
+                "Only hourly line overrides may contain quantityMinutes"
+            )
+        change: dict[str, Any] = {}
+        if "description" in item:
+            change["description"] = _required_text(
+                item["description"],
+                "Line description",
+                MAX_INVOICE_LINE_DESCRIPTION_LENGTH,
+            )
+        if "rateCents" in item:
+            change["rateCents"] = _positive_int(
+                item["rateCents"], "Rate cents", MAX_RATE_CENTS
+            )
+        if has_quantity:
+            change["quantity"] = _positive_int(
+                item["quantity"], "Quantity", MAX_RATE_CENTS
+            )
+        if has_minutes:
+            change["quantityMinutes"] = _positive_int(
+                item["quantityMinutes"], "Quantity minutes", MAX_RATE_CENTS
+            )
+        if not change:
+            raise CommercialBillingCandidateOverrideValidationError(
+                "Line override must change at least one permitted field"
+            )
+        normalized[key] = change
+    return normalized
+
+
+def _adjustment(raw: Any, billing_period: str) -> dict[str, Any] | None:
+    if raw is None:
+        return None
+    if not isinstance(raw, Mapping):
+        raise CommercialBillingCandidateOverrideValidationError("Adjustment is invalid")
+    if set(raw) != {"kind", "description", "amountCents"}:
+        raise CommercialBillingCandidateOverrideValidationError(
+            "Adjustment must contain kind, description, and amountCents"
+        )
+    kind = raw.get("kind")
+    if kind not in {"credit", "charge"}:
+        raise CommercialBillingCandidateOverrideValidationError(
+            "Adjustment kind must be credit or charge"
+        )
+    amount = _positive_int(
+        raw.get("amountCents"), "Adjustment cents", MAX_ADJUSTMENT_CENTS
+    )
+    signed = -amount if kind == "credit" else amount
+    return {
+        "amountCents": signed,
+        "description": _required_text(
+            raw.get("description"),
+            "Adjustment description",
+            MAX_INVOICE_LINE_DESCRIPTION_LENGTH,
+        ),
+        "kind": "adjustment",
+        "quantity": 1,
+        "quantityUnit": "adjustment",
+        "rateCents": signed,
+        "sourceDate": f"{billing_period}-01",
+    }
+
+
+def _recipient(base: Mapping[str, Any], raw: Any) -> dict[str, Any]:
+    existing = deepcopy(dict(base)) if isinstance(base, Mapping) else {}
+    if raw is None:
+        return existing
+    if not isinstance(raw, Mapping) or set(raw) - {"displayName", "email"}:
+        raise CommercialBillingCandidateOverrideValidationError(
+            "Billing recipient is invalid"
+        )
+    email = normalize_contact_email(raw.get("email"))
+    if email is None:
+        raise CommercialBillingCandidateOverrideValidationError(
+            "Billing recipient email is invalid"
+        )
+    display_name = _optional_text(
+        raw.get("displayName"), "Billing recipient name", MAX_RECIPIENT_NAME_LENGTH
+    )
+    return {
+        "contactId": existing.get("contactId"),
+        "displayName": display_name or email,
+        "email": email,
+    }
+
+
+def _missing_billing_email_blocker() -> dict[str, Any]:
+    """Return the canonical blocker when effective Gmail delivery lacks mail."""
+
+    return {
+        "code": "missing_billing_email",
+        "eventIds": [],
+        "message": "The canonical commercial customer has no valid billing email.",
+        "serviceId": None,
+    }
+
+
+def _invalid_rate_blocker_is_repaired(
+    blocker: Mapping[str, Any],
+    *,
+    keyed_source_lines: list[dict[str, Any]],
+    overrides: Mapping[str, Mapping[str, Any]],
+) -> bool:
+    """Return whether every targetable unpriced line for one service was fixed.
+
+    The canonical candidate producer omits lines when a service has no valid
+    rate.  An override cannot invent that omitted source evidence, so a
+    service-level ``invalid_rate`` blocker must remain unless the retained
+    snapshot actually contains every affected source line and each one has an
+    explicit valid rate override.  Looking only at the effective lines would
+    incorrectly make an omitted service disappear whenever other lines happen
+    to be valid.
+    """
+
+    service_id = blocker.get("serviceId")
+    if not isinstance(service_id, str) or not service_id:
+        return False
+    affected = [
+        line
+        for line in keyed_source_lines
+        if line.get("serviceId") == service_id
+        and _valid_source_rate(line.get("rateCents")) is None
+    ]
+    return bool(affected) and all(
+        _valid_source_rate(overrides.get(line["lineKey"], {}).get("rateCents"))
+        is not None
+        for line in affected
+    )
+
+
+def _build_effective_snapshot(
+    source_snapshot: Mapping[str, Any],
+    *,
+    line_overrides: Any,
+    adjustment: Any,
+    recipient: Any,
+    delivery_method: Any,
+    require_change: bool,
+) -> dict[str, Any]:
+    """Apply the explicitly permitted one-run edits without touching source evidence."""
+
+    if not isinstance(source_snapshot, Mapping):
+        raise CommercialBillingCandidateOverrideValidationError(
+            "Commercial billing snapshot is invalid"
+        )
+    effective = deepcopy(dict(source_snapshot))
+    billing_period = _required_text(effective.get("billingPeriod"), "Billing period", 7)
+    source_lines = effective.get("lineItems")
+    if not isinstance(source_lines, list):
+        raise CommercialBillingCandidateOverrideValidationError(
+            "Commercial billing line items are invalid"
+        )
+    overrides = _line_override_map(source_snapshot, line_overrides)
+    keyed_source = decorate_line_keys(source_snapshot)["lineItems"]
+    effective_lines: list[dict[str, Any]] = []
+    incomplete_line = False
+    for source_line, decorated in zip(source_lines, keyed_source):
+        if not isinstance(source_line, Mapping):
+            raise CommercialBillingCandidateOverrideValidationError(
+                "Commercial billing line item is invalid"
+            )
+        line = deepcopy(dict(source_line))
+        change = overrides.get(decorated["lineKey"], {})
+        line.update(change)
+        unit = _source_line_unit(line)
+        rate = _valid_source_rate(line.get("rateCents"))
+        if unit == "hour":
+            minutes = _valid_source_quantity(line.get("quantityMinutes"))
+            if minutes is None:
+                line["quantity"] = None
+                line["amountCents"] = None
+                incomplete_line = True
+            elif rate is None:
+                line["amountCents"] = None
+                incomplete_line = True
+            else:
+                line["quantityMinutes"] = minutes
+                line["quantity"] = _hour_text(minutes)
+                line["amountCents"] = _hour_amount(rate, minutes)
+        else:
+            quantity = _valid_source_quantity(line.get("quantity"))
+            if quantity is None or rate is None:
+                line["amountCents"] = None
+                incomplete_line = True
+            else:
+                line["quantity"] = quantity
+                line["amountCents"] = quantity * rate
+        effective_lines.append(line)
+
+    effective["lineItems"] = effective_lines
+    effective_recipient = _recipient(effective.get("recipient"), recipient)
+    effective["recipient"] = effective_recipient
+    if delivery_method is not None:
+        if delivery_method not in OVERRIDE_DELIVERY_METHODS:
+            raise CommercialBillingCandidateOverrideValidationError(
+                "Billing delivery method must be Gmail PDF or Manual Square"
+            )
+        effective["deliveryMethod"] = delivery_method
+    if effective.get("deliveryMethod") not in OVERRIDE_DELIVERY_METHODS:
+        # The source's missing/receipt-only delivery preference remains a blocker.
+        pass
+
+    adjustment_line = _adjustment(adjustment, billing_period)
+    if adjustment_line is not None:
+        effective_lines.append(adjustment_line)
+
+    blockers = effective.get("blockers")
+    if not isinstance(blockers, list):
+        raise CommercialBillingCandidateOverrideValidationError(
+            "Commercial billing blockers are invalid"
+        )
+    remaining: list[dict[str, Any]] = []
+    all_hourly_complete = all(
+        _source_line_unit(line) != "hour"
+        or _valid_source_quantity(line.get("quantityMinutes")) is not None
+        for line in effective_lines
+        if line.get("kind") != "adjustment"
+    )
+    delivery_ok = effective.get("deliveryMethod") in OVERRIDE_DELIVERY_METHODS
+    recipient_ok = (
+        effective.get("deliveryMethod") != "gmail_pdf"
+        or normalize_contact_email(effective_recipient.get("email")) is not None
+    )
+    for blocker in blockers:
+        if not isinstance(blocker, Mapping):
+            raise CommercialBillingCandidateOverrideValidationError(
+                "Commercial billing blocker is invalid"
+            )
+        code = blocker.get("code")
+        if code == "missing_hours" and all_hourly_complete:
+            continue
+        if code == "invalid_rate" and _invalid_rate_blocker_is_repaired(
+            blocker,
+            keyed_source_lines=keyed_source,
+            overrides=overrides,
+        ):
+            continue
+        if code == "missing_billing_email" and recipient_ok:
+            continue
+        if (
+            code
+            in {"missing_billing_delivery_preference", "no_invoice_delivery_preference"}
+            and delivery_ok
+        ):
+            continue
+        if code == "zero_or_invalid_total":
+            continue
+        remaining.append(deepcopy(dict(blocker)))
+    if not recipient_ok and not any(
+        blocker.get("code") == "missing_billing_email" for blocker in remaining
+    ):
+        remaining.append(_missing_billing_email_blocker())
+
+    tax_rate = effective.get("taxRateBasisPoints")
+    if (
+        isinstance(tax_rate, bool)
+        or not isinstance(tax_rate, int)
+        or not 0 <= tax_rate <= 10_000
+    ):
+        raise CommercialBillingCandidateOverrideValidationError(
+            "Commercial billing tax evidence is invalid"
+        )
+    subtotal = sum(
+        int(line["amountCents"])
+        for line in effective_lines
+        if isinstance(line.get("amountCents"), int)
+        and not isinstance(line.get("amountCents"), bool)
+    )
+    can_total = not incomplete_line and not remaining and subtotal > 0
+    if can_total:
+        tax = _tax_amount(subtotal, tax_rate)
+        total = subtotal + tax
+        if total <= 0 or total > MAX_ADJUSTMENT_CENTS:
+            can_total = False
+    if can_total:
+        effective["subtotalCents"] = subtotal
+        effective["taxCents"] = tax
+        effective["totalCents"] = total
+    else:
+        effective["subtotalCents"] = None
+        effective["taxCents"] = None
+        effective["totalCents"] = None
+        remaining.append(
+            {
+                "code": "zero_or_invalid_total",
+                "eventIds": [],
+                "message": "The candidate total is zero or cannot be calculated from effective review evidence.",
+                "serviceId": None,
+            }
+        )
+    effective["blockers"] = sorted(
+        remaining,
+        key=lambda blocker: (
+            str(blocker.get("code") or ""),
+            str(blocker.get("serviceId") or ""),
+            tuple(blocker.get("eventIds") or []),
+        ),
+    )
+    if require_change:
+        baseline = _build_effective_snapshot(
+            source_snapshot,
+            line_overrides=[],
+            adjustment=None,
+            recipient=None,
+            delivery_method=None,
+            require_change=False,
+        )
+        if canonical_json(effective) == canonical_json(baseline):
+            raise CommercialBillingCandidateOverrideValidationError(
+                "Commercial billing override must change permitted review evidence"
+            )
+    return effective
+
+
+def build_effective_snapshot(
+    source_snapshot: Mapping[str, Any],
+    *,
+    line_overrides: Any,
+    adjustment: Any,
+    recipient: Any,
+    delivery_method: Any,
+) -> dict[str, Any]:
+    """Project one permitted run-only change over immutable source evidence."""
+
+    return _build_effective_snapshot(
+        source_snapshot,
+        line_overrides=line_overrides,
+        adjustment=adjustment,
+        recipient=recipient,
+        delivery_method=delivery_method,
+        require_change=True,
+    )
+
+
+def override_review_fingerprint(
+    billing_run_id: UUID,
+    source_fingerprint: str,
+    revision: int,
+    effective_snapshot: Mapping[str, Any],
+) -> str:
+    if not isinstance(billing_run_id, UUID):
+        raise CommercialBillingCandidateOverrideValidationError(
+            "Commercial billing override run identity is invalid"
+        )
+    if not isinstance(revision, int) or revision <= 0:
+        raise CommercialBillingCandidateOverrideValidationError(
+            "Override revision is invalid"
+        )
+    return fingerprint(
+        {
+            "billingRunId": str(billing_run_id),
+            "effectiveSnapshot": dict(effective_snapshot),
+            "overrideRevision": revision,
+            "sourceFingerprint": source_fingerprint,
+        }
+    )
+
+
+__all__ = [
+    "CommercialBillingCandidateOverrideValidationError",
+    "MAX_INVOICE_LINE_DESCRIPTION_LENGTH",
+    "MAX_NOTE_LENGTH",
+    "OVERRIDE_DELIVERY_METHODS",
+    "OVERRIDE_REASON_CODES",
+    "build_effective_snapshot",
+    "canonical_json",
+    "decorate_effective_line_keys",
+    "decorate_line_keys",
+    "fingerprint",
+    "override_review_fingerprint",
+]

--- a/atlas_brain/services/commercial_billing_runs.py
+++ b/atlas_brain/services/commercial_billing_runs.py
@@ -27,6 +27,17 @@ from .commercial_billing_candidates import (
     get_commercial_billing_candidate_service,
     parse_billing_period,
 )
+from .commercial_billing_candidate_overrides import (
+    CommercialBillingCandidateOverrideValidationError,
+    MAX_NOTE_LENGTH,
+    OVERRIDE_REASON_CODES,
+    build_effective_snapshot,
+    canonical_json as _override_canonical_json,
+    decorate_effective_line_keys,
+    decorate_line_keys,
+    fingerprint as _override_fingerprint,
+    override_review_fingerprint,
+)
 
 
 _RUN_SOURCE = "eom_admin"
@@ -34,6 +45,7 @@ _MAX_IDEMPOTENCY_KEY_LENGTH = 128
 _MAX_CANDIDATE_KEY_LENGTH = 512
 _MAX_CANDIDATES = 500
 _MAX_REASON_LENGTH = 1000
+_MAX_OVERRIDE_REASON_CODE_LENGTH = 64
 _FINGERPRINT_PATTERN = re.compile(r"^[0-9a-f]{64}$")
 _REVIEW_DECISIONS = frozenset({"included", "excluded"})
 _DATABASE_UNAVAILABLE_ERRORS = (
@@ -207,6 +219,40 @@ def _required_text(value: Any, field: str, *, limit: int) -> str:
             f"{field} must contain 1 to {limit} characters"
         )
     return normalized
+
+
+def _optional_source_fingerprint(value: Any) -> str | None:
+    if value is None:
+        return None
+    return _validate_source_fingerprint(value)
+
+
+def _row_value(row: Any, key: str, default: Any = None) -> Any:
+    """Read asyncpg/dict rows while retaining older in-memory test seams."""
+
+    if row is None:
+        return default
+    if isinstance(row, Mapping):
+        return row.get(key, default)
+    try:
+        return row[key]
+    except (KeyError, IndexError):
+        return default
+
+
+def _override_view(row: Any | None) -> dict[str, Any] | None:
+    if row is None:
+        return None
+    return {
+        "createdAt": _timestamp(_row_value(row, "created_at")),
+        "id": str(_row_value(row, "id")),
+        "reason": _row_value(row, "reason"),
+        "reasonCode": _row_value(row, "reason_code"),
+        "reviewFingerprint": _row_value(row, "review_fingerprint"),
+        "revision": _row_value(row, "revision"),
+        "overriddenAt": _timestamp(_row_value(row, "overridden_at")),
+        "overriddenBy": _row_value(row, "overridden_by"),
+    }
 
 
 async def lock_commercial_billing_candidate_identity(
@@ -485,6 +531,195 @@ class CommercialBillingRunService:
                 "Commercial billing database unavailable"
             ) from exc
 
+    async def set_candidate_override(
+        self,
+        *,
+        billing_run_id: UUID,
+        candidate_key: str,
+        expected_source_fingerprint: str,
+        expected_override_revision: int,
+        reason_code: str,
+        reason: str,
+        line_overrides: Any,
+        adjustment: Any,
+        recipient: Any,
+        delivery_method: Any,
+        idempotency_key: str,
+        actor: str,
+    ) -> dict[str, Any]:
+        """Append one audited, no-side-effect effective-candidate revision."""
+
+        if not isinstance(billing_run_id, UUID):
+            raise CommercialBillingRunValidationError("Billing run id is invalid")
+        selected = _validate_candidate_key(candidate_key)
+        source_fingerprint = _validate_source_fingerprint(expected_source_fingerprint)
+        if (
+            isinstance(expected_override_revision, bool)
+            or not isinstance(expected_override_revision, int)
+            or expected_override_revision < 0
+        ):
+            raise CommercialBillingRunValidationError(
+                "Expected override revision must be a nonnegative integer"
+            )
+        normalized_reason_code = _required_text(
+            reason_code, "Override reason code", limit=_MAX_OVERRIDE_REASON_CODE_LENGTH
+        )
+        if normalized_reason_code not in OVERRIDE_REASON_CODES:
+            raise CommercialBillingRunValidationError("Override reason code is invalid")
+        normalized_reason = _required_text(reason, "Override reason", limit=MAX_NOTE_LENGTH)
+        key = _validate_idempotency_key(idempotency_key)
+        overridden_by = _required_text(actor, "Authenticated actor", limit=128)
+        request = {
+            "adjustment": adjustment,
+            "billingRunId": str(billing_run_id),
+            "candidateKey": selected,
+            "deliveryMethod": delivery_method,
+            "expectedOverrideRevision": expected_override_revision,
+            "lineOverrides": line_overrides,
+            "reason": normalized_reason,
+            "reasonCode": normalized_reason_code,
+            "recipient": recipient,
+            "sourceFingerprint": source_fingerprint,
+        }
+        try:
+            request_fingerprint = _override_fingerprint(request)
+        except CommercialBillingCandidateOverrideValidationError as exc:
+            raise CommercialBillingRunValidationError(str(exc)) from exc
+
+        try:
+            async with self.pool.transaction() as conn:
+                await self._lock_override_operation_key(conn, key)
+                existing = await self._find_override_by_operation_key(conn, key)
+                if existing is not None:
+                    self._assert_override_request(existing, request_fingerprint)
+                    return {
+                        "candidate": await self._candidate_for_override_row(conn, existing),
+                        "override": _override_view(existing),
+                        "replayed": True,
+                    }
+
+                await lock_commercial_billing_candidate_identity(
+                    conn,
+                    candidate_key=selected,
+                    source_fingerprint=source_fingerprint,
+                )
+                stored = await lock_commercial_billing_run_candidate(
+                    conn,
+                    billing_run_id=billing_run_id,
+                    candidate_key=selected,
+                )
+                if stored is None:
+                    raise CommercialBillingRunNotFoundError(
+                        "Commercial billing candidate not found"
+                    )
+                if stored["source_fingerprint"] != source_fingerprint:
+                    raise CommercialBillingRunConflictError(
+                        "Commercial billing candidate fingerprint does not match review evidence"
+                    )
+                approved = await self._find_approval_for_candidate_identity(
+                    conn,
+                    candidate_key=selected,
+                    source_fingerprint=source_fingerprint,
+                )
+                if approved is not None:
+                    raise CommercialBillingRunConflictError(
+                        "Approved commercial billing candidates cannot be overridden"
+                    )
+                latest = await self._latest_override(
+                    conn,
+                    billing_run_id=billing_run_id,
+                    candidate_key=selected,
+                    source_fingerprint=source_fingerprint,
+                )
+                current_revision = _row_value(latest, "revision", 0)
+                if current_revision != expected_override_revision:
+                    raise CommercialBillingRunConflictError(
+                        "Commercial billing candidate override revision changed; reload before retrying"
+                    )
+                source_snapshot = _json_object(stored["snapshot"])
+                if (
+                    source_snapshot.get("candidateKey") != selected
+                    or source_snapshot.get("sourceFingerprint") != source_fingerprint
+                ):
+                    raise CommercialBillingRunUnavailableError(
+                        "Commercial billing snapshot evidence is invalid"
+                    )
+                try:
+                    effective_snapshot = build_effective_snapshot(
+                        source_snapshot,
+                        line_overrides=line_overrides,
+                        adjustment=adjustment,
+                        recipient=recipient,
+                        delivery_method=delivery_method,
+                    )
+                except CommercialBillingCandidateOverrideValidationError as exc:
+                    raise CommercialBillingRunValidationError(str(exc)) from exc
+                revision = current_revision + 1
+                review_fingerprint = override_review_fingerprint(
+                    billing_run_id, source_fingerprint, revision, effective_snapshot
+                )
+                now = datetime.now(timezone.utc)
+                created = await conn.fetchrow(
+                    """
+                    INSERT INTO commercial_billing_candidate_overrides (
+                        id, billing_run_id, candidate_key, source_fingerprint,
+                        revision, review_fingerprint, effective_snapshot,
+                        reason_code, reason, source, idempotency_key,
+                        request_fingerprint, overridden_by, overridden_at, created_at
+                    )
+                    VALUES (
+                        $1, $2, $3, $4, $5, $6, $7::jsonb, $8, $9, $10, $11,
+                        $12, $13, $14, $14
+                    )
+                    RETURNING id, billing_run_id, candidate_key, source_fingerprint,
+                              revision, review_fingerprint, effective_snapshot,
+                              reason_code, reason, request_fingerprint,
+                              overridden_by, overridden_at, created_at
+                    """,
+                    uuid4(),
+                    billing_run_id,
+                    selected,
+                    source_fingerprint,
+                    revision,
+                    review_fingerprint,
+                    _override_canonical_json(effective_snapshot),
+                    normalized_reason_code,
+                    normalized_reason,
+                    _RUN_SOURCE,
+                    key,
+                    request_fingerprint,
+                    overridden_by,
+                    now,
+                )
+                if created is None:  # pragma: no cover - INSERT RETURNING invariant
+                    raise CommercialBillingRunUnavailableError(
+                        "Commercial billing candidate override could not be reconciled"
+                    )
+                return {
+                    "candidate": self._candidate_view(
+                        billing_run_id=billing_run_id,
+                        source_snapshot=source_snapshot,
+                        source_fingerprint=source_fingerprint,
+                        override=created,
+                    ),
+                    "override": _override_view(created),
+                    "replayed": False,
+                }
+        except CommercialBillingRunError:
+            raise
+        except (asyncpg.UniqueViolationError, asyncpg.ForeignKeyViolationError) as exc:
+            raise CommercialBillingRunConflictError(
+                "Commercial billing candidate override could not be reconciled"
+            ) from exc
+        except asyncpg.PostgresError as exc:
+            raise CommercialBillingRunUnavailableError(
+                "Commercial billing database unavailable"
+            ) from exc
+        except _DATABASE_UNAVAILABLE_ERRORS as exc:
+            raise CommercialBillingRunUnavailableError(
+                "Commercial billing database unavailable"
+            ) from exc
+
     async def set_candidate_review_decision(
         self,
         *,
@@ -495,6 +730,7 @@ class CommercialBillingRunService:
         reason: str,
         idempotency_key: str,
         actor: str,
+        expected_review_fingerprint: str | None = None,
     ) -> dict[str, Any]:
         """Append one include/exclude decision without creating financial state."""
 
@@ -502,6 +738,11 @@ class CommercialBillingRunService:
             raise CommercialBillingRunValidationError("Billing run id is invalid")
         selected = _validate_candidate_key(candidate_key)
         fingerprint = _validate_source_fingerprint(expected_source_fingerprint)
+        requested_review_fingerprint = _optional_source_fingerprint(
+            expected_review_fingerprint
+        )
+        if requested_review_fingerprint is None:
+            requested_review_fingerprint = fingerprint
         if not isinstance(decision, str) or decision not in _REVIEW_DECISIONS:
             raise CommercialBillingRunValidationError(
                 "Review decision must be included or excluded"
@@ -513,10 +754,24 @@ class CommercialBillingRunService:
             {
                 "billingRunId": str(billing_run_id),
                 "candidateKey": selected,
+                "reviewFingerprint": requested_review_fingerprint,
                 "sourceFingerprint": fingerprint,
                 "decision": decision,
                 "reason": decision_reason,
             }
+        )
+        legacy_request_fingerprint = (
+            _fingerprint(
+                {
+                    "billingRunId": str(billing_run_id),
+                    "candidateKey": selected,
+                    "sourceFingerprint": fingerprint,
+                    "decision": decision,
+                    "reason": decision_reason,
+                }
+            )
+            if requested_review_fingerprint == fingerprint
+            else None
         )
 
         try:
@@ -524,7 +779,9 @@ class CommercialBillingRunService:
                 await self._lock_review_decision_operation_key(conn, key)
                 existing = await self._find_review_decision_by_operation_key(conn, key)
                 if existing is not None:
-                    self._assert_review_decision_request(existing, request_fingerprint)
+                    self._assert_review_decision_request(
+                        existing, request_fingerprint, legacy_request_fingerprint
+                    )
                     return {
                         "reviewDecision": _review_decision_view(existing),
                         "replayed": True,
@@ -558,6 +815,20 @@ class CommercialBillingRunService:
                         "Approved commercial billing candidates cannot be reviewed again"
                     )
 
+                latest_override = await self._latest_override(
+                    conn,
+                    billing_run_id=billing_run_id,
+                    candidate_key=selected,
+                    source_fingerprint=fingerprint,
+                )
+                active_review_fingerprint = _row_value(
+                    latest_override, "review_fingerprint", fingerprint
+                )
+                if requested_review_fingerprint != active_review_fingerprint:
+                    raise CommercialBillingRunConflictError(
+                        "Commercial billing candidate review identity changed; reload before deciding"
+                    )
+
                 revision = await self._next_review_decision_revision(
                     conn,
                     candidate_key=selected,
@@ -566,14 +837,14 @@ class CommercialBillingRunService:
                 created = await conn.fetchrow(
                     """
                     INSERT INTO commercial_billing_candidate_review_decisions (
-                        id, billing_run_id, candidate_key, source_fingerprint,
+                        id, billing_run_id, candidate_key, source_fingerprint, review_fingerprint,
                         revision, decision, reason, source, idempotency_key,
                         request_fingerprint, decided_by, decided_at, created_at
                     )
                     VALUES (
-                        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $12
+                        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $13
                     )
-                    RETURNING id, billing_run_id, candidate_key, source_fingerprint,
+                    RETURNING id, billing_run_id, candidate_key, source_fingerprint, review_fingerprint,
                               revision, decision, reason, request_fingerprint,
                               decided_by, decided_at
                     """,
@@ -581,6 +852,7 @@ class CommercialBillingRunService:
                     billing_run_id,
                     selected,
                     fingerprint,
+                    active_review_fingerprint,
                     revision,
                     decision,
                     decision_reason,
@@ -648,7 +920,12 @@ class CommercialBillingRunService:
                     COALESCE(
                         SUM(
                             CASE
-                                WHEN jsonb_array_length(candidate.snapshot -> 'blockers') > 0
+                                WHEN jsonb_array_length(
+                                    COALESCE(
+                                        override.effective_snapshot,
+                                        candidate.snapshot
+                                    ) -> 'blockers'
+                                ) > 0
                                 THEN 1 ELSE 0
                             END
                         ),
@@ -657,6 +934,15 @@ class CommercialBillingRunService:
                 FROM commercial_billing_runs AS run
                 LEFT JOIN commercial_billing_run_candidates AS candidate
                     ON candidate.billing_run_id = run.id
+                LEFT JOIN LATERAL (
+                    SELECT effective_snapshot
+                    FROM commercial_billing_candidate_overrides AS candidate_override
+                    WHERE candidate_override.billing_run_id = candidate.billing_run_id
+                      AND candidate_override.candidate_key = candidate.candidate_key
+                      AND candidate_override.source_fingerprint = candidate.source_fingerprint
+                    ORDER BY candidate_override.revision DESC
+                    LIMIT 1
+                ) AS override ON TRUE
                 WHERE ($1::varchar IS NULL OR run.billing_period = $1)
                 GROUP BY run.id
                 ORDER BY run.created_at DESC, run.id DESC
@@ -788,6 +1074,13 @@ class CommercialBillingRunService:
         )
 
     @staticmethod
+    async def _lock_override_operation_key(conn: Any, key: str) -> None:
+        await conn.fetchval(
+            "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+            f"commercial-billing-run-override:{_RUN_SOURCE}:{key}",
+        )
+
+    @staticmethod
     async def _find_by_operation_key(conn: Any, key: str) -> Any | None:
         return await conn.fetchrow(
             """
@@ -823,10 +1116,34 @@ class CommercialBillingRunService:
         )
 
     @staticmethod
-    def _assert_review_decision_request(row: Any, expected: str) -> None:
-        if row["request_fingerprint"] != expected:
+    async def _find_override_by_operation_key(conn: Any, key: str) -> Any | None:
+        return await conn.fetchrow(
+            """
+            SELECT id, billing_run_id, candidate_key, source_fingerprint,
+                   revision, review_fingerprint, effective_snapshot, reason_code,
+                   reason, request_fingerprint, overridden_by, overridden_at, created_at
+            FROM commercial_billing_candidate_overrides
+            WHERE source = $1 AND idempotency_key = $2
+            FOR UPDATE
+            """,
+            _RUN_SOURCE,
+            key,
+        )
+
+    @staticmethod
+    def _assert_review_decision_request(
+        row: Any, expected: str, legacy_expected: str | None = None
+    ) -> None:
+        if row["request_fingerprint"] not in {expected, legacy_expected}:
             raise CommercialBillingRunConflictError(
                 "Idempotency key was already used with a different review decision"
+            )
+
+    @staticmethod
+    def _assert_override_request(row: Any, expected: str) -> None:
+        if _row_value(row, "request_fingerprint") != expected:
+            raise CommercialBillingRunConflictError(
+                "Idempotency key was already used with a different commercial billing override"
             )
 
     @staticmethod
@@ -869,6 +1186,100 @@ class CommercialBillingRunService:
             )
         return latest + 1
 
+    @staticmethod
+    async def _latest_override(
+        conn: Any,
+        *,
+        billing_run_id: UUID,
+        candidate_key: str,
+        source_fingerprint: str,
+    ) -> Any | None:
+        return await conn.fetchrow(
+            """
+            SELECT id, billing_run_id, candidate_key, source_fingerprint,
+                   revision, review_fingerprint, effective_snapshot, reason_code,
+                   reason, request_fingerprint, overridden_by, overridden_at, created_at
+            FROM commercial_billing_candidate_overrides
+            WHERE billing_run_id = $1
+              AND candidate_key = $2
+              AND source_fingerprint = $3
+            ORDER BY revision DESC
+            LIMIT 1
+            """,
+            billing_run_id,
+            candidate_key,
+            source_fingerprint,
+        )
+
+    async def _candidate_for_override_row(self, conn: Any, override: Any) -> dict[str, Any]:
+        billing_run_id = _row_value(override, "billing_run_id")
+        if not isinstance(billing_run_id, UUID):
+            raise CommercialBillingRunUnavailableError(
+                "Commercial billing override source snapshot is unavailable"
+            )
+        stored = await conn.fetchrow(
+            """
+            SELECT source_fingerprint, snapshot
+            FROM commercial_billing_run_candidates
+            WHERE billing_run_id = $1 AND candidate_key = $2
+            """,
+            billing_run_id,
+            _row_value(override, "candidate_key"),
+        )
+        if stored is None:
+            raise CommercialBillingRunUnavailableError(
+                "Commercial billing override source snapshot is unavailable"
+            )
+        return self._candidate_view(
+            billing_run_id=billing_run_id,
+            source_snapshot=_json_object(stored["snapshot"]),
+            source_fingerprint=stored["source_fingerprint"],
+            override=override,
+        )
+
+    @staticmethod
+    def _candidate_view(
+        *,
+        billing_run_id: UUID,
+        source_snapshot: Mapping[str, Any],
+        source_fingerprint: str,
+        override: Any | None,
+    ) -> dict[str, Any]:
+        if not isinstance(billing_run_id, UUID):
+            raise CommercialBillingRunUnavailableError(
+                "Commercial billing run identity is invalid"
+            )
+        raw_source = _json_object(source_snapshot)
+        if raw_source.get("sourceFingerprint") != source_fingerprint:
+            raise CommercialBillingRunUnavailableError(
+                "Commercial billing snapshot evidence is invalid"
+            )
+        if override is None:
+            effective = raw_source
+            review_fingerprint = source_fingerprint
+        else:
+            effective = _json_object(_row_value(override, "effective_snapshot"))
+            if effective.get("sourceFingerprint") != source_fingerprint:
+                raise CommercialBillingRunUnavailableError(
+                    "Commercial billing override evidence is invalid"
+                )
+            review_fingerprint = _row_value(override, "review_fingerprint")
+            expected = override_review_fingerprint(
+                billing_run_id,
+                source_fingerprint,
+                _row_value(override, "revision"),
+                effective,
+            )
+            if review_fingerprint != expected:
+                raise CommercialBillingRunUnavailableError(
+                    "Commercial billing override evidence is invalid"
+                )
+        candidate = decorate_effective_line_keys(raw_source, effective)
+        candidate["override"] = _override_view(override)
+        candidate["reviewFingerprint"] = review_fingerprint
+        candidate["sourceCandidate"] = decorate_line_keys(raw_source)
+        return candidate
+
     async def _run_view(self, executor: Any, run_id: UUID) -> dict[str, Any]:
         row = await executor.fetchrow(
             """
@@ -891,17 +1302,39 @@ class CommercialBillingRunService:
             raise CommercialBillingRunNotFoundError("Commercial billing run not found")
         candidate_rows = await executor.fetch(
             """
-            SELECT candidate_key, source_fingerprint, display_order, snapshot
-            FROM commercial_billing_run_candidates
-            WHERE billing_run_id = $1
-            ORDER BY display_order ASC, candidate_key ASC
+            SELECT candidate.candidate_key, candidate.source_fingerprint,
+                   candidate.display_order, candidate.snapshot,
+                   override.id AS override_id,
+                   override.revision AS override_revision,
+                   override.review_fingerprint AS override_review_fingerprint,
+                   override.effective_snapshot AS override_effective_snapshot,
+                   override.reason_code AS override_reason_code,
+                   override.reason AS override_reason,
+                   override.request_fingerprint AS override_request_fingerprint,
+                   override.overridden_by AS override_overridden_by,
+                   override.overridden_at AS override_overridden_at,
+                   override.created_at AS override_created_at
+            FROM commercial_billing_run_candidates AS candidate
+            LEFT JOIN LATERAL (
+                SELECT id, revision, review_fingerprint, effective_snapshot,
+                       reason_code, reason, request_fingerprint, overridden_by,
+                       overridden_at, created_at
+                FROM commercial_billing_candidate_overrides AS candidate_override
+                WHERE candidate_override.billing_run_id = candidate.billing_run_id
+                  AND candidate_override.candidate_key = candidate.candidate_key
+                  AND candidate_override.source_fingerprint = candidate.source_fingerprint
+                ORDER BY candidate_override.revision DESC
+                LIMIT 1
+            ) AS override ON TRUE
+            WHERE candidate.billing_run_id = $1
+            ORDER BY candidate.display_order ASC, candidate.candidate_key ASC
             """,
             run_id,
         )
         decision_rows = await executor.fetch(
             """
-            SELECT DISTINCT ON (decision.candidate_key, decision.source_fingerprint)
-                   decision.id, decision.candidate_key, decision.source_fingerprint,
+            SELECT DISTINCT ON (decision.candidate_key, decision.source_fingerprint, decision.review_fingerprint)
+                   decision.id, decision.candidate_key, decision.source_fingerprint, decision.review_fingerprint,
                    decision.revision, decision.decision, decision.reason,
                    decision.decided_by, decision.decided_at
             FROM commercial_billing_candidate_review_decisions AS decision
@@ -909,30 +1342,51 @@ class CommercialBillingRunService:
               ON candidate.candidate_key = decision.candidate_key
              AND candidate.source_fingerprint = decision.source_fingerprint
             WHERE candidate.billing_run_id = $1
-            ORDER BY decision.candidate_key, decision.source_fingerprint,
+            ORDER BY decision.candidate_key, decision.source_fingerprint, decision.review_fingerprint,
                      decision.revision DESC
             """,
             run_id,
         )
         latest_decision_by_candidate = {
-            (decision["candidate_key"], decision["source_fingerprint"]): decision
+            (
+                decision["candidate_key"],
+                decision["source_fingerprint"],
+                _row_value(decision, "review_fingerprint", decision["source_fingerprint"]),
+            ): decision
             for decision in decision_rows
         }
-        candidates = [_json_object(candidate["snapshot"]) for candidate in candidate_rows]
-        for candidate, row_candidate in zip(candidates, candidate_rows):
-            if (
-                candidate.get("candidateKey") != row_candidate["candidate_key"]
-                or candidate.get("sourceFingerprint")
-                != row_candidate["source_fingerprint"]
-            ):
-                raise CommercialBillingRunUnavailableError(
-                    "Commercial billing snapshot evidence is invalid"
-                )
+        candidates: list[dict[str, Any]] = []
+        for row_candidate in candidate_rows:
+            override = None
+            if _row_value(row_candidate, "override_id") is not None:
+                override = {
+                    "id": _row_value(row_candidate, "override_id"),
+                    "revision": _row_value(row_candidate, "override_revision"),
+                    "review_fingerprint": _row_value(row_candidate, "override_review_fingerprint"),
+                    "effective_snapshot": _row_value(row_candidate, "override_effective_snapshot"),
+                    "reason_code": _row_value(row_candidate, "override_reason_code"),
+                    "reason": _row_value(row_candidate, "override_reason"),
+                    "request_fingerprint": _row_value(row_candidate, "override_request_fingerprint"),
+                    "overridden_by": _row_value(row_candidate, "override_overridden_by"),
+                    "overridden_at": _row_value(row_candidate, "override_overridden_at"),
+                    "created_at": _row_value(row_candidate, "override_created_at"),
+                }
+            candidate = self._candidate_view(
+                billing_run_id=run_id,
+                source_snapshot=_json_object(row_candidate["snapshot"]),
+                source_fingerprint=row_candidate["source_fingerprint"],
+                override=override,
+            )
             candidate["reviewDecision"] = _review_decision_view(
                 latest_decision_by_candidate.get(
-                    (row_candidate["candidate_key"], row_candidate["source_fingerprint"])
+                    (
+                        row_candidate["candidate_key"],
+                        row_candidate["source_fingerprint"],
+                        candidate["reviewFingerprint"],
+                    )
                 )
             )
+            candidates.append(candidate)
         return {
             "billingPeriod": row["billing_period"],
             "calendarId": row["calendar_id"],

--- a/atlas_brain/storage/migrations/382_commercial_billing_candidate_overrides.sql
+++ b/atlas_brain/storage/migrations/382_commercial_billing_candidate_overrides.sql
@@ -1,0 +1,284 @@
+-- atlas: atomic-bookkeeping
+-- Append-only, one-run EOM commercial billing candidate overrides.
+--
+-- The source candidate snapshot remains immutable.  A revision captures the
+-- separately approved one-time effective evidence, and its review fingerprint
+-- prevents an Include decision for prior money/recipient data from approving a
+-- newer revision.  This migration is additive and never creates an invoice,
+-- PDF, Gmail draft, email, Square record, or sent state.
+
+CREATE TABLE IF NOT EXISTS commercial_billing_candidate_overrides (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    billing_run_id UUID NOT NULL
+        REFERENCES commercial_billing_runs(id) ON DELETE RESTRICT,
+    candidate_key VARCHAR(512) NOT NULL,
+    source_fingerprint VARCHAR(64) NOT NULL,
+    revision INTEGER NOT NULL,
+    review_fingerprint VARCHAR(64) NOT NULL,
+    effective_snapshot JSONB NOT NULL,
+    reason_code VARCHAR(64) NOT NULL,
+    reason VARCHAR(1000) NOT NULL,
+    source VARCHAR(32) NOT NULL DEFAULT 'eom_admin',
+    idempotency_key VARCHAR(128) NOT NULL,
+    request_fingerprint VARCHAR(64) NOT NULL,
+    overridden_by VARCHAR(128) NOT NULL,
+    overridden_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT commercial_billing_candidate_overrides_source_fingerprint_check
+        CHECK (source_fingerprint ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT commercial_billing_candidate_overrides_review_fingerprint_check
+        CHECK (review_fingerprint ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT commercial_billing_candidate_overrides_revision_check
+        CHECK (revision > 0),
+    CONSTRAINT commercial_billing_candidate_overrides_reason_code_check
+        CHECK (reason_code IN (
+            'one_time_service_variation',
+            'partial_or_missed_service',
+            'approved_pricing_exception',
+            'customer_credit',
+            'additional_charge',
+            'source_correction_pending',
+            'billing_delivery_exception'
+        )),
+    CONSTRAINT commercial_billing_candidate_overrides_reason_check
+        CHECK (length(btrim(reason)) > 0),
+    CONSTRAINT commercial_billing_candidate_overrides_request_fingerprint_check
+        CHECK (request_fingerprint ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT commercial_billing_candidate_overrides_actor_check
+        CHECK (length(btrim(overridden_by)) > 0),
+    CONSTRAINT commercial_billing_candidate_overrides_source_key
+        UNIQUE (source, idempotency_key),
+    CONSTRAINT commercial_billing_candidate_overrides_revision_key
+        UNIQUE (billing_run_id, candidate_key, source_fingerprint, revision),
+    CONSTRAINT commercial_billing_candidate_overrides_review_key
+        UNIQUE (review_fingerprint),
+    CONSTRAINT commercial_billing_candidate_overrides_snapshot_fkey
+        FOREIGN KEY (billing_run_id, candidate_key, source_fingerprint)
+        REFERENCES commercial_billing_run_candidates (
+            billing_run_id, candidate_key, source_fingerprint
+        ) ON DELETE RESTRICT
+);
+
+CREATE INDEX IF NOT EXISTS idx_commercial_billing_candidate_overrides_active
+    ON commercial_billing_candidate_overrides (
+        billing_run_id, candidate_key, source_fingerprint, revision DESC
+    );
+
+-- Migration 381 made these audit rows append-only. The temporary drop is
+-- enclosed by this atomic migration and its table lock; it only permits the
+-- deterministic derived identity backfill below, after which the same guard
+-- is restored before commit.
+DROP TRIGGER IF EXISTS trg_prevent_commercial_billing_review_decision_mutation
+    ON commercial_billing_candidate_review_decisions;
+DROP TRIGGER IF EXISTS trg_prevent_commercial_billing_review_decision_truncate
+    ON commercial_billing_candidate_review_decisions;
+
+ALTER TABLE commercial_billing_candidate_review_decisions
+    ADD COLUMN IF NOT EXISTS review_fingerprint VARCHAR(64);
+UPDATE commercial_billing_candidate_review_decisions
+SET review_fingerprint = source_fingerprint
+WHERE review_fingerprint IS NULL;
+ALTER TABLE commercial_billing_candidate_review_decisions
+    ALTER COLUMN review_fingerprint SET NOT NULL;
+ALTER TABLE commercial_billing_candidate_review_decisions
+    DROP CONSTRAINT IF EXISTS commercial_billing_candidate_review_decisions_review_fingerprint_check;
+ALTER TABLE commercial_billing_candidate_review_decisions
+    ADD CONSTRAINT commercial_billing_candidate_review_decisions_review_fingerprint_check
+    CHECK (review_fingerprint ~ '^[0-9a-f]{64}$');
+CREATE INDEX IF NOT EXISTS idx_commercial_billing_candidate_review_decisions_review
+    ON commercial_billing_candidate_review_decisions (
+        candidate_key, source_fingerprint, review_fingerprint, revision DESC
+    );
+
+CREATE OR REPLACE FUNCTION prevent_commercial_billing_review_decision_mutation()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION 'commercial_billing_candidate_review_decisions is append-only';
+END;
+$$;
+
+CREATE TRIGGER trg_prevent_commercial_billing_review_decision_mutation
+    BEFORE UPDATE OR DELETE ON commercial_billing_candidate_review_decisions
+    FOR EACH ROW
+    EXECUTE FUNCTION prevent_commercial_billing_review_decision_mutation();
+CREATE TRIGGER trg_prevent_commercial_billing_review_decision_truncate
+    BEFORE TRUNCATE ON commercial_billing_candidate_review_decisions
+    FOR EACH STATEMENT
+    EXECUTE FUNCTION prevent_commercial_billing_review_decision_mutation();
+
+ALTER TABLE commercial_billing_candidate_approvals
+    ADD COLUMN IF NOT EXISTS review_fingerprint VARCHAR(64);
+UPDATE commercial_billing_candidate_approvals
+SET review_fingerprint = source_fingerprint
+WHERE review_fingerprint IS NULL;
+ALTER TABLE commercial_billing_candidate_approvals
+    ALTER COLUMN review_fingerprint SET NOT NULL;
+ALTER TABLE commercial_billing_candidate_approvals
+    DROP CONSTRAINT IF EXISTS commercial_billing_candidate_approvals_review_fingerprint_check;
+ALTER TABLE commercial_billing_candidate_approvals
+    ADD CONSTRAINT commercial_billing_candidate_approvals_review_fingerprint_check
+    CHECK (review_fingerprint ~ '^[0-9a-f]{64}$');
+
+-- A temporarily mixed Atlas rollout can still have a prior provider binary
+-- writing its old INSERT column list. Keep that writer safe for unoverridden
+-- candidates by deriving the legacy review identity at the database boundary.
+-- A later override still cannot be approved by that legacy identity because
+-- the invoice trigger below compares it to the active effective identity.
+CREATE OR REPLACE FUNCTION default_commercial_billing_review_fingerprint()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF NEW.review_fingerprint IS NULL THEN
+        NEW.review_fingerprint := NEW.source_fingerprint;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_default_commercial_billing_review_decision_fingerprint
+    ON commercial_billing_candidate_review_decisions;
+CREATE TRIGGER trg_default_commercial_billing_review_decision_fingerprint
+    BEFORE INSERT ON commercial_billing_candidate_review_decisions
+    FOR EACH ROW
+    EXECUTE FUNCTION default_commercial_billing_review_fingerprint();
+
+DROP TRIGGER IF EXISTS trg_default_commercial_billing_approval_fingerprint
+    ON commercial_billing_candidate_approvals;
+CREATE TRIGGER trg_default_commercial_billing_approval_fingerprint
+    BEFORE INSERT ON commercial_billing_candidate_approvals
+    FOR EACH ROW
+    EXECUTE FUNCTION default_commercial_billing_review_fingerprint();
+
+CREATE OR REPLACE FUNCTION prevent_commercial_billing_candidate_override_mutation()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION 'commercial_billing_candidate_overrides is append-only';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_prevent_commercial_billing_candidate_override_mutation
+    ON commercial_billing_candidate_overrides;
+CREATE TRIGGER trg_prevent_commercial_billing_candidate_override_mutation
+    BEFORE UPDATE OR DELETE ON commercial_billing_candidate_overrides
+    FOR EACH ROW
+    EXECUTE FUNCTION prevent_commercial_billing_candidate_override_mutation();
+
+DROP TRIGGER IF EXISTS trg_prevent_commercial_billing_candidate_override_truncate
+    ON commercial_billing_candidate_overrides;
+CREATE TRIGGER trg_prevent_commercial_billing_candidate_override_truncate
+    BEFORE TRUNCATE ON commercial_billing_candidate_overrides
+    FOR EACH STATEMENT
+    EXECUTE FUNCTION prevent_commercial_billing_candidate_override_mutation();
+
+-- Replace the earlier excluded-only trigger.  Legacy, unoverridden candidates
+-- retain their default-include behavior; an overridden candidate instead needs
+-- an explicit Include recorded for its current effective review fingerprint.
+CREATE OR REPLACE FUNCTION prevent_commercial_billing_invoice_for_excluded_candidate()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    candidate_identity_key TEXT;
+    candidate_identity_fingerprint TEXT;
+    candidate_identity_billing_run_id UUID;
+    review_identity_fingerprint TEXT;
+    active_review_fingerprint TEXT;
+    current_decision VARCHAR(16);
+BEGIN
+    IF NEW.source IS DISTINCT FROM 'eom_commercial_billing' THEN
+        RETURN NEW;
+    END IF;
+
+    IF jsonb_typeof(NEW.metadata -> 'candidateKey') IS DISTINCT FROM 'string'
+       OR jsonb_typeof(NEW.metadata -> 'commercialBillingRunId') IS DISTINCT FROM 'string'
+       OR jsonb_typeof(NEW.metadata -> 'sourceFingerprint') IS DISTINCT FROM 'string' THEN
+        RAISE EXCEPTION 'Commercial billing invoice review identity is invalid';
+    END IF;
+    candidate_identity_key := NEW.metadata ->> 'candidateKey';
+    BEGIN
+        candidate_identity_billing_run_id :=
+            (NEW.metadata ->> 'commercialBillingRunId')::UUID;
+    EXCEPTION WHEN invalid_text_representation THEN
+        RAISE EXCEPTION 'Commercial billing invoice review identity is invalid';
+    END;
+    candidate_identity_fingerprint := NEW.metadata ->> 'sourceFingerprint';
+    review_identity_fingerprint := COALESCE(
+        NEW.metadata ->> 'reviewFingerprint', candidate_identity_fingerprint
+    );
+    IF candidate_identity_key IS NULL
+       OR candidate_identity_key = ''
+       OR length(candidate_identity_key) > 512
+       OR candidate_identity_fingerprint IS NULL
+       OR candidate_identity_fingerprint !~ '^[0-9a-f]{64}$'
+       OR review_identity_fingerprint !~ '^[0-9a-f]{64}$' THEN
+        RAISE EXCEPTION 'Commercial billing invoice review identity is invalid';
+    END IF;
+
+    PERFORM 1
+    FROM commercial_billing_run_candidates
+    WHERE billing_run_id = candidate_identity_billing_run_id
+      AND candidate_key = candidate_identity_key
+      AND source_fingerprint = candidate_identity_fingerprint
+    LIMIT 1;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'Commercial billing invoice review identity is invalid';
+    END IF;
+
+    PERFORM pg_advisory_xact_lock(
+        hashtextextended(
+            'commercial-billing-approval:candidate:'
+            || candidate_identity_key || ':' || candidate_identity_fingerprint,
+            0
+        )
+    );
+
+    SELECT review_fingerprint
+    INTO active_review_fingerprint
+    FROM commercial_billing_candidate_overrides
+    WHERE billing_run_id = candidate_identity_billing_run_id
+      AND candidate_key = candidate_identity_key
+      AND source_fingerprint = candidate_identity_fingerprint
+    ORDER BY revision DESC
+    LIMIT 1;
+    active_review_fingerprint := COALESCE(
+        active_review_fingerprint, candidate_identity_fingerprint
+    );
+    IF review_identity_fingerprint IS DISTINCT FROM active_review_fingerprint THEN
+        RAISE EXCEPTION 'Commercial billing candidate review identity is stale';
+    END IF;
+
+    SELECT decision
+    INTO current_decision
+    FROM commercial_billing_candidate_review_decisions
+    WHERE candidate_key = candidate_identity_key
+      AND source_fingerprint = candidate_identity_fingerprint
+      AND review_fingerprint = active_review_fingerprint
+    ORDER BY revision DESC
+    LIMIT 1;
+
+    IF active_review_fingerprint <> candidate_identity_fingerprint
+       AND current_decision IS DISTINCT FROM 'included' THEN
+        RAISE EXCEPTION 'Commercial billing candidate override requires an explicit include decision';
+    END IF;
+    IF active_review_fingerprint = candidate_identity_fingerprint
+       AND current_decision = 'excluded' THEN
+        RAISE EXCEPTION 'Commercial billing candidate is excluded; include it before invoice creation';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_prevent_commercial_billing_invoice_for_excluded_candidate
+    ON invoices;
+CREATE TRIGGER trg_prevent_commercial_billing_invoice_for_excluded_candidate
+    BEFORE INSERT ON invoices
+    FOR EACH ROW
+    EXECUTE FUNCTION prevent_commercial_billing_invoice_for_excluded_candidate();
+
+COMMENT ON TABLE commercial_billing_candidate_overrides IS
+    'Append-only actor-audited one-run EOM candidate overrides; source evidence remains immutable and no delivery side effect is created.';

--- a/atlas_brain/storage/repositories/invoice.py
+++ b/atlas_brain/storage/repositories/invoice.py
@@ -8,7 +8,7 @@ import json
 import logging
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from typing import Any, Optional
 from uuid import UUID, uuid4
 
@@ -16,6 +16,13 @@ from ..database import get_db_pool
 from ..exceptions import DatabaseUnavailableError, DatabaseOperationError
 
 logger = logging.getLogger("atlas.storage.invoice")
+
+
+# Only the commercial-billing approval writer sets this marker.  Its line
+# amounts are derived from retained whole-minute evidence, so a later
+# non-financial draft edit must preserve those exact cents rather than multiply
+# a rounded display quantity by its unit price again.
+_COMMERCIAL_BILLING_EXACT_LINE_AMOUNTS_MARKER = "commercialBillingExactLineAmounts"
 
 
 @dataclass(frozen=True)
@@ -51,6 +58,60 @@ def _line_items_with_amounts(items: list[dict], *, overwrite: bool) -> list[dict
             )
         normalized.append(line)
     return normalized
+
+
+def _line_items_subtotal(
+    items: list[dict], *, prefer_recorded_amounts: bool
+) -> Decimal:
+    """Calculate a draft subtotal without losing trusted committed cents.
+
+    A notes-only or due-date-only edit does not replace the line-item evidence.
+    A commercial-billing approval explicitly marks its persisted amounts as
+    authoritative because an hourly line can display rounded hours while its
+    approved amount was calculated from whole minutes.  Generic invoices do
+    not receive that authority: their caller-supplied ``amount`` field remains
+    display data and their subtotal is recalculated from quantity and price.
+    Replacing line items always retains the existing recalculation behavior.
+    """
+
+    subtotal = Decimal("0")
+    for item in items:
+        amount: Decimal | None = None
+        if prefer_recorded_amounts and "amount" in item:
+            try:
+                recorded = Decimal(str(item["amount"]))
+            except (InvalidOperation, TypeError, ValueError):
+                recorded = None
+            if (
+                recorded is not None
+                and recorded.is_finite()
+                and recorded == recorded.quantize(Decimal("0.01"))
+            ):
+                amount = recorded
+        if amount is None:
+            amount = Decimal(str(item.get("quantity", 1))) * Decimal(
+                str(item.get("unit_price", 0))
+            )
+        subtotal += amount
+    return subtotal
+
+
+def _has_trusted_commercial_billing_line_amounts(invoice: dict[str, Any]) -> bool:
+    """Return whether approved commercial evidence may retain line amounts.
+
+    The generic repository and MCP create paths accept line-item dictionaries
+    from callers, including an optional ``amount`` field.  Those fields cannot
+    become authoritative merely because a later edit omitted ``line_items``.
+    The approval writer is the one controlled producer that records exact-cent
+    amounts from retained billing evidence and marks that fact explicitly.
+    """
+
+    metadata = invoice.get("metadata")
+    return (
+        invoice.get("source") == "eom_commercial_billing"
+        and isinstance(metadata, dict)
+        and metadata.get(_COMMERCIAL_BILLING_EXACT_LINE_AMOUNTS_MARKER) is True
+    )
 
 
 class InvoiceRepository:
@@ -344,9 +405,12 @@ class InvoiceRepository:
         ):
             metadata = {**metadata, "needs_hours": False}
 
-        subtotal = sum(
-            Decimal(str(item.get("quantity", 1))) * Decimal(str(item.get("unit_price", 0)))
-            for item in items
+        subtotal = _line_items_subtotal(
+            items,
+            prefer_recorded_amounts=(
+                line_items is None
+                and _has_trusted_commercial_billing_line_amounts(current)
+            ),
         )
         tax_amt = subtotal * Decimal(str(tax_r))
         total = subtotal + tax_amt - Decimal(str(disc))

--- a/plans/PR-EOM-Commercial-Billing-Candidate-Overrides.md
+++ b/plans/PR-EOM-Commercial-Billing-Candidate-Overrides.md
@@ -1,0 +1,361 @@
+# PR-EOM-Commercial-Billing-Candidate-Overrides
+
+## Why this slice exists
+
+The completed EOM commercial billing workflow can retain a source-evidence
+preview and record audited Include/Exclude decisions, but it cannot correct a
+one-time quantity/rate, resolve missing hourly quantity, add a disclosed
+credit/charge, or route an individual candidate to a run-only recipient before
+an invoice exists. Juan explicitly approved a hybrid policy: source correction
+for recurring truth, and immutable run-only overrides for legitimate one-time
+exceptions. This provider slice is the financial and audit boundary required
+before tracker and website consumers can expose that policy.
+
+This intentionally exceeds the repository's 400-LOC soft target. The durable
+override projection, one atomic migration, API admission, review/approval
+guards, and real-Postgres recovery tests must ship together: splitting the
+migration from the provider guard would create an interval where a prior
+Include could approve changed money or recipient evidence. The resulting diff
+is large because it closes that single financial invariant across the existing
+run, approval, and database boundaries rather than adding an unrelated
+product surface.
+
+### Problem-derived contract
+
+- Root cause: retained candidates are immutable source snapshots and approval
+  is keyed only by their source fingerprint, so a direct edit would either
+  rewrite evidence or leave a prior Include decision eligible for different
+  money/recipient data.
+- Correct fix must touch/change: append immutable override revisions outside
+  the source snapshot; derive an effective candidate and a review identity;
+  scope review decisions and approval to that identity; revalidate exact-cent
+  money and permitted blocker recovery server-side; expose an additive ATLAS
+  route with idempotency and actor audit; and prove the normal, rejected,
+  replay, stale, and post-approval paths.
+- Must not change: canonical contacts/services/rates/calendar evidence/tax
+  policy; legacy preview shape or source fingerprints; existing no-override
+  review/approval/PDF/Gmail/Square/MCP workflows; invoice sending behavior;
+  tracker ledger ownership; and customer-facing email/PDF rendering.
+
+## Scope (this PR)
+
+Ownership lane: eom-commercial-billing/candidate-overrides
+Slice phase: Vertical slice
+Max files: 12
+
+1. Add append-only, one-run-only commercial candidate override evidence and an
+   effective candidate projection before approval.
+2. Add an audited ATLAS override endpoint and extend review/approval identity
+   additively so an override always requires a fresh explicit Include.
+3. Prove exact-cent calculations, retry/concurrency rejection, stale source
+   blocking, and preservation of legacy no-override behavior.
+4. Review-fix iteration: bind every override review identity and final invoice
+   trigger lookup to the retained billing run; canonicalize equivalent legacy
+   review-decision retries before hashing; and preserve a committed exact line
+   amount when a draft invoice is edited without replacing its line items.
+5. Review-fix iteration: admit override descriptions only up to the shared
+   invoice-line limit and validate Gmail recipients with the canonical contact
+   email normalizer so an accepted, otherwise-billable override cannot strand
+   its later approval or Gmail-draft path.
+6. Review-fix iteration: derive the missing-billing-email blocker from the
+   effective Gmail delivery state, including when a delivery-method override
+   changes a no-recipient manual-Square or receipt-only candidate to Gmail.
+7. Review-fix iteration: preserve recorded line amounts only when the
+   controlled commercial-billing approval writer marks its exact-cent evidence;
+   notes-only edits of generic/MCP invoices must continue to calculate from
+   quantity and unit price.
+8. Review-fix iteration: retain an `invalid_rate` blocker for a service the
+   canonical producer omitted from line items, because an override cannot
+   safely invent that missing source evidence.
+9. Review-fix iteration: state the PostgreSQL transaction/lock execution model
+   and prove a contended same-key override commits one revision and replays the
+   other caller.
+
+### Review Contract
+
+- Acceptance criteria:
+  1. `POST /receivables/commercial-billing-runs/{id}/candidates/{key}/override`
+     appends one actor/audit revision and returns an effective candidate without
+     creating an invoice, PDF, Gmail draft, email, Square record, or sent state;
+     settled by the real route and
+     `tests/test_commercial_billing_candidate_overrides.py`.
+  2. The effective projection preserves the retained source snapshot and source
+     fingerprint, derives a distinct review fingerprint for an override, and
+     recomputes money in integer cents; settled by service tests covering minutes,
+     rate/quantity, signed adjustment, and inherited tax.
+  3. A review decision and approval require the submitted effective review
+     fingerprint. A newly appended override has no eligible Include decision;
+     settled by real-Postgres migration/service tests and approval tests.
+  4. Matching retries return the original override, changed idempotency reuse
+     conflicts, stale revisions/source and post-approval writes create no rows;
+     settled by real-Postgres override/review/approval tests.
+  5. Existing requests that omit the additive review-fingerprint field keep their
+     current no-override behavior; settled by current commercial billing run and
+     approval regression tests.
+  6. The same candidate/source pair in separate retained runs has independent
+     override review identities: a run-B override cannot stale run A at the final
+     invoice trigger, and same-content run overrides cannot collide; settled by
+     real-Postgres and pure identity tests.
+  7. A notes- or due-date-only edit preserves an approved hourly line's explicit
+     exact-cent amount only when the commercial approval writer marked that
+     retained evidence; generic/MCP caller-supplied amounts recalculate from
+     quantity and price instead of becoming authoritative; settled by repository
+     regression tests using multiple minute/rate pairs and untrusted sources.
+  8. An override with an overlong line/adjustment description or a Gmail
+     recipient rejected by the downstream contact grammar fails at admission;
+     a maximum-length line description still produces an approvable draft;
+     settled by diverse pure override and approval regression tests.
+  9. A delivery-method override to Gmail with no effective canonical recipient
+     includes exactly one `missing_billing_email` blocker (and the normal
+     derived zero-total blocker) rather than becoming approval-eligible;
+     settled by diverse manual-Square, receipt-only, and missing-preference
+     transition tests.
+  10. An `invalid_rate` blocker can clear only when every affected retained
+      source line has a specific valid rate override. If the canonical producer
+      omitted the unpriced service entirely, valid sibling lines or an
+      adjustment leave it visibly blocked and unapprovable; settled by pure
+      effective-projection tests.
+  11. Concurrency execution model: all durable writes occur in PostgreSQL
+      transactions. Each operation first serializes its idempotency key, then
+      candidate mutations and final approval share the candidate/source
+      transaction advisory lock and lock the retained run candidate row. The
+      approval's read-only preview/preflight may run between transactions, but
+      its final transaction reacquires both authoritative locks before writing.
+      Across every admitted interleaving for one operation key, exactly one
+      matching request commits and all matching retries replay it; a different
+      request conflicts. Across every admitted interleaving for one
+      candidate/source, the candidate lock defines the commit order: a prior
+      review/override is observed by approval, while a prior approval causes a
+      later review/override to reject. A cancelled or failing transaction
+      commits neither partial override/review state nor an invoice/approval
+      pair. The migration's uniqueness constraints and invoice trigger remain
+      the database backstop for direct and mixed-version writers. This is
+      settled by
+      `test_real_postgres_concurrent_override_replays_one_committed_revision`
+      (same operation key),
+      `test_real_postgres_exclusion_and_approval_serialize_at_the_same_candidate_boundary`
+      (shared candidate lock),
+      `test_real_postgres_override_requires_a_fresh_include_and_retries_without_invoice_side_effects`
+      (retry/stale order), and
+      `test_real_postgres_rolls_back_the_invoice_when_approval_audit_insert_fails`
+      (transaction abort).
+- Reachability proof: exercise the FastAPI receivables route with the actual
+  dependency boundary and assert its returned effective candidate/audit state;
+  direct service tests additionally settle the Postgres locking/migration facts.
+- Affected surfaces: commercial billing run snapshots/review decisions,
+  approvals/invoice metadata, receivables API models/routes, and additive
+  migrations only.
+- Risk areas: exact money, mutable-history prevention, review-selection reset,
+  concurrency/idempotency, stale source evidence, legacy mixed-version readers,
+  and no-delivery side effects.
+- Reviewer rules triggered: R1, R2, R3, R4, R5, R6, R8, R10, R12, R13, R14.
+
+### Boundary-change enumeration
+
+Required when this diff changes a guard, validator, normalizer, resolver,
+router/classifier, or admission boundary. Name each changed boundary path or
+seam in the enumeration; otherwise write "N/A - no boundary change."
+
+- Boundary path/seam: the new override request validator and the existing
+  review-decision/approval identity admission checks, including the final
+  invoice trigger's `commercialBillingRunId` metadata binding.
+- Replaced-path behaviors: legacy no-override calls derive
+  `reviewFingerprint == sourceFingerprint`; overridden candidates require the
+  supplied current review fingerprint.
+- Guard-relevant fields: billing run UUID, invoice `commercialBillingRunId`,
+  candidate key, source fingerprint,
+  expected override revision, review fingerprint, line key, integer cents,
+  whole minutes, delivery method, recipient, closed reason code, note, actor,
+  idempotency key, canonical Gmail recipient, and invoice-line description
+  length.
+- Caller x input shape: direct ATLAS API callers may omit the additive review
+  fingerprint only when the candidate has no override; new tracker callers send
+  it for every review/approval after this provider deploys.
+
+### Deployed-config probing
+
+Required for guard, validator, resolver, admission-boundary, or env/config
+fallback changes; otherwise write "N/A - no guard/config boundary change."
+
+- Deployed/default config values: N/A - no environment/config fallback changes.
+- Explicit value probe: N/A.
+- Absent value probe: an absent review fingerprint is accepted only for an
+  unoverridden candidate and rejected once an override exists.
+- Default-session/default-context probe: N/A.
+- Side-effect ordering: all validation, locks, source/revision checks, and
+  idempotency lookup occur before the override insert; override itself is the
+  only successful write and approval still separately creates the first invoice.
+
+### Guard class-closure declaration
+
+- `OVERRIDE_REASON_CODES` and `OVERRIDE_DELIVERY_METHODS` are **CLOSED** policy
+  sets authored in `commercial_billing_candidate_overrides.py`; API, service,
+  and migration constraints admit only their enumerated members. An out-of-set
+  value rejects before any write because billing evidence must never infer a
+  delivery or exception policy.
+- The source fingerprint/review fingerprint language is a **CLOSED** structural
+  format (64 lowercase hexadecimal characters); malformed or stale values
+  reject at route/service/database admission. The effective snapshot is not an
+  open customer-text classifier: the route permits only its typed fields and
+  the service projects them over retained source evidence.
+- The strict heuristic's changed `_validate_*` definitions therefore do not
+  represent a trigger-A open-input safety guard. Its requested grammar-derived
+  property test is inapplicable; the PR body records the supported
+  `guard-class-closure: waived` marker with this rationale while the direct
+  malformed/closed-set/real-Postgres tests remain required evidence.
+
+### Files touched
+
+- `.github/workflows/atlas_invoicing_checks.yml`
+- `atlas_brain/api/invoicing/receivables.py`
+- `atlas_brain/main.py`
+- `atlas_brain/services/commercial_billing_approvals.py`
+- `atlas_brain/services/commercial_billing_candidate_overrides.py`
+- `atlas_brain/services/commercial_billing_runs.py`
+- `atlas_brain/storage/migrations/382_commercial_billing_candidate_overrides.sql`
+- `atlas_brain/storage/repositories/invoice.py`
+- `plans/PR-EOM-Commercial-Billing-Candidate-Overrides.md`
+- `tests/test_commercial_billing_approvals.py`
+- `tests/test_commercial_billing_candidate_overrides.py`
+- `tests/test_commercial_billing_runs.py`
+
+## Mechanism
+
+The migration creates an append-only override history keyed to an immutable
+run candidate and its source fingerprint. Each revision stores the validated
+effective snapshot, exact request fingerprint, actor, reason code, note, and
+operation key. Its review identity includes that retained run, and the final
+invoice trigger validates the invoice's `commercialBillingRunId` before looking
+up an active override. The base candidate row is never changed.
+
+The run reader overlays only the latest override and exposes both source and
+effective evidence. An override calculates its review fingerprint from the
+retained run, source identity, and effective snapshot. Review-decision and
+approval records carry that identity; legacy rows use their existing source
+fingerprint as the review fingerprint. This makes an older Include decision
+ineligible as soon as an override revision exists.
+
+For a draft edit that does not replace line items, the invoice repository
+preserves a persisted explicit line `amount` only when the controlled
+commercial-billing approval writer marked its exact-cent evidence. This retains
+the exact cents approved from whole minutes while generic/MCP caller-supplied
+amount fields still recalculate from quantity and unit price. Supplying
+replacement line items always retains the existing recalculation behavior.
+
+Override admission shares the approval line-description limit and canonical
+contact-email normalizer. This rejects an invalid description or Gmail
+recipient before it can clear a blocker, receive a review decision, or create
+an invoice that the PDF/Gmail delivery path cannot process.
+
+The effective projection also recomputes the Gmail-recipient blocker after a
+delivery-method override. A candidate that becomes Gmail-routed without a
+canonical recipient stays visibly blocked instead of failing later during
+invoice approval or Gmail draft creation.
+
+An `invalid_rate` blocker is service-specific evidence, not a summary of the
+currently materialized lines. The canonical producer intentionally omits an
+unpriced service line, so an override can clear that blocker only when every
+affected retained source line carries its own valid rate override. An omitted
+service has no targetable source line and remains blocked; a sibling line or
+one-time adjustment cannot silently bill around it.
+
+The migration is atomic and preserves mixed-version safety: legacy provider
+INSERTs that omit the new review-fingerprint column receive the source
+fingerprint in a database trigger, while the invoice trigger rejects any
+legacy source identity once a newer effective review identity exists. A
+rollback therefore cannot silently approve an override through an older
+provider binary.
+
+Concurrency is intentionally modeled at the PostgreSQL transaction boundary.
+Override and review-decision writers take an operation-key transaction advisory
+lock before idempotency lookup, then the candidate/source transaction advisory
+lock shared with approval, followed by `FOR UPDATE` on the retained run
+candidate. Approval performs a no-write preflight, then reacquires its
+operation and candidate locks and the retained row in the final write
+transaction before it inserts the invoice and approval audit row. Therefore a
+same-key retry has one durable linearization point, candidate mutations and
+approval have one shared commit order, and any cancellation or exception before
+commit releases transaction-scoped locks with no partial durable result. The
+real-Postgres contention, serialization, stale/retry, and injected-rollback
+tests exercise the representative lock waits and both commit/abort outcomes;
+the stated lock/transaction invariant, rather than sampling alone, covers all
+admitted orderings.
+
+Permitted source line edits are description, rate cents, and quantity. Hourly
+quantities are whole minutes and calculate a line amount with Decimal
+ROUND_HALF_UP; visit/month quantities are positive integers. One explicit
+credit or charge adjustment is allowed per effective revision and inherits the
+existing candidate tax basis points. Recipient/delivery overrides are run-only:
+Gmail accepts a valid named address, Manual Square needs no recipient, and
+receipt-only delivery is not admitted. Unresolvable source blockers remain.
+
+## Intentional
+
+- A recurring rate/service/calendar correction remains a source-data task;
+  overrides do not write canonical records or carry to a later run.
+- A stale source candidate is regenerated and the override is deliberately
+  reapplied or discarded; this slice does not silently transplant overrides.
+- One signed adjustment line is intentionally narrower than arbitrary custom
+  lines and makes credits/charges legible in invoice evidence.
+- Tax is inherited from the candidate's existing tax basis points. The slice
+  does not introduce a tax-policy editor.
+- The provider stores an effective snapshot rather than mutating the original,
+  even though that duplicates data, because it preserves financial review
+  evidence and a deterministic approval artifact.
+
+## Deferred
+
+- Tracker proxy and Website edit/review UI are separate dependent PRs after
+  this provider deploys.
+- Canonical service/rate/calendar editing and any multi-line adjustment editor
+  remain out of scope; the existing source workflows own recurring corrections.
+
+Parking predicate: UI polish, expanded adjustment catalogues, source-data
+editing, and reporting features that do not affect the provider's money/audit
+correctness are parked in ATLAS issue #2363.
+
+Parked hardening: none.
+
+## Verification
+
+- `ATLAS_RECEIVABLES_TEST_DATABASE_URL=<isolated local Postgres> python -m
+  pytest tests/test_commercial_billing_candidate_overrides.py
+  tests/test_commercial_billing_runs.py tests/test_commercial_billing_approvals.py -q`
+  — **191 passed, 1 warning** against disposable local PostgreSQL.
+- The complete current local equivalent of the receivables list in
+  `.github/workflows/atlas_invoicing_checks.yml` was run against the same
+  isolated database — **726 passed, 1 warning** — including payment/receipt,
+  candidate/run/approval, Gmail/Square, repository/PDF, and canonical
+  contact-email grammar paths.
+- `python -m pytest tests/test_monthly_invoice_generation.py -k
+  "update_invoice_clears_needs_hours_when_line_items_are_billable or
+  line_items_are_billable_requires_all_positive_quantities" -q` — **2 passed,
+  41 deselected**.
+- `python -m pytest tests/test_invoicing_readonly_mcp.py
+  tests/test_invoicing_readonly_oauth.py tests/test_invoicing_draft_writer_mcp.py
+  tests/test_invoicing_draft_writer_oauth.py -q` — **43 passed**.
+- `git diff --check`, `python -m py_compile` on changed Python paths, targeted
+  `ruff check`, `ruff check --ignore E402 atlas_brain/main.py`, Black checks
+  for the new Python files, and a YAML parse of the changed workflow all pass.
+  `E402` is pre-existing in `main.py` because dotenv loading deliberately
+  precedes imports.
+- `bash scripts/push_pr.sh <body> -u origin HEAD` will run the required local
+  mechanical review bundle once before publishing.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_invoicing_checks.yml` | 7 |
+| `atlas_brain/api/invoicing/receivables.py` | 174 |
+| `atlas_brain/main.py` | 4 |
+| `atlas_brain/services/commercial_billing_approvals.py` | 305 |
+| `atlas_brain/services/commercial_billing_candidate_overrides.py` | 632 |
+| `atlas_brain/services/commercial_billing_runs.py` | 506 |
+| `atlas_brain/storage/migrations/382_commercial_billing_candidate_overrides.sql` | 284 |
+| `atlas_brain/storage/repositories/invoice.py` | 72 |
+| `plans/PR-EOM-Commercial-Billing-Candidate-Overrides.md` | 361 |
+| `tests/test_commercial_billing_approvals.py` | 733 |
+| `tests/test_commercial_billing_candidate_overrides.py` | 578 |
+| `tests/test_commercial_billing_runs.py` | 317 |
+| **Total** | **3973** |

--- a/tests/test_commercial_billing_approvals.py
+++ b/tests/test_commercial_billing_approvals.py
@@ -12,7 +12,7 @@ import os
 import threading
 from contextlib import asynccontextmanager
 from datetime import date, datetime, timezone
-from decimal import Decimal
+from decimal import Decimal, ROUND_HALF_UP
 from itertools import product
 from pathlib import Path
 from types import SimpleNamespace
@@ -41,6 +41,10 @@ from atlas_brain.services.commercial_billing_runs import (
     CommercialBillingRunConflictError,
     CommercialBillingRunService,
 )
+from atlas_brain.services.commercial_billing_candidate_overrides import (
+    decorate_line_keys,
+)
+from atlas_brain.storage.repositories.invoice import InvoiceRepository
 
 
 def _fingerprint(value: object) -> str:
@@ -174,6 +178,7 @@ class _MemoryConnection:
         self.approvals_by_candidate: dict[tuple[str, str], dict] = {}
         self.insert_attempts = 0
         self.review_decision: dict | None = None
+        self.override: dict | None = None
 
     async def fetchval(self, query, *_args):
         assert "pg_advisory_xact_lock" in query
@@ -196,6 +201,8 @@ class _MemoryConnection:
             return self._view_row(approval) if approval else None
         if "FROM commercial_billing_candidate_review_decisions" in query:
             return self.review_decision
+        if "FROM commercial_billing_candidate_overrides" in query:
+            return self.override
         if "INSERT INTO invoices" in query:
             self.insert_attempts += 1
             invoice_id = args[0]
@@ -220,11 +227,11 @@ class _MemoryConnection:
         if "INSERT INTO commercial_billing_candidate_approvals" in query:
             approval = {
                 "approval_id": args[0], "billing_run_id": args[1], "candidate_key": args[2],
-                "source_fingerprint": args[3], "request_fingerprint": args[6],
-                "invoice_id": args[7], "state": "invoice_created", "approved_by": args[8],
-                "approved_at": args[9],
+                "source_fingerprint": args[3], "review_fingerprint": args[4],
+                "request_fingerprint": args[7], "invoice_id": args[8],
+                "state": "invoice_created", "approved_by": args[9], "approved_at": args[10],
             }
-            self.approvals_by_key[args[5]] = approval
+            self.approvals_by_key[args[6]] = approval
             self.approvals_by_candidate[(args[2], args[3])] = approval
             return {"id": args[0]}
         raise AssertionError(query)
@@ -298,6 +305,8 @@ async def _approval_database():
             "370_commercial_billing_runs.sql",
             "372_commercial_billing_candidate_approvals.sql",
             "380_commercial_billing_candidate_review_decisions.sql",
+            "381_commercial_billing_candidate_review_decisions_recovery.sql",
+            "382_commercial_billing_candidate_overrides.sql",
             "373_commercial_billing_invoice_pdf_artifacts.sql",
         ):
             await connection.execute((migrations / name).read_text())
@@ -501,6 +510,384 @@ async def test_manual_square_candidate_creates_draft_without_a_gmail_recipient()
 
 
 @pytest.mark.asyncio
+async def test_real_postgres_override_requires_a_fresh_include_and_retries_without_invoice_side_effects():
+    async with _approval_database() as (connection, schema):
+        run_id, candidate = uuid4(), _candidate(
+            candidate_key="commercial-billing:override:2026-03"
+        )
+        fingerprint = candidate["sourceFingerprint"]
+        contact_id = UUID(candidate["customer"]["contactId"])
+        await connection.execute("INSERT INTO contacts (id) VALUES ($1)", contact_id)
+        await connection.execute(
+            """
+            INSERT INTO commercial_billing_runs (
+                id, billing_period, state, candidate_contract_version,
+                snapshot_fingerprint, source, idempotency_key,
+                request_fingerprint, created_by
+            ) VALUES ($1, '2026-03', 'draft', 2, $2, 'eom_admin', 'override-run-1', $2, 'Juan')
+            """,
+            run_id,
+            fingerprint,
+        )
+        await connection.execute(
+            """
+            INSERT INTO commercial_billing_run_candidates (
+                id, billing_run_id, candidate_key, source_fingerprint,
+                display_order, snapshot
+            ) VALUES ($1, $2, $3, $4, 0, $5::jsonb)
+            """,
+            uuid4(),
+            run_id,
+            candidate["candidateKey"],
+            fingerprint,
+            json.dumps(candidate),
+        )
+
+        legacy_decision_id = uuid4()
+        await connection.execute(
+            """
+            INSERT INTO commercial_billing_candidate_review_decisions (
+                id, billing_run_id, candidate_key, source_fingerprint,
+                revision, decision, reason, source, idempotency_key,
+                request_fingerprint, decided_by
+            ) VALUES ($1, $2, $3, $4, 1, 'included',
+                      'A mixed rollout legacy writer omitted the new column.',
+                      'eom_admin', 'legacy-override-decision-1', $5, 'Juan')
+            """,
+            legacy_decision_id,
+            run_id,
+            candidate["candidateKey"],
+            fingerprint,
+            _fingerprint("legacy-override-decision"),
+        )
+        assert await connection.fetchval(
+            "SELECT review_fingerprint FROM commercial_billing_candidate_review_decisions WHERE id = $1",
+            legacy_decision_id,
+        ) == fingerprint
+
+        review_service = CommercialBillingRunService(pool=_SchemaPool(connection, schema))
+        line_key = decorate_line_keys(candidate)["lineItems"][0]["lineKey"]
+        created_override = await review_service.set_candidate_override(
+            billing_run_id=run_id,
+            candidate_key=candidate["candidateKey"],
+            expected_source_fingerprint=fingerprint,
+            expected_override_revision=0,
+            reason_code="additional_charge",
+            reason="The customer approved an after-hours access fee for this run.",
+            line_overrides=[{"lineKey": line_key, "quantity": 3}],
+            adjustment={
+                "kind": "charge",
+                "description": "After-hours access fee",
+                "amountCents": 17,
+            },
+            recipient=None,
+            delivery_method="gmail_pdf",
+            idempotency_key="override-1",
+            actor="Juan",
+        )
+        active_review_fingerprint = created_override["candidate"]["reviewFingerprint"]
+        assert active_review_fingerprint != fingerprint
+        assert created_override["candidate"]["lineItems"][0]["amountCents"] == 14_475
+        assert created_override["candidate"]["totalCents"] == 14_492
+        assert created_override["candidate"]["lineItems"][0]["lineKey"] == line_key
+        assert candidate["lineItems"][0]["quantity"] == 2
+        assert await connection.fetchval("SELECT COUNT(*) FROM invoices") == 0
+
+        replayed_override = await review_service.set_candidate_override(
+            billing_run_id=run_id,
+            candidate_key=candidate["candidateKey"],
+            expected_source_fingerprint=fingerprint,
+            expected_override_revision=0,
+            reason_code="additional_charge",
+            reason="The customer approved an after-hours access fee for this run.",
+            line_overrides=[{"lineKey": line_key, "quantity": 3}],
+            adjustment={
+                "kind": "charge",
+                "description": "After-hours access fee",
+                "amountCents": 17,
+            },
+            recipient=None,
+            delivery_method="gmail_pdf",
+            idempotency_key="override-1",
+            actor="Juan",
+        )
+        assert replayed_override == {**created_override, "replayed": True}
+        assert await connection.fetchval(
+            "SELECT COUNT(*) FROM commercial_billing_candidate_overrides"
+        ) == 1
+
+        revised_override = await review_service.set_candidate_override(
+            billing_run_id=run_id,
+            candidate_key=candidate["candidateKey"],
+            expected_source_fingerprint=fingerprint,
+            expected_override_revision=1,
+            reason_code="additional_charge",
+            reason="The final approved after-hours quantity is four visits for this run.",
+            line_overrides=[
+                {
+                    "lineKey": created_override["candidate"]["lineItems"][0]["lineKey"],
+                    "quantity": 4,
+                }
+            ],
+            adjustment={
+                "kind": "charge",
+                "description": "After-hours access fee",
+                "amountCents": 17,
+            },
+            recipient=None,
+            delivery_method="gmail_pdf",
+            idempotency_key="override-2",
+            actor="Juan",
+        )
+        active_review_fingerprint = revised_override["candidate"]["reviewFingerprint"]
+        assert revised_override["override"]["revision"] == 2
+        assert revised_override["candidate"]["lineItems"][0]["amountCents"] == 19_300
+        assert revised_override["candidate"]["totalCents"] == 19_317
+        assert await connection.fetchval(
+            "SELECT COUNT(*) FROM commercial_billing_candidate_overrides"
+        ) == 2
+
+        with pytest.raises(CommercialBillingRunConflictError, match="Idempotency key"):
+            await review_service.set_candidate_review_decision(
+                billing_run_id=run_id,
+                candidate_key=candidate["candidateKey"],
+                expected_source_fingerprint=fingerprint,
+                expected_review_fingerprint=active_review_fingerprint,
+                decision="included",
+                reason="A mixed rollout legacy writer omitted the new column.",
+                idempotency_key="legacy-override-decision-1",
+                actor="Juan",
+            )
+
+        with pytest.raises(CommercialBillingRunConflictError, match="override revision changed"):
+            await review_service.set_candidate_override(
+                billing_run_id=run_id,
+                candidate_key=candidate["candidateKey"],
+                expected_source_fingerprint=fingerprint,
+                expected_override_revision=0,
+                reason_code="additional_charge",
+                reason="A stale browser tab must not replace the active review evidence.",
+                line_overrides=[{"lineKey": line_key, "quantity": 4}],
+                adjustment=None,
+                recipient=None,
+                delivery_method=None,
+                idempotency_key="override-stale-1",
+                actor="Juan",
+            )
+
+        current_source = _CandidateService(candidate)
+        approval_service = _service(_SchemaPool(connection, schema), current_source)
+        with pytest.raises(
+            CommercialBillingApprovalConflictError,
+            match="requires an explicit include",
+        ):
+            await approval_service.approve(
+                billing_run_id=run_id,
+                candidate_key=candidate["candidateKey"],
+                expected_source_fingerprint=fingerprint,
+                expected_review_fingerprint=active_review_fingerprint,
+                idempotency_key="override-approval-before-include-1",
+                actor="Juan",
+            )
+        assert await connection.fetchval("SELECT COUNT(*) FROM invoices") == 0
+
+        with pytest.raises(CommercialBillingRunConflictError, match="review identity changed"):
+            await review_service.set_candidate_review_decision(
+                billing_run_id=run_id,
+                candidate_key=candidate["candidateKey"],
+                expected_source_fingerprint=fingerprint,
+                decision="included",
+                reason="A stale Include must be rejected.",
+                idempotency_key="override-include-stale-1",
+                actor="Juan",
+            )
+
+        included = await review_service.set_candidate_review_decision(
+            billing_run_id=run_id,
+            candidate_key=candidate["candidateKey"],
+            expected_source_fingerprint=fingerprint,
+            expected_review_fingerprint=active_review_fingerprint,
+            decision="included",
+            reason="The effective one-run adjustment was reviewed and approved.",
+            idempotency_key="override-include-1",
+            actor="Juan",
+        )
+        assert included["reviewDecision"]["decision"] == "included"
+
+        changed_source = copy.deepcopy(candidate)
+        changed_source["lineItems"][0]["description"] = "Changed source service evidence"
+        _refresh_fingerprint(changed_source)
+        current_source.candidate = changed_source
+        with pytest.raises(CommercialBillingApprovalStaleError, match="regenerate"):
+            await approval_service.approve(
+                billing_run_id=run_id,
+                candidate_key=candidate["candidateKey"],
+                expected_source_fingerprint=fingerprint,
+                expected_review_fingerprint=active_review_fingerprint,
+                idempotency_key="override-approval-stale-source-1",
+                actor="Juan",
+            )
+        assert await connection.fetchval("SELECT COUNT(*) FROM invoices") == 0
+        current_source.candidate = candidate
+
+        approved = await approval_service.approve(
+            billing_run_id=run_id,
+            candidate_key=candidate["candidateKey"],
+            expected_source_fingerprint=fingerprint,
+            expected_review_fingerprint=active_review_fingerprint,
+            idempotency_key="override-approval-1",
+            actor="Juan",
+        )
+        assert approved["replayed"] is False
+        assert approved["approval"]["reviewFingerprint"] == active_review_fingerprint
+        assert await connection.fetchval("SELECT COUNT(*) FROM invoices") == 1
+        invoice = await connection.fetchrow(
+            "SELECT metadata, total_amount FROM invoices"
+        )
+        invoice_metadata = json.loads(invoice["metadata"])
+        assert invoice_metadata["reviewFingerprint"] == active_review_fingerprint
+        assert invoice_metadata["commercialBillingExactLineAmounts"] is True
+        assert invoice["total_amount"] == Decimal("193.17")
+
+        with pytest.raises(CommercialBillingRunConflictError, match="cannot be overridden"):
+            await review_service.set_candidate_override(
+                billing_run_id=run_id,
+                candidate_key=candidate["candidateKey"],
+                expected_source_fingerprint=fingerprint,
+                expected_override_revision=2,
+                reason_code="additional_charge",
+                reason="Approved candidates are immutable.",
+                line_overrides=[{"lineKey": line_key, "quantity": 4}],
+                adjustment=None,
+                recipient=None,
+                delivery_method=None,
+                idempotency_key="override-after-approval-1",
+                actor="Juan",
+            )
+        asyncpg = pytest.importorskip("asyncpg")
+        with pytest.raises(asyncpg.PostgresError, match="append-only"):
+            await connection.execute(
+                "UPDATE commercial_billing_candidate_overrides SET reason = 'mutated'"
+            )
+
+
+@pytest.mark.asyncio
+async def test_real_postgres_concurrent_override_replays_one_committed_revision():
+    """Two same-key writers serialize at the operation lock and commit once."""
+
+    async with _approval_database() as (connection, schema):
+        run_id, candidate = uuid4(), _candidate(
+            candidate_key="commercial-billing:concurrent-override:2026-03"
+        )
+        fingerprint = candidate["sourceFingerprint"]
+        await connection.execute(
+            """
+            INSERT INTO commercial_billing_runs (
+                id, billing_period, state, candidate_contract_version,
+                snapshot_fingerprint, source, idempotency_key,
+                request_fingerprint, created_by
+            ) VALUES ($1, '2026-03', 'draft', 2, $2, 'eom_admin',
+                      'concurrent-override-run-1', $2, 'Juan')
+            """,
+            run_id,
+            fingerprint,
+        )
+        await connection.execute(
+            """
+            INSERT INTO commercial_billing_run_candidates (
+                id, billing_run_id, candidate_key, source_fingerprint,
+                display_order, snapshot
+            ) VALUES ($1, $2, $3, $4, 0, $5::jsonb)
+            """,
+            uuid4(),
+            run_id,
+            candidate["candidateKey"],
+            fingerprint,
+            json.dumps(candidate),
+        )
+
+        asyncpg = pytest.importorskip("asyncpg")
+        database_url = os.environ["ATLAS_RECEIVABLES_TEST_DATABASE_URL"]
+        operation_key = "override-concurrent-replay-1"
+        operation_lock = f"commercial-billing-run-override:eom_admin:{operation_key}"
+        locker = await asyncpg.connect(database_url)
+        await locker.fetchval(
+            "SELECT pg_advisory_lock(hashtextextended($1, 0))", operation_lock
+        )
+        first_task = None
+        second_task = None
+        lock_released = False
+        line_key = decorate_line_keys(candidate)["lineItems"][0]["lineKey"]
+        request = {
+            "billing_run_id": run_id,
+            "candidate_key": candidate["candidateKey"],
+            "expected_source_fingerprint": fingerprint,
+            "expected_override_revision": 0,
+            "reason_code": "additional_charge",
+            "reason": "The operator documented this one-time extra visit.",
+            "line_overrides": [{"lineKey": line_key, "quantity": 3}],
+            "adjustment": None,
+            "recipient": None,
+            "delivery_method": None,
+            "idempotency_key": operation_key,
+            "actor": "Juan",
+        }
+        try:
+            first_service = CommercialBillingRunService(
+                pool=_IsolatedSchemaPool(database_url, schema)
+            )
+            second_service = CommercialBillingRunService(
+                pool=_IsolatedSchemaPool(database_url, schema)
+            )
+            first_task = asyncio.create_task(
+                first_service.set_candidate_override(**request)
+            )
+            second_task = asyncio.create_task(
+                second_service.set_candidate_override(**request)
+            )
+            for _ in range(100):
+                waiting = await connection.fetchval(
+                    "SELECT COUNT(*) FROM pg_locks "
+                    "WHERE locktype = 'advisory' AND NOT granted"
+                )
+                if waiting >= 2:
+                    break
+                await asyncio.sleep(0.01)
+            else:
+                raise AssertionError(
+                    "both override calls did not wait on the operation lock"
+                )
+
+            await locker.fetchval(
+                "SELECT pg_advisory_unlock(hashtextextended($1, 0))", operation_lock
+            )
+            lock_released = True
+            first_result, second_result = await asyncio.wait_for(
+                asyncio.gather(first_task, second_task), timeout=5
+            )
+        finally:
+            if not lock_released:
+                await locker.fetchval(
+                    "SELECT pg_advisory_unlock(hashtextextended($1, 0))", operation_lock
+                )
+            await locker.close()
+            if first_task is not None and second_task is not None:
+                await asyncio.gather(first_task, second_task, return_exceptions=True)
+
+        assert {first_result["replayed"], second_result["replayed"]} == {False, True}
+        assert {
+            first_result["override"]["revision"],
+            second_result["override"]["revision"],
+        } == {1}
+        assert (
+            await connection.fetchval(
+                "SELECT COUNT(*) FROM commercial_billing_candidate_overrides"
+            )
+            == 1
+        )
+
+
+@pytest.mark.asyncio
 async def test_real_postgres_approval_is_atomic_and_reuses_same_candidate_across_runs():
     async with _approval_database() as (connection, schema):
         run_id, second_run_id, candidate = uuid4(), uuid4(), _candidate()
@@ -551,6 +938,272 @@ async def test_real_postgres_approval_is_atomic_and_reuses_same_candidate_across
         invoice = await connection.fetchrow("SELECT status, total_amount, amount_due FROM invoices")
         assert dict(invoice) == {"status": "draft", "total_amount": Decimal("96.50"), "amount_due": Decimal("96.50")}
         assert source.calls == ["2026-03", "2026-03"]
+
+
+@pytest.mark.asyncio
+async def test_real_postgres_override_identity_and_final_invoice_trigger_are_scoped_to_run():
+    """An override in one retained run cannot stale the same source in another."""
+
+    asyncpg = pytest.importorskip("asyncpg")
+    async with _approval_database() as (connection, schema):
+        first_run_id, second_run_id = uuid4(), uuid4()
+        candidate = _candidate(
+            candidate_key="commercial-billing:run-scoped-override:2026-03"
+        )
+        fingerprint = candidate["sourceFingerprint"]
+        contact_id = UUID(candidate["customer"]["contactId"])
+        await connection.execute("INSERT INTO contacts (id) VALUES ($1)", contact_id)
+        for run_id, operation_key in (
+            (first_run_id, "run-scope-a"),
+            (second_run_id, "run-scope-b"),
+        ):
+            await connection.execute(
+                """
+                INSERT INTO commercial_billing_runs (
+                    id, billing_period, state, candidate_contract_version,
+                    snapshot_fingerprint, source, idempotency_key,
+                    request_fingerprint, created_by
+                ) VALUES ($1, '2026-03', 'draft', 2, $2, 'eom_admin', $3, $2, 'Juan')
+                """,
+                run_id,
+                fingerprint,
+                operation_key,
+            )
+            await connection.execute(
+                """
+                INSERT INTO commercial_billing_run_candidates (
+                    id, billing_run_id, candidate_key, source_fingerprint,
+                    display_order, snapshot
+                ) VALUES ($1, $2, $3, $4, 0, $5::jsonb)
+                """,
+                uuid4(),
+                run_id,
+                candidate["candidateKey"],
+                fingerprint,
+                json.dumps(candidate),
+            )
+
+        review_service = CommercialBillingRunService(pool=_SchemaPool(connection, schema))
+        line_key = decorate_line_keys(candidate)["lineItems"][0]["lineKey"]
+        second_override = await review_service.set_candidate_override(
+            billing_run_id=second_run_id,
+            candidate_key=candidate["candidateKey"],
+            expected_source_fingerprint=fingerprint,
+            expected_override_revision=0,
+            reason_code="additional_charge",
+            reason="The second run includes a documented one-time extra visit.",
+            line_overrides=[{"lineKey": line_key, "quantity": 3}],
+            adjustment=None,
+            recipient=None,
+            delivery_method=None,
+            idempotency_key="run-scope-override-b",
+            actor="Juan",
+        )
+        assert second_override["candidate"]["reviewFingerprint"] != fingerprint
+
+        first_metadata = {
+            "candidateKey": candidate["candidateKey"],
+            "commercialBillingRunId": str(first_run_id),
+            "reviewFingerprint": fingerprint,
+            "sourceFingerprint": fingerprint,
+        }
+        await connection.execute(
+            """
+            INSERT INTO invoices (
+                id, invoice_number, contact_id, customer_name, line_items,
+                subtotal, tax_rate, tax_amount, total_amount, due_date,
+                source, source_ref, business_context_id, metadata
+            ) VALUES (
+                $1, 'INV-RUN-A-0001', $2, 'Acme Office', $3::jsonb,
+                96.50, 0, 0, 96.50, $4,
+                'eom_commercial_billing', 'run-scope-a-invoice', 'effingham_maids', $5::jsonb
+            )
+            """,
+            uuid4(),
+            contact_id,
+            json.dumps([]),
+            date(2026, 4, 16),
+            json.dumps(first_metadata),
+        )
+        assert await connection.fetchval("SELECT COUNT(*) FROM invoices") == 1
+
+        second_metadata = {
+            **first_metadata,
+            "commercialBillingRunId": str(second_run_id),
+        }
+        with pytest.raises(asyncpg.PostgresError, match="review identity is stale"):
+            await connection.execute(
+                """
+                INSERT INTO invoices (
+                    id, invoice_number, contact_id, customer_name, line_items,
+                    subtotal, tax_rate, tax_amount, total_amount, due_date,
+                    source, source_ref, business_context_id, metadata
+                ) VALUES (
+                    $1, 'INV-RUN-B-0001', $2, 'Acme Office', $3::jsonb,
+                    96.50, 0, 0, 96.50, $4,
+                    'eom_commercial_billing', 'run-scope-b-invoice', 'effingham_maids', $5::jsonb
+                )
+                """,
+                uuid4(),
+                contact_id,
+                json.dumps([]),
+                date(2026, 4, 16),
+                json.dumps(second_metadata),
+            )
+        assert await connection.fetchval("SELECT COUNT(*) FROM invoices") == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("minutes", "rate_cents"),
+    ((1, 4825), (2, 4825), (17, 1999), (31, 1045), (59, 7999)),
+)
+async def test_notes_only_draft_edits_preserve_exact_hourly_line_amounts(
+    monkeypatch, minutes, rate_cents
+):
+    """Committed cents win over rounded display hours when lines are unchanged."""
+
+    invoice_id = uuid4()
+    exact_cents = int(
+        (Decimal(rate_cents) * Decimal(minutes) / Decimal(60)).quantize(
+            Decimal("1"), rounding=ROUND_HALF_UP
+        )
+    )
+    exact_amount = Decimal(exact_cents) / Decimal(100)
+    display_hours = f"{(Decimal(minutes) / Decimal(60)):.4f}".rstrip("0").rstrip(".")
+    line_item = {
+        "amount": f"{exact_amount:.2f}",
+        "date": "2026-03-03",
+        "description": "Hourly cleaning",
+        "quantity": display_hours,
+        "unit_price": f"{Decimal(rate_cents) / Decimal(100):.2f}",
+    }
+
+    class _UpdatePool:
+        is_initialized = True
+
+        def __init__(self) -> None:
+            self.arguments = None
+
+        async def fetchrow(self, query, *arguments):
+            assert "UPDATE invoices" in query
+            self.arguments = arguments
+            return {
+                "id": invoice_id,
+                "invoice_number": "INV-EXACT-HOURLY",
+                "status": "draft",
+                "line_items": arguments[1],
+                "due_date": arguments[2],
+                "notes": arguments[3],
+                "tax_rate": Decimal(str(arguments[4])),
+                "tax_amount": Decimal(str(arguments[5])),
+                "discount_amount": Decimal(str(arguments[6])),
+                "subtotal": Decimal(str(arguments[7])),
+                "total_amount": Decimal(str(arguments[8])),
+                "amount_paid": Decimal("0"),
+                "amount_due": Decimal(str(arguments[8])),
+                "metadata": arguments[11],
+            }
+
+    pool = _UpdatePool()
+    repository = InvoiceRepository(pool=pool)
+
+    async def _current(_invoice_id):
+        return {
+            "id": invoice_id,
+            "source": "eom_commercial_billing",
+            "status": "draft",
+            "line_items": [line_item],
+            "tax_rate": 0.0,
+            "discount_amount": 0.0,
+            "metadata": {"commercialBillingExactLineAmounts": True},
+        }
+
+    monkeypatch.setattr(repository, "get_by_id", _current)
+    updated = await repository.update_invoice(
+        invoice_id=invoice_id, notes="Operator added a non-financial note."
+    )
+
+    assert pool.arguments is not None
+    assert Decimal(str(pool.arguments[7])) == exact_amount
+    assert Decimal(str(pool.arguments[8])) == exact_amount
+    assert updated["line_items"] == [line_item]
+    assert Decimal(str(updated["subtotal"])) == exact_amount
+    assert Decimal(str(updated["total_amount"])) == exact_amount
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("source", "metadata"),
+    (
+        ("mcp_tool", {}),
+        ("eom_commercial_billing", {}),
+        ("mcp_tool", {"commercialBillingExactLineAmounts": True}),
+    ),
+)
+async def test_notes_only_draft_edits_recalculate_untrusted_recorded_amounts(
+    monkeypatch, source, metadata
+):
+    """Generic caller amounts cannot become authoritative after invoice creation."""
+
+    invoice_id = uuid4()
+    line_item = {
+        "amount": "1.00",
+        "description": "Caller supplied a stale amount",
+        "quantity": 2,
+        "unit_price": "50.00",
+    }
+
+    class _UpdatePool:
+        is_initialized = True
+
+        def __init__(self) -> None:
+            self.arguments = None
+
+        async def fetchrow(self, query, *arguments):
+            assert "UPDATE invoices" in query
+            self.arguments = arguments
+            return {
+                "id": invoice_id,
+                "invoice_number": "INV-UNTRUSTED-AMOUNT",
+                "status": "draft",
+                "line_items": arguments[1],
+                "due_date": arguments[2],
+                "notes": arguments[3],
+                "tax_rate": Decimal(str(arguments[4])),
+                "tax_amount": Decimal(str(arguments[5])),
+                "discount_amount": Decimal(str(arguments[6])),
+                "subtotal": Decimal(str(arguments[7])),
+                "total_amount": Decimal(str(arguments[8])),
+                "amount_paid": Decimal("0"),
+                "amount_due": Decimal(str(arguments[8])),
+                "metadata": arguments[11],
+            }
+
+    pool = _UpdatePool()
+    repository = InvoiceRepository(pool=pool)
+
+    async def _current(_invoice_id):
+        return {
+            "id": invoice_id,
+            "source": source,
+            "status": "draft",
+            "line_items": [line_item],
+            "tax_rate": 0.0,
+            "discount_amount": 0.0,
+            "metadata": metadata,
+        }
+
+    monkeypatch.setattr(repository, "get_by_id", _current)
+    updated = await repository.update_invoice(
+        invoice_id=invoice_id, notes="Operator added a non-financial note."
+    )
+
+    assert pool.arguments is not None
+    assert Decimal(str(pool.arguments[7])) == Decimal("100.00")
+    assert Decimal(str(pool.arguments[8])) == Decimal("100.00")
+    assert Decimal(str(updated["subtotal"])) == Decimal("100.00")
+    assert Decimal(str(updated["total_amount"])) == Decimal("100.00")
 
 
 @pytest.mark.asyncio
@@ -757,6 +1410,7 @@ async def test_real_postgres_global_review_decision_fences_duplicate_runs_and_ol
                 json.dumps(
                     {
                         "candidateKey": candidate["candidateKey"],
+                        "commercialBillingRunId": str(second_run_id),
                         "sourceFingerprint": fingerprint,
                     }
                 ),
@@ -872,6 +1526,75 @@ async def test_real_postgres_invoice_trigger_rejects_noncanonical_or_nonstring_r
                 ) VALUES (
                     $1, 'INV-GUARD-0001', 'Guarded commercial invoice', $2,
                     'eom_commercial_billing', 'guard1', $3::jsonb
+                )
+                """,
+                uuid4(),
+                date(2026, 4, 16),
+                json.dumps(metadata),
+            )
+        assert await connection.fetchval("SELECT COUNT(*) FROM invoices") == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "billing_run_identity",
+    (None, "", "not-a-uuid", 7, "00000000-0000-0000-0000-000000000099"),
+)
+async def test_real_postgres_invoice_trigger_rejects_invalid_or_unretained_run_identity(
+    billing_run_identity,
+):
+    """Final invoice admission cannot borrow an override scope from another run."""
+
+    asyncpg = pytest.importorskip("asyncpg")
+    async with _approval_database() as (connection, _schema):
+        run_id = uuid4()
+        candidate_key = "commercial-billing:run-identity-guard:2026-03"
+        source_fingerprint = "b" * 64
+        await connection.execute(
+            """
+            INSERT INTO commercial_billing_runs (
+                id, billing_period, state, candidate_contract_version,
+                snapshot_fingerprint, source, idempotency_key,
+                request_fingerprint, created_by
+            ) VALUES ($1, '2026-03', 'draft', 2, $2, 'eom_admin', $3, $2, 'Juan')
+            """,
+            run_id,
+            source_fingerprint,
+            f"run-identity-{run_id.hex}",
+        )
+        await connection.execute(
+            """
+            INSERT INTO commercial_billing_run_candidates (
+                id, billing_run_id, candidate_key, source_fingerprint,
+                display_order, snapshot
+            ) VALUES ($1, $2, $3, $4, 0, $5::jsonb)
+            """,
+            uuid4(),
+            run_id,
+            candidate_key,
+            source_fingerprint,
+            json.dumps(
+                {
+                    "candidateKey": candidate_key,
+                    "sourceFingerprint": source_fingerprint,
+                }
+            ),
+        )
+        metadata = {
+            "candidateKey": candidate_key,
+            "sourceFingerprint": source_fingerprint,
+        }
+        if billing_run_identity is not None:
+            metadata["commercialBillingRunId"] = billing_run_identity
+        with pytest.raises(asyncpg.PostgresError, match="review identity is invalid"):
+            await connection.execute(
+                """
+                INSERT INTO invoices (
+                    id, invoice_number, customer_name, due_date,
+                    source, source_ref, metadata
+                ) VALUES (
+                    $1, 'INV-RUN-GUARD-0001', 'Guarded commercial invoice', $2,
+                    'eom_commercial_billing', 'run-guard-1', $3::jsonb
                 )
                 """,
                 uuid4(),

--- a/tests/test_commercial_billing_candidate_overrides.py
+++ b/tests/test_commercial_billing_candidate_overrides.py
@@ -1,0 +1,578 @@
+"""Contract tests for bounded one-run commercial billing candidate overrides."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+
+from atlas_brain.services.commercial_billing_approvals import _invoice_draft
+from atlas_brain.services.commercial_billing_candidate_overrides import (
+    CommercialBillingCandidateOverrideValidationError,
+    MAX_INVOICE_LINE_DESCRIPTION_LENGTH,
+    build_effective_snapshot,
+    decorate_effective_line_keys,
+    decorate_line_keys,
+    override_review_fingerprint,
+)
+
+_CANDIDATE_KEY = "commercial-billing:acme:2026-03"
+_SOURCE_FINGERPRINT = "a" * 64
+
+
+def _source_snapshot(*, total_cents: int | None = None) -> dict:
+    """One blocked hourly candidate with immutable source evidence."""
+
+    return {
+        "billingPeriod": "2026-03",
+        "blockers": [
+            {
+                "code": "invalid_rate",
+                "eventIds": ["event-1"],
+                "message": "The service rate must be a positive cent-precise amount.",
+                "serviceId": "service-1",
+            },
+            {
+                "code": "missing_billing_delivery_preference",
+                "eventIds": [],
+                "message": "No explicit delivery preference.",
+                "serviceId": None,
+            },
+            {
+                "code": "missing_billing_email",
+                "eventIds": [],
+                "message": "A billing email is required.",
+                "serviceId": None,
+            },
+            {
+                "code": "missing_hours",
+                "eventIds": ["event-1"],
+                "message": "Hours must be supplied before this service can be billed.",
+                "serviceId": "service-1",
+            },
+            {
+                "code": "zero_or_invalid_total",
+                "eventIds": [],
+                "message": "The candidate total is zero or invalid.",
+                "serviceId": None,
+            },
+        ],
+        "candidateKey": _CANDIDATE_KEY,
+        "customer": {
+            "contactId": "00000000-0000-0000-0000-000000000001",
+            "customerType": "commercial",
+            "displayName": "Acme Office",
+        },
+        "deliveryMethod": None,
+        "lineItems": [
+            {
+                "amountCents": None,
+                "description": "Hourly cleaning",
+                "eventIds": ["event-1"],
+                "locations": ["100 Main St"],
+                "quantity": None,
+                "quantityUnit": "hour",
+                "rateCents": None,
+                "serviceId": "service-1",
+                "sourceDate": "2026-03-03",
+            }
+        ],
+        "recipient": {
+            "contactId": "00000000-0000-0000-0000-000000000001",
+            "displayName": "Acme Accounts Payable",
+            "email": None,
+        },
+        "sourceFingerprint": _SOURCE_FINGERPRINT,
+        "subtotalCents": total_cents,
+        "taxCents": None,
+        "taxRateBasisPoints": 750,
+        "totalCents": total_cents,
+    }
+
+
+def _complete_override(snapshot: dict) -> dict:
+    line_key = decorate_line_keys(snapshot)["lineItems"][0]["lineKey"]
+    return build_effective_snapshot(
+        snapshot,
+        line_overrides=[
+            {
+                "lineKey": line_key,
+                "description": "After-hours cleaning",
+                "quantityMinutes": 75,
+                "rateCents": 4825,
+            }
+        ],
+        adjustment={
+            "kind": "charge",
+            "description": "One-time access fee",
+            "amountCents": 17,
+        },
+        recipient={"displayName": "Acme AP", "email": "Billing@Example.Test"},
+        delivery_method="gmail_pdf",
+    )
+
+
+def _missing_billing_email_blocker() -> dict:
+    return {
+        "code": "missing_billing_email",
+        "eventIds": [],
+        "message": "The canonical commercial customer has no valid billing email.",
+        "serviceId": None,
+    }
+
+
+def test_effective_override_is_exact_cent_scoped_and_leaves_source_immutable():
+    source = _source_snapshot()
+    retained_source = deepcopy(source)
+
+    effective = _complete_override(source)
+
+    assert source == retained_source
+    assert effective["sourceFingerprint"] == _SOURCE_FINGERPRINT
+    assert effective["deliveryMethod"] == "gmail_pdf"
+    assert effective["recipient"] == {
+        "contactId": "00000000-0000-0000-0000-000000000001",
+        "displayName": "Acme AP",
+        "email": "billing@example.test",
+    }
+    assert effective["blockers"] == []
+    assert effective["lineItems"] == [
+        {
+            **source["lineItems"][0],
+            "description": "After-hours cleaning",
+            "quantity": "1.25",
+            "quantityMinutes": 75,
+            "rateCents": 4825,
+            "amountCents": 6031,
+        },
+        {
+            "amountCents": 17,
+            "description": "One-time access fee",
+            "kind": "adjustment",
+            "quantity": 1,
+            "quantityUnit": "adjustment",
+            "rateCents": 17,
+            "sourceDate": "2026-03-01",
+        },
+    ]
+    assert (
+        effective["subtotalCents"],
+        effective["taxCents"],
+        effective["totalCents"],
+    ) == (
+        6048,
+        454,
+        6502,
+    )
+    decorated = decorate_effective_line_keys(source, effective)
+    assert (
+        decorated["lineItems"][0]["lineKey"]
+        == decorate_line_keys(source)["lineItems"][0]["lineKey"]
+    )
+    assert "lineKey" not in decorated["lineItems"][1]
+
+
+@pytest.mark.parametrize(
+    ("line_description", "adjustment_description"),
+    (
+        ("l" * 257, None),
+        (None, "a" * 257),
+        ("l" * 512, None),
+        (None, "a" * 512),
+        (f" {'l' * 257} ", None),
+    ),
+)
+def test_override_description_admission_matches_invoice_line_limit(
+    line_description, adjustment_description
+):
+    """An admitted override cannot contain a line approval will later reject."""
+
+    source = _source_snapshot()
+    line_key = decorate_line_keys(source)["lineItems"][0]["lineKey"]
+    line_overrides = (
+        [{"lineKey": line_key, "description": line_description}]
+        if line_description is not None
+        else []
+    )
+    adjustment = (
+        {
+            "kind": "charge",
+            "description": adjustment_description,
+            "amountCents": 17,
+        }
+        if adjustment_description is not None
+        else None
+    )
+
+    with pytest.raises(
+        CommercialBillingCandidateOverrideValidationError,
+        match=f"1 to {MAX_INVOICE_LINE_DESCRIPTION_LENGTH} safe characters",
+    ):
+        build_effective_snapshot(
+            source,
+            line_overrides=line_overrides,
+            adjustment=adjustment,
+            recipient=None,
+            delivery_method=None,
+        )
+
+
+def test_maximum_override_description_remains_approvable():
+    """The shared limit admits the largest line approval can carry forward."""
+
+    source = _source_snapshot()
+    line_key = decorate_line_keys(source)["lineItems"][0]["lineKey"]
+    description = "l" * MAX_INVOICE_LINE_DESCRIPTION_LENGTH
+    effective = build_effective_snapshot(
+        source,
+        line_overrides=[
+            {
+                "lineKey": line_key,
+                "description": description,
+                "quantityMinutes": 60,
+                "rateCents": 4825,
+            }
+        ],
+        adjustment=None,
+        recipient={"email": "billing@example.test"},
+        delivery_method="gmail_pdf",
+    )
+    billing_run_id = UUID("00000000-0000-0000-0000-000000000004")
+    review_fingerprint = override_review_fingerprint(
+        billing_run_id, _SOURCE_FINGERPRINT, 1, effective
+    )
+
+    draft = _invoice_draft(
+        effective,
+        billing_run_id=billing_run_id,
+        expected_candidate_key=_CANDIDATE_KEY,
+        expected_source_fingerprint=_SOURCE_FINGERPRINT,
+        expected_review_fingerprint=review_fingerprint,
+        actor="Juan Canfield",
+        due_days=14,
+        issue_date=date(2026, 4, 2),
+    )
+
+    assert draft.line_items[0]["description"] == description
+
+
+@pytest.mark.parametrize(
+    "email",
+    (
+        "billing@example..com",
+        "billing@.example.com",
+        "billing@example.com.",
+        ".billing@example.com",
+        "billing..team@example.com",
+        "billing@example",
+        "billing@exam_ple.com",
+        "billing@-example.com",
+    ),
+)
+def test_gmail_recipient_override_uses_canonical_contact_email(email):
+    """A recipient that Gmail will reject never clears the billing-email blocker."""
+
+    source = _source_snapshot()
+    line_key = decorate_line_keys(source)["lineItems"][0]["lineKey"]
+
+    with pytest.raises(
+        CommercialBillingCandidateOverrideValidationError,
+        match="Billing recipient email is invalid",
+    ):
+        build_effective_snapshot(
+            source,
+            line_overrides=[
+                {
+                    "lineKey": line_key,
+                    "quantityMinutes": 60,
+                    "rateCents": 4825,
+                }
+            ],
+            adjustment=None,
+            recipient={"email": email},
+            delivery_method="gmail_pdf",
+        )
+
+
+@pytest.mark.parametrize(
+    ("source_delivery_method", "source_recipient", "source_blockers"),
+    (
+        ("manual_square", None, []),
+        (
+            "manual_square",
+            {
+                "contactId": "00000000-0000-0000-0000-000000000001",
+                "displayName": "Acme AP",
+                "email": None,
+            },
+            [],
+        ),
+        ("manual_square", {}, []),
+        (
+            "no_invoice_residential_receipt",
+            None,
+            [
+                {
+                    "code": "no_invoice_delivery_preference",
+                    "eventIds": [],
+                    "message": "The recorded delivery preference does not permit a commercial invoice.",
+                    "serviceId": None,
+                }
+            ],
+        ),
+        (
+            None,
+            None,
+            [
+                {
+                    "code": "missing_billing_delivery_preference",
+                    "eventIds": [],
+                    "message": "No explicit billing delivery preference is recorded.",
+                    "serviceId": None,
+                }
+            ],
+        ),
+        ("manual_square", {"email": "not-an-email"}, []),
+    ),
+)
+def test_gmail_delivery_override_readds_missing_recipient_blocker(
+    source_delivery_method, source_recipient, source_blockers
+):
+    """Delivery changes cannot make a no-recipient candidate approval-eligible."""
+
+    source = _complete_override(_source_snapshot())
+    source["deliveryMethod"] = source_delivery_method
+    source["recipient"] = deepcopy(source_recipient)
+    source["blockers"] = deepcopy(source_blockers)
+
+    effective = build_effective_snapshot(
+        source,
+        line_overrides=[],
+        adjustment=None,
+        recipient=None,
+        delivery_method="gmail_pdf",
+    )
+
+    assert effective["blockers"][0] == _missing_billing_email_blocker()
+    assert [blocker["code"] for blocker in effective["blockers"]] == [
+        "missing_billing_email",
+        "zero_or_invalid_total",
+    ]
+
+
+def test_omitted_invalid_rate_service_stays_blocked_after_an_adjustment_override():
+    """A valid retained line cannot silently erase an omitted unpriced service."""
+
+    source = _source_snapshot()
+    source["deliveryMethod"] = "manual_square"
+    source["recipient"] = None
+    source["lineItems"][0].update(
+        {
+            "amountCents": 4825,
+            "quantity": "1",
+            "quantityMinutes": 60,
+            "rateCents": 4825,
+        }
+    )
+    source["blockers"] = [
+        {
+            "code": "invalid_rate",
+            "eventIds": ["event-unpriced"],
+            "message": "The service rate must be a positive cent-precise amount.",
+            "serviceId": "service-omitted-by-producer",
+        },
+        {
+            "code": "zero_or_invalid_total",
+            "eventIds": [],
+            "message": "The candidate total is zero or invalid.",
+            "serviceId": None,
+        },
+    ]
+    source["subtotalCents"] = None
+    source["taxCents"] = None
+    source["totalCents"] = None
+
+    effective = build_effective_snapshot(
+        source,
+        line_overrides=[],
+        adjustment={
+            "kind": "charge",
+            "description": "Documented after-hours access fee",
+            "amountCents": 17,
+        },
+        recipient=None,
+        delivery_method=None,
+    )
+
+    assert effective["subtotalCents"] is None
+    assert effective["taxCents"] is None
+    assert effective["totalCents"] is None
+    assert [blocker["code"] for blocker in effective["blockers"]] == [
+        "invalid_rate",
+        "zero_or_invalid_total",
+    ]
+
+
+def test_effective_override_requires_a_real_permitted_change_and_rejects_source_edits():
+    source = _source_snapshot()
+    line_key = decorate_line_keys(source)["lineItems"][0]["lineKey"]
+
+    with pytest.raises(
+        CommercialBillingCandidateOverrideValidationError,
+        match="must change permitted review evidence",
+    ):
+        build_effective_snapshot(
+            source,
+            line_overrides=[],
+            adjustment=None,
+            recipient=None,
+            delivery_method=None,
+        )
+
+    with pytest.raises(
+        CommercialBillingCandidateOverrideValidationError,
+        match="unsupported fields",
+    ):
+        build_effective_snapshot(
+            source,
+            line_overrides=[
+                {
+                    "lineKey": line_key,
+                    "sourceDate": "2026-03-04",
+                }
+            ],
+            adjustment=None,
+            recipient=None,
+            delivery_method=None,
+        )
+
+    with pytest.raises(
+        CommercialBillingCandidateOverrideValidationError,
+        match="whole quantityMinutes",
+    ):
+        build_effective_snapshot(
+            source,
+            line_overrides=[{"lineKey": line_key, "quantity": 2}],
+            adjustment=None,
+            recipient=None,
+            delivery_method=None,
+        )
+
+
+def test_credit_that_leaves_no_positive_total_stays_blocked_and_unapprovable():
+    source = _source_snapshot()
+    effective = _complete_override(source)
+    hourly_key = decorate_line_keys(source)["lineItems"][0]["lineKey"]
+
+    credited = build_effective_snapshot(
+        source,
+        line_overrides=[
+            {
+                "lineKey": hourly_key,
+                "quantityMinutes": 60,
+                "rateCents": 100,
+            }
+        ],
+        adjustment={
+            "kind": "credit",
+            "description": "Customer credit",
+            "amountCents": 100,
+        },
+        recipient={"email": "billing@example.test"},
+        delivery_method="gmail_pdf",
+    )
+
+    assert effective["totalCents"] == 6502
+    assert credited["subtotalCents"] is None
+    assert credited["taxCents"] is None
+    assert credited["totalCents"] is None
+    assert [blocker["code"] for blocker in credited["blockers"]] == [
+        "zero_or_invalid_total"
+    ]
+
+
+def test_each_override_revision_has_a_new_review_identity_and_invoice_uses_effective_money():
+    effective = _complete_override(_source_snapshot())
+    first_run = UUID("00000000-0000-0000-0000-000000000002")
+    second_run = UUID("00000000-0000-0000-0000-000000000003")
+    revision_one = override_review_fingerprint(
+        first_run, _SOURCE_FINGERPRINT, 1, effective
+    )
+    revision_two = override_review_fingerprint(
+        first_run, _SOURCE_FINGERPRINT, 2, effective
+    )
+    same_revision_other_run = override_review_fingerprint(
+        second_run, _SOURCE_FINGERPRINT, 1, effective
+    )
+
+    assert revision_one != revision_two
+    assert revision_one != same_revision_other_run
+    draft = _invoice_draft(
+        effective,
+        billing_run_id=first_run,
+        expected_candidate_key=_CANDIDATE_KEY,
+        expected_source_fingerprint=_SOURCE_FINGERPRINT,
+        expected_review_fingerprint=revision_one,
+        actor="Juan Canfield",
+        due_days=14,
+        issue_date=date(2026, 4, 2),
+    )
+
+    assert draft.line_items == [
+        {
+            "amount": "60.31",
+            "date": "2026-03-03",
+            "description": "After-hours cleaning",
+            "quantity": "1.25",
+            "unit_price": "48.25",
+        },
+        {
+            "amount": "0.17",
+            "date": "2026-03-01",
+            "description": "One-time access fee",
+            "quantity": 1,
+            "unit_price": "0.17",
+        },
+    ]
+    assert (draft.subtotal, draft.tax_amount, draft.total) == (
+        Decimal("60.48"),
+        Decimal("4.54"),
+        Decimal("65.02"),
+    )
+    assert draft.metadata["reviewFingerprint"] == revision_one
+    assert draft.metadata["sourceFingerprint"] == _SOURCE_FINGERPRINT
+    assert draft.metadata["commercialBillingExactLineAmounts"] is True
+
+
+def test_candidate_override_migration_is_atomic_append_only_and_delivery_free():
+    migration = (
+        Path(__file__).parents[1]
+        / "atlas_brain/storage/migrations/382_commercial_billing_candidate_overrides.sql"
+    ).read_text(encoding="utf-8")
+
+    assert migration.startswith("-- atlas: atomic-bookkeeping")
+    assert (
+        "CREATE TABLE IF NOT EXISTS commercial_billing_candidate_overrides" in migration
+    )
+    assert (
+        "FOREIGN KEY (billing_run_id, candidate_key, source_fingerprint)" in migration
+    )
+    assert (
+        "UNIQUE (billing_run_id, candidate_key, source_fingerprint, revision)"
+        in migration
+    )
+    assert "trg_prevent_commercial_billing_candidate_override_mutation" in migration
+    assert "review_fingerprint" in migration
+    assert "requires an explicit include decision" in migration
+    executable = "\n".join(
+        line for line in migration.splitlines() if not line.lstrip().startswith("--")
+    )
+    assert "DROP TABLE" not in executable
+    assert "INSERT INTO invoices" not in executable
+    assert "UPDATE invoices" not in executable
+    assert "gmail" not in executable.lower()
+    assert "email" not in executable.lower()

--- a/tests/test_commercial_billing_runs.py
+++ b/tests/test_commercial_billing_runs.py
@@ -198,6 +198,7 @@ async def _billing_run_database():
             "372_commercial_billing_candidate_approvals.sql",
             "380_commercial_billing_candidate_review_decisions.sql",
             "381_commercial_billing_candidate_review_decisions_recovery.sql",
+            "382_commercial_billing_candidate_overrides.sql",
         ):
             await conn.execute((migrations / name).read_text(encoding="utf-8"))
         yield conn, schema, database_url
@@ -351,6 +352,43 @@ def _service(pool, candidate_service: _CandidateService) -> CommercialBillingRun
     return CommercialBillingRunService(
         pool=pool,
         candidate_service_loader=lambda: candidate_service,
+    )
+
+
+async def _insert_legacy_run_candidate(
+    conn,
+    *,
+    run_id: UUID,
+    candidate: dict,
+    idempotency_key: str,
+) -> None:
+    """Seed a pre-382 run without asking current provider code to serve it."""
+
+    fingerprint = candidate["sourceFingerprint"]
+    await conn.execute(
+        """
+        INSERT INTO commercial_billing_runs (
+            id, billing_period, state, candidate_contract_version,
+            snapshot_fingerprint, source, idempotency_key,
+            request_fingerprint, created_by
+        ) VALUES ($1, '2026-03', 'draft', 2, $2, 'eom_admin', $3, $2, 'Migration recovery test')
+        """,
+        run_id,
+        fingerprint,
+        idempotency_key,
+    )
+    await conn.execute(
+        """
+        INSERT INTO commercial_billing_run_candidates (
+            id, billing_run_id, candidate_key, source_fingerprint,
+            display_order, snapshot
+        ) VALUES ($1, $2, $3, $4, 0, $5::jsonb)
+        """,
+        uuid4(),
+        run_id,
+        candidate["candidateKey"],
+        fingerprint,
+        json.dumps(candidate),
     )
 
 
@@ -727,6 +765,59 @@ async def test_real_postgres_review_decisions_are_append_only_idempotent_and_der
             )
             == before_updated_at
         )
+
+
+@pytest.mark.asyncio
+async def test_real_postgres_review_idempotency_canonicalizes_no_override_identity_variants():
+    """Omitted and explicit legacy identities are the same retry request."""
+
+    async with _billing_run_database() as (conn, schema, _database_url):
+        candidate = _candidate(
+            "commercial-billing:review-idempotency:2026-03", _fingerprint("a")
+        )
+        service = _service(_SchemaPool(conn, schema), _CandidateService(_preview(candidate)))
+        created_run = await service.create_run(
+            billing_period="2026-03",
+            idempotency_key="billing-run-review-idempotency-1",
+            actor="Juan Canfield",
+        )
+        run_id = UUID(created_run["billingRun"]["id"])
+        source_fingerprint = candidate["sourceFingerprint"]
+
+        for index, (first_identity, retry_identity, decision) in enumerate(
+            (
+                (None, source_fingerprint, "excluded"),
+                (source_fingerprint, None, "included"),
+            ),
+            start=1,
+        ):
+            created = await service.set_candidate_review_decision(
+                billing_run_id=run_id,
+                candidate_key=candidate["candidateKey"],
+                expected_source_fingerprint=source_fingerprint,
+                expected_review_fingerprint=first_identity,
+                decision=decision,
+                reason=f"Canonical retry identity case {index}.",
+                idempotency_key=f"review-identity-{index}",
+                actor="Juan Canfield",
+            )
+            replayed = await service.set_candidate_review_decision(
+                billing_run_id=run_id,
+                candidate_key=candidate["candidateKey"],
+                expected_source_fingerprint=source_fingerprint,
+                expected_review_fingerprint=retry_identity,
+                decision=decision,
+                reason=f"Canonical retry identity case {index}.",
+                idempotency_key=f"review-identity-{index}",
+                actor="Juan Canfield",
+            )
+
+            assert created["replayed"] is False
+            assert replayed == {**created, "replayed": True}
+
+        assert await conn.fetchval(
+            "SELECT COUNT(*) FROM commercial_billing_candidate_review_decisions"
+        ) == 2
 
 
 @pytest.mark.asyncio
@@ -1128,6 +1219,7 @@ class _RouteRunService:
     def __init__(self) -> None:
         self.create_calls: list[tuple[str, str, str]] = []
         self.decision_calls: list[dict] = []
+        self.override_calls: list[dict] = []
         self.get_calls: list[UUID] = []
         self.reconcile_calls: list[UUID] = []
 
@@ -1153,6 +1245,14 @@ class _RouteRunService:
                 "id": "review-decision-1",
                 "isExplicit": True,
             },
+            "replayed": False,
+        }
+
+    async def set_candidate_override(self, **kwargs):
+        self.override_calls.append(kwargs)
+        return {
+            "candidate": {"reviewFingerprint": _fingerprint("b")},
+            "override": {"revision": 1},
             "replayed": False,
         }
 
@@ -1311,6 +1411,110 @@ async def test_review_decision_route_requires_auth_actor_shape_and_idempotency()
             "decision": "excluded",
             "reason": "Resolve a customer question before approval.",
             "idempotency_key": "route-1",
+            "actor": "Juan Canfield",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_candidate_override_route_bounds_the_operator_edit_surface_and_actor_audit():
+    service = _RouteRunService()
+    app, token = _route_app(service)
+    run_id = "00000000-0000-0000-0000-000000000001"
+    candidate_key = "commercial-billing:acme:2026-03"
+    path = (
+        f"/receivables/commercial-billing-runs/{run_id}/candidates/"
+        f"{candidate_key}/override"
+    )
+    line_key = _fingerprint("c")
+    body = {
+        "expected_source_fingerprint": _fingerprint("a"),
+        "expected_override_revision": 0,
+        "reason_code": "one_time_service_variation",
+        "reason": "The customer asked for 75 minutes after hours.",
+        "line_overrides": [
+            {
+                "line_key": line_key,
+                "description": "After-hours cleaning",
+                "rate_cents": 4825,
+                "quantity_minutes": 75,
+            }
+        ],
+        "adjustment": {
+            "kind": "charge",
+            "description": "One-time access fee",
+            "amount_cents": 17,
+        },
+        "recipient": {"display_name": "Acme AP", "email": "billing@example.test"},
+        "delivery_method": "gmail_pdf",
+    }
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Idempotency-Key": "override-route-1",
+        "X-EOM-Actor": "Juan Canfield",
+    }
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://receivables.test",
+    ) as client:
+        assert (await client.post(path, json=body)).status_code == 401
+        assert service.override_calls == []
+        assert (
+            await client.post(
+                path,
+                json=body,
+                headers={"Authorization": f"Bearer {token}", "Idempotency-Key": "override-route-1"},
+            )
+        ).status_code == 422
+        assert service.override_calls == []
+        assert (
+            await client.post(
+                path,
+                json={**body, "source_date": "2026-03-04"},
+                headers=headers,
+            )
+        ).status_code == 422
+        assert service.override_calls == []
+        assert (
+            await client.post(
+                path,
+                json={
+                    **body,
+                    "line_overrides": [{"line_key": line_key, "quantity_minutes": 75.0}],
+                },
+                headers=headers,
+            )
+        ).status_code == 422
+        assert service.override_calls == []
+        accepted = await client.post(path, json=body, headers=headers)
+
+    assert accepted.status_code == 201
+    assert accepted.json()["override"] == {"revision": 1}
+    assert service.override_calls == [
+        {
+            "billing_run_id": UUID(run_id),
+            "candidate_key": candidate_key,
+            "expected_source_fingerprint": _fingerprint("a"),
+            "expected_override_revision": 0,
+            "reason_code": "one_time_service_variation",
+            "reason": "The customer asked for 75 minutes after hours.",
+            "line_overrides": [
+                {
+                    "lineKey": line_key,
+                    "description": "After-hours cleaning",
+                    "rateCents": 4825,
+                    "quantityMinutes": 75,
+                }
+            ],
+            "adjustment": {
+                "kind": "charge",
+                "description": "One-time access fee",
+                "amountCents": 17,
+            },
+            "recipient": {"displayName": "Acme AP", "email": "billing@example.test"},
+            "delivery_method": "gmail_pdf",
+            "idempotency_key": "override-route-1",
             "actor": "Juan Canfield",
         }
     ]
@@ -1938,22 +2142,31 @@ async def test_current_380_schema_runs_pending_381_once_without_rewriting_catalo
         ] == expected_ledger[:-1]
 
         candidate = _candidate("commercial-billing:current-380:2026-03", _fingerprint("a"))
-        service = _service(_SchemaPool(conn, schema), _CandidateService(_preview(candidate)))
-        created = await service.create_run(
-            billing_period="2026-03",
+        run_id = uuid4()
+        await _insert_legacy_run_candidate(
+            conn,
+            run_id=run_id,
+            candidate=candidate,
             idempotency_key="billing-run-current-380-pending-381",
-            actor="Migration recovery test",
         )
-        recorded = await service.set_candidate_review_decision(
-            billing_run_id=UUID(created["billingRun"]["id"]),
-            candidate_key=candidate["candidateKey"],
-            expected_source_fingerprint=candidate["sourceFingerprint"],
-            decision="included",
-            reason="Preserve the current-schema review decision during recovery.",
-            idempotency_key="current-380-pending-381-decision",
-            actor="Migration recovery test",
+        decision_id = uuid4()
+        await conn.execute(
+            """
+            INSERT INTO commercial_billing_candidate_review_decisions (
+                id, billing_run_id, candidate_key, source_fingerprint,
+                revision, decision, reason, source, idempotency_key,
+                request_fingerprint, decided_by
+            ) VALUES ($1, $2, $3, $4, 1, 'included', $5, 'eom_admin', $6, $7,
+                      'Migration recovery test')
+            """,
+            decision_id,
+            run_id,
+            candidate["candidateKey"],
+            candidate["sourceFingerprint"],
+            "Preserve the current-schema review decision during recovery.",
+            "current-380-pending-381-decision",
+            _fingerprint("c"),
         )
-        decision_id = UUID(recorded["reviewDecision"]["id"])
         history_before = dict(
             await conn.fetchrow(
                 """
@@ -2073,22 +2286,31 @@ async def test_recorded_380_recovery_restores_review_decision_enforcement():
         ) is False
 
         candidate = _candidate("commercial-billing:recovery:2026-03", _fingerprint("a"))
-        service = _service(_SchemaPool(conn, schema), _CandidateService(_preview(candidate)))
-        created = await service.create_run(
-            billing_period="2026-03",
+        run_id = uuid4()
+        await _insert_legacy_run_candidate(
+            conn,
+            run_id=run_id,
+            candidate=candidate,
             idempotency_key="billing-run-recorded-380-recovery",
-            actor="Migration recovery test",
         )
-        legacy_recorded = await service.set_candidate_review_decision(
-            billing_run_id=UUID(created["billingRun"]["id"]),
-            candidate_key=candidate["candidateKey"],
-            expected_source_fingerprint=candidate["sourceFingerprint"],
-            decision="included",
-            reason="Preserve the legacy review decision during recovery.",
-            idempotency_key="legacy-review-1",
-            actor="Migration recovery test",
+        legacy_decision_id = uuid4()
+        await conn.execute(
+            """
+            INSERT INTO commercial_billing_candidate_review_decisions (
+                id, billing_run_id, candidate_key, source_fingerprint,
+                revision, decision, reason, source, idempotency_key,
+                request_fingerprint, decided_by
+            ) VALUES ($1, $2, $3, $4, 1, 'included', $5, 'eom_admin', $6, $7,
+                      'Migration recovery test')
+            """,
+            legacy_decision_id,
+            run_id,
+            candidate["candidateKey"],
+            candidate["sourceFingerprint"],
+            "Preserve the legacy review decision during recovery.",
+            "legacy-review-1",
+            _fingerprint("c"),
         )
-        legacy_decision_id = UUID(legacy_recorded["reviewDecision"]["id"])
         legacy_history_before = await conn.fetchrow(
             """
             SELECT id, billing_run_id, candidate_key, source_fingerprint, revision,
@@ -2178,8 +2400,14 @@ async def test_recorded_380_recovery_restores_review_decision_enforcement():
             ),
         }
 
+        await run_migrations(
+            pool,
+            migrations_dir=migrations_dir,
+            only={"382_commercial_billing_candidate_overrides"},
+        )
+        service = _service(_SchemaPool(conn, schema), _CandidateService(_preview(candidate)))
         recorded = await service.set_candidate_review_decision(
-            billing_run_id=UUID(created["billingRun"]["id"]),
+            billing_run_id=run_id,
             candidate_key=candidate["candidateKey"],
             expected_source_fingerprint=candidate["sourceFingerprint"],
             decision="excluded",
@@ -2212,6 +2440,7 @@ async def test_recorded_380_recovery_restores_review_decision_enforcement():
                 json.dumps(
                     {
                         "candidateKey": candidate["candidateKey"],
+                        "commercialBillingRunId": str(run_id),
                         "sourceFingerprint": candidate["sourceFingerprint"],
                     }
                 ),
@@ -2273,20 +2502,20 @@ async def test_recorded_380_recovery_rejects_ambiguous_global_revision_history()
         )
         pool, migrations_dir = await _recorded_380_legacy_schema(conn, schema)
         candidate = _candidate("commercial-billing:conflict:2026-03", _fingerprint("b"))
-        service = _service(_SchemaPool(conn, schema), _CandidateService(_preview(candidate)))
-        first = await service.create_run(
-            billing_period="2026-03",
-            idempotency_key="billing-run-recorded-380-conflict-1",
-            actor="Migration recovery test",
-        )
-        second = await service.create_run(
-            billing_period="2026-03",
-            idempotency_key="billing-run-recorded-380-conflict-2",
-            actor="Migration recovery test",
-        )
-        for run, key, fingerprint in (
-            (first, "recorded-380-conflict-decision-1", _fingerprint("c")),
-            (second, "recorded-380-conflict-decision-2", _fingerprint("d")),
+        first_run_id, second_run_id = uuid4(), uuid4()
+        for run_id, key in (
+            (first_run_id, "billing-run-recorded-380-conflict-1"),
+            (second_run_id, "billing-run-recorded-380-conflict-2"),
+        ):
+            await _insert_legacy_run_candidate(
+                conn,
+                run_id=run_id,
+                candidate=candidate,
+                idempotency_key=key,
+            )
+        for run_id, key, fingerprint in (
+            (first_run_id, "recorded-380-conflict-decision-1", _fingerprint("c")),
+            (second_run_id, "recorded-380-conflict-decision-2", _fingerprint("d")),
         ):
             await conn.execute(
                 """
@@ -2299,7 +2528,7 @@ async def test_recorded_380_recovery_rejects_ambiguous_global_revision_history()
                           $6, 'Migration recovery test')
                 """,
                 uuid4(),
-                UUID(run["billingRun"]["id"]),
+                run_id,
                 candidate["candidateKey"],
                 candidate["sourceFingerprint"],
                 key,
@@ -2406,10 +2635,14 @@ def test_invoicing_workflow_enrolls_billing_run_contract_for_pr_and_main_push():
 
     for path in (
         "atlas_brain/services/commercial_billing_runs.py",
+        "atlas_brain/services/commercial_billing_candidate_overrides.py",
         "atlas_brain/storage/migrations/370_commercial_billing_runs.sql",
         "atlas_brain/storage/migrations/380_commercial_billing_candidate_review_decisions.sql",
         "atlas_brain/storage/migrations/381_commercial_billing_candidate_review_decisions_recovery.sql",
+        "atlas_brain/storage/migrations/382_commercial_billing_candidate_overrides.sql",
         "tests/test_commercial_billing_runs.py",
+        "tests/test_commercial_billing_candidate_overrides.py",
     ):
         assert workflow.count(f'      - "{path}"') == 2
     assert "tests/test_commercial_billing_runs.py \\" in workflow
+    assert "tests/test_commercial_billing_candidate_overrides.py \\" in workflow


### PR DESCRIPTION
Plan: plans/PR-EOM-Commercial-Billing-Candidate-Overrides.md
Slice phase: Vertical slice
Ownership lane: eom-commercial-billing/candidate-overrides

Commercial billing candidates currently preserve source evidence but cannot safely carry a one-time rate, quantity, adjustment, recipient, or delivery exception into approval: direct edits would rewrite retained evidence and a prior Include could approve different money. This provider-only slice adds an immutable effective-candidate revision with its own review identity, preserves existing no-override consumers, and has no invoice, PDF, Gmail, Square, email, or sent-state side effect until the already-separate explicit approval operation.

## Intentional

- Source service/rate/calendar corrections remain canonical-data work; an override is a one-run exception and cannot carry forward.
- Existing unoverridden review/approval callers remain backward-compatible. An overridden candidate alone must receive a fresh explicit Include for its active review fingerprint.
- One signed credit/charge and inherited tax are deliberately narrower than an arbitrary invoice-line editor.
- guard-class-closure: waived — the strict heuristic matches changed `_validate_*` functions, but this slice admits only closed policy/format sets and typed projection fields; it adds no open-input classifier or permissive fallback. The plan's Guard class-closure declaration names the canonical sets and reject-on-out-of-set behavior.

## AI reconciliation

- AI findings reviewed: Yes
- All fixed or waived: Yes
- Scope active overrides to the invoice's run -- fixed-in: `932a7158e` / `atlas_brain/services/commercial_billing_candidate_overrides.py`, `atlas_brain/services/commercial_billing_approvals.py`, `atlas_brain/storage/migrations/382_commercial_billing_candidate_overrides.sql`, and `tests/test_commercial_billing_approvals.py`.
- Canonicalize the default review identity before hashing -- fixed-in: `932a7158e` / `atlas_brain/services/commercial_billing_runs.py` and `tests/test_commercial_billing_runs.py`.
- Preserve exact cents through hourly invoice edits -- fixed-in: `932a7158e` / `atlas_brain/storage/repositories/invoice.py` and `tests/test_commercial_billing_approvals.py`.
- Align override descriptions with the invoice limit -- fixed-in: `932a7158e` / `atlas_brain/services/commercial_billing_candidate_overrides.py`, `atlas_brain/services/commercial_billing_approvals.py`, and `tests/test_commercial_billing_candidate_overrides.py`.
- Validate override recipients with the delivery grammar -- fixed-in: `932a7158e` / `atlas_brain/services/commercial_billing_candidate_overrides.py`, `atlas_brain/services/eom_crm_mutations.py`, and `tests/test_commercial_billing_candidate_overrides.py`.
- Re-add the Gmail recipient blocker after delivery changes -- fixed-in: `932a7158e` / `atlas_brain/services/commercial_billing_candidate_overrides.py` and `tests/test_commercial_billing_candidate_overrides.py`.
- Limit recorded-amount trust to exact-cent invoices -- fixed-in: `932a7158e` / `atlas_brain/storage/repositories/invoice.py`, `atlas_brain/services/commercial_billing_approvals.py`, and `tests/test_commercial_billing_approvals.py`.
- Preserve invalid-rate blockers without a repaired source line -- fixed-in: `932a7158e` / `atlas_brain/services/commercial_billing_candidate_overrides.py` and `tests/test_commercial_billing_candidate_overrides.py`.
- Define the concurrency invariant beyond sampled tests -- fixed-in: `932a7158e` / `plans/PR-EOM-Commercial-Billing-Candidate-Overrides.md` and `tests/test_commercial_billing_approvals.py`.

## Fix-loop disposition preflight

- Root decision: Scope active overrides to the invoice's run
- Source trace: review report -> final-invoice trigger global active-override lookup -> retained-run effective-review identity
- Upstream files: atlas_brain/services/commercial_billing_candidate_overrides.py, atlas_brain/services/commercial_billing_approvals.py, atlas_brain/storage/migrations/382_commercial_billing_candidate_overrides.sql
- Fix strategy: upstream-root
- Blocking predicate: money
- Disposition: fixed-in
- Allowed files: .github/workflows/atlas_invoicing_checks.yml, atlas_brain/api/invoicing/receivables.py, atlas_brain/main.py, atlas_brain/services/commercial_billing_approvals.py, atlas_brain/services/commercial_billing_candidate_overrides.py, atlas_brain/storage/migrations/382_commercial_billing_candidate_overrides.sql, plans/PR-EOM-Commercial-Billing-Candidate-Overrides.md, tests/test_commercial_billing_approvals.py, tests/test_commercial_billing_candidate_overrides.py
- Max files: 12
- Parked hardening: #2363
- Root decision: Canonicalize the default review identity before hashing
- Source trace: review report -> review-decision request fingerprint -> idempotency replay comparison
- Upstream files: atlas_brain/services/commercial_billing_runs.py
- Fix strategy: upstream-root
- Blocking predicate: back-compat
- Disposition: fixed-in
- Allowed files: atlas_brain/services/commercial_billing_runs.py, tests/test_commercial_billing_runs.py
- Max files: 12
- Parked hardening: #2363
- Root decision: Preserve exact cents through hourly invoice edits
- Source trace: review report -> generic draft invoice update -> committed line amount subtotal
- Upstream files: atlas_brain/storage/repositories/invoice.py
- Fix strategy: upstream-root
- Blocking predicate: money
- Disposition: fixed-in
- Allowed files: atlas_brain/storage/repositories/invoice.py
- Max files: 12
- Parked hardening: #2363
- Root decision: Align override descriptions with the invoice limit
- Source trace: review report -> override description admission -> invoice draft line-description validation
- Upstream files: atlas_brain/services/commercial_billing_candidate_overrides.py, atlas_brain/services/commercial_billing_approvals.py
- Fix strategy: upstream-root
- Blocking predicate: money
- Disposition: fixed-in
- Allowed files: atlas_brain/services/commercial_billing_candidate_overrides.py, atlas_brain/services/commercial_billing_approvals.py, tests/test_commercial_billing_candidate_overrides.py
- Max files: 12
- Parked hardening: #2363
- Root decision: Validate override recipients with the delivery grammar
- Source trace: review report -> override recipient and blocker admission -> Gmail draft canonical recipient validation
- Upstream files: atlas_brain/services/commercial_billing_candidate_overrides.py
- Fix strategy: upstream-root
- Blocking predicate: money
- Disposition: fixed-in
- Allowed files: atlas_brain/services/commercial_billing_candidate_overrides.py, tests/test_commercial_billing_candidate_overrides.py
- Max files: 12
- Parked hardening: #2363
- Root decision: Re-add the Gmail recipient blocker after delivery changes
- Source trace: review report -> effective delivery-method projection -> candidate blocker derivation before approval
- Upstream files: atlas_brain/services/commercial_billing_candidate_overrides.py
- Fix strategy: upstream-root
- Blocking predicate: money
- Disposition: fixed-in
- Allowed files: atlas_brain/services/commercial_billing_candidate_overrides.py, tests/test_commercial_billing_candidate_overrides.py
- Max files: 12
- Parked hardening: #2363
- Root decision: Limit recorded-amount trust to exact-cent invoices
- Source trace: review report -> notes-only generic invoice update -> caller-supplied line amount versus approved commercial exact-cent evidence
- Upstream files: atlas_brain/storage/repositories/invoice.py, atlas_brain/services/commercial_billing_approvals.py
- Fix strategy: upstream-root
- Blocking predicate: money
- Disposition: fixed-in
- Allowed files: atlas_brain/storage/repositories/invoice.py, atlas_brain/services/commercial_billing_approvals.py, plans/PR-EOM-Commercial-Billing-Candidate-Overrides.md, tests/test_commercial_billing_approvals.py
- Max files: 12
- Parked hardening: #2363
- Root decision: Preserve invalid-rate blockers without a repaired source line
- Source trace: review report -> effective candidate blocker projection -> service-level invalid-rate evidence omitted by the canonical producer
- Upstream files: atlas_brain/services/commercial_billing_candidate_overrides.py
- Fix strategy: upstream-root
- Blocking predicate: money
- Disposition: fixed-in
- Allowed files: atlas_brain/services/commercial_billing_candidate_overrides.py, plans/PR-EOM-Commercial-Billing-Candidate-Overrides.md, tests/test_commercial_billing_candidate_overrides.py
- Max files: 12
- Parked hardening: #2363
- Root decision: Define the concurrency invariant beyond sampled tests
- Source trace: review report -> review contract -> PostgreSQL transaction, operation-key, candidate-lock, and rollback model
- Upstream files: plans/PR-EOM-Commercial-Billing-Candidate-Overrides.md, tests/test_commercial_billing_approvals.py
- Fix strategy: upstream-root
- Blocking predicate: money
- Disposition: fixed-in
- Allowed files: plans/PR-EOM-Commercial-Billing-Candidate-Overrides.md, tests/test_commercial_billing_approvals.py
- Max files: 12
- Parked hardening: #2363

## Deferred

- Add the eom-timetracker proxy only after this provider version is merged and deployed; add Website review/edit controls only after the proxy deploys.
- Canonical source-data edits, multi-line adjustments, and UX/polish remain outside this provider contract; the current hardening/deferred tracker is #2363.

## Parked hardening

- None. No newly discovered item meets this slice's provider money/audit correctness boundary.

## Cold diff reconstruction

- Changed: `atlas_brain/services/commercial_billing_candidate_overrides.py:219-485` admits only source-line description/rate/quantity changes, whole-minute hourly quantities, one signed adjustment, recipient/delivery changes, and exact-cent recomputation; it never mutates the source snapshot.
- Changed: `atlas_brain/services/commercial_billing_candidate_overrides.py:546-567`, `atlas_brain/services/commercial_billing_runs.py:656-707,735-830,1212-1271`, and `atlas_brain/services/commercial_billing_approvals.py:526-595,691-733` bind the effective override identity to its retained run everywhere it is produced, read, and revalidated.
- Changed: `atlas_brain/services/commercial_billing_runs.py:741-775` canonicalizes omitted legacy review identity before the idempotency hash while retaining the field-less legacy request hash for already-recorded retries.
- Changed: `atlas_brain/storage/migrations/382_commercial_billing_candidate_overrides.sql:181-253` requires and validates invoice `commercialBillingRunId`, proves its candidate belongs to that run, and scopes the active-override lookup to that run before it admits an invoice.
- Changed: `atlas_brain/storage/repositories/invoice.py:21-114,408-416` treats recorded line amounts as authoritative only when the controlled commercial approval writer marked exact-cent evidence; generic/MCP caller amounts and non-cent values recalculate from quantity and unit price on notes/due-date-only edits.
- Changed: `atlas_brain/services/commercial_billing_approvals.py:418-426` writes that exact-cent marker only with the already-validated commercial approval metadata.
- Changed: `atlas_brain/services/commercial_billing_candidate_overrides.py:17-36,265-345,441-457` reuses the canonical contact-email normalizer for new Gmail recipients and blocker clearance, and shares the 256-character invoice-line description limit with line/adjustment override admission.
- Changed: `atlas_brain/services/commercial_billing_approvals.py:35-40,292-302` consumes that shared description limit when it constructs the final invoice draft.
- Changed: `tests/test_commercial_billing_candidate_overrides.py:170-289` covers five over-limit description variants, the maximum downstream-approvable description, and eight distinct invalid Gmail-recipient forms.
- Changed: `atlas_brain/services/commercial_billing_candidate_overrides.py:348-358,441-480` derives and appends the canonical missing-email blocker when the effective delivery method is Gmail but its recipient is absent or invalid, preserving the normal derived zero-total blocker.
- Changed: `tests/test_commercial_billing_candidate_overrides.py:302-367` covers six manual-Square, receipt-only, missing-preference, and malformed-retained-recipient transitions to Gmail.
- Changed: `atlas_brain/services/commercial_billing_candidate_overrides.py:359-389,473-513` clears `invalid_rate` only when every targetable invalid source line for that service has an explicit valid rate override; an omitted producer line remains blocked despite valid sibling lines or an adjustment.
- Changed: `tests/test_commercial_billing_candidate_overrides.py:367-419` proves an adjustment cannot make an omitted unpriced service approval-eligible; `tests/test_commercial_billing_approvals.py:775-965,1137-1210` proves same-key real-Postgres override serialization and trusted-versus-untrusted notes-only amount behavior.
- Changed: `plans/PR-EOM-Commercial-Billing-Candidate-Overrides.md:99-141,238-282` names the complete transaction/lock interleaving invariant and maps same-key contention, candidate serialization, stale/retry, and rollback tests to it.
- Changed: `atlas_brain/api/invoicing/receivables.py:238-1050`, `atlas_brain/main.py:47-49`, and `.github/workflows/atlas_invoicing_checks.yml:31-226` expose strict authenticated admission, fence startup on migration 382, and enroll the route/migration/tests in the local/hosted invoicing test path.
- Contract match: the diff satisfies the plan's immutable-audit, trusted exact-money, fresh-Include, stale/retry, run-isolation, mixed-version, downstream-admission, invalid-rate, concurrency, and effective-delivery parity requirements; real-PostgreSQL and parametrized regression tests exercise those boundaries.
- Gaps: none found. No canonical customer/service/rate/calendar record, legacy source fingerprint, customer-facing PDF/email, Gmail send path, tracker ledger, or financial delivery state is changed.

## Verification

- Isolated local PostgreSQL: 191 override/run/approval tests passed, with one known warning.
- Complete local receivables workflow equivalent: 726 tests passed, with one known warning, across payment/receipt, candidate/run/approval, Gmail/Square, repository/PDF, and canonical recipient grammar.
- Existing workflow blockers passed 2 tests (41 deselected); MCP/OAuth draft/read-only surfaces passed 43 tests.
- Changed Python compiled; Ruff, new-file Black, workflow YAML parsing, and `git diff --check` passed.

## Mechanical verification

- Command: `ATLAS_RECEIVABLES_TEST_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:32774/atlas_receivables_test python -m pytest tests/test_commercial_billing_candidate_overrides.py tests/test_commercial_billing_runs.py tests/test_commercial_billing_approvals.py -q --disable-warnings --tb=short` - Result: 191 passed. 1 warning. - Environment: local
- Command: `ATLAS_RECEIVABLES_TEST_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:32774/atlas_receivables_test python -m pytest tests/test_eom_render_profile.py tests/test_receivables.py tests/test_eom_billing_recipients.py tests/test_eom_payment_receipts.py tests/test_residential_payment_receipt_delivery.py tests/test_commercial_billing_candidates.py tests/test_commercial_billing_candidate_overrides.py tests/test_commercial_billing_runs.py tests/test_commercial_billing_approvals.py tests/test_commercial_billing_gmail_drafts.py tests/test_commercial_billing_manual_square_invoices.py tests/test_invoice_repository.py tests/test_invoice_pdf.py -q --disable-warnings --tb=short` - Result: 726 passed. 1 warning. - Environment: local
- Command: `ATLAS_RECEIVABLES_TEST_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:32774/atlas_receivables_test python -m pytest tests/test_monthly_invoice_generation.py -k "update_invoice_clears_needs_hours_when_line_items_are_billable or line_items_are_billable_requires_all_positive_quantities" -q --disable-warnings --tb=short` - Result: 2 passed. 41 deselected. - Environment: local
- Command: `ATLAS_RECEIVABLES_TEST_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:32774/atlas_receivables_test python -m pytest tests/test_invoicing_readonly_mcp.py tests/test_invoicing_readonly_oauth.py tests/test_invoicing_draft_writer_mcp.py tests/test_invoicing_draft_writer_oauth.py -q --disable-warnings --tb=short` - Result: 43 passed - Environment: local
- Command: `git diff --check origin/main...HEAD && python -m py_compile atlas_brain/api/invoicing/receivables.py atlas_brain/main.py atlas_brain/services/commercial_billing_runs.py atlas_brain/services/commercial_billing_approvals.py atlas_brain/services/commercial_billing_candidate_overrides.py atlas_brain/storage/repositories/invoice.py tests/test_commercial_billing_runs.py tests/test_commercial_billing_approvals.py tests/test_commercial_billing_candidate_overrides.py && ruff check atlas_brain/api/invoicing/receivables.py atlas_brain/services/commercial_billing_runs.py atlas_brain/services/commercial_billing_approvals.py atlas_brain/services/commercial_billing_candidate_overrides.py atlas_brain/storage/repositories/invoice.py tests/test_commercial_billing_runs.py tests/test_commercial_billing_approvals.py tests/test_commercial_billing_candidate_overrides.py && ruff check --ignore E402 atlas_brain/main.py && black --check atlas_brain/services/commercial_billing_candidate_overrides.py tests/test_commercial_billing_candidate_overrides.py && python -c "import yaml; yaml.compose(open('.github/workflows/atlas_invoicing_checks.yml', encoding='utf-8').read())"` - Result: passed - Environment: local

## Diff size

- 12 files, +3845 / -128.
- Diff-budget override: The migration, exact-cent effective projection, strict route, current-review approval fence, and real-PostgreSQL recovery proof form one financial invariant; splitting them would leave an interval where legacy review identity could approve changed candidate evidence.

<!-- atlas-open-pr-wrapper: v1 -->
