### PR TITLE
EOM: add office onboarding link follow-up controls

### DIFF
--- a/.github/workflows/atlas_eom_lead_pipeline_checks.yml
+++ b/.github/workflows/atlas_eom_lead_pipeline_checks.yml
@@ -240,6 +240,7 @@ jobs:
             tests/test_eom_billing_recipients.py \
             tests/test_eom_lead_conversion.py \
             tests/test_eom_lead_conversion_integration.py \
+            tests/test_eom_funnel_capability_manifest.py \
             tests/test_eom_public_onboarding.py \
             tests/test_eom_write_boundary_audit.py \
             tests/test_eom_lead_pipeline_integration.py \

--- a/atlas_brain/eom_api/funnel.py
+++ b/atlas_brain/eom_api/funnel.py
@@ -410,6 +410,35 @@ class EOMOnboardingDraftListResponse(BaseModel):
     )
 
 
+class EOMPublicOnboardingIssuedLinkItem(BaseModel):
+    """Closed office projection of one currently usable onboarding link.
+
+    The durable token row is the lifecycle authority.  The opaque token ID and
+    raw bearer are deliberately absent: office revocation already addresses the
+    record through its draft ID, so neither value has a browser use here.
+    """
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    draft_id: UUID = Field(serialization_alias="draftId")
+    contact_id: UUID = Field(serialization_alias="contactId")
+    full_name: str = Field(serialization_alias="fullName")
+    recipient_email: str | None = Field(
+        default=None, serialization_alias="recipientEmail"
+    )
+    status: Literal["issued"]
+    issued_at: datetime = Field(serialization_alias="issuedAt")
+
+
+class EOMPublicOnboardingIssuedLinkListResponse(BaseModel):
+    """Bounded current-state list for the office follow-up queue."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    links: list[EOMPublicOnboardingIssuedLinkItem]
+    limit: Annotated[int, Field(ge=1, le=_MAX_LEAD_REVIEW_LIMIT)]
+
+
 def _crm_dependency(request: Request) -> Any:
     provider_factory = getattr(request.app.state, "eom_funnel_crm_provider", None)
     if callable(provider_factory):
@@ -593,6 +622,18 @@ _CAPABILITY_ROUTES: dict[str, tuple[str, str]] = {
     "onboarding.draft.confirm_sent": (
         "POST",
         "/eom-funnel/onboarding-drafts/{draft_id}/confirm-sent",
+    ),
+    "onboarding.public_link.list": (
+        "GET",
+        "/eom-funnel/public-onboarding/issued-links",
+    ),
+    "onboarding.public_link.revoke": (
+        "POST",
+        "/eom-funnel/onboarding-drafts/{draft_id}/revoke-link",
+    ),
+    "onboarding.public_handoff.recover": (
+        "POST",
+        "/eom-funnel/public-onboarding/recover",
     ),
     "contact.link_verification": ("GET", "/eom-funnel/known-contacts"),
 }
@@ -1153,6 +1194,37 @@ async def recover_eom_public_onboarding(
             status.HTTP_200_OK if bool(result.get("idempotent")) else status.HTTP_201_CREATED
         ),
         content=_public_onboarding_recovery_content(result),
+    )
+
+
+@router.get(
+    "/public-onboarding/issued-links",
+    response_model=EOMPublicOnboardingIssuedLinkListResponse,
+    dependencies=[Depends(require_eom_funnel_api)],
+)
+async def list_eom_public_onboarding_issued_links(
+    limit: Annotated[
+        int,
+        Query(ge=1, le=_MAX_LEAD_REVIEW_LIMIT),
+    ] = _DEFAULT_LEAD_REVIEW_LIMIT,
+    _actor: dict[str, object] = Depends(require_eom_funnel_actor),
+    crm: Any = Depends(_crm_dependency),
+) -> EOMPublicOnboardingIssuedLinkListResponse:
+    """List only durable tokens that remain issued for office follow-up.
+
+    A sent onboarding draft is not sufficient evidence here: the customer may
+    have redeemed its token, or an operator may have revoked it.  This
+    projection reads the token lifecycle authority and alters no handoff,
+    delivery, or token state.
+    """
+
+    try:
+        rows = await crm.list_eom_public_onboarding_issued_links(limit=limit)
+    except EOMLeadConversionError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
+    return EOMPublicOnboardingIssuedLinkListResponse(
+        links=[EOMPublicOnboardingIssuedLinkItem.model_validate(row) for row in rows],
+        limit=limit,
     )
 
 

--- a/atlas_brain/eom_api/funnel.py
+++ b/atlas_brain/eom_api/funnel.py
@@ -44,6 +44,7 @@ from ..services.eom_public_onboarding_tokens import (
     AuthenticatedEOMPublicOnboardingToken,
     EOMPublicOnboardingTokenError,
     authenticate_eom_public_onboarding_token,
+    eom_public_onboarding_hmac_key_fingerprint,
 )
 from ..services.crm_provider import get_crm_provider
 from .funnel_auth import (
@@ -285,6 +286,23 @@ class EOMLeadReviewResponse(BaseModel):
     # (Render) auto-deploy from main; Atlas deploys by hand, so callers
     # routinely run ahead of it. See ATLAS #2275 and website #112.
     capabilities: list[str] = Field(default_factory=list)
+    # Names alone are a presentation convenience. The Tracker derives the
+    # public-onboarding controls from these registered route signatures so it
+    # cannot accidentally treat a copied capability spelling as deployment
+    # evidence.
+    capability_routes: list["EOMFunnelCapabilityRoute"] = Field(
+        default_factory=list,
+        serialization_alias="capabilityRoutes",
+    )
+
+
+class EOMFunnelCapabilityRoute(BaseModel):
+    """One registered method/path signature behind an advertised capability."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    method: str
+    path: str
 
 
 class EOMKnownContactsResponse(BaseModel):
@@ -437,6 +455,12 @@ class EOMPublicOnboardingIssuedLinkListResponse(BaseModel):
 
     links: list[EOMPublicOnboardingIssuedLinkItem]
     limit: Annotated[int, Field(ge=1, le=_MAX_LEAD_REVIEW_LIMIT)]
+    cursor: str | None = None
+    has_more: bool = Field(serialization_alias="hasMore")
+    next_cursor: str | None = Field(
+        default=None,
+        serialization_alias="nextCursor",
+    )
 
 
 def _crm_dependency(request: Request) -> Any:
@@ -465,6 +489,21 @@ def _authenticated_public_onboarding_token(
             status_code=404,
             detail="Public onboarding link is unavailable",
         ) from exc
+
+
+def _accepted_public_onboarding_signing_key_fingerprints(
+    public_onboarding: EOMPublicOnboardingConfig,
+) -> tuple[str, ...]:
+    """Return the only durable key identities that can authenticate now."""
+
+    secrets = (public_onboarding.hmac_secret, public_onboarding.previous_hmac_secret)
+    return tuple(
+        dict.fromkeys(
+            eom_public_onboarding_hmac_key_fingerprint(secret=secret)
+            for secret in secrets
+            if secret is not None
+        )
+    )
 
 
 def _public_onboarding_session_content(result: Mapping[str, Any]) -> dict[str, Any]:
@@ -665,6 +704,17 @@ def served_capabilities() -> tuple[str, ...]:
     return _served_capabilities_cache
 
 
+def served_capability_routes() -> tuple[tuple[str, str], ...]:
+    """Registered signatures for the same derived capability set.
+
+    Keep this projection mechanically tied to ``served_capabilities``: callers
+    may use the names for existing generic controls, but new cross-service
+    controls must derive their proof from the registered method/path pair.
+    """
+
+    return tuple(_CAPABILITY_ROUTES[name] for name in served_capabilities())
+
+
 def _operator_contact_fields(payload: EOMOperatorContactRequest) -> dict[str, Any]:
     model_to_contact = {
         "full_name": "full_name",
@@ -804,6 +854,10 @@ async def list_eom_lead_review_items(
         has_more=has_more,
         next_cursor=next_cursor,
         capabilities=list(served_capabilities()),
+        capability_routes=[
+            EOMFunnelCapabilityRoute(method=method, path=path)
+            for method, path in served_capability_routes()
+        ],
     )
 
 
@@ -1207,24 +1261,54 @@ async def list_eom_public_onboarding_issued_links(
         int,
         Query(ge=1, le=_MAX_LEAD_REVIEW_LIMIT),
     ] = _DEFAULT_LEAD_REVIEW_LIMIT,
+    cursor: Annotated[str | None, Query(min_length=16, max_length=512)] = None,
     _actor: dict[str, object] = Depends(require_eom_funnel_actor),
+    public_onboarding: EOMPublicOnboardingConfig = Depends(
+        require_eom_public_onboarding_config
+    ),
     crm: Any = Depends(_crm_dependency),
 ) -> EOMPublicOnboardingIssuedLinkListResponse:
     """List only durable tokens that remain issued for office follow-up.
 
     A sent onboarding draft is not sufficient evidence here: the customer may
-    have redeemed its token, or an operator may have revoked it.  This
-    projection reads the token lifecycle authority and alters no handoff,
-    delivery, or token state.
+    have redeemed its token, an operator may have revoked it, or its signing
+    key may no longer be accepted. This projection reads that live authority
+    and alters no handoff, delivery, or token state.
     """
 
+    decoded_cursor = _decode_lead_review_cursor(cursor)
     try:
-        rows = await crm.list_eom_public_onboarding_issued_links(limit=limit)
+        rows = await crm.list_eom_public_onboarding_issued_links(
+            accepted_signing_key_fingerprints=(
+                _accepted_public_onboarding_signing_key_fingerprints(public_onboarding)
+            ),
+            limit=limit + 1,
+            cursor_issued_at=(
+                decoded_cursor["created_at"] if decoded_cursor is not None else None
+            ),
+            cursor_draft_id=(
+                decoded_cursor["contact_id"] if decoded_cursor is not None else None
+            ),
+        )
     except EOMLeadConversionError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
+    page_rows = rows[:limit]
+    has_more = len(rows) > limit
+    next_cursor = None
+    if has_more and page_rows:
+        last_row = EOMPublicOnboardingIssuedLinkItem.model_validate(page_rows[-1])
+        next_cursor = _encode_lead_review_cursor(
+            created_at=last_row.issued_at,
+            contact_id=last_row.draft_id,
+        )
     return EOMPublicOnboardingIssuedLinkListResponse(
-        links=[EOMPublicOnboardingIssuedLinkItem.model_validate(row) for row in rows],
+        links=[
+            EOMPublicOnboardingIssuedLinkItem.model_validate(row) for row in page_rows
+        ],
         limit=limit,
+        cursor=cursor,
+        has_more=has_more,
+        next_cursor=next_cursor,
     )
 
 

--- a/atlas_brain/services/crm_provider.py
+++ b/atlas_brain/services/crm_provider.py
@@ -3669,6 +3669,46 @@ class DatabaseCRMProvider:
         )
         return [dict(row) for row in rows]
 
+    async def list_eom_public_onboarding_issued_links(
+        self, *, limit: int = 100
+    ) -> list[dict[str, Any]]:
+        """Return current issued-token evidence for the private office queue.
+
+        Draft ``sent`` state proves delivery evidence, not whether the customer
+        can still use the link.  The token row owns that decision, and this
+        read deliberately exposes no token ID, signing material, approval key,
+        or bearer.
+        """
+
+        from .eom_lead_conversion import EOMLeadConversionError
+
+        pool = self._get_pool()
+        if not await pool.fetchval(
+            "SELECT to_regclass('eom_public_onboarding_tokens') IS NOT NULL"
+        ):
+            raise EOMLeadConversionError(
+                503, "Public onboarding token storage is unavailable"
+            )
+        rows = await pool.fetch(
+            """
+            SELECT
+                token.draft_id,
+                token.contact_id,
+                contact.full_name,
+                draft.recipient_email,
+                token.status,
+                token.issued_at
+            FROM eom_public_onboarding_tokens AS token
+            JOIN eom_onboarding_email_drafts AS draft ON draft.id = token.draft_id
+            JOIN contacts AS contact ON contact.id = token.contact_id
+            WHERE token.status = 'issued'
+            ORDER BY token.issued_at DESC, token.id DESC
+            LIMIT $1
+            """,
+            limit,
+        )
+        return [dict(row) for row in rows]
+
     async def get_eom_onboarding_draft(self, draft_id: str) -> dict[str, Any] | None:
         pool = self._get_pool()
         row = await pool.fetchrow(

--- a/atlas_brain/services/crm_provider.py
+++ b/atlas_brain/services/crm_provider.py
@@ -3680,20 +3680,22 @@ class DatabaseCRMProvider:
         """Return current issued-token evidence for the private office queue.
 
         Draft ``sent`` state proves delivery evidence, not whether the customer
-        can still use the link. The token row plus an accepted signing-key
-        fingerprint owns that decision. This read deliberately exposes no token
-        ID, signing material, approval key, or bearer.
+        can still use the link. The token row, accepted signing-key fingerprint,
+        and current draft/contact readiness predicate jointly own that decision.
+        This read deliberately exposes no token ID, signing material, approval
+        key, or bearer.
         """
 
         from .eom_lead_conversion import EOMLeadConversionError
+        from .eom_lead_ingress import EOM_BUSINESS_CONTEXT_ID
 
         accepted_fingerprints = tuple(accepted_signing_key_fingerprints)
         if not accepted_fingerprints:
             return []
         cursor_clause = ""
-        params: list[Any] = [accepted_fingerprints, limit]
+        params: list[Any] = [accepted_fingerprints, limit, EOM_BUSINESS_CONTEXT_ID]
         if cursor_issued_at is not None and cursor_draft_id is not None:
-            cursor_clause = "AND (token.issued_at, token.draft_id) < ($3::timestamptz, $4::uuid)"
+            cursor_clause = "AND (token.issued_at, token.draft_id) < ($4::timestamptz, $5::uuid)"
             params.extend([cursor_issued_at, cursor_draft_id])
         pool = self._get_pool()
         if not await pool.fetchval(
@@ -3716,6 +3718,11 @@ class DatabaseCRMProvider:
             JOIN contacts AS contact ON contact.id = token.contact_id
             WHERE token.status = 'issued'
               AND token.signing_key_fingerprint = ANY($1::varchar[])
+              AND draft.status IN ('sending', 'sent')
+              AND contact.business_context_id = $3
+              AND contact.status = 'active'
+              AND contact.contact_type = 'lead'
+              AND contact.lead_stage = 'won'
               {cursor_clause}
             ORDER BY token.issued_at DESC, token.draft_id DESC
             LIMIT $2

--- a/atlas_brain/services/crm_provider.py
+++ b/atlas_brain/services/crm_provider.py
@@ -3670,18 +3670,31 @@ class DatabaseCRMProvider:
         return [dict(row) for row in rows]
 
     async def list_eom_public_onboarding_issued_links(
-        self, *, limit: int = 100
+        self,
+        *,
+        accepted_signing_key_fingerprints: Collection[str],
+        limit: int = 100,
+        cursor_issued_at: datetime | None = None,
+        cursor_draft_id: UUID | None = None,
     ) -> list[dict[str, Any]]:
         """Return current issued-token evidence for the private office queue.
 
         Draft ``sent`` state proves delivery evidence, not whether the customer
-        can still use the link.  The token row owns that decision, and this
-        read deliberately exposes no token ID, signing material, approval key,
-        or bearer.
+        can still use the link. The token row plus an accepted signing-key
+        fingerprint owns that decision. This read deliberately exposes no token
+        ID, signing material, approval key, or bearer.
         """
 
         from .eom_lead_conversion import EOMLeadConversionError
 
+        accepted_fingerprints = tuple(accepted_signing_key_fingerprints)
+        if not accepted_fingerprints:
+            return []
+        cursor_clause = ""
+        params: list[Any] = [accepted_fingerprints, limit]
+        if cursor_issued_at is not None and cursor_draft_id is not None:
+            cursor_clause = "AND (token.issued_at, token.draft_id) < ($3::timestamptz, $4::uuid)"
+            params.extend([cursor_issued_at, cursor_draft_id])
         pool = self._get_pool()
         if not await pool.fetchval(
             "SELECT to_regclass('eom_public_onboarding_tokens') IS NOT NULL"
@@ -3690,7 +3703,7 @@ class DatabaseCRMProvider:
                 503, "Public onboarding token storage is unavailable"
             )
         rows = await pool.fetch(
-            """
+            f"""
             SELECT
                 token.draft_id,
                 token.contact_id,
@@ -3702,10 +3715,12 @@ class DatabaseCRMProvider:
             JOIN eom_onboarding_email_drafts AS draft ON draft.id = token.draft_id
             JOIN contacts AS contact ON contact.id = token.contact_id
             WHERE token.status = 'issued'
-            ORDER BY token.issued_at DESC, token.id DESC
-            LIMIT $1
+              AND token.signing_key_fingerprint = ANY($1::varchar[])
+              {cursor_clause}
+            ORDER BY token.issued_at DESC, token.draft_id DESC
+            LIMIT $2
             """,
-            limit,
+            *params,
         )
         return [dict(row) for row in rows]
 

--- a/plans/PR-EOM-Onboarding-Office-Followup.md
+++ b/plans/PR-EOM-Onboarding-Office-Followup.md
@@ -1,0 +1,204 @@
+# PR-EOM-Onboarding-Office-Followup
+
+## Why this slice exists
+
+Juan approved the next EOM public-onboarding vertical slice: office staff need
+to see active customer onboarding links, Juan needs to revoke one safely, and
+Juan needs to recover a Tracker-local handoff that did not finish in Atlas.
+The existing private revoke and recovery commands exist, but the canonical
+office UI cannot determine which `sent` drafts still have an **issued** token.
+`sent` is email evidence, not current token truth: a token may already be
+redeemed or revoked.
+
+This Atlas dependency supplies the one safe source projection required by the
+Tracker relay and Website Leads UI. The companion Tracker and Website PRs are
+ordered after this API contract is available.
+
+### Problem-derived contract
+
+- Root cause: `eom_onboarding_email_drafts.status = 'sent'` describes email
+  delivery, while `eom_public_onboarding_tokens.status` owns whether a link is
+  currently usable. The existing draft list therefore cannot identify active
+  links for a safe revoke control; no issued-token list is exposed to the
+  office boundary.
+- Correct fix must touch/change:
+  1. Add a service-and-actor authenticated Atlas read projection that joins the
+     existing token, draft, and contact records and admits only
+     `token.status = 'issued'` rows.
+  2. Return exactly the office fields needed to identify and revoke that
+     record: `draftId`, `contactId`, `fullName`, `recipientEmail`, `issuedAt`,
+     and fixed `status: 'issued'`. Do not return the token ID, raw bearer,
+     HMAC/signing material, approval key, or a link URL.
+  3. Advertise the new read plus the existing private link-revoke and handoff
+     recovery routes through the derived capability manifest, so downstream
+     deployments can fail closed instead of rendering an action that 404s.
+  4. Prove the route through its registered FastAPI entrypoint and the provider
+     projection against disposable PostgreSQL state containing issued,
+     redeemed, and revoked tokens.
+- Must not change:
+  1. Do not alter public session, tracker-context, finalization, token parsing,
+     HMAC rotation, issuance, email transport, draft state, customer handoff,
+     or revocation/recovery mutation semantics.
+  2. Do not mint, resend, replace, expose, store, log, or return a raw bearer
+     or customer-facing onboarding URL.
+  3. Do not add a migration, configuration setting, table, dependency, or
+     production-data change. Payroll, QR/GPS, Home Base, scheduling, billing,
+     and lead-stage vocabulary remain outside this slice.
+
+## Scope (this PR)
+
+Ownership lane: eom-public-onboarding
+Slice phase: Vertical slice
+
+1. Add the issued-token-only Atlas office projection and derived capability
+   manifest entries that the Tracker can relay.
+2. Add focused provider and FastAPI tests proving its authorization, closed
+   response shape, token-state filter, and capability reachability.
+3. Leave Tracker and Website rendering/actions to their coordinated follow-up
+   PRs; this API remains additive and independently deployable.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [x] `GET /eom-funnel/public-onboarding/issued-links` requires the existing
+    service credential and office actor before invoking the CRM provider, and
+    returns a bounded `links` list of only issued-token projections; settled by
+    `tests/test_eom_public_onboarding.py` ASGI route tests.
+  - [x] The provider projection joins the existing token/draft/contact rows,
+    selects only `status = 'issued'`, orders newest issued evidence first, and
+    does not select or serialize raw token material; settled by
+    `tests/test_eom_lead_conversion_integration.py` disposable-Postgres test.
+  - [x] Issued-link list/revoke/recovery capabilities are advertised only when
+    their exact registered routes exist; settled by
+    `tests/test_eom_funnel_capability_manifest.py`.
+  - [x] Existing public browser and private recovery routes retain their
+    response/error behavior; settled by focused public-onboarding route tests
+    and the cold diff reconstruction.
+- Reachability proof: ASGI tests call the registered issued-links route and
+  observe the safe JSON response; the provider test persists token states and
+  observes that only the issued record is returned.
+- Affected surfaces: `atlas_brain/eom_api/funnel.py`,
+  `atlas_brain/services/crm_provider.py`, the EOM capability manifest, and
+  focused public-onboarding/provider tests.
+- Risk areas: service/actor authorization, browser/private data separation,
+  capability deployment skew, token lifecycle truth, and response compatibility.
+- Reviewer rules triggered: R1, R2, R3, R5, R6, R8, R10, R12, R14.
+
+### Boundary-change enumeration
+
+- Boundary path/seam: new private office read
+  `GET /eom-funnel/public-onboarding/issued-links`; derived capability manifest
+  gains this read and the pre-existing revoke/recovery routes.
+- Replaced-path behaviors: none. Existing draft listing retains its email-draft
+  semantics; existing public and private mutation paths are untouched.
+- Guard-relevant fields: service bearer, actor headers, bounded `limit`, and
+  durable `token.status`. No raw bearer is an admitted request or response
+  field at this seam.
+- Caller x input shape: authenticated Tracker service plus valid office actor
+  gets only issued-link metadata; absent service/actor rejects before provider
+  access; issued/redeemed/revoked durable rows return issued only.
+
+### Deployed-config probing
+
+- Deployed/default config values: this read and the existing private repair
+  routes use the configured service/actor boundary and remain available when
+  public issuance is disabled, so prior issued tokens stay operable.
+- Explicit value probe: valid service and actor credentials return a safe
+  issued-link page.
+- Absent value probe: absent service credential or actor header rejects before
+  provider access.
+- Default-session/default-context probe: no public browser token, public URL,
+  or HMAC configuration is read by this office projection.
+- Side-effect ordering: the route validates service/actor/limit before the
+  provider call; the provider performs a single read and makes no write.
+
+### Files touched
+
+- `atlas_brain/eom_api/funnel.py`
+- `atlas_brain/services/crm_provider.py`
+- `plans/PR-EOM-Onboarding-Office-Followup.md`
+- `tests/test_eom_funnel_capability_manifest.py`
+- `tests/test_eom_lead_conversion_integration.py`
+- `tests/test_eom_public_onboarding.py`
+
+## Mechanism
+
+`DatabaseCRMProvider.list_eom_public_onboarding_issued_links` reads the durable
+`eom_public_onboarding_tokens` state and joins its draft/contact identity. It
+projects no token identifier or bearer, returns only rows whose status is
+`issued`, and orders by `issued_at DESC, token.id DESC`. The router validates
+the closed model and exposes it behind the existing EOM service and actor
+dependencies. The capability map derives three controls from their registered
+routes: issued-link list, issued-link revoke, and public-handoff recovery.
+
+The later Tracker relay validates the closed Atlas response before exposing it
+to the Website. The later Website uses the `draftId` only for the existing
+Juan-gated revoke command and uses Tracker's separate local-reservation queue
+for recovery; this endpoint neither sends a replacement nor changes a token.
+
+## Intentional
+
+- The response omits token IDs as well as raw tokens. A revoke action already
+  addresses the durable record by `draftId`; the browser does not need another
+  correlator.
+- The new list does not reuse `sent` drafts. Email-delivery state and usable
+  token state are intentionally distinct.
+- The limit is bounded and no cursor is added in this small, operational queue,
+  matching the existing Tracker recovery list rather than broadening this slice
+  into a generic history browser.
+- The list/revoke/recovery routes remain usable after issuance is paused; they
+  repair already-issued records and do not mint a link.
+
+## Deferred
+
+- Tracker PR: authenticated relay, deployment proofs, and capability-gated
+  calls to the existing revoke/recovery commands.
+- Website PR: bilingual Leads panels, all-admin read visibility, Juan-only
+  actions, and confirmation dialogs.
+- Replacement-link issuance, email resend, expiry/reminders, history browsing,
+  additional recovery metadata, and dashboard metrics remain future work.
+
+Parking predicate: park UI polish, link-history browsing, replacement delivery,
+and non-safety observability additions. Keep incorrect token-state filtering,
+raw bearer disclosure, missing office authorization, or a capability that
+advertises an absent route in scope because each would make the operator action
+unsafe or misleading.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m compileall -q atlas_brain/eom_api/funnel.py
+  atlas_brain/services/crm_provider.py tests/test_eom_public_onboarding.py
+  tests/test_eom_funnel_capability_manifest.py
+  tests/test_eom_lead_conversion_integration.py` — passed.
+- `python -m pytest -q tests/test_eom_public_onboarding.py
+  tests/test_eom_funnel_capability_manifest.py
+  tests/test_eom_lead_conversion_integration.py -k 'public_onboarding or
+  onboarding_draft_list_projection or capability'` — 48 passed, 13 skipped,
+  78 deselected.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=<isolated local PostgreSQL container>
+  python -m pytest -q tests/test_eom_lead_conversion_integration.py -k
+  public_onboarding_issued_link_projection_excludes_terminal_tokens -rs` —
+  1 passed, 90 deselected. The temporary disposable container was removed
+  afterward.
+- ruff check atlas_brain/eom_api/funnel.py
+  atlas_brain/services/crm_provider.py tests/test_eom_public_onboarding.py
+  tests/test_eom_funnel_capability_manifest.py
+  tests/test_eom_lead_conversion_integration.py — passed.
+- `git diff --check` — passed.
+- Cold diff audit: route/provider/manifest/test changes trace only to the
+  Problem-derived contract. No public lifecycle mutation, token/bearer field,
+  migration, configuration, or unrelated product surface changed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/eom_api/funnel.py` | 72 |
+| `atlas_brain/services/crm_provider.py` | 40 |
+| `plans/PR-EOM-Onboarding-Office-Followup.md` | 204 |
+| `tests/test_eom_funnel_capability_manifest.py` | 3 |
+| `tests/test_eom_lead_conversion_integration.py` | 59 |
+| `tests/test_eom_public_onboarding.py` | 69 |
+| **Total** | **447** |

--- a/plans/PR-EOM-Onboarding-Office-Followup.md
+++ b/plans/PR-EOM-Onboarding-Office-Followup.md
@@ -20,7 +20,7 @@ The review findings expose one cross-repository contract defect, not unrelated
 polish: the office queue must represent links that remain publicly authorized,
 must page beyond the first response, and must let the downstream relay prove
 the exact registered controls it may invoke. Atlas, Tracker, and Website each
-change only their part of that same contract. The larger seven-file Atlas
+change only their part of that same contract. The larger eight-file Atlas
 budget is indivisible because the provider, public response, route capability
 projection, CI enrollment, and focused route/provider tests must agree before
 the Tracker can safely consume it.
@@ -65,13 +65,14 @@ the Tracker can safely consume it.
 
 Ownership lane: eom-public-onboarding
 Slice phase: Vertical slice
-Max files: 7
+Max files: 8
 
 1. Add the publicly-authorized, keyset-paged Atlas office projection and
    derived capability route signatures that the Tracker can relay.
-2. Add focused provider and FastAPI tests proving authorization, closed
-   response shape, current/previous-key authority filtering, cursor behavior,
-   capability reachability, and CI enrollment.
+2. Add focused provider and FastAPI tests proving authorization, the additive
+   closed response shape (including derived capability routes),
+   current/previous-key authority filtering, cursor behavior, capability
+   reachability, and CI enrollment.
 3. Leave Tracker and Website rendering/actions to their coordinated follow-up
    PRs; this API remains additive and independently deployable.
 
@@ -92,14 +93,16 @@ Max files: 7
     advertised only when their exact registered routes exist; settled by
     `tests/test_eom_funnel_capability_manifest.py`.
   - [x] Existing public browser and private recovery routes retain their
-    response/error behavior; settled by focused public-onboarding route tests
-    and the cold diff reconstruction.
+    response/error behavior; the private lead-review response advances only
+    additively with derived `capabilityRoutes`, settled by focused
+    public-onboarding and lead-review route tests plus the cold diff
+    reconstruction.
 - Reachability proof: ASGI tests call the registered issued-links route and
   observe the safe JSON response; the provider test persists token states and
   observes that only the issued record is returned.
 - Affected surfaces: `atlas_brain/eom_api/funnel.py`,
   `atlas_brain/services/crm_provider.py`, the EOM capability manifest, and
-  focused public-onboarding/provider tests.
+  focused public-onboarding, lead-review, and provider tests.
 - Risk areas: service/actor authorization, browser/private data separation,
   capability deployment skew, token lifecycle truth, and response compatibility.
 - Reviewer rules triggered: R1, R2, R3, R5, R6, R8, R10, R12, R14.
@@ -161,6 +164,7 @@ that disposition is added. No generic `defer` disposition is permitted.
 - `atlas_brain/services/crm_provider.py`
 - `plans/PR-EOM-Onboarding-Office-Followup.md`
 - `tests/test_eom_funnel_capability_manifest.py`
+- `tests/test_eom_lead_conversion.py`
 - `tests/test_eom_lead_conversion_integration.py`
 - `tests/test_eom_public_onboarding.py`
 
@@ -240,8 +244,9 @@ Parked hardening: none.
 | `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 1 |
 | `atlas_brain/eom_api/funnel.py` | 156 |
 | `atlas_brain/services/crm_provider.py` | 55 |
-| `plans/PR-EOM-Onboarding-Office-Followup.md` | 247 |
+| `plans/PR-EOM-Onboarding-Office-Followup.md` | 252 |
 | `tests/test_eom_funnel_capability_manifest.py` | 24 |
+| `tests/test_eom_lead_conversion.py` | 12 |
 | `tests/test_eom_lead_conversion_integration.py` | 160 |
 | `tests/test_eom_public_onboarding.py` | 182 |
-| **Total** | **825** |
+| **Total** | **842** |

--- a/plans/PR-EOM-Onboarding-Office-Followup.md
+++ b/plans/PR-EOM-Onboarding-Office-Followup.md
@@ -14,27 +14,43 @@ This Atlas dependency supplies the one safe source projection required by the
 Tracker relay and Website Leads UI. The companion Tracker and Website PRs are
 ordered after this API contract is available.
 
+### Review-remediation rationale
+
+The review findings expose one cross-repository contract defect, not unrelated
+polish: the office queue must represent links that remain publicly authorized,
+must page beyond the first response, and must let the downstream relay prove
+the exact registered controls it may invoke. Atlas, Tracker, and Website each
+change only their part of that same contract. The larger seven-file Atlas
+budget is indivisible because the provider, public response, route capability
+projection, CI enrollment, and focused route/provider tests must agree before
+the Tracker can safely consume it.
+
 ### Problem-derived contract
 
 - Root cause: `eom_onboarding_email_drafts.status = 'sent'` describes email
-  delivery, while `eom_public_onboarding_tokens.status` owns whether a link is
-  currently usable. The existing draft list therefore cannot identify active
-  links for a safe revoke control; no issued-token list is exposed to the
-  office boundary.
+  delivery, while `eom_public_onboarding_tokens.status` plus the currently
+  accepted signing-key fingerprints own whether a link is currently usable.
+  The existing draft list therefore cannot identify active links for a safe
+  revoke control; the initial issued-token projection also admitted retired
+  signing-key rows and exposed only a first page.
 - Correct fix must touch/change:
   1. Add a service-and-actor authenticated Atlas read projection that joins the
-     existing token, draft, and contact records and admits only
-     `token.status = 'issued'` rows.
+     existing token, draft, and contact records and admits only `issued` rows
+     signed by the current primary or configured previous public-onboarding
+     key. It must fail closed when public onboarding authority is unavailable.
   2. Return exactly the office fields needed to identify and revoke that
      record: `draftId`, `contactId`, `fullName`, `recipientEmail`, `issuedAt`,
      and fixed `status: 'issued'`. Do not return the token ID, raw bearer,
      HMAC/signing material, approval key, or a link URL.
-  3. Advertise the new read plus the existing private link-revoke and handoff
-     recovery routes through the derived capability manifest, so downstream
-     deployments can fail closed instead of rendering an action that 404s.
-  4. Prove the route through its registered FastAPI entrypoint and the provider
-     projection against disposable PostgreSQL state containing issued,
-     redeemed, and revoked tokens.
+  3. Page the bounded queue with the existing opaque cursor grammar and stable
+     newest-first keyset ordering, without returning a token identifier.
+  4. Advertise the new read plus the existing private link-revoke and handoff
+     recovery routes through the derived capability manifest *and* their
+     registered method/path signatures, so downstream deployments derive rather
+     than copy the decision set.
+  5. Prove the route through its registered FastAPI entrypoint and the provider
+     projection against disposable PostgreSQL state containing current-key,
+     previous-key, retired-key, redeemed, and revoked tokens.
 - Must not change:
   1. Do not alter public session, tracker-context, finalization, token parsing,
      HMAC rotation, issuance, email transport, draft state, customer handoff,
@@ -49,11 +65,13 @@ ordered after this API contract is available.
 
 Ownership lane: eom-public-onboarding
 Slice phase: Vertical slice
+Max files: 7
 
-1. Add the issued-token-only Atlas office projection and derived capability
-   manifest entries that the Tracker can relay.
-2. Add focused provider and FastAPI tests proving its authorization, closed
-   response shape, token-state filter, and capability reachability.
+1. Add the publicly-authorized, keyset-paged Atlas office projection and
+   derived capability route signatures that the Tracker can relay.
+2. Add focused provider and FastAPI tests proving authorization, closed
+   response shape, current/previous-key authority filtering, cursor behavior,
+   capability reachability, and CI enrollment.
 3. Leave Tracker and Website rendering/actions to their coordinated follow-up
    PRs; this API remains additive and independently deployable.
 
@@ -62,14 +80,16 @@ Slice phase: Vertical slice
 - Acceptance criteria:
   - [x] `GET /eom-funnel/public-onboarding/issued-links` requires the existing
     service credential and office actor before invoking the CRM provider, and
-    returns a bounded `links` list of only issued-token projections; settled by
+    returns a bounded, keyset-paged `links` list of only publicly-authorized
+    issued-token projections; settled by
     `tests/test_eom_public_onboarding.py` ASGI route tests.
   - [x] The provider projection joins the existing token/draft/contact rows,
-    selects only `status = 'issued'`, orders newest issued evidence first, and
+    selects only `status = 'issued'` under an accepted current/previous signing
+    key, orders newest issued evidence first with an opaque next cursor, and
     does not select or serialize raw token material; settled by
     `tests/test_eom_lead_conversion_integration.py` disposable-Postgres test.
-  - [x] Issued-link list/revoke/recovery capabilities are advertised only when
-    their exact registered routes exist; settled by
+  - [x] Issued-link list/revoke/recovery capabilities and route signatures are
+    advertised only when their exact registered routes exist; settled by
     `tests/test_eom_funnel_capability_manifest.py`.
   - [x] Existing public browser and private recovery routes retain their
     response/error behavior; settled by focused public-onboarding route tests
@@ -84,36 +104,59 @@ Slice phase: Vertical slice
   capability deployment skew, token lifecycle truth, and response compatibility.
 - Reviewer rules triggered: R1, R2, R3, R5, R6, R8, R10, R12, R14.
 
+### Fix-loop disposition preflight
+
+Before a later remote update, classify every current thread as `fixed-in`,
+`waived-*`, or `not-applicable` with file/test evidence; rerun the guard after
+that disposition is added. No generic `defer` disposition is permitted.
+
 ### Boundary-change enumeration
 
 - Boundary path/seam: new private office read
   `GET /eom-funnel/public-onboarding/issued-links`; derived capability manifest
-  gains this read and the pre-existing revoke/recovery routes.
+  gains this read and the pre-existing revoke/recovery routes, with canonical
+  registered method/path signatures for each advertised capability.
 - Replaced-path behaviors: none. Existing draft listing retains its email-draft
   semantics; existing public and private mutation paths are untouched.
-- Guard-relevant fields: service bearer, actor headers, bounded `limit`, and
-  durable `token.status`. No raw bearer is an admitted request or response
-  field at this seam.
+- Guard-relevant fields: service bearer, actor headers, bounded `limit`, opaque
+  cursor, durable `token.status`, and accepted signing-key fingerprints. No raw
+  bearer is an admitted request or response field at this seam.
 - Caller x input shape: authenticated Tracker service plus valid office actor
   gets only issued-link metadata; absent service/actor rejects before provider
-  access; issued/redeemed/revoked durable rows return issued only.
+  access; current/previous-key issued rows return issued only; retired-key,
+  redeemed, and revoked rows do not enter the active queue.
+
+### Capability-set closure declaration
+
+- Closed decision set: `GET /eom-funnel/public-onboarding/issued-links`,
+  `POST /eom-funnel/onboarding-drafts/{draft_id}/revoke-link`, and
+  `POST /eom-funnel/public-onboarding/recover`.
+- Canonical source: `served_capabilities()` filtered through
+  `_CAPABILITY_ROUTES` in `atlas_brain/eom_api/funnel.py`; the response derives
+  both capability names and method/path signatures from that exact registry.
+- Deployment default: absent, malformed, or nonmatching route signatures are
+  unavailable downstream. The Tracker must fail closed rather than treating a
+  copied capability spelling as evidence that an action is deployed.
 
 ### Deployed-config probing
 
-- Deployed/default config values: this read and the existing private repair
-  routes use the configured service/actor boundary and remain available when
-  public issuance is disabled, so prior issued tokens stay operable.
+- Deployed/default config values: the list route requires valid public
+  onboarding authority because it asserts that a link remains usable now.
+  Existing private revoke/recovery routes remain usable when issuance is
+  paused, because they repair already-issued records rather than mint one.
 - Explicit value probe: valid service and actor credentials return a safe
   issued-link page.
 - Absent value probe: absent service credential or actor header rejects before
   provider access.
-- Default-session/default-context probe: no public browser token, public URL,
-  or HMAC configuration is read by this office projection.
+- Default-session/default-context probe: the office route derives only HMAC
+  fingerprints from the configured primary/previous secret; it returns neither
+  the secret, a public browser token, nor a public URL.
 - Side-effect ordering: the route validates service/actor/limit before the
   provider call; the provider performs a single read and makes no write.
 
 ### Files touched
 
+- `.github/workflows/atlas_eom_lead_pipeline_checks.yml`
 - `atlas_brain/eom_api/funnel.py`
 - `atlas_brain/services/crm_provider.py`
 - `plans/PR-EOM-Onboarding-Office-Followup.md`
@@ -125,11 +168,14 @@ Slice phase: Vertical slice
 
 `DatabaseCRMProvider.list_eom_public_onboarding_issued_links` reads the durable
 `eom_public_onboarding_tokens` state and joins its draft/contact identity. It
-projects no token identifier or bearer, returns only rows whose status is
-`issued`, and orders by `issued_at DESC, token.id DESC`. The router validates
-the closed model and exposes it behind the existing EOM service and actor
-dependencies. The capability map derives three controls from their registered
-routes: issued-link list, issued-link revoke, and public-handoff recovery.
+projects no token identifier or bearer, returns only `issued` rows whose
+signing-key fingerprint is current or configured as previous, and pages with
+`issued_at DESC, draft_id DESC` through the existing opaque cursor grammar. The
+router derives fingerprints from the configured public-onboarding authority,
+validates the closed model, and exposes it behind the existing EOM service and
+actor dependencies. The capability map derives three controls and their
+method/path signatures from registered routes: issued-link list, issued-link
+revoke, and public-handoff recovery.
 
 The later Tracker relay validates the closed Atlas response before exposing it
 to the Website. The later Website uses the `draftId` only for the existing
@@ -143,9 +189,8 @@ for recovery; this endpoint neither sends a replacement nor changes a token.
   correlator.
 - The new list does not reuse `sent` drafts. Email-delivery state and usable
   token state are intentionally distinct.
-- The limit is bounded and no cursor is added in this small, operational queue,
-  matching the existing Tracker recovery list rather than broadening this slice
-  into a generic history browser.
+- The limit remains bounded. A cursor is added only to make the active queue
+  complete; it does not turn this slice into a token history browser.
 - The list/revoke/recovery routes remain usable after issuance is paused; they
   repair already-issued records and do not mint a link.
 
@@ -173,14 +218,11 @@ Parked hardening: none.
   tests/test_eom_funnel_capability_manifest.py
   tests/test_eom_lead_conversion_integration.py` — passed.
 - `python -m pytest -q tests/test_eom_public_onboarding.py
-  tests/test_eom_funnel_capability_manifest.py
-  tests/test_eom_lead_conversion_integration.py -k 'public_onboarding or
-  onboarding_draft_list_projection or capability'` — 48 passed, 13 skipped,
-  78 deselected.
+  tests/test_eom_funnel_capability_manifest.py` — 49 passed.
 - `ATLAS_MIGRATION_TEST_DATABASE_URL=<isolated local PostgreSQL container>
   python -m pytest -q tests/test_eom_lead_conversion_integration.py -k
-  public_onboarding_issued_link_projection_excludes_terminal_tokens -rs` —
-  1 passed, 90 deselected. The temporary disposable container was removed
+  'public_onboarding_issued_link_projection'` — 2 passed, 90 deselected. The
+  temporary disposable container was removed
   afterward.
 - ruff check atlas_brain/eom_api/funnel.py
   atlas_brain/services/crm_provider.py tests/test_eom_public_onboarding.py
@@ -195,10 +237,11 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `atlas_brain/eom_api/funnel.py` | 72 |
-| `atlas_brain/services/crm_provider.py` | 40 |
-| `plans/PR-EOM-Onboarding-Office-Followup.md` | 204 |
-| `tests/test_eom_funnel_capability_manifest.py` | 3 |
-| `tests/test_eom_lead_conversion_integration.py` | 59 |
-| `tests/test_eom_public_onboarding.py` | 69 |
-| **Total** | **447** |
+| `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 1 |
+| `atlas_brain/eom_api/funnel.py` | 156 |
+| `atlas_brain/services/crm_provider.py` | 55 |
+| `plans/PR-EOM-Onboarding-Office-Followup.md` | 247 |
+| `tests/test_eom_funnel_capability_manifest.py` | 24 |
+| `tests/test_eom_lead_conversion_integration.py` | 160 |
+| `tests/test_eom_public_onboarding.py` | 182 |
+| **Total** | **825** |

--- a/plans/PR-EOM-Onboarding-Office-Followup.md
+++ b/plans/PR-EOM-Onboarding-Office-Followup.md
@@ -28,16 +28,20 @@ the Tracker can safely consume it.
 ### Problem-derived contract
 
 - Root cause: `eom_onboarding_email_drafts.status = 'sent'` describes email
-  delivery, while `eom_public_onboarding_tokens.status` plus the currently
-  accepted signing-key fingerprints own whether a link is currently usable.
+  delivery, while `eom_public_onboarding_tokens.status`, the currently
+  accepted signing-key fingerprints, and the canonical draft/contact predicate
+  together own whether a link is currently usable.
   The existing draft list therefore cannot identify active links for a safe
   revoke control; the initial issued-token projection also admitted retired
-  signing-key rows and exposed only a first page.
+  signing-key rows, exposed only a first page, and did not apply the canonical
+  public-session readiness predicate after a contact or draft later changed.
 - Correct fix must touch/change:
   1. Add a service-and-actor authenticated Atlas read projection that joins the
      existing token, draft, and contact records and admits only `issued` rows
      signed by the current primary or configured previous public-onboarding
-     key. It must fail closed when public onboarding authority is unavailable.
+     key that satisfy the canonical public-session predicate: a `sending` or
+     `sent` draft plus an active EOM `lead` at `won`. It must fail closed when
+     public onboarding authority is unavailable.
   2. Return exactly the office fields needed to identify and revoke that
      record: `draftId`, `contactId`, `fullName`, `recipientEmail`, `issuedAt`,
      and fixed `status: 'issued'`. Do not return the token ID, raw bearer,
@@ -71,8 +75,8 @@ Max files: 8
    derived capability route signatures that the Tracker can relay.
 2. Add focused provider and FastAPI tests proving authorization, the additive
    closed response shape (including derived capability routes),
-   current/previous-key authority filtering, cursor behavior, capability
-   reachability, and CI enrollment.
+   current/previous-key authority filtering, canonical public-session
+   readiness, cursor behavior, capability reachability, and CI enrollment.
 3. Leave Tracker and Website rendering/actions to their coordinated follow-up
    PRs; this API remains additive and independently deployable.
 
@@ -86,8 +90,9 @@ Max files: 8
     `tests/test_eom_public_onboarding.py` ASGI route tests.
   - [x] The provider projection joins the existing token/draft/contact rows,
     selects only `status = 'issued'` under an accepted current/previous signing
-    key, orders newest issued evidence first with an opaque next cursor, and
-    does not select or serialize raw token material; settled by
+    key whose draft/contact state satisfies the canonical public-session
+    predicate, orders newest issued evidence first with an opaque next cursor,
+    and does not select or serialize raw token material; settled by
     `tests/test_eom_lead_conversion_integration.py` disposable-Postgres test.
   - [x] Issued-link list/revoke/recovery capabilities and route signatures are
     advertised only when their exact registered routes exist; settled by
@@ -126,8 +131,10 @@ that disposition is added. No generic `defer` disposition is permitted.
   bearer is an admitted request or response field at this seam.
 - Caller x input shape: authenticated Tracker service plus valid office actor
   gets only issued-link metadata; absent service/actor rejects before provider
-  access; current/previous-key issued rows return issued only; retired-key,
-  redeemed, and revoked rows do not enter the active queue.
+  access; current/previous-key issued rows return issued only when their
+  `sending`/`sent` draft and active EOM won-lead state remain valid; retired-key,
+  terminal, inactive, archived, cross-context, and non-won rows do not enter
+  the active queue.
 
 ### Capability-set closure declaration
 
@@ -173,9 +180,10 @@ that disposition is added. No generic `defer` disposition is permitted.
 `DatabaseCRMProvider.list_eom_public_onboarding_issued_links` reads the durable
 `eom_public_onboarding_tokens` state and joins its draft/contact identity. It
 projects no token identifier or bearer, returns only `issued` rows whose
-signing-key fingerprint is current or configured as previous, and pages with
-`issued_at DESC, draft_id DESC` through the existing opaque cursor grammar. The
-router derives fingerprints from the configured public-onboarding authority,
+signing-key fingerprint is current or configured as previous and whose
+draft/contact state remains valid for the canonical public session, and pages
+with `issued_at DESC, draft_id DESC` through the existing opaque cursor grammar.
+The router derives fingerprints from the configured public-onboarding authority,
 validates the closed model, and exposes it behind the existing EOM service and
 actor dependencies. The capability map derives three controls and their
 method/path signatures from registered routes: issued-link list, issued-link
@@ -191,8 +199,9 @@ for recovery; this endpoint neither sends a replacement nor changes a token.
 - The response omits token IDs as well as raw tokens. A revoke action already
   addresses the durable record by `draftId`; the browser does not need another
   correlator.
-- The new list does not reuse `sent` drafts. Email-delivery state and usable
-  token state are intentionally distinct.
+- The new list does not treat `sent` draft state alone as authority. It
+  intersects the canonical `sending`/`sent` draft/contact predicate with live
+  issued-token state and current signing authority.
 - The limit remains bounded. A cursor is added only to make the active queue
   complete; it does not turn this slice into a token history browser.
 - The list/revoke/recovery routes remain usable after issuance is paused; they
@@ -219,18 +228,21 @@ Parked hardening: none.
 
 - `python -m compileall -q atlas_brain/eom_api/funnel.py
   atlas_brain/services/crm_provider.py tests/test_eom_public_onboarding.py
-  tests/test_eom_funnel_capability_manifest.py
+  tests/test_eom_funnel_capability_manifest.py tests/test_eom_lead_conversion.py
   tests/test_eom_lead_conversion_integration.py` — passed.
 - `python -m pytest -q tests/test_eom_public_onboarding.py
-  tests/test_eom_funnel_capability_manifest.py` — 49 passed.
+  tests/test_eom_funnel_capability_manifest.py
+  tests/test_eom_lead_conversion.py::test_full_atlas_app_serves_public_intake_and_private_handoff_together
+  tests/test_eom_lead_conversion.py::test_private_lead_review_forwards_keyset_cursor_for_continuation
+  tests/test_eom_lead_conversion.py::test_private_lead_review_returns_only_the_closed_projection` — 52 passed.
 - `ATLAS_MIGRATION_TEST_DATABASE_URL=<isolated local PostgreSQL container>
   python -m pytest -q tests/test_eom_lead_conversion_integration.py -k
-  'public_onboarding_issued_link_projection'` — 2 passed, 90 deselected. The
+  'public_onboarding_issued_link_projection'` — 3 passed, 90 deselected. The
   temporary disposable container was removed
   afterward.
 - ruff check atlas_brain/eom_api/funnel.py
   atlas_brain/services/crm_provider.py tests/test_eom_public_onboarding.py
-  tests/test_eom_funnel_capability_manifest.py
+  tests/test_eom_funnel_capability_manifest.py tests/test_eom_lead_conversion.py
   tests/test_eom_lead_conversion_integration.py — passed.
 - `git diff --check` — passed.
 - Cold diff audit: route/provider/manifest/test changes trace only to the
@@ -243,10 +255,10 @@ Parked hardening: none.
 |---|---:|
 | `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 1 |
 | `atlas_brain/eom_api/funnel.py` | 156 |
-| `atlas_brain/services/crm_provider.py` | 55 |
-| `plans/PR-EOM-Onboarding-Office-Followup.md` | 252 |
+| `atlas_brain/services/crm_provider.py` | 62 |
+| `plans/PR-EOM-Onboarding-Office-Followup.md` | 264 |
 | `tests/test_eom_funnel_capability_manifest.py` | 24 |
 | `tests/test_eom_lead_conversion.py` | 12 |
-| `tests/test_eom_lead_conversion_integration.py` | 160 |
+| `tests/test_eom_lead_conversion_integration.py` | 268 |
 | `tests/test_eom_public_onboarding.py` | 182 |
-| **Total** | **842** |
+| **Total** | **969** |

--- a/tests/test_eom_funnel_capability_manifest.py
+++ b/tests/test_eom_funnel_capability_manifest.py
@@ -155,6 +155,25 @@ async def test_lead_review_response_advertises_lost_and_reopen() -> None:
     assert "onboarding.public_link.list" in capabilities
     assert "onboarding.public_link.revoke" in capabilities
     assert "onboarding.public_handoff.recover" in capabilities
+    capability_routes = {
+        (route["method"], route["path"])
+        for route in response.json()["capabilityRoutes"]
+    }
+    assert capability_routes == {
+        funnel_mod._CAPABILITY_ROUTES[name] for name in capabilities
+    }
+    assert (
+        "GET",
+        "/eom-funnel/public-onboarding/issued-links",
+    ) in capability_routes
+    assert (
+        "POST",
+        "/eom-funnel/onboarding-drafts/{draft_id}/revoke-link",
+    ) in capability_routes
+    assert (
+        "POST",
+        "/eom-funnel/public-onboarding/recover",
+    ) in capability_routes
 
 
 @pytest.mark.asyncio
@@ -192,6 +211,7 @@ async def test_pre_manifest_caller_still_reads_every_field_it_knew() -> None:
     body = response.json()
     for key in ("leads", "limit", "cursor", "hasMore", "nextCursor"):
         assert key in body, key
+    assert "capabilityRoutes" in body
     lead = body["leads"][0]
     for key in (
         "contactId",
@@ -216,3 +236,4 @@ def test_response_model_defaults_capabilities_for_a_caller_that_omits_it() -> No
         leads=[], limit=25, cursor=None, has_more=False, next_cursor=None
     )
     assert response.capabilities == []
+    assert response.capability_routes == []

--- a/tests/test_eom_funnel_capability_manifest.py
+++ b/tests/test_eom_funnel_capability_manifest.py
@@ -152,6 +152,9 @@ async def test_lead_review_response_advertises_lost_and_reopen() -> None:
     capabilities = response.json()["capabilities"]
     assert "lead.lost" in capabilities
     assert "lead.reopen" in capabilities
+    assert "onboarding.public_link.list" in capabilities
+    assert "onboarding.public_link.revoke" in capabilities
+    assert "onboarding.public_handoff.recover" in capabilities
 
 
 @pytest.mark.asyncio

--- a/tests/test_eom_lead_conversion.py
+++ b/tests/test_eom_lead_conversion.py
@@ -611,6 +611,10 @@ async def test_full_atlas_app_serves_public_intake_and_private_handoff_together(
         "hasMore": False,
         "nextCursor": None,
         "capabilities": list(funnel_mod.served_capabilities()),
+        "capabilityRoutes": [
+            {"method": method, "path": path}
+            for method, path in funnel_mod.served_capability_routes()
+        ],
     }
     assert crm.review_calls == [
         {"limit": 101, "cursor_created_at": None, "cursor_contact_id": None}
@@ -957,6 +961,10 @@ async def test_private_lead_review_returns_only_the_closed_projection():
         "hasMore": True,
         "nextCursor": expected_cursor,
         "capabilities": list(funnel_mod.served_capabilities()),
+        "capabilityRoutes": [
+            {"method": method, "path": path}
+            for method, path in funnel_mod.served_capability_routes()
+        ],
     }
     assert crm.review_calls == [
         {"limit": 2, "cursor_created_at": None, "cursor_contact_id": None}
@@ -989,6 +997,10 @@ async def test_private_lead_review_forwards_keyset_cursor_for_continuation():
         "hasMore": False,
         "nextCursor": None,
         "capabilities": list(funnel_mod.served_capabilities()),
+        "capabilityRoutes": [
+            {"method": method, "path": path}
+            for method, path in funnel_mod.served_capability_routes()
+        ],
     }
     assert crm.review_calls == [
         {

--- a/tests/test_eom_lead_conversion_integration.py
+++ b/tests/test_eom_lead_conversion_integration.py
@@ -5805,7 +5805,10 @@ async def test_public_onboarding_issued_link_projection_excludes_terminal_tokens
             draft_id=revoked_draft_id
         )
 
-        links = await provider.list_eom_public_onboarding_issued_links(limit=100)
+        links = await provider.list_eom_public_onboarding_issued_links(
+            accepted_signing_key_fingerprints=(_PUBLIC_ONBOARDING_KEY_FINGERPRINT,),
+            limit=100,
+        )
 
         assert [{str(row["draft_id"]), str(row["contact_id"])} for row in links] == [
             {issued_draft_id, str(issued_contact_id)}
@@ -5820,6 +5823,104 @@ async def test_public_onboarding_issued_link_projection_excludes_terminal_tokens
         assert str(revoked_contact_id) not in str(links)
         assert str(redeemed_token_id) not in str(links)
         assert str(revoked_token_id) not in str(links)
+    finally:
+        await conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_public_onboarding_issued_link_projection_pages_current_and_previous_keys():
+    """Only keys that can authenticate now enter a complete newest-first queue."""
+
+    previous_secret = "previous-test-only-public-onboarding-secret-value-654321"
+    retired_secret = "retired-test-only-public-onboarding-secret-value-987654"
+    previous_fingerprint = eom_public_onboarding_hmac_key_fingerprint(
+        secret=previous_secret
+    )
+    retired_fingerprint = eom_public_onboarding_hmac_key_fingerprint(
+        secret=retired_secret
+    )
+    database_url = _database_url_or_skip()
+    schema = f"atlas_eom_public_onboarding_issued_link_page_{uuid.uuid4().hex}"
+    conn = await asyncpg.connect(database_url)
+    try:
+        await _prepare_schema(conn, schema, apply_public_onboarding_migration=True)
+        provider = DatabaseCRMProvider(pool=conn)
+
+        newest_contact_id, newest_draft_id = await _book_first_clean_draft(
+            conn, provider, full_name="Current Newest"
+        )
+        _, newest_token_id = await _claim_public_onboarding_token(
+            provider, draft_id=newest_draft_id
+        )
+        previous_contact_id, previous_draft_id = await _book_first_clean_draft(
+            conn, provider, full_name="Previous Key"
+        )
+        _, previous_token_id = await _claim_public_onboarding_token(
+            provider,
+            draft_id=previous_draft_id,
+            hmac_secret=previous_secret,
+        )
+        older_contact_id, older_draft_id = await _book_first_clean_draft(
+            conn, provider, full_name="Current Older"
+        )
+        _, older_token_id = await _claim_public_onboarding_token(
+            provider, draft_id=older_draft_id
+        )
+        retired_contact_id, retired_draft_id = await _book_first_clean_draft(
+            conn, provider, full_name="Retired Key"
+        )
+        _, retired_token_id = await _claim_public_onboarding_token(
+            provider,
+            draft_id=retired_draft_id,
+            hmac_secret=retired_secret,
+        )
+        assert retired_fingerprint not in (
+            _PUBLIC_ONBOARDING_KEY_FINGERPRINT,
+            previous_fingerprint,
+        )
+
+        for token_id, issued_at in (
+            (newest_token_id, datetime(2026, 8, 19, 12, tzinfo=timezone.utc)),
+            (previous_token_id, datetime(2026, 8, 18, 12, tzinfo=timezone.utc)),
+            (older_token_id, datetime(2026, 8, 17, 12, tzinfo=timezone.utc)),
+            (retired_token_id, datetime(2026, 8, 20, 12, tzinfo=timezone.utc)),
+        ):
+            await conn.execute(
+                "UPDATE eom_public_onboarding_tokens SET issued_at = $2 WHERE id = $1",
+                token_id,
+                issued_at,
+            )
+
+        first_page = await provider.list_eom_public_onboarding_issued_links(
+            accepted_signing_key_fingerprints=(
+                _PUBLIC_ONBOARDING_KEY_FINGERPRINT,
+                previous_fingerprint,
+            ),
+            limit=2,
+        )
+        second_page = await provider.list_eom_public_onboarding_issued_links(
+            accepted_signing_key_fingerprints=(
+                _PUBLIC_ONBOARDING_KEY_FINGERPRINT,
+                previous_fingerprint,
+            ),
+            limit=2,
+            cursor_issued_at=first_page[-1]["issued_at"],
+            cursor_draft_id=first_page[-1]["draft_id"],
+        )
+
+        assert [str(row["draft_id"]) for row in first_page] == [
+            newest_draft_id,
+            previous_draft_id,
+        ]
+        assert [str(row["draft_id"]) for row in second_page] == [older_draft_id]
+        assert {str(row["contact_id"]) for row in first_page + second_page} == {
+            str(newest_contact_id),
+            str(previous_contact_id),
+            str(older_contact_id),
+        }
+        assert str(retired_contact_id) not in str(first_page + second_page)
+        assert str(retired_token_id) not in str(first_page + second_page)
     finally:
         await conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
         await conn.close()

--- a/tests/test_eom_lead_conversion_integration.py
+++ b/tests/test_eom_lead_conversion_integration.py
@@ -5767,6 +5767,65 @@ async def test_onboarding_draft_list_projection_filters_and_paginates():
 
 
 @pytest.mark.asyncio
+async def test_public_onboarding_issued_link_projection_excludes_terminal_tokens():
+    database_url = _database_url_or_skip()
+    schema = f"atlas_eom_public_onboarding_issued_links_{uuid.uuid4().hex}"
+    conn = await asyncpg.connect(database_url)
+    try:
+        await _prepare_schema(conn, schema, apply_public_onboarding_migration=True)
+        provider = DatabaseCRMProvider(pool=conn)
+        issued_contact_id, issued_draft_id = await _book_first_clean_draft(
+            conn, provider, full_name="Issued Link"
+        )
+        _, issued_token_id = await _claim_public_onboarding_token(
+            provider, draft_id=issued_draft_id
+        )
+        redeemed_contact_id, redeemed_draft_id = await _book_first_clean_draft(
+            conn, provider, full_name="Redeemed Link"
+        )
+        _, redeemed_token_id = await _claim_public_onboarding_token(
+            provider, draft_id=redeemed_draft_id
+        )
+        await conn.execute(
+            """
+            UPDATE eom_public_onboarding_tokens
+               SET status = 'redeemed', redeemed_at = NOW(), handoff_id = $2::uuid
+             WHERE id = $1::uuid
+            """,
+            redeemed_token_id,
+            uuid.uuid4(),
+        )
+        revoked_contact_id, revoked_draft_id = await _book_first_clean_draft(
+            conn, provider, full_name="Revoked Link"
+        )
+        _, revoked_token_id = await _claim_public_onboarding_token(
+            provider, draft_id=revoked_draft_id
+        )
+        revoked = await provider.revoke_eom_public_onboarding_token(
+            draft_id=revoked_draft_id
+        )
+
+        links = await provider.list_eom_public_onboarding_issued_links(limit=100)
+
+        assert [{str(row["draft_id"]), str(row["contact_id"])} for row in links] == [
+            {issued_draft_id, str(issued_contact_id)}
+        ]
+        assert links[0]["full_name"] == "Issued Link"
+        assert links[0]["recipient_email"] == "won-lead@example.com"
+        assert links[0]["status"] == "issued"
+        assert "id" not in links[0]
+        assert str(issued_token_id) not in str(links[0])
+        assert revoked["status"] == "revoked"
+        assert str(redeemed_contact_id) not in str(links)
+        assert str(revoked_contact_id) not in str(links)
+        assert str(redeemed_token_id) not in str(links)
+        assert str(revoked_token_id) not in str(links)
+    finally:
+        await conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        await conn.close()
+
+
+@pytest.mark.asyncio
 async def test_mark_lead_lost_records_reason_is_idempotent_and_reopens():
     database_url = _database_url_or_skip()
     schema = f"atlas_eom_lead_lost_{uuid.uuid4().hex}"

--- a/tests/test_eom_lead_conversion_integration.py
+++ b/tests/test_eom_lead_conversion_integration.py
@@ -5829,6 +5829,114 @@ async def test_public_onboarding_issued_link_projection_excludes_terminal_tokens
 
 
 @pytest.mark.asyncio
+async def test_public_onboarding_issued_link_projection_matches_session_readiness():
+    """The office queue includes exactly the rows a public session can open."""
+
+    database_url = _database_url_or_skip()
+    schema = f"atlas_eom_public_onboarding_issued_link_readiness_{uuid.uuid4().hex}"
+    conn = await asyncpg.connect(database_url)
+    try:
+        await _prepare_schema(conn, schema, apply_public_onboarding_migration=True)
+        provider = DatabaseCRMProvider(pool=conn)
+
+        async def issued(full_name: str) -> tuple[uuid.UUID, str, uuid.UUID]:
+            contact_id, draft_id = await _book_first_clean_draft(
+                conn, provider, full_name=full_name
+            )
+            _, token_id = await _claim_public_onboarding_token(
+                provider, draft_id=draft_id
+            )
+            return contact_id, draft_id, token_id
+
+        sending_contact_id, sending_draft_id, sending_token_id = await issued(
+            "Sending Link"
+        )
+        sent_contact_id, sent_draft_id, sent_token_id = await issued("Sent Link")
+        inactive_contact_id, _, inactive_token_id = await issued("Inactive Link")
+        archived_contact_id, _, archived_token_id = await issued("Archived Link")
+        other_context_contact_id, _, other_context_token_id = await issued(
+            "Other Context Link"
+        )
+        non_lead_contact_id, _, non_lead_token_id = await issued("Customer Link")
+        non_won_contact_id, _, non_won_token_id = await issued("Non-won Link")
+        _, pending_draft_id, pending_token_id = await issued("Pending Draft Link")
+        _, revoked_draft_id, revoked_draft_token_id = await issued("Revoked Draft Link")
+
+        await conn.execute(
+            "UPDATE eom_onboarding_email_drafts SET status = 'sent', sent_at = NOW() "
+            "WHERE id = $1::uuid",
+            sent_draft_id,
+        )
+        await conn.execute(
+            "UPDATE contacts SET status = 'inactive' WHERE id = $1", inactive_contact_id
+        )
+        await conn.execute(
+            "UPDATE contacts SET status = 'archived' WHERE id = $1", archived_contact_id
+        )
+        await conn.execute(
+            "UPDATE contacts SET business_context_id = 'other_business' WHERE id = $1",
+            other_context_contact_id,
+        )
+        await conn.execute(
+            "UPDATE contacts SET contact_type = 'customer' WHERE id = $1",
+            non_lead_contact_id,
+        )
+        await conn.execute(
+            "UPDATE contacts SET lead_stage = 'qualified' WHERE id = $1",
+            non_won_contact_id,
+        )
+        await conn.execute(
+            "UPDATE eom_onboarding_email_drafts SET status = 'pending' WHERE id = $1::uuid",
+            pending_draft_id,
+        )
+        await conn.execute(
+            "UPDATE eom_onboarding_email_drafts SET status = 'revoked', revoked_at = NOW() "
+            "WHERE id = $1::uuid",
+            revoked_draft_id,
+        )
+
+        for token_id in (
+            inactive_token_id,
+            archived_token_id,
+            other_context_token_id,
+            non_lead_token_id,
+            non_won_token_id,
+            pending_token_id,
+            revoked_draft_token_id,
+        ):
+            with pytest.raises(EOMLeadConversionError) as exc_info:
+                await provider.get_eom_public_onboarding_session(
+                    token_id=str(token_id),
+                    signing_key_fingerprint=_PUBLIC_ONBOARDING_KEY_FINGERPRINT,
+                )
+            assert exc_info.value.status_code == 404
+
+        for token_id in (sending_token_id, sent_token_id):
+            session = await provider.get_eom_public_onboarding_session(
+                token_id=str(token_id),
+                signing_key_fingerprint=_PUBLIC_ONBOARDING_KEY_FINGERPRINT,
+            )
+            assert session["status"] == "ready"
+
+        links = await provider.list_eom_public_onboarding_issued_links(
+            accepted_signing_key_fingerprints=(_PUBLIC_ONBOARDING_KEY_FINGERPRINT,),
+            limit=100,
+        )
+
+        assert {str(row["draft_id"]) for row in links} == {
+            sending_draft_id,
+            sent_draft_id,
+        }
+        assert {str(row["contact_id"]) for row in links} == {
+            str(sending_contact_id),
+            str(sent_contact_id),
+        }
+    finally:
+        await conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        await conn.close()
+
+
+@pytest.mark.asyncio
 async def test_public_onboarding_issued_link_projection_pages_current_and_previous_keys():
     """Only keys that can authenticate now enter a complete newest-first queue."""
 

--- a/tests/test_eom_public_onboarding.py
+++ b/tests/test_eom_public_onboarding.py
@@ -68,6 +68,7 @@ class _CRM:
         self.recovery_calls: list[dict[str, object]] = []
         self.revoke_calls: list[str] = []
         self.claim_calls: list[dict[str, object]] = []
+        self.issued_link_calls: list[int] = []
         self.context_status = "ready"
         self.recovery_idempotent = False
         self.draft_id = uuid4()
@@ -86,6 +87,19 @@ class _CRM:
             "revoked_at": None,
             "approved_by_name": "Juan Canfield",
         }
+
+    async def list_eom_public_onboarding_issued_links(self, *, limit: int):
+        self.issued_link_calls.append(limit)
+        return [
+            {
+                "draft_id": self.draft_id,
+                "contact_id": self.contact_id,
+                "full_name": "Customer Name",
+                "recipient_email": "customer@example.com",
+                "status": "issued",
+                "issued_at": datetime(2026, 8, 19, tzinfo=timezone.utc),
+            }
+        ]
 
     async def get_eom_public_onboarding_session(
         self, *, token_id: str, signing_key_fingerprint: str
@@ -1136,3 +1150,58 @@ async def test_staff_link_revocation_requires_an_actor_and_survives_feature_disa
     assert disabled.status_code == 201
     assert crm.revoke_calls == [str(crm.draft_id)]
     assert disabled_crm.revoke_calls == [str(disabled_crm.draft_id)]
+
+
+@pytest.mark.asyncio
+async def test_staff_issued_link_list_requires_office_auth_and_exposes_no_token_material():
+    crm = _CRM()
+    app = _app(crm)
+    disabled_crm = _CRM()
+    disabled_app = _app(disabled_crm, enabled=False)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        no_service = await client.get("/eom-funnel/public-onboarding/issued-links")
+        no_actor = await client.get(
+            "/eom-funnel/public-onboarding/issued-links",
+            headers=_service_headers(),
+        )
+        invalid_limit = await client.get(
+            "/eom-funnel/public-onboarding/issued-links?limit=0",
+            headers=_service_headers(actor=True),
+        )
+        listed = await client.get(
+            "/eom-funnel/public-onboarding/issued-links?limit=1",
+            headers=_service_headers(actor=True),
+        )
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=disabled_app), base_url="http://test"
+    ) as client:
+        listed_while_disabled = await client.get(
+            "/eom-funnel/public-onboarding/issued-links?limit=1",
+            headers=_service_headers(actor=True),
+        )
+
+    assert no_service.status_code == 401
+    assert no_actor.status_code == 422
+    assert invalid_limit.status_code == 422
+    assert listed.status_code == 200
+    assert listed_while_disabled.status_code == 200
+    assert listed.json() == {
+        "links": [
+            {
+                "draftId": str(crm.draft_id),
+                "contactId": str(crm.contact_id),
+                "fullName": "Customer Name",
+                "recipientEmail": "customer@example.com",
+                "status": "issued",
+                "issuedAt": "2026-08-19T00:00:00Z",
+            }
+        ],
+        "limit": 1,
+    }
+    assert {"tokenId", "token", "link", "approvalKey"}.isdisjoint(
+        listed.json()["links"][0]
+    )
+    assert crm.issued_link_calls == [1]
+    assert disabled_crm.issued_link_calls == [1]

--- a/tests/test_eom_public_onboarding.py
+++ b/tests/test_eom_public_onboarding.py
@@ -68,11 +68,21 @@ class _CRM:
         self.recovery_calls: list[dict[str, object]] = []
         self.revoke_calls: list[str] = []
         self.claim_calls: list[dict[str, object]] = []
-        self.issued_link_calls: list[int] = []
+        self.issued_link_calls: list[dict[str, object]] = []
         self.context_status = "ready"
         self.recovery_idempotent = False
         self.draft_id = uuid4()
         self.contact_id = uuid4()
+        self.issued_link_rows = [
+            {
+                "draft_id": self.draft_id,
+                "contact_id": self.contact_id,
+                "full_name": "Customer Name",
+                "recipient_email": "customer@example.com",
+                "status": "issued",
+                "issued_at": datetime(2026, 8, 19, tzinfo=timezone.utc),
+            }
+        ]
         self._draft = {
             "draft_id": str(self.draft_id),
             "contact_id": str(self.contact_id),
@@ -88,18 +98,35 @@ class _CRM:
             "approved_by_name": "Juan Canfield",
         }
 
-    async def list_eom_public_onboarding_issued_links(self, *, limit: int):
-        self.issued_link_calls.append(limit)
-        return [
+    async def list_eom_public_onboarding_issued_links(
+        self,
+        *,
+        accepted_signing_key_fingerprints: tuple[str, ...],
+        limit: int,
+        cursor_issued_at: datetime | None,
+        cursor_draft_id: UUID | None,
+    ):
+        self.issued_link_calls.append(
             {
-                "draft_id": self.draft_id,
-                "contact_id": self.contact_id,
-                "full_name": "Customer Name",
-                "recipient_email": "customer@example.com",
-                "status": "issued",
-                "issued_at": datetime(2026, 8, 19, tzinfo=timezone.utc),
+                "accepted_signing_key_fingerprints": accepted_signing_key_fingerprints,
+                "limit": limit,
+                "cursor_issued_at": cursor_issued_at,
+                "cursor_draft_id": cursor_draft_id,
             }
-        ]
+        )
+        rows = sorted(
+            self.issued_link_rows,
+            key=lambda row: (row["issued_at"], row["draft_id"]),
+            reverse=True,
+        )
+        if cursor_issued_at is not None and cursor_draft_id is not None:
+            rows = [
+                row
+                for row in rows
+                if (row["issued_at"], row["draft_id"])
+                < (cursor_issued_at, cursor_draft_id)
+            ]
+        return rows[:limit]
 
     async def get_eom_public_onboarding_session(
         self, *, token_id: str, signing_key_fingerprint: str
@@ -1153,11 +1180,13 @@ async def test_staff_link_revocation_requires_an_actor_and_survives_feature_disa
 
 
 @pytest.mark.asyncio
-async def test_staff_issued_link_list_requires_office_auth_and_exposes_no_token_material():
+async def test_staff_issued_link_list_requires_office_auth_and_live_public_authority():
     crm = _CRM()
     app = _app(crm)
     disabled_crm = _CRM()
     disabled_app = _app(disabled_crm, enabled=False)
+    paused_crm = _CRM()
+    paused_app = _app(paused_crm, issuance_enabled=False)
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app), base_url="http://test"
     ) as client:
@@ -1181,12 +1210,20 @@ async def test_staff_issued_link_list_requires_office_auth_and_exposes_no_token_
             "/eom-funnel/public-onboarding/issued-links?limit=1",
             headers=_service_headers(actor=True),
         )
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=paused_app), base_url="http://test"
+    ) as client:
+        listed_while_issuance_paused = await client.get(
+            "/eom-funnel/public-onboarding/issued-links?limit=1",
+            headers=_service_headers(actor=True),
+        )
 
     assert no_service.status_code == 401
     assert no_actor.status_code == 422
     assert invalid_limit.status_code == 422
     assert listed.status_code == 200
-    assert listed_while_disabled.status_code == 200
+    assert listed_while_disabled.status_code == 503
+    assert listed_while_issuance_paused.status_code == 200
     assert listed.json() == {
         "links": [
             {
@@ -1199,9 +1236,85 @@ async def test_staff_issued_link_list_requires_office_auth_and_exposes_no_token_
             }
         ],
         "limit": 1,
+        "cursor": None,
+        "hasMore": False,
+        "nextCursor": None,
     }
     assert {"tokenId", "token", "link", "approvalKey"}.isdisjoint(
         listed.json()["links"][0]
     )
-    assert crm.issued_link_calls == [1]
-    assert disabled_crm.issued_link_calls == [1]
+    assert crm.issued_link_calls == [
+        {
+            "accepted_signing_key_fingerprints": (
+                eom_public_onboarding_hmac_key_fingerprint(secret=_PUBLIC_SECRET),
+            ),
+            "limit": 2,
+            "cursor_issued_at": None,
+            "cursor_draft_id": None,
+        }
+    ]
+    assert disabled_crm.issued_link_calls == []
+    assert paused_crm.issued_link_calls == [
+        {
+            "accepted_signing_key_fingerprints": (
+                eom_public_onboarding_hmac_key_fingerprint(secret=_PUBLIC_SECRET),
+            ),
+            "limit": 2,
+            "cursor_issued_at": None,
+            "cursor_draft_id": None,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_staff_issued_link_list_pages_by_issued_at_and_draft_id():
+    crm = _CRM()
+    newest_draft_id = uuid4()
+    older_draft_id = uuid4()
+    crm.issued_link_rows = [
+        {
+            "draft_id": older_draft_id,
+            "contact_id": uuid4(),
+            "full_name": "Older Link",
+            "recipient_email": "older@example.com",
+            "status": "issued",
+            "issued_at": datetime(2026, 8, 18, tzinfo=timezone.utc),
+        },
+        {
+            "draft_id": newest_draft_id,
+            "contact_id": uuid4(),
+            "full_name": "Newest Link",
+            "recipient_email": "newest@example.com",
+            "status": "issued",
+            "issued_at": datetime(2026, 8, 19, tzinfo=timezone.utc),
+        },
+    ]
+    app = _app(crm, previous_secret=_PREVIOUS_PUBLIC_SECRET)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        first = await client.get(
+            "/eom-funnel/public-onboarding/issued-links?limit=1",
+            headers=_service_headers(actor=True),
+        )
+        first_body = first.json()
+        second = await client.get(
+            "/eom-funnel/public-onboarding/issued-links",
+            params={"limit": 1, "cursor": first_body["nextCursor"]},
+            headers=_service_headers(actor=True),
+        )
+
+    assert first.status_code == 200
+    assert first_body["links"][0]["draftId"] == str(newest_draft_id)
+    assert first_body["hasMore"] is True
+    assert isinstance(first_body["nextCursor"], str)
+    assert second.status_code == 200
+    assert second.json()["links"][0]["draftId"] == str(older_draft_id)
+    assert second.json()["hasMore"] is False
+    assert crm.issued_link_calls[0]["limit"] == 2
+    assert crm.issued_link_calls[1]["limit"] == 2
+    assert crm.issued_link_calls[1]["cursor_draft_id"] == newest_draft_id
+    assert crm.issued_link_calls[0]["accepted_signing_key_fingerprints"] == (
+        eom_public_onboarding_hmac_key_fingerprint(secret=_PUBLIC_SECRET),
+        eom_public_onboarding_hmac_key_fingerprint(secret=_PREVIOUS_PUBLIC_SECRET),
+    )


### PR DESCRIPTION
Plan: plans/PR-EOM-Onboarding-Office-Followup.md
Slice phase: Vertical slice
Ownership lane: eom-public-onboarding

This remediates the one cross-repository office-control defect: an issued token
is active only while its signing authority is accepted, and the office queue
needs a complete, derived route contract before Tracker and Website can expose
safe follow-up actions. The change is additive and leaves public onboarding
lifecycle and mutation semantics unchanged.

## Intentional

- Project only safe office metadata; token IDs, raw bearers, signing material,
  approval keys, and customer-facing URLs remain absent.
- Keep the read/revoke/recovery controls separate from new issuance. Pausing
  issuance does not prevent repair of existing work.
- Keep the Tracker relay and Website UI in their dependent coordinated PRs.

## AI reconciliation

- Exclude issued rows whose authority is unavailable -- fixed-in: 27cb7545b `atlas_brain/eom_api/funnel.py:494-506`, `atlas_brain/services/crm_provider.py:3672-3732`, and `tests/test_eom_lead_conversion_integration.py:5770-6034` filter to current/previous signing keys.
- Prove the newest-first ordering with multiple issued rows -- fixed-in: 27cb7545b `tests/test_eom_lead_conversion_integration.py:5940-6034` persists current, previous, retired, and terminal rows and verifies two keyset pages in newest-first order.
- Add the mandatory capability-set closure declaration -- fixed-in: 27cb7545b `plans/PR-EOM-Onboarding-Office-Followup.md:139-149` declares the closed source, membership, and fail-closed deployment default.
- Enroll the capability manifest test in PR CI -- fixed-in: 27cb7545b `.github/workflows/atlas_eom_lead_pipeline_checks.yml:241-244` includes `tests/test_eom_funnel_capability_manifest.py`.
- Justify the diff-budget overage in the plan -- fixed-in: 27cb7545b `plans/PR-EOM-Onboarding-Office-Followup.md:17-26` explains why provider, route, manifest, CI enrollment, and proof form one indivisible protocol.
- Match the public-session usability predicate -- fixed-in: 27cb7545b `atlas_brain/services/crm_provider.py:3719-3727` intersects issued/current-key rows with the canonical `sending`/`sent`, active EOM won-lead predicate; `tests/test_eom_lead_conversion_integration.py:5831-5936` proves the queue matches the public session for valid and invalid draft/contact states.

## Fix-loop disposition preflight

- Root decision: Exclude issued rows whose authority is unavailable
- Source trace: office active-link queue -> durable token signing-key authority
- Upstream files: `atlas_brain/eom_api/funnel.py`, `atlas_brain/services/crm_provider.py`, `.github/workflows/atlas_eom_lead_pipeline_checks.yml`, `plans/PR-EOM-Onboarding-Office-Followup.md`, `tests/test_eom_funnel_capability_manifest.py`, `tests/test_eom_lead_conversion.py`, `tests/test_eom_lead_conversion_integration.py`, `tests/test_eom_public_onboarding.py`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `atlas_brain/eom_api/funnel.py`, `atlas_brain/services/crm_provider.py`, `.github/workflows/atlas_eom_lead_pipeline_checks.yml`, `plans/PR-EOM-Onboarding-Office-Followup.md`, `tests/test_eom_funnel_capability_manifest.py`, `tests/test_eom_lead_conversion.py`, `tests/test_eom_lead_conversion_integration.py`, `tests/test_eom_public_onboarding.py`
- Max files: 8
- Parked hardening: none

- Root decision: Prove the newest-first ordering with multiple issued rows
- Source trace: office active-link queue -> provider keyset ordering proof
- Upstream files: `atlas_brain/eom_api/funnel.py`, `atlas_brain/services/crm_provider.py`, `.github/workflows/atlas_eom_lead_pipeline_checks.yml`, `plans/PR-EOM-Onboarding-Office-Followup.md`, `tests/test_eom_funnel_capability_manifest.py`, `tests/test_eom_lead_conversion.py`, `tests/test_eom_lead_conversion_integration.py`, `tests/test_eom_public_onboarding.py`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `atlas_brain/eom_api/funnel.py`, `atlas_brain/services/crm_provider.py`, `.github/workflows/atlas_eom_lead_pipeline_checks.yml`, `plans/PR-EOM-Onboarding-Office-Followup.md`, `tests/test_eom_funnel_capability_manifest.py`, `tests/test_eom_lead_conversion.py`, `tests/test_eom_lead_conversion_integration.py`, `tests/test_eom_public_onboarding.py`
- Max files: 8
- Parked hardening: none

- Root decision: Add the mandatory capability-set closure declaration
- Source trace: derived capability registry -> plan closure declaration
- Upstream files: `atlas_brain/eom_api/funnel.py`, `atlas_brain/services/crm_provider.py`, `.github/workflows/atlas_eom_lead_pipeline_checks.yml`, `plans/PR-EOM-Onboarding-Office-Followup.md`, `tests/test_eom_funnel_capability_manifest.py`, `tests/test_eom_lead_conversion.py`, `tests/test_eom_lead_conversion_integration.py`, `tests/test_eom_public_onboarding.py`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `atlas_brain/eom_api/funnel.py`, `atlas_brain/services/crm_provider.py`, `.github/workflows/atlas_eom_lead_pipeline_checks.yml`, `plans/PR-EOM-Onboarding-Office-Followup.md`, `tests/test_eom_funnel_capability_manifest.py`, `tests/test_eom_lead_conversion.py`, `tests/test_eom_lead_conversion_integration.py`, `tests/test_eom_public_onboarding.py`
- Max files: 8
- Parked hardening: none

- Root decision: Enroll the capability manifest test in PR CI
- Source trace: capability route contract -> explicit EOM pytest workflow
- Upstream files: `atlas_brain/eom_api/funnel.py`, `atlas_brain/services/crm_provider.py`, `.github/workflows/atlas_eom_lead_pipeline_checks.yml`, `plans/PR-EOM-Onboarding-Office-Followup.md`, `tests/test_eom_funnel_capability_manifest.py`, `tests/test_eom_lead_conversion.py`, `tests/test_eom_lead_conversion_integration.py`, `tests/test_eom_public_onboarding.py`
- Fix strategy: upstream-root
- Blocking predicate: ci
- Disposition: fixed-in
- Allowed files: `atlas_brain/eom_api/funnel.py`, `atlas_brain/services/crm_provider.py`, `.github/workflows/atlas_eom_lead_pipeline_checks.yml`, `plans/PR-EOM-Onboarding-Office-Followup.md`, `tests/test_eom_funnel_capability_manifest.py`, `tests/test_eom_lead_conversion.py`, `tests/test_eom_lead_conversion_integration.py`, `tests/test_eom_public_onboarding.py`
- Max files: 8
- Parked hardening: none

- Root decision: Justify the diff-budget overage in the plan
- Source trace: indivisible provider-route-test protocol -> plan rationale
- Upstream files: `atlas_brain/eom_api/funnel.py`, `atlas_brain/services/crm_provider.py`, `.github/workflows/atlas_eom_lead_pipeline_checks.yml`, `plans/PR-EOM-Onboarding-Office-Followup.md`, `tests/test_eom_funnel_capability_manifest.py`, `tests/test_eom_lead_conversion.py`, `tests/test_eom_lead_conversion_integration.py`, `tests/test_eom_public_onboarding.py`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `atlas_brain/eom_api/funnel.py`, `atlas_brain/services/crm_provider.py`, `.github/workflows/atlas_eom_lead_pipeline_checks.yml`, `plans/PR-EOM-Onboarding-Office-Followup.md`, `tests/test_eom_funnel_capability_manifest.py`, `tests/test_eom_lead_conversion.py`, `tests/test_eom_lead_conversion_integration.py`, `tests/test_eom_public_onboarding.py`
- Max files: 8
- Parked hardening: none

- Root decision: Match the public-session usability predicate
- Source trace: active-link queue -> canonical public-session draft/contact readiness
- Upstream files: `atlas_brain/eom_api/funnel.py`, `atlas_brain/services/crm_provider.py`, `.github/workflows/atlas_eom_lead_pipeline_checks.yml`, `plans/PR-EOM-Onboarding-Office-Followup.md`, `tests/test_eom_funnel_capability_manifest.py`, `tests/test_eom_lead_conversion.py`, `tests/test_eom_lead_conversion_integration.py`, `tests/test_eom_public_onboarding.py`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `atlas_brain/eom_api/funnel.py`, `atlas_brain/services/crm_provider.py`, `.github/workflows/atlas_eom_lead_pipeline_checks.yml`, `plans/PR-EOM-Onboarding-Office-Followup.md`, `tests/test_eom_funnel_capability_manifest.py`, `tests/test_eom_lead_conversion.py`, `tests/test_eom_lead_conversion_integration.py`, `tests/test_eom_public_onboarding.py`
- Max files: 8
- Parked hardening: none

## Deferred

- Tracker #207 owns the authenticated relay, exact deployment proofs, and
  capability-gated private calls; Website #226 owns bilingual presentation and
  Juan-only confirmation UI.
- Replacement links, resend, expiry/reminders, history browsing, and broader
  onboarding metrics remain outside this vertical slice.

## Parked hardening

- None. The plan parks non-safety UI/history/observability additions; authority
  filtering, authorization, raw-bearer safety, and capability truth are in
  scope because the office action would otherwise be misleading or unsafe.

## Cold diff reconstruction

- Changed: `atlas_brain/eom_api/funnel.py:293-305,494-506,665-715,856-860,1255-1312` adds the closed page/route model, derives accepted fingerprints and registered route signatures, and exposes the authenticated keyset page.
- Changed: `atlas_brain/services/crm_provider.py:3672-3732` performs the no-write current/previous-key issued-token query, intersects it with the canonical `sending`/`sent`, active EOM won-lead predicate, and retains stable keyset ordering.
- Changed: `.github/workflows/atlas_eom_lead_pipeline_checks.yml:241-244` enrolls the manifest proof; `tests/test_eom_public_onboarding.py:1183-1319`, `tests/test_eom_lead_conversion_integration.py:5770-6034`, and `tests/test_eom_funnel_capability_manifest.py:145-176` prove the route, database projection, readiness predicate, paging, and registry agreement.
- Changed: `tests/test_eom_lead_conversion.py:596-618,946-968,992-1004` advances each exact private lead-review response assertion with the same derived `capabilityRoutes` projection the route emits.
- Changed: `plans/PR-EOM-Onboarding-Office-Followup.md:17-110,132-149,227-264` records the pre-code contract, additive private-response compatibility, canonical session readiness, closure declaration, remediation rationale, and generated diff inventory.
- Contract match: every changed production, workflow, plan, and test path implements a declared requirement for active-authority filtering, canonical session readiness, pagination, exact route proof, CI reachability, or additive response compatibility.
- Gaps: none. No public lifecycle mutation, token/bearer field, migration, configuration, dependency, payroll, or unrelated product surface changed.

## Verification

- `python -m pytest -q tests/test_eom_public_onboarding.py tests/test_eom_funnel_capability_manifest.py tests/test_eom_lead_conversion.py::test_full_atlas_app_serves_public_intake_and_private_handoff_together tests/test_eom_lead_conversion.py::test_private_lead_review_forwards_keyset_cursor_for_continuation tests/test_eom_lead_conversion.py::test_private_lead_review_returns_only_the_closed_projection` -- 52 passed.
- `ATLAS_MIGRATION_TEST_DATABASE_URL=<isolated local PostgreSQL> python -m pytest -q tests/test_eom_lead_conversion_integration.py -k 'public_onboarding_issued_link_projection'` -- 3 passed, 90 deselected; the disposable container was removed afterward.
- `env -u ATLAS_CURRENT_PR_BODY_FILE -u ATLAS_CURRENT_PR_AUTHOR ATLAS_SKIP_LOCAL_PR_REVIEW=1 ATLAS_DB_CONNECTION_STRING= ATLAS_DB_HOST=127.0.0.1 ATLAS_DB_PORT=1 ATLAS_DB_DATABASE=atlas ATLAS_DB_USER=atlas ATLAS_DB_PASSWORD=atlas_dev_password ATLAS_DB_SOCKET_PATH= python scripts/check_unit_gate.py --baseline tests/unit_gate_baseline.txt --base-baseline tests/unit_gate_baseline.txt` -- passed: 157 baseline failures, 0 regressions, 0 newly passing.
- Ruff, compileall, plan-shape/synchronization, and `git diff --check` passed locally.

## Mechanical verification

- Command: `python scripts/audit_plan_doc.py plans/PR-EOM-Onboarding-Office-Followup.md` - Result: passed - Environment: local
- Command: `python scripts/sync_pr_plan.py --check plans/PR-EOM-Onboarding-Office-Followup.md origin/main` - Result: passed - Environment: local
- Command: `ruff check atlas_brain/eom_api/funnel.py atlas_brain/services/crm_provider.py tests/test_eom_public_onboarding.py tests/test_eom_funnel_capability_manifest.py tests/test_eom_lead_conversion.py tests/test_eom_lead_conversion_integration.py` - Result: passed - Environment: local
- Command: `python -m compileall -q atlas_brain/eom_api/funnel.py atlas_brain/services/crm_provider.py tests/test_eom_public_onboarding.py tests/test_eom_funnel_capability_manifest.py tests/test_eom_lead_conversion.py tests/test_eom_lead_conversion_integration.py` - Result: passed - Environment: local
- Command: `git diff --check` - Result: passed - Environment: local

## Diff size

8 files, +969 / -0

Diff-budget override: The provider query, authenticated route and manifest projection, Tracker-facing deployment proof, CI enrollment, and route/provider regression coverage form one cross-repository safety protocol; splitting them would expose partial controls or leave the dependent relay unproven.

<!-- atlas-open-pr-wrapper: v1 -->

