### PR TITLE
docs: define atomic migration bookkeeping authoring

### DIFF
--- a/docs/MIGRATION_AUTHORING.md
+++ b/docs/MIGRATION_AUTHORING.md
@@ -1,0 +1,92 @@
+# Migration SQL Authoring
+
+## Purpose
+
+Atlas normally records each newly applied migration in `schema_migrations` after
+its SQL succeeds. Some historic and recovery migrations also write their own
+ledger row. That pattern is safe only when the migration SQL, ledger row, and
+source digest are committed as one transaction.
+
+The migration runner selects that atomic-bookkeeping path automatically for a
+direct, executable `INSERT INTO schema_migrations`. It also has one explicit
+authoring opt-in for an equivalent write that is constructed dynamically and
+cannot be recognized safely from static SQL source.
+
+This guide is for new, forward-only migration authoring. Do not edit an
+already-applied migration or its ledger row merely to add the marker.
+
+## Choose the correct form
+
+### Direct static ledger insert
+
+When the migration contains a direct executable statement such as:
+
+```sql
+INSERT INTO schema_migrations (version, name)
+VALUES (900, '900_example');
+```
+
+the runner recognizes it and uses atomic bookkeeping automatically. Do not add
+the marker just for that direct form. The recognizer deliberately ignores
+comments and quoted or dollar-quoted literals, so examples and rollback notes
+do not change execution mode.
+
+### Dynamic self-recording SQL
+
+When a migration owns the equivalent ledger write through `EXECUTE`, `format`,
+a procedure body, or another dynamic construct, place this exact line as the
+**first non-empty line** of the file:
+
+```sql
+-- atlas: atomic-bookkeeping
+```
+
+It must precede every other non-empty comment and every SQL statement. A marker
+below a header comment is not an opt-in. For example:
+
+```sql
+-- atlas: atomic-bookkeeping
+DO $$
+BEGIN
+    EXECUTE 'INSERT INTO schema_migrations (version, name) VALUES (...)';
+END $$;
+```
+
+The static recognizer intentionally masks quoted literals and dollar-quoted
+bodies. It therefore cannot reliably infer this dynamic write, and the marker
+is the safe, explicit declaration that the whole operation must use the
+atomic-bookkeeping path.
+
+## Transaction constraint
+
+An atomic-bookkeeping migration cannot contain executable `CONCURRENTLY` DDL,
+including `CREATE INDEX CONCURRENTLY`. PostgreSQL requires those statements to
+run outside a transaction, while atomic bookkeeping requires one transaction.
+Split the work into separately reviewed, forward-only migrations instead. A
+comment or string literal that merely mentions `CONCURRENTLY` is not DDL.
+
+## Required proof before review
+
+For a new dynamic self-recording migration:
+
+1. Add a focused test that writes the exact source into a temporary migration
+   catalog and calls `run_migrations()` against a disposable PostgreSQL schema.
+2. Prove the dynamic source is outside the direct static recognizer, then prove
+   the exact marker-first source persists its ledger row and source digest.
+3. Cover the boundary that a marker after another non-empty line does not opt
+   in, and prove a failed dynamic ledger/digest update rolls back both the
+   migration effects and its ledger row before an unchanged retry succeeds.
+4. Let GitHub run the full migration-runner and database checks before merge.
+
+Do not broaden the recognizer by scanning arbitrary literals or by adding a
+regex for dynamic SQL in a migration PR. A new automatic classifier needs a
+separate, evidence-backed design with explicit false-positive and
+false-negative semantics.
+
+## Recovery boundary
+
+If a deployment fails, preserve the SQL source, runner error, target-confirmed
+evidence, and recorded ledger state. Do not delete or rewrite migration history
+to retry. Follow the [Migration Content Integrity Admission
+Runbook](MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md) for content-evidence admission
+and use a separately reviewed, forward-only repair when needed.

--- a/plans/PR-EOM-Migration-Atomic-Bookkeeping-Authoring.md
+++ b/plans/PR-EOM-Migration-Atomic-Bookkeeping-Authoring.md
@@ -1,0 +1,203 @@
+# PR-EOM-Migration-Atomic-Bookkeeping-Authoring
+
+## Why this slice exists
+
+H-18 in [ATLAS #2461](https://github.com/canfieldjuan/ATLAS/issues/2461)
+is now through its runtime admission-policy slice (#2469). The migration runner
+correctly detects direct executable `INSERT INTO schema_migrations` statements,
+but it deliberately masks quoted and dollar-quoted SQL before that recognizer.
+Consequently a migration that writes its own ledger row through `EXECUTE`,
+`format`, or a procedure body is opaque to automatic detection. The existing
+`-- atlas: atomic-bookkeeping` first-line marker is the designed escape hatch,
+but the repository has no durable authoring guide or exact dynamic-SQL proof
+that explains why it is required.
+
+This slice completes that bounded H-18 follow-up. It documents the authoring
+contract and proves the real runner still selects the atomic path for a marked,
+otherwise-opaque dynamic self-recorder. It does not widen the SQL recognizer,
+invent a heuristic for string literals, or alter any packaged migration.
+
+### Problem-derived contract
+
+- Root cause: the static self-recording recognizer must mask SQL literals and
+  PL/pgSQL bodies to avoid false positives. A dynamic ledger write is therefore
+  intentionally not discoverable from the executable-token grammar, and an
+  author who omits the explicit marker could reintroduce the SQL-to-ledger crash
+  window that atomic bookkeeping closes.
+- Correct fix must touch/change: add one durable migration-authoring reference
+  that names the exact first-nonempty-line marker, the direct-vs-dynamic
+  boundary, `CONCURRENTLY` incompatibility, and required proof. Add focused
+  `run_migrations()` tests that use dynamic `EXECUTE` source to demonstrate the
+  opaque boundary and a disposable-PostgreSQL source-row/digest rollback and
+  retry proof for the marked atomic entrypoint.
+- Must not change: `_SELF_RECORDING_INSERT_RE`, `_executable_sql`, marker
+  spelling/placement semantics, `run_migrations()` execution behavior,
+  packaged migration SQL, `schema_migrations` history, migration admission,
+  database configuration, financial/customer data, or any Gmail/Square/payment
+  behavior. This is authoring guidance plus regression proof, not a dynamic SQL
+  parser or a new runtime rejection policy.
+
+## Scope (this PR)
+
+Ownership lane: eom/migration-content-integrity
+Slice phase: Production hardening
+Max files: 3
+
+1. Add a migration-authoring guide for dynamic self-recording SQL: its first
+   non-empty source line must be exactly `-- atlas: atomic-bookkeeping`; direct
+   static inserts remain automatically covered; marked migrations cannot use
+   executable `CONCURRENTLY`; and authors must prove the exact source through
+   `run_migrations()`.
+2. Add focused runner regression coverage proving an `EXECUTE`-hosted ledger
+   insert is intentionally opaque to the direct recognizer, a late marker does
+   not select the atomic path, and the exact first-line marker makes the real
+   runner execute the same dynamic source in its atomic bookkeeping path.
+3. Keep the dynamic parser boundary explicit and forward compatible: any future
+   automatic detection requires a separate, evidence-backed H-18 slice rather
+   than a literal/regex heuristic in this PR.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] `docs/MIGRATION_AUTHORING.md` names the exact first-nonempty marker,
+    distinguishes direct static self-recording from dynamic SQL, explains the
+    transaction/`CONCURRENTLY` constraint, and requires a real-runner proof;
+    settled by the checked-in guide.
+  - [ ] A dynamic `EXECUTE` source containing a ledger insert remains outside
+    `_contains_executable_self_recording_insert`, and moving the marker below
+    another non-empty line does not select atomic bookkeeping; settled by the
+    new focused test in `tests/test_migrations_runner.py`.
+  - [ ] The same dynamic source with the exact marker as its first non-empty
+    line reaches `run_migrations()` against PostgreSQL; a forced digest-update
+    failure rolls back its table and self-recorded ledger row, and an unchanged
+    retry persists the expected version and source digest; settled by the
+    focused real-PostgreSQL runner test.
+  - [ ] Existing direct self-recording, marker, concurrent-DDL, retry, and
+    no-pending behavior remain covered by the focused migration runner suite;
+    settled by `tests/test_migrations_runner.py` and GitHub's `Atlas Migrations
+    Runner Checks`.
+  - [ ] No production migration source, runtime parser, ledger row, target
+    configuration, or financial/customer state changes; settled by cold diff
+    reconstruction and changed-file review.
+- Reachability proof: the test writes a dynamic migration into a temporary
+  catalog and calls the real `run_migrations()` entrypoint against a disposable
+  PostgreSQL schema; observable results are the rolled-back table/ledger row
+  on failure and the persisted version/source digest after retry.
+- Affected surfaces: `docs/MIGRATION_AUTHORING.md`, the runner's existing
+  marker/recognizer contract, `tests/test_migrations_runner.py`, and the
+  already-enrolled `Atlas Migrations Runner Checks` workflow.
+- Risk areas: false-positive parser expansion, accidental autocommit of dynamic
+  ledger bookkeeping, unsafe `CONCURRENTLY` guidance, rewrites of historic SQL,
+  and a test that proves only a helper rather than the runner entrypoint.
+- Reviewer rules triggered: R1, R2, R4, R5, R10, R12, R13, R14.
+
+### Boundary-change enumeration
+
+N/A — the runner's parser, marker predicate, and admission behavior do not
+change. This slice documents and regression-tests the existing boundary.
+
+### Deployed-config probing
+
+N/A — no configuration, environment fallback, deployed target, or runtime
+connection behavior changes.
+
+### Files touched
+
+- `docs/MIGRATION_AUTHORING.md`
+- `plans/PR-EOM-Migration-Atomic-Bookkeeping-Authoring.md`
+- `tests/test_migrations_runner.py`
+
+## Mechanism
+
+The guide makes the existing boundary operational rather than implicit. Static
+executable `INSERT INTO schema_migrations` statements keep their automatic
+atomic selection. Dynamic SQL is intentionally opaque because the recognizer
+masks literals and dollar-quoted bodies; its author must put the exact existing
+marker first, before any prose comment or SQL. The runner then uses the same
+atomic transaction it already uses for marked migrations, where migration SQL,
+ledger row, and digest verification either commit together or roll back.
+
+The regression fixture contains a valid-looking PL/pgSQL `EXECUTE` string. It
+first proves the direct recognizer cannot see that literal and that a late
+marker is not an opt-in. The real PostgreSQL runner fixture then injects a
+digest-update failure after the dynamic ledger insert: both the table and ledger
+row must roll back. Removing that fault and retrying the unchanged source must
+persist the expected version and digest. The test intentionally does not claim
+to interpret arbitrary dynamic SQL; that omission is the safety boundary being
+preserved.
+
+## Intentional
+
+- Preserve automatic direct-insert recognition and the exact marker spelling;
+  existing/historical migration source remains byte-stable.
+- Do not scan string literals, `EXECUTE`, `format`, procedures, or arbitrary
+  dynamic constructs for hidden ledger operations. Such a parser would have
+  false-positive and false-negative semantics that require separate evidence.
+- Do not make startup reject every dynamic SQL migration. The authoring policy
+  applies only when the migration itself owns `schema_migrations` bookkeeping.
+- Do not add an operator rollout, database query, external API, or financial
+  side effect; the guide is source-authoring guidance.
+
+## Deferred
+
+- A broader dynamic-SQL classifier or runtime enforcement requires a separately
+  reviewed H-18 issue with a concrete observed failure mode and a bounded
+  grammar; it is explicitly outside this slice.
+- #2363 remains the target-confirmed forensic decision for the unrelated 382
+  missing-source record; this authoring policy creates no reconciliation or
+  admission exception.
+- Migration SQL/data repair, historical source rewriting, and generic migration
+  framework replacement remain outside this thin authoring/proof slice.
+
+Parking predicate: Keep findings in this slice only when they are necessary to
+make the existing marker's authoring boundary or its disposable-PostgreSQL
+rollback/retry proof materially correct. Park parser expansion, generic dynamic
+SQL enforcement, historical migration/data repair, framework replacement, and
+deployment orchestration unless a verified defect blocks that predicate.
+
+Parked hardening: none against this predicate.
+
+## Verification
+
+- Executed locally: Command: python -m pytest -q tests/test_migrations_runner.py
+  tests/test_migration_content_integrity_preflight.py. Result: 77 passed, 1
+  skipped; the skipped real-PostgreSQL test had no configured local disposable
+  target.
+- Executed locally: Command: ruff check tests/test_migrations_runner.py.
+  Result: passed. Command: python -m py_compile
+  tests/test_migrations_runner.py. Result: passed. Command: git diff --check.
+  Result: passed.
+- Executed locally: Command: python scripts/audit_plan_code_consistency.py
+  --base-ref origin/main plans/PR-EOM-Migration-Atomic-Bookkeeping-Authoring.md.
+  Result: passed. Command: python scripts/sync_pr_plan.py --check
+  plans/PR-EOM-Migration-Atomic-Bookkeeping-Authoring.md origin/main. Result:
+  passed.
+- Executed locally: Command: python scripts/audit_plan_doc.py
+  plans/PR-EOM-Migration-Atomic-Bookkeeping-Authoring.md. Result: passed.
+  Command: python scripts/audit_plan_doc_files_touched.py
+  plans/PR-EOM-Migration-Atomic-Bookkeeping-Authoring.md origin/main. Result:
+  passed. Command: python scripts/audit_plan_doc_diff_size.py
+  plans/PR-EOM-Migration-Atomic-Bookkeeping-Authoring.md origin/main. Result:
+  passed.
+- Executed locally: Command: python scripts/audit_review_rules_triggered.py
+  --plan plans/PR-EOM-Migration-Atomic-Bookkeeping-Authoring.md origin/main.
+  Result: passed. Command: python scripts/check_boundary_change_enumeration.py
+  --base origin/main --strict. Result: passed. Command: python
+  scripts/check_guard_class_closure.py --base origin/main --strict. Result:
+  passed.
+- Skipped locally: the real PostgreSQL dynamic self-recording proof because
+  ATLAS_MIGRATION_TEST_DATABASE_URL is not configured locally; GitHub's
+  already-enrolled Atlas Migrations Runner Checks provides the disposable
+  PostgreSQL service.
+- Skipped locally: repository unit gate and broad CI mirror. Per operator
+  direction, GitHub runs the full unit, security, integration, and required
+  checks on the published head.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `docs/MIGRATION_AUTHORING.md` | 92 |
+| `plans/PR-EOM-Migration-Atomic-Bookkeeping-Authoring.md` | 203 |
+| `tests/test_migrations_runner.py` | 77 |
+| **Total** | **372** |

--- a/tests/test_migrations_runner.py
+++ b/tests/test_migrations_runner.py
@@ -1563,6 +1563,32 @@ async def test_marked_migration_records_its_ledger_entry_in_one_transaction(tmp_
     assert any("CREATE TABLE atomic_probe" in sql for sql in pool.applied_sql)
 
 
+def test_dynamic_self_recording_requires_the_first_line_atomic_marker():
+    """Dynamic ledger SQL remains opaque until its exact marker opts it in."""
+    from atlas_brain.storage.migrations import (
+        _contains_executable_self_recording_insert,
+        _requires_atomic_bookkeeping,
+    )
+
+    dynamic_source = (
+        "DO $$\n"
+        "BEGIN\n"
+        "    EXECUTE 'INSERT INTO schema_migrations (version, name) "
+        "VALUES (900, ''900_dynamic_self_recording'')';\n"
+        "END $$;\n"
+    )
+    late_marker_source = (
+        "-- authoring note precedes the marker\n"
+        "-- atlas: atomic-bookkeeping\n"
+        f"{dynamic_source}"
+    )
+    marked_source = f"-- atlas: atomic-bookkeeping\n{dynamic_source}"
+
+    assert not _contains_executable_self_recording_insert(dynamic_source)
+    assert not _requires_atomic_bookkeeping(late_marker_source)
+    assert _requires_atomic_bookkeeping(marked_source)
+
+
 @pytest.mark.asyncio
 async def test_marked_migration_rejects_concurrently_ddl_before_a_transaction(tmp_path):
     """The opt-in cannot silently break concurrent-index migration safety."""
@@ -1839,20 +1865,27 @@ async def test_real_postgres_concurrent_runners_apply_each_migration_once(tmp_pa
             "transaction, Postgres would have rejected it"
         )
 
-        retry_source = (
-            b"CREATE TABLE migration_lock_probe_retry (id integer primary key);\n"
-            b"INSERT INTO schema_migrations (version, name) "
-            b"VALUES (5, '005_self_recording_retry');"
+        dynamic_retry_source = (
+            b"-- atlas: atomic-bookkeeping\n"
+            b"CREATE TABLE migration_lock_probe_dynamic_retry "
+            b"(id integer primary key);\n"
+            b"DO $$\n"
+            b"BEGIN\n"
+            b"    EXECUTE 'INSERT INTO schema_migrations (version, name) "
+            b"VALUES (5, ''005_dynamic_self_recording_retry'')';\n"
+            b"END $$;\n"
         )
-        (tmp_path / "005_self_recording_retry.sql").write_bytes(retry_source)
+        (tmp_path / "005_dynamic_self_recording_retry.sql").write_bytes(
+            dynamic_retry_source
+        )
         await admin.execute(
             """
-            CREATE OR REPLACE FUNCTION suppress_self_recording_retry_digest()
+            CREATE OR REPLACE FUNCTION suppress_dynamic_self_recording_retry_digest()
             RETURNS trigger
             LANGUAGE plpgsql
             AS $$
             BEGIN
-                IF NEW.name = '005_self_recording_retry'
+                IF NEW.name = '005_dynamic_self_recording_retry'
                    AND NEW.content_sha256 IS NOT NULL THEN
                     RETURN NULL;
                 END IF;
@@ -1863,10 +1896,10 @@ async def test_real_postgres_concurrent_runners_apply_each_migration_once(tmp_pa
         )
         await admin.execute(
             """
-            CREATE TRIGGER suppress_self_recording_retry_digest_trigger
+            CREATE TRIGGER suppress_dynamic_self_recording_retry_digest_trigger
             BEFORE UPDATE OF content_sha256 ON schema_migrations
             FOR EACH ROW
-            EXECUTE FUNCTION suppress_self_recording_retry_digest()
+            EXECUTE FUNCTION suppress_dynamic_self_recording_retry_digest()
             """
         )
 
@@ -1874,35 +1907,39 @@ async def test_real_postgres_concurrent_runners_apply_each_migration_once(tmp_pa
             await run_migrations(
                 pool,
                 migrations_dir=tmp_path,
-                only={"005_self_recording_retry"},
+                only={"005_dynamic_self_recording_retry"},
             )
 
         assert await admin.fetchval(
-            "SELECT to_regclass($1)", "migration_lock_probe_retry"
+            "SELECT to_regclass($1)", "migration_lock_probe_dynamic_retry"
         ) is None
         assert await admin.fetch(
             "SELECT name FROM schema_migrations WHERE name = $1",
-            "005_self_recording_retry",
+            "005_dynamic_self_recording_retry",
         ) == []
 
         await admin.execute(
-            "DROP TRIGGER suppress_self_recording_retry_digest_trigger "
+            "DROP TRIGGER suppress_dynamic_self_recording_retry_digest_trigger "
             "ON schema_migrations"
         )
-        await admin.execute("DROP FUNCTION suppress_self_recording_retry_digest()")
+        await admin.execute("DROP FUNCTION suppress_dynamic_self_recording_retry_digest()")
         await run_migrations(
             pool,
             migrations_dir=tmp_path,
-            only={"005_self_recording_retry"},
+            only={"005_dynamic_self_recording_retry"},
         )
 
         assert await admin.fetchval(
-            "SELECT to_regclass($1)", "migration_lock_probe_retry"
+            "SELECT to_regclass($1)", "migration_lock_probe_dynamic_retry"
         ) is not None
-        assert await admin.fetchval(
-            "SELECT content_sha256 FROM schema_migrations WHERE name = $1",
-            "005_self_recording_retry",
-        ) == hashlib.sha256(retry_source).hexdigest()
+        persisted_dynamic_row = await admin.fetchrow(
+            "SELECT version, content_sha256 FROM schema_migrations WHERE name = $1",
+            "005_dynamic_self_recording_retry",
+        )
+        assert persisted_dynamic_row["version"] == 5
+        assert persisted_dynamic_row["content_sha256"] == hashlib.sha256(
+            dynamic_retry_source
+        ).hexdigest()
 
         # The SESSION lock outlives its transaction, so it must be released
         # explicitly or the pooled connection carries it into unrelated work.


### PR DESCRIPTION
Plan: plans/PR-EOM-Migration-Atomic-Bookkeeping-Authoring.md
Slice phase: Production hardening
Ownership lane: eom/migration-content-integrity
<!-- atlas-open-pr-wrapper: v1 -->

H-18 Slice 4 makes the existing atomic-bookkeeping marker safe to author against: dynamic self-recording SQL remains intentionally opaque to the static recognizer, while an exact first-line marker selects the already-existing atomic runner path. This is documentation plus regression proof only; no parser, migration SQL, financial record, or runtime admission behavior changes.

## Intentional

- Preserve the direct executable-insert recognizer and the exact marker semantics.
- Keep dynamic-SQL parsing, generic dynamic-migration rejection, historical migration rewrites, and database changes out of this slice.
- Keep every financial, Gmail, Square, customer, and deployed-configuration surface unchanged.

## AI reconciliation

- Exercise the dynamic self-recording path against PostgreSQL -- fixed-in: 3a20fa28c8d38c16aed8e273705653f1d774778c; `tests/test_migrations_runner.py` now executes the marked `DO` block in disposable PostgreSQL, forces the digest update to fail, verifies table/ledger rollback, then verifies the unchanged retry persists version 5 and the exact source SHA.
- Replace planned checks with executed verification -- fixed-in: 3a20fa28c8d38c16aed8e273705653f1d774778c; `plans/PR-EOM-Migration-Atomic-Bookkeeping-Authoring.md` now records the exact focused local commands, pass/skip outcomes, and the explicit GitHub-only full-gate boundary.
- Define the referenced parking predicate -- fixed-in: 3a20fa28c8d38c16aed8e273705653f1d774778c; `plans/PR-EOM-Migration-Atomic-Bookkeeping-Authoring.md` now defines which material authoring/proof findings remain in scope and which adjacent work is parked.

## Fix-loop disposition preflight

- Root decision: Exercise the dynamic self-recording path against PostgreSQL
- Source trace: GitHub R2 review thread -> tests/test_migrations_runner.py -> dynamic self-recording ledger/digest transaction
- Upstream files: docs/MIGRATION_AUTHORING.md, plans/PR-EOM-Migration-Atomic-Bookkeeping-Authoring.md, tests/test_migrations_runner.py
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: docs/MIGRATION_AUTHORING.md, plans/PR-EOM-Migration-Atomic-Bookkeeping-Authoring.md, tests/test_migrations_runner.py
- Max files: 3
- Parked hardening: broader dynamic-SQL classification remains separately evidence-gated.

- Root decision: Replace planned checks with executed verification
- Source trace: GitHub R2 review thread -> plans/PR-EOM-Migration-Atomic-Bookkeeping-Authoring.md -> canonical executed verification receipts
- Upstream files: plans/PR-EOM-Migration-Atomic-Bookkeeping-Authoring.md
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: plans/PR-EOM-Migration-Atomic-Bookkeeping-Authoring.md
- Max files: 3
- Parked hardening: none; the plan is the canonical verification artifact.

- Root decision: Define the referenced parking predicate
- Source trace: GitHub R1 review thread -> plans/PR-EOM-Migration-Atomic-Bookkeeping-Authoring.md -> explicit in-scope versus parked boundary
- Upstream files: plans/PR-EOM-Migration-Atomic-Bookkeeping-Authoring.md
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: plans/PR-EOM-Migration-Atomic-Bookkeeping-Authoring.md
- Max files: 3
- Parked hardening: parser expansion, repair, framework, and deployment work remain parked unless they block the stated predicate.

## Deferred

- A broader dynamic-SQL classifier or runtime enforcement needs a separate, evidence-backed H-18 issue with explicit false-positive and false-negative semantics.
- [ATLAS #2363](https://github.com/canfieldjuan/ATLAS/issues/2363) retains the unrelated target-confirmed 382 missing-source forensic decision.

## Parked hardening

- None. Parser expansion, migration repair, and generic framework work are outside this authoring/proof contract.

## Cold diff reconstruction

- Changed: `docs/MIGRATION_AUTHORING.md:68-92` defines the marker contract and requires a disposable-PostgreSQL ledger/digest rollback-and-retry proof; `tests/test_migrations_runner.py:1566-1589` proves the dynamic recognizer boundary, while `tests/test_migrations_runner.py:1868-1942` executes the marked dynamic self-recorder in PostgreSQL and observes rollback/retry state; `plans/PR-EOM-Migration-Atomic-Bookkeeping-Authoring.md:1-203` records the bounded review contract, parking predicate, and executed verification receipts.
- Contract match: the guide operationalizes the existing escape hatch, and the focused tests prove dynamic quoted SQL is intentionally opaque, a late marker is rejected, and the real runner atomically rolls back the dynamic table/ledger row before an unchanged retry persists the expected version and digest.
- Gaps: none in the diff. GitHub's full migration/database, unit, security, and required checks remain pending on this exact head.

## Verification

- Focused migration-runner/preflight selection: 77 passed, 1 skipped because the disposable PostgreSQL URL is not configured locally.
- Ruff, Python compilation, diff check, plan sync, plan/code consistency, plan/file/diff-size audit, reviewer-rule audit, boundary enumeration, and guard-class closure passed.
- GitHub owns the disposable PostgreSQL execution plus the full repository unit, security, and required PR gates.

## Mechanical verification

- Command: `python -m pytest -q tests/test_migrations_runner.py tests/test_migration_content_integrity_preflight.py` - Result: 77 passed, 1 skipped - Environment: local
- Command: `ruff check tests/test_migrations_runner.py` - Result: passed - Environment: local
- Command: `python -m py_compile tests/test_migrations_runner.py` - Result: passed - Environment: local
- Command: `git diff --check origin/main...HEAD` - Result: passed - Environment: local
- Command: `python scripts/audit_plan_code_consistency.py --base-ref origin/main plans/PR-EOM-Migration-Atomic-Bookkeeping-Authoring.md` - Result: passed - Environment: local
- Command: `python scripts/sync_pr_plan.py --check plans/PR-EOM-Migration-Atomic-Bookkeeping-Authoring.md origin/main` - Result: passed - Environment: local
- Command: `python scripts/audit_plan_doc_files_touched.py plans/PR-EOM-Migration-Atomic-Bookkeeping-Authoring.md origin/main` - Result: passed - Environment: local
- Command: `python scripts/audit_plan_doc_diff_size.py plans/PR-EOM-Migration-Atomic-Bookkeeping-Authoring.md origin/main` - Result: passed - Environment: local
- Command: `python scripts/audit_review_rules_triggered.py --plan plans/PR-EOM-Migration-Atomic-Bookkeeping-Authoring.md origin/main` - Result: passed - Environment: local
- Command: `python scripts/check_boundary_change_enumeration.py --base origin/main --strict` - Result: passed - Environment: local
- Command: `python scripts/check_guard_class_closure.py --base origin/main --strict` - Result: passed - Environment: local
- Skipped: real PostgreSQL dynamic self-recording proof - Reason: ATLAS_MIGRATION_TEST_DATABASE_URL is not configured locally; GitHub's atlas-migrations-runner-checks job supplies a disposable PostgreSQL service.
- Skipped: repository unit gate and broad CI mirror - Reason: operator directed full suites to GitHub; GitHub reruns the required full checks on this head.

## Diff size

3 files, +352 / -20

## Slice contract

- Dynamic `EXECUTE` self-recording remains outside the direct recognizer until the exact first-line marker opts it into the existing atomic bookkeeping transaction.
- A late marker does not opt in; a marked migration still cannot use executable `CONCURRENTLY` DDL.
- A real PostgreSQL failure rolls back dynamic migration effects and its self-recorded ledger row; an unchanged retry persists the expected version and source digest.

## Deployment order

1. Merge and deploy this ATLAS authoring/proof slice alone; it carries no SQL migration or runtime configuration change.
2. Apply the documented marker only in separately reviewed, forward-only dynamic self-recording migrations.

## Failure and retry behavior

This PR creates no new runtime failure mode. The documented path retains the runner's existing atomic behavior: if migration SQL or ledger bookkeeping fails, the transaction rolls back; the unchanged source can be retried through the existing advisory-lock path without rewriting history.
