### PR TITLE
EOM: publish canonical contact-directory editability

### DIFF
--- a/atlas_brain/eom_api/funnel.py
+++ b/atlas_brain/eom_api/funnel.py
@@ -36,6 +36,7 @@ from ..services.eom_won_lead_loss import mark_eom_lead_lost_with_won_teardown
 from ..services.eom_crm_mutations import (
     EOM_CUSTOMER_TYPES,
     EOM_OPERATOR_CONTACT_TYPES,
+    EOM_OPERATOR_EDIT_BLOCK_REASONS,
     EOMOperatorContactMutation,
     EOMOperatorContactMutationError,
     mutate_eom_operator_contact,
@@ -395,6 +396,23 @@ class EOMContactDirectoryItem(BaseModel):
     source: str | None = None
     created_at: datetime = Field(serialization_alias="createdAt")
     updated_at: datetime | None = Field(default=None, serialization_alias="updatedAt")
+    editable: bool
+    edit_block_reason: str | None = Field(
+        serialization_alias="editBlockedReason"
+    )
+
+    @field_validator("edit_block_reason")
+    @classmethod
+    def _edit_block_reason_is_closed(cls, value: str | None) -> str | None:
+        if value is not None and value not in EOM_OPERATOR_EDIT_BLOCK_REASONS:
+            raise ValueError("edit_block_reason must be a supported reason")
+        return value
+
+    @model_validator(mode="after")
+    def _editability_matches_reason(self) -> "EOMContactDirectoryItem":
+        if self.editable != (self.edit_block_reason is None):
+            raise ValueError("editable must match edit_block_reason")
+        return self
 
     @field_validator("contact_type")
     @classmethod
@@ -769,6 +787,11 @@ _CAPABILITY_ROUTES: dict[str, tuple[str, str]] = {
     ),
     "contact.link_verification": ("GET", "/eom-funnel/known-contacts"),
     "contact.directory": ("GET", "/eom-funnel/contact-directory"),
+    # Same route as contact.directory: this name proves the response includes
+    # the per-contact editability verdict and closed reason code. Older builds
+    # cannot advertise it, so downstream consumers can fail closed on a stale
+    # deployment instead of treating route reachability as semantic parity.
+    "contact.directory.editability": ("GET", "/eom-funnel/contact-directory"),
     "contact.archive": ("POST", "/eom-funnel/contacts/{contact_id}/archive"),
     "contact.restore": ("POST", "/eom-funnel/contacts/{contact_id}/restore"),
     # Same registered route as contact.directory, deliberately: the name

--- a/atlas_brain/services/crm_provider.py
+++ b/atlas_brain/services/crm_provider.py
@@ -162,7 +162,6 @@ _ALL_EOM_REQUESTED_EVENTS = frozenset(
     family.requested_event for family in _EOM_BOOKING_FAMILIES
 )
 _EOM_LOST_RESTORABLE_STAGES = ("new", "estimate_booked")
-_EOM_ACTIVE_LEAD_STAGES = ("new", "estimate_booked", "won")
 _EOM_LOST_REPLAY_DISPOSITION_EVENTS = ("lead_lost", "lead_reopened")
 _EOM_CONTACT_ARCHIVE_DISPOSITION_EVENTS = ("contact_archived", "contact_restored")
 _EOM_CONTACT_DIRECTORY_LIFECYCLES = ("active", "archived")
@@ -1333,10 +1332,14 @@ class DatabaseCRMProvider:
         from .eom_crm_mutations import (
             EOM_OPERATOR_CONTACT_CREATED,
             EOM_OPERATOR_CONTACT_EVENT_TYPES,
-            EOM_OPERATOR_CONTACT_TYPES,
             EOM_OPERATOR_CONTACT_UPDATED,
+            EOM_OPERATOR_EDIT_BLOCK_REASON_ARCHIVED,
+            EOM_OPERATOR_EDIT_BLOCK_REASON_CONTACT_TYPE,
+            EOM_OPERATOR_EDIT_BLOCK_REASON_LEAD_STATUS,
+            EOM_OPERATOR_EDIT_BLOCK_REASON_STAGE,
             EOM_BUSINESS_CONTEXT_ID,
             EOMOperatorContactMutationError,
+            get_eom_operator_contact_editability,
         )
 
         def _metadata_from_row(value: Any) -> dict[str, Any]:
@@ -1540,7 +1543,11 @@ class DatabaseCRMProvider:
                     raise EOMOperatorContactMutationError(
                         404, "EOM contact was not found"
                     )
-                if row.get("status") == "archived":
+                editability = get_eom_operator_contact_editability(row)
+                if (
+                    editability.edit_block_reason
+                    == EOM_OPERATOR_EDIT_BLOCK_REASON_ARCHIVED
+                ):
                     raise EOMOperatorContactMutationError(
                         409, "Archived EOM contacts cannot be edited"
                     )
@@ -1562,25 +1569,33 @@ class DatabaseCRMProvider:
             return matches[0] if matches else None
 
         def _assert_contact_type_matches(target: Mapping[str, Any]) -> None:
-            stored_type = str(target.get("contact_type") or "")
-            if stored_type not in EOM_OPERATOR_CONTACT_TYPES:
+            editability = get_eom_operator_contact_editability(target)
+            if not editability.editable:
+                reason = editability.edit_block_reason
+                if reason == EOM_OPERATOR_EDIT_BLOCK_REASON_ARCHIVED:
+                    raise EOMOperatorContactMutationError(
+                        409, "Archived EOM contacts cannot be edited"
+                    )
+                if reason == EOM_OPERATOR_EDIT_BLOCK_REASON_CONTACT_TYPE:
+                    raise EOMOperatorContactMutationError(
+                        409,
+                        "EOM operator contact updates require an existing lead or customer",
+                    )
+                if reason == EOM_OPERATOR_EDIT_BLOCK_REASON_STAGE:
+                    raise EOMOperatorContactMutationError(
+                        409,
+                        "EOM operator lead updates require a supported lead stage",
+                    )
+                if reason == EOM_OPERATOR_EDIT_BLOCK_REASON_LEAD_STATUS:
+                    raise EOMOperatorContactMutationError(
+                        409, "EOM operator lead updates require an active lead"
+                    )
                 raise EOMOperatorContactMutationError(
-                    409,
-                    "EOM operator contact updates require an existing lead or customer",
-                )
-            if (
-                stored_type == "lead"
-                and target.get("lead_stage") not in _EOM_ACTIVE_LEAD_STAGES
-            ):
-                raise EOMOperatorContactMutationError(
-                    409, "EOM operator lead updates require a supported lead stage"
-                )
-            if stored_type == "lead" and target.get("status") != "active":
-                raise EOMOperatorContactMutationError(
-                    409, "EOM operator lead updates require an active lead"
+                    409, "EOM operator contact updates require an editable contact"
                 )
             if command.contact_type is None:
                 return
+            stored_type = str(target.get("contact_type") or "")
             if stored_type != command.contact_type:
                 raise EOMOperatorContactMutationError(
                     409,
@@ -2283,7 +2298,10 @@ class DatabaseCRMProvider:
         # DERIVED from the canonical operator-mutation kind set: a kind the
         # write boundary admits must be discoverable here in the same commit,
         # or its records become write-only -- the defect this read closes.
-        from .eom_crm_mutations import EOM_OPERATOR_CONTACT_TYPES
+        from .eom_crm_mutations import (
+            EOM_OPERATOR_CONTACT_TYPES,
+            get_eom_operator_contact_editability,
+        )
         from .eom_lead_ingress import EOM_BUSINESS_CONTEXT_ID
 
         if kind not in ("all", *EOM_OPERATOR_CONTACT_TYPES):
@@ -2355,7 +2373,14 @@ class DatabaseCRMProvider:
             """,
             *params,
         )
-        return [dict(row) for row in rows]
+        directory_rows: list[dict[str, Any]] = []
+        for row in rows:
+            contact = dict(row)
+            editability = get_eom_operator_contact_editability(contact)
+            contact["editable"] = editability.editable
+            contact["edit_block_reason"] = editability.edit_block_reason
+            directory_rows.append(contact)
+        return directory_rows
 
     async def list_billing_recipients(
         self,

--- a/atlas_brain/services/eom_crm_mutations.py
+++ b/atlas_brain/services/eom_crm_mutations.py
@@ -33,6 +33,69 @@ EOM_OPERATOR_SOURCE_CHANNELS = (
     "manual_import",
 )
 EOM_OPERATOR_CONTACT_TYPES = ("lead", "customer")
+EOM_OPERATOR_EDIT_BLOCK_REASON_ARCHIVED = "not_editable_archived"
+EOM_OPERATOR_EDIT_BLOCK_REASON_CONTACT_TYPE = "not_editable_contact_type"
+EOM_OPERATOR_EDIT_BLOCK_REASON_STAGE = "not_editable_stage"
+EOM_OPERATOR_EDIT_BLOCK_REASON_LEAD_STATUS = "not_editable_lead_status"
+EOM_OPERATOR_EDIT_BLOCK_REASONS = (
+    EOM_OPERATOR_EDIT_BLOCK_REASON_ARCHIVED,
+    EOM_OPERATOR_EDIT_BLOCK_REASON_CONTACT_TYPE,
+    EOM_OPERATOR_EDIT_BLOCK_REASON_STAGE,
+    EOM_OPERATOR_EDIT_BLOCK_REASON_LEAD_STATUS,
+)
+EOM_OPERATOR_EDITABLE_LEAD_STAGES = ("new", "estimate_booked", "won")
+
+
+@dataclass(frozen=True)
+class EOMOperatorContactEditability:
+    """Closed row-state verdict for the EOM operator edit boundary."""
+
+    editable: bool
+    edit_block_reason: str | None
+
+
+def get_eom_operator_contact_editability(
+    target: Mapping[str, Any],
+) -> EOMOperatorContactEditability:
+    """Return the one lifecycle verdict shared by read and write paths.
+
+    The order mirrors the existing mutation boundary. In particular, an
+    archived row is refused before identity-conflict handling, while a Lost
+    lead remains discoverable and is rejected at the later type/stage guard.
+    """
+
+    status = target.get("status")
+    if status == "archived":
+        return EOMOperatorContactEditability(
+            editable=False,
+            edit_block_reason=EOM_OPERATOR_EDIT_BLOCK_REASON_ARCHIVED,
+        )
+
+    stored_type = str(target.get("contact_type") or "")
+    if stored_type not in EOM_OPERATOR_CONTACT_TYPES:
+        return EOMOperatorContactEditability(
+            editable=False,
+            edit_block_reason=EOM_OPERATOR_EDIT_BLOCK_REASON_CONTACT_TYPE,
+        )
+
+    if (
+        stored_type == "lead"
+        and target.get("lead_stage") not in EOM_OPERATOR_EDITABLE_LEAD_STAGES
+    ):
+        return EOMOperatorContactEditability(
+            editable=False,
+            edit_block_reason=EOM_OPERATOR_EDIT_BLOCK_REASON_STAGE,
+        )
+
+    if stored_type == "lead" and status != "active":
+        return EOMOperatorContactEditability(
+            editable=False,
+            edit_block_reason=EOM_OPERATOR_EDIT_BLOCK_REASON_LEAD_STATUS,
+        )
+
+    return EOMOperatorContactEditability(editable=True, edit_block_reason=None)
+
+
 # Residential/commercial, on the account record. A DIFFERENT axis from
 # EOM_OPERATOR_CONTACT_TYPES above (lead vs customer) -- the two answer
 # unrelated questions and neither may be inferred from the other.

--- a/plans/PR-EOM-Contact-Directory-Editability.md
+++ b/plans/PR-EOM-Contact-Directory-Editability.md
@@ -1,0 +1,191 @@
+# PR-EOM-Contact-Directory-Editability
+
+## Why this slice exists
+
+Website issue #247 item 7 records a live operator failure: an active Lost lead
+is intentionally discoverable in the CRM contact directory, but the existing
+operator-mutation boundary rejects edits to a lead whose stage is outside its
+supported active-stage set. The portal therefore offers an action that the
+authoritative service will refuse.
+
+The full diff is expected to exceed the 400 LOC soft cap only because the
+required plan and cross-path regression coverage are part of the receipt; the
+production mechanism stays three narrow modules with no migration or new route.
+
+### Problem-derived contract
+
+- Root cause: Atlas makes the editability decision only inside
+  `DatabaseCRMProvider.mutate_eom_operator_contact_atomic`, while
+  `DatabaseCRMProvider.list_eom_contact_directory` deliberately returns all
+  active leads, including `lead_stage=lost`. The directory response exposes
+  the stage but no authoritative decision or reason, so a consumer can only
+  offer Edit globally or copy Atlas stage policy.
+- Correct fix must touch/change: the canonical EOM operator-contact domain
+  module must own one closed, row-state editability decision over stored
+  contact type, lifecycle status, and lead stage. The existing mutation guard
+  and the directory projection must consume that one decision. The funnel
+  directory schema must serialize `editable` and a closed
+  `editBlockedReason`, and advertise a distinct capability tied to the
+  existing directory route so downstream services can require this response
+  semantic rather than infer it from route reachability. Focused API and
+  provider tests must prove active supported leads/customers remain editable,
+  Lost leads remain visible but are non-editable with the stage reason, and
+  archived rows are non-editable with the lifecycle reason.
+- Must not change: lead-stage transitions, the definition of a Lost lead,
+  directory membership/search/pagination, archive/restore behavior, existing
+  authentication and tenant scoping, edit-field validation, mutation status
+  codes, database schema/migrations, or any tracker/Website code. In
+  particular, this PR must not reimplement the stage list in a downstream
+  client or hide Lost leads to mask the offered-but-fails Edit control.
+
+## Scope (this PR)
+
+Ownership lane: eom/contact-directory-editability
+Slice phase: Vertical slice
+
+1. Publish an Atlas-owned, per-directory-contact editability verdict and
+   closed reason code from the same lifecycle policy the mutation boundary
+   already enforces.
+2. Version that additive directory response semantic with a capability name
+   and prove it through the real `/api/v1/eom-funnel/contact-directory`
+   entrypoint on both shipped Atlas app objects.
+
+### Review Contract
+
+- Acceptance criteria:
+  - [ ] An authenticated directory request for an active Lost lead returns the
+    same contact row with `editable: false` and
+    `editBlockedReason: "not_editable_stage"`; it does not filter the row out.
+    Settled by `tests/test_eom_contact_directory.py` route and real-Postgres
+    projection cases.
+  - [ ] Active customers and active leads in the stages already admitted by
+    the mutation boundary return `editable: true` and no block reason, while
+    an archived directory row returns `editable: false` with the closed
+    lifecycle reason. Settled by the shared-policy and route contract tests.
+  - [ ] The mutation boundary uses the same canonical decision rather than a
+    second copy of the supported-stage rule, and retains its existing refusal
+    behavior for non-editable records. Settled by direct policy tests plus the
+    existing mutation integration coverage exercised in the focused test run.
+  - [ ] `contact.directory.editability` is advertised only by a build that
+    serves the existing `GET /eom-funnel/contact-directory` contract carrying
+    these fields. Settled by capability-manifest and deployed-entrypoint tests.
+  - [ ] The additive fields preserve the existing directory envelope,
+    authentication, tenant filtering, lifecycle filtering, and keyset
+    pagination. Settled by `tests/test_eom_contact_directory.py`.
+- Reachability proof: invoke the real mounted
+  `/api/v1/eom-funnel/contact-directory` route on both `atlas_brain.main:app`
+  and `atlas_brain.main_eom:app`, with the service bearer and actor headers,
+  and assert the serialized per-row verdict.
+- Affected surfaces: Atlas EOM funnel response schema and capability manifest;
+  canonical operator-contact domain policy; database CRM directory projection;
+  no browser or tracker surface in this PR.
+- Risk areas: public response compatibility, mismatch between read and write
+  eligibility, lifecycle-status ordering, and stale deployments that expose
+  the route without the new fields.
+- Reviewer rules triggered: R1, R2, R3, R5, R6, R10, R12, R13, R14.
+
+### Boundary-change enumeration
+
+- Boundary path/seam: canonical row-state editability decision used by
+  `mutate_eom_operator_contact_atomic` and emitted by the contact-directory
+  projection; additive Pydantic serialization boundary for directory items.
+- Replaced-path behaviors: the mutation duplicated inline stage predicate is
+  replaced with the canonical decision; directory admission stays status-based
+  and does not become a stage filter.
+- Guard-relevant fields: `contact_type`, `status`, and `lead_stage`; no
+  browser-supplied eligibility field is accepted.
+- Caller x input shape: the database provider and test CRM yield canonical
+  stored-row mappings; the authenticated GET route serializes the derived
+  verdict. Existing mutation commands remain unchanged.
+
+### Deployed-config probing
+
+N/A - this slice adds no environment variable, fallback, or configuration
+branch. It remains behind the existing EOM funnel enablement and authentication
+dependencies; the capability is the deployment-proof mechanism for the new
+response semantic.
+
+### Files touched
+
+- `atlas_brain/eom_api/funnel.py`
+- `atlas_brain/services/crm_provider.py`
+- `atlas_brain/services/eom_crm_mutations.py`
+- `plans/PR-EOM-Contact-Directory-Editability.md`
+- `tests/test_eom_contact_directory.py`
+- `tests/test_eom_lead_conversion_integration.py`
+
+## Mechanism
+
+The domain module returns a small immutable decision with exactly one of the
+closed outcomes: editable, blocked by lifecycle status, blocked by unsupported
+contact kind, or blocked by lead stage. Its order preserves the existing
+mutation behavior: lifecycle status wins where it already won before identity
+conflict handling; a Lost lead remains discoverable but is blocked by stage.
+
+`DatabaseCRMProvider` uses that decision when it validates an existing-contact
+edit and when it turns each canonical directory row into the closed directory
+projection. The route schema requires a boolean and either `null` or one of the
+same closed reason codes. `contact.directory.editability` maps to the existing
+GET route, so older Atlas deployments cannot advertise the field contract and
+downstream relays can fail closed rather than treating route availability as
+semantic compatibility.
+
+## Intentional
+
+- A non-editable verdict is a truthful lifecycle precondition, not a promise
+  that every future mutation will succeed: identity-collision checks remain
+  request-specific and fail closed at the existing write boundary.
+- Lost leads stay in the active directory. Removing them would destroy the
+  operator ability to find/reopen/inspect them instead of correcting the
+  offered-but-fails Edit control.
+- The capability has its own name even though it uses the same route, matching
+  the existing `contact.directory.archived` and `contact.field_clear` rollout
+  pattern for response semantics that older builds do not understand.
+
+## Deferred
+
+- Tracker capability proof/parser and Website rendering/translated explanation
+  will consume this Atlas contract in the two downstream slices for Website
+  #247 item 7. They must not carry a copied lead-stage list.
+- Collision-resolution UX, cross-tab recovery, same-field concurrency, address
+  and `customer_type` editing remain deferred exactly as listed in Website
+  #247.
+- No new endpoint, database table, migration, or generic edit-workflow
+  redesign is justified by this read/write contract correction.
+
+Parked hardening: request-specific identity conflict handling, general edit
+workflow redesign, and downstream recovery/copy changes are parked unless they
+block the per-row verdict or violate the existing mutation safety boundary.
+
+## Verification
+
+- `pytest tests/test_eom_contact_directory.py -q` - 43 passed, 6 skipped;
+  the skipped real-Postgres cases require `ATLAS_MIGRATION_TEST_DATABASE_URL`.
+- `pytest tests/test_eom_lead_conversion_integration.py -q -k
+  "unsupported_lead_stages or rejects_inactive_legacy_lead or
+  rejects_unsupported_existing_contact_type"` - 4 skipped, 108 deselected;
+  the focused real-Postgres guard cases, including Lost, require the same
+  unavailable local migration-test database.
+- `ruff check --ignore F401` on the five changed Python files - passed. The
+  excluded F401 is pre-existing on the `EOM_BUSINESS_CONTEXT_ID` re-export in
+  `atlas_brain/services/eom_crm_mutations.py`, verified against `origin/main`.
+- `bash scripts/check_ascii_python.sh` - passed.
+- `python scripts/check_guard_class_closure.py --base origin/main --strict` -
+  passed with no guard-shaped change missing a property test.
+- `python scripts/sync_pr_plan.py
+  plans/PR-EOM-Contact-Directory-Editability.md --check` - passed.
+- Pending before push: cold diff reconstruction with file-and-line citations
+  in the PR body, then `bash scripts/push_pr.sh` as the single local-review
+  entrypoint.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/eom_api/funnel.py` | 23 |
+| `atlas_brain/services/crm_provider.py` | 65 |
+| `atlas_brain/services/eom_crm_mutations.py` | 63 |
+| `plans/PR-EOM-Contact-Directory-Editability.md` | 191 |
+| `tests/test_eom_contact_directory.py` | 98 |
+| `tests/test_eom_lead_conversion_integration.py` | 27 |
+| **Total** | **467** |

--- a/tests/test_eom_contact_directory.py
+++ b/tests/test_eom_contact_directory.py
@@ -29,6 +29,9 @@ from atlas_brain.services.crm_provider import (
     _eom_directory_phone_search_digits,
     _escape_eom_directory_like_pattern,
 )
+from atlas_brain.services.eom_crm_mutations import (
+    get_eom_operator_contact_editability,
+)
 
 ROOT = Path(__file__).resolve().parent.parent
 MIGRATIONS = ROOT / "atlas_brain" / "storage" / "migrations"
@@ -53,7 +56,7 @@ def _row(
     status: str = "active",
     customer_type: str = "unknown",
 ) -> dict[str, object]:
-    return {
+    row: dict[str, object] = {
         "contact_id": contact_id or uuid4(),
         "full_name": full_name,
         "email": "directory@example.test",
@@ -67,6 +70,10 @@ def _row(
         "created_at": created_at or _BASE_CREATED_AT,
         "updated_at": created_at or _BASE_CREATED_AT,
     }
+    editability = get_eom_operator_contact_editability(row)
+    row["editable"] = editability.editable
+    row["edit_block_reason"] = editability.edit_block_reason
+    return row
 
 
 class _CRM:
@@ -200,8 +207,12 @@ async def test_both_contact_kinds_come_back_and_the_projection_is_closed():
             "source",
             "createdAt",
             "updatedAt",
+            "editable",
+            "editBlockedReason",
         }
         assert item["status"] == "active"
+        assert item["editable"] is True
+        assert item["editBlockedReason"] is None
 
 
 @pytest.mark.asyncio
@@ -407,6 +418,78 @@ async def test_a_lost_lead_is_rendered_with_its_stage():
     item = response.json()["contacts"][0]
     assert item["contactType"] == "lead"
     assert item["leadStage"] == "lost"
+    assert item["editable"] is False
+    assert item["editBlockedReason"] == "not_editable_stage"
+
+
+@pytest.mark.parametrize(
+    ("contact", "expected"),
+    [
+        ({"contact_type": "customer", "status": "active"}, (True, None)),
+        (
+            {"contact_type": "lead", "status": "active", "lead_stage": "new"},
+            (True, None),
+        ),
+        (
+            {
+                "contact_type": "lead",
+                "status": "active",
+                "lead_stage": "estimate_booked",
+            },
+            (True, None),
+        ),
+        (
+            {"contact_type": "lead", "status": "active", "lead_stage": "won"},
+            (True, None),
+        ),
+        (
+            {"contact_type": "lead", "status": "active", "lead_stage": "lost"},
+            (False, "not_editable_stage"),
+        ),
+        (
+            {"contact_type": "lead", "status": "inactive", "lead_stage": "new"},
+            (False, "not_editable_lead_status"),
+        ),
+        (
+            {"contact_type": "customer", "status": "archived"},
+            (False, "not_editable_archived"),
+        ),
+        (
+            {"contact_type": "vendor", "status": "active"},
+            (False, "not_editable_contact_type"),
+        ),
+    ],
+)
+def test_the_editability_policy_is_closed_and_preserves_write_boundary_order(
+    contact: dict[str, str], expected: tuple[bool, str | None]
+):
+    decision = get_eom_operator_contact_editability(contact)
+
+    assert (decision.editable, decision.edit_block_reason) == expected
+
+
+@pytest.mark.asyncio
+async def test_an_archived_directory_row_has_a_closed_non_editable_verdict():
+    response = await _get(_CRM([_row(status="archived")]), "?lifecycle=archived")
+
+    assert response.status_code == 200
+    item = response.json()["contacts"][0]
+    assert item["status"] == "archived"
+    assert item["editable"] is False
+    assert item["editBlockedReason"] == "not_editable_archived"
+
+
+def test_the_directory_schema_refuses_incoherent_or_unknown_editability_values():
+    mismatched = _row(contact_type="lead", lead_stage="lost")
+    mismatched["editable"] = True
+    with pytest.raises(ValueError, match="editable"):
+        funnel_mod.EOMContactDirectoryItem.model_validate(mismatched)
+
+    unknown_reason = _row()
+    unknown_reason["editable"] = False
+    unknown_reason["edit_block_reason"] = "not_a_reason"
+    with pytest.raises(ValueError, match="edit_block_reason"):
+        funnel_mod.EOMContactDirectoryItem.model_validate(unknown_reason)
 
 
 # ---------------------------------------------------------------------------
@@ -416,6 +499,7 @@ async def test_a_lost_lead_is_rendered_with_its_stage():
 
 def test_the_directory_is_advertised_in_the_capability_manifest():
     assert "contact.directory" in funnel_mod.served_capabilities()
+    assert "contact.directory.editability" in funnel_mod.served_capabilities()
     assert ("GET", "/eom-funnel/contact-directory") in funnel_mod.served_capability_routes()
 
 
@@ -431,6 +515,7 @@ async def test_the_lead_review_response_advertises_the_directory():
         response = await client.get("/eom-funnel/leads", headers=_headers())
     body = response.json()
     assert "contact.directory" in body["capabilities"]
+    assert "contact.directory.editability" in body["capabilities"]
     assert {"method": "GET", "path": "/eom-funnel/contact-directory"} in body[
         "capabilityRoutes"
     ]
@@ -478,7 +563,10 @@ async def test_every_deployed_entrypoint_serves_the_route_at_its_path():
         assert response.status_code == 200, (
             f"{name} must serve the deployed path, not 404"
         )
-        assert len(response.json()["contacts"]) == 1, name
+        contacts = response.json()["contacts"]
+        assert len(contacts) == 1, name
+        assert contacts[0]["editable"] is True, name
+        assert contacts[0]["editBlockedReason"] is None, name
 
 
 # ---------------------------------------------------------------------------
@@ -721,6 +809,8 @@ async def test_tenant_scope_and_lifecycle_hold_against_real_postgres(
     assert vendor not in ids, "kinds outside lead/customer are not directory rows"
     lost_row = next(row for row in rows if row["contact_id"] == eom_lost_lead)
     assert lost_row["lead_stage"] == "lost"
+    assert lost_row["editable"] is False
+    assert lost_row["edit_block_reason"] == "not_editable_stage"
 
 
 @pytest.mark.asyncio
@@ -833,5 +923,9 @@ async def test_directory_rows_carry_the_projection_columns(_directory_provider):
         "source",
         "created_at",
         "updated_at",
+        "editable",
+        "edit_block_reason",
     }
     assert row["customer_type"] == "unknown", "migration 366 default must surface"
+    assert row["editable"] is True
+    assert row["edit_block_reason"] is None

--- a/tests/test_eom_lead_conversion_integration.py
+++ b/tests/test_eom_lead_conversion_integration.py
@@ -1205,8 +1205,20 @@ async def test_operator_contact_mutation_rejects_unsupported_existing_contact_ty
         await conn.close()
 
 
+@pytest.mark.parametrize(
+    ("lead_stage", "full_name", "source_ref", "email"),
+    [
+        (None, "Legacy Unstaged Lead", "lead:unstaged", "unstaged@example.com"),
+        ("lost", "Lost Lead", "lead:lost", "lost@example.com"),
+    ],
+)
 @pytest.mark.asyncio
-async def test_operator_contact_mutation_rejects_legacy_lead_without_stage():
+async def test_operator_contact_mutation_rejects_unsupported_lead_stages(
+    lead_stage: str | None,
+    full_name: str,
+    source_ref: str,
+    email: str,
+):
     database_url = _database_url_or_skip()
     schema = f"atlas_eom_operator_bad_stage_{uuid.uuid4().hex}"
     conn = await asyncpg.connect(database_url)
@@ -1218,18 +1230,18 @@ async def test_operator_contact_mutation_rejects_legacy_lead_without_stage():
             conn,
             contact_id=contact_id,
             business_context_id=None,
-            full_name="Legacy Unstaged Lead",
+            full_name=full_name,
             contact_type="lead",
-            lead_stage=None,
+            lead_stage=lead_stage,
             phone="2175550100",
-            email="unstaged@example.com",
+            email=email,
         )
         command = EOMOperatorContactMutation.from_raw(
             operation_key=f"operator-bad-stage-{uuid.uuid4().hex}",
             actor_id=10,
             actor_name="Juan Canfield",
             source_channel="time_tracker",
-            source_ref="lead:unstaged",
+            source_ref=source_ref,
             contact_id=str(contact_id),
             fields={"phone": "217-555-0100", "notes": "needs funnel stage"},
         )
@@ -1238,10 +1250,13 @@ async def test_operator_contact_mutation_rejects_legacy_lead_without_stage():
             await mutate_eom_operator_contact(provider, command)
 
         assert exc_info.value.status_code == 409
+        assert str(exc_info.value) == (
+            "EOM operator lead updates require a supported lead stage"
+        )
         row = await conn.fetchrow("SELECT * FROM contacts WHERE id = $1", contact_id)
         assert row["business_context_id"] is None
         assert row["contact_type"] == "lead"
-        assert row["lead_stage"] is None
+        assert row["lead_stage"] == lead_stage
         assert row["notes"] is None
         assert await conn.fetchval(
             """


### PR DESCRIPTION
Plan: plans/PR-EOM-Contact-Directory-Editability.md
Slice phase: Vertical slice
Ownership lane: eom/contact-directory-editability

The root cause is that Atlas kept the operator edit-eligibility rule inside the mutation boundary while the canonical directory deliberately returns active Lost leads without a verdict. A downstream client therefore had to offer Edit globally or copy the policy. This producer-only slice fixes that root by publishing the same closed row-state decision that the write boundary enforces, without changing lifecycle transitions or hiding Lost leads.

## Intentional
- Lost leads remain visible in the active directory. The new `not_editable_stage` result corrects the offered-but-fails Edit control without destroying inspection or future lifecycle handling.
- The new capability shares the existing GET route. It versions response semantics, not route reachability, so a stale deployment cannot claim the new field contract.
- Identity-collision checks remain request-specific at the existing write boundary; a row verdict is not a promise that every edit request will succeed.

## AI reconciliation
- no-findings

## Deferred
- Tracker capability parsing and Website gating/explanation follow in the downstream slices for Website issue #247 item 7. Those consumers must use the Atlas capability and row data rather than copy a stage list.
- Collision-resolution UX, same-field concurrency, address/customer-type editing, and general edit-workflow redesign remain deferred because they do not block this producer contract.

## Parked hardening
- No HARDENING.md entry. The parking predicate is work outside the per-row producer verdict: broader edit-workflow redesign, request-specific collision UX, and downstream recovery/copy changes stay parked unless they block the verdict or violate the existing mutation safety boundary.

## Cold diff reconstruction
- Changed: `atlas_brain/services/eom_crm_mutations.py:35-96` defines one closed immutable decision for contact type, lifecycle status, and lead stage.
- Changed: `atlas_brain/services/crm_provider.py:1538-1603` makes the existing mutation guard consume that decision while preserving refusal ordering and 409 messages; `:2301-2383` emits the same verdict for existing directory rows without changing SQL admission, tenant scope, search, or pagination.
- Changed: `atlas_brain/eom_api/funnel.py:388-415` requires coherent `editable` and `editBlockedReason` output; `:788-802` advertises the response semantic on the existing directory route.
- Changed: `tests/test_eom_contact_directory.py:413-503` proves Lost/archived outcomes and the closed matrix; `:548-569` proves both shipped application objects serialize the new fields; `tests/test_eom_lead_conversion_integration.py:1208-1267` proves Lost and unstaged mutation attempts retain the existing 409/no-write behavior.
- Contract match: every production change maps to the plan requirement for one canonical decision, its existing read/write consumers, response serialization, or deployment capability proof.
- Gaps: no implementation or scope gap found. No migration, route, lifecycle transition, auth behavior, tracker module, or Website module moved. Local database integration execution remains unverified because `ATLAS_MIGRATION_TEST_DATABASE_URL` is absent; CI must execute the already-present cases.

## Verification
- `pytest tests/test_eom_contact_directory.py -q` - 43 passed, 6 skipped.
- `pytest tests/test_eom_lead_conversion_integration.py -q -k "unsupported_lead_stages or rejects_inactive_legacy_lead or rejects_unsupported_existing_contact_type"` - 4 skipped, 108 deselected because the local migration database is unavailable.
- `ruff check --ignore F401` on the five changed Python files - passed; the excluded `EOM_BUSINESS_CONTEXT_ID` F401 is pre-existing on `origin/main`.
- `bash scripts/check_ascii_python.sh` - passed.
- `python scripts/check_guard_class_closure.py --base origin/main --strict` - passed.
- `python scripts/sync_pr_plan.py plans/PR-EOM-Contact-Directory-Editability.md --check` - passed.

## Mechanical verification
- Command: `pytest tests/test_eom_contact_directory.py -q` - Result: 43 passed, 6 skipped - Environment: local
- Command: `ruff check --ignore F401 atlas_brain/eom_api/funnel.py atlas_brain/services/crm_provider.py atlas_brain/services/eom_crm_mutations.py tests/test_eom_contact_directory.py tests/test_eom_lead_conversion_integration.py` - Result: passed - Environment: local
- Command: `bash scripts/check_ascii_python.sh` - Result: passed - Environment: local
- Command: `python scripts/check_guard_class_closure.py --base origin/main --strict` - Result: passed - Environment: local
- Skipped: focused real-Postgres mutation cases - Reason: `ATLAS_MIGRATION_TEST_DATABASE_URL` is not configured locally; CI has the required migration database.

## Diff size
6 files, +439 / -28

Diff-budget override: The shared producer policy, existing write/read consumers, additive response contract, capability declaration, and cross-path regression proof are one indivisible vertical slice; splitting them would leave either the API behavior or its safety proof incomplete.

<!-- atlas-open-pr-wrapper: v1 -->
