### PR TITLE
EOM: clarify shared onboarding quality check

### DIFF
--- a/atlas_brain/templates/email/onboarding_welcome.py
+++ b/atlas_brain/templates/email/onboarding_welcome.py
@@ -33,7 +33,7 @@ instructions and come back to a finished space. If you'd rather be present
 for the first visit, that works too.
 
 3. After we finish, please take a walk through the space and let us know if
-anything needs attention. We'll take care of it right away.
+anything needs attention. We'll take care of it.
 
 4. After the first cleaning, tell us what you thought. We adjust to your
 feedback, and there's no long-term contract holding you here - we keep the

--- a/atlas_brain/templates/email/onboarding_welcome.py
+++ b/atlas_brain/templates/email/onboarding_welcome.py
@@ -32,8 +32,8 @@ leave it out and let us know.
 instructions and come back to a finished space. If you'd rather be present
 for the first visit, that works too.
 
-3. Walk the space with your team lead at the start or end of the visit if
-you'd like - it's the fastest way to tell us what matters most to you.
+3. After we finish, please take a walk through the space and let us know if
+anything needs attention. We'll take care of it right away.
 
 4. After the first cleaning, tell us what you thought. We adjust to your
 feedback, and there's no long-term contract holding you here - we keep the

--- a/plans/PR-EOM-Residential-Onboarding-Quality-Check-Copy.md
+++ b/plans/PR-EOM-Residential-Onboarding-Quality-Check-Copy.md
@@ -1,0 +1,125 @@
+# PR-EOM-Residential-Onboarding-Quality-Check-Copy
+
+## Why this slice exists
+
+The operator reported that point 3 of the residential onboarding email tells a
+customer to walk the space with a team lead at the start or end of a visit. That
+instruction does not describe the intended post-cleaning quality-check flow.
+This product-polish slice changes the source template for future onboarding
+drafts only, under the operator's explicit copy direction in this session.
+
+### Problem-derived contract
+
+- Root cause: `ONBOARDING_TEMPLATE` presents an ambiguous in-visit walkthrough
+  as the way to communicate priorities, even though the intended customer action
+  is to inspect the cleaned space after service and report anything needing
+  attention.
+- Correct fix must touch/change: replace only point 3 in
+  `atlas_brain/templates/email/onboarding_welcome.py`, and add a direct renderer
+  assertion in `tests/test_eom_lead_conversion.py` for the approved post-cleaning
+  wording and absence of the legacy team-lead instruction.
+- Must not change: first-clean booking, draft enqueue/idempotency, approval or
+  send behavior, recipient resolution, existing persisted draft bodies,
+  business contact details, APIs, schemas, migrations, Website/Tracker code,
+  and unrelated onboarding copy.
+
+## Scope (this PR)
+
+Ownership lane: eom/residential-onboarding-copy
+Slice phase: Product polish
+
+1. Replace point 3 with a post-cleaning quality-check invitation for newly
+   rendered English onboarding drafts.
+2. Render and test the new wording as a post-cleaning quality-check invitation.
+
+### Review Contract
+
+- Acceptance criteria:
+  1. `format_onboarding_welcome()` renders point 3 as an after-cleaning
+     walkthrough that asks the customer to report anything needing attention
+     and says the team will take care of it right away; the focused renderer test
+     settles the exact customer-visible text.
+  2. The rendered body no longer contains the legacy `team lead at the start or
+     end` instruction; the same focused test settles the removal.
+  3. The established first-clean draft enqueue path still obtains its subject
+     and body through `format_onboarding_welcome()` at
+     `atlas_brain/services/crm_provider.py:3960-3962`; the existing enqueue
+     regression remains in the focused test file.
+- Reachability proof: a first-clean booking reaches
+  `DatabaseCRMProvider._enqueue_eom_onboarding_email_draft()`, which renders
+  the template before inserting the approval-only draft; the direct renderer
+  test verifies the observable body that this path snapshots.
+- Affected surfaces: the English residential onboarding-welcome template and
+  its focused EOM lead-conversion test coverage.
+- Risk areas: accidental reintroduction of the legacy wording; changing the
+  queue/send lifecycle while editing customer-facing copy.
+- Reviewer rules triggered: R1 requirements match, R2 test evidence, R5
+  backward compatibility, R10 maintainability, R12 deployment safety, R14
+  codebase verification.
+
+### Boundary-change enumeration
+
+Required when this diff changes a guard, validator, normalizer, resolver,
+router/classifier, or admission boundary. Name each changed boundary path or
+seam in the enumeration; otherwise write "N/A - no boundary change."
+
+- Boundary path/seam: N/A - no boundary change.
+- Replaced-path behaviors: N/A - no boundary change.
+- Guard-relevant fields: N/A - no boundary change.
+- Caller x input shape: N/A - no boundary change.
+
+### Deployed-config probing
+
+Required for guard, validator, resolver, admission-boundary, or env/config
+fallback changes; otherwise write "N/A - no guard/config boundary change."
+
+- Deployed/default config values: N/A - no guard/config boundary change.
+- Explicit value probe: N/A - no guard/config boundary change.
+- Absent value probe: N/A - no guard/config boundary change.
+- Default-session/default-context probe: N/A - no guard/config boundary change.
+- Side-effect ordering: N/A - no guard/config boundary change.
+
+### Files touched
+
+- `atlas_brain/templates/email/onboarding_welcome.py`
+- `plans/PR-EOM-Residential-Onboarding-Quality-Check-Copy.md`
+- `tests/test_eom_lead_conversion.py`
+
+## Mechanism
+
+Replace the third numbered paragraph in the existing English template with
+plain post-cleaning quality-check language. The renderer continues to format
+the same subject, customer name fallback, and business contact values. A focused
+test calls that renderer directly and asserts the approved wording is present
+and the superseded team-lead wording is absent.
+
+## Intentional
+
+- The email continues to describe only future draft bodies. Existing draft rows
+  remain immutable snapshots for office review; this slice does not bulk-edit
+  or resend customer communications.
+- This is an English-template correction. No Spanish counterpart exists in the
+  current template package, so this slice does not invent a parallel
+  localization surface.
+
+## Deferred
+
+- None.
+
+Parked hardening: none.
+
+## Verification
+
+- Completed locally: focused onboarding-template regression selection
+  (`7 passed, 219 deselected`) and `py_compile` for the changed Python template.
+- Pending before push: the repository's single pre-push mechanical review bundle
+  through `scripts/push_pr.sh`; the full suite remains a GitHub CI responsibility.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/templates/email/onboarding_welcome.py` | 4 |
+| `plans/PR-EOM-Residential-Onboarding-Quality-Check-Copy.md` | 125 |
+| `tests/test_eom_lead_conversion.py` | 13 |
+| **Total** | **142** |

--- a/plans/PR-EOM-Residential-Onboarding-Quality-Check-Copy.md
+++ b/plans/PR-EOM-Residential-Onboarding-Quality-Check-Copy.md
@@ -2,7 +2,7 @@
 
 ## Why this slice exists
 
-The operator reported that point 3 of the residential onboarding email tells a
+The operator reported that point 3 of the EOM onboarding email tells a
 customer to walk the space with a team lead at the start or end of a visit. That
 instruction does not describe the intended post-cleaning quality-check flow.
 This product-polish slice changes the source template for future onboarding
@@ -13,35 +13,61 @@ drafts only, under the operator's explicit copy direction in this session.
 - Root cause: `ONBOARDING_TEMPLATE` presents an ambiguous in-visit walkthrough
   as the way to communicate priorities, even though the intended customer action
   is to inspect the cleaned space after service and report anything needing
-  attention.
+  attention. The template's own module contract also forbids clock promises,
+  so an immediate-remediation promise would be an invalid implementation of
+  that action.
 - Correct fix must touch/change: replace only point 3 in
   `atlas_brain/templates/email/onboarding_welcome.py`, and add a direct renderer
-  assertion in `tests/test_eom_lead_conversion.py` for the approved post-cleaning
-  wording and absence of the legacy team-lead instruction.
+  assertion in `tests/test_eom_lead_conversion.py` for the approved,
+  non-temporal post-cleaning wording and absence of the legacy team-lead
+  instruction.
 - Must not change: first-clean booking, draft enqueue/idempotency, approval or
   send behavior, recipient resolution, existing persisted draft bodies,
   business contact details, APIs, schemas, migrations, Website/Tracker code,
   and unrelated onboarding copy.
 
+### Contract revision (review evidence)
+
+- New evidence: the template documents a no-clock-promise rule at
+  `atlas_brain/templates/email/onboarding_welcome.py:6-8`; the first-clean
+  completion query admits EOM leads without a `customer_type` predicate at
+  `atlas_brain/services/crm_provider.py:3766-3789` and always invokes this
+  renderer at `atlas_brain/services/crm_provider.py:3908-3912`.
+- Revised root cause: the old in-visit direction is wrong, and the first
+  proposed replacement accidentally made a clock promise while calling the
+  shared EOM first-clean template residential-only.
+- Revised required change surface: retain the same template and focused test;
+  make the assurance non-temporal and state the existing shared EOM first-clean
+  scope accurately in this plan and the PR body.
+- Revised non-scope: do not add customer-type routing, a new template variant,
+  or a lifecycle admission rule to a copy correction.
+- Revised verification: the focused renderer test must require the non-temporal
+  assurance and reject both the former team-lead direction and `right away`.
+
 ## Scope (this PR)
 
 Ownership lane: eom/residential-onboarding-copy
 Slice phase: Product polish
+Max files: 3
 
-1. Replace point 3 with a post-cleaning quality-check invitation for newly
-   rendered English onboarding drafts.
-2. Render and test the new wording as a post-cleaning quality-check invitation.
+1. Replace point 3 with a non-temporal post-cleaning quality-check invitation
+   for newly rendered English EOM onboarding drafts.
+2. Render and test the shared-template wording without adding customer-type
+   routing or changing the first-clean lifecycle.
 
 ### Review Contract
 
 - Acceptance criteria:
-  1. `format_onboarding_welcome()` renders point 3 as an after-cleaning
+  1. `format_onboarding_welcome()` renders point 3 as an after-cleaning,
+     non-temporal
      walkthrough that asks the customer to report anything needing attention
-     and says the team will take care of it right away; the focused renderer test
-     settles the exact customer-visible text.
+     and says the team will take care of it; the focused renderer test settles
+     the exact customer-visible text.
   2. The rendered body no longer contains the legacy `team lead at the start or
-     end` instruction; the same focused test settles the removal.
-  3. The established first-clean draft enqueue path still obtains its subject
+     end` instruction or `right away`; the same focused test settles both
+     removals.
+  3. The established shared EOM first-clean draft enqueue path still obtains its
+     subject
      and body through `format_onboarding_welcome()` at
      `atlas_brain/services/crm_provider.py:3960-3962`; the existing enqueue
      regression remains in the focused test file.
@@ -49,7 +75,7 @@ Slice phase: Product polish
   `DatabaseCRMProvider._enqueue_eom_onboarding_email_draft()`, which renders
   the template before inserting the approval-only draft; the direct renderer
   test verifies the observable body that this path snapshots.
-- Affected surfaces: the English residential onboarding-welcome template and
+- Affected surfaces: the shared English EOM onboarding-welcome template and
   its focused EOM lead-conversion test coverage.
 - Risk areas: accidental reintroduction of the legacy wording; changing the
   queue/send lifecycle while editing customer-facing copy.
@@ -87,17 +113,20 @@ fallback changes; otherwise write "N/A - no guard/config boundary change."
 
 ## Mechanism
 
-Replace the third numbered paragraph in the existing English template with
-plain post-cleaning quality-check language. The renderer continues to format
-the same subject, customer name fallback, and business contact values. A focused
-test calls that renderer directly and asserts the approved wording is present
-and the superseded team-lead wording is absent.
+Replace the third numbered paragraph in the existing shared English template
+with non-temporal post-cleaning quality-check language. The renderer continues
+to format the same subject, customer name fallback, and business contact values.
+A focused test calls that renderer directly and asserts the approved wording is
+present while the superseded team-lead and `right away` wording are absent.
 
 ## Intentional
 
 - The email continues to describe only future draft bodies. Existing draft rows
   remain immutable snapshots for office review; this slice does not bulk-edit
   or resend customer communications.
+- Current code uses this template for all EOM first-clean drafts; the corrected
+  quality-check wording is intentionally neutral across that existing shared
+  output. This slice does not introduce a residential/commercial routing rule.
 - This is an English-template correction. No Spanish counterpart exists in the
   current template package, so this slice does not invent a parallel
   localization surface.
@@ -120,6 +149,6 @@ Parked hardening: none.
 | File | LOC |
 |---|---:|
 | `atlas_brain/templates/email/onboarding_welcome.py` | 4 |
-| `plans/PR-EOM-Residential-Onboarding-Quality-Check-Copy.md` | 125 |
-| `tests/test_eom_lead_conversion.py` | 13 |
-| **Total** | **142** |
+| `plans/PR-EOM-Residential-Onboarding-Quality-Check-Copy.md` | 154 |
+| `tests/test_eom_lead_conversion.py` | 14 |
+| **Total** | **172** |

--- a/plans/PR-EOM-Residential-Onboarding-Quality-Check-Copy.md
+++ b/plans/PR-EOM-Residential-Onboarding-Quality-Check-Copy.md
@@ -133,6 +133,11 @@ present while the superseded team-lead and `right away` wording are absent.
 
 - None.
 
+Parking predicate: this copy-only slice parks customer-type routing,
+localization, delivery/lifecycle, and broader CRM/template hardening unless it
+directly prevents future shared EOM first-clean drafts from conveying the
+post-service quality-check instruction without a clock promise.
+
 Parked hardening: none.
 
 ## Verification

--- a/plans/PR-EOM-Residential-Onboarding-Quality-Check-Copy.md
+++ b/plans/PR-EOM-Residential-Onboarding-Quality-Check-Copy.md
@@ -34,8 +34,8 @@ drafts only, under the operator's explicit copy direction in this session.
   `atlas_brain/services/crm_provider.py:3766-3789` and always invokes this
   renderer at `atlas_brain/services/crm_provider.py:3908-3912`.
 - Revised root cause: the old in-visit direction is wrong, and the first
-  proposed replacement accidentally made a clock promise while calling the
-  shared EOM first-clean template residential-only.
+  proposed replacement accidentally made a clock promise while the plan
+  misdescribed the shared EOM first-clean template as residential-only.
 - Revised required change surface: retain the same template and focused test;
   make the assurance non-temporal and state the existing shared EOM first-clean
   scope accurately in this plan and the PR body.
@@ -58,17 +58,15 @@ Max files: 3
 ### Review Contract
 
 - Acceptance criteria:
-  1. `format_onboarding_welcome()` renders point 3 as an after-cleaning,
-     non-temporal
-     walkthrough that asks the customer to report anything needing attention
+  1. `format_onboarding_welcome()` renders point 3 as a non-temporal,
+     after-cleaning walkthrough that asks the customer to report anything needing attention
      and says the team will take care of it; the focused renderer test settles
      the exact customer-visible text.
   2. The rendered body no longer contains the legacy `team lead at the start or
      end` instruction or `right away`; the same focused test settles both
      removals.
   3. The established shared EOM first-clean draft enqueue path still obtains its
-     subject
-     and body through `format_onboarding_welcome()` at
+     subject and body through `format_onboarding_welcome()` at
      `atlas_brain/services/crm_provider.py:3960-3962`; the existing enqueue
      regression remains in the focused test file.
 - Reachability proof: a first-clean booking reaches
@@ -141,14 +139,15 @@ Parked hardening: none.
 
 - Completed locally: focused onboarding-template regression selection
   (`7 passed, 219 deselected`) and `py_compile` for the changed Python template.
-- Pending before push: the repository's single pre-push mechanical review bundle
-  through `scripts/push_pr.sh`; the full suite remains a GitHub CI responsibility.
+- Pending before push: the repository's mandatory `scripts/push_pr.sh` review
+  wrapper, including its full unit-gate mirror for this exact update; GitHub CI
+  will independently run its required checks after the push.
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
 | `atlas_brain/templates/email/onboarding_welcome.py` | 4 |
-| `plans/PR-EOM-Residential-Onboarding-Quality-Check-Copy.md` | 154 |
+| `plans/PR-EOM-Residential-Onboarding-Quality-Check-Copy.md` | 153 |
 | `tests/test_eom_lead_conversion.py` | 14 |
-| **Total** | **172** |
+| **Total** | **171** |

--- a/tests/test_eom_lead_conversion.py
+++ b/tests/test_eom_lead_conversion.py
@@ -2391,6 +2391,19 @@ async def test_private_first_clean_booking_idempotent_replay_skips_calendar_side
     assert crm.first_clean_failed_calls == []
 
 
+def test_onboarding_welcome_asks_for_post_cleaning_quality_check():
+    """Future onboarding drafts invite a post-cleaning quality check."""
+    from atlas_brain.templates.email import format_onboarding_welcome
+
+    _, body = format_onboarding_welcome(client_name="Quality Check Lead")
+
+    assert (
+        "3. After we finish, please take a walk through the space and let us know if\n"
+        "anything needs attention. We'll take care of it right away."
+    ) in body
+    assert "Walk the space with your team lead at the start or end" not in body
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("contact_email", "latest_intake_email", "expected_recipient", "expected_blocker"),

--- a/tests/test_eom_lead_conversion.py
+++ b/tests/test_eom_lead_conversion.py
@@ -2399,9 +2399,10 @@ def test_onboarding_welcome_asks_for_post_cleaning_quality_check():
 
     assert (
         "3. After we finish, please take a walk through the space and let us know if\n"
-        "anything needs attention. We'll take care of it right away."
+        "anything needs attention. We'll take care of it."
     ) in body
     assert "Walk the space with your team lead at the start or end" not in body
+    assert "right away" not in body
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-EOM-Residential-Onboarding-Quality-Check-Copy.md
Slice phase: Product polish
Ownership lane: eom/residential-onboarding-copy

This narrow product-polish slice corrects the confusing shared EOM first-clean
onboarding instruction for future drafts only, while preserving the established
booking, review, and delivery workflow.

## Problem

The shared EOM first-clean onboarding email told customers to walk the space
with a team lead at the start or end of a visit. That conflicts with the
intended post-cleaning quality-check workflow.

Related: #2156

## Current behavior

First-clean booking creates a pending, approval-only onboarding draft. The
draft body is rendered by `format_onboarding_welcome()` before persistence;
the current booking query does not select or gate `customer_type`, so this
single template remains shared across EOM first-clean drafts. Existing rows are
historical snapshots.

## Slice contract

- Future English EOM first-clean onboarding drafts invite the customer to
  inspect the cleaned space after service, report anything needing attention,
  and say the team will take care of it without a clock promise.
- The superseded team-lead/start-or-end wording and `right away` are absent.
- Booking, enqueue idempotency, approval, sending, recipients, and persisted
  draft snapshots retain their current behavior.

## Implementation

- Replaced point 3 in the authoritative shared onboarding renderer with a
  non-temporal quality-check assurance.
- Added a direct renderer regression that proves the approved wording appears
  while the former instruction and `right away` do not.
- Reconciled the plan with the actual shared first-clean scope; no type-routing
  or lifecycle change was added.

## Deployment order

ATLAS only. This is a backward-compatible template-copy correction and can
ship through the normal ATLAS deployment path after merge. No Website or
eom-timetracker deployment is required.

## Failure and retry behavior

No delivery code runs in this slice. Existing first-clean behavior still
creates an approval-only draft, and only newly rendered drafts receive the
corrected copy. Email delivery failures and retries retain their established
workflow because no enqueue, claim, approval, or send path changed.

## Intentional

- Do not rewrite existing pending or approved draft bodies; they are reviewed
  historical snapshots.
- The corrected neutral copy applies to the existing shared EOM first-clean
  template; this slice deliberately does not invent a residential/commercial
  routing variant.
- Do not introduce a Spanish template because the current onboarding template
  package has no Spanish counterpart.

## AI reconciliation

- Remove the immediate-remediation promise -- fixed-in: `1bc483df6` / `atlas_brain/templates/email/onboarding_welcome.py:35-36` / `tests/test_eom_lead_conversion.py:2394-2405`.
- Scope the copy change to residential drafts -- fixed-in: `1bc483df6` and `948d1aa95` / `plans/PR-EOM-Residential-Onboarding-Quality-Check-Copy.md` / this PR body.
- Declare the slice's parking predicate -- fixed-in: `32b0d7704` / `plans/PR-EOM-Residential-Onboarding-Quality-Check-Copy.md:136-141` / this PR body.

## Fix-loop disposition preflight

- Root decision: Remove the immediate-remediation promise
- Source trace: Codex thread -> `ONBOARDING_TEMPLATE` no-clock-promise contract -> point 3 renderer text
- Upstream files: atlas_brain/templates/email/onboarding_welcome.py, tests/test_eom_lead_conversion.py, plans/PR-EOM-Residential-Onboarding-Quality-Check-Copy.md
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: atlas_brain/templates/email/onboarding_welcome.py, tests/test_eom_lead_conversion.py, plans/PR-EOM-Residential-Onboarding-Quality-Check-Copy.md
- Max files: 3
- Parked hardening: none

- Root decision: Scope the copy change to residential drafts
- Source trace: Codex thread -> first-clean booking query without customer_type admission -> shared renderer contract and plan
- Upstream files: atlas_brain/templates/email/onboarding_welcome.py, tests/test_eom_lead_conversion.py, plans/PR-EOM-Residential-Onboarding-Quality-Check-Copy.md
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: atlas_brain/templates/email/onboarding_welcome.py, tests/test_eom_lead_conversion.py, plans/PR-EOM-Residential-Onboarding-Quality-Check-Copy.md
- Max files: 3
- Parked hardening: none

- Root decision: Declare the slice's parking predicate
- Source trace: Codex thread -> required plan Deferred predicate -> unsupported "Parked hardening: none" claim
- Upstream files: plans/PR-EOM-Residential-Onboarding-Quality-Check-Copy.md
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: plans/PR-EOM-Residential-Onboarding-Quality-Check-Copy.md
- Max files: 3
- Parked hardening: none

## Deferred

- None.

Parking predicate: this copy-only slice parks customer-type routing,
localization, delivery/lifecycle, and broader CRM/template hardening unless it
directly prevents future shared EOM first-clean drafts from conveying the
post-service quality-check instruction without a clock promise.

## Parked hardening

- None.

## Cold diff reconstruction

- Changed: `atlas_brain/templates/email/onboarding_welcome.py:35-36` replaces
  point 3 with non-temporal wording; `tests/test_eom_lead_conversion.py:2394-2405`
  protects the rendered copy and both forbidden phrases; the plan records the
  shared first-clean scope.
- Contract match: the direct renderer remains the source used by
  `DatabaseCRMProvider` before draft persistence at
  `atlas_brain/services/crm_provider.py:3960-3962`, while the first-clean query
  remains intentionally untouched and customer-type-neutral.
- Gaps: none found within the slice contract.
- effect-trace: customer-visible point 3 | `ONBOARDING_TEMPLATE` rendered by
  `format_onboarding_welcome()` | focused test asserts the new paragraph and
  rejects the legacy instruction and temporal promise.

## Verification

- The focused renderer and existing first-clean draft enqueue regression passed
  on the reconciled wording.
- The changed template compiled successfully.
- The mandatory repository wrapper will run its full unit mirror for this exact
  update before push; GitHub CI will independently run the required checks.

## Mechanical verification

- Command: `/home/juan-canfield/Desktop/Atlas/.venv/bin/python -m pytest tests/test_eom_lead_conversion.py -k 'onboarding_welcome_asks_for_post_cleaning_quality_check or onboarding_draft_enqueue_snapshots_recipient_or_records_blocker' -q` - Result: pass (`7 passed, 219 deselected in 0.78s`) - Environment: local
- Command: `/home/juan-canfield/Desktop/Atlas/.venv/bin/python -m py_compile atlas_brain/templates/email/onboarding_welcome.py` - Result: pass - Environment: local
- Skipped: standalone full unit gate - Reason: the mandated `scripts/push_pr.sh` wrapper runs it once on this exact update before push.

## Diff size

3 files, +169 / -2

<!-- atlas-open-pr-wrapper: v1 -->
