### PR TITLE
Advertise contact.field_clear and audit cleared_fields on the operator mutation

### DIFF
--- a/atlas_brain/eom_api/funnel.py
+++ b/atlas_brain/eom_api/funnel.py
@@ -720,6 +720,14 @@ _CAPABILITY_ROUTES: dict[str, tuple[str, str]] = {
     ),
     "lead.customer_handoff": ("POST", "/eom-funnel/customer-handoffs"),
     "contact.operator_mutation": ("POST", "/eom-funnel/operator-contacts"),
+    # Same route as contact.operator_mutation ON PURPOSE: this name versions
+    # the route's SEMANTICS, not its existence. A build advertises it only by
+    # shipping this dict entry, which lands together with the audited
+    # null-clear contract (present-null clears email/phone, cleared_fields in
+    # the lifecycle event). A caller must not infer null semantics from the
+    # mutation route existing -- an older build serves the same route without
+    # them -- so the tracker gates field-clearing on THIS name + route pair.
+    "contact.field_clear": ("POST", "/eom-funnel/operator-contacts"),
     "lead.lost": ("POST", "/eom-funnel/leads/{contact_id}/lost"),
     "lead.reopen": ("POST", "/eom-funnel/leads/{contact_id}/reopen"),
     "onboarding.draft.list": ("GET", "/eom-funnel/onboarding-drafts"),

--- a/atlas_brain/services/crm_provider.py
+++ b/atlas_brain/services/crm_provider.py
@@ -1651,6 +1651,16 @@ class DatabaseCRMProvider:
                 metadata["previous_values"] = {
                     key: previous.get(key) for key in changed
                 }
+                # Field NAMES only -- deliberately no new_values map. The new
+                # value already lives on the contact row (and becomes the next
+                # event's previous_values if edited again), so copying it here
+                # would duplicate PII into the audit stream for no recovery
+                # benefit. With this key the event alone distinguishes all
+                # three operator intents: OMITTED = absent from changed_fields,
+                # CLEARED = listed here, CHANGED = changed_fields minus this.
+                metadata["cleared_fields"] = sorted(
+                    key for key in changed if contact.get(key) is None
+                )
             await conn.execute(
                 """
                 INSERT INTO eom_lead_lifecycle_events (

--- a/plans/PR-EOM-Contact-Field-Clear-Contract.md
+++ b/plans/PR-EOM-Contact-Field-Clear-Contract.md
@@ -1,0 +1,245 @@
+# PR-EOM-Contact-Field-Clear-Contract
+
+## Why this slice exists
+
+Website #254 (Slice 5 of the CRM arc, child of website #105) locks a tri-state
+field-clearing contract for contact editing: an operator must be able to CLEAR
+an obsolete email/phone (explicit JSON null), distinct from OMITTING an
+untouched field (key absent) and from REPLACING it (non-empty value), with
+audit evidence that distinguishes all three. This is the Juan-directed
+follow-up to the shipped Slice 4 edit boundary (tracker #229/#231, website
+#249): editing that cannot remove an obsolete value is incomplete editing.
+
+The Slice 5 investigation (recorded on website #254) proved the Atlas
+mutation ALREADY implements the wire mechanics: `_operator_contact_fields`
+gates on `model_fields_set` (present-null kept as an explicit clear, absent
+key dropped as an omit), the domain normalizer stores `None` under the key,
+`_update_existing` writes SQL NULL, and `request_fingerprint` hashes
+present-null distinctly from key-absent. Two gaps remain, and they are this
+PR:
+
+1. **The audit cannot tell a clear from a re-point.** `_write_lifecycle_event`
+   records `changed_fields` + `previous_values` (old values only), so
+   `email -> null` and `email -> new@addr` produce identical event shapes.
+2. **No capability names the clear semantics.** `contact.operator_mutation`
+   proves the route exists, not that its null semantics + audit are supported;
+   an older Atlas serves the same route. Downstream (tracker, website) must
+   gate clearing on a versioned capability or they cannot deploy fail-closed.
+
+### Problem-derived contract
+
+- Root cause: the operator-mutation audit under-describes intent (old values
+  only, no cleared-vs-changed distinction), and the capability manifest has no
+  name for the null-clear semantics, so no downstream caller can safely enable
+  clearing against a deployed Atlas.
+- Correct fix must touch/change:
+  - `_write_lifecycle_event` gains an additive, PII-free `cleared_fields`
+    metadata key (field NAMES whose post-update value is NULL) on the update
+    path, making OMITTED (absent from `changed_fields`) / CLEARED (listed in
+    `cleared_fields`) / CHANGED (`changed_fields` minus `cleared_fields`)
+    distinguishable from the event alone;
+  - `_CAPABILITY_ROUTES` gains `contact.field_clear` mapped to the SAME
+    `POST /eom-funnel/operator-contacts` signature, versioning the route's
+    semantics: the dict entry ships only with builds that carry the audited
+    clear contract;
+  - tests pinning the tri-state at both tiers (HTTP boundary present-null vs
+    absent; DB-backed clear/omit/change with audit assertions), idempotent
+    clear replay, the omit-vs-clear fingerprint conflict, the clearable-set
+    edges (full_name/customer_type refuse null), and the shared-route
+    capability pairing.
+- Must not change:
+  - no request/response schema change (`EOMOperatorContactRequest` and
+    `_operator_contact_item` already carry the contract);
+  - no change to `_operator_contact_fields`, `_normalize_fields`,
+    `_blank_to_none`, or `_update_existing` -- the clear mechanics are live,
+    documented behavior (see `_normalize_customer_type`'s docstring);
+  - no migration (contacts.email/phone already nullable; event metadata is
+    jsonb);
+  - no tracker/website work in this PR (they are the next two legs, gated on
+    this deploy);
+  - no widening of the clearable set: full_name and customer_type keep
+    refusing blank/null with 422; address-family fields keep their existing
+    generic-boundary behavior and are out of the #254 capability contract.
+
+## Scope (this PR)
+
+Ownership lane: eom-crm/lead-funnel
+Slice phase: vertical slice
+
+1. Advertise `contact.field_clear` as a semantics-versioning capability on the
+   existing operator-mutation route.
+2. Record `cleared_fields` (names only) in the `contact_updated` lifecycle
+   event so cleared/changed/omitted are distinguishable without duplicating
+   PII.
+3. Prove the locked tri-state contract with route-tier, manifest, and
+   DB-integration tests.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] `contact.field_clear` maps to `("POST", "/eom-funnel/operator-contacts")`
+        and is advertised iff `contact.operator_mutation` is -- settled by
+        `tests/test_eom_funnel_capability_manifest.py::test_field_clear_capability_versions_the_operator_mutation_semantics`.
+  - [ ] A request carrying `"email": null` reaches the command with
+        `fields["email"] is None` while an absent `phone` key never appears --
+        settled by `tests/test_eom_lead_conversion.py::test_operator_contact_route_keeps_present_null_distinct_from_absent`.
+  - [ ] A clear persists as SQL NULL, the mutation result echoes the null, an
+        omitted sibling field is preserved, and the event carries
+        `changed_fields == ["email"]`, `cleared_fields == ["email"]`,
+        `previous_values == {"email": <old>}` -- settled by
+        `tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_clear_vs_omit_vs_change_tri_state`.
+  - [ ] A re-point (value -> new value) lists the field in `changed_fields`
+        with `cleared_fields == []` -- settled by the same test's CHANGED
+        control.
+  - [ ] A retried clear with the same Idempotency-Key replays (one lifecycle
+        row), and the same key with the null dropped (omit) conflicts 409 --
+        settled by `tests/test_eom_lead_conversion_integration.py::test_operator_contact_clear_replay_is_idempotent_and_omit_conflicts`.
+  - [ ] `full_name: null` and `customer_type: null` are refused 422, and a
+        repeat clear of an already-null field is a no-op update with a uniform
+        empty tri-state event -- settled by
+        `tests/test_eom_lead_conversion_integration.py::test_operator_contact_clear_is_scoped_to_nullable_optional_fields`.
+  - [ ] The event carries field NAMES only in the new key (no `new_values`
+        map) -- settled by the `"new_values" not in metadata` assertion in the
+        tri-state test plus the `cleared_fields` implementation at its
+        `crm_provider.py` insertion point.
+  - [ ] Creates are unaffected: the create path still omits
+        `changed_fields`/`previous_values` (and therefore `cleared_fields`) --
+        settled by the pre-existing
+        `tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_creates_replays_and_records_actor`
+        assertions.
+- Reachability proof: real ASGI POST to `/eom-funnel/operator-contacts` with a
+  present-null field (route-tier test above) plus DB-backed provider tests
+  asserting the persisted contact row NULL and the lifecycle event metadata.
+- Affected surfaces: `atlas_brain/eom_api/funnel.py` (capability map only),
+  `atlas_brain/services/crm_provider.py` (`_write_lifecycle_event` only), EOM
+  funnel manifest/route/integration tests.
+- Risk areas: capability-manifest drift (two names sharing one route),
+  lifecycle-event shape compatibility for existing consumers, idempotency
+  fingerprint stability, clearable-set boundary (full_name/customer_type).
+- Reviewer rules triggered: R2, R3, R5, R8, R12.
+- Guard/set closure declaration: the clearable field set is CLOSED by the
+  existing domain boundary, not by new code: `EOM_OPERATOR_CONTACT_FIELDS`
+  enumerates operator fields; within it, `full_name` (422 on blank/null via
+  `_normalize_text_field`) and `customer_type` (422 via
+  `_normalize_customer_type`) refuse clearing, and the remaining optional
+  fields map blank/null to SQL NULL. This PR adds no admission logic; the
+  negative tests above pin the closed edges the #254 contract names.
+
+### Boundary-change enumeration
+
+N/A - no boundary change. No guard, validator, normalizer, resolver, or
+admission boundary is modified; the diff adds one capability-map entry and one
+additive audit metadata key, plus tests pinning existing boundary behavior.
+
+### Deployed-config probing
+
+N/A - no guard/config boundary change. No env/config read is added or altered;
+`ATLAS_EOM_FUNNEL_API_ENABLED` gating is untouched (existing tests already
+exercise enabled/disabled).
+
+### Files touched
+
+- `atlas_brain/eom_api/funnel.py`
+- `atlas_brain/services/crm_provider.py`
+- `plans/PR-EOM-Contact-Field-Clear-Contract.md`
+- `tests/test_eom_funnel_capability_manifest.py`
+- `tests/test_eom_lead_conversion.py`
+- `tests/test_eom_lead_conversion_integration.py`
+
+## Mechanism
+
+`contact.field_clear` is a second name for the already-registered
+`POST /eom-funnel/operator-contacts` signature in `_CAPABILITY_ROUTES`.
+`served_capabilities()` derives advertisement from registered routes, so the
+name is served exactly when the mutation route is -- but only on builds whose
+dict carries the entry, which is exactly the builds that ship this audited
+clear contract. Callers therefore gate clearing on the NAME (+ exact route,
+tracker-side strict proof), never on the route's existence.
+
+`_write_lifecycle_event` already computes `changed = sorted(key for key in
+command.fields if previous.get(key) != contact.get(key))` on the update path.
+The new `cleared_fields = sorted(key for key in changed if contact.get(key) is
+None)` derives the cleared subset from the post-update row already in scope --
+no new queries, no new writes, one additive jsonb key. Field names only:
+the overwritten value already lives in `previous_values` (the sole surviving
+copy; there is no contacts history table), and the new value lives on the
+contact row itself, so a `new_values` map would duplicate PII into the audit
+stream for zero recovery benefit.
+
+Tri-state, end to end: OMITTED = key absent from the request ->
+`model_fields_set` drops it -> not in `command.fields` -> not in
+`changed_fields`. CLEARED = present null -> normalizer stores `None` ->
+`_update_existing` writes SQL NULL -> in `changed_fields` AND in
+`cleared_fields`. CHANGED = present value -> normalized/replaced -> in
+`changed_fields`, not in `cleared_fields`. Idempotency: the request
+fingerprint serializes `fields` with present-nulls (`"email":null`), so a
+replayed clear matches its receipt and a same-key omit conflicts 409.
+
+## Intentional
+
+- Two capability names deliberately share one route signature. The manifest's
+  derivation stays honest (never advertise what this build cannot serve), and
+  the pinned pairing test makes the sharing explicit so a future "dedupe"
+  cannot silently drop the semantics version.
+- No `new_values` in the event: names-only `cleared_fields` is the
+  PII-conscious minimum that completes the tri-state (see Mechanism).
+- `cleared_fields` is emitted on every update event (empty list when nothing
+  cleared) rather than only-when-non-empty: consumers distinguish "new-format
+  event, nothing cleared" from "pre-slice event" by key presence.
+- Atlas boundary behavior for address/city/state/zip/notes (blank/null clears
+  at the generic operator boundary) is pre-existing, documented behavior and
+  is left untouched; the #254 capability contract scopes portal-reachable
+  clearing to email/phone at the tracker (`extra="forbid"` admits no other
+  field), not by narrowing this boundary under its existing callers.
+- The route-tier present-null test asserts `status in (200, 201)` because the
+  `_CRM` fake decides created-vs-updated; the assertion that matters there is
+  the command's field presence shape, and the DB tests pin real status
+  semantics.
+
+## Deferred
+
+- Tracker leg (next PR, gated on this deploy): strict
+  `contact.field_clear` proof -> `contactFieldClearAvailable`, present-null
+  forwarding on the edit path only, blank-on-edit 422, response projection
+  widened to email/phone.
+- Website leg (after the tracker is live): dirty-field tri-state body
+  assembly, #252 refusal retained as the no-capability fallback, EN/ES copy.
+- #247 ledger items are unchanged by this PR (notably item 7's
+  Atlas-emitted `editable` flag -- separate slice).
+
+Parking predicate: this slice parks only the downstream caller legs that the
+deploy order (Atlas first) requires to land separately, plus previously
+ledgered #247 hardening. It does not park correctness, security, idempotency,
+or audit defects in the Atlas clear contract itself.
+
+Parked hardening: none.
+
+## Verification
+
+- `python3 -m py_compile atlas_brain/eom_api/funnel.py atlas_brain/services/crm_provider.py tests/test_eom_funnel_capability_manifest.py tests/test_eom_lead_conversion.py tests/test_eom_lead_conversion_integration.py`
+  -- passed.
+- `python3 -m pytest tests/test_eom_funnel_capability_manifest.py -q`
+  -- 9 passed.
+- `python3 -m pytest tests/test_eom_lead_conversion.py::test_operator_contact_route_keeps_present_null_distinct_from_absent -q`
+  -- 1 passed.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python3 -m pytest tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_clear_vs_omit_vs_change_tri_state tests/test_eom_lead_conversion_integration.py::test_operator_contact_clear_replay_is_idempotent_and_omit_conflicts tests/test_eom_lead_conversion_integration.py::test_operator_contact_clear_is_scoped_to_nullable_optional_fields -q`
+  -- 3 passed.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python3 -m pytest tests/test_eom_lead_conversion_integration.py -q -k "operator_contact"`
+  -- 24 passed, 87 deselected.
+- `python3 -m pytest tests/test_eom_lead_conversion.py -q`
+  -- 225 passed, 1 warning.
+- Pending before push: `python scripts/check_guard_class_closure.py --base origin/main --strict`,
+  `python scripts/sync_pr_plan.py plans/PR-EOM-Contact-Field-Clear-Contract.md --check`,
+  `git diff --check`, `bash scripts/local_pr_review.sh` / `scripts/push_pr.sh`.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/eom_api/funnel.py` | 8 |
+| `atlas_brain/services/crm_provider.py` | 10 |
+| `plans/PR-EOM-Contact-Field-Clear-Contract.md` | 245 |
+| `tests/test_eom_funnel_capability_manifest.py` | 25 |
+| `tests/test_eom_lead_conversion.py` | 31 |
+| `tests/test_eom_lead_conversion_integration.py` | 273 |
+| **Total** | **592** |

--- a/plans/PR-EOM-Contact-Field-Clear-Contract.md
+++ b/plans/PR-EOM-Contact-Field-Clear-Contract.md
@@ -26,6 +26,17 @@ PR:
    an older Atlas serves the same route. Downstream (tracker, website) must
    gate clearing on a versioned capability or they cannot deploy fail-closed.
 
+Diff-budget override: 592 added lines are 21 production LOC (one
+capability-map entry + one additive audit metadata key) plus the mandated
+plan doc and the tri-state proof tests. The slice is genuinely indivisible:
+the #254 contract requires the tri-state PROVEN at the write authority before
+any downstream leg ships, so the capability (the advertisement), the audit
+key (the semantics being advertised), and the tests (the proof) must land
+atomically -- a capability advertised without its proven audit contract is
+exactly the over-advertising failure the manifest exists to prevent, and
+tests split into a follow-up would leave a live, advertised semantics
+unproven in the window between merges.
+
 ### Problem-derived contract
 
 - Root cause: the operator-mutation audit under-describes intent (old values
@@ -74,6 +85,8 @@ Slice phase: vertical slice
 3. Prove the locked tri-state contract with route-tier, manifest, and
    DB-integration tests.
 
+Max files: 6
+
 ### Review Contract
 
 - Acceptance criteria:
@@ -102,11 +115,11 @@ Slice phase: vertical slice
         map) -- settled by the `"new_values" not in metadata` assertion in the
         tri-state test plus the `cleared_fields` implementation at its
         `crm_provider.py` insertion point.
-  - [ ] Creates are unaffected: the create path still omits
-        `changed_fields`/`previous_values` (and therefore `cleared_fields`) --
-        settled by the pre-existing
-        `tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_creates_replays_and_records_actor`
-        assertions.
+  - [ ] Creates are unaffected: the create path omits
+        `changed_fields`, `previous_values`, AND the new `cleared_fields` --
+        settled by the direct `"cleared_fields" not in metadata` assertion
+        added to
+        `tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_creates_replays_and_records_actor`.
 - Reachability proof: real ASGI POST to `/eom-funnel/operator-contacts` with a
   present-null field (route-tier test above) plus DB-backed provider tests
   asserting the persisted contact row NULL and the lifecycle event metadata.
@@ -238,8 +251,8 @@ Parked hardening: none.
 |---|---:|
 | `atlas_brain/eom_api/funnel.py` | 8 |
 | `atlas_brain/services/crm_provider.py` | 10 |
-| `plans/PR-EOM-Contact-Field-Clear-Contract.md` | 245 |
+| `plans/PR-EOM-Contact-Field-Clear-Contract.md` | 258 |
 | `tests/test_eom_funnel_capability_manifest.py` | 25 |
 | `tests/test_eom_lead_conversion.py` | 31 |
-| `tests/test_eom_lead_conversion_integration.py` | 273 |
-| **Total** | **592** |
+| `tests/test_eom_lead_conversion_integration.py` | 278 |
+| **Total** | **610** |

--- a/plans/PR-EOM-Contact-Field-Clear-Contract.md
+++ b/plans/PR-EOM-Contact-Field-Clear-Contract.md
@@ -93,9 +93,11 @@ Max files: 6
   - [ ] `contact.field_clear` maps to `("POST", "/eom-funnel/operator-contacts")`
         and is advertised iff `contact.operator_mutation` is -- settled by
         `tests/test_eom_funnel_capability_manifest.py::test_field_clear_capability_versions_the_operator_mutation_semantics`.
-  - [ ] A request carrying `"email": null` reaches the command with
-        `fields["email"] is None` while an absent `phone` key never appears --
-        settled by `tests/test_eom_lead_conversion.py::test_operator_contact_route_keeps_present_null_distinct_from_absent`.
+  - [ ] A request carrying a present-null optional field reaches the command
+        with `fields[<field>] is None` while an absent sibling key never
+        appears -- proven for BOTH advertised fields (email-cleared/phone-absent
+        and phone-cleared/email-absent) by
+        `tests/test_eom_lead_conversion.py::test_operator_contact_route_keeps_present_null_distinct_from_absent`.
   - [ ] A clear persists as SQL NULL, the mutation result echoes the null, an
         omitted sibling field is preserved, and the event carries
         `changed_fields == ["email"]`, `cleared_fields == ["email"]`,
@@ -104,6 +106,10 @@ Max files: 6
   - [ ] A re-point (value -> new value) lists the field in `changed_fields`
         with `cleared_fields == []` -- settled by the same test's CHANGED
         control.
+  - [ ] The phone sibling clears end-to-end through its own normalizer and
+        column: row NULL, result echo null, `changed_fields == ["phone"]`,
+        `cleared_fields == ["phone"]`, `previous_values == {"phone": <old>}`
+        -- settled by the phone-clear leg of the same tri-state test.
   - [ ] A retried clear with the same Idempotency-Key replays (one lifecycle
         row), and the same key with the null dropped (omit) conflicts 409 --
         settled by `tests/test_eom_lead_conversion_integration.py::test_operator_contact_clear_replay_is_idempotent_and_omit_conflicts`.
@@ -251,8 +257,8 @@ Parked hardening: none.
 |---|---:|
 | `atlas_brain/eom_api/funnel.py` | 8 |
 | `atlas_brain/services/crm_provider.py` | 10 |
-| `plans/PR-EOM-Contact-Field-Clear-Contract.md` | 258 |
+| `plans/PR-EOM-Contact-Field-Clear-Contract.md` | 264 |
 | `tests/test_eom_funnel_capability_manifest.py` | 25 |
-| `tests/test_eom_lead_conversion.py` | 31 |
-| `tests/test_eom_lead_conversion_integration.py` | 278 |
-| **Total** | **610** |
+| `tests/test_eom_lead_conversion.py` | 32 |
+| `tests/test_eom_lead_conversion_integration.py` | 315 |
+| **Total** | **654** |

--- a/tests/test_eom_funnel_capability_manifest.py
+++ b/tests/test_eom_funnel_capability_manifest.py
@@ -237,3 +237,28 @@ def test_response_model_defaults_capabilities_for_a_caller_that_omits_it() -> No
     )
     assert response.capabilities == []
     assert response.capability_routes == []
+
+
+def test_field_clear_capability_versions_the_operator_mutation_semantics() -> None:
+    """`contact.field_clear` shares the operator-mutation route ON PURPOSE.
+
+    The name versions the route's SEMANTICS (audited present-null clearing,
+    website #254), not its existence: an older build serves the same POST
+    route but never advertises this name because the dict entry ships with
+    the clearing contract. Pin the pairing so a route move or a well-meaning
+    'dedupe' of the shared signature breaks loudly instead of silently
+    un-advertising field-clearing.
+    """
+    assert funnel_mod._CAPABILITY_ROUTES["contact.field_clear"] == (
+        "POST",
+        "/eom-funnel/operator-contacts",
+    )
+    assert (
+        funnel_mod._CAPABILITY_ROUTES["contact.field_clear"]
+        == funnel_mod._CAPABILITY_ROUTES["contact.operator_mutation"]
+    )
+    served = funnel_mod.served_capabilities()
+    assert ("contact.field_clear" in served) == (
+        "contact.operator_mutation" in served
+    ), "shared route means shared availability"
+    assert "contact.field_clear" in served

--- a/tests/test_eom_lead_conversion.py
+++ b/tests/test_eom_lead_conversion.py
@@ -4467,3 +4467,34 @@ async def test_operator_contact_route_omits_customer_type_when_not_sent():
 
     assert response.status_code == 201
     assert "customer_type" not in crm.operator_contact_calls[0].fields
+
+
+@pytest.mark.asyncio
+async def test_operator_contact_route_keeps_present_null_distinct_from_absent():
+    """The clear wire shape (website #254): present JSON null survives to the
+    command as an explicit None while an absent key never appears at all.
+
+    This is the HTTP-boundary half of the tri-state contract. If Pydantic
+    default-handling or `_operator_contact_fields` ever collapsed present-null
+    into absent, a tracker-forwarded clear would silently become an omit and
+    the operator's delete would report saved without saving.
+    """
+    crm = _CRM()
+    app = _app(crm, _enabled_config())
+    payload = _operator_contact_payload(email=None)
+    del payload["phone"]
+    payload["contactId"] = str(uuid4())
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            "/eom-funnel/operator-contacts",
+            headers=_headers(approval_key=f"office-clear-{uuid4().hex}"),
+            json=payload,
+        )
+
+    assert response.status_code in (200, 201), response.text
+    command = crm.operator_contact_calls[0]
+    assert "email" in command.fields, "present null must reach the command"
+    assert command.fields["email"] is None
+    assert "phone" not in command.fields, "absent key must stay absent"

--- a/tests/test_eom_lead_conversion.py
+++ b/tests/test_eom_lead_conversion.py
@@ -4479,22 +4479,23 @@ async def test_operator_contact_route_keeps_present_null_distinct_from_absent():
     into absent, a tracker-forwarded clear would silently become an omit and
     the operator's delete would report saved without saving.
     """
-    crm = _CRM()
-    app = _app(crm, _enabled_config())
-    payload = _operator_contact_payload(email=None)
-    del payload["phone"]
-    payload["contactId"] = str(uuid4())
-    async with httpx.AsyncClient(
-        transport=httpx.ASGITransport(app=app), base_url="http://test"
-    ) as client:
-        response = await client.post(
-            "/eom-funnel/operator-contacts",
-            headers=_headers(approval_key=f"office-clear-{uuid4().hex}"),
-            json=payload,
-        )
+    for cleared_field, absent_field in (("email", "phone"), ("phone", "email")):
+        crm = _CRM()
+        app = _app(crm, _enabled_config())
+        payload = _operator_contact_payload(**{cleared_field: None})
+        del payload[absent_field]
+        payload["contactId"] = str(uuid4())
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            response = await client.post(
+                "/eom-funnel/operator-contacts",
+                headers=_headers(approval_key=f"office-clear-{uuid4().hex}"),
+                json=payload,
+            )
 
-    assert response.status_code in (200, 201), response.text
-    command = crm.operator_contact_calls[0]
-    assert "email" in command.fields, "present null must reach the command"
-    assert command.fields["email"] is None
-    assert "phone" not in command.fields, "absent key must stay absent"
+        assert response.status_code in (200, 201), response.text
+        command = crm.operator_contact_calls[0]
+        assert cleared_field in command.fields, "present null must reach the command"
+        assert command.fields[cleared_field] is None
+        assert absent_field not in command.fields, "absent key must stay absent"

--- a/tests/test_eom_lead_conversion_integration.py
+++ b/tests/test_eom_lead_conversion_integration.py
@@ -8879,6 +8879,43 @@ async def test_operator_contact_mutation_clear_vs_omit_vs_change_tri_state():
         assert change_metadata["changed_fields"] == ["phone"]
         assert change_metadata["cleared_fields"] == []
         assert change_metadata["previous_values"] == {"phone": "2175550181"}
+
+        # Sibling-path proof (both advertised fields, not just email): phone
+        # rides its own normalizer and column, so its clear is proven through
+        # the same DB + audit shape rather than inferred from email's.
+        phone_clear_key = f"clear-phone-{uuid.uuid4().hex}"
+        phone_cleared = await mutate_eom_operator_contact(
+            provider,
+            EOMOperatorContactMutation.from_raw(
+                operation_key=phone_clear_key,
+                actor_id=7,
+                actor_name="Mayra Canfield",
+                source_channel="time_tracker",
+                source_ref="portal-contact:clear-phone",
+                contact_type="customer",
+                contact_id=contact_id,
+                fields={"phone": None},
+            ),
+        )
+        assert phone_cleared["operation"] == "contact_updated"
+        assert phone_cleared["contact"]["phone"] is None
+        phone_row = await conn.fetchrow(
+            "SELECT email, phone FROM contacts WHERE id = $1",
+            uuid.UUID(contact_id),
+        )
+        assert phone_row["phone"] is None
+        assert phone_row["email"] is None, "the earlier email clear must persist"
+        phone_event = await conn.fetchrow(
+            """
+            SELECT metadata FROM eom_lead_lifecycle_events
+            WHERE operation_key = $1 AND event_type = 'contact_updated'
+            """,
+            phone_clear_key,
+        )
+        phone_metadata = _metadata_dict(phone_event["metadata"])
+        assert phone_metadata["changed_fields"] == ["phone"]
+        assert phone_metadata["cleared_fields"] == ["phone"]
+        assert phone_metadata["previous_values"] == {"phone": "2175550182"}
     finally:
         await conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
         await conn.close()

--- a/tests/test_eom_lead_conversion_integration.py
+++ b/tests/test_eom_lead_conversion_integration.py
@@ -8774,3 +8774,276 @@ async def test_a_generic_create_cannot_set_customer_type():
     finally:
         await conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
         await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_operator_contact_mutation_clear_vs_omit_vs_change_tri_state():
+    """The locked field-clearing contract (website #254), at the write authority.
+
+    Present-null clears to SQL NULL; an absent key preserves; a value replaces.
+    The lifecycle event alone distinguishes all three: OMITTED is absent from
+    changed_fields, CLEARED is listed in cleared_fields, CHANGED is
+    changed_fields minus cleared_fields.
+    """
+    database_url = _database_url_or_skip()
+    schema = f"atlas_eom_operator_clear_{uuid.uuid4().hex}"
+    conn = await asyncpg.connect(database_url)
+    try:
+        await _prepare_schema(conn, schema, apply_privilege_migration=False)
+        provider = DatabaseCRMProvider(pool=conn)
+        created = await mutate_eom_operator_contact(
+            provider,
+            EOMOperatorContactMutation.from_raw(
+                operation_key=f"clear-seed-{uuid.uuid4().hex}",
+                actor_id=7,
+                actor_name="Mayra Canfield",
+                source_channel="time_tracker",
+                source_ref="portal-contact:seed",
+                contact_type="customer",
+                fields={
+                    "full_name": "Clear Target",
+                    "email": "clear-target@example.com",
+                    "phone": "(217) 555-0181",
+                },
+            ),
+        )
+        contact_id = created["contact_id"]
+
+        # CLEAR email (present null) while OMITTING phone (key absent).
+        clear_key = f"clear-email-{uuid.uuid4().hex}"
+        cleared = await mutate_eom_operator_contact(
+            provider,
+            EOMOperatorContactMutation.from_raw(
+                operation_key=clear_key,
+                actor_id=7,
+                actor_name="Mayra Canfield",
+                source_channel="time_tracker",
+                source_ref="portal-contact:clear",
+                contact_type="customer",
+                contact_id=contact_id,
+                fields={"email": None},
+            ),
+        )
+        assert cleared["operation"] == "contact_updated"
+        # The mutation result itself must prove the clear persisted.
+        assert cleared["contact"]["email"] is None
+        row = await conn.fetchrow(
+            "SELECT email, phone FROM contacts WHERE id = $1",
+            uuid.UUID(contact_id),
+        )
+        assert row["email"] is None
+        assert row["phone"] == "2175550181", "omitted phone must be preserved"
+        event = await conn.fetchrow(
+            """
+            SELECT metadata FROM eom_lead_lifecycle_events
+            WHERE operation_key = $1 AND event_type = 'contact_updated'
+            """,
+            clear_key,
+        )
+        metadata = _metadata_dict(event["metadata"])
+        assert metadata["changed_fields"] == ["email"]
+        assert metadata["cleared_fields"] == ["email"]
+        assert metadata["previous_values"] == {"email": "clear-target@example.com"}
+        # Names only in the tri-state keys: the cleared value appears in
+        # previous_values (sole surviving copy) and nowhere else.
+        assert "new_values" not in metadata
+
+        # CHANGED control: a re-point lists the field but not as cleared.
+        change_key = f"change-phone-{uuid.uuid4().hex}"
+        await mutate_eom_operator_contact(
+            provider,
+            EOMOperatorContactMutation.from_raw(
+                operation_key=change_key,
+                actor_id=7,
+                actor_name="Mayra Canfield",
+                source_channel="time_tracker",
+                source_ref="portal-contact:change",
+                contact_type="customer",
+                contact_id=contact_id,
+                fields={"phone": "(217) 555-0182"},
+            ),
+        )
+        change_event = await conn.fetchrow(
+            """
+            SELECT metadata FROM eom_lead_lifecycle_events
+            WHERE operation_key = $1 AND event_type = 'contact_updated'
+            """,
+            change_key,
+        )
+        change_metadata = _metadata_dict(change_event["metadata"])
+        assert change_metadata["changed_fields"] == ["phone"]
+        assert change_metadata["cleared_fields"] == []
+        assert change_metadata["previous_values"] == {"phone": "2175550181"}
+    finally:
+        await conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_operator_contact_clear_replay_is_idempotent_and_omit_conflicts():
+    """A retried clear replays; the same key with omit-instead-of-clear 409s.
+
+    The second half is the fingerprint proof: fields={'email': None} and
+    fields without the email key must hash differently, or a retry that
+    dropped the null would silently replay the wrong intent.
+    """
+    database_url = _database_url_or_skip()
+    schema = f"atlas_eom_operator_clear_replay_{uuid.uuid4().hex}"
+    conn = await asyncpg.connect(database_url)
+    try:
+        await _prepare_schema(conn, schema, apply_privilege_migration=False)
+        provider = DatabaseCRMProvider(pool=conn)
+        created = await mutate_eom_operator_contact(
+            provider,
+            EOMOperatorContactMutation.from_raw(
+                operation_key=f"clear-replay-seed-{uuid.uuid4().hex}",
+                actor_id=7,
+                actor_name="Mayra Canfield",
+                source_channel="time_tracker",
+                source_ref="portal-contact:seed",
+                contact_type="customer",
+                fields={
+                    "full_name": "Replay Target",
+                    "email": "replay-target@example.com",
+                    "phone": "(217) 555-0183",
+                },
+            ),
+        )
+        contact_id = created["contact_id"]
+        clear_key = f"clear-replay-{uuid.uuid4().hex}"
+
+        def clear_command():
+            return EOMOperatorContactMutation.from_raw(
+                operation_key=clear_key,
+                actor_id=7,
+                actor_name="Mayra Canfield",
+                source_channel="time_tracker",
+                source_ref="portal-contact:clear",
+                contact_type="customer",
+                contact_id=contact_id,
+                fields={"email": None, "phone": "(217) 555-0183"},
+            )
+
+        first = await mutate_eom_operator_contact(provider, clear_command())
+        assert first["idempotent"] is False
+        assert first["contact"]["email"] is None
+
+        replay = await mutate_eom_operator_contact(provider, clear_command())
+        assert replay["idempotent"] is True
+        assert replay["contact"]["email"] is None
+        assert await conn.fetchval(
+            """
+            SELECT COUNT(*) FROM eom_lead_lifecycle_events
+            WHERE operation_key = $1
+            """,
+            clear_key,
+        ) == 1
+
+        omit_instead = EOMOperatorContactMutation.from_raw(
+            operation_key=clear_key,
+            actor_id=7,
+            actor_name="Mayra Canfield",
+            source_channel="time_tracker",
+            source_ref="portal-contact:clear",
+            contact_type="customer",
+            contact_id=contact_id,
+            fields={"phone": "(217) 555-0183"},
+        )
+        with pytest.raises(EOMOperatorContactMutationError) as exc_info:
+            await mutate_eom_operator_contact(provider, omit_instead)
+        assert exc_info.value.status_code == 409
+    finally:
+        await conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_operator_contact_clear_is_scoped_to_nullable_optional_fields():
+    """full_name and customer_type refuse a clear; a repeat clear no-ops.
+
+    The refusals are the closed edge of the clearable set (website #254 locks
+    clearing to optional contact fields; identity/type never null out), and
+    the repeat clear proves clearing an already-null field is a safe no-op
+    update, not an error and not a duplicate event shape.
+    """
+    database_url = _database_url_or_skip()
+    schema = f"atlas_eom_operator_clear_scope_{uuid.uuid4().hex}"
+    conn = await asyncpg.connect(database_url)
+    try:
+        await _prepare_schema(conn, schema, apply_privilege_migration=False)
+        provider = DatabaseCRMProvider(pool=conn)
+        created = await mutate_eom_operator_contact(
+            provider,
+            EOMOperatorContactMutation.from_raw(
+                operation_key=f"clear-scope-seed-{uuid.uuid4().hex}",
+                actor_id=7,
+                actor_name="Mayra Canfield",
+                source_channel="time_tracker",
+                source_ref="portal-contact:seed",
+                contact_type="customer",
+                fields={
+                    "full_name": "Scope Target",
+                    "phone": "(217) 555-0184",
+                },
+            ),
+        )
+        contact_id = created["contact_id"]
+
+        with pytest.raises(EOMOperatorContactMutationError) as name_exc:
+            EOMOperatorContactMutation.from_raw(
+                operation_key=f"clear-name-{uuid.uuid4().hex}",
+                actor_id=7,
+                actor_name="Mayra Canfield",
+                source_channel="time_tracker",
+                source_ref="portal-contact:clear",
+                contact_type="customer",
+                contact_id=contact_id,
+                fields={"full_name": None},
+            )
+        assert name_exc.value.status_code == 422
+
+        with pytest.raises(EOMOperatorContactMutationError) as type_exc:
+            EOMOperatorContactMutation.from_raw(
+                operation_key=f"clear-type-{uuid.uuid4().hex}",
+                actor_id=7,
+                actor_name="Mayra Canfield",
+                source_channel="time_tracker",
+                source_ref="portal-contact:clear",
+                contact_type="customer",
+                contact_id=contact_id,
+                fields={"customer_type": None},
+            )
+        assert type_exc.value.status_code == 422
+
+        # email is already NULL (never set): clearing it again is a no-op
+        # update with a uniform, empty tri-state event shape.
+        noop_key = f"clear-noop-{uuid.uuid4().hex}"
+        noop = await mutate_eom_operator_contact(
+            provider,
+            EOMOperatorContactMutation.from_raw(
+                operation_key=noop_key,
+                actor_id=7,
+                actor_name="Mayra Canfield",
+                source_channel="time_tracker",
+                source_ref="portal-contact:clear",
+                contact_type="customer",
+                contact_id=contact_id,
+                fields={"email": None},
+            ),
+        )
+        assert noop["operation"] == "contact_updated"
+        assert noop["contact"]["email"] is None
+        noop_event = await conn.fetchrow(
+            """
+            SELECT metadata FROM eom_lead_lifecycle_events
+            WHERE operation_key = $1 AND event_type = 'contact_updated'
+            """,
+            noop_key,
+        )
+        noop_metadata = _metadata_dict(noop_event["metadata"])
+        assert noop_metadata["changed_fields"] == []
+        assert noop_metadata["cleared_fields"] == []
+        assert noop_metadata["previous_values"] == {}
+    finally:
+        await conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        await conn.close()

--- a/tests/test_eom_lead_conversion_integration.py
+++ b/tests/test_eom_lead_conversion_integration.py
@@ -373,6 +373,11 @@ async def test_operator_contact_mutation_creates_replays_and_records_actor():
         # values to creates.
         assert "previous_values" not in metadata
         assert "changed_fields" not in metadata
+        # The #254 tri-state key is update-only by the same rule: a create
+        # overwrote (and cleared) nothing, and consumers distinguish
+        # pre-slice events from new-format ones by key presence, so a create
+        # emitting the key would corrupt that signal.
+        assert "cleared_fields" not in metadata
 
         replay = await mutate_eom_operator_contact(provider, command)
 


### PR DESCRIPTION
Plan: plans/PR-EOM-Contact-Field-Clear-Contract.md
Slice phase: vertical slice
Ownership lane: eom-crm/lead-funnel

Website #254 (Slice 5, child of #105) locks a tri-state field-clearing contract for contact editing: explicit JSON null = clear, omitted key = preserve, non-empty value = replace — provable end-to-end with audit evidence distinguishing all three. The Slice 5 investigation proved Atlas already implements the wire mechanics (`model_fields_set` presence gate, null -> SQL NULL, fingerprints hash present-null distinctly); the two real gaps are that the update audit cannot tell a clear from a re-point, and that no capability names the null-clear semantics for downstream fail-closed gating. This PR closes exactly those two gaps, Atlas-first in the #254 deploy order (Atlas -> tracker -> website, dependents held until the predecessor is live).

Diff-budget override: 592 added lines are 21 production LOC (one capability-map entry + one additive audit key) plus the mandated plan doc (245) and the tri-state proof tests (326). The tests ARE the slice's deliverable -- #254 requires the locked contract proven at this boundary before any downstream leg ships -- and splitting them from the two-line semantic change would ship an unproven audit/capability contract.

## Intentional
- Two capability names deliberately share one route signature: `contact.field_clear` versions the operator-mutation route's SEMANTICS, not its existence; an older build serves the same route but never advertises the name. Pinned by a dedicated manifest test so a future "dedupe" breaks loudly.
- No `new_values` map in the audit: `cleared_fields` carries field NAMES only. The overwritten value already lives in `previous_values` (sole surviving copy) and the new value on the contact row; duplicating the new value into the event stream adds PII for zero recovery benefit.
- `cleared_fields` is emitted on every update event (empty list included) so consumers distinguish "new-format event, nothing cleared" from "pre-slice event" by key presence.
- Atlas boundary behavior for address/city/state/zip/notes is left untouched; the #254 capability contract scopes portal-reachable clearing to email/phone at the tracker (`extra="forbid"`), not by narrowing this boundary under its existing callers.

## AI reconciliation
- Add the required over-budget rationale -- fixed-in: plans/PR-EOM-Contact-Field-Clear-Contract.md "Why this slice exists" now carries the indivisibility rationale (capability + audit + proof must land atomically; an advertised-but-unproven semantics is the over-advertising failure the manifest prevents).
- Assert the new key stays absent on creates -- fixed-in: tests/test_eom_lead_conversion_integration.py::test_operator_contact_mutation_creates_replays_and_records_actor now asserts `"cleared_fields" not in metadata` directly; the plan's create-path criterion cites that assertion instead of the indirect pre-existing ones.
- Add an end-to-end phone-clear contract test -- fixed-in: the DB tri-state test gains a phone-clear leg (row NULL, echo null, changed_fields/cleared_fields/previous_values all asserted for phone) and the route-tier presence test is mirrored over both advertised fields; the plan's criteria now name both fields.

## Fix-loop disposition preflight
- Root decision: Add the required over-budget rationale
- Source trace: Codex thread on plans/PR-EOM-Contact-Field-Clear-Contract.md:245 -> the plan's "Why this slice exists" lacked the mandated indivisibility rationale for the 592-LOC diff -> fixed at the plan's Why section.
- Upstream files: plans/PR-EOM-Contact-Field-Clear-Contract.md
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: atlas_brain/eom_api/funnel.py, atlas_brain/services/crm_provider.py, plans/PR-EOM-Contact-Field-Clear-Contract.md, tests/test_eom_funnel_capability_manifest.py, tests/test_eom_lead_conversion.py, tests/test_eom_lead_conversion_integration.py
- Max files: 6
- Parked hardening: none

- Root decision: Add an end-to-end phone-clear contract test
- Source trace: Codex thread on atlas_brain/eom_api/funnel.py:726 -> every clear proof exercised email only; phone-clear (its own normalizer + column) was inferred, not proven -> fixed in both test tiers.
- Upstream files: tests/test_eom_lead_conversion_integration.py, tests/test_eom_lead_conversion.py, plans/PR-EOM-Contact-Field-Clear-Contract.md
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: atlas_brain/eom_api/funnel.py, atlas_brain/services/crm_provider.py, plans/PR-EOM-Contact-Field-Clear-Contract.md, tests/test_eom_funnel_capability_manifest.py, tests/test_eom_lead_conversion.py, tests/test_eom_lead_conversion_integration.py
- Max files: 6
- Parked hardening: none

- Root decision: Assert the new key stays absent on creates
- Source trace: Codex thread on plans/PR-EOM-Contact-Field-Clear-Contract.md:109 -> the create-path acceptance criterion cited pre-existing assertions that do not cover cleared_fields -> fixed by a direct absence assertion in the create test and a corrected criterion citation.
- Upstream files: tests/test_eom_lead_conversion_integration.py, plans/PR-EOM-Contact-Field-Clear-Contract.md
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: atlas_brain/eom_api/funnel.py, atlas_brain/services/crm_provider.py, plans/PR-EOM-Contact-Field-Clear-Contract.md, tests/test_eom_funnel_capability_manifest.py, tests/test_eom_lead_conversion.py, tests/test_eom_lead_conversion_integration.py
- Max files: 6
- Parked hardening: none

## Deferred
- Tracker leg (next PR, gated on this deploy): strict `contact.field_clear` proof -> `contactFieldClearAvailable`, present-null forwarding on the edit path only, blank-on-edit 422, response projection widened to email/phone.
- Website leg (after the tracker is live): dirty-field tri-state body assembly; the #252 blank-clear refusal becomes the permanent no-capability fallback.
- #247 ledger unchanged (incl. item 7 Atlas-emitted `editable` flag — separate slice).

## Parked hardening
- None.

## Cold diff reconstruction
- Changed: `atlas_brain/eom_api/funnel.py:723-730` — adds `"contact.field_clear": ("POST", "/eom-funnel/operator-contacts")` to `_CAPABILITY_ROUTES` with a comment stating it versions semantics and shares the operator-mutation signature on purpose. Nothing else in the module changes.
- Changed: `atlas_brain/services/crm_provider.py:1654-1663` — inside `_write_lifecycle_event`'s existing `if previous is not None:` block, after `previous_values`, adds `metadata["cleared_fields"] = sorted(key for key in changed if contact.get(key) is None)` plus the names-only rationale comment. Derived from values already in scope; no new queries or writes.
- Changed: `tests/test_eom_funnel_capability_manifest.py` (+25) — pins the shared-route pairing and served-iff-operator-mutation availability.
- Changed: `tests/test_eom_lead_conversion.py` (+31) — route-tier pin: POST with `"email": null` + absent `phone` reaches the command as `fields["email"] is None` with `phone` absent.
- Changed: `tests/test_eom_lead_conversion_integration.py` (+273) — three DB-backed tests: tri-state clear/omit/change with full audit assertions; idempotent clear replay + same-key omit-instead-of-clear 409 (the fingerprint proof); clearable-set edges (`full_name`/`customer_type` null -> 422) + already-null repeat clear as uniform no-op.
- Contract match: gap 1 (audit) -> crm_provider edit + tri-state/no-op audit assertions; gap 2 (capability) -> funnel map entry + manifest pin; locked-contract items "retried clears idempotent" / "fingerprints distinguish omitted, changed, cleared" / "restrict clearing to phone/email" / "response returns null" -> the three integration tests' assertions. "Must not change" respected: no request/response schema, normalizer, `_operator_contact_fields`, or migration touched.
- Changed (review round 1): plan doc "Why" gains the diff-budget indivisibility rationale; the create-path integration test gains a direct `"cleared_fields" not in metadata` assertion and the plan criterion now cites it.
- Gaps: none.

## Verification
- New tests were run against real Postgres and the real ASGI router; full changed test files re-run green. See Mechanical verification.

## Mechanical verification
- Command: `python3 -m pytest tests/test_eom_funnel_capability_manifest.py -q` - Result: 9 passed - Environment: local
- Command: `python3 -m pytest tests/test_eom_lead_conversion.py -q` - Result: 225 passed, 0 failed - Environment: local
- Command: `ATLAS_MIGRATION_TEST_DATABASE_URL=postgresql://atlas@127.0.0.1:5433/atlas python3 -m pytest tests/test_eom_lead_conversion_integration.py -q -k "operator_contact"` - Result: 24 passed, 0 failed - Environment: local
- Command: `python3 scripts/check_guard_class_closure.py --base origin/main --strict` - Result: pass - Environment: local
- Command: `python3 scripts/sync_pr_plan.py plans/PR-EOM-Contact-Field-Clear-Contract.md --check` - Result: pass - Environment: local
- Skipped: full integration suite (non-operator_contact selections) - Reason: unchanged surfaces; CI runs the full suite on the PR (per standing don't-duplicate-CI rule)

## Diff size
6 files, +672 / -24

<!-- atlas-open-pr-wrapper: v1 -->
