### PR TITLE
Migration content integrity: read-only provenance preflight

### DIFF
--- a/.github/workflows/atlas_migrations_runner_checks.yml
+++ b/.github/workflows/atlas_migrations_runner_checks.yml
@@ -8,7 +8,9 @@ on:
     paths:
       - ".github/workflows/atlas_migrations_runner_checks.yml"
       - "atlas_brain/storage/migrations/**"
+      - "scripts/check_migration_content_integrity.py"
       - "tests/test_migrations_runner.py"
+      - "tests/test_migration_content_integrity_preflight.py"
       - "tests/test_eom_public_onboarding_migration_repair.py"
   push:
     branches:
@@ -16,7 +18,9 @@ on:
     paths:
       - ".github/workflows/atlas_migrations_runner_checks.yml"
       - "atlas_brain/storage/migrations/**"
+      - "scripts/check_migration_content_integrity.py"
       - "tests/test_migrations_runner.py"
+      - "tests/test_migration_content_integrity_preflight.py"
       - "tests/test_eom_public_onboarding_migration_repair.py"
 
 jobs:
@@ -59,5 +63,6 @@ jobs:
         run: |
           python -m pytest \
             tests/test_migrations_runner.py \
+            tests/test_migration_content_integrity_preflight.py \
             tests/test_eom_public_onboarding_migration_repair.py \
             -q

--- a/atlas_brain/storage/migrations/__init__.py
+++ b/atlas_brain/storage/migrations/__init__.py
@@ -150,7 +150,7 @@ def _migration_content_sha256(source: bytes) -> str:
     return hashlib.sha256(source).hexdigest()
 
 
-async def _migration_content_integrity_report(
+async def migration_content_integrity_report(
     executor,
     migration_files: Collection[Path],
 ) -> MigrationContentIntegrityReport:
@@ -195,6 +195,14 @@ async def _migration_content_integrity_report(
         mismatched=tuple(sorted(mismatched)),
         missing_source=tuple(sorted(missing_source)),
     )
+
+
+async def _migration_content_integrity_report(
+    executor,
+    migration_files: Collection[Path],
+) -> MigrationContentIntegrityReport:
+    """Backward-compatible internal alias for the canonical read-only report."""
+    return await migration_content_integrity_report(executor, migration_files)
 
 
 def _log_migration_content_integrity(report: MigrationContentIntegrityReport) -> None:
@@ -560,7 +568,7 @@ async def run_migrations(
 
             migration_files = sorted(directory.glob("*.sql"))
             _log_migration_content_integrity(
-                await _migration_content_integrity_report(conn, migration_files)
+                await migration_content_integrity_report(conn, migration_files)
             )
             if only is not None:
                 requested = set(only)

--- a/plans/PR-EOM-Migration-Content-Preflight.md
+++ b/plans/PR-EOM-Migration-Content-Preflight.md
@@ -1,0 +1,270 @@
+# PR-EOM-Migration-Content-Preflight
+
+## Why this slice exists
+
+H-18 in [ATLAS #2363](https://github.com/canfieldjuan/ATLAS/issues/2363)
+records the financial-provider deployment failure mode where a filename-recorded
+migration can conceal changed source bytes. Phase one ([#2447](https://github.com/canfieldjuan/ATLAS/pull/2447)) correctly stores identities for newly applied migrations and classifies legacy, mismatched, and missing-source rows, but its classifier is reachable only through the write-capable migration runner.
+
+The production checkpoint for [#2452](https://github.com/canfieldjuan/ATLAS/pull/2452)
+then established the first real H-18 evidence case: migration 387 has a
+historical digest/timestamp discrepancy, while the final catalog/readiness
+predicate proves its required schema is currently present. An operator needs a
+safe way to inspect that discrepancy before a future migration-bearing cutover.
+Calling `run_migrations()` as an inspection tool is not safe: it evolves the
+ledger bootstrap and can apply pending SQL.
+
+This is Slice 1 of [#2461](https://github.com/canfieldjuan/ATLAS/issues/2461):
+read-only provenance preflight. It is production hardening justified by a real
+financial-provider migration incident, not a new billing behavior or a generic
+CI/process slice.
+
+**Diff-budget exception:** the expected 700-plus-line diff includes the
+indivisible plan/contract, one small no-write CLI, failure-branch fixtures that
+prove its nonzero, redaction, read-only, and target-confirmation behavior, and
+CI enrollment. Splitting the checker from the tests or enrollment would violate
+the repository's checker-fixture/CI requirements; no unrelated refactor is
+included.
+
+### Problem-derived contract
+
+- Root cause: the only migration-content classifier is invoked inside
+  `run_migrations()`. That entrypoint first performs DDL bootstrap and may run
+  pending migration SQL, so it cannot be used as a no-mutation production
+  provenance check. The current runtime therefore has no canonical
+  operator-facing way to distinguish verified, legacy-unverified, mismatched,
+  and missing-source ledger evidence before a cutover.
+- Correct fix must touch/change: promote the existing classifier to one
+  canonical reusable helper without changing its classifications; add a
+  standalone `scripts/check_migration_content_integrity.py` entrypoint that
+  connects through the existing typed Atlas database settings, wraps the query
+  in a read-only transaction, emits deterministic redacted JSON, and returns a
+  nonzero status only for unresolved mismatch/missing-source evidence or an
+  unavailable check. Add failure-branch tests and enroll them in the existing
+  migration-runner workflow.
+- Must not change: historical migration SQL or `schema_migrations` rows;
+  pending migration selection, runner startup behavior, source-hash recording,
+  runtime service units, financial records, invoices, payments, Gmail, Square,
+  #2034's generic collision investigation, or #2035's branch-protection/CI
+  policy.
+
+### Contract revision
+
+- New evidence: the existing typed database configuration defaults to
+  `localhost:5433/atlas` when no deployed `ATLAS_DB_*` value is present
+  (`atlas_brain/storage/config.py:25-52,77-131`). A no-argument preflight
+  could therefore return a truthful report for the wrong local database and be
+  misread as a production cutover receipt.
+- Revised root cause: besides lacking a standalone no-write classifier path,
+  the first draft lacked an explicit operator-to-config target binding.
+- Revised required change surface: the CLI must expose the log-safe current
+  `db_settings.target_label`, require an exact `--expected-target` before it
+  opens a connection, include that label in the emitted receipt, and return the
+  existing unavailable exit code before any database query when the expected
+  target is absent or different. Tests must prove matching, absent, and
+  mismatched target paths.
+- Revised explicit non-scope: connection target confirmation is limited to the
+  existing log-safe typed configuration label. It does not add a DSN argument,
+  invent a second connection configuration source, prove cluster identity, or
+  change application/runtime configuration.
+- Revised assumptions/blockers: the label is an operator confirmation guard,
+  not cryptographic database identity. The next H-18 reconciliation/enforcement
+  slices remain responsible for durable policy after the preflight reports.
+- Revised verification plan: add focused CLI tests showing no connection is
+  attempted for an absent or mismatched target, and that only a matching label
+  reaches the async preflight.
+
+## Scope (this PR)
+
+Ownership lane: eom/migration-content-integrity
+Slice phase: Production hardening
+Max files: 5
+
+1. Expose the phase-one content-integrity classifier as the migration module's
+   canonical reusable read function while retaining the existing internal name
+   as a compatibility alias; the runner retains its current diagnostic
+   behavior.
+2. Add a read-only operator preflight command. It uses the existing typed
+   `ATLAS_DB_*` configuration, creates no schema object, executes no migration
+   SQL, and runs its catalog query inside an asyncpg read-only transaction. The
+   command exposes a log-safe configured-target label and requires an exact
+   `--expected-target` confirmation before connecting.
+3. Emit only classification names/counts and generic error class information:
+   no connection string, credentials, SQL text, invoice data, or customer data.
+   A mismatch or missing source returns exit code 2; an unavailable preflight
+   returns exit code 3; legacy-unverified evidence remains visible but retains
+   phase one's observe-only exit behavior.
+4. Add focused behavior tests and enroll the new test file in
+   `.github/workflows/atlas_migrations_runner_checks.yml`.
+
+### Review Contract
+
+- Acceptance criteria:
+  1. `scripts/check_migration_content_integrity.py` calls the exact migration
+     content classifier through a read-only transaction and does not invoke
+     `execute`, `_ensure_migrations_table`, or `run_migrations`; settled by
+     `tests/test_migration_content_integrity_preflight.py` fake connection
+     state and source inspection.
+  2. A verified row, a readable null-digest legacy row, a mismatched row, and
+     a missing-source row appear under their exact stable JSON keys; a
+     mismatch/missing-source result exits 2; settled by
+     `tests/test_migration_content_integrity_preflight.py::test_preflight_reports_unresolved_drift_without_writes`.
+  3. A legacy-only report remains explicit but exits 0 under phase one's
+     observe-only policy; settled by
+     `tests/test_migration_content_integrity_preflight.py::test_preflight_keeps_legacy_evidence_visible_without_treating_it_as_drift`.
+  4. A connection/classification failure exits 3 with a generic error class
+     rather than an exception message or DSN; settled by
+     `tests/test_migration_content_integrity_preflight.py::test_main_redacts_database_failure_details`.
+  5. The migration workflow runs the new test file on changes to the script or
+     test; settled by `.github/workflows/atlas_migrations_runner_checks.yml`
+     and its current-head GitHub job.
+  6. The real CLI does not open a connection for an absent or mismatched
+     expected target, and a matching log-safe label is included in the receipt;
+     settled by target-confirmation tests in
+     `tests/test_migration_content_integrity_preflight.py`.
+- Reachability proof: executing the script's real async entrypoint against an
+  isolated fake external database connection returns JSON plus its documented
+  process status; no HTTP or customer-facing surface is added.
+- Affected surfaces: migration-content classifier utility, one operator CLI,
+  its focused tests, and the migration-runner CI workflow.
+- Risk areas: migration source truthfulness, read-only database safety,
+  historical ledger availability, secret redaction, CI enrollment, and
+  backward-compatible runner diagnostics.
+- Reviewer rules triggered: R1, R2, R4, R5, R6, R10, R12, and R14.
+
+### Boundary-change enumeration
+
+- Boundary path/seam: the new CLI binds an operator-provided
+  `--expected-target` to the existing `db_settings.target_label` before it
+  opens a database connection; after that admission, the existing closed-set
+  content classifier maps its four categories to the documented receipt and
+  exit status.
+- Replaced-path behaviors: no production caller is replaced. `run_migrations()`
+  retains its diagnostic behavior; the new operator path replaces unsafe use of
+  that write-capable runner as an inspection command.
+- Guard-relevant fields: the non-secret configured target label, expected
+  target label, connection availability, and existing `verified`,
+  `legacy_unverified`, `mismatched`, and `missing_source` category values.
+  Absent/mismatched target and unavailable connection default to exit 3 before
+  the catalog query; mismatch/missing source default to exit 2; legacy evidence
+  remains explicit but observe-only under phase one's policy.
+- Caller x input shape: `--show-target` returns the log-safe label without a
+  connection; absent/mismatched `--expected-target` is rejected before any
+  connection; an exact label executes one read-only catalog query against the
+  packaged SQL catalog.
+
+### Guard class-closure declaration
+
+- The classifier input set is closed per invocation: migration source members
+  come only from `sorted(MIGRATIONS_DIR.glob("*.sql"))`, and ledger members come
+  only from the one `schema_migrations` query. The command accepts no caller
+  supplied migration names, digest values, or SQL.
+- The target admission input is a single exact equality comparison against the
+  repository's existing log-safe typed configuration label. Any absent,
+  unmatched, or unavailable value fails before a query. The tests exercise both
+  error directions: a matching label reaches the preflight and a mismatched or
+  absent label does not.
+
+### Deployed-config probing
+
+The command introduces no new setting or fallback. It reuses the existing typed
+`atlas_brain.storage.config.db_settings` and requires the operator to bind the
+non-secret `db_settings.target_label` explicitly before any query.
+
+- Deployed/default config values: `DatabaseConfig` is the existing
+  `ATLAS_DB_*` authority; its effective deployed target is deliberately exposed
+  only as `target_label`, never as a DSN or credential.
+- Explicit value probe: an exact `--expected-target` reaches the read-only
+  preflight and returns that label in JSON.
+- Absent value probe: argparse rejects a preflight without
+  `--expected-target` (except the no-query `--show-target` command).
+- Default-session/default-context probe: the current typed default label is
+  treated like any other label; only an exact explicit confirmation admits a
+  query.
+- Side-effect ordering: target admission completes before `_connect_read_only`;
+  the catalog query itself is inside `readonly=True` transaction.
+
+### Files touched
+
+- `.github/workflows/atlas_migrations_runner_checks.yml`
+- `atlas_brain/storage/migrations/__init__.py`
+- `plans/PR-EOM-Migration-Content-Preflight.md`
+- `scripts/check_migration_content_integrity.py`
+- `tests/test_migration_content_integrity_preflight.py`
+
+## Mechanism
+
+`MigrationContentIntegrityReport` remains the source of classification truth.
+The module's canonical helper receives the actual migration catalog plus a
+database executor and only reads `schema_migrations`; the former private helper
+continues delegating to it so the existing runner behavior and direct tests stay
+compatible.
+
+The script obtains the already configured database connection target through
+`db_settings`. `--show-target` displays its log-safe label without connecting;
+the query path requires a matching `--expected-target`, then establishes a
+dedicated connection and opens
+`connection.transaction(readonly=True)` before invoking that canonical helper.
+It never imports or calls `run_migrations()`. Its payload contains sorted names
+in the existing four categories and a status. `mismatched` or
+`missing_source` is `unresolved_drift` / exit 2; a connection or catalog error
+is `could_not_determine` / exit 3; a legacy-only result stays visibly
+`legacy_unverified` but exits 0 because this phase deliberately does not yet
+block a deployment.
+
+## Intentional
+
+- This slice does not fail application startup or alter pending migration
+  selection. The current production 387 mismatch is real; applying a global
+  fail-closed rule before an explicit reconciliation path exists would make
+  ordinary migration-bearing deployments unavailable.
+- The preflight does not offer a `--database-url` argument, avoiding DSNs on
+  process listings and keeping it on the existing typed Atlas configuration
+  boundary. It also does not load a `.env` itself.
+- It requires a non-secret target confirmation instead of silently trusting
+  fallback database defaults. This reduces wrong-environment receipts without
+  pretending that host/database naming is a cryptographic cluster identity.
+- Legacy null digests remain an explicit observation rather than a failure
+  because phase one deliberately preserved those historical rows and did not
+  prove their source bytes. This script must not relabel them as verified.
+- The command reuses the one phase-one classifier rather than copying its
+  categories into a second reporting implementation.
+
+## Deferred
+
+Parking predicate: historical-source reconstruction, any mutation of a
+recorded ledger row, policy that blocks a new migration, rollback automation,
+and parser expansion for dynamic self-recording SQL are parked unless they are
+required to make this read-only preflight truthful.
+
+- #2461 Slice 2: a separately reviewed, additive reconciliation-evidence model
+  for the known 387 discrepancy. It must preserve the source mismatch and
+  attach catalog/readiness proof rather than claim historical-byte verification.
+- #2461 Slice 3: pending-migration admission policy plus documented rollout,
+  rollback, and recovery after an explicit reconciliation record exists.
+- #2461 Slice 4: dynamic self-recording migration authoring policy; retain the
+  existing `-- atlas: atomic-bookkeeping` marker until then.
+- #2034 remains a non-overlapping investigation-only issue; this PR does not
+  change its semantic reservation/drift audit. #2035 remains the owner of
+  branch-protection policy; this PR only enrolls its own focused test.
+
+Parked hardening: none against the stated predicate.
+
+## Verification
+
+- Fast local checks planned: `python -m py_compile
+  atlas_brain/storage/migrations/__init__.py
+  scripts/check_migration_content_integrity.py`, then the focused pytest file.
+- GitHub: `Atlas Migrations Runner Checks` executes the new focused test on the
+  exact PR head. No full test suite is duplicated locally.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_migrations_runner_checks.yml` | 5 |
+| `atlas_brain/storage/migrations/__init__.py` | 12 |
+| `plans/PR-EOM-Migration-Content-Preflight.md` | 270 |
+| `scripts/check_migration_content_integrity.py` | 198 |
+| `tests/test_migration_content_integrity_preflight.py` | 248 |
+| **Total** | **733** |

--- a/scripts/check_migration_content_integrity.py
+++ b/scripts/check_migration_content_integrity.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Inspect Atlas migration-source provenance without mutating the database.
+
+Run this from the exact Atlas release-candidate worktree before a
+migration-bearing cutover. It reads the configured Atlas database target through
+the existing typed `ATLAS_DB_*` settings and emits JSON only. It never invokes
+the migration runner, evolves `schema_migrations`, or executes migration SQL.
+
+Exit status:
+  0: the configured target was displayed, or the check completed without
+     mismatched or missing-source evidence.
+     Legacy null hashes remain explicitly visible as `legacy_unverified`.
+  2: mismatched or missing-source evidence requires reconciliation.
+  3: the check could not determine the state (for example, connection failure).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from atlas_brain.storage.config import db_settings  # noqa: E402
+from atlas_brain.storage.migrations import (  # noqa: E402
+    MIGRATIONS_DIR,
+    MigrationContentIntegrityReport,
+    migration_content_integrity_report,
+)
+
+
+UNRESOLVED_DRIFT_EXIT = 2
+COULD_NOT_DETERMINE_EXIT = 3
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    target_group = parser.add_mutually_exclusive_group()
+    target_group.add_argument(
+        "--show-target",
+        action="store_true",
+        help="Print the configured log-safe target label without connecting.",
+    )
+    target_group.add_argument(
+        "--expected-target",
+        help="Exact log-safe target label required before the catalog query runs.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Accepted for operator consistency; output is always JSON.",
+    )
+    return parser.parse_args(argv)
+
+
+def _status(report: MigrationContentIntegrityReport) -> tuple[str, int]:
+    if report.mismatched or report.missing_source:
+        return "unresolved_drift", UNRESOLVED_DRIFT_EXIT
+    if report.legacy_unverified:
+        return "legacy_unverified", 0
+    return "verified", 0
+
+
+def _report_payload(report: MigrationContentIntegrityReport) -> tuple[int, dict[str, object]]:
+    status, exit_code = _status(report)
+    categories = {
+        "verified": list(report.verified),
+        "legacy_unverified": list(report.legacy_unverified),
+        "mismatched": list(report.mismatched),
+        "missing_source": list(report.missing_source),
+    }
+    return exit_code, {
+        "check_completed": True,
+        "status": status,
+        "exit_code": exit_code,
+        "report": categories,
+        "counts": {name: len(values) for name, values in categories.items()},
+    }
+
+
+def _failure_payload(exc: Exception) -> dict[str, object]:
+    """Return diagnosable failure metadata without leaking connection details."""
+    return {
+        "check_completed": False,
+        "status": "could_not_determine",
+        "exit_code": COULD_NOT_DETERMINE_EXIT,
+        "error_type": exc.__class__.__name__,
+    }
+
+
+def _target_confirmation_payload(
+    *,
+    target_label: str,
+    status: str,
+) -> dict[str, object]:
+    return {
+        "check_completed": False,
+        "status": status,
+        "exit_code": COULD_NOT_DETERMINE_EXIT,
+        "database_target": target_label,
+    }
+
+
+async def _connect_read_only() -> Any:
+    if not db_settings.enabled:
+        raise RuntimeError("Atlas database persistence is disabled")
+    try:
+        import asyncpg
+    except ImportError as exc:  # pragma: no cover - host dependency
+        raise RuntimeError("asyncpg is required for the migration integrity preflight") from exc
+
+    connection_kwargs = dict(db_settings.connection_kwargs())
+    existing_settings = connection_kwargs.get("server_settings")
+    server_settings = dict(existing_settings) if isinstance(existing_settings, Mapping) else {}
+    server_settings["default_transaction_read_only"] = "on"
+    connection_kwargs["server_settings"] = server_settings
+    return await asyncpg.connect(**connection_kwargs)
+
+
+async def run_migration_content_integrity_preflight(
+    connection: Any,
+    *,
+    migrations_dir: Path = MIGRATIONS_DIR,
+) -> tuple[int, dict[str, object]]:
+    """Read the packaged catalog and ledger in a transaction that rejects writes."""
+    migration_files = sorted(migrations_dir.glob("*.sql"))
+    async with connection.transaction(readonly=True):
+        report = await migration_content_integrity_report(connection, migration_files)
+    return _report_payload(report)
+
+
+async def _main(
+    *,
+    migrations_dir: Path = MIGRATIONS_DIR,
+    database_target: str | None = None,
+) -> int:
+    connection: Any | None = None
+    exit_code = COULD_NOT_DETERMINE_EXIT
+    payload: dict[str, object]
+    target_label = db_settings.target_label if database_target is None else database_target
+    try:
+        connection = await _connect_read_only()
+        exit_code, payload = await run_migration_content_integrity_preflight(
+            connection,
+            migrations_dir=migrations_dir,
+        )
+    except Exception as exc:
+        payload = _failure_payload(exc)
+    finally:
+        if connection is not None:
+            try:
+                await connection.close()
+            except Exception as exc:
+                if exit_code == 0:
+                    exit_code = COULD_NOT_DETERMINE_EXIT
+                    payload = _failure_payload(exc)
+    payload["database_target"] = target_label
+    print(json.dumps(payload, sort_keys=True))
+    return exit_code
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    target_label = db_settings.target_label
+    if args.show_target:
+        print(json.dumps({"database_target": target_label, "status": "target_displayed"}, sort_keys=True))
+        return 0
+    if args.expected_target is None:
+        print(json.dumps(
+            _target_confirmation_payload(
+                target_label=target_label,
+                status="target_confirmation_required",
+            ),
+            sort_keys=True,
+        ))
+        return COULD_NOT_DETERMINE_EXIT
+    if args.expected_target != target_label:
+        print(json.dumps(
+            _target_confirmation_payload(
+                target_label=target_label,
+                status="target_confirmation_mismatch",
+            ),
+            sort_keys=True,
+        ))
+        return COULD_NOT_DETERMINE_EXIT
+    return asyncio.run(_main(database_target=target_label))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_migration_content_integrity_preflight.py
+++ b/tests/test_migration_content_integrity_preflight.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = ROOT / "scripts" / "check_migration_content_integrity.py"
+SPEC = importlib.util.spec_from_file_location("check_migration_content_integrity", SCRIPT)
+module = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+sys.modules[SPEC.name] = module
+SPEC.loader.exec_module(module)
+
+
+class FakeReadOnlyTransaction:
+    def __init__(self, connection: "FakeConnection", readonly: bool):
+        self.connection = connection
+        self.readonly = readonly
+
+    async def __aenter__(self) -> "FakeReadOnlyTransaction":
+        self.connection.transaction_readonly.append(self.readonly)
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback) -> None:
+        return None
+
+
+class FakeConnection:
+    def __init__(self, records: list[tuple[str, str | None]]):
+        self.records = records
+        self.queries: list[str] = []
+        self.transaction_readonly: list[bool] = []
+        self.execute_calls: list[str] = []
+        self.closed = False
+
+    def transaction(self, *, readonly: bool = False) -> FakeReadOnlyTransaction:
+        return FakeReadOnlyTransaction(self, readonly)
+
+    async def fetch(self, query: str):
+        self.queries.append(query)
+        assert query == "SELECT name, content_sha256 FROM schema_migrations"
+        return [
+            {"name": name, "content_sha256": content_sha256}
+            for name, content_sha256 in self.records
+        ]
+
+    async def execute(self, query: str, *args) -> None:
+        self.execute_calls.append(query)
+        raise AssertionError("read-only provenance preflight must not execute SQL")
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _write_migration(directory: Path, name: str, content: bytes) -> Path:
+    path = directory / f"{name}.sql"
+    path.write_bytes(content)
+    return path
+
+
+@pytest.mark.asyncio
+async def test_preflight_reports_unresolved_drift_without_writes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    verified = _write_migration(tmp_path, "900_verified", b"SELECT 'verified';\n")
+    _write_migration(tmp_path, "901_legacy", b"SELECT 'legacy';\n")
+    _write_migration(tmp_path, "902_mismatched", b"SELECT 'mismatched';\n")
+    connection = FakeConnection([
+        ("900_verified", hashlib.sha256(verified.read_bytes()).hexdigest()),
+        ("901_legacy", None),
+        ("902_mismatched", "not-the-current-digest"),
+        ("903_missing_source", "f" * 64),
+    ])
+
+    async def connect_read_only() -> FakeConnection:
+        return connection
+
+    monkeypatch.setattr(module, "_connect_read_only", connect_read_only)
+
+    code = await module._main(migrations_dir=tmp_path)
+
+    payload = json.loads(capsys.readouterr().out)
+    assert code == module.UNRESOLVED_DRIFT_EXIT
+    assert payload == {
+        "check_completed": True,
+        "counts": {
+            "legacy_unverified": 1,
+            "mismatched": 1,
+            "missing_source": 1,
+            "verified": 1,
+        },
+        "database_target": module.db_settings.target_label,
+        "exit_code": module.UNRESOLVED_DRIFT_EXIT,
+        "report": {
+            "legacy_unverified": ["901_legacy"],
+            "mismatched": ["902_mismatched"],
+            "missing_source": ["903_missing_source"],
+            "verified": ["900_verified"],
+        },
+        "status": "unresolved_drift",
+    }
+    assert connection.queries == ["SELECT name, content_sha256 FROM schema_migrations"]
+    assert connection.transaction_readonly == [True]
+    assert connection.execute_calls == []
+    assert connection.closed is True
+
+
+@pytest.mark.asyncio
+async def test_preflight_keeps_legacy_evidence_visible_without_treating_it_as_drift(
+    tmp_path: Path,
+) -> None:
+    _write_migration(tmp_path, "901_legacy", b"SELECT 'legacy';\n")
+    connection = FakeConnection([("901_legacy", None)])
+
+    code, payload = await module.run_migration_content_integrity_preflight(
+        connection,
+        migrations_dir=tmp_path,
+    )
+
+    assert code == 0
+    assert payload["status"] == "legacy_unverified"
+    assert payload["report"] == {
+        "verified": [],
+        "legacy_unverified": ["901_legacy"],
+        "mismatched": [],
+        "missing_source": [],
+    }
+    assert connection.transaction_readonly == [True]
+    assert connection.execute_calls == []
+
+
+@pytest.mark.asyncio
+async def test_main_redacts_database_failure_details(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    async def connect_read_only() -> FakeConnection:
+        raise RuntimeError("connection details must not appear in preflight output")
+
+    monkeypatch.setattr(module, "_connect_read_only", connect_read_only)
+
+    code = await module._main()
+
+    output = capsys.readouterr().out
+    payload = json.loads(output)
+    assert code == module.COULD_NOT_DETERMINE_EXIT
+    assert payload == {
+        "check_completed": False,
+        "database_target": module.db_settings.target_label,
+        "error_type": "RuntimeError",
+        "exit_code": module.COULD_NOT_DETERMINE_EXIT,
+        "status": "could_not_determine",
+    }
+    assert "connection details" not in output
+
+
+@pytest.mark.asyncio
+async def test_connection_defaults_to_read_only_without_printing_connection_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_kwargs: dict[str, object] = {}
+    sentinel = object()
+
+    async def connect(**kwargs):
+        captured_kwargs.update(kwargs)
+        return sentinel
+
+    monkeypatch.setitem(sys.modules, "asyncpg", types.SimpleNamespace(connect=connect))
+
+    connection = await module._connect_read_only()
+
+    assert connection is sentinel
+    server_settings = captured_kwargs["server_settings"]
+    assert isinstance(server_settings, dict)
+    assert server_settings["default_transaction_read_only"] == "on"
+
+
+def test_main_displays_the_safe_target_without_opening_a_connection(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    async def should_not_connect() -> FakeConnection:
+        raise AssertionError("--show-target must not connect")
+
+    monkeypatch.setattr(module, "_connect_read_only", should_not_connect)
+
+    code = module.main(["--show-target"])
+
+    assert code == 0
+    assert json.loads(capsys.readouterr().out) == {
+        "database_target": module.db_settings.target_label,
+        "status": "target_displayed",
+    }
+
+
+@pytest.mark.parametrize(
+    ("argv", "status"),
+    [
+        ([], "target_confirmation_required"),
+        (["--expected-target", "other-safe-target"], "target_confirmation_mismatch"),
+    ],
+)
+def test_main_rejects_unconfirmed_or_mismatched_target_before_connection(
+    argv: list[str],
+    status: str,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    async def should_not_connect() -> FakeConnection:
+        raise AssertionError("target admission must happen before connection")
+
+    monkeypatch.setattr(module, "_connect_read_only", should_not_connect)
+
+    code = module.main(argv)
+
+    assert code == module.COULD_NOT_DETERMINE_EXIT
+    assert json.loads(capsys.readouterr().out) == {
+        "check_completed": False,
+        "database_target": module.db_settings.target_label,
+        "exit_code": module.COULD_NOT_DETERMINE_EXIT,
+        "status": status,
+    }
+
+
+def test_main_passes_a_matching_target_to_the_async_preflight(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: list[str] = []
+
+    async def fake_main(*, database_target: str) -> int:
+        observed.append(database_target)
+        return 0
+
+    monkeypatch.setattr(module, "_main", fake_main)
+
+    code = module.main(["--expected-target", module.db_settings.target_label])
+
+    assert code == 0
+    assert observed == [module.db_settings.target_label]


### PR DESCRIPTION
Plan: plans/PR-EOM-Migration-Content-Preflight.md
Slice phase: Production hardening
Ownership lane: eom/migration-content-integrity

H-18 phase one can classify migration-source evidence, but only from the
write-capable migration runner. This adds the first H-18 phase-two slice: a
target-confirmed, read-only operator preflight for #2461. It is deliberately
non-mutating and does not alter current startup/migration admission behavior.

## Intentional

- The CLI requires a matching non-secret configured target label before it opens
  a database connection; `--show-target` is a no-connection discovery path.
- Mismatch/missing-source evidence exits 2. Legacy null digests remain visible
  but observe-only until H-18 has an explicit reconciliation mechanism.
- No historical ledger row, migration SQL file, invoice, payment, Gmail, Square,
  runtime unit, #2034 drift audit, or #2035 branch-protection policy is changed.

## AI reconciliation

- no-findings

## Deferred

- #2461 Slice 2: immutable historical reconciliation evidence for the known
  migration-387 discrepancy; never relabel unavailable source bytes as verified.
- #2461 Slice 3: pending-migration admission policy with rollout, rollback, and
  recovery instructions after reconciliation exists.
- #2461 Slice 4: dynamic self-recording SQL authoring policy; retain the
  existing atomic-bookkeeping marker until then.

## Parked hardening

- None against the plan's parking predicate. #2034 and #2035 were considered
  and remain explicitly out of this ownership lane.

## Cold diff reconstruction

- Changed: `atlas_brain/storage/migrations/__init__.py` promotes the existing
  read-only classifier to the canonical helper while preserving the private
  alias and runner diagnostic behavior.
- Changed: `scripts/check_migration_content_integrity.py` runs that classifier
  only after exact target confirmation, on a default-read-only connection and
  `readonly=True` transaction; it emits redacted JSON and documented statuses.
- Changed: `tests/test_migration_content_integrity_preflight.py` proves four
  classification categories, no `execute`, read-only transaction use, error
  redaction, and target admission before connection.
- Changed: `.github/workflows/atlas_migrations_runner_checks.yml` enrolls the
  script/test paths and runs the new fixture suite.
- Changed: `plans/PR-EOM-Migration-Content-Preflight.md` records the root
  cause, scope, target-confirmation contract revision, non-scope, and recovery
  sequencing.
- Contract match: every changed file is named in the plan's Files touched and
  traces to the standalone no-write preflight contract.
- Gaps: none found in the staged diff.

## Verification

- `git diff --check` + `python -m py_compile atlas_brain/storage/migrations/__init__.py scripts/check_migration_content_integrity.py` — passed locally.
- `python -m pytest -q tests/test_migration_content_integrity_preflight.py tests/test_migrations_runner.py` — 58 passed, 1 skipped locally.
- `python scripts/check_guard_class_closure.py --base origin/main --strict` — passed (advisory lint: no guard-shaped change without a property test).
- `python scripts/check_deployed_config_probing.py --base origin/main --strict` — passed (advisory lint).
- `bash scripts/check_ascii_python.sh` — passed.
- `python scripts/check_migration_content_integrity.py --show-target` — passed locally; displayed only the default worktree's log-safe target label and opened no database connection.
- Broad migration/onboarding suite: intentionally not duplicated locally; GitHub `Atlas Migrations Runner Checks` is enrolled for this exact head.

## Mechanical verification

- Command: `python scripts/sync_pr_plan.py plans/PR-EOM-Migration-Content-Preflight.md origin/main --check` - Result: pass - Environment: local
- Command: `git diff --check` - Result: pass - Environment: local
- Skipped: wrapper-managed local full unit gate - Reason: this workflow edit
  escalates the repository wrapper from its fast mechanical checks to the full
  suite. Per operator instruction, it was stopped before publication; the
  focused migration tests and all earlier mechanical checks passed, and broad
  runner/onboarding coverage is delegated to GitHub.
- Skipped: production preflight - Reason: no live database, financial record,
  or deployment state is used for this PR.

## Diff size

5 files, +731 / -2

Diff-budget override: This five-file, 731-line slice is genuinely indivisible because the no-write preflight, its regression tests, CI path enrollment, and binding plan contract must ship together; omitting any of them removes either the safety proof or GitHub enforcement.

<!-- atlas-open-pr-wrapper: v1 -->
