### PR TITLE
EOM: repair public onboarding token schema drift

### DIFF
--- a/.github/workflows/atlas_migrations_runner_checks.yml
+++ b/.github/workflows/atlas_migrations_runner_checks.yml
@@ -9,6 +9,7 @@ on:
       - ".github/workflows/atlas_migrations_runner_checks.yml"
       - "atlas_brain/storage/migrations/**"
       - "tests/test_migrations_runner.py"
+      - "tests/test_eom_public_onboarding_migration_repair.py"
   push:
     branches:
       - main
@@ -16,10 +17,27 @@ on:
       - ".github/workflows/atlas_migrations_runner_checks.yml"
       - "atlas_brain/storage/migrations/**"
       - "tests/test_migrations_runner.py"
+      - "tests/test_eom_public_onboarding_migration_repair.py"
 
 jobs:
   atlas-migrations-runner-checks:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16@sha256:081f1bc7bd5e143dbb6e487b710bbc27712cdcfaced4c071b8e47349aa1b4171
+        env:
+          POSTGRES_USER: atlas
+          POSTGRES_PASSWORD: atlas
+          POSTGRES_DB: atlas_migration_tests
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U atlas -d atlas_migration_tests"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      ATLAS_MIGRATION_TEST_DATABASE_URL: postgresql://atlas:atlas@localhost:5432/atlas_migration_tests
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -35,14 +53,11 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install asyncpg pytest pytest-asyncio pydantic pydantic-settings
 
-      # No database service: test_migrations_runner.py uses a fake migration pool
-      # and pure-Path prefix checks. A real-DB apply check for the deflection
-      # migrations (328/332/336) lives on the #1462 reconciliation slice, where a
-      # fresh DB can apply that chain without the migration set's out-of-band
-      # product_metadata dependency (referenced by 076+ but never created by a
-      # migration, so a full fresh apply is not viable here).
-      - name: Run migrations runner tests
+      # The runner tests mostly use a fake pool, but this disposable service also
+      # executes the public-onboarding legacy-schema repair against PostgreSQL.
+      - name: Run migration checks
         run: |
           python -m pytest \
             tests/test_migrations_runner.py \
+            tests/test_eom_public_onboarding_migration_repair.py \
             -q

--- a/atlas_brain/storage/migrations/384_eom_public_onboarding_tokens_schema_repair.sql
+++ b/atlas_brain/storage/migrations/384_eom_public_onboarding_tokens_schema_repair.sql
@@ -1,0 +1,55 @@
+-- atlas: atomic-bookkeeping
+-- Repair the legacy public-onboarding token relation created before migration
+-- 383 supplied the immutable signing and prefill projection. Migration 383 is
+-- CREATE TABLE IF NOT EXISTS, so it cannot alter that already-existing table.
+--
+-- An immutable token snapshot cannot be reconstructed from a legacy row. The
+-- repair is therefore deliberately limited to an empty relation; a nonempty
+-- incomplete relation fails atomically and requires an operator-approved,
+-- record-specific recovery instead of fabricated values.
+
+DO $$
+DECLARE
+    missing_immutable_columns TEXT[];
+BEGIN
+    SELECT array_agg(required.column_name ORDER BY required.column_name)
+    INTO missing_immutable_columns
+    FROM unnest(ARRAY[
+        'signing_key_fingerprint',
+        'prefill_full_name',
+        'prefill_email',
+        'prefill_phone',
+        'prefill_address',
+        'prefill_city',
+        'prefill_state',
+        'prefill_zip',
+        'prefill_customer_type'
+    ]) AS required(column_name)
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM pg_attribute
+        WHERE attrelid = 'eom_public_onboarding_tokens'::regclass
+          AND attname = required.column_name
+          AND NOT attisdropped
+    );
+
+    IF missing_immutable_columns IS NOT NULL
+       AND EXISTS (SELECT 1 FROM eom_public_onboarding_tokens) THEN
+        RAISE EXCEPTION
+            'cannot safely repair nonempty eom_public_onboarding_tokens; missing immutable columns: %',
+            array_to_string(missing_immutable_columns, ', ');
+    END IF;
+END;
+$$;
+
+ALTER TABLE eom_public_onboarding_tokens
+    ADD COLUMN IF NOT EXISTS signing_key_fingerprint VARCHAR(64) NOT NULL
+        CHECK (signing_key_fingerprint ~ '^[0-9a-f]{64}$'),
+    ADD COLUMN IF NOT EXISTS prefill_full_name VARCHAR(256) NOT NULL,
+    ADD COLUMN IF NOT EXISTS prefill_email VARCHAR(256),
+    ADD COLUMN IF NOT EXISTS prefill_phone VARCHAR(32),
+    ADD COLUMN IF NOT EXISTS prefill_address TEXT,
+    ADD COLUMN IF NOT EXISTS prefill_city VARCHAR(128),
+    ADD COLUMN IF NOT EXISTS prefill_state VARCHAR(64),
+    ADD COLUMN IF NOT EXISTS prefill_zip VARCHAR(16),
+    ADD COLUMN IF NOT EXISTS prefill_customer_type VARCHAR(32) NOT NULL;

--- a/plans/PR-EOM-Public-Onboarding-Schema-Repair.md
+++ b/plans/PR-EOM-Public-Onboarding-Schema-Repair.md
@@ -1,0 +1,155 @@
+# PR-EOM-Public-Onboarding-Schema-Repair
+
+## Why this slice exists
+
+The public Website → Tracker → Atlas onboarding path is deployed but cannot be
+safely enabled. A live Tracker-to-Atlas probe reached the authenticated Atlas
+route and received `503 Public onboarding is not enabled`. Enabling its three
+runtime settings in a no-write preflight then made Atlas's startup readiness
+guard fail because the production token table is incomplete, despite its
+current migration ledger recording the public-onboarding migration.
+
+### Problem-derived contract
+
+- Root cause: a prior, version-collided
+  `382_eom_public_onboarding_tokens` migration was recorded under a synthetic
+  negative ledger version after it created a partial token relation. The later
+  `383_eom_public_onboarding_tokens` migration is `CREATE TABLE IF NOT
+  EXISTS`, so PostgreSQL left that pre-existing relation unchanged while the
+  runner recorded 383 as applied. The live, empty relation consequently lacks
+  the immutable signing and prefill fields that enabled public-onboarding
+  readiness requires.
+- Correct fix must touch/change: add one new, atomic, forward-only migration
+  that detects the known incomplete table shape, refuses to invent immutable
+  values for a nonempty legacy relation, and repairs the empty relation in
+  place with the exact signing/prefill column semantics required by migration
+  383. Add a real-PostgreSQL regression test that uses the migration runner to
+  prove both the empty-table repair and the nonempty-table fail-closed fence.
+  The migration must be a new normal ledger entry; it must not alter migration
+  history.
+- Must not change: `382_*` and `383_*`; Website and Tracker code; public-route,
+  HMAC, bearer, issuance, redemption, revocation, email, customer-handoff,
+  payroll, receivables, commercial-billing, or CRM lifecycle semantics; and
+  runtime public-onboarding configuration. Configuration remains a separate,
+  post-merge production operation only after this migration proves readiness.
+
+## Scope (this PR)
+
+Ownership lane: eom-public-onboarding/schema-repair
+Slice phase: Production hardening
+Max files: 3
+
+1. Repair an empty legacy `eom_public_onboarding_tokens` relation whose
+   migration ledger already records 383 but whose immutable public-onboarding
+   projection columns are absent.
+2. Add database-level regression proof for the repair, fail-closed nonempty
+   legacy state, and no-op behavior on an already complete relation.
+
+### Review Contract
+
+- Acceptance criteria:
+  1. `384_eom_public_onboarding_tokens_schema_repair.sql` is an
+     `-- atlas: atomic-bookkeeping` migration and is the only migration source
+     changed. It contains an explicit pre-mutation fence: if any required
+     immutable column is missing and the relation has rows, migration execution
+     raises rather than adding unknown values.
+  2. On the exact known empty legacy shape, the migration runner records 384
+     and the repaired relation has each 383-only field with the 383 type,
+     nullability, and signing-key check semantics. Settled by
+     `tests/test_eom_public_onboarding_migration_repair.py` against a real
+     disposable PostgreSQL schema.
+  3. On the known nonempty legacy shape, migration execution fails and leaves
+     the table's columns and row count unchanged. Settled by the same
+     real-PostgreSQL test.
+  4. On an already complete 383 relation that has a valid token row, migration
+     execution records 384 without changing that row. Settled by the same
+     real-PostgreSQL test.
+  5. The existing 382 and 383 migration files remain byte-for-byte outside the
+     diff. Settled by the final cold diff audit.
+  6. The migration is run through `run_migrations(..., only={...})`, so its
+     DDL and ledger record are proven together under the production runner's
+     atomic-bookkeeping path rather than by executing a copied SQL string.
+- Reachability proof: after merge/deployment, the live `atlas-api` startup
+  runner applies 384 before public-onboarding configuration is set. With the
+  explicit public settings then present, a Tracker public-session request with
+  a fake bearer must traverse the configured service and return the expected
+  unavailable-link `404`, not the current configuration-disabled `503`.
+- Affected surfaces: Atlas migration ledger; the durable public-onboarding
+  token relation required by `require_eom_funnel_data_store`; and the deployed
+  Website → Tracker → Atlas onboarding handoff only.
+- Risk areas: destructive schema repair, impossible immutable-data backfill,
+  migration/ledger atomicity, legacy relation compatibility, and accidental
+  configuration activation before datastore readiness.
+- Reviewer rules triggered: R1, R2, R4, R5, R12, R14.
+
+### Boundary-change enumeration
+
+N/A - no application guard, validator, resolver, router, or admission
+boundary changes. The migration restores the existing datastore contract;
+`require_eom_funnel_data_store` remains unchanged.
+
+### Deployed-config probing
+
+N/A - this code diff changes no configuration lookup or fallback. The live
+preflight established that Atlas's funnel API and Tracker bearer are set,
+while all public-onboarding settings are absent. The explicit runtime
+activation is deliberately sequenced after the merged migration and fresh
+service startup; it is not a PR code change.
+
+### Files touched
+
+- `atlas_brain/storage/migrations/384_eom_public_onboarding_tokens_schema_repair.sql`
+- `plans/PR-EOM-Public-Onboarding-Schema-Repair.md`
+- `tests/test_eom_public_onboarding_migration_repair.py`
+
+## Mechanism
+
+Migration 384 first asks PostgreSQL whether any of the nine immutable
+signing/prefill columns are absent. If so, it checks the legacy relation before
+DDL: a nonempty table aborts because neither the signing-key fingerprint nor
+the snapshot values can be reconstructed truthfully. For the observed empty
+legacy relation, it adds the missing columns with the same type, nullability,
+and fingerprint check used by 383. The atomic-bookkeeping marker makes the
+schema changes and new ledger row one transaction under the existing runner.
+
+## Intentional
+
+- Do not rewrite the accidentally colliding 382 ledger record or edit 383:
+  deployed databases may already record both, so a new forward migration is
+  the recoverable compatibility path.
+- Do not backfill or relax immutable fields for a nonempty legacy relation.
+  Such data would be fabricated; fail closed and require an explicitly scoped
+  forensic migration instead.
+- Do not set the public enablement flag in source. The operational service must
+  start successfully with 384 before its public authority is activated.
+
+## Deferred
+
+If a different deployment has a nonempty incomplete relation, resolve its
+individual records and provenance in a separate operator-approved migration;
+this repair intentionally refuses it.
+
+Parked hardening: none.
+
+## Verification
+
+- Passed: `ATLAS_MIGRATION_TEST_DATABASE_URL=... pytest -q
+  tests/test_eom_public_onboarding_migration_repair.py` — 3 passed against a
+  disposable schema in the local development PostgreSQL database.
+- Passed: `pytest -q tests/test_migrations_runner.py` — 30 passed, 1 skipped.
+- Passed: `pytest -q tests/test_eom_public_onboarding.py` — 39 passed.
+- Passed: Ruff check and formatter checks for
+  `tests/test_eom_public_onboarding_migration_repair.py`.
+- Environment limitation recorded: the two existing public-onboarding
+  readiness integration tests skip because the configured test role cannot
+  administer disposable PostgreSQL roles; the new migration test exercises
+  the actual runner and DDL without that unavailable privilege.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/storage/migrations/384_eom_public_onboarding_tokens_schema_repair.sql` | 55 |
+| `plans/PR-EOM-Public-Onboarding-Schema-Repair.md` | 155 |
+| `tests/test_eom_public_onboarding_migration_repair.py` | 400 |
+| **Total** | **610** |

--- a/plans/PR-EOM-Public-Onboarding-Schema-Repair.md
+++ b/plans/PR-EOM-Public-Onboarding-Schema-Repair.md
@@ -18,15 +18,20 @@ current migration ledger recording the public-onboarding migration.
   EXISTS`, so PostgreSQL left that pre-existing relation unchanged while the
   runner recorded 383 as applied. The live, empty relation consequently lacks
   the immutable signing and prefill fields that enabled public-onboarding
-  readiness requires.
+  readiness requires. Separately, the required real-PostgreSQL regression
+  proof was local-only: the existing migration-check workflow neither started
+  PostgreSQL nor supplied `ATLAS_MIGRATION_TEST_DATABASE_URL`, so this test's
+  explicit environment guard skipped every case in CI.
 - Correct fix must touch/change: add one new, atomic, forward-only migration
   that detects the known incomplete table shape, refuses to invent immutable
   values for a nonempty legacy relation, and repairs the empty relation in
   place with the exact signing/prefill column semantics required by migration
   383. Add a real-PostgreSQL regression test that uses the migration runner to
   prove both the empty-table repair and the nonempty-table fail-closed fence.
-  The migration must be a new normal ledger entry; it must not alter migration
-  history.
+  Enroll that regression test in the existing migration-check workflow with a
+  disposable PostgreSQL service and `ATLAS_MIGRATION_TEST_DATABASE_URL`, so
+  the required CI evidence executes rather than skips. The migration must be a
+  new normal ledger entry; it must not alter migration history.
 - Must not change: `382_*` and `383_*`; Website and Tracker code; public-route,
   HMAC, bearer, issuance, redemption, revocation, email, customer-handoff,
   payroll, receivables, commercial-billing, or CRM lifecycle semantics; and
@@ -37,13 +42,16 @@ current migration ledger recording the public-onboarding migration.
 
 Ownership lane: eom-public-onboarding/schema-repair
 Slice phase: Production hardening
-Max files: 3
+Max files: 4
 
 1. Repair an empty legacy `eom_public_onboarding_tokens` relation whose
    migration ledger already records 383 but whose immutable public-onboarding
    projection columns are absent.
 2. Add database-level regression proof for the repair, fail-closed nonempty
    legacy state, and no-op behavior on an already complete relation.
+3. Make the existing migration-check workflow provide the disposable PostgreSQL
+   URL and invoke that proof on pull requests that change this migration or its
+   test.
 
 ### Review Contract
 
@@ -69,14 +77,19 @@ Max files: 3
   6. The migration is run through `run_migrations(..., only={...})`, so its
      DDL and ledger record are proven together under the production runner's
      atomic-bookkeeping path rather than by executing a copied SQL string.
+  7. The migration-check workflow starts a disposable PostgreSQL service,
+     supplies `ATLAS_MIGRATION_TEST_DATABASE_URL`, and invokes
+     `tests/test_eom_public_onboarding_migration_repair.py`; the test therefore
+     cannot skip in required CI for lack of a database URL.
 - Reachability proof: after merge/deployment, the live `atlas-api` startup
   runner applies 384 before public-onboarding configuration is set. With the
   explicit public settings then present, a Tracker public-session request with
   a fake bearer must traverse the configured service and return the expected
   unavailable-link `404`, not the current configuration-disabled `503`.
 - Affected surfaces: Atlas migration ledger; the durable public-onboarding
-  token relation required by `require_eom_funnel_data_store`; and the deployed
-  Website → Tracker → Atlas onboarding handoff only.
+  token relation required by `require_eom_funnel_data_store`; the migration
+  workflow's disposable PostgreSQL test environment; and the deployed Website
+  → Tracker → Atlas onboarding handoff only.
 - Risk areas: destructive schema repair, impossible immutable-data backfill,
   migration/ledger atomicity, legacy relation compatibility, and accidental
   configuration activation before datastore readiness.
@@ -98,6 +111,7 @@ service startup; it is not a PR code change.
 
 ### Files touched
 
+- `.github/workflows/atlas_migrations_runner_checks.yml`
 - `atlas_brain/storage/migrations/384_eom_public_onboarding_tokens_schema_repair.sql`
 - `plans/PR-EOM-Public-Onboarding-Schema-Repair.md`
 - `tests/test_eom_public_onboarding_migration_repair.py`
@@ -111,6 +125,9 @@ the snapshot values can be reconstructed truthfully. For the observed empty
 legacy relation, it adds the missing columns with the same type, nullability,
 and fingerprint check used by 383. The atomic-bookkeeping marker makes the
 schema changes and new ledger row one transaction under the existing runner.
+The existing migration-check workflow supplies the test's database URL through
+an isolated PostgreSQL service and runs the repair proof alongside the
+runner-level checks.
 
 ## Intentional
 
@@ -133,10 +150,11 @@ Parked hardening: none.
 
 ## Verification
 
-- Passed: `ATLAS_MIGRATION_TEST_DATABASE_URL=... pytest -q
-  tests/test_eom_public_onboarding_migration_repair.py` — 3 passed against a
-  disposable schema in the local development PostgreSQL database.
-- Passed: `pytest -q tests/test_migrations_runner.py` — 30 passed, 1 skipped.
+- Passed: local workflow-equivalent `ATLAS_MIGRATION_TEST_DATABASE_URL=...
+  python -m pytest -q tests/test_migrations_runner.py
+  tests/test_eom_public_onboarding_migration_repair.py` — 34 passed against a
+  disposable PostgreSQL schema; the repair proof executed rather than skipped.
+- Passed: workflow YAML parse with Python's YAML loader.
 - Passed: `pytest -q tests/test_eom_public_onboarding.py` — 39 passed.
 - Passed: Ruff check and formatter checks for
   `tests/test_eom_public_onboarding_migration_repair.py`.
@@ -149,7 +167,8 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
+| `.github/workflows/atlas_migrations_runner_checks.yml` | 29 |
 | `atlas_brain/storage/migrations/384_eom_public_onboarding_tokens_schema_repair.sql` | 55 |
-| `plans/PR-EOM-Public-Onboarding-Schema-Repair.md` | 155 |
+| `plans/PR-EOM-Public-Onboarding-Schema-Repair.md` | 174 |
 | `tests/test_eom_public_onboarding_migration_repair.py` | 400 |
-| **Total** | **610** |
+| **Total** | **658** |

--- a/tests/test_eom_public_onboarding_migration_repair.py
+++ b/tests/test_eom_public_onboarding_migration_repair.py
@@ -1,0 +1,400 @@
+"""Real-PostgreSQL regression proof for the public-onboarding schema repair."""
+
+from __future__ import annotations
+
+import os
+import uuid
+from pathlib import Path
+
+import pytest
+
+asyncpg = pytest.importorskip("asyncpg")
+
+from atlas_brain.storage.migrations import run_migrations  # noqa: E402
+
+
+ROOT = Path(__file__).resolve().parent.parent
+MIGRATIONS = ROOT / "atlas_brain" / "storage" / "migrations"
+DATABASE_URL_ENV = "ATLAS_MIGRATION_TEST_DATABASE_URL"
+MIGRATION_STEM = "384_eom_public_onboarding_tokens_schema_repair"
+
+_EXPECTED_REPAIRED_COLUMNS = {
+    "signing_key_fingerprint": ("character varying", 64, "NO"),
+    "prefill_full_name": ("character varying", 256, "NO"),
+    "prefill_email": ("character varying", 256, "YES"),
+    "prefill_phone": ("character varying", 32, "YES"),
+    "prefill_address": ("text", None, "YES"),
+    "prefill_city": ("character varying", 128, "YES"),
+    "prefill_state": ("character varying", 64, "YES"),
+    "prefill_zip": ("character varying", 16, "YES"),
+    "prefill_customer_type": ("character varying", 32, "NO"),
+}
+
+
+def _database_url_or_skip() -> str:
+    database_url = os.environ.get(DATABASE_URL_ENV)
+    if not database_url:
+        pytest.skip(f"{DATABASE_URL_ENV} is not configured")
+    return database_url
+
+
+def _quote_ident(identifier: str) -> str:
+    return '"' + identifier.replace('"', '""') + '"'
+
+
+class _MigrationPool:
+    def __init__(self, conn) -> None:
+        self._conn = conn
+
+    async def acquire(self):
+        return self._conn
+
+    async def release(self, released) -> None:
+        assert released is self._conn
+
+
+async def _prepare_known_legacy_schema(conn, schema: str) -> None:
+    """Create the exact pre-383 token shape observed in production.
+
+    The negative ledger record models the old prefix collision. The normal 383
+    ledger record models why the production runner will not revisit its
+    `CREATE TABLE IF NOT EXISTS` body.
+    """
+    schema_ident = _quote_ident(schema)
+    await conn.execute(f"CREATE SCHEMA {schema_ident}")
+    await conn.execute(f"SET search_path TO {schema_ident}, public")
+    await conn.execute("""
+        CREATE TABLE schema_migrations (
+            version INTEGER PRIMARY KEY,
+            name VARCHAR(255) NOT NULL,
+            applied_at TIMESTAMPTZ DEFAULT NOW()
+        );
+        INSERT INTO schema_migrations (version, name) VALUES
+            (-11, '382_eom_public_onboarding_tokens'),
+            (383, '383_eom_public_onboarding_tokens');
+
+        CREATE TABLE contacts (id UUID PRIMARY KEY);
+        CREATE TABLE eom_onboarding_email_drafts (id UUID PRIMARY KEY);
+
+        CREATE TABLE eom_public_onboarding_tokens (
+            id UUID NOT NULL,
+            draft_id UUID NOT NULL REFERENCES eom_onboarding_email_drafts(id)
+                ON DELETE RESTRICT,
+            contact_id UUID NOT NULL REFERENCES contacts(id) ON DELETE RESTRICT,
+            approval_key VARCHAR(128) NOT NULL,
+            status VARCHAR(16) NOT NULL DEFAULT 'issued',
+            approved_by_employee_id BIGINT NOT NULL
+                CHECK (approved_by_employee_id > 0),
+            approved_by_name VARCHAR(128) NOT NULL,
+            issued_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            redeemed_at TIMESTAMPTZ,
+            revoked_at TIMESTAMPTZ,
+            handoff_id UUID,
+            CONSTRAINT pk_eom_public_onboarding_tokens PRIMARY KEY (id),
+            CONSTRAINT uq_eom_public_onboarding_tokens_draft UNIQUE (draft_id),
+            CONSTRAINT uq_eom_public_onboarding_tokens_approval UNIQUE (approval_key),
+            CONSTRAINT uq_eom_public_onboarding_tokens_handoff UNIQUE (handoff_id),
+            CONSTRAINT ck_eom_public_onboarding_tokens_status
+                CHECK (status IN ('issued', 'redeemed', 'revoked')),
+            CONSTRAINT ck_eom_public_onboarding_tokens_terminal_state CHECK (
+                (status = 'issued'
+                    AND redeemed_at IS NULL
+                    AND revoked_at IS NULL
+                    AND handoff_id IS NULL)
+                OR (status = 'redeemed'
+                    AND redeemed_at IS NOT NULL
+                    AND revoked_at IS NULL
+                    AND handoff_id IS NOT NULL)
+                OR (status = 'revoked'
+                    AND redeemed_at IS NULL
+                    AND revoked_at IS NOT NULL
+                    AND handoff_id IS NULL)
+            )
+        );
+        CREATE UNIQUE INDEX uq_eom_public_onboarding_tokens_issued_contact
+            ON eom_public_onboarding_tokens (contact_id)
+            WHERE status = 'issued';
+        CREATE INDEX idx_eom_public_onboarding_tokens_status
+            ON eom_public_onboarding_tokens (status, issued_at DESC);
+        """)
+
+
+async def _prepare_complete_schema(conn, schema: str) -> None:
+    """Create the normal, complete 383 relation through the migration runner."""
+    schema_ident = _quote_ident(schema)
+    await conn.execute(f"CREATE SCHEMA {schema_ident}")
+    await conn.execute(f"SET search_path TO {schema_ident}, public")
+    await conn.execute("""
+        CREATE TABLE contacts (id UUID PRIMARY KEY);
+        CREATE TABLE eom_onboarding_email_drafts (id UUID PRIMARY KEY);
+        """)
+    await run_migrations(
+        _MigrationPool(conn),
+        migrations_dir=MIGRATIONS,
+        only={"383_eom_public_onboarding_tokens"},
+    )
+
+
+async def _run_schema_repair(conn) -> None:
+    await run_migrations(
+        _MigrationPool(conn),
+        migrations_dir=MIGRATIONS,
+        only={MIGRATION_STEM},
+    )
+
+
+async def _legacy_columns(conn, schema: str) -> set[str]:
+    rows = await conn.fetch(
+        """
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_schema = $1
+          AND table_name = 'eom_public_onboarding_tokens'
+        ORDER BY column_name
+        """,
+        schema,
+    )
+    return {row["column_name"] for row in rows}
+
+
+@pytest.mark.asyncio
+async def test_schema_repair_adds_383_immutable_projection_to_empty_legacy_table():
+    database_url = _database_url_or_skip()
+    schema = f"eom_public_repair_{uuid.uuid4().hex}"
+    conn = await asyncpg.connect(database_url)
+    try:
+        await _prepare_known_legacy_schema(conn, schema)
+        await _run_schema_repair(conn)
+
+        assert (
+            await conn.fetchval(
+                """
+            SELECT version
+            FROM schema_migrations
+            WHERE name = $1
+            """,
+                MIGRATION_STEM,
+            )
+            == 384
+        )
+
+        rows = await conn.fetch(
+            """
+            SELECT column_name, data_type, character_maximum_length, is_nullable
+            FROM information_schema.columns
+            WHERE table_schema = $1
+              AND table_name = 'eom_public_onboarding_tokens'
+              AND column_name = ANY($2::text[])
+            """,
+            schema,
+            list(_EXPECTED_REPAIRED_COLUMNS),
+        )
+        actual_columns = {
+            row["column_name"]: (
+                row["data_type"],
+                row["character_maximum_length"],
+                row["is_nullable"],
+            )
+            for row in rows
+        }
+        assert actual_columns == _EXPECTED_REPAIRED_COLUMNS
+
+        check_definitions = await conn.fetch(
+            """
+            SELECT pg_get_constraintdef(oid) AS definition
+            FROM pg_constraint
+            WHERE conrelid = 'eom_public_onboarding_tokens'::regclass
+              AND contype = 'c'
+            """
+        )
+        assert any(
+            "signing_key_fingerprint" in row["definition"]
+            and "^[0-9a-f]{64}$" in row["definition"]
+            for row in check_definitions
+        )
+
+        contact_id = uuid.uuid4()
+        draft_id = uuid.uuid4()
+        await conn.execute("INSERT INTO contacts (id) VALUES ($1)", contact_id)
+        await conn.execute(
+            "INSERT INTO eom_onboarding_email_drafts (id) VALUES ($1)", draft_id
+        )
+        valid_values = (
+            uuid.uuid4(),
+            draft_id,
+            contact_id,
+            "a" * 64,
+            "Immutable Person",
+            "residential",
+            "approval-valid",
+            1,
+            "Office User",
+        )
+        await conn.execute(
+            """
+            INSERT INTO eom_public_onboarding_tokens (
+                id, draft_id, contact_id, signing_key_fingerprint,
+                prefill_full_name, prefill_customer_type, approval_key,
+                approved_by_employee_id, approved_by_name
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            """,
+            *valid_values,
+        )
+
+        invalid_contact_id = uuid.uuid4()
+        invalid_draft_id = uuid.uuid4()
+        await conn.execute("INSERT INTO contacts (id) VALUES ($1)", invalid_contact_id)
+        await conn.execute(
+            "INSERT INTO eom_onboarding_email_drafts (id) VALUES ($1)",
+            invalid_draft_id,
+        )
+        with pytest.raises(asyncpg.CheckViolationError):
+            await conn.execute(
+                """
+                INSERT INTO eom_public_onboarding_tokens (
+                    id, draft_id, contact_id, signing_key_fingerprint,
+                    prefill_full_name, prefill_customer_type, approval_key,
+                    approved_by_employee_id, approved_by_name
+                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+                """,
+                uuid.uuid4(),
+                invalid_draft_id,
+                invalid_contact_id,
+                "g" * 64,
+                "Immutable Person",
+                "residential",
+                "approval-invalid",
+                1,
+                "Office User",
+            )
+    finally:
+        await conn.execute(f"DROP SCHEMA IF EXISTS {_quote_ident(schema)} CASCADE")
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_schema_repair_fails_without_mutating_nonempty_legacy_table():
+    database_url = _database_url_or_skip()
+    schema = f"eom_public_repair_nonempty_{uuid.uuid4().hex}"
+    conn = await asyncpg.connect(database_url)
+    try:
+        await _prepare_known_legacy_schema(conn, schema)
+        contact_id = uuid.uuid4()
+        draft_id = uuid.uuid4()
+        await conn.execute("INSERT INTO contacts (id) VALUES ($1)", contact_id)
+        await conn.execute(
+            "INSERT INTO eom_onboarding_email_drafts (id) VALUES ($1)", draft_id
+        )
+        await conn.execute(
+            """
+            INSERT INTO eom_public_onboarding_tokens (
+                id, draft_id, contact_id, approval_key,
+                approved_by_employee_id, approved_by_name
+            ) VALUES ($1, $2, $3, $4, $5, $6)
+            """,
+            uuid.uuid4(),
+            draft_id,
+            contact_id,
+            "legacy-approval",
+            1,
+            "Office User",
+        )
+        columns_before = await _legacy_columns(conn, schema)
+
+        with pytest.raises(
+            asyncpg.RaiseError,
+            match="cannot safely repair nonempty eom_public_onboarding_tokens",
+        ):
+            await _run_schema_repair(conn)
+
+        assert await _legacy_columns(conn, schema) == columns_before
+        assert (
+            await conn.fetchval("SELECT COUNT(*) FROM eom_public_onboarding_tokens")
+            == 1
+        )
+        assert (
+            await conn.fetchval(
+                """
+            SELECT COUNT(*)
+            FROM schema_migrations
+            WHERE name = $1
+            """,
+                MIGRATION_STEM,
+            )
+            == 0
+        )
+    finally:
+        await conn.execute(f"DROP SCHEMA IF EXISTS {_quote_ident(schema)} CASCADE")
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_schema_repair_is_a_noop_for_complete_relation_with_token_rows():
+    database_url = _database_url_or_skip()
+    schema = f"eom_public_repair_compatible_{uuid.uuid4().hex}"
+    conn = await asyncpg.connect(database_url)
+    try:
+        await _prepare_complete_schema(conn, schema)
+        contact_id = uuid.uuid4()
+        draft_id = uuid.uuid4()
+        token_id = uuid.uuid4()
+        await conn.execute("INSERT INTO contacts (id) VALUES ($1)", contact_id)
+        await conn.execute(
+            "INSERT INTO eom_onboarding_email_drafts (id) VALUES ($1)", draft_id
+        )
+        await conn.execute(
+            """
+            INSERT INTO eom_public_onboarding_tokens (
+                id, draft_id, contact_id, signing_key_fingerprint,
+                prefill_full_name, prefill_customer_type, approval_key,
+                approved_by_employee_id, approved_by_name
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            """,
+            token_id,
+            draft_id,
+            contact_id,
+            "a" * 64,
+            "Immutable Person",
+            "residential",
+            "complete-approval",
+            1,
+            "Office User",
+        )
+        before = dict(
+            await conn.fetchrow(
+                """
+                SELECT id, draft_id, contact_id, signing_key_fingerprint,
+                       prefill_full_name, prefill_customer_type, approval_key,
+                       approved_by_employee_id, approved_by_name, status
+                FROM eom_public_onboarding_tokens
+                WHERE id = $1
+                """,
+                token_id,
+            )
+        )
+
+        await _run_schema_repair(conn)
+
+        assert (
+            await conn.fetchval(
+                "SELECT version FROM schema_migrations WHERE name = $1",
+                MIGRATION_STEM,
+            )
+            == 384
+        )
+        after = dict(
+            await conn.fetchrow(
+                """
+                SELECT id, draft_id, contact_id, signing_key_fingerprint,
+                       prefill_full_name, prefill_customer_type, approval_key,
+                       approved_by_employee_id, approved_by_name, status
+                FROM eom_public_onboarding_tokens
+                WHERE id = $1
+                """,
+                token_id,
+            )
+        )
+        assert after == before
+    finally:
+        await conn.execute(f"DROP SCHEMA IF EXISTS {_quote_ident(schema)} CASCADE")
+        await conn.close()


### PR DESCRIPTION
Plan: plans/PR-EOM-Public-Onboarding-Schema-Repair.md
Slice phase: Production hardening
Ownership lane: eom-public-onboarding/schema-repair

Repairs the recorded-but-incomplete public-onboarding token table that blocks
safe activation of the already deployed Website → Tracker → Atlas handoff, and
makes its real-PostgreSQL regression proof execute in CI.

## Intentional

- Adds only migration 384, its real-PostgreSQL regression proof, the focused
  migration-check workflow enrollment, and the canonical slice plan.
- A nonempty legacy table fails closed; this PR never invents immutable signing
  or customer-prefill data.
- Leaves migrations 382/383, route semantics, Website/Tracker code, and runtime
  configuration untouched.

## AI reconciliation

- Run the migration repair test against PostgreSQL in CI -- fixed-in: b4a916f7c .github/workflows/atlas_migrations_runner_checks.yml provisions the pinned PostgreSQL service and URL, then invokes tests/test_eom_public_onboarding_migration_repair.py.

## Fix-loop disposition preflight

- Root decision: Run the migration repair test against PostgreSQL in CI
- Source trace: R12 review thread -> migration workflow lacked PostgreSQL and ATLAS_MIGRATION_TEST_DATABASE_URL -> explicit test guard skipped every case -> required CI proof was absent.
- Upstream files: .github/workflows/atlas_migrations_runner_checks.yml
- Fix strategy: upstream-root
- Blocking predicate: ci
- Disposition: fixed-in
- Allowed files: .github/workflows/atlas_migrations_runner_checks.yml, atlas_brain/storage/migrations/384_eom_public_onboarding_tokens_schema_repair.sql, plans/PR-EOM-Public-Onboarding-Schema-Repair.md, tests/test_eom_public_onboarding_migration_repair.py
- Max files: 4
- Parked hardening: none

## Deferred

- A nonempty incomplete legacy table needs a separately approved,
  record-specific forensic migration.

## Parked hardening

None for this slice.

## Cold diff reconstruction

- `.github/workflows/atlas_migrations_runner_checks.yml:6-63` adds pull-request
  path enrollment, a pinned disposable PostgreSQL service and test URL, then
  invokes the real repair proof with the existing runner tests.
- `atlas_brain/storage/migrations/384_eom_public_onboarding_tokens_schema_repair.sql:11-55`
  detects any absent immutable field, blocks nonempty legacy data, then adds
  the nine fields with migration-383 semantics.
- `tests/test_eom_public_onboarding_migration_repair.py:34-400` recreates the
  observed legacy ledger/table shape and proves empty repair, nonempty rollback,
  and no-op behavior for an already complete table with a token row.
- `plans/PR-EOM-Public-Onboarding-Schema-Repair.md:12-174` records the
  problem-derived contract, the focused CI enrollment, and verification evidence.
- No gap found: every changed file traces to the contract; all contract
  requirements are represented; migrations 382/383 and every declared
  out-of-scope application surface remain unchanged.

## Verification

- Local workflow-equivalent runner and repair command passed 34 tests against a
  disposable PostgreSQL schema; the repair cases executed instead of skipping.
- Public-onboarding unit suite passed 39 tests.
- Workflow YAML, plan contract, diff-rule mapping, and boundary enumeration
  checks passed locally.
- The existing role-sensitive readiness integration pair remains skipped because
  the local test role cannot create disposable PostgreSQL roles.

## Mechanical verification

- Command: ATLAS_MIGRATION_TEST_DATABASE_URL=[local-dev-test-db] python -m pytest -q tests/test_migrations_runner.py tests/test_eom_public_onboarding_migration_repair.py - Result: 34 passed - Environment: local
- Command: python -m pytest -q tests/test_eom_public_onboarding.py - Result: 39 passed - Environment: local
- Command: ruff check tests/test_eom_public_onboarding_migration_repair.py - Result: passed - Environment: local
- Command: ruff format --check tests/test_eom_public_onboarding_migration_repair.py - Result: passed - Environment: local
- Command: Python YAML loader for .github/workflows/atlas_migrations_runner_checks.yml - Result: passed - Environment: local
- Command: python scripts/sync_pr_plan.py plans/PR-EOM-Public-Onboarding-Schema-Repair.md origin/main --check - Result: passed - Environment: local
- Command: python scripts/audit_plan_doc.py plans/PR-EOM-Public-Onboarding-Schema-Repair.md - Result: passed - Environment: local
- Command: python scripts/audit_review_rules_triggered.py origin/main --plan plans/PR-EOM-Public-Onboarding-Schema-Repair.md - Result: passed - Environment: local
- Command: python scripts/check_boundary_change_enumeration.py --base origin/main --strict - Result: passed - Environment: local
- Command: git diff --check origin/main - Result: passed - Environment: local
- Skipped: existing public-onboarding readiness integration pair; Reason: local test role lacks disposable PostgreSQL role-administration privilege.

## Diff size

4 files, 651 added lines, 7 deleted lines.

Diff-budget override: The one atomic schema repair, its three real-PostgreSQL
legacy-state proofs, and the one workflow enrollment that makes those proofs
execute in CI are inseparable at rollout; splitting them would leave the
production fix unverified.

<!-- atlas-open-pr-wrapper: v1 -->
