### PR TITLE
EOM: durable missed-call recovery provider

### DIFF
--- a/.github/workflows/atlas_eom_lead_pipeline_checks.yml
+++ b/.github/workflows/atlas_eom_lead_pipeline_checks.yml
@@ -12,6 +12,7 @@ on:
       - "atlas_brain/autonomous/tasks/gmail_digest.py"
       - "atlas_brain/config.py"
       - "atlas_brain/main.py"
+      - "atlas_brain/main_eom.py"
       - "atlas_brain/storage/database.py"
       - "atlas_brain/api/__init__.py"
       - "atlas_brain/api/contacts.py"
@@ -31,11 +32,13 @@ on:
       - "scripts/check_contact_write_boundary.py"
       - "atlas_brain/services/eom_lead_ingress.py"
       - "atlas_brain/services/eom_onboarding_drafts.py"
+      - "atlas_brain/services/eom_missed_call_recovery.py"
       - "atlas_brain/services/eom_public_onboarding_tokens.py"
       - "atlas_brain/templates/email/__init__.py"
       - "atlas_brain/templates/email/estimate_confirmation.py"
       - "atlas_brain/templates/email/onboarding_welcome.py"
       - "atlas_brain/templates/email/request_acknowledgement.py"
+      - "atlas_brain/templates/email/missed_call_recovery.py"
       - "atlas_brain/eom_api/config.py"
       - "atlas_brain/eom_api/auth.py"
       - "atlas_brain/eom_api/funnel.py"
@@ -68,6 +71,7 @@ on:
       - "atlas_brain/storage/migrations/383_eom_public_onboarding_tokens.sql"
       - "atlas_brain/storage/migrations/386_eom_won_loss_nocodb_fence.sql"
       - "atlas_brain/storage/migrations/388_eom_contact_archive_disposition_index.sql"
+      - "atlas_brain/storage/migrations/389_eom_missed_call_recovery.sql"
       - "atlas_brain/tools/calendar.py"
       - "atlas_brain/tools/scheduling.py"
       - "tests/test_ack_commercial_templates.py"
@@ -81,6 +85,7 @@ on:
       - "tests/test_eom_contact_directory.py"
       - "tests/test_eom_contact_archive.py"
       - "tests/test_eom_lead_conversion.py"
+      - "tests/test_eom_missed_call_recovery.py"
       - "tests/test_eom_lead_conversion_integration.py"
       - "tests/test_eom_public_onboarding.py"
       - "tests/test_eom_write_boundary_audit.py"
@@ -109,6 +114,7 @@ on:
       - "atlas_brain/autonomous/tasks/gmail_digest.py"
       - "atlas_brain/config.py"
       - "atlas_brain/main.py"
+      - "atlas_brain/main_eom.py"
       - "atlas_brain/storage/database.py"
       - "atlas_brain/api/__init__.py"
       - "atlas_brain/api/contacts.py"
@@ -128,11 +134,13 @@ on:
       - "scripts/check_contact_write_boundary.py"
       - "atlas_brain/services/eom_lead_ingress.py"
       - "atlas_brain/services/eom_onboarding_drafts.py"
+      - "atlas_brain/services/eom_missed_call_recovery.py"
       - "atlas_brain/services/eom_public_onboarding_tokens.py"
       - "atlas_brain/templates/email/__init__.py"
       - "atlas_brain/templates/email/estimate_confirmation.py"
       - "atlas_brain/templates/email/onboarding_welcome.py"
       - "atlas_brain/templates/email/request_acknowledgement.py"
+      - "atlas_brain/templates/email/missed_call_recovery.py"
       - "atlas_brain/eom_api/config.py"
       - "atlas_brain/eom_api/auth.py"
       - "atlas_brain/eom_api/funnel.py"
@@ -165,6 +173,7 @@ on:
       - "atlas_brain/storage/migrations/383_eom_public_onboarding_tokens.sql"
       - "atlas_brain/storage/migrations/386_eom_won_loss_nocodb_fence.sql"
       - "atlas_brain/storage/migrations/388_eom_contact_archive_disposition_index.sql"
+      - "atlas_brain/storage/migrations/389_eom_missed_call_recovery.sql"
       - "atlas_brain/tools/calendar.py"
       - "atlas_brain/tools/scheduling.py"
       - "tests/test_ack_commercial_templates.py"
@@ -178,6 +187,7 @@ on:
       - "tests/test_eom_contact_directory.py"
       - "tests/test_eom_contact_archive.py"
       - "tests/test_eom_lead_conversion.py"
+      - "tests/test_eom_missed_call_recovery.py"
       - "tests/test_eom_lead_conversion_integration.py"
       - "tests/test_eom_public_onboarding.py"
       - "tests/test_eom_write_boundary_audit.py"
@@ -251,6 +261,7 @@ jobs:
             tests/test_eom_contact_archive.py \
             tests/test_eom_billing_recipients.py \
             tests/test_eom_lead_conversion.py \
+            tests/test_eom_missed_call_recovery.py \
             tests/test_eom_lead_conversion_integration.py \
             tests/test_eom_funnel_capability_manifest.py \
             tests/test_eom_public_onboarding.py \

--- a/atlas_brain/eom_api/config.py
+++ b/atlas_brain/eom_api/config.py
@@ -6,6 +6,7 @@ import os
 from collections.abc import Iterable, Mapping
 from pathlib import Path
 from urllib.parse import urlsplit
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from dotenv import dotenv_values
 from pydantic import Field, SecretStr
@@ -214,6 +215,47 @@ class EOMFunnelConfig(BaseSettings):
             "rotation are still active"
         ),
     )
+    missed_call_recovery_enabled: bool = Field(
+        default=False,
+        description=(
+            "Allow the EOM missed-call worker to deliver configured residential "
+            "recovery emails. Disabled keeps recorded sequences blocked."
+        ),
+    )
+    missed_call_booking_link: str = Field(
+        default="",
+        description=(
+            "Authoritative HTTPS Google Calendar appointment-request link for "
+            "EOM missed-call recovery emails; never a browser-supplied value."
+        ),
+    )
+    missed_call_timezone: str = Field(
+        default="America/Chicago",
+        description=(
+            "IANA time zone used for EOM missed-call business-day scheduling."
+        ),
+    )
+    missed_call_poll_interval_seconds: int = Field(
+        default=60,
+        ge=30,
+        le=900,
+        description="Bounded polling interval for the EOM missed-call outbox worker.",
+    )
+    missed_call_max_delivery_attempts: int = Field(
+        default=3,
+        ge=1,
+        le=5,
+        description=(
+            "Maximum definite-pre-acceptance delivery attempts per missed-call "
+            "sequence step."
+        ),
+    )
+    missed_call_delivery_timeout_seconds: int = Field(
+        default=10,
+        ge=1,
+        le=30,
+        description="Bounded Resend request timeout for a missed-call recovery step.",
+    )
 
     @property
     def public_onboarding_issuance_is_enabled(self) -> bool:
@@ -228,6 +270,37 @@ class EOMFunnelConfig(BaseSettings):
         if self.public_onboarding_issuance_enabled is None:
             return self.public_onboarding_enabled
         return self.public_onboarding_issuance_enabled
+
+    @property
+    def missed_call_recovery_delivery_is_configured(self) -> bool:
+        """Whether a worker may deliver recovery mail in this process.
+
+        A blank booking link deliberately does not make the whole EOM API
+        unavailable.  An operator's real no-answer evidence can still be
+        recorded as a visible blocked sequence, but no message can render or
+        send until a valid deploy-time destination is supplied.
+        """
+
+        return bool(
+            self.missed_call_recovery_enabled and self.missed_call_booking_link.strip()
+        )
+
+    @property
+    def missed_call_recovery_delivery_block_reason(self) -> str | None:
+        """Return the honest operator-visible reason delivery cannot begin.
+
+        ``disabled`` and ``missing link`` are intentionally distinct.  The
+        former is a deployment/operator control; the latter is an incomplete
+        customer-facing configuration.  Collapsing them would make a recovery
+        action look like a bad Calendar configuration when an operator had
+        deliberately paused the feature.
+        """
+
+        if not self.missed_call_recovery_enabled:
+            return "recovery_disabled"
+        if not self.missed_call_booking_link.strip():
+            return "booking_link_unavailable"
+        return None
 
     @model_validator(mode="after")
     def reject_raw_eom_funnel_service_token_env(self) -> "EOMFunnelConfig":
@@ -329,6 +402,61 @@ class EOMFunnelConfig(BaseSettings):
             raise ValueError(
                 "public onboarding previous HMAC secret must be at least 32 bytes"
             )
+        return self
+
+    @model_validator(mode="after")
+    def validate_missed_call_recovery_configuration(self) -> "EOMFunnelConfig":
+        """Validate a supplied customer-facing booking URL before any send.
+
+        A missing link is a supported, fail-closed rollout state. A nonblank
+        malformed/non-Google link is not: accepting it would turn a config typo
+        into a customer email with an unusable or unintended destination.
+        """
+
+        if self.missed_call_recovery_enabled and not self.api_enabled:
+            raise ValueError(
+                "missed-call recovery requires ATLAS_EOM_FUNNEL_API_ENABLED=true"
+            )
+        booking_link = self.missed_call_booking_link.strip()
+        if booking_link:
+            if any(
+                character.isspace()
+                or character == "\\"
+                or ord(character) < 32
+                or ord(character) == 127
+                for character in booking_link
+            ):
+                raise ValueError(
+                    "missed-call booking link must not contain control characters, "
+                    "whitespace, or backslashes"
+                )
+            try:
+                parsed = urlsplit(booking_link)
+                port = parsed.port
+            except ValueError as exc:
+                raise ValueError(
+                    "missed-call booking link must be a valid HTTPS Google Calendar URL"
+                ) from exc
+            allowed_hosts = {"calendar.google.com", "calendar.app.google"}
+            hostname = (parsed.hostname or "").casefold()
+            if (
+                parsed.scheme != "https"
+                or hostname not in allowed_hosts
+                or parsed.username is not None
+                or parsed.password is not None
+                # Google Calendar hosts its public scheduler on the standard
+                # HTTPS endpoint.  An explicit alternate port can never be a
+                # supported public booking URL and is easy to mistype.
+                or port is not None
+                or not parsed.path.strip("/")
+            ):
+                raise ValueError(
+                    "missed-call booking link must be an HTTPS Google Calendar URL"
+                )
+        try:
+            ZoneInfo(self.missed_call_timezone)
+        except ZoneInfoNotFoundError as exc:
+            raise ValueError("missed-call time zone must be a valid IANA zone") from exc
         return self
 
 

--- a/atlas_brain/eom_api/funnel.py
+++ b/atlas_brain/eom_api/funnel.py
@@ -47,6 +47,10 @@ from ..services.eom_onboarding_drafts import (
     approve_and_send_eom_onboarding_draft,
     record_operator_confirmed_send_evidence,
 )
+from ..services.eom_missed_call_recovery import (
+    EOMMissedCallRecoveryError,
+    EOMMissedCallRecoveryService,
+)
 from ..services.eom_public_onboarding_tokens import (
     AuthenticatedEOMPublicOnboardingToken,
     EOMPublicOnboardingTokenError,
@@ -54,6 +58,7 @@ from ..services.eom_public_onboarding_tokens import (
     eom_public_onboarding_hmac_key_fingerprint,
 )
 from ..services.crm_provider import get_crm_provider
+from .config import funnel_settings
 from .funnel_auth import (
     EOMPublicOnboardingConfig,
     get_eom_funnel_api_config,
@@ -211,6 +216,14 @@ class EOMLeadLostRequest(BaseModel):
         return value
 
 
+class EOMMissedCallRecoveryCancelRequest(BaseModel):
+    """One verified reason an operator must stop future recovery mail."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    reason: Literal["callback_recorded", "response_recorded", "opt_out", "manual"]
+
+
 class EOMOperatorContactRequest(BaseModel):
     """Authenticated operator-authored EOM contact create/update request."""
 
@@ -318,6 +331,41 @@ class EOMLeadReviewResponse(BaseModel):
         default_factory=list,
         serialization_alias="capabilityRoutes",
     )
+
+
+class EOMMissedCallRecoveryStatusItem(BaseModel):
+    """Non-PII status that the tracker may render on an existing lead card."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    contact_id: UUID = Field(alias="contactId")
+    sequence_id: UUID = Field(alias="sequenceId")
+    state: Literal[
+        "active",
+        "blocked_configuration",
+        "completed",
+        "cancelled",
+        "failed",
+        "recovery_required",
+    ]
+    blocked_reason: str | None = Field(default=None, alias="blockedReason")
+    cancellation_reason: str | None = Field(default=None, alias="cancellationReason")
+    next_step_number: int | None = Field(default=None, alias="nextStepNumber")
+    next_follow_up_at: datetime | None = Field(default=None, alias="nextFollowUpAt")
+    last_event: str | None = Field(default=None, alias="lastEvent")
+    last_reason: str | None = Field(default=None, alias="lastReason")
+    created_at: datetime = Field(alias="createdAt")
+    terminal_at: datetime | None = Field(default=None, alias="terminalAt")
+
+
+class EOMMissedCallRecoveryStatusResponse(BaseModel):
+    """Bounded recovery-status batch for the current CRM lead page."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    sequences: list[EOMMissedCallRecoveryStatusItem]
+    checked: int
+    limit: Annotated[int, Field(ge=1, le=_MAX_KNOWN_CONTACT_IDS)]
 
 
 class EOMFunnelCapabilityRoute(BaseModel):
@@ -573,6 +621,26 @@ def _crm_dependency(request: Request) -> Any:
     return get_crm_provider()
 
 
+def _missed_call_recovery_dependency(request: Request) -> EOMMissedCallRecoveryService:
+    """Bind recovery state to the same authoritative pool as this API profile.
+
+    The full Atlas application uses its global canonical pool.  The slim EOM
+    profile injects its explicitly validated funnel pool on app state, so this
+    route never silently splits lead lifecycle state across databases.
+    """
+
+    pool_factory = getattr(
+        request.app.state, "eom_funnel_missed_call_recovery_pool", None
+    )
+    if callable(pool_factory):
+        pool = pool_factory()
+    else:
+        from ..storage.database import get_db_pool
+
+        pool = get_db_pool()
+    return EOMMissedCallRecoveryService(pool=pool, config=funnel_settings)
+
+
 def _authenticated_public_onboarding_token(
     token: object,
     public_onboarding: EOMPublicOnboardingConfig,
@@ -759,6 +827,27 @@ _CAPABILITY_ROUTES: dict[str, tuple[str, str]] = {
     "contact.field_clear": ("POST", "/eom-funnel/operator-contacts"),
     "lead.lost": ("POST", "/eom-funnel/leads/{contact_id}/lost"),
     "lead.reopen": ("POST", "/eom-funnel/leads/{contact_id}/reopen"),
+    # A separate, narrow seam rather than an inferred lead-stage: the office
+    # must record an actual unanswered call before Atlas creates its durable
+    # recovery outbox. The status read is batch-only and contains no recipient
+    # or template data, so the active CRM card can render it without owning
+    # sequence state in the browser.
+    "lead.missed_call_attempt.record": (
+        "POST",
+        "/eom-funnel/leads/{contact_id}/missed-call-attempts",
+    ),
+    "lead.missed_call_recovery.status": (
+        "GET",
+        "/eom-funnel/missed-call-recovery-status",
+    ),
+    "lead.missed_call_recovery.resume": (
+        "POST",
+        "/eom-funnel/leads/{contact_id}/missed-call-recovery/resume",
+    ),
+    "lead.missed_call_recovery.cancel": (
+        "POST",
+        "/eom-funnel/leads/{contact_id}/missed-call-recovery/cancel",
+    ),
     "onboarding.draft.list": ("GET", "/eom-funnel/onboarding-drafts"),
     "onboarding.draft.edit": ("PATCH", "/eom-funnel/onboarding-drafts/{draft_id}"),
     "onboarding.draft.approve_send": (
@@ -983,6 +1072,135 @@ async def list_eom_lead_review_items(
             EOMFunnelCapabilityRoute(method=method, path=path)
             for method, path in served_capability_routes()
         ],
+    )
+
+
+@router.post(
+    "/leads/{contact_id}/missed-call-attempts",
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(require_eom_funnel_api)],
+)
+async def record_eom_missed_call_attempt(
+    contact_id: UUID,
+    operation_key: str = Depends(_approval_key_dependency),
+    actor: dict[str, object] = Depends(require_eom_funnel_actor),
+    recovery: EOMMissedCallRecoveryService = Depends(_missed_call_recovery_dependency),
+) -> JSONResponse:
+    """Record a real office no-answer; Atlas alone decides whether mail starts."""
+
+    try:
+        await recovery.require_schema_ready()
+        result = await recovery.record_no_answer(
+            contact_id=contact_id,
+            operation_key=operation_key,
+            actor_id=int(actor["id"]),
+            actor_name=str(actor["name"]),
+        )
+    except EOMMissedCallRecoveryError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
+    return JSONResponse(
+        status_code=(
+            status.HTTP_200_OK
+            if bool(result.get("idempotent"))
+            else status.HTTP_201_CREATED
+        ),
+        content={"success": True, **result},
+    )
+
+
+@router.get(
+    "/missed-call-recovery-status",
+    response_model=EOMMissedCallRecoveryStatusResponse,
+    dependencies=[Depends(require_eom_funnel_api)],
+)
+async def list_eom_missed_call_recovery_status(
+    contact_id: Annotated[
+        list[UUID],
+        Query(min_length=1, max_length=_MAX_KNOWN_CONTACT_IDS),
+    ],
+    _actor: dict[str, object] = Depends(require_eom_funnel_actor),
+    recovery: EOMMissedCallRecoveryService = Depends(_missed_call_recovery_dependency),
+) -> EOMMissedCallRecoveryStatusResponse:
+    """Return bounded status for lead cards already visible to the office."""
+
+    requested = list(dict.fromkeys(contact_id))
+    try:
+        await recovery.require_schema_ready()
+        rows = await recovery.statuses(contact_ids=requested)
+    except EOMMissedCallRecoveryError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
+    return EOMMissedCallRecoveryStatusResponse(
+        sequences=[EOMMissedCallRecoveryStatusItem.model_validate(row) for row in rows],
+        checked=len(requested),
+        limit=_MAX_KNOWN_CONTACT_IDS,
+    )
+
+
+@router.post(
+    "/leads/{contact_id}/missed-call-recovery/resume",
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(require_eom_funnel_api)],
+)
+async def resume_eom_missed_call_recovery(
+    contact_id: UUID,
+    operation_key: str = Depends(_approval_key_dependency),
+    actor: dict[str, object] = Depends(require_eom_funnel_actor),
+    recovery: EOMMissedCallRecoveryService = Depends(_missed_call_recovery_dependency),
+) -> JSONResponse:
+    """Explicitly resume one previously configuration-blocked sequence."""
+
+    try:
+        await recovery.require_schema_ready()
+        result = await recovery.resume_blocked_sequence(
+            contact_id=contact_id,
+            operation_key=operation_key,
+            actor_id=int(actor["id"]),
+            actor_name=str(actor["name"]),
+        )
+    except EOMMissedCallRecoveryError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
+    return JSONResponse(
+        status_code=(
+            status.HTTP_200_OK
+            if bool(result.get("idempotent"))
+            else status.HTTP_201_CREATED
+        ),
+        content={"success": True, **result},
+    )
+
+
+@router.post(
+    "/leads/{contact_id}/missed-call-recovery/cancel",
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(require_eom_funnel_api)],
+)
+async def cancel_eom_missed_call_recovery(
+    contact_id: UUID,
+    payload: EOMMissedCallRecoveryCancelRequest,
+    operation_key: str = Depends(_approval_key_dependency),
+    actor: dict[str, object] = Depends(require_eom_funnel_actor),
+    recovery: EOMMissedCallRecoveryService = Depends(_missed_call_recovery_dependency),
+) -> JSONResponse:
+    """Persist a verified stop condition without altering lead history."""
+
+    try:
+        await recovery.require_schema_ready()
+        result = await recovery.cancel_sequence(
+            contact_id=contact_id,
+            operation_key=operation_key,
+            actor_id=int(actor["id"]),
+            actor_name=str(actor["name"]),
+            reason=payload.reason,
+        )
+    except EOMMissedCallRecoveryError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
+    return JSONResponse(
+        status_code=(
+            status.HTTP_200_OK
+            if bool(result.get("idempotent"))
+            else status.HTTP_201_CREATED
+        ),
+        content={"success": True, **result},
     )
 
 

--- a/atlas_brain/main.py
+++ b/atlas_brain/main.py
@@ -912,38 +912,28 @@ async def lifespan(app: FastAPI):
         except Exception as e:
             logger.error("Failed to register alert UI callback: %s", e, exc_info=True)
 
-    # This worker starts only after the full generic migration pass and all
-    # existing application startup work have completed. When enabled, its
-    # schema fence turns a partial migration into a startup failure instead of
-    # a process that could record office call attempts but silently lack a
-    # durable outbox. A missing booking link is an intentional blocked rollout
-    # state: the route still records evidence, but no worker is allowed to send.
+    # This worker boundary runs only after the full generic migration pass and
+    # all existing application startup work have completed. Its schema fence
+    # turns an enabled partial migration into a startup failure; a disabled or
+    # incomplete deployment instead durably blocks existing active sequences,
+    # so restoring configuration cannot auto-send overdue customer email.
     from .eom_api.config import funnel_settings
 
-    if funnel_settings.missed_call_recovery_enabled:
+    if db_settings.enabled:
         from .services.eom_missed_call_recovery import (
-            EOMMissedCallRecoveryService,
-            start_eom_missed_call_recovery_worker,
+            prepare_eom_missed_call_recovery_worker,
         )
 
         missed_call_pool = get_db_pool()
-        recovery = EOMMissedCallRecoveryService(
+        missed_call_worker = await prepare_eom_missed_call_recovery_worker(
             pool=missed_call_pool,
             config=funnel_settings,
         )
-        await recovery.require_schema_ready()
-        delivery_block_reason = recovery.delivery_block_reason()
-        if delivery_block_reason is None:
-            missed_call_worker = start_eom_missed_call_recovery_worker(
-                pool=missed_call_pool,
-                config=funnel_settings,
-            )
-            logger.info("EOM missed-call recovery worker started")
-        else:
-            logger.warning(
-                "EOM missed-call recovery is enabled but delivery is blocked: %s",
-                delivery_block_reason,
-            )
+    elif funnel_settings.missed_call_recovery_enabled:
+        # This branch was previously reached only through the schema fence.
+        # Keep the enabled worker fail-closed if a deployment disables its
+        # canonical database rather than silently serving recovery mutations.
+        raise RuntimeError("EOM missed-call recovery requires database persistence")
 
     yield  # Application runs here
 

--- a/atlas_brain/main.py
+++ b/atlas_brain/main.py
@@ -453,6 +453,7 @@ async def lifespan(app: FastAPI):
     Handles startup (model loading) and shutdown (cleanup).
     """
     # --- Startup ---
+    missed_call_worker = None
     logger.info("Atlas Brain starting up...")
     _enforce_paid_funnel_alert_channel(settings)
     from .api.invoicing.auth import validate_receivables_api_config
@@ -911,10 +912,54 @@ async def lifespan(app: FastAPI):
         except Exception as e:
             logger.error("Failed to register alert UI callback: %s", e, exc_info=True)
 
+    # This worker starts only after the full generic migration pass and all
+    # existing application startup work have completed. When enabled, its
+    # schema fence turns a partial migration into a startup failure instead of
+    # a process that could record office call attempts but silently lack a
+    # durable outbox. A missing booking link is an intentional blocked rollout
+    # state: the route still records evidence, but no worker is allowed to send.
+    from .eom_api.config import funnel_settings
+
+    if funnel_settings.missed_call_recovery_enabled:
+        from .services.eom_missed_call_recovery import (
+            EOMMissedCallRecoveryService,
+            start_eom_missed_call_recovery_worker,
+        )
+
+        missed_call_pool = get_db_pool()
+        recovery = EOMMissedCallRecoveryService(
+            pool=missed_call_pool,
+            config=funnel_settings,
+        )
+        await recovery.require_schema_ready()
+        delivery_block_reason = recovery.delivery_block_reason()
+        if delivery_block_reason is None:
+            missed_call_worker = start_eom_missed_call_recovery_worker(
+                pool=missed_call_pool,
+                config=funnel_settings,
+            )
+            logger.info("EOM missed-call recovery worker started")
+        else:
+            logger.warning(
+                "EOM missed-call recovery is enabled but delivery is blocked: %s",
+                delivery_block_reason,
+            )
+
     yield  # Application runs here
 
     # --- Shutdown ---
     logger.info("Atlas Brain shutting down...")
+
+    if missed_call_worker is not None:
+        try:
+            from .services.eom_missed_call_recovery import (
+                stop_eom_missed_call_recovery_worker,
+            )
+
+            await stop_eom_missed_call_recovery_worker(missed_call_worker)
+            logger.info("EOM missed-call recovery worker stopped")
+        except Exception as e:
+            logger.error("Error stopping EOM missed-call recovery worker: %s", e)
 
     # NOTE: Presence service runs in atlas_vision, no local shutdown needed
 

--- a/atlas_brain/main_eom.py
+++ b/atlas_brain/main_eom.py
@@ -245,32 +245,25 @@ async def lifespan(app: FastAPI):
         await _validate_eom_funnel_startup()
         if db_settings.enabled and eom_profile_settings.run_migrations:
             await _run_startup_migrations()
-        if funnel_settings.missed_call_recovery_enabled:
-            if eom_profile_settings.run_migrations:
-                await _run_eom_missed_call_recovery_startup_migrations()
-            from .services.eom_missed_call_recovery import (
-                EOMMissedCallRecoveryService,
-                start_eom_missed_call_recovery_worker,
-            )
+        if (
+            funnel_settings.missed_call_recovery_enabled
+            and eom_profile_settings.run_migrations
+        ):
+            await _run_eom_missed_call_recovery_startup_migrations()
+        from .services.eom_missed_call_recovery import (
+            prepare_eom_missed_call_recovery_worker,
+        )
 
-            missed_call_pool = get_eom_funnel_db_pool()
-            recovery = EOMMissedCallRecoveryService(
+        missed_call_pool = get_eom_funnel_db_pool()
+        if getattr(missed_call_pool, "is_initialized", False):
+            missed_call_worker = await prepare_eom_missed_call_recovery_worker(
                 pool=missed_call_pool,
                 config=funnel_settings,
             )
-            await recovery.require_schema_ready()
-            delivery_block_reason = recovery.delivery_block_reason()
-            if delivery_block_reason is None:
-                missed_call_worker = start_eom_missed_call_recovery_worker(
-                    pool=missed_call_pool,
-                    config=funnel_settings,
-                )
-                logger.info("EOM missed-call recovery worker started")
-            else:
-                logger.warning(
-                    "EOM missed-call recovery is enabled but delivery is blocked: %s",
-                    delivery_block_reason,
-                )
+        elif funnel_settings.missed_call_recovery_enabled:
+            raise RuntimeError(
+                "EOM missed-call recovery requires the canonical funnel database"
+            )
         if db_settings.enabled and invoicing_settings.receivables_api_enabled:
             await _require_receivables_schema_ready()
         yield

--- a/atlas_brain/main_eom.py
+++ b/atlas_brain/main_eom.py
@@ -108,6 +108,20 @@ EOM_RECEIVABLES_READINESS_MIGRATIONS: tuple[str, ...] = (
     "379_receivables_payment_receipt_delivery_recovery",
 )
 
+# This worker owns EOM lead lifecycle evidence in the canonical funnel store,
+# not the global receivables pool. The set is deliberately closed: a newly
+# provisioned supported funnel database receives the columns, interaction
+# dedupe, lifecycle ledger, classification, and outbox schema it needs, while
+# unrelated Atlas migrations remain outside this slim-profile startup path.
+EOM_MISSED_CALL_RECOVERY_READINESS_MIGRATIONS: tuple[str, ...] = (
+    "035_contacts",
+    "256_contact_interaction_dedupe",
+    "346_contact_lead_pipeline",
+    "351_eom_lead_lifecycle_events",
+    "366_contacts_customer_type",
+    "389_eom_missed_call_recovery",
+)
+
 
 async def _apply_eom_receivables_migrations(
     pool: Any,
@@ -130,6 +144,31 @@ async def _run_startup_migrations() -> None:
         logger.info(
             "EOM receivables readiness migrations checked: %s",
             ", ".join(EOM_RECEIVABLES_READINESS_MIGRATIONS),
+        )
+
+
+async def _apply_eom_missed_call_recovery_migrations(
+    pool: Any,
+    run_migrations_fn: MigrationRunner | None = None,
+) -> None:
+    """Apply only the recovery worker's canonical-funnel prerequisites."""
+
+    if run_migrations_fn is None:
+        from .storage.migrations import run_migrations
+
+        runner = run_migrations
+    else:
+        runner = run_migrations_fn
+    await runner(pool, only=EOM_MISSED_CALL_RECOVERY_READINESS_MIGRATIONS)
+
+
+async def _run_eom_missed_call_recovery_startup_migrations() -> None:
+    pool = get_eom_funnel_db_pool()
+    if pool.is_initialized:
+        await _apply_eom_missed_call_recovery_migrations(pool)
+        logger.info(
+            "EOM missed-call recovery readiness migrations checked: %s",
+            ", ".join(EOM_MISSED_CALL_RECOVERY_READINESS_MIGRATIONS),
         )
 
 
@@ -195,6 +234,7 @@ async def lifespan(app: FastAPI):
         ),
     )
 
+    missed_call_worker = None
     try:
         if db_settings.enabled:
             await init_database()
@@ -205,11 +245,43 @@ async def lifespan(app: FastAPI):
         await _validate_eom_funnel_startup()
         if db_settings.enabled and eom_profile_settings.run_migrations:
             await _run_startup_migrations()
+        if funnel_settings.missed_call_recovery_enabled:
+            if eom_profile_settings.run_migrations:
+                await _run_eom_missed_call_recovery_startup_migrations()
+            from .services.eom_missed_call_recovery import (
+                EOMMissedCallRecoveryService,
+                start_eom_missed_call_recovery_worker,
+            )
+
+            missed_call_pool = get_eom_funnel_db_pool()
+            recovery = EOMMissedCallRecoveryService(
+                pool=missed_call_pool,
+                config=funnel_settings,
+            )
+            await recovery.require_schema_ready()
+            delivery_block_reason = recovery.delivery_block_reason()
+            if delivery_block_reason is None:
+                missed_call_worker = start_eom_missed_call_recovery_worker(
+                    pool=missed_call_pool,
+                    config=funnel_settings,
+                )
+                logger.info("EOM missed-call recovery worker started")
+            else:
+                logger.warning(
+                    "EOM missed-call recovery is enabled but delivery is blocked: %s",
+                    delivery_block_reason,
+                )
         if db_settings.enabled and invoicing_settings.receivables_api_enabled:
             await _require_receivables_schema_ready()
         yield
     finally:
         try:
+            if missed_call_worker is not None:
+                from .services.eom_missed_call_recovery import (
+                    stop_eom_missed_call_recovery_worker,
+                )
+
+                await stop_eom_missed_call_recovery_worker(missed_call_worker)
             # Mirrors init_eom_funnel_database's condition. Closing only when
             # the funnel API is on would leak the pool in the deployment that
             # opened it for receivables alone.
@@ -248,4 +320,5 @@ async def ping() -> dict[str, str]:
 
 app.include_router(receivables_router, prefix="/api/v1")
 app.state.eom_funnel_crm_provider = get_eom_funnel_crm_provider
+app.state.eom_funnel_missed_call_recovery_pool = get_eom_funnel_db_pool
 app.include_router(funnel_router, prefix="/api/v1")

--- a/atlas_brain/main_eom.py
+++ b/atlas_brain/main_eom.py
@@ -245,10 +245,11 @@ async def lifespan(app: FastAPI):
         await _validate_eom_funnel_startup()
         if db_settings.enabled and eom_profile_settings.run_migrations:
             await _run_startup_migrations()
-        if (
-            funnel_settings.missed_call_recovery_enabled
-            and eom_profile_settings.run_migrations
-        ):
+        # Migration 389 is additive state and route readiness, not permission
+        # to send email. A safe first deployment deliberately runs it while
+        # delivery remains disabled so a qualifying operator action records an
+        # inspectable blocked sequence instead of a schema 503.
+        if eom_profile_settings.run_migrations:
             await _run_eom_missed_call_recovery_startup_migrations()
         from .services.eom_missed_call_recovery import (
             prepare_eom_missed_call_recovery_worker,

--- a/atlas_brain/services/eom_missed_call_recovery.py
+++ b/atlas_brain/services/eom_missed_call_recovery.py
@@ -60,6 +60,11 @@ _TRACKED_RESPONSE_INTERACTIONS = frozenset(
         "opt_out",
     }
 )
+# CLOSED / ENUMERATED: these are the only browser-originated mutations this
+# recovery slice accepts. The database receipt records this finite vocabulary
+# with one globally unique operation key, so a retry can never move to another
+# lead or mutation kind after an interrupted browser request.
+_OPERATION_KINDS = frozenset({"no_answer", "resume", "cancel"})
 
 
 class EOMMissedCallRecoveryError(Exception):
@@ -124,8 +129,18 @@ class ResendMissedCallRecoveryGateway:
 
     _URL = "https://api.resend.com/emails"
 
-    def __init__(self, *, timeout_seconds: int) -> None:
+    def __init__(
+        self,
+        *,
+        timeout_seconds: int,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
         self._timeout_seconds = timeout_seconds
+        # Production uses httpx's normal transport. The optional injected
+        # transport is deliberately narrow test plumbing so this exact adapter
+        # (headers and result classification included) can be proven without a
+        # real provider call.
+        self._transport = transport
 
     async def send(
         self,
@@ -155,7 +170,7 @@ class ResendMissedCallRecoveryGateway:
         }
         try:
             async with httpx.AsyncClient(
-                timeout=float(self._timeout_seconds)
+                timeout=float(self._timeout_seconds), transport=self._transport
             ) as client:
                 response = await client.post(self._URL, json=payload, headers=headers)
         except (httpx.TimeoutException, httpx.NetworkError, httpx.ProtocolError) as exc:
@@ -373,6 +388,7 @@ async def missed_call_recovery_schema_ready(pool: Any) -> bool:
             await pool.fetchval(
                 """
                 SELECT to_regclass('eom_missed_call_attempts') IS NOT NULL
+                   AND to_regclass('eom_missed_call_operation_receipts') IS NOT NULL
                    AND to_regclass('eom_missed_call_contact_suppressions') IS NOT NULL
                    AND to_regclass('eom_missed_call_sequences') IS NOT NULL
                    AND to_regclass('eom_missed_call_sequence_steps') IS NOT NULL
@@ -474,6 +490,130 @@ class EOMMissedCallRecoveryService:
             return "email_transport_unavailable"
         return None
 
+    async def _bind_operation_receipt(
+        self,
+        conn: Any,
+        *,
+        contact_id: UUID,
+        operation_key: str,
+        operation_kind: str,
+        fingerprint: str,
+    ) -> bool:
+        """Durably bind one browser operation key before mutating a lead.
+
+        ``True`` means the exact same completed operation owns the key and the
+        caller must return its current authoritative status. A different lead,
+        mutation kind, or request fingerprint is a conflict, never a second
+        action. ``ON CONFLICT DO NOTHING`` keeps two concurrent contacts from
+        poisoning their transactions with a unique-violation before the loser
+        can inspect the winning receipt.
+        """
+
+        if operation_kind not in _OPERATION_KINDS:
+            raise RuntimeError("Unsupported missed-call recovery operation kind")
+
+        existing = await conn.fetchrow(
+            """
+            SELECT contact_id, operation_kind, request_fingerprint
+            FROM eom_missed_call_operation_receipts
+            WHERE operation_key = $1
+            FOR UPDATE
+            """,
+            operation_key,
+        )
+        if existing is None:
+            inserted = await conn.fetchrow(
+                """
+                INSERT INTO eom_missed_call_operation_receipts (
+                    operation_key, contact_id, operation_kind, request_fingerprint
+                ) VALUES ($1, $2, $3, $4)
+                ON CONFLICT (operation_key) DO NOTHING
+                RETURNING operation_key
+                """,
+                operation_key,
+                contact_id,
+                operation_kind,
+                fingerprint,
+            )
+            if inserted is not None:
+                return False
+            # A concurrent transaction just committed the winning receipt.
+            # Re-read it under lock before deciding whether this is a replay or
+            # a cross-contact/key-reuse conflict.
+            existing = await conn.fetchrow(
+                """
+                SELECT contact_id, operation_kind, request_fingerprint
+                FROM eom_missed_call_operation_receipts
+                WHERE operation_key = $1
+                FOR UPDATE
+                """,
+                operation_key,
+            )
+            if existing is None:
+                raise EOMMissedCallRecoveryUnavailableError(
+                    "Missed-call recovery operation receipt is unavailable"
+                )
+
+        if (
+            _uuid(existing["contact_id"], "Receipt contact id") != contact_id
+            or existing["operation_kind"] != operation_kind
+            or existing["request_fingerprint"] != fingerprint
+        ):
+            raise EOMMissedCallRecoveryConflictError(
+                "Idempotency key belongs to a different missed-call recovery operation"
+            )
+        return True
+
+    async def block_active_sequences_for_configuration(
+        self,
+        *,
+        reason: str | None = None,
+    ) -> int:
+        """Persist a deployment pause before a worker can quiesce delivery.
+
+        A configuration change can happen while a sequence has pending steps.
+        Those rows must become visibly blocked and require an explicit resume
+        after configuration is restored; silently retaining ``active`` would
+        otherwise let a restart send overdue messages automatically.
+        """
+
+        block_reason = reason or self.delivery_block_reason()
+        if block_reason is None:
+            return 0
+        try:
+            async with self.pool.transaction() as conn:
+                now = self._now()
+                blocked = await conn.fetch(
+                    """
+                    UPDATE eom_missed_call_sequences
+                       SET state = 'blocked_configuration', blocked_reason = $1,
+                           updated_at = $2
+                     WHERE state = 'active'
+                     RETURNING id
+                    """,
+                    block_reason,
+                    now,
+                )
+                for row in blocked:
+                    await self._event(
+                        conn,
+                        sequence_id=row["id"],
+                        event_type="sequence_blocked",
+                        reason_code=block_reason,
+                        actor_id=None,
+                        actor_name="system",
+                        source="worker",
+                        metadata={"configuration_block": True},
+                        occurred_at=now,
+                    )
+                return len(blocked)
+        except EOMMissedCallRecoveryError:
+            raise
+        except (asyncpg.PostgresError, OSError) as exc:
+            raise EOMMissedCallRecoveryUnavailableError(
+                "Missed-call recovery configuration block could not be recorded"
+            ) from exc
+
     async def record_no_answer(
         self,
         *,
@@ -493,19 +633,25 @@ class EOMMissedCallRecoveryService:
         try:
             async with self.pool.transaction() as conn:
                 contact = await self._contact_for_update(conn, contact_id)
-                previous = await conn.fetchrow(
-                    """
-                    SELECT * FROM eom_missed_call_attempts
-                    WHERE contact_id = $1 AND operation_key = $2
-                    FOR UPDATE
-                    """,
-                    contact_id,
-                    operation_key,
+                replayed = await self._bind_operation_receipt(
+                    conn,
+                    contact_id=contact_id,
+                    operation_key=operation_key,
+                    operation_kind="no_answer",
+                    fingerprint=fingerprint,
                 )
-                if previous is not None:
-                    if previous["request_fingerprint"] != fingerprint:
-                        raise EOMMissedCallRecoveryConflictError(
-                            "Idempotency key belongs to a different no-answer operation"
+                if replayed:
+                    previous = await conn.fetchrow(
+                        """
+                        SELECT id FROM eom_missed_call_attempts
+                        WHERE operation_key = $1
+                        FOR UPDATE
+                        """,
+                        operation_key,
+                    )
+                    if previous is None:
+                        raise EOMMissedCallRecoveryUnavailableError(
+                            "Missed-call recovery operation evidence is unavailable"
                         )
                     status = await self._status_for_contact(conn, contact_id)
                     return {
@@ -722,24 +868,29 @@ class EOMMissedCallRecoveryService:
         contact_id = _uuid(contact_id, "Contact id")
         operation_key = _safe_operation_key(operation_key)
         actor_id, actor_name = _safe_actor(actor_id, actor_name)
-        delivery_block_reason = self.delivery_block_reason()
-        if delivery_block_reason is not None:
-            raise EOMMissedCallRecoveryConflictError(
-                "Missed-call recovery delivery is not configured"
-            )
+        fingerprint = _fingerprint(
+            {"contactId": str(contact_id), "operation": "resume"}
+        )
         try:
             async with self.pool.transaction() as conn:
                 contact = await self._contact_for_update(conn, contact_id)
-                prior = await conn.fetchrow(
-                    """
-                    SELECT * FROM eom_lead_lifecycle_events
-                    WHERE contact_id = $1
-                      AND event_type = 'missed_call_recovery_resumed'
-                      AND operation_key = $2
-                    """,
-                    contact_id,
-                    operation_key,
+                replayed = await self._bind_operation_receipt(
+                    conn,
+                    contact_id=contact_id,
+                    operation_key=operation_key,
+                    operation_kind="resume",
+                    fingerprint=fingerprint,
                 )
+                if replayed:
+                    return {
+                        "idempotent": True,
+                        "sequence": await self._status_for_contact(conn, contact_id),
+                    }
+                delivery_block_reason = self.delivery_block_reason()
+                if delivery_block_reason is not None:
+                    raise EOMMissedCallRecoveryConflictError(
+                        "Missed-call recovery delivery is not configured"
+                    )
                 sequence = await conn.fetchrow(
                     """
                     SELECT * FROM eom_missed_call_sequences
@@ -748,11 +899,6 @@ class EOMMissedCallRecoveryService:
                     """,
                     contact_id,
                 )
-                if prior is not None:
-                    return {
-                        "idempotent": True,
-                        "sequence": await self._status_for_contact(conn, contact_id),
-                    }
                 if sequence is None:
                     raise EOMMissedCallRecoveryConflictError(
                         "No blocked missed-call recovery sequence exists"
@@ -847,6 +993,13 @@ class EOMMissedCallRecoveryService:
         actor_id, actor_name = _safe_actor(actor_id, actor_name)
         if reason not in _MANUAL_CANCEL_REASONS:
             raise EOMMissedCallRecoveryValidationError("Cancellation reason is invalid")
+        fingerprint = _fingerprint(
+            {
+                "contactId": str(contact_id),
+                "operation": "cancel",
+                "reason": reason,
+            }
+        )
         interaction_type = {
             "callback_recorded": "callback_completed",
             "response_recorded": "lead_response",
@@ -856,32 +1009,14 @@ class EOMMissedCallRecoveryService:
         try:
             async with self.pool.transaction() as conn:
                 contact = await self._contact_for_update(conn, contact_id)
-                prior = await conn.fetchrow(
-                    """
-                    SELECT metadata FROM eom_lead_lifecycle_events
-                    WHERE contact_id = $1
-                      AND event_type = 'missed_call_recovery_cancelled'
-                      AND operation_key = $2
-                    """,
-                    contact_id,
-                    operation_key,
+                replayed = await self._bind_operation_receipt(
+                    conn,
+                    contact_id=contact_id,
+                    operation_key=operation_key,
+                    operation_kind="cancel",
+                    fingerprint=fingerprint,
                 )
-                if prior is not None:
-                    metadata = prior.get("metadata")
-                    if isinstance(metadata, str):
-                        try:
-                            metadata = json.loads(metadata)
-                        except ValueError:
-                            metadata = None
-                    prior_reason = (
-                        metadata.get("reason")
-                        if isinstance(metadata, Mapping)
-                        else None
-                    )
-                    if prior_reason != reason:
-                        raise EOMMissedCallRecoveryConflictError(
-                            "Idempotency key belongs to a different recovery cancellation"
-                        )
+                if replayed:
                     return {
                         "idempotent": True,
                         "sequence": await self._status_for_contact(conn, contact_id),
@@ -1037,7 +1172,11 @@ class EOMMissedCallRecoveryService:
 
         if limit < 1 or limit > _MAX_WORK_BATCH:
             raise EOMMissedCallRecoveryValidationError("Worker limit is invalid")
-        if self.delivery_block_reason() is not None:
+        delivery_block_reason = self.delivery_block_reason()
+        if delivery_block_reason is not None:
+            await self.block_active_sequences_for_configuration(
+                reason=delivery_block_reason
+            )
             return 0
         await self._recover_stale_claims(limit=limit)
         completed = 0
@@ -1386,6 +1525,13 @@ class EOMMissedCallRecoveryService:
                     limit,
                 )
                 for row in rows:
+                    if row["sequence_state"] == "blocked_configuration":
+                        # A configuration pause can race an already persisted
+                        # claim. It is not proof that the provider did or did
+                        # not accept the email, so preserve the claim/key until
+                        # an explicit resume restores ``active`` and the normal
+                        # recovery rules can safely decide its outcome.
+                        continue
                     if row["sequence_state"] != "active":
                         skipped = await conn.fetchrow(
                             """
@@ -2084,6 +2230,54 @@ class EOMMissedCallRecoveryService:
                 history.step_id,
                 type(exc).__name__,
             )
+
+
+async def prepare_eom_missed_call_recovery_worker(
+    *,
+    pool: Any,
+    config: EOMFunnelConfig | None = None,
+) -> tuple[asyncio.Event, asyncio.Task[None]] | None:
+    """Fence, durably pause, or start the recovery worker for one app lifespan.
+
+    Both supported Atlas entrypoints call this exact boundary. A disabled or
+    incomplete deployment first blocks any existing active sequence; restoring
+    configuration later never resumes those steps without the operator's
+    explicit recovery action. A first rollout with no recovery schema is safe
+    while disabled, whereas an enabled rollout fails startup rather than
+    serving an unbacked mutation route.
+    """
+
+    effective_config = config or funnel_settings
+    recovery = EOMMissedCallRecoveryService(pool=pool, config=effective_config)
+    schema_ready = await missed_call_recovery_schema_ready(pool)
+    if not schema_ready:
+        if effective_config.missed_call_recovery_enabled:
+            raise EOMMissedCallRecoveryUnavailableError(
+                "Missed-call recovery schema is unavailable"
+            )
+        logger.info(
+            "EOM missed-call recovery schema is absent while delivery is disabled"
+        )
+        return None
+
+    delivery_block_reason = recovery.delivery_block_reason()
+    if delivery_block_reason is not None:
+        blocked_count = await recovery.block_active_sequences_for_configuration(
+            reason=delivery_block_reason
+        )
+        logger.warning(
+            "EOM missed-call recovery delivery is blocked reason=%s sequences=%s",
+            delivery_block_reason,
+            blocked_count,
+        )
+        return None
+
+    worker = start_eom_missed_call_recovery_worker(
+        pool=pool,
+        config=effective_config,
+    )
+    logger.info("EOM missed-call recovery worker started")
+    return worker
 
 
 async def run_eom_missed_call_recovery_worker(

--- a/atlas_brain/services/eom_missed_call_recovery.py
+++ b/atlas_brain/services/eom_missed_call_recovery.py
@@ -97,10 +97,22 @@ class EOMMissedCallRecoveryUnavailableError(EOMMissedCallRecoveryError):
 class _DefiniteDeliveryError(Exception):
     """The provider positively rejected a request before accepting mail."""
 
-    def __init__(self, code: str, *, retryable: bool) -> None:
+    def __init__(
+        self,
+        code: str,
+        *,
+        retryable: bool,
+        recovery_required_if_exhausted: bool = False,
+    ) -> None:
         super().__init__(code)
         self.code = code
         self.retryable = retryable
+        # A retryable transport rejection can safely become ``failed`` after
+        # its bounded attempts are exhausted. A provider response that says
+        # this idempotency key is currently being processed is different: its
+        # eventual acceptance remains unknown, so exhaustion must preserve
+        # ambiguity for an operator rather than claim a definite failure.
+        self.recovery_required_if_exhausted = recovery_required_if_exhausted
 
 
 class _AmbiguousDeliveryError(Exception):
@@ -198,7 +210,9 @@ class ResendMissedCallRecoveryGateway:
         if response.status_code == 409:
             if provider_code == "concurrent_idempotent_requests":
                 raise _DefiniteDeliveryError(
-                    "resend_request_in_progress", retryable=True
+                    "resend_request_in_progress",
+                    retryable=True,
+                    recovery_required_if_exhausted=True,
                 )
             # An idempotency conflict can mean another in-flight request
             # accepted this exact key. It is not proof that Resend rejected
@@ -411,6 +425,12 @@ async def missed_call_recovery_schema_ready(pool: Any) -> bool:
                        SELECT 1 FROM pg_trigger AS trigger
                        WHERE trigger.tgrelid = 'contacts'::regclass
                          AND trigger.tgname = 'trg_cancel_eom_missed_call_on_contact_change'
+                         AND NOT trigger.tgisinternal
+                   )
+                   AND EXISTS (
+                       SELECT 1 FROM pg_trigger AS trigger
+                       WHERE trigger.tgrelid = 'contact_interactions'::regclass
+                         AND trigger.tgname = 'trg_lock_eom_missed_call_interaction_contact'
                          AND NOT trigger.tgisinternal
                    )
                    AND EXISTS (
@@ -1198,8 +1218,41 @@ class EOMMissedCallRecoveryService:
         return delivery_attempts
 
     async def _contact_for_update(
-        self, conn: Any, contact_id: UUID
+        self,
+        conn: Any,
+        contact_id: UUID,
+        *,
+        allow_non_eom: bool = False,
     ) -> Mapping[str, Any]:
+        """Lock one canonical contact before reading delivery evidence.
+
+        Worker delivery uses ``allow_non_eom`` so a contact that was reassigned
+        after its EOM sequence began can be terminalized rather than being
+        mistaken for a missing row. Operator routes retain the stricter EOM
+        lookup and therefore never mutate a lead outside this tenant.
+        """
+
+        locked = await conn.fetchrow(
+            """
+            SELECT id
+            FROM contacts
+            WHERE id = $1
+              AND (business_context_id = $2 OR $3::boolean)
+            FOR UPDATE
+            """,
+            contact_id,
+            _EOM_CONTEXT,
+            allow_non_eom,
+        )
+        if locked is None:
+            raise EOMMissedCallRecoveryNotFoundError("EOM lead was not found")
+
+        # This must be a new statement after the row lock. Under PostgreSQL's
+        # read-committed isolation a statement snapshot can predate waiting on
+        # a ``FOR UPDATE`` lock held by an interaction correction. Reading the
+        # latest form evidence only after that wait gives the worker the
+        # correction's committed recipient/variant rather than a stale
+        # snapshot.
         contact = await conn.fetchrow(
             """
             SELECT c.*, latest.submitted_email, latest.ack_variant,
@@ -1217,11 +1270,9 @@ class EOMMissedCallRecoveryService:
                 ORDER BY ci.occurred_at DESC, ci.created_at DESC, ci.id DESC
                 LIMIT 1
             ) AS latest ON TRUE
-            WHERE c.id = $1 AND c.business_context_id = $2
-            FOR UPDATE OF c
+            WHERE c.id = $1
             """,
             contact_id,
-            _EOM_CONTEXT,
         )
         if contact is None:
             raise EOMMissedCallRecoveryNotFoundError("EOM lead was not found")
@@ -1235,6 +1286,8 @@ class EOMMissedCallRecoveryService:
         sequence_created_at: datetime | None,
         recipient_snapshot: str | None,
     ) -> _Eligibility:
+        if contact.get("business_context_id") != _EOM_CONTEXT:
+            return _Eligibility(False, "tenant_changed", None, None)
         if contact.get("contact_type") != "lead":
             return _Eligibility(False, "became_customer", None, None)
         if contact.get("status") != "active":
@@ -1623,39 +1676,20 @@ class EOMMissedCallRecoveryService:
         now = self._now()
         try:
             async with self.pool.transaction() as conn:
-                row = await conn.fetchrow(
+                # Claim the step first so peer workers still use SKIP LOCKED,
+                # then lock the canonical contact before the sequence. Contact
+                # and interaction mutations use that same contact-first order
+                # in migration 389. The second, fresh contact query below is
+                # therefore the linearization point for every mutable piece of
+                # delivery eligibility (including a corrected form recipient).
+                candidate = await conn.fetchrow(
                     """
                     SELECT
                         step.id AS step_id,
                         step.sequence_id,
-                        sequence.contact_id,
-                        sequence.created_at AS sequence_created_at,
-                        sequence.recipient_email,
-                        contact.id AS id,
-                        contact.contact_type,
-                        contact.status,
-                        contact.lead_stage,
-                        contact.customer_type,
-                        contact.email,
-                        contact.full_name,
-                        latest.submitted_email,
-                        latest.ack_variant,
-                        latest.latest_intake_at
+                        sequence.contact_id
                     FROM eom_missed_call_sequence_steps AS step
                     JOIN eom_missed_call_sequences AS sequence ON sequence.id = step.sequence_id
-                    JOIN contacts AS contact ON contact.id = sequence.contact_id
-                    LEFT JOIN LATERAL (
-                        SELECT
-                            NULLIF(ci.metadata->>'submitted_email', '') AS submitted_email,
-                            NULLIF(ci.metadata->>'ack_variant', '') AS ack_variant,
-                            ci.occurred_at AS latest_intake_at
-                        FROM contact_interactions AS ci
-                        WHERE ci.contact_id = contact.id
-                          AND ci.interaction_type = 'web_form'
-                          AND ci.intent = 'estimate_request'
-                        ORDER BY ci.occurred_at DESC, ci.created_at DESC, ci.id DESC
-                        LIMIT 1
-                    ) AS latest ON TRUE
                     WHERE step.state = 'pending'
                       AND sequence.state = 'active'
                       AND COALESCE(step.next_attempt_at, step.due_at) <= $1
@@ -1666,23 +1700,47 @@ class EOMMissedCallRecoveryService:
                             AND earlier.state NOT IN ('sent', 'skipped')
                       )
                     ORDER BY COALESCE(step.next_attempt_at, step.due_at), step.step_number, step.id
-                    FOR UPDATE OF step, sequence, contact SKIP LOCKED
+                    FOR UPDATE OF step SKIP LOCKED
                     LIMIT 1
                     """,
                     now,
                 )
-                if row is None:
+                if candidate is None:
                     return _ClaimResult(processed=False)
+                sequence_id = _uuid(candidate["sequence_id"], "sequence id")
+                contact_id = _uuid(candidate["contact_id"], "contact id")
+                contact = await self._contact_for_update(
+                    conn,
+                    contact_id,
+                    allow_non_eom=True,
+                )
+                sequence = await conn.fetchrow(
+                    """
+                    SELECT id, contact_id, created_at, recipient_email
+                    FROM eom_missed_call_sequences
+                    WHERE id = $1
+                      AND contact_id = $2
+                      AND state = 'active'
+                    FOR UPDATE
+                    """,
+                    sequence_id,
+                    contact_id,
+                )
+                if sequence is None:
+                    # Another contact-first mutation terminalized this exact
+                    # sequence after the step was selected. It is progress for
+                    # this bounded sweep, but it is not a sendable claim.
+                    return _ClaimResult(processed=True)
                 eligibility = await self._evaluate_contact_eligibility(
                     conn,
-                    row,
-                    sequence_created_at=row["sequence_created_at"],
-                    recipient_snapshot=row["recipient_email"],
+                    contact,
+                    sequence_created_at=sequence["created_at"],
+                    recipient_snapshot=sequence["recipient_email"],
                 )
                 if not eligibility.eligible:
                     await self._cancel_for_reason(
                         conn,
-                        sequence_id=row["sequence_id"],
+                        sequence_id=sequence_id,
                         reason=eligibility.reason or "ineligible",
                         source="worker",
                         actor_id=None,
@@ -1701,7 +1759,7 @@ class EOMMissedCallRecoveryService:
                      WHERE id = $1 AND state = 'pending'
                      RETURNING *
                     """,
-                    row["step_id"],
+                    candidate["step_id"],
                     claim_token,
                     now,
                     now + _ATTEMPT_LEASE,
@@ -1711,8 +1769,8 @@ class EOMMissedCallRecoveryService:
                     return _ClaimResult(processed=False)
                 await self._event(
                     conn,
-                    sequence_id=row["sequence_id"],
-                    step_id=row["step_id"],
+                    sequence_id=sequence_id,
+                    step_id=candidate["step_id"],
                     event_type="step_claimed",
                     reason_code=None,
                     actor_id=None,
@@ -1731,7 +1789,7 @@ class EOMMissedCallRecoveryService:
                     claim=_ClaimedStep(
                         step_id=_uuid(claimed["id"], "step id"),
                         sequence_id=_uuid(claimed["sequence_id"], "sequence id"),
-                        contact_id=_uuid(row["contact_id"], "contact id"),
+                        contact_id=contact_id,
                         claim_token=claim_token,
                         recipient_email=recipient,
                         subject=str(claimed["subject"]),
@@ -1758,6 +1816,17 @@ class EOMMissedCallRecoveryService:
         now = self._now()
         try:
             async with self.pool.transaction() as conn:
+                # The migration's BEFORE interaction trigger takes this same
+                # contact row lock before it writes any intake/response
+                # evidence. Taking it before the sequence means either that
+                # mutation commits before this fresh recheck, or it waits until
+                # this provider call finishes; no correction can slip between
+                # the final snapshot and external delivery.
+                contact = await self._contact_for_update(
+                    conn,
+                    claim.contact_id,
+                    allow_non_eom=True,
+                )
                 row = await conn.fetchrow(
                     """
                     SELECT
@@ -1769,37 +1838,14 @@ class EOMMissedCallRecoveryService:
                         step.body,
                         sequence.contact_id,
                         sequence.created_at AS sequence_created_at,
-                        sequence.recipient_email,
-                        contact.id AS id,
-                        contact.contact_type,
-                        contact.status,
-                        contact.lead_stage,
-                        contact.customer_type,
-                        contact.email,
-                        contact.full_name,
-                        latest.submitted_email,
-                        latest.ack_variant,
-                        latest.latest_intake_at
+                        sequence.recipient_email
                     FROM eom_missed_call_sequence_steps AS step
                     JOIN eom_missed_call_sequences AS sequence ON sequence.id = step.sequence_id
-                    JOIN contacts AS contact ON contact.id = sequence.contact_id
-                    LEFT JOIN LATERAL (
-                        SELECT
-                            NULLIF(ci.metadata->>'submitted_email', '') AS submitted_email,
-                            NULLIF(ci.metadata->>'ack_variant', '') AS ack_variant,
-                            ci.occurred_at AS latest_intake_at
-                        FROM contact_interactions AS ci
-                        WHERE ci.contact_id = contact.id
-                          AND ci.interaction_type = 'web_form'
-                          AND ci.intent = 'estimate_request'
-                        ORDER BY ci.occurred_at DESC, ci.created_at DESC, ci.id DESC
-                        LIMIT 1
-                    ) AS latest ON TRUE
                     WHERE step.id = $1
                       AND step.state = 'attempting'
                       AND step.claim_token = $2
                       AND sequence.state = 'active'
-                    FOR UPDATE OF step, sequence, contact
+                    FOR UPDATE OF step, sequence
                     """,
                     claim.step_id,
                     claim.claim_token,
@@ -1863,7 +1909,7 @@ class EOMMissedCallRecoveryService:
 
                 eligibility = await self._evaluate_contact_eligibility(
                     conn,
-                    row,
+                    contact,
                     sequence_created_at=row["sequence_created_at"],
                     recipient_snapshot=row["recipient_email"],
                 )
@@ -2037,6 +2083,18 @@ class EOMMissedCallRecoveryService:
                 source="worker",
                 metadata={"attempt": claim.attempt_count},
                 occurred_at=now,
+            )
+        elif error.recovery_required_if_exhausted:
+            # Resend explicitly says another request for this stable key is
+            # still running. It is safe to retry that same key while its
+            # evidence window remains open, but once the bounded retry budget
+            # is exhausted we cannot claim the other request was rejected.
+            await self._mark_recovery_required(
+                conn,
+                sequence_id=claim.sequence_id,
+                step_id=claim.step_id,
+                reason=error.code,
+                now=now,
             )
         else:
             await self._mark_failed(

--- a/atlas_brain/services/eom_missed_call_recovery.py
+++ b/atlas_brain/services/eom_missed_call_recovery.py
@@ -1179,18 +1179,23 @@ class EOMMissedCallRecoveryService:
             )
             return 0
         await self._recover_stale_claims(limit=limit)
-        completed = 0
+        # This return value represents rows that crossed the durable claim
+        # boundary and entered the delivery phase (including a definite
+        # provider rejection that scheduled a retry). A pending row that is
+        # cancelled by the first authoritative eligibility read is useful
+        # worker progress, but it is not a delivery attempt.
+        delivery_attempts = 0
         for _ in range(limit):
             claim_result = await self._claim_one_due_step()
             if not claim_result.processed:
                 break
-            completed += 1
             if claim_result.claim is None:
                 continue
+            delivery_attempts += 1
             history = await self._deliver_claim(claim_result.claim)
             if history is not None and history.provider_message_id:
                 await self._write_sent_history(history)
-        return completed
+        return delivery_attempts
 
     async def _contact_for_update(
         self, conn: Any, contact_id: UUID

--- a/atlas_brain/services/eom_missed_call_recovery.py
+++ b/atlas_brain/services/eom_missed_call_recovery.py
@@ -1,0 +1,2143 @@
+"""Durable EOM missed-call recovery state and delivery worker.
+
+The public estimate acknowledgement is intentionally outside this module.  A
+recovery sequence begins only after the authenticated office records a no-answer
+call against a canonical EOM lead.  The database stores every operator action,
+sequence transition, and delivery result before a caller sees success.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable, Mapping, Protocol, Sequence
+from uuid import UUID, uuid4
+from zoneinfo import ZoneInfo
+
+import asyncpg
+import httpx
+
+from ..eom_api.config import EOMFunnelConfig, funnel_settings
+from ..templates.email.estimate_confirmation import (
+    BUSINESS_EMAIL,
+    BUSINESS_NAME,
+)
+from ..templates.email.missed_call_recovery import (
+    MissedCallRecoveryEmail,
+    render_missed_call_recovery_email,
+)
+
+
+logger = logging.getLogger("atlas.eom.missed_call_recovery")
+
+_EOM_CONTEXT = "effingham_maids"
+_MAX_ACTOR_NAME_LENGTH = 128
+_MAX_OPERATION_KEY_LENGTH = 128
+_MAX_STATUS_IDS = 200
+_MAX_WORK_BATCH = 25
+_ATTEMPT_LEASE = timedelta(minutes=5)
+# Resend retains idempotency keys for 24 hours.  Leave a one-hour safety margin:
+# a delayed process must become visibly recoverable instead of sending a second
+# customer email after provider-side de-duplication has expired.
+_PROVIDER_KEY_WINDOW = timedelta(hours=23)
+_RETRY_DELAYS = (timedelta(minutes=5), timedelta(minutes=30), timedelta(hours=2))
+_EMAIL_PATTERN = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+_OPERATION_KEY_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{15,127}$")
+_MANUAL_CANCEL_REASONS = frozenset(
+    {"callback_recorded", "response_recorded", "opt_out", "manual"}
+)
+_TRACKED_RESPONSE_INTERACTIONS = frozenset(
+    {
+        "email_inbound",
+        "lead_response",
+        "callback_completed",
+        "conversation_completed",
+        "opt_out",
+    }
+)
+
+
+class EOMMissedCallRecoveryError(Exception):
+    """Base class for a stable API-safe recovery error."""
+
+    status_code = 409
+    code = "missed_call_recovery_error"
+
+
+class EOMMissedCallRecoveryValidationError(EOMMissedCallRecoveryError):
+    status_code = 422
+    code = "invalid_missed_call_recovery_request"
+
+
+class EOMMissedCallRecoveryNotFoundError(EOMMissedCallRecoveryError):
+    status_code = 404
+    code = "missed_call_recovery_not_found"
+
+
+class EOMMissedCallRecoveryConflictError(EOMMissedCallRecoveryError):
+    status_code = 409
+    code = "missed_call_recovery_conflict"
+
+
+class EOMMissedCallRecoveryUnavailableError(EOMMissedCallRecoveryError):
+    status_code = 503
+    code = "missed_call_recovery_unavailable"
+
+
+class _DefiniteDeliveryError(Exception):
+    """The provider positively rejected a request before accepting mail."""
+
+    def __init__(self, code: str, *, retryable: bool) -> None:
+        super().__init__(code)
+        self.code = code
+        self.retryable = retryable
+
+
+class _AmbiguousDeliveryError(Exception):
+    """The provider outcome cannot prove that mail was not accepted."""
+
+
+class _RecoveryEmailGateway(Protocol):
+    async def send(
+        self,
+        *,
+        recipient_email: str,
+        subject: str,
+        body: str,
+        idempotency_key: str,
+    ) -> str: ...
+
+
+class ResendMissedCallRecoveryGateway:
+    """Small Resend adapter with no customer data in application logs.
+
+    The generic email tool predates delivery idempotency and does not expose an
+    accepted-vs-ambiguous result.  This narrow adapter reuses its authoritative
+    deploy-time Resend configuration while preserving the provider key required
+    for a durable outbox.
+    """
+
+    _URL = "https://api.resend.com/emails"
+
+    def __init__(self, *, timeout_seconds: int) -> None:
+        self._timeout_seconds = timeout_seconds
+
+    async def send(
+        self,
+        *,
+        recipient_email: str,
+        subject: str,
+        body: str,
+        idempotency_key: str,
+    ) -> str:
+        from ..config import settings
+
+        email_config = settings.email
+        api_key = (email_config.api_key or "").strip()
+        if not email_config.enabled or not api_key:
+            raise _DefiniteDeliveryError("email_not_configured", retryable=False)
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "Idempotency-Key": idempotency_key,
+        }
+        payload = {
+            "from": f"{BUSINESS_NAME} <{BUSINESS_EMAIL}>",
+            "to": [recipient_email],
+            "subject": subject,
+            "text": body,
+            "reply_to": BUSINESS_EMAIL,
+        }
+        try:
+            async with httpx.AsyncClient(
+                timeout=float(self._timeout_seconds)
+            ) as client:
+                response = await client.post(self._URL, json=payload, headers=headers)
+        except (httpx.TimeoutException, httpx.NetworkError, httpx.ProtocolError) as exc:
+            raise _AmbiguousDeliveryError("resend_transport_unknown") from exc
+
+        if 200 <= response.status_code < 300:
+            try:
+                payload = response.json()
+            except ValueError as exc:
+                raise _AmbiguousDeliveryError("resend_success_body_unknown") from exc
+            message_id = payload.get("id") if isinstance(payload, Mapping) else None
+            if not isinstance(message_id, str) or not message_id.strip():
+                raise _AmbiguousDeliveryError("resend_success_identity_unknown")
+            return message_id.strip()
+
+        provider_code = ""
+        try:
+            error_payload = response.json()
+            if isinstance(error_payload, Mapping):
+                raw = error_payload.get("name") or error_payload.get("code")
+                if isinstance(raw, str):
+                    provider_code = raw.strip().casefold()
+        except ValueError:
+            pass
+        if response.status_code == 409:
+            if provider_code == "concurrent_idempotent_requests":
+                raise _DefiniteDeliveryError(
+                    "resend_request_in_progress", retryable=True
+                )
+            # An idempotency conflict can mean another in-flight request
+            # accepted this exact key. It is not proof that Resend rejected
+            # mail, so leave recovery evidence instead of inviting an unsafe
+            # manual resend from a false terminal "failed" state.
+            raise _AmbiguousDeliveryError("resend_idempotency_conflict_unknown")
+        if response.status_code in (408, 429) or response.status_code >= 500:
+            # The stable provider key keeps the retry safe while it remains in
+            # Resend's retention window.
+            raise _DefiniteDeliveryError("resend_transient_rejection", retryable=True)
+        if response.status_code in (400, 401, 403, 404, 409, 422):
+            raise _DefiniteDeliveryError("resend_rejected", retryable=False)
+        raise _AmbiguousDeliveryError("resend_unclassified_response")
+
+
+@dataclass(frozen=True)
+class _Eligibility:
+    eligible: bool
+    reason: str | None
+    recipient_email: str | None
+    full_name: str | None
+
+
+@dataclass(frozen=True)
+class _ClaimedStep:
+    step_id: UUID
+    sequence_id: UUID
+    contact_id: UUID
+    claim_token: UUID
+    recipient_email: str
+    subject: str
+    body: str
+    provider_idempotency_key: str
+    provider_key_expires_at: datetime
+    attempt_count: int
+
+
+@dataclass(frozen=True)
+class _ClaimResult:
+    """One dispatch iteration's durable claim outcome."""
+
+    processed: bool
+    claim: _ClaimedStep | None = None
+
+
+@dataclass(frozen=True)
+class _SentHistory:
+    contact_id: UUID
+    recipient_email: str
+    subject: str
+    body: str
+    provider_message_id: str
+    sequence_id: UUID
+    step_id: UUID
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _fingerprint(value: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        value, sort_keys=True, separators=(",", ":"), allow_nan=False
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _safe_operation_key(value: object) -> str:
+    if not isinstance(value, str):
+        raise EOMMissedCallRecoveryValidationError("Idempotency key is required")
+    value = value.strip()
+    if not _OPERATION_KEY_PATTERN.fullmatch(value):
+        raise EOMMissedCallRecoveryValidationError("Idempotency key is invalid")
+    return value
+
+
+def _safe_actor(actor_id: object, actor_name: object) -> tuple[int, str]:
+    if isinstance(actor_id, bool):
+        raise EOMMissedCallRecoveryValidationError("Authenticated actor is invalid")
+    try:
+        parsed_id = int(actor_id)
+    except (TypeError, ValueError) as exc:
+        raise EOMMissedCallRecoveryValidationError(
+            "Authenticated actor is invalid"
+        ) from exc
+    if parsed_id <= 0:
+        raise EOMMissedCallRecoveryValidationError("Authenticated actor is invalid")
+    if not isinstance(actor_name, str):
+        raise EOMMissedCallRecoveryValidationError("Authenticated actor is invalid")
+    parsed_name = actor_name.strip()
+    if (
+        not parsed_name
+        or len(parsed_name) > _MAX_ACTOR_NAME_LENGTH
+        or "\x00" in parsed_name
+    ):
+        raise EOMMissedCallRecoveryValidationError("Authenticated actor is invalid")
+    return parsed_id, parsed_name
+
+
+def _uuid(value: object, field: str) -> UUID:
+    if isinstance(value, UUID):
+        return value
+    try:
+        return UUID(str(value))
+    except (TypeError, ValueError, AttributeError) as exc:
+        raise EOMMissedCallRecoveryValidationError(f"{field} is invalid") from exc
+
+
+def _datetime(value: object, field: str) -> datetime:
+    if not isinstance(value, datetime) or value.tzinfo is None:
+        raise EOMMissedCallRecoveryConflictError(
+            f"Missed-call recovery {field} is invalid"
+        )
+    return value
+
+
+def _normalize_recipient(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower()
+    if (
+        not normalized
+        or len(normalized) > 254
+        or not _EMAIL_PATTERN.fullmatch(normalized)
+    ):
+        return None
+    return normalized
+
+
+def next_business_day_due(
+    from_time: datetime,
+    *,
+    timezone_name: str,
+) -> datetime:
+    """Return 09:00 local on the next Monday-Friday date.
+
+    The configured zone—not the worker machine zone—owns the policy.  EOM has
+    no holiday calendar or office-hours configuration today, so weekday is the
+    explicit, tested initial business-day definition.
+    """
+
+    current = _datetime(from_time, "due time")
+    try:
+        zone = ZoneInfo(timezone_name)
+    except Exception as exc:
+        raise EOMMissedCallRecoveryValidationError(
+            "Missed-call recovery time zone is invalid"
+        ) from exc
+    local = current.astimezone(zone)
+    candidate = local.date() + timedelta(days=1)
+    while candidate.weekday() >= 5:
+        candidate += timedelta(days=1)
+    return datetime(
+        candidate.year,
+        candidate.month,
+        candidate.day,
+        9,
+        0,
+        tzinfo=zone,
+    ).astimezone(timezone.utc)
+
+
+def _third_step_due(second_step_due: datetime, *, timezone_name: str) -> datetime:
+    """Return the same configured local clock time three calendar days later.
+
+    Calendar-day follow-up is an EOM business rule, not a raw 72-hour duration.
+    Converting back through the configured zone means a Friday 09:00 message
+    remains a Monday 09:00 message when a daylight-saving boundary sits between
+    the two dates.
+    """
+
+    current = _datetime(second_step_due, "second step due")
+    try:
+        zone = ZoneInfo(timezone_name)
+    except Exception as exc:
+        raise EOMMissedCallRecoveryValidationError(
+            "Missed-call recovery time zone is invalid"
+        ) from exc
+    return (current.astimezone(zone) + timedelta(days=3)).astimezone(timezone.utc)
+
+
+async def missed_call_recovery_schema_ready(pool: Any) -> bool:
+    """Return whether the additive provider schema is safe to serve."""
+
+    try:
+        return bool(
+            await pool.fetchval(
+                """
+                SELECT to_regclass('eom_missed_call_attempts') IS NOT NULL
+                   AND to_regclass('eom_missed_call_contact_suppressions') IS NOT NULL
+                   AND to_regclass('eom_missed_call_sequences') IS NOT NULL
+                   AND to_regclass('eom_missed_call_sequence_steps') IS NOT NULL
+                   AND to_regclass('eom_missed_call_sequence_events') IS NOT NULL
+                   AND EXISTS (
+                       SELECT 1 FROM pg_index AS idx
+                       JOIN pg_class AS rel ON rel.oid = idx.indexrelid
+                       WHERE idx.indrelid = 'eom_missed_call_sequences'::regclass
+                         AND rel.relname = 'uq_eom_missed_call_sequences_active_contact'
+                         AND idx.indisunique
+                         AND idx.indpred IS NOT NULL
+                   )
+                   AND EXISTS (
+                       SELECT 1 FROM pg_attribute AS attribute
+                       WHERE attribute.attrelid = 'eom_missed_call_sequence_steps'::regclass
+                         AND attribute.attname = 'claim_token'
+                         AND NOT attribute.attisdropped
+                   )
+                   AND EXISTS (
+                       SELECT 1 FROM pg_trigger AS trigger
+                       WHERE trigger.tgrelid = 'contacts'::regclass
+                         AND trigger.tgname = 'trg_cancel_eom_missed_call_on_contact_change'
+                         AND NOT trigger.tgisinternal
+                   )
+                   AND EXISTS (
+                       SELECT 1 FROM pg_trigger AS trigger
+                       WHERE trigger.tgrelid = 'contact_interactions'::regclass
+                         AND trigger.tgname = 'trg_cancel_eom_missed_call_on_interaction'
+                         AND NOT trigger.tgisinternal
+                   )
+                   AND to_regprocedure(
+                       'eom_missed_call_has_proven_inbound_sms(jsonb)'
+                   ) IS NOT NULL
+                """
+            )
+        )
+    except Exception:
+        return False
+
+
+class EOMMissedCallRecoveryService:
+    """Owns the EOM call evidence, eligibility, outbox, and worker state."""
+
+    def __init__(
+        self,
+        *,
+        pool: Any,
+        config: EOMFunnelConfig | None = None,
+        gateway: _RecoveryEmailGateway | None = None,
+        now: Callable[[], datetime] | None = None,
+        email_history: Any | None = None,
+    ) -> None:
+        self._pool = pool
+        self._config = config or funnel_settings
+        self._gateway = gateway
+        self._now = now or _now_utc
+        self._email_history = email_history
+
+    @property
+    def pool(self) -> Any:
+        if not bool(getattr(self._pool, "is_initialized", True)):
+            raise EOMMissedCallRecoveryUnavailableError(
+                "Missed-call recovery database is unavailable"
+            )
+        return self._pool
+
+    @property
+    def gateway(self) -> _RecoveryEmailGateway:
+        if self._gateway is not None:
+            return self._gateway
+        return ResendMissedCallRecoveryGateway(
+            timeout_seconds=self._config.missed_call_delivery_timeout_seconds
+        )
+
+    async def require_schema_ready(self) -> None:
+        if not await missed_call_recovery_schema_ready(self.pool):
+            raise EOMMissedCallRecoveryUnavailableError(
+                "Missed-call recovery schema is unavailable"
+            )
+
+    def delivery_block_reason(self) -> str | None:
+        """Return why this service must not render or send customer mail.
+
+        The sequence state records the reason instead of discovering it only
+        after a due worker has claimed a customer email. Tests supply a fake
+        gateway deliberately, which is a configured transport seam rather than
+        permission to consult a real Resend credential.
+        """
+
+        configured_reason = self._config.missed_call_recovery_delivery_block_reason
+        if configured_reason is not None:
+            return configured_reason
+        if self._gateway is not None:
+            return None
+        from ..config import settings
+
+        email_config = settings.email
+        if not email_config.enabled or not (email_config.api_key or "").strip():
+            return "email_transport_unavailable"
+        return None
+
+    async def record_no_answer(
+        self,
+        *,
+        contact_id: UUID,
+        operation_key: str,
+        actor_id: int,
+        actor_name: str,
+    ) -> dict[str, Any]:
+        """Record one real operator no-answer and create/reuse its sequence."""
+
+        contact_id = _uuid(contact_id, "Contact id")
+        operation_key = _safe_operation_key(operation_key)
+        actor_id, actor_name = _safe_actor(actor_id, actor_name)
+        fingerprint = _fingerprint(
+            {"contactId": str(contact_id), "operation": "no_answer"}
+        )
+        try:
+            async with self.pool.transaction() as conn:
+                contact = await self._contact_for_update(conn, contact_id)
+                previous = await conn.fetchrow(
+                    """
+                    SELECT * FROM eom_missed_call_attempts
+                    WHERE contact_id = $1 AND operation_key = $2
+                    FOR UPDATE
+                    """,
+                    contact_id,
+                    operation_key,
+                )
+                if previous is not None:
+                    if previous["request_fingerprint"] != fingerprint:
+                        raise EOMMissedCallRecoveryConflictError(
+                            "Idempotency key belongs to a different no-answer operation"
+                        )
+                    status = await self._status_for_contact(conn, contact_id)
+                    return {
+                        "attemptId": str(previous["id"]),
+                        "idempotent": True,
+                        "sequence": status,
+                    }
+
+                eligibility = await self._evaluate_contact_eligibility(
+                    conn, contact, sequence_created_at=None, recipient_snapshot=None
+                )
+                now = self._now()
+                attempt_id = uuid4()
+                await conn.execute(
+                    """
+                    INSERT INTO eom_missed_call_attempts (
+                        id, contact_id, operation_key, request_fingerprint,
+                        actor_id, actor_name, source, occurred_at
+                    ) VALUES ($1, $2, $3, $4, $5, $6, 'time_tracker', $7)
+                    """,
+                    attempt_id,
+                    contact_id,
+                    operation_key,
+                    fingerprint,
+                    actor_id,
+                    actor_name,
+                    now,
+                )
+                await conn.execute(
+                    """
+                    INSERT INTO contact_interactions (
+                        id, contact_id, interaction_type, summary, intent,
+                        occurred_at, metadata, interaction_dedupe_key
+                    ) VALUES ($1, $2, 'call',
+                              'Operator recorded unanswered call', 'no_answer',
+                              $3, $4::jsonb, $5)
+                    """,
+                    uuid4(),
+                    contact_id,
+                    now,
+                    json.dumps(
+                        {
+                            "missed_call_attempt_id": str(attempt_id),
+                            "operation_key": operation_key,
+                            "actor_id": actor_id,
+                        }
+                    ),
+                    _fingerprint(
+                        {
+                            "contactId": str(contact_id),
+                            "operationKey": operation_key,
+                            "interaction": "no_answer",
+                        }
+                    ),
+                )
+                await conn.execute(
+                    """
+                    INSERT INTO eom_lead_lifecycle_events (
+                        contact_id, event_type, from_stage, to_stage, actor,
+                        source, operation_key, metadata, occurred_at
+                    ) VALUES ($1, 'call_attempt_no_answer', $2, $2, $3,
+                              'time_tracker', $4, $5::jsonb, $6)
+                    """,
+                    contact_id,
+                    contact["lead_stage"],
+                    actor_name,
+                    operation_key,
+                    json.dumps({"attempt_id": str(attempt_id), "actor_id": actor_id}),
+                    now,
+                )
+
+                active = await conn.fetchrow(
+                    """
+                    SELECT * FROM eom_missed_call_sequences
+                    WHERE contact_id = $1
+                      AND state IN ('active', 'blocked_configuration')
+                    FOR UPDATE
+                    """,
+                    contact_id,
+                )
+                if active is not None:
+                    # The database trigger normally terminalizes a sequence as
+                    # soon as lead evidence changes. Recheck here too so a
+                    # historical/manual data repair that bypassed that trigger
+                    # cannot make a stale sequence reusable.
+                    if not eligibility.eligible:
+                        await self._cancel_for_reason(
+                            conn,
+                            sequence_id=active["id"],
+                            reason=eligibility.reason or "ineligible",
+                            source="time_tracker",
+                            actor_id=actor_id,
+                            actor_name=actor_name,
+                        )
+                        return {
+                            "attemptId": str(attempt_id),
+                            "idempotent": False,
+                            "sequence": await self._status_for_contact(
+                                conn, contact_id
+                            ),
+                        }
+                    await self._event(
+                        conn,
+                        sequence_id=active["id"],
+                        event_type="sequence_reused",
+                        reason_code="active_sequence_exists",
+                        actor_id=actor_id,
+                        actor_name=actor_name,
+                        source="time_tracker",
+                        metadata={"attempt_id": str(attempt_id)},
+                        occurred_at=now,
+                    )
+                    return {
+                        "attemptId": str(attempt_id),
+                        "idempotent": False,
+                        "sequence": await self._status_for_contact(conn, contact_id),
+                    }
+
+                if not eligibility.eligible:
+                    return {
+                        "attemptId": str(attempt_id),
+                        "idempotent": False,
+                        "sequence": None,
+                        "notStartedReason": eligibility.reason,
+                    }
+
+                sequence_id = uuid4()
+                recipient = eligibility.recipient_email
+                if recipient is None or eligibility.full_name is None:
+                    raise EOMMissedCallRecoveryConflictError(
+                        "Missed-call recovery eligibility is incomplete"
+                    )
+                delivery_block_reason = self.delivery_block_reason()
+                if delivery_block_reason is not None:
+                    await conn.execute(
+                        """
+                        INSERT INTO eom_missed_call_sequences (
+                            id, contact_id, initiating_attempt_id, recipient_email,
+                            state, blocked_reason, created_at, updated_at
+                        ) VALUES ($1, $2, $3, $4, 'blocked_configuration',
+                                  $5, $6, $6)
+                        """,
+                        sequence_id,
+                        contact_id,
+                        attempt_id,
+                        recipient,
+                        delivery_block_reason,
+                        now,
+                    )
+                    await self._event(
+                        conn,
+                        sequence_id=sequence_id,
+                        event_type="sequence_blocked",
+                        reason_code=delivery_block_reason,
+                        actor_id=actor_id,
+                        actor_name=actor_name,
+                        source="time_tracker",
+                        metadata={},
+                        occurred_at=now,
+                    )
+                else:
+                    await conn.execute(
+                        """
+                        INSERT INTO eom_missed_call_sequences (
+                            id, contact_id, initiating_attempt_id, recipient_email,
+                            state, created_at, updated_at
+                        ) VALUES ($1, $2, $3, $4, 'active', $5, $5)
+                        """,
+                        sequence_id,
+                        contact_id,
+                        attempt_id,
+                        recipient,
+                        now,
+                    )
+                    await self._insert_steps(
+                        conn,
+                        sequence_id=sequence_id,
+                        full_name=eligibility.full_name,
+                        now=now,
+                    )
+                    await self._event(
+                        conn,
+                        sequence_id=sequence_id,
+                        event_type="sequence_started",
+                        reason_code=None,
+                        actor_id=actor_id,
+                        actor_name=actor_name,
+                        source="time_tracker",
+                        metadata={},
+                        occurred_at=now,
+                    )
+                return {
+                    "attemptId": str(attempt_id),
+                    "idempotent": False,
+                    "sequence": await self._status_for_contact(conn, contact_id),
+                }
+        except EOMMissedCallRecoveryError:
+            raise
+        except (asyncpg.PostgresError, OSError) as exc:
+            raise EOMMissedCallRecoveryUnavailableError(
+                "Missed-call recovery could not be recorded"
+            ) from exc
+
+    async def resume_blocked_sequence(
+        self,
+        *,
+        contact_id: UUID,
+        operation_key: str,
+        actor_id: int,
+        actor_name: str,
+    ) -> dict[str, Any]:
+        """Explicitly recover a sequence blocked by missing delivery config."""
+
+        contact_id = _uuid(contact_id, "Contact id")
+        operation_key = _safe_operation_key(operation_key)
+        actor_id, actor_name = _safe_actor(actor_id, actor_name)
+        delivery_block_reason = self.delivery_block_reason()
+        if delivery_block_reason is not None:
+            raise EOMMissedCallRecoveryConflictError(
+                "Missed-call recovery delivery is not configured"
+            )
+        try:
+            async with self.pool.transaction() as conn:
+                contact = await self._contact_for_update(conn, contact_id)
+                prior = await conn.fetchrow(
+                    """
+                    SELECT * FROM eom_lead_lifecycle_events
+                    WHERE contact_id = $1
+                      AND event_type = 'missed_call_recovery_resumed'
+                      AND operation_key = $2
+                    """,
+                    contact_id,
+                    operation_key,
+                )
+                sequence = await conn.fetchrow(
+                    """
+                    SELECT * FROM eom_missed_call_sequences
+                    WHERE contact_id = $1 AND state = 'blocked_configuration'
+                    FOR UPDATE
+                    """,
+                    contact_id,
+                )
+                if prior is not None:
+                    return {
+                        "idempotent": True,
+                        "sequence": await self._status_for_contact(conn, contact_id),
+                    }
+                if sequence is None:
+                    raise EOMMissedCallRecoveryConflictError(
+                        "No blocked missed-call recovery sequence exists"
+                    )
+                eligibility = await self._evaluate_contact_eligibility(
+                    conn,
+                    contact,
+                    sequence_created_at=sequence["created_at"],
+                    recipient_snapshot=sequence["recipient_email"],
+                )
+                if not eligibility.eligible or eligibility.full_name is None:
+                    await self._cancel_for_reason(
+                        conn,
+                        sequence_id=sequence["id"],
+                        reason=eligibility.reason or "ineligible",
+                        source="time_tracker",
+                        actor_id=actor_id,
+                        actor_name=actor_name,
+                    )
+                    return {
+                        "idempotent": False,
+                        "sequence": await self._status_for_contact(conn, contact_id),
+                    }
+                now = self._now()
+                await conn.execute(
+                    """
+                    UPDATE eom_missed_call_sequences
+                       SET state = 'active', blocked_reason = NULL, updated_at = $2
+                     WHERE id = $1 AND state = 'blocked_configuration'
+                    """,
+                    sequence["id"],
+                    now,
+                )
+                await self._insert_steps(
+                    conn,
+                    sequence_id=sequence["id"],
+                    full_name=eligibility.full_name,
+                    now=now,
+                )
+                await self._event(
+                    conn,
+                    sequence_id=sequence["id"],
+                    event_type="sequence_resumed",
+                    reason_code=None,
+                    actor_id=actor_id,
+                    actor_name=actor_name,
+                    source="time_tracker",
+                    metadata={},
+                    occurred_at=now,
+                )
+                await conn.execute(
+                    """
+                    INSERT INTO eom_lead_lifecycle_events (
+                        contact_id, event_type, from_stage, to_stage, actor,
+                        source, operation_key, metadata, occurred_at
+                    ) VALUES ($1, 'missed_call_recovery_resumed', $2, $2, $3,
+                              'time_tracker', $4, $5::jsonb, $6)
+                    """,
+                    contact_id,
+                    contact["lead_stage"],
+                    actor_name,
+                    operation_key,
+                    json.dumps(
+                        {"sequence_id": str(sequence["id"]), "actor_id": actor_id}
+                    ),
+                    now,
+                )
+                return {
+                    "idempotent": False,
+                    "sequence": await self._status_for_contact(conn, contact_id),
+                }
+        except EOMMissedCallRecoveryError:
+            raise
+        except (asyncpg.PostgresError, OSError) as exc:
+            raise EOMMissedCallRecoveryUnavailableError(
+                "Missed-call recovery could not be resumed"
+            ) from exc
+
+    async def cancel_sequence(
+        self,
+        *,
+        contact_id: UUID,
+        operation_key: str,
+        actor_id: int,
+        actor_name: str,
+        reason: str,
+    ) -> dict[str, Any]:
+        """Record a manually verified stop condition without rewriting history."""
+
+        contact_id = _uuid(contact_id, "Contact id")
+        operation_key = _safe_operation_key(operation_key)
+        actor_id, actor_name = _safe_actor(actor_id, actor_name)
+        if reason not in _MANUAL_CANCEL_REASONS:
+            raise EOMMissedCallRecoveryValidationError("Cancellation reason is invalid")
+        interaction_type = {
+            "callback_recorded": "callback_completed",
+            "response_recorded": "lead_response",
+            "opt_out": "opt_out",
+            "manual": "lead_response",
+        }[reason]
+        try:
+            async with self.pool.transaction() as conn:
+                contact = await self._contact_for_update(conn, contact_id)
+                prior = await conn.fetchrow(
+                    """
+                    SELECT metadata FROM eom_lead_lifecycle_events
+                    WHERE contact_id = $1
+                      AND event_type = 'missed_call_recovery_cancelled'
+                      AND operation_key = $2
+                    """,
+                    contact_id,
+                    operation_key,
+                )
+                if prior is not None:
+                    metadata = prior.get("metadata")
+                    if isinstance(metadata, str):
+                        try:
+                            metadata = json.loads(metadata)
+                        except ValueError:
+                            metadata = None
+                    prior_reason = (
+                        metadata.get("reason")
+                        if isinstance(metadata, Mapping)
+                        else None
+                    )
+                    if prior_reason != reason:
+                        raise EOMMissedCallRecoveryConflictError(
+                            "Idempotency key belongs to a different recovery cancellation"
+                        )
+                    return {
+                        "idempotent": True,
+                        "sequence": await self._status_for_contact(conn, contact_id),
+                    }
+                now = self._now()
+                # Cancel through the service before recording the standard CRM
+                # interaction. Both rows commit together, but this preserves the
+                # authenticated actor in the sequence-event ledger; the later
+                # interaction trigger then sees no current sequence to cancel.
+                current_sequence = await conn.fetchrow(
+                    """
+                    SELECT id FROM eom_missed_call_sequences
+                    WHERE contact_id = $1
+                      AND state IN ('active', 'blocked_configuration')
+                    FOR UPDATE
+                    """,
+                    contact_id,
+                )
+                if current_sequence is not None:
+                    await self._cancel_for_reason(
+                        conn,
+                        sequence_id=current_sequence["id"],
+                        reason=reason,
+                        source="time_tracker",
+                        actor_id=actor_id,
+                        actor_name=actor_name,
+                    )
+                await conn.execute(
+                    """
+                    INSERT INTO contact_interactions (
+                        id, contact_id, interaction_type, summary, intent,
+                        occurred_at, metadata, interaction_dedupe_key
+                    ) VALUES ($1, $2, $3, 'Operator recorded recovery stop condition',
+                              'missed_call_recovery', $4, $5::jsonb, $6)
+                    """,
+                    uuid4(),
+                    contact_id,
+                    interaction_type,
+                    now,
+                    json.dumps(
+                        {
+                            "reason": reason,
+                            "actor_id": actor_id,
+                            "missed_call_recovery_cancel_reason": reason,
+                        }
+                    ),
+                    _fingerprint(
+                        {
+                            "contactId": str(contact_id),
+                            "operationKey": operation_key,
+                            "interaction": interaction_type,
+                        }
+                    ),
+                )
+                if reason == "opt_out":
+                    await conn.execute(
+                        """
+                        INSERT INTO eom_missed_call_contact_suppressions (
+                            contact_id, reason_code, actor_id, actor_name, source
+                        ) VALUES ($1, 'opt_out', $2, $3, 'time_tracker')
+                        ON CONFLICT (contact_id) DO NOTHING
+                        """,
+                        contact_id,
+                        actor_id,
+                        actor_name,
+                    )
+                await conn.execute(
+                    """
+                    INSERT INTO eom_lead_lifecycle_events (
+                        contact_id, event_type, from_stage, to_stage, actor,
+                        source, operation_key, metadata, occurred_at
+                    ) VALUES ($1, 'missed_call_recovery_cancelled', $2, $2, $3,
+                              'time_tracker', $4, $5::jsonb, $6)
+                    """,
+                    contact_id,
+                    contact["lead_stage"],
+                    actor_name,
+                    operation_key,
+                    json.dumps({"reason": reason, "actor_id": actor_id}),
+                    now,
+                )
+                return {
+                    "idempotent": False,
+                    "sequence": await self._status_for_contact(conn, contact_id),
+                }
+        except EOMMissedCallRecoveryError:
+            raise
+        except (asyncpg.PostgresError, OSError) as exc:
+            raise EOMMissedCallRecoveryUnavailableError(
+                "Missed-call recovery could not be cancelled"
+            ) from exc
+
+    async def statuses(self, *, contact_ids: Sequence[UUID]) -> list[dict[str, Any]]:
+        """Return bounded, non-PII sequence status for known EOM contact ids."""
+
+        unique_ids = list(
+            dict.fromkeys(_uuid(value, "Contact id") for value in contact_ids)
+        )
+        if not unique_ids:
+            raise EOMMissedCallRecoveryValidationError(
+                "At least one contact id is required"
+            )
+        if len(unique_ids) > _MAX_STATUS_IDS:
+            raise EOMMissedCallRecoveryValidationError("Too many contact ids")
+        try:
+            rows = await self.pool.fetch(
+                """
+                SELECT
+                    s.contact_id, s.id AS sequence_id, s.state, s.blocked_reason,
+                    s.cancellation_reason, s.created_at, s.terminal_at,
+                    next_step.step_number AS next_step_number,
+                    next_step.due_at AS next_due_at,
+                    last_event.event_type AS last_event_type,
+                    last_event.reason_code AS last_event_reason
+                FROM eom_missed_call_sequences AS s
+                JOIN contacts AS c ON c.id = s.contact_id
+                LEFT JOIN LATERAL (
+                    SELECT step_number, COALESCE(next_attempt_at, due_at) AS due_at
+                    FROM eom_missed_call_sequence_steps
+                    WHERE sequence_id = s.id
+                      AND state IN ('pending', 'attempting')
+                    ORDER BY step_number ASC
+                    LIMIT 1
+                ) AS next_step ON TRUE
+                LEFT JOIN LATERAL (
+                    SELECT event_type, reason_code
+                    FROM eom_missed_call_sequence_events
+                    WHERE sequence_id = s.id
+                    ORDER BY occurred_at DESC, id DESC
+                    LIMIT 1
+                ) AS last_event ON TRUE
+                WHERE s.contact_id = ANY($1::uuid[])
+                  AND c.business_context_id = $2
+                ORDER BY s.created_at DESC, s.id DESC
+                """,
+                unique_ids,
+                _EOM_CONTEXT,
+            )
+            newest: dict[UUID, dict[str, Any]] = {}
+            for row in rows:
+                contact_id = _uuid(row["contact_id"], "Contact id")
+                newest.setdefault(contact_id, self._serialize_status(row))
+            return [newest[value] for value in unique_ids if value in newest]
+        except EOMMissedCallRecoveryError:
+            raise
+        except (asyncpg.PostgresError, OSError) as exc:
+            raise EOMMissedCallRecoveryUnavailableError(
+                "Missed-call recovery status is unavailable"
+            ) from exc
+
+    async def dispatch_due_steps(self, *, limit: int = _MAX_WORK_BATCH) -> int:
+        """Recover stale claims then deliver a bounded number of due steps."""
+
+        if limit < 1 or limit > _MAX_WORK_BATCH:
+            raise EOMMissedCallRecoveryValidationError("Worker limit is invalid")
+        if self.delivery_block_reason() is not None:
+            return 0
+        await self._recover_stale_claims(limit=limit)
+        completed = 0
+        for _ in range(limit):
+            claim_result = await self._claim_one_due_step()
+            if not claim_result.processed:
+                break
+            completed += 1
+            if claim_result.claim is None:
+                continue
+            history = await self._deliver_claim(claim_result.claim)
+            if history is not None and history.provider_message_id:
+                await self._write_sent_history(history)
+        return completed
+
+    async def _contact_for_update(
+        self, conn: Any, contact_id: UUID
+    ) -> Mapping[str, Any]:
+        contact = await conn.fetchrow(
+            """
+            SELECT c.*, latest.submitted_email, latest.ack_variant,
+                   latest.latest_intake_at
+            FROM contacts AS c
+            LEFT JOIN LATERAL (
+                SELECT
+                    NULLIF(ci.metadata->>'submitted_email', '') AS submitted_email,
+                    NULLIF(ci.metadata->>'ack_variant', '') AS ack_variant,
+                    ci.occurred_at AS latest_intake_at
+                FROM contact_interactions AS ci
+                WHERE ci.contact_id = c.id
+                  AND ci.interaction_type = 'web_form'
+                  AND ci.intent = 'estimate_request'
+                ORDER BY ci.occurred_at DESC, ci.created_at DESC, ci.id DESC
+                LIMIT 1
+            ) AS latest ON TRUE
+            WHERE c.id = $1 AND c.business_context_id = $2
+            FOR UPDATE OF c
+            """,
+            contact_id,
+            _EOM_CONTEXT,
+        )
+        if contact is None:
+            raise EOMMissedCallRecoveryNotFoundError("EOM lead was not found")
+        return contact
+
+    async def _evaluate_contact_eligibility(
+        self,
+        conn: Any,
+        contact: Mapping[str, Any],
+        *,
+        sequence_created_at: datetime | None,
+        recipient_snapshot: str | None,
+    ) -> _Eligibility:
+        if contact.get("contact_type") != "lead":
+            return _Eligibility(False, "became_customer", None, None)
+        if contact.get("status") != "active":
+            return _Eligibility(False, "contact_inactive", None, None)
+        if contact.get("lead_stage") != "new":
+            return _Eligibility(False, "lead_advanced", None, None)
+        if contact.get("customer_type") == "commercial":
+            return _Eligibility(False, "non_residential", None, None)
+        if contact.get("ack_variant") != "residential":
+            return _Eligibility(False, "not_residential_estimate", None, None)
+        recipient = _normalize_recipient(
+            contact.get("submitted_email") or contact.get("email")
+        )
+        if recipient is None:
+            return _Eligibility(False, "missing_or_invalid_recipient", None, None)
+        if recipient_snapshot is not None and recipient != recipient_snapshot:
+            return _Eligibility(False, "recipient_changed", None, None)
+        if await conn.fetchval(
+            """
+            SELECT EXISTS (
+                SELECT 1 FROM eom_missed_call_contact_suppressions
+                WHERE contact_id = $1 AND business_context_id = $2
+            )
+            """,
+            contact["id"],
+            _EOM_CONTEXT,
+        ):
+            return _Eligibility(False, "suppressed_recipient", None, None)
+        # Before a sequence exists, response evidence is measured from the
+        # latest qualifying estimate request. Once it exists, only newer
+        # evidence can cancel it because the start path already rejected a
+        # response that preceded the call attempt.
+        response_since = sequence_created_at or contact.get("latest_intake_at")
+        if isinstance(response_since, datetime):
+            response = await conn.fetchval(
+                """
+                SELECT interaction_type
+                FROM contact_interactions
+                WHERE contact_id = $1
+                  AND occurred_at > $2
+                  AND (
+                    interaction_type = ANY($3::varchar[])
+                    OR (
+                        interaction_type = 'sms'
+                        AND eom_missed_call_has_proven_inbound_sms(metadata)
+                    )
+                    OR (interaction_type = 'web_form' AND intent = 'estimate_request')
+                  )
+                ORDER BY occurred_at DESC, created_at DESC, id DESC
+                LIMIT 1
+                """,
+                contact["id"],
+                response_since,
+                list(_TRACKED_RESPONSE_INTERACTIONS),
+            )
+            if response is not None:
+                return _Eligibility(
+                    False, "tracked_response_or_new_request", None, None
+                )
+        full_name = contact.get("full_name")
+        if not isinstance(full_name, str) or not full_name.strip():
+            return _Eligibility(False, "invalid_contact_name", None, None)
+        return _Eligibility(True, None, recipient, full_name.strip())
+
+    async def _insert_steps(
+        self,
+        conn: Any,
+        *,
+        sequence_id: UUID,
+        full_name: str,
+        now: datetime,
+    ) -> None:
+        booking_link = self._config.missed_call_booking_link.strip()
+        if not booking_link:
+            raise EOMMissedCallRecoveryConflictError(
+                "Missed-call recovery booking link is not configured"
+            )
+        step_one_due = _datetime(now, "current time")
+        step_two_due = next_business_day_due(
+            step_one_due, timezone_name=self._config.missed_call_timezone
+        )
+        due_times = (
+            step_one_due,
+            step_two_due,
+            _third_step_due(
+                step_two_due,
+                timezone_name=self._config.missed_call_timezone,
+            ),
+        )
+        for step_number, due_at in enumerate(due_times, start=1):
+            message: MissedCallRecoveryEmail = render_missed_call_recovery_email(
+                step_number=step_number,
+                full_name=full_name,
+                booking_link=booking_link,
+            )
+            step_id = uuid4()
+            provider_key = f"eom-missed-call/{step_id}"
+            await conn.execute(
+                """
+                INSERT INTO eom_missed_call_sequence_steps (
+                    id, sequence_id, step_number, due_at, subject, body,
+                    provider_idempotency_key, state, created_at, updated_at
+                ) VALUES ($1, $2, $3, $4, $5, $6, $7, 'pending', $8, $8)
+                ON CONFLICT (sequence_id, step_number) DO NOTHING
+                """,
+                step_id,
+                sequence_id,
+                step_number,
+                due_at,
+                message.subject,
+                message.body,
+                provider_key,
+                now,
+            )
+
+    async def _event(
+        self,
+        conn: Any,
+        *,
+        sequence_id: UUID,
+        event_type: str,
+        reason_code: str | None,
+        actor_id: int | None,
+        actor_name: str,
+        source: str,
+        metadata: Mapping[str, Any],
+        occurred_at: datetime,
+        step_id: UUID | None = None,
+    ) -> None:
+        await conn.execute(
+            """
+            INSERT INTO eom_missed_call_sequence_events (
+                sequence_id, step_id, event_type, reason_code, actor_id,
+                actor_name, source, metadata, occurred_at
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9)
+            """,
+            sequence_id,
+            step_id,
+            event_type,
+            reason_code,
+            actor_id,
+            actor_name,
+            source,
+            json.dumps(dict(metadata), sort_keys=True, separators=(",", ":")),
+            occurred_at,
+        )
+
+    async def _status_for_contact(
+        self, conn: Any, contact_id: UUID
+    ) -> dict[str, Any] | None:
+        row = await conn.fetchrow(
+            """
+            SELECT
+                s.contact_id, s.id AS sequence_id, s.state, s.blocked_reason,
+                s.cancellation_reason, s.created_at, s.terminal_at,
+                next_step.step_number AS next_step_number,
+                next_step.due_at AS next_due_at,
+                last_event.event_type AS last_event_type,
+                last_event.reason_code AS last_event_reason
+            FROM eom_missed_call_sequences AS s
+            LEFT JOIN LATERAL (
+                SELECT step_number, COALESCE(next_attempt_at, due_at) AS due_at
+                FROM eom_missed_call_sequence_steps
+                WHERE sequence_id = s.id
+                  AND state IN ('pending', 'attempting')
+                ORDER BY step_number ASC
+                LIMIT 1
+            ) AS next_step ON TRUE
+            LEFT JOIN LATERAL (
+                SELECT event_type, reason_code
+                FROM eom_missed_call_sequence_events
+                WHERE sequence_id = s.id
+                ORDER BY occurred_at DESC, id DESC
+                LIMIT 1
+            ) AS last_event ON TRUE
+            WHERE s.contact_id = $1
+            ORDER BY s.created_at DESC, s.id DESC
+            LIMIT 1
+            """,
+            contact_id,
+        )
+        return None if row is None else self._serialize_status(row)
+
+    @staticmethod
+    def _serialize_status(row: Mapping[str, Any]) -> dict[str, Any]:
+        def timestamp(value: object) -> str | None:
+            return value.isoformat() if isinstance(value, datetime) else None
+
+        return {
+            "contactId": str(row["contact_id"]),
+            "sequenceId": str(row["sequence_id"]),
+            "state": str(row["state"]),
+            "blockedReason": row.get("blocked_reason"),
+            "cancellationReason": row.get("cancellation_reason"),
+            "nextStepNumber": (
+                int(row["next_step_number"])
+                if row.get("next_step_number") is not None
+                else None
+            ),
+            "nextFollowUpAt": timestamp(row.get("next_due_at")),
+            "lastEvent": row.get("last_event_type"),
+            "lastReason": row.get("last_event_reason"),
+            "createdAt": timestamp(row.get("created_at")),
+            "terminalAt": timestamp(row.get("terminal_at")),
+        }
+
+    async def _cancel_for_reason(
+        self,
+        conn: Any,
+        *,
+        sequence_id: UUID,
+        reason: str,
+        source: str,
+        actor_id: int | None,
+        actor_name: str,
+    ) -> None:
+        sequence = await conn.fetchrow(
+            "SELECT * FROM eom_missed_call_sequences WHERE id = $1 FOR UPDATE",
+            sequence_id,
+        )
+        if sequence is None or sequence["state"] not in {
+            "active",
+            "blocked_configuration",
+        }:
+            return
+        now = self._now()
+        await conn.execute(
+            """
+            UPDATE eom_missed_call_sequences
+               SET state = 'cancelled', blocked_reason = NULL,
+                   cancellation_reason = $2,
+                   terminal_at = $3, updated_at = $3
+             WHERE id = $1
+            """,
+            sequence_id,
+            reason,
+            now,
+        )
+        skipped = await conn.fetch(
+            """
+            UPDATE eom_missed_call_sequence_steps
+               SET state = 'skipped', terminal_reason = $2,
+                   next_attempt_at = NULL, claim_token = NULL, claimed_at = NULL,
+                   claim_expires_at = NULL, updated_at = $3
+             WHERE sequence_id = $1 AND state IN ('pending', 'attempting')
+            RETURNING id
+            """,
+            sequence_id,
+            reason,
+            now,
+        )
+        await self._event(
+            conn,
+            sequence_id=sequence_id,
+            event_type="sequence_cancelled",
+            reason_code=reason,
+            actor_id=actor_id,
+            actor_name=actor_name,
+            source=source,
+            metadata={},
+            occurred_at=now,
+        )
+        for row in skipped:
+            await self._event(
+                conn,
+                sequence_id=sequence_id,
+                step_id=row["id"],
+                event_type="step_skipped",
+                reason_code=reason,
+                actor_id=actor_id,
+                actor_name=actor_name,
+                source=source,
+                metadata={},
+                occurred_at=now,
+            )
+
+    async def _recover_stale_claims(self, *, limit: int) -> None:
+        now = self._now()
+        try:
+            async with self.pool.transaction() as conn:
+                rows = await conn.fetch(
+                    """
+                    SELECT step.*, sequence.contact_id, sequence.state AS sequence_state
+                    FROM eom_missed_call_sequence_steps AS step
+                    JOIN eom_missed_call_sequences AS sequence ON sequence.id = step.sequence_id
+                    WHERE step.state = 'attempting'
+                      AND step.claim_expires_at <= $1
+                    ORDER BY step.claim_expires_at ASC, step.id ASC
+                    FOR UPDATE OF step, sequence SKIP LOCKED
+                    LIMIT $2
+                    """,
+                    now,
+                    limit,
+                )
+                for row in rows:
+                    if row["sequence_state"] != "active":
+                        skipped = await conn.fetchrow(
+                            """
+                            UPDATE eom_missed_call_sequence_steps
+                               SET state = 'skipped', terminal_reason = 'sequence_terminal',
+                                   claim_token = NULL, claimed_at = NULL, claim_expires_at = NULL,
+                                   next_attempt_at = NULL, updated_at = $2
+                             WHERE id = $1 AND state = 'attempting'
+                            RETURNING id
+                            """,
+                            row["id"],
+                            now,
+                        )
+                        if skipped is not None:
+                            await self._event(
+                                conn,
+                                sequence_id=row["sequence_id"],
+                                step_id=skipped["id"],
+                                event_type="step_skipped",
+                                reason_code="sequence_terminal",
+                                actor_id=None,
+                                actor_name="system",
+                                source="worker",
+                                metadata={},
+                                occurred_at=now,
+                            )
+                        continue
+                    expires_at = row["provider_key_expires_at"]
+                    if (
+                        isinstance(expires_at, datetime)
+                        and now < expires_at
+                        and int(row["attempt_count"])
+                        < self._config.missed_call_max_delivery_attempts
+                    ):
+                        await conn.execute(
+                            """
+                            UPDATE eom_missed_call_sequence_steps
+                               SET state = 'pending', next_attempt_at = $2,
+                                   claim_token = NULL, claimed_at = NULL, claim_expires_at = NULL,
+                                   updated_at = $2
+                             WHERE id = $1 AND state = 'attempting'
+                            """,
+                            row["id"],
+                            now,
+                        )
+                        await self._event(
+                            conn,
+                            sequence_id=row["sequence_id"],
+                            step_id=row["id"],
+                            event_type="step_retry_scheduled",
+                            reason_code="claim_lease_expired",
+                            actor_id=None,
+                            actor_name="system",
+                            source="worker",
+                            metadata={},
+                            occurred_at=now,
+                        )
+                    else:
+                        await self._mark_recovery_required(
+                            conn,
+                            sequence_id=row["sequence_id"],
+                            step_id=row["id"],
+                            reason="provider_idempotency_window_expired",
+                            now=now,
+                        )
+        except EOMMissedCallRecoveryError:
+            raise
+        except (asyncpg.PostgresError, OSError) as exc:
+            raise EOMMissedCallRecoveryUnavailableError(
+                "Missed-call recovery stale claim check is unavailable"
+            ) from exc
+
+    async def _claim_one_due_step(self) -> _ClaimResult:
+        """Durably claim one due step before any external email request.
+
+        The first short transaction makes the provider key's expiry durable.
+        If a process dies after Resend accepts mail but before the second
+        transaction can confirm it, a later worker knows it may only reuse that
+        same key inside the provider's retention window; after the window it
+        leaves operator-visible recovery evidence instead of risking a second
+        customer message.
+        """
+
+        now = self._now()
+        try:
+            async with self.pool.transaction() as conn:
+                row = await conn.fetchrow(
+                    """
+                    SELECT
+                        step.id AS step_id,
+                        step.sequence_id,
+                        sequence.contact_id,
+                        sequence.created_at AS sequence_created_at,
+                        sequence.recipient_email,
+                        contact.id AS id,
+                        contact.contact_type,
+                        contact.status,
+                        contact.lead_stage,
+                        contact.customer_type,
+                        contact.email,
+                        contact.full_name,
+                        latest.submitted_email,
+                        latest.ack_variant,
+                        latest.latest_intake_at
+                    FROM eom_missed_call_sequence_steps AS step
+                    JOIN eom_missed_call_sequences AS sequence ON sequence.id = step.sequence_id
+                    JOIN contacts AS contact ON contact.id = sequence.contact_id
+                    LEFT JOIN LATERAL (
+                        SELECT
+                            NULLIF(ci.metadata->>'submitted_email', '') AS submitted_email,
+                            NULLIF(ci.metadata->>'ack_variant', '') AS ack_variant,
+                            ci.occurred_at AS latest_intake_at
+                        FROM contact_interactions AS ci
+                        WHERE ci.contact_id = contact.id
+                          AND ci.interaction_type = 'web_form'
+                          AND ci.intent = 'estimate_request'
+                        ORDER BY ci.occurred_at DESC, ci.created_at DESC, ci.id DESC
+                        LIMIT 1
+                    ) AS latest ON TRUE
+                    WHERE step.state = 'pending'
+                      AND sequence.state = 'active'
+                      AND COALESCE(step.next_attempt_at, step.due_at) <= $1
+                      AND NOT EXISTS (
+                          SELECT 1 FROM eom_missed_call_sequence_steps AS earlier
+                          WHERE earlier.sequence_id = step.sequence_id
+                            AND earlier.step_number < step.step_number
+                            AND earlier.state NOT IN ('sent', 'skipped')
+                      )
+                    ORDER BY COALESCE(step.next_attempt_at, step.due_at), step.step_number, step.id
+                    FOR UPDATE OF step, sequence, contact SKIP LOCKED
+                    LIMIT 1
+                    """,
+                    now,
+                )
+                if row is None:
+                    return _ClaimResult(processed=False)
+                eligibility = await self._evaluate_contact_eligibility(
+                    conn,
+                    row,
+                    sequence_created_at=row["sequence_created_at"],
+                    recipient_snapshot=row["recipient_email"],
+                )
+                if not eligibility.eligible:
+                    await self._cancel_for_reason(
+                        conn,
+                        sequence_id=row["sequence_id"],
+                        reason=eligibility.reason or "ineligible",
+                        source="worker",
+                        actor_id=None,
+                        actor_name="system",
+                    )
+                    return _ClaimResult(processed=True)
+
+                claim_token = uuid4()
+                claimed = await conn.fetchrow(
+                    """
+                    UPDATE eom_missed_call_sequence_steps
+                       SET state = 'attempting', attempt_count = attempt_count + 1,
+                           claim_token = $2, claimed_at = $3, claim_expires_at = $4,
+                           provider_key_expires_at = COALESCE(provider_key_expires_at, $5),
+                           next_attempt_at = NULL, updated_at = $3
+                     WHERE id = $1 AND state = 'pending'
+                     RETURNING *
+                    """,
+                    row["step_id"],
+                    claim_token,
+                    now,
+                    now + _ATTEMPT_LEASE,
+                    now + _PROVIDER_KEY_WINDOW,
+                )
+                if claimed is None:
+                    return _ClaimResult(processed=False)
+                await self._event(
+                    conn,
+                    sequence_id=row["sequence_id"],
+                    step_id=row["step_id"],
+                    event_type="step_claimed",
+                    reason_code=None,
+                    actor_id=None,
+                    actor_name="system",
+                    source="worker",
+                    metadata={"attempt": int(claimed["attempt_count"])},
+                    occurred_at=now,
+                )
+                recipient = eligibility.recipient_email
+                if recipient is None:
+                    raise EOMMissedCallRecoveryConflictError(
+                        "Missed-call recovery recipient is invalid"
+                    )
+                return _ClaimResult(
+                    processed=True,
+                    claim=_ClaimedStep(
+                        step_id=_uuid(claimed["id"], "step id"),
+                        sequence_id=_uuid(claimed["sequence_id"], "sequence id"),
+                        contact_id=_uuid(row["contact_id"], "contact id"),
+                        claim_token=claim_token,
+                        recipient_email=recipient,
+                        subject=str(claimed["subject"]),
+                        body=str(claimed["body"]),
+                        provider_idempotency_key=str(
+                            claimed["provider_idempotency_key"]
+                        ),
+                        provider_key_expires_at=_datetime(
+                            claimed["provider_key_expires_at"], "provider key expiry"
+                        ),
+                        attempt_count=int(claimed["attempt_count"]),
+                    ),
+                )
+        except EOMMissedCallRecoveryError:
+            raise
+        except (asyncpg.PostgresError, OSError) as exc:
+            raise EOMMissedCallRecoveryUnavailableError(
+                "Missed-call recovery claim is unavailable"
+            ) from exc
+
+    async def _deliver_claim(self, claim: _ClaimedStep) -> _SentHistory | None:
+        """Re-read authoritative state, then send while it remains locked."""
+
+        now = self._now()
+        try:
+            async with self.pool.transaction() as conn:
+                row = await conn.fetchrow(
+                    """
+                    SELECT
+                        step.sequence_id,
+                        step.claim_expires_at,
+                        step.provider_key_expires_at,
+                        step.provider_idempotency_key,
+                        step.subject,
+                        step.body,
+                        sequence.contact_id,
+                        sequence.created_at AS sequence_created_at,
+                        sequence.recipient_email,
+                        contact.id AS id,
+                        contact.contact_type,
+                        contact.status,
+                        contact.lead_stage,
+                        contact.customer_type,
+                        contact.email,
+                        contact.full_name,
+                        latest.submitted_email,
+                        latest.ack_variant,
+                        latest.latest_intake_at
+                    FROM eom_missed_call_sequence_steps AS step
+                    JOIN eom_missed_call_sequences AS sequence ON sequence.id = step.sequence_id
+                    JOIN contacts AS contact ON contact.id = sequence.contact_id
+                    LEFT JOIN LATERAL (
+                        SELECT
+                            NULLIF(ci.metadata->>'submitted_email', '') AS submitted_email,
+                            NULLIF(ci.metadata->>'ack_variant', '') AS ack_variant,
+                            ci.occurred_at AS latest_intake_at
+                        FROM contact_interactions AS ci
+                        WHERE ci.contact_id = contact.id
+                          AND ci.interaction_type = 'web_form'
+                          AND ci.intent = 'estimate_request'
+                        ORDER BY ci.occurred_at DESC, ci.created_at DESC, ci.id DESC
+                        LIMIT 1
+                    ) AS latest ON TRUE
+                    WHERE step.id = $1
+                      AND step.state = 'attempting'
+                      AND step.claim_token = $2
+                      AND sequence.state = 'active'
+                    FOR UPDATE OF step, sequence, contact
+                    """,
+                    claim.step_id,
+                    claim.claim_token,
+                )
+                if row is None:
+                    return None
+                if row["claim_expires_at"] is None or row["claim_expires_at"] <= now:
+                    await conn.execute(
+                        """
+                        UPDATE eom_missed_call_sequence_steps
+                           SET state = 'pending', claim_token = NULL,
+                               claimed_at = NULL, claim_expires_at = NULL,
+                               next_attempt_at = $2, updated_at = $2
+                         WHERE id = $1 AND state = 'attempting' AND claim_token = $3
+                        """,
+                        claim.step_id,
+                        now,
+                        claim.claim_token,
+                    )
+                    await self._event(
+                        conn,
+                        sequence_id=claim.sequence_id,
+                        step_id=claim.step_id,
+                        event_type="step_retry_scheduled",
+                        reason_code="claim_lease_expired_before_delivery",
+                        actor_id=None,
+                        actor_name="system",
+                        source="worker",
+                        metadata={},
+                        occurred_at=now,
+                    )
+                    return None
+                if (
+                    row["provider_key_expires_at"] is None
+                    or now >= row["provider_key_expires_at"]
+                ):
+                    await self._mark_recovery_required(
+                        conn,
+                        sequence_id=claim.sequence_id,
+                        step_id=claim.step_id,
+                        reason="provider_idempotency_window_expired",
+                        now=now,
+                    )
+                    return None
+                if (
+                    _uuid(row["sequence_id"], "sequence id") != claim.sequence_id
+                    or _uuid(row["contact_id"], "contact id") != claim.contact_id
+                    or str(row["provider_idempotency_key"])
+                    != claim.provider_idempotency_key
+                    or str(row["subject"]) != claim.subject
+                    or str(row["body"]) != claim.body
+                ):
+                    await self._mark_recovery_required(
+                        conn,
+                        sequence_id=claim.sequence_id,
+                        step_id=claim.step_id,
+                        reason="claimed_payload_changed",
+                        now=now,
+                    )
+                    return None
+
+                eligibility = await self._evaluate_contact_eligibility(
+                    conn,
+                    row,
+                    sequence_created_at=row["sequence_created_at"],
+                    recipient_snapshot=row["recipient_email"],
+                )
+                if not eligibility.eligible:
+                    await self._cancel_for_reason(
+                        conn,
+                        sequence_id=claim.sequence_id,
+                        reason=eligibility.reason or "ineligible",
+                        source="worker",
+                        actor_id=None,
+                        actor_name="system",
+                    )
+                    return None
+                if eligibility.recipient_email != claim.recipient_email:
+                    await self._cancel_for_reason(
+                        conn,
+                        sequence_id=claim.sequence_id,
+                        reason="recipient_changed",
+                        source="worker",
+                        actor_id=None,
+                        actor_name="system",
+                    )
+                    return None
+
+                try:
+                    message_id = await self.gateway.send(
+                        recipient_email=claim.recipient_email,
+                        subject=claim.subject,
+                        body=claim.body,
+                        idempotency_key=claim.provider_idempotency_key,
+                    )
+                except _DefiniteDeliveryError as exc:
+                    return await self._handle_definite_delivery_error(
+                        conn, claim=claim, error=exc, now=now
+                    )
+                except _AmbiguousDeliveryError as exc:
+                    await self._mark_recovery_required(
+                        conn,
+                        sequence_id=claim.sequence_id,
+                        step_id=claim.step_id,
+                        reason=str(exc),
+                        now=now,
+                    )
+                    return None
+
+                sent_at = self._now()
+                updated = await conn.fetchrow(
+                    """
+                    UPDATE eom_missed_call_sequence_steps
+                       SET state = 'sent', provider_message_id = $2, sent_at = $3,
+                           claim_token = NULL, claimed_at = NULL, claim_expires_at = NULL,
+                           terminal_reason = NULL, updated_at = $3
+                     WHERE id = $1 AND state = 'attempting' AND claim_token = $4
+                     RETURNING step_number
+                    """,
+                    claim.step_id,
+                    message_id,
+                    sent_at,
+                    claim.claim_token,
+                )
+                if updated is None:
+                    raise EOMMissedCallRecoveryConflictError(
+                        "Missed-call recovery delivery claim was lost"
+                    )
+                await self._event(
+                    conn,
+                    sequence_id=claim.sequence_id,
+                    step_id=claim.step_id,
+                    event_type="step_sent",
+                    reason_code="provider_accepted",
+                    actor_id=None,
+                    actor_name="system",
+                    source="worker",
+                    metadata={"attempt": claim.attempt_count},
+                    occurred_at=sent_at,
+                )
+                if int(updated["step_number"]) == 2:
+                    # Step 3 is intentionally relative to successful Email 2,
+                    # not merely Email 2's original due time. A delayed/retried
+                    # second message must never compress the promised three-day
+                    # final follow-up interval.
+                    await conn.execute(
+                        """
+                        UPDATE eom_missed_call_sequence_steps
+                           SET due_at = $2, next_attempt_at = NULL, updated_at = $3
+                         WHERE sequence_id = $1
+                           AND step_number = 3
+                           AND state = 'pending'
+                        """,
+                        claim.sequence_id,
+                        _third_step_due(
+                            sent_at,
+                            timezone_name=self._config.missed_call_timezone,
+                        ),
+                        sent_at,
+                    )
+                elif int(updated["step_number"]) == 3:
+                    await conn.execute(
+                        """
+                        UPDATE eom_missed_call_sequences
+                           SET state = 'completed', terminal_at = $2, updated_at = $2
+                         WHERE id = $1 AND state = 'active'
+                        """,
+                        claim.sequence_id,
+                        sent_at,
+                    )
+                    await self._event(
+                        conn,
+                        sequence_id=claim.sequence_id,
+                        event_type="sequence_completed",
+                        reason_code=None,
+                        actor_id=None,
+                        actor_name="system",
+                        source="worker",
+                        metadata={},
+                        occurred_at=sent_at,
+                    )
+                return _SentHistory(
+                    contact_id=claim.contact_id,
+                    recipient_email=claim.recipient_email,
+                    subject=claim.subject,
+                    body=claim.body,
+                    provider_message_id=message_id,
+                    sequence_id=claim.sequence_id,
+                    step_id=claim.step_id,
+                )
+        except EOMMissedCallRecoveryError:
+            raise
+        except (asyncpg.PostgresError, OSError) as exc:
+            raise EOMMissedCallRecoveryUnavailableError(
+                "Missed-call recovery delivery is unavailable"
+            ) from exc
+
+    async def _handle_definite_delivery_error(
+        self,
+        conn: Any,
+        *,
+        claim: _ClaimedStep,
+        error: _DefiniteDeliveryError,
+        now: datetime,
+    ) -> _SentHistory:
+        retry_allowed = (
+            error.retryable
+            and claim.attempt_count < self._config.missed_call_max_delivery_attempts
+            and now < claim.provider_key_expires_at
+        )
+        if retry_allowed:
+            delay = _RETRY_DELAYS[min(claim.attempt_count - 1, len(_RETRY_DELAYS) - 1)]
+            next_attempt = now + delay
+            await conn.execute(
+                """
+                UPDATE eom_missed_call_sequence_steps
+                   SET state = 'pending', next_attempt_at = $2, claim_token = NULL,
+                       claimed_at = NULL,
+                       claim_expires_at = NULL, last_error_code = $3, updated_at = $1
+                 WHERE id = $4 AND state = 'attempting'
+                """,
+                now,
+                next_attempt,
+                error.code,
+                claim.step_id,
+            )
+            await self._event(
+                conn,
+                sequence_id=claim.sequence_id,
+                step_id=claim.step_id,
+                event_type="step_retry_scheduled",
+                reason_code=error.code,
+                actor_id=None,
+                actor_name="system",
+                source="worker",
+                metadata={"attempt": claim.attempt_count},
+                occurred_at=now,
+            )
+        else:
+            await self._mark_failed(
+                conn,
+                sequence_id=claim.sequence_id,
+                step_id=claim.step_id,
+                reason=("retry_exhausted" if error.retryable else error.code),
+                now=now,
+            )
+        return _SentHistory(
+            contact_id=claim.contact_id,
+            recipient_email="",
+            subject="",
+            body="",
+            provider_message_id="",
+            sequence_id=claim.sequence_id,
+            step_id=claim.step_id,
+        )
+
+    async def _mark_failed(
+        self,
+        conn: Any,
+        *,
+        sequence_id: UUID,
+        step_id: UUID,
+        reason: str,
+        now: datetime,
+    ) -> None:
+        await conn.execute(
+            """
+            UPDATE eom_missed_call_sequence_steps
+               SET state = 'failed', terminal_reason = $2, last_error_code = $2,
+                   claim_token = NULL, claimed_at = NULL, claim_expires_at = NULL,
+                   updated_at = $3
+             WHERE id = $1
+            """,
+            step_id,
+            reason,
+            now,
+        )
+        await conn.execute(
+            """
+            UPDATE eom_missed_call_sequences
+               SET state = 'failed', cancellation_reason = $2,
+                   terminal_at = $3, updated_at = $3
+             WHERE id = $1 AND state = 'active'
+            """,
+            sequence_id,
+            reason,
+            now,
+        )
+        skipped = await conn.fetch(
+            """
+            UPDATE eom_missed_call_sequence_steps
+               SET state = 'skipped', terminal_reason = $2,
+                   next_attempt_at = NULL, claim_expires_at = NULL, updated_at = $3
+             WHERE sequence_id = $1 AND state = 'pending'
+             RETURNING id
+            """,
+            sequence_id,
+            reason,
+            now,
+        )
+        await self._event(
+            conn,
+            sequence_id=sequence_id,
+            step_id=step_id,
+            event_type="step_failed",
+            reason_code=reason,
+            actor_id=None,
+            actor_name="system",
+            source="worker",
+            metadata={},
+            occurred_at=now,
+        )
+        for row in skipped:
+            await self._event(
+                conn,
+                sequence_id=sequence_id,
+                step_id=row["id"],
+                event_type="step_skipped",
+                reason_code=reason,
+                actor_id=None,
+                actor_name="system",
+                source="worker",
+                metadata={},
+                occurred_at=now,
+            )
+
+    async def _mark_recovery_required(
+        self,
+        conn: Any,
+        *,
+        sequence_id: UUID,
+        step_id: UUID,
+        reason: str,
+        now: datetime,
+    ) -> None:
+        await conn.execute(
+            """
+            UPDATE eom_missed_call_sequence_steps
+               SET state = 'recovery_required', terminal_reason = $2,
+                   last_error_code = $2, claim_token = NULL, claimed_at = NULL,
+                   claim_expires_at = NULL,
+                   updated_at = $3
+             WHERE id = $1
+            """,
+            step_id,
+            reason,
+            now,
+        )
+        await conn.execute(
+            """
+            UPDATE eom_missed_call_sequences
+               SET state = 'recovery_required', cancellation_reason = $2,
+                   terminal_at = $3, updated_at = $3
+             WHERE id = $1 AND state = 'active'
+            """,
+            sequence_id,
+            reason,
+            now,
+        )
+        skipped = await conn.fetch(
+            """
+            UPDATE eom_missed_call_sequence_steps
+               SET state = 'skipped', terminal_reason = $2,
+                   next_attempt_at = NULL, claim_expires_at = NULL, updated_at = $3
+             WHERE sequence_id = $1 AND state = 'pending'
+             RETURNING id
+            """,
+            sequence_id,
+            reason,
+            now,
+        )
+        await self._event(
+            conn,
+            sequence_id=sequence_id,
+            step_id=step_id,
+            event_type="step_recovery_required",
+            reason_code=reason,
+            actor_id=None,
+            actor_name="system",
+            source="worker",
+            metadata={},
+            occurred_at=now,
+        )
+        for row in skipped:
+            await self._event(
+                conn,
+                sequence_id=sequence_id,
+                step_id=row["id"],
+                event_type="step_skipped",
+                reason_code=reason,
+                actor_id=None,
+                actor_name="system",
+                source="worker",
+                metadata={},
+                occurred_at=now,
+            )
+
+    async def _write_sent_history(self, history: _SentHistory) -> None:
+        """Write secondary sent-history evidence after primary state commits."""
+
+        if not history.provider_message_id:
+            return
+        repository = self._email_history
+        if repository is None:
+            # The slim EOM profile imports this module with the funnel router;
+            # keep the broader repository/model graph lazy until a confirmed
+            # provider acceptance actually needs secondary history evidence.
+            from ..storage.repositories.email import EmailRepository
+
+            repository = EmailRepository(pool=self.pool)
+        try:
+            await repository.create(
+                to_addresses=[history.recipient_email],
+                subject=history.subject,
+                body=history.body,
+                template_type="eom_missed_call_recovery",
+                resend_message_id=history.provider_message_id,
+                metadata={
+                    "source": "eom_missed_call_recovery",
+                    "contact_id": str(history.contact_id),
+                    "sequence_id": str(history.sequence_id),
+                    "step_id": str(history.step_id),
+                },
+                business_context_id=_EOM_CONTEXT,
+            )
+        except Exception as exc:
+            # The provider acceptance and durable sequence result are already
+            # committed. History is valuable secondary evidence, never an
+            # authorization to resend or to roll back a truthful send.
+            logger.warning(
+                "Missed-call sent-email history write failed sequence=%s step=%s error=%s",
+                history.sequence_id,
+                history.step_id,
+                type(exc).__name__,
+            )
+
+
+async def run_eom_missed_call_recovery_worker(
+    *,
+    service: EOMMissedCallRecoveryService,
+    stop_event: asyncio.Event,
+) -> None:
+    """Run a bounded, multi-process-safe EOM delivery loop until shutdown."""
+
+    interval = service._config.missed_call_poll_interval_seconds
+    while not stop_event.is_set():
+        try:
+            await service.dispatch_due_steps()
+        except Exception as exc:
+            logger.error(
+                "Missed-call recovery worker cycle failed error=%s",
+                type(exc).__name__,
+            )
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=interval)
+        except TimeoutError:
+            pass
+
+
+def start_eom_missed_call_recovery_worker(
+    *,
+    pool: Any,
+    config: EOMFunnelConfig | None = None,
+) -> tuple[asyncio.Event, asyncio.Task[None]]:
+    """Start one process-local loop; database locks make many loops safe."""
+
+    service = EOMMissedCallRecoveryService(pool=pool, config=config)
+    stop_event = asyncio.Event()
+    task = asyncio.create_task(
+        run_eom_missed_call_recovery_worker(service=service, stop_event=stop_event),
+        name="eom-missed-call-recovery-worker",
+    )
+    return stop_event, task
+
+
+async def stop_eom_missed_call_recovery_worker(
+    worker: tuple[asyncio.Event, asyncio.Task[None]] | None,
+) -> None:
+    """Stop a local worker without cancelling an in-flight transactional send."""
+
+    if worker is None:
+        return
+    stop_event, task = worker
+    stop_event.set()
+    try:
+        await asyncio.wait_for(task, timeout=15)
+    except TimeoutError:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass

--- a/atlas_brain/storage/migrations/389_eom_missed_call_recovery.sql
+++ b/atlas_brain/storage/migrations/389_eom_missed_call_recovery.sql
@@ -327,10 +327,21 @@ AS $$
 BEGIN
     IF NOT EXISTS (
         SELECT 1
-          FROM contacts
+         FROM contacts
          WHERE id = NEW.contact_id
            AND business_context_id = 'effingham_maids'
     ) THEN
+        -- A canonical contact can leave EOM after an old recovery sequence
+        -- exists. Its contacts trigger must be able to terminalize that
+        -- sequence without reopening it or allowing any other mutation under
+        -- a non-EOM owner. Keep this one-way cancellation exception narrow.
+        IF TG_OP = 'UPDATE'
+           AND OLD.business_context_id = 'effingham_maids'
+           AND NEW.business_context_id = 'effingham_maids'
+           AND OLD.state IN ('active', 'blocked_configuration')
+           AND NEW.state = 'cancelled' THEN
+            RETURN NEW;
+        END IF;
         RAISE EXCEPTION 'eom missed-call recovery rows require an EOM contact';
     END IF;
 
@@ -419,6 +430,52 @@ BEGIN
 END;
 $$;
 
+CREATE OR REPLACE FUNCTION lock_eom_missed_call_interaction_contact()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    -- Delivery takes the contact row lock before it reads latest intake or
+    -- response evidence and before it calls Resend. Every interaction write
+    -- takes the same per-contact lock *before* changing that evidence. This
+    -- gives a single transaction-order boundary for inserts, corrections,
+    -- contact reassignment, and deletes without serializing unrelated leads.
+    IF TG_OP = 'INSERT' THEN
+        PERFORM 1
+          FROM contacts
+         WHERE id = NEW.contact_id
+           AND business_context_id = 'effingham_maids'
+         FOR UPDATE;
+        RETURN NEW;
+    ELSIF TG_OP = 'DELETE' THEN
+        PERFORM 1
+          FROM contacts
+         WHERE id = OLD.contact_id
+           AND business_context_id = 'effingham_maids'
+         FOR UPDATE;
+        RETURN OLD;
+    END IF;
+
+    -- A rare repair can move an interaction between contacts. Lock both EOM
+    -- contact rows in UUID order so two inverse repairs cannot deadlock while
+    -- a delivery worker holds one of their canonical locks.
+    PERFORM 1
+      FROM contacts
+     WHERE id = ANY(ARRAY[OLD.contact_id, NEW.contact_id])
+       AND business_context_id = 'effingham_maids'
+     ORDER BY id
+     FOR UPDATE;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_lock_eom_missed_call_interaction_contact
+    ON contact_interactions;
+CREATE TRIGGER trg_lock_eom_missed_call_interaction_contact
+    BEFORE INSERT OR UPDATE OR DELETE ON contact_interactions
+    FOR EACH ROW
+    EXECUTE FUNCTION lock_eom_missed_call_interaction_contact();
+
 CREATE OR REPLACE FUNCTION eom_missed_call_effective_recipient(
     target_contact_id UUID,
     fallback_contact_email TEXT
@@ -452,6 +509,40 @@ AS $$
     );
 $$;
 
+CREATE OR REPLACE FUNCTION cancel_eom_missed_call_on_recipient_change(
+    target_contact_id UUID
+)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    effective_recipient TEXT;
+BEGIN
+    SELECT eom_missed_call_effective_recipient(c.id, c.email)
+      INTO effective_recipient
+      FROM contacts AS c
+     WHERE c.id = target_contact_id
+       AND c.business_context_id = 'effingham_maids';
+
+    IF NOT FOUND THEN
+        RETURN;
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+          FROM eom_missed_call_sequences AS sequence
+         WHERE sequence.contact_id = target_contact_id
+           AND sequence.state IN ('active', 'blocked_configuration')
+           AND lower(btrim(sequence.recipient_email)) IS DISTINCT FROM
+               effective_recipient
+    ) THEN
+        PERFORM cancel_eom_missed_call_sequences_for_contact(
+            target_contact_id, 'recipient_changed', 'interaction_trigger'
+        );
+    END IF;
+END;
+$$;
+
 CREATE OR REPLACE FUNCTION cancel_eom_missed_call_on_contact_change()
 RETURNS TRIGGER
 LANGUAGE plpgsql
@@ -459,11 +550,16 @@ AS $$
 DECLARE
     cancellation_reason VARCHAR(64);
 BEGIN
-    IF NEW.business_context_id IS DISTINCT FROM 'effingham_maids' THEN
+    IF OLD.business_context_id = 'effingham_maids'
+       AND NEW.business_context_id IS DISTINCT FROM 'effingham_maids' THEN
+        -- The sequence belongs to its original EOM interaction evidence, but
+        -- a canonical ownership transfer makes any remaining EOM email
+        -- ineligible. Terminalize before the sequence scope fence sees the
+        -- new tenant and never treat a missing status row as permission.
+        cancellation_reason := 'tenant_changed';
+    ELSIF NEW.business_context_id IS DISTINCT FROM 'effingham_maids' THEN
         RETURN NEW;
-    END IF;
-
-    IF NEW.contact_type <> 'lead' THEN
+    ELSIF NEW.contact_type <> 'lead' THEN
         cancellation_reason := 'became_customer';
     ELSIF NEW.status <> 'active' THEN
         cancellation_reason := 'contact_inactive';
@@ -494,7 +590,8 @@ $$;
 
 DROP TRIGGER IF EXISTS trg_cancel_eom_missed_call_on_contact_change ON contacts;
 CREATE TRIGGER trg_cancel_eom_missed_call_on_contact_change
-    AFTER UPDATE OF contact_type, status, lead_stage, customer_type, email ON contacts
+    AFTER UPDATE OF business_context_id, contact_type, status, lead_stage,
+                    customer_type, email ON contacts
     FOR EACH ROW
     EXECUTE FUNCTION cancel_eom_missed_call_on_contact_change();
 
@@ -523,6 +620,24 @@ AS $$
 DECLARE
     cancellation_reason VARCHAR(64);
 BEGIN
+    IF TG_OP <> 'INSERT' THEN
+        -- The BEFORE lock trigger serialized this correction/deletion with a
+        -- final delivery check. Now that the new effective recipient is
+        -- committed within this transaction, terminalize any sequence whose
+        -- immutable recipient snapshot no longer matches it. Other changed
+        -- eligibility fields are still re-read by the worker under the same
+        -- lock before every provider call.
+        PERFORM cancel_eom_missed_call_on_recipient_change(OLD.contact_id);
+        IF TG_OP = 'UPDATE'
+           AND NEW.contact_id IS DISTINCT FROM OLD.contact_id THEN
+            PERFORM cancel_eom_missed_call_on_recipient_change(NEW.contact_id);
+        END IF;
+        IF TG_OP = 'DELETE' THEN
+            RETURN OLD;
+        END IF;
+        RETURN NEW;
+    END IF;
+
     IF NOT EXISTS (
         SELECT 1
           FROM contacts
@@ -584,7 +699,7 @@ $$;
 DROP TRIGGER IF EXISTS trg_cancel_eom_missed_call_on_interaction
     ON contact_interactions;
 CREATE TRIGGER trg_cancel_eom_missed_call_on_interaction
-    AFTER INSERT ON contact_interactions
+    AFTER INSERT OR UPDATE OR DELETE ON contact_interactions
     FOR EACH ROW
     EXECUTE FUNCTION cancel_eom_missed_call_on_interaction();
 

--- a/atlas_brain/storage/migrations/389_eom_missed_call_recovery.sql
+++ b/atlas_brain/storage/migrations/389_eom_missed_call_recovery.sql
@@ -10,6 +10,27 @@
 -- additive evidence. Never delete attempts, sequence events, or sent-step
 -- evidence during an ordinary application rollback.
 
+-- All operator mutations bind their Idempotency-Key globally before any
+-- contact-specific work. A stale browser retry whose route changes from lead
+-- A to lead B must fail closed rather than recording a second call or queueing
+-- customer mail for the wrong lead.
+CREATE TABLE IF NOT EXISTS eom_missed_call_operation_receipts (
+    operation_key VARCHAR(128) PRIMARY KEY,
+    contact_id UUID NOT NULL REFERENCES contacts(id) ON DELETE RESTRICT,
+    business_context_id VARCHAR(64) NOT NULL DEFAULT 'effingham_maids',
+    operation_kind VARCHAR(32) NOT NULL,
+    request_fingerprint VARCHAR(64) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT ck_eom_missed_call_operation_receipts_context
+        CHECK (business_context_id = 'effingham_maids'),
+    CONSTRAINT ck_eom_missed_call_operation_receipts_key
+        CHECK (length(btrim(operation_key)) BETWEEN 16 AND 128),
+    CONSTRAINT ck_eom_missed_call_operation_receipts_kind
+        CHECK (operation_kind IN ('no_answer', 'resume', 'cancel')),
+    CONSTRAINT ck_eom_missed_call_operation_receipts_fingerprint
+        CHECK (request_fingerprint ~ '^[0-9a-f]{64}$')
+);
+
 CREATE TABLE IF NOT EXISTS eom_missed_call_attempts (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     contact_id UUID NOT NULL REFERENCES contacts(id) ON DELETE RESTRICT,
@@ -32,7 +53,7 @@ CREATE TABLE IF NOT EXISTS eom_missed_call_attempts (
     CONSTRAINT ck_eom_missed_call_attempts_source
         CHECK (source = 'time_tracker'),
     CONSTRAINT uq_eom_missed_call_attempt_operation
-        UNIQUE (contact_id, operation_key)
+        UNIQUE (operation_key)
 );
 
 CREATE TABLE IF NOT EXISTS eom_missed_call_contact_suppressions (
@@ -198,6 +219,29 @@ BEGIN
 END;
 $$;
 
+CREATE OR REPLACE FUNCTION prevent_eom_missed_call_operation_receipt_mutation()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION 'eom_missed_call_operation_receipts is append-only';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_prevent_eom_missed_call_operation_receipt_mutation
+    ON eom_missed_call_operation_receipts;
+CREATE TRIGGER trg_prevent_eom_missed_call_operation_receipt_mutation
+    BEFORE UPDATE OR DELETE ON eom_missed_call_operation_receipts
+    FOR EACH ROW
+    EXECUTE FUNCTION prevent_eom_missed_call_operation_receipt_mutation();
+
+DROP TRIGGER IF EXISTS trg_prevent_eom_missed_call_operation_receipt_truncate
+    ON eom_missed_call_operation_receipts;
+CREATE TRIGGER trg_prevent_eom_missed_call_operation_receipt_truncate
+    BEFORE TRUNCATE ON eom_missed_call_operation_receipts
+    FOR EACH STATEMENT
+    EXECUTE FUNCTION prevent_eom_missed_call_operation_receipt_mutation();
+
 DROP TRIGGER IF EXISTS trg_prevent_eom_missed_call_attempt_mutation
     ON eom_missed_call_attempts;
 CREATE TRIGGER trg_prevent_eom_missed_call_attempt_mutation
@@ -311,6 +355,13 @@ CREATE TRIGGER trg_validate_eom_missed_call_attempt_scope
     FOR EACH ROW
     EXECUTE FUNCTION validate_eom_missed_call_contact_scope();
 
+DROP TRIGGER IF EXISTS trg_validate_eom_missed_call_operation_receipt_scope
+    ON eom_missed_call_operation_receipts;
+CREATE TRIGGER trg_validate_eom_missed_call_operation_receipt_scope
+    BEFORE INSERT OR UPDATE ON eom_missed_call_operation_receipts
+    FOR EACH ROW
+    EXECUTE FUNCTION validate_eom_missed_call_contact_scope();
+
 DROP TRIGGER IF EXISTS trg_validate_eom_missed_call_suppression_scope
     ON eom_missed_call_contact_suppressions;
 CREATE TRIGGER trg_validate_eom_missed_call_suppression_scope
@@ -368,6 +419,39 @@ BEGIN
 END;
 $$;
 
+CREATE OR REPLACE FUNCTION eom_missed_call_effective_recipient(
+    target_contact_id UUID,
+    fallback_contact_email TEXT
+)
+RETURNS TEXT
+LANGUAGE sql
+STABLE
+AS $$
+    -- Keep this precedence equal to the delivery service: an estimate form's
+    -- submitted address remains the recovery recipient until a later estimate
+    -- request replaces it. A routine edit to contacts.email alone must not
+    -- silently cancel a sequence that still targets that submitted address.
+    SELECT lower(
+        NULLIF(
+            btrim(
+                COALESCE(
+                    (
+                        SELECT NULLIF(ci.metadata->>'submitted_email', '')
+                        FROM contact_interactions AS ci
+                        WHERE ci.contact_id = target_contact_id
+                          AND ci.interaction_type = 'web_form'
+                          AND ci.intent = 'estimate_request'
+                        ORDER BY ci.occurred_at DESC, ci.created_at DESC, ci.id DESC
+                        LIMIT 1
+                    ),
+                    fallback_contact_email
+                )
+            ),
+            ''
+        )
+    );
+$$;
+
 CREATE OR REPLACE FUNCTION cancel_eom_missed_call_on_contact_change()
 RETURNS TRIGGER
 LANGUAGE plpgsql
@@ -387,7 +471,15 @@ BEGIN
         cancellation_reason := 'lead_advanced';
     ELSIF NEW.customer_type = 'commercial' THEN
         cancellation_reason := 'non_residential';
-    ELSIF NEW.email IS DISTINCT FROM OLD.email THEN
+    ELSIF NEW.email IS DISTINCT FROM OLD.email
+       AND EXISTS (
+           SELECT 1
+           FROM eom_missed_call_sequences AS sequence
+           WHERE sequence.contact_id = NEW.id
+             AND sequence.state IN ('active', 'blocked_configuration')
+             AND lower(btrim(sequence.recipient_email)) IS DISTINCT FROM
+                 eom_missed_call_effective_recipient(NEW.id, NEW.email)
+       ) THEN
         cancellation_reason := 'recipient_changed';
     ELSE
         RETURN NEW;
@@ -471,9 +563,20 @@ BEGIN
         ) ON CONFLICT (contact_id) DO NOTHING;
     END IF;
 
-    PERFORM cancel_eom_missed_call_sequences_for_contact(
-        NEW.contact_id, cancellation_reason, 'interaction_trigger'
-    );
+    -- A later-arriving historical event is evidence about an earlier point in
+    -- time, not a new response after this sequence began. The delivery worker
+    -- uses the same strict ordering when it rechecks current eligibility.
+    IF EXISTS (
+        SELECT 1
+        FROM eom_missed_call_sequences AS sequence
+        WHERE sequence.contact_id = NEW.contact_id
+          AND sequence.state IN ('active', 'blocked_configuration')
+          AND NEW.occurred_at > sequence.created_at
+    ) THEN
+        PERFORM cancel_eom_missed_call_sequences_for_contact(
+            NEW.contact_id, cancellation_reason, 'interaction_trigger'
+        );
+    END IF;
     RETURN NEW;
 END;
 $$;
@@ -487,6 +590,8 @@ CREATE TRIGGER trg_cancel_eom_missed_call_on_interaction
 
 COMMENT ON TABLE eom_missed_call_attempts IS
     'Immutable, actor-attributed EOM no-answer call evidence; never inferred from public form submission.';
+COMMENT ON TABLE eom_missed_call_operation_receipts IS
+    'Globally unique EOM missed-call recovery operation-key ownership; cross-contact replays fail closed.';
 COMMENT ON TABLE eom_missed_call_sequences IS
     'Current durable state for one EOM residential lead missed-call recovery sequence.';
 COMMENT ON TABLE eom_missed_call_contact_suppressions IS

--- a/atlas_brain/storage/migrations/389_eom_missed_call_recovery.sql
+++ b/atlas_brain/storage/migrations/389_eom_missed_call_recovery.sql
@@ -1,0 +1,497 @@
+-- atlas: atomic-bookkeeping
+-- Durable, tenant-scoped missed-call recovery for EOM residential estimate leads.
+--
+-- A public form acknowledgement is a separate transactional message. These
+-- tables begin only after an authenticated office operator records a real
+-- unanswered call. The current sequence is mutable state; every meaningful
+-- transition is preserved in the append-only event ledger.
+--
+-- Rollback: stop the worker and the new routes first, then retain this
+-- additive evidence. Never delete attempts, sequence events, or sent-step
+-- evidence during an ordinary application rollback.
+
+CREATE TABLE IF NOT EXISTS eom_missed_call_attempts (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    contact_id UUID NOT NULL REFERENCES contacts(id) ON DELETE RESTRICT,
+    business_context_id VARCHAR(64) NOT NULL DEFAULT 'effingham_maids',
+    operation_key VARCHAR(128) NOT NULL,
+    request_fingerprint VARCHAR(64) NOT NULL,
+    actor_id BIGINT NOT NULL,
+    actor_name VARCHAR(128) NOT NULL,
+    source VARCHAR(32) NOT NULL DEFAULT 'time_tracker',
+    occurred_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT ck_eom_missed_call_attempts_context
+        CHECK (business_context_id = 'effingham_maids'),
+    CONSTRAINT ck_eom_missed_call_attempts_operation_key
+        CHECK (length(btrim(operation_key)) BETWEEN 16 AND 128),
+    CONSTRAINT ck_eom_missed_call_attempts_fingerprint
+        CHECK (request_fingerprint ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT ck_eom_missed_call_attempts_actor
+        CHECK (actor_id > 0 AND length(btrim(actor_name)) > 0),
+    CONSTRAINT ck_eom_missed_call_attempts_source
+        CHECK (source = 'time_tracker'),
+    CONSTRAINT uq_eom_missed_call_attempt_operation
+        UNIQUE (contact_id, operation_key)
+);
+
+CREATE TABLE IF NOT EXISTS eom_missed_call_contact_suppressions (
+    contact_id UUID PRIMARY KEY REFERENCES contacts(id) ON DELETE RESTRICT,
+    business_context_id VARCHAR(64) NOT NULL DEFAULT 'effingham_maids',
+    reason_code VARCHAR(64) NOT NULL,
+    actor_id BIGINT,
+    actor_name VARCHAR(128) NOT NULL DEFAULT 'system',
+    source VARCHAR(32) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT ck_eom_missed_call_suppressions_context
+        CHECK (business_context_id = 'effingham_maids'),
+    CONSTRAINT ck_eom_missed_call_suppressions_reason
+        CHECK (reason_code IN ('opt_out', 'unsubscribed', 'do_not_contact')),
+    CONSTRAINT ck_eom_missed_call_suppressions_actor
+        CHECK (length(btrim(actor_name)) > 0),
+    CONSTRAINT ck_eom_missed_call_suppressions_source
+        CHECK (source IN ('time_tracker', 'interaction_trigger'))
+);
+
+CREATE TABLE IF NOT EXISTS eom_missed_call_sequences (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    contact_id UUID NOT NULL REFERENCES contacts(id) ON DELETE RESTRICT,
+    initiating_attempt_id UUID NOT NULL
+        REFERENCES eom_missed_call_attempts(id) ON DELETE RESTRICT,
+    business_context_id VARCHAR(64) NOT NULL DEFAULT 'effingham_maids',
+    recipient_email VARCHAR(256) NOT NULL,
+    state VARCHAR(32) NOT NULL,
+    blocked_reason VARCHAR(64),
+    cancellation_reason VARCHAR(64),
+    terminal_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT ck_eom_missed_call_sequences_context
+        CHECK (business_context_id = 'effingham_maids'),
+    CONSTRAINT uq_eom_missed_call_sequences_initiating_attempt
+        UNIQUE (initiating_attempt_id),
+    CONSTRAINT ck_eom_missed_call_sequences_state
+        CHECK (state IN (
+            'active', 'blocked_configuration', 'completed', 'cancelled',
+            'failed', 'recovery_required'
+        )),
+    CONSTRAINT ck_eom_missed_call_sequences_terminal_shape
+        CHECK (
+            (state IN ('active', 'blocked_configuration') AND terminal_at IS NULL)
+            OR (state NOT IN ('active', 'blocked_configuration') AND terminal_at IS NOT NULL)
+        ),
+    CONSTRAINT ck_eom_missed_call_sequences_reason_shape
+        CHECK (
+            (state = 'blocked_configuration' AND blocked_reason IS NOT NULL)
+            OR (state <> 'blocked_configuration' AND blocked_reason IS NULL)
+        )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_eom_missed_call_sequences_active_contact
+    ON eom_missed_call_sequences (contact_id)
+    WHERE state IN ('active', 'blocked_configuration');
+
+CREATE INDEX IF NOT EXISTS idx_eom_missed_call_sequences_contact
+    ON eom_missed_call_sequences (contact_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS eom_missed_call_sequence_steps (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    sequence_id UUID NOT NULL REFERENCES eom_missed_call_sequences(id)
+        ON DELETE RESTRICT,
+    step_number SMALLINT NOT NULL,
+    due_at TIMESTAMPTZ NOT NULL,
+    subject VARCHAR(500) NOT NULL,
+    body TEXT NOT NULL,
+    provider_idempotency_key VARCHAR(192) NOT NULL,
+    provider_key_expires_at TIMESTAMPTZ,
+    state VARCHAR(32) NOT NULL DEFAULT 'pending',
+    attempt_count SMALLINT NOT NULL DEFAULT 0,
+    next_attempt_at TIMESTAMPTZ,
+    claim_token UUID,
+    claimed_at TIMESTAMPTZ,
+    claim_expires_at TIMESTAMPTZ,
+    provider_message_id VARCHAR(256),
+    sent_at TIMESTAMPTZ,
+    terminal_reason VARCHAR(64),
+    last_error_code VARCHAR(64),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_eom_missed_call_sequence_step
+        UNIQUE (sequence_id, step_number),
+    CONSTRAINT uq_eom_missed_call_step_provider_key
+        UNIQUE (provider_idempotency_key),
+    CONSTRAINT ck_eom_missed_call_step_number
+        CHECK (step_number BETWEEN 1 AND 3),
+    CONSTRAINT ck_eom_missed_call_step_state
+        CHECK (state IN (
+            'pending', 'attempting', 'sent', 'skipped', 'failed',
+            'recovery_required'
+        )),
+    CONSTRAINT ck_eom_missed_call_step_attempt_count
+        CHECK (attempt_count >= 0 AND attempt_count <= 5),
+    CONSTRAINT ck_eom_missed_call_step_pending_shape
+        CHECK (
+            (state = 'pending' AND sent_at IS NULL AND provider_message_id IS NULL)
+            OR state <> 'pending'
+        ),
+    CONSTRAINT ck_eom_missed_call_step_sent_shape
+        CHECK (
+            (state = 'sent' AND sent_at IS NOT NULL
+             AND length(btrim(COALESCE(provider_message_id, ''))) > 0)
+            OR (state <> 'sent' AND sent_at IS NULL AND provider_message_id IS NULL)
+        ),
+    -- A claim has to be durable and complete before a worker may call Resend.
+    -- This makes an impossible half-claimed state reject at the same boundary
+    -- that owns the provider idempotency window.
+    CONSTRAINT ck_eom_missed_call_step_claim_shape
+        CHECK (
+            (state = 'attempting'
+             AND claim_token IS NOT NULL
+             AND claimed_at IS NOT NULL
+             AND claim_expires_at IS NOT NULL)
+            OR (state <> 'attempting'
+                AND claim_token IS NULL
+                AND claimed_at IS NULL
+                AND claim_expires_at IS NULL)
+        )
+);
+
+CREATE INDEX IF NOT EXISTS idx_eom_missed_call_steps_due
+    ON eom_missed_call_sequence_steps (due_at, next_attempt_at, created_at)
+    WHERE state IN ('pending', 'attempting');
+
+CREATE TABLE IF NOT EXISTS eom_missed_call_sequence_events (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    sequence_id UUID NOT NULL REFERENCES eom_missed_call_sequences(id)
+        ON DELETE RESTRICT,
+    step_id UUID REFERENCES eom_missed_call_sequence_steps(id) ON DELETE RESTRICT,
+    event_type VARCHAR(64) NOT NULL,
+    reason_code VARCHAR(64),
+    actor_id BIGINT,
+    actor_name VARCHAR(128) NOT NULL DEFAULT 'system',
+    source VARCHAR(32) NOT NULL,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    occurred_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT ck_eom_missed_call_events_actor
+        CHECK (length(btrim(actor_name)) > 0),
+    CONSTRAINT ck_eom_missed_call_events_source
+        CHECK (source IN ('time_tracker', 'worker', 'contact_trigger', 'interaction_trigger')),
+    CONSTRAINT ck_eom_missed_call_events_type
+        CHECK (event_type IN (
+            'sequence_started', 'sequence_reused', 'sequence_blocked',
+            'sequence_resumed', 'sequence_cancelled', 'sequence_completed',
+            'step_claimed', 'step_sent', 'step_retry_scheduled', 'step_skipped',
+            'step_failed', 'step_recovery_required'
+        ))
+);
+
+CREATE INDEX IF NOT EXISTS idx_eom_missed_call_sequence_events_sequence
+    ON eom_missed_call_sequence_events (sequence_id, occurred_at DESC, id DESC);
+
+CREATE OR REPLACE FUNCTION prevent_eom_missed_call_attempt_mutation()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION 'eom_missed_call_attempts is append-only';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_prevent_eom_missed_call_attempt_mutation
+    ON eom_missed_call_attempts;
+CREATE TRIGGER trg_prevent_eom_missed_call_attempt_mutation
+    BEFORE UPDATE OR DELETE ON eom_missed_call_attempts
+    FOR EACH ROW
+    EXECUTE FUNCTION prevent_eom_missed_call_attempt_mutation();
+
+DROP TRIGGER IF EXISTS trg_prevent_eom_missed_call_attempt_truncate
+    ON eom_missed_call_attempts;
+CREATE TRIGGER trg_prevent_eom_missed_call_attempt_truncate
+    BEFORE TRUNCATE ON eom_missed_call_attempts
+    FOR EACH STATEMENT
+    EXECUTE FUNCTION prevent_eom_missed_call_attempt_mutation();
+
+CREATE OR REPLACE FUNCTION prevent_eom_missed_call_sequence_event_mutation()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION 'eom_missed_call_sequence_events is append-only';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_prevent_eom_missed_call_sequence_event_mutation
+    ON eom_missed_call_sequence_events;
+CREATE TRIGGER trg_prevent_eom_missed_call_sequence_event_mutation
+    BEFORE UPDATE OR DELETE ON eom_missed_call_sequence_events
+    FOR EACH ROW
+    EXECUTE FUNCTION prevent_eom_missed_call_sequence_event_mutation();
+
+DROP TRIGGER IF EXISTS trg_prevent_eom_missed_call_sequence_event_truncate
+    ON eom_missed_call_sequence_events;
+CREATE TRIGGER trg_prevent_eom_missed_call_sequence_event_truncate
+    BEFORE TRUNCATE ON eom_missed_call_sequence_events
+    FOR EACH STATEMENT
+    EXECUTE FUNCTION prevent_eom_missed_call_sequence_event_mutation();
+
+CREATE OR REPLACE FUNCTION prevent_eom_missed_call_suppression_mutation()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION 'eom_missed_call_contact_suppressions is append-only';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_prevent_eom_missed_call_suppression_mutation
+    ON eom_missed_call_contact_suppressions;
+CREATE TRIGGER trg_prevent_eom_missed_call_suppression_mutation
+    BEFORE UPDATE OR DELETE ON eom_missed_call_contact_suppressions
+    FOR EACH ROW
+    EXECUTE FUNCTION prevent_eom_missed_call_suppression_mutation();
+
+DROP TRIGGER IF EXISTS trg_prevent_eom_missed_call_suppression_truncate
+    ON eom_missed_call_contact_suppressions;
+CREATE TRIGGER trg_prevent_eom_missed_call_suppression_truncate
+    BEFORE TRUNCATE ON eom_missed_call_contact_suppressions
+    FOR EACH STATEMENT
+    EXECUTE FUNCTION prevent_eom_missed_call_suppression_mutation();
+
+CREATE OR REPLACE FUNCTION validate_eom_missed_call_contact_scope()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+          FROM contacts
+         WHERE id = NEW.contact_id
+           AND business_context_id = 'effingham_maids'
+    ) THEN
+        RAISE EXCEPTION 'eom missed-call recovery rows require an EOM contact';
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION validate_eom_missed_call_sequence_scope()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+          FROM contacts
+         WHERE id = NEW.contact_id
+           AND business_context_id = 'effingham_maids'
+    ) THEN
+        RAISE EXCEPTION 'eom missed-call recovery rows require an EOM contact';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+          FROM eom_missed_call_attempts AS attempt
+         WHERE attempt.id = NEW.initiating_attempt_id
+           AND attempt.contact_id = NEW.contact_id
+           AND attempt.business_context_id = 'effingham_maids'
+    ) THEN
+        RAISE EXCEPTION 'eom missed-call recovery sequence must match its initiating attempt';
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_validate_eom_missed_call_attempt_scope
+    ON eom_missed_call_attempts;
+CREATE TRIGGER trg_validate_eom_missed_call_attempt_scope
+    BEFORE INSERT OR UPDATE ON eom_missed_call_attempts
+    FOR EACH ROW
+    EXECUTE FUNCTION validate_eom_missed_call_contact_scope();
+
+DROP TRIGGER IF EXISTS trg_validate_eom_missed_call_suppression_scope
+    ON eom_missed_call_contact_suppressions;
+CREATE TRIGGER trg_validate_eom_missed_call_suppression_scope
+    BEFORE INSERT OR UPDATE ON eom_missed_call_contact_suppressions
+    FOR EACH ROW
+    EXECUTE FUNCTION validate_eom_missed_call_contact_scope();
+
+DROP TRIGGER IF EXISTS trg_validate_eom_missed_call_sequence_scope
+    ON eom_missed_call_sequences;
+CREATE TRIGGER trg_validate_eom_missed_call_sequence_scope
+    BEFORE INSERT OR UPDATE ON eom_missed_call_sequences
+    FOR EACH ROW
+    EXECUTE FUNCTION validate_eom_missed_call_sequence_scope();
+
+CREATE OR REPLACE FUNCTION cancel_eom_missed_call_sequences_for_contact(
+    target_contact_id UUID,
+    target_reason VARCHAR(64),
+    target_source VARCHAR(32)
+)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    WITH cancelled AS (
+        UPDATE eom_missed_call_sequences
+           SET state = 'cancelled',
+               blocked_reason = NULL,
+               cancellation_reason = target_reason,
+               terminal_at = CURRENT_TIMESTAMP,
+               updated_at = CURRENT_TIMESTAMP
+         WHERE contact_id = target_contact_id
+           AND state IN ('active', 'blocked_configuration')
+         RETURNING id
+    ), skipped AS (
+        UPDATE eom_missed_call_sequence_steps
+           SET state = 'skipped',
+               terminal_reason = target_reason,
+               next_attempt_at = NULL,
+               claim_token = NULL,
+               claimed_at = NULL,
+               claim_expires_at = NULL,
+               updated_at = CURRENT_TIMESTAMP
+         WHERE sequence_id IN (SELECT id FROM cancelled)
+           AND state IN ('pending', 'attempting')
+         RETURNING id, sequence_id
+    )
+    INSERT INTO eom_missed_call_sequence_events (
+        sequence_id, step_id, event_type, reason_code, actor_name, source
+    )
+    SELECT id, NULL, 'sequence_cancelled', target_reason, 'system', target_source
+      FROM cancelled
+    UNION ALL
+    SELECT sequence_id, id, 'step_skipped', target_reason, 'system', target_source
+      FROM skipped;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION cancel_eom_missed_call_on_contact_change()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    cancellation_reason VARCHAR(64);
+BEGIN
+    IF NEW.business_context_id IS DISTINCT FROM 'effingham_maids' THEN
+        RETURN NEW;
+    END IF;
+
+    IF NEW.contact_type <> 'lead' THEN
+        cancellation_reason := 'became_customer';
+    ELSIF NEW.status <> 'active' THEN
+        cancellation_reason := 'contact_inactive';
+    ELSIF NEW.lead_stage IS DISTINCT FROM 'new' THEN
+        cancellation_reason := 'lead_advanced';
+    ELSIF NEW.customer_type = 'commercial' THEN
+        cancellation_reason := 'non_residential';
+    ELSIF NEW.email IS DISTINCT FROM OLD.email THEN
+        cancellation_reason := 'recipient_changed';
+    ELSE
+        RETURN NEW;
+    END IF;
+
+    PERFORM cancel_eom_missed_call_sequences_for_contact(
+        NEW.id, cancellation_reason, 'contact_trigger'
+    );
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_cancel_eom_missed_call_on_contact_change ON contacts;
+CREATE TRIGGER trg_cancel_eom_missed_call_on_contact_change
+    AFTER UPDATE OF contact_type, status, lead_stage, customer_type, email ON contacts
+    FOR EACH ROW
+    EXECUTE FUNCTION cancel_eom_missed_call_on_contact_change();
+
+CREATE OR REPLACE FUNCTION eom_missed_call_has_proven_inbound_sms(
+    candidate_metadata JSONB
+)
+RETURNS BOOLEAN
+LANGUAGE sql
+IMMUTABLE
+AS $$
+    -- EOM's current inbound SMS bridge writes crm_event_id="sms:<provider id>".
+    -- A future bridge may instead carry an explicit direction. Any other
+    -- generic CRM `sms` interaction (including an outgoing reminder) is not
+    -- evidence that this lead replied, so it intentionally does not cancel.
+    SELECT COALESCE(
+        candidate_metadata->>'direction' = 'inbound'
+        OR NULLIF(btrim(candidate_metadata->>'crm_event_id'), '') LIKE 'sms:%',
+        FALSE
+    );
+$$;
+
+CREATE OR REPLACE FUNCTION cancel_eom_missed_call_on_interaction()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    cancellation_reason VARCHAR(64);
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+          FROM contacts
+         WHERE id = NEW.contact_id
+           AND business_context_id = 'effingham_maids'
+    ) THEN
+        RETURN NEW;
+    END IF;
+
+    IF NEW.metadata->>'missed_call_recovery_cancel_reason' IN (
+        'callback_recorded', 'response_recorded', 'opt_out', 'manual'
+    ) THEN
+        -- The authenticated operator route records both the standard CRM
+        -- interaction type and the operator's more precise stop reason. Keep
+        -- that durable reason in the sequence ledger instead of flattening it
+        -- to the generic interaction vocabulary.
+        cancellation_reason := NEW.metadata->>'missed_call_recovery_cancel_reason';
+    ELSIF NEW.interaction_type = 'sms'
+       AND eom_missed_call_has_proven_inbound_sms(NEW.metadata) THEN
+        cancellation_reason := 'tracked_inbound_response';
+    ELSIF NEW.interaction_type IN (
+        'email_inbound', 'lead_response', 'callback_completed',
+        'conversation_completed', 'opt_out'
+    ) THEN
+        cancellation_reason := NEW.interaction_type;
+    ELSIF NEW.interaction_type = 'web_form'
+       AND NEW.intent = 'estimate_request' THEN
+        cancellation_reason := 'new_estimate_request';
+    ELSE
+        RETURN NEW;
+    END IF;
+
+    IF NEW.interaction_type = 'opt_out' THEN
+        INSERT INTO eom_missed_call_contact_suppressions (
+            contact_id, reason_code, actor_name, source
+        ) VALUES (
+            NEW.contact_id, 'opt_out', 'system', 'interaction_trigger'
+        ) ON CONFLICT (contact_id) DO NOTHING;
+    END IF;
+
+    PERFORM cancel_eom_missed_call_sequences_for_contact(
+        NEW.contact_id, cancellation_reason, 'interaction_trigger'
+    );
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_cancel_eom_missed_call_on_interaction
+    ON contact_interactions;
+CREATE TRIGGER trg_cancel_eom_missed_call_on_interaction
+    AFTER INSERT ON contact_interactions
+    FOR EACH ROW
+    EXECUTE FUNCTION cancel_eom_missed_call_on_interaction();
+
+COMMENT ON TABLE eom_missed_call_attempts IS
+    'Immutable, actor-attributed EOM no-answer call evidence; never inferred from public form submission.';
+COMMENT ON TABLE eom_missed_call_sequences IS
+    'Current durable state for one EOM residential lead missed-call recovery sequence.';
+COMMENT ON TABLE eom_missed_call_contact_suppressions IS
+    'EOM-local durable do-not-contact evidence for future missed-call sequences.';
+COMMENT ON TABLE eom_missed_call_sequence_steps IS
+    'Deterministic outbox steps with bounded retry and Resend idempotency evidence.';
+COMMENT ON TABLE eom_missed_call_sequence_events IS
+    'Append-only EOM missed-call recovery transition and delivery evidence.';

--- a/atlas_brain/templates/email/missed_call_recovery.py
+++ b/atlas_brain/templates/email/missed_call_recovery.py
@@ -1,0 +1,114 @@
+"""Deterministic EOM residential missed-call recovery messages.
+
+This module deliberately owns copy only.  Delivery eligibility, scheduling,
+idempotency, and state all live in ``services.eom_missed_call_recovery`` so a
+template render can never create a sequence or send customer mail.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .estimate_confirmation import BUSINESS_NAME, BUSINESS_PHONE
+
+
+@dataclass(frozen=True)
+class MissedCallRecoveryEmail:
+    """One immutable message snapshot suitable for the durable outbox."""
+
+    step_number: int
+    subject: str
+    body: str
+
+
+_SUBJECTS = {
+    1: "I tried reaching you about your cleaning estimate",
+    2: "Still interested in a cleaning estimate?",
+    3: "Should I keep your estimate request open?",
+}
+
+
+def _first_name(value: str) -> str:
+    """Return a safe, human greeting from canonical display text.
+
+    Contacts normally require a full name.  The fallback remains friendly for
+    historical rows that are malformed or were created by a channel that only
+    supplied a phone number; it never changes canonical contact data.
+    """
+
+    if not isinstance(value, str):
+        return "there"
+    parts = value.strip().split()
+    return parts[0] if parts else "there"
+
+
+def render_missed_call_recovery_email(
+    *,
+    step_number: int,
+    full_name: str,
+    booking_link: str,
+) -> MissedCallRecoveryEmail:
+    """Render one approved plaintext recovery email.
+
+    ``booking_link`` is a deploy-time setting supplied by the delivery service;
+    it is not a browser argument and is not stored in a response projection.
+    """
+
+    if step_number not in _SUBJECTS:
+        raise ValueError("missed-call recovery step number is invalid")
+    if not isinstance(booking_link, str) or not booking_link.strip():
+        raise ValueError("missed-call recovery booking link is required")
+
+    first_name = _first_name(full_name)
+    link = booking_link.strip()
+    if step_number == 1:
+        body = f"""Hi {first_name},
+
+I just tried calling you about your residential cleaning estimate.
+
+Whenever you have a moment, you can call or text me at {BUSINESS_PHONE}. You can also reply to this email or request a convenient estimate time here:
+
+{link}
+
+Requested times are not confirmed until we verify the appointment with you by phone or text.
+
+Thanks,
+Juan
+{BUSINESS_NAME}
+{BUSINESS_PHONE}
+"""
+    elif step_number == 2:
+        body = f"""Hi {first_name},
+
+I wanted to follow up in case we missed each other.
+
+I’d be happy to answer your questions and provide a residential cleaning estimate. You can call or text me at {BUSINESS_PHONE}, reply to this email, or request a time here:
+
+{link}
+
+We’ll confirm the appointment by phone or text before coming out.
+
+Thanks,
+Juan
+"""
+    else:
+        body = f"""Hi {first_name},
+
+I haven’t been able to catch you by phone, so I wanted to check in one last time.
+
+If you’re still looking for cleaning service, reply to this email, call or text {BUSINESS_PHONE}, or request an estimate time here:
+
+{link}
+
+If now isn’t the right time, no problem. You’re welcome to reach out whenever you’re ready.
+
+Requested times are not confirmed until we verify them by phone or text.
+
+Thanks,
+Juan
+"""
+    return MissedCallRecoveryEmail(
+        step_number=step_number,
+        subject=_SUBJECTS[step_number],
+        body=body,
+    )

--- a/docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md
+++ b/docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md
@@ -1,0 +1,108 @@
+# EOM missed-call recovery runbook
+
+This runbook operates the Atlas-owned recovery sequence that begins only after
+an authenticated office operator records an unanswered call for a current EOM
+residential estimate lead. It does not alter public form acknowledgement,
+confirm an estimate appointment, or send a message merely because a form was
+submitted.
+
+## Ownership and current deployment shape
+
+- Atlas owns call-attempt evidence, sequence/step state, eligibility,
+  scheduling, delivery evidence, retries, and cancellation.
+- The tracker proxies authenticated operator actions; the Website's CRM Leads
+  page displays status and never calls Atlas or Resend directly.
+- The 2026-08-21 preflight found production on the full
+  `atlas_brain.main:app` service. Re-check the active unit before every deploy;
+  the slim `atlas_brain.main_eom:app` configuration is kept compatible but is
+  not assumed to be the live process.
+
+Do not copy a booking URL, EOM service token, email token, contact email, or
+phone number into this document, shell history, PR text, fixtures, or logs.
+
+## Configuration
+
+Set these values in the authoritative Atlas runtime configuration. The booking
+URL must be a real public Google Calendar appointment-request URL; it is not an
+Atlas private booking endpoint and requesting a time does not confirm an
+appointment.
+
+| Setting | Safe value / purpose |
+| --- | --- |
+| `ATLAS_EOM_FUNNEL_MISSED_CALL_RECOVERY_ENABLED` | `false` by default. `true` permits the worker only after all preflight checks below pass. |
+| `ATLAS_EOM_FUNNEL_MISSED_CALL_BOOKING_LINK` | Private deploy-time Google Calendar URL. Never commit it. A blank value produces an inspectable blocked sequence and sends nothing. |
+| `ATLAS_EOM_FUNNEL_MISSED_CALL_TIMEZONE` | `America/Chicago` unless EOM's business timezone changes through an approved policy update. |
+| `ATLAS_EOM_FUNNEL_MISSED_CALL_POLL_INTERVAL_SECONDS` | Optional bounded worker interval; default `60`. |
+| `ATLAS_EOM_FUNNEL_MISSED_CALL_MAX_DELIVERY_ATTEMPTS` | Optional bounded definite-rejection retry limit; default `3`. |
+| `ATLAS_EOM_FUNNEL_MISSED_CALL_DELIVERY_TIMEOUT_SECONDS` | Optional bounded provider request timeout; default `10`. |
+
+The existing Atlas email configuration remains authoritative for sender and
+transport. Do not add a second EOM Resend key or browser-visible sender
+configuration. If email transport is unavailable, Atlas records the call but
+creates `blocked_configuration / email_transport_unavailable`; it does not
+claim or send a step.
+
+## Safe rollout order
+
+1. Deploy the Atlas provider code and migration `389_eom_missed_call_recovery`
+   with recovery disabled. Verify the full application starts, the migration is
+   recorded, and no worker is running.
+2. Deploy the tracker capability-backed proxy after Atlas is serving the named
+   endpoints.
+3. Deploy the Website CRM Leads card after the tracker advertises the exact
+   capability names and routes.
+4. Configure the private booking link and validate the process still starts
+   with recovery disabled. Do not place a placeholder or test link in customer
+   configuration.
+5. Verify the existing email transport is enabled and the sender remains the
+   established EOM sender. Then set recovery enabled and restart the Atlas
+   service.
+6. Use only controlled non-customer test data and a fake/sandbox provider for
+   pre-production verification. Do not test this by emailing a real lead.
+
+The sender is dormant until a real operator action creates an eligible sequence.
+Form submission by itself cannot create one.
+
+Email 2 becomes due at 09:00 on the next Monday-Friday date in the configured
+time zone. Email 3 becomes due three calendar days after Atlas records
+successful delivery of Email 2, so a delayed second email never compresses the
+final follow-up interval.
+
+## Operator-visible states and recovery
+
+| State | Meaning | Safe response |
+| --- | --- | --- |
+| `active` | Eligible sequence with a pending step or a completed earlier step. | The worker rechecks current lead state immediately before each send. |
+| `blocked_configuration` | Call evidence was saved, but recovery is disabled, no booking URL is present, or transport is unavailable. | Correct deploy configuration, then use the explicit resume action. Configuration alone does not silently send an old sequence. |
+| `cancelled` | A current lifecycle/response/suppression/recipient rule stopped future steps. | Do not restart it from the old call. Record a new real call only if follow-up is again appropriate. |
+| `completed` | All three approved messages were confirmed as sent. | No further automation occurs. |
+| `failed` | A definite provider rejection exhausted its bounded retries. | Investigate the provider/configuration. Do not assume an email was sent. A new sequence requires a new real call attempt. |
+| `recovery_required` | Provider delivery could not be proved without risking a duplicate message, or its idempotency window elapsed during recovery. | Treat as potentially sent. Do not retry or resend automatically; verify externally and use a separately recorded, deliberate operator action if needed. |
+
+Every current sequence state and step event is durable Atlas evidence. The
+legacy `sent_emails` history write is secondary: a post-send history failure
+never reverses truthful sequence delivery state or authorizes another send.
+
+## Immediate safety stop / rollback
+
+To halt new recovery mail, set
+`ATLAS_EOM_FUNNEL_MISSED_CALL_RECOVERY_ENABLED=false` and restart the Atlas
+service. This stops the worker while retaining immutable call attempts and
+sequence history. Do not drop migration 389 tables, events, or steps as a
+routine rollback.
+
+After an incident, retain the rows and inspect the sequence state, step state,
+provider message identifier, event ledger, and current contact/interactions
+before any manual customer outreach. A missing delivery confirmation is never
+evidence that a message was not accepted.
+
+## Current proof boundary
+
+Atlas stops a sequence from state it can prove: a recorded inbound CRM response,
+callback/conversation record, explicit opt-out, new estimate request, lifecycle
+advancement, customer conversion, loss/closure, commercial classification,
+recipient change/invalidity, or cancellation. The current system does **not**
+prove EOM email-reply correlation, eVoice call events, or a Google Calendar
+appointment-request selection for a canonical contact. Those channels must be
+recorded through the CRM/operator flow until a separately verified ingestion
+slice exists.

--- a/docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md
+++ b/docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md
@@ -46,7 +46,10 @@ claim or send a step.
 
 1. Deploy the Atlas provider code and migration `389_eom_missed_call_recovery`
    with recovery disabled. Verify the full application starts, the migration is
-   recorded, and no worker is running.
+   recorded, and no worker is running. On the compatible slim EOM profile,
+   `ATLAS_EOM_RUN_MIGRATIONS=true` applies this additive schema even while the
+   recovery flag remains disabled; that flag controls delivery, not schema
+   readiness.
 2. Deploy the tracker capability-backed proxy after Atlas is serving the named
    endpoints.
 3. Deploy the Website CRM Leads card after the tracker advertises the exact

--- a/docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md
+++ b/docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md
@@ -87,9 +87,12 @@ never reverses truthful sequence delivery state or authorizes another send.
 
 To halt new recovery mail, set
 `ATLAS_EOM_FUNNEL_MISSED_CALL_RECOVERY_ENABLED=false` and restart the Atlas
-service. This stops the worker while retaining immutable call attempts and
-sequence history. Do not drop migration 389 tables, events, or steps as a
-routine rollback.
+service. Startup durably moves every currently active sequence to
+`blocked_configuration / recovery_disabled`, then stops the worker while
+retaining immutable call attempts and sequence history. Restoring the flag does
+not send those overdue emails: an authenticated operator must explicitly resume
+each still-eligible sequence. Do not drop migration 389 tables, events, or
+steps as a routine rollback.
 
 After an incident, retain the rows and inspect the sequence state, step state,
 provider message identifier, event ledger, and current contact/interactions

--- a/plans/PR-EOM-Missed-Call-Recovery.md
+++ b/plans/PR-EOM-Missed-Call-Recovery.md
@@ -38,6 +38,7 @@ follow-up PRs.
 
 Ownership lane: eom/missed-call-recovery
 Slice phase: Vertical slice
+Max files: 13
 
 1. Add a provider-owned missed-call recovery sequence for one eligible
    residential web-estimate lead after a deliberate, actor-authenticated
@@ -332,8 +333,8 @@ Calendar correlation.
 | `atlas_brain/storage/migrations/389_eom_missed_call_recovery.sql` | 602 |
 | `atlas_brain/templates/email/missed_call_recovery.py` | 114 |
 | `docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md` | 111 |
-| `plans/PR-EOM-Missed-Call-Recovery.md` | 339 |
+| `plans/PR-EOM-Missed-Call-Recovery.md` | 340 |
 | `render.eom.yaml` | 9 |
 | `tests/test_eom_missed_call_recovery.py` | 1908 |
 | `tests/test_eom_render_profile.py` | 43 |
-| **Total** | **5921** |
+| **Total** | **5922** |

--- a/plans/PR-EOM-Missed-Call-Recovery.md
+++ b/plans/PR-EOM-Missed-Call-Recovery.md
@@ -335,6 +335,6 @@ Calendar correlation.
 | `docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md` | 111 |
 | `plans/PR-EOM-Missed-Call-Recovery.md` | 340 |
 | `render.eom.yaml` | 9 |
-| `tests/test_eom_missed_call_recovery.py` | 1908 |
+| `tests/test_eom_missed_call_recovery.py` | 1905 |
 | `tests/test_eom_render_profile.py` | 43 |
-| **Total** | **5922** |
+| **Total** | **5919** |

--- a/plans/PR-EOM-Missed-Call-Recovery.md
+++ b/plans/PR-EOM-Missed-Call-Recovery.md
@@ -1,0 +1,319 @@
+# PR-EOM-Missed-Call-Recovery
+
+## Why this slice exists
+
+EOM's public estimate form already captures a lead and sends one immediate
+transactional acknowledgement. There is no canonical record for Juan's later
+unanswered call and no durable, eligibility-gated recovery sequence. ATLAS
+#2474 previously scoped a first-email exploration; the approved product
+contract now supplies the three messages, timing, stop conditions, and
+explicit-operator trigger for this provider slice.
+
+Diff-budget override: this provider slice is intentionally above the 400-LOC
+target (about 5,000 added lines including real-Postgres proof and operating
+documentation) because a safe vertical boundary needs its additive database
+schema, durable two-phase provider claim, exact approved copy, both supported
+app lifespans, capability contract, controlled real-Postgres proof, and
+operating runbook in the same deployable change. Splitting those pieces would
+either expose a mutable/browser-owned sequence or ship a sender without its
+safety state. Tracker and Website consumption remain separate, smaller
+follow-up PRs.
+
+### Problem-derived contract
+
+- Root cause: an authenticated EOM operator cannot persist a no-answer outcome
+  against a canonical lead or safely cause a retryable follow-up. The generic
+  telecom callback has no proved lead identity and must not send customer mail.
+- Correct fix must touch/change: an additive Atlas migration, an Atlas-owned
+  call-attempt/sequence/step/event state machine, deterministic approved email
+  rendering, deploy-time configuration, a bounded in-process EOM worker, named
+  capability-backed funnel routes for the later tracker/UI bridge, and an
+  operating/recovery runbook.
+- Must not change: the public Website -> Web3Forms -> Atlas intake path, the
+  immediate acknowledgement copy and idempotency, generic telecom callbacks,
+  onboarding drafts, B2B campaigns, existing lead lifecycle commands, or the
+  in-flight tracker #237 / Website #258 CRM-directory work.
+
+## Scope (this PR)
+
+Ownership lane: eom/missed-call-recovery
+Slice phase: Vertical slice
+
+1. Add a provider-owned missed-call recovery sequence for one eligible
+   residential web-estimate lead after a deliberate, actor-authenticated
+   `Called - no answer` operation. It records immutable evidence before it
+   queues any email, calculates step 1 immediately, step 2 at 09:00 on the
+   next Monday-Friday business day in the configured EOM time zone, and step 3
+   three calendar days after successful delivery of step 2 at the same
+   configured local clock time.
+2. Add a locked, idempotent outbox worker with a durable pre-send claim and
+   stable Resend idempotency key, bounded retry only while that key is still
+   provider-valid, and an explicit `recovery_required` terminal state for
+   ambiguous delivery. It re-reads the canonical
+   contact/interaction/suppression state immediately before send and records
+   every send, skip, retry, cancellation, failure, or configuration block in an
+   append-only sequence-event ledger.
+3. Expose only additive Atlas routes: record no-answer, bounded status batch,
+   explicit resume after a configuration block, and explicit cancellation for
+   a manually verified callback/response/opt-out. The consumer bridge is
+   intentionally deferred until the published heads of tracker #237 and
+   Website #258 are stable.
+
+### Review Contract
+
+- Acceptance criteria:
+  - `record_no_answer` commits one actor-attributed call attempt and one active
+    sequence only for a current EOM lead whose latest intake proves the
+    residential estimate variant; focused tests prove form submission alone has
+    no sequence, commercial/closed leads do not start one, and same-key retries
+    return the original call-attempt result.
+  - A unique active-sequence constraint plus transaction-scoped contact and
+    sequence locks makes contemporaneous operations converge on one sequence.
+    A first transaction persists `attempting`, a claim token, and the provider
+    key expiry before external I/O; the second transaction locks and rechecks
+    current state immediately before delivery. The real-Postgres
+    concurrent-worker test proves one external gateway call, and the
+    crash-after-claim test proves expired unconfirmed work becomes visible
+    `recovery_required` rather than reusing a stale provider key.
+  - Each persisted step has deterministic subject/body/recipient snapshot and
+    a stable provider key. The Resend gateway attaches that key and retries only
+    inside its 24-hour evidence window; tests prove success, definite rejection,
+    retry exhaustion, and ambiguous crash/transport recovery do not duplicate
+    a send.
+  - The eligibility query and contacts/contact-interactions triggers cancel
+    remaining work for lifecycle advancement, customer conversion, lost or
+    archived state, commercial reclassification, later estimate request,
+    tracked inbound response, suppression, missing/invalid recipient, or an
+    explicit cancellation. SMS is positive-evidence-gated so a generic outbound
+    CRM SMS cannot impersonate a lead reply. Tests settle each permitted proof
+    path and show a change after scheduling but before delivery skips the send.
+  - The booking link is accepted only from deploy-time configuration and is
+    never returned by status endpoints or logged. A missing link, disabled
+    recovery flag, or unavailable email transport leaves a visible blocked
+    sequence and no email; explicit resume after a valid configuration is the
+    only configuration-block recovery path.
+  - `main.py` and `main_eom.py` start the bounded worker only when recovery is
+    enabled; a migration/readiness fence prevents an enabled deployment from
+    serving the new routes on a partial schema.
+  - Existing acknowledgement tests stay unchanged and all new fixtures use
+    `.example.test` identities plus a recording gateway; no test uses an Atlas
+    email credential or a real recipient.
+- Reachability proof: `POST /api/v1/eom-funnel/leads/{contact_id}/missed-call-attempts`
+  -> transactionally persisted call attempt/sequence/step rows -> background
+  worker claim -> current-state recheck -> Resend request with durable
+  idempotency key -> sequence event and tenant-scoped sent-email history. The
+  companion `GET /missed-call-recovery-status` exposes only status and next due
+  time for the tracker bridge.
+- Affected surfaces: EOM funnel configuration/startup, canonical contacts and
+  interactions, migration/readiness contract, Resend send adapter, and the
+  named Atlas service routes. Tracker #237 and Website #258 are explicitly out
+  of this provider PR.
+- Risk areas: customer-email duplication, recipient/config leakage, stale
+  lifecycle state, multiple workers, partial migration/startup, retry after
+  unknown delivery result, branch collisions, and accidental changes to intake
+  acknowledgement behavior.
+- Reviewer rules triggered: R1, R2, R3, R4, R5, R6, R8, R11, R12, R14.
+
+### Boundary-change enumeration
+
+- Boundary path/seam: authenticated tracker -> Atlas no-answer mutation;
+  Atlas worker -> Resend; contact/interaction state -> eligibility and
+  cancellation; configuration -> email rendering/startup readiness.
+- Replaced-path behaviors: none. The public intake acknowledgement and telecom
+  callback remain independent and unchanged.
+- Guard-relevant fields: EOM tenant, contact id, contact type/status/stage,
+  customer type, latest intake variant, snapshot recipient, operation key,
+  worker claim lease/provider idempotency key, booking URL, configuration
+  enablement, current interaction/suppression evidence.
+- Caller x input shape: tracker service credential + authenticated actor + a
+  UUID lead path and standard idempotency key; untrusted/malformed path and
+  JSON input fail before a CRM write; absent/older consumers omit all new calls
+  and therefore observe no behavior change.
+
+### Guard-class closure
+
+- **Lifecycle admission (`lead`, `active`, `new`, non-commercial, residential
+  intake): CLOSED / DERIVED / BLOCK.** Membership comes from the canonical
+  contact row plus the latest `web_form` estimate interaction already produced
+  by `atlas_brain/api/leads.py`; anything outside the affirmative shape records only the
+  call evidence and never creates a sequence. This is the safer side because a
+  false admission can send customer mail.
+- **Recovery states, step numbers, cancellation reasons, and capability names:
+  CLOSED / AUTHORED HERE or DERIVED / OMIT-BLOCK.** Migration 389 owns the
+  finite state/reason/step sets; route capability membership is mechanically
+  derived from registered router paths. Unknown database/API values are not
+  rendered as a sendable state, and unregistered capabilities are omitted so a
+  consumer disables its control.
+- **Booking-link host admission: CLOSED / AUTHORED HERE / BLOCK.** The only
+  approved public Google Calendar hosts are `calendar.google.com` and
+  `calendar.app.google`; malformed, credential-bearing, root, or alternate-port
+  URLs fail settings validation before a message can render. A generated
+  scheme/host/credential/port/path/suffix grammar matrix proves the exact
+  admission rule and unsafe-character rejection rather than approving only a
+  fixed list of sample URLs.
+- **Inbound-response recognition: OPEN / EVIDENCE-GATED / NO AUTOMATIC STOP.**
+  Free-form CRM interaction history cannot prove that every generic `sms` row
+  is inbound. The one currently verified EOM producer writes
+  `crm_event_id="sms:<provider id>"`; an explicit `direction=inbound` is a
+  future structural equivalent. All other SMS shapes continue the normal
+  eligibility path rather than claiming a reply. Dedicated inbound/response
+  interaction types, lifecycle transitions, suppression, and explicit operator
+  cancellation remain positive stop evidence. This preserves truthfulness while
+  the missing eVoice/email/calendar correlation is deferred.
+
+### Deployed-config probing
+
+- Deployed/default config values: recovery is disabled by default, booking URL
+  is blank by default, time zone defaults to `America/Chicago`, worker polling
+  and retry limits are bounded typed settings.
+- Explicit value probe: valid enablement plus HTTPS Google Calendar booking URL
+  yields rendered/persisted steps; time-zone tests cover Friday and weekend
+  origins.
+- Absent value probe: disabled or missing booking URL creates a blocked,
+  inspectable sequence with no rendered/sendable step and no provider call.
+- Default-session/default-context probe: a lead outside `effingham_maids`, a
+  non-residential intake, or a non-active/new contact is not admitted; status
+  reads never disclose another tenant's result.
+- Side-effect ordering: call attempt + sequence + event commit first; worker
+  claim and fresh eligibility check commit before provider I/O; provider result
+  becomes durable delivery evidence before optional sent-email-history write.
+
+### Files touched
+
+- `.github/workflows/atlas_eom_lead_pipeline_checks.yml`
+- `atlas_brain/eom_api/config.py`
+- `atlas_brain/eom_api/funnel.py`
+- `atlas_brain/main.py`
+- `atlas_brain/main_eom.py`
+- `atlas_brain/services/eom_missed_call_recovery.py`
+- `atlas_brain/storage/migrations/389_eom_missed_call_recovery.sql`
+- `atlas_brain/templates/email/missed_call_recovery.py`
+- `docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md`
+- `plans/PR-EOM-Missed-Call-Recovery.md`
+- `render.eom.yaml`
+- `tests/test_eom_missed_call_recovery.py`
+- `tests/test_eom_render_profile.py`
+
+## Mechanism
+
+Migration 389 creates four additive EOM-only tables: immutable no-answer call
+attempts; one current sequence per contact; exactly three deterministic outbox
+steps; and an append-only event ledger. The operator mutation also appends a
+canonical `contact_interactions` `call` / `no_answer` record and lifecycle
+event, so existing CRM history retains the action. Partial unique indexes and
+transaction-scoped row locks make the operation key a replay receipt and make
+an active sequence non-overlapping.
+
+The sequence starts only when the canonical contact is active, a lead at the
+`new` stage, has current residential web-estimate evidence, and has a valid
+recipient. Existing `unknown` customer type is permitted only because the
+web-form interaction carries the already-used residential acknowledgement
+variant; an explicit later commercial classification cancels the sequence. The
+contact, lifecycle, and interaction axes otherwise remain semantically
+unchanged.
+
+An explicit operator cancellation acquires/cancels the current sequence before
+it appends the ordinary CRM interaction in the same transaction. That ordering
+preserves the authenticated actor and stated reason in the sequence-event
+ledger; the interaction trigger then has no active sequence left to cancel.
+
+The worker first claims a due row with `FOR UPDATE SKIP LOCKED` and commits
+`attempting`, a random claim token, and a 23-hour provider-key safety window
+**before** any provider call. A second transaction locks the exact token,
+re-reads all eligibility, sends with `Idempotency-Key:
+eom-missed-call/<step UUID>`, and commits provider acceptance. A retry keeps
+the same immutable payload/key. A definite pre-acceptance rejection may retry
+up to the configured limit; an uncertain result, claim crash beyond the
+provider-key window, or unrecognized idempotency conflict becomes
+`recovery_required` rather than authorizing a duplicate email.
+
+The current code has no verified EOM email-reply correlation and eVoice does
+not emit canonical call/SMS events. The service therefore cancels only for
+responses it can prove now (a recorded inbound CRM interaction or an explicit
+operator cancellation), plus existing lifecycle and recipient evidence. This
+limitation is exposed in the issue/operating notes rather than represented as
+an unsupported automatic claim.
+
+## Intentional
+
+- Do not infer a no-answer from SignalWire/eVoice callbacks: the current
+  callback does not prove a canonical EOM contact.
+- Do not use the B2B campaign tables: their tenant, unsubscribe, and delivery
+  semantics are not the EOM CRM contract.
+- Do not use browser timers or direct browser email calls.
+- Use next weekday at 09:00 local time for email 2 because current EOM code
+  has no business-holiday calendar or office-hours scheduling representation;
+  email 3 is exactly three local-calendar days after successfully delivered
+  email 2 at the same local clock time, including across daylight-saving time.
+- Persist a short claim transaction before external I/O, then hold the
+  canonical contact lock only during the final recheck and bounded outbound
+  request. A concurrent lifecycle/response commit therefore linearizes either
+  before the final recheck (skip) or after the send (truthfully current at
+  send), while a process crash retains the claim/key window as durable evidence.
+
+## Deferred
+
+1. Tracker proxy + Website lead-card action/status integration follows published
+   tracker #237 then Website #258, so it does not race their active
+   `time_tracker_api.py` / `lead-review.js` edits. See ATLAS #2474.
+2. EOM-specific inbound email reply correlation and eVoice/telephony event
+   ingestion are not currently evidenced; add them as a separate verified
+   intake slice before claiming automatic coverage beyond recorded interactions.
+   This is parked in ATLAS #2474 because an uncorrelated inbox/call record is
+   not safe stop evidence.
+3. A holiday calendar/office-hours policy is deferred; the initial definition
+   of "business day" is Monday-Friday in the configured time zone.
+
+Parking predicate: inbound-channel correlation and holiday policy are deferred
+only because no current canonical producer can prove them. Customer-mail safety,
+sequence correctness, and deployment readiness remain in this provider slice.
+
+Parked hardening: ATLAS #2474 follow-up for verified EOM email/eVoice/Google
+Calendar correlation.
+
+## Verification
+
+- `ruff format --check atlas_brain/services/eom_missed_call_recovery.py
+  atlas_brain/templates/email/missed_call_recovery.py
+  tests/test_eom_missed_call_recovery.py` — pass.
+- `python -m py_compile atlas_brain/services/eom_missed_call_recovery.py
+  atlas_brain/templates/email/missed_call_recovery.py atlas_brain/eom_api/config.py
+  atlas_brain/eom_api/funnel.py atlas_brain/main.py atlas_brain/main_eom.py` —
+  pass.
+- `ruff check --ignore E402 atlas_brain/eom_api/config.py
+  atlas_brain/eom_api/funnel.py atlas_brain/main.py atlas_brain/main_eom.py
+  atlas_brain/services/eom_missed_call_recovery.py
+  atlas_brain/templates/email/missed_call_recovery.py
+  tests/test_eom_missed_call_recovery.py tests/test_eom_render_profile.py` —
+  pass. `E402` is the existing two-entrypoint dotenv-before-import startup
+  pattern; this slice does not reformat or move that runtime behavior.
+- `pytest -q tests/test_eom_missed_call_recovery.py
+  tests/test_eom_render_profile.py::test_eom_profile_import_does_not_load_full_api_package
+  tests/test_eom_render_profile.py::test_eom_render_blueprint_maps_database_and_receivables_auth
+  tests/test_eom_render_profile.py::test_eom_missed_call_recovery_migration_helper_uses_funnel_curated_set
+  tests/test_leads_intake.py` — `95 passed, 31 skipped, 1 upstream pynvml
+  deprecation warning`; the real-Postgres cases are correctly skipped locally
+  because `ATLAS_MIGRATION_TEST_DATABASE_URL` is unavailable.
+- `git diff --check` — pass.
+- Full pipeline, migration integration, and security checks run on GitHub CI
+  after the ready-for-review PR is opened; do not duplicate that full suite
+  locally.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 11 |
+| `atlas_brain/eom_api/config.py` | 128 |
+| `atlas_brain/eom_api/funnel.py` | 218 |
+| `atlas_brain/main.py` | 45 |
+| `atlas_brain/main_eom.py` | 73 |
+| `atlas_brain/services/eom_missed_call_recovery.py` | 2143 |
+| `atlas_brain/storage/migrations/389_eom_missed_call_recovery.sql` | 497 |
+| `atlas_brain/templates/email/missed_call_recovery.py` | 114 |
+| `docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md` | 108 |
+| `plans/PR-EOM-Missed-Call-Recovery.md` | 319 |
+| `render.eom.yaml` | 9 |
+| `tests/test_eom_missed_call_recovery.py` | 1325 |
+| `tests/test_eom_render_profile.py` | 43 |
+| **Total** | **5033** |

--- a/plans/PR-EOM-Missed-Call-Recovery.md
+++ b/plans/PR-EOM-Missed-Call-Recovery.md
@@ -67,11 +67,14 @@ Slice phase: Vertical slice
     residential estimate variant; focused tests prove form submission alone has
     no sequence, commercial/closed leads do not start one, and same-key retries
     return the original call-attempt result.
-  - A unique active-sequence constraint plus transaction-scoped contact and
-    sequence locks makes contemporaneous operations converge on one sequence.
-    A first transaction persists `attempting`, a claim token, and the provider
-    key expiry before external I/O; the second transaction locks and rechecks
-    current state immediately before delivery. The real-Postgres
+  - A globally unique, append-only operation receipt binds every no-answer,
+    resume, or cancellation idempotency key to one contact, mutation kind, and
+    request fingerprint before state changes. Cross-contact/key-reuse fails
+    closed; a unique active-sequence constraint plus transaction-scoped contact
+    and sequence locks makes contemporaneous qualifying calls converge on one
+    sequence. A first transaction persists `attempting`, a claim token, and
+    the provider key expiry before external I/O; the second transaction locks
+    and rechecks current state immediately before delivery. The real-Postgres
     concurrent-worker test proves one external gateway call, and the
     crash-after-claim test proves expired unconfirmed work becomes visible
     `recovery_required` rather than reusing a stale provider key.
@@ -84,17 +87,25 @@ Slice phase: Vertical slice
     remaining work for lifecycle advancement, customer conversion, lost or
     archived state, commercial reclassification, later estimate request,
     tracked inbound response, suppression, missing/invalid recipient, or an
-    explicit cancellation. SMS is positive-evidence-gated so a generic outbound
-    CRM SMS cannot impersonate a lead reply. Tests settle each permitted proof
-    path and show a change after scheduling but before delivery skips the send.
+    explicit cancellation. Recipient-change cancellation compares the actual
+    latest estimate-form recipient rather than a non-authoritative contact
+    email correction, and interaction cancellation requires evidence occurring
+    after the sequence began. SMS is positive-evidence-gated so a generic
+    outbound CRM SMS cannot impersonate a lead reply. Tests settle each
+    permitted proof path and show a change after scheduling but before delivery
+    skips the send.
   - The booking link is accepted only from deploy-time configuration and is
     never returned by status endpoints or logged. A missing link, disabled
     recovery flag, or unavailable email transport leaves a visible blocked
-    sequence and no email; explicit resume after a valid configuration is the
-    only configuration-block recovery path.
-  - `main.py` and `main_eom.py` start the bounded worker only when recovery is
-    enabled; a migration/readiness fence prevents an enabled deployment from
-    serving the new routes on a partial schema.
+    sequence and no email. Worker startup and each dispatch persist that block
+    for every previously active sequence. A pre-send claim racing that pause is
+    preserved as unproven provider evidence, not skipped; restoring
+    configuration requires an explicit resume and cannot silently send an
+    overdue email.
+  - Both `main.py` and `main_eom.py` call one shared prepare boundary during a
+    canonical-database lifespan. It blocks active rows when disabled or
+    misconfigured, starts only a delivery-ready worker, and makes an enabled
+    partial schema a startup failure.
   - Existing acknowledgement tests stay unchanged and all new fixtures use
     `.example.test` identities plus a recording gateway; no test uses an Atlas
     email credential or a real recipient.
@@ -196,13 +207,15 @@ Slice phase: Vertical slice
 
 ## Mechanism
 
-Migration 389 creates four additive EOM-only tables: immutable no-answer call
-attempts; one current sequence per contact; exactly three deterministic outbox
-steps; and an append-only event ledger. The operator mutation also appends a
-canonical `contact_interactions` `call` / `no_answer` record and lifecycle
-event, so existing CRM history retains the action. Partial unique indexes and
-transaction-scoped row locks make the operation key a replay receipt and make
-an active sequence non-overlapping.
+Migration 389 creates five additive EOM-only tables: globally unique immutable
+operation receipts; immutable no-answer call attempts; one current sequence per
+contact; exactly three deterministic outbox steps; and an append-only event
+ledger. The operation receipt binds key, contact, mutation kind, and request
+fingerprint before a mutation, so a stale retry cannot cross contacts or reuse
+another recovery action. The operator mutation also appends a canonical
+`contact_interactions` `call` / `no_answer` record and lifecycle event, so
+existing CRM history retains the action. Partial unique indexes and
+transaction-scoped row locks make an active sequence non-overlapping.
 
 The sequence starts only when the canonical contact is active, a lead at the
 `new` stage, has current residential web-estimate evidence, and has a valid
@@ -250,6 +263,13 @@ an unsupported automatic claim.
   request. A concurrent lifecycle/response commit therefore linearizes either
   before the final recheck (skip) or after the send (truthfully current at
   send), while a process crash retains the claim/key window as durable evidence.
+- Use the real Resend adapter in a mock transport test so accepted, definite
+  rejection, and ambiguous response classifications prove its exact wire
+  behavior without sending an actual email.
+- Preserve any durable pre-send claim across a configuration pause. After an
+  explicit resume, the normal provider-key recovery window decides whether it
+  can be safely retried or must become `recovery_required`; the pause itself
+  never rewrites that unknown outcome as a skipped message.
 
 ## Deferred
 
@@ -291,7 +311,7 @@ Calendar correlation.
   tests/test_eom_render_profile.py::test_eom_profile_import_does_not_load_full_api_package
   tests/test_eom_render_profile.py::test_eom_render_blueprint_maps_database_and_receivables_auth
   tests/test_eom_render_profile.py::test_eom_missed_call_recovery_migration_helper_uses_funnel_curated_set
-  tests/test_leads_intake.py` — `95 passed, 31 skipped, 1 upstream pynvml
+  tests/test_leads_intake.py` — `99 passed, 37 skipped, 1 upstream pynvml
   deprecation warning`; the real-Postgres cases are correctly skipped locally
   because `ATLAS_MIGRATION_TEST_DATABASE_URL` is unavailable.
 - `git diff --check` — pass.
@@ -306,14 +326,14 @@ Calendar correlation.
 | `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 11 |
 | `atlas_brain/eom_api/config.py` | 128 |
 | `atlas_brain/eom_api/funnel.py` | 218 |
-| `atlas_brain/main.py` | 45 |
-| `atlas_brain/main_eom.py` | 73 |
-| `atlas_brain/services/eom_missed_call_recovery.py` | 2143 |
-| `atlas_brain/storage/migrations/389_eom_missed_call_recovery.sql` | 497 |
+| `atlas_brain/main.py` | 35 |
+| `atlas_brain/main_eom.py` | 66 |
+| `atlas_brain/services/eom_missed_call_recovery.py` | 2337 |
+| `atlas_brain/storage/migrations/389_eom_missed_call_recovery.sql` | 602 |
 | `atlas_brain/templates/email/missed_call_recovery.py` | 114 |
-| `docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md` | 108 |
-| `plans/PR-EOM-Missed-Call-Recovery.md` | 319 |
+| `docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md` | 111 |
+| `plans/PR-EOM-Missed-Call-Recovery.md` | 339 |
 | `render.eom.yaml` | 9 |
-| `tests/test_eom_missed_call_recovery.py` | 1325 |
+| `tests/test_eom_missed_call_recovery.py` | 1908 |
 | `tests/test_eom_render_profile.py` | 43 |
-| **Total** | **5033** |
+| **Total** | **5921** |

--- a/plans/PR-EOM-Missed-Call-Recovery.md
+++ b/plans/PR-EOM-Missed-Call-Recovery.md
@@ -38,7 +38,7 @@ follow-up PRs.
 
 Ownership lane: eom/missed-call-recovery
 Slice phase: Vertical slice
-Max files: 13
+Max files: 14
 
 1. Add a provider-owned missed-call recovery sequence for one eligible
    residential web-estimate lead after a deliberate, actor-authenticated
@@ -203,6 +203,7 @@ Max files: 13
 - `docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md`
 - `plans/PR-EOM-Missed-Call-Recovery.md`
 - `render.eom.yaml`
+- `tests/test_eom_lead_conversion.py`
 - `tests/test_eom_missed_call_recovery.py`
 - `tests/test_eom_render_profile.py`
 
@@ -315,6 +316,17 @@ Calendar correlation.
   tests/test_leads_intake.py` — `99 passed, 37 skipped, 1 upstream pynvml
   deprecation warning`; the real-Postgres cases are correctly skipped locally
   because `ATLAS_MIGRATION_TEST_DATABASE_URL` is unavailable.
+- `ruff check --ignore E402 atlas_brain/services/eom_missed_call_recovery.py
+  tests/test_eom_lead_conversion.py`, `python -m py_compile
+  atlas_brain/services/eom_missed_call_recovery.py
+  tests/test_eom_lead_conversion.py`, and `pytest -q
+  tests/test_eom_lead_conversion.py::test_full_app_lifespan_executes_enabled_preflight_before_handoff_request`
+  — pass; the one focused full-app lifespan proof emitted only the upstream
+  `pynvml` deprecation warning.
+- With a disposable local PostgreSQL schema and the recording gateway,
+  `pytest -q tests/test_eom_missed_call_recovery.py::test_effective_form_recipient_change_cancels_before_delivery`
+  — `1 passed`; it proves that correcting the actual estimate-form recipient
+  cancels before any fake provider call.
 - `git diff --check` — pass.
 - Full pipeline, migration integration, and security checks run on GitHub CI
   after the ready-for-review PR is opened; do not duplicate that full suite
@@ -329,12 +341,13 @@ Calendar correlation.
 | `atlas_brain/eom_api/funnel.py` | 218 |
 | `atlas_brain/main.py` | 35 |
 | `atlas_brain/main_eom.py` | 66 |
-| `atlas_brain/services/eom_missed_call_recovery.py` | 2337 |
+| `atlas_brain/services/eom_missed_call_recovery.py` | 2342 |
 | `atlas_brain/storage/migrations/389_eom_missed_call_recovery.sql` | 602 |
 | `atlas_brain/templates/email/missed_call_recovery.py` | 114 |
 | `docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md` | 111 |
-| `plans/PR-EOM-Missed-Call-Recovery.md` | 340 |
+| `plans/PR-EOM-Missed-Call-Recovery.md` | 353 |
 | `render.eom.yaml` | 9 |
+| `tests/test_eom_lead_conversion.py` | 19 |
 | `tests/test_eom_missed_call_recovery.py` | 1905 |
 | `tests/test_eom_render_profile.py` | 79 |
-| **Total** | **5955** |
+| **Total** | **5992** |

--- a/plans/PR-EOM-Missed-Call-Recovery.md
+++ b/plans/PR-EOM-Missed-Call-Recovery.md
@@ -83,7 +83,9 @@ Max files: 14
     a stable provider key. The Resend gateway attaches that key and retries only
     inside its 24-hour evidence window; tests prove success, definite rejection,
     retry exhaustion, and ambiguous crash/transport recovery do not duplicate
-    a send.
+    a send. A Resend `concurrent_idempotent_requests` response retries the
+    same key while safe but becomes visible `recovery_required` rather than a
+    false definite failure when its bounded attempts are exhausted.
   - The eligibility query and contacts/contact-interactions triggers cancel
     remaining work for lifecycle advancement, customer conversion, lost or
     archived state, commercial reclassification, later estimate request,
@@ -94,7 +96,11 @@ Max files: 14
     after the sequence began. SMS is positive-evidence-gated so a generic
     outbound CRM SMS cannot impersonate a lead reply. Tests settle each
     permitted proof path and show a change after scheduling but before delivery
-    skips the send.
+    skips the send. Every mutable interaction first takes the same canonical
+    contact lock as final delivery; after acquiring it, the worker reads latest
+    intake evidence in a fresh statement. Controlled cross-connection proofs
+    cover both correction-before-recheck (skip) and correction-after-final-lock
+    (the correction waits, then cancels remaining work).
   - The booking link is accepted only from deploy-time configuration and is
     never returned by status endpoints or logged. A missing link, disabled
     recovery flag, or unavailable email transport leaves a visible blocked
@@ -106,7 +112,9 @@ Max files: 14
   - Both `main.py` and `main_eom.py` call one shared prepare boundary during a
     canonical-database lifespan. It blocks active rows when disabled or
     misconfigured, starts only a delivery-ready worker, and makes an enabled
-    partial schema a startup failure.
+    partial schema a startup failure. The slim profile applies the additive
+    recovery migration whenever its startup-migration flag is set, even while
+    customer-email delivery remains disabled.
   - Existing acknowledgement tests stay unchanged and all new fixtures use
     `.example.test` identities plus a recording gateway; no test uses an Atlas
     email credential or a real recipient.
@@ -327,6 +335,15 @@ Calendar correlation.
   `pytest -q tests/test_eom_missed_call_recovery.py::test_effective_form_recipient_change_cancels_before_delivery`
   — `1 passed`; it proves that correcting the actual estimate-form recipient
   cancels before any fake provider call.
+- `ruff check --ignore E402`, `ruff format --check`, and `python -m py_compile`
+  over the changed recovery service, slim entrypoint, and recovery test module
+  — pass. The focused real-adapter/slim-disabled-startup/full-app-startup
+  regression command passed `3` tests (the existing full-app proof emitted only
+  the upstream `pynvml` warning).
+- With a disposable local PostgreSQL schema, the focused recipient-lock,
+  tenant-transfer, concurrent-idempotency, normal-delivery, and two-worker
+  proofs passed `6` tests. They use only `.example.test` identities and fake or
+  mock-transport gateways; no test sends customer email.
 - `git diff --check` — pass.
 - Full pipeline, migration integration, and security checks run on GitHub CI
   after the ready-for-review PR is opened; do not duplicate that full suite
@@ -340,14 +357,14 @@ Calendar correlation.
 | `atlas_brain/eom_api/config.py` | 128 |
 | `atlas_brain/eom_api/funnel.py` | 218 |
 | `atlas_brain/main.py` | 35 |
-| `atlas_brain/main_eom.py` | 66 |
-| `atlas_brain/services/eom_missed_call_recovery.py` | 2342 |
-| `atlas_brain/storage/migrations/389_eom_missed_call_recovery.sql` | 602 |
+| `atlas_brain/main_eom.py` | 67 |
+| `atlas_brain/services/eom_missed_call_recovery.py` | 2400 |
+| `atlas_brain/storage/migrations/389_eom_missed_call_recovery.sql` | 717 |
 | `atlas_brain/templates/email/missed_call_recovery.py` | 114 |
-| `docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md` | 111 |
-| `plans/PR-EOM-Missed-Call-Recovery.md` | 353 |
+| `docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md` | 114 |
+| `plans/PR-EOM-Missed-Call-Recovery.md` | 370 |
 | `render.eom.yaml` | 9 |
 | `tests/test_eom_lead_conversion.py` | 19 |
-| `tests/test_eom_missed_call_recovery.py` | 1905 |
+| `tests/test_eom_missed_call_recovery.py` | 2235 |
 | `tests/test_eom_render_profile.py` | 79 |
-| **Total** | **5992** |
+| **Total** | **6516** |

--- a/plans/PR-EOM-Missed-Call-Recovery.md
+++ b/plans/PR-EOM-Missed-Call-Recovery.md
@@ -336,5 +336,5 @@ Calendar correlation.
 | `plans/PR-EOM-Missed-Call-Recovery.md` | 340 |
 | `render.eom.yaml` | 9 |
 | `tests/test_eom_missed_call_recovery.py` | 1905 |
-| `tests/test_eom_render_profile.py` | 43 |
-| **Total** | **5919** |
+| `tests/test_eom_render_profile.py` | 79 |
+| **Total** | **5955** |

--- a/render.eom.yaml
+++ b/render.eom.yaml
@@ -32,6 +32,15 @@ services:
         sync: false
       - key: ATLAS_EOM_FUNNEL_DB_CONNECTION_STRING
         sync: false
+      # Remains fail-closed until the Atlas provider, tracker proxy, and CRM
+      # Leads card are all deployed. The booking URL is intentionally a
+      # deploy-time secret/configuration value rather than repository copy.
+      - key: ATLAS_EOM_FUNNEL_MISSED_CALL_RECOVERY_ENABLED
+        value: "false"
+      - key: ATLAS_EOM_FUNNEL_MISSED_CALL_BOOKING_LINK
+        sync: false
+      - key: ATLAS_EOM_FUNNEL_MISSED_CALL_TIMEZONE
+        value: "America/Chicago"
       - key: ATLAS_EOM_CANONICAL_CRM_DATABASE_CONFIRMED
         value: "false"
       - key: ATLAS_EOM_RUN_MIGRATIONS

--- a/tests/test_eom_lead_conversion.py
+++ b/tests/test_eom_lead_conversion.py
@@ -3154,6 +3154,13 @@ async def test_full_app_lifespan_executes_enabled_preflight_before_handoff_reque
         async def fetchval(self, _query: str) -> bool:
             return True
 
+        @asynccontextmanager
+        async def transaction(self):
+            yield self
+
+        async def fetch(self, _query: str, *_args: object) -> list[object]:
+            return []
+
     async def no_op(*_args, **_kwargs):
         return None
 
@@ -3178,7 +3185,17 @@ async def test_full_app_lifespan_executes_enabled_preflight_before_handoff_reque
     monkeypatch.setattr(auth_mod, "funnel_settings", config)
     monkeypatch.setattr(main, "settings", runtime_settings)
     monkeypatch.setattr(main, "db_settings", SimpleNamespace(enabled=True))
-    pools = iter((_Pool(initialized=False), _Pool(initialized=True)))
+    # Full-app startup now performs the generic migration check, the existing
+    # EOM lifecycle preflight, and its independent disabled-recovery pause
+    # fence. Model all three canonical-pool reads so this test continues to
+    # exercise the real lifespan rather than stubbing the new safety boundary.
+    pools = iter(
+        (
+            _Pool(initialized=False),
+            _Pool(initialized=True),
+            _Pool(initialized=True),
+        )
+    )
     monkeypatch.setattr(main, "get_db_pool", lambda: next(pools))
     monkeypatch.setattr(main, "init_database", no_op)
     monkeypatch.setattr(main, "close_database", no_op)

--- a/tests/test_eom_missed_call_recovery.py
+++ b/tests/test_eom_missed_call_recovery.py
@@ -1,0 +1,1325 @@
+"""Durable EOM missed-call recovery proof.
+
+All addresses in this module use the reserved ``example.test`` domain.  The
+worker receives fake gateways only; no test can call a live email provider or
+schedule a real appointment.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
+from itertools import product
+from pathlib import Path
+from typing import Any
+from uuid import UUID, uuid4
+from zoneinfo import ZoneInfo
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+asyncpg = pytest.importorskip("asyncpg")
+
+from atlas_brain.eom_api import funnel as funnel_mod  # noqa: E402
+from atlas_brain.eom_api import funnel_auth as funnel_auth_mod  # noqa: E402
+from atlas_brain.eom_api.config import EOMFunnelConfig  # noqa: E402
+from atlas_brain.services.eom_missed_call_recovery import (  # noqa: E402
+    EOMMissedCallRecoveryConflictError,
+    EOMMissedCallRecoveryService,
+    _DefiniteDeliveryError,
+    _third_step_due,
+    next_business_day_due,
+)
+from atlas_brain.templates.email.estimate_confirmation import (  # noqa: E402
+    BUSINESS_NAME,
+    BUSINESS_PHONE,
+)
+from atlas_brain.templates.email.missed_call_recovery import (  # noqa: E402
+    render_missed_call_recovery_email,
+)
+
+
+ROOT = Path(__file__).resolve().parent.parent
+MIGRATIONS = ROOT / "atlas_brain" / "storage" / "migrations"
+DATABASE_URL_ENV = "ATLAS_MIGRATION_TEST_DATABASE_URL"
+_EOM_CONTEXT = "effingham_maids"
+_BOOKING_LINK = "https://calendar.app.google/eom-test-booking"
+_NOW = datetime(2026, 8, 21, 15, 0, tzinfo=timezone.utc)
+
+
+class _ConnectionPool:
+    """Give a real asyncpg connection the small pool API this service needs."""
+
+    is_initialized = True
+
+    def __init__(self, connection: Any) -> None:
+        self._connection = connection
+
+    @asynccontextmanager
+    async def transaction(self):
+        async with self._connection.transaction():
+            yield self._connection
+
+    async def fetch(self, *args: Any, **kwargs: Any) -> Any:
+        return await self._connection.fetch(*args, **kwargs)
+
+    async def fetchrow(self, *args: Any, **kwargs: Any) -> Any:
+        return await self._connection.fetchrow(*args, **kwargs)
+
+    async def fetchval(self, *args: Any, **kwargs: Any) -> Any:
+        return await self._connection.fetchval(*args, **kwargs)
+
+
+class _FakeGateway:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, str]] = []
+
+    async def send(self, **kwargs: str) -> str:
+        self.calls.append(dict(kwargs))
+        return f"test-resend-{len(self.calls)}"
+
+
+class _BlockingGateway(_FakeGateway):
+    def __init__(self) -> None:
+        super().__init__()
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def send(self, **kwargs: str) -> str:
+        self.calls.append(dict(kwargs))
+        self.started.set()
+        await self.release.wait()
+        return f"test-resend-{len(self.calls)}"
+
+
+class _RetryingGateway(_FakeGateway):
+    async def send(self, **kwargs: str) -> str:
+        self.calls.append(dict(kwargs))
+        raise _DefiniteDeliveryError("test_transport_rejected", retryable=True)
+
+
+class _History:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def create(self, **kwargs: Any) -> object:
+        self.calls.append(kwargs)
+        return object()
+
+
+def _database_url_or_skip() -> str:
+    database_url = os.environ.get(DATABASE_URL_ENV)
+    if not database_url:
+        pytest.skip(f"{DATABASE_URL_ENV} is not configured")
+    return database_url
+
+
+async def _apply_schema(connection: Any, schema: str) -> None:
+    await connection.execute(f'CREATE SCHEMA "{schema}"')
+    await connection.execute(f'SET search_path TO "{schema}", public')
+    # 035 keeps the FK additive for existing Atlas schema, but a focused empty
+    # migration schema needs the referenced base relation before it runs.
+    await connection.execute("CREATE TABLE appointments (id UUID PRIMARY KEY)")
+    for name in (
+        "035_contacts.sql",
+        "256_contact_interaction_dedupe.sql",
+        "346_contact_lead_pipeline.sql",
+        "351_eom_lead_lifecycle_events.sql",
+        "363_eom_lead_lifecycle_sequence.sql",
+        "366_contacts_customer_type.sql",
+        "389_eom_missed_call_recovery.sql",
+    ):
+        await connection.execute((MIGRATIONS / name).read_text())
+
+
+@asynccontextmanager
+async def _test_store():
+    database_url = _database_url_or_skip()
+    schema = f"atlas_eom_missed_call_{uuid4().hex}"
+    connection = await asyncpg.connect(database_url)
+    try:
+        await _apply_schema(connection, schema)
+        yield _ConnectionPool(connection), schema
+    finally:
+        try:
+            await connection.execute("RESET search_path")
+            await connection.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        finally:
+            await connection.close()
+
+
+async def _schema_connection(database_url: str, schema: str) -> _ConnectionPool:
+    connection = await asyncpg.connect(database_url)
+    await connection.execute(f'SET search_path TO "{schema}", public')
+    return _ConnectionPool(connection)
+
+
+async def _close_schema_connection(pool: _ConnectionPool) -> None:
+    await pool._connection.close()
+
+
+def _config(
+    *, enabled: bool = True, booking_link: str = _BOOKING_LINK
+) -> EOMFunnelConfig:
+    return EOMFunnelConfig(
+        api_enabled=True,
+        missed_call_recovery_enabled=enabled,
+        missed_call_booking_link=booking_link,
+        missed_call_timezone="America/Chicago",
+        missed_call_poll_interval_seconds=30,
+        missed_call_max_delivery_attempts=3,
+        missed_call_delivery_timeout_seconds=5,
+    )
+
+
+def _operation_key(prefix: str = "missed-call") -> str:
+    return f"{prefix}-{uuid4().hex}"
+
+
+async def _insert_estimate_lead(
+    pool: _ConnectionPool,
+    *,
+    contact_id: UUID | None = None,
+    ack_variant: str = "residential",
+    email: str = "lead@example.test",
+) -> UUID:
+    contact_id = contact_id or uuid4()
+    now = _NOW - timedelta(minutes=2)
+    await pool._connection.execute(
+        """
+        INSERT INTO contacts (
+            id, full_name, email, business_context_id, contact_type, status,
+            lead_stage, source, customer_type, created_at
+        ) VALUES ($1, 'Recovery Test Lead', $2, $3, 'lead', 'active', 'new',
+                  'web', 'unknown', $4)
+        """,
+        contact_id,
+        email,
+        _EOM_CONTEXT,
+        now,
+    )
+    await pool._connection.execute(
+        """
+        INSERT INTO contact_interactions (
+            id, contact_id, interaction_type, summary, intent, occurred_at,
+            metadata, interaction_dedupe_key
+        ) VALUES ($1, $2, 'web_form', 'Controlled estimate request',
+                  'estimate_request', $3, $4::jsonb, $5)
+        """,
+        uuid4(),
+        contact_id,
+        now,
+        json.dumps(
+            {
+                "submitted_email": email,
+                "ack_variant": ack_variant,
+                "service": "residential cleaning",
+            }
+        ),
+        f"estimate-{contact_id}",
+    )
+    return contact_id
+
+
+def _service(
+    pool: _ConnectionPool,
+    *,
+    gateway: Any | None = None,
+    now_box: dict[str, datetime] | None = None,
+    history: Any | None = None,
+    config: EOMFunnelConfig | None = None,
+) -> EOMMissedCallRecoveryService:
+    clock = now_box if now_box is not None else {"now": _NOW}
+    return EOMMissedCallRecoveryService(
+        pool=pool,
+        config=config or _config(),
+        # Tests always use an explicit local gateway; never fall through to
+        # process-level email credentials even if a developer has them loaded.
+        gateway=gateway if gateway is not None else _FakeGateway(),
+        now=lambda: clock["now"],
+        email_history=history,
+    )
+
+
+def test_recovery_templates_match_approved_copy_exactly() -> None:
+    first = render_missed_call_recovery_email(
+        step_number=1,
+        full_name="Ada Lovelace",
+        booking_link=_BOOKING_LINK,
+    )
+    assert first.subject == "I tried reaching you about your cleaning estimate"
+    assert (
+        first.body
+        == f"""Hi Ada,
+
+I just tried calling you about your residential cleaning estimate.
+
+Whenever you have a moment, you can call or text me at {BUSINESS_PHONE}. You can also reply to this email or request a convenient estimate time here:
+
+{_BOOKING_LINK}
+
+Requested times are not confirmed until we verify the appointment with you by phone or text.
+
+Thanks,
+Juan
+{BUSINESS_NAME}
+{BUSINESS_PHONE}
+"""
+    )
+
+    second = render_missed_call_recovery_email(
+        step_number=2,
+        full_name="Ada Lovelace",
+        booking_link=_BOOKING_LINK,
+    )
+    assert second.subject == "Still interested in a cleaning estimate?"
+    assert (
+        second.body
+        == f"""Hi Ada,
+
+I wanted to follow up in case we missed each other.
+
+I’d be happy to answer your questions and provide a residential cleaning estimate. You can call or text me at {BUSINESS_PHONE}, reply to this email, or request a time here:
+
+{_BOOKING_LINK}
+
+We’ll confirm the appointment by phone or text before coming out.
+
+Thanks,
+Juan
+"""
+    )
+
+    third = render_missed_call_recovery_email(
+        step_number=3,
+        full_name="Ada Lovelace",
+        booking_link=_BOOKING_LINK,
+    )
+    assert third.subject == "Should I keep your estimate request open?"
+    assert (
+        third.body
+        == f"""Hi Ada,
+
+I haven’t been able to catch you by phone, so I wanted to check in one last time.
+
+If you’re still looking for cleaning service, reply to this email, call or text {BUSINESS_PHONE}, or request an estimate time here:
+
+{_BOOKING_LINK}
+
+If now isn’t the right time, no problem. You’re welcome to reach out whenever you’re ready.
+
+Requested times are not confirmed until we verify them by phone or text.
+
+Thanks,
+Juan
+"""
+    )
+
+
+@pytest.mark.parametrize(
+    "from_time, expected_date",
+    (
+        (datetime(2026, 8, 21, 15, tzinfo=timezone.utc), "2026-08-24"),
+        (datetime(2026, 8, 22, 15, tzinfo=timezone.utc), "2026-08-24"),
+        (datetime(2026, 8, 23, 15, tzinfo=timezone.utc), "2026-08-24"),
+    ),
+)
+def test_next_business_day_is_local_weekday_nine_am(
+    from_time: datetime,
+    expected_date: str,
+) -> None:
+    due = next_business_day_due(from_time, timezone_name="America/Chicago")
+    local = due.astimezone(ZoneInfo("America/Chicago"))
+    assert local.date().isoformat() == expected_date
+    assert (local.hour, local.minute, local.weekday()) == (9, 0, 0)
+
+
+def test_third_step_preserves_eom_local_clock_time_across_dst() -> None:
+    # Friday 09:00 CDT becomes Monday 09:00 CST, not Monday 08:00 CST from a
+    # raw UTC +72-hour calculation.
+    second_step_sent_at = datetime(2026, 10, 30, 14, 0, tzinfo=timezone.utc)
+
+    due = _third_step_due(
+        second_step_sent_at,
+        timezone_name="America/Chicago",
+    )
+
+    assert due == datetime(2026, 11, 2, 15, 0, tzinfo=timezone.utc)
+
+
+def test_missing_booking_link_is_a_supported_fail_closed_configuration() -> None:
+    config = _config(booking_link="")
+    assert config.missed_call_recovery_delivery_is_configured is False
+    assert (
+        config.missed_call_recovery_delivery_block_reason == "booking_link_unavailable"
+    )
+    paused = _config(enabled=False)
+    assert paused.missed_call_recovery_delivery_is_configured is False
+    assert paused.missed_call_recovery_delivery_block_reason == "recovery_disabled"
+    with pytest.raises(ValueError, match="Google Calendar"):
+        _config(booking_link="https://example.test/not-a-calendar-link")
+    with pytest.raises(ValueError, match="Google Calendar"):
+        _config(booking_link="https://calendar.google.com")
+    with pytest.raises(ValueError, match="Google Calendar"):
+        _config(booking_link="https://calendar.google.com:444/appointments")
+    with pytest.raises(ValueError, match="requires ATLAS_EOM_FUNNEL_API_ENABLED"):
+        EOMFunnelConfig(missed_call_recovery_enabled=True)
+
+
+def test_booking_link_validator_evidence_gates_the_url_grammar() -> None:
+    """Exercise the URL grammar instead of blessing a short allow-list sample.
+
+    The source-of-truth policy is deliberately narrow: only an HTTPS URL at one
+    of the two public Google Calendar hosts, with no credentials or explicit
+    port and a non-root path, can enter a customer-email template.  Query and
+    fragment are permitted because valid public Google Calendar invitation
+    links use them in the wild. The independent expected-admission oracle spans
+    token/value families (scheme and host), URL authority/path containers, and
+    query/fragment keys rather than deriving its verdict from the validator.
+    """
+
+    allowed_hosts = {"calendar.google.com", "calendar.app.google"}
+    schemes = ("https", "http", "ftp")
+    hosts = (
+        "calendar.google.com",
+        "CALENDAR.APP.GOOGLE",
+        "calendar.google.com.evil.test",
+        "calendar.google.com.",
+    )
+    credentials = ("", "operator@", "operator:secret@")
+    ports = ("", ":443")
+    paths = ("/appointment-request", "/", "")
+    suffixes = ("", "?source=eom", "#request")
+
+    for scheme, host, credentials_part, port, path, suffix in product(
+        schemes,
+        hosts,
+        credentials,
+        ports,
+        paths,
+        suffixes,
+    ):
+        candidate = f"{scheme}://{credentials_part}{host}{port}{path}{suffix}"
+        expected_admission = (
+            scheme == "https"
+            and host.casefold() in allowed_hosts
+            and not credentials_part
+            and not port
+            and bool(path.strip("/"))
+        )
+        if expected_admission:
+            config = _config(booking_link=candidate)
+            assert config.missed_call_booking_link == candidate
+        else:
+            with pytest.raises(ValueError, match="Google Calendar"):
+                _config(booking_link=candidate)
+
+    for unsafe_character_variant in (
+        "https://calendar.google.com/appointment request",
+        "https://calendar.google.com/appointment\\request",
+        "https://calendar.google.com/appointment\x00request",
+    ):
+        with pytest.raises(ValueError, match="control characters|Google Calendar"):
+            _config(booking_link=unsafe_character_variant)
+
+
+@pytest.mark.asyncio
+async def test_form_submission_evidence_alone_never_creates_a_recovery_sequence() -> (
+    None
+):
+    async with _test_store() as (pool, _schema):
+        contact_id = await _insert_estimate_lead(pool)
+
+        assert (
+            await pool.fetchval(
+                "SELECT COUNT(*) FROM eom_missed_call_sequences WHERE contact_id = $1",
+                contact_id,
+            )
+            == 0
+        )
+        assert (
+            await pool.fetchval(
+                """
+            SELECT COUNT(*) FROM contact_interactions
+            WHERE contact_id = $1 AND interaction_type = 'web_form'
+            """,
+                contact_id,
+            )
+            == 1
+        )
+
+
+@pytest.mark.asyncio
+async def test_qualifying_no_answer_creates_one_sequence_and_replays_idempotently() -> (
+    None
+):
+    async with _test_store() as (pool, _schema):
+        contact_id = await _insert_estimate_lead(pool)
+        service = _service(pool)
+        operation_key = _operation_key()
+
+        created = await service.record_no_answer(
+            contact_id=contact_id,
+            operation_key=operation_key,
+            actor_id=7,
+            actor_name="Juan",
+        )
+        replay = await service.record_no_answer(
+            contact_id=contact_id,
+            operation_key=operation_key,
+            actor_id=7,
+            actor_name="Juan",
+        )
+
+        assert created["idempotent"] is False
+        assert replay["idempotent"] is True
+        assert replay["attemptId"] == created["attemptId"]
+        assert created["sequence"]["state"] == "active"
+        assert (
+            await pool.fetchval(
+                "SELECT COUNT(*) FROM eom_missed_call_attempts WHERE contact_id = $1",
+                contact_id,
+            )
+            == 1
+        )
+        interaction = await pool.fetchrow(
+            """
+            SELECT interaction_type, intent, metadata
+            FROM contact_interactions
+            WHERE contact_id = $1 AND interaction_type = 'call'
+            """,
+            contact_id,
+        )
+        assert interaction is not None
+        assert interaction["intent"] == "no_answer"
+        assert interaction["metadata"] is not None
+        assert (
+            await pool.fetchval(
+                "SELECT COUNT(*) FROM eom_missed_call_sequences WHERE contact_id = $1",
+                contact_id,
+            )
+            == 1
+        )
+        assert (
+            await pool.fetchval(
+                """
+            SELECT COUNT(*) FROM eom_missed_call_sequence_steps AS step
+            JOIN eom_missed_call_sequences AS sequence ON sequence.id = step.sequence_id
+            WHERE sequence.contact_id = $1
+            """,
+                contact_id,
+            )
+            == 3
+        )
+
+        # A later real call is separate immutable evidence, but it cannot make
+        # overlapping follow-up mail for the same lead.
+        later = await service.record_no_answer(
+            contact_id=contact_id,
+            operation_key=_operation_key("later-missed-call"),
+            actor_id=7,
+            actor_name="Juan",
+        )
+        assert later["idempotent"] is False
+        assert later["sequence"]["sequenceId"] == created["sequence"]["sequenceId"]
+        assert (
+            await pool.fetchval(
+                "SELECT COUNT(*) FROM eom_missed_call_attempts WHERE contact_id = $1",
+                contact_id,
+            )
+            == 2
+        )
+        assert (
+            await pool.fetchval(
+                "SELECT COUNT(*) FROM eom_missed_call_sequences WHERE contact_id = $1",
+                contact_id,
+            )
+            == 1
+        )
+
+
+@pytest.mark.asyncio
+async def test_concurrent_same_call_attempt_key_creates_one_attempt_and_sequence() -> (
+    None
+):
+    database_url = _database_url_or_skip()
+    async with _test_store() as (pool, schema):
+        contact_id = await _insert_estimate_lead(pool)
+        first_pool = await _schema_connection(database_url, schema)
+        second_pool = await _schema_connection(database_url, schema)
+        operation_key = _operation_key("concurrent-no-answer")
+        try:
+            first, second = await asyncio.gather(
+                _service(first_pool).record_no_answer(
+                    contact_id=contact_id,
+                    operation_key=operation_key,
+                    actor_id=7,
+                    actor_name="Juan",
+                ),
+                _service(second_pool).record_no_answer(
+                    contact_id=contact_id,
+                    operation_key=operation_key,
+                    actor_id=7,
+                    actor_name="Juan",
+                ),
+            )
+        finally:
+            await _close_schema_connection(first_pool)
+            await _close_schema_connection(second_pool)
+
+        assert sorted((first["idempotent"], second["idempotent"])) == [False, True]
+        assert first["attemptId"] == second["attemptId"]
+        assert (
+            await pool.fetchval(
+                "SELECT COUNT(*) FROM eom_missed_call_attempts WHERE contact_id = $1",
+                contact_id,
+            )
+            == 1
+        )
+        assert (
+            await pool.fetchval(
+                "SELECT COUNT(*) FROM eom_missed_call_sequences WHERE contact_id = $1",
+                contact_id,
+            )
+            == 1
+        )
+
+
+@pytest.mark.asyncio
+async def test_non_residential_estimate_records_call_but_never_starts_recovery() -> (
+    None
+):
+    async with _test_store() as (pool, _schema):
+        contact_id = await _insert_estimate_lead(pool, ack_variant="commercial")
+        result = await _service(pool).record_no_answer(
+            contact_id=contact_id,
+            operation_key=_operation_key(),
+            actor_id=7,
+            actor_name="Juan",
+        )
+
+        assert result["sequence"] is None
+        assert result["notStartedReason"] == "not_residential_estimate"
+        assert (
+            await pool.fetchval(
+                "SELECT COUNT(*) FROM eom_missed_call_attempts WHERE contact_id = $1",
+                contact_id,
+            )
+            == 1
+        )
+        assert (
+            await pool.fetchval(
+                "SELECT COUNT(*) FROM eom_missed_call_sequences WHERE contact_id = $1",
+                contact_id,
+            )
+            == 0
+        )
+
+
+@pytest.mark.asyncio
+async def test_response_after_estimate_but_before_no_answer_never_starts_recovery() -> (
+    None
+):
+    async with _test_store() as (pool, _schema):
+        contact_id = await _insert_estimate_lead(pool)
+        await pool._connection.execute(
+            """
+            INSERT INTO contact_interactions (
+                id, contact_id, interaction_type, summary, intent, occurred_at,
+                metadata, interaction_dedupe_key
+            ) VALUES ($1, $2, 'sms', 'Controlled inbound response', 'reply', $3,
+                      $4::jsonb, $5)
+            """,
+            uuid4(),
+            contact_id,
+            _NOW - timedelta(minutes=1),
+            json.dumps({"crm_event_id": f"sms:{uuid4().hex}"}),
+            f"prior-response-{uuid4().hex}",
+        )
+
+        result = await _service(pool).record_no_answer(
+            contact_id=contact_id,
+            operation_key=_operation_key(),
+            actor_id=7,
+            actor_name="Juan",
+        )
+
+        assert result["sequence"] is None
+        assert result["notStartedReason"] == "tracked_response_or_new_request"
+        assert (
+            await pool.fetchval(
+                "SELECT COUNT(*) FROM eom_missed_call_sequences WHERE contact_id = $1",
+                contact_id,
+            )
+            == 0
+        )
+
+
+@pytest.mark.asyncio
+async def test_missing_booking_configuration_creates_visible_block_without_gateway_call() -> (
+    None
+):
+    async with _test_store() as (pool, _schema):
+        contact_id = await _insert_estimate_lead(pool)
+        gateway = _FakeGateway()
+        service = _service(pool, gateway=gateway, config=_config(booking_link=""))
+
+        result = await service.record_no_answer(
+            contact_id=contact_id,
+            operation_key=_operation_key(),
+            actor_id=7,
+            actor_name="Juan",
+        )
+        delivered = await service.dispatch_due_steps()
+
+        assert result["sequence"]["state"] == "blocked_configuration"
+        assert result["sequence"]["blockedReason"] == "booking_link_unavailable"
+        assert delivered == 0
+        assert gateway.calls == []
+        assert (
+            await pool.fetchval("SELECT COUNT(*) FROM eom_missed_call_sequence_steps")
+            == 0
+        )
+
+
+@pytest.mark.asyncio
+async def test_disabled_recovery_creates_an_honest_visible_block_without_gateway_call() -> (
+    None
+):
+    async with _test_store() as (pool, _schema):
+        contact_id = await _insert_estimate_lead(pool)
+        gateway = _FakeGateway()
+        service = _service(pool, gateway=gateway, config=_config(enabled=False))
+
+        result = await service.record_no_answer(
+            contact_id=contact_id,
+            operation_key=_operation_key(),
+            actor_id=7,
+            actor_name="Juan",
+        )
+
+        assert result["sequence"]["state"] == "blocked_configuration"
+        assert result["sequence"]["blockedReason"] == "recovery_disabled"
+        assert await service.dispatch_due_steps() == 0
+        assert gateway.calls == []
+
+
+@pytest.mark.asyncio
+async def test_blocked_configuration_sequence_can_still_stop_for_a_lead_advance() -> (
+    None
+):
+    """Terminalizing a blocked sequence must clear its blocked-only fields."""
+
+    async with _test_store() as (pool, _schema):
+        contact_id = await _insert_estimate_lead(pool)
+        service = _service(pool, config=_config(booking_link=""))
+        await service.record_no_answer(
+            contact_id=contact_id,
+            operation_key=_operation_key(),
+            actor_id=7,
+            actor_name="Juan",
+        )
+
+        await pool._connection.execute(
+            "UPDATE contacts SET lead_stage = 'estimate_booked' WHERE id = $1",
+            contact_id,
+        )
+        sequence = await pool.fetchrow(
+            """
+            SELECT state, blocked_reason, cancellation_reason
+            FROM eom_missed_call_sequences
+            WHERE contact_id = $1
+            """,
+            contact_id,
+        )
+        assert dict(sequence) == {
+            "state": "cancelled",
+            "blocked_reason": None,
+            "cancellation_reason": "lead_advanced",
+        }
+
+
+@pytest.mark.asyncio
+async def test_worker_sends_each_step_once_and_records_tenant_scoped_history() -> None:
+    async with _test_store() as (pool, _schema):
+        contact_id = await _insert_estimate_lead(pool)
+        clock = {"now": _NOW}
+        gateway = _FakeGateway()
+        history = _History()
+        service = _service(pool, gateway=gateway, now_box=clock, history=history)
+        await service.record_no_answer(
+            contact_id=contact_id,
+            operation_key=_operation_key(),
+            actor_id=7,
+            actor_name="Juan",
+        )
+
+        assert await service.dispatch_due_steps() == 1
+        assert await service.dispatch_due_steps() == 0
+        assert len(gateway.calls) == 1
+        assert gateway.calls[0]["recipient_email"] == "lead@example.test"
+        assert len(history.calls) == 1
+        history_call = history.calls[0]
+        assert history_call["business_context_id"] == _EOM_CONTEXT
+        assert history_call["template_type"] == "eom_missed_call_recovery"
+        assert history_call["metadata"]["contact_id"] == str(contact_id)
+        assert "lead@example.test" not in json.dumps(history_call["metadata"])
+
+        sequence_id = UUID(history_call["metadata"]["sequence_id"])
+        second_due = await pool.fetchval(
+            """
+            SELECT due_at FROM eom_missed_call_sequence_steps
+            WHERE sequence_id = $1 AND step_number = 2
+            """,
+            sequence_id,
+        )
+        assert second_due == next_business_day_due(
+            _NOW, timezone_name="America/Chicago"
+        )
+        # A late worker must preserve Email 3's full three-day interval from
+        # actual Email 2 delivery, rather than compressing it from the old due.
+        clock["now"] = second_due + timedelta(hours=4)
+        assert await service.dispatch_due_steps() == 1
+        second_sent_at = await pool.fetchval(
+            """
+            SELECT sent_at FROM eom_missed_call_sequence_steps
+            WHERE sequence_id = $1 AND step_number = 2
+            """,
+            sequence_id,
+        )
+        third_due = await pool.fetchval(
+            """
+            SELECT due_at FROM eom_missed_call_sequence_steps
+            WHERE sequence_id = $1 AND step_number = 3
+            """,
+            sequence_id,
+        )
+        assert third_due == second_sent_at + timedelta(days=3)
+        clock["now"] = third_due
+        assert await service.dispatch_due_steps() == 1
+        assert await service.dispatch_due_steps() == 0
+        assert len(gateway.calls) == 3
+        assert (
+            await pool.fetchval(
+                "SELECT state FROM eom_missed_call_sequences WHERE id = $1", sequence_id
+            )
+            == "completed"
+        )
+
+
+@pytest.mark.asyncio
+async def test_two_workers_cannot_send_the_same_due_step_twice() -> None:
+    database_url = _database_url_or_skip()
+    async with _test_store() as (pool, schema):
+        contact_id = await _insert_estimate_lead(pool)
+        await _service(pool).record_no_answer(
+            contact_id=contact_id,
+            operation_key=_operation_key(),
+            actor_id=7,
+            actor_name="Juan",
+        )
+        first_pool = await _schema_connection(database_url, schema)
+        second_pool = await _schema_connection(database_url, schema)
+        try:
+            gateway = _BlockingGateway()
+            first = _service(first_pool, gateway=gateway)
+            second = _service(second_pool, gateway=gateway)
+            first_task = asyncio.create_task(first.dispatch_due_steps())
+            await asyncio.wait_for(gateway.started.wait(), timeout=5)
+            assert await second.dispatch_due_steps() == 0
+            gateway.release.set()
+            assert await asyncio.wait_for(first_task, timeout=5) == 1
+        finally:
+            await _close_schema_connection(first_pool)
+            await _close_schema_connection(second_pool)
+
+        assert len(gateway.calls) == 1
+        assert (
+            await pool.fetchval(
+                """
+            SELECT COUNT(*) FROM eom_missed_call_sequence_steps
+            WHERE state = 'sent'
+            """
+            )
+            == 1
+        )
+
+
+@pytest.mark.asyncio
+async def test_state_change_between_durable_claim_and_delivery_stops_the_send() -> None:
+    """The second state read is after the durable claim, not just before it."""
+
+    async with _test_store() as (pool, _schema):
+        contact_id = await _insert_estimate_lead(pool)
+        gateway = _FakeGateway()
+        service = _service(pool, gateway=gateway)
+        await service.record_no_answer(
+            contact_id=contact_id,
+            operation_key=_operation_key(),
+            actor_id=7,
+            actor_name="Juan",
+        )
+
+        claimed = await service._claim_one_due_step()
+        assert claimed.claim is not None
+
+        # An appointment advance after the worker claimed the step but before
+        # its provider call must terminalize the sequence. The delivery phase
+        # then re-reads the claim/current lead state and cannot call the gateway.
+        await pool._connection.execute(
+            "UPDATE contacts SET lead_stage = 'estimate_booked' WHERE id = $1",
+            contact_id,
+        )
+
+        assert await service._deliver_claim(claimed.claim) is None
+        assert gateway.calls == []
+        assert (
+            await pool.fetchval(
+                "SELECT state FROM eom_missed_call_sequences WHERE contact_id = $1",
+                contact_id,
+            )
+            == "cancelled"
+        )
+
+
+@pytest.mark.asyncio
+async def test_crash_after_durable_claim_never_reuses_an_expired_provider_key() -> None:
+    """A restart after an unconfirmed provider call fails visible, not duplicate."""
+
+    async with _test_store() as (pool, _schema):
+        contact_id = await _insert_estimate_lead(pool)
+        clock = {"now": _NOW}
+        original = _service(pool, now_box=clock)
+        await original.record_no_answer(
+            contact_id=contact_id,
+            operation_key=_operation_key(),
+            actor_id=7,
+            actor_name="Juan",
+        )
+
+        # Claim is its own committed transaction. Simulate the process dying
+        # after the provider request could have left the process but before it
+        # recorded acceptance; no `deliver_claim` call is made here.
+        claimed = await original._claim_one_due_step()
+        assert claimed.processed is True
+        assert claimed.claim is not None
+        assert (
+            await pool.fetchval(
+                "SELECT state FROM eom_missed_call_sequence_steps WHERE id = $1",
+                claimed.claim.step_id,
+            )
+            == "attempting"
+        )
+
+        clock["now"] = _NOW + timedelta(hours=24)
+        restarted_gateway = _FakeGateway()
+        restarted = _service(
+            pool,
+            gateway=restarted_gateway,
+            now_box=clock,
+        )
+        assert await restarted.dispatch_due_steps() == 0
+        assert restarted_gateway.calls == []
+        assert (
+            await pool.fetchval(
+                "SELECT state FROM eom_missed_call_sequences WHERE contact_id = $1",
+                contact_id,
+            )
+            == "recovery_required"
+        )
+        assert (
+            await pool.fetchval(
+                "SELECT state FROM eom_missed_call_sequence_steps WHERE id = $1",
+                claimed.claim.step_id,
+            )
+            == "recovery_required"
+        )
+
+
+@pytest.mark.asyncio
+async def test_retry_is_bounded_and_never_erases_call_evidence() -> None:
+    async with _test_store() as (pool, _schema):
+        contact_id = await _insert_estimate_lead(pool)
+        clock = {"now": _NOW}
+        gateway = _RetryingGateway()
+        service = _service(pool, gateway=gateway, now_box=clock)
+        await service.record_no_answer(
+            contact_id=contact_id,
+            operation_key=_operation_key(),
+            actor_id=7,
+            actor_name="Juan",
+        )
+
+        for _ in range(3):
+            assert await service.dispatch_due_steps() == 1
+            next_attempt = await pool.fetchval(
+                """
+                SELECT next_attempt_at FROM eom_missed_call_sequence_steps
+                WHERE step_number = 1
+                """
+            )
+            if next_attempt is not None:
+                status = await service.statuses(contact_ids=[contact_id])
+                assert status[0]["nextFollowUpAt"] == next_attempt.isoformat()
+                clock["now"] = next_attempt
+
+        assert len(gateway.calls) == 3
+        assert (
+            await pool.fetchval("SELECT state FROM eom_missed_call_sequences")
+            == "failed"
+        )
+        assert (
+            await pool.fetchval(
+                "SELECT state FROM eom_missed_call_sequence_steps WHERE step_number = 1"
+            )
+            == "failed"
+        )
+        assert (
+            await pool.fetchval(
+                "SELECT COUNT(*) FROM eom_missed_call_attempts WHERE contact_id = $1",
+                contact_id,
+            )
+            == 1
+        )
+        assert await service.dispatch_due_steps() == 0
+        assert len(gateway.calls) == 3
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("column", "value", "expected_reason"),
+    (
+        ("lead_stage", "estimate_booked", "lead_advanced"),
+        ("lead_stage", "completed", "lead_advanced"),
+        ("contact_type", "customer", "became_customer"),
+        ("status", "lost", "contact_inactive"),
+        ("status", "closed", "contact_inactive"),
+        ("customer_type", "commercial", "non_residential"),
+        ("email", "changed@example.test", "recipient_changed"),
+    ),
+)
+async def test_lifecycle_stop_conditions_cancel_before_later_delivery(
+    column: str,
+    value: str,
+    expected_reason: str,
+) -> None:
+    async with _test_store() as (pool, _schema):
+        contact_id = await _insert_estimate_lead(pool)
+        gateway = _FakeGateway()
+        service = _service(pool, gateway=gateway)
+        await service.record_no_answer(
+            contact_id=contact_id,
+            operation_key=_operation_key(),
+            actor_id=7,
+            actor_name="Juan",
+        )
+
+        # Values are parametrized from this closed test tuple, never request
+        # input, so the identifier interpolation cannot turn this into SQL.
+        await pool._connection.execute(
+            f"UPDATE contacts SET {column} = $2 WHERE id = $1",
+            contact_id,
+            value,
+        )
+
+        assert await service.dispatch_due_steps() == 0
+        assert gateway.calls == []
+        sequence = await pool.fetchrow(
+            """
+            SELECT state, cancellation_reason FROM eom_missed_call_sequences
+            WHERE contact_id = $1
+            """,
+            contact_id,
+        )
+        assert dict(sequence) == {
+            "state": "cancelled",
+            "cancellation_reason": expected_reason,
+        }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("interaction_type", "intent", "expected_reason"),
+    (
+        ("sms", "reply", "tracked_inbound_response"),
+        ("email_inbound", "reply", "email_inbound"),
+        ("lead_response", "reply", "lead_response"),
+        ("callback_completed", "phone", "callback_completed"),
+        ("conversation_completed", "phone", "conversation_completed"),
+        ("opt_out", "unsubscribe", "opt_out"),
+        ("web_form", "estimate_request", "new_estimate_request"),
+    ),
+)
+async def test_recorded_response_stop_conditions_cancel_before_later_delivery(
+    interaction_type: str,
+    intent: str,
+    expected_reason: str,
+) -> None:
+    async with _test_store() as (pool, _schema):
+        contact_id = await _insert_estimate_lead(pool)
+        gateway = _FakeGateway()
+        service = _service(pool, gateway=gateway)
+        await service.record_no_answer(
+            contact_id=contact_id,
+            operation_key=_operation_key(),
+            actor_id=7,
+            actor_name="Juan",
+        )
+
+        await pool._connection.execute(
+            """
+            INSERT INTO contact_interactions (
+                id, contact_id, interaction_type, summary, intent, occurred_at,
+                metadata, interaction_dedupe_key
+            ) VALUES ($1, $2, $3, 'Controlled stop-condition evidence', $4, $5,
+                      $6::jsonb, $7)
+            """,
+            uuid4(),
+            contact_id,
+            interaction_type,
+            intent,
+            _NOW + timedelta(minutes=1),
+            json.dumps(
+                # The current EOM inbound SMS producer uses this provider
+                # marker. A bare CRM `sms` row can also represent an outgoing
+                # reminder, and must not be mistaken for a lead response.
+                {"crm_event_id": f"sms:{uuid4().hex}"}
+                if interaction_type == "sms"
+                else {}
+            ),
+            f"stop-{interaction_type}-{uuid4().hex}",
+        )
+
+        assert await service.dispatch_due_steps() == 0
+        assert gateway.calls == []
+        sequence = await pool.fetchrow(
+            """
+            SELECT state, cancellation_reason FROM eom_missed_call_sequences
+            WHERE contact_id = $1
+            """,
+            contact_id,
+        )
+        assert dict(sequence) == {
+            "state": "cancelled",
+            "cancellation_reason": expected_reason,
+        }
+        if interaction_type == "opt_out":
+            assert (
+                await pool.fetchval(
+                    """
+                SELECT EXISTS (
+                    SELECT 1 FROM eom_missed_call_contact_suppressions
+                    WHERE contact_id = $1
+                )
+                """,
+                    contact_id,
+                )
+                is True
+            )
+
+
+@pytest.mark.asyncio
+async def test_generic_sms_without_inbound_evidence_does_not_claim_a_lead_replied() -> (
+    None
+):
+    async with _test_store() as (pool, _schema):
+        contact_id = await _insert_estimate_lead(pool)
+        gateway = _FakeGateway()
+        service = _service(pool, gateway=gateway)
+        await service.record_no_answer(
+            contact_id=contact_id,
+            operation_key=_operation_key(),
+            actor_id=7,
+            actor_name="Juan",
+        )
+
+        await pool._connection.execute(
+            """
+            INSERT INTO contact_interactions (
+                id, contact_id, interaction_type, summary, intent, occurred_at,
+                metadata, interaction_dedupe_key
+            ) VALUES ($1, $2, 'sms', 'Controlled outbound reminder', 'follow_up',
+                      $3, '{}'::jsonb, $4)
+            """,
+            uuid4(),
+            contact_id,
+            _NOW + timedelta(minutes=1),
+            f"outbound-sms-{uuid4().hex}",
+        )
+
+        assert await service.dispatch_due_steps() == 1
+        assert len(gateway.calls) == 1
+        assert (
+            await pool.fetchval(
+                "SELECT state FROM eom_missed_call_sequences WHERE contact_id = $1",
+                contact_id,
+            )
+            == "active"
+        )
+
+
+@pytest.mark.asyncio
+async def test_explicit_resume_after_missing_booking_configuration_is_the_only_recovery_path() -> (
+    None
+):
+    async with _test_store() as (pool, _schema):
+        contact_id = await _insert_estimate_lead(pool)
+        blocked = _service(pool, config=_config(booking_link=""))
+        created = await blocked.record_no_answer(
+            contact_id=contact_id,
+            operation_key=_operation_key(),
+            actor_id=7,
+            actor_name="Juan",
+        )
+        assert created["sequence"]["state"] == "blocked_configuration"
+
+        gateway = _FakeGateway()
+        resumed = _service(pool, gateway=gateway)
+        result = await resumed.resume_blocked_sequence(
+            contact_id=contact_id,
+            operation_key=_operation_key("resume"),
+            actor_id=7,
+            actor_name="Juan",
+        )
+        assert result["idempotent"] is False
+        assert result["sequence"]["state"] == "active"
+        assert await resumed.dispatch_due_steps() == 1
+        assert len(gateway.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_explicit_cancellation_is_idempotent_only_for_the_same_reason() -> None:
+    async with _test_store() as (pool, _schema):
+        contact_id = await _insert_estimate_lead(pool)
+        service = _service(pool)
+        await service.record_no_answer(
+            contact_id=contact_id,
+            operation_key=_operation_key(),
+            actor_id=7,
+            actor_name="Juan",
+        )
+        operation_key = _operation_key("cancel")
+
+        cancelled = await service.cancel_sequence(
+            contact_id=contact_id,
+            operation_key=operation_key,
+            actor_id=7,
+            actor_name="Juan",
+            reason="response_recorded",
+        )
+        replay = await service.cancel_sequence(
+            contact_id=contact_id,
+            operation_key=operation_key,
+            actor_id=7,
+            actor_name="Juan",
+            reason="response_recorded",
+        )
+        assert cancelled["idempotent"] is False
+        assert replay["idempotent"] is True
+        assert cancelled["sequence"]["cancellationReason"] == "response_recorded"
+        cancellation_event = await pool.fetchrow(
+            """
+            SELECT actor_id, actor_name, source, reason_code
+            FROM eom_missed_call_sequence_events
+            WHERE sequence_id = $1 AND event_type = 'sequence_cancelled'
+            """,
+            UUID(cancelled["sequence"]["sequenceId"]),
+        )
+        assert dict(cancellation_event) == {
+            "actor_id": 7,
+            "actor_name": "Juan",
+            "source": "time_tracker",
+            "reason_code": "response_recorded",
+        }
+        with pytest.raises(
+            EOMMissedCallRecoveryConflictError,
+            match="Idempotency key belongs to a different recovery cancellation",
+        ):
+            await service.cancel_sequence(
+                contact_id=contact_id,
+                operation_key=operation_key,
+                actor_id=7,
+                actor_name="Juan",
+                reason="manual",
+            )
+
+
+@pytest.mark.asyncio
+async def test_operator_route_reaches_persisted_call_and_status_state() -> None:
+    async with _test_store() as (pool, _schema):
+        contact_id = await _insert_estimate_lead(pool)
+        service = _service(pool, gateway=_FakeGateway())
+        app = FastAPI()
+        app.include_router(funnel_mod.router, prefix="/api/v1")
+        app.dependency_overrides[funnel_auth_mod.require_eom_funnel_api] = lambda: None
+        app.dependency_overrides[funnel_auth_mod.require_eom_funnel_actor] = lambda: {
+            "id": 7,
+            "name": "Juan",
+        }
+        app.dependency_overrides[funnel_mod._missed_call_recovery_dependency] = lambda: (
+            service
+        )
+        key = _operation_key()
+        headers = {"Idempotency-Key": key}
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://testserver",
+        ) as client:
+            created = await client.post(
+                f"/api/v1/eom-funnel/leads/{contact_id}/missed-call-attempts",
+                headers=headers,
+            )
+            assert created.status_code == 201
+            assert created.json()["sequence"]["state"] == "active"
+
+            replay = await client.post(
+                f"/api/v1/eom-funnel/leads/{contact_id}/missed-call-attempts",
+                headers=headers,
+            )
+            assert replay.status_code == 200
+            assert replay.json()["idempotent"] is True
+
+            status_response = await client.get(
+                "/api/v1/eom-funnel/missed-call-recovery-status",
+                params=[("contact_id", str(contact_id))],
+            )
+            assert status_response.status_code == 200
+            payload = status_response.json()
+            assert payload["checked"] == 1
+            assert payload["sequences"][0]["contactId"] == str(contact_id)
+            assert payload["sequences"][0]["nextStepNumber"] == 1
+
+        assert (
+            await pool.fetchval(
+                "SELECT COUNT(*) FROM eom_missed_call_attempts WHERE contact_id = $1",
+                contact_id,
+            )
+            == 1
+        )
+
+
+def test_funnel_advertises_the_additive_missed_call_contract_only_when_routes_exist() -> (
+    None
+):
+    expected = {
+        "lead.missed_call_attempt.record",
+        "lead.missed_call_recovery.status",
+        "lead.missed_call_recovery.resume",
+        "lead.missed_call_recovery.cancel",
+    }
+    assert expected <= set(funnel_mod.served_capabilities())
+    registered = {
+        (method, route.path)
+        for route in funnel_mod.router.routes
+        for method in (route.methods or ())
+    }
+    assert {
+        ("POST", "/eom-funnel/leads/{contact_id}/missed-call-attempts"),
+        ("GET", "/eom-funnel/missed-call-recovery-status"),
+        ("POST", "/eom-funnel/leads/{contact_id}/missed-call-recovery/resume"),
+        ("POST", "/eom-funnel/leads/{contact_id}/missed-call-recovery/cancel"),
+    } <= registered

--- a/tests/test_eom_missed_call_recovery.py
+++ b/tests/test_eom_missed_call_recovery.py
@@ -450,7 +450,6 @@ async def test_full_atlas_lifespan_wires_and_stops_the_missed_call_worker(
     """The deployed aggregate entrypoint reaches the same startup boundary."""
 
     from atlas_brain import main
-    from atlas_brain.api.invoicing import auth as invoicing_auth_mod
     from atlas_brain.eom_api import config as funnel_config_mod
 
     events: list[str] = []
@@ -489,14 +488,12 @@ async def test_full_atlas_lifespan_wires_and_stops_the_missed_call_worker(
     runtime_settings.invoicing.enabled = False
     runtime_settings.invoicing.receivables_api_enabled = False
     runtime_settings.invoicing.auto_invoice_enabled = False
+    runtime_settings.invoicing.receivables_service_token = ""
 
     monkeypatch.setattr(main, "settings", runtime_settings)
     monkeypatch.setattr(main, "db_settings", SimpleNamespace(enabled=True))
     monkeypatch.setattr(
         main, "_enforce_paid_funnel_alert_channel", lambda _settings: None
-    )
-    monkeypatch.setattr(
-        invoicing_auth_mod, "validate_receivables_api_config", lambda _config: None
     )
     monkeypatch.setattr(main, "init_database", no_op)
     monkeypatch.setattr(main, "close_database", no_op)

--- a/tests/test_eom_missed_call_recovery.py
+++ b/tests/test_eom_missed_call_recovery.py
@@ -14,6 +14,7 @@ from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
 from itertools import product
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 from uuid import UUID, uuid4
 from zoneinfo import ZoneInfo
@@ -27,10 +28,15 @@ asyncpg = pytest.importorskip("asyncpg")
 from atlas_brain.eom_api import funnel as funnel_mod  # noqa: E402
 from atlas_brain.eom_api import funnel_auth as funnel_auth_mod  # noqa: E402
 from atlas_brain.eom_api.config import EOMFunnelConfig  # noqa: E402
+from atlas_brain.services import eom_missed_call_recovery as recovery_mod  # noqa: E402
 from atlas_brain.services.eom_missed_call_recovery import (  # noqa: E402
     EOMMissedCallRecoveryConflictError,
     EOMMissedCallRecoveryService,
+    EOMMissedCallRecoveryUnavailableError,
+    ResendMissedCallRecoveryGateway,
+    _AmbiguousDeliveryError,
     _DefiniteDeliveryError,
+    prepare_eom_missed_call_recovery_worker,
     _third_step_due,
     next_business_day_due,
 )
@@ -243,6 +249,269 @@ def _service(
         now=lambda: clock["now"],
         email_history=history,
     )
+
+
+@pytest.mark.asyncio
+async def test_real_resend_gateway_preserves_provider_idempotency_and_outcome_classes(
+    monkeypatch,
+) -> None:
+    """Exercise the real adapter with a transport seam, never Resend itself."""
+
+    from atlas_brain.config import settings
+
+    monkeypatch.setattr(settings.email, "enabled", True)
+    monkeypatch.setattr(settings.email, "api_key", "test-resend-key")
+    request_key = _operation_key("provider-key")
+    seen: list[httpx.Request] = []
+
+    async def accepted(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(202, json={"id": "resend-message-test"})
+
+    gateway = ResendMissedCallRecoveryGateway(
+        timeout_seconds=5,
+        transport=httpx.MockTransport(accepted),
+    )
+    assert (
+        await gateway.send(
+            recipient_email="lead@example.test",
+            subject="Controlled test",
+            body="Controlled test body",
+            idempotency_key=request_key,
+        )
+        == "resend-message-test"
+    )
+    assert len(seen) == 1
+    assert seen[0].url == httpx.URL("https://api.resend.com/emails")
+    assert seen[0].headers["Idempotency-Key"] == request_key
+
+    async def rejected(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(422, json={"name": "validation_error"})
+
+    with pytest.raises(_DefiniteDeliveryError) as rejected_error:
+        await ResendMissedCallRecoveryGateway(
+            timeout_seconds=5,
+            transport=httpx.MockTransport(rejected),
+        ).send(
+            recipient_email="lead@example.test",
+            subject="Controlled test",
+            body="Controlled test body",
+            idempotency_key=_operation_key("provider-rejected"),
+        )
+    assert rejected_error.value.code == "resend_rejected"
+    assert rejected_error.value.retryable is False
+
+    async def ambiguous(_request: httpx.Request) -> httpx.Response:
+        # A 2xx without Resend's stable message identity cannot prove delivery.
+        return httpx.Response(200, json={})
+
+    with pytest.raises(
+        _AmbiguousDeliveryError, match="resend_success_identity_unknown"
+    ):
+        await ResendMissedCallRecoveryGateway(
+            timeout_seconds=5,
+            transport=httpx.MockTransport(ambiguous),
+        ).send(
+            recipient_email="lead@example.test",
+            subject="Controlled test",
+            body="Controlled test body",
+            idempotency_key=_operation_key("provider-ambiguous"),
+        )
+
+
+@pytest.mark.asyncio
+async def test_worker_startup_fences_enabled_disabled_and_blocked_configurations(
+    monkeypatch,
+) -> None:
+    """One shared startup boundary is explicit about every safe branch."""
+
+    events: list[str] = []
+    ready = {"value": True}
+    worker = object()
+
+    class _StartupRecovery:
+        def __init__(self, *, pool: object, config: EOMFunnelConfig) -> None:
+            self._config = config
+
+        def delivery_block_reason(self) -> str | None:
+            return self._config.missed_call_recovery_delivery_block_reason
+
+        async def block_active_sequences_for_configuration(self, *, reason: str) -> int:
+            events.append(f"block:{reason}")
+            return 2
+
+    async def schema_ready(_pool: object) -> bool:
+        return ready["value"]
+
+    def start_worker(*, pool: object, config: EOMFunnelConfig) -> object:
+        assert pool is pool_token
+        assert config.missed_call_recovery_enabled is True
+        events.append("start")
+        return worker
+
+    pool_token = object()
+    monkeypatch.setattr(recovery_mod, "EOMMissedCallRecoveryService", _StartupRecovery)
+    monkeypatch.setattr(recovery_mod, "missed_call_recovery_schema_ready", schema_ready)
+    monkeypatch.setattr(
+        recovery_mod, "start_eom_missed_call_recovery_worker", start_worker
+    )
+
+    assert (
+        await prepare_eom_missed_call_recovery_worker(
+            pool=pool_token, config=_config(enabled=False)
+        )
+        is None
+    )
+    assert (
+        await prepare_eom_missed_call_recovery_worker(
+            pool=pool_token, config=_config(booking_link="")
+        )
+        is None
+    )
+    assert (
+        await prepare_eom_missed_call_recovery_worker(pool=pool_token, config=_config())
+        is worker
+    )
+    assert events == [
+        "block:recovery_disabled",
+        "block:booking_link_unavailable",
+        "start",
+    ]
+
+    ready["value"] = False
+    with pytest.raises(
+        EOMMissedCallRecoveryUnavailableError, match="schema is unavailable"
+    ):
+        await prepare_eom_missed_call_recovery_worker(pool=pool_token, config=_config())
+
+
+@pytest.mark.asyncio
+async def test_slim_eom_lifespan_wires_and_stops_the_missed_call_worker(
+    monkeypatch,
+) -> None:
+    """The Render EOM entrypoint reaches the shared startup boundary."""
+
+    from atlas_brain import main_eom
+
+    events: list[str] = []
+    worker = object()
+    pool = SimpleNamespace(is_initialized=True)
+
+    async def no_op(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    async def prepare(*, pool: object, config: EOMFunnelConfig) -> object:
+        assert pool is not None
+        assert config.missed_call_recovery_enabled is True
+        events.append("prepare")
+        return worker
+
+    async def stop(value: object) -> None:
+        assert value is worker
+        events.append("stop")
+
+    monkeypatch.setattr(main_eom, "funnel_settings", _config())
+    monkeypatch.setattr(main_eom, "invoicing_settings", SimpleNamespace())
+    monkeypatch.setattr(
+        main_eom,
+        "eom_profile_settings",
+        SimpleNamespace(run_migrations=False, canonical_crm_database_confirmed=True),
+    )
+    monkeypatch.setattr(main_eom, "db_settings", SimpleNamespace(enabled=False))
+    monkeypatch.setattr(
+        main_eom, "validate_receivables_api_config", lambda _config: None
+    )
+    monkeypatch.setattr(
+        main_eom, "validate_eom_funnel_api_config", lambda _config: None
+    )
+    monkeypatch.setattr(
+        main_eom,
+        "validate_eom_funnel_canonical_crm_config",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(main_eom, "init_eom_funnel_database", no_op)
+    monkeypatch.setattr(main_eom, "close_eom_funnel_database", no_op)
+    monkeypatch.setattr(main_eom, "_validate_eom_funnel_startup", no_op)
+    monkeypatch.setattr(main_eom, "get_eom_funnel_db_pool", lambda: pool)
+    monkeypatch.setattr(
+        recovery_mod, "prepare_eom_missed_call_recovery_worker", prepare
+    )
+    monkeypatch.setattr(recovery_mod, "stop_eom_missed_call_recovery_worker", stop)
+
+    async with main_eom.lifespan(FastAPI()):
+        assert events == ["prepare"]
+    assert events == ["prepare", "stop"]
+
+
+@pytest.mark.asyncio
+async def test_full_atlas_lifespan_wires_and_stops_the_missed_call_worker(
+    monkeypatch,
+) -> None:
+    """The deployed aggregate entrypoint reaches the same startup boundary."""
+
+    from atlas_brain import main
+    from atlas_brain.api.invoicing import auth as invoicing_auth_mod
+    from atlas_brain.eom_api import config as funnel_config_mod
+
+    events: list[str] = []
+    worker = object()
+    pool = SimpleNamespace(is_initialized=True)
+
+    async def no_op(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    async def prepare(*, pool: object, config: EOMFunnelConfig) -> object:
+        assert pool is not None
+        assert config.missed_call_recovery_enabled is True
+        events.append("prepare")
+        return worker
+
+    async def stop(value: object) -> None:
+        assert value is worker
+        events.append("stop")
+
+    runtime_settings = main.settings.model_copy(deep=True)
+    runtime_settings.load_llm_on_startup = False
+    runtime_settings.llm.model_swap_enabled = False
+    runtime_settings.llm.cloud_enabled = False
+    runtime_settings.intent_router.llm_fallback_enabled = False
+    runtime_settings.email_draft.enabled = False
+    runtime_settings.email_draft.triage_enabled = False
+    runtime_settings.reasoning.enabled = False
+    runtime_settings.discovery.enabled = False
+    runtime_settings.alerts.enabled = False
+    runtime_settings.reminder.enabled = False
+    runtime_settings.autonomous.enabled = False
+    runtime_settings.mqtt.enabled = False
+    runtime_settings.tools.calendar_enabled = False
+    runtime_settings.mcp.client_enabled = False
+    runtime_settings.voice.enabled = False
+    runtime_settings.invoicing.enabled = False
+    runtime_settings.invoicing.receivables_api_enabled = False
+    runtime_settings.invoicing.auto_invoice_enabled = False
+
+    monkeypatch.setattr(main, "settings", runtime_settings)
+    monkeypatch.setattr(main, "db_settings", SimpleNamespace(enabled=True))
+    monkeypatch.setattr(
+        main, "_enforce_paid_funnel_alert_channel", lambda _settings: None
+    )
+    monkeypatch.setattr(
+        invoicing_auth_mod, "validate_receivables_api_config", lambda _config: None
+    )
+    monkeypatch.setattr(main, "init_database", no_op)
+    monkeypatch.setattr(main, "close_database", no_op)
+    monkeypatch.setattr(main, "get_db_pool", lambda: pool)
+    monkeypatch.setattr(main, "_run_database_migration_check", no_op)
+    monkeypatch.setattr(main, "_validate_eom_funnel_startup", no_op)
+    monkeypatch.setattr(funnel_config_mod, "funnel_settings", _config())
+    monkeypatch.setattr(
+        recovery_mod, "prepare_eom_missed_call_recovery_worker", prepare
+    )
+    monkeypatch.setattr(recovery_mod, "stop_eom_missed_call_recovery_worker", stop)
+
+    async with main.lifespan(FastAPI()):
+        assert events == ["prepare"]
+    assert events == ["prepare", "stop"]
 
 
 def test_recovery_templates_match_approved_copy_exactly() -> None:
@@ -590,6 +859,39 @@ async def test_concurrent_same_call_attempt_key_creates_one_attempt_and_sequence
 
 
 @pytest.mark.asyncio
+async def test_recovery_operation_key_cannot_move_a_retry_to_another_contact() -> None:
+    async with _test_store() as (pool, _schema):
+        first_contact_id = await _insert_estimate_lead(pool)
+        second_contact_id = await _insert_estimate_lead(pool)
+        service = _service(pool)
+        operation_key = _operation_key("cross-contact")
+        await service.record_no_answer(
+            contact_id=first_contact_id,
+            operation_key=operation_key,
+            actor_id=7,
+            actor_name="Juan",
+        )
+
+        with pytest.raises(
+            EOMMissedCallRecoveryConflictError,
+            match="different missed-call recovery operation",
+        ):
+            await service.record_no_answer(
+                contact_id=second_contact_id,
+                operation_key=operation_key,
+                actor_id=7,
+                actor_name="Juan",
+            )
+        assert (
+            await pool.fetchval(
+                "SELECT COUNT(*) FROM eom_missed_call_attempts WHERE contact_id = $1",
+                second_contact_id,
+            )
+            == 0
+        )
+
+
+@pytest.mark.asyncio
 async def test_non_residential_estimate_records_call_but_never_starts_recovery() -> (
     None
 ):
@@ -706,6 +1008,115 @@ async def test_disabled_recovery_creates_an_honest_visible_block_without_gateway
         assert result["sequence"]["blockedReason"] == "recovery_disabled"
         assert await service.dispatch_due_steps() == 0
         assert gateway.calls == []
+
+
+@pytest.mark.asyncio
+async def test_configuration_pause_blocks_existing_active_sequence_until_explicit_resume() -> (
+    None
+):
+    async with _test_store() as (pool, _schema):
+        contact_id = await _insert_estimate_lead(pool)
+        active_gateway = _FakeGateway()
+        active = _service(pool, gateway=active_gateway)
+        await active.record_no_answer(
+            contact_id=contact_id,
+            operation_key=_operation_key(),
+            actor_id=7,
+            actor_name="Juan",
+        )
+
+        paused = _service(pool, gateway=active_gateway, config=_config(enabled=False))
+        assert await paused.dispatch_due_steps() == 0
+        sequence = await pool.fetchrow(
+            """
+            SELECT state, blocked_reason FROM eom_missed_call_sequences
+            WHERE contact_id = $1
+            """,
+            contact_id,
+        )
+        assert dict(sequence) == {
+            "state": "blocked_configuration",
+            "blocked_reason": "recovery_disabled",
+        }
+        assert active_gateway.calls == []
+
+        restored_gateway = _FakeGateway()
+        restored = _service(pool, gateway=restored_gateway)
+        # Restoring deploy-time configuration alone cannot revive overdue mail.
+        assert await restored.dispatch_due_steps() == 0
+        assert restored_gateway.calls == []
+
+        resumed = await restored.resume_blocked_sequence(
+            contact_id=contact_id,
+            operation_key=_operation_key("resume-after-pause"),
+            actor_id=7,
+            actor_name="Juan",
+        )
+        assert resumed["sequence"]["state"] == "active"
+        assert await restored.dispatch_due_steps() == 1
+        assert len(restored_gateway.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_configuration_pause_preserves_a_pre_send_claim_until_resume() -> None:
+    """A deployment pause must not turn an unproven claim into a skipped email."""
+
+    async with _test_store() as (pool, _schema):
+        contact_id = await _insert_estimate_lead(pool)
+        clock = {"now": _NOW}
+        gateway = _FakeGateway()
+        active = _service(pool, gateway=gateway, now_box=clock)
+        await active.record_no_answer(
+            contact_id=contact_id,
+            operation_key=_operation_key(),
+            actor_id=7,
+            actor_name="Juan",
+        )
+        claim_result = await active._claim_one_due_step()
+        assert claim_result.claim is not None
+
+        paused = _service(
+            pool,
+            gateway=gateway,
+            now_box=clock,
+            config=_config(enabled=False),
+        )
+        assert await paused.dispatch_due_steps() == 0
+        assert (
+            await pool.fetchval(
+                "SELECT state FROM eom_missed_call_sequence_steps WHERE id = $1",
+                claim_result.claim.step_id,
+            )
+            == "attempting"
+        )
+
+        # Once the lease has expired, normal claim-recovery is safe only after
+        # an operator deliberately resumes the still-eligible sequence.
+        clock["now"] += timedelta(minutes=6)
+        restored = _service(pool, gateway=gateway, now_box=clock)
+        assert await restored.dispatch_due_steps() == 0
+        assert (
+            await pool.fetchval(
+                "SELECT state FROM eom_missed_call_sequence_steps WHERE id = $1",
+                claim_result.claim.step_id,
+            )
+            == "attempting"
+        )
+        await restored.resume_blocked_sequence(
+            contact_id=contact_id,
+            operation_key=_operation_key("resume-preserved-claim"),
+            actor_id=7,
+            actor_name="Juan",
+        )
+        assert await restored.dispatch_due_steps() == 1
+        assert len(gateway.calls) == 1
+        assert (
+            await pool.fetchval(
+                "SELECT state FROM eom_missed_call_sequence_steps WHERE id = $1",
+                claim_result.claim.step_id,
+            )
+            == "sent"
+        )
 
 
 @pytest.mark.asyncio
@@ -999,7 +1410,6 @@ async def test_retry_is_bounded_and_never_erases_call_evidence() -> None:
         ("status", "lost", "contact_inactive"),
         ("status", "closed", "contact_inactive"),
         ("customer_type", "commercial", "non_residential"),
-        ("email", "changed@example.test", "recipient_changed"),
     ),
 )
 async def test_lifecycle_stop_conditions_cancel_before_later_delivery(
@@ -1039,6 +1449,82 @@ async def test_lifecycle_stop_conditions_cancel_before_later_delivery(
             "state": "cancelled",
             "cancellation_reason": expected_reason,
         }
+
+
+@pytest.mark.asyncio
+async def test_contact_email_edit_keeps_sequence_when_form_recipient_is_unchanged() -> (
+    None
+):
+    """The form submission owns the effective recipient, not a shadow field."""
+
+    async with _test_store() as (pool, _schema):
+        contact_id = await _insert_estimate_lead(pool)
+        gateway = _FakeGateway()
+        service = _service(pool, gateway=gateway)
+        await service.record_no_answer(
+            contact_id=contact_id,
+            operation_key=_operation_key(),
+            actor_id=7,
+            actor_name="Juan",
+        )
+        await pool._connection.execute(
+            "UPDATE contacts SET email = $2 WHERE id = $1",
+            contact_id,
+            "directory-correction@example.test",
+        )
+
+        assert await service.dispatch_due_steps() == 1
+        assert len(gateway.calls) == 1
+        sequence = await pool.fetchrow(
+            """
+            SELECT state, cancellation_reason FROM eom_missed_call_sequences
+            WHERE contact_id = $1
+            """,
+            contact_id,
+        )
+        assert dict(sequence) == {"state": "active", "cancellation_reason": None}
+
+
+@pytest.mark.asyncio
+async def test_effective_form_recipient_change_cancels_before_delivery() -> None:
+    """A repair that changes the actual snapshotted recipient must stop mail."""
+
+    async with _test_store() as (pool, _schema):
+        contact_id = await _insert_estimate_lead(pool)
+        gateway = _FakeGateway()
+        service = _service(pool, gateway=gateway)
+        await service.record_no_answer(
+            contact_id=contact_id,
+            operation_key=_operation_key(),
+            actor_id=7,
+            actor_name="Juan",
+        )
+        await pool._connection.execute(
+            """
+            UPDATE contact_interactions
+               SET metadata = jsonb_set(
+                   metadata, '{submitted_email}', to_jsonb($2::text), true
+               )
+             WHERE contact_id = $1
+               AND interaction_type = 'web_form'
+               AND intent = 'estimate_request'
+            """,
+            contact_id,
+            "corrected-recipient@example.test",
+        )
+
+        assert await service.dispatch_due_steps() == 0
+        assert gateway.calls == []
+        assert (
+            await pool.fetchval(
+                """
+            SELECT cancellation_reason FROM eom_missed_call_sequences
+            WHERE contact_id = $1
+            """,
+                contact_id,
+            )
+            == "recipient_changed"
+        )
 
 
 @pytest.mark.asyncio
@@ -1120,6 +1606,47 @@ async def test_recorded_response_stop_conditions_cancel_before_later_delivery(
                 )
                 is True
             )
+
+
+@pytest.mark.asyncio
+async def test_backfilled_response_before_sequence_does_not_cancel_current_follow_up() -> (
+    None
+):
+    """Trigger evaluation uses the evidence timeline, not insertion order."""
+
+    async with _test_store() as (pool, _schema):
+        contact_id = await _insert_estimate_lead(pool)
+        gateway = _FakeGateway()
+        service = _service(pool, gateway=gateway)
+        await service.record_no_answer(
+            contact_id=contact_id,
+            operation_key=_operation_key(),
+            actor_id=7,
+            actor_name="Juan",
+        )
+        await pool._connection.execute(
+            """
+            INSERT INTO contact_interactions (
+                id, contact_id, interaction_type, summary, intent, occurred_at,
+                metadata, interaction_dedupe_key
+            ) VALUES ($1, $2, 'lead_response', 'Historical controlled response',
+                      'reply', $3, '{}'::jsonb, $4)
+            """,
+            uuid4(),
+            contact_id,
+            _NOW - timedelta(minutes=1),
+            f"backfilled-response-{uuid4().hex}",
+        )
+
+        assert await service.dispatch_due_steps() == 1
+        assert len(gateway.calls) == 1
+        assert (
+            await pool.fetchval(
+                "SELECT state FROM eom_missed_call_sequences WHERE contact_id = $1",
+                contact_id,
+            )
+            == "active"
+        )
 
 
 @pytest.mark.asyncio
@@ -1237,11 +1764,67 @@ async def test_explicit_cancellation_is_idempotent_only_for_the_same_reason() ->
         }
         with pytest.raises(
             EOMMissedCallRecoveryConflictError,
-            match="Idempotency key belongs to a different recovery cancellation",
+            match="different missed-call recovery operation",
         ):
             await service.cancel_sequence(
                 contact_id=contact_id,
                 operation_key=operation_key,
+                actor_id=7,
+                actor_name="Juan",
+                reason="manual",
+            )
+
+
+@pytest.mark.asyncio
+async def test_resume_and_cancel_keys_are_globally_bound_to_their_original_contact() -> (
+    None
+):
+    async with _test_store() as (pool, _schema):
+        first_contact_id = await _insert_estimate_lead(pool)
+        second_contact_id = await _insert_estimate_lead(pool)
+        blocked = _service(pool, config=_config(booking_link=""))
+        for contact_id in (first_contact_id, second_contact_id):
+            await blocked.record_no_answer(
+                contact_id=contact_id,
+                operation_key=_operation_key("blocked-sequence"),
+                actor_id=7,
+                actor_name="Juan",
+            )
+
+        service = _service(pool)
+        resume_key = _operation_key("cross-contact-resume")
+        await service.resume_blocked_sequence(
+            contact_id=first_contact_id,
+            operation_key=resume_key,
+            actor_id=7,
+            actor_name="Juan",
+        )
+        with pytest.raises(
+            EOMMissedCallRecoveryConflictError,
+            match="different missed-call recovery operation",
+        ):
+            await service.resume_blocked_sequence(
+                contact_id=second_contact_id,
+                operation_key=resume_key,
+                actor_id=7,
+                actor_name="Juan",
+            )
+
+        cancel_key = _operation_key("cross-contact-cancel")
+        await service.cancel_sequence(
+            contact_id=second_contact_id,
+            operation_key=cancel_key,
+            actor_id=7,
+            actor_name="Juan",
+            reason="manual",
+        )
+        with pytest.raises(
+            EOMMissedCallRecoveryConflictError,
+            match="different missed-call recovery operation",
+        ):
+            await service.cancel_sequence(
+                contact_id=first_contact_id,
+                operation_key=cancel_key,
                 actor_id=7,
                 actor_name="Juan",
                 reason="manual",

--- a/tests/test_eom_missed_call_recovery.py
+++ b/tests/test_eom_missed_call_recovery.py
@@ -169,7 +169,10 @@ async def _close_schema_connection(pool: _ConnectionPool) -> None:
 
 
 def _config(
-    *, enabled: bool = True, booking_link: str = _BOOKING_LINK
+    *,
+    enabled: bool = True,
+    booking_link: str = _BOOKING_LINK,
+    max_delivery_attempts: int = 3,
 ) -> EOMFunnelConfig:
     return EOMFunnelConfig(
         api_enabled=True,
@@ -177,7 +180,7 @@ def _config(
         missed_call_booking_link=booking_link,
         missed_call_timezone="America/Chicago",
         missed_call_poll_interval_seconds=30,
-        missed_call_max_delivery_attempts=3,
+        missed_call_max_delivery_attempts=max_delivery_attempts,
         missed_call_delivery_timeout_seconds=5,
     )
 
@@ -300,6 +303,26 @@ async def test_real_resend_gateway_preserves_provider_idempotency_and_outcome_cl
         )
     assert rejected_error.value.code == "resend_rejected"
     assert rejected_error.value.retryable is False
+
+    async def concurrent_idempotency(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            409,
+            json={"name": "concurrent_idempotent_requests"},
+        )
+
+    with pytest.raises(_DefiniteDeliveryError) as concurrent_error:
+        await ResendMissedCallRecoveryGateway(
+            timeout_seconds=5,
+            transport=httpx.MockTransport(concurrent_idempotency),
+        ).send(
+            recipient_email="lead@example.test",
+            subject="Controlled test",
+            body="Controlled test body",
+            idempotency_key=_operation_key("provider-concurrent"),
+        )
+    assert concurrent_error.value.code == "resend_request_in_progress"
+    assert concurrent_error.value.retryable is True
+    assert concurrent_error.value.recovery_required_if_exhausted is True
 
     async def ambiguous(_request: httpx.Request) -> httpx.Response:
         # A 2xx without Resend's stable message identity cannot prove delivery.
@@ -441,6 +464,71 @@ async def test_slim_eom_lifespan_wires_and_stops_the_missed_call_worker(
     async with main_eom.lifespan(FastAPI()):
         assert events == ["prepare"]
     assert events == ["prepare", "stop"]
+
+
+@pytest.mark.asyncio
+async def test_slim_eom_lifespan_applies_recovery_schema_while_delivery_disabled(
+    monkeypatch,
+) -> None:
+    """Schema rollout and customer-email permission are independent gates."""
+
+    from atlas_brain import main_eom
+
+    events: list[str] = []
+    pool = SimpleNamespace(is_initialized=True)
+
+    async def no_op(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    async def run_recovery_migrations() -> None:
+        events.append("recovery-migrations")
+
+    async def prepare(*, pool: object, config: EOMFunnelConfig) -> None:
+        assert pool is not None
+        assert config.missed_call_recovery_enabled is False
+        events.append("prepare-disabled")
+        return None
+
+    monkeypatch.setattr(main_eom, "funnel_settings", _config(enabled=False))
+    monkeypatch.setattr(
+        main_eom,
+        "invoicing_settings",
+        SimpleNamespace(receivables_api_enabled=False),
+    )
+    monkeypatch.setattr(
+        main_eom,
+        "eom_profile_settings",
+        SimpleNamespace(run_migrations=True, canonical_crm_database_confirmed=True),
+    )
+    monkeypatch.setattr(main_eom, "db_settings", SimpleNamespace(enabled=False))
+    monkeypatch.setattr(
+        main_eom, "validate_receivables_api_config", lambda _config: None
+    )
+    monkeypatch.setattr(
+        main_eom, "validate_eom_funnel_api_config", lambda _config: None
+    )
+    monkeypatch.setattr(
+        main_eom,
+        "validate_eom_funnel_canonical_crm_config",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(main_eom, "init_eom_funnel_database", no_op)
+    monkeypatch.setattr(main_eom, "close_eom_funnel_database", no_op)
+    monkeypatch.setattr(main_eom, "_validate_eom_funnel_startup", no_op)
+    monkeypatch.setattr(
+        main_eom,
+        "_run_eom_missed_call_recovery_startup_migrations",
+        run_recovery_migrations,
+    )
+    monkeypatch.setattr(main_eom, "get_eom_funnel_db_pool", lambda: pool)
+    monkeypatch.setattr(
+        recovery_mod, "prepare_eom_missed_call_recovery_worker", prepare
+    )
+
+    async with main_eom.lifespan(FastAPI()):
+        events.append("inside")
+
+    assert events == ["recovery-migrations", "prepare-disabled", "inside"]
 
 
 @pytest.mark.asyncio
@@ -1398,6 +1486,77 @@ async def test_retry_is_bounded_and_never_erases_call_evidence() -> None:
 
 
 @pytest.mark.asyncio
+async def test_concurrent_provider_key_exhaustion_preserves_delivery_ambiguity(
+    monkeypatch,
+) -> None:
+    """A still-running provider request cannot become a false failure."""
+
+    from atlas_brain.config import settings
+
+    monkeypatch.setattr(settings.email, "enabled", True)
+    monkeypatch.setattr(settings.email, "api_key", "test-resend-key")
+    requests: list[httpx.Request] = []
+
+    async def concurrent_idempotency(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(409, json={"name": "concurrent_idempotent_requests"})
+
+    async with _test_store() as (pool, _schema):
+        contact_id = await _insert_estimate_lead(pool)
+        clock = {"now": _NOW}
+        service = _service(
+            pool,
+            gateway=ResendMissedCallRecoveryGateway(
+                timeout_seconds=5,
+                transport=httpx.MockTransport(concurrent_idempotency),
+            ),
+            now_box=clock,
+            config=_config(max_delivery_attempts=2),
+        )
+        await service.record_no_answer(
+            contact_id=contact_id,
+            operation_key=_operation_key(),
+            actor_id=7,
+            actor_name="Juan",
+        )
+
+        assert await service.dispatch_due_steps() == 1
+        next_attempt = await pool.fetchval(
+            """
+            SELECT next_attempt_at FROM eom_missed_call_sequence_steps
+            WHERE step_number = 1
+            """
+        )
+        assert isinstance(next_attempt, datetime)
+        assert (
+            await pool.fetchval(
+                "SELECT state FROM eom_missed_call_sequences WHERE contact_id = $1",
+                contact_id,
+            )
+            == "active"
+        )
+
+        clock["now"] = next_attempt
+        assert await service.dispatch_due_steps() == 1
+        assert len(requests) == 2
+        assert len({request.headers["Idempotency-Key"] for request in requests}) == 1
+        assert (
+            await pool.fetchval(
+                "SELECT state FROM eom_missed_call_sequences WHERE contact_id = $1",
+                contact_id,
+            )
+            == "recovery_required"
+        )
+        assert (
+            await pool.fetchval(
+                "SELECT terminal_reason FROM eom_missed_call_sequence_steps "
+                "WHERE step_number = 1"
+            )
+            == "resend_request_in_progress"
+        )
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("column", "value", "expected_reason"),
     (
@@ -1445,6 +1604,42 @@ async def test_lifecycle_stop_conditions_cancel_before_later_delivery(
         assert dict(sequence) == {
             "state": "cancelled",
             "cancellation_reason": expected_reason,
+        }
+
+
+@pytest.mark.asyncio
+async def test_tenant_reassignment_cancels_remaining_recovery_before_delivery() -> None:
+    """An EOM sequence cannot outlive canonical contact ownership."""
+
+    async with _test_store() as (pool, _schema):
+        contact_id = await _insert_estimate_lead(pool)
+        gateway = _FakeGateway()
+        service = _service(pool, gateway=gateway)
+        await service.record_no_answer(
+            contact_id=contact_id,
+            operation_key=_operation_key(),
+            actor_id=7,
+            actor_name="Juan",
+        )
+
+        await pool._connection.execute(
+            "UPDATE contacts SET business_context_id = $2 WHERE id = $1",
+            contact_id,
+            "controlled_other_tenant",
+        )
+
+        assert await service.dispatch_due_steps() == 0
+        assert gateway.calls == []
+        sequence = await pool.fetchrow(
+            """
+            SELECT state, cancellation_reason FROM eom_missed_call_sequences
+            WHERE contact_id = $1
+            """,
+            contact_id,
+        )
+        assert dict(sequence) == {
+            "state": "cancelled",
+            "cancellation_reason": "tenant_changed",
         }
 
 
@@ -1522,6 +1717,141 @@ async def test_effective_form_recipient_change_cancels_before_delivery() -> None
             )
             == "recipient_changed"
         )
+
+
+@pytest.mark.asyncio
+async def test_intake_correction_that_wins_contact_lock_stops_delivery() -> None:
+    """The worker rereads committed latest-form evidence after lock waits."""
+
+    database_url = _database_url_or_skip()
+    async with _test_store() as (pool, schema):
+        contact_id = await _insert_estimate_lead(pool)
+        gateway = _FakeGateway()
+        service = _service(pool, gateway=gateway)
+        await service.record_no_answer(
+            contact_id=contact_id,
+            operation_key=_operation_key(),
+            actor_id=7,
+            actor_name="Juan",
+        )
+
+        correction_pool = await _schema_connection(database_url, schema)
+        transaction = correction_pool._connection.transaction()
+        committed = False
+        worker_task = None
+        try:
+            await transaction.start()
+            await correction_pool._connection.execute(
+                """
+                UPDATE contact_interactions
+                   SET metadata = jsonb_set(
+                       metadata, '{ack_variant}', to_jsonb($2::text), true
+                   )
+                 WHERE contact_id = $1
+                   AND interaction_type = 'web_form'
+                   AND intent = 'estimate_request'
+                """,
+                contact_id,
+                "commercial",
+            )
+
+            worker_task = asyncio.create_task(service.dispatch_due_steps())
+            await asyncio.sleep(0)
+            assert worker_task.done() is False
+
+            await transaction.commit()
+            committed = True
+            assert await asyncio.wait_for(worker_task, timeout=5) == 0
+        finally:
+            if not committed:
+                await transaction.rollback()
+            if worker_task is not None and not worker_task.done():
+                await asyncio.wait_for(worker_task, timeout=5)
+            await _close_schema_connection(correction_pool)
+
+        assert gateway.calls == []
+        sequence = await pool.fetchrow(
+            """
+            SELECT state, cancellation_reason FROM eom_missed_call_sequences
+            WHERE contact_id = $1
+            """,
+            contact_id,
+        )
+        assert dict(sequence) == {
+            "state": "cancelled",
+            "cancellation_reason": "not_residential_estimate",
+        }
+
+
+@pytest.mark.asyncio
+async def test_recipient_correction_serializes_with_final_delivery_check() -> None:
+    """A correction cannot commit between the final recipient read and send."""
+
+    database_url = _database_url_or_skip()
+    async with _test_store() as (pool, schema):
+        contact_id = await _insert_estimate_lead(pool)
+        gateway = _BlockingGateway()
+        service = _service(pool, gateway=gateway)
+        await service.record_no_answer(
+            contact_id=contact_id,
+            operation_key=_operation_key(),
+            actor_id=7,
+            actor_name="Juan",
+        )
+        claimed = await service._claim_one_due_step()
+        assert claimed.claim is not None
+
+        correction_pool = await _schema_connection(database_url, schema)
+        delivery_task = None
+        correction_task = None
+        try:
+            delivery_task = asyncio.create_task(service._deliver_claim(claimed.claim))
+            await asyncio.wait_for(gateway.started.wait(), timeout=5)
+
+            correction_task = asyncio.create_task(
+                correction_pool._connection.execute(
+                    """
+                    UPDATE contact_interactions
+                       SET metadata = jsonb_set(
+                           metadata, '{submitted_email}', to_jsonb($2::text), true
+                       )
+                     WHERE contact_id = $1
+                       AND interaction_type = 'web_form'
+                       AND intent = 'estimate_request'
+                    """,
+                    contact_id,
+                    "corrected-recipient@example.test",
+                )
+            )
+            # Let the second transaction reach migration 389's BEFORE trigger.
+            # It must wait on the contact lock held across the provider call.
+            await asyncio.sleep(0)
+            assert correction_task.done() is False
+
+            gateway.release.set()
+            history = await asyncio.wait_for(delivery_task, timeout=5)
+            assert history is not None
+            assert gateway.calls[0]["recipient_email"] == "lead@example.test"
+            await asyncio.wait_for(correction_task, timeout=5)
+        finally:
+            gateway.release.set()
+            if delivery_task is not None and not delivery_task.done():
+                await asyncio.wait_for(delivery_task, timeout=5)
+            if correction_task is not None and not correction_task.done():
+                await asyncio.wait_for(correction_task, timeout=5)
+            await _close_schema_connection(correction_pool)
+
+        sequence = await pool.fetchrow(
+            """
+            SELECT state, cancellation_reason FROM eom_missed_call_sequences
+            WHERE contact_id = $1
+            """,
+            contact_id,
+        )
+        assert dict(sequence) == {
+            "state": "cancelled",
+            "cancellation_reason": "recipient_changed",
+        }
 
 
 @pytest.mark.asyncio

--- a/tests/test_eom_render_profile.py
+++ b/tests/test_eom_render_profile.py
@@ -248,6 +248,10 @@ print(json.dumps({
     assert "/api/v1/ping" in paths
     assert "/api/v1/receivables/ready" in paths
     assert "/api/v1/eom-funnel/leads" in paths
+    assert "/api/v1/eom-funnel/leads/{contact_id}/missed-call-attempts" in paths
+    assert "/api/v1/eom-funnel/missed-call-recovery-status" in paths
+    assert "/api/v1/eom-funnel/leads/{contact_id}/missed-call-recovery/resume" in paths
+    assert "/api/v1/eom-funnel/leads/{contact_id}/missed-call-recovery/cancel" in paths
     assert "/api/v1/eom-funnel/leads/{contact_id}/estimate-bookings" in paths
     assert "/api/v1/eom-funnel/leads/{contact_id}/first-clean-bookings" in paths
     assert "/api/v1/eom-funnel/customer-handoffs" in paths
@@ -467,6 +471,18 @@ def test_eom_render_blueprint_maps_database_and_receivables_auth():
         "key": "ATLAS_EOM_FUNNEL_DB_CONNECTION_STRING",
         "sync": False,
     }
+    assert env_vars["ATLAS_EOM_FUNNEL_MISSED_CALL_RECOVERY_ENABLED"] == {
+        "key": "ATLAS_EOM_FUNNEL_MISSED_CALL_RECOVERY_ENABLED",
+        "value": "false",
+    }
+    assert env_vars["ATLAS_EOM_FUNNEL_MISSED_CALL_BOOKING_LINK"] == {
+        "key": "ATLAS_EOM_FUNNEL_MISSED_CALL_BOOKING_LINK",
+        "sync": False,
+    }
+    assert env_vars["ATLAS_EOM_FUNNEL_MISSED_CALL_TIMEZONE"] == {
+        "key": "ATLAS_EOM_FUNNEL_MISSED_CALL_TIMEZONE",
+        "value": "America/Chicago",
+    }
     assert env_vars["ATLAS_EOM_CANONICAL_CRM_DATABASE_CONFIRMED"] == {
         "key": "ATLAS_EOM_CANONICAL_CRM_DATABASE_CONFIRMED",
         "value": "false",
@@ -647,6 +663,33 @@ def test_eom_migration_helper_uses_curated_set():
     )
 
     assert calls == [(pool, main_eom.EOM_RECEIVABLES_READINESS_MIGRATIONS)]
+
+
+def test_eom_missed_call_recovery_migration_helper_uses_funnel_curated_set():
+    from atlas_brain import main_eom
+
+    pool = SimpleNamespace(is_initialized=True)
+    calls = []
+
+    async def run_migrations(observed_pool, *, only=None):
+        calls.append((observed_pool, tuple(only or ())))
+
+    asyncio.run(
+        main_eom._apply_eom_missed_call_recovery_migrations(
+            pool,
+            run_migrations_fn=run_migrations,
+        )
+    )
+
+    assert calls == [(pool, main_eom.EOM_MISSED_CALL_RECOVERY_READINESS_MIGRATIONS)]
+    assert main_eom.EOM_MISSED_CALL_RECOVERY_READINESS_MIGRATIONS == (
+        "035_contacts",
+        "256_contact_interaction_dedupe",
+        "346_contact_lead_pipeline",
+        "351_eom_lead_lifecycle_events",
+        "366_contacts_customer_type",
+        "389_eom_missed_call_recovery",
+    )
 
 
 def test_eom_startup_migration_runner_skips_uninitialized_pool(monkeypatch):

--- a/tests/test_eom_render_profile.py
+++ b/tests/test_eom_render_profile.py
@@ -1827,6 +1827,22 @@ def test_eom_lifespan_closes_generic_database_when_funnel_close_fails(monkeypatc
             events.append("datastore-check")
             return True
 
+        def transaction(self):
+            return _PoolTransaction(self)
+
+        async def fetch(self, *_args):
+            return []
+
+    class _PoolTransaction:
+        def __init__(self, pool) -> None:
+            self._pool = pool
+
+        async def __aenter__(self):
+            return self._pool
+
+        async def __aexit__(self, *_args) -> bool:
+            return False
+
     async def init_database():
         events.append("init")
 
@@ -1883,6 +1899,7 @@ def test_eom_lifespan_closes_generic_database_when_funnel_close_fails(monkeypatc
     assert events == [
         "init",
         "funnel-init",
+        "datastore-check",
         "datastore-check",
         "inside",
         "funnel-close",
@@ -2211,8 +2228,25 @@ class _ReadyPool:
         self.queries.append(query)
         return True
 
+    def transaction(self):
+        return _PoolTransaction(self)
+
+    async def fetch(self, *_args):
+        return []
+
     async def close(self):
         self.closed += 1
+
+
+class _PoolTransaction:
+    def __init__(self, pool):
+        self._pool = pool
+
+    async def __aenter__(self):
+        return self._pool
+
+    async def __aexit__(self, *_args):
+        return False
 
 
 pool = _ReadyPool()
@@ -2327,7 +2361,7 @@ print(json.dumps({
         "env_projected_enabled": True,
         "env_projected_digest": True,
         "dependency_overrides": 0,
-        "startup_guard_queries": 1,
+        "startup_guard_queries": 2,
         "funnel_pool_closed": 1,
     }
 


### PR DESCRIPTION
Plan: plans/PR-EOM-Missed-Call-Recovery.md
Slice phase: Vertical slice
Ownership lane: eom/missed-call-recovery

This provider slice adds the durable, Atlas-owned missed-call recovery state
machine requested in #2474. It begins only after an authenticated office
operator records a real no-answer outcome; the public form acknowledgement and
generic telecom callbacks remain independent.

## Intentional

Diff-budget override: The durable provider boundary is indivisible: the
append-only schema, transaction-safe state machine, configuration fence,
authenticated capability routes, startup worker, and cross-boundary tests must
ship together so a recorded no-answer can never create an uninspectable or
duplicate customer email.

- Recovery is opt-in and fail-closed: missing booking configuration or email
  transport preserves the call evidence as a visible blocked sequence and sends
  no customer email.
- The booking link is Atlas deploy-time configuration and never appears in a
  browser/API status projection, test fixture, log message, or this PR body.
- This slice introduces only provider capabilities. It does not touch the
  active tracker #237 or Website #258 CRM-directory implementation files.
- The current system lacks verified EOM eVoice, inbound-email, and public
  Calendar-selection correlation, so generic events are not misrepresented as
  automatic lead responses.

## AI reconciliation

- Test the real Resend delivery adapter -- fixed-in: atlas_brain/services/eom_missed_call_recovery.py and tests/test_eom_missed_call_recovery.py
- Preserve ambiguity when concurrent requests exhaust retries -- fixed-in: atlas_brain/services/eom_missed_call_recovery.py and tests/test_eom_missed_call_recovery.py
- Prove worker startup through both application lifespans -- fixed-in: atlas_brain/main.py, atlas_brain/main_eom.py, tests/test_eom_missed_call_recovery.py, and tests/test_eom_lead_conversion.py
- Apply the recovery schema while delivery is disabled -- fixed-in: atlas_brain/main_eom.py, docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md, and tests/test_eom_missed_call_recovery.py
- Persist configuration blocks for existing active sequences -- fixed-in: atlas_brain/services/eom_missed_call_recovery.py, docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md, and tests/test_eom_missed_call_recovery.py
- Make cancellation triggers evaluate effective current evidence -- fixed-in: atlas_brain/storage/migrations/389_eom_missed_call_recovery.sql, atlas_brain/services/eom_missed_call_recovery.py, and tests/test_eom_missed_call_recovery.py
- Serialize recipient corrections before delivery -- fixed-in: atlas_brain/storage/migrations/389_eom_missed_call_recovery.sql, atlas_brain/services/eom_missed_call_recovery.py, and tests/test_eom_missed_call_recovery.py
- Fence sequences when contacts leave the EOM tenant -- fixed-in: atlas_brain/storage/migrations/389_eom_missed_call_recovery.sql, atlas_brain/services/eom_missed_call_recovery.py, and tests/test_eom_missed_call_recovery.py
- Bind recovery idempotency keys across contacts -- fixed-in: atlas_brain/storage/migrations/389_eom_missed_call_recovery.sql, atlas_brain/services/eom_missed_call_recovery.py, and tests/test_eom_missed_call_recovery.py

## Fix-loop disposition preflight

- Root decision: Test the real Resend delivery adapter
- Source trace: Provider outcome review gap -> Resend gateway request and response classification
- Upstream files: `atlas_brain/services/eom_missed_call_recovery.py`, `tests/test_eom_missed_call_recovery.py`
- Fix strategy: upstream-root
- Blocking predicate: claimed-mechanism
- Disposition: fixed-in
- Allowed files: `atlas_brain/services/eom_missed_call_recovery.py`, `atlas_brain/templates/email/missed_call_recovery.py`, `atlas_brain/eom_api/config.py`, `tests/test_eom_missed_call_recovery.py`
- Max files: 14
- Parked hardening: none

- Root decision: Preserve ambiguity when concurrent requests exhaust retries
- Source trace: Provider retry review gap -> a 409 names another request for the same key as in progress, not rejected
- Upstream files: `atlas_brain/services/eom_missed_call_recovery.py`, `tests/test_eom_missed_call_recovery.py`
- Fix strategy: upstream-root
- Blocking predicate: claimed-mechanism
- Disposition: fixed-in
- Allowed files: `atlas_brain/services/eom_missed_call_recovery.py`, `tests/test_eom_missed_call_recovery.py`
- Max files: 14
- Parked hardening: none

- Root decision: Prove worker startup through both application lifespans
- Source trace: Lifecycle review gap -> shared worker preparation at both application entrypoints plus additive slim-profile schema rollout before delivery enablement
- Upstream files: `atlas_brain/main.py`, `atlas_brain/main_eom.py`, `tests/test_eom_missed_call_recovery.py`, `tests/test_eom_lead_conversion.py`
- Fix strategy: upstream-root
- Blocking predicate: claimed-mechanism
- Disposition: fixed-in
- Allowed files: `atlas_brain/main.py`, `atlas_brain/main_eom.py`, `render.eom.yaml`, `.github/workflows/atlas_eom_lead_pipeline_checks.yml`, `docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md`, `tests/test_eom_render_profile.py`, `tests/test_eom_missed_call_recovery.py`, `tests/test_eom_lead_conversion.py`
- Max files: 14
- Parked hardening: none

- Root decision: Apply the recovery schema while delivery is disabled
- Source trace: Slim startup rollout gap -> migration 389 was incorrectly coupled to worker enablement
- Upstream files: `atlas_brain/main_eom.py`, `docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md`, `tests/test_eom_missed_call_recovery.py`
- Fix strategy: upstream-root
- Blocking predicate: ci
- Disposition: fixed-in
- Allowed files: `atlas_brain/main_eom.py`, `docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md`, `tests/test_eom_missed_call_recovery.py`, `plans/PR-EOM-Missed-Call-Recovery.md`
- Max files: 14
- Parked hardening: none

- Root decision: Persist configuration blocks for existing active sequences
- Source trace: Disabled deployment review gap -> durable sequence block and explicit resume boundary
- Upstream files: `atlas_brain/services/eom_missed_call_recovery.py`, `docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md`, `tests/test_eom_missed_call_recovery.py`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `atlas_brain/services/eom_missed_call_recovery.py`, `docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md`, `plans/PR-EOM-Missed-Call-Recovery.md`, `tests/test_eom_missed_call_recovery.py`
- Max files: 14
- Parked hardening: none

- Root decision: Make cancellation triggers evaluate effective current evidence
- Source trace: Trigger review gap -> effective recipient and occurred-at comparison plus contact-locked fresh worker rechecks
- Upstream files: `atlas_brain/storage/migrations/389_eom_missed_call_recovery.sql`, `atlas_brain/services/eom_missed_call_recovery.py`, `tests/test_eom_missed_call_recovery.py`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `atlas_brain/storage/migrations/389_eom_missed_call_recovery.sql`, `atlas_brain/services/eom_missed_call_recovery.py`, `tests/test_eom_missed_call_recovery.py`
- Max files: 14
- Parked hardening: none

- Root decision: Serialize recipient corrections before delivery
- Source trace: Recipient-correction concurrency gap -> a mutable interaction could commit between an old final snapshot and Resend delivery
- Upstream files: `atlas_brain/storage/migrations/389_eom_missed_call_recovery.sql`, `atlas_brain/services/eom_missed_call_recovery.py`, `tests/test_eom_missed_call_recovery.py`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `atlas_brain/storage/migrations/389_eom_missed_call_recovery.sql`, `atlas_brain/services/eom_missed_call_recovery.py`, `tests/test_eom_missed_call_recovery.py`, `plans/PR-EOM-Missed-Call-Recovery.md`
- Max files: 14
- Parked hardening: none

- Root decision: Fence sequences when contacts leave the EOM tenant
- Source trace: Tenant-transfer gap -> a non-EOM reassignment could leave an active EOM sequence eligible for delivery
- Upstream files: `atlas_brain/storage/migrations/389_eom_missed_call_recovery.sql`, `atlas_brain/services/eom_missed_call_recovery.py`, `tests/test_eom_missed_call_recovery.py`
- Fix strategy: upstream-root
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: `atlas_brain/storage/migrations/389_eom_missed_call_recovery.sql`, `atlas_brain/services/eom_missed_call_recovery.py`, `tests/test_eom_missed_call_recovery.py`, `plans/PR-EOM-Missed-Call-Recovery.md`
- Max files: 14
- Parked hardening: none

- Root decision: Bind recovery idempotency keys across contacts
- Source trace: Cross-contact retry review gap -> global operation receipt before provider mutation
- Upstream files: `atlas_brain/storage/migrations/389_eom_missed_call_recovery.sql`, `atlas_brain/services/eom_missed_call_recovery.py`, `tests/test_eom_missed_call_recovery.py`
- Fix strategy: upstream-root
- Blocking predicate: data
- Disposition: fixed-in
- Allowed files: `atlas_brain/storage/migrations/389_eom_missed_call_recovery.sql`, `atlas_brain/services/eom_missed_call_recovery.py`, `atlas_brain/eom_api/funnel.py`, `tests/test_eom_missed_call_recovery.py`
- Max files: 14
- Parked hardening: none

## Deferred

- Tracker proxy and the existing CRM Leads-card action/status integration land
  only after tracker #237 and Website #258 publish; they consume the named
  capability contract without a competing UI.
- Verified EOM inbound email, eVoice/telephony, and Calendar-selection
  correlation; ATLAS #2474 tracks the safe follow-up boundary.
- Holiday/office-hours policy. The present, explicitly tested rule is weekday
  Email 2 at 09:00 America/Chicago and Email 3 three local calendar days after
  successful Email 2 delivery.

## Parked hardening

- ATLAS #2474: build only positive-evidence EOM inbound-channel correlation;
  generic provider events must not become a false cancellation trigger.

## Cold diff reconstruction

- `atlas_brain/storage/migrations/389_eom_missed_call_recovery.sql:430` adds a
  per-contact BEFORE interaction lock, `:509` terminalizes changed recipient
  snapshots, and `:550` terminalizes EOM tenant departure while preserving the
  existing additive sequence/event ledger.
- `atlas_brain/services/eom_missed_call_recovery.py:1218` acquires that contact
  lock before a fresh latest-intake read; `:1659`/`:1799` apply the same order
  to claim and final delivery. The Resend adapter preserves a concurrent-key
  outcome as `recovery_required` on retry exhaustion rather than false failure.
- `atlas_brain/templates/email/missed_call_recovery.py:24` renders the three
  approved deterministic messages only from provider-supplied configuration.
- `atlas_brain/eom_api/config.py:218`, `funnel.py:624`, and `funnel.py:1083`
  add validated deploy-time config plus authenticated, capability-backed routes
  and non-PII status. `main.py:915` and `main_eom.py:248` use the common
  startup fence/worker preparation boundary; slim startup applies migration
  389 whenever its migration flag is enabled, even while delivery is disabled.
- `tests/test_eom_missed_call_recovery.py:251` proves the real Resend adapter,
  both application lifespans, global operation-key ownership, pause/resume
  recovery, real Atlas route, persistence, concurrent-worker claim, retries,
  recipient-lock interleavings, tenant-transfer cancellation, stop conditions,
  and no-real-email boundary; CI enrollment and the
  slim-profile tests are in
  `.github/workflows/atlas_eom_lead_pipeline_checks.yml:35` and
  `tests/test_eom_render_profile.py:248`. The existing full-app handoff proof
  at `tests/test_eom_lead_conversion.py:3147` now models the third canonical-
  pool read needed by the disabled-recovery block fence.
- Contract match: every changed runtime/schema/test/configuration path is
  required for the provider-owned state machine. Public intake, immediate
  acknowledgement, generic telecom callbacks, and CRM-page files are unchanged.
  The new GitHub rerun remains the pending verification gap.

## Verification

- Focused recovery, form-intake regression, API-profile, syntax, lint, format,
  and whitespace checks passed locally. The reviewed database interleavings
  also ran against a disposable local PostgreSQL schema with fake recipients
  and mock/recording gateways; GitHub retains the full EOM pipeline.
- Resend's current primary API documentation confirms `POST /emails` accepts
  `Idempotency-Key` and retains it for 24 hours; this implementation uses a
  23-hour safety window and moves uncertain outcomes to `recovery_required`.

## Mechanical verification

- Command: `python -m py_compile atlas_brain/eom_api/config.py atlas_brain/eom_api/funnel.py atlas_brain/main.py atlas_brain/main_eom.py atlas_brain/services/eom_missed_call_recovery.py atlas_brain/templates/email/missed_call_recovery.py` - Result: passed - Environment: local
- Command: `ruff format --check atlas_brain/services/eom_missed_call_recovery.py atlas_brain/templates/email/missed_call_recovery.py tests/test_eom_missed_call_recovery.py` - Result: passed - Environment: local
- Command: `ruff check --ignore E402 atlas_brain/eom_api/config.py atlas_brain/eom_api/funnel.py atlas_brain/main.py atlas_brain/main_eom.py atlas_brain/services/eom_missed_call_recovery.py atlas_brain/templates/email/missed_call_recovery.py tests/test_eom_missed_call_recovery.py tests/test_eom_render_profile.py` - Result: passed - Environment: local
- Command: `pytest -q tests/test_eom_missed_call_recovery.py tests/test_eom_render_profile.py::test_eom_profile_import_does_not_load_full_api_package tests/test_eom_render_profile.py::test_eom_render_blueprint_maps_database_and_receivables_auth tests/test_eom_render_profile.py::test_eom_missed_call_recovery_migration_helper_uses_funnel_curated_set tests/test_leads_intake.py` - Result: 99 passed, 37 skipped - Environment: local
- Command: `pytest -q tests/test_eom_render_profile.py::test_eom_lifespan_closes_generic_database_when_funnel_close_fails tests/test_eom_render_profile.py::test_eom_profile_reaches_private_funnel_handoff_through_real_app` - Result: 2 passed - Environment: local
- Command: `ruff check --ignore E402 atlas_brain/services/eom_missed_call_recovery.py tests/test_eom_lead_conversion.py && python -m py_compile atlas_brain/services/eom_missed_call_recovery.py tests/test_eom_lead_conversion.py && pytest -q tests/test_eom_lead_conversion.py::test_full_app_lifespan_executes_enabled_preflight_before_handoff_request` - Result: passed; 1 targeted lifespan proof passed (one upstream pynvml deprecation warning) - Environment: local
- Command: `ATLAS_MIGRATION_TEST_DATABASE_URL=<ephemeral local PostgreSQL> pytest -q tests/test_eom_missed_call_recovery.py::test_effective_form_recipient_change_cancels_before_delivery` - Result: 1 passed; disposable test database with fake `.example.test` recipient and recording gateway only - Environment: local
- Command: `ruff check --ignore E402 atlas_brain/services/eom_missed_call_recovery.py atlas_brain/main_eom.py tests/test_eom_missed_call_recovery.py && ruff format --check atlas_brain/services/eom_missed_call_recovery.py atlas_brain/main_eom.py tests/test_eom_missed_call_recovery.py && python -m py_compile atlas_brain/services/eom_missed_call_recovery.py atlas_brain/main_eom.py tests/test_eom_missed_call_recovery.py` - Result: passed - Environment: local
- Command: `pytest -q tests/test_eom_missed_call_recovery.py::test_real_resend_gateway_preserves_provider_idempotency_and_outcome_classes tests/test_eom_missed_call_recovery.py::test_slim_eom_lifespan_applies_recovery_schema_while_delivery_disabled tests/test_eom_lead_conversion.py::test_full_app_lifespan_executes_enabled_preflight_before_handoff_request` - Result: 3 passed; one upstream pynvml deprecation warning - Environment: local
- Command: `ATLAS_MIGRATION_TEST_DATABASE_URL=<ephemeral local PostgreSQL> pytest -q tests/test_eom_missed_call_recovery.py::test_intake_correction_that_wins_contact_lock_stops_delivery tests/test_eom_missed_call_recovery.py::test_recipient_correction_serializes_with_final_delivery_check tests/test_eom_missed_call_recovery.py::test_tenant_reassignment_cancels_remaining_recovery_before_delivery tests/test_eom_missed_call_recovery.py::test_concurrent_provider_key_exhaustion_preserves_delivery_ambiguity tests/test_eom_missed_call_recovery.py::test_worker_sends_each_step_once_and_records_tenant_scoped_history tests/test_eom_missed_call_recovery.py::test_two_workers_cannot_send_the_same_due_step_twice` - Result: 6 passed; disposable database with only fake or mock-transport email delivery - Environment: local
- Command: `git diff --check` - Result: passed - Environment: local
- Skipped: full EOM lead-pipeline, integration, security, and unit-gate suites - Reason: they are enrolled on GitHub; the operator requested only fast targeted local checks.

## Diff size

14 files, +6514 / -2

<!-- atlas-open-pr-wrapper: v1 -->
