### PR TITLE
Migration content integrity: gate pending SQL on unresolved evidence

### DIFF
--- a/atlas_brain/storage/migrations/__init__.py
+++ b/atlas_brain/storage/migrations/__init__.py
@@ -145,6 +145,10 @@ class MigrationContentIntegrityReport:
     missing_source: tuple[str, ...]
 
 
+class PendingMigrationContentIntegrityError(RuntimeError):
+    """Raised before pending SQL when provenance evidence remains unresolved."""
+
+
 def _migration_content_sha256(source: bytes) -> str:
     """Return the deterministic identity for exactly one migration source."""
     return hashlib.sha256(source).hexdigest()
@@ -218,6 +222,58 @@ def _log_migration_content_integrity(report: MigrationContentIntegrityReport) ->
             ", ".join(report.mismatched) or "none",
             ", ".join(report.missing_source) or "none",
         )
+
+
+async def _unresolved_pending_migration_content_evidence(
+    executor,
+    migration_files: Collection[Path],
+    report: MigrationContentIntegrityReport,
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """Return evidence that still cannot admit a new migration application.
+
+    Generic content reports intentionally keep historical discrepancies visible.
+    A current attestation may satisfy admission only for its own reviewed name;
+    it never changes the underlying report or treats unavailable source bytes as
+    verified.
+    """
+    evidence_names = frozenset(report.mismatched) | frozenset(report.missing_source)
+    if not evidence_names:
+        return report.mismatched, report.missing_source
+
+    from .reconciliation import (
+        attest_known_historical_migration_reconciliations,
+        known_historical_migration_reconciliation_names,
+    )
+
+    candidate_names = (
+        frozenset(report.mismatched)
+        & known_historical_migration_reconciliation_names()
+    )
+    if not candidate_names:
+        return report.mismatched, report.missing_source
+
+    try:
+        attestations = await attest_known_historical_migration_reconciliations(
+            executor,
+            migration_files,
+        )
+    except Exception as exc:
+        raise PendingMigrationContentIntegrityError(
+            "Refusing to apply pending migrations because known historical "
+            "migration evidence could not be attested for "
+            f"{','.join(sorted(candidate_names))}"
+        ) from exc
+
+    attested_names = frozenset(
+        attestation.migration_name
+        for attestation in attestations
+        if attestation.migration_name in candidate_names
+        and attestation.status == "attested"
+    )
+    return (
+        tuple(name for name in report.mismatched if name not in attested_names),
+        report.missing_source,
+    )
 
 
 # Cluster-wide advisory key serializing migration runs. Concurrent first
@@ -566,10 +622,13 @@ async def run_migrations(
             # winner recorded its work.
             applied = await _get_applied_migrations(conn)
 
-            migration_files = sorted(directory.glob("*.sql"))
-            _log_migration_content_integrity(
-                await migration_content_integrity_report(conn, migration_files)
+            migration_catalog = sorted(directory.glob("*.sql"))
+            integrity_report = await migration_content_integrity_report(
+                conn,
+                migration_catalog,
             )
+            _log_migration_content_integrity(integrity_report)
+            migration_files = migration_catalog
             if only is not None:
                 requested = set(only)
                 migration_files = [
@@ -590,6 +649,22 @@ async def run_migrations(
             if not pending:
                 logger.debug("All %d migrations already applied", len(migration_files))
                 return
+
+            unresolved_mismatched, unresolved_missing_source = (
+                await _unresolved_pending_migration_content_evidence(
+                    conn,
+                    migration_catalog,
+                    report=integrity_report,
+                )
+            )
+            if unresolved_mismatched or unresolved_missing_source:
+                raise PendingMigrationContentIntegrityError(
+                    "Refusing to apply pending migrations with unresolved "
+                    "migration-content evidence: "
+                    f"mismatched={','.join(unresolved_mismatched) or 'none'} "
+                    f"missing_source={','.join(unresolved_missing_source) or 'none'} "
+                    f"pending={','.join(migration_file.stem for migration_file in pending)}"
+                )
 
             logger.info("Running %d pending migrations (of %d total)", len(pending), len(migration_files))
 

--- a/atlas_brain/storage/migrations/reconciliation.py
+++ b/atlas_brain/storage/migrations/reconciliation.py
@@ -103,6 +103,17 @@ MIGRATION_387_RECONCILIATION = HistoricalMigrationReconciliation(
     ),
 )
 
+
+def known_historical_migration_reconciliation_names() -> frozenset[str]:
+    """Return the reviewed migration names eligible for current attestation.
+
+    The runner derives this closed set from the source-controlled evidence
+    module instead of maintaining a second exception list. Adding another name
+    still requires its own reviewed record and catalog predicate here.
+    """
+    return frozenset((MIGRATION_387_RECONCILIATION.migration_name,))
+
+
 def _packaged_migration_digest(
     migration_files: Collection[Path],
     migration_name: str,

--- a/docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md
+++ b/docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md
@@ -1,0 +1,107 @@
+# Migration Content Integrity Admission Runbook
+
+## Purpose
+
+This runbook governs Atlas releases that may apply SQL migrations. The normal
+runner records source identity for newly applied files and reports historical
+drift. Its admission policy refuses to execute a pending migration when a
+recorded source mismatch or missing packaged source remains unexplained.
+
+The policy is deliberately narrower than source verification. A reviewed
+historical reconciliation can make its exact mismatch admissible only while its
+current evidence is attested. It does not make unavailable historical source
+bytes verified, and the read-only preflight continues to report that mismatch.
+
+## Before a migration-bearing rollout
+
+1. Start from the exact Atlas release-candidate worktree and identify the
+   configured, log-safe database target without opening a connection:
+
+   ```bash
+   python scripts/check_migration_content_integrity.py --show-target
+   ```
+
+2. Compare that label with the target you intend to inspect. Then run the
+   target-confirmed, read-only receipt against that same target:
+
+   ```bash
+   python scripts/check_migration_content_integrity.py \
+     --expected-target '<exact target label from step 1>' \
+     --attest-known-reconciliations
+   ```
+
+   The command never runs migrations or writes financial data. Preserve its
+   JSON output with the release record. Do not pass a DSN, credential, or
+   database URL on the command line.
+
+3. Interpret the result conservatively:
+
+   - `verified` and `legacy_unverified` can proceed under the normal runner
+     policy. Legacy null hashes remain visible; they are not silently repaired.
+   - `unresolved_drift` with a matching known record may be admissible only when
+     every entry in `known_reconciliation_evidence` for that reported name is
+     `attested`, there is no `missing_source`, and there are no additional
+     mismatched names. The preflight still exits 2 to preserve forensic truth;
+     do not treat exit 2 alone as approval.
+   - Any unknown mismatch, missing source, a known record that is currently
+     reported as mismatched but has absent/non-attested evidence, target
+     mismatch, or `could_not_determine` result is a stop condition. Do not
+     probe a known reconciliation that is not an active mismatch as a reason to
+     stop an otherwise clean target.
+
+4. Deploy the admission-policy release to every Atlas process that can invoke
+   `run_migrations()` before adding a later migration-bearing release. This
+   policy release contains no SQL migration itself. Do not use a standalone
+   MCP process or an older checkout as an alternate migration path.
+
+5. For the later migration-bearing release, use the ordinary service deployment
+   entrypoint. The runner holds its existing advisory lock, evaluates the
+   evidence under that lock, and either applies the selected pending files or
+   fails before their SQL and `schema_migrations` records are written. Capture
+   the startup/migration log and repeat the read-only receipt after the rollout.
+
+## When admission refuses a pending migration
+
+1. Stop the migration-bearing rollout. Do not edit `schema_migrations`, replace
+   packaged historical source bytes, replay migration 387, or downgrade solely
+   to make the runner apply SQL.
+2. Preserve the target-confirmed preflight JSON, the release SHA, the blocked
+   migration names, and the runner error. These are the recovery evidence.
+3. Classify the evidence:
+
+   - A known reconciliation that is `not_attested` means its current ledger,
+     package, timestamp, or catalog predicate no longer matches the reviewed
+     record. Repair the real schema/data condition through a separately
+     reviewed, forward-only recovery; then rerun the preflight and retry the
+     unchanged pending migration.
+   - An unknown mismatch or missing source is not an allowlist request. Open a
+     dedicated H-18 follow-up with immutable source evidence and a named
+     catalog predicate. If historical source bytes cannot be proven, keep the
+     migration blocked rather than fabricating a digest.
+
+4. Retry only after the read-only receipt is current for the intended target.
+   A failed admission executes no pending SQL, so the existing runner's
+   advisory-lock and ledger behavior keeps the retry idempotent.
+
+## Rollback
+
+This policy adds no database migration and changes no financial records. A
+runtime rollback can return a no-pending service to its prior application
+revision, but it is never an approved way to bypass a refused pending migration.
+Keep the policy-capable revision deployed while a migration-bearing release is
+pending or under investigation.
+
+If another release already applied SQL before an application rollback, retain
+the recorded schema and ledger evidence. Use a separate, forward-compatible
+repair or an explicitly authorized database rollback plan for that other
+release; do not delete migration history as part of this policy rollback.
+
+## Non-negotiable constraints
+
+- ATLAS remains the financial source of truth; this runbook never authorizes
+  invoice, payment, allocation, Gmail, or Square mutations for verification.
+- The preflight is read-only evidence, not a migration executor.
+- A known reconciliation is admission evidence for one exact migration name,
+  not a global exception and not historical-source verification.
+- Every new historical discrepancy requires its own reviewed evidence record;
+  do not extend a generic runner allowlist.

--- a/plans/PR-EOM-Migration-Admission-Policy.md
+++ b/plans/PR-EOM-Migration-Admission-Policy.md
@@ -1,0 +1,314 @@
+# PR-EOM-Migration-Admission-Policy
+
+## Why this slice exists
+
+H-18 phase two in [ATLAS #2461](https://github.com/canfieldjuan/ATLAS/issues/2461)
+now has both prerequisites: #2462 provides a target-confirmed, read-only
+provenance preflight and #2467 supplies immutable evidence for the real
+migration-387 historical source gap. The production migration runner still only
+logs mismatched or missing-source evidence, then applies any pending SQL. That
+would allow a newly packaged migration to change a financial provider's schema
+while the same deployment has unresolved provenance drift.
+
+This production-hardening slice closes that precise admission gap. It is
+justified by the recorded financial migration incident, not a new billing
+workflow: it permits a pending migration only when every mismatch is absent or
+represented by a current, attested, source-controlled reconciliation record and
+no missing-source row exists. It leaves a no-pending startup available, and
+documents the operator rollout, rollback, and recovery path.
+
+### Contract revision — existing repair proof exposed by GitHub CI
+
+GitHub's required migration-runner job proved that the real public-onboarding
+repair test deliberately recreates an observed negative ledger record named
+`382_eom_public_onboarding_tokens`, for which no same-named packaged source
+exists. The new policy correctly rejects its pending 384 repair before SQL.
+That is not evidence to weaken missing-source admission: phase one's archived
+contract explicitly defines an unreadable/absent source as `missing_source`,
+and the 384 repair plan records the historical collision as a real production
+condition.
+
+The narrow correction is test isolation, not a runtime exception. Preserve the
+real-package refusal as a disposable-PostgreSQL regression; let the older 384
+DDL tests use a test-owned readable legacy catalog solely to exercise the DDL
+contract. Do not add an unproven reconciliation record for 382. Record its
+target-confirmed evidence/reconciliation decision as a dedicated H-18 follow-up
+in #2363 before a production migration-bearing rollout relies on this policy.
+
+**Diff-budget exception:** the expected 600-plus-line change consists of the
+required plan/Review Contract, one durable operator runbook, a small admission
+decision, and an indivisible real-runner fixture matrix that proves refusal,
+known attestation, retry recovery, and no-pending availability. Splitting the
+runbook or the recovery tests would either leave operators without a safe
+response to a financial migration refusal or make the new fail-closed boundary
+unproven; no unrelated refactor is included.
+
+### Problem-derived contract
+
+- Root cause: `run_migrations()` computes and logs the generic
+  `MigrationContentIntegrityReport`, but its pending-file loop does not use
+  that report for admission. A known 387 reconciliation record exists but is
+  deliberately not source verification, so the runner needs a separate policy
+  decision that consumes only its current attestation rather than relabeling
+  history as verified.
+- Correct fix must touch/change: make the existing runner calculate pending
+  files under its advisory lock, resolve only the candidate names exposed by
+  the source-controlled reconciliation module, and refuse all pending SQL when
+  any mismatch/missing-source evidence remains unresolved. Add behavior tests
+  for unknown drift, attested 387, returned/transport-failed 387
+  attestation/retry recovery, mixed known-plus-unresolved evidence, and
+  no-pending availability. Add a stable operator runbook with exact rollout,
+  rollback, and recovery constraints.
+- Must not change: migration SQL, `schema_migrations` historical rows, source
+  hashes, the generic preflight categories/exit code, invoice/payment/Gmail/
+  Square behavior, target/database configuration, current no-pending startup,
+  or any unrelated migration, CI, deployment, or billing lane. A historical
+  record must never become `verified` merely because it is admission-attested.
+
+## Scope (this PR)
+
+Ownership lane: eom/migration-content-integrity
+Slice phase: Production hardening
+Max files: 6
+
+1. Add an advisory-lock-held pending-migration admission decision to the
+   canonical runner. It blocks before executing a pending migration when
+   unresolved generic mismatch/missing-source evidence remains.
+2. Reuse the immutable reconciliation module as the sole source for names that
+   can be attested. An attested record can satisfy admission for its own current
+   mismatch only; unknown, missing-source, or non-attested evidence remains a
+   blocker.
+3. Preserve the pre-existing no-pending behavior: diagnostics remain visible,
+   but no reconciliation catalog query or startup failure is introduced solely
+   by historical drift when this run would apply no SQL.
+4. Add focused runner tests and a durable runbook. The runbook documents the
+   target-confirmed read-only preflight, deployment sequence, safe recovery,
+   and the fact that rollback is never a way to bypass an admission refusal.
+5. Keep the existing public-onboarding repair DDL proof meaningful without
+   creating a production bypass: its test-owned readable legacy catalog proves
+   migration 384's schema behavior, while a separate real packaged-catalog
+   case proves the known missing 382 source now refuses the repair before SQL.
+6. Scope a known reconciliation's non-attested result to an actively reported
+   mismatch, and prove both a thrown attestation transport error and an
+   attested 387 plus another unresolved row remain fail-closed before SQL.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] With a pending temporary migration and either an unknown digest mismatch
+    or a missing packaged source, `run_migrations()` raises the named admission
+    error before the pending SQL or ledger record is executed; settled by the
+    parametrized failure test in `tests/test_migrations_runner.py`.
+  - [ ] With the existing 387 mismatch plus a current full attestation,
+    `run_migrations()` accepts a later pending migration and records its exact
+    digest; settled by the attested-runner test using the real reconciliation
+    predicate fixture in `tests/test_migrations_runner.py`.
+  - [ ] A failed known attestation applies no pending SQL; after the controlled
+    catalog evidence is restored, retry applies the same pending file exactly
+    once; settled by the recovery test in `tests/test_migrations_runner.py`.
+  - [ ] A thrown known-attestation transport error raises the named refusal,
+    releases the advisory lock and connection, writes no pending SQL or ledger
+    row, and applies the unchanged pending file once after retry; settled by
+    the transport-failure runner test in `tests/test_migrations_runner.py`.
+  - [ ] A current attestation for 387 cannot clear an additional unknown
+    mismatch or missing source: each mixed fixture still refuses before pending
+    SQL and ledger writes; settled by the parametrized mixed-evidence runner
+    test in `tests/test_migrations_runner.py`.
+  - [ ] With no pending migration, a recorded mismatch remains a logged
+    diagnostic and the runner returns without calling the reconciliation
+    catalog probe; settled by the no-pending runner test and its fake executor
+    call surface.
+  - [ ] The real package's observed 382 missing-source ledger shape rejects
+    pending 384 before its SQL or ledger record; the schema-repair test keeps
+    its old DDL/failure proof only with an explicitly test-owned readable
+    legacy catalog, settled by
+    `tests/test_eom_public_onboarding_migration_repair.py` on disposable
+    PostgreSQL.
+  - [ ] `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` directs operators to the
+    existing target-confirmed read-only preflight, refuses ledger edits/replay
+    as recovery, and names safe rollout/rollback/reconciliation decisions;
+    settled by cold diff review and the checked-in document.
+- Reachability proof: the real `run_migrations()` entrypoint runs against its
+  existing acquired-connection fake, and observable pending SQL/ledger state
+  proves the admission decision occurs before migration execution. The operator
+  runbook points to the existing real preflight entrypoint; no new public API is
+  introduced.
+- Affected surfaces: migration runner admission, immutable reconciliation
+  evidence lookup, focused runner tests, and the Atlas operator migration
+  runbook.
+- Risk areas: financial-schema deployment safety, source provenance, startup
+  availability, retry/idempotency, no-write ordering, backward compatibility,
+  and operator recovery.
+- Reviewer rules triggered: R1, R2, R4, R5, R6, R8, R10, R12, R13, R14.
+
+### Boundary-change enumeration
+
+- Boundary path/seam: `run_migrations()` now uses the pre-existing content
+  report at the single point after it knows a run has pending files and before
+  any pending SQL is executed. The policy consumes generic
+  `mismatched`/`missing_source` names plus named reconciliation attestations.
+  Only a reported mismatch can be cleared by a matching current attestation;
+  every missing source remains admission-blocking.
+- Replaced-path behaviors: phase one's log-only handling is replaced only for a
+  run that would apply at least one pending file. A no-pending run remains
+  diagnostic-only; legacy-null evidence remains observe-only.
+- Guard-relevant fields: pending migration stems, `mismatched` names,
+  `missing_source` names, the closed derived set of reconciliation candidates,
+  and each candidate's `attested`/`not_attested` status. The safe default is
+  refusal: unrecognized, missing, unavailable, or non-attested evidence cannot
+  satisfy admission, because executing new financial-schema SQL is the more
+  expensive error direction.
+- Caller x input shape: full application/MCP runner with pending SQL; `only=`
+  runner with a targeted pending prerequisite; no pending files; known 387
+  evidence attested; known evidence not attested; and unknown mismatch/missing
+  source. The runner never accepts a caller-supplied digest or reconciliation
+  identity.
+
+### Closure declaration
+
+1. **Closed or open:** the packaged migration and applied-ledger members are
+   **CLOSED per run**: they come from the migration directory and the one
+   `schema_migrations` snapshot. Reconciliation candidates are also **CLOSED**
+   at each source revision: the reconciliation module exposes the reviewed
+   named records. The caller's `only` collection is open, but its valid members
+   are derived from the actual packaged directory and unknown names already
+   raise before any migration SQL.
+2. **Membership source:** all three decision sets are **DERIVED**: packaged
+   files use `directory.glob("*.sql")`, applied names use the locked ledger
+   snapshot, and known reconciliation names use the source-controlled
+   reconciliation module. No copied allowlist exists in the runner or runbook.
+3. **Outside-set behavior:** any mismatch not returned as currently attested,
+   and every missing-source name, remains unresolved and rejects pending
+   application. An absent/unreadable/non-attested known record has the same
+   result. This is the safer default because a false refusal is recoverable by
+   evidence/reconciliation, while applying schema SQL alongside unexplained
+   provenance drift can create an unreconstructible financial deployment state.
+
+### Deployed-config probing
+
+- Deployed/default config values: no new setting, environment variable, or
+  fallback is introduced. The normal runner retains its existing packaged
+  `MIGRATIONS_DIR` default and existing typed database configuration.
+- Explicit value probe: a caller may use the existing `only=` collection; a
+  targeted pending migration is still subject to the same admission decision.
+- Absent value probe: omitted `only` retains the full packaged-run behavior;
+  no pending file returns before reconciliation catalog attestation.
+- Default-session/default-context probe: the configured production runner and
+  standalone MCP callers all reach the same `run_migrations()` implementation,
+  so no caller can opt out through a new setting.
+- Side-effect ordering: the runner obtains its existing lock/bootstrap and
+  locked ledger snapshot, computes pending files, then resolves evidence before
+  its first pending migration `execute()` or `_record_migration()` call.
+
+### Files touched
+
+- `atlas_brain/storage/migrations/__init__.py`
+- `atlas_brain/storage/migrations/reconciliation.py`
+- `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`
+- `plans/PR-EOM-Migration-Admission-Policy.md`
+- `tests/test_eom_public_onboarding_migration_repair.py`
+- `tests/test_migrations_runner.py`
+
+## Mechanism
+
+The runner keeps its existing advisory-lock and diagnostic report. Only if its
+selected migration set contains a pending file does it ask the reconciliation
+module which named historical records are eligible for attestation. It evaluates
+those records only when the generic report names one as mismatched; every other
+report name remains unresolved without extra catalog work. An attested
+reconciliation removes only its exact migration name from the admission-blocking
+mismatch set. Missing source evidence is never removed from that blocking set.
+
+The runner raises one log-safe error containing only migration names/categories
+before entering the pending-file loop. It makes no migration SQL or ledger
+record write on that refusal. Existing retries remain safe because a corrected
+attestation re-evaluates the unchanged pending set under the same advisory lock
+and executes/records each file through the established idempotent mechanism.
+
+The runbook makes the preflight an evidence receipt, not an alternate migration
+runner: operators confirm the target, inspect the JSON, deploy the policy before
+future migration-bearing releases, and use a reviewed forward reconciliation or
+repair when admission blocks. It expressly prohibits editing historical ledger
+rows, replaying migration 387, or rolling back to evade the policy.
+
+## Intentional
+
+- Generic preflight output remains `unresolved_drift` / exit 2 even for a
+  currently attested historical record. Admission attestation is not historical
+  source verification and must not obscure the forensic truth.
+- The policy does not add a new migration, feature flag, CLI mode, schema table,
+  or automated recovery. The existing runner is the canonical admission point;
+  a parallel deployment gate would drift from actual application behavior.
+- No-pending startup does not query current catalog reconciliation evidence.
+  This preserves availability for services that merely inspect an already
+  migrated database while still blocking any new migration application.
+- Existing legacy-null hashes with a readable packaged source remain explicit
+  but non-blocking. A legacy row with no readable same-named source is still
+  `missing_source`, so it stays fail-closed until separately reconciled.
+- A test-only readable 382 fixture is not a provenance reconciliation and does
+  not add, replace, or bless a packaged migration source. It merely keeps the
+  pre-existing 384 DDL regression test focused on its schema contract; the
+  real packaged catalog remains fail-closed in a neighboring assertion.
+
+## Deferred
+
+Parking predicate: park any new historical reconciliation record, source-byte
+reconstruction, migration SQL/data repair, startup/profile behavior change,
+general deployment orchestrator, or dynamic-SQL parser expansion unless it is
+required to enforce the single runner admission decision above.
+
+- #2461 Slice 4: document/validate dynamic self-recording migration authoring
+  around the existing atomic-bookkeeping marker without broadening the SQL
+  parser speculatively.
+- H-18 382 public-onboarding missing-source evidence: GitHub CI proved the
+  existing repair fixture models a historical, same-named source absence. Do
+  not create an admission exception from test evidence; #2363 must receive a
+  target-confirmed forensic/preflight follow-up before a production migration
+  run is unblocked on that name.
+- H-18 known-reconciliation expansion remains parked: this loop documents the
+  inactive-record condition and proves the current 387 boundary; #2363 remains
+  the only target-confirmed forensic/evidence path for any additional name.
+- A future source discrepancy requires its own reviewed evidence record and
+  named catalog predicate; it must not be added as an ad hoc runner exception.
+- #2034 generic cross-session reservation/semantic-drift investigation and
+  #2035 branch-protection/CI policy remain outside this ownership lane.
+
+Parked hardening: none against the stated predicate.
+
+## Verification
+
+- Fast local checks executed:
+  `python -m pytest -q tests/test_migrations_runner.py
+  tests/test_migration_content_integrity_preflight.py` — 73 passed, 1 skipped.
+  This is the focused migration runner/preflight selection, not the repository
+  unit gate.
+- Fast local checks executed:
+
+      ruff check atlas_brain/storage/migrations/__init__.py atlas_brain/storage/migrations/reconciliation.py tests/test_migrations_runner.py
+      python -m py_compile atlas_brain/storage/migrations/__init__.py atlas_brain/storage/migrations/reconciliation.py tests/test_migrations_runner.py
+      git diff --check
+
+  All passed.
+- Fast local collection check executed with the migration-test database URL
+  explicitly unset: `tests/test_eom_public_onboarding_migration_repair.py` —
+  4 skipped. The disposable-PostgreSQL proof is intentionally GitHub-only
+  because no local target was independently verified as non-production.
+- Fast local checks executed: `python scripts/sync_pr_plan.py --check
+  plans/PR-EOM-Migration-Admission-Policy.md`, the reviewer-rule audit, and
+  `python scripts/check_guard_class_closure.py --base origin/main --strict` —
+  passed after the planned files are visible to Git's diff.
+- GitHub-only: the complete `Atlas Migrations Runner Checks`, repository unit
+  gate, security scans, and all required PR checks. Per operator direction, no
+  broad unit gate will be run locally.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/storage/migrations/__init__.py` | 81 |
+| `atlas_brain/storage/migrations/reconciliation.py` | 11 |
+| `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` | 107 |
+| `plans/PR-EOM-Migration-Admission-Policy.md` | 314 |
+| `tests/test_eom_public_onboarding_migration_repair.py` | 81 |
+| `tests/test_migrations_runner.py` | 277 |
+| **Total** | **871** |

--- a/tests/test_eom_public_onboarding_migration_repair.py
+++ b/tests/test_eom_public_onboarding_migration_repair.py
@@ -10,13 +10,18 @@ import pytest
 
 asyncpg = pytest.importorskip("asyncpg")
 
-from atlas_brain.storage.migrations import run_migrations  # noqa: E402
+from atlas_brain.storage.migrations import (  # noqa: E402
+    PendingMigrationContentIntegrityError,
+    run_migrations,
+)
 
 
 ROOT = Path(__file__).resolve().parent.parent
 MIGRATIONS = ROOT / "atlas_brain" / "storage" / "migrations"
 DATABASE_URL_ENV = "ATLAS_MIGRATION_TEST_DATABASE_URL"
 MIGRATION_STEM = "384_eom_public_onboarding_tokens_schema_repair"
+_LEGACY_SOURCE_STEM = "382_eom_public_onboarding_tokens"
+_COMPLETE_SCHEMA_STEM = "383_eom_public_onboarding_tokens"
 
 _EXPECTED_REPAIRED_COLUMNS = {
     "signing_key_fingerprint": ("character varying", 64, "NO"),
@@ -51,6 +56,29 @@ class _MigrationPool:
 
     async def release(self, released) -> None:
         assert released is self._conn
+
+
+def _test_owned_legacy_repair_catalog(tmp_path: Path) -> Path:
+    """Return a readable fixture catalog for the schema-only repair contract.
+
+    The real package intentionally has no source named
+    ``382_eom_public_onboarding_tokens``: it now has an unrelated 382 prefix
+    collision and the original source bytes were not retained. The admission
+    policy must reject that real package; a neighboring test covers it. These
+    older DDL tests instead need only a readable null-digest legacy record so
+    they can keep exercising migration 384's schema behavior through the real
+    runner without inventing a production reconciliation.
+    """
+    catalog = tmp_path / "readable_legacy_migrations"
+    catalog.mkdir()
+    (catalog / f"{_LEGACY_SOURCE_STEM}.sql").write_text(
+        "-- test-only readable source sentinel for a legacy null-digest row\n"
+    )
+    for stem in (_COMPLETE_SCHEMA_STEM, MIGRATION_STEM):
+        (catalog / f"{stem}.sql").write_bytes(
+            (MIGRATIONS / f"{stem}.sql").read_bytes()
+        )
+    return catalog
 
 
 async def _prepare_known_legacy_schema(conn, schema: str) -> None:
@@ -135,10 +163,10 @@ async def _prepare_complete_schema(conn, schema: str) -> None:
     )
 
 
-async def _run_schema_repair(conn) -> None:
+async def _run_schema_repair(conn, *, migrations_dir: Path = MIGRATIONS) -> None:
     await run_migrations(
         _MigrationPool(conn),
-        migrations_dir=MIGRATIONS,
+        migrations_dir=migrations_dir,
         only={MIGRATION_STEM},
     )
 
@@ -158,13 +186,18 @@ async def _legacy_columns(conn, schema: str) -> set[str]:
 
 
 @pytest.mark.asyncio
-async def test_schema_repair_adds_383_immutable_projection_to_empty_legacy_table():
+async def test_schema_repair_adds_383_immutable_projection_to_empty_legacy_table(
+    tmp_path,
+):
     database_url = _database_url_or_skip()
     schema = f"eom_public_repair_{uuid.uuid4().hex}"
     conn = await asyncpg.connect(database_url)
     try:
         await _prepare_known_legacy_schema(conn, schema)
-        await _run_schema_repair(conn)
+        await _run_schema_repair(
+            conn,
+            migrations_dir=_test_owned_legacy_repair_catalog(tmp_path),
+        )
 
         assert (
             await conn.fetchval(
@@ -273,7 +306,9 @@ async def test_schema_repair_adds_383_immutable_projection_to_empty_legacy_table
 
 
 @pytest.mark.asyncio
-async def test_schema_repair_fails_without_mutating_nonempty_legacy_table():
+async def test_schema_repair_fails_without_mutating_nonempty_legacy_table(
+    tmp_path,
+):
     database_url = _database_url_or_skip()
     schema = f"eom_public_repair_nonempty_{uuid.uuid4().hex}"
     conn = await asyncpg.connect(database_url)
@@ -305,7 +340,10 @@ async def test_schema_repair_fails_without_mutating_nonempty_legacy_table():
             asyncpg.RaiseError,
             match="cannot safely repair nonempty eom_public_onboarding_tokens",
         ):
-            await _run_schema_repair(conn)
+            await _run_schema_repair(
+                conn,
+                migrations_dir=_test_owned_legacy_repair_catalog(tmp_path),
+            )
 
         assert await _legacy_columns(conn, schema) == columns_before
         assert (
@@ -319,6 +357,35 @@ async def test_schema_repair_fails_without_mutating_nonempty_legacy_table():
             FROM schema_migrations
             WHERE name = $1
             """,
+                MIGRATION_STEM,
+            )
+            == 0
+        )
+    finally:
+        await conn.execute(f"DROP SCHEMA IF EXISTS {_quote_ident(schema)} CASCADE")
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_schema_repair_refuses_observed_missing_382_source_before_sql():
+    """The real packaged catalog cannot bypass the H-18 source-evidence gate."""
+    database_url = _database_url_or_skip()
+    schema = f"eom_repair_missing_source_{uuid.uuid4().hex}"
+    conn = await asyncpg.connect(database_url)
+    try:
+        await _prepare_known_legacy_schema(conn, schema)
+        columns_before = await _legacy_columns(conn, schema)
+
+        with pytest.raises(
+            PendingMigrationContentIntegrityError,
+            match=f"missing_source={_LEGACY_SOURCE_STEM}",
+        ):
+            await _run_schema_repair(conn)
+
+        assert await _legacy_columns(conn, schema) == columns_before
+        assert (
+            await conn.fetchval(
+                "SELECT COUNT(*) FROM schema_migrations WHERE name = $1",
                 MIGRATION_STEM,
             )
             == 0

--- a/tests/test_migrations_runner.py
+++ b/tests/test_migrations_runner.py
@@ -8,7 +8,19 @@ from pathlib import Path
 
 import pytest
 
+from atlas_brain.storage import recurring_invoice_schema
+
 DATABASE_URL_ENV = "ATLAS_MIGRATION_TEST_DATABASE_URL"
+
+
+def _migration_387_source() -> bytes:
+    return (
+        Path(__file__).resolve().parents[1]
+        / "atlas_brain"
+        / "storage"
+        / "migrations"
+        / "387_eom_recurring_invoice_dedup_recovery.sql"
+    ).read_bytes()
 
 
 class FakeMigrationPool:
@@ -803,6 +815,71 @@ class _SerializingPool(FakeMigrationPool):
         return _RollbackMigrationTransaction(self)
 
 
+class _AttestedReconciliationPool(_SerializingPool):
+    """Runner fixture that answers the real 387 catalog-attestation queries."""
+
+    def __init__(
+        self,
+        *,
+        recurring_schema_ready: bool = True,
+        zero_active_null_period_rows: bool = True,
+    ):
+        super().__init__()
+        self.recurring_schema_ready = recurring_schema_ready
+        self.zero_active_null_period_rows = zero_active_null_period_rows
+        self.reconciliation_rows: list[dict[str, object]] = []
+
+    async def fetch(self, query, *args):
+        from atlas_brain.storage.migrations.reconciliation import (
+            MIGRATION_387_RECONCILIATION,
+        )
+
+        normalized = " ".join(query.split())
+        if normalized == (
+            "SELECT content_sha256, applied_at FROM schema_migrations "
+            "WHERE name = $1 LIMIT 2"
+        ):
+            assert args == (MIGRATION_387_RECONCILIATION.migration_name,)
+            return list(self.reconciliation_rows)
+        if "FROM pg_constraint AS actual" in query:
+            assert args == (
+                list(recurring_invoice_schema._RECURRING_INVOICE_DEDUP_CONSTRAINTS),
+            )
+            return [
+                {"conname": name, "definition": definition}
+                for name, definition in (
+                    recurring_invoice_schema._RECURRING_INVOICE_DEDUP_CONSTRAINT_EXPRESSIONS.items()
+                )
+            ]
+        return await super().fetch(query, *args)
+
+    async def fetchrow(self, query, *args):
+        assert "FROM pg_index AS index_state" in query
+        assert args == (recurring_invoice_schema._RECURRING_INVOICE_DEDUP_INDEX,)
+        return {
+            "indisunique": True,
+            "indisvalid": True,
+            "indisready": True,
+            "indnkeyatts": 2,
+            "key_column_1": "contact_id",
+            "key_column_2": "billing_period",
+            "predicate": (
+                "(billing_period IS NOT NULL) AND "
+                "(source = ANY (ARRAY['monthly_auto', 'eom_commercial_billing'])) "
+                "AND (status <> 'void')"
+            ),
+        }
+
+    async def fetchval(self, query, *args):
+        if "information_schema.columns AS actual" in query:
+            assert args == ()
+            return self.recurring_schema_ready
+        if "FROM invoices" in query:
+            assert args == ()
+            return self.zero_active_null_period_rows
+        return await super().fetchval(query, *args)
+
+
 class _RollbackMigrationTransaction:
     """In-memory transaction seam that restores migration effects on failure."""
 
@@ -866,6 +943,9 @@ class _Conn:
             self.held = True
             return True
         return await self.pool.fetchval(query, *args)
+
+    async def fetchrow(self, query, *args):
+        return await self.pool.fetchrow(query, *args)
 
     def transaction(self):
         return self.pool.transaction()
@@ -1132,27 +1212,210 @@ async def test_mixed_case_quoted_ledger_lookalike_preserves_concurrent_autocommi
     assert any("CREATE INDEX CONCURRENTLY" in sql for sql in pool.applied_sql)
 
 
+def _stage_historical_387_mismatch(tmp_path, pool):
+    from atlas_brain.storage.migrations.reconciliation import (
+        MIGRATION_387_RECONCILIATION,
+    )
+
+    record = MIGRATION_387_RECONCILIATION
+    (tmp_path / f"{record.migration_name}.sql").write_bytes(_migration_387_source())
+    pool.records.append((387, record.migration_name, record.historical_ledger_sha256))
+    if hasattr(pool, "reconciliation_rows"):
+        pool.reconciliation_rows = [{
+            "content_sha256": record.historical_ledger_sha256,
+            "applied_at": record.observed_applied_at,
+        }]
+    return record
+
+
 @pytest.mark.asyncio
-async def test_mismatch_is_logged_without_blocking_a_later_pending_migration(
+@pytest.mark.parametrize(
+    ("case", "source_present", "expected_category"),
+    [
+        ("digest mismatch", True, "mismatched=900_recorded"),
+        ("missing packaged source", False, "missing_source=900_recorded"),
+    ],
+)
+async def test_unresolved_content_evidence_blocks_pending_migration_before_sql(
+    tmp_path,
+    case,
+    source_present,
+    expected_category,
+):
+    from atlas_brain.storage.migrations import (
+        PendingMigrationContentIntegrityError,
+        run_migrations,
+    )
+
+    if source_present:
+        (tmp_path / "900_recorded.sql").write_text("SELECT 900")
+    (tmp_path / "901_pending.sql").write_text("SELECT 901")
+    pool = _SerializingPool(honor_lock=True)
+    pool.records.append((900, "900_recorded", "f" * 64))
+
+    with pytest.raises(PendingMigrationContentIntegrityError) as exc_info:
+        await run_migrations(pool, migrations_dir=tmp_path)
+
+    assert expected_category in str(exc_info.value), case
+    assert pool.applied_sql == [], case
+    assert pool.records == [(900, "900_recorded", "f" * 64)], case
+    assert pool.inserted_with_digest == [], case
+
+
+@pytest.mark.asyncio
+async def test_attested_historical_mismatch_admits_targeted_pending_migration(tmp_path):
+    from atlas_brain.storage.migrations import run_migrations
+
+    pool = _AttestedReconciliationPool()
+    _stage_historical_387_mismatch(tmp_path, pool)
+    (tmp_path / "901_pending.sql").write_text("SELECT 901")
+
+    await run_migrations(
+        pool,
+        migrations_dir=tmp_path,
+        only={"901_pending"},
+    )
+
+    assert pool.applied_sql == ["SELECT 901"]
+    assert pool.inserted_with_digest == [
+        (901, "901_pending", hashlib.sha256(b"SELECT 901").hexdigest())
+    ]
+
+
+@pytest.mark.asyncio
+async def test_failed_historical_attestation_blocks_then_retry_applies_once(tmp_path):
+    from atlas_brain.storage.migrations import (
+        PendingMigrationContentIntegrityError,
+        run_migrations,
+    )
+
+    pool = _AttestedReconciliationPool(zero_active_null_period_rows=False)
+    _stage_historical_387_mismatch(tmp_path, pool)
+    (tmp_path / "901_pending.sql").write_text("SELECT 901")
+
+    with pytest.raises(PendingMigrationContentIntegrityError, match="mismatched="):
+        await run_migrations(pool, migrations_dir=tmp_path)
+
+    assert pool.applied_sql == []
+    assert pool.inserted == []
+    assert pool.inserted_with_digest == []
+    assert pool.updated == []
+
+    pool.zero_active_null_period_rows = True
+    await run_migrations(pool, migrations_dir=tmp_path)
+
+    assert pool.applied_sql == ["SELECT 901"]
+    assert pool.inserted_with_digest == [
+        (901, "901_pending", hashlib.sha256(b"SELECT 901").hexdigest())
+    ]
+
+
+@pytest.mark.asyncio
+async def test_attestation_transport_failure_blocks_then_retry_applies_once(tmp_path):
+    """Attestation transport failures fail closed and release the runner lock."""
+    from atlas_brain.storage.migrations import (
+        PendingMigrationContentIntegrityError,
+        run_migrations,
+    )
+
+    class _FailingAttestationTransportPool(_AttestedReconciliationPool):
+        def __init__(self):
+            super().__init__()
+            self.fail_attestation_transport = True
+
+        async def fetchrow(self, query, *args):
+            if self.fail_attestation_transport:
+                raise RuntimeError("injected 387 attestation transport failure")
+            return await super().fetchrow(query, *args)
+
+    pool = _FailingAttestationTransportPool()
+    _stage_historical_387_mismatch(tmp_path, pool)
+    (tmp_path / "901_pending.sql").write_text("SELECT 901")
+
+    with pytest.raises(
+        PendingMigrationContentIntegrityError,
+        match="known historical migration evidence could not be attested",
+    ):
+        await run_migrations(pool, migrations_dir=tmp_path)
+
+    assert pool.applied_sql == []
+    assert pool.inserted == []
+    assert pool.inserted_with_digest == []
+    assert pool.updated == []
+    assert not pool._lock().locked()
+    assert pool.acquired == 0
+
+    pool.fail_attestation_transport = False
+    await run_migrations(pool, migrations_dir=tmp_path)
+
+    assert pool.applied_sql == ["SELECT 901"]
+    assert pool.inserted_with_digest == [
+        (901, "901_pending", hashlib.sha256(b"SELECT 901").hexdigest())
+    ]
+    assert not pool._lock().locked()
+    assert pool.acquired == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("case", "other_source_present", "expected_category"),
+    [
+        ("unknown digest mismatch", True, "mismatched=900_other_recorded"),
+        ("missing packaged source", False, "missing_source=900_other_recorded"),
+    ],
+)
+async def test_attested_known_mismatch_cannot_clear_other_content_evidence(
+    tmp_path,
+    case,
+    other_source_present,
+    expected_category,
+):
+    """A successful 387 attestation clears only its exact reviewed mismatch."""
+    from atlas_brain.storage.migrations import (
+        PendingMigrationContentIntegrityError,
+        run_migrations,
+    )
+
+    pool = _AttestedReconciliationPool()
+    record = _stage_historical_387_mismatch(tmp_path, pool)
+    pool.records.append((900, "900_other_recorded", "f" * 64))
+    if other_source_present:
+        (tmp_path / "900_other_recorded.sql").write_text("SELECT 900")
+    (tmp_path / "901_pending.sql").write_text("SELECT 901")
+
+    with pytest.raises(PendingMigrationContentIntegrityError) as exc_info:
+        await run_migrations(pool, migrations_dir=tmp_path)
+
+    message = str(exc_info.value)
+    assert expected_category in message, case
+    assert record.migration_name not in message, case
+    assert pool.applied_sql == [], case
+    assert pool.inserted == [], case
+    assert pool.inserted_with_digest == [], case
+    assert pool.updated == [], case
+    assert not pool._lock().locked(), case
+    assert pool.acquired == 0, case
+
+
+@pytest.mark.asyncio
+async def test_historical_mismatch_without_pending_migration_remains_available(
     tmp_path,
     caplog,
 ):
     from atlas_brain.storage.migrations import run_migrations
 
-    (tmp_path / "900_recorded.sql").write_text("SELECT 900")
-    (tmp_path / "901_pending.sql").write_text("SELECT 901")
     pool = _SerializingPool(honor_lock=True)
-    pool.records.append((900, "900_recorded", "f" * 64))
+    _stage_historical_387_mismatch(tmp_path, pool)
     caplog.set_level(logging.ERROR, logger="atlas.storage.migrations")
 
     await run_migrations(pool, migrations_dir=tmp_path)
 
-    assert any("mismatched=900_recorded" in message for message in caplog.messages)
-    assert pool.applied_sql == ["SELECT 901"]
-    assert pool.records[0] == (900, "900_recorded", "f" * 64)
-    assert pool.inserted_with_digest == [
-        (901, "901_pending", hashlib.sha256(b"SELECT 901").hexdigest())
-    ]
+    assert any(
+        "mismatched=387_eom_recurring_invoice_dedup_recovery" in message
+        for message in caplog.messages
+    )
+    assert pool.applied_sql == []
+    assert pool.inserted_with_digest == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-EOM-Migration-Admission-Policy.md
Slice phase: Production hardening
Ownership lane: eom/migration-content-integrity
<!-- atlas-open-pr-wrapper: v1 -->

This H-18 Slice 3 closes the narrow runner-admission gap exposed by the real
migration-387 provenance incident: pending financial-schema SQL must not run
beside unresolved source evidence, while already-migrated services remain
available and diagnostic-only.

Diff-budget override: The 854 added lines are an indivisible six-file slice:
the mandatory plan and durable operator runbook, the single runner decision,
the source-controlled reconciliation seam, and the real-runner refusal/retry
fixture matrix must ship together to prove and operate one fail-closed boundary;
the required legacy-repair test isolation, active-evidence runbook correction,
and failure-isolation proofs are regression coverage for that same boundary,
not production bypasses.

## Intentional

- Generic preflight remains `unresolved_drift` / exit 2 for historical source
  gaps, even when its exact record is currently admission-attested.
- No migration SQL, historical ledger row, invoice, payment, Gmail, Square,
  public API, configuration, dependency, or unrelated startup path changes.

## AI reconciliation

- Qualify non-attested evidence by an active mismatch -- fixed-in: b59f6f79be63c0d056a935d81f8313c191376fe6; docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md now limits non-attested evidence to a known record reported as mismatched and preserves `could_not_determine` as a stop.
- Exercise attestation exceptions through the runner -- fixed-in: b59f6f79be63c0d056a935d81f8313c191376fe6; tests/test_migrations_runner.py injects a real attestation transport failure, proves named refusal/no SQL/no ledger writes/lock release, then proves retry applies once.
- Prove mixed evidence cannot be cleared by one attestation -- fixed-in: b59f6f79be63c0d056a935d81f8313c191376fe6; tests/test_migrations_runner.py proves an attested 387 mismatch cannot clear either an unknown mismatch or a missing source.

## Fix-loop disposition preflight

- Root decision: Qualify non-attested evidence by an active mismatch
- Source trace: GitHub R1 review thread -> docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md -> active mismatch stop condition
- Upstream files: docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: atlas_brain/storage/migrations/__init__.py, atlas_brain/storage/migrations/reconciliation.py, docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md, plans/PR-EOM-Migration-Admission-Policy.md, tests/test_eom_public_onboarding_migration_repair.py, tests/test_migrations_runner.py
- Max files: 6
- Parked hardening: #2363 retains target-confirmed 382 provenance work; no new admission exception.

- Root decision: Exercise attestation exceptions through the runner
- Source trace: GitHub R2 review thread -> tests/test_migrations_runner.py -> attestation transport refusal path
- Upstream files: tests/test_migrations_runner.py
- Fix strategy: upstream-root
- Blocking predicate: ci
- Disposition: fixed-in
- Allowed files: atlas_brain/storage/migrations/__init__.py, atlas_brain/storage/migrations/reconciliation.py, docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md, plans/PR-EOM-Migration-Admission-Policy.md, tests/test_eom_public_onboarding_migration_repair.py, tests/test_migrations_runner.py
- Max files: 6
- Parked hardening: #2363 retains target-confirmed 382 provenance work; no new admission exception.

- Root decision: Prove mixed evidence cannot be cleared by one attestation
- Source trace: GitHub R2 review thread -> tests/test_migrations_runner.py -> per-name admission filter
- Upstream files: tests/test_migrations_runner.py
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: atlas_brain/storage/migrations/__init__.py, atlas_brain/storage/migrations/reconciliation.py, docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md, plans/PR-EOM-Migration-Admission-Policy.md, tests/test_eom_public_onboarding_migration_repair.py, tests/test_migrations_runner.py
- Max files: 6
- Parked hardening: #2363 retains target-confirmed 382 provenance work; no new admission exception.

## Deferred

- [ATLAS #2461](https://github.com/canfieldjuan/ATLAS/issues/2461) Slice 4:
  atomic-bookkeeping authoring policy.
- [ATLAS #2363](https://github.com/canfieldjuan/ATLAS/issues/2363) retains the
  target-confirmed forensic/evidence decision for the observed 382
  missing-source record; this slice creates no exception for it.
- A future historical discrepancy needs its own reviewed evidence record and
  named catalog predicate; #2034 and #2035 remain outside this lane.

## Parked hardening

- None. The parking predicate is new provenance reconciliation, migration
  repair, deployment orchestration, or parser expansion beyond this admission
  decision.

## Cold diff reconstruction

- Changed: `atlas_brain/storage/migrations/__init__.py:148-276,625-667` adds
  the error and pre-SQL admission decision; `reconciliation.py:107-114` supplies
  the closed named-attestation set; `tests/test_eom_public_onboarding_migration_repair.py`
  separates the older repair DDL proof from a real-package 382 missing-source
  refusal and uses a PostgreSQL-valid disposable schema identifier; focused
  tests, the runbook, and the plan prove/refine the behavior.
- Contract match: unknown mismatch/missing-source evidence fails before SQL or
  ledger writes; only a current exact named attestation clears its mismatch;
  an attestation transport failure and mixed evidence remain fail-closed;
  no-pending runs return before reconciliation catalog probing.
- Gaps: GitHub's disposable PostgreSQL and full-suite checks remain pending on
  this exact head; no customer or production financial operation occurred.

## Verification

- Focused migration runner/preflight selection: 76 passed, 1 skipped.
- Public-onboarding migration test collection with its database URL explicitly
  unset: 4 skipped; GitHub's disposable PostgreSQL job exercises all four.
- Ruff, compilation, diff check, guard-class closure, plan sync, plan/code
  consistency, and actual-commit reviewer-rule audit passed.
- GitHub owns the PostgreSQL integration, full repository suite, security scans,
  and all required checks.

## Mechanical verification

- Command: python -m pytest -q tests/test_migrations_runner.py tests/test_migration_content_integrity_preflight.py - Result: 76 passed, 1 skipped - Environment: local
- Command: env -u ATLAS_MIGRATION_TEST_DATABASE_URL python -m pytest -q tests/test_eom_public_onboarding_migration_repair.py - Result: 4 skipped - Environment: local
- Command: ruff check atlas_brain/storage/migrations/__init__.py atlas_brain/storage/migrations/reconciliation.py tests/test_migrations_runner.py tests/test_eom_public_onboarding_migration_repair.py - Result: passed - Environment: local
- Command: python -m py_compile atlas_brain/storage/migrations/__init__.py atlas_brain/storage/migrations/reconciliation.py tests/test_migrations_runner.py tests/test_eom_public_onboarding_migration_repair.py - Result: passed - Environment: local
- Command: git diff --check - Result: passed - Environment: local
- Command: python scripts/check_guard_class_closure.py --base origin/main --strict - Result: passed - Environment: local
- Command: python scripts/audit_plan_code_consistency.py --base-ref origin/main plans/PR-EOM-Migration-Admission-Policy.md - Result: passed - Environment: local
- Skipped: repository unit gate and broad CI mirror - Reason: operator directed full suites to GitHub; GitHub's required checks rerun on this head.

## Diff size

6 files, +854 / -17

## Slice contract

- Refuse a pending migration before its SQL or `schema_migrations` write when an
  unknown mismatch, missing source, or failed known attestation remains.
- Permit the documented migration-387 mismatch only with a current, named,
  source-controlled attestation; never clear missing-source evidence.
- Prove the real package's known 382 source absence rejects the old pending 384
  repair, while retaining its DDL-only test through an explicit test catalog.
- Keep a no-pending run diagnostic-only and add target-confirmed preflight,
  rollout, rollback, and forward-recovery instructions without a new write path.

## Deployment order

1. Deploy this policy-only release to every Atlas process that can invoke
   `run_migrations()`.
2. Preserve the target-confirmed read-only preflight receipt with that release.
3. Deploy a later migration-bearing release through the ordinary entrypoint.

This PR carries no SQL migration or financial/customer mutation.

## Failure and retry behavior

On refusal, the runner raises a log-safe error before pending SQL and ledger
bookkeeping. A retry re-evaluates the unchanged pending set under the existing
advisory lock; after genuine attestation, it applies and records the file once.
Unknown or missing-source evidence cannot become an exception.
