### PR TITLE
EOM: hydrate durable commercial billing approvals

### DIFF
--- a/atlas_brain/services/commercial_billing_runs.py
+++ b/atlas_brain/services/commercial_billing_runs.py
@@ -12,7 +12,7 @@ import hashlib
 import json
 import re
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from typing import Any, Callable, Mapping, Optional
 from uuid import UUID, uuid4
 
@@ -38,9 +38,11 @@ from .commercial_billing_candidate_overrides import (
     fingerprint as _override_fingerprint,
     override_review_fingerprint,
 )
+from .eom_lead_ingress import EOM_BUSINESS_CONTEXT_ID
 
 
 _RUN_SOURCE = "eom_admin"
+_INVOICE_SOURCE = "eom_commercial_billing"
 _MAX_IDEMPOTENCY_KEY_LENGTH = 128
 _MAX_CANDIDATE_KEY_LENGTH = 512
 _MAX_CANDIDATES = 500
@@ -252,6 +254,98 @@ def _override_view(row: Any | None) -> dict[str, Any] | None:
         "revision": _row_value(row, "revision"),
         "overriddenAt": _timestamp(_row_value(row, "overridden_at")),
         "overriddenBy": _row_value(row, "overridden_by"),
+    }
+
+
+def _stored_text(row: Any, key: str, field: str, *, limit: int) -> str:
+    value = _row_value(row, key)
+    if not isinstance(value, str) or not value or value != value.strip() or len(value) > limit:
+        raise CommercialBillingRunUnavailableError(
+            f"Commercial billing {field} evidence is invalid"
+        )
+    return value
+
+
+def _stored_uuid(row: Any, key: str, field: str) -> UUID:
+    value = _row_value(row, key)
+    if not isinstance(value, UUID):
+        raise CommercialBillingRunUnavailableError(
+            f"Commercial billing {field} evidence is invalid"
+        )
+    return value
+
+
+def _stored_fingerprint(row: Any, key: str, field: str) -> str:
+    value = _row_value(row, key)
+    if not isinstance(value, str) or _FINGERPRINT_PATTERN.fullmatch(value) is None:
+        raise CommercialBillingRunUnavailableError(
+            f"Commercial billing {field} evidence is invalid"
+        )
+    return value
+
+
+def _approval_view(row: Any | None) -> dict[str, Any] | None:
+    """Project durable approval evidence only when its linked invoice is canonical."""
+
+    if row is None or _row_value(row, "approval_id") is None:
+        return None
+    approval_id = _stored_uuid(row, "approval_id", "approval id")
+    billing_run_id = _stored_uuid(row, "approval_billing_run_id", "approval run id")
+    invoice_id = _stored_uuid(row, "approval_invoice_id", "approval invoice id")
+    approved_at = _row_value(row, "approval_approved_at")
+    issue_date = _row_value(row, "invoice_issue_date")
+    due_date = _row_value(row, "invoice_due_date")
+    total_cents = _row_value(row, "invoice_total_cents")
+    if not isinstance(approved_at, datetime):
+        raise CommercialBillingRunUnavailableError(
+            "Commercial billing approval timestamp evidence is invalid"
+        )
+    if not isinstance(issue_date, date) or not isinstance(due_date, date):
+        raise CommercialBillingRunUnavailableError(
+            "Commercial billing approval invoice date evidence is invalid"
+        )
+    if isinstance(total_cents, bool) or not isinstance(total_cents, int) or total_cents <= 0:
+        raise CommercialBillingRunUnavailableError(
+            "Commercial billing approval invoice amount evidence is invalid"
+        )
+    if _stored_text(row, "approval_state", "approval state", limit=32) != "invoice_created":
+        raise CommercialBillingRunUnavailableError(
+            "Commercial billing approval state evidence is invalid"
+        )
+    if _stored_text(row, "approval_source", "approval source", limit=32) != _RUN_SOURCE:
+        raise CommercialBillingRunUnavailableError(
+            "Commercial billing approval source evidence is invalid"
+        )
+    if _stored_text(row, "invoice_source", "invoice source", limit=64) != _INVOICE_SOURCE:
+        raise CommercialBillingRunUnavailableError(
+            "Commercial billing approval invoice source evidence is invalid"
+        )
+    if _stored_text(row, "invoice_business_context_id", "invoice context", limit=128) != EOM_BUSINESS_CONTEXT_ID:
+        raise CommercialBillingRunUnavailableError(
+            "Commercial billing approval invoice context evidence is invalid"
+        )
+    return {
+        "approvedAt": approved_at.isoformat(),
+        "approvedBy": _stored_text(row, "approval_approved_by", "approval actor", limit=128),
+        "billingRunId": str(billing_run_id),
+        "candidateKey": _stored_text(row, "approval_candidate_key", "approval candidate", limit=_MAX_CANDIDATE_KEY_LENGTH),
+        "id": str(approval_id),
+        "invoice": {
+            "dueDate": due_date.isoformat(),
+            "id": str(invoice_id),
+            "invoiceNumber": _stored_text(row, "invoice_number", "invoice number", limit=64),
+            "issueDate": issue_date.isoformat(),
+            "sourceRef": _stored_text(row, "invoice_source_ref", "invoice source reference", limit=256),
+            "status": _stored_text(row, "invoice_status", "invoice status", limit=32),
+            "totalCents": total_cents,
+        },
+        "reviewFingerprint": _stored_fingerprint(
+            row, "approval_review_fingerprint", "approval review fingerprint"
+        ),
+        "sourceFingerprint": _stored_fingerprint(
+            row, "approval_source_fingerprint", "approval source fingerprint"
+        ),
+        "state": "invoice_created",
     }
 
 
@@ -1313,7 +1407,25 @@ class CommercialBillingRunService:
                    override.request_fingerprint AS override_request_fingerprint,
                    override.overridden_by AS override_overridden_by,
                    override.overridden_at AS override_overridden_at,
-                   override.created_at AS override_created_at
+                   override.created_at AS override_created_at,
+                   approval.id AS approval_id,
+                   approval.billing_run_id AS approval_billing_run_id,
+                   approval.candidate_key AS approval_candidate_key,
+                   approval.source_fingerprint AS approval_source_fingerprint,
+                   approval.review_fingerprint AS approval_review_fingerprint,
+                   approval.invoice_id AS approval_invoice_id,
+                   approval.state AS approval_state,
+                   approval.source AS approval_source,
+                   approval.approved_by AS approval_approved_by,
+                   approval.approved_at AS approval_approved_at,
+                   invoice.invoice_number,
+                   invoice.status AS invoice_status,
+                   invoice.issue_date AS invoice_issue_date,
+                   invoice.due_date AS invoice_due_date,
+                   invoice.source_ref AS invoice_source_ref,
+                   invoice.source AS invoice_source,
+                   invoice.business_context_id AS invoice_business_context_id,
+                   ROUND(invoice.total_amount * 100)::BIGINT AS invoice_total_cents
             FROM commercial_billing_run_candidates AS candidate
             LEFT JOIN LATERAL (
                 SELECT id, revision, review_fingerprint, effective_snapshot,
@@ -1326,6 +1438,24 @@ class CommercialBillingRunService:
                 ORDER BY candidate_override.revision DESC
                 LIMIT 1
             ) AS override ON TRUE
+            LEFT JOIN LATERAL (
+                SELECT candidate_approval.id,
+                       candidate_approval.billing_run_id,
+                       candidate_approval.candidate_key,
+                       candidate_approval.source_fingerprint,
+                       candidate_approval.review_fingerprint,
+                       candidate_approval.invoice_id,
+                       candidate_approval.state,
+                       candidate_approval.source,
+                       candidate_approval.approved_by,
+                       candidate_approval.approved_at
+                FROM commercial_billing_candidate_approvals AS candidate_approval
+                WHERE candidate_approval.candidate_key = candidate.candidate_key
+                  AND candidate_approval.source_fingerprint = candidate.source_fingerprint
+                ORDER BY candidate_approval.approved_at DESC, candidate_approval.id DESC
+                LIMIT 1
+            ) AS approval ON TRUE
+            LEFT JOIN invoices AS invoice ON invoice.id = approval.invoice_id
             WHERE candidate.billing_run_id = $1
             ORDER BY candidate.display_order ASC, candidate.candidate_key ASC
             """,
@@ -1377,6 +1507,25 @@ class CommercialBillingRunService:
                 source_fingerprint=row_candidate["source_fingerprint"],
                 override=override,
             )
+            approval = _approval_view(row_candidate)
+            if approval is not None:
+                if approval["candidateKey"] != candidate["candidateKey"]:
+                    raise CommercialBillingRunUnavailableError(
+                        "Commercial billing approval candidate evidence is invalid"
+                    )
+                if approval["sourceFingerprint"] != candidate["sourceFingerprint"]:
+                    raise CommercialBillingRunUnavailableError(
+                        "Commercial billing approval source evidence is invalid"
+                    )
+                if approval["reviewFingerprint"] != candidate["reviewFingerprint"]:
+                    raise CommercialBillingRunUnavailableError(
+                        "Commercial billing approval review identity is stale"
+                    )
+                if approval["invoice"]["totalCents"] != candidate["totalCents"]:
+                    raise CommercialBillingRunUnavailableError(
+                        "Commercial billing approval invoice amount does not match review evidence"
+                    )
+            candidate["approval"] = approval
             candidate["reviewDecision"] = _review_decision_view(
                 latest_decision_by_candidate.get(
                     (

--- a/plans/PR-EOM-Commercial-Billing-Approval-Hydration.md
+++ b/plans/PR-EOM-Commercial-Billing-Approval-Hydration.md
@@ -1,0 +1,178 @@
+# PR-EOM-Commercial-Billing-Approval-Hydration
+
+## Why this slice exists
+
+Website PR #219's post-merge review found that reopening a saved commercial
+billing run clears the portal's page-local approval map.  The page can then
+offer a candidate adjustment even though ATLAS has already created the
+candidate's immutable draft invoice.  The user asked to address that thread in
+the EOM Billing & Payments lane.  ATLAS owns approvals and invoices, so the
+durable state must be exposed by the existing saved-run reader before the
+Website consumes it through the already-deployed tracker proxy.
+
+### Problem-derived contract
+
+- Root cause: `CommercialBillingRunService._run_view` returns source/effective
+  candidate evidence and review decisions but not the durable
+  `commercial_billing_candidate_approvals` record.  A browser reload therefore
+  has no ATLAS-owned evidence with which to distinguish an unapproved candidate
+  from an already-invoiced one.
+- Correct fix must touch/change: the saved-run reader must project one matching
+  durable approval and its linked invoice for the candidate's exact
+  candidate/source/review identity; the projection must also find an approval
+  that ATLAS idempotently reused from an equivalent run.  Contract tests must
+  prove the normal no-approval read, same-run approval read, equivalent-run
+  reuse, and a mismatched review identity failing closed.  A real authenticated
+  `/api/v1/receivables/commercial-billing-runs/{id}` read must expose the same
+  data without a financial or delivery write.
+- Must not change: no migration, approval/invoice writer, invoice lifecycle,
+  review/override writer, Gmail/Square behavior, customer-visible invoice/PDF
+  content, or tracker authentication is changed.  The existing saved-run JSON
+  remains compatible; `candidate.approval` is additive and may be `null`.
+
+## Scope (this PR)
+
+Ownership lane: eom-billing-payments
+Slice phase: Production hardening
+Max files: 4
+
+1. Add the read-only durable approval projection to each retained commercial
+   billing candidate returned by ATLAS.
+2. Preserve the projection's exact identity fence and linked invoice evidence,
+   including an equivalent-run idempotency reuse.
+3. Add service and full API-entrypoint regression proof.  The Website-side
+   validation/rendering repair remains the dependent follow-up PR.
+
+### Review Contract
+
+- Acceptance criteria:
+   - [ ] Every saved candidate has an additive `approval: null` when ATLAS has
+     no matching approval; settled by the real-Postgres service test in
+     `tests/test_commercial_billing_runs.py`.
+   - [ ] A matching durable approval projects its immutable approval identity
+     and linked invoice identity/amount into the saved candidate; settled by
+     the real-Postgres saved-run tests in
+     `tests/test_commercial_billing_approvals.py`.
+   - [ ] The reader joins candidate key and source fingerprint, then proves the
+     approval's review fingerprint against the current effective candidate, so
+     an approval from an equivalent run is visible but a mismatched review
+     identity fails the saved-run read closed; settled by the equivalent-run and
+     mismatch test cases in
+     `tests/test_commercial_billing_approvals.py`.
+   - [ ] The reader performs no invoice, approval, override, review-decision,
+     Gmail, or Square write; settled by the before/after row-count assertions
+     in `tests/test_commercial_billing_approvals.py`.
+   - [ ] Existing commercial billing service and API behavior remains green;
+     settled by the focused invoicing CI-equivalent command and static checks
+     recorded below.
+- Reachability proof: an authenticated in-process request through
+  `atlas_brain.main.app` to the real `/api/v1/receivables/commercial-billing-runs/{id}`
+  route returns the persisted approval projection, without mutating the test
+  schema.
+- Affected surfaces: `CommercialBillingRunService` saved-run read model; the
+  existing receivables GET route; persisted approval/invoice joins; the Website
+  consumer contract via the existing tracker proxy.
+- Risk areas: financial lifecycle interpretation, equivalent-run idempotency,
+  read-model backward compatibility, stale/malformed identity evidence, and
+  mixed provider deployment.
+- Reviewer rules triggered: R1, R2, R3, R5, R6, R7, R8, R10, R12, R13, R14.
+
+### Boundary-change enumeration
+
+The saved-run projection is a CLOSED, DERIVED identity boundary.  Membership is
+derived from durable approval rows rather than an enumerated list: matching
+rows have the candidate's key and source fingerprint, then must prove the
+active effective-review fingerprint.  No matching approval row produces
+`approval: null`; a persisted row with a mismatched identity fails the
+saved-run read closed.
+
+- Boundary path/seam: `CommercialBillingRunService._run_view` -> the existing
+  authenticated saved-run GET route.
+- Replaced-path behaviors: retained candidates previously exposed only
+  source/effective review evidence; they now also expose one matched durable
+  approval or `null`.
+- Guard-relevant fields: approval candidate key, source fingerprint, review
+  fingerprint, approval state, linked invoice source/context, and linked invoice
+  identity/amount.
+- Caller x input shape: no browser-supplied approval fields; a UUID route path
+  selects a persisted run and the reader derives the projection from ATLAS.
+
+### Deployed-config probing
+
+N/A - no config, environment fallback, or credential behavior changes.  The
+reader uses the existing ATLAS database pool and receives no external-service
+credentials.
+
+### Files touched
+
+- `atlas_brain/services/commercial_billing_runs.py`
+- `plans/PR-EOM-Commercial-Billing-Approval-Hydration.md`
+- `tests/test_commercial_billing_approvals.py`
+- `tests/test_commercial_billing_runs.py`
+
+## Mechanism
+
+`_run_view` already materializes every retained candidate in one query and
+derives its active effective-review fingerprint from the latest append-only
+override.  Extend that query with one lateral, bounded approval/invoice join.
+The join deliberately has no request-side input and matches durable candidate
+and source identity; the reader then proves the active review fingerprint
+before returning the projection.  It returns an approval view only when ATLAS
+can prove the invoice belongs to the EOM commercial billing source and business
+context.  The response decorates the existing candidate with `approval`,
+leaving its source snapshot, effective candidate, review decision, and invoice
+lifecycle untouched.
+
+## Intentional
+
+- Add an additive field to the existing saved-run response instead of a second
+  approval-list URL: reopening a review already loads this response, so a
+  separate reader would add race/loading state without improving authority.
+- Match an equivalent-run approval by exact candidate/source/review identity,
+  not only the current run id: ATLAS deliberately reuses the financial approval
+  for that identity and the UI must not offer a duplicate path.
+- Do not project Gmail or Square delivery artifacts: they belong to their own
+  recovery readers and are not needed to lock a financial approval.
+- Do not add a migration: all durable fields already exist, and this is a
+  backwards-compatible read-model addition.
+
+## Deferred
+
+- The dependent Website PR validates the new read evidence, rejects malformed
+  stored override relationships, binds override responses to submitted change
+  sets, and updates the operator guide.  It is held until this provider change
+  is deployed.
+- The tracker proxy already forwards this GET response as untyped JSON; no
+  tracker change is required.  A future typed response schema, if adopted, must
+  preserve this additive field.
+
+Parking predicate: implementation-polish and delivery-artifact hydration that
+does not affect whether an approved candidate can be adjusted or re-approved
+are parked.  A discovered financial identity, authorization, duplicate-invoice,
+or data-loss defect remains in scope.
+
+## Verification
+
+- Passed locally before push (Python 3.13; hosted workflow will repeat these
+  under its pinned Python 3.11):
+  - Ruff and compileall passed for changed Python;
+  - the extended billing regression command with its real local Postgres
+    fixture: `509 passed` in 83.80s, including saved-run, approval, receipt,
+    Gmail-draft, manual-Square, repository, and PDF coverage;
+  - the exact three Atlas invoicing workflow commands from
+    `.github/workflows/atlas_invoicing_checks.yml`: `2 passed, 41 deselected`
+    for the monthly blocker proof; `726 passed` in 92.49s for the receivables
+    ledger/repository proof; and `43 passed` for the MCP/OAuth proof;
+  - `git diff --check`.
+- Pending before push: diff-budget, audit-format, and the one local PR review
+  run through `scripts/push_pr.sh`.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/services/commercial_billing_runs.py` | 153 |
+| `plans/PR-EOM-Commercial-Billing-Approval-Hydration.md` | 178 |
+| `tests/test_commercial_billing_approvals.py` | 58 |
+| `tests/test_commercial_billing_runs.py` | 5 |
+| **Total** | **394** |

--- a/tests/test_commercial_billing_approvals.py
+++ b/tests/test_commercial_billing_approvals.py
@@ -40,6 +40,7 @@ from atlas_brain.services.commercial_billing_invoice_pdfs import (
 from atlas_brain.services.commercial_billing_runs import (
     CommercialBillingRunConflictError,
     CommercialBillingRunService,
+    CommercialBillingRunUnavailableError,
 )
 from atlas_brain.services.commercial_billing_candidate_overrides import (
     decorate_line_keys,
@@ -1438,6 +1439,63 @@ async def test_real_postgres_global_review_decision_fences_duplicate_runs_and_ol
             actor="Juan",
         )
         assert approved["replayed"] is False
+        assert await connection.fetchval("SELECT COUNT(*) FROM invoices") == 1
+        first_approved_view = await review_service.get_run(first_run_id)
+        second_approved_view = await review_service.get_run(second_run_id)
+        assert first_approved_view["candidates"][0]["approval"] == approved["approval"]
+        assert second_approved_view["candidates"][0]["approval"] == approved["approval"]
+
+        # Exercise the real public reader as well as the service: the original
+        # approval belongs to the equivalent second run, but its exact durable
+        # candidate/source/review identity must lock either saved review.
+        from atlas_brain.api.invoicing import auth as receivables_auth
+        from atlas_brain.api.invoicing import receivables as routes
+        from atlas_brain.eom_api.auth import generate_receivables_service_token
+        from atlas_brain.main import app
+
+        generated = generate_receivables_service_token()
+        original_overrides = dict(app.dependency_overrides)
+        app.dependency_overrides[receivables_auth.get_receivables_api_config] = lambda: (
+            SimpleNamespace(
+                receivables_api_enabled=True,
+                receivables_service_token="",
+                receivables_service_token_sha256=generated.sha256,
+            )
+        )
+        app.dependency_overrides[routes.get_commercial_billing_run_service] = (
+            lambda: review_service
+        )
+        try:
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app), base_url="http://atlas.test"
+            ) as client:
+                response = await client.get(
+                    f"/api/v1/receivables/commercial-billing-runs/{first_run_id}",
+                    headers={"Authorization": f"Bearer {generated.token}"},
+                )
+        finally:
+            app.dependency_overrides.clear()
+            app.dependency_overrides.update(original_overrides)
+        assert response.status_code == 200
+        assert response.json()["candidates"][0]["approval"] == approved["approval"]
+        assert await connection.fetchval("SELECT COUNT(*) FROM invoices") == 1
+        assert (
+            await connection.fetchval(
+                "SELECT COUNT(*) FROM commercial_billing_candidate_approvals"
+            )
+            == 1
+        )
+
+        # A retained approval with the wrong effective review identity is not
+        # silently downgraded to an unapproved candidate after a browser reload.
+        await connection.execute(
+            "UPDATE commercial_billing_candidate_approvals "
+            "SET review_fingerprint = $1 WHERE id = $2",
+            _fingerprint("mismatched-review"),
+            UUID(approved["approval"]["id"]),
+        )
+        with pytest.raises(CommercialBillingRunUnavailableError, match="review identity"):
+            await review_service.get_run(first_run_id)
         assert await connection.fetchval("SELECT COUNT(*) FROM invoices") == 1
 
 

--- a/tests/test_commercial_billing_runs.py
+++ b/tests/test_commercial_billing_runs.py
@@ -190,7 +190,9 @@ async def _billing_run_database():
         await conn.execute(f'SET search_path TO "{schema}"')
         await conn.execute(
             "CREATE TABLE invoices ("
-            "id UUID PRIMARY KEY, source TEXT, source_ref TEXT"
+            "id UUID PRIMARY KEY, source TEXT, source_ref TEXT, "
+            "invoice_number TEXT, status TEXT, issue_date DATE, due_date DATE, "
+            "total_amount NUMERIC, business_context_id TEXT"
             ")"
         )
         for name in (
@@ -427,6 +429,7 @@ async def test_real_postgres_snapshot_is_immutable_and_same_key_replays_without_
         assert run["summary"] == {"blockedCandidateCount": 1, "candidateCount": 1}
         assert run["candidates"][0]["lineItems"][0]["amountCents"] == 9650
         assert run["candidates"][0]["sourceEvents"][0]["location"] == "100 Main St"
+        assert run["candidates"][0]["approval"] is None
         assert run["candidates"][0]["reviewDecision"] == {
             "decidedAt": None,
             "decidedBy": None,


### PR DESCRIPTION
Plan: plans/PR-EOM-Commercial-Billing-Approval-Hydration.md
Slice phase: Production hardening
Ownership lane: eom-billing-payments

Reopening a saved commercial billing run previously lost the browser-only record that a candidate already had an ATLAS draft invoice. This provider-first repair makes the existing saved-run read expose exact, durable approval evidence so the dependent Website repair can lock that candidate without adding another financial endpoint. It is additive, read-only, and does not change invoicing, delivery, or tracker authorization. Coordinating issue: #2362.

## Intentional

- Add `candidate.approval` to the existing authenticated saved-run response, returning `null` when no durable approval exists.
- Read the approval by durable candidate/source identity, then prove its active review fingerprint and linked EOM invoice identity/amount before returning it.
- Preserve equivalent-run idempotency: an approval created through an equivalent run is visible when its immutable evidence still matches.
- Fail the saved-run read closed rather than silently treating inconsistent durable approval data as unapproved.
- Deploy ATLAS first. The deployed tracker GET proxy already preserves additive JSON; the Website follow-up will consume this field only after provider deployment.

## AI reconciliation

- Saved-run reload loses durable approval state -- fixed-in: `c5458f027`; Website #219 thread `PRRT_kwDORSuNU86aSe-U` identified the gap, `atlas_brain/services/commercial_billing_runs.py:1411-1528` projects and verifies the evidence, and `tests/test_commercial_billing_approvals.py:1443-1499` proves equivalent-run reuse, the authenticated route, no reader writes, and stale-review rejection.

## Fix-loop disposition preflight

- Root decision: Saved-run reload loses durable approval state
- Source trace: Saved-run reload -> `CommercialBillingRunService._run_view` -> durable approval and invoice projection
- Upstream files: `atlas_brain/services/commercial_billing_runs.py`, `tests/test_commercial_billing_approvals.py`, `tests/test_commercial_billing_runs.py`
- Fix strategy: upstream-root
- Blocking predicate: money
- Disposition: fixed-in
- Allowed files: `atlas_brain/services/commercial_billing_runs.py`, `plans/PR-EOM-Commercial-Billing-Approval-Hydration.md`, `tests/test_commercial_billing_approvals.py`, `tests/test_commercial_billing_runs.py`
- Max files: 4
- Parked hardening: none

## Deferred

- The dependent Website repair will validate the returned evidence, reject malformed stored overrides, bind override results to the submitted change set, and update the operator guide after this provider change is deployed. It remains tracked under #2362.
- A typed tracker response model is not required because the existing GET proxy forwards this response without transformation; any future schema must preserve the additive field.

## Parked hardening

- None. Gmail/Square delivery-artifact hydration is intentionally outside the approval-lock boundary and remains in its existing recovery readers.

## Cold diff reconstruction

- Changed: `atlas_brain/services/commercial_billing_runs.py:260-349` validates a durable approval and linked invoice before exposing it; `:1411-1528` adds one bounded approval/invoice join and attaches the additive field to each saved candidate.
- Changed: `tests/test_commercial_billing_runs.py:191-202,424-432` covers the no-approval projection. `tests/test_commercial_billing_approvals.py:1443-1499` covers equivalent-run reuse, authenticated route reachability, zero reader writes, and mismatch fail-closed behavior.
- Contract match: the reader remains the existing authenticated financial source-of-truth boundary; no new URL, migration, financial write, Gmail/Square action, or customer-visible invoice/PDF content is introduced.
- Gaps: none found within the declared boundary.

## Verification

- Local Python 3.13 regression proof passed against an isolated local Postgres fixture. The hosted invoicing workflow reruns its own pinned Python 3.11 environment.
- No live financial records, Gmail drafts, or email were created during verification.

## Mechanical verification

- Command: `ATLAS_RECEIVABLES_TEST_DATABASE_URL=<local-test-db> python -m pytest tests/test_monthly_invoice_generation.py -k 'update_invoice_clears_needs_hours_when_line_items_are_billable or line_items_are_billable_requires_all_positive_quantities' -q -rF` - Result: 2 passed; 41 deselected - Environment: local
- Command: `ATLAS_RECEIVABLES_TEST_DATABASE_URL=<local-test-db> python -m pytest tests/test_eom_render_profile.py tests/test_receivables.py tests/test_eom_billing_recipients.py tests/test_eom_payment_receipts.py tests/test_residential_payment_receipt_delivery.py tests/test_commercial_billing_candidates.py tests/test_commercial_billing_candidate_overrides.py tests/test_commercial_billing_runs.py tests/test_commercial_billing_approvals.py tests/test_commercial_billing_gmail_drafts.py tests/test_commercial_billing_manual_square_invoices.py tests/test_invoice_repository.py tests/test_invoice_pdf.py -q -rF` - Result: 726 passed; 1 known warning - Environment: local
- Command: `ATLAS_RECEIVABLES_TEST_DATABASE_URL=<local-test-db> python -m pytest tests/test_invoicing_readonly_mcp.py tests/test_invoicing_readonly_oauth.py tests/test_invoicing_draft_writer_mcp.py tests/test_invoicing_draft_writer_oauth.py -q -rF` - Result: 43 passed - Environment: local
- Command: `ruff check atlas_brain/services/commercial_billing_runs.py tests/test_commercial_billing_approvals.py tests/test_commercial_billing_runs.py && python -m compileall -q atlas_brain/services/commercial_billing_runs.py tests/test_commercial_billing_approvals.py tests/test_commercial_billing_runs.py && git diff --check origin/main...HEAD` - Result: passed - Environment: local

## Diff size

4 files, +391 / -3 (394 absolute LOC; under the repository's <400 target).

<!-- atlas-open-pr-wrapper: v1 -->
