### PR TITLE
ci: require deliberate Dependabot major migrations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,14 @@ updates:
         update-types:
           - "patch"
           - "minor"
+    # Major toolchain/runtime changes are deliberate migrations, not unattended
+    # version maintenance. allow.update-types applies only to version updates,
+    # so Dependabot security updates remain eligible across a major boundary.
+    allow:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
 
   - package-ecosystem: "npm"
     # atlas-mobile is frozen on Expo SDK 54, isolated in its own entry so the FULL
@@ -137,6 +145,14 @@ updates:
         update-types:
           - "patch"
           - "minor"
+    # Major Python runtime changes require a coordinated interpreter/platform
+    # migration. allow.update-types applies only to version updates, preserving
+    # Dependabot security updates even when the secure release is a new major.
+    allow:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     # The heavy ML / CUDA stack is version-locked as a set: torch <-> torchaudio/
     # torchvision <-> the CUDA toolkit and nvidia-cuda-* runtime must move together.
     # Single-package minor bumps break pip resolution (torch 2.13.0 vs the pinned

--- a/plans/PR-Dependabot-Major-Compatibility-Guard.md
+++ b/plans/PR-Dependabot-Major-Compatibility-Guard.md
@@ -37,6 +37,7 @@ the individual PRs leaves the weekly schedule free to recreate the same class.
 
 Ownership lane: dev-workflow/dependabot-config
 Slice phase: Workflow/process
+Max files: 3
 
 1. Admit only semver-minor and semver-patch ordinary version updates for the
    five web UI directories and five leaf-service Python directories.
@@ -120,10 +121,11 @@ still created independently. The existing patch/minor groups and frozen-stack
 ignores remain byte-for-byte unchanged.
 
 The policy parser now records the update types attached to `allow` and `ignore`
-dependency rules instead of proving only that an ignored dependency name is
-present. The regression test requires the exact wildcard patch/minor set on
-both entries, rejecting a missing rule, an accidentally admitted major, or a
-policy narrowed to selected package names.
+dependency rules only when the section is a direct child of its update entry,
+instead of proving only that an ignored dependency name is present. The regression
+test requires the exact wildcard patch/minor set on both entries, rejecting a
+missing rule, an accidentally admitted major, a policy narrowed to selected
+package names, or a rule incorrectly nested under a group.
 
 ## Intentional
 
@@ -157,7 +159,7 @@ Parked hardening: none.
 - `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml', encoding='utf-8'))"`
   — passed.
 - `python3 -m pytest tests/test_security_policy_docs.py::DependabotFrozenSubsystemPolicyTest -q`
-  — `4 passed in 0.01s`.
+  — `5 passed in 0.37s`.
 - `python scripts/sync_pr_plan.py plans/PR-Dependabot-Major-Compatibility-Guard.md origin/main --check`
   — passed after synchronizing the generated diff-size table.
 - `python scripts/audit_plan_doc.py plans/PR-Dependabot-Major-Compatibility-Guard.md`
@@ -171,6 +173,6 @@ Parked hardening: none.
 | File | LOC |
 |---|---:|
 | `.github/dependabot.yml` | 16 |
-| `plans/PR-Dependabot-Major-Compatibility-Guard.md` | 176 |
-| `tests/test_security_policy_docs.py` | 57 |
-| **Total** | **249** |
+| `plans/PR-Dependabot-Major-Compatibility-Guard.md` | 178 |
+| `tests/test_security_policy_docs.py` | 109 |
+| **Total** | **303** |

--- a/plans/PR-Dependabot-Major-Compatibility-Guard.md
+++ b/plans/PR-Dependabot-Major-Compatibility-Guard.md
@@ -1,0 +1,176 @@
+# PR-Dependabot-Major-Compatibility-Guard
+
+## Why this slice exists
+
+Juan asked to process the open Dependabot PRs carefully because dependency
+bumps may break adjacent systems. The current queue contains nine PRs and none
+is merge-ready. Five independently move TypeScript 6 to 7, two raise the NumPy
+floor from 1.24 to 2.5, one moves the pinned Atlas Edge NeMo release from 2.6.2
+to 3.0.0, and one stale 66-package group still edits the compiler-owned root
+Python lock that current `main` has already excluded from Dependabot.
+
+Those eight major-version PRs expose one policy defect: compatibility-coupled
+runtime/toolchain majors are admitted as unattended version maintenance. The
+TypeScript PRs either exceed `typescript-eslint`'s supported compiler range or
+lack mandatory build proof; NumPy 2.5 drops the Python 3.11 audit baseline; and
+NeMo 3 contradicts the code-owned Edge Python 3.10/3.11 pin contract. Closing
+the individual PRs leaves the weekly schedule free to recreate the same class.
+
+### Problem-derived contract
+
+- Root cause: the web npm and leaf-service pip entries group patch/minor updates
+  but leave every major version update eligible as an individual PR. Major
+  compiler/runtime lines require coordinated toolchain, interpreter, platform,
+  and CI evidence that Dependabot cannot supply through an isolated manifest
+  edit.
+- Correct fix must touch/change: constrain ordinary version maintenance in the
+  two existing entries to wildcard patch/minor `allow.update-types`; extend the
+  enrolled policy parser/test to prove the exact admitted levels; add this plan.
+  After the guard lands, close the nine stale/incompatible PRs and let current
+  `main` generate only eligible maintenance groups.
+- Must not change: no package manifest, lockfile, requirements/constraints file,
+  runtime code, Python/Node baseline, dependency version, UI, API, deployment,
+  security-update eligibility, existing mobile/ML ignore policy, or PR outside
+  the operator-assigned Dependabot queue changes in this slice.
+
+## Scope (this PR)
+
+Ownership lane: dev-workflow/dependabot-config
+Slice phase: Workflow/process
+
+1. Admit only semver-minor and semver-patch ordinary version updates for the
+   five web UI directories and five leaf-service Python directories.
+2. Extend the existing policy parser/test so deleting, widening, or mis-scoping
+   either wildcard allow rule fails the CI-enrolled policy test.
+
+### Review Contract
+
+- Acceptance criteria:
+  - The web npm entry's `allow_update_types` parses exactly as wildcard
+    semver-minor plus semver-patch, settled by
+    `test_routine_version_policy_requires_deliberate_major_migrations`.
+  - The leaf-service pip entry has the same exact wildcard policy, settled by
+    the same test.
+  - GitHub documents `allow.update-types` as affecting version updates, not
+    security updates; the configured allow therefore preserves security-update
+    eligibility across a major boundary. Settled by GitHub's official
+    Dependabot options reference and controlling-updates documentation.
+  - Existing groups, mobile freezes, ML/CUDA ignores, root pip exclusion, and
+    every other ecosystem entry remain unchanged, settled by the focused policy
+    class plus the cold diff.
+  - `.github/dependabot.yml` remains valid YAML, settled by `yaml.safe_load`.
+- Reachability proof: Dependabot reads `.github/dependabot.yml` from default
+  `main`; after merge, its next scheduled/recreated ordinary version-update
+  queue omits semver majors for these entries while security updates remain
+  separately eligible. This PR adds no runtime surface.
+- Affected surfaces: ordinary Dependabot version-update admission for the five
+  web UI directories and five leaf-service Python directories; the existing
+  security-policy test.
+- Risk areas: accidentally suppressing security updates, changing patch/minor
+  grouping, applying the policy to atlas-mobile or root pip, and parser false
+  positives that pass while the allow rule has a wrong update type.
+- Reviewer rules triggered: R1, R2, R11, R12, R13, R14.
+
+### Boundary-change enumeration
+
+- Boundary path/seam: ordinary Dependabot version-update admission for the web
+  npm and leaf-service pip entries.
+- Replaced-path behaviors: semver-major ordinary version proposals change from
+  admitted to unallowed; semver-minor, semver-patch, and the separately governed
+  security-update path remain eligible.
+- Guard-relevant fields: `package-ecosystem`, `directories`, wildcard
+  `allow.dependency-name`, and `allow.update-types`.
+- Caller x input shape: Dependabot reading default-branch config x ordinary
+  version updates for any dependency in either declared directory set.
+
+Closure declaration: the admitted ordinary-version class is **CLOSED by SemVer
+level**, not by a dependency-name list. Minor and patch are admitted; major is
+not. The reviewable surface is the complete web npm entry and complete
+leaf-service pip entry. Any future dependency follows the same default without
+growing a member list. Security updates are a separate GitHub-governed path and
+are not restricted by `allow.update-types`.
+
+### Deployed-config probing
+
+- Deployed/default config values: current default-branch entries omit `allow`,
+  so the eight live major PRs demonstrate the ordinary-major admitted default.
+- Explicit value probe: the focused test parses both wildcard allow rules and
+  requires exactly semver-minor plus semver-patch.
+- Absent value probe: deleting either allow block makes the focused test fail;
+  the open major PRs are live evidence of the absent-policy behavior.
+- Default-session/default-context probe: YAML validation and the test read the
+  repository-default `.github/dependabot.yml`, matching Dependabot's consumer.
+- Side-effect ordering: N/A; this is scheduler admission configuration and has
+  no runtime mutation path.
+
+### Files touched
+
+- `.github/dependabot.yml`
+- `plans/PR-Dependabot-Major-Compatibility-Guard.md`
+- `tests/test_security_policy_docs.py`
+
+## Mechanism
+
+Each applicable ecosystem entry gets one wildcard `allow` rule containing only
+`version-update:semver-minor` and `version-update:semver-patch`. Dependabot then
+does not create unattended major version PRs for those directories. This uses
+`allow`, not `ignore`: GitHub's official documentation states that
+`allow.update-types` only controls version updates and security updates are
+still created independently. The existing patch/minor groups and frozen-stack
+ignores remain byte-for-byte unchanged.
+
+The policy parser now records the update types attached to `allow` and `ignore`
+dependency rules instead of proving only that an ignored dependency name is
+present. The regression test requires the exact wildcard patch/minor set on
+both entries, rejecting a missing rule, an accidentally admitted major, or a
+policy narrowed to selected package names.
+
+## Intentional
+
+- All ordinary majors in the two active maintenance entries require a deliberate
+  migration PR. This avoids a growing dependency-name denylist and covers future
+  compilers/runtimes by the same safe default.
+- Security updates are not traded away to stop version-update noise. The first
+  attempted `ignore` mechanism was rejected after official documentation showed
+  that ignore filters can affect security updates.
+- The stale 66-package PR is not repaired by hand. Its root files are no longer
+  Dependabot-owned on current `main`, so recreation from current policy is the
+  truthful path.
+
+## Deferred
+
+- Deliberate major migrations after the affected package supplies toolchain,
+  resolver, build/lint, and owned-platform runtime proof.
+- Close #2443/#2430/#2429/#2426/#2425/#2421/#2419/#2416/#2413 after this guard
+  is merged; permit Dependabot to recreate only the eligible current-main queue.
+- The pre-existing atlas-mobile and ML/CUDA `ignore` policy is unchanged. Its
+  security-update semantics are not widened into this ordinary-major admission
+  slice.
+
+Parking predicate: dependency migrations that require a new runtime/toolchain
+baseline or new CI surface are separate slices rather than inline additions.
+
+Parked hardening: none.
+
+## Verification
+
+- `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml', encoding='utf-8'))"`
+  — passed.
+- `python3 -m pytest tests/test_security_policy_docs.py::DependabotFrozenSubsystemPolicyTest -q`
+  — `4 passed in 0.01s`.
+- `python scripts/sync_pr_plan.py plans/PR-Dependabot-Major-Compatibility-Guard.md origin/main --check`
+  — passed after synchronizing the generated diff-size table.
+- `python scripts/audit_plan_doc.py plans/PR-Dependabot-Major-Compatibility-Guard.md`
+  — passed.
+- `python scripts/audit_plan_code_consistency.py plans/PR-Dependabot-Major-Compatibility-Guard.md --base-ref origin/main`
+  — passed.
+- `git diff --check` — passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/dependabot.yml` | 16 |
+| `plans/PR-Dependabot-Major-Compatibility-Guard.md` | 176 |
+| `tests/test_security_policy_docs.py` | 57 |
+| **Total** | **249** |

--- a/tests/test_security_policy_docs.py
+++ b/tests/test_security_policy_docs.py
@@ -452,16 +452,19 @@ def _dependabot_update_blocks(config_text: str) -> list[dict[str, object]]:
     """Parse dependabot.yml text into per-entry blocks (no PyYAML dependency).
 
     Returns one record per entry. ``allow``/``ignore`` hold dependency names;
-    their companion maps hold each dependency's configured update types.
+    their companion maps hold each dependency's configured update types. Only
+    direct children of an update entry can open a parsed section.
     """
     blocks: list[dict[str, object]] = []
     current: dict[str, object] | None = None
     section: str | None = None
     current_dependency: str | None = None
+    entry_child_indent: int | None = None
     section_headers = {"directories:": "directories", "allow:": "allow", "ignore:": "ignore"}
     reset_headers = {"schedule:", "labels:", "groups:", "open-pull-requests-limit:"}
     for raw_line in config_text.splitlines():
         stripped = raw_line.strip()
+        indent = len(raw_line) - len(raw_line.lstrip(" "))
         if not stripped or stripped.startswith("#"):
             continue
         if stripped.startswith("- package-ecosystem:"):
@@ -477,36 +480,49 @@ def _dependabot_update_blocks(config_text: str) -> list[dict[str, object]]:
             }
             section = None
             current_dependency = None
+            entry_child_indent = indent + 2
             continue
-        if current is None:
+        if current is None or entry_child_indent is None:
             continue
-        if stripped in section_headers:
+        if indent == entry_child_indent and stripped in section_headers:
             section = section_headers[stripped]
             current_dependency = None
             continue
         # Dependabot also accepts the singular scalar form `directory: "/path"`.
         # Treat it as a one-element directory set so the root-exclusion guard cannot
         # be defeated by re-adding root as `directory: "/"` instead of `directories:`.
-        if stripped.startswith("directory:"):
+        if indent == entry_child_indent and stripped.startswith("directory:"):
             current["directories"].add(  # type: ignore[union-attr]
                 stripped.split(":", 1)[1].strip().strip('"')
             )
             section = None
             current_dependency = None
             continue
-        if stripped in reset_headers:
+        if indent == entry_child_indent and stripped in reset_headers:
             section = None
             current_dependency = None
             continue
-        if section == "directories" and stripped.startswith("- "):
+        if (
+            section == "directories"
+            and indent == entry_child_indent + 2
+            and stripped.startswith("- ")
+        ):
             current["directories"].add(stripped[2:].strip().strip('"'))  # type: ignore[union-attr]
             continue
-        if section in {"allow", "ignore"} and stripped.startswith("- dependency-name:"):
+        if (
+            section in {"allow", "ignore"}
+            and indent == entry_child_indent + 2
+            and stripped.startswith("- dependency-name:")
+        ):
             current_dependency = stripped.split(":", 1)[1].strip().strip('"')
             current[section].add(current_dependency)  # type: ignore[union-attr]
             current[f"{section}_update_types"][current_dependency] = set()  # type: ignore[index]
             continue
-        if section in {"allow", "ignore"} and current_dependency is not None:
+        if (
+            section in {"allow", "ignore"}
+            and current_dependency is not None
+            and indent > entry_child_indent + 2
+        ):
             update_types = set(
                 re.findall(r"version-update:semver-(?:major|minor|patch)", stripped)
             )
@@ -637,6 +653,32 @@ class DependabotFrozenSubsystemPolicyTest(unittest.TestCase):
 
         self.assertEqual(web_allows, {"*": routine})
         self.assertEqual(pip_allows, {"*": routine})
+
+    def test_routine_version_policy_rejects_allow_nested_under_group(self) -> None:
+        malformed = "\n".join(
+            [
+                "version: 2",
+                "updates:",
+                '  - package-ecosystem: "npm"',
+                "    directories:",
+                '      - "/atlas-ui"',
+                "    groups:",
+                "      routine:",
+                "        allow:",
+                '          - dependency-name: "*"',
+                "            update-types:",
+                '              - "version-update:semver-minor"',
+                '              - "version-update:semver-patch"',
+            ]
+        )
+
+        blocks = _dependabot_update_blocks(malformed)
+
+        self.assertEqual(
+            blocks[0]["allow_update_types"],
+            {},
+            "allow must be a direct child of the Dependabot update entry",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_security_policy_docs.py
+++ b/tests/test_security_policy_docs.py
@@ -451,13 +451,14 @@ ATLAS_MOBILE_NON_SDK_DEPS: frozenset[str] = frozenset()
 def _dependabot_update_blocks(config_text: str) -> list[dict[str, object]]:
     """Parse dependabot.yml text into per-entry blocks (no PyYAML dependency).
 
-    Returns a list of {"ecosystem": str, "directories": set[str], "ignore": set[str]}
-    where "ignore" holds the dependency-name values under that entry's ignore block.
+    Returns one record per entry. ``allow``/``ignore`` hold dependency names;
+    their companion maps hold each dependency's configured update types.
     """
     blocks: list[dict[str, object]] = []
     current: dict[str, object] | None = None
     section: str | None = None
-    section_headers = {"directories:": "directories", "ignore:": "ignore"}
+    current_dependency: str | None = None
+    section_headers = {"directories:": "directories", "allow:": "allow", "ignore:": "ignore"}
     reset_headers = {"schedule:", "labels:", "groups:", "open-pull-requests-limit:"}
     for raw_line in config_text.splitlines():
         stripped = raw_line.strip()
@@ -469,14 +470,19 @@ def _dependabot_update_blocks(config_text: str) -> list[dict[str, object]]:
             current = {
                 "ecosystem": stripped.split(":", 1)[1].strip().strip('"'),
                 "directories": set(),
+                "allow": set(),
+                "allow_update_types": {},
                 "ignore": set(),
+                "ignore_update_types": {},
             }
             section = None
+            current_dependency = None
             continue
         if current is None:
             continue
         if stripped in section_headers:
             section = section_headers[stripped]
+            current_dependency = None
             continue
         # Dependabot also accepts the singular scalar form `directory: "/path"`.
         # Treat it as a one-element directory set so the root-exclusion guard cannot
@@ -486,15 +492,26 @@ def _dependabot_update_blocks(config_text: str) -> list[dict[str, object]]:
                 stripped.split(":", 1)[1].strip().strip('"')
             )
             section = None
+            current_dependency = None
             continue
         if stripped in reset_headers:
             section = None
+            current_dependency = None
             continue
         if section == "directories" and stripped.startswith("- "):
             current["directories"].add(stripped[2:].strip().strip('"'))  # type: ignore[union-attr]
             continue
-        if section == "ignore" and stripped.startswith("- dependency-name:"):
-            current["ignore"].add(stripped.split(":", 1)[1].strip().strip('"'))  # type: ignore[union-attr]
+        if section in {"allow", "ignore"} and stripped.startswith("- dependency-name:"):
+            current_dependency = stripped.split(":", 1)[1].strip().strip('"')
+            current[section].add(current_dependency)  # type: ignore[union-attr]
+            current[f"{section}_update_types"][current_dependency] = set()  # type: ignore[index]
+            continue
+        if section in {"allow", "ignore"} and current_dependency is not None:
+            update_types = set(
+                re.findall(r"version-update:semver-(?:major|minor|patch)", stripped)
+            )
+            if update_types:
+                current[f"{section}_update_types"][current_dependency].update(update_types)  # type: ignore[index,union-attr]
             continue
     if current is not None:
         blocks.append(current)
@@ -518,6 +535,21 @@ class DependabotFrozenSubsystemPolicyTest(unittest.TestCase):
 
     def _npm_blocks(self) -> list[dict[str, object]]:
         return [b for b in self.blocks if b["ecosystem"] == "npm"]
+
+    def _pip_blocks(self) -> list[dict[str, object]]:
+        return [b for b in self.blocks if b["ecosystem"] == "pip"]
+
+    def _web_npm_block(self) -> dict[str, object]:
+        web_directories = {
+            "/atlas-admin-ui",
+            "/atlas-churn-ui",
+            "/atlas-intel-ui",
+            "/atlas-ui",
+            "/portfolio-ui",
+        }
+        web = [b for b in self._npm_blocks() if b["directories"] == web_directories]
+        self.assertEqual(len(web), 1, "expected one npm entry owning all web UIs")
+        return web[0]
 
     def _atlas_mobile_block(self) -> dict[str, object]:
         mobile = [
@@ -582,7 +614,7 @@ class DependabotFrozenSubsystemPolicyTest(unittest.TestCase):
         )
 
     def test_root_excluded_from_pip_updates(self) -> None:
-        pip = [b for b in self.blocks if b["ecosystem"] == "pip"]
+        pip = self._pip_blocks()
         self.assertTrue(pip, "expected a pip update entry")
         for block in pip:
             self.assertNotIn(
@@ -592,6 +624,19 @@ class DependabotFrozenSubsystemPolicyTest(unittest.TestCase):
                 "requirements.txt is bound to the generated constraints.root-asr.txt "
                 "(sha256 pin) that Dependabot cannot recompile",
             )
+
+    def test_routine_version_policy_requires_deliberate_major_migrations(self) -> None:
+        routine = {
+            "version-update:semver-minor",
+            "version-update:semver-patch",
+        }
+        web_allows = self._web_npm_block()["allow_update_types"]
+        pip = self._pip_blocks()
+        self.assertEqual(len(pip), 1, "expected one pip update entry")
+        pip_allows = pip[0]["allow_update_types"]
+
+        self.assertEqual(web_allows, {"*": routine})
+        self.assertEqual(pip_allows, {"*": routine})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Plan: plans/PR-Dependabot-Major-Compatibility-Guard.md
Slice phase: Workflow/process
Ownership lane: dev-workflow/dependabot-config

The current Dependabot queue repeatedly proposes isolated major compiler and runtime migrations that already contradict code-owned compatibility boundaries. This closes that admission class at the scheduler boundary: routine web npm and leaf-service pip maintenance remains limited to minor and patch updates, while Dependabot security updates remain separately eligible.

## Intentional
- Add wildcard minor/patch-only version-update admission to the existing web npm entry.
- Add the same admission policy to the existing leaf-service pip entry.
- Extend the enrolled policy test to parse and require both exact wildcard rules at the direct update-entry depth.
- Leave all manifests, lockfiles, requirements, constraints, runtime code, platform baselines, and dependency versions unchanged.

## AI reconciliation
- Validate allow at the Dependabot entry depth -- fixed-in: `70ad0ab44` / `tests/test_security_policy_docs.py::DependabotFrozenSubsystemPolicyTest::test_routine_version_policy_rejects_allow_nested_under_group`
- Replace the unsupported allow.update-types option -- waived-speculative: GitHub current official Dependabot options reference explicitly lists update-types under allow and states it affects version updates, not security updates

## Deferred
- Deliberate major migrations after the package supplies toolchain, resolver, build/lint, and owned-platform runtime proof.
- Close #2443, #2430, #2429, #2426, #2425, #2421, #2419, #2416, and #2413 after this guard merges; permit Dependabot to recreate only eligible updates from current main.
- The pre-existing atlas-mobile and ML/CUDA ignore semantics remain unchanged.

## Parked hardening
- None.

## Cold diff reconstruction
- Changed: `.github/dependabot.yml:42-49` limits ordinary web npm version updates to wildcard semver-minor and semver-patch.
- Changed: `.github/dependabot.yml:148-155` applies the same ordinary-version rule to leaf-service pip directories.
- Changed: `tests/test_security_policy_docs.py:451-536` records allow/ignore rules only when their sections occur at the direct update-entry depth.
- Changed: `tests/test_security_policy_docs.py:555-568` resolves the complete pip and web entry surfaces instead of a dependency-name subset.
- Changed: `tests/test_security_policy_docs.py:644-655` requires the exact wildcard minor/patch set for both entries.
- Changed: `tests/test_security_policy_docs.py:657-681` rejects the malformed group-nested `allow:` shape named by review.
- Changed: `plans/PR-Dependabot-Major-Compatibility-Guard.md:1-178` records the problem-derived contract, boundary closure, scope budget, review repair, and evidence.
- Contract match: every code change traces to stopping unattended routine major migrations or proving the exact admitted class and placement.
- Gaps: none. The contract required no dependency/runtime movement, and none occurred; no out-of-scope module moved.

## Verification
- YAML configuration loaded successfully with `yaml.safe_load`.
- Focused policy class: `5 passed in 0.37s`.
- Plan synchronization check passed.
- Plan-document audit passed.
- Plan/code consistency audit passed.
- `git diff --check` passed.

## Mechanical verification
- Command: `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml', encoding='utf-8'))"` - Result: pass - Environment: local
- Command: `python3 -m pytest tests/test_security_policy_docs.py::DependabotFrozenSubsystemPolicyTest -q` - Result: 5 passed - Environment: local
- Command: `python scripts/sync_pr_plan.py plans/PR-Dependabot-Major-Compatibility-Guard.md origin/main --check` - Result: pass - Environment: local
- Command: `python scripts/audit_plan_doc.py plans/PR-Dependabot-Major-Compatibility-Guard.md` - Result: pass - Environment: local
- Command: `python scripts/audit_plan_code_consistency.py plans/PR-Dependabot-Major-Compatibility-Guard.md --base-ref origin/main` - Result: pass - Environment: local
- Command: `git diff --check` - Result: pass - Environment: local
- Skipped: broad repository test suite - Reason: configuration-only workflow slice; the focused CI-enrolled policy class and YAML parser directly settle the changed contract.

## Risk areas
- Accidentally suppressing security updates, widening the admitted SemVer levels, mis-scoping the rule below an update entry, or applying the rule to atlas-mobile/root pip. The mechanism uses `allow.update-types`, whose official GitHub contract applies only to version updates, and the focused test asserts the exact entry surfaces, depth, and admitted levels.

## Fix-loop disposition preflight
- Root decision: Validate allow at the Dependabot entry depth
- Source trace: group-nested allow passes policy test -> indentation-stripping parser -> entry-level admission proof
- Upstream files: tests/test_security_policy_docs.py
- Fix strategy: upstream-root
- Blocking predicate: claimed-mechanism
- Disposition: fixed-in
- Allowed files: .github/dependabot.yml, plans/PR-Dependabot-Major-Compatibility-Guard.md, tests/test_security_policy_docs.py
- Max files: 3
- Parked hardening: none

- Root decision: Replace the unsupported allow.update-types option
- Source trace: unsupported-option review claim -> current GitHub allow parameter table -> documented allow.update-types support
- Upstream files: .github/dependabot.yml
- Fix strategy: upstream-root
- Blocking predicate: not-blocking
- Disposition: waived-speculative
- Allowed files: .github/dependabot.yml, plans/PR-Dependabot-Major-Compatibility-Guard.md, tests/test_security_policy_docs.py
- Max files: 3
- Parked hardening: none

## Gap audit
- No untraced change, missing contract requirement, or forbidden touch remains.

## Diff size
3 files, +292 / -11


<!-- atlas-open-pr-wrapper: v1 -->
