### PR TITLE
EOM: record future migration content identity

### DIFF
--- a/atlas_brain/storage/migrations/__init__.py
+++ b/atlas_brain/storage/migrations/__init__.py
@@ -5,9 +5,11 @@ Tracks applied migrations in `schema_migrations` table to avoid re-running.
 """
 
 import asyncio
+import hashlib
 import logging
 import re
 from collections.abc import Collection
+from dataclasses import dataclass
 from pathlib import Path
 
 logger = logging.getLogger("atlas.storage.migrations")
@@ -46,9 +48,14 @@ async def _ensure_migrations_table(executor) -> None:
         CREATE TABLE IF NOT EXISTS schema_migrations (
             version INTEGER PRIMARY KEY,
             name VARCHAR(255) NOT NULL,
+            content_sha256 VARCHAR(64),
             applied_at TIMESTAMPTZ DEFAULT NOW()
         )
     """)
+    await executor.execute(
+        "ALTER TABLE schema_migrations "
+        "ADD COLUMN IF NOT EXISTS content_sha256 VARCHAR(64)"
+    )
 
 
 async def _get_applied_migrations(executor) -> set[str]:
@@ -57,17 +64,42 @@ async def _get_applied_migrations(executor) -> set[str]:
     return {row["name"] for row in rows}
 
 
-async def _record_migration(executor, filename: str) -> None:
+async def _record_migration(
+    executor,
+    filename: str,
+    content_sha256: str,
+    *,
+    fill_newly_self_recorded_digest: bool = False,
+) -> None:
     """Record that a migration has been applied.
 
     ``executor`` is a pool or a single acquired connection (see
-    _ensure_migrations_table)."""
+    _ensure_migrations_table). A migration may insert its own legacy ledger row
+    in SQL. Only the runner that just executed a pending file may fill that
+    newly-created row's digest; existing historical rows remain untouched.
+    """
     version, name = _parse_migration_identity(filename)
     existing_version = await executor.fetchval(
         "SELECT version FROM schema_migrations WHERE name = $1",
         name,
     )
     if existing_version is not None:
+        if fill_newly_self_recorded_digest:
+            await executor.execute(
+                "UPDATE schema_migrations SET content_sha256 = $2 "
+                "WHERE name = $1 AND content_sha256 IS DISTINCT FROM $2",
+                name,
+                content_sha256,
+            )
+            persisted_digest = await executor.fetchval(
+                "SELECT content_sha256 FROM schema_migrations WHERE name = $1",
+                name,
+            )
+            if persisted_digest != content_sha256:
+                raise RuntimeError(
+                    "self-recorded migration did not persist its expected "
+                    f"content SHA-256: {name}"
+                )
         return
 
     record_version = version
@@ -95,10 +127,89 @@ async def _record_migration(executor, filename: str) -> None:
         )
 
     await executor.execute(
-        "INSERT INTO schema_migrations (version, name) VALUES ($1, $2)",
+        "INSERT INTO schema_migrations (version, name, content_sha256) "
+        "VALUES ($1, $2, $3)",
         record_version,
         name,
+        content_sha256,
     )
+
+
+@dataclass(frozen=True)
+class MigrationContentIntegrityReport:
+    """Read-only migration-source identity classification for one run."""
+
+    verified: tuple[str, ...]
+    legacy_unverified: tuple[str, ...]
+    mismatched: tuple[str, ...]
+    missing_source: tuple[str, ...]
+
+
+def _migration_content_sha256(source: bytes) -> str:
+    """Return the deterministic identity for exactly one migration source."""
+    return hashlib.sha256(source).hexdigest()
+
+
+async def _migration_content_integrity_report(
+    executor,
+    migration_files: Collection[Path],
+) -> MigrationContentIntegrityReport:
+    """Classify stored migration identities without altering ledger rows."""
+    source_by_name = {path.stem: path for path in migration_files}
+    rows = await executor.fetch("SELECT name, content_sha256 FROM schema_migrations")
+    verified: list[str] = []
+    legacy_unverified: list[str] = []
+    mismatched: list[str] = []
+    missing_source: list[str] = []
+
+    for row in rows:
+        name = row["name"]
+        migration_file = source_by_name.get(name)
+        if migration_file is None:
+            missing_source.append(name)
+            continue
+
+        try:
+            source = migration_file.read_bytes()
+        except OSError:
+            # This phase is diagnostic-only. A deployment with no readable
+            # packaged source still has no evidence to verify, but it must not
+            # lose startup availability merely because the new report ran.
+            missing_source.append(name)
+            continue
+
+        recorded_digest = row["content_sha256"]
+        if recorded_digest is None:
+            legacy_unverified.append(name)
+            continue
+
+        current_digest = _migration_content_sha256(source)
+        if current_digest == recorded_digest:
+            verified.append(name)
+        else:
+            mismatched.append(name)
+
+    return MigrationContentIntegrityReport(
+        verified=tuple(sorted(verified)),
+        legacy_unverified=tuple(sorted(legacy_unverified)),
+        mismatched=tuple(sorted(mismatched)),
+        missing_source=tuple(sorted(missing_source)),
+    )
+
+
+def _log_migration_content_integrity(report: MigrationContentIntegrityReport) -> None:
+    """Expose evidence without making historical records a startup blocker."""
+    if report.legacy_unverified:
+        logger.info(
+            "Migration content identity is unavailable for %d legacy ledger rows",
+            len(report.legacy_unverified),
+        )
+    if report.mismatched or report.missing_source:
+        logger.error(
+            "Migration content integrity mismatch: mismatched=%s missing_source=%s",
+            ", ".join(report.mismatched) or "none",
+            ", ".join(report.missing_source) or "none",
+        )
 
 
 # Cluster-wide advisory key serializing migration runs. Concurrent first
@@ -111,19 +222,24 @@ _ATOMIC_BOOKKEEPING_MARKER = "-- atlas: atomic-bookkeeping"
 
 
 def _requires_atomic_bookkeeping(sql: str) -> bool:
-    """Return whether this migration opts into atomic SQL + ledger recording.
+    """Return whether SQL and its ledger identity must commit together.
 
     Most Atlas migrations remain deliberately autocommit: several use ``CREATE
     INDEX CONCURRENTLY``. A migration whose safety depends on its privilege or
     ownership changes committing with its ``schema_migrations`` record may opt
-    into this narrow execution mode with the first non-empty SQL line.
+    into this narrow execution mode with the first non-empty SQL line. A direct
+    insert into the ledger also requires it: otherwise its SQL can commit a
+    legacy-looking row before the runner attaches the source digest.
     """
     first_line = next((line.strip() for line in sql.splitlines() if line.strip()), "")
-    return first_line == _ATOMIC_BOOKKEEPING_MARKER
+    return (
+        first_line == _ATOMIC_BOOKKEEPING_MARKER
+        or _contains_executable_self_recording_insert(sql)
+    )
 
 
-def _contains_executable_concurrently(sql: str) -> bool:
-    """Return whether SQL uses CONCURRENTLY outside comments and literals."""
+def _executable_sql(sql: str, *, preserve_quoted_identifiers: bool = False) -> str:
+    """Mask comments and literals so recognizers see executable SQL only."""
     code: list[str] = []
     i = 0
     single_quote = False
@@ -177,9 +293,9 @@ def _contains_executable_concurrently(sql: str) -> bool:
             continue
 
         if double_quote:
-            code.append("\n" if ch == "\n" else " ")
+            code.append(ch if preserve_quoted_identifiers else ("\n" if ch == "\n" else " "))
             if ch == '"' and nxt == '"':
-                code.append(" ")
+                code.append(nxt if preserve_quoted_identifiers else " ")
                 i += 2
                 continue
             if ch == '"':
@@ -206,7 +322,7 @@ def _contains_executable_concurrently(sql: str) -> bool:
             continue
 
         if ch == '"':
-            code.append(" ")
+            code.append(ch if preserve_quoted_identifiers else " ")
             double_quote = True
             i += 1
             continue
@@ -222,7 +338,36 @@ def _contains_executable_concurrently(sql: str) -> bool:
         code.append(ch)
         i += 1
 
-    return bool(re.search(r"\bCONCURRENTLY\b", "".join(code), re.IGNORECASE))
+    return "".join(code)
+
+
+def _contains_executable_concurrently(sql: str) -> bool:
+    """Return whether SQL uses CONCURRENTLY outside comments and literals."""
+    return bool(re.search(r"\bCONCURRENTLY\b", _executable_sql(sql), re.IGNORECASE))
+
+
+_SELF_RECORDING_INSERT_RE = re.compile(
+    r"(?i:\bINSERT\s+INTO\s+(?:ONLY\s+)?)"
+    r"(?:(?:\"[A-Za-z_][A-Za-z0-9_$]*\"|[A-Za-z_][A-Za-z0-9_$]*)\s*\.\s*)?"
+    r"(?:(?i:schema_migrations)|\"schema_migrations\")(?![A-Za-z0-9_$])",
+)
+
+
+def _contains_executable_self_recording_insert(sql: str) -> bool:
+    """Return whether migration SQL directly inserts its ledger row.
+
+    The existing explicit marker remains the escape hatch for a migration that
+    performs equivalent bookkeeping through dynamic SQL. Direct inserts are
+    recognized automatically so legacy self-recording files get the same
+    rollback-safe SQL-plus-digest unit without rewriting their historical text.
+    Unquoted target identifiers use PostgreSQL's case-folding rules; quoted
+    targets must be the exact lowercase ledger identifier.
+    """
+    return bool(
+        _SELF_RECORDING_INSERT_RE.search(
+            _executable_sql(sql, preserve_quoted_identifiers=True)
+        )
+    )
 
 
 def _split_sql_statements(sql: str) -> list[str]:
@@ -414,6 +559,9 @@ async def run_migrations(
             applied = await _get_applied_migrations(conn)
 
             migration_files = sorted(directory.glob("*.sql"))
+            _log_migration_content_integrity(
+                await _migration_content_integrity_report(conn, migration_files)
+            )
             if only is not None:
                 requested = set(only)
                 migration_files = [
@@ -440,7 +588,9 @@ async def run_migrations(
             for migration_file in pending:
                 logger.info("Running migration: %s", migration_file.name)
 
-                sql = migration_file.read_text()
+                source = migration_file.read_bytes()
+                content_sha256 = _migration_content_sha256(source)
+                sql = source.decode("utf-8")
 
                 try:
                     if _requires_atomic_bookkeeping(sql):
@@ -454,14 +604,29 @@ async def run_migrations(
                             )
                         async with conn.transaction():
                             await conn.execute(sql)
-                            await _record_migration(conn, migration_file.name)
+                            await _record_migration(
+                                conn,
+                                migration_file.name,
+                                content_sha256,
+                                fill_newly_self_recorded_digest=True,
+                            )
                     elif _contains_executable_concurrently(sql):
                         for statement in _split_sql_statements(sql):
                             await conn.execute(statement)
-                        await _record_migration(conn, migration_file.name)
+                        await _record_migration(
+                            conn,
+                            migration_file.name,
+                            content_sha256,
+                            fill_newly_self_recorded_digest=True,
+                        )
                     else:
                         await conn.execute(sql)
-                        await _record_migration(conn, migration_file.name)
+                        await _record_migration(
+                            conn,
+                            migration_file.name,
+                            content_sha256,
+                            fill_newly_self_recorded_digest=True,
+                        )
                     logger.info("Migration %s completed successfully", migration_file.name)
                 except Exception as e:
                     logger.error("Migration %s failed: %s", migration_file.name, e)

--- a/plans/PR-EOM-Migration-Content-Integrity.md
+++ b/plans/PR-EOM-Migration-Content-Integrity.md
@@ -1,0 +1,294 @@
+# PR-EOM-Migration-Content-Integrity
+
+## Why this slice exists
+
+H-18 in [ATLAS #2363](https://github.com/canfieldjuan/ATLAS/issues/2363)
+records two Billing & Payments deployment incidents: a migration filename was
+recorded, then later source edits were skipped because the global runner treats
+that name as sufficient evidence of application. The resulting provider schema
+was incomplete even though the ledger looked current. This is a real money and
+deployment-safety risk for the next migration-bearing Billing slice, not generic
+process polish.
+
+This first, independently deployable H-18 phase prevents that exact class for
+newly applied migrations and makes legacy uncertainty truthful. It deliberately
+does not rewrite historical migration records, infer their original contents,
+or make an existing deployment fail because its historical ledger predates
+content identities.
+
+**Diff-budget exception:** this is expected to approach 1,100 changed lines,
+above the 400-LOC soft target, because the indivisible regression proof includes
+the real runner's existing fake/executor seam, all four evidence states,
+self-recording atomic rollback/retry/persisted-digest validation,
+direct-insert recognizer boundaries,
+concurrency compatibility, and the opt-in PostgreSQL adapter assertion.
+Cutting those tests would leave migration safety dependent on an unproven
+internal call shape; no unrelated refactor or product behavior is included.
+
+### Problem-derived contract
+
+- Root cause: `schema_migrations` records only a version and filename. After a
+  file has been recorded, `run_migrations` builds its pending set solely from
+  the filename, so it has no source identity with which to distinguish an
+  unchanged applied file from one whose contents changed after deployment.
+- Correct fix must touch/change: the migration-runner bootstrap must
+  idempotently add a nullable source-hash column to its own ledger; the runner
+  must read each new migration's bytes once, derive SHA-256 from those exact
+  bytes, execute the same decoded bytes, and record and verify that digest
+  atomically with a direct self-recording SQL insert. The direct-insert
+  recognizer must respect PostgreSQL's case distinction for quoted target
+  identifiers. A read-only integrity classifier must
+  read a present source before it labels a null digest legacy, so it can
+  distinguish verified, legacy-unverified, mismatched, and unavailable-source
+  records. Focused runner tests must prove normal, self-recording,
+  mismatch, missing-source, failure/retry, and legacy-row behavior.
+- Must not change: any historical migration SQL file or existing ledger row;
+  migration filename/version selection and duplicate-prefix compatibility;
+  financial tables, invoices, payments, Gmail, the legacy monthly task,
+  deployment credentials, external systems, or current deployment availability
+  for a legacy/null ledger row. Phase one must report diagnostics rather than
+  block startup on a mismatch; an enforcement/backfill policy is a later H-18
+  decision.
+
+## Scope (this PR)
+
+Ownership lane: eom/billing-payments-security-hardening
+Slice phase: Production hardening
+Max files: 4
+
+1. Add a nullable `content_sha256` column through the runner's already
+   idempotent `schema_migrations` bootstrap, under its existing advisory lock.
+   It is runner metadata, not a financial-domain migration; the normal
+   bootstrap is the only safe way to evolve a ledger that must exist before a
+   normal migration can be recorded.
+2. Record SHA-256 for migrations newly applied by this runner, including a
+   direct migration-owned ledger insert in the same transaction as its SQL and
+   digest update, then verify the exact expected digest persisted before that
+   transaction commits. Reject a direct self-recording migration with concurrent
+   DDL before it writes; a distinct mixed-case quoted lookalike must retain the
+   existing autocommit path. Do not
+   backfill rows that were already applied before the run began.
+3. Add a read-only integrity report for the real runner entrypoint. It derives
+   the current migration catalog from the directory and reports verified,
+   legacy-unverified, mismatched, and missing-source rows. Mismatch/missing
+   diagnostics are observable in logs but do not alter pending selection or
+   block phase-one startup.
+4. Add focused fake-runner tests plus the existing opt-in PostgreSQL runner
+   path where appropriate. No production database or financial record is used.
+
+### Review Contract
+
+- Acceptance criteria:
+  1. `run_migrations` hashes the exact source bytes it decodes and executes,
+     then passes that digest to `_record_migration`; settled by a temp-file
+     runner test that asserts the SQL and stored digest originate from one byte
+     payload.
+  2. `_ensure_migrations_table` adds a nullable `content_sha256` column
+     idempotently before any digest query or record, and it runs under the
+     existing session advisory lock; settled by the runner call order and
+     focused fake-executor tests.
+  3. A direct ledger row written by a pending migration receives and proves the
+     exact source digest in that transaction. An injected digest-update failure
+     or silent `UPDATE 0` rolls back both its SQL and ledger row so retry
+     records it once; a supplied wrong non-null digest is replaced; an existing
+     readable legacy null row remains unchanged. Settled by separate
+     self-recording, failure/retry, and legacy-row tests.
+  4. The integrity classifier derives the migration-file set from the supplied
+     directory and classifies four outcomes exactly: matching digest, readable
+     null legacy digest, differing/malformed digest, and a recorded name with
+     no readable source file; settled by one focused classification test over
+     the report, including a present-but-unreadable file.
+  5. A mismatch is logged and remains visible while a later pending migration
+     can still execute in phase one; settled by a real `run_migrations` test
+     that observes the log and resulting record. No hidden fail-open claim is
+     made: mismatched rows are never classified as verified.
+  6. The runner's existing name/version collision, atomic-bookkeeping,
+     concurrently-DDL, retry, no-pending, and unquoted-identifier behavior
+     retain their established tests. A mixed-case quoted `"SCHEMA_MIGRATIONS"`
+     lookalike does not select the atomic/concurrent rejection path; the
+     focused runner suite passes.
+- Reachability proof: the real `run_migrations` entrypoint creates/evolves the
+  runner ledger, classifies its applied rows, records a digest after executing a
+  pending temp migration, and emits the mismatch diagnostic. The observable
+  output is the fake/isolated ledger state and captured runner log; there is no
+  new public or customer-facing surface.
+- Affected surfaces: `atlas_brain.storage.migrations.run_migrations`, its
+  internal `schema_migrations` bootstrap/bookkeeping table, and
+  `tests/test_migrations_runner.py`.
+- Risk areas: migration bootstrap compatibility, self-recording early
+  migrations, byte/SQL TOCTOU, legacy ledger truthfulness, repeated startup,
+  advisory-lock ordering, and accidental fail-closed deployment behavior.
+- Reviewer rules triggered: R1, R2, R4, R5, R6, R8, R10, R12, R13, and R14.
+
+### Boundary-change enumeration
+
+- Boundary path/seam: `run_migrations` is the sole migration-admission and
+  bookkeeping entrypoint. Its internal ledger row gains a source identity after
+  successfully executing a newly pending file.
+- Replaced-path behaviors: filename-only pending selection remains unchanged in
+  phase one. The new digest/report path supplements it; it does not rerun a
+  mismatched file or reinterpret a legacy row as applied content.
+- Guard-relevant fields: `schema_migrations.name` is the existing migration
+  identity; nullable `content_sha256` is source evidence. A null, malformed,
+  differing, or missing-source value is non-verified by construction.
+- Atomic-bookkeeping admission: a migration uses the transaction path when its
+  first non-empty line is the existing explicit marker or its executable SQL
+  directly inserts `schema_migrations`. A direct self-recorder with executable
+  `CONCURRENTLY` is rejected before any write; comments, literals, and an
+  unrelated table retain the existing autocommit path.
+- SQL-recognizer fields: raw migration SQL after comments and literals are
+  masked; the static `INSERT INTO [ONLY] [schema.]schema_migrations` grammar;
+  quoted identifiers; and executable `CONCURRENTLY`. Unquoted identifiers are
+  PostgreSQL-case-folded, while quoted target identifiers must exactly equal
+  lowercase `"schema_migrations"`. Dynamic SQL is outside this static recognizer
+  and must use the pre-existing marker.
+- Caller x input shape: application/MCP startup calls the real runner with the
+  packaged migration directory; focused tests pass a temporary directory and a
+  fake or opt-in isolated executor. The runner never accepts a caller-provided
+  checksum.
+
+### Guard class-closure declaration
+
+- Content-identity input/set: CLOSED for each run. Migration source membership
+  is derived from `sorted(directory.glob("*.sql"))`; applied ledger membership
+  is derived from the database rows. Neither list is copied into source or the
+  plan as a manually maintained inventory. The report maps each recorded `name`
+  to its current source stem exactly once. A row without a current readable
+  source is `missing_source`; null, malformed, or unequal evidence is
+  non-verified, never silently verified.
+- Self-recording recognizer input/set: OPEN raw SQL, with a deliberately narrow
+  static grammar rather than a maintained migration inventory. The
+  grammar-derived matrix varies SQL operation tokens, executable/comment/literal
+  containers, and unquoted/quoted/qualified target keys (including mixed-case
+  quoted lookalikes); its independent expected verdict is direct `INSERT` into
+  the ledger only. Dynamic SQL is not claimed as auto-detectable: the existing
+  marker selects the same atomic path.
+- Error direction: reporting rather than blocking is the deliberately cheap
+  phase-one direction for ledger evidence. A direct static self-recorder is
+  fail-safe transactional; only that self-recorder combined with executable
+  `CONCURRENTLY` fails before a write, because PostgreSQL cannot safely run it
+  in that transaction.
+
+### Deployed-config probing
+
+N/A — no configuration or environment fallback changes. The existing migration
+entrypoint owns the additive bootstrap and all source identity derives from the
+local packaged SQL bytes.
+
+### Files touched
+
+- `atlas_brain/storage/migrations/__init__.py`
+- `plans/PR-EOM-Migration-Content-Integrity.md`
+- `tests/test_commercial_billing_runs.py`
+- `tests/test_migrations_runner.py`
+
+## Mechanism
+
+The existing advisory-locked bootstrap will retain `schema_migrations` and
+idempotently add nullable `content_sha256`. For each pending file,
+`run_migrations` reads the raw file once, computes SHA-256 from those bytes,
+decodes the same bytes for `asyncpg.execute`, and sends the digest to its
+existing record helper. A direct executable `INSERT INTO schema_migrations`
+selects the existing single-connection transaction path, so its SQL and the
+just-created row's digest roll back together if either fails; a direct
+self-recording migration with concurrent DDL is rejected before execution.
+The runner overwrites a newly self-recorded wrong/non-null digest with the
+exact source digest, then reads it back and aborts the transaction if it did
+not persist. The recognizer applies PostgreSQL case folding only to unquoted
+target identifiers, so a distinct mixed-case quoted table is not admitted.
+The explicit atomic marker remains available for equivalent dynamic SQL. A row
+already in the snapshot is never updated.
+
+The report reads ledger names/digests and derives current source files from the
+same migration directory. It reads a present file before classifying its null
+or non-null digest, then returns sorted verified, legacy-unverified,
+mismatched, and unavailable-source names. The real entrypoint logs
+mismatch/unavailable evidence without changing the existing filename-only
+pending behavior. That makes new mutation of an applied source detectable while
+avoiding a surprise availability change for the historical null ledger
+population or an unavailable packaged source.
+
+## Intentional
+
+- `content_sha256` evolves through runner bootstrap rather than a normal SQL
+  migration because normal migration bookkeeping needs that internal table
+  before it can decide or record any SQL file; `ADD COLUMN IF NOT EXISTS` is
+  additive, idempotent, and serialized by the existing advisory lock.
+- SHA-256 is calculated over raw bytes, not a re-rendered SQL string, and those
+  same bytes are decoded for execution. This avoids a read/hash/execute source
+  mismatch.
+- Direct ledger inserts select atomic bookkeeping automatically while comments,
+  literals, unrelated tables, and mixed-case quoted ledger lookalikes do not.
+  Dynamic self-recording SQL must retain the existing explicit marker; this
+  keeps the recognition boundary small and does not rewrite historical
+  migration text.
+- Legacy null rows remain unverified. Writing today's file hash into them would
+  falsely claim evidence of the historical deployed content H-18 says is
+  missing.
+- Mismatch/missing-source evidence logs rather than halts phase-one startup.
+  A fail-closed policy, historical reconciliation, deployment gates, and
+  rollback runbook require a separately reviewed H-18 phase.
+- No content-hash API, environment flag, or customer-visible output is added.
+
+## Deferred
+
+- H-18 phase two: decide whether verified mismatch/missing-source evidence
+  blocks a migration run or deployment, with a documented rollout, rollback,
+  and operator recovery path.
+- Historical forensic reconciliation/backfill: only independently proven
+  historical source identities may ever receive evidence, and no automatic
+  backfill is permitted.
+- Cross-product migration policy for non-Atlas migration runners remains
+  separate from this Atlas runner proof.
+- H-18 phase two: decide whether dynamic self-recording SQL should receive a
+  broader parser or a declared migration-authoring policy. Until that review,
+  the existing `-- atlas: atomic-bookkeeping` marker is required for dynamic
+  self-recording SQL.
+
+Parking predicate: new migration-framework abstractions, API surfaces,
+historical rewrites, and enforcement policy are parked unless required to
+record an exact digest for a newly applied migration or to truthfully classify
+it.
+
+Parked hardening: dynamic self-recording SQL policy/parser work remains H-18
+phase two in ATLAS #2363; it is not required to make direct packaged ledger
+inserts rollback-safe today.
+
+## Verification
+
+- Ruff and byte-compilation passed for
+  `atlas_brain/storage/migrations/__init__.py` and
+  `tests/test_migrations_runner.py`.
+- The focused migration/Billing regression selection passed: 198 passed,
+  55 skipped, and 1 warning across `tests/test_migrations_runner.py`,
+  `tests/test_receivables.py`,
+  `tests/test_residential_payment_receipt_delivery.py`,
+  `tests/test_commercial_billing_runs.py`, and
+  `tests/test_eom_public_onboarding_migration_repair.py`.
+- With only a fresh local Docker PostgreSQL 16 instance on loopback and
+  `ATLAS_MIGRATION_TEST_DATABASE_URL` set for that command,
+  `python -m pytest -q tests/test_migrations_runner.py` passed: 51 passed.
+  The workflow-mirror migration/onboarding selection passed: 54 passed. Both
+  probes used a disposable container; no production connection was used.
+- The exact `atlas_brain/storage` maturity-ratchet command from the workflow
+  passed with no new brittleness above baseline. Whitespace and plan-sync checks
+  also passed.
+- An unrelated cross-layer selection completed its test output but leaked a
+  local nested process during teardown, so it is intentionally not counted as
+  verification for this runner-only change. The isolated process group was
+  stopped; no source, production process, or financial state was changed.
+- A broader legacy monthly-invoice selection has two known current-main
+  failures in `tests/test_monthly_invoice_generation.py` because the approved
+  safety setting disables invoice reminders; the same two tests fail in a
+  detached `origin/main` worktree and are already tracked by ATLAS #2271. They
+  are not a migration-integrity regression and are not folded into this PR.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/storage/migrations/__init__.py` | 197 |
+| `plans/PR-EOM-Migration-Content-Integrity.md` | 294 |
+| `tests/test_commercial_billing_runs.py` | 4 |
+| `tests/test_migrations_runner.py` | 585 |
+| **Total** | **1080** |

--- a/tests/test_commercial_billing_runs.py
+++ b/tests/test_commercial_billing_runs.py
@@ -1984,6 +1984,9 @@ async def test_full_atlas_lifespan_uses_enabled_receivables_recovery_fence(monke
             if "CREATE TABLE IF NOT EXISTS schema_migrations" in query:
                 events.append("ensure")
                 return "CREATE TABLE"
+            if "ADD COLUMN IF NOT EXISTS content_sha256" in query:
+                events.append("ensure-content-identity")
+                return "ALTER TABLE"
             assert query == "SELECT pg_advisory_unlock($1)"
             assert args
             events.append("unlock")
@@ -2032,6 +2035,7 @@ async def test_full_atlas_lifespan_uses_enabled_receivables_recovery_fence(monke
         "acquire",
         "lock",
         "ensure",
+        "ensure-content-identity",
         "migrate",
         "unlock",
         "release",

--- a/tests/test_migrations_runner.py
+++ b/tests/test_migrations_runner.py
@@ -1,4 +1,7 @@
 import asyncio
+import hashlib
+import itertools
+import logging
 import os
 import uuid
 from pathlib import Path
@@ -10,36 +13,65 @@ DATABASE_URL_ENV = "ATLAS_MIGRATION_TEST_DATABASE_URL"
 
 class FakeMigrationPool:
     def __init__(self, records=None):
-        self.records = list(records or [])
+        self.records = [
+            (record[0], record[1], record[2] if len(record) > 2 else None)
+            for record in (records or [])
+        ]
         self.inserted = []
+        self.inserted_with_digest = []
+        self.updated = []
 
     async def fetchval(self, query, *args):
         normalized = " ".join(query.split())
+        if normalized == "SELECT content_sha256 FROM schema_migrations WHERE name = $1":
+            name = args[0]
+            for _version, record_name, content_sha256 in self.records:
+                if record_name == name:
+                    return content_sha256
+            return None
         if "WHERE name = $1" in normalized:
             name = args[0]
-            for version, record_name in self.records:
+            for version, record_name, _content_sha256 in self.records:
                 if record_name == name:
                     return version
             return None
         if "WHERE version = $1" in normalized:
             version = args[0]
-            for record_version, name in self.records:
+            for record_version, name, _content_sha256 in self.records:
                 if record_version == version:
                     return name
             return None
         if "MIN(version)" in normalized:
             if not self.records:
                 return -1
-            min_version = min(version for version, _ in self.records)
+            min_version = min(version for version, _name, _digest in self.records)
             return min_version - 1 if min_version < 0 else -1
         raise AssertionError(f"Unexpected fetchval query: {query}")
 
+    async def fetch(self, query, *args):
+        assert query == "SELECT name, content_sha256 FROM schema_migrations"
+        return [
+            {"name": name, "content_sha256": content_sha256}
+            for _version, name, content_sha256 in self.records
+        ]
+
     async def execute(self, query, *args):
         normalized = " ".join(query.split())
+        if normalized.startswith("UPDATE schema_migrations SET content_sha256"):
+            name, content_sha256 = args
+            self.records = [
+                (version, record_name, content_sha256)
+                if record_name == name
+                else (version, record_name, existing_digest)
+                for version, record_name, existing_digest in self.records
+            ]
+            self.updated.append((name, content_sha256))
+            return
         if normalized.startswith("INSERT INTO schema_migrations"):
-            record = (args[0], args[1])
+            record = (args[0], args[1], args[2])
             self.records.append(record)
-            self.inserted.append(record)
+            self.inserted.append(record[:2])
+            self.inserted_with_digest.append(record)
             return
         raise AssertionError(f"Unexpected execute query: {query}")
 
@@ -49,10 +81,18 @@ async def test_record_migration_uses_prefix_version_when_available():
     from atlas_brain.storage.migrations import _record_migration
 
     pool = FakeMigrationPool(records=[(1, "001_initial_schema")])
+    content_sha256 = "a" * 64
 
-    await _record_migration(pool, "247_b2b_vendor_witness_packets.sql")
+    await _record_migration(
+        pool,
+        "247_b2b_vendor_witness_packets.sql",
+        content_sha256,
+    )
 
     assert pool.inserted == [(247, "247_b2b_vendor_witness_packets")]
+    assert pool.inserted_with_digest == [
+        (247, "247_b2b_vendor_witness_packets", content_sha256)
+    ]
 
 
 @pytest.mark.asyncio
@@ -64,13 +104,124 @@ async def test_record_migration_uses_negative_version_on_prefix_collision():
         (230, "230_scrape_target_checkpoints"),
     ])
 
-    await _record_migration(pool, "076_consumer_analytics_views.sql")
-    await _record_migration(pool, "230_b2b_reasoning_synthesis.sql")
+    await _record_migration(pool, "076_consumer_analytics_views.sql", "b" * 64)
+    await _record_migration(pool, "230_b2b_reasoning_synthesis.sql", "c" * 64)
 
     assert pool.inserted == [
         (-1, "076_consumer_analytics_views"),
         (-2, "230_b2b_reasoning_synthesis"),
     ]
+
+
+@pytest.mark.asyncio
+async def test_record_migration_leaves_existing_legacy_row_unchanged_without_pending_proof():
+    from atlas_brain.storage.migrations import _record_migration
+
+    pool = FakeMigrationPool(records=[(247, "247_probe", None)])
+
+    await _record_migration(pool, "247_probe.sql", "d" * 64)
+
+    assert pool.records == [(247, "247_probe", None)]
+    assert pool.updated == []
+
+
+@pytest.mark.asyncio
+async def test_migration_content_integrity_report_classifies_all_evidence_states(
+    tmp_path,
+    monkeypatch,
+):
+    from atlas_brain.storage.migrations import _migration_content_integrity_report
+
+    verified = tmp_path / "900_verified.sql"
+    legacy = tmp_path / "901_legacy.sql"
+    mismatched = tmp_path / "902_mismatched.sql"
+    unreadable = tmp_path / "903_unreadable.sql"
+    verified.write_bytes(b"SELECT 'verified';\n")
+    legacy.write_bytes(b"SELECT 'legacy';\n")
+    mismatched.write_bytes(b"SELECT 'mismatched';\n")
+    unreadable.write_bytes(b"SELECT 'unreadable';\n")
+    pool = FakeMigrationPool(records=[
+        (900, "900_verified", hashlib.sha256(verified.read_bytes()).hexdigest()),
+        (901, "901_legacy", None),
+        (902, "902_mismatched", "not-a-sha256"),
+        (903, "903_unreadable", None),
+        (904, "904_missing_source", "f" * 64),
+    ])
+
+    original_read_bytes = Path.read_bytes
+
+    def read_bytes_or_raise(path):
+        if path == unreadable:
+            raise PermissionError("migration source is unreadable")
+        return original_read_bytes(path)
+
+    monkeypatch.setattr(Path, "read_bytes", read_bytes_or_raise)
+
+    report = await _migration_content_integrity_report(
+        pool,
+        [verified, legacy, mismatched, unreadable],
+    )
+
+    assert report.verified == ("900_verified",)
+    assert report.legacy_unverified == ("901_legacy",)
+    assert report.mismatched == ("902_mismatched",)
+    assert report.missing_source == ("903_unreadable", "904_missing_source")
+
+
+@pytest.mark.parametrize(
+    ("sql", "expected"),
+    [
+        ("INSERT INTO schema_migrations (version, name) VALUES (1, '001');", True),
+        ('INSERT INTO "schema_migrations" (version, name) VALUES (1, \'001\');', True),
+        ("INSERT INTO public.schema_migrations (version, name) VALUES (1, '001');", True),
+        ('INSERT INTO "public"."schema_migrations" (version, name) VALUES (1, \'001\');', True),
+        ('INSERT INTO "SCHEMA_MIGRATIONS" (version, name) VALUES (1, \'001\');', False),
+        ("-- INSERT INTO schema_migrations (version, name) VALUES (1, '001');", False),
+        ("SELECT 'INSERT INTO schema_migrations (version, name)';", False),
+        ("INSERT INTO migration_audit (name) VALUES ('schema_migrations');", False),
+    ],
+)
+def test_self_recording_detector_only_admits_executable_ledger_inserts(sql, expected):
+    from atlas_brain.storage.migrations import _contains_executable_self_recording_insert
+
+    assert _contains_executable_self_recording_insert(sql) is expected
+
+
+def test_self_recording_detector_matches_static_sql_grammar_matrix():
+    """Derive expected admission from SQL token, context, and target axes."""
+    from atlas_brain.storage.migrations import _contains_executable_self_recording_insert
+
+    grammar_axes = {
+        "tokens": (("INSERT", True), ("insert", True), ("UPDATE", False)),
+        "containers": ("direct", "line-comment", "literal"),
+        "keys": (
+            ("schema_migrations", True),
+            ("SCHEMA_MIGRATIONS", True),
+            ('"schema_migrations"', True),
+            ('"SCHEMA_MIGRATIONS"', False),
+            ("public.schema_migrations", True),
+            ('"public"."schema_migrations"', True),
+            ('public."SCHEMA_MIGRATIONS"', False),
+            ("migration_audit", False),
+        ),
+    }
+
+    for (token, is_insert), container, (target, is_ledger) in itertools.product(
+        grammar_axes["tokens"],
+        grammar_axes["containers"],
+        grammar_axes["keys"],
+    ):
+        statement = f"{token} INTO ONLY {target} (version, name) VALUES (1, '001');"
+        if container == "direct":
+            sql = statement
+        elif container == "line-comment":
+            sql = f"-- {statement}"
+        else:
+            literal = statement.replace("'", "''")
+            sql = f"SELECT '{literal}'"
+
+        expected = is_insert and is_ledger and container == "direct"
+        assert _contains_executable_self_recording_insert(sql) is expected
 
 
 def test_find_duplicate_migration_prefixes_detects_repo_collisions():
@@ -601,6 +752,8 @@ class _SerializingPool(FakeMigrationPool):
         super().__init__()
         self.honor_lock = honor_lock
         self.applied_sql = []
+        self.atomic_transactions = 0
+        self.atomic_transaction_errors = 0
         self.acquired = 0
         self.max_acquired = 0
         self._gate = None
@@ -619,7 +772,10 @@ class _SerializingPool(FakeMigrationPool):
         # concurrent runner's write leak into this result and mask the race.
         import asyncio
 
-        snapshot = [{"name": name} for _version, name in self.records]
+        snapshot = [
+            {"name": name, "content_sha256": content_sha256}
+            for _version, name, content_sha256 in self.records
+        ]
         await asyncio.sleep(0)
         return snapshot
 
@@ -627,7 +783,11 @@ class _SerializingPool(FakeMigrationPool):
         normalized = " ".join(query.split())
         if normalized.startswith("CREATE TABLE IF NOT EXISTS schema_migrations"):
             return
+        if normalized.startswith("ALTER TABLE schema_migrations ADD COLUMN"):
+            return
         if normalized.startswith("INSERT INTO schema_migrations"):
+            return await super().execute(query, *args)
+        if normalized.startswith("UPDATE schema_migrations SET content_sha256"):
             return await super().execute(query, *args)
         self.applied_sql.append(normalized)
 
@@ -638,6 +798,40 @@ class _SerializingPool(FakeMigrationPool):
 
     async def release(self, conn):
         self.acquired -= 1
+
+    def transaction(self):
+        return _RollbackMigrationTransaction(self)
+
+
+class _RollbackMigrationTransaction:
+    """In-memory transaction seam that restores migration effects on failure."""
+
+    def __init__(self, pool):
+        self.pool = pool
+        self.snapshot = None
+
+    async def __aenter__(self):
+        self.pool.atomic_transactions += 1
+        self.snapshot = (
+            list(self.pool.records),
+            list(self.pool.inserted),
+            list(self.pool.inserted_with_digest),
+            list(self.pool.updated),
+            list(self.pool.applied_sql),
+        )
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        if exc_type is not None:
+            self.pool.atomic_transaction_errors += 1
+            (
+                self.pool.records,
+                self.pool.inserted,
+                self.pool.inserted_with_digest,
+                self.pool.updated,
+                self.pool.applied_sql,
+            ) = self.snapshot
+        return False
 
 
 class _Conn:
@@ -673,6 +867,9 @@ class _Conn:
             return True
         return await self.pool.fetchval(query, *args)
 
+    def transaction(self):
+        return self.pool.transaction()
+
 
 @pytest.mark.asyncio
 async def test_concurrent_runners_apply_each_migration_once(tmp_path):
@@ -694,6 +891,9 @@ async def test_concurrent_runners_apply_each_migration_once(tmp_path):
         "pending"
     )
     assert pool.inserted == [(900, "900_probe")]
+    assert pool.inserted_with_digest == [
+        (900, "900_probe", hashlib.sha256(b"SELECT 900").hexdigest())
+    ]
 
 
 @pytest.mark.asyncio
@@ -714,6 +914,268 @@ async def test_without_the_advisory_lock_both_runners_apply(tmp_path):
     assert len(pool.applied_sql) == 2, (
         "no-op lock must reproduce the double-apply race the real lock prevents"
     )
+
+
+@pytest.mark.asyncio
+async def test_pending_migration_hashes_and_executes_one_source_read(
+    tmp_path,
+    monkeypatch,
+):
+    from atlas_brain.storage.migrations import run_migrations
+
+    source_path = tmp_path / "900_one_read.sql"
+    source = b"SELECT 'one source read'"
+    expected_digest = hashlib.sha256(source).hexdigest()
+    source_path.write_bytes(source)
+    original_read_bytes = Path.read_bytes
+    reads = []
+
+    def read_bytes_once(path):
+        if path == source_path:
+            reads.append(path)
+            if len(reads) > 1:
+                raise AssertionError("pending migration source was read more than once")
+        return original_read_bytes(path)
+
+    monkeypatch.setattr(Path, "read_bytes", read_bytes_once)
+    pool = _SerializingPool()
+
+    await run_migrations(pool, migrations_dir=tmp_path)
+
+    assert reads == [source_path]
+    assert pool.applied_sql == [source.decode("utf-8")]
+    assert pool.inserted_with_digest == [(900, "900_one_read", expected_digest)]
+
+
+@pytest.mark.asyncio
+async def test_pending_self_recording_migration_receives_its_digest(tmp_path):
+    from atlas_brain.storage.migrations import run_migrations
+
+    source = (
+        "INSERT INTO schema_migrations (version, name, content_sha256) "
+        "VALUES (900, '900_self_recording', 'wrong-digest');"
+    )
+    (tmp_path / "900_self_recording.sql").write_text(source)
+
+    class _SelfRecordingPool(_SerializingPool):
+        async def execute(self, query, *args):
+            if query == source:
+                self.records.append((900, "900_self_recording", "wrong-digest"))
+                self.applied_sql.append(query)
+                return
+            return await super().execute(query, *args)
+
+    pool = _SelfRecordingPool()
+    await run_migrations(pool, migrations_dir=tmp_path)
+
+    expected_digest = hashlib.sha256(source.encode("utf-8")).hexdigest()
+    assert pool.records == [(900, "900_self_recording", expected_digest)]
+    assert pool.updated == [("900_self_recording", expected_digest)]
+    assert pool.atomic_transactions == 1
+    assert pool.atomic_transaction_errors == 0
+
+
+@pytest.mark.asyncio
+async def test_self_recording_digest_must_persist_before_transaction_commits(tmp_path):
+    """A silent UPDATE 0 cannot commit a stale self-recorded digest."""
+    from atlas_brain.storage.migrations import run_migrations
+
+    source = (
+        "CREATE TABLE self_recording_persistence_probe (id int);\n"
+        "INSERT INTO schema_migrations (version, name) "
+        "VALUES (900, '900_self_recording_persistence');"
+    )
+    (tmp_path / "900_self_recording_persistence.sql").write_text(source)
+
+    class _SuppressOnceDigestUpdatePool(_SerializingPool):
+        def __init__(self):
+            super().__init__()
+            self.suppress_next_digest_update = True
+
+        async def execute(self, query, *args):
+            if query == source:
+                self.records.append((900, "900_self_recording_persistence", None))
+                self.applied_sql.append(query)
+                return
+            normalized = " ".join(query.split())
+            if (
+                normalized.startswith("UPDATE schema_migrations SET content_sha256")
+                and self.suppress_next_digest_update
+            ):
+                self.suppress_next_digest_update = False
+                return "UPDATE 0"
+            return await super().execute(query, *args)
+
+    pool = _SuppressOnceDigestUpdatePool()
+    with pytest.raises(RuntimeError, match="did not persist its expected content SHA-256"):
+        await run_migrations(pool, migrations_dir=tmp_path)
+
+    assert pool.records == []
+    assert pool.applied_sql == []
+    assert pool.atomic_transactions == 1
+    assert pool.atomic_transaction_errors == 1
+
+    await run_migrations(pool, migrations_dir=tmp_path)
+
+    expected_digest = hashlib.sha256(source.encode("utf-8")).hexdigest()
+    assert pool.records == [
+        (900, "900_self_recording_persistence", expected_digest)
+    ]
+    assert pool.atomic_transactions == 2
+
+
+@pytest.mark.asyncio
+async def test_self_recording_digest_failure_rolls_back_and_retry_records_once(tmp_path):
+    """A failed digest update cannot leave a self-recorded row permanently legacy."""
+    from atlas_brain.storage.migrations import run_migrations
+
+    source = (
+        "CREATE TABLE self_recording_retry_probe (id int);\n"
+        "INSERT INTO schema_migrations (version, name) "
+        "VALUES (900, '900_self_recording_retry');"
+    )
+    (tmp_path / "900_self_recording_retry.sql").write_text(source)
+
+    class _FailOnceDigestUpdatePool(_SerializingPool):
+        def __init__(self):
+            super().__init__()
+            self.fail_next_digest_update = True
+
+        async def execute(self, query, *args):
+            if query == source:
+                self.records.append((900, "900_self_recording_retry", None))
+                self.applied_sql.append(query)
+                return
+            normalized = " ".join(query.split())
+            if (
+                normalized.startswith("UPDATE schema_migrations SET content_sha256")
+                and self.fail_next_digest_update
+            ):
+                self.fail_next_digest_update = False
+                raise RuntimeError("injected digest update failure")
+            return await super().execute(query, *args)
+
+    pool = _FailOnceDigestUpdatePool()
+    with pytest.raises(RuntimeError, match="injected digest update failure"):
+        await run_migrations(pool, migrations_dir=tmp_path)
+
+    assert pool.records == []
+    assert pool.applied_sql == []
+    assert pool.updated == []
+    assert pool.atomic_transactions == 1
+    assert pool.atomic_transaction_errors == 1
+
+    await run_migrations(pool, migrations_dir=tmp_path)
+
+    expected_digest = hashlib.sha256(source.encode("utf-8")).hexdigest()
+    assert pool.records == [(900, "900_self_recording_retry", expected_digest)]
+    assert pool.updated == [("900_self_recording_retry", expected_digest)]
+    assert pool.atomic_transactions == 2
+
+
+@pytest.mark.asyncio
+async def test_comment_or_literal_ledger_insert_does_not_force_a_transaction(tmp_path):
+    """Mentions are not self-recording SQL and preserve autocommit behavior."""
+    from atlas_brain.storage.migrations import run_migrations
+
+    (tmp_path / "900_mention_only.sql").write_text(
+        "CREATE TABLE mention_only_probe (id int);\n"
+        "-- INSERT INTO schema_migrations (version, name) VALUES (900, 'noop');\n"
+        "SELECT 'INSERT INTO schema_migrations (version, name)';"
+    )
+    pool = _SingleConnectionPool(tmp_path)
+
+    await run_migrations(pool, migrations_dir=tmp_path)
+
+    assert getattr(pool, "atomic_transactions", 0) == 0
+
+
+@pytest.mark.asyncio
+async def test_self_recording_concurrent_ddl_is_rejected_before_any_write(tmp_path):
+    """A self-recording concurrent-DDL migration cannot reopen the crash window."""
+    from atlas_brain.storage.migrations import run_migrations
+
+    source = (
+        "CREATE INDEX CONCURRENTLY idx_self_recording_probe ON probe (id);\n"
+        "INSERT INTO schema_migrations (version, name) "
+        "VALUES (900, '900_self_recording_concurrent');"
+    )
+    (tmp_path / "900_self_recording_concurrent.sql").write_text(source)
+    pool = _SingleConnectionPool(tmp_path)
+
+    with pytest.raises(
+        RuntimeError, match="atomic-bookkeeping migration cannot use CONCURRENTLY"
+    ):
+        await run_migrations(pool, migrations_dir=tmp_path)
+
+    assert getattr(pool, "atomic_transactions", 0) == 0
+    assert source not in pool.applied_sql
+
+
+@pytest.mark.asyncio
+async def test_mixed_case_quoted_ledger_lookalike_preserves_concurrent_autocommit(tmp_path):
+    """A distinct quoted table does not select the atomic/concurrent guard."""
+    from atlas_brain.storage.migrations import run_migrations
+
+    source = (
+        "CREATE INDEX CONCURRENTLY idx_quoted_ledger_lookalike ON probe (id);\n"
+        'INSERT INTO "SCHEMA_MIGRATIONS" (version, name) '
+        "VALUES (900, '900_quoted_ledger_lookalike');"
+    )
+    (tmp_path / "900_quoted_ledger_lookalike.sql").write_text(source)
+    pool = _SingleConnectionPool(tmp_path)
+
+    await run_migrations(pool, migrations_dir=tmp_path)
+
+    assert getattr(pool, "atomic_transactions", 0) == 0
+    assert source not in pool.applied_sql
+    assert any("CREATE INDEX CONCURRENTLY" in sql for sql in pool.applied_sql)
+
+
+@pytest.mark.asyncio
+async def test_mismatch_is_logged_without_blocking_a_later_pending_migration(
+    tmp_path,
+    caplog,
+):
+    from atlas_brain.storage.migrations import run_migrations
+
+    (tmp_path / "900_recorded.sql").write_text("SELECT 900")
+    (tmp_path / "901_pending.sql").write_text("SELECT 901")
+    pool = _SerializingPool(honor_lock=True)
+    pool.records.append((900, "900_recorded", "f" * 64))
+    caplog.set_level(logging.ERROR, logger="atlas.storage.migrations")
+
+    await run_migrations(pool, migrations_dir=tmp_path)
+
+    assert any("mismatched=900_recorded" in message for message in caplog.messages)
+    assert pool.applied_sql == ["SELECT 901"]
+    assert pool.records[0] == (900, "900_recorded", "f" * 64)
+    assert pool.inserted_with_digest == [
+        (901, "901_pending", hashlib.sha256(b"SELECT 901").hexdigest())
+    ]
+
+
+@pytest.mark.asyncio
+async def test_legacy_null_row_is_reported_but_never_backfilled_by_a_later_run(
+    tmp_path,
+    caplog,
+):
+    from atlas_brain.storage.migrations import run_migrations
+
+    (tmp_path / "900_legacy.sql").write_text("SELECT 900")
+    (tmp_path / "901_pending.sql").write_text("SELECT 901")
+    pool = _SerializingPool(honor_lock=True)
+    pool.records.append((900, "900_legacy", None))
+    caplog.set_level(logging.INFO, logger="atlas.storage.migrations")
+
+    await run_migrations(pool, migrations_dir=tmp_path)
+
+    assert any(
+        "unavailable for 1 legacy ledger rows" in message
+        for message in caplog.messages
+    )
+    assert pool.records[0] == (900, "900_legacy", None)
+    assert pool.updated == []
 
 
 class _SingleConnectionPool:
@@ -1031,7 +1493,6 @@ async def test_real_postgres_concurrent_runners_apply_each_migration_once(tmp_pa
     session-lock design exists to provide. Skips when no database is wired,
     same as the other real-PostgreSQL probes in this repo."""
     import asyncpg
-
     from atlas_brain.storage.migrations import run_migrations
 
     database_url = os.environ.get(DATABASE_URL_ENV)
@@ -1045,19 +1506,25 @@ async def test_real_postgres_concurrent_runners_apply_each_migration_once(tmp_pa
     try:
         await admin.execute(f'CREATE SCHEMA "{schema}"')
 
-        (tmp_path / "001_first.sql").write_text(
-            "CREATE TABLE migration_lock_probe_a (id integer primary key);"
+        first_source = b"CREATE TABLE migration_lock_probe_a (id integer primary key);"
+        second_source = b"CREATE TABLE migration_lock_probe_b (id integer primary key);"
+        concurrent_index_source = (
+            b"CREATE INDEX CONCURRENTLY migration_lock_probe_idx "
+            b"ON migration_lock_probe_a (id);"
         )
-        (tmp_path / "002_second.sql").write_text(
-            "CREATE TABLE migration_lock_probe_b (id integer primary key);"
+        self_recording_source = (
+            b"CREATE TABLE migration_lock_probe_self_recording "
+            b"(id integer primary key);\n"
+            b"INSERT INTO schema_migrations (version, name, content_sha256) "
+            b"VALUES (4, '004_self_recording', 'wrong-digest');"
         )
+        (tmp_path / "001_first.sql").write_bytes(first_source)
+        (tmp_path / "002_second.sql").write_bytes(second_source)
         # Statement Postgres refuses inside a transaction block: it passes only
         # because the run holds a SESSION-level lock on an autocommit
         # connection, not a transaction-scoped one.
-        (tmp_path / "003_concurrent_index.sql").write_text(
-            "CREATE INDEX CONCURRENTLY migration_lock_probe_idx "
-            "ON migration_lock_probe_a (id);"
-        )
+        (tmp_path / "003_concurrent_index.sql").write_bytes(concurrent_index_source)
+        (tmp_path / "004_self_recording.sql").write_bytes(self_recording_source)
 
         # TWO INDEPENDENT pools -> two independent backend sessions. A single
         # max_size=1 pool would serialize the runners in acquire() before they
@@ -1087,13 +1554,16 @@ async def test_real_postgres_concurrent_runners_apply_each_migration_once(tmp_pa
 
         await admin.execute(f'SET search_path TO "{schema}", public')
         applied = await admin.fetch(
-            "SELECT name FROM schema_migrations ORDER BY name"
+            "SELECT name, content_sha256 FROM schema_migrations ORDER BY name"
         )
-        assert [r["name"] for r in applied] == [
-            "001_first",
-            "002_second",
-            "003_concurrent_index",
-        ], "each migration must be recorded exactly once"
+        assert {
+            row["name"]: row["content_sha256"] for row in applied
+        } == {
+            "001_first": hashlib.sha256(first_source).hexdigest(),
+            "002_second": hashlib.sha256(second_source).hexdigest(),
+            "003_concurrent_index": hashlib.sha256(concurrent_index_source).hexdigest(),
+            "004_self_recording": hashlib.sha256(self_recording_source).hexdigest(),
+        }, "each migration must be recorded exactly once with its exact source identity"
 
         index_rows = await admin.fetch(
             "SELECT indexname FROM pg_indexes "
@@ -1105,6 +1575,71 @@ async def test_real_postgres_concurrent_runners_apply_each_migration_once(tmp_pa
             "CREATE INDEX CONCURRENTLY must have run -- if the runner opened a "
             "transaction, Postgres would have rejected it"
         )
+
+        retry_source = (
+            b"CREATE TABLE migration_lock_probe_retry (id integer primary key);\n"
+            b"INSERT INTO schema_migrations (version, name) "
+            b"VALUES (5, '005_self_recording_retry');"
+        )
+        (tmp_path / "005_self_recording_retry.sql").write_bytes(retry_source)
+        await admin.execute(
+            """
+            CREATE OR REPLACE FUNCTION suppress_self_recording_retry_digest()
+            RETURNS trigger
+            LANGUAGE plpgsql
+            AS $$
+            BEGIN
+                IF NEW.name = '005_self_recording_retry'
+                   AND NEW.content_sha256 IS NOT NULL THEN
+                    RETURN NULL;
+                END IF;
+                RETURN NEW;
+            END;
+            $$
+            """
+        )
+        await admin.execute(
+            """
+            CREATE TRIGGER suppress_self_recording_retry_digest_trigger
+            BEFORE UPDATE OF content_sha256 ON schema_migrations
+            FOR EACH ROW
+            EXECUTE FUNCTION suppress_self_recording_retry_digest()
+            """
+        )
+
+        with pytest.raises(RuntimeError, match="did not persist its expected content SHA-256"):
+            await run_migrations(
+                pool,
+                migrations_dir=tmp_path,
+                only={"005_self_recording_retry"},
+            )
+
+        assert await admin.fetchval(
+            "SELECT to_regclass($1)", "migration_lock_probe_retry"
+        ) is None
+        assert await admin.fetch(
+            "SELECT name FROM schema_migrations WHERE name = $1",
+            "005_self_recording_retry",
+        ) == []
+
+        await admin.execute(
+            "DROP TRIGGER suppress_self_recording_retry_digest_trigger "
+            "ON schema_migrations"
+        )
+        await admin.execute("DROP FUNCTION suppress_self_recording_retry_digest()")
+        await run_migrations(
+            pool,
+            migrations_dir=tmp_path,
+            only={"005_self_recording_retry"},
+        )
+
+        assert await admin.fetchval(
+            "SELECT to_regclass($1)", "migration_lock_probe_retry"
+        ) is not None
+        assert await admin.fetchval(
+            "SELECT content_sha256 FROM schema_migrations WHERE name = $1",
+            "005_self_recording_retry",
+        ) == hashlib.sha256(retry_source).hexdigest()
 
         # The SESSION lock outlives its transaction, so it must be released
         # explicitly or the pooled connection carries it into unrelated work.


### PR DESCRIPTION
Plan: plans/PR-EOM-Migration-Content-Integrity.md
Slice phase: Production hardening
Ownership lane: eom/billing-payments-security-hardening

H-18 closes the forward-looking half of a real Billing & Payments deployment
risk: once the filename-only migration ledger accepts a file, later source
edits cannot be distinguished from the deployed source. This slice gives every
newly applied migration a SHA-256 identity and emits truthful diagnostic states
for legacy, mismatched, or unavailable evidence. It does not rewrite history,
rerun a changed migration, or alter financial behavior.

Diff-budget override: The runner change and its regression proof are one safety
unit: exact-byte hashing, all four evidence states, self-recording atomic
rollback/retry/persisted-digest validation, direct-insert recognizer boundaries,
and real PostgreSQL concurrency coverage share the migration execution seam.
Splitting them would leave the ledger change or one of its failure modes
unproven.

## Intentional

- The runner evolves its own nullable metadata column under the existing
  advisory lock; a normal SQL migration cannot safely bootstrap the table that
  records normal SQL migrations.
- Existing null ledger rows remain legacy-unverified. A source hash calculated
  today cannot prove what historically deployed.
- Mismatch and unavailable-source evidence remains diagnostic in phase one.
  Enforcement, backfill, and rollout/rollback policy stay in H-18 phase two.
- Direct static ledger inserts use the transaction path automatically; dynamic
  self-recording SQL retains the established explicit atomic marker.
- Unquoted ledger identifiers use PostgreSQL case folding; quoted targets must
  exactly match lowercase `"schema_migrations"`.
- A new self-recorded row's digest is replaced when wrong and read back before
  its transaction commits; historical rows are still not rewritten.

## AI reconciliation

- Make self-recording digest updates retry-safe -- fixed-in: 1ff383a `atlas_brain/storage/migrations/__init__.py` and `tests/test_migrations_runner.py::test_self_recording_digest_failure_rolls_back_and_retry_records_once` make the direct ledger insert and digest update one rollback-safe unit.
- Exercise the unreadable-source branch -- fixed-in: 1ff383a `tests/test_migrations_runner.py::test_migration_content_integrity_report_classifies_all_evidence_states` now supplies the unreadable file and proves the injected `PermissionError`.
- Report unreadable legacy files as missing sources -- fixed-in: 1ff383a `atlas_brain/storage/migrations/__init__.py` reads a present source before classifying its nullable digest; the same focused test proves this result.
- Preserve case when matching quoted ledger identifiers -- fixed-in: 1ff383a `atlas_brain/storage/migrations/__init__.py` scopes case folding to unquoted names, and `tests/test_migrations_runner.py::test_mixed_case_quoted_ledger_lookalike_preserves_concurrent_autocommit` proves the distinct quoted table is not rejected.
- Verify the self-recorded digest was actually persisted -- fixed-in: 1ff383a `atlas_brain/storage/migrations/__init__.py` replaces/reads back the digest, while `tests/test_migrations_runner.py::test_self_recording_digest_must_persist_before_transaction_commits` proves silent `UPDATE 0` rolls back and retries safely.

## Fix-loop disposition preflight

- Root decision: Make self-recording digest updates retry-safe
- Source trace: pending direct ledger insert -> ledger row -> failed or suppressed digest update -> stale applied-name skip
- Upstream files: atlas_brain/storage/migrations/__init__.py, tests/test_migrations_runner.py
- Fix strategy: upstream-root
- Blocking predicate: data
- Disposition: fixed-in
- Allowed files: atlas_brain/storage/migrations/__init__.py, tests/test_migrations_runner.py, tests/test_commercial_billing_runs.py, plans/PR-EOM-Migration-Content-Integrity.md
- Max files: 4
- Parked hardening: H-18 phase two dynamic self-recording policy/parser in ATLAS #2363

- Root decision: Preserve case when matching quoted ledger identifiers
- Source trace: quoted mixed-case target -> global case-insensitive recognizer -> false self-recorder admission -> concurrent-DDL rejection
- Upstream files: atlas_brain/storage/migrations/__init__.py, tests/test_migrations_runner.py
- Fix strategy: upstream-root
- Blocking predicate: back-compat
- Disposition: fixed-in
- Allowed files: atlas_brain/storage/migrations/__init__.py, tests/test_migrations_runner.py, tests/test_commercial_billing_runs.py, plans/PR-EOM-Migration-Content-Integrity.md
- Max files: 4
- Parked hardening: H-18 phase two dynamic self-recording policy/parser in ATLAS #2363

- Root decision: Verify the self-recorded digest was actually persisted
- Source trace: pending self-recorder -> non-null or suppressed digest update -> ignored UPDATE 0 -> mismatched committed ledger row
- Upstream files: atlas_brain/storage/migrations/__init__.py, tests/test_migrations_runner.py
- Fix strategy: upstream-root
- Blocking predicate: data
- Disposition: fixed-in
- Allowed files: atlas_brain/storage/migrations/__init__.py, tests/test_migrations_runner.py, tests/test_commercial_billing_runs.py, plans/PR-EOM-Migration-Content-Integrity.md
- Max files: 4
- Parked hardening: H-18 phase two dynamic self-recording policy/parser in ATLAS #2363

- Root decision: Exercise the unreadable-source branch
- Source trace: supplied migration-file list -> unreadable Path.read_bytes -> OSError handler -> missing_source report
- Upstream files: tests/test_migrations_runner.py, atlas_brain/storage/migrations/__init__.py
- Fix strategy: upstream-root
- Blocking predicate: claimed-mechanism
- Disposition: fixed-in
- Allowed files: atlas_brain/storage/migrations/__init__.py, tests/test_migrations_runner.py, tests/test_commercial_billing_runs.py, plans/PR-EOM-Migration-Content-Integrity.md
- Max files: 4
- Parked hardening: H-18 phase two dynamic self-recording policy/parser in ATLAS #2363

- Root decision: Report unreadable legacy files as missing sources
- Source trace: legacy null ledger row plus unreadable path -> source read -> OSError handler -> missing_source classification
- Upstream files: atlas_brain/storage/migrations/__init__.py, tests/test_migrations_runner.py
- Fix strategy: upstream-root
- Blocking predicate: data
- Disposition: fixed-in
- Allowed files: atlas_brain/storage/migrations/__init__.py, tests/test_migrations_runner.py, tests/test_commercial_billing_runs.py, plans/PR-EOM-Migration-Content-Integrity.md
- Max files: 4
- Parked hardening: H-18 phase two dynamic self-recording policy/parser in ATLAS #2363

## Deferred

- H-18 phase two: decide fail-closed enforcement, historical evidence
  reconciliation, rollout/rollback, and operator recovery.
- Cross-product migration-runner policy remains separate from this Atlas proof.
- H-18 phase two: choose a broader parser or migration-authoring policy for
  dynamic self-recording SQL; the existing marker remains required meanwhile.

## Parked hardening

- H-18 phase two in ATLAS #2363: dynamic self-recording SQL policy/parser. The
  parking predicate remains new migration-framework abstractions, public APIs,
  historical rewrites, and enforcement policy not needed to record or
  truthfully classify a future digest.

## Cold diff reconstruction

- Changed: `atlas_brain/storage/migrations/__init__.py:40-188` adds the
  idempotent nullable ledger column and source-first evidence classifier;
  `:67-103` replaces and reads back a newly self-recorded digest;
  `:215-370` recognizes executable direct ledger inserts after masking comments
  and literals while preserving quoted-target case; `:591-629` wraps direct
  self-recording SQL and digest recording in the existing single-connection
  transaction path.
- Changed: `tests/test_migrations_runner.py:129-224` covers all classification
  states (including a supplied unreadable source) and a grammar-derived
  recognizer matrix; `:950-1132` proves wrong-digest replacement, injected
  update-failure or silent-update rollback/retry, comments/literals, quoted
  lookalikes, and concurrent-DDL behavior; `:1487-1642` verifies the same
  failure/retry path against isolated PostgreSQL.
  The direct
  application-lifespan fixture at
  `tests/test_commercial_billing_runs.py:1983-2044` accepts the additive
  bootstrap DDL and retains ordering evidence.
- Contract match: every implementation change traces to the plan's runner
  bootstrap, exact-byte identity, non-destructive classification, or direct
  caller/regression proof. No historical migration SQL, financial table,
  invoice/payment/Gmail path, public API, setting, or deployment credential is
  touched.
- Gaps: none found in the reviewed head.

## Verification

- Focused migration/Billing regression selection: 198 passed, 55 skipped,
  1 warning.
- Disposable loopback Docker PostgreSQL 16 runner probe: 51 passed; workflow
  mirror migration/onboarding probe: 54 passed. No production connection was
  used.
- Ruff, byte-compilation, whitespace, plan-shape/consistency/rules/fix-loop
  audits, strict guard class-closure, and exact storage maturity ratchet passed
  locally.
- The unrelated cross-layer caller selection leaked a local nested process in
  teardown after reporting its test output; it is not counted as verification
  for this runner-only change, and the isolated process group was stopped.
- The two legacy payment-reminder failures in the broader monthly task file
  reproduce in a detached `origin/main` worktree and are already tracked by
  #2271; they are not this PR's regression.

## Mechanical verification

- Command: `ruff check atlas_brain/storage/migrations/__init__.py tests/test_migrations_runner.py` - Result: pass - Environment: local
- Command: `python -m py_compile atlas_brain/storage/migrations/__init__.py tests/test_migrations_runner.py` - Result: pass - Environment: local
- Command: `python -m pytest -q tests/test_migrations_runner.py tests/test_receivables.py tests/test_residential_payment_receipt_delivery.py tests/test_commercial_billing_runs.py tests/test_eom_public_onboarding_migration_repair.py` - Result: 198 passed, 55 skipped - Environment: local
- Command: `ATLAS_MIGRATION_TEST_DATABASE_URL=<disposable loopback PostgreSQL> python -m pytest -q tests/test_migrations_runner.py` - Result: 51 passed - Environment: local
- Command: `ATLAS_MIGRATION_TEST_DATABASE_URL=<disposable loopback PostgreSQL> python -m pytest -q tests/test_migrations_runner.py tests/test_eom_public_onboarding_migration_repair.py` - Result: 54 passed - Environment: local
- Command: exact `atlas_brain/storage` maturity-ratchet workflow command - Result: pass; no new brittleness above baseline - Environment: local
- Command: `python scripts/audit_plan_doc.py`, plan consistency/rules audits, fix-loop audit, plan sync check, `python scripts/check_guard_class_closure.py --base origin/main --strict`, and `git diff --check` - Result: pass - Environment: local
- Skipped: formatter rewrite - Reason: current `origin/main` already fails the installed Ruff formatter on the same pre-existing formatting hunks; no formatter-wide rewrite is included.

## Diff size

4 files, +1039 / -41.

<!-- atlas-open-pr-wrapper: v1 -->
