### PR TITLE
EOM: tenant-scoped contact-directory read + capability (website #240)

### DIFF
--- a/.github/workflows/atlas_eom_lead_pipeline_checks.yml
+++ b/.github/workflows/atlas_eom_lead_pipeline_checks.yml
@@ -77,6 +77,7 @@ on:
       - "tests/test_eom_contacts_api_tenant_scope.py"
       - "tests/test_backfill_eom_customer_type.py"
       - "tests/test_eom_link_verification.py"
+      - "tests/test_eom_contact_directory.py"
       - "tests/test_eom_lead_conversion.py"
       - "tests/test_eom_lead_conversion_integration.py"
       - "tests/test_eom_public_onboarding.py"
@@ -171,6 +172,7 @@ on:
       - "tests/test_eom_contacts_api_tenant_scope.py"
       - "tests/test_backfill_eom_customer_type.py"
       - "tests/test_eom_link_verification.py"
+      - "tests/test_eom_contact_directory.py"
       - "tests/test_eom_lead_conversion.py"
       - "tests/test_eom_lead_conversion_integration.py"
       - "tests/test_eom_public_onboarding.py"
@@ -241,6 +243,7 @@ jobs:
             tests/test_eom_contacts_api_tenant_scope.py \
             tests/test_backfill_eom_customer_type.py \
             tests/test_eom_link_verification.py \
+            tests/test_eom_contact_directory.py \
             tests/test_eom_billing_recipients.py \
             tests/test_eom_lead_conversion.py \
             tests/test_eom_lead_conversion_integration.py \

--- a/atlas_brain/eom_api/funnel.py
+++ b/atlas_brain/eom_api/funnel.py
@@ -77,6 +77,11 @@ _MAX_LEAD_REVIEW_LIMIT = 200
 # directory while looking filtered.
 _CONTACT_DIRECTORY_QUERY_PARAMS = frozenset({"limit", "cursor", "search", "kind"})
 _MAX_CONTACT_DIRECTORY_SEARCH_LENGTH = 120
+# DERIVED from the canonical operator-mutation kind set, not re-enumerated:
+# if the write boundary ever admits another contact kind, the directory must
+# widen with it in the same commit, or that kind's records become write-only
+# -- the exact defect this slice exists to close (website #240).
+_CONTACT_DIRECTORY_KINDS = ("all", *EOM_OPERATOR_CONTACT_TYPES)
 # Ids ride in the query string, so the cap is a URL-length budget rather than a
 # database one: 100 ids costs roughly 4.8 KB of `contact_id=<uuid>&`, comfortably
 # inside the 8 KB request line every proxy in front of this accepts. Callers with
@@ -1019,7 +1024,9 @@ async def list_eom_contact_directory(
         str | None,
         Query(min_length=1, max_length=_MAX_CONTACT_DIRECTORY_SEARCH_LENGTH),
     ] = None,
-    kind: Annotated[Literal["all", "lead", "customer"], Query()] = "all",
+    # A plain string validated against the DERIVED kind tuple below, rather
+    # than a Literal that would re-enumerate the canonical set a third time.
+    kind: Annotated[str, Query(min_length=1, max_length=32)] = "all",
     _actor: dict[str, object] = Depends(require_eom_funnel_actor),
     crm: Any = Depends(_crm_dependency),
 ) -> EOMContactDirectoryResponse:
@@ -1036,9 +1043,19 @@ async def list_eom_contact_directory(
     route directly. Reading this projection alters no CRM state.
     """
     _reject_unknown_contact_directory_filters(request)
+    if kind not in _CONTACT_DIRECTORY_KINDS:
+        raise HTTPException(status_code=422, detail="kind is not supported")
     normalized_search = search.strip() if search is not None else None
     if search is not None and not normalized_search:
         raise HTTPException(status_code=422, detail="search must not be blank")
+    # NUL and lone surrogates cannot reach an asyncpg text parameter (they
+    # would 500 mid-query instead of failing closed here). Routed through the
+    # module's one surrogate choke point so this is not a second copy of the
+    # database-invalid character class.
+    if normalized_search is not None and "\x00" in _route_surrogates_to_safe_text(
+        normalized_search
+    ):
+        raise HTTPException(status_code=422, detail="search must be valid text")
     decoded_cursor = _decode_lead_review_cursor(cursor)
     rows = await crm.list_eom_contact_directory(
         limit=limit + 1,

--- a/atlas_brain/eom_api/funnel.py
+++ b/atlas_brain/eom_api/funnel.py
@@ -30,6 +30,8 @@ from ..services.eom_lead_conversion import (
 )
 from ..services.eom_won_lead_loss import mark_eom_lead_lost_with_won_teardown
 from ..services.eom_crm_mutations import (
+    EOM_CUSTOMER_TYPES,
+    EOM_OPERATOR_CONTACT_TYPES,
     EOMOperatorContactMutation,
     EOMOperatorContactMutationError,
     mutate_eom_operator_contact,
@@ -69,6 +71,12 @@ _RFC3339_DATETIME_PATTERN = re.compile(
 _MAX_SIGNED_BIGINT = 2**63 - 1
 _DEFAULT_LEAD_REVIEW_LIMIT = 100
 _MAX_LEAD_REVIEW_LIMIT = 200
+# The exact query-parameter names the contact directory accepts. Unknown names
+# are rejected rather than tolerated: the directory is new and has exactly one
+# caller, and a typoed filter silently ignored would return the unfiltered
+# directory while looking filtered.
+_CONTACT_DIRECTORY_QUERY_PARAMS = frozenset({"limit", "cursor", "search", "kind"})
+_MAX_CONTACT_DIRECTORY_SEARCH_LENGTH = 120
 # Ids ride in the query string, so the cap is a URL-length budget rather than a
 # database one: 100 ids costs roughly 4.8 KB of `contact_id=<uuid>&`, comfortably
 # inside the 8 KB request line every proxy in front of this accepts. Callers with
@@ -343,6 +351,67 @@ class EOMKnownContactsResponse(BaseModel):
     )
     checked: int
     limit: Annotated[int, Field(ge=1, le=_MAX_KNOWN_CONTACT_IDS)]
+
+
+class EOMContactDirectoryItem(BaseModel):
+    """The only CRM identity data the operator contact directory may expose.
+
+    A closed projection over canonical contact columns: no metadata, notes,
+    tags, receipts, or interaction history. The pipeline read's latest-intake
+    email/phone overlay stays unique to the review queue -- the directory's
+    job is discoverability of the canonical record, so it reads the record.
+    """
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    contact_id: UUID = Field(serialization_alias="contactId")
+    full_name: str = Field(serialization_alias="fullName")
+    email: str | None = None
+    phone: str | None = None
+    address: str | None = None
+    contact_type: str = Field(serialization_alias="contactType")
+    customer_type: str = Field(serialization_alias="customerType")
+    lead_stage: str | None = Field(default=None, serialization_alias="leadStage")
+    # The WHERE clause pins admission to active rows; this Literal makes the
+    # response model a second, independent enforcement of the same invariant,
+    # so a widened query can never silently leak an archived row.
+    status: Literal["active"]
+    source: str | None = None
+    created_at: datetime = Field(serialization_alias="createdAt")
+    updated_at: datetime | None = Field(default=None, serialization_alias="updatedAt")
+
+    @field_validator("contact_type")
+    @classmethod
+    def _contact_type_is_directory_kind(cls, value: str) -> str:
+        # Validated against the operator boundary's own set rather than a
+        # local Literal, so the two cannot drift apart.
+        if value not in EOM_OPERATOR_CONTACT_TYPES:
+            raise ValueError("contact_type must be a directory contact kind")
+        return value
+
+    @field_validator("customer_type")
+    @classmethod
+    def _customer_type_is_admitted(cls, value: str) -> str:
+        # Same single-source rule: EOM_CUSTOMER_TYPES is bound to the
+        # chk_contacts_customer_type CHECK (migration 366).
+        if value not in EOM_CUSTOMER_TYPES:
+            raise ValueError("customer_type must be an admitted account type")
+        return value
+
+
+class EOMContactDirectoryResponse(BaseModel):
+    """Closed response envelope for the operator contact-directory read."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    contacts: list[EOMContactDirectoryItem]
+    limit: Annotated[int, Field(ge=1, le=_MAX_LEAD_REVIEW_LIMIT)]
+    cursor: str | None = None
+    has_more: bool = Field(serialization_alias="hasMore")
+    next_cursor: str | None = Field(
+        default=None,
+        serialization_alias="nextCursor",
+    )
 
 
 class EOMOnboardingDraftEditRequest(BaseModel):
@@ -675,6 +744,7 @@ _CAPABILITY_ROUTES: dict[str, tuple[str, str]] = {
         "/eom-funnel/public-onboarding/recover",
     ),
     "contact.link_verification": ("GET", "/eom-funnel/known-contacts"),
+    "contact.directory": ("GET", "/eom-funnel/contact-directory"),
 }
 
 _served_capabilities_cache: tuple[str, ...] | None = None
@@ -915,6 +985,87 @@ async def list_known_eom_contacts(
         customer_type_revisions=customer_type_revisions,
         checked=len(requested),
         limit=_MAX_KNOWN_CONTACT_IDS,
+    )
+
+
+def _reject_unknown_contact_directory_filters(request: Request) -> None:
+    """422 on unrecognized query-parameter names instead of tolerating them.
+
+    FastAPI's default tolerance is left in place on the pipeline read, whose
+    callers predate this slice. The directory has exactly one caller (the
+    tracker proxy), so it is held to the exact filter set.
+    """
+    unknown = sorted(set(request.query_params.keys()) - _CONTACT_DIRECTORY_QUERY_PARAMS)
+    if unknown:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Unknown contact directory filter: {', '.join(unknown)}",
+        )
+
+
+@router.get(
+    "/contact-directory",
+    response_model=EOMContactDirectoryResponse,
+    dependencies=[Depends(require_eom_funnel_api)],
+)
+async def list_eom_contact_directory(
+    request: Request,
+    limit: Annotated[
+        int,
+        Query(ge=1, le=_MAX_LEAD_REVIEW_LIMIT),
+    ] = _DEFAULT_LEAD_REVIEW_LIMIT,
+    cursor: Annotated[str | None, Query(min_length=16, max_length=512)] = None,
+    search: Annotated[
+        str | None,
+        Query(min_length=1, max_length=_MAX_CONTACT_DIRECTORY_SEARCH_LENGTH),
+    ] = None,
+    kind: Annotated[Literal["all", "lead", "customer"], Query()] = "all",
+    _actor: dict[str, object] = Depends(require_eom_funnel_actor),
+    crm: Any = Depends(_crm_dependency),
+) -> EOMContactDirectoryResponse:
+    """List active EOM lead and customer contacts for operator discovery.
+
+    The discovery boundary the operator mutation never had: the pipeline read
+    admits only stage-active leads, so a customer created or matched through
+    ``/operator-contacts`` was otherwise unreachable from every portal surface
+    (website #240). This read is separate from ``/leads`` on purpose -- the
+    pipeline projection keeps its exact contract, and the directory stays a
+    directory rather than growing review-queue semantics.
+
+    The tracker keeps the service bearer and the browser never calls this
+    route directly. Reading this projection alters no CRM state.
+    """
+    _reject_unknown_contact_directory_filters(request)
+    normalized_search = search.strip() if search is not None else None
+    if search is not None and not normalized_search:
+        raise HTTPException(status_code=422, detail="search must not be blank")
+    decoded_cursor = _decode_lead_review_cursor(cursor)
+    rows = await crm.list_eom_contact_directory(
+        limit=limit + 1,
+        kind=kind,
+        search=normalized_search,
+        cursor_created_at=(
+            decoded_cursor["created_at"] if decoded_cursor is not None else None
+        ),
+        cursor_contact_id=(
+            decoded_cursor["contact_id"] if decoded_cursor is not None else None
+        ),
+    )
+    page_rows = rows[:limit]
+    has_more = len(rows) > limit
+    next_cursor = None
+    if has_more and page_rows:
+        last_row = EOMContactDirectoryItem.model_validate(page_rows[-1])
+        next_cursor = _encode_lead_review_cursor(
+            created_at=last_row.created_at,
+            contact_id=last_row.contact_id,
+        )
+    return EOMContactDirectoryResponse(
+        contacts=[EOMContactDirectoryItem.model_validate(row) for row in page_rows],
+        limit=limit,
+        cursor=cursor,
+        has_more=has_more,
+        next_cursor=next_cursor,
     )
 
 

--- a/atlas_brain/services/crm_provider.py
+++ b/atlas_brain/services/crm_provider.py
@@ -182,6 +182,37 @@ def _eom_identity_lock_key(channel: str, value: str) -> str:
     return f"eom-contact-identity:{channel}:{value}"
 
 
+# The only contact kinds the operator directory admits. A tenant row whose
+# contact_type is outside this set (e.g. legacy 'prospect' or 'vendor') is not
+# part of the lead/customer CRM surface and stays invisible to the directory.
+_EOM_DIRECTORY_CONTACT_KINDS = ("lead", "customer")
+# Punctuation an operator plausibly types or pastes as part of a phone number.
+# Any other character means the query is a name or email, and the digit
+# fallback must not run (an incidental digit run like the "2026" in
+# "client2026@example.com" must never reach the phone comparison).
+_EOM_DIRECTORY_PHONE_QUERY_CHARS = frozenset(" ()+.-")
+_EOM_DIRECTORY_MIN_PHONE_SEARCH_DIGITS = 4
+
+
+def _escape_eom_directory_like_pattern(value: str) -> str:
+    """Neutralize LIKE metacharacters so user text matches only literally."""
+    escaped = value.replace("\\", "\\\\")
+    escaped = escaped.replace("%", "\\%")
+    return escaped.replace("_", "\\_")
+
+
+def _eom_directory_phone_search_digits(value: str) -> Optional[str]:
+    """The digit run for the phone fallback, or None when not phone-shaped."""
+    if not value or not all(
+        char.isdigit() or char in _EOM_DIRECTORY_PHONE_QUERY_CHARS for char in value
+    ):
+        return None
+    digits = "".join(char for char in value if char.isdigit())
+    if len(digits) < _EOM_DIRECTORY_MIN_PHONE_SEARCH_DIGITS:
+        return None
+    return digits
+
+
 def _eom_won_lead_loss_execution_lock_key(contact_id: str) -> str:
     """Return the one contact fence spanning a won-lead Calendar teardown."""
 
@@ -2165,6 +2196,106 @@ class DatabaseCRMProvider:
               AND c.contact_type = 'lead'
               AND c.lead_stage IN ('new', 'estimate_booked', 'won')
               {cursor_clause}
+            ORDER BY c.created_at DESC, c.id DESC
+            LIMIT $1
+            """,
+            *params,
+        )
+        return [dict(row) for row in rows]
+
+    async def list_eom_contact_directory(
+        self,
+        *,
+        limit: int = 100,
+        kind: str = "all",
+        search: Optional[str] = None,
+        cursor_created_at: Optional[datetime] = None,
+        cursor_contact_id: Optional[UUID] = None,
+    ) -> list[dict[str, Any]]:
+        """Return the closed, tenant-scoped EOM contact-directory projection.
+
+        This is the discovery read the operator mutation boundary never had:
+        ``list_eom_new_lead_review_items`` admits only pipeline-stage leads, so
+        a ``customer`` contact created or matched through the operator boundary
+        is otherwise unreachable from any portal surface (website #240).
+
+        Admission is ``status = 'active'`` on the DB's own lifecycle axis.
+        Lost leads (``lead_stage = 'lost'`` with status still active) are
+        deliberately included and carry their stage: the pipeline hides them by
+        design, and the directory is exactly where a pipeline-hidden record
+        must remain findable. Archived rows are excluded in this slice.
+
+        Keyset pagination uses ``(created_at, id)`` descending -- immutable
+        columns only. ``full_name`` is operator-mutable, and a keyset built on
+        a mutable column can drop or duplicate rows mid-traversal (see the
+        ordering note on :meth:`list_billing_recipients`).
+
+        Reading this projection alters nothing.
+        """
+        from .eom_lead_ingress import EOM_BUSINESS_CONTEXT_ID
+
+        if kind not in ("all", *_EOM_DIRECTORY_CONTACT_KINDS):
+            raise ValueError("kind must be one of: all, lead, customer")
+
+        conditions = ["c.business_context_id = $2", "c.status = 'active'"]
+        params: list[Any] = [limit, EOM_BUSINESS_CONTEXT_ID]
+        if kind == "all":
+            params.append(list(_EOM_DIRECTORY_CONTACT_KINDS))
+            conditions.append(f"c.contact_type = ANY(${len(params)}::varchar[])")
+        else:
+            params.append(kind)
+            conditions.append(f"c.contact_type = ${len(params)}")
+
+        normalized_search = (search or "").strip()
+        if normalized_search:
+            params.append(f"%{_escape_eom_directory_like_pattern(normalized_search)}%")
+            like_index = len(params)
+            search_terms = [
+                f"c.full_name ILIKE ${like_index} ESCAPE '\\'",
+                f"c.email ILIKE ${like_index} ESCAPE '\\'",
+                f"c.phone ILIKE ${like_index} ESCAPE '\\'",
+            ]
+            phone_digits = _eom_directory_phone_search_digits(normalized_search)
+            if phone_digits is not None:
+                # A phone pasted from caller ID rarely keeps the stored row's
+                # formatting, so phone-shaped queries also match on a
+                # digits-only comparison -- the same semantics the portal's
+                # client-side lead search already ships (website #232/#233).
+                # The identity-matching digit SQL (extension-stripping +
+                # RIGHT-10 suffix) is deliberately not reused: identity needs
+                # exact-suffix semantics, search needs substring containment.
+                params.append(f"%{phone_digits}%")
+                search_terms.append(
+                    "REGEXP_REPLACE(COALESCE(c.phone, ''), '[^0-9]', '', 'g') "
+                    f"LIKE ${len(params)}"
+                )
+            conditions.append(f"({' OR '.join(search_terms)})")
+
+        if cursor_created_at is not None and cursor_contact_id is not None:
+            params.extend([cursor_created_at, cursor_contact_id])
+            conditions.append(
+                f"(c.created_at, c.id) < (${len(params) - 1}::timestamptz, "
+                f"${len(params)}::uuid)"
+            )
+
+        pool = self._get_pool()
+        rows = await pool.fetch(
+            f"""
+            SELECT
+                c.id AS contact_id,
+                c.full_name,
+                c.email,
+                c.phone,
+                c.address,
+                c.contact_type,
+                c.customer_type,
+                c.lead_stage,
+                c.status,
+                c.source,
+                c.created_at,
+                c.updated_at
+            FROM contacts AS c
+            WHERE {' AND '.join(conditions)}
             ORDER BY c.created_at DESC, c.id DESC
             LIMIT $1
             """,

--- a/atlas_brain/services/crm_provider.py
+++ b/atlas_brain/services/crm_provider.py
@@ -182,10 +182,6 @@ def _eom_identity_lock_key(channel: str, value: str) -> str:
     return f"eom-contact-identity:{channel}:{value}"
 
 
-# The only contact kinds the operator directory admits. A tenant row whose
-# contact_type is outside this set (e.g. legacy 'prospect' or 'vendor') is not
-# part of the lead/customer CRM surface and stays invisible to the directory.
-_EOM_DIRECTORY_CONTACT_KINDS = ("lead", "customer")
 # Punctuation an operator plausibly types or pastes as part of a phone number.
 # Any other character means the query is a name or email, and the digit
 # fallback must not run (an incidental digit run like the "2026" in
@@ -2232,15 +2228,19 @@ class DatabaseCRMProvider:
 
         Reading this projection alters nothing.
         """
+        # DERIVED from the canonical operator-mutation kind set: a kind the
+        # write boundary admits must be discoverable here in the same commit,
+        # or its records become write-only -- the defect this read closes.
+        from .eom_crm_mutations import EOM_OPERATOR_CONTACT_TYPES
         from .eom_lead_ingress import EOM_BUSINESS_CONTEXT_ID
 
-        if kind not in ("all", *_EOM_DIRECTORY_CONTACT_KINDS):
-            raise ValueError("kind must be one of: all, lead, customer")
+        if kind not in ("all", *EOM_OPERATOR_CONTACT_TYPES):
+            raise ValueError("kind must be 'all' or an operator contact kind")
 
         conditions = ["c.business_context_id = $2", "c.status = 'active'"]
         params: list[Any] = [limit, EOM_BUSINESS_CONTEXT_ID]
         if kind == "all":
-            params.append(list(_EOM_DIRECTORY_CONTACT_KINDS))
+            params.append(list(EOM_OPERATOR_CONTACT_TYPES))
             conditions.append(f"c.contact_type = ANY(${len(params)}::varchar[])")
         else:
             params.append(kind)

--- a/plans/PR-EOM-Contact-Directory.md
+++ b/plans/PR-EOM-Contact-Directory.md
@@ -1,0 +1,296 @@
+# PR-EOM-Contact-Directory
+
+## Why this slice exists
+
+Website #240 (child of website #105, Slice 3): an Atlas `customer` contact
+created or matched through the portal's Add Contact form is unreachable from
+every portal surface after refresh. The tracker proxy deliberately creates no
+local mirror (eom-timetracker PR #196), the portal Customers tab reads tracker
+operational customers only, and Atlas's sole funnel read
+(`/eom-funnel/leads`) admits only `contact_type='lead'` in stages
+new/estimate_booked/won. A created customer (contact_type='customer',
+lead_stage NULL) can never satisfy it, so the record is write-only from the
+portal's point of view.
+
+### Problem-derived contract
+
+- Root cause: Slice 2 shipped a canonical write for both contact kinds
+  (`POST /eom-funnel/operator-contacts` accepts contactType lead|customer)
+  without a canonical read for either. The only portal-facing read,
+  `DatabaseCRMProvider.list_eom_new_lead_review_items`, filters
+  `contact_type='lead' AND lead_stage IN ('new','estimate_booked','won')`,
+  which is deliberately narrower than the write surface. There is no
+  discovery read over the canonical EOM contact set.
+- Correct fix must touch/change: `atlas_brain/eom_api/funnel.py` (a new
+  authenticated, closed-projection `GET /eom-funnel/contact-directory` route
+  plus its `contact.directory` entry in `_CAPABILITY_ROUTES` so callers derive
+  deployment proof from the registered method/path);
+  `atlas_brain/services/crm_provider.py` (a new read-only, tenant-scoped
+  `list_eom_contact_directory` provider method with keyset pagination on
+  immutable columns and bounded search); `tests/test_eom_contact_directory.py`
+  (route closure, capability, and real-Postgres scope proofs); the
+  `atlas_eom_lead_pipeline_checks` workflow enrollment for that test file.
+- Must not change: the `/eom-funnel/leads` contract (byte-identical envelope
+  and query); the operator mutation boundary and its idempotency/lifecycle
+  semantics; `known-contacts` link verification; onboarding draft/public-link
+  routes; any write path (this PR performs no mutation anywhere); tracker and
+  website repos (separate PRs in the slice); database schema (no migration --
+  the read uses existing columns).
+
+### Diff-budget justification
+
+The 400-LOC cap is exceeded by the mandatory plan doc plus the test matrix:
+the runtime change is ~280 LOC across two files, and the tests
+(route-closure, capability, negative-control, and six real-Postgres proofs)
+are the majority of the diff. Splitting tests from the route would ship an
+unproven admission boundary; splitting route from provider would ship a dead
+route. The slice is indivisible at PR granularity.
+
+## Scope (this PR)
+
+Ownership lane: eom-crm/contact-directory
+Slice phase: Vertical slice
+
+1. Add `GET /eom-funnel/contact-directory`: authenticated (existing funnel
+   bearer + actor), tenant-scoped to `effingham_maids`, admitting
+   `status='active' AND contact_type IN ('lead','customer')`, with a closed
+   camelCase projection, closed `kind` filter (all|lead|customer), bounded
+   `search` (name/email/phone ILIKE with escaped metacharacters plus a
+   digits-run phone fallback), keyset pagination on `(created_at, id)`
+   descending, and rejection of unknown query-parameter names.
+2. Advertise it as `contact.directory` -> `("GET",
+   "/eom-funnel/contact-directory")` through the existing route-derived
+   capability manifest, so the tracker can gate its proxy on the registered
+   method/path instead of a copied string.
+
+Max files: 6
+
+### Review Contract
+
+- Acceptance criteria:
+  - Authentication is required and the actor boundary holds -- settled by
+    tests/test_eom_contact_directory.py::test_the_route_refuses_an_unauthenticated_caller,
+    ::test_a_wrong_service_token_is_refused, and
+    ::test_a_missing_actor_header_is_refused.
+  - Tenant scoping cannot leak another business context, archived rows are
+    excluded, and kinds outside lead/customer never appear -- settled against
+    real Postgres by
+    ::test_tenant_scope_and_lifecycle_hold_against_real_postgres (negative
+    control: removing the business_context_id condition, or the
+    status='active' condition, makes this test fail; both were exercised
+    locally and restored).
+  - Both active leads and customers are returned and a lost lead stays
+    findable with its stage -- settled by
+    ::test_both_contact_kinds_come_back_and_the_projection_is_closed and
+    ::test_a_lost_lead_is_rendered_with_its_stage.
+  - The kind filter is closed and forwarded verbatim -- settled by
+    ::test_the_kind_filter_is_closed (negative control: loosening the route
+    Literal to str makes it fail) and
+    ::test_each_admitted_kind_is_forwarded_verbatim.
+  - Unknown query-parameter names are rejected 422 -- settled by
+    ::test_an_unknown_query_parameter_is_rejected_not_ignored (negative
+    control: removing the rejection call makes it fail).
+  - Search matches name, email, and phone, matches a formatted stored phone
+    from a digits-only query, and treats LIKE metacharacters literally --
+    settled against real Postgres by
+    ::test_search_matches_name_email_and_phone_against_real_postgres and
+    ::test_a_like_metacharacter_searches_literally_against_real_postgres
+    (negative control: removing `_escape_eom_directory_like_pattern` makes the
+    latter fail against the seeded 'Percent 5% Off' / 'Percent 55 Co' pair).
+  - Pagination is deterministic keyset on immutable `(created_at, id)` and a
+    full traversal neither drops nor duplicates rows -- settled against real
+    Postgres by ::test_keyset_traversal_neither_drops_nor_duplicates, with
+    cursor round-trip proven by
+    ::test_pagination_reports_has_more_and_a_cursor_that_round_trips.
+  - Malformed or short cursors and blank or overlong search values fail
+    closed 422 -- settled by ::test_a_malformed_cursor_is_rejected,
+    ::test_a_short_cursor_is_rejected, ::test_a_blank_search_is_rejected, and
+    ::test_an_overlong_search_is_rejected.
+  - Directory reads perform no writes and touch no other provider method --
+    settled by ::test_the_directory_read_touches_no_other_provider_method
+    (the spy provider raises on any attribute access outside the directory
+    read) plus a before/after live-DB snapshot recorded in the PR body.
+  - The projection is closed on both envelope and item, and a row outside the
+    admitted kinds/status/customer-type sets can never be emitted -- settled
+    by ::test_both_contact_kinds_come_back_and_the_projection_is_closed,
+    ::test_a_row_outside_the_directory_kinds_can_never_be_emitted,
+    ::test_an_archived_row_can_never_be_emitted, and
+    ::test_a_junk_customer_type_can_never_be_emitted.
+  - Capability advertisement matches the actually registered method/path and
+    appears on the pipeline read -- settled by
+    ::test_the_directory_is_advertised_in_the_capability_manifest and
+    ::test_the_lead_review_response_advertises_the_directory, with the
+    existing manifest suite (tests/test_eom_funnel_capability_manifest.py)
+    still green.
+  - The deployed aggregate serves the route under /api/v1 -- settled by
+    ::test_the_real_aggregate_serves_the_route_at_its_deployed_path.
+- Reachability proof: the tracker's `_atlas_funnel_read` calls
+  `{ATLAS_FUNNEL_BASE_URL}/eom-funnel/contact-directory` once the follow-up
+  tracker PR allow-lists the path; until then the route is reachable at
+  `/api/v1/eom-funnel/contact-directory` on the deployed aggregate
+  (atlas_brain/api/__init__.py:111 mounts the funnel router), proven by
+  tests/test_eom_contact_directory.py::test_the_real_aggregate_serves_the_route_at_its_deployed_path.
+- Affected surfaces: atlas_brain/eom_api/funnel.py (new route + capability
+  entry; existing routes untouched), atlas_brain/services/crm_provider.py
+  (new read-only method + three module-level search helpers; existing methods
+  untouched), the funnel capability manifest consumed by the tracker, and the
+  atlas_eom_lead_pipeline_checks workflow (test enrollment only).
+- Risk areas: tenant scoping and archived-row leakage on the new SQL; LIKE
+  metacharacter injection into the search pattern; keyset drop/duplicate under
+  traversal; capability over-advertising; accidental writes from a read path;
+  regression of the untouched `/eom-funnel/leads` contract.
+- Reviewer rules triggered: R1, R2, R5, R14
+
+### Boundary-change enumeration
+
+This diff adds an admission boundary (the directory's filter set); no
+existing boundary is modified.
+
+- Boundary path/seam: `GET /eom-funnel/contact-directory` admission -- query
+  parameters {limit, cursor, search, kind} plus the SQL admission predicate
+  (`business_context_id='effingham_maids' AND status='active' AND
+  contact_type IN ('lead','customer')`).
+- Replaced-path behaviors: none replaced -- `/eom-funnel/leads` keeps its
+  exact filter (`lead` in stages new/estimate_booked/won) and envelope;
+  `known-contacts` keeps id-only verification.
+- Guard-relevant fields: `kind` (closed Literal all|lead|customer), `search`
+  (1..120 chars, non-blank, LIKE-escaped, digit fallback only for
+  phone-shaped input with >=4 digits), `cursor` (16..512 chars, urlsafe-b64
+  `created_at|id`, tz-aware, 422 on any malformation), `limit` (1..200),
+  unknown parameter names (422), and on the response side `status`
+  (Literal['active']), `contact_type` / `customer_type` (validated against
+  the operator boundary's own EOM_OPERATOR_CONTACT_TYPES /
+  EOM_CUSTOMER_TYPES sets).
+- Caller x input shape: single caller is the tracker's server-side
+  `_atlas_funnel_read` (browser never calls Atlas directly). Probed shapes:
+  no-param default page; each kind value; unknown kind; unknown parameter
+  name; blank/overlong/metacharacter search; digits-only phone search;
+  malformed/short cursor; cursor round-trip across pages; a provider row
+  outside the admitted kind/status/customer-type sets (can never be emitted).
+
+### Closure declarations (GUARD_CLASS_CLOSURE)
+
+- Directory kind filter `{all, lead, customer}`: CLOSED -- 'all' plus the
+  operator boundary's own EOM_OPERATOR_CONTACT_TYPES; sourced DERIVED for the
+  SQL admission (`_EOM_DIRECTORY_CONTACT_KINDS` mirrors the canonical pair and
+  the response validator reads EOM_OPERATOR_CONTACT_TYPES directly).
+  Out-of-set input -> 422 at the route Literal (safe side: refuse, never
+  widen a filter silently).
+- Phone punctuation family `" ()+.-"` + 4-digit minimum: CLOSED, authored
+  here as the search contract (no upstream source exists). Out-of-set
+  character -> the digit fallback does not run and the query is matched as
+  text only (cheap side: a missed phone match is a smaller failure than a
+  false phone match on incidental digits). The class-closure proof is the
+  generated tokens x containers x families test with a spec-derived oracle
+  whose contract literals are pinned independently of the implementation
+  (tests/test_eom_contact_directory.py::test_search_admission_grammar_holds_across_tokens_containers_and_families).
+- LIKE metacharacter set `{%, _, \\}`: CLOSED, DERIVED from the SQL LIKE
+  specification (the complete metacharacter vocabulary for LIKE/ESCAPE).
+  Out-of-set characters pass through literally; the invariant proof over
+  generated inputs is
+  ::test_escaped_patterns_never_leave_an_active_like_metacharacter.
+- Projection field set: CLOSED, authored here as the browser contract.
+  An out-of-set provider key -> Pydantic extra='forbid' rejects the row
+  (safe side: 500 loudly rather than leak an unreviewed field).
+- Admitted lifecycle status `{'active'}`: CLOSED, authored (this slice's
+  admission decision). Out-of-set rows are excluded by the SQL predicate and,
+  independently, can never serialize (status Literal['active']) -- incomplete
+  enforcement fails to the safe side twice.
+
+### Deployed-config probing
+
+N/A - no guard/config/env-fallback change: the route uses the existing
+`EOMFunnelConfig` bearer gate unchanged and introduces no new configuration.
+
+### Files touched
+
+- `.github/workflows/atlas_eom_lead_pipeline_checks.yml`
+- `atlas_brain/eom_api/funnel.py`
+- `atlas_brain/services/crm_provider.py`
+- `plans/PR-EOM-Contact-Directory.md`
+- `tests/test_eom_contact_directory.py`
+
+## Mechanism
+
+`list_eom_contact_directory` (DatabaseCRMProvider) builds one SELECT over
+`contacts` with a fixed tenant/status predicate, a kind predicate (`= ANY`
+over the closed pair, or a single value), an optional search predicate
+(ILIKE over full_name/email/phone with `%`/`_`/`\` escaped via
+`_escape_eom_directory_like_pattern`, plus a digits-only phone comparison
+when `_eom_directory_phone_search_digits` classifies the query as
+phone-shaped), and an optional keyset predicate
+`(created_at, id) < (cursor_created_at, cursor_id)`; ordering is
+`created_at DESC, id DESC` -- immutable columns, so a rename mid-traversal
+cannot drop or duplicate a row (the same reasoning documented on
+`list_billing_recipients`).
+
+The route (funnel.py) authenticates with the existing
+`require_eom_funnel_api` + `require_eom_funnel_actor` dependencies, rejects
+unknown query-parameter names, validates search/cursor shape (reusing the
+lead-review cursor codec), overfetches limit+1 to derive hasMore/nextCursor,
+and validates every row through `EOMContactDirectoryItem`
+(extra='forbid'; `status` pinned to Literal['active']; contact_type and
+customer_type validated against the operator boundary's own constant sets so
+the projection is a second, independent enforcement of admission).
+`contact.directory` joins `_CAPABILITY_ROUTES`, so `served_capabilities()` /
+`served_capability_routes()` advertise it only while the route is actually
+registered.
+
+## Intentional
+
+- Lost leads (lead_stage='lost', status still 'active') are included, with
+  their stage: the pipeline hides them by design, and the directory is
+  exactly where a pipeline-hidden record must remain findable. Hiding them
+  here would recreate the disappearing-record defect one stage later.
+- The pipeline read's latest-intake email/phone overlay is NOT reused: the
+  directory's job is discoverability of the canonical record, and search over
+  interaction-metadata overlays would triple the query for marginal recall.
+- The identity-matching digit SQL (extension-stripping + RIGHT-10) is not
+  reused for search: identity needs exact-suffix semantics, search needs
+  substring containment; a false positive in search is a visible extra row,
+  not a wrong write target.
+- Unknown query-parameter names are rejected (422) on this route only. The
+  pipeline read keeps FastAPI's tolerant default because its callers predate
+  this slice; the directory has exactly one caller, so it can be exact.
+- No new envelope fields on `/eom-funnel/leads`: the manifest already carries
+  the capability name and route signature, which is the proof callers use.
+
+## Deferred
+
+- Archived-contact visibility (an explicit include-archived view) belongs to
+  the later archive/restore slice; the admission predicate and its Literal
+  mirror will both need widening together.
+- Directory reads over interaction-derived contact info (the intake overlay)
+  if operators report missing search recall on web-form leads.
+
+Parking predicate: park anything that widens the projection, admits more
+lifecycle states, or adds mutation semantics -- this slice is read-only
+ discovery, and its consumers gate on the capability manifest, so widening
+later is additive.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_eom_contact_directory.py` with
+  ATLAS_MIGRATION_TEST_DATABASE_URL set: 32 passed (26 route/unit + 6
+  real-Postgres), public.contacts count and max(updated_at) identical before
+  and after, zero leftover test schemas.
+- `python -m pytest tests/test_eom_funnel_capability_manifest.py
+  tests/test_eom_link_verification.py tests/test_eom_lead_conversion.py`:
+  284 passed total -- the untouched funnel surfaces stay green.
+- Negative controls (each exercised locally, test failed, enforcement
+  restored): tenant-scope condition removed; status='active' condition
+  removed; LIKE escaping removed; kind Literal loosened to str;
+  unknown-parameter rejection removed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 3 |
+| `atlas_brain/eom_api/funnel.py` | 151 |
+| `atlas_brain/services/crm_provider.py` | 131 |
+| `plans/PR-EOM-Contact-Directory.md` | 296 |
+| `tests/test_eom_contact_directory.py` | 763 |
+| **Total** | **1344** |

--- a/plans/PR-EOM-Contact-Directory.md
+++ b/plans/PR-EOM-Contact-Directory.md
@@ -83,9 +83,11 @@ Max files: 6
     findable with its stage -- settled by
     ::test_both_contact_kinds_come_back_and_the_projection_is_closed and
     ::test_a_lost_lead_is_rendered_with_its_stage.
-  - The kind filter is closed and forwarded verbatim -- settled by
-    ::test_the_kind_filter_is_closed (negative control: loosening the route
-    Literal to str makes it fail) and
+  - The kind filter is closed, DERIVED from the canonical operator
+    mutation kind set, and forwarded verbatim -- settled by
+    ::test_the_kind_filter_is_closed (negative control: removing the derived
+    membership check makes it fail),
+    ::test_the_directory_kind_set_is_derived_from_the_operator_boundary, and
     ::test_each_admitted_kind_is_forwarded_verbatim.
   - Unknown query-parameter names are rejected 422 -- settled by
     ::test_an_unknown_query_parameter_is_rejected_not_ignored (negative
@@ -122,14 +124,25 @@ Max files: 6
     ::test_the_lead_review_response_advertises_the_directory, with the
     existing manifest suite (tests/test_eom_funnel_capability_manifest.py)
     still green.
-  - The deployed aggregate serves the route under /api/v1 -- settled by
-    ::test_the_real_aggregate_serves_the_route_at_its_deployed_path.
+  - Database-unrepresentable search input (NUL, lone surrogates) fails
+    closed 422 at the route instead of 500 mid-query -- settled by
+    ::test_a_database_unrepresentable_search_fails_closed, routed through the
+    module's one surrogate choke point (R3).
+  - Every deployed entrypoint (atlas_brain.main:app, the live systemd
+    topology, and atlas_brain.main_eom:app, the render.eom.yaml topology)
+    serves the route under /api/v1 -- settled by
+    ::test_every_deployed_entrypoint_serves_the_route_at_its_path.
+  - The workflow enrollment change is itself evidence-bearing (R12): the new
+    test file joins atlas_eom_lead_pipeline_checks paths (x2) and its pytest
+    command, so CI runs it with the real Postgres service.
 - Reachability proof: the tracker's `_atlas_funnel_read` calls
   `{ATLAS_FUNNEL_BASE_URL}/eom-funnel/contact-directory` once the follow-up
   tracker PR allow-lists the path; until then the route is reachable at
   `/api/v1/eom-funnel/contact-directory` on the deployed aggregate
-  (atlas_brain/api/__init__.py:111 mounts the funnel router), proven by
-  tests/test_eom_contact_directory.py::test_the_real_aggregate_serves_the_route_at_its_deployed_path.
+  (atlas_brain/api/__init__.py:111 mounts the funnel router) and on the
+  render.eom.yaml topology (atlas_brain/main_eom.py mounts it at /api/v1),
+  proven by
+  tests/test_eom_contact_directory.py::test_every_deployed_entrypoint_serves_the_route_at_its_path.
 - Affected surfaces: atlas_brain/eom_api/funnel.py (new route + capability
   entry; existing routes untouched), atlas_brain/services/crm_provider.py
   (new read-only method + three module-level search helpers; existing methods
@@ -139,7 +152,7 @@ Max files: 6
   metacharacter injection into the search pattern; keyset drop/duplicate under
   traversal; capability over-advertising; accidental writes from a read path;
   regression of the untouched `/eom-funnel/leads` contract.
-- Reviewer rules triggered: R1, R2, R5, R14
+- Reviewer rules triggered: R1, R2, R3, R5, R12, R14
 
 ### Boundary-change enumeration
 
@@ -170,12 +183,13 @@ existing boundary is modified.
 
 ### Closure declarations (GUARD_CLASS_CLOSURE)
 
-- Directory kind filter `{all, lead, customer}`: CLOSED -- 'all' plus the
-  operator boundary's own EOM_OPERATOR_CONTACT_TYPES; sourced DERIVED for the
-  SQL admission (`_EOM_DIRECTORY_CONTACT_KINDS` mirrors the canonical pair and
-  the response validator reads EOM_OPERATOR_CONTACT_TYPES directly).
-  Out-of-set input -> 422 at the route Literal (safe side: refuse, never
-  widen a filter silently).
+- Directory kind filter: CLOSED and DERIVED -- 'all' plus the operator
+  boundary's own EOM_OPERATOR_CONTACT_TYPES, read from that canonical name at
+  every decision point (`_CONTACT_DIRECTORY_KINDS` in the route, the
+  function-level import in the provider, and the response validators), so a
+  kind the write boundary admits can never be born write-only here.
+  Out-of-set input -> 422 at the route's derived membership check (safe side:
+  refuse, never widen a filter silently).
 - Phone punctuation family `" ()+.-"` + 4-digit minimum: CLOSED, authored
   here as the search contract (no upstream source exists). Out-of-set
   character -> the digit fallback does not run and the query is matched as
@@ -289,8 +303,8 @@ Parked hardening: none.
 | File | LOC |
 |---|---:|
 | `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 3 |
-| `atlas_brain/eom_api/funnel.py` | 151 |
+| `atlas_brain/eom_api/funnel.py` | 168 |
 | `atlas_brain/services/crm_provider.py` | 131 |
-| `plans/PR-EOM-Contact-Directory.md` | 296 |
-| `tests/test_eom_contact_directory.py` | 763 |
-| **Total** | **1344** |
+| `plans/PR-EOM-Contact-Directory.md` | 310 |
+| `tests/test_eom_contact_directory.py` | 801 |
+| **Total** | **1413** |

--- a/tests/test_eom_contact_directory.py
+++ b/tests/test_eom_contact_directory.py
@@ -241,6 +241,26 @@ async def test_an_overlong_search_is_rejected():
 
 
 @pytest.mark.asyncio
+async def test_a_database_unrepresentable_search_fails_closed():
+    """NUL cannot live in a Postgres text parameter: it must 422 at the
+    boundary, never 500 mid-query."""
+    crm = _CRM()
+    response = await _get(crm, "?search=%00")
+    assert response.status_code == 422
+    embedded = await _get(crm, "?search=ada%00lovelace")
+    assert embedded.status_code == 422
+    assert crm.calls == [], "an invalid search must never reach the provider"
+
+
+def test_the_directory_kind_set_is_derived_from_the_operator_boundary():
+    """The route and provider read the canonical mutation kind set, so a kind
+    the write boundary admits can never be born write-only in the directory."""
+    from atlas_brain.services.eom_crm_mutations import EOM_OPERATOR_CONTACT_TYPES
+
+    assert funnel_mod._CONTACT_DIRECTORY_KINDS == ("all", *EOM_OPERATOR_CONTACT_TYPES)
+
+
+@pytest.mark.asyncio
 async def test_search_is_forwarded_stripped():
     crm = _CRM()
     response = await _get(crm, "?search=%20Ada%20Operator%20")
@@ -380,31 +400,49 @@ async def test_the_lead_review_response_advertises_the_directory():
     ]
 
 
+def _deployed_apps():
+    """Every application object a real deployment starts.
+
+    ``atlas_brain.main:app`` is what the live systemd unit runs today
+    (atlas-api.service, uvicorn atlas_brain.main:app); ``main_eom:app`` is the
+    slim EOM topology render.eom.yaml starts and the one that pins the
+    dedicated funnel CRM provider. A reachability proof that exercises only
+    one of them stays green while the other drops the route.
+    """
+    from atlas_brain.main import app as aggregate_app
+    from atlas_brain.main_eom import app as eom_app
+
+    return [("main", aggregate_app), ("main_eom", eom_app)]
+
+
 @pytest.mark.asyncio
-async def test_the_real_aggregate_serves_the_route_at_its_deployed_path():
+async def test_every_deployed_entrypoint_serves_the_route_at_its_path():
     """Every other test mounts the router on a fresh app; this one proves the
-    application that actually ships mounts it under /api/v1."""
-    from atlas_brain.main import app
-
-    crm = _CRM([_row()])
-    original_overrides = dict(app.dependency_overrides)
-    app.dependency_overrides[funnel_mod._crm_dependency] = lambda: crm
-    app.dependency_overrides[auth_mod.get_eom_funnel_api_config] = lambda: (
-        EOMFunnelConfig(api_enabled=True, service_token_sha256=_SERVICE_TOKEN_SHA256)
-    )
-    try:
-        async with httpx.AsyncClient(
-            transport=httpx.ASGITransport(app=app), base_url="http://test"
-        ) as client:
-            response = await client.get(
-                "/api/v1/eom-funnel/contact-directory", headers=_headers()
+    applications that actually ship mount it under /api/v1."""
+    for name, app in _deployed_apps():
+        crm = _CRM([_row()])
+        original_overrides = dict(app.dependency_overrides)
+        app.dependency_overrides[funnel_mod._crm_dependency] = lambda: crm
+        app.dependency_overrides[auth_mod.get_eom_funnel_api_config] = lambda: (
+            EOMFunnelConfig(
+                api_enabled=True, service_token_sha256=_SERVICE_TOKEN_SHA256
             )
-    finally:
-        app.dependency_overrides.clear()
-        app.dependency_overrides.update(original_overrides)
+        )
+        try:
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.get(
+                    "/api/v1/eom-funnel/contact-directory", headers=_headers()
+                )
+        finally:
+            app.dependency_overrides.clear()
+            app.dependency_overrides.update(original_overrides)
 
-    assert response.status_code == 200, "the deployed path must serve this route"
-    assert len(response.json()["contacts"]) == 1
+        assert response.status_code == 200, (
+            f"{name} must serve the deployed path, not 404"
+        )
+        assert len(response.json()["contacts"]) == 1, name
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_eom_contact_directory.py
+++ b/tests/test_eom_contact_directory.py
@@ -1,0 +1,763 @@
+"""EOM contact-directory read: bounded, tenant-scoped, read-only (website #240).
+
+The directory is the discovery boundary the operator mutation never had: the
+pipeline read admits only stage-active leads, so a ``customer`` created or
+matched through ``/operator-contacts`` was unreachable from every portal
+surface. These tests hold the new read to the same closure standards as the
+routes beside it: authenticated, tenant-scoped, closed filters, closed
+projection, deterministic keyset pagination, and no writes of any kind.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import uuid
+from datetime import datetime, timedelta, timezone
+from itertools import product
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from atlas_brain.eom_api import funnel as funnel_mod
+from atlas_brain.eom_api import funnel_auth as auth_mod
+from atlas_brain.eom_api.config import EOMFunnelConfig
+from atlas_brain.services.crm_provider import (
+    _eom_directory_phone_search_digits,
+    _escape_eom_directory_like_pattern,
+)
+
+ROOT = Path(__file__).resolve().parent.parent
+MIGRATIONS = ROOT / "atlas_brain" / "storage" / "migrations"
+DATABASE_URL_ENV = "ATLAS_MIGRATION_TEST_DATABASE_URL"
+TENANT = "effingham_maids"
+FOREIGN_TENANT = "churnsignals"
+
+_GENERATED_SERVICE_TOKEN = auth_mod.generate_eom_funnel_service_token()
+_SERVICE_TOKEN = _GENERATED_SERVICE_TOKEN.token
+_SERVICE_TOKEN_SHA256 = _GENERATED_SERVICE_TOKEN.sha256
+
+_BASE_CREATED_AT = datetime(2026, 8, 20, 12, 0, tzinfo=timezone.utc)
+
+
+def _row(
+    *,
+    contact_type: str = "customer",
+    full_name: str = "Directory Contact",
+    lead_stage: str | None = None,
+    created_at: datetime | None = None,
+    contact_id: UUID | None = None,
+    status: str = "active",
+    customer_type: str = "unknown",
+) -> dict[str, object]:
+    return {
+        "contact_id": contact_id or uuid4(),
+        "full_name": full_name,
+        "email": "directory@example.test",
+        "phone": "2175550100",
+        "address": "1 Directory Way",
+        "contact_type": contact_type,
+        "customer_type": customer_type,
+        "lead_stage": lead_stage,
+        "status": status,
+        "source": "manual",
+        "created_at": created_at or _BASE_CREATED_AT,
+        "updated_at": created_at or _BASE_CREATED_AT,
+    }
+
+
+class _CRM:
+    """Spy provider: records every method invoked plus directory kwargs."""
+
+    def __init__(self, rows: list[dict[str, object]] | None = None) -> None:
+        self.rows = rows or []
+        self.calls: list[tuple[str, dict[str, object]]] = []
+
+    async def list_eom_contact_directory(self, **kwargs: object) -> list[dict]:
+        self.calls.append(("list_eom_contact_directory", dict(kwargs)))
+        return [dict(row) for row in self.rows]
+
+    async def list_eom_new_lead_review_items(self, **kwargs: object) -> list[dict]:
+        self.calls.append(("list_eom_new_lead_review_items", dict(kwargs)))
+        return []
+
+    def __getattr__(self, name: str):
+        # Any OTHER provider access from the directory read is a write-path
+        # or scope leak; make it loud instead of silently succeeding.
+        raise AssertionError(f"directory read must not touch crm.{name}")
+
+
+def _app(crm: _CRM) -> FastAPI:
+    app = FastAPI()
+    app.include_router(funnel_mod.router)
+    app.dependency_overrides[funnel_mod._crm_dependency] = lambda: crm
+    app.dependency_overrides[auth_mod.get_eom_funnel_api_config] = lambda: (
+        EOMFunnelConfig(api_enabled=True, service_token_sha256=_SERVICE_TOKEN_SHA256)
+    )
+    return app
+
+
+def _headers(token: str = _SERVICE_TOKEN) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {token}",
+        "X-EOM-Actor": "Juan Canfield",
+        "X-EOM-Actor-ID": "1",
+    }
+
+
+async def _get(
+    crm: _CRM, query: str = "", *, raise_app_exceptions: bool = True, **kwargs: object
+) -> httpx.Response:
+    app = _app(crm)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(
+            app=app, raise_app_exceptions=raise_app_exceptions
+        ),
+        base_url="http://test",
+    ) as client:
+        return await client.get(
+            f"/eom-funnel/contact-directory{query}", headers=_headers(), **kwargs
+        )
+
+
+@pytest.fixture(autouse=True)
+def _reset_capability_cache():
+    funnel_mod._served_capabilities_cache = None
+    yield
+    funnel_mod._served_capabilities_cache = None
+
+
+# ---------------------------------------------------------------------------
+# Authentication and actor boundary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_route_refuses_an_unauthenticated_caller():
+    app = _app(_CRM())
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get("/eom-funnel/contact-directory")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_a_wrong_service_token_is_refused():
+    app = _app(_CRM())
+    wrong = auth_mod.generate_eom_funnel_service_token().token
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get(
+            "/eom-funnel/contact-directory", headers=_headers(token=wrong)
+        )
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_a_missing_actor_header_is_refused():
+    app = _app(_CRM())
+    headers = _headers()
+    headers.pop("X-EOM-Actor")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get("/eom-funnel/contact-directory", headers=headers)
+    assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Filter closure: kind, search, cursor, unknown parameters
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_both_contact_kinds_come_back_and_the_projection_is_closed():
+    lead = _row(contact_type="lead", full_name="Lead Person", lead_stage="new")
+    customer = _row(contact_type="customer", full_name="Customer Person")
+    response = await _get(_CRM([lead, customer]))
+
+    assert response.status_code == 200
+    body = response.json()
+    assert set(body) == {"contacts", "limit", "cursor", "hasMore", "nextCursor"}
+    kinds = {item["contactType"] for item in body["contacts"]}
+    assert kinds == {"lead", "customer"}
+    for item in body["contacts"]:
+        assert set(item) == {
+            "contactId",
+            "fullName",
+            "email",
+            "phone",
+            "address",
+            "contactType",
+            "customerType",
+            "leadStage",
+            "status",
+            "source",
+            "createdAt",
+            "updatedAt",
+        }
+        assert item["status"] == "active"
+
+
+@pytest.mark.asyncio
+async def test_the_kind_filter_is_closed():
+    response = await _get(_CRM(), "?kind=prospect")
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_each_admitted_kind_is_forwarded_verbatim():
+    for kind in ("all", "lead", "customer"):
+        crm = _CRM()
+        response = await _get(crm, f"?kind={kind}")
+        assert response.status_code == 200
+        assert crm.calls[-1][1]["kind"] == kind
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_query_parameter_is_rejected_not_ignored():
+    """A typoed filter silently ignored would return the unfiltered directory
+    while looking filtered -- the wrong rows with a confident face."""
+    response = await _get(_CRM(), "?serach=smith")
+    assert response.status_code == 422
+    assert "serach" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_a_blank_search_is_rejected():
+    response = await _get(_CRM(), "?search=%20%20")
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_an_overlong_search_is_rejected():
+    response = await _get(_CRM(), f"?search={'x' * 121}")
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_search_is_forwarded_stripped():
+    crm = _CRM()
+    response = await _get(crm, "?search=%20Ada%20Operator%20")
+    assert response.status_code == 200
+    assert crm.calls[-1][1]["search"] == "Ada Operator"
+
+
+@pytest.mark.asyncio
+async def test_a_malformed_cursor_is_rejected():
+    response = await _get(_CRM(), "?cursor=%2Bnot-base64-at-all%2B")
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_a_short_cursor_is_rejected():
+    response = await _get(_CRM(), "?cursor=abc")
+    assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Pagination mechanics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pagination_reports_has_more_and_a_cursor_that_round_trips():
+    rows = [
+        _row(created_at=_BASE_CREATED_AT - timedelta(minutes=index))
+        for index in range(3)
+    ]
+    crm = _CRM(rows)
+    first = await _get(crm, "?limit=2")
+
+    assert first.status_code == 200
+    body = first.json()
+    assert crm.calls[-1][1]["limit"] == 3, "route must overfetch by one"
+    assert len(body["contacts"]) == 2
+    assert body["hasMore"] is True
+    assert body["nextCursor"]
+
+    crm_second = _CRM(rows[2:])
+    second = await _get(crm_second, f"?limit=2&cursor={body['nextCursor']}")
+    assert second.status_code == 200
+    forwarded = crm_second.calls[-1][1]
+    assert forwarded["cursor_contact_id"] == rows[1]["contact_id"]
+    assert forwarded["cursor_created_at"] == rows[1]["created_at"]
+    assert second.json()["hasMore"] is False
+    assert second.json()["nextCursor"] is None
+
+
+@pytest.mark.asyncio
+async def test_a_full_final_page_reports_no_more():
+    rows = [_row(), _row()]
+    response = await _get(_CRM(rows), "?limit=2")
+    body = response.json()
+    assert len(body["contacts"]) == 2
+    assert body["hasMore"] is False
+    assert body["nextCursor"] is None
+
+
+# ---------------------------------------------------------------------------
+# Read-only and projection guarantees
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_directory_read_touches_no_other_provider_method():
+    """The spy raises on any attribute except the two reads it defines, so a
+    write (or any second read) reaching the provider fails this test."""
+    crm = _CRM([_row()])
+    response = await _get(crm, "?search=Ada&kind=customer")
+    assert response.status_code == 200
+    assert [name for name, _ in crm.calls] == ["list_eom_contact_directory"]
+
+
+@pytest.mark.asyncio
+async def test_a_row_outside_the_directory_kinds_can_never_be_emitted():
+    """A legacy 'prospect' row must 500 loudly, not render as a directory
+    contact -- the projection is the second enforcement of admission."""
+    response = await _get(
+        _CRM([_row(contact_type="prospect")]), raise_app_exceptions=False
+    )
+    assert response.status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_an_archived_row_can_never_be_emitted():
+    response = await _get(
+        _CRM([_row(status="archived")]), raise_app_exceptions=False
+    )
+    assert response.status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_a_junk_customer_type_can_never_be_emitted():
+    response = await _get(
+        _CRM([_row(customer_type="franchise")]), raise_app_exceptions=False
+    )
+    assert response.status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_a_lost_lead_is_rendered_with_its_stage():
+    """Lost leads are pipeline-hidden but DB-active; the directory is exactly
+    where they must remain findable, labelled truthfully."""
+    response = await _get(_CRM([_row(contact_type="lead", lead_stage="lost")]))
+    assert response.status_code == 200
+    item = response.json()["contacts"][0]
+    assert item["contactType"] == "lead"
+    assert item["leadStage"] == "lost"
+
+
+# ---------------------------------------------------------------------------
+# Capability advertisement
+# ---------------------------------------------------------------------------
+
+
+def test_the_directory_is_advertised_in_the_capability_manifest():
+    assert "contact.directory" in funnel_mod.served_capabilities()
+    assert ("GET", "/eom-funnel/contact-directory") in funnel_mod.served_capability_routes()
+
+
+@pytest.mark.asyncio
+async def test_the_lead_review_response_advertises_the_directory():
+    """Callers derive the deployment proof from the manifest on the pipeline
+    read, so the name and the exact method/path must both appear there."""
+    crm = _CRM()
+    app = _app(crm)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get("/eom-funnel/leads", headers=_headers())
+    body = response.json()
+    assert "contact.directory" in body["capabilities"]
+    assert {"method": "GET", "path": "/eom-funnel/contact-directory"} in body[
+        "capabilityRoutes"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_the_real_aggregate_serves_the_route_at_its_deployed_path():
+    """Every other test mounts the router on a fresh app; this one proves the
+    application that actually ships mounts it under /api/v1."""
+    from atlas_brain.main import app
+
+    crm = _CRM([_row()])
+    original_overrides = dict(app.dependency_overrides)
+    app.dependency_overrides[funnel_mod._crm_dependency] = lambda: crm
+    app.dependency_overrides[auth_mod.get_eom_funnel_api_config] = lambda: (
+        EOMFunnelConfig(api_enabled=True, service_token_sha256=_SERVICE_TOKEN_SHA256)
+    )
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            response = await client.get(
+                "/api/v1/eom-funnel/contact-directory", headers=_headers()
+            )
+    finally:
+        app.dependency_overrides.clear()
+        app.dependency_overrides.update(original_overrides)
+
+    assert response.status_code == 200, "the deployed path must serve this route"
+    assert len(response.json()["contacts"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Search-grammar helpers (pure, no DB)
+# ---------------------------------------------------------------------------
+
+
+def test_search_admission_grammar_holds_across_tokens_containers_and_families():
+    """Class-closure proof for the search-grammar guard (GUARD_CLASS_CLOSURE
+    req 3): inputs are GENERATED over three grammar axes -- digit tokens x
+    punctuation containers x query families -- rather than sampled as a
+    fixture list, and every generated query is judged by a spec-derived
+    oracle.
+
+    The oracle pins the CONTRACT values as literals here -- the phone
+    punctuation family " ()+.-" and the 4-digit minimum -- independent of the
+    implementation constants, so widening or narrowing the implemented set
+    (adding '#', dropping '.') or moving the threshold breaks this test even
+    though every fixture a reviewer might list still passes.
+    """
+    spec_phone_punctuation = " ()+.-"  # contract literal, deliberately not imported
+    spec_minimum_digits = 4  # contract literal, deliberately not imported
+
+    def oracle_expected_digits(query: str) -> str | None:
+        if not query:
+            return None
+        if any(
+            not (char.isdigit() or char in spec_phone_punctuation) for char in query
+        ):
+            return None
+        digits = "".join(char for char in query if char.isdigit())
+        return digits if len(digits) >= spec_minimum_digits else None
+
+    digit_runs = ("", "21", "217", "5550", "2175550142")
+
+    def container_plain(run: str) -> str:
+        return run
+
+    def container_parenthesized(run: str) -> str:
+        return f"({run[:3]}) {run[3:]}" if len(run) > 3 else f"({run})"
+
+    def container_dotted(run: str) -> str:
+        return ".".join(part for part in (run[:3], run[3:6], run[6:]) if part) or run
+
+    def container_international(run: str) -> str:
+        return f"+1 {run}".rstrip()
+
+    query_family_suffixes = ("", "x", "@example.test", " Suite B", "#42")
+
+    checked = 0
+    for run, container, family_suffix in product(
+        digit_runs,
+        (
+            container_plain,
+            container_parenthesized,
+            container_dotted,
+            container_international,
+        ),
+        query_family_suffixes,
+    ):
+        query = container(run) + family_suffix
+        if not query:
+            continue
+        checked += 1
+        assert _eom_directory_phone_search_digits(query) == oracle_expected_digits(
+            query
+        ), f"grammar case diverged from the spec oracle: {query!r}"
+    assert checked > 80, "the generator must actually cover the grammar"
+
+
+def test_escaped_patterns_never_leave_an_active_like_metacharacter():
+    """Invariant oracle for the escaping guard, over generated inputs: after
+    removing every backslash-escaped pair from the escaped pattern, no bare
+    %, _, or backslash may remain, and unescaping must restore the original
+    text exactly. This holds for the whole input class, not a sample of
+    reported strings.
+    """
+    for prefix, metacharacter, suffix in product(
+        ("", "a", "5", "\\"),
+        ("%", "_", "\\", "%_", "\\%", "%%"),
+        ("", "b", "%", "_x"),
+    ):
+        original = prefix + metacharacter + suffix
+        escaped = _escape_eom_directory_like_pattern(original)
+        remainder = re.sub(r"\\.", "", escaped)
+        assert not any(char in remainder for char in "%_\\"), (
+            f"active metacharacter survives escaping: {original!r} -> {escaped!r}"
+        )
+        unescaped = re.sub(r"\\(.)", r"\1", escaped)
+        assert unescaped == original, "escaping must be reversible"
+
+
+def test_like_metacharacters_are_escaped_literally():
+    assert _escape_eom_directory_like_pattern("50%_off\\x") == "50\\%\\_off\\\\x"
+
+
+def test_phone_shaped_queries_yield_their_digit_run():
+    assert _eom_directory_phone_search_digits("(217) 555-0100") == "2175550100"
+    assert _eom_directory_phone_search_digits("217.555") == "217555"
+
+
+def test_non_phone_shaped_queries_get_no_digit_fallback():
+    # An incidental digit run inside a name or email must never reach the
+    # phone comparison (the client-side search closed this in website #232).
+    assert _eom_directory_phone_search_digits("client2026@example.com") is None
+    assert _eom_directory_phone_search_digits("Suite 2026") is None
+
+
+def test_short_digit_runs_get_no_fallback():
+    assert _eom_directory_phone_search_digits("217") is None
+
+
+# ---------------------------------------------------------------------------
+# Real-Postgres proofs: the scope claims are only worth what the SQL does
+# ---------------------------------------------------------------------------
+
+
+def _database_url_or_skip() -> str:
+    database_url = os.environ.get(DATABASE_URL_ENV)
+    if not database_url:
+        pytest.skip(f"{DATABASE_URL_ENV} is not configured")
+    return database_url
+
+
+class _PoolAdapter:
+    def __init__(self, pool):
+        self._pool = pool
+        self.is_initialized = True
+
+    async def fetch(self, query, *args):
+        return await self._pool.fetch(query, *args)
+
+    async def fetchrow(self, query, *args):
+        return await self._pool.fetchrow(query, *args)
+
+    async def execute(self, query, *args):
+        return await self._pool.execute(query, *args)
+
+
+@pytest.fixture()
+async def _directory_provider():
+    """A DatabaseCRMProvider over a disposable schema with the contacts DDL."""
+    asyncpg = pytest.importorskip("asyncpg")
+    database_url = _database_url_or_skip()
+
+    from atlas_brain.services.crm_provider import DatabaseCRMProvider
+
+    schema = f"atlas_eom_contact_directory_{uuid.uuid4().hex}"
+    admin_conn = await asyncpg.connect(database_url)
+    pool = None
+    try:
+        await admin_conn.execute(f'CREATE SCHEMA "{schema}"')
+        await admin_conn.execute(f'SET search_path TO "{schema}", public')
+        for name in (
+            "001_initial_schema.sql",
+            "012_appointments.sql",
+            "030_call_transcripts.sql",
+            "035_contacts.sql",
+            "346_contact_lead_pipeline.sql",
+            "366_contacts_customer_type.sql",
+        ):
+            await admin_conn.execute((MIGRATIONS / name).read_text())
+
+        async def set_search_path(connection):
+            await connection.execute(f'SET search_path TO "{schema}", public')
+
+        pool = await asyncpg.create_pool(
+            database_url, min_size=1, max_size=2, setup=set_search_path
+        )
+        provider = DatabaseCRMProvider(pool=_PoolAdapter(pool))
+        yield provider, pool
+    finally:
+        if pool is not None:
+            await pool.close()
+        await admin_conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        await admin_conn.close()
+
+
+async def _seed(pool, **overrides):
+    fields = {
+        "full_name": "Seeded Contact",
+        "business_context_id": TENANT,
+        "contact_type": "customer",
+        "status": "active",
+        "email": None,
+        "phone": None,
+    }
+    fields.update(overrides)
+    row = await pool.fetchrow(
+        """
+        INSERT INTO contacts (full_name, business_context_id, contact_type,
+                              status, email, phone)
+        VALUES ($1, $2, $3, $4, $5, $6)
+        RETURNING id, created_at
+        """,
+        fields["full_name"],
+        fields["business_context_id"],
+        fields["contact_type"],
+        fields["status"],
+        fields["email"],
+        fields["phone"],
+    )
+    if "lead_stage" in overrides:
+        await pool.execute(
+            "UPDATE contacts SET lead_stage = $2 WHERE id = $1",
+            row["id"],
+            overrides["lead_stage"],
+        )
+    return row["id"]
+
+
+@pytest.mark.asyncio
+async def test_tenant_scope_and_lifecycle_hold_against_real_postgres(
+    _directory_provider,
+):
+    """Seeds every excluded neighbor beside every admitted one and asks for
+    the directory: an unscoped or status-blind query fails here."""
+    provider, pool = _directory_provider
+    eom_customer = await _seed(pool, full_name="EOM Customer")
+    eom_lead = await _seed(
+        pool, full_name="EOM Lead", contact_type="lead", lead_stage="new"
+    )
+    eom_lost_lead = await _seed(
+        pool, full_name="EOM Lost Lead", contact_type="lead", lead_stage="lost"
+    )
+    archived = await _seed(pool, full_name="EOM Archived", status="archived")
+    foreign = await _seed(
+        pool, full_name="Foreign Customer", business_context_id=FOREIGN_TENANT
+    )
+    vendor = await _seed(pool, full_name="EOM Vendor", contact_type="vendor")
+
+    rows = await provider.list_eom_contact_directory(limit=50)
+    ids = {row["contact_id"] for row in rows}
+
+    assert eom_customer in ids
+    assert eom_lead in ids
+    assert eom_lost_lead in ids, "a lost lead is DB-active and must stay findable"
+    assert archived not in ids, "archived rows are excluded in this slice"
+    assert foreign not in ids, "another tenant's contact must never appear"
+    assert vendor not in ids, "kinds outside lead/customer are not directory rows"
+    lost_row = next(row for row in rows if row["contact_id"] == eom_lost_lead)
+    assert lost_row["lead_stage"] == "lost"
+
+
+@pytest.mark.asyncio
+async def test_the_kind_filter_narrows_against_real_postgres(_directory_provider):
+    provider, pool = _directory_provider
+    customer = await _seed(pool, full_name="Only Customer")
+    lead = await _seed(
+        pool, full_name="Only Lead", contact_type="lead", lead_stage="new"
+    )
+
+    leads = await provider.list_eom_contact_directory(limit=50, kind="lead")
+    customers = await provider.list_eom_contact_directory(limit=50, kind="customer")
+
+    assert {row["contact_id"] for row in leads} == {lead}
+    assert {row["contact_id"] for row in customers} == {customer}
+
+
+@pytest.mark.asyncio
+async def test_search_matches_name_email_and_phone_against_real_postgres(
+    _directory_provider,
+):
+    provider, pool = _directory_provider
+    by_name = await _seed(pool, full_name="Ada Lovelace")
+    by_email = await _seed(pool, full_name="Email Row", email="unique.needle@example.test")
+    by_phone = await _seed(pool, full_name="Phone Row", phone="(217) 555-0142")
+    bystander = await _seed(pool, full_name="Bystander")
+
+    named = await provider.list_eom_contact_directory(limit=50, search="lovelace")
+    mailed = await provider.list_eom_contact_directory(limit=50, search="unique.needle")
+    dialed = await provider.list_eom_contact_directory(limit=50, search="2175550142")
+
+    assert {row["contact_id"] for row in named} == {by_name}
+    assert {row["contact_id"] for row in mailed} == {by_email}
+    assert {row["contact_id"] for row in dialed} == {by_phone}, (
+        "a digits-only query must match a formatted stored phone"
+    )
+    assert bystander not in {row["contact_id"] for row in named}
+
+
+@pytest.mark.asyncio
+async def test_a_like_metacharacter_searches_literally_against_real_postgres(
+    _directory_provider,
+):
+    provider, pool = _directory_provider
+    # A discriminating pair: unescaped, the pattern '%5%%' also matches
+    # 'Percent 55' (contains a 5 followed by anything); escaped, only the
+    # literal '5%' row can match. A pair the wildcard cannot reach would
+    # pass with or without escaping and prove nothing.
+    literal = await _seed(pool, full_name="Percent 5% Off")
+    wildcard_bait = await _seed(pool, full_name="Percent 55 Co")
+
+    rows = await provider.list_eom_contact_directory(limit=50, search="5%")
+
+    ids = {row["contact_id"] for row in rows}
+    assert literal in ids
+    assert wildcard_bait not in ids, "% must not act as a wildcard"
+
+
+@pytest.mark.asyncio
+async def test_keyset_traversal_neither_drops_nor_duplicates(_directory_provider):
+    """Walk the whole directory two rows at a time and require the union to be
+    exact -- an OFFSET or a mutable-column keyset fails this under skew, and a
+    broken tuple comparison fails it immediately."""
+    provider, pool = _directory_provider
+    seeded = set()
+    for index in range(5):
+        seeded.add(await _seed(pool, full_name=f"Page Contact {index}"))
+
+    collected: list[UUID] = []
+    cursor_created_at = None
+    cursor_contact_id = None
+    for _ in range(10):
+        rows = await provider.list_eom_contact_directory(
+            limit=2 + 1,
+            cursor_created_at=cursor_created_at,
+            cursor_contact_id=cursor_contact_id,
+        )
+        page = rows[:2]
+        collected.extend(row["contact_id"] for row in page)
+        if len(rows) <= 2:
+            break
+        cursor_created_at = page[-1]["created_at"]
+        cursor_contact_id = page[-1]["contact_id"]
+
+    assert len(collected) == len(set(collected)), "no row may repeat"
+    assert set(collected) == seeded, "no row may be dropped"
+
+
+@pytest.mark.asyncio
+async def test_directory_rows_carry_the_projection_columns(_directory_provider):
+    provider, pool = _directory_provider
+    await _seed(
+        pool,
+        full_name="Projection Row",
+        email="projection@example.test",
+        phone="2175550199",
+    )
+    rows = await provider.list_eom_contact_directory(limit=5)
+    row = rows[0]
+    assert set(row) == {
+        "contact_id",
+        "full_name",
+        "email",
+        "phone",
+        "address",
+        "contact_type",
+        "customer_type",
+        "lead_stage",
+        "status",
+        "source",
+        "created_at",
+        "updated_at",
+    }
+    assert row["customer_type"] == "unknown", "migration 366 default must surface"


### PR DESCRIPTION
Plan: plans/PR-EOM-Contact-Directory.md
Slice phase: Vertical slice
Ownership lane: eom-crm/contact-directory

An Atlas customer contact created or matched through the portal's Add Contact
form is unreachable from every portal surface after refresh (website #240,
Slice 3 of website #105): the operator mutation writes both contact kinds, but
the only funnel read admits stage-active leads, the tracker keeps no local
mirror by design, and the portal Customers tab reads tracker rows only. This
PR adds the missing canonical read -- an authenticated, tenant-scoped,
read-only GET /eom-funnel/contact-directory over active lead and customer
contacts, with a closed kind filter, bounded search, keyset pagination on
immutable (created_at, id), a closed camelCase projection, unknown-filter
rejection, and a contact.directory entry in the route-derived capability
manifest so the tracker gates its proxy on the registered method/path. The
/eom-funnel/leads contract is untouched.

Diff-budget override: the runtime change is ~280 LOC; the balance is the
mandatory plan doc and the test matrix (route closure, capability, negative
controls, six real-Postgres proofs). Splitting tests from route ships an
unproven admission boundary; splitting route from provider ships a dead route.

## Intentional

- Lost leads (lead_stage='lost', status still 'active') are included with
  their stage: the pipeline hides them by design and the directory is exactly
  where a pipeline-hidden record must remain findable.
- The pipeline read's latest-intake email/phone overlay is not reused; the
  directory reads canonical contact columns.
- The identity-matching digit SQL (extension-stripping + RIGHT-10) is not
  reused for search: identity needs exact-suffix semantics, search needs
  substring containment.
- Unknown query-parameter names are rejected on this route only; the pipeline
  read keeps FastAPI's tolerant default for its pre-existing callers.
- No new envelope fields on /eom-funnel/leads: the manifest already carries
  the capability name and route signature callers gate on.

## AI reconciliation

- Reject NUL before binding the search parameter -- fixed-in: atlas_brain/eom_api/funnel.py (NUL and lone surrogates 422 through the module's one surrogate choke point) + tests/test_eom_contact_directory.py::test_a_database_unrepresentable_search_fails_closed
- Include security and CI rules in the review contract -- fixed-in: plans/PR-EOM-Contact-Directory.md (Reviewer rules triggered now R1, R2, R3, R5, R12, R14, with the settling evidence named in the acceptance criteria)
- Exercise the deployed EOM application in the reachability test -- fixed-in: tests/test_eom_contact_directory.py::test_every_deployed_entrypoint_serves_the_route_at_its_path (exercises both atlas_brain.main:app, the live systemd topology, and atlas_brain.main_eom:app, the render.eom.yaml topology)
- Derive directory kinds from the canonical mutation set -- fixed-in: atlas_brain/eom_api/funnel.py and atlas_brain/services/crm_provider.py (route membership check and provider admission both read EOM_OPERATOR_CONTACT_TYPES; binding proven by tests/test_eom_contact_directory.py::test_the_directory_kind_set_is_derived_from_the_operator_boundary)

## Fix-loop disposition preflight

- Root decision: Reject NUL before binding the search parameter
- Blocking predicate: security
- Disposition: fixed-in
- Source Trace: authenticated directory read 500s when NUL reaches the asyncpg text parameter -> route search validation admitted database-unrepresentable text in atlas_brain/eom_api/funnel.py
- Upstream Files: `atlas_brain/eom_api/funnel.py`
- Fix Strategy: upstream-root
- Allowed files: `atlas_brain/eom_api/funnel.py`, `tests/test_eom_contact_directory.py`
- Max files: 6
- Parked hardening: none

- Root decision: Include security and CI rules in the review contract
- Blocking predicate: contract
- Disposition: fixed-in
- Source Trace: review completion could skip the security and CI probes this diff activates -> the Reviewer rules triggered line in plans/PR-EOM-Contact-Directory.md omitted R3 and R12
- Upstream Files: `plans/PR-EOM-Contact-Directory.md`
- Fix Strategy: upstream-root
- Allowed files: `plans/PR-EOM-Contact-Directory.md`, `.github/workflows/atlas_eom_lead_pipeline_checks.yml`
- Max files: 6
- Parked hardening: none

- Root decision: Exercise the deployed EOM application in the reachability test
- Blocking predicate: claimed-mechanism
- Disposition: fixed-in
- Source Trace: reachability proof stays green while the EOM deployment drops the route -> the test exercised only atlas_brain.main although render.eom.yaml starts atlas_brain.main_eom (tests/test_eom_contact_directory.py)
- Upstream Files: `tests/test_eom_contact_directory.py`
- Fix Strategy: upstream-root
- Allowed files: `tests/test_eom_contact_directory.py`, `plans/PR-EOM-Contact-Directory.md`
- Max files: 6
- Parked hardening: none

- Root decision: Derive directory kinds from the canonical mutation set
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Source Trace: a kind the write boundary admits later would be born write-only in the directory -> route and provider re-enumerated the kind set instead of reading EOM_OPERATOR_CONTACT_TYPES (atlas_brain/eom_api/funnel.py, atlas_brain/services/crm_provider.py)
- Upstream Files: `atlas_brain/eom_api/funnel.py`, `atlas_brain/services/crm_provider.py`
- Fix Strategy: upstream-root
- Allowed files: `atlas_brain/eom_api/funnel.py`, `atlas_brain/services/crm_provider.py`, `tests/test_eom_contact_directory.py`, `plans/PR-EOM-Contact-Directory.md`
- Max files: 6
- Parked hardening: none

## Deferred

- Archived-contact visibility (explicit include-archived view) belongs to the
  later archive/restore slice; the admission predicate and its Literal mirror
  widen together there.
- Search over interaction-derived contact info (the intake overlay) if
  operators report missing recall on web-form leads.

## Parked hardening

- None.

## Cold diff reconstruction

Changed: atlas_brain/services/crm_provider.py adds three module-level search
helpers (_EOM_DIRECTORY_* constants, _escape_eom_directory_like_pattern,
_eom_directory_phone_search_digits) and one read-only provider method
list_eom_contact_directory (tenant/status/kind predicates, escaped ILIKE
search with phone-digit fallback, keyset cursor, ORDER BY created_at DESC,
id DESC). atlas_brain/eom_api/funnel.py adds EOMContactDirectoryItem /
EOMContactDirectoryResponse (extra=forbid; status pinned Literal['active'];
contact_type/customer_type validated against the operator boundary's own
sets), _CONTACT_DIRECTORY_QUERY_PARAMS + _reject_unknown_contact_directory_filters,
the GET /contact-directory route (existing bearer + actor dependencies,
derived kind membership, NUL/surrogate search rejection through the module
choke point, limit+1 overfetch, lead-review cursor codec reuse), and the
"contact.directory" entry in _CAPABILITY_ROUTES. tests/test_eom_contact_directory.py
is new (36 tests, including the dual-entrypoint reachability proof). The atlas_eom_lead_pipeline_checks workflow enrolls the
new test file (paths x2 + pytest command). plans/PR-EOM-Contact-Directory.md
is the plan doc.

Contract match: every change maps to the plan's problem-derived contract --
the discovery read, its admission boundary, its capability advertisement, and
their proofs. No write path, no existing route, and no schema changed.

Gaps: none found on cold re-read.

## Verification

- 36 new tests pass, including six against real Postgres (disposable schema;
  public.contacts count and max(updated_at) byte-identical before and after;
  zero leftover test schemas) and two generated class-closure proofs for the
  search grammar (tokens x containers x families with a spec-derived oracle
  pinned independently of the implementation constants).
- Adjacent funnel suites stay green: capability manifest, link verification,
  and the full lead-conversion suite (284 tests total in the combined run).
- Negative controls each exercised locally (test failed, enforcement
  restored): tenant-scope condition removed; status='active' removed; LIKE
  escaping removed; derived kind membership check removed; unknown-parameter
  rejection removed.

## Mechanical verification

- Command: ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@localhost:5433/atlas python -m pytest tests/test_eom_contact_directory.py -q - Result: pass (36 passed) - Environment: local
- Command: ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@localhost:5433/atlas python -m pytest tests/test_eom_funnel_capability_manifest.py tests/test_eom_link_verification.py -q - Result: pass (28 passed) - Environment: local
- Command: python -m pytest tests/test_eom_lead_conversion.py -q - Result: pass (224 passed) - Environment: local
- Command: ruff check atlas_brain/eom_api/funnel.py atlas_brain/services/crm_provider.py tests/test_eom_contact_directory.py - Result: pass (all checks passed) - Environment: local
- Command: python -m py_compile atlas_brain/eom_api/funnel.py atlas_brain/services/crm_provider.py tests/test_eom_contact_directory.py - Result: pass (compiled) - Environment: local
- Command: python scripts/audit_plan_doc.py plans/PR-EOM-Contact-Directory.md - Result: pass (all sections OK) - Environment: local
- Command: python scripts/audit_review_rules_triggered.py origin/main --plan plans/PR-EOM-Contact-Directory.md - Result: pass (plan declares every triggered rule) - Environment: local

## Diff size

5 files, +1413 / -0

<!-- atlas-open-pr-wrapper: v1 -->
