### PR TITLE
EOM: restore missed-call recovery runtime privileges

### DIFF
--- a/.github/workflows/atlas_eom_lead_pipeline_checks.yml
+++ b/.github/workflows/atlas_eom_lead_pipeline_checks.yml
@@ -75,6 +75,7 @@ on:
       - "atlas_brain/storage/migrations/390_eom_won_loss_direct_sql_fence_recovery.sql"
       - "atlas_brain/storage/migrations/391_eom_commercial_billing_run_fence_recovery.sql"
       - "atlas_brain/storage/migrations/392_eom_commercial_billing_run_fence_schema_binding.sql"
+      - "atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql"
       - "atlas_brain/storage/migrations/reconciliation.py"
       - "atlas_brain/tools/calendar.py"
       - "atlas_brain/tools/scheduling.py"
@@ -90,6 +91,7 @@ on:
       - "tests/test_eom_contact_archive.py"
       - "tests/test_eom_lead_conversion.py"
       - "tests/test_eom_missed_call_recovery.py"
+      - "tests/test_eom_missed_call_privilege_runner.py"
       - "tests/test_eom_lead_conversion_integration.py"
       - "tests/test_eom_render_profile.py"
       - "tests/test_eom_public_onboarding.py"
@@ -109,6 +111,7 @@ on:
       - "atlas_brain/storage/migrations/366_contacts_customer_type.sql"
       - "atlas_brain/storage/migrations/367_contacts_customer_type_revision.sql"
       - "scripts/backfill_eom_customer_type.py"
+      - "scripts/apply_eom_missed_call_recovery_runtime_privileges.py"
   push:
     branches:
       - main
@@ -182,6 +185,7 @@ on:
       - "atlas_brain/storage/migrations/390_eom_won_loss_direct_sql_fence_recovery.sql"
       - "atlas_brain/storage/migrations/391_eom_commercial_billing_run_fence_recovery.sql"
       - "atlas_brain/storage/migrations/392_eom_commercial_billing_run_fence_schema_binding.sql"
+      - "atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql"
       - "atlas_brain/storage/migrations/reconciliation.py"
       - "atlas_brain/tools/calendar.py"
       - "atlas_brain/tools/scheduling.py"
@@ -197,6 +201,7 @@ on:
       - "tests/test_eom_contact_archive.py"
       - "tests/test_eom_lead_conversion.py"
       - "tests/test_eom_missed_call_recovery.py"
+      - "tests/test_eom_missed_call_privilege_runner.py"
       - "tests/test_eom_lead_conversion_integration.py"
       - "tests/test_eom_render_profile.py"
       - "tests/test_eom_public_onboarding.py"
@@ -216,6 +221,7 @@ on:
       - "atlas_brain/storage/migrations/366_contacts_customer_type.sql"
       - "atlas_brain/storage/migrations/367_contacts_customer_type_revision.sql"
       - "scripts/backfill_eom_customer_type.py"
+      - "scripts/apply_eom_missed_call_recovery_runtime_privileges.py"
 
 jobs:
   eom-lead-pipeline:
@@ -272,6 +278,7 @@ jobs:
             tests/test_eom_billing_recipients.py \
             tests/test_eom_lead_conversion.py \
             tests/test_eom_missed_call_recovery.py \
+            tests/test_eom_missed_call_privilege_runner.py \
             tests/test_eom_lead_conversion_integration.py \
             tests/test_eom_render_profile.py \
             tests/test_eom_funnel_capability_manifest.py \

--- a/atlas_brain/config.py
+++ b/atlas_brain/config.py
@@ -33,6 +33,9 @@ EOM_FIRST_CLEAN_COMPLETION_DBA_DATABASE_URL_ENV = (
 EOM_FIRST_CLEAN_COMPLETION_DBA_SCHEMA_ENV = (
     "ATLAS_EOM_FIRST_CLEAN_COMPLETION_DBA_SCHEMA"
 )
+EOM_MISSED_CALL_RECOVERY_DBA_DATABASE_URL_ENV = (
+    "ATLAS_EOM_MISSED_CALL_RECOVERY_DBA_DATABASE_URL"
+)
 _IMAP_PORT_ADAPTER = TypeAdapter(Annotated[int, Field(ge=1, le=65535)])
 _IMAP_SSL_ADAPTER = TypeAdapter(bool)
 
@@ -2579,6 +2582,26 @@ class EOMFirstCleanCompletionDBAConfig(BaseSettings):
                 "PostgreSQL identifier"
             )
         return normalized
+
+
+class EOMMissedCallRecoveryDBAConfig(BaseSettings):
+    """Protected DBA-only configuration for the missed-call recovery runner.
+
+    The ordinary Atlas runtime does not instantiate this settings boundary, so
+    it never needs the privileged connection used by the one controlled repair.
+    """
+
+    model_config = SettingsConfigDict(env_file=ENV_FILES, extra="ignore")
+
+    database_url: SecretStr = Field(
+        default=SecretStr(""),
+        validation_alias=AliasChoices(EOM_MISSED_CALL_RECOVERY_DBA_DATABASE_URL_ENV),
+        repr=False,
+        description=(
+            "Protected PostgreSQL superuser DSN used only by the controlled "
+            "EOM missed-call recovery privilege runner."
+        ),
+    )
 
 
 class ExternalDataConfig(BaseSettings):

--- a/atlas_brain/main_eom.py
+++ b/atlas_brain/main_eom.py
@@ -125,6 +125,7 @@ EOM_MISSED_CALL_RECOVERY_READINESS_MIGRATIONS: tuple[str, ...] = (
     "390_eom_won_loss_direct_sql_fence_recovery",
     "391_eom_commercial_billing_run_fence_recovery",
     "392_eom_commercial_billing_run_fence_schema_binding",
+    "393_eom_missed_call_recovery_runtime_privileges",
 )
 
 

--- a/atlas_brain/main_eom.py
+++ b/atlas_brain/main_eom.py
@@ -111,8 +111,10 @@ EOM_RECEIVABLES_READINESS_MIGRATIONS: tuple[str, ...] = (
 # This worker owns EOM lead lifecycle evidence in the canonical funnel store,
 # not the global receivables pool. The set is deliberately closed: a newly
 # provisioned supported funnel database receives the columns, interaction
-# dedupe, lifecycle ledger, classification, and outbox schema it needs, while
-# unrelated Atlas migrations remain outside this slim-profile startup path.
+# dedupe, lifecycle ledger, classification, and recovery schema it needs. The
+# targeted historical recoveries 390-392 and the DBA-only ownership repair 393
+# are deliberately excluded: a normal runtime must encounter those recorded
+# already, never attempt privileged or historical repair SQL during startup.
 EOM_MISSED_CALL_RECOVERY_READINESS_MIGRATIONS: tuple[str, ...] = (
     "035_contacts",
     "256_contact_interaction_dedupe",
@@ -120,12 +122,6 @@ EOM_MISSED_CALL_RECOVERY_READINESS_MIGRATIONS: tuple[str, ...] = (
     "351_eom_lead_lifecycle_events",
     "366_contacts_customer_type",
     "389_eom_missed_call_recovery",
-    # The runner may need this explicit predecessor before 389 when the
-    # canonical target retains either reviewed historical recovery boundary.
-    "390_eom_won_loss_direct_sql_fence_recovery",
-    "391_eom_commercial_billing_run_fence_recovery",
-    "392_eom_commercial_billing_run_fence_schema_binding",
-    "393_eom_missed_call_recovery_runtime_privileges",
 )
 
 

--- a/atlas_brain/services/eom_missed_call_recovery.py
+++ b/atlas_brain/services/eom_missed_call_recovery.py
@@ -610,6 +610,40 @@ async def missed_call_recovery_schema_ready(pool: Any) -> bool:
                                )
                          )
                    )
+                   AND NOT EXISTS (
+                       SELECT 1
+                       FROM pg_roles AS runtime_role_state
+                       WHERE runtime_role_state.rolname = current_user
+                         AND EXISTS (
+                             SELECT 1
+                             FROM pg_roles AS delegating_login
+                             WHERE delegating_login.rolcanlogin
+                               AND NOT delegating_login.rolsuper
+                               AND delegating_login.oid <> runtime_role_state.oid
+                               AND pg_has_role(
+                                   delegating_login.oid,
+                                   runtime_role_state.oid,
+                                   'MEMBER'
+                               )
+                         )
+                   )
+                   AND NOT EXISTS (
+                       SELECT 1
+                       FROM pg_roles AS nocodb_role
+                       WHERE nocodb_role.rolname = 'atlas_nocodb'
+                         AND EXISTS (
+                             SELECT 1
+                             FROM pg_roles AS delegating_login
+                             WHERE delegating_login.rolcanlogin
+                               AND NOT delegating_login.rolsuper
+                               AND delegating_login.oid <> nocodb_role.oid
+                               AND pg_has_role(
+                                   delegating_login.oid,
+                                   nocodb_role.oid,
+                                   'MEMBER'
+                               )
+                         )
+                   )
                    AND EXISTS (
                        SELECT 1 FROM pg_index AS idx
                        JOIN pg_class AS rel ON rel.oid = idx.indexrelid

--- a/atlas_brain/services/eom_missed_call_recovery.py
+++ b/atlas_brain/services/eom_missed_call_recovery.py
@@ -65,6 +65,31 @@ _TRACKED_RESPONSE_INTERACTIONS = frozenset(
 # with one globally unique operation key, so a retry can never move to another
 # lead or mutation kind after an interrupted browser request.
 _OPERATION_KINDS = frozenset({"no_answer", "resume", "cancel"})
+_MISSED_CALL_RECOVERY_GUARD_FUNCTION_SIGNATURES = (
+    "cancel_eom_missed_call_sequences_for_contact(UUID, VARCHAR, VARCHAR)",
+    "lock_eom_missed_call_interaction_contact()",
+    "eom_missed_call_effective_recipient(UUID, TEXT)",
+    "cancel_eom_missed_call_on_recipient_change(UUID)",
+    "cancel_eom_missed_call_on_contact_change()",
+    "cancel_eom_missed_call_on_interaction()",
+    "prevent_eom_missed_call_operation_receipt_mutation()",
+    "prevent_eom_missed_call_attempt_mutation()",
+    "prevent_eom_missed_call_sequence_event_mutation()",
+    "prevent_eom_missed_call_suppression_mutation()",
+    "validate_eom_missed_call_contact_scope()",
+    "validate_eom_missed_call_sequence_scope()",
+    "eom_missed_call_has_proven_inbound_sms(JSONB)",
+)
+_MISSED_CALL_RECOVERY_DEFINER_FUNCTION_SIGNATURES = (
+    "cancel_eom_missed_call_sequences_for_contact(UUID, VARCHAR, VARCHAR)",
+    "lock_eom_missed_call_interaction_contact()",
+    "eom_missed_call_effective_recipient(UUID, TEXT)",
+    "cancel_eom_missed_call_on_recipient_change(UUID)",
+    "cancel_eom_missed_call_on_contact_change()",
+    "cancel_eom_missed_call_on_interaction()",
+    "validate_eom_missed_call_contact_scope()",
+    "validate_eom_missed_call_sequence_scope()",
+)
 
 
 class EOMMissedCallRecoveryError(Exception):
@@ -588,6 +613,19 @@ async def missed_call_recovery_schema_ready(pool: Any) -> bool:
                        JOIN pg_language AS language_state
                          ON language_state.oid = procedure.prolang
                    )
+                   AND (
+                       SELECT COUNT(*) = cardinality($1::text[])
+                          AND BOOL_AND(
+                              function_owner.rolname = 'atlas_eom_handoff_owner'
+                          )
+                       FROM unnest($1::text[]) AS expected_function(signature)
+                       JOIN pg_proc AS procedure
+                         ON procedure.oid = to_regprocedure(
+                             format('%I.%s', current_schema(), expected_function.signature)
+                         )
+                       JOIN pg_roles AS function_owner
+                         ON function_owner.oid = procedure.proowner
+                   )
                    AND EXISTS (
                        SELECT 1 FROM pg_trigger AS trigger
                        WHERE trigger.tgrelid = 'contacts'::regclass
@@ -622,7 +660,7 @@ async def missed_call_recovery_schema_ready(pool: Any) -> bool:
                          AND NOT trigger.tgisinternal
                    )
                    AND (
-                       SELECT COUNT(*) = 6
+                       SELECT COUNT(*) = cardinality($2::text[])
                           AND BOOL_AND(
                               procedure.prosecdef
                               AND function_owner.rolname = 'atlas_eom_handoff_owner'
@@ -642,25 +680,20 @@ async def missed_call_recovery_schema_ready(pool: Any) -> bool:
                                   current_user, procedure.oid, 'EXECUTE'
                               )
                           )
-                       FROM pg_proc AS procedure
-                       JOIN pg_namespace AS function_namespace
-                         ON function_namespace.oid = procedure.pronamespace
+                       FROM unnest($2::text[]) AS expected_function(signature)
+                       JOIN pg_proc AS procedure
+                         ON procedure.oid = to_regprocedure(
+                             format('%I.%s', current_schema(), expected_function.signature)
+                         )
                        JOIN pg_roles AS function_owner
                          ON function_owner.oid = procedure.proowner
-                      WHERE function_namespace.nspname = current_schema()
-                        AND procedure.proname = ANY (ARRAY[
-                            'cancel_eom_missed_call_sequences_for_contact',
-                            'lock_eom_missed_call_interaction_contact',
-                            'eom_missed_call_effective_recipient',
-                            'cancel_eom_missed_call_on_recipient_change',
-                            'cancel_eom_missed_call_on_contact_change',
-                            'cancel_eom_missed_call_on_interaction'
-                        ])
                    )
                    AND to_regprocedure(
                        'eom_missed_call_has_proven_inbound_sms(jsonb)'
                    ) IS NOT NULL
-                """
+                """,
+                _MISSED_CALL_RECOVERY_GUARD_FUNCTION_SIGNATURES,
+                _MISSED_CALL_RECOVERY_DEFINER_FUNCTION_SIGNATURES,
             )
         )
     except Exception:

--- a/atlas_brain/services/eom_missed_call_recovery.py
+++ b/atlas_brain/services/eom_missed_call_recovery.py
@@ -564,6 +564,30 @@ async def missed_call_recovery_schema_ready(pool: Any) -> bool:
                          AND trigger.tgenabled = 'O'
                          AND NOT trigger.tgisinternal
                    )
+                   AND (
+                       SELECT COUNT(*) = 2
+                          AND BOOL_AND(
+                              language_state.lanname = 'plpgsql'
+                              AND procedure.prosrc = expected_function.body
+                          )
+                       FROM (
+                           VALUES
+                               (
+                                   'prevent_eom_missed_call_operation_receipt_mutation()',
+                                   E'\\nBEGIN\\n    RAISE EXCEPTION ''eom_missed_call_operation_receipts is append-only'';\\nEND;\\n'
+                               ),
+                               (
+                                   'prevent_eom_missed_call_attempt_mutation()',
+                                   E'\\nBEGIN\\n    RAISE EXCEPTION ''eom_missed_call_attempts is append-only'';\\nEND;\\n'
+                               )
+                       ) AS expected_function(signature, body)
+                       JOIN pg_proc AS procedure
+                         ON procedure.oid = to_regprocedure(
+                             expected_function.signature
+                         )
+                       JOIN pg_language AS language_state
+                         ON language_state.oid = procedure.prolang
+                   )
                    AND EXISTS (
                        SELECT 1 FROM pg_trigger AS trigger
                        WHERE trigger.tgrelid = 'contacts'::regclass

--- a/atlas_brain/services/eom_missed_call_recovery.py
+++ b/atlas_brain/services/eom_missed_call_recovery.py
@@ -526,6 +526,63 @@ async def missed_call_recovery_schema_ready(pool: Any) -> bool:
                          ON table_owner.oid = relation.relowner
                       WHERE namespace.nspname = current_schema()
                    )
+                   AND NOT EXISTS (
+                       SELECT 1
+                       FROM (
+                           VALUES
+                               ('eom_missed_call_operation_receipts'),
+                               ('eom_missed_call_attempts'),
+                               ('eom_missed_call_contact_suppressions'),
+                               ('eom_missed_call_sequences'),
+                               ('eom_missed_call_sequence_steps'),
+                               ('eom_missed_call_sequence_events')
+                       ) AS required_relation(relation_name)
+                       JOIN pg_class AS relation
+                         ON relation.oid = to_regclass(
+                             format(
+                                 '%I.%I', current_schema(),
+                                 required_relation.relation_name
+                             )
+                         )
+                       CROSS JOIN LATERAL pg_catalog.aclexplode(
+                           COALESCE(
+                               relation.relacl,
+                               pg_catalog.acldefault('r', relation.relowner)
+                           )
+                       ) AS table_acl
+                       LEFT JOIN pg_roles AS grantee_role
+                         ON grantee_role.oid = table_acl.grantee
+                       WHERE table_acl.grantee = 0
+                          OR grantee_role.rolname NOT IN (
+                              'atlas_eom_handoff_owner', current_user
+                          )
+                   )
+                   AND NOT EXISTS (
+                       SELECT 1
+                       FROM (
+                           VALUES
+                               ('eom_missed_call_operation_receipts'),
+                               ('eom_missed_call_attempts'),
+                               ('eom_missed_call_contact_suppressions'),
+                               ('eom_missed_call_sequences'),
+                               ('eom_missed_call_sequence_steps'),
+                               ('eom_missed_call_sequence_events')
+                       ) AS required_relation(relation_name)
+                       JOIN pg_class AS relation
+                         ON relation.oid = to_regclass(
+                             format(
+                                 '%I.%I', current_schema(),
+                                 required_relation.relation_name
+                             )
+                         )
+                       JOIN pg_attribute AS attribute
+                         ON attribute.attrelid = relation.oid
+                       CROSS JOIN LATERAL pg_catalog.aclexplode(
+                           attribute.attacl
+                       ) AS column_acl
+                       WHERE attribute.attnum > 0
+                         AND NOT attribute.attisdropped
+                   )
                    AND EXISTS (
                        SELECT 1
                        FROM pg_roles AS guard_role

--- a/atlas_brain/services/eom_missed_call_recovery.py
+++ b/atlas_brain/services/eom_missed_call_recovery.py
@@ -638,6 +638,9 @@ async def missed_call_recovery_schema_ready(pool: Any) -> bool:
                               AND NOT has_function_privilege(
                                   'atlas_nocodb', procedure.oid, 'EXECUTE'
                               )
+                              AND NOT has_function_privilege(
+                                  current_user, procedure.oid, 'EXECUTE'
+                              )
                           )
                        FROM pg_proc AS procedure
                        JOIN pg_namespace AS function_namespace

--- a/atlas_brain/services/eom_missed_call_recovery.py
+++ b/atlas_brain/services/eom_missed_call_recovery.py
@@ -414,10 +414,36 @@ async def missed_call_recovery_schema_ready(pool: Any) -> bool:
                               AND has_table_privilege(current_user, relation.oid, 'SELECT')
                               AND has_table_privilege(current_user, relation.oid, 'INSERT')
                               AND (
-                                  NOT required_relation.requires_update
-                                  OR has_table_privilege(
-                                      current_user, relation.oid, 'UPDATE'
+                                  (
+                                      required_relation.requires_update
+                                      AND has_table_privilege(
+                                          current_user, relation.oid, 'UPDATE'
+                                      )
                                   )
+                                  OR (
+                                      NOT required_relation.requires_update
+                                      AND NOT has_table_privilege(
+                                          current_user, relation.oid, 'UPDATE'
+                                      )
+                                      AND NOT has_any_column_privilege(
+                                          current_user, relation.oid, 'UPDATE'
+                                      )
+                                  )
+                              )
+                              AND NOT has_table_privilege(
+                                  current_user, relation.oid, 'DELETE'
+                              )
+                              AND NOT has_table_privilege(
+                                  current_user, relation.oid, 'TRUNCATE'
+                              )
+                              AND NOT has_table_privilege(
+                                  current_user, relation.oid, 'REFERENCES'
+                              )
+                              AND NOT has_any_column_privilege(
+                                  current_user, relation.oid, 'REFERENCES'
+                              )
+                              AND NOT has_table_privilege(
+                                  current_user, relation.oid, 'TRIGGER'
                               )
                               AND NOT has_table_privilege(
                                   'atlas_nocodb', relation.oid, 'SELECT'
@@ -443,6 +469,15 @@ async def missed_call_recovery_schema_ready(pool: Any) -> bool:
                               AND NOT has_table_privilege(
                                   'atlas_nocodb', relation.oid, 'TRUNCATE'
                               )
+                              AND NOT has_table_privilege(
+                                  'atlas_nocodb', relation.oid, 'REFERENCES'
+                              )
+                              AND NOT has_any_column_privilege(
+                                  'atlas_nocodb', relation.oid, 'REFERENCES'
+                              )
+                              AND NOT has_table_privilege(
+                                  'atlas_nocodb', relation.oid, 'TRIGGER'
+                              )
                           )
                        FROM (
                            VALUES
@@ -462,9 +497,36 @@ async def missed_call_recovery_schema_ready(pool: Any) -> bool:
                          )
                        JOIN pg_namespace AS namespace
                          ON namespace.oid = relation.relnamespace
-                       JOIN pg_roles AS table_owner
+                      JOIN pg_roles AS table_owner
                          ON table_owner.oid = relation.relowner
                       WHERE namespace.nspname = current_schema()
+                   )
+                   AND EXISTS (
+                       SELECT 1
+                       FROM pg_roles AS guard_role
+                       WHERE guard_role.rolname = 'atlas_eom_handoff_owner'
+                         AND NOT guard_role.rolcanlogin
+                         AND NOT guard_role.rolinherit
+                         AND NOT guard_role.rolsuper
+                         AND NOT guard_role.rolcreaterole
+                         AND NOT guard_role.rolcreatedb
+                         AND NOT guard_role.rolreplication
+                         AND NOT guard_role.rolbypassrls
+                         AND has_schema_privilege(
+                             guard_role.oid, current_schema(), 'USAGE'
+                         )
+                         AND has_schema_privilege(
+                             guard_role.oid, current_schema(), 'CREATE'
+                         )
+                         AND NOT EXISTS (
+                             SELECT 1
+                             FROM pg_roles AS member_role
+                             WHERE member_role.rolcanlogin
+                               AND NOT member_role.rolsuper
+                               AND pg_has_role(
+                                   member_role.oid, guard_role.oid, 'MEMBER'
+                               )
+                         )
                    )
                    AND EXISTS (
                        SELECT 1 FROM pg_index AS idx
@@ -482,11 +544,35 @@ async def missed_call_recovery_schema_ready(pool: Any) -> bool:
                    )
                    AND EXISTS (
                        SELECT 1 FROM pg_trigger AS trigger
+                       WHERE trigger.tgrelid = 'eom_missed_call_operation_receipts'::regclass
+                         AND trigger.tgname = 'trg_prevent_eom_missed_call_operation_receipt_mutation'
+                         AND trigger.tgfoid = to_regprocedure(
+                             'prevent_eom_missed_call_operation_receipt_mutation()'
+                         )
+                         AND trigger.tgtype = 27
+                         AND trigger.tgenabled = 'O'
+                         AND NOT trigger.tgisinternal
+                   )
+                   AND EXISTS (
+                       SELECT 1 FROM pg_trigger AS trigger
+                       WHERE trigger.tgrelid = 'eom_missed_call_attempts'::regclass
+                         AND trigger.tgname = 'trg_prevent_eom_missed_call_attempt_mutation'
+                         AND trigger.tgfoid = to_regprocedure(
+                             'prevent_eom_missed_call_attempt_mutation()'
+                         )
+                         AND trigger.tgtype = 27
+                         AND trigger.tgenabled = 'O'
+                         AND NOT trigger.tgisinternal
+                   )
+                   AND EXISTS (
+                       SELECT 1 FROM pg_trigger AS trigger
                        WHERE trigger.tgrelid = 'contacts'::regclass
                          AND trigger.tgname = 'trg_cancel_eom_missed_call_on_contact_change'
                          AND trigger.tgfoid = to_regprocedure(
                              'cancel_eom_missed_call_on_contact_change()'
                          )
+                         AND trigger.tgtype = 17
+                         AND trigger.tgenabled = 'O'
                          AND NOT trigger.tgisinternal
                    )
                    AND EXISTS (
@@ -496,6 +582,8 @@ async def missed_call_recovery_schema_ready(pool: Any) -> bool:
                          AND trigger.tgfoid = to_regprocedure(
                              'lock_eom_missed_call_interaction_contact()'
                          )
+                         AND trigger.tgtype = 31
+                         AND trigger.tgenabled = 'O'
                          AND NOT trigger.tgisinternal
                    )
                    AND EXISTS (
@@ -505,6 +593,8 @@ async def missed_call_recovery_schema_ready(pool: Any) -> bool:
                          AND trigger.tgfoid = to_regprocedure(
                              'cancel_eom_missed_call_on_interaction()'
                          )
+                         AND trigger.tgtype = 29
+                         AND trigger.tgenabled = 'O'
                          AND NOT trigger.tgisinternal
                    )
                    AND (

--- a/atlas_brain/services/eom_missed_call_recovery.py
+++ b/atlas_brain/services/eom_missed_call_recovery.py
@@ -407,6 +407,65 @@ async def missed_call_recovery_schema_ready(pool: Any) -> bool:
                    AND to_regclass('eom_missed_call_sequences') IS NOT NULL
                    AND to_regclass('eom_missed_call_sequence_steps') IS NOT NULL
                    AND to_regclass('eom_missed_call_sequence_events') IS NOT NULL
+                   AND (
+                       SELECT COUNT(*) = 6
+                          AND BOOL_AND(
+                              table_owner.rolname = 'atlas_eom_handoff_owner'
+                              AND has_table_privilege(current_user, relation.oid, 'SELECT')
+                              AND has_table_privilege(current_user, relation.oid, 'INSERT')
+                              AND (
+                                  NOT required_relation.requires_update
+                                  OR has_table_privilege(
+                                      current_user, relation.oid, 'UPDATE'
+                                  )
+                              )
+                              AND NOT has_table_privilege(
+                                  'atlas_nocodb', relation.oid, 'SELECT'
+                              )
+                              AND NOT has_any_column_privilege(
+                                  'atlas_nocodb', relation.oid, 'SELECT'
+                              )
+                              AND NOT has_table_privilege(
+                                  'atlas_nocodb', relation.oid, 'INSERT'
+                              )
+                              AND NOT has_any_column_privilege(
+                                  'atlas_nocodb', relation.oid, 'INSERT'
+                              )
+                              AND NOT has_table_privilege(
+                                  'atlas_nocodb', relation.oid, 'UPDATE'
+                              )
+                              AND NOT has_any_column_privilege(
+                                  'atlas_nocodb', relation.oid, 'UPDATE'
+                              )
+                              AND NOT has_table_privilege(
+                                  'atlas_nocodb', relation.oid, 'DELETE'
+                              )
+                              AND NOT has_table_privilege(
+                                  'atlas_nocodb', relation.oid, 'TRUNCATE'
+                              )
+                          )
+                       FROM (
+                           VALUES
+                               ('eom_missed_call_operation_receipts', TRUE),
+                               ('eom_missed_call_attempts', TRUE),
+                               ('eom_missed_call_contact_suppressions', FALSE),
+                               ('eom_missed_call_sequences', TRUE),
+                               ('eom_missed_call_sequence_steps', TRUE),
+                               ('eom_missed_call_sequence_events', FALSE)
+                       ) AS required_relation(relation_name, requires_update)
+                       JOIN pg_class AS relation
+                         ON relation.oid = to_regclass(
+                             format(
+                                 '%I.%I', current_schema(),
+                                 required_relation.relation_name
+                             )
+                         )
+                       JOIN pg_namespace AS namespace
+                         ON namespace.oid = relation.relnamespace
+                       JOIN pg_roles AS table_owner
+                         ON table_owner.oid = relation.relowner
+                      WHERE namespace.nspname = current_schema()
+                   )
                    AND EXISTS (
                        SELECT 1 FROM pg_index AS idx
                        JOIN pg_class AS rel ON rel.oid = idx.indexrelid
@@ -425,19 +484,61 @@ async def missed_call_recovery_schema_ready(pool: Any) -> bool:
                        SELECT 1 FROM pg_trigger AS trigger
                        WHERE trigger.tgrelid = 'contacts'::regclass
                          AND trigger.tgname = 'trg_cancel_eom_missed_call_on_contact_change'
+                         AND trigger.tgfoid = to_regprocedure(
+                             'cancel_eom_missed_call_on_contact_change()'
+                         )
                          AND NOT trigger.tgisinternal
                    )
                    AND EXISTS (
                        SELECT 1 FROM pg_trigger AS trigger
                        WHERE trigger.tgrelid = 'contact_interactions'::regclass
                          AND trigger.tgname = 'trg_lock_eom_missed_call_interaction_contact'
+                         AND trigger.tgfoid = to_regprocedure(
+                             'lock_eom_missed_call_interaction_contact()'
+                         )
                          AND NOT trigger.tgisinternal
                    )
                    AND EXISTS (
                        SELECT 1 FROM pg_trigger AS trigger
                        WHERE trigger.tgrelid = 'contact_interactions'::regclass
                          AND trigger.tgname = 'trg_cancel_eom_missed_call_on_interaction'
+                         AND trigger.tgfoid = to_regprocedure(
+                             'cancel_eom_missed_call_on_interaction()'
+                         )
                          AND NOT trigger.tgisinternal
+                   )
+                   AND (
+                       SELECT COUNT(*) = 6
+                          AND BOOL_AND(
+                              procedure.prosecdef
+                              AND function_owner.rolname = 'atlas_eom_handoff_owner'
+                              AND COALESCE(
+                                  procedure.proconfig @> ARRAY[
+                                      format(
+                                          'search_path=pg_catalog, %I, pg_temp',
+                                          current_schema()
+                                      )
+                                  ],
+                                  FALSE
+                              )
+                              AND NOT has_function_privilege(
+                                  'atlas_nocodb', procedure.oid, 'EXECUTE'
+                              )
+                          )
+                       FROM pg_proc AS procedure
+                       JOIN pg_namespace AS function_namespace
+                         ON function_namespace.oid = procedure.pronamespace
+                       JOIN pg_roles AS function_owner
+                         ON function_owner.oid = procedure.proowner
+                      WHERE function_namespace.nspname = current_schema()
+                        AND procedure.proname = ANY (ARRAY[
+                            'cancel_eom_missed_call_sequences_for_contact',
+                            'lock_eom_missed_call_interaction_contact',
+                            'eom_missed_call_effective_recipient',
+                            'cancel_eom_missed_call_on_recipient_change',
+                            'cancel_eom_missed_call_on_contact_change',
+                            'cancel_eom_missed_call_on_interaction'
+                        ])
                    )
                    AND to_regprocedure(
                        'eom_missed_call_has_proven_inbound_sms(jsonb)'

--- a/atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql
+++ b/atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql
@@ -101,6 +101,16 @@ BEGIN
                 WHERE membership.member = runtime_role_state.oid
                   AND guard_role.rolname = 'atlas_eom_handoff_owner'
            )
+           AND NOT EXISTS (
+               SELECT 1
+                 FROM pg_catalog.pg_roles AS delegating_login
+                WHERE delegating_login.rolcanlogin
+                  AND NOT delegating_login.rolsuper
+                  AND delegating_login.oid <> runtime_role_state.oid
+                  AND pg_catalog.pg_has_role(
+                      delegating_login.oid, runtime_role_state.oid, 'MEMBER'
+                  )
+           )
     )
       INTO runtime_role_ready;
 
@@ -125,6 +135,16 @@ BEGIN
                SELECT 1
                  FROM pg_catalog.pg_auth_members AS membership
                 WHERE membership.member = nocodb_role.oid
+           )
+           AND NOT EXISTS (
+               SELECT 1
+                 FROM pg_catalog.pg_roles AS delegating_login
+                WHERE delegating_login.rolcanlogin
+                  AND NOT delegating_login.rolsuper
+                  AND delegating_login.oid <> nocodb_role.oid
+                  AND pg_catalog.pg_has_role(
+                      delegating_login.oid, nocodb_role.oid, 'MEMBER'
+                  )
            )
     )
       INTO nocodb_role_ready;

--- a/atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql
+++ b/atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql
@@ -427,6 +427,16 @@ BEGIN
             'eom_missed_call_sequence_events'
         ])
     LOOP
+        -- Transfer ownership before revoking legacy role ACLs. Revoking an
+        -- old owner first creates an explicit empty ACL entry, and PostgreSQL
+        -- carries that entry to the isolated guard on ownership transfer. That
+        -- would prevent the guard's SECURITY DEFINER validators from reading
+        -- their own protected relations.
+        EXECUTE format(
+            'ALTER TABLE %I.%I OWNER TO atlas_eom_handoff_owner',
+            schema_name,
+            relation_name
+        );
         EXECUTE format(
             'REVOKE ALL PRIVILEGES ON TABLE %I.%I FROM PUBLIC',
             schema_name,
@@ -491,11 +501,6 @@ BEGIN
                 );
             END LOOP;
         END LOOP;
-        EXECUTE format(
-            'ALTER TABLE %I.%I OWNER TO atlas_eom_handoff_owner',
-            schema_name,
-            relation_name
-        );
     END LOOP;
 
     -- The remaining recovery functions either enforce immutable/scope fences

--- a/atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql
+++ b/atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql
@@ -21,6 +21,12 @@ DECLARE
     relation_name TEXT;
     column_name TEXT;
     function_signature TEXT;
+    expected_function_language TEXT;
+    expected_function_body_sha256 TEXT;
+    observed_function_language TEXT;
+    observed_function_body TEXT;
+    observed_function_body_sha256 TEXT;
+    pgcrypto_schema TEXT;
     append_only_triggers_ready BOOLEAN;
 BEGIN
     SELECT COALESCE(executor_role.rolsuper, FALSE)
@@ -97,6 +103,91 @@ BEGIN
         RAISE EXCEPTION
             'atlas_nocodb must be an unprivileged LOGIN NOINHERIT role before running 393_eom_missed_call_recovery_runtime_privileges';
     END IF;
+
+    -- 393 is the first migration to give the CRM bridge functions definer
+    -- authority. Never elevate an object merely because its signature still
+    -- exists: its stored body and language must be the exact trusted migration-
+    -- 389 source before this migration changes its owner or security mode.
+    SELECT namespace_state.nspname
+      INTO pgcrypto_schema
+      FROM pg_catalog.pg_extension AS extension_state
+      JOIN pg_catalog.pg_namespace AS namespace_state
+        ON namespace_state.oid = extension_state.extnamespace
+     WHERE extension_state.extname = 'pgcrypto'
+     LIMIT 1;
+
+    IF pgcrypto_schema IS NULL THEN
+        RAISE EXCEPTION
+            'pgcrypto SHA-256 support is required before elevating EOM missed-call bridge functions';
+    END IF;
+
+    FOR function_signature, expected_function_language, expected_function_body_sha256 IN
+        SELECT expected_function.signature,
+               expected_function.language_name,
+               expected_function.body_sha256
+          FROM (
+              VALUES
+                  (
+                      'cancel_eom_missed_call_sequences_for_contact(UUID, VARCHAR, VARCHAR)',
+                      'plpgsql',
+                      'd4c08e5d18af991621648f89297fb83170f7355948c52f5da85749cfeb0e535b'
+                  ),
+                  (
+                      'lock_eom_missed_call_interaction_contact()',
+                      'plpgsql',
+                      'f7b6b3a3057c2b68b46c1854a64a693105bda4732d0dea5b8c772400d314e18e'
+                  ),
+                  (
+                      'eom_missed_call_effective_recipient(UUID, TEXT)',
+                      'sql',
+                      '128b147313d03f1bf05a4ce086e225f09647078dfdf43bced4f2b47c0d3f4371'
+                  ),
+                  (
+                      'cancel_eom_missed_call_on_recipient_change(UUID)',
+                      'plpgsql',
+                      '9f099f30ae2303e1f8610217222d40f1bde51ea5adbc2964b72b4b2581c18c0f'
+                  ),
+                  (
+                      'cancel_eom_missed_call_on_contact_change()',
+                      'plpgsql',
+                      'ae2cac20a094b376008dc249098aafef8592aa46ea4e224ba6effc8271cebe8d'
+                  ),
+                  (
+                      'cancel_eom_missed_call_on_interaction()',
+                      'plpgsql',
+                      '0751a416b37e46a3d1960edbc6f4c65496b46465244bae04eeeaf45bd555feee'
+                  )
+          ) AS expected_function(signature, language_name, body_sha256)
+    LOOP
+        SELECT procedure.prosrc, language_state.lanname
+          INTO observed_function_body, observed_function_language
+          FROM pg_catalog.pg_proc AS procedure
+          JOIN pg_catalog.pg_language AS language_state
+            ON language_state.oid = procedure.prolang
+         WHERE procedure.oid = pg_catalog.to_regprocedure(
+                   format('%I.%s', schema_name, function_signature)
+               );
+
+        IF observed_function_body IS NULL
+           OR observed_function_language IS DISTINCT FROM expected_function_language THEN
+            RAISE EXCEPTION
+                'required EOM missed-call bridge function % is not the trusted migration-389 function',
+                function_signature;
+        END IF;
+
+        EXECUTE format(
+            'SELECT encode(%1$I.digest($1::text, ''sha256''), ''hex'')',
+            pgcrypto_schema
+        )
+          INTO observed_function_body_sha256
+          USING observed_function_body;
+
+        IF observed_function_body_sha256 IS DISTINCT FROM expected_function_body_sha256 THEN
+            RAISE EXCEPTION
+                'required EOM missed-call bridge function % does not match its trusted migration-389 body',
+                function_signature;
+        END IF;
+    END LOOP;
 
     FOR relation_name IN
         SELECT unnest(ARRAY[

--- a/atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql
+++ b/atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql
@@ -1,0 +1,311 @@
+-- atlas: atomic-bookkeeping
+-- Forward-only privilege repair for durable EOM missed-call recovery.
+--
+-- Migration 389 is intentionally additive, but it did not assign the recovery
+-- objects to EOM's no-login guard or materialize the normal runtime ACL. If a
+-- DBA applies 389, PostgreSQL otherwise leaves those tables owned by that DBA
+-- and Atlas cannot serve the recovery route or worker. Preserve 389's evidence
+-- and receipt; repair ownership/privileges in this new, recorded migration.
+--
+-- A database administrator must run this migration. The normal Atlas runtime
+-- must never receive membership in atlas_eom_handoff_owner just to operate the
+-- recovery service, and NocoDB must never receive direct recovery-table access.
+
+DO $$
+DECLARE
+    schema_name TEXT := current_schema();
+    executor_is_superuser BOOLEAN;
+    trusted_guard_role_ready BOOLEAN;
+    runtime_role_ready BOOLEAN;
+    nocodb_role_ready BOOLEAN;
+    relation_name TEXT;
+BEGIN
+    SELECT COALESCE(executor_role.rolsuper, FALSE)
+      INTO executor_is_superuser
+      FROM pg_catalog.pg_roles AS executor_role
+     WHERE executor_role.rolname = current_user;
+
+    IF NOT executor_is_superuser THEN
+        RAISE EXCEPTION
+            'database administrator must run 393_eom_missed_call_recovery_runtime_privileges';
+    END IF;
+
+    SELECT EXISTS (
+        SELECT 1
+          FROM pg_catalog.pg_roles AS guard_role
+         WHERE guard_role.rolname = 'atlas_eom_handoff_owner'
+           AND NOT guard_role.rolcanlogin
+           AND NOT guard_role.rolinherit
+           AND NOT guard_role.rolsuper
+           AND NOT guard_role.rolcreaterole
+           AND NOT guard_role.rolcreatedb
+           AND NOT guard_role.rolreplication
+           AND NOT guard_role.rolbypassrls
+           AND NOT EXISTS (
+               SELECT 1
+                 FROM pg_catalog.pg_roles AS member_role
+                WHERE member_role.rolcanlogin
+                  AND NOT member_role.rolsuper
+                  AND pg_catalog.pg_has_role(
+                      member_role.oid, guard_role.oid, 'MEMBER'
+                  )
+           )
+    )
+      INTO trusted_guard_role_ready;
+
+    IF NOT trusted_guard_role_ready THEN
+        RAISE EXCEPTION
+            'atlas_eom_handoff_owner must be a no-login, membership-isolated guard role before running 393_eom_missed_call_recovery_runtime_privileges';
+    END IF;
+
+    SELECT EXISTS (
+        SELECT 1
+          FROM pg_catalog.pg_roles AS runtime_role
+         WHERE runtime_role.rolname = 'atlas'
+           AND runtime_role.rolcanlogin
+    )
+      INTO runtime_role_ready;
+
+    IF NOT runtime_role_ready THEN
+        RAISE EXCEPTION
+            'atlas must be a login runtime role before running 393_eom_missed_call_recovery_runtime_privileges';
+    END IF;
+
+    SELECT EXISTS (
+        SELECT 1
+          FROM pg_catalog.pg_roles AS nocodb_role
+         WHERE nocodb_role.rolname = 'atlas_nocodb'
+           AND nocodb_role.rolcanlogin
+           AND NOT nocodb_role.rolsuper
+           AND NOT nocodb_role.rolcreaterole
+           AND NOT nocodb_role.rolcreatedb
+           AND NOT nocodb_role.rolreplication
+           AND NOT nocodb_role.rolbypassrls
+           AND NOT nocodb_role.rolinherit
+           AND NOT EXISTS (
+               SELECT 1
+                 FROM pg_catalog.pg_auth_members AS membership
+                WHERE membership.member = nocodb_role.oid
+           )
+    )
+      INTO nocodb_role_ready;
+
+    IF NOT nocodb_role_ready THEN
+        RAISE EXCEPTION
+            'atlas_nocodb must be an unprivileged LOGIN NOINHERIT role before running 393_eom_missed_call_recovery_runtime_privileges';
+    END IF;
+
+    FOR relation_name IN
+        SELECT unnest(ARRAY[
+            'eom_missed_call_operation_receipts',
+            'eom_missed_call_attempts',
+            'eom_missed_call_contact_suppressions',
+            'eom_missed_call_sequences',
+            'eom_missed_call_sequence_steps',
+            'eom_missed_call_sequence_events'
+        ])
+    LOOP
+        IF to_regclass(format('%I.%I', schema_name, relation_name)) IS NULL THEN
+            RAISE EXCEPTION
+                'required EOM missed-call relation %.% is absent before privilege repair',
+                schema_name,
+                relation_name;
+        END IF;
+    END LOOP;
+
+    -- PostgreSQL requires the target owner to hold CREATE on the schema. The
+    -- guard remains no-login and membership-isolated, so this grant does not
+    -- create an executable path for Atlas or NocoDB.
+    EXECUTE format(
+        'GRANT USAGE, CREATE ON SCHEMA %I TO atlas_eom_handoff_owner',
+        schema_name
+    );
+
+    FOR relation_name IN
+        SELECT unnest(ARRAY[
+            'eom_missed_call_operation_receipts',
+            'eom_missed_call_attempts',
+            'eom_missed_call_contact_suppressions',
+            'eom_missed_call_sequences',
+            'eom_missed_call_sequence_steps',
+            'eom_missed_call_sequence_events'
+        ])
+    LOOP
+        EXECUTE format(
+            'REVOKE ALL PRIVILEGES ON TABLE %I.%I FROM PUBLIC',
+            schema_name,
+            relation_name
+        );
+        EXECUTE format(
+            'REVOKE ALL PRIVILEGES ON TABLE %I.%I FROM atlas_nocodb',
+            schema_name,
+            relation_name
+        );
+        -- Rebuild the runtime allowlist below rather than preserving a stale
+        -- DBA-era direct grant such as DELETE after ownership changes.
+        EXECUTE format(
+            'REVOKE ALL PRIVILEGES ON TABLE %I.%I FROM atlas',
+            schema_name,
+            relation_name
+        );
+        EXECUTE format(
+            'ALTER TABLE %I.%I OWNER TO atlas_eom_handoff_owner',
+            schema_name,
+            relation_name
+        );
+    END LOOP;
+
+    -- The guarded trigger chain reads CRM evidence and uses a contact row lock.
+    -- Its owner cannot log in and receives no broad CRM write capability.
+    EXECUTE format(
+        'GRANT SELECT, UPDATE ON TABLE %I.contacts TO atlas_eom_handoff_owner',
+        schema_name
+    );
+    EXECUTE format(
+        'GRANT SELECT ON TABLE %I.contact_interactions TO atlas_eom_handoff_owner',
+        schema_name
+    );
+
+    -- These six functions are the only recovery helpers reached from CRM table
+    -- triggers. Run them as the isolated owner with a deterministic search path
+    -- so an allowed NocoDB CRM mutation can cancel a sequence without granting
+    -- NocoDB direct access to recovery evidence.
+    EXECUTE format(
+        'ALTER FUNCTION %I.cancel_eom_missed_call_sequences_for_contact(UUID, VARCHAR, VARCHAR) SECURITY DEFINER',
+        schema_name
+    );
+    EXECUTE format(
+        'ALTER FUNCTION %I.cancel_eom_missed_call_sequences_for_contact(UUID, VARCHAR, VARCHAR) SET search_path = pg_catalog, %I, pg_temp',
+        schema_name,
+        schema_name
+    );
+    EXECUTE format(
+        'REVOKE ALL ON FUNCTION %I.cancel_eom_missed_call_sequences_for_contact(UUID, VARCHAR, VARCHAR) FROM PUBLIC',
+        schema_name
+    );
+    EXECUTE format(
+        'ALTER FUNCTION %I.cancel_eom_missed_call_sequences_for_contact(UUID, VARCHAR, VARCHAR) OWNER TO atlas_eom_handoff_owner',
+        schema_name
+    );
+
+    EXECUTE format(
+        'ALTER FUNCTION %I.lock_eom_missed_call_interaction_contact() SECURITY DEFINER',
+        schema_name
+    );
+    EXECUTE format(
+        'ALTER FUNCTION %I.lock_eom_missed_call_interaction_contact() SET search_path = pg_catalog, %I, pg_temp',
+        schema_name,
+        schema_name
+    );
+    EXECUTE format(
+        'REVOKE ALL ON FUNCTION %I.lock_eom_missed_call_interaction_contact() FROM PUBLIC',
+        schema_name
+    );
+    EXECUTE format(
+        'ALTER FUNCTION %I.lock_eom_missed_call_interaction_contact() OWNER TO atlas_eom_handoff_owner',
+        schema_name
+    );
+
+    EXECUTE format(
+        'ALTER FUNCTION %I.eom_missed_call_effective_recipient(UUID, TEXT) SECURITY DEFINER',
+        schema_name
+    );
+    EXECUTE format(
+        'ALTER FUNCTION %I.eom_missed_call_effective_recipient(UUID, TEXT) SET search_path = pg_catalog, %I, pg_temp',
+        schema_name,
+        schema_name
+    );
+    EXECUTE format(
+        'REVOKE ALL ON FUNCTION %I.eom_missed_call_effective_recipient(UUID, TEXT) FROM PUBLIC',
+        schema_name
+    );
+    EXECUTE format(
+        'ALTER FUNCTION %I.eom_missed_call_effective_recipient(UUID, TEXT) OWNER TO atlas_eom_handoff_owner',
+        schema_name
+    );
+
+    EXECUTE format(
+        'ALTER FUNCTION %I.cancel_eom_missed_call_on_recipient_change(UUID) SECURITY DEFINER',
+        schema_name
+    );
+    EXECUTE format(
+        'ALTER FUNCTION %I.cancel_eom_missed_call_on_recipient_change(UUID) SET search_path = pg_catalog, %I, pg_temp',
+        schema_name,
+        schema_name
+    );
+    EXECUTE format(
+        'REVOKE ALL ON FUNCTION %I.cancel_eom_missed_call_on_recipient_change(UUID) FROM PUBLIC',
+        schema_name
+    );
+    EXECUTE format(
+        'ALTER FUNCTION %I.cancel_eom_missed_call_on_recipient_change(UUID) OWNER TO atlas_eom_handoff_owner',
+        schema_name
+    );
+
+    EXECUTE format(
+        'ALTER FUNCTION %I.cancel_eom_missed_call_on_contact_change() SECURITY DEFINER',
+        schema_name
+    );
+    EXECUTE format(
+        'ALTER FUNCTION %I.cancel_eom_missed_call_on_contact_change() SET search_path = pg_catalog, %I, pg_temp',
+        schema_name,
+        schema_name
+    );
+    EXECUTE format(
+        'REVOKE ALL ON FUNCTION %I.cancel_eom_missed_call_on_contact_change() FROM PUBLIC',
+        schema_name
+    );
+    EXECUTE format(
+        'ALTER FUNCTION %I.cancel_eom_missed_call_on_contact_change() OWNER TO atlas_eom_handoff_owner',
+        schema_name
+    );
+
+    EXECUTE format(
+        'ALTER FUNCTION %I.cancel_eom_missed_call_on_interaction() SECURITY DEFINER',
+        schema_name
+    );
+    EXECUTE format(
+        'ALTER FUNCTION %I.cancel_eom_missed_call_on_interaction() SET search_path = pg_catalog, %I, pg_temp',
+        schema_name,
+        schema_name
+    );
+    EXECUTE format(
+        'REVOKE ALL ON FUNCTION %I.cancel_eom_missed_call_on_interaction() FROM PUBLIC',
+        schema_name
+    );
+    EXECUTE format(
+        'ALTER FUNCTION %I.cancel_eom_missed_call_on_interaction() OWNER TO atlas_eom_handoff_owner',
+        schema_name
+    );
+
+    -- Direct runtime access intentionally remains narrower than object owner
+    -- access. UPDATE on immutable receipt/attempt rows is required for the
+    -- existing SELECT ... FOR UPDATE locks; their append-only triggers reject
+    -- any attempted data mutation.
+    EXECUTE format('GRANT USAGE ON SCHEMA %I TO atlas', schema_name);
+    EXECUTE format(
+        'GRANT SELECT, INSERT, UPDATE ON TABLE %I.eom_missed_call_operation_receipts TO atlas',
+        schema_name
+    );
+    EXECUTE format(
+        'GRANT SELECT, INSERT, UPDATE ON TABLE %I.eom_missed_call_attempts TO atlas',
+        schema_name
+    );
+    EXECUTE format(
+        'GRANT SELECT, INSERT ON TABLE %I.eom_missed_call_contact_suppressions TO atlas',
+        schema_name
+    );
+    EXECUTE format(
+        'GRANT SELECT, INSERT, UPDATE ON TABLE %I.eom_missed_call_sequences TO atlas',
+        schema_name
+    );
+    EXECUTE format(
+        'GRANT SELECT, INSERT, UPDATE ON TABLE %I.eom_missed_call_sequence_steps TO atlas',
+        schema_name
+    );
+    EXECUTE format(
+        'GRANT SELECT, INSERT ON TABLE %I.eom_missed_call_sequence_events TO atlas',
+        schema_name
+    );
+END;
+$$;

--- a/atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql
+++ b/atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql
@@ -19,6 +19,9 @@ DECLARE
     runtime_role_ready BOOLEAN;
     nocodb_role_ready BOOLEAN;
     relation_name TEXT;
+    column_name TEXT;
+    function_signature TEXT;
+    append_only_triggers_ready BOOLEAN;
 BEGIN
     SELECT COALESCE(executor_role.rolsuper, FALSE)
       INTO executor_is_superuser
@@ -113,6 +116,56 @@ BEGIN
         END IF;
     END LOOP;
 
+    -- UPDATE is needed for the worker's existing FOR UPDATE locks. Do not
+    -- grant it until the immutable-evidence triggers from migration 389 are
+    -- present, enabled, and still bound to their rejecting functions.
+    SELECT EXISTS (
+        SELECT 1
+          FROM pg_catalog.pg_trigger AS trigger
+         WHERE trigger.tgrelid = to_regclass(
+                   format(
+                       '%I.%I',
+                       schema_name,
+                       'eom_missed_call_operation_receipts'
+                   )
+               )
+           AND trigger.tgname = 'trg_prevent_eom_missed_call_operation_receipt_mutation'
+           AND trigger.tgfoid = to_regprocedure(
+               format(
+                   '%I.%I()',
+                   schema_name,
+                   'prevent_eom_missed_call_operation_receipt_mutation'
+               )
+           )
+           AND trigger.tgtype = 27
+           AND trigger.tgenabled = 'O'
+           AND NOT trigger.tgisinternal
+    )
+    AND EXISTS (
+        SELECT 1
+          FROM pg_catalog.pg_trigger AS trigger
+         WHERE trigger.tgrelid = to_regclass(
+                   format('%I.%I', schema_name, 'eom_missed_call_attempts')
+               )
+           AND trigger.tgname = 'trg_prevent_eom_missed_call_attempt_mutation'
+           AND trigger.tgfoid = to_regprocedure(
+               format(
+                   '%I.%I()',
+                   schema_name,
+                   'prevent_eom_missed_call_attempt_mutation'
+               )
+           )
+           AND trigger.tgtype = 27
+           AND trigger.tgenabled = 'O'
+           AND NOT trigger.tgisinternal
+    )
+      INTO append_only_triggers_ready;
+
+    IF NOT append_only_triggers_ready THEN
+        RAISE EXCEPTION
+            'append-only receipt and attempt triggers must be intact before running 393_eom_missed_call_recovery_runtime_privileges';
+    END IF;
+
     -- PostgreSQL requires the target owner to hold CREATE on the schema. The
     -- guard remains no-login and membership-isolated, so this grant does not
     -- create an executable path for Atlas or NocoDB.
@@ -148,6 +201,37 @@ BEGIN
             schema_name,
             relation_name
         );
+        -- Table and column ACLs are separate PostgreSQL catalogs. Rebuild the
+        -- entire direct access surface so an old column grant cannot survive
+        -- the table-level revoke and expose recovery evidence to NocoDB.
+        FOR column_name IN
+            SELECT attribute.attname
+              FROM pg_catalog.pg_attribute AS attribute
+             WHERE attribute.attrelid = to_regclass(
+                       format('%I.%I', schema_name, relation_name)
+                   )
+               AND attribute.attnum > 0
+               AND NOT attribute.attisdropped
+        LOOP
+            EXECUTE format(
+                'REVOKE ALL PRIVILEGES (%I) ON TABLE %I.%I FROM PUBLIC',
+                column_name,
+                schema_name,
+                relation_name
+            );
+            EXECUTE format(
+                'REVOKE ALL PRIVILEGES (%I) ON TABLE %I.%I FROM atlas_nocodb',
+                column_name,
+                schema_name,
+                relation_name
+            );
+            EXECUTE format(
+                'REVOKE ALL PRIVILEGES (%I) ON TABLE %I.%I FROM atlas',
+                column_name,
+                schema_name,
+                relation_name
+            );
+        END LOOP;
         EXECUTE format(
             'ALTER TABLE %I.%I OWNER TO atlas_eom_handoff_owner',
             schema_name,
@@ -277,6 +361,25 @@ BEGIN
         'ALTER FUNCTION %I.cancel_eom_missed_call_on_interaction() OWNER TO atlas_eom_handoff_owner',
         schema_name
     );
+
+    -- REVOKE FROM PUBLIC does not remove an explicit old NocoDB EXECUTE
+    -- grant. Clear that direct path on all SECURITY DEFINER bridge helpers.
+    FOR function_signature IN
+        SELECT unnest(ARRAY[
+            'cancel_eom_missed_call_sequences_for_contact(UUID, VARCHAR, VARCHAR)',
+            'lock_eom_missed_call_interaction_contact()',
+            'eom_missed_call_effective_recipient(UUID, TEXT)',
+            'cancel_eom_missed_call_on_recipient_change(UUID)',
+            'cancel_eom_missed_call_on_contact_change()',
+            'cancel_eom_missed_call_on_interaction()'
+        ])
+    LOOP
+        EXECUTE format(
+            'REVOKE ALL ON FUNCTION %I.%s FROM atlas_nocodb',
+            schema_name,
+            function_signature
+        );
+    END LOOP;
 
     -- Direct runtime access intentionally remains narrower than object owner
     -- access. UPDATE on immutable receipt/attempt rows is required for the

--- a/atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql
+++ b/atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql
@@ -194,6 +194,58 @@ BEGIN
         END IF;
     END LOOP;
 
+    -- The runtime receives UPDATE on these two append-only tables only to take
+    -- existing FOR UPDATE locks. PostgreSQL preserves a trigger function's OID
+    -- across CREATE OR REPLACE FUNCTION, so the trigger binding below cannot
+    -- prove that its body still rejects mutations by itself.
+    FOR function_signature, expected_function_language, expected_function_body_sha256 IN
+        SELECT expected_function.signature,
+               expected_function.language_name,
+               expected_function.body_sha256
+          FROM (
+              VALUES
+                  (
+                      'prevent_eom_missed_call_operation_receipt_mutation()',
+                      'plpgsql',
+                      '7bc869fec7fe5493b5859da8ab1a26da547d53db518b6e32fa2ab9e3cd9d08a7'
+                  ),
+                  (
+                      'prevent_eom_missed_call_attempt_mutation()',
+                      'plpgsql',
+                      '7647fbfe7a9642e0434e0a0e3930aa221f6d93323205cd0633ba809cf31c579d'
+                  )
+          ) AS expected_function(signature, language_name, body_sha256)
+    LOOP
+        SELECT procedure.prosrc, language_state.lanname
+          INTO observed_function_body, observed_function_language
+          FROM pg_catalog.pg_proc AS procedure
+          JOIN pg_catalog.pg_language AS language_state
+            ON language_state.oid = procedure.prolang
+         WHERE procedure.oid = pg_catalog.to_regprocedure(
+                   format('%I.%s', schema_name, function_signature)
+               );
+
+        IF observed_function_body IS NULL
+           OR observed_function_language IS DISTINCT FROM expected_function_language THEN
+            RAISE EXCEPTION
+                'required EOM missed-call append-only fence function % is not the trusted migration-389 function',
+                function_signature;
+        END IF;
+
+        EXECUTE format(
+            'SELECT encode(%1$I.digest($1::text, ''sha256''), ''hex'')',
+            pgcrypto_schema
+        )
+          INTO observed_function_body_sha256
+          USING observed_function_body;
+
+        IF observed_function_body_sha256 IS DISTINCT FROM expected_function_body_sha256 THEN
+            RAISE EXCEPTION
+                'required EOM missed-call append-only fence function % does not match its trusted migration-389 body',
+                function_signature;
+        END IF;
+    END LOOP;
+
     FOR relation_name IN
         SELECT unnest(ARRAY[
             'eom_missed_call_operation_receipts',

--- a/atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql
+++ b/atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql
@@ -341,6 +341,191 @@ BEGIN
         END IF;
     END LOOP;
 
+    -- The application schema can remain writable by the normal runtime for
+    -- ordinary migrations. Its guard-owned callbacks therefore cannot rely on
+    -- search-path position alone for user-defined function dispatch: a runtime
+    -- overload with a closer VARCHAR or unknown-literal signature could win.
+    -- The trusted migration-389 bodies above establish the source we are
+    -- replacing. Recreate only the callbacks with user-defined calls so every
+    -- such dispatch names this schema and its exact trusted argument types.
+    EXECUTE format(
+        $definition$
+        CREATE OR REPLACE FUNCTION %1$I.cancel_eom_missed_call_on_recipient_change(
+            target_contact_id UUID
+        )
+        RETURNS VOID
+        LANGUAGE plpgsql
+        AS $body$
+        DECLARE
+            effective_recipient TEXT;
+        BEGIN
+            SELECT %1$I.eom_missed_call_effective_recipient(
+                c.id::UUID,
+                c.email::TEXT
+            )
+              INTO effective_recipient
+              FROM contacts AS c
+             WHERE c.id = target_contact_id
+               AND c.business_context_id = 'effingham_maids';
+
+            IF NOT FOUND THEN
+                RETURN;
+            END IF;
+
+            IF EXISTS (
+                SELECT 1
+                  FROM eom_missed_call_sequences AS sequence
+                 WHERE sequence.contact_id = target_contact_id
+                   AND sequence.state IN ('active', 'blocked_configuration')
+                   AND lower(btrim(sequence.recipient_email)) IS DISTINCT FROM
+                       effective_recipient
+            ) THEN
+                PERFORM %1$I.cancel_eom_missed_call_sequences_for_contact(
+                    target_contact_id::UUID,
+                    'recipient_changed'::VARCHAR,
+                    'interaction_trigger'::VARCHAR
+                );
+            END IF;
+        END;
+        $body$;
+        $definition$,
+        schema_name
+    );
+
+    EXECUTE format(
+        $definition$
+        CREATE OR REPLACE FUNCTION %1$I.cancel_eom_missed_call_on_contact_change()
+        RETURNS TRIGGER
+        LANGUAGE plpgsql
+        AS $body$
+        DECLARE
+            cancellation_reason VARCHAR(64);
+        BEGIN
+            IF OLD.business_context_id = 'effingham_maids'
+               AND NEW.business_context_id IS DISTINCT FROM 'effingham_maids' THEN
+                cancellation_reason := 'tenant_changed';
+            ELSIF NEW.business_context_id IS DISTINCT FROM 'effingham_maids' THEN
+                RETURN NEW;
+            ELSIF NEW.contact_type <> 'lead' THEN
+                cancellation_reason := 'became_customer';
+            ELSIF NEW.status <> 'active' THEN
+                cancellation_reason := 'contact_inactive';
+            ELSIF NEW.lead_stage IS DISTINCT FROM 'new' THEN
+                cancellation_reason := 'lead_advanced';
+            ELSIF NEW.customer_type = 'commercial' THEN
+                cancellation_reason := 'non_residential';
+            ELSIF NEW.email IS DISTINCT FROM OLD.email
+               AND EXISTS (
+                   SELECT 1
+                     FROM eom_missed_call_sequences AS sequence
+                    WHERE sequence.contact_id = NEW.id
+                      AND sequence.state IN ('active', 'blocked_configuration')
+                      AND lower(btrim(sequence.recipient_email)) IS DISTINCT FROM
+                          %1$I.eom_missed_call_effective_recipient(
+                              NEW.id::UUID,
+                              NEW.email::TEXT
+                          )
+               ) THEN
+                cancellation_reason := 'recipient_changed';
+            ELSE
+                RETURN NEW;
+            END IF;
+
+            PERFORM %1$I.cancel_eom_missed_call_sequences_for_contact(
+                NEW.id::UUID,
+                cancellation_reason::VARCHAR,
+                'contact_trigger'::VARCHAR
+            );
+            RETURN NEW;
+        END;
+        $body$;
+        $definition$,
+        schema_name
+    );
+
+    EXECUTE format(
+        $definition$
+        CREATE OR REPLACE FUNCTION %1$I.cancel_eom_missed_call_on_interaction()
+        RETURNS TRIGGER
+        LANGUAGE plpgsql
+        AS $body$
+        DECLARE
+            cancellation_reason VARCHAR(64);
+        BEGIN
+            IF TG_OP <> 'INSERT' THEN
+                PERFORM %1$I.cancel_eom_missed_call_on_recipient_change(
+                    OLD.contact_id::UUID
+                );
+                IF TG_OP = 'UPDATE'
+                   AND NEW.contact_id IS DISTINCT FROM OLD.contact_id THEN
+                    PERFORM %1$I.cancel_eom_missed_call_on_recipient_change(
+                        NEW.contact_id::UUID
+                    );
+                END IF;
+                IF TG_OP = 'DELETE' THEN
+                    RETURN OLD;
+                END IF;
+                RETURN NEW;
+            END IF;
+
+            IF NOT EXISTS (
+                SELECT 1
+                  FROM contacts
+                 WHERE id = NEW.contact_id
+                   AND business_context_id = 'effingham_maids'
+            ) THEN
+                RETURN NEW;
+            END IF;
+
+            IF NEW.metadata->>'missed_call_recovery_cancel_reason' IN (
+                'callback_recorded', 'response_recorded', 'opt_out', 'manual'
+            ) THEN
+                cancellation_reason := NEW.metadata->>'missed_call_recovery_cancel_reason';
+            ELSIF NEW.interaction_type = 'sms'
+               AND %1$I.eom_missed_call_has_proven_inbound_sms(
+                   NEW.metadata::JSONB
+               ) THEN
+                cancellation_reason := 'tracked_inbound_response';
+            ELSIF NEW.interaction_type IN (
+                'email_inbound', 'lead_response', 'callback_completed',
+                'conversation_completed', 'opt_out'
+            ) THEN
+                cancellation_reason := NEW.interaction_type;
+            ELSIF NEW.interaction_type = 'web_form'
+               AND NEW.intent = 'estimate_request' THEN
+                cancellation_reason := 'new_estimate_request';
+            ELSE
+                RETURN NEW;
+            END IF;
+
+            IF NEW.interaction_type = 'opt_out' THEN
+                INSERT INTO eom_missed_call_contact_suppressions (
+                    contact_id, reason_code, actor_name, source
+                ) VALUES (
+                    NEW.contact_id, 'opt_out', 'system', 'interaction_trigger'
+                ) ON CONFLICT (contact_id) DO NOTHING;
+            END IF;
+
+            IF EXISTS (
+                SELECT 1
+                FROM eom_missed_call_sequences AS sequence
+                WHERE sequence.contact_id = NEW.contact_id
+                  AND sequence.state IN ('active', 'blocked_configuration')
+                  AND NEW.occurred_at > sequence.created_at
+            ) THEN
+                PERFORM %1$I.cancel_eom_missed_call_sequences_for_contact(
+                    NEW.contact_id::UUID,
+                    cancellation_reason::VARCHAR,
+                    'interaction_trigger'::VARCHAR
+                );
+            END IF;
+            RETURN NEW;
+        END;
+        $body$;
+        $definition$,
+        schema_name
+    );
+
     FOR relation_name IN
         SELECT unnest(ARRAY[
             'eom_missed_call_operation_receipts',

--- a/atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql
+++ b/atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql
@@ -14,6 +14,15 @@
 DO $$
 DECLARE
     schema_name TEXT := current_schema();
+    runtime_role TEXT := NULLIF(
+        btrim(
+            pg_catalog.current_setting(
+                'atlas.eom_missed_call_recovery_runtime_role',
+                TRUE
+            )
+        ),
+        ''
+    );
     executor_is_superuser BOOLEAN;
     trusted_guard_role_ready BOOLEAN;
     runtime_role_ready BOOLEAN;
@@ -21,6 +30,7 @@ DECLARE
     relation_name TEXT;
     column_name TEXT;
     function_signature TEXT;
+    acl_role TEXT;
     expected_function_language TEXT;
     expected_function_body_sha256 TEXT;
     observed_function_language TEXT;
@@ -67,17 +77,37 @@ BEGIN
             'atlas_eom_handoff_owner must be a no-login, membership-isolated guard role before running 393_eom_missed_call_recovery_runtime_privileges';
     END IF;
 
+    IF runtime_role IS NULL THEN
+        RAISE EXCEPTION
+            'configured EOM runtime role is required before running 393_eom_missed_call_recovery_runtime_privileges';
+    END IF;
+
     SELECT EXISTS (
         SELECT 1
-          FROM pg_catalog.pg_roles AS runtime_role
-         WHERE runtime_role.rolname = 'atlas'
-           AND runtime_role.rolcanlogin
+          FROM pg_catalog.pg_roles AS runtime_role_state
+         WHERE runtime_role_state.rolname = runtime_role
+           AND runtime_role_state.rolcanlogin
+           AND runtime_role_state.rolname <> 'atlas_nocodb'
+           AND NOT runtime_role_state.rolsuper
+           AND NOT runtime_role_state.rolcreaterole
+           AND NOT runtime_role_state.rolcreatedb
+           AND NOT runtime_role_state.rolreplication
+           AND NOT runtime_role_state.rolbypassrls
+           AND NOT EXISTS (
+               SELECT 1
+                 FROM pg_catalog.pg_auth_members AS membership
+                 JOIN pg_catalog.pg_roles AS guard_role
+                   ON guard_role.oid = membership.roleid
+                WHERE membership.member = runtime_role_state.oid
+                  AND guard_role.rolname = 'atlas_eom_handoff_owner'
+           )
     )
       INTO runtime_role_ready;
 
     IF NOT runtime_role_ready THEN
         RAISE EXCEPTION
-            'atlas must be a login runtime role before running 393_eom_missed_call_recovery_runtime_privileges';
+            'configured EOM runtime role % must be an unprivileged, guard-isolated login before running 393_eom_missed_call_recovery_runtime_privileges',
+            runtime_role;
     END IF;
 
     SELECT EXISTS (
@@ -194,10 +224,9 @@ BEGIN
         END IF;
     END LOOP;
 
-    -- The runtime receives UPDATE on these two append-only tables only to take
-    -- existing FOR UPDATE locks. PostgreSQL preserves a trigger function's OID
-    -- across CREATE OR REPLACE FUNCTION, so the trigger binding below cannot
-    -- prove that its body still rejects mutations by itself.
+    -- PostgreSQL preserves a trigger function's OID across CREATE OR REPLACE
+    -- FUNCTION, so trigger bindings cannot prove that their bodies still
+    -- enforce the recovery append-only boundary by themselves.
     FOR function_signature, expected_function_language, expected_function_body_sha256 IN
         SELECT expected_function.signature,
                expected_function.language_name,
@@ -213,6 +242,16 @@ BEGIN
                       'prevent_eom_missed_call_attempt_mutation()',
                       'plpgsql',
                       '7647fbfe7a9642e0434e0a0e3930aa221f6d93323205cd0633ba809cf31c579d'
+                  ),
+                  (
+                      'prevent_eom_missed_call_sequence_event_mutation()',
+                      'plpgsql',
+                      '3f88a357faf419060b4c01046a49e06be87302e573fe831f8ab1f5c9dfe072a4'
+                  ),
+                  (
+                      'prevent_eom_missed_call_suppression_mutation()',
+                      'plpgsql',
+                      'eb3762cb1c676d7527d3637c8850920c2f486dd30b34a6ca541f77072c618528'
                   )
           ) AS expected_function(signature, language_name, body_sha256)
     LOOP
@@ -242,6 +281,62 @@ BEGIN
         IF observed_function_body_sha256 IS DISTINCT FROM expected_function_body_sha256 THEN
             RAISE EXCEPTION
                 'required EOM missed-call append-only fence function % does not match its trusted migration-389 body',
+                function_signature;
+        END IF;
+    END LOOP;
+
+    -- Scope validators run on every recovery write, and the inbound-SMS helper
+    -- runs inside a SECURITY DEFINER CRM trigger. They therefore share the
+    -- guard boundary even though they are not independently security-definer.
+    FOR function_signature, expected_function_language, expected_function_body_sha256 IN
+        SELECT expected_function.signature,
+               expected_function.language_name,
+               expected_function.body_sha256
+          FROM (
+              VALUES
+                  (
+                      'validate_eom_missed_call_contact_scope()',
+                      'plpgsql',
+                      '685cbc52f37986f0603795132bd1f71962f40912e3e294194f08ade00174fad9'
+                  ),
+                  (
+                      'validate_eom_missed_call_sequence_scope()',
+                      'plpgsql',
+                      '7d6e532059f3a7862eb8fe339c0166766d7188c71e71526c49f65fd25395152d'
+                  ),
+                  (
+                      'eom_missed_call_has_proven_inbound_sms(JSONB)',
+                      'sql',
+                      '8e988b596b85d2e62de3cfb2f49ec6463b8a38116855809db78801c735890567'
+                  )
+          ) AS expected_function(signature, language_name, body_sha256)
+    LOOP
+        SELECT procedure.prosrc, language_state.lanname
+          INTO observed_function_body, observed_function_language
+          FROM pg_catalog.pg_proc AS procedure
+          JOIN pg_catalog.pg_language AS language_state
+            ON language_state.oid = procedure.prolang
+         WHERE procedure.oid = pg_catalog.to_regprocedure(
+                   format('%I.%s', schema_name, function_signature)
+               );
+
+        IF observed_function_body IS NULL
+           OR observed_function_language IS DISTINCT FROM expected_function_language THEN
+            RAISE EXCEPTION
+                'required EOM missed-call guard function % is not the trusted migration-389 function',
+                function_signature;
+        END IF;
+
+        EXECUTE format(
+            'SELECT encode(%1$I.digest($1::text, ''sha256''), ''hex'')',
+            pgcrypto_schema
+        )
+          INTO observed_function_body_sha256
+          USING observed_function_body;
+
+        IF observed_function_body_sha256 IS DISTINCT FROM expected_function_body_sha256 THEN
+            RAISE EXCEPTION
+                'required EOM missed-call guard function % does not match its trusted migration-389 body',
                 function_signature;
         END IF;
     END LOOP;
@@ -342,13 +437,22 @@ BEGIN
             schema_name,
             relation_name
         );
-        -- Rebuild the runtime allowlist below rather than preserving a stale
-        -- DBA-era direct grant such as DELETE after ownership changes.
-        EXECUTE format(
-            'REVOKE ALL PRIVILEGES ON TABLE %I.%I FROM atlas',
-            schema_name,
-            relation_name
-        );
+        -- Rebuild the configured-runtime allowlist below rather than preserving
+        -- a stale DBA-era direct grant such as DELETE after ownership changes.
+        -- Clear the legacy default only when it exists so a deployment whose
+        -- configured runtime has another name does not require an `atlas` role.
+        FOR acl_role IN
+            SELECT role_state.rolname
+              FROM pg_catalog.pg_roles AS role_state
+             WHERE role_state.rolname IN ('atlas', runtime_role)
+        LOOP
+            EXECUTE format(
+                'REVOKE ALL PRIVILEGES ON TABLE %I.%I FROM %I',
+                schema_name,
+                relation_name,
+                acl_role
+            );
+        END LOOP;
         -- Table and column ACLs are separate PostgreSQL catalogs. Rebuild the
         -- entire direct access surface so an old column grant cannot survive
         -- the table-level revoke and expose recovery evidence to NocoDB.
@@ -373,17 +477,46 @@ BEGIN
                 schema_name,
                 relation_name
             );
-            EXECUTE format(
-                'REVOKE ALL PRIVILEGES (%I) ON TABLE %I.%I FROM atlas',
-                column_name,
-                schema_name,
-                relation_name
-            );
+            FOR acl_role IN
+                SELECT role_state.rolname
+                  FROM pg_catalog.pg_roles AS role_state
+                 WHERE role_state.rolname IN ('atlas', runtime_role)
+            LOOP
+                EXECUTE format(
+                    'REVOKE ALL PRIVILEGES (%I) ON TABLE %I.%I FROM %I',
+                    column_name,
+                    schema_name,
+                    relation_name,
+                    acl_role
+                );
+            END LOOP;
         END LOOP;
         EXECUTE format(
             'ALTER TABLE %I.%I OWNER TO atlas_eom_handoff_owner',
             schema_name,
             relation_name
+        );
+    END LOOP;
+
+    -- The remaining recovery functions either enforce immutable/scope fences
+    -- or execute inside the definer chain. A normal runtime owner could replace
+    -- one after this migration, so transfer every attested function before any
+    -- runtime grant is rebuilt.
+    FOR function_signature IN
+        SELECT unnest(ARRAY[
+            'prevent_eom_missed_call_operation_receipt_mutation()',
+            'prevent_eom_missed_call_attempt_mutation()',
+            'prevent_eom_missed_call_sequence_event_mutation()',
+            'prevent_eom_missed_call_suppression_mutation()',
+            'validate_eom_missed_call_contact_scope()',
+            'validate_eom_missed_call_sequence_scope()',
+            'eom_missed_call_has_proven_inbound_sms(JSONB)'
+        ])
+    LOOP
+        EXECUTE format(
+            'ALTER FUNCTION %I.%s OWNER TO atlas_eom_handoff_owner',
+            schema_name,
+            function_signature
         );
     END LOOP;
 
@@ -397,6 +530,33 @@ BEGIN
         'GRANT SELECT ON TABLE %I.contact_interactions TO atlas_eom_handoff_owner',
         schema_name
     );
+
+    -- These table-trigger validators must read contacts while the configured
+    -- runtime writes recovery rows. Keep that CRM read under the no-login guard
+    -- rather than widening the runtime's direct CRM-table access.
+    FOR function_signature IN
+        SELECT unnest(ARRAY[
+            'validate_eom_missed_call_contact_scope()',
+            'validate_eom_missed_call_sequence_scope()'
+        ])
+    LOOP
+        EXECUTE format(
+            'ALTER FUNCTION %I.%s SECURITY DEFINER',
+            schema_name,
+            function_signature
+        );
+        EXECUTE format(
+            'ALTER FUNCTION %I.%s SET search_path = pg_catalog, %I, pg_temp',
+            schema_name,
+            function_signature,
+            schema_name
+        );
+        EXECUTE format(
+            'REVOKE ALL ON FUNCTION %I.%s FROM PUBLIC',
+            schema_name,
+            function_signature
+        );
+    END LOOP;
 
     -- These six functions are the only recovery helpers reached from CRM table
     -- triggers. Run them as the isolated owner with a deterministic search path
@@ -510,9 +670,9 @@ BEGIN
         schema_name
     );
 
-    -- REVOKE FROM PUBLIC does not remove an explicit old NocoDB or runtime
-    -- EXECUTE grant. Clear both direct paths on all SECURITY DEFINER bridge
-    -- helpers; CRM table triggers remain the only supported invocation path.
+    -- REVOKE FROM PUBLIC does not remove an explicit role grant. Rebuild the
+    -- complete direct-execution deny surface on every SECURITY DEFINER helper;
+    -- CRM table triggers remain the only supported invocation path.
     FOR function_signature IN
         SELECT unnest(ARRAY[
             'cancel_eom_missed_call_sequences_for_contact(UUID, VARCHAR, VARCHAR)',
@@ -520,49 +680,74 @@ BEGIN
             'eom_missed_call_effective_recipient(UUID, TEXT)',
             'cancel_eom_missed_call_on_recipient_change(UUID)',
             'cancel_eom_missed_call_on_contact_change()',
-            'cancel_eom_missed_call_on_interaction()'
+            'cancel_eom_missed_call_on_interaction()',
+            'validate_eom_missed_call_contact_scope()',
+            'validate_eom_missed_call_sequence_scope()'
         ])
     LOOP
-        EXECUTE format(
-            'REVOKE ALL ON FUNCTION %I.%s FROM atlas_nocodb',
-            schema_name,
-            function_signature
-        );
-        EXECUTE format(
-            'REVOKE ALL ON FUNCTION %I.%s FROM atlas',
-            schema_name,
-            function_signature
-        );
+        FOR acl_role IN
+            SELECT grantee_role.rolname
+              FROM pg_catalog.pg_proc AS procedure
+              JOIN pg_catalog.pg_namespace AS function_namespace
+                ON function_namespace.oid = procedure.pronamespace
+              CROSS JOIN LATERAL pg_catalog.aclexplode(
+                  COALESCE(
+                      procedure.proacl,
+                      pg_catalog.acldefault('f', procedure.proowner)
+                  )
+              ) AS function_acl
+              JOIN pg_catalog.pg_roles AS grantee_role
+                ON grantee_role.oid = function_acl.grantee
+             WHERE function_namespace.nspname = schema_name
+               AND procedure.oid = pg_catalog.to_regprocedure(
+                   format('%I.%s', schema_name, function_signature)
+               )
+               AND function_acl.privilege_type = 'EXECUTE'
+               AND grantee_role.rolname <> 'atlas_eom_handoff_owner'
+        LOOP
+            EXECUTE format(
+                'REVOKE ALL ON FUNCTION %I.%s FROM %I',
+                schema_name,
+                function_signature,
+                acl_role
+            );
+        END LOOP;
     END LOOP;
 
     -- Direct runtime access intentionally remains narrower than object owner
     -- access. UPDATE on immutable receipt/attempt rows is required for the
     -- existing SELECT ... FOR UPDATE locks; their append-only triggers reject
     -- any attempted data mutation.
-    EXECUTE format('GRANT USAGE ON SCHEMA %I TO atlas', schema_name);
+    EXECUTE format('GRANT USAGE ON SCHEMA %I TO %I', schema_name, runtime_role);
     EXECUTE format(
-        'GRANT SELECT, INSERT, UPDATE ON TABLE %I.eom_missed_call_operation_receipts TO atlas',
-        schema_name
+        'GRANT SELECT, INSERT, UPDATE ON TABLE %I.eom_missed_call_operation_receipts TO %I',
+        schema_name,
+        runtime_role
     );
     EXECUTE format(
-        'GRANT SELECT, INSERT, UPDATE ON TABLE %I.eom_missed_call_attempts TO atlas',
-        schema_name
+        'GRANT SELECT, INSERT, UPDATE ON TABLE %I.eom_missed_call_attempts TO %I',
+        schema_name,
+        runtime_role
     );
     EXECUTE format(
-        'GRANT SELECT, INSERT ON TABLE %I.eom_missed_call_contact_suppressions TO atlas',
-        schema_name
+        'GRANT SELECT, INSERT ON TABLE %I.eom_missed_call_contact_suppressions TO %I',
+        schema_name,
+        runtime_role
     );
     EXECUTE format(
-        'GRANT SELECT, INSERT, UPDATE ON TABLE %I.eom_missed_call_sequences TO atlas',
-        schema_name
+        'GRANT SELECT, INSERT, UPDATE ON TABLE %I.eom_missed_call_sequences TO %I',
+        schema_name,
+        runtime_role
     );
     EXECUTE format(
-        'GRANT SELECT, INSERT, UPDATE ON TABLE %I.eom_missed_call_sequence_steps TO atlas',
-        schema_name
+        'GRANT SELECT, INSERT, UPDATE ON TABLE %I.eom_missed_call_sequence_steps TO %I',
+        schema_name,
+        runtime_role
     );
     EXECUTE format(
-        'GRANT SELECT, INSERT ON TABLE %I.eom_missed_call_sequence_events TO atlas',
-        schema_name
+        'GRANT SELECT, INSERT ON TABLE %I.eom_missed_call_sequence_events TO %I',
+        schema_name,
+        runtime_role
     );
 END;
 $$;

--- a/atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql
+++ b/atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql
@@ -104,6 +104,11 @@ BEGIN
             'atlas_nocodb must be an unprivileged LOGIN NOINHERIT role before running 393_eom_missed_call_recovery_runtime_privileges';
     END IF;
 
+    -- The protected DBA is the only actor allowed to establish this
+    -- database-level prerequisite. Do it only after every role boundary is
+    -- valid, rather than relying on an undocumented deployment or test fixture.
+    EXECUTE 'CREATE EXTENSION IF NOT EXISTS pgcrypto';
+
     -- 393 is the first migration to give the CRM bridge functions definer
     -- authority. Never elevate an object merely because its signature still
     -- exists: its stored body and language must be the exact trusted migration-

--- a/atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql
+++ b/atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql
@@ -510,8 +510,9 @@ BEGIN
         schema_name
     );
 
-    -- REVOKE FROM PUBLIC does not remove an explicit old NocoDB EXECUTE
-    -- grant. Clear that direct path on all SECURITY DEFINER bridge helpers.
+    -- REVOKE FROM PUBLIC does not remove an explicit old NocoDB or runtime
+    -- EXECUTE grant. Clear both direct paths on all SECURITY DEFINER bridge
+    -- helpers; CRM table triggers remain the only supported invocation path.
     FOR function_signature IN
         SELECT unnest(ARRAY[
             'cancel_eom_missed_call_sequences_for_contact(UUID, VARCHAR, VARCHAR)',
@@ -524,6 +525,11 @@ BEGIN
     LOOP
         EXECUTE format(
             'REVOKE ALL ON FUNCTION %I.%s FROM atlas_nocodb',
+            schema_name,
+            function_signature
+        );
+        EXECUTE format(
+            'REVOKE ALL ON FUNCTION %I.%s FROM atlas',
             schema_name,
             function_signature
         );

--- a/atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql
+++ b/atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql
@@ -437,24 +437,38 @@ BEGIN
             schema_name,
             relation_name
         );
+        -- An old owner can carry an explicit empty ACL through ownership
+        -- transfer. Make the no-login guard's table authority explicit before
+        -- rebuilding the direct-grantee allowlist below.
+        EXECUTE format(
+            'GRANT ALL PRIVILEGES ON TABLE %I.%I TO atlas_eom_handoff_owner',
+            schema_name,
+            relation_name
+        );
         EXECUTE format(
             'REVOKE ALL PRIVILEGES ON TABLE %I.%I FROM PUBLIC',
             schema_name,
             relation_name
         );
-        EXECUTE format(
-            'REVOKE ALL PRIVILEGES ON TABLE %I.%I FROM atlas_nocodb',
-            schema_name,
-            relation_name
-        );
-        -- Rebuild the configured-runtime allowlist below rather than preserving
-        -- a stale DBA-era direct grant such as DELETE after ownership changes.
-        -- Clear the legacy default only when it exists so a deployment whose
-        -- configured runtime has another name does not require an `atlas` role.
+        -- Rebuild the direct table allowlist from every catalog grantee, not
+        -- just the current runtime's named predecessor. A stale login or a
+        -- group inherited by one can otherwise retain recovery evidence access
+        -- after ownership transfer.
         FOR acl_role IN
-            SELECT role_state.rolname
-              FROM pg_catalog.pg_roles AS role_state
-             WHERE role_state.rolname IN ('atlas', runtime_role)
+            SELECT DISTINCT grantee_role.rolname
+              FROM pg_catalog.pg_class AS relation
+              CROSS JOIN LATERAL pg_catalog.aclexplode(
+                  COALESCE(
+                      relation.relacl,
+                      pg_catalog.acldefault('r', relation.relowner)
+                  )
+              ) AS relation_acl
+              JOIN pg_catalog.pg_roles AS grantee_role
+                ON grantee_role.oid = relation_acl.grantee
+             WHERE relation.oid = to_regclass(
+                       format('%I.%I', schema_name, relation_name)
+                   )
+               AND grantee_role.rolname <> 'atlas_eom_handoff_owner'
         LOOP
             EXECUTE format(
                 'REVOKE ALL PRIVILEGES ON TABLE %I.%I FROM %I',
@@ -464,8 +478,9 @@ BEGIN
             );
         END LOOP;
         -- Table and column ACLs are separate PostgreSQL catalogs. Rebuild the
-        -- entire direct access surface so an old column grant cannot survive
-        -- the table-level revoke and expose recovery evidence to NocoDB.
+        -- entire direct access surface so no stale column grant can survive
+        -- the table-level rebuild and expose recovery evidence to a login or
+        -- one of its inherited groups.
         FOR column_name IN
             SELECT attribute.attname
               FROM pg_catalog.pg_attribute AS attribute
@@ -488,9 +503,19 @@ BEGIN
                 relation_name
             );
             FOR acl_role IN
-                SELECT role_state.rolname
-                  FROM pg_catalog.pg_roles AS role_state
-                 WHERE role_state.rolname IN ('atlas', runtime_role)
+                SELECT DISTINCT grantee_role.rolname
+                  FROM pg_catalog.pg_attribute AS attribute
+                  CROSS JOIN LATERAL pg_catalog.aclexplode(
+                      attribute.attacl
+                  ) AS column_acl
+                  JOIN pg_catalog.pg_roles AS grantee_role
+                    ON grantee_role.oid = column_acl.grantee
+                 WHERE attribute.attrelid = to_regclass(
+                           format('%I.%I', schema_name, relation_name)
+                       )
+                   AND attribute.attname = column_name
+                   AND attribute.attnum > 0
+                   AND NOT attribute.attisdropped
             LOOP
                 EXECUTE format(
                     'REVOKE ALL PRIVILEGES (%I) ON TABLE %I.%I FROM %I',

--- a/atlas_brain/storage/migrations/__init__.py
+++ b/atlas_brain/storage/migrations/__init__.py
@@ -21,7 +21,10 @@ MIGRATIONS_DIR = Path(__file__).parent
 # identity verification and explicit, narrow runner selection, but generic
 # startup/MCP runs must not attempt them.
 CONTROLLED_DBA_MIGRATION_NAMES = frozenset(
-    {"394_eom_first_clean_completion_receipts"}
+    {
+        "393_eom_missed_call_recovery_runtime_privileges",
+        "394_eom_first_clean_completion_receipts",
+    }
 )
 
 

--- a/docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md
+++ b/docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md
@@ -44,23 +44,45 @@ claim or send a step.
 
 ## Safe rollout order
 
-1. Deploy the Atlas provider code and migration `389_eom_missed_call_recovery`
-   with recovery disabled. Verify the full application starts, the migration is
-   recorded, and no worker is running. On the compatible slim EOM profile,
-   `ATLAS_EOM_RUN_MIGRATIONS=true` applies this additive schema even while the
-   recovery flag remains disabled; that flag controls delivery, not schema
-   readiness.
-2. Deploy the tracker capability-backed proxy after Atlas is serving the named
+1. Keep recovery disabled. On a fresh target, or one that has not yet recorded
+   migration `389_eom_missed_call_recovery`, deploy this source and use the
+   compatible slim EOM profile with `ATLAS_EOM_RUN_MIGRATIONS=true` once. That
+   profile applies the ordinary recovery prerequisites through migration 389,
+   deliberately excludes migration 393, and leaves the worker stopped while
+   recovery is disabled. Verify migration 389 is recorded before continuing.
+2. After migration 389 is recorded, and before any full generic Atlas startup
+   or enabling recovery, apply the DBA-only privilege repair from the release
+   worktree in a protected DBA shell where
+   `ATLAS_EOM_MISSED_CALL_RECOVERY_DBA_DATABASE_URL` is already injected, run:
+
+   ```bash
+   python scripts/apply_eom_missed_call_recovery_runtime_privileges.py --json
+   python scripts/apply_eom_missed_call_recovery_runtime_privileges.py --apply --json
+   ```
+
+   The first command is read-only. The second applies only migration
+   `393_eom_missed_call_recovery_runtime_privileges` through Atlas's normal
+   migration ledger and requires a PostgreSQL superuser. Do not pass a DBA DSN
+   on the command line, add it to the normal Atlas service environment, or give
+   the `atlas` runtime role guard membership. Confirm the result reports
+   `migration_recorded: true`, then remove the temporary DBA secret injection.
+3. Start the Atlas entrypoint with recovery still disabled. Verify the full
+   application starts, migration 389 and migration 393 are recorded, and no
+   worker is running. On the compatible slim EOM profile,
+   `ATLAS_EOM_RUN_MIGRATIONS=true` applies only ordinary recovery prerequisites;
+   it never applies the DBA-only ownership repair. That flag controls normal
+   migration startup, not delivery permission or DBA authority.
+4. Deploy the tracker capability-backed proxy after Atlas is serving the named
    endpoints.
-3. Deploy the Website CRM Leads card after the tracker advertises the exact
+5. Deploy the Website CRM Leads card after the tracker advertises the exact
    capability names and routes.
-4. Configure the private booking link and validate the process still starts
+6. Configure the private booking link and validate the process still starts
    with recovery disabled. Do not place a placeholder or test link in customer
    configuration.
-5. Verify the existing email transport is enabled and the sender remains the
+7. Verify the existing email transport is enabled and the sender remains the
    established EOM sender. Then set recovery enabled and restart the Atlas
    service.
-6. Use only controlled non-customer test data and a fake/sandbox provider for
+8. Use only controlled non-customer test data and a fake/sandbox provider for
    pre-production verification. Do not test this by emailing a real lead.
 
 The sender is dormant until a real operator action creates an eligible sequence.

--- a/docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md
+++ b/docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md
@@ -75,8 +75,10 @@ claim or send a step.
    first gives the existing selector only 390-392, then refuses to run 393 until
    `389_eom_missed_call_recovery` is recorded. It never applies 389. Once 389
    is recorded, it applies only 393 through Atlas's normal migration ledger.
-   Migration 393 also refuses to elevate any CRM bridge function whose stored
-   body is not the trusted migration-389 body. Do not pass a DBA DSN on the
+   After it verifies the DBA executor, migration 393 provisions the stock
+   PostgreSQL `pgcrypto` extension if needed, then refuses to elevate any CRM
+   bridge function whose stored body is not the trusted migration-389 body. Do
+   not pre-seed that extension through the normal runtime, pass a DBA DSN on the
    command line, add it to the normal Atlas service environment, or give the
    `atlas` runtime role guard membership. Confirm the result reports
    `prerequisite_migration_recorded: true` and `migration_recorded: true`, then

--- a/docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md
+++ b/docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md
@@ -44,13 +44,22 @@ claim or send a step.
 
 ## Safe rollout order
 
-1. Keep recovery disabled. On a fresh target, or one that has not yet recorded
-   migration `389_eom_missed_call_recovery`, deploy this source and use the
-   compatible slim EOM profile with `ATLAS_EOM_RUN_MIGRATIONS=true` once. That
-   profile applies the ordinary recovery prerequisites through migration 389,
-   deliberately excludes migration 393, and leaves the worker stopped while
-   recovery is disabled. Verify migration 389 is recorded before continuing.
-2. After migration 389 is recorded, and before any full generic Atlas startup
+1. Keep recovery disabled. Before a target missing migration
+   `389_eom_missed_call_recovery` uses the slim EOM bootstrap, run the
+   read-only DBA preflight below from the release worktree. On `--apply`, the
+   controlled DBA command first gives Atlas's existing attested selector only
+   the historical EOM recovery names 390-392. That is the only allowed way to
+   clear an exact legacy 379/386 recovery state before the slim bootstrap; the
+   normal `atlas` runtime never receives this authority. When 389 is still
+   absent, `--apply` intentionally stops before 393 with a missing-389 error;
+   re-run the read-only preflight, then continue to the slim bootstrap. A fresh
+   target has no selected historical prelude, so this leaves no migration change
+   before the expected missing-389 stop.
+2. Use the compatible slim EOM profile with `ATLAS_EOM_RUN_MIGRATIONS=true`
+   once. It applies the ordinary recovery prerequisites through migration 389,
+   deliberately excludes 390-393, and leaves the worker stopped while recovery
+   is disabled. Verify migration 389 is recorded before continuing.
+3. After migration 389 is recorded, and before any full generic Atlas startup
    or enabling recovery, apply the DBA-only privilege repair from the release
    worktree in a protected DBA shell where
    `ATLAS_EOM_MISSED_CALL_RECOVERY_DBA_DATABASE_URL` is already injected, run:
@@ -60,33 +69,35 @@ claim or send a step.
    python scripts/apply_eom_missed_call_recovery_runtime_privileges.py --apply --json
    ```
 
-   The first command is read-only and reports both the migration-389
-   prerequisite receipt and the migration-393 repair receipt. The second
-   refuses to apply unless migration `389_eom_missed_call_recovery` is already
-   recorded, then applies only
-   `393_eom_missed_call_recovery_runtime_privileges` through Atlas's normal
-   migration ledger and requires a PostgreSQL superuser. Do not pass a DBA DSN
-   on the command line, add it to the normal Atlas service environment, or give
-   the `atlas` runtime role guard membership. Confirm the result reports
+   The first command is read-only and reports the 390-392 historical-prelude
+   receipts plus the migration-389 prerequisite and migration-393 repair
+   receipts. The second requires a PostgreSQL superuser. If 393 is absent, it
+   first gives the existing selector only 390-392, then refuses to run 393 until
+   `389_eom_missed_call_recovery` is recorded. It never applies 389. Once 389
+   is recorded, it applies only 393 through Atlas's normal migration ledger.
+   Migration 393 also refuses to elevate any CRM bridge function whose stored
+   body is not the trusted migration-389 body. Do not pass a DBA DSN on the
+   command line, add it to the normal Atlas service environment, or give the
+   `atlas` runtime role guard membership. Confirm the result reports
    `prerequisite_migration_recorded: true` and `migration_recorded: true`, then
    remove the temporary DBA secret injection.
-3. Start the Atlas entrypoint with recovery still disabled. Verify the full
+4. Start the Atlas entrypoint with recovery still disabled. Verify the full
    application starts, migration 389 and migration 393 are recorded, and no
    worker is running. On the compatible slim EOM profile,
    `ATLAS_EOM_RUN_MIGRATIONS=true` applies only ordinary recovery prerequisites;
    it never applies the DBA-only ownership repair. That flag controls normal
    migration startup, not delivery permission or DBA authority.
-4. Deploy the tracker capability-backed proxy after Atlas is serving the named
+5. Deploy the tracker capability-backed proxy after Atlas is serving the named
    endpoints.
-5. Deploy the Website CRM Leads card after the tracker advertises the exact
+6. Deploy the Website CRM Leads card after the tracker advertises the exact
    capability names and routes.
-6. Configure the private booking link and validate the process still starts
+7. Configure the private booking link and validate the process still starts
    with recovery disabled. Do not place a placeholder or test link in customer
    configuration.
-7. Verify the existing email transport is enabled and the sender remains the
+8. Verify the existing email transport is enabled and the sender remains the
    established EOM sender. Then set recovery enabled and restart the Atlas
    service.
-8. Use only controlled non-customer test data and a fake/sandbox provider for
+9. Use only controlled non-customer test data and a fake/sandbox provider for
    pre-production verification. Do not test this by emailing a real lead.
 
 The sender is dormant until a real operator action creates an eligible sequence.

--- a/docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md
+++ b/docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md
@@ -35,6 +35,7 @@ appointment.
 | `ATLAS_EOM_FUNNEL_MISSED_CALL_POLL_INTERVAL_SECONDS` | Optional bounded worker interval; default `60`. |
 | `ATLAS_EOM_FUNNEL_MISSED_CALL_MAX_DELIVERY_ATTEMPTS` | Optional bounded definite-rejection retry limit; default `3`. |
 | `ATLAS_EOM_FUNNEL_MISSED_CALL_DELIVERY_TIMEOUT_SECONDS` | Optional bounded provider request timeout; default `10`. |
+| `ATLAS_EOM_FUNNEL_DB_CONNECTION_STRING` | Existing authoritative EOM funnel DSN. The controlled DBA command reads only its username to bind the migration's exact runtime ACL; never print or pass the DSN on a command line. |
 
 The existing Atlas email configuration remains authoritative for sender and
 transport. Do not add a second EOM Resend key or browser-visible sender
@@ -50,7 +51,7 @@ claim or send a step.
    controlled DBA command first gives Atlas's existing attested selector only
    the historical EOM recovery names 390-392. That is the only allowed way to
    clear an exact legacy 379/386 recovery state before the slim bootstrap; the
-   normal `atlas` runtime never receives this authority. When 389 is still
+   configured EOM runtime never receives this authority. When 389 is still
    absent, `--apply` intentionally stops before 393 with a missing-389 error;
    re-run the read-only preflight, then continue to the slim bootstrap. A fresh
    target has no selected historical prelude, so this leaves no migration change
@@ -62,30 +63,39 @@ claim or send a step.
 3. After migration 389 is recorded, and before any full generic Atlas startup
    or enabling recovery, apply the DBA-only privilege repair from the release
    worktree in a protected DBA shell where
-   `ATLAS_EOM_MISSED_CALL_RECOVERY_DBA_DATABASE_URL` is already injected, run:
+   `ATLAS_EOM_MISSED_CALL_RECOVERY_DBA_DATABASE_URL` and the existing
+   `ATLAS_EOM_FUNNEL_DB_CONNECTION_STRING` are already injected, run:
 
    ```bash
    python scripts/apply_eom_missed_call_recovery_runtime_privileges.py --json
    python scripts/apply_eom_missed_call_recovery_runtime_privileges.py --apply --json
    ```
 
-   The first command is read-only and reports the 390-392 historical-prelude
-   receipts plus the migration-389 prerequisite and migration-393 repair
-   receipts. The second requires a PostgreSQL superuser. If 393 is absent, it
-   first gives the existing selector only 390-392, then refuses to run 393 until
+   The first command is read-only and reports the configured runtime role, the
+   390-392 historical-prelude receipts, plus the migration-389 prerequisite and
+   migration-393 repair receipts. The second requires a PostgreSQL superuser.
+   It derives only the username from the EOM funnel DSN--it never prints that
+   DSN--and fails closed if the resulting role is absent, elevated, or a guard
+   member. If 393 is absent, it first establishes the stock PostgreSQL
+   `pgcrypto` extension through the protected DBA connection, then gives the
+   existing selector only 390-392 and refuses to run 393 until
    `389_eom_missed_call_recovery` is recorded. It never applies 389. Once 389
    is recorded, it applies only 393 through Atlas's normal migration ledger.
    The generic runner can stop after committing one selected historical prelude
    while another exact receipt remains unresolved; the controlled command
    re-reads the ledger and continues only when that selected receipt advanced.
    An unchanged integrity stop still aborts the command. After it verifies the
-   DBA executor, migration 393 provisions the stock PostgreSQL `pgcrypto`
-   extension if needed, then refuses to elevate any CRM bridge function or grant
-   runtime `UPDATE` when either bridge or append-only fence body is not the
-   trusted migration-389 body.
+   DBA executor, migration 393 repeats the `pgcrypto` prerequisite if needed,
+   then refuses to elevate any CRM bridge function or grant runtime `UPDATE`
+   when any bridge, fence, validator, or nested helper body is not the trusted
+   migration-389 body. It grants that surface only to the configured EOM role,
+   runs the two CRM-reading scope validators as fixed-search-path definer
+   functions under the no-login guard rather than granting the runtime direct
+   `contacts` access, removes every non-guard direct execution grant from the
+   definer helpers, and moves every guard-critical function under that guard.
    Do not pre-seed that extension through the normal runtime, pass a DBA DSN on
    the command line, add it to the normal Atlas service environment, or give
-   the `atlas` runtime role guard membership. Confirm the result reports
+   the configured EOM runtime role guard membership. Confirm the result reports
    `prerequisite_migration_recorded: true` and `migration_recorded: true`, then
    remove the temporary DBA secret injection.
 4. Start the Atlas entrypoint with recovery still disabled. Verify the full

--- a/docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md
+++ b/docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md
@@ -75,12 +75,17 @@ claim or send a step.
    first gives the existing selector only 390-392, then refuses to run 393 until
    `389_eom_missed_call_recovery` is recorded. It never applies 389. Once 389
    is recorded, it applies only 393 through Atlas's normal migration ledger.
-   After it verifies the DBA executor, migration 393 provisions the stock
-   PostgreSQL `pgcrypto` extension if needed, then refuses to elevate any CRM
-   bridge function whose stored body is not the trusted migration-389 body. Do
-   not pre-seed that extension through the normal runtime, pass a DBA DSN on the
-   command line, add it to the normal Atlas service environment, or give the
-   `atlas` runtime role guard membership. Confirm the result reports
+   The generic runner can stop after committing one selected historical prelude
+   while another exact receipt remains unresolved; the controlled command
+   re-reads the ledger and continues only when that selected receipt advanced.
+   An unchanged integrity stop still aborts the command. After it verifies the
+   DBA executor, migration 393 provisions the stock PostgreSQL `pgcrypto`
+   extension if needed, then refuses to elevate any CRM bridge function or grant
+   runtime `UPDATE` when either bridge or append-only fence body is not the
+   trusted migration-389 body.
+   Do not pre-seed that extension through the normal runtime, pass a DBA DSN on
+   the command line, add it to the normal Atlas service environment, or give
+   the `atlas` runtime role guard membership. Confirm the result reports
    `prerequisite_migration_recorded: true` and `migration_recorded: true`, then
    remove the temporary DBA secret injection.
 4. Start the Atlas entrypoint with recovery still disabled. Verify the full

--- a/docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md
+++ b/docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md
@@ -60,12 +60,16 @@ claim or send a step.
    python scripts/apply_eom_missed_call_recovery_runtime_privileges.py --apply --json
    ```
 
-   The first command is read-only. The second applies only migration
+   The first command is read-only and reports both the migration-389
+   prerequisite receipt and the migration-393 repair receipt. The second
+   refuses to apply unless migration `389_eom_missed_call_recovery` is already
+   recorded, then applies only
    `393_eom_missed_call_recovery_runtime_privileges` through Atlas's normal
    migration ledger and requires a PostgreSQL superuser. Do not pass a DBA DSN
    on the command line, add it to the normal Atlas service environment, or give
    the `atlas` runtime role guard membership. Confirm the result reports
-   `migration_recorded: true`, then remove the temporary DBA secret injection.
+   `prerequisite_migration_recorded: true` and `migration_recorded: true`, then
+   remove the temporary DBA secret injection.
 3. Start the Atlas entrypoint with recovery still disabled. Verify the full
    application starts, migration 389 and migration 393 are recorded, and no
    worker is running. On the compatible slim EOM profile,

--- a/docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md
+++ b/docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md
@@ -73,10 +73,15 @@ claim or send a step.
 
    The first command is read-only and reports the configured runtime role, the
    390-392 historical-prelude receipts, plus the migration-389 prerequisite and
-   migration-393 repair receipts. The second requires a PostgreSQL superuser.
-   It derives only the username from the EOM funnel DSN--it never prints that
-   DSN--and fails closed if the resulting role is absent, elevated, or a guard
-   member. If 393 is absent, it first establishes the stock PostgreSQL
+   migration-393 repair receipts. Both DSNs are loaded only through their
+   typed settings boundaries. Before either command can mutate anything, it
+   reads the live runtime schema/database/session identity, binds the DBA pool
+   to that schema, and proves both pools contend on one transaction-scoped
+   advisory lock; a wrong database, schema, cluster, or delegated runtime
+   session fails closed. The second requires a PostgreSQL superuser. It derives
+   only the username from the EOM funnel DSN--it never prints that DSN--and
+   fails closed if the resulting role is absent, elevated, or a guard member.
+   If 393 is absent, it first establishes the stock PostgreSQL
    `pgcrypto` extension through the protected DBA connection, then gives the
    existing selector only 390-392 and refuses to run 393 until
    `389_eom_missed_call_recovery` is recorded. It never applies 389. Once 389

--- a/plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md
+++ b/plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md
@@ -433,9 +433,9 @@ Max files: 11
 - Revised required test surface: load that executable file through an explicit
   `importlib` file-spec fixture in the test instead of relying on package
   import discovery.
-- Explicit non-scope remains unchanged: do not create `scripts/__init__.py`,
-  alter Python packaging, or change the command's CLI behavior merely to make
-  its internal helper importable.
+- Explicit non-scope remains unchanged: do not turn `scripts/` into an import
+  package, alter Python packaging, or change the command's CLI behavior merely
+  to make its internal helper importable.
 
 ### Review Contract
 

--- a/plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md
+++ b/plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md
@@ -19,7 +19,7 @@ can report a structurally present but unusable schema as ready.
   predicate has no privilege check.
 - Correct fix must touch/change: add one forward-only, DBA-only migration after
   389 that assigns recovery-object ownership to `atlas_eom_handoff_owner`,
-  provides the precise `atlas` privileges needed by the recovery service
+  provides the precise configured EOM funnel runtime privileges needed by the recovery service
   (including the `UPDATE` capability required for its `FOR UPDATE` row locks),
   preserves NocoDB's direct denial across table, column, and function ACLs,
   and verifies each CRM-trigger bridge body against migration 389 before making
@@ -84,7 +84,18 @@ Max files: 10
   Finally, migration 393 clears direct definer execution for `atlas_nocodb`
   but not `atlas`; an explicit pre-existing or later `atlas` `EXECUTE` grant
   can bypass the intended CRM-trigger-only path and terminalize arbitrary
-  active sequences.
+  active sequences. The resulting repair still treats the literal role `atlas`
+  as the runtime authority even though missed-call recovery actually runs from
+  the configured EOM funnel connection, whose login can differ. It also leaves
+  the two append-only fence functions and the helper called inside the definer
+  chain owned by migration 389's runtime executor after attesting them; that
+  executor can replace a fence body after the repair and before using the
+  existing mutable-row grants. The two scope-validation trigger functions also
+  remain `SECURITY INVOKER` after their ownership transfer: the restricted
+  runtime must invoke them for recovery writes, but is intentionally not
+  granted direct `SELECT` on `contacts`, which those validators read. Finally,
+  391 and 392 require `pgcrypto`, but the controlled runner selects those
+  historical preludes before migration 393 creates the extension.
 - Required change surface: update only the controlled DBA runner, migration
   393, their existing focused tests, the EOM workflow enrollment, the rollout
   runbook, and this plan. On
@@ -114,12 +125,29 @@ Max files: 10
   revoke direct `EXECUTE` from `atlas` on all six definer helpers, and readiness
   must reject an admitted runtime role that regains direct execution on any of
   them; tests must prove the migration clears all six and the probe rejects then
-  re-admits one runtime-role grant/revoke boundary.
+  re-admits one runtime-role grant/revoke boundary. The controlled runner must
+  derive the EOM runtime login from the configured EOM funnel DSN without
+  exposing its credentials, install `pgcrypto` through the already-admitted DBA
+  connection before an authorized 390-392 prelude can run, and bind that exact
+  login into the migration session. Migration 393 must validate the configured
+  login as an unprivileged, guard-isolated runtime role, revoke stale recovery
+  table ACLs from it (and from a present legacy `atlas` role), remove every
+  non-guard direct `EXECUTE` grant from the definer helpers, and grant only that
+  configured login. It must attest and transfer every guard-critical recovery
+  function--the CRM bridge, all append-only fences, scope validators, and the
+  nested inbound-SMS helper--to the no-login guard before granting runtime
+  access. The two scope validators must run as guard-owned `SECURITY DEFINER`
+  functions with the fixed schema search path, so the restricted runtime can
+  invoke its existing recovery-table triggers without a direct `contacts`
+  grant. Readiness must reject a missing/incorrect owner or validator definer
+  configuration on that exact guard-function set. Tests must prove a non-default
+  configured runtime receives the allowed surface, owner/validator-authority
+  drift rejects readiness, and `pgcrypto` setup precedes every selected prelude.
 - Explicit non-scope: do not alter migration 389, the generic migration runner,
-  the slim startup tuple, database schema, role memberships, service routes,
-  delivery behavior, PostgreSQL CI image, or production state. Do not reapply
-  389 from the DBA runner and do not let the normal `atlas` runtime execute
-  390-393.
+  the slim startup tuple, application connection-pool configuration, database
+  schema, role memberships, service routes, delivery behavior, PostgreSQL CI
+  image, or production state. Do not reapply 389 from the DBA runner and do not
+  let the normal runtime execute 390-393.
 - Assumption/blocker: migration 393 remains unrecorded until this source repair
   is merged and a DBA follows the runbook. The existing migration ledger and
   reconciliation selector remain authoritative for whether an exact historical
@@ -137,28 +165,38 @@ Max files: 10
 - Acceptance criteria:
   1. The new migration is forward-only and DBA-gated; it keeps the existing
      no-login, membership-isolated guard model, transfers all six recovery
-     tables plus the privileged CRM-trigger functions to that guard, clears
-     stale table/column/function ACLs, and refuses to grant mutable evidence
-     access unless the exact append-only trigger bindings and trusted migration-
-     389 function bodies are intact. It also leaves neither NocoDB nor the
-     runtime role with direct `EXECUTE` on the six definer helpers.
-  2. After applying the migration in a disposable schema, the runtime role has
+     tables plus every guard-critical bridge, fence, validator, and nested
+     definer-chain helper to that guard, makes the two CRM-reading scope
+     validators guard-owned `SECURITY DEFINER` functions with a fixed search
+     path, clears stale table/column/function
+     ACLs, and refuses to grant mutable evidence access unless the exact
+     append-only trigger bindings and trusted migration-389 function bodies are
+     intact. It also leaves neither NocoDB nor the configured runtime role with
+     direct `EXECUTE` on the six definer helpers.
+  2. The controlled DBA runner derives the EOM runtime login from the configured
+     funnel DSN without logging its credentials, installs `pgcrypto` before an
+     allowed historical prelude, and binds that login to migration 393. The
+     migration fails closed if that role is absent, elevated, or has guard
+     membership; it does not assume a literal `atlas` login exists.
+  3. After applying the migration in a disposable schema, the configured runtime
+     role has
      the exact required table privileges: read/insert/lock for receipts and
      attempts, read/insert for suppressions/events, and read/insert/update for
      sequences/steps. `tests/test_eom_missed_call_recovery.py` proves the real
      role can perform the service's locked read and mutations.
-  3. `atlas_nocodb` cannot directly select, insert, update, or delete recovery
+  4. `atlas_nocodb` cannot directly select, insert, update, or delete recovery
      tables, but an allowed CRM-table mutation still reaches the guarded trigger
      and terminalizes affected recovery work. The same disposable-Postgres test
      proves both sides.
-  4. `missed_call_recovery_schema_ready` returns false for a structurally
+  5. `missed_call_recovery_schema_ready` returns false for a structurally
      complete schema with missing or extra runtime ACLs, runtime guard
      membership, a disabled/rebound immutable-evidence trigger, or an untrusted
      NocoDB direct path; it returns true only after the migration establishes
-     the expected privilege/guard properties and rejects either replaced
-     receipt/attempt fence body. The integration test settles the effect through
-     the real query.
-  5. `EOM_MISSED_CALL_RECOVERY_READINESS_MIGRATIONS` excludes DBA-only and
+     the expected privilege/guard properties, rejects any guard-function owner
+     or scope-validator authority drift, and rejects either replaced
+     receipt/attempt fence body. The
+     integration test settles the effect through the real query.
+  6. `EOM_MISSED_CALL_RECOVERY_READINESS_MIGRATIONS` excludes DBA-only and
      historical recovery SQL. The dedicated DBA runner defaults to a redacted,
      read-only preflight that reports the three historical-prelude receipts plus
      migration 389/393. With `--apply`, it first gives the existing selector
@@ -170,7 +208,7 @@ Max files: 10
      runtime `UPDATE`, retries only a ledger-advancing historical-progress stop,
      and is enrolled with the controlled-runner proof in the EOM workflow. The
      corresponding source and disposable-Postgres tests settle both boundaries.
-  6. No route, provider, delivery configuration, email copy, booking state, or
+  7. No route, provider, delivery configuration, email copy, booking state, or
      recorded recovery evidence changes. Settled by the focused existing
      recovery test suite and a cold diff audit.
 - Reachability proof: the service calls `missed_call_recovery_schema_ready`
@@ -195,10 +233,12 @@ Required when this diff changes a guard, validator, normalizer, resolver,
 router/classifier, or admission boundary. Name each changed boundary path or
 seam in the enumeration; otherwise write "N/A - no boundary change."
 
-- Boundary path/seam: `atlas` service role -> recovery tables; `atlas`/NocoDB
-  direct function execution -> guarded CRM-trigger functions; startup probe ->
-  worker admission; protected DBA DSN -> exact 390-392 historical prelude ->
-  recorded migration 389 -> recorded migration 393 -> normal runtime startup.
+- Boundary path/seam: configured EOM funnel service role -> recovery tables;
+  configured-runtime/NocoDB direct function execution -> guarded CRM-trigger
+  functions; runtime-owned guard function -> immutable/scope/definer chain;
+  startup probe -> worker admission; protected DBA DSN -> `pgcrypto` -> exact
+  390-392 historical prelude -> recorded migration 389 -> recorded migration
+  393 -> normal runtime startup.
 - Replaced-path behaviors: previously a table's mere existence admitted the
   worker; after this change only structural presence plus usable runtime ACLs
   and guarded trigger properties admit it. Previously the DBA runner could not
@@ -207,17 +247,20 @@ seam in the enumeration; otherwise write "N/A - no boundary change."
   set to the existing selector, requires the 389 receipt before 393, and
   rejects bridge and mutable-evidence fence bodies outside the migration-389
   allowlist before elevation or runtime `UPDATE`, and removes/rejects direct
-  runtime execution of the definer helpers. A committed historical prelude's
-  expected integrity stop now continues only when the ledger proves that exact
-  prelude advanced.
+  runtime execution of the definer helpers. The configured EOM funnel role now
+  receives the exact ACL, every guard-critical function is guard-owned, and the
+  DBA runner establishes `pgcrypto` before it can select a historical prelude.
+  A committed historical prelude's expected integrity stop now continues only
+  when the ledger proves that exact prelude advanced.
 - Guard-relevant fields: table/column/function ACL, table owner, function owner,
-  `prosecdef`, function `search_path`, trusted bridge/fence function-body
-  SHA-256 or source body, trigger identity/enabled state, role
-  login/inheritance/membership properties, the six recovery table names,
-  installed `pgcrypto` extension, and the 390-393 ledger receipts.
-- Caller x input shape: `atlas` executes its existing service SQL; NocoDB only
-  performs its documented contacts/contact-interactions mutations. Neither
-  caller receives a new public route or payload shape.
+  `prosecdef`, function `search_path`, trusted bridge/fence/validator/helper
+  function-body SHA-256 or source body, trigger identity/enabled state, role
+  login/inheritance/membership properties, the configured EOM funnel DSN user,
+  the six recovery table names, installed `pgcrypto` extension, and the 390-393
+  ledger receipts.
+- Caller x input shape: the configured EOM funnel runtime executes its existing
+  service SQL; NocoDB only performs its documented contacts/contact-interactions
+  mutations. Neither caller receives a new public route or payload shape.
 
 ### Deployed-config probing
 
@@ -260,21 +303,21 @@ fallback changes; otherwise write "N/A - no guard/config boundary change."
 
 ## Mechanism
 
-The migration validates that a DBA is applying it and that
-`atlas_eom_handoff_owner` remains a no-login, membership-isolated guard. Before
-it changes any bridge function's authority or grants runtime `UPDATE`, it
-compares the six bridge and two mutable-evidence fence bodies against trusted
-migration-389 source. After the DBA-only role checks but before this digest
-check, it installs
-the stock PostgreSQL `pgcrypto` extension when absent and reads its actual
-installed schema; the focused integration test deliberately begins without
-that extension and observes the migration establish it. It then moves recovery
-tables and the CRM-trigger execution chain under that guard, sets trusted
-trigger functions to `SECURITY DEFINER` with a fixed schema search path, clears
-public/NocoDB/runtime table and column ACLs plus explicit NocoDB function
-execution, and then grants the runtime only its proven SQL surface. It refuses
-to proceed unless the receipt/attempt append-only triggers are still enabled,
-bound to their rejecting functions, and retain their trusted bodies.
+The controlled runner reads the configured EOM funnel DSN only to derive its
+username, never logs that DSN, and binds the role into each selected migration
+connection. After the DBA admission and before any selected historical prelude,
+it establishes `pgcrypto`. Migration 393 validates that the configured login is
+an unprivileged, guard-isolated runtime and that `atlas_eom_handoff_owner`
+remains a no-login, membership-isolated guard. Before it changes any bridge
+function's authority or grants runtime `UPDATE`, it compares every guard-critical
+bridge, fence, validator, and nested helper body against trusted migration-389
+source. It then moves recovery tables and every such function under that guard,
+  sets the six CRM-trigger bridge functions and two CRM-reading scope validators
+  to `SECURITY DEFINER` with a fixed schema search path, clears public/NocoDB/runtime table and column ACLs plus
+explicit NocoDB/runtime definer execution, and grants only the configured runtime
+its proven SQL surface. It refuses to proceed unless the receipt/attempt
+append-only triggers are still enabled, bound to their rejecting functions, and
+retain their trusted bodies.
 
 The service's existing structural probe becomes an admission predicate for that
 same privilege/guard contract, so a partial, over-privileged, trigger-drifted,
@@ -347,15 +390,15 @@ Parked hardening: none.
 |---|---:|
 | `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 7 |
 | `atlas_brain/main_eom.py` | 11 |
-| `atlas_brain/services/eom_missed_call_recovery.py` | 218 |
-| `atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql` | 568 |
-| `docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md` | 66 |
-| `plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md` | 366 |
-| `scripts/apply_eom_missed_call_recovery_runtime_privileges.py` | 293 |
-| `tests/test_eom_missed_call_privilege_runner.py` | 403 |
-| `tests/test_eom_missed_call_recovery.py` | 953 |
-| `tests/test_eom_render_profile.py` | 3 |
-| **Total** | **2888** |
+| `atlas_brain/services/eom_missed_call_recovery.py` | 253 |
+| `atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql` | 753 |
+| `docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md` | 76 |
+| `plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md` | 409 |
+| `scripts/apply_eom_missed_call_recovery_runtime_privileges.py` | 356 |
+| `tests/test_eom_missed_call_privilege_runner.py` | 492 |
+| `tests/test_eom_missed_call_recovery.py` | 1187 |
+| `tests/test_eom_render_profile.py` | 7 |
+| **Total** | **3551** |
 
 ## Diff size rationale
 

--- a/plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md
+++ b/plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md
@@ -245,6 +245,37 @@ Max files: 10
   direct recovery-table reads remain denied, and the separate interaction path
   remains covered.
 
+### Recovery ACL allowlist repair contract (current review round)
+
+- Root cause: migration 393 clears direct recovery-table and column grants
+  only from `PUBLIC`, NocoDB, the literal legacy `atlas` role, and the current
+  runtime role. PostgreSQL preserves grants to every other login or group role
+  across ownership transfer. Readiness separately checks only the current
+  runtime and NocoDB, so an inherited group grant or an old runtime's direct
+  grant can keep reading or mutating recovery evidence while the worker still
+  reports the schema ready.
+- Correct fix must touch/change: rebuild each recovery table's direct ACL from
+  the catalog after ownership transfer: make the no-login guard's effective
+  table authority explicit, revoke every other direct table grantee and every
+  direct column grantee, then re-grant only the existing configured runtime
+  allowlist. Extend readiness to fail closed on any direct table ACL grantee
+  other than the guard/current runtime or on any direct column ACL.
+  Extend the disposable PostgreSQL proof with a unique stale login and inherited
+  group role: it must prove migration cleanup removes pre-existing table and
+  column grants, readiness rejects post-migration grants, and revocation
+  re-admits the schema.
+- Must not change: do not change the guard or runtime role flags/memberships,
+  the existing runtime privilege matrix, NocoDB's CRM permissions, definer
+  functions, migration 389, generic migration runner, normal startup tuple,
+  routes, providers, billing, production grants, or PostgreSQL superuser
+  semantics. Superuser access remains PostgreSQL's DBA boundary, not an ACL
+  allowlist exception to be silently widened.
+- Acceptance criteria: a pre-existing stale login/group table or column grant
+  cannot survive migration 393; a newly granted stale login/group table or
+  column privilege makes `missed_call_recovery_schema_ready` return false;
+  revoking it restores readiness; and the existing exact runtime/NocoDB
+  allowed/denied real-role paths remain green.
+
 ### Review Contract
 
 - Acceptance criteria:
@@ -475,15 +506,15 @@ Parked hardening: none.
 |---|---:|
 | `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 7 |
 | `atlas_brain/main_eom.py` | 11 |
-| `atlas_brain/services/eom_missed_call_recovery.py` | 253 |
-| `atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql` | 758 |
+| `atlas_brain/services/eom_missed_call_recovery.py` | 310 |
+| `atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql` | 783 |
 | `docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md` | 76 |
-| `plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md` | 494 |
+| `plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md` | 525 |
 | `scripts/apply_eom_missed_call_recovery_runtime_privileges.py` | 445 |
 | `tests/test_eom_missed_call_privilege_runner.py` | 547 |
-| `tests/test_eom_missed_call_recovery.py` | 1225 |
+| `tests/test_eom_missed_call_recovery.py` | 1333 |
 | `tests/test_eom_render_profile.py` | 7 |
-| **Total** | **3823** |
+| **Total** | **4044** |
 
 ## Diff size rationale
 

--- a/plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md
+++ b/plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md
@@ -44,7 +44,7 @@ can report a structurally present but unusable schema as ready.
 
 Ownership lane: eom/missed-call-recovery-runtime-privileges
 Slice phase: Production hardening
-Max files: 9
+Max files: 10
 
 1. Add the additive recovery-ACL migration and security-definer trigger bridge.
 2. Make readiness fail closed when the runtime role cannot execute the service's
@@ -55,6 +55,9 @@ Max files: 9
    it, then refuses to apply 393 before migration 389 has a ledger receipt.
 4. Prove the runtime/NocoDB boundary in a disposable Postgres schema.
 5. Document the redacted-DSN DBA cutover before normal runtime startup.
+6. Enroll the controlled DBA-runner migration/test surface in the explicit EOM
+   workflow so a runner-only or migration-393 change cannot bypass its required
+   PostgreSQL proof.
 
 ### Fix-loop repair contract (current review round)
 
@@ -66,24 +69,36 @@ Max files: 9
   ordinary migration-389 bootstrap. Separately, migration 393 changes six
   existing migration-389 bridge functions to security-definer ownership without
   proving their stored `pg_proc.prosrc` bodies are the trusted source bodies.
+  The trusted-body comparison itself depends on an installed `pgcrypto`
+  extension, but neither migration 393 nor the fresh disposable-schema path
+  creates it. The explicit EOM workflow also uses path allowlists and a named
+  pytest list which omit migration 393, the controlled runner, and its focused
+  unit test, so a change to either migration gate can receive no EOM CI proof.
 - Required change surface: update only the controlled DBA runner, migration
-  393, their existing focused tests, the rollout runbook, and this plan. On
+  393, their existing focused tests, the EOM workflow enrollment, the rollout
+  runbook, and this plan. On
   `--apply`, an existing migration ledger lets the runner first give the
   existing migration runner only the three explicitly enumerated 390-392
   historical recovery names, allowing it to apply at most one selected prelude
   per invocation; an absent ledger must reject without invoking that generic
   runner. It must never apply 389 itself, and must still reject a missing 389
   receipt before applying 393. Its read-only result must report all prelude
-  receipts. Migration 393 must verify
+  receipts. After it validates the protected DBA/role boundary and before it
+  calculates any trusted bridge-function digest, migration 393 must provision
+  and locate `pgcrypto`; the disposable-schema test must observe that the
+  applied migration established that extension rather than pre-seeding it in a
+  fixture. Migration 393 must verify
   the exact trusted body digest for all six bridge functions before any
   `SECURITY DEFINER` or ownership change. Tests must prove the DBA prelude is
   ordered before 393, an absent ledger and a missing 389 never reach 393, and
   each bridge function rejects a tampered body without gaining definer
-  authority.
+  authority. The EOM workflow must trigger on and execute the controlled
+  runner/migration-393 proof on both pull requests and post-merge pushes.
 - Explicit non-scope: do not alter migration 389, the generic migration runner,
   the slim startup tuple, database schema, role memberships, service routes,
-  delivery behavior, or production state. Do not reapply 389 from the DBA
-  runner and do not let the normal `atlas` runtime execute 390-393.
+  delivery behavior, PostgreSQL CI image, or production state. Do not reapply
+  389 from the DBA runner and do not let the normal `atlas` runtime execute
+  390-393.
 - Assumption/blocker: migration 393 remains unrecorded until this source repair
   is merged and a DBA follows the runbook. The existing migration ledger and
   reconciliation selector remain authoritative for whether an exact historical
@@ -93,7 +108,8 @@ Max files: 9
   prerequisite branches; run the focused recovery test file (with the
   disposable role test skipped locally when no test DSN is configured); compile
   changed Python files; run the plan sync and whitespace checks; then let hosted
-  `eom-lead-pipeline` exercise the real PostgreSQL tamper rejection.
+  `eom-lead-pipeline` exercise the real PostgreSQL extension provisioning,
+  tamper rejection, and controlled-runner test enrollment.
 
 ### Review Contract
 
@@ -125,9 +141,10 @@ Max files: 9
      only 390-392, then refuses to apply 393 until 389 is recorded; it never
      applies 389 and the normal runtime never executes the prelude. A fresh
      target first receives 389 from the slim EOM bootstrap path. Migration 393
-     rejects every altered bridge-function body before granting definer
-     authority. The corresponding source and disposable-Postgres tests settle
-     both boundaries.
+     provisions `pgcrypto` only after DBA admission, rejects every altered
+     bridge-function body before granting definer authority, and is enrolled
+     with the controlled-runner proof in the EOM workflow. The corresponding
+     source and disposable-Postgres tests settle both boundaries.
   6. No route, provider, delivery configuration, email copy, booking state, or
      recorded recovery evidence changes. Settled by the focused existing
      recovery test suite and a cold diff audit.
@@ -167,7 +184,8 @@ seam in the enumeration; otherwise write "N/A - no boundary change."
 - Guard-relevant fields: table/column ACL, table owner, function ACL/owner,
   `prosecdef`, function `search_path`, trusted function-body SHA-256, trigger
   identity/enabled state, role login/inheritance/membership properties, the six
-  recovery table names, and the 390-393 ledger receipts.
+  recovery table names, installed `pgcrypto` extension, and the 390-393 ledger
+  receipts.
 - Caller x input shape: `atlas` executes its existing service SQL; NocoDB only
   performs its documented contacts/contact-interactions mutations. Neither
   caller receives a new public route or payload shape.
@@ -200,6 +218,7 @@ fallback changes; otherwise write "N/A - no guard/config boundary change."
 
 ### Files touched
 
+- `.github/workflows/atlas_eom_lead_pipeline_checks.yml`
 - `atlas_brain/main_eom.py`
 - `atlas_brain/services/eom_missed_call_recovery.py`
 - `atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql`
@@ -216,12 +235,16 @@ The migration validates that a DBA is applying it and that
 `atlas_eom_handoff_owner` remains a no-login, membership-isolated guard. Before
 it changes any bridge function's authority, it compares every one of the six
 stored bodies against an embedded SHA-256 allowlist generated from migration
-389. It then moves recovery tables and the CRM-trigger execution chain under
-that guard, sets trusted trigger functions to `SECURITY DEFINER` with a fixed
-schema search path, clears public/NocoDB/runtime table and column ACLs plus
-explicit NocoDB function execution, and then grants the runtime only its proven
-SQL surface. It refuses to proceed unless the receipt/attempt append-only
-triggers are still enabled and bound to their rejecting functions.
+389. After the DBA-only role checks but before this digest check, it installs
+the stock PostgreSQL `pgcrypto` extension when absent and reads its actual
+installed schema; the focused integration test deliberately begins without
+that extension and observes the migration establish it. It then moves recovery
+tables and the CRM-trigger execution chain under that guard, sets trusted
+trigger functions to `SECURITY DEFINER` with a fixed schema search path, clears
+public/NocoDB/runtime table and column ACLs plus explicit NocoDB function
+execution, and then grants the runtime only its proven SQL surface. It refuses
+to proceed unless the receipt/attempt append-only triggers are still enabled
+and bound to their rejecting functions.
 
 The service's existing structural probe becomes an admission predicate for that
 same privilege/guard contract, so a partial, over-privileged, trigger-drifted,
@@ -235,7 +258,8 @@ historical selector, so an exact legacy recovery can be completed under the DBA
 connection without handing that authority to normal startup. It never applies
 389, then records 393 before a full generic Atlas runtime starts or recovery is
 enabled. The slim readiness tuple intentionally carries only ordinary schema
-prerequisites.
+prerequisites. The EOM workflow lists the migration, controlled runner, and
+runner test in both trigger filters and runs the focused runner test explicitly.
 
 ## Intentional
 
@@ -248,6 +272,9 @@ prerequisites.
   trigger functions instead.
 - Do not alter historical migration 389; a new, recorded migration is the
   auditable recovery path.
+- Provision `pgcrypto` inside the DBA-gated forward migration rather than in
+  the test fixture or normal runtime configuration, so a stock PostgreSQL
+  target proves the same deployment prerequisite.
 
 ## Deferred
 
@@ -284,16 +311,17 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
+| `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 7 |
 | `atlas_brain/main_eom.py` | 11 |
 | `atlas_brain/services/eom_missed_call_recovery.py` | 191 |
-| `atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql` | 505 |
-| `docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md` | 59 |
-| `plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md` | 304 |
+| `atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql` | 510 |
+| `docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md` | 61 |
+| `plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md` | 332 |
 | `scripts/apply_eom_missed_call_recovery_runtime_privileges.py` | 271 |
 | `tests/test_eom_missed_call_privilege_runner.py` | 299 |
-| `tests/test_eom_missed_call_recovery.py` | 739 |
+| `tests/test_eom_missed_call_recovery.py` | 758 |
 | `tests/test_eom_render_profile.py` | 3 |
-| **Total** | **2382** |
+| **Total** | **2443** |
 
 ## Diff size rationale
 

--- a/plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md
+++ b/plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md
@@ -28,14 +28,16 @@ can report a structurally present but unusable schema as ready.
   the guard remains membership-isolated, and immutable-evidence triggers are
   intact. Keep migration 393 out of ordinary EOM startup migration selection;
   provide a controlled DBA-only runner and runbook step so runtime startup sees
-  the recorded repair. Add disposable-PostgreSQL proof for both roles, trigger
-  fencing, and the controlled runner.
+  the recorded repair only after the ordinary migration-389 receipt is present.
+  Add disposable-PostgreSQL proof for both roles, trigger fencing, and the
+  controlled runner.
 - Must not change: do not rewrite migration 389 or its recorded receipt; do not
   modify existing recovery evidence, provider defaults, booking/email behavior,
   authenticated routes, CRM UI, role memberships, billing logic, or historical
-  migration contents or the generic full migration runner. Do not repair
-  production through manual grants or restart services before the forward
-  migration is source-reviewed and applied.
+  migration contents or the generic full migration runner. The controlled
+  runner must not apply or recreate migration 389; the slim bootstrap remains
+  its only application path. Do not repair production through manual grants or
+  restart services before the forward migration is source-reviewed and applied.
 
 ## Scope (this PR)
 
@@ -47,9 +49,40 @@ Max files: 9
 2. Make readiness fail closed when the runtime role cannot execute the service's
    actual recovery-table operations.
 3. Keep DBA-only/historical recovery SQL out of the slim-profile's ordinary
-   migration set and provide a controlled runner for migration 393.
+   migration set and provide a controlled runner for migration 393 that refuses
+   to apply before migration 389 has a ledger receipt.
 4. Prove the runtime/NocoDB boundary in a disposable Postgres schema.
 5. Document the redacted-DSN DBA cutover before normal runtime startup.
+
+### Fix-loop repair contract (current review round)
+
+- Root cause: the controlled runner checks only the migration-393 receipt, even
+  though the slim EOM startup set still selects migration 389 when that earlier
+  receipt is absent. Applying the ownership repair in that state can leave the
+  normal runtime selected to replay migration-389 trigger DDL against
+  guard-owned objects. Separately, the disposable-PostgreSQL proof constructs
+  an invalid empty ACL array before `aclexplode`, so hosted CI stops before it
+  can assert the repaired column ACL boundary.
+- Required change surface: update only the controlled runner, its unit test,
+  the existing disposable-PostgreSQL assertion, the rollout runbook, and this
+  plan. The runner's read-only preflight must expose both ledger receipts;
+  `--apply` must reject a missing migration-389 receipt before calling the
+  migration runner. The unit proof must cover recorded and missing prerequisite
+  states and prove no migration call occurs on rejection. The role test must
+  pass the nullable catalog ACL directly to `aclexplode` so an absent ACL means
+  no rows rather than an invalid array.
+- Explicit non-scope: do not alter migration 389, migration 393, the generic
+  migration runner, the slim startup tuple, database schema, role memberships,
+  service routes, delivery behavior, or production state. Do not reapply 389
+  from the DBA runner.
+- Assumption/blocker: the source migration ledger is authoritative for whether
+  migration 389 has completed. The local workspace lacks the disposable
+  PostgreSQL URL, so hosted CI remains the real-role proof for the SQL query.
+- Verification plan: run the runner unit tests for the prerequisite-present and
+  prerequisite-missing branches, run the focused recovery test file (with the
+  disposable role test skipped locally when no test DSN is configured), compile
+  the changed Python files, run the plan sync and whitespace checks, then let
+  hosted `eom-lead-pipeline` exercise the real PostgreSQL assertion.
 
 ### Review Contract
 
@@ -77,10 +110,11 @@ Max files: 9
   5. `EOM_MISSED_CALL_RECOVERY_READINESS_MIGRATIONS` excludes DBA-only and
      historical recovery SQL. The dedicated DBA runner defaults to a redacted,
      read-only preflight, applies only migration 393 after `--apply`, and
-     verifies the migration ledger before a full generic Atlas startup or
-     enabling recovery. A fresh target first receives migration 389 from the
-     slim EOM bootstrap path. The corresponding source-level tests settle both
-     boundaries.
+     reports the migration-389 prerequisite receipt and refuses `--apply` until
+     it is recorded, then verifies migration 393 before a full generic Atlas
+     startup or enabling recovery. A fresh target first receives migration 389
+     from the slim EOM bootstrap path. The corresponding source-level tests
+     settle both boundaries.
   6. No route, provider, delivery configuration, email copy, booking state, or
      recorded recovery evidence changes. Settled by the focused existing
      recovery test suite and a cold diff audit.
@@ -108,14 +142,17 @@ seam in the enumeration; otherwise write "N/A - no boundary change."
 
 - Boundary path/seam: `atlas` service role -> recovery tables; `atlas_nocodb`
   CRM-table write -> guarded recovery trigger functions; startup probe -> worker
-  admission; protected DBA DSN -> recorded migration 393 -> normal runtime
-  startup.
+  admission; protected DBA DSN -> recorded migration 389 -> recorded migration
+  393 -> normal runtime startup.
 - Replaced-path behaviors: previously a table's mere existence admitted the
   worker; after this change only structural presence plus usable runtime ACLs
-  and guarded trigger properties admit it.
+  and guarded trigger properties admit it. Previously the DBA runner selected
+  393 whenever its own receipt was absent; it now selects 393 only after the
+  migration-389 receipt is present.
 - Guard-relevant fields: table/column ACL, table owner, function ACL/owner,
   `prosecdef`, function `search_path`, trigger identity/enabled state, role
-  login/inheritance/membership properties, and the six recovery table names.
+  login/inheritance/membership properties, the six recovery table names, and
+  the migration-389/393 ledger receipts.
 - Caller x input shape: `atlas` executes its existing service SQL; NocoDB only
   performs its documented contacts/contact-interactions mutations. Neither
   caller receives a new public route or payload shape.
@@ -131,9 +168,15 @@ fallback changes; otherwise write "N/A - no guard/config boundary change."
   the real schema probe returns true.
 - Absent value probe: removing a required runtime privilege makes the same probe
   return false before the worker can be started.
+- Explicit migration-ledger probe: a recorded migration 389 and absent 393
+  receipt lets the DBA runner select only migration 393 after `--apply`.
+- Absent migration-ledger probe: an absent ledger table, empty ledger,
+  unrelated receipt, 393-only receipt, and mixed unrelated/393 receipt all
+  reject `--apply` before the runner can make a write.
 - Default-session/default-context probe: the query uses `current_user`, so the
   integration proof connects as the runtime role rather than spoofing a role
-  name in a superuser session.
+  name in a superuser session; the DBA runner reads the target's ledger rather
+  than trusting an environment flag for migration-389 completion.
 - Side-effect ordering: readiness is a catalog/ACL read before worker admission;
   role-bound runtime mutations are proved only after the migration establishes
   grants in the disposable schema.
@@ -167,10 +210,11 @@ or DBA-owned deployment fails closed before any provider worker can run. The
 test applies the source migration to an empty disposable schema, connects as
 each restricted role, and exercises both allowed runtime locking/writes and
 denied direct NocoDB data access plus the guarded CRM trigger path. A fresh
-target's slim EOM bootstrap records migration 389; the separate DBA runner then
-records migration 393 before a full generic Atlas runtime starts or recovery is
-enabled. The slim readiness tuple intentionally carries only ordinary schema
-prerequisites.
+target's slim EOM bootstrap records migration 389; the separate DBA runner
+reports that prerequisite in its read-only preflight and refuses `--apply` until
+the receipt is present, then records migration 393 before a full generic Atlas
+runtime starts or recovery is enabled. The slim readiness tuple intentionally
+carries only ordinary schema prerequisites.
 
 ## Intentional
 
@@ -199,18 +243,17 @@ Parked hardening: none.
 
 ## Verification
 
-- `python -m compileall -q atlas_brain/main_eom.py
-  atlas_brain/services/eom_missed_call_recovery.py
-  scripts/apply_eom_missed_call_recovery_runtime_privileges.py
-  tests/test_eom_missed_call_recovery.py
-  tests/test_eom_missed_call_privilege_runner.py
-  tests/test_eom_render_profile.py` — passed locally.
+- `python -m pytest -q tests/test_eom_missed_call_privilege_runner.py` — `8
+  passed` locally, including five missing-prerequisite ledger shapes that must
+  refuse `--apply` without calling the migration runner.
 - `python -m pytest -q tests/test_eom_missed_call_recovery.py` — `13 passed,
   42 skipped` locally. The disposable-PostgreSQL role test is skipped because
   `ATLAS_MIGRATION_TEST_DATABASE_URL` is absent in this workspace; hosted CI
   remains the required real-role proof.
-- `python -m pytest -q tests/test_eom_missed_call_privilege_runner.py
-  tests/test_eom_render_profile.py` — `67 passed` locally.
+- `python -m pytest -q tests/test_eom_render_profile.py` — `64 passed` locally.
+- `python -m compileall -q scripts/apply_eom_missed_call_recovery_runtime_privileges.py
+  tests/test_eom_missed_call_privilege_runner.py
+  tests/test_eom_missed_call_recovery.py` — passed locally.
 - `git diff --check` and the repository mechanical review wrapper remain
   required before publishing. No production database, role, migration, or
   service restart was touched by this source slice.
@@ -222,13 +265,13 @@ Parked hardening: none.
 | `atlas_brain/main_eom.py` | 11 |
 | `atlas_brain/services/eom_missed_call_recovery.py` | 191 |
 | `atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql` | 414 |
-| `docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md` | 44 |
-| `plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md` | 239 |
-| `scripts/apply_eom_missed_call_recovery_runtime_privileges.py` | 174 |
-| `tests/test_eom_missed_call_privilege_runner.py` | 158 |
-| `tests/test_eom_missed_call_recovery.py` | 563 |
+| `docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md` | 48 |
+| `plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md` | 282 |
+| `scripts/apply_eom_missed_call_recovery_runtime_privileges.py` | 198 |
+| `tests/test_eom_missed_call_privilege_runner.py` | 227 |
+| `tests/test_eom_missed_call_recovery.py` | 561 |
 | `tests/test_eom_render_profile.py` | 3 |
-| **Total** | **1797** |
+| **Total** | **1935** |
 
 ## Diff size rationale
 

--- a/plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md
+++ b/plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md
@@ -142,11 +142,11 @@ fallback changes; otherwise write "N/A - no guard/config boundary change."
 - `atlas_brain/main_eom.py`
 - `atlas_brain/services/eom_missed_call_recovery.py`
 - `atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql`
-- `scripts/apply_eom_missed_call_recovery_runtime_privileges.py`
 - `docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md`
 - `plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md`
-- `tests/test_eom_missed_call_recovery.py`
+- `scripts/apply_eom_missed_call_recovery_runtime_privileges.py`
 - `tests/test_eom_missed_call_privilege_runner.py`
+- `tests/test_eom_missed_call_recovery.py`
 - `tests/test_eom_render_profile.py`
 
 ## Mechanism
@@ -213,6 +213,21 @@ Parked hardening: none.
 - `git diff --check` and the repository mechanical review wrapper remain
   required before publishing. No production database, role, migration, or
   service restart was touched by this source slice.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/main_eom.py` | 11 |
+| `atlas_brain/services/eom_missed_call_recovery.py` | 191 |
+| `atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql` | 414 |
+| `docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md` | 44 |
+| `plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md` | 238 |
+| `scripts/apply_eom_missed_call_recovery_runtime_privileges.py` | 174 |
+| `tests/test_eom_missed_call_privilege_runner.py` | 158 |
+| `tests/test_eom_missed_call_recovery.py` | 563 |
+| `tests/test_eom_render_profile.py` | 3 |
+| **Total** | **1796** |
 
 ## Diff size rationale
 

--- a/plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md
+++ b/plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md
@@ -21,18 +21,21 @@ can report a structurally present but unusable schema as ready.
   389 that assigns recovery-object ownership to `atlas_eom_handoff_owner`,
   provides the precise `atlas` privileges needed by the recovery service
   (including the `UPDATE` capability required for its `FOR UPDATE` row locks),
-  preserves NocoDB's direct denial, and makes the CRM-trigger bridge run with
-  the isolated owner and a fixed search path. Extend
-  `missed_call_recovery_schema_ready` to prove that the configured runtime role
-  can actually use the schema. Add migration 393 to the slim EOM profile's
-  closed readiness tuple. Add disposable-PostgreSQL proof for both roles and
-  the trigger bridge.
+  preserves NocoDB's direct denial across table, column, and function ACLs,
+  and makes the CRM-trigger bridge run with the isolated owner and a fixed
+  search path. Extend `missed_call_recovery_schema_ready` to prove that the
+  configured runtime role can actually use only the intended schema surface,
+  the guard remains membership-isolated, and immutable-evidence triggers are
+  intact. Keep migration 393 out of ordinary EOM startup migration selection;
+  provide a controlled DBA-only runner and runbook step so runtime startup sees
+  the recorded repair. Add disposable-PostgreSQL proof for both roles, trigger
+  fencing, and the controlled runner.
 - Must not change: do not rewrite migration 389 or its recorded receipt; do not
   modify existing recovery evidence, provider defaults, booking/email behavior,
   authenticated routes, CRM UI, role memberships, billing logic, or historical
-  migration-recovery selection. Do not repair production through manual grants
-  or restart services before the forward migration is source-reviewed and
-  applied.
+  migration contents or the generic full migration runner. Do not repair
+  production through manual grants or restart services before the forward
+  migration is source-reviewed and applied.
 
 ## Scope (this PR)
 
@@ -42,15 +45,19 @@ Slice phase: Production hardening
 1. Add the additive recovery-ACL migration and security-definer trigger bridge.
 2. Make readiness fail closed when the runtime role cannot execute the service's
    actual recovery-table operations.
-3. Enroll migration 393 in the closed slim-profile recovery migration set.
+3. Keep DBA-only/historical recovery SQL out of the slim-profile's ordinary
+   migration set and provide a controlled runner for migration 393.
 4. Prove the runtime/NocoDB boundary in a disposable Postgres schema.
+5. Document the redacted-DSN DBA cutover before normal runtime startup.
 
 ### Review Contract
 
 - Acceptance criteria:
   1. The new migration is forward-only and DBA-gated; it keeps the existing
-     no-login, membership-isolated guard model and transfers all six recovery
-     tables plus the privileged CRM-trigger functions to that guard.
+     no-login, membership-isolated guard model, transfers all six recovery
+     tables plus the privileged CRM-trigger functions to that guard, clears
+     stale table/column/function ACLs, and refuses to grant mutable evidence
+     access unless the exact append-only trigger bindings are intact.
   2. After applying the migration in a disposable schema, the runtime role has
      the exact required table privileges: read/insert/lock for receipts and
      attempts, read/insert for suppressions/events, and read/insert/update for
@@ -61,25 +68,35 @@ Slice phase: Production hardening
      and terminalizes affected recovery work. The same disposable-Postgres test
      proves both sides.
   4. `missed_call_recovery_schema_ready` returns false for a structurally
-     complete schema with missing runtime ACLs, and true only after the
-     migration establishes the expected privilege/guard properties. The
-     integration test settles the effect through the real query.
-  5. `EOM_MISSED_CALL_RECOVERY_READINESS_MIGRATIONS` includes migration 393, so
-     the slim EOM migration path can apply the forward repair. The corresponding
-     source-level migration-set test settles the closed-set change.
+     complete schema with missing or extra runtime ACLs, runtime guard
+     membership, a disabled/rebound immutable-evidence trigger, or an untrusted
+     NocoDB direct path; it returns true only after the migration establishes
+     the expected privilege/guard properties. The integration test settles the
+     effect through the real query.
+  5. `EOM_MISSED_CALL_RECOVERY_READINESS_MIGRATIONS` excludes DBA-only and
+     historical recovery SQL. The dedicated DBA runner defaults to a redacted,
+     read-only preflight, applies only migration 393 after `--apply`, and
+     verifies the migration ledger before a full generic Atlas startup or
+     enabling recovery. A fresh target first receives migration 389 from the
+     slim EOM bootstrap path. The corresponding source-level tests settle both
+     boundaries.
   6. No route, provider, delivery configuration, email copy, booking state, or
      recorded recovery evidence changes. Settled by the focused existing
      recovery test suite and a cold diff audit.
 - Reachability proof: the service calls `missed_call_recovery_schema_ready`
   before starting the worker; the disposable Postgres proof applies the actual
   migration, connects as each real role, executes the schema probe, and observes
-  the corresponding allowed/denied database effects.
+  the corresponding allowed/denied database effects. The controlled DBA runner
+  uses the existing migration ledger after the slim bootstrap records 389 and
+  before a full generic Atlas process starts or recovery is enabled.
 - Affected surfaces: `atlas_brain/storage/migrations/`,
   `atlas_brain/main_eom.py`, `atlas_brain/services/eom_missed_call_recovery.py`,
-  and its disposable Postgres tests.
+  the controlled migration runner/runbook, and their disposable Postgres/unit
+  tests.
 - Risk areas: PostgreSQL ownership/ACL semantics, `FOR UPDATE` lock privileges,
   security-definer search paths and direct function execution, NocoDB direct
-  data exposure, migration retry/atomicity, and worker startup gating.
+  data exposure, migration retry/atomicity, immutable-evidence fences, and
+  worker startup gating.
 - Reviewer rules triggered: R1, R2, R3, R4, R5, R6, R8, R10, R11, R12, R13.
 
 ### Boundary-change enumeration
@@ -90,13 +107,14 @@ seam in the enumeration; otherwise write "N/A - no boundary change."
 
 - Boundary path/seam: `atlas` service role -> recovery tables; `atlas_nocodb`
   CRM-table write -> guarded recovery trigger functions; startup probe -> worker
-  admission.
+  admission; protected DBA DSN -> recorded migration 393 -> normal runtime
+  startup.
 - Replaced-path behaviors: previously a table's mere existence admitted the
   worker; after this change only structural presence plus usable runtime ACLs
   and guarded trigger properties admit it.
-- Guard-relevant fields: table owner/ACL, function owner, `prosecdef`, function
-  `search_path`, role login/inheritance/membership properties, and the six
-  recovery table names.
+- Guard-relevant fields: table/column ACL, table owner, function ACL/owner,
+  `prosecdef`, function `search_path`, trigger identity/enabled state, role
+  login/inheritance/membership properties, and the six recovery table names.
 - Caller x input shape: `atlas` executes its existing service SQL; NocoDB only
   performs its documented contacts/contact-interactions mutations. Neither
   caller receives a new public route or payload shape.
@@ -124,8 +142,11 @@ fallback changes; otherwise write "N/A - no guard/config boundary change."
 - `atlas_brain/main_eom.py`
 - `atlas_brain/services/eom_missed_call_recovery.py`
 - `atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql`
+- `scripts/apply_eom_missed_call_recovery_runtime_privileges.py`
+- `docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md`
 - `plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md`
 - `tests/test_eom_missed_call_recovery.py`
+- `tests/test_eom_missed_call_privilege_runner.py`
 - `tests/test_eom_render_profile.py`
 
 ## Mechanism
@@ -134,19 +155,21 @@ The migration validates that a DBA is applying it and that
 `atlas_eom_handoff_owner` remains a no-login, membership-isolated guard. It
 moves recovery tables and the CRM-trigger execution chain under that guard,
 sets privileged trigger functions to `SECURITY DEFINER` with a fixed schema
-search path, and revokes public execution. It explicitly revokes NocoDB's
-direct table access, clears stale direct `atlas` rights, and then grants the
-runtime only its proven SQL surface; the append-only triggers still reject
-mutation of immutable evidence even where `UPDATE` is needed solely to take a
-row lock.
+search path, clears public/NocoDB/runtime table and column ACLs plus explicit
+NocoDB function execution, and then grants the runtime only its proven SQL
+surface. It refuses to proceed unless the receipt/attempt append-only triggers
+are still enabled and bound to their rejecting functions.
 
 The service's existing structural probe becomes an admission predicate for that
-same privilege/guard contract, so a partial or DBA-owned deployment fails closed
-before any provider worker can run. The test applies the source migration to an
-empty disposable schema, connects as each restricted role, and exercises both
-allowed runtime locking/writes and denied direct NocoDB data access plus the
-guarded CRM trigger path. The slim profile's explicit readiness tuple receives
-the new migration name, preserving its closed-set deployment behavior.
+same privilege/guard contract, so a partial, over-privileged, trigger-drifted,
+or DBA-owned deployment fails closed before any provider worker can run. The
+test applies the source migration to an empty disposable schema, connects as
+each restricted role, and exercises both allowed runtime locking/writes and
+denied direct NocoDB data access plus the guarded CRM trigger path. A fresh
+target's slim EOM bootstrap records migration 389; the separate DBA runner then
+records migration 393 before a full generic Atlas runtime starts or recovery is
+enabled. The slim readiness tuple intentionally carries only ordinary schema
+prerequisites.
 
 ## Intentional
 
@@ -163,9 +186,9 @@ the new migration name, preserving its closed-set deployment behavior.
 ## Deferred
 
 - Production cutover happens only after this source slice is reviewed, merged,
-  and its forward migration is applied through the controlled DBA runner. The
-  required post-apply role probes and service restart are operational proof, not
-  a manual ACL workaround.
+  migration 389 is present, and its forward repair is applied through the
+  controlled DBA runner. The required post-apply role probes and service restart
+  are operational proof, not a manual ACL workaround.
 
 Parking predicate: speculative privilege hardening unrelated to the six
 recovery tables or the existing CRM trigger bridge is parked; only a proven
@@ -175,43 +198,26 @@ Parked hardening: none.
 
 ## Verification
 
-- `python -m pytest -q tests/test_eom_missed_call_recovery.py
-  tests/test_eom_render_profile.py` — `77 passed, 42 skipped` locally. The
-  database-gated cases remain CI proof; no local test was pointed at the
-  operational schema.
-- `python -m compileall -q atlas_brain/services/eom_missed_call_recovery.py
-  tests/test_eom_missed_call_recovery.py tests/test_eom_render_profile.py` —
-  passed locally.
-- Rollback-only PostgreSQL boundary smoke — applied migrations 035, 256, 346,
-  351, 363, 366, 389, and source migration 393 in a random schema inside one
-  uncommitted transaction; seeded a stale `atlas` `DELETE` grant and observed
-  migration 393 remove it, asserted `atlas`-role readiness, revoked one
-  required `UPDATE` grant and observed readiness become false, restored it, and
-  rolled the transaction back. Passed locally.
-- Rollback-only NocoDB bridge smoke — in the same disposable pattern, a
-  `SET ROLE atlas_nocodb` direct recovery-table read was denied while an allowed
-  contact email edit cancelled the active sequence through the guarded trigger;
-  the transaction was rolled back. Passed locally.
-- `git diff --check origin/main` — passed locally.
-- No supported Python formatter/linter package is installed in the current
-  virtual environment. The required `scripts/push_pr.sh` wrapper will run the
-  repository's mechanical local-review bundle before publishing.
-
-## Estimated diff size
-
-| File | LOC |
-|---|---:|
-| `atlas_brain/main_eom.py` | 1 |
-| `atlas_brain/services/eom_missed_call_recovery.py` | 101 |
-| `atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql` | 311 |
-| `plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md` | 217 |
-| `tests/test_eom_missed_call_recovery.py` | 432 |
-| `tests/test_eom_render_profile.py` | 1 |
-| **Total** | **1063** |
+- `python -m compileall -q atlas_brain/main_eom.py
+  atlas_brain/services/eom_missed_call_recovery.py
+  scripts/apply_eom_missed_call_recovery_runtime_privileges.py
+  tests/test_eom_missed_call_recovery.py
+  tests/test_eom_missed_call_privilege_runner.py
+  tests/test_eom_render_profile.py` — passed locally.
+- `python -m pytest -q tests/test_eom_missed_call_recovery.py` — `13 passed,
+  42 skipped` locally. The disposable-PostgreSQL role test is skipped because
+  `ATLAS_MIGRATION_TEST_DATABASE_URL` is absent in this workspace; hosted CI
+  remains the required real-role proof.
+- `python -m pytest -q tests/test_eom_missed_call_privilege_runner.py
+  tests/test_eom_render_profile.py` — `67 passed` locally.
+- `git diff --check` and the repository mechanical review wrapper remain
+  required before publishing. No production database, role, migration, or
+  service restart was touched by this source slice.
 
 ## Diff size rationale
 
 The source/test diff exceeds the 400-LOC soft budget because the indivisible
 security repair requires one forward migration, an executable readiness
-predicate, and a real-role disposable-Postgres proof. No provider, route,
-configuration, UI, or historical-evidence behavior is included.
+predicate, a controlled DBA-only runner, and a real-role disposable-Postgres
+proof. No provider, route, configuration, UI, or historical-evidence behavior
+is included.

--- a/plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md
+++ b/plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md
@@ -22,8 +22,9 @@ can report a structurally present but unusable schema as ready.
   provides the precise `atlas` privileges needed by the recovery service
   (including the `UPDATE` capability required for its `FOR UPDATE` row locks),
   preserves NocoDB's direct denial across table, column, and function ACLs,
-  and makes the CRM-trigger bridge run with the isolated owner and a fixed
-  search path. Extend `missed_call_recovery_schema_ready` to prove that the
+  and verifies each CRM-trigger bridge body against migration 389 before making
+  it security-definer under the isolated owner and a fixed search path. Extend
+  `missed_call_recovery_schema_ready` to prove that the
   configured runtime role can actually use only the intended schema surface,
   the guard remains membership-isolated, and immutable-evidence triggers are
   intact. Keep migration 393 out of ordinary EOM startup migration selection;
@@ -49,40 +50,50 @@ Max files: 9
 2. Make readiness fail closed when the runtime role cannot execute the service's
    actual recovery-table operations.
 3. Keep DBA-only/historical recovery SQL out of the slim-profile's ordinary
-   migration set and provide a controlled runner for migration 393 that refuses
-   to apply before migration 389 has a ledger receipt.
+   migration set and provide a controlled DBA runner that admits only the
+   exact 390-392 historical prelude when the generic migration guard requires
+   it, then refuses to apply 393 before migration 389 has a ledger receipt.
 4. Prove the runtime/NocoDB boundary in a disposable Postgres schema.
 5. Document the redacted-DSN DBA cutover before normal runtime startup.
 
 ### Fix-loop repair contract (current review round)
 
-- Root cause: the controlled runner checks only the migration-393 receipt, even
-  though the slim EOM startup set still selects migration 389 when that earlier
-  receipt is absent. Applying the ownership repair in that state can leave the
-  normal runtime selected to replay migration-389 trigger DDL against
-  guard-owned objects. Separately, the disposable-PostgreSQL proof constructs
-  an invalid empty ACL array before `aclexplode`, so hosted CI stops before it
-  can assert the repaired column ACL boundary.
-- Required change surface: update only the controlled runner, its unit test,
-  the existing disposable-PostgreSQL assertion, the rollout runbook, and this
-  plan. The runner's read-only preflight must expose both ledger receipts;
-  `--apply` must reject a missing migration-389 receipt before calling the
-  migration runner. The unit proof must cover recorded and missing prerequisite
-  states and prove no migration call occurs on rejection. The role test must
-  pass the nullable catalog ACL directly to `aclexplode` so an absent ACL means
-  no rows rather than an invalid array.
-- Explicit non-scope: do not alter migration 389, migration 393, the generic
-  migration runner, the slim startup tuple, database schema, role memberships,
-  service routes, delivery behavior, or production state. Do not reapply 389
-  from the DBA runner.
-- Assumption/blocker: the source migration ledger is authoritative for whether
-  migration 389 has completed. The local workspace lacks the disposable
-  PostgreSQL URL, so hosted CI remains the real-role proof for the SQL query.
-- Verification plan: run the runner unit tests for the prerequisite-present and
-  prerequisite-missing branches, run the focused recovery test file (with the
-  disposable role test skipped locally when no test DSN is configured), compile
-  the changed Python files, run the plan sync and whitespace checks, then let
-  hosted `eom-lead-pipeline` exercise the real PostgreSQL assertion.
+- Root cause: `run_migrations(..., only=...)` still computes global unresolved
+  historical migration evidence before it applies the selected pending files.
+  For an exact 379/386 recovery state it will select 391/392/390 only when that
+  name is in the caller's pending set. The slim migration tuple deliberately
+  omits those DBA/historical names, so a legacy target can fail before its
+  ordinary migration-389 bootstrap. Separately, migration 393 changes six
+  existing migration-389 bridge functions to security-definer ownership without
+  proving their stored `pg_proc.prosrc` bodies are the trusted source bodies.
+- Required change surface: update only the controlled DBA runner, migration
+  393, their existing focused tests, the rollout runbook, and this plan. On
+  `--apply`, an existing migration ledger lets the runner first give the
+  existing migration runner only the three explicitly enumerated 390-392
+  historical recovery names, allowing it to apply at most one selected prelude
+  per invocation; an absent ledger must reject without invoking that generic
+  runner. It must never apply 389 itself, and must still reject a missing 389
+  receipt before applying 393. Its read-only result must report all prelude
+  receipts. Migration 393 must verify
+  the exact trusted body digest for all six bridge functions before any
+  `SECURITY DEFINER` or ownership change. Tests must prove the DBA prelude is
+  ordered before 393, an absent ledger and a missing 389 never reach 393, and
+  each bridge function rejects a tampered body without gaining definer
+  authority.
+- Explicit non-scope: do not alter migration 389, the generic migration runner,
+  the slim startup tuple, database schema, role memberships, service routes,
+  delivery behavior, or production state. Do not reapply 389 from the DBA
+  runner and do not let the normal `atlas` runtime execute 390-393.
+- Assumption/blocker: migration 393 remains unrecorded until this source repair
+  is merged and a DBA follows the runbook. The existing migration ledger and
+  reconciliation selector remain authoritative for whether an exact historical
+  prelude is permitted. The local workspace lacks the disposable PostgreSQL
+  URL, so hosted CI remains the real-role proof for the SQL migration behavior.
+- Verification plan: run the runner unit tests for no-op, prelude, and missing-
+  prerequisite branches; run the focused recovery test file (with the
+  disposable role test skipped locally when no test DSN is configured); compile
+  changed Python files; run the plan sync and whitespace checks; then let hosted
+  `eom-lead-pipeline` exercise the real PostgreSQL tamper rejection.
 
 ### Review Contract
 
@@ -109,12 +120,14 @@ Max files: 9
      effect through the real query.
   5. `EOM_MISSED_CALL_RECOVERY_READINESS_MIGRATIONS` excludes DBA-only and
      historical recovery SQL. The dedicated DBA runner defaults to a redacted,
-     read-only preflight, applies only migration 393 after `--apply`, and
-     reports the migration-389 prerequisite receipt and refuses `--apply` until
-     it is recorded, then verifies migration 393 before a full generic Atlas
-     startup or enabling recovery. A fresh target first receives migration 389
-     from the slim EOM bootstrap path. The corresponding source-level tests
-     settle both boundaries.
+     read-only preflight that reports the three historical-prelude receipts plus
+     migration 389/393. With `--apply`, it first gives the existing selector
+     only 390-392, then refuses to apply 393 until 389 is recorded; it never
+     applies 389 and the normal runtime never executes the prelude. A fresh
+     target first receives 389 from the slim EOM bootstrap path. Migration 393
+     rejects every altered bridge-function body before granting definer
+     authority. The corresponding source and disposable-Postgres tests settle
+     both boundaries.
   6. No route, provider, delivery configuration, email copy, booking state, or
      recorded recovery evidence changes. Settled by the focused existing
      recovery test suite and a cold diff audit.
@@ -142,17 +155,19 @@ seam in the enumeration; otherwise write "N/A - no boundary change."
 
 - Boundary path/seam: `atlas` service role -> recovery tables; `atlas_nocodb`
   CRM-table write -> guarded recovery trigger functions; startup probe -> worker
-  admission; protected DBA DSN -> recorded migration 389 -> recorded migration
-  393 -> normal runtime startup.
+  admission; protected DBA DSN -> exact 390-392 historical prelude -> recorded
+  migration 389 -> recorded migration 393 -> normal runtime startup.
 - Replaced-path behaviors: previously a table's mere existence admitted the
   worker; after this change only structural presence plus usable runtime ACLs
-  and guarded trigger properties admit it. Previously the DBA runner selected
-  393 whenever its own receipt was absent; it now selects 393 only after the
-  migration-389 receipt is present.
+  and guarded trigger properties admit it. Previously the DBA runner could not
+  clear an exact required historical prelude before a missing 389 receipt, and
+  393 trusted pre-existing bridge code; it now gives only the proven prelude
+  set to the existing selector, requires the 389 receipt before 393, and
+  rejects bridge bodies outside the migration-389 allowlist before elevation.
 - Guard-relevant fields: table/column ACL, table owner, function ACL/owner,
-  `prosecdef`, function `search_path`, trigger identity/enabled state, role
-  login/inheritance/membership properties, the six recovery table names, and
-  the migration-389/393 ledger receipts.
+  `prosecdef`, function `search_path`, trusted function-body SHA-256, trigger
+  identity/enabled state, role login/inheritance/membership properties, the six
+  recovery table names, and the 390-393 ledger receipts.
 - Caller x input shape: `atlas` executes its existing service SQL; NocoDB only
   performs its documented contacts/contact-interactions mutations. Neither
   caller receives a new public route or payload shape.
@@ -168,11 +183,13 @@ fallback changes; otherwise write "N/A - no guard/config boundary change."
   the real schema probe returns true.
 - Absent value probe: removing a required runtime privilege makes the same probe
   return false before the worker can be started.
-- Explicit migration-ledger probe: a recorded migration 389 and absent 393
-  receipt lets the DBA runner select only migration 393 after `--apply`.
-- Absent migration-ledger probe: an absent ledger table, empty ledger,
-  unrelated receipt, 393-only receipt, and mixed unrelated/393 receipt all
-  reject `--apply` before the runner can make a write.
+- Explicit migration-ledger probe: an exact historical state permits only its
+  selected 390-392 prelude through the DBA runner; a recorded migration 389 and
+  absent 393 receipt then lets the runner select 393.
+- Absent migration-ledger probe: an absent ledger table rejects before the DBA
+  runner can invoke the generic migration runner or create a ledger. An empty
+  ledger, unrelated receipt, 393-only receipt, and mixed unrelated/393 receipt
+  all reject before 393 can run.
 - Default-session/default-context probe: the query uses `current_user`, so the
   integration proof connects as the runtime role rather than spoofing a role
   name in a superuser session; the DBA runner reads the target's ledger rather
@@ -196,13 +213,15 @@ fallback changes; otherwise write "N/A - no guard/config boundary change."
 ## Mechanism
 
 The migration validates that a DBA is applying it and that
-`atlas_eom_handoff_owner` remains a no-login, membership-isolated guard. It
-moves recovery tables and the CRM-trigger execution chain under that guard,
-sets privileged trigger functions to `SECURITY DEFINER` with a fixed schema
-search path, clears public/NocoDB/runtime table and column ACLs plus explicit
-NocoDB function execution, and then grants the runtime only its proven SQL
-surface. It refuses to proceed unless the receipt/attempt append-only triggers
-are still enabled and bound to their rejecting functions.
+`atlas_eom_handoff_owner` remains a no-login, membership-isolated guard. Before
+it changes any bridge function's authority, it compares every one of the six
+stored bodies against an embedded SHA-256 allowlist generated from migration
+389. It then moves recovery tables and the CRM-trigger execution chain under
+that guard, sets trusted trigger functions to `SECURITY DEFINER` with a fixed
+schema search path, clears public/NocoDB/runtime table and column ACLs plus
+explicit NocoDB function execution, and then grants the runtime only its proven
+SQL surface. It refuses to proceed unless the receipt/attempt append-only
+triggers are still enabled and bound to their rejecting functions.
 
 The service's existing structural probe becomes an admission predicate for that
 same privilege/guard contract, so a partial, over-privileged, trigger-drifted,
@@ -210,11 +229,13 @@ or DBA-owned deployment fails closed before any provider worker can run. The
 test applies the source migration to an empty disposable schema, connects as
 each restricted role, and exercises both allowed runtime locking/writes and
 denied direct NocoDB data access plus the guarded CRM trigger path. A fresh
-target's slim EOM bootstrap records migration 389; the separate DBA runner
-reports that prerequisite in its read-only preflight and refuses `--apply` until
-the receipt is present, then records migration 393 before a full generic Atlas
-runtime starts or recovery is enabled. The slim readiness tuple intentionally
-carries only ordinary schema prerequisites.
+target's slim EOM bootstrap records migration 389. Before the runner requires
+that receipt, its `--apply` path gives only 390-392 to the existing attested
+historical selector, so an exact legacy recovery can be completed under the DBA
+connection without handing that authority to normal startup. It never applies
+389, then records 393 before a full generic Atlas runtime starts or recovery is
+enabled. The slim readiness tuple intentionally carries only ordinary schema
+prerequisites.
 
 ## Intentional
 
@@ -243,20 +264,21 @@ Parked hardening: none.
 
 ## Verification
 
-- `python -m pytest -q tests/test_eom_missed_call_privilege_runner.py` — `8
-  passed` locally, including five missing-prerequisite ledger shapes that must
-  refuse `--apply` without calling the migration runner.
-- `python -m pytest -q tests/test_eom_missed_call_recovery.py` — `13 passed,
-  42 skipped` locally. The disposable-PostgreSQL role test is skipped because
+- `python -m pytest -q tests/test_eom_missed_call_privilege_runner.py` — `9
+  passed` locally, including the historical-prelude ordering and missing-ledger
+  boundaries.
+- `python -m pytest -q tests/test_eom_missed_call_recovery.py` — `14 passed,
+  48 skipped` locally. The disposable-PostgreSQL role test is skipped because
   `ATLAS_MIGRATION_TEST_DATABASE_URL` is absent in this workspace; hosted CI
   remains the required real-role proof.
 - `python -m pytest -q tests/test_eom_render_profile.py` — `64 passed` locally.
 - `python -m compileall -q scripts/apply_eom_missed_call_recovery_runtime_privileges.py
   tests/test_eom_missed_call_privilege_runner.py
   tests/test_eom_missed_call_recovery.py` — passed locally.
-- `git diff --check` and the repository mechanical review wrapper remain
-  required before publishing. No production database, role, migration, or
-  service restart was touched by this source slice.
+- `git diff --check` and `python scripts/check_guard_class_closure.py --base
+  origin/main --strict` — passed locally. The repository mechanical review
+  wrapper remains required before publishing. No production database, role,
+  migration, or service restart was touched by this source slice.
 
 ## Estimated diff size
 
@@ -264,14 +286,14 @@ Parked hardening: none.
 |---|---:|
 | `atlas_brain/main_eom.py` | 11 |
 | `atlas_brain/services/eom_missed_call_recovery.py` | 191 |
-| `atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql` | 414 |
-| `docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md` | 48 |
-| `plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md` | 282 |
-| `scripts/apply_eom_missed_call_recovery_runtime_privileges.py` | 198 |
-| `tests/test_eom_missed_call_privilege_runner.py` | 227 |
-| `tests/test_eom_missed_call_recovery.py` | 561 |
+| `atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql` | 505 |
+| `docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md` | 59 |
+| `plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md` | 304 |
+| `scripts/apply_eom_missed_call_recovery_runtime_privileges.py` | 271 |
+| `tests/test_eom_missed_call_privilege_runner.py` | 299 |
+| `tests/test_eom_missed_call_recovery.py` | 739 |
 | `tests/test_eom_render_profile.py` | 3 |
-| **Total** | **1935** |
+| **Total** | **2382** |
 
 ## Diff size rationale
 

--- a/plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md
+++ b/plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md
@@ -41,6 +41,7 @@ can report a structurally present but unusable schema as ready.
 
 Ownership lane: eom/missed-call-recovery-runtime-privileges
 Slice phase: Production hardening
+Max files: 9
 
 1. Add the additive recovery-ACL migration and security-definer trigger bridge.
 2. Make readiness fail closed when the runtime role cannot execute the service's
@@ -222,12 +223,12 @@ Parked hardening: none.
 | `atlas_brain/services/eom_missed_call_recovery.py` | 191 |
 | `atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql` | 414 |
 | `docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md` | 44 |
-| `plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md` | 238 |
+| `plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md` | 239 |
 | `scripts/apply_eom_missed_call_recovery_runtime_privileges.py` | 174 |
 | `tests/test_eom_missed_call_privilege_runner.py` | 158 |
 | `tests/test_eom_missed_call_recovery.py` | 563 |
 | `tests/test_eom_render_profile.py` | 3 |
-| **Total** | **1796** |
+| **Total** | **1797** |
 
 ## Diff size rationale
 

--- a/plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md
+++ b/plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md
@@ -160,6 +160,33 @@ Max files: 10
   `eom-lead-pipeline` exercise the real PostgreSQL extension provisioning,
   bridge/fence tamper rejection, and controlled-runner test enrollment.
 
+### Follow-up repair contract (current review round)
+
+- Root cause: the controlled runner checks only that its executor is a
+  superuser before calling `_ensure_pgcrypto()`. The authoritative role
+  admissions live later in migration 393, so an invalid guard, runtime, or
+  NocoDB role can cause a permanent extension write before the migration
+  rejects. Separately, the body-tamper tests configure `atlas` as the runtime
+  role even though the disposable CI service makes `atlas` a PostgreSQL
+  superuser; migration 393 therefore stops at role admission before either
+  trusted-body assertion is exercised.
+- Correct fix must touch/change: add a read-only runner preflight that mirrors
+  migration 393's guard/runtime/NocoDB role admissions before `pgcrypto` or an
+  authorized historical prelude can run, with unit proof for each rejected
+  admission and the valid ordering. Change only the disposable tamper-test
+  setup to bind a unique `LOGIN NOINHERIT` probe role and clean it up, so each
+  case reaches its expected bridge/fence body rejection.
+- Must not change: migration 393 remains the authoritative, in-transaction
+  role-enforcement point; do not change its SQL, the PostgreSQL CI service's
+  `atlas` superuser identity, role memberships, normal startup migration tuple,
+  historical selector, runtime connection configuration, routes, providers,
+  delivery behavior, billing, or production state.
+- Acceptance criteria: an invalid guard, runtime, or NocoDB admission rejects
+  before extension creation and before any migration runner call; the valid
+  path still establishes `pgcrypto` before an allowed historical prelude; and
+  every bridge/fence tamper case fails for its trusted-body message rather than
+  for a superuser-runtime admission failure.
+
 ### Review Contract
 
 - Acceptance criteria:
@@ -393,12 +420,12 @@ Parked hardening: none.
 | `atlas_brain/services/eom_missed_call_recovery.py` | 253 |
 | `atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql` | 753 |
 | `docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md` | 76 |
-| `plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md` | 409 |
-| `scripts/apply_eom_missed_call_recovery_runtime_privileges.py` | 356 |
-| `tests/test_eom_missed_call_privilege_runner.py` | 492 |
-| `tests/test_eom_missed_call_recovery.py` | 1187 |
+| `plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md` | 436 |
+| `scripts/apply_eom_missed_call_recovery_runtime_privileges.py` | 445 |
+| `tests/test_eom_missed_call_privilege_runner.py` | 547 |
+| `tests/test_eom_missed_call_recovery.py` | 1216 |
 | `tests/test_eom_render_profile.py` | 7 |
-| **Total** | **3551** |
+| **Total** | **3751** |
 
 ## Diff size rationale
 

--- a/plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md
+++ b/plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md
@@ -329,6 +329,47 @@ Max files: 10
   and first-clean paths/tests/services, while `main_eom` retains both the
   historical/DBA-only recovery exclusion and the first-clean pool hook.
 
+### Delegated-login admission repair contract (current review round)
+
+- Root cause: the intended exact runtime/NocoDB identity boundary is an
+  authorization-graph invariant, but migration 393 and the controlled DBA
+  runner inspect only memberships granted *to* the configured runtime or
+  `atlas_nocodb`. They do not reject a separate non-superuser login that can
+  assume either admitted login through a direct or transitive membership.
+  PostgreSQL's `pg_has_role(actor, target, 'MEMBER')` reports that ability, and
+  the admitted actor can then `SET ROLE` to the target. The service readiness
+  predicate checks table and guard state but does not attest either admitted
+  login against that incoming delegation path.
+- Correct fix must touch/change: before migration 393 creates `pgcrypto` or
+  changes an ACL, and before the runner creates `pgcrypto` or runs a historical
+  prelude, reject any non-superuser `LOGIN` other than the target role for which
+  `pg_has_role(login, target, 'MEMBER')` is true. Apply the same admission
+  boundary to the runtime worker's schema-readiness predicate for both the
+  current runtime identity and `atlas_nocodb`. Extend disposable-PostgreSQL
+  proof to cover direct and transitive delegated-login paths for both admitted
+  identities, including failed migration/readiness admission followed by
+  revocation and successful re-admission. Exercise the controlled runner's
+  read-only admission query against the same real role graph.
+- Must not change: do not grant, revoke, alter, or otherwise repair production
+  role memberships; the code must only refuse an unsafe graph. Do not change
+  the existing direct table/function ACL matrix, guard role flags, migration
+  389, generic migration runner, historical selector, normal startup tuple,
+  CRM routes/APIs, providers, billing, first-clean behavior, database schema,
+  or production data. Preserve the existing superuser DBA boundary: the new
+  delegated-login scan excludes superusers rather than treating DBA authority as
+  an ordinary runtime admission path.
+- Assumptions: a direct or transitive non-superuser `LOGIN` membership that
+  PostgreSQL reports through `pg_has_role(..., 'MEMBER')` is an assumable target
+  identity; the disposable database probes establish that behavior. The target
+  role itself is excluded because PostgreSQL reports a role as a member of
+  itself.
+- Acceptance criteria: migration 393 and the DBA runner reject direct and
+  transitive non-superuser login delegation to either admitted identity before
+  mutable work; worker readiness returns false for the same post-migration
+  graph and true again after revocation. The configured runtime and NocoDB
+  retain their prior allowed/denied operations when no unsafe delegation
+  exists.
+
 ### Review Contract
 
 - Acceptance criteria:
@@ -346,7 +387,9 @@ Max files: 10
      funnel DSN without logging its credentials, installs `pgcrypto` before an
      allowed historical prelude, and binds that login to migration 393. The
      migration fails closed if that role is absent, elevated, or has guard
-     membership; it does not assume a literal `atlas` login exists.
+     membership, or if a separate non-superuser login can assume either
+     admitted runtime/NocoDB identity; it does not assume a literal `atlas`
+     login exists.
   3. After applying the migration in a disposable schema, the configured runtime
      role has
      the exact required table privileges: read/insert/lock for receipts and
@@ -359,10 +402,11 @@ Max files: 10
      proves both sides.
   5. `missed_call_recovery_schema_ready` returns false for a structurally
      complete schema with missing or extra runtime ACLs, runtime guard
-     membership, a disabled/rebound immutable-evidence trigger, or an untrusted
-     NocoDB direct path; it returns true only after the migration establishes
-     the expected privilege/guard properties, rejects any guard-function owner
-     or scope-validator authority drift, and rejects either replaced
+     membership, incoming delegation to either admitted login, a
+     disabled/rebound immutable-evidence trigger, or an untrusted NocoDB direct
+     path; it returns true only after the migration establishes the expected
+     privilege/guard properties, rejects any guard-function owner or
+     scope-validator authority drift, and rejects either replaced
      receipt/attempt fence body. The
      integration test settles the effect through the real query.
   6. `EOM_MISSED_CALL_RECOVERY_READINESS_MIGRATIONS` excludes DBA-only and
@@ -536,22 +580,30 @@ Parked hardening: none.
 
 ## Verification
 
-- `python -m pytest -q tests/test_eom_missed_call_privilege_runner.py` — `11
-  passed` locally, including committed-prelude retry and non-prelude-progress
-  rejection boundaries.
-- `python -m pytest -q tests/test_eom_missed_call_recovery.py` — `14 passed,
-  50 skipped` locally. The disposable-PostgreSQL role test is skipped because
-  `ATLAS_MIGRATION_TEST_DATABASE_URL` is absent in this workspace; hosted CI
-  remains the required real-role proof.
+- `python -m pytest -q tests/test_eom_missed_call_privilege_runner.py` — `17
+  passed` locally, including the controlled prelude admission boundary.
+- `ATLAS_MIGRATION_TEST_DATABASE_URL=... python -m pytest -q
+  tests/test_eom_missed_call_recovery.py` — `72 passed` locally against the
+  disposable PostgreSQL database. The new proof creates a non-superuser
+  `LOGIN NOINHERIT` actor and a `NOLOGIN NOINHERIT` intermediary, confirms
+  direct and transitive `pg_has_role(..., 'MEMBER')` plus actual `SET ROLE`,
+  then proves migration/runner rejection before privilege mutation and
+  readiness rejection/re-admission for both admitted identities.
 - `python -m pytest -q tests/test_eom_render_profile.py` — `64 passed` locally.
 - `python -m compileall -q scripts/apply_eom_missed_call_recovery_runtime_privileges.py
   atlas_brain/services/eom_missed_call_recovery.py
   tests/test_eom_missed_call_privilege_runner.py
   tests/test_eom_missed_call_recovery.py` — passed locally.
+- `python -m ruff format --check` for the changed Python sources — passed.
+  The file-wide `ruff check` remains non-green on its existing lint baseline;
+  a `HEAD` comparison of `tests/test_eom_missed_call_recovery.py` reports `11`
+  pre-existing errors. This privilege-boundary repair does not broaden into a
+  lint-baseline rewrite.
 - `git diff --check` and `python scripts/check_guard_class_closure.py --base
-  origin/main --strict` — passed locally. The repository mechanical review
-  wrapper remains required before publishing. No production database, role,
-  migration, or service restart was touched by this source slice.
+  origin/main --strict`, plus `python scripts/audit_plan_doc.py` — passed
+  locally. The repository mechanical review wrapper remains required before
+  publishing. No production database, role, migration, or service restart was
+  touched by this source slice.
 
 ## Estimated diff size
 
@@ -559,15 +611,15 @@ Parked hardening: none.
 |---|---:|
 | `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 7 |
 | `atlas_brain/main_eom.py` | 11 |
-| `atlas_brain/services/eom_missed_call_recovery.py` | 310 |
-| `atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql` | 968 |
+| `atlas_brain/services/eom_missed_call_recovery.py` | 344 |
+| `atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql` | 988 |
 | `docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md` | 76 |
-| `plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md` | 578 |
-| `scripts/apply_eom_missed_call_recovery_runtime_privileges.py` | 445 |
+| `plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md` | 630 |
+| `scripts/apply_eom_missed_call_recovery_runtime_privileges.py` | 465 |
 | `tests/test_eom_missed_call_privilege_runner.py` | 547 |
-| `tests/test_eom_missed_call_recovery.py` | 1459 |
+| `tests/test_eom_missed_call_recovery.py` | 1634 |
 | `tests/test_eom_render_profile.py` | 7 |
-| **Total** | **4408** |
+| **Total** | **4709** |
 
 ## Diff size rationale
 

--- a/plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md
+++ b/plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md
@@ -1,0 +1,217 @@
+# PR-EOM-Missed-Call-Recovery-Runtime-Privileges
+
+## Why this slice exists
+
+The first production application of the EOM missed-call recovery schema reached
+the new additive migration through a DBA account. PostgreSQL therefore made the
+new recovery tables and functions owned by `postgres`; the normal `atlas`
+runtime role has no table privileges. The recovery service nevertheless reads,
+locks, inserts, and updates those tables. Its startup probe currently checks
+only that relations, one index/column, triggers, and one function exist, so it
+can report a structurally present but unusable schema as ready.
+
+### Problem-derived contract
+
+- Root cause: a privileged migration executor becomes the owner of newly created
+  PostgreSQL objects unless the migration assigns a protected no-login owner and
+  materializes the runtime ACL after ownership transfer. Migration 389 creates
+  the missed-call tables/functions without either step; the service readiness
+  predicate has no privilege check.
+- Correct fix must touch/change: add one forward-only, DBA-only migration after
+  389 that assigns recovery-object ownership to `atlas_eom_handoff_owner`,
+  provides the precise `atlas` privileges needed by the recovery service
+  (including the `UPDATE` capability required for its `FOR UPDATE` row locks),
+  preserves NocoDB's direct denial, and makes the CRM-trigger bridge run with
+  the isolated owner and a fixed search path. Extend
+  `missed_call_recovery_schema_ready` to prove that the configured runtime role
+  can actually use the schema. Add migration 393 to the slim EOM profile's
+  closed readiness tuple. Add disposable-PostgreSQL proof for both roles and
+  the trigger bridge.
+- Must not change: do not rewrite migration 389 or its recorded receipt; do not
+  modify existing recovery evidence, provider defaults, booking/email behavior,
+  authenticated routes, CRM UI, role memberships, billing logic, or historical
+  migration-recovery selection. Do not repair production through manual grants
+  or restart services before the forward migration is source-reviewed and
+  applied.
+
+## Scope (this PR)
+
+Ownership lane: eom/missed-call-recovery-runtime-privileges
+Slice phase: Production hardening
+
+1. Add the additive recovery-ACL migration and security-definer trigger bridge.
+2. Make readiness fail closed when the runtime role cannot execute the service's
+   actual recovery-table operations.
+3. Enroll migration 393 in the closed slim-profile recovery migration set.
+4. Prove the runtime/NocoDB boundary in a disposable Postgres schema.
+
+### Review Contract
+
+- Acceptance criteria:
+  1. The new migration is forward-only and DBA-gated; it keeps the existing
+     no-login, membership-isolated guard model and transfers all six recovery
+     tables plus the privileged CRM-trigger functions to that guard.
+  2. After applying the migration in a disposable schema, the runtime role has
+     the exact required table privileges: read/insert/lock for receipts and
+     attempts, read/insert for suppressions/events, and read/insert/update for
+     sequences/steps. `tests/test_eom_missed_call_recovery.py` proves the real
+     role can perform the service's locked read and mutations.
+  3. `atlas_nocodb` cannot directly select, insert, update, or delete recovery
+     tables, but an allowed CRM-table mutation still reaches the guarded trigger
+     and terminalizes affected recovery work. The same disposable-Postgres test
+     proves both sides.
+  4. `missed_call_recovery_schema_ready` returns false for a structurally
+     complete schema with missing runtime ACLs, and true only after the
+     migration establishes the expected privilege/guard properties. The
+     integration test settles the effect through the real query.
+  5. `EOM_MISSED_CALL_RECOVERY_READINESS_MIGRATIONS` includes migration 393, so
+     the slim EOM migration path can apply the forward repair. The corresponding
+     source-level migration-set test settles the closed-set change.
+  6. No route, provider, delivery configuration, email copy, booking state, or
+     recorded recovery evidence changes. Settled by the focused existing
+     recovery test suite and a cold diff audit.
+- Reachability proof: the service calls `missed_call_recovery_schema_ready`
+  before starting the worker; the disposable Postgres proof applies the actual
+  migration, connects as each real role, executes the schema probe, and observes
+  the corresponding allowed/denied database effects.
+- Affected surfaces: `atlas_brain/storage/migrations/`,
+  `atlas_brain/main_eom.py`, `atlas_brain/services/eom_missed_call_recovery.py`,
+  and its disposable Postgres tests.
+- Risk areas: PostgreSQL ownership/ACL semantics, `FOR UPDATE` lock privileges,
+  security-definer search paths and direct function execution, NocoDB direct
+  data exposure, migration retry/atomicity, and worker startup gating.
+- Reviewer rules triggered: R1, R2, R3, R4, R5, R6, R8, R10, R11, R12, R13.
+
+### Boundary-change enumeration
+
+Required when this diff changes a guard, validator, normalizer, resolver,
+router/classifier, or admission boundary. Name each changed boundary path or
+seam in the enumeration; otherwise write "N/A - no boundary change."
+
+- Boundary path/seam: `atlas` service role -> recovery tables; `atlas_nocodb`
+  CRM-table write -> guarded recovery trigger functions; startup probe -> worker
+  admission.
+- Replaced-path behaviors: previously a table's mere existence admitted the
+  worker; after this change only structural presence plus usable runtime ACLs
+  and guarded trigger properties admit it.
+- Guard-relevant fields: table owner/ACL, function owner, `prosecdef`, function
+  `search_path`, role login/inheritance/membership properties, and the six
+  recovery table names.
+- Caller x input shape: `atlas` executes its existing service SQL; NocoDB only
+  performs its documented contacts/contact-interactions mutations. Neither
+  caller receives a new public route or payload shape.
+
+### Deployed-config probing
+
+Required for guard, validator, resolver, admission-boundary, or env/config
+fallback changes; otherwise write "N/A - no guard/config boundary change."
+
+- Deployed/default config values: recovery delivery remains disabled by current
+  configuration; this slice neither enables it nor changes its defaults.
+- Explicit value probe: with a structurally complete schema and correct ACLs,
+  the real schema probe returns true.
+- Absent value probe: removing a required runtime privilege makes the same probe
+  return false before the worker can be started.
+- Default-session/default-context probe: the query uses `current_user`, so the
+  integration proof connects as the runtime role rather than spoofing a role
+  name in a superuser session.
+- Side-effect ordering: readiness is a catalog/ACL read before worker admission;
+  role-bound runtime mutations are proved only after the migration establishes
+  grants in the disposable schema.
+
+### Files touched
+
+- `atlas_brain/main_eom.py`
+- `atlas_brain/services/eom_missed_call_recovery.py`
+- `atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql`
+- `plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md`
+- `tests/test_eom_missed_call_recovery.py`
+- `tests/test_eom_render_profile.py`
+
+## Mechanism
+
+The migration validates that a DBA is applying it and that
+`atlas_eom_handoff_owner` remains a no-login, membership-isolated guard. It
+moves recovery tables and the CRM-trigger execution chain under that guard,
+sets privileged trigger functions to `SECURITY DEFINER` with a fixed schema
+search path, and revokes public execution. It explicitly revokes NocoDB's
+direct table access, clears stale direct `atlas` rights, and then grants the
+runtime only its proven SQL surface; the append-only triggers still reject
+mutation of immutable evidence even where `UPDATE` is needed solely to take a
+row lock.
+
+The service's existing structural probe becomes an admission predicate for that
+same privilege/guard contract, so a partial or DBA-owned deployment fails closed
+before any provider worker can run. The test applies the source migration to an
+empty disposable schema, connects as each restricted role, and exercises both
+allowed runtime locking/writes and denied direct NocoDB data access plus the
+guarded CRM trigger path. The slim profile's explicit readiness tuple receives
+the new migration name, preserving its closed-set deployment behavior.
+
+## Intentional
+
+- Preserve `FOR UPDATE` concurrency semantics rather than weakening locks to
+  avoid an `UPDATE` privilege grant; immutable-row triggers remain the actual
+  mutation fence.
+- Reuse the existing no-login handoff guard rather than create a second EOM
+  ownership role.
+- Do not give NocoDB a direct recovery-table grant. Its CRM writes use guarded
+  trigger functions instead.
+- Do not alter historical migration 389; a new, recorded migration is the
+  auditable recovery path.
+
+## Deferred
+
+- Production cutover happens only after this source slice is reviewed, merged,
+  and its forward migration is applied through the controlled DBA runner. The
+  required post-apply role probes and service restart are operational proof, not
+  a manual ACL workaround.
+
+Parking predicate: speculative privilege hardening unrelated to the six
+recovery tables or the existing CRM trigger bridge is parked; only a proven
+runtime-access or direct-data-exposure gap belongs in this slice.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m pytest -q tests/test_eom_missed_call_recovery.py
+  tests/test_eom_render_profile.py` — `77 passed, 42 skipped` locally. The
+  database-gated cases remain CI proof; no local test was pointed at the
+  operational schema.
+- `python -m compileall -q atlas_brain/services/eom_missed_call_recovery.py
+  tests/test_eom_missed_call_recovery.py tests/test_eom_render_profile.py` —
+  passed locally.
+- Rollback-only PostgreSQL boundary smoke — applied migrations 035, 256, 346,
+  351, 363, 366, 389, and source migration 393 in a random schema inside one
+  uncommitted transaction; seeded a stale `atlas` `DELETE` grant and observed
+  migration 393 remove it, asserted `atlas`-role readiness, revoked one
+  required `UPDATE` grant and observed readiness become false, restored it, and
+  rolled the transaction back. Passed locally.
+- Rollback-only NocoDB bridge smoke — in the same disposable pattern, a
+  `SET ROLE atlas_nocodb` direct recovery-table read was denied while an allowed
+  contact email edit cancelled the active sequence through the guarded trigger;
+  the transaction was rolled back. Passed locally.
+- `git diff --check origin/main` — passed locally.
+- No supported Python formatter/linter package is installed in the current
+  virtual environment. The required `scripts/push_pr.sh` wrapper will run the
+  repository's mechanical local-review bundle before publishing.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/main_eom.py` | 1 |
+| `atlas_brain/services/eom_missed_call_recovery.py` | 101 |
+| `atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql` | 311 |
+| `plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md` | 217 |
+| `tests/test_eom_missed_call_recovery.py` | 432 |
+| `tests/test_eom_render_profile.py` | 1 |
+| **Total** | **1063** |
+
+## Diff size rationale
+
+The source/test diff exceeds the 400-LOC soft budget because the indivisible
+security repair requires one forward migration, an executable readiness
+predicate, and a real-role disposable-Postgres proof. No provider, route,
+configuration, UI, or historical-evidence behavior is included.

--- a/plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md
+++ b/plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md
@@ -44,7 +44,7 @@ can report a structurally present but unusable schema as ready.
 
 Ownership lane: eom/missed-call-recovery-runtime-privileges
 Slice phase: Production hardening
-Max files: 10
+Max files: 11
 
 1. Add the additive recovery-ACL migration and security-definer trigger bridge.
 2. Make readiness fail closed when the runtime role cannot execute the service's
@@ -370,6 +370,73 @@ Max files: 10
   retain their prior allowed/denied operations when no unsafe delegation
   exists.
 
+### Controlled-runner config and target-attestation contract (current review round)
+
+- Root cause: the controlled runner accepts independent protected-DBA and EOM
+  runtime DSNs, but it reads them directly from `os.environ` and uses the
+  runtime DSN only to parse a username. It consequently bypasses the supported
+  `.env`/`.env.local` settings boundary and has no evidence that the DBA pool
+  mutates the runtime database, cluster, or schema. A valid runtime DSN can
+  therefore point at a different target from the DBA DSN while `--apply`
+  reports the wrong target repaired.
+- Correct fix must touch/change: define a dedicated typed `SecretStr` DBA
+  setting under the canonical `ATLAS_EOM_MISSED_CALL_RECOVERY_*` namespace and
+  reuse `EOMFunnelConfig` for the runtime DSN. Before any extension or
+  migration mutation, connect to the runtime target read-only, record its
+  schema/database/session identity, bind the DBA pool to that schema, and
+  require both pools to contend on one transaction-scoped random advisory lock.
+  Re-attest the DBA pool's schema/database identity before and after controlled
+  migration work. Extend the DBA-runner tests to prove valid same-target
+  execution, typed `.env` loading, mismatched runtime/DBA database or schema
+  rejection, and same-name clone rejection before any `pgcrypto` or migration
+  call.
+- Must not change: do not change migration 393 SQL, recovery-table/function
+  ACL policy, the ordinary EOM runtime tuple, generic migration runner,
+  first-clean runner, route/provider/billing behavior, existing production
+  environment values, database contents, or role grants. Do not make the normal
+  application runtime load or require the protected DBA secret. Preserve the
+  runner's `--apply`/`--json` behavior and redacted target result; only remove
+  the newly introduced arbitrary environment-variable indirection in favor of
+  the canonical typed configuration.
+- Assumptions: the controlled DBA target must be the runtime target's exact
+  current schema and database identity, and an advisory-lock contention probe
+  distinguishes a live shared PostgreSQL cluster from a same-named clone. The
+  runtime DSN must establish its direct configured login; the existing funnel
+  setting is typed and `.env` aware but intentionally remains a plain string.
+- Acceptance criteria: deployment values supplied through the supported typed
+  settings files are accepted without exposing a DSN; a wrong database, schema,
+  cluster, or runtime session identity is rejected before any mutable call;
+  matching runtime/DBA targets retain the existing preflight/apply path and
+  redacted output.
+
+### Contract revision: transaction-pooled target attestation
+
+- New evidence: the adjacent controlled first-clean DBA runner disables
+  asyncpg's prepared-statement cache on both pools because acquire/release
+  boundaries can cross PostgreSQL backends under transaction pooling
+  (`scripts/apply_eom_first_clean_completion_schema.py`). The missed-call
+  runner now holds a transaction-scoped advisory lock across two controlled
+  pools, so the same backend-switching risk applies to its new attestation
+  queries.
+- Revised required change surface: disable asyncpg's statement cache in the
+  controlled missed-call runtime and DBA pools while preserving their one-slot
+  pool bounds; bind only the DBA pool's validated runtime schema through startup
+  settings.
+- Explicit non-scope remains unchanged: this does not change the normal Atlas
+  application pool or any generic migration-pool configuration.
+
+### Contract revision: executable-runner test import
+
+- New evidence: `scripts/` is not an importable Python package in this
+  repository, while the disposable-role test needs the runner's admission
+  helper as a direct unit under test.
+- Revised required test surface: load that executable file through an explicit
+  `importlib` file-spec fixture in the test instead of relying on package
+  import discovery.
+- Explicit non-scope remains unchanged: do not create `scripts/__init__.py`,
+  alter Python packaging, or change the command's CLI behavior merely to make
+  its internal helper importable.
+
 ### Review Contract
 
 - Acceptance criteria:
@@ -504,6 +571,7 @@ fallback changes; otherwise write "N/A - no guard/config boundary change."
 ### Files touched
 
 - `.github/workflows/atlas_eom_lead_pipeline_checks.yml`
+- `atlas_brain/config.py`
 - `atlas_brain/main_eom.py`
 - `atlas_brain/services/eom_missed_call_recovery.py`
 - `atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql`
@@ -580,8 +648,10 @@ Parked hardening: none.
 
 ## Verification
 
-- `python -m pytest -q tests/test_eom_missed_call_privilege_runner.py` — `17
-  passed` locally, including the controlled prelude admission boundary.
+- `pytest tests/test_eom_missed_call_privilege_runner.py -q` — `28 passed`
+  locally, including typed `.env`/`.env.local` loading, exact target/schema
+  binding, direct-runtime-session rejection, database/OID mismatch rejection,
+  and same-name clone rejection before any mutable call.
 - `ATLAS_MIGRATION_TEST_DATABASE_URL=... python -m pytest -q
   tests/test_eom_missed_call_recovery.py` — `72 passed` locally against the
   disposable PostgreSQL database. The new proof creates a non-superuser
@@ -589,16 +659,16 @@ Parked hardening: none.
   direct and transitive `pg_has_role(..., 'MEMBER')` plus actual `SET ROLE`,
   then proves migration/runner rejection before privilege mutation and
   readiness rejection/re-admission for both admitted identities.
-- `python -m pytest -q tests/test_eom_render_profile.py` — `64 passed` locally.
+- `pytest tests/test_eom_render_profile.py -q` — `64 passed, 1 warning`
+  locally.
 - `python -m compileall -q scripts/apply_eom_missed_call_recovery_runtime_privileges.py
-  atlas_brain/services/eom_missed_call_recovery.py
+  atlas_brain/config.py
   tests/test_eom_missed_call_privilege_runner.py
   tests/test_eom_missed_call_recovery.py` — passed locally.
-- `python -m ruff format --check` for the changed Python sources — passed.
-  The file-wide `ruff check` remains non-green on its existing lint baseline;
-  a `HEAD` comparison of `tests/test_eom_missed_call_recovery.py` reports `11`
-  pre-existing errors. This privilege-boundary repair does not broaden into a
-  lint-baseline rewrite.
+- `ruff check` for the changed Python sources and `ruff format --check` for
+  the runner/test sources — passed locally. `atlas_brain/config.py` retains
+  its existing repository formatting: a whole-file format check would rewrite
+  unrelated baseline lines, so that churn was deliberately not applied.
 - `git diff --check` and `python scripts/check_guard_class_closure.py --base
   origin/main --strict`, plus `python scripts/audit_plan_doc.py` — passed
   locally. The repository mechanical review wrapper remains required before
@@ -610,16 +680,17 @@ Parked hardening: none.
 | File | LOC |
 |---|---:|
 | `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 7 |
+| `atlas_brain/config.py` | 23 |
 | `atlas_brain/main_eom.py` | 11 |
 | `atlas_brain/services/eom_missed_call_recovery.py` | 344 |
 | `atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql` | 988 |
-| `docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md` | 76 |
-| `plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md` | 630 |
-| `scripts/apply_eom_missed_call_recovery_runtime_privileges.py` | 465 |
-| `tests/test_eom_missed_call_privilege_runner.py` | 547 |
-| `tests/test_eom_missed_call_recovery.py` | 1634 |
+| `docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md` | 81 |
+| `plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md` | 701 |
+| `scripts/apply_eom_missed_call_recovery_runtime_privileges.py` | 634 |
+| `tests/test_eom_missed_call_privilege_runner.py` | 923 |
+| `tests/test_eom_missed_call_recovery.py` | 1655 |
 | `tests/test_eom_render_profile.py` | 7 |
-| **Total** | **4709** |
+| **Total** | **5374** |
 
 ## Diff size rationale
 

--- a/plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md
+++ b/plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md
@@ -276,6 +276,36 @@ Max files: 10
   revoking it restores readiness; and the existing exact runtime/NocoDB
   allowed/denied real-role paths remain green.
 
+### Definer function-resolution repair contract (current review round)
+
+- Root cause: migration 393 deliberately retains the application schema in its
+  guard-owned `SECURITY DEFINER` functions' search paths so the existing CRM and
+  recovery relations remain reachable. Migration 354 and its supported
+  deployment shape can leave that schema owned or `CREATE`-writable by the
+  normal runtime. Three guarded callbacks then call user-defined helpers with
+  non-exact `VARCHAR` or unknown-literal arguments, so a runtime-created
+  overload can win PostgreSQL function resolution and execute in the guard's
+  definer context.
+- Correct fix must touch/change: after attesting the trusted migration-389
+  functions and before marking them `SECURITY DEFINER`, replace only the three
+  callbacks that make user-defined calls. Every such call must be schema
+  qualified and its arguments explicitly cast to the trusted signature. Extend
+  the disposable real-role proof by granting the configured runtime schema
+  `CREATE`, installing competing overloads before migration 393, and proving a
+  permitted NocoDB contact update neither invokes them nor loses its normal
+  guarded terminalization behavior.
+- Must not change: do not transfer the application schema's ownership, revoke
+  the runtime's general schema `CREATE` capability, change migration 354,
+  change table/function role membership or the direct runtime ACL matrix,
+  introduce a new schema/role/table, alter migration 389, alter generic startup
+  or migration-runner behavior, or change CRM/NocoDB APIs, routes, providers,
+  billing, or production deployment data.
+- Acceptance criteria: a malicious `UUID, VARCHAR` effective-recipient
+  overload and a `UUID, TEXT, TEXT` cancellation overload remain present and
+  callable by the runtime, but cannot run during the NocoDB-triggered guarded
+  contact-update path; the legitimate sequence still terminalizes as
+  `recipient_changed` and the existing runtime/NocoDB proof remains green.
+
 ### Review Contract
 
 - Acceptance criteria:
@@ -507,14 +537,14 @@ Parked hardening: none.
 | `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 7 |
 | `atlas_brain/main_eom.py` | 11 |
 | `atlas_brain/services/eom_missed_call_recovery.py` | 310 |
-| `atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql` | 783 |
+| `atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql` | 968 |
 | `docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md` | 76 |
-| `plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md` | 525 |
+| `plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md` | 555 |
 | `scripts/apply_eom_missed_call_recovery_runtime_privileges.py` | 445 |
 | `tests/test_eom_missed_call_privilege_runner.py` | 547 |
-| `tests/test_eom_missed_call_recovery.py` | 1333 |
+| `tests/test_eom_missed_call_recovery.py` | 1459 |
 | `tests/test_eom_render_profile.py` | 7 |
-| **Total** | **4044** |
+| **Total** | **4385** |
 
 ## Diff size rationale
 

--- a/plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md
+++ b/plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md
@@ -187,6 +187,64 @@ Max files: 10
   every bridge/fence tamper case fails for its trusted-body message rather than
   for a superuser-runtime admission failure.
 
+### Hosted-PostgreSQL repair contract (current review round)
+
+- Root cause: migration 393 revokes table and column privileges from the
+  legacy `atlas` login before it transfers a recovery relation to the
+  no-login guard. On a fresh disposable database, `atlas` owns migration-389
+  objects. PostgreSQL represents that owner-targeted revoke as an explicit
+  empty ACL item; `ALTER TABLE ... OWNER TO atlas_eom_handoff_owner` carries
+  it to the new owner. The runtime still receives its cataloged direct ACL,
+  but the guard-owned `SECURITY DEFINER`
+  `validate_eom_missed_call_sequence_scope()` cannot read
+  `eom_missed_call_attempts`, so an otherwise allowed sequence insert fails.
+  Separately, the tamper helpers use `CREATE OR REPLACE FUNCTION` definitions
+  that omit existing argument names. PostgreSQL treats that as an attempted
+  parameter rename and rejects before migration 393 can prove its trusted-body
+  boundary.
+- Correct fix must touch/change: in migration 393, transfer each recovery
+  table to the guard before revoking direct table or column ACLs from `PUBLIC`,
+  NocoDB, legacy `atlas`, or the configured runtime. Keep those revokes and
+  the exact runtime allowlist in the same transaction, after ownership has
+  changed. Update the disposable PostgreSQL proof to assert that the guard has
+  effective access to the recovery relation it reads and to exercise the real
+  runtime insert path. Update only the tamper replacement definitions so every
+  existing named input parameter is preserved while its body is changed.
+- Must not change: do not alter migration 389, role admissions, guard-role
+  flags or memberships, the configured-runtime allowlist, the normal startup
+  tuple, generic migration runner, service/readiness implementation, routes,
+  providers, billing, production state, or the PostgreSQL CI identity. Do not
+  add broad runtime CRM or guard membership grants.
+- Acceptance criteria: applying 393 where `atlas` owns the migration-389
+  relations leaves the guard able to execute its trusted validator and the
+  configured unprivileged runtime able to create an allowed sequence; the
+  runtime and NocoDB direct-denial checks remain intact. Each bridge/support
+  tamper fixture reaches migration 393's trusted-body failure rather than a
+  PostgreSQL argument-name error.
+
+### Hosted-PostgreSQL test-fixture correction contract (current review round)
+
+- Root cause: the NocoDB integration proof creates an estimate-request
+  interaction whose `submitted_email` is intentionally the effective recovery
+  recipient. It then changes only `contacts.email` and expects a
+  `recipient_changed` cancellation. Migration 389 deliberately preserves that
+  submitted recipient across an ordinary canonical-email edit, so the update
+  correctly leaves the sequence active and the test asserts behavior the
+  product does not implement.
+- Correct fix must touch/change: change only that disposable NocoDB fixture to
+  grant and update `lead_stage`, then assert its existing `lead_advanced`
+  cancellation branch. This still proves that an allowed NocoDB CRM mutation
+  reaches the guard-owned trigger while NocoDB retains no direct recovery-table
+  access.
+- Must not change: do not change migration 389's effective-recipient
+  precedence, recipient-change behavior, CRM trigger definitions, runtime or
+  NocoDB production privileges, service logic, routes, provider behavior, or
+  data.
+- Acceptance criteria: the disposable real-role test proves a permitted NocoDB
+  contact update terminalizes an active sequence with `lead_advanced`; its
+  direct recovery-table reads remain denied, and the separate interaction path
+  remains covered.
+
 ### Review Contract
 
 - Acceptance criteria:
@@ -418,14 +476,14 @@ Parked hardening: none.
 | `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 7 |
 | `atlas_brain/main_eom.py` | 11 |
 | `atlas_brain/services/eom_missed_call_recovery.py` | 253 |
-| `atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql` | 753 |
+| `atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql` | 758 |
 | `docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md` | 76 |
-| `plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md` | 436 |
+| `plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md` | 494 |
 | `scripts/apply_eom_missed_call_recovery_runtime_privileges.py` | 445 |
 | `tests/test_eom_missed_call_privilege_runner.py` | 547 |
-| `tests/test_eom_missed_call_recovery.py` | 1216 |
+| `tests/test_eom_missed_call_recovery.py` | 1225 |
 | `tests/test_eom_render_profile.py` | 7 |
-| **Total** | **3751** |
+| **Total** | **3823** |
 
 ## Diff size rationale
 

--- a/plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md
+++ b/plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md
@@ -44,7 +44,7 @@ can report a structurally present but unusable schema as ready.
 
 Ownership lane: eom/missed-call-recovery-runtime-privileges
 Slice phase: Production hardening
-Max files: 11
+Max files: 13
 
 1. Add the additive recovery-ACL migration and security-definer trigger bridge.
 2. Make readiness fail closed when the runtime role cannot execute the service's
@@ -437,6 +437,40 @@ Max files: 11
   package, alter Python packaging, or change the command's CLI behavior merely
   to make its internal helper importable.
 
+### Controlled-migration reservation and backend-pinning contract (current review round)
+
+- Root cause: migration 393 is a DBA-only migration, but the generic catalog
+  reserves only migration 394. An unrestricted `run_migrations(...)` therefore
+  selects 393 and reaches its superuser guard during ordinary startup instead
+  of leaving it for the controlled DBA command. Separately, the controlled
+  command writes the runtime-role setting through a pool wrapper, then lets the
+  generic migration runner acquire from that pool again. Under transaction
+  pooling those two acquisitions can use different PostgreSQL backends, so the
+  migration can lose the session setting it requires even though the command
+  preflighted the correct target.
+- Correct fix must touch/change: add migration 393 to the existing controlled
+  DBA catalog reservation, without changing the generic runner's selection or
+  locking algorithm. Extend its existing runner test so an unrestricted run
+  skips both controlled migrations and explicit selection reaches each one.
+  In the missed-call controlled command, run only migration 393 through one
+  explicit transaction-pinned connection, acquire and release the canonical
+  migration serialization lock around that invocation, and bind the runtime
+  role setting through that same pinned connection. Extend the focused command
+  tests to prove a contention retry waits outside the transaction and that the
+  setting, generic-runner invocation, lock, migration, and bookkeeping share
+  the one pinned connection.
+- Must not change: do not edit migration 393 SQL, historical migrations
+  390--392, the normal generic migration algorithm, the first-clean controlled
+  runner, the slim startup tuple, role/ACL policy, API or UI behavior, workflow
+  configuration, production data, or the command's public CLI/result shape.
+  Historical prelude selection remains limited to 390--392; only 393 receives
+  the new transaction-pinned execution boundary.
+- Acceptance criteria: normal generic startup never selects an unrecorded 393
+  or 394; each remains selectable only through an explicit `only` request. A
+  controlled 393 run retries a busy canonical lock without an open transaction,
+  then runs the real migration adapter inside one transaction on the exact
+  acquired DBA connection with the runtime-role setting installed there.
+
 ### Review Contract
 
 - Acceptance criteria:
@@ -574,6 +608,7 @@ fallback changes; otherwise write "N/A - no guard/config boundary change."
 - `atlas_brain/config.py`
 - `atlas_brain/main_eom.py`
 - `atlas_brain/services/eom_missed_call_recovery.py`
+- `atlas_brain/storage/migrations/__init__.py`
 - `atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql`
 - `docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md`
 - `plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md`
@@ -581,13 +616,19 @@ fallback changes; otherwise write "N/A - no guard/config boundary change."
 - `tests/test_eom_missed_call_privilege_runner.py`
 - `tests/test_eom_missed_call_recovery.py`
 - `tests/test_eom_render_profile.py`
+- `tests/test_migrations_runner.py`
 
 ## Mechanism
 
-The controlled runner reads the configured EOM funnel DSN only to derive its
-username, never logs that DSN, and binds the role into each selected migration
-connection. After the DBA admission and before any selected historical prelude,
-it establishes `pgcrypto`. Migration 393 validates that the configured login is
+The generic catalog reserves migrations 393 and 394 from ordinary startup; a
+dedicated command must select either one explicitly. The controlled runner reads
+the configured EOM funnel DSN only to derive its username, never logs that DSN,
+and binds the role into each selected migration connection. For atomic migration
+393, it holds the canonical migration lock and pins the generic runner plus that
+role setting to one explicit transaction connection, so a transaction-pooling
+proxy cannot split the migration from its required session setting. After the
+DBA admission and before any selected historical prelude, it establishes
+`pgcrypto`. Migration 393 validates that the configured login is
 an unprivileged, guard-isolated runtime and that `atlas_eom_handoff_owner`
 remains a no-login, membership-isolated guard. Before it changes any bridge
 function's authority or grants runtime `UPDATE`, it compares every guard-critical
@@ -683,14 +724,16 @@ Parked hardening: none.
 | `atlas_brain/config.py` | 23 |
 | `atlas_brain/main_eom.py` | 11 |
 | `atlas_brain/services/eom_missed_call_recovery.py` | 344 |
+| `atlas_brain/storage/migrations/__init__.py` | 5 |
 | `atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql` | 988 |
 | `docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md` | 81 |
-| `plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md` | 701 |
-| `scripts/apply_eom_missed_call_recovery_runtime_privileges.py` | 634 |
-| `tests/test_eom_missed_call_privilege_runner.py` | 923 |
+| `plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md` | 744 |
+| `scripts/apply_eom_missed_call_recovery_runtime_privileges.py` | 708 |
+| `tests/test_eom_missed_call_privilege_runner.py` | 1024 |
 | `tests/test_eom_missed_call_recovery.py` | 1655 |
 | `tests/test_eom_render_profile.py` | 7 |
-| **Total** | **5374** |
+| `tests/test_migrations_runner.py` | 41 |
+| **Total** | **5638** |
 
 ## Diff size rationale
 

--- a/plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md
+++ b/plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md
@@ -81,6 +81,10 @@ Max files: 10
   the receipt/attempt fence checks attest only each trigger's OID binding.
   PostgreSQL preserves that OID under `CREATE OR REPLACE FUNCTION`, so a
   replaced append-only function body can admit a table-wide runtime `UPDATE`.
+  Finally, migration 393 clears direct definer execution for `atlas_nocodb`
+  but not `atlas`; an explicit pre-existing or later `atlas` `EXECUTE` grant
+  can bypass the intended CRM-trigger-only path and terminalize arbitrary
+  active sequences.
 - Required change surface: update only the controlled DBA runner, migration
   393, their existing focused tests, the EOM workflow enrollment, the rollout
   runbook, and this plan. On
@@ -106,7 +110,11 @@ Max files: 10
   only when an explicitly authorized 390-392 receipt advanced; an unchanged
   ledger must re-raise. Migration 393 must attest both receipt/attempt fence
   function bodies before it grants `UPDATE`, and runtime readiness must reject
-  either body outside the exact migration-389 source body.
+  either body outside the exact migration-389 source body. Migration 393 must
+  revoke direct `EXECUTE` from `atlas` on all six definer helpers, and readiness
+  must reject an admitted runtime role that regains direct execution on any of
+  them; tests must prove the migration clears all six and the probe rejects then
+  re-admits one runtime-role grant/revoke boundary.
 - Explicit non-scope: do not alter migration 389, the generic migration runner,
   the slim startup tuple, database schema, role memberships, service routes,
   delivery behavior, PostgreSQL CI image, or production state. Do not reapply
@@ -132,7 +140,8 @@ Max files: 10
      tables plus the privileged CRM-trigger functions to that guard, clears
      stale table/column/function ACLs, and refuses to grant mutable evidence
      access unless the exact append-only trigger bindings and trusted migration-
-     389 function bodies are intact.
+     389 function bodies are intact. It also leaves neither NocoDB nor the
+     runtime role with direct `EXECUTE` on the six definer helpers.
   2. After applying the migration in a disposable schema, the runtime role has
      the exact required table privileges: read/insert/lock for receipts and
      attempts, read/insert for suppressions/events, and read/insert/update for
@@ -186,10 +195,10 @@ Required when this diff changes a guard, validator, normalizer, resolver,
 router/classifier, or admission boundary. Name each changed boundary path or
 seam in the enumeration; otherwise write "N/A - no boundary change."
 
-- Boundary path/seam: `atlas` service role -> recovery tables; `atlas_nocodb`
-  CRM-table write -> guarded recovery trigger functions; startup probe -> worker
-  admission; protected DBA DSN -> exact 390-392 historical prelude -> recorded
-  migration 389 -> recorded migration 393 -> normal runtime startup.
+- Boundary path/seam: `atlas` service role -> recovery tables; `atlas`/NocoDB
+  direct function execution -> guarded CRM-trigger functions; startup probe ->
+  worker admission; protected DBA DSN -> exact 390-392 historical prelude ->
+  recorded migration 389 -> recorded migration 393 -> normal runtime startup.
 - Replaced-path behaviors: previously a table's mere existence admitted the
   worker; after this change only structural presence plus usable runtime ACLs
   and guarded trigger properties admit it. Previously the DBA runner could not
@@ -197,10 +206,11 @@ seam in the enumeration; otherwise write "N/A - no boundary change."
   393 trusted pre-existing bridge code; it now gives only the proven prelude
   set to the existing selector, requires the 389 receipt before 393, and
   rejects bridge and mutable-evidence fence bodies outside the migration-389
-  allowlist before elevation or runtime `UPDATE`. A committed historical
-  prelude's expected integrity stop now continues only when the ledger proves
-  that exact prelude advanced.
-- Guard-relevant fields: table/column ACL, table owner, function ACL/owner,
+  allowlist before elevation or runtime `UPDATE`, and removes/rejects direct
+  runtime execution of the definer helpers. A committed historical prelude's
+  expected integrity stop now continues only when the ledger proves that exact
+  prelude advanced.
+- Guard-relevant fields: table/column/function ACL, table owner, function owner,
   `prosecdef`, function `search_path`, trusted bridge/fence function-body
   SHA-256 or source body, trigger identity/enabled state, role
   login/inheritance/membership properties, the six recovery table names,
@@ -337,15 +347,15 @@ Parked hardening: none.
 |---|---:|
 | `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 7 |
 | `atlas_brain/main_eom.py` | 11 |
-| `atlas_brain/services/eom_missed_call_recovery.py` | 215 |
-| `atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql` | 562 |
+| `atlas_brain/services/eom_missed_call_recovery.py` | 218 |
+| `atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql` | 568 |
 | `docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md` | 66 |
-| `plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md` | 356 |
+| `plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md` | 366 |
 | `scripts/apply_eom_missed_call_recovery_runtime_privileges.py` | 293 |
 | `tests/test_eom_missed_call_privilege_runner.py` | 403 |
-| `tests/test_eom_missed_call_recovery.py` | 917 |
+| `tests/test_eom_missed_call_recovery.py` | 953 |
 | `tests/test_eom_render_profile.py` | 3 |
-| **Total** | **2833** |
+| **Total** | **2888** |
 
 ## Diff size rationale
 

--- a/plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md
+++ b/plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md
@@ -74,6 +74,13 @@ Max files: 10
   creates it. The explicit EOM workflow also uses path allowlists and a named
   pytest list which omit migration 393, the controlled runner, and its focused
   unit test, so a change to either migration gate can receive no EOM CI proof.
+  The generic migration runner deliberately commits one selected historical
+  recovery and then raises `PendingMigrationContentIntegrityError` while more
+  historical evidence remains; the controlled DBA loop does not distinguish
+  that committed-progress stop from a no-progress integrity failure. Finally,
+  the receipt/attempt fence checks attest only each trigger's OID binding.
+  PostgreSQL preserves that OID under `CREATE OR REPLACE FUNCTION`, so a
+  replaced append-only function body can admit a table-wide runtime `UPDATE`.
 - Required change surface: update only the controlled DBA runner, migration
   393, their existing focused tests, the EOM workflow enrollment, the rollout
   runbook, and this plan. On
@@ -94,6 +101,12 @@ Max files: 10
   each bridge function rejects a tampered body without gaining definer
   authority. The EOM workflow must trigger on and execute the controlled
   runner/migration-393 proof on both pull requests and post-merge pushes.
+  The DBA loop must catch only the expected post-recovery
+  `PendingMigrationContentIntegrityError`, re-read the ledger, and continue
+  only when an explicitly authorized 390-392 receipt advanced; an unchanged
+  ledger must re-raise. Migration 393 must attest both receipt/attempt fence
+  function bodies before it grants `UPDATE`, and runtime readiness must reject
+  either body outside the exact migration-389 source body.
 - Explicit non-scope: do not alter migration 389, the generic migration runner,
   the slim startup tuple, database schema, role memberships, service routes,
   delivery behavior, PostgreSQL CI image, or production state. Do not reapply
@@ -109,7 +122,7 @@ Max files: 10
   disposable role test skipped locally when no test DSN is configured); compile
   changed Python files; run the plan sync and whitespace checks; then let hosted
   `eom-lead-pipeline` exercise the real PostgreSQL extension provisioning,
-  tamper rejection, and controlled-runner test enrollment.
+  bridge/fence tamper rejection, and controlled-runner test enrollment.
 
 ### Review Contract
 
@@ -118,7 +131,8 @@ Max files: 10
      no-login, membership-isolated guard model, transfers all six recovery
      tables plus the privileged CRM-trigger functions to that guard, clears
      stale table/column/function ACLs, and refuses to grant mutable evidence
-     access unless the exact append-only trigger bindings are intact.
+     access unless the exact append-only trigger bindings and trusted migration-
+     389 function bodies are intact.
   2. After applying the migration in a disposable schema, the runtime role has
      the exact required table privileges: read/insert/lock for receipts and
      attempts, read/insert for suppressions/events, and read/insert/update for
@@ -132,8 +146,9 @@ Max files: 10
      complete schema with missing or extra runtime ACLs, runtime guard
      membership, a disabled/rebound immutable-evidence trigger, or an untrusted
      NocoDB direct path; it returns true only after the migration establishes
-     the expected privilege/guard properties. The integration test settles the
-     effect through the real query.
+     the expected privilege/guard properties and rejects either replaced
+     receipt/attempt fence body. The integration test settles the effect through
+     the real query.
   5. `EOM_MISSED_CALL_RECOVERY_READINESS_MIGRATIONS` excludes DBA-only and
      historical recovery SQL. The dedicated DBA runner defaults to a redacted,
      read-only preflight that reports the three historical-prelude receipts plus
@@ -142,9 +157,10 @@ Max files: 10
      applies 389 and the normal runtime never executes the prelude. A fresh
      target first receives 389 from the slim EOM bootstrap path. Migration 393
      provisions `pgcrypto` only after DBA admission, rejects every altered
-     bridge-function body before granting definer authority, and is enrolled
-     with the controlled-runner proof in the EOM workflow. The corresponding
-     source and disposable-Postgres tests settle both boundaries.
+     bridge or mutable-evidence fence body before granting definer authority or
+     runtime `UPDATE`, retries only a ledger-advancing historical-progress stop,
+     and is enrolled with the controlled-runner proof in the EOM workflow. The
+     corresponding source and disposable-Postgres tests settle both boundaries.
   6. No route, provider, delivery configuration, email copy, booking state, or
      recorded recovery evidence changes. Settled by the focused existing
      recovery test suite and a cold diff audit.
@@ -180,12 +196,15 @@ seam in the enumeration; otherwise write "N/A - no boundary change."
   clear an exact required historical prelude before a missing 389 receipt, and
   393 trusted pre-existing bridge code; it now gives only the proven prelude
   set to the existing selector, requires the 389 receipt before 393, and
-  rejects bridge bodies outside the migration-389 allowlist before elevation.
+  rejects bridge and mutable-evidence fence bodies outside the migration-389
+  allowlist before elevation or runtime `UPDATE`. A committed historical
+  prelude's expected integrity stop now continues only when the ledger proves
+  that exact prelude advanced.
 - Guard-relevant fields: table/column ACL, table owner, function ACL/owner,
-  `prosecdef`, function `search_path`, trusted function-body SHA-256, trigger
-  identity/enabled state, role login/inheritance/membership properties, the six
-  recovery table names, installed `pgcrypto` extension, and the 390-393 ledger
-  receipts.
+  `prosecdef`, function `search_path`, trusted bridge/fence function-body
+  SHA-256 or source body, trigger identity/enabled state, role
+  login/inheritance/membership properties, the six recovery table names,
+  installed `pgcrypto` extension, and the 390-393 ledger receipts.
 - Caller x input shape: `atlas` executes its existing service SQL; NocoDB only
   performs its documented contacts/contact-interactions mutations. Neither
   caller receives a new public route or payload shape.
@@ -233,9 +252,10 @@ fallback changes; otherwise write "N/A - no guard/config boundary change."
 
 The migration validates that a DBA is applying it and that
 `atlas_eom_handoff_owner` remains a no-login, membership-isolated guard. Before
-it changes any bridge function's authority, it compares every one of the six
-stored bodies against an embedded SHA-256 allowlist generated from migration
-389. After the DBA-only role checks but before this digest check, it installs
+it changes any bridge function's authority or grants runtime `UPDATE`, it
+compares the six bridge and two mutable-evidence fence bodies against trusted
+migration-389 source. After the DBA-only role checks but before this digest
+check, it installs
 the stock PostgreSQL `pgcrypto` extension when absent and reads its actual
 installed schema; the focused integration test deliberately begins without
 that extension and observes the migration establish it. It then moves recovery
@@ -243,8 +263,8 @@ tables and the CRM-trigger execution chain under that guard, sets trusted
 trigger functions to `SECURITY DEFINER` with a fixed schema search path, clears
 public/NocoDB/runtime table and column ACLs plus explicit NocoDB function
 execution, and then grants the runtime only its proven SQL surface. It refuses
-to proceed unless the receipt/attempt append-only triggers are still enabled
-and bound to their rejecting functions.
+to proceed unless the receipt/attempt append-only triggers are still enabled,
+bound to their rejecting functions, and retain their trusted bodies.
 
 The service's existing structural probe becomes an admission predicate for that
 same privilege/guard contract, so a partial, over-privileged, trigger-drifted,
@@ -255,11 +275,14 @@ denied direct NocoDB data access plus the guarded CRM trigger path. A fresh
 target's slim EOM bootstrap records migration 389. Before the runner requires
 that receipt, its `--apply` path gives only 390-392 to the existing attested
 historical selector, so an exact legacy recovery can be completed under the DBA
-connection without handing that authority to normal startup. It never applies
-389, then records 393 before a full generic Atlas runtime starts or recovery is
-enabled. The slim readiness tuple intentionally carries only ordinary schema
-prerequisites. The EOM workflow lists the migration, controlled runner, and
-runner test in both trigger filters and runs the focused runner test explicitly.
+connection without handing that authority to normal startup. When the generic
+runner raises its expected post-commit integrity stop, the DBA command
+continues only if its new ledger snapshot advanced an authorized prelude. It
+never applies 389, then records 393 before a full generic Atlas runtime starts
+or recovery is enabled. The slim readiness tuple intentionally carries only
+ordinary schema prerequisites. The EOM workflow lists the migration,
+controlled runner, and runner test in both trigger filters and runs the focused
+runner test explicitly.
 
 ## Intentional
 
@@ -291,15 +314,16 @@ Parked hardening: none.
 
 ## Verification
 
-- `python -m pytest -q tests/test_eom_missed_call_privilege_runner.py` — `9
-  passed` locally, including the historical-prelude ordering and missing-ledger
-  boundaries.
+- `python -m pytest -q tests/test_eom_missed_call_privilege_runner.py` — `11
+  passed` locally, including committed-prelude retry and non-prelude-progress
+  rejection boundaries.
 - `python -m pytest -q tests/test_eom_missed_call_recovery.py` — `14 passed,
-  48 skipped` locally. The disposable-PostgreSQL role test is skipped because
+  50 skipped` locally. The disposable-PostgreSQL role test is skipped because
   `ATLAS_MIGRATION_TEST_DATABASE_URL` is absent in this workspace; hosted CI
   remains the required real-role proof.
 - `python -m pytest -q tests/test_eom_render_profile.py` — `64 passed` locally.
 - `python -m compileall -q scripts/apply_eom_missed_call_recovery_runtime_privileges.py
+  atlas_brain/services/eom_missed_call_recovery.py
   tests/test_eom_missed_call_privilege_runner.py
   tests/test_eom_missed_call_recovery.py` — passed locally.
 - `git diff --check` and `python scripts/check_guard_class_closure.py --base
@@ -313,15 +337,15 @@ Parked hardening: none.
 |---|---:|
 | `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 7 |
 | `atlas_brain/main_eom.py` | 11 |
-| `atlas_brain/services/eom_missed_call_recovery.py` | 191 |
-| `atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql` | 510 |
-| `docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md` | 61 |
-| `plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md` | 332 |
-| `scripts/apply_eom_missed_call_recovery_runtime_privileges.py` | 271 |
-| `tests/test_eom_missed_call_privilege_runner.py` | 299 |
-| `tests/test_eom_missed_call_recovery.py` | 758 |
+| `atlas_brain/services/eom_missed_call_recovery.py` | 215 |
+| `atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql` | 562 |
+| `docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md` | 66 |
+| `plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md` | 356 |
+| `scripts/apply_eom_missed_call_recovery_runtime_privileges.py` | 293 |
+| `tests/test_eom_missed_call_privilege_runner.py` | 403 |
+| `tests/test_eom_missed_call_recovery.py` | 917 |
 | `tests/test_eom_render_profile.py` | 3 |
-| **Total** | **2443** |
+| **Total** | **2833** |
 
 ## Diff size rationale
 

--- a/scripts/apply_eom_missed_call_recovery_runtime_privileges.py
+++ b/scripts/apply_eom_missed_call_recovery_runtime_privileges.py
@@ -12,8 +12,9 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+from dataclasses import dataclass
 import json
-import os
+import secrets
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 import sys
@@ -25,14 +26,19 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+from atlas_brain.config import (  # noqa: E402
+    EOM_MISSED_CALL_RECOVERY_DBA_DATABASE_URL_ENV,
+    EOMMissedCallRecoveryDBAConfig,
+)
+from atlas_brain.eom_api.config import EOMFunnelConfig  # noqa: E402
 from atlas_brain.storage.migrations import (  # noqa: E402
     PendingMigrationContentIntegrityError,
     run_migrations,
 )
 
 
-DEFAULT_DSN_ENV = "ATLAS_EOM_MISSED_CALL_RECOVERY_DBA_DATABASE_URL"
-DEFAULT_RUNTIME_DATABASE_URL_ENV = "ATLAS_EOM_FUNNEL_DB_CONNECTION_STRING"
+DBA_DSN_ENV = EOM_MISSED_CALL_RECOVERY_DBA_DATABASE_URL_ENV
+FUNNEL_DSN_ENV = "ATLAS_EOM_FUNNEL_DB_CONNECTION_STRING"
 RUNTIME_ROLE_SETTING = "atlas.eom_missed_call_recovery_runtime_role"
 PREREQUISITE_MIGRATION_NAME = "389_eom_missed_call_recovery"
 MIGRATION_NAME = "393_eom_missed_call_recovery_runtime_privileges"
@@ -50,28 +56,11 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         )
     )
     parser.add_argument(
-        "--database-url-env",
-        default=DEFAULT_DSN_ENV,
-        help=(
-            "Environment variable holding the protected DBA PostgreSQL DSN "
-            f"(default: {DEFAULT_DSN_ENV})."
-        ),
-    )
-    parser.add_argument(
         "--apply",
         action="store_true",
         help=(
             "Apply an exact historical EOM recovery prelude if required, then "
             "run migration 393 after the read-only DBA preflight."
-        ),
-    )
-    parser.add_argument(
-        "--runtime-database-url-env",
-        default=DEFAULT_RUNTIME_DATABASE_URL_ENV,
-        help=(
-            "Environment variable holding the configured EOM funnel PostgreSQL "
-            "DSN; its username selects the runtime role granted by migration 393 "
-            f"(default: {DEFAULT_RUNTIME_DATABASE_URL_ENV})."
         ),
     )
     parser.add_argument(
@@ -107,14 +96,148 @@ def _runtime_role_from_database_url(database_url: str) -> str:
     return runtime_role
 
 
-async def _create_pool(database_url: str) -> Any:
+def _require_schema_name(value: object, *, source: str) -> str:
+    """Accept one canonical PostgreSQL identifier from a trusted query result."""
+
+    if not isinstance(value, str):
+        raise RuntimeError(f"Missing or invalid schema from {source}")
+    schema_name = value.strip()
+    if not schema_name or not schema_name.isascii() or not schema_name.isidentifier():
+        raise RuntimeError(f"Missing or invalid schema from {source}")
+    return schema_name
+
+
+def _schema_search_path(schema_name: str) -> str:
+    """Render the validated schema for an asyncpg startup setting."""
+
+    return f'"{schema_name}", pg_catalog'
+
+
+def _require_database_name(value: object, *, source: str) -> str:
+    """Reject a missing database name rather than comparing an ambiguous target."""
+
+    if not isinstance(value, str) or not value.strip():
+        raise RuntimeError(f"Missing or invalid database identity from {source}")
+    return value
+
+
+def _require_database_oid(value: object, *, source: str) -> int:
+    """Accept only one positive PostgreSQL database OID."""
+
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise RuntimeError(f"Missing or invalid database identity from {source}")
+    return value
+
+
+def _require_role_name(value: object, *, source: str) -> str:
+    """Require a non-empty PostgreSQL role name from a catalog identity row."""
+
+    if not isinstance(value, str) or not value.strip():
+        raise RuntimeError(f"Missing or invalid session identity from {source}")
+    return value
+
+
+@dataclass(frozen=True)
+class _TargetIdentity:
+    """One connection's canonical EOM database and schema target."""
+
+    schema_name: str
+    database_name: str
+    database_oid: int
+    current_user: str
+    session_user: str
+
+    @property
+    def database_identity(self) -> tuple[str, int]:
+        """Return only fields that must match across runtime and DBA pools."""
+
+        return (self.database_name, self.database_oid)
+
+
+async def _create_pool(
+    database_url: str,
+    *,
+    schema_name: str | None = None,
+) -> Any:
     try:
         import asyncpg
     except ImportError as exc:  # pragma: no cover - host dependency
         raise RuntimeError(
             "asyncpg is required to run the DBA migration preflight"
         ) from exc
-    return await asyncpg.create_pool(dsn=database_url, min_size=1, max_size=1)
+    pool_kwargs: dict[str, Any] = {
+        "dsn": database_url,
+        "min_size": 1,
+        "max_size": 1,
+        "statement_cache_size": 0,
+    }
+    if schema_name is not None:
+        pool_kwargs["server_settings"] = {
+            "search_path": _schema_search_path(schema_name)
+        }
+    return await asyncpg.create_pool(**pool_kwargs)
+
+
+async def _target_identity(pool: Any, *, source: str) -> _TargetIdentity:
+    """Read the current schema and database identity without DDL."""
+
+    async with pool.acquire() as connection:
+        row = await connection.fetchrow(
+            """
+            SELECT pg_catalog.current_schema() AS schema_name,
+                   pg_catalog.current_database() AS database_name,
+                   CURRENT_USER AS current_user,
+                   SESSION_USER AS session_user,
+                   (
+                       SELECT oid
+                         FROM pg_catalog.pg_database
+                        WHERE datname = pg_catalog.current_database()
+                   ) AS database_oid
+            """
+        )
+    if row is None:
+        raise RuntimeError(f"Missing or invalid database identity from {source}")
+    return _TargetIdentity(
+        schema_name=_require_schema_name(
+            row["schema_name"],
+            source=f"{source} current_schema()",
+        ),
+        database_name=_require_database_name(row["database_name"], source=source),
+        database_oid=_require_database_oid(row["database_oid"], source=source),
+        current_user=_require_role_name(row["current_user"], source=source),
+        session_user=_require_role_name(row["session_user"], source=source),
+    )
+
+
+async def _attest_shared_database_lock(runtime_pool: Any, dba_pool: Any) -> None:
+    """Require both pools to contend on one unpredictable advisory lock."""
+
+    for _attempt in range(3):
+        lock_key = secrets.randbits(63)
+        async with runtime_pool.acquire() as runtime_connection:
+            async with runtime_connection.transaction():
+                runtime_acquired = bool(
+                    await runtime_connection.fetchval(
+                        "SELECT pg_catalog.pg_try_advisory_xact_lock($1)",
+                        lock_key,
+                    )
+                )
+                if not runtime_acquired:
+                    continue
+                async with dba_pool.acquire() as dba_connection:
+                    dba_acquired = bool(
+                        await dba_connection.fetchval(
+                            "SELECT pg_catalog.pg_try_advisory_xact_lock($1)",
+                            lock_key,
+                        )
+                    )
+                    if dba_acquired:
+                        raise RuntimeError(
+                            "Controlled DBA pool does not share the EOM "
+                            "funnel runtime database"
+                        )
+                return
+    raise RuntimeError("Could not reserve a fresh EOM funnel target-attestation lock")
 
 
 class _RuntimeRoleMigrationPool:
@@ -258,8 +381,23 @@ async def _require_role_admission_before_mutation(pool: Any, runtime_role: str) 
 
 async def _migration_state(
     pool: Any,
+    *,
+    expected_target: _TargetIdentity,
 ) -> tuple[bool, bool, bool, bool, dict[str, bool]]:
-    """Return executor, ledger, and exact EOM migration state without writes."""
+    """Return executor and ledger state after re-attesting the DBA target."""
+
+    observed_target = await _target_identity(
+        pool,
+        source="controlled DBA pool",
+    )
+    if observed_target.schema_name != expected_target.schema_name:
+        raise RuntimeError(
+            "Controlled DBA pool did not resolve to the EOM funnel runtime schema"
+        )
+    if observed_target.database_identity != expected_target.database_identity:
+        raise RuntimeError(
+            "Controlled DBA pool does not target the EOM funnel runtime database"
+        )
 
     async with pool.acquire() as connection:
         executor_is_superuser = bool(
@@ -315,6 +453,7 @@ async def _migration_state(
 async def _apply_required_historical_prelude(
     pool: Any,
     *,
+    expected_target: _TargetIdentity,
     migration_pool: Any,
     run_migrations_fn: Callable[..., Awaitable[None]],
 ) -> None:
@@ -328,7 +467,10 @@ async def _apply_required_historical_prelude(
     """
 
     for _ in HISTORICAL_PRELUDE_MIGRATION_NAMES:
-        _, _, _, _, before = await _migration_state(pool)
+        _, _, _, _, before = await _migration_state(
+            pool,
+            expected_target=expected_target,
+        )
         try:
             await run_migrations_fn(
                 migration_pool,
@@ -339,14 +481,20 @@ async def _apply_required_historical_prelude(
             # recovery, then raises while another evidence gap remains. Admit
             # only that exact committed-progress stop; every no-progress
             # integrity failure remains fail-closed.
-            _, _, _, _, after = await _migration_state(pool)
+            _, _, _, _, after = await _migration_state(
+                pool,
+                expected_target=expected_target,
+            )
             if not any(
                 not before[name] and after[name]
                 for name in HISTORICAL_PRELUDE_MIGRATION_NAMES
             ):
                 raise
             continue
-        _, _, _, _, after = await _migration_state(pool)
+        _, _, _, _, after = await _migration_state(
+            pool,
+            expected_target=expected_target,
+        )
         if all(
             after[name] == before[name] for name in HISTORICAL_PRELUDE_MIGRATION_NAMES
         ):
@@ -356,93 +504,114 @@ async def _apply_required_historical_prelude(
 async def _run(
     args: argparse.Namespace,
     *,
-    create_pool: Callable[[str], Awaitable[Any]] = _create_pool,
+    create_pool: Callable[..., Awaitable[Any]] = _create_pool,
     run_migrations_fn: Callable[..., Awaitable[None]] = run_migrations,
+    config_factory: Callable[[], EOMMissedCallRecoveryDBAConfig] = (
+        EOMMissedCallRecoveryDBAConfig
+    ),
+    funnel_config_factory: Callable[[], EOMFunnelConfig] = EOMFunnelConfig,
 ) -> dict[str, object]:
-    database_url = os.environ.get(args.database_url_env, "").strip()
+    config = config_factory()
+    database_url = config.database_url.get_secret_value().strip()
     if not database_url:
-        raise RuntimeError(
-            f"Missing protected DBA DSN environment variable {args.database_url_env}"
-        )
-    runtime_database_url = os.environ.get(args.runtime_database_url_env, "").strip()
+        raise RuntimeError(f"Missing protected DBA DSN configuration {DBA_DSN_ENV}")
+    runtime_database_url = funnel_config_factory().db_connection_string.strip()
     if not runtime_database_url:
         raise RuntimeError(
-            "Missing configured EOM runtime DSN environment variable "
-            f"{args.runtime_database_url_env}"
+            f"Missing EOM funnel runtime DSN configuration {FUNNEL_DSN_ENV}"
         )
     runtime_role = _runtime_role_from_database_url(runtime_database_url)
 
-    pool = await create_pool(database_url)
-    migration_pool = _RuntimeRoleMigrationPool(pool, runtime_role)
+    runtime_pool = await create_pool(runtime_database_url)
     try:
-        (
-            executor_is_superuser,
-            migrations_table_exists,
-            prerequisite_migration_recorded,
-            migration_recorded,
-            historical_prelude_migration_records,
-        ) = await _migration_state(pool)
-        result: dict[str, object] = {
-            "target": _safe_target_label(database_url),
-            "executor_is_superuser": executor_is_superuser,
-            "runtime_role": runtime_role,
-            "historical_prelude_migrations": historical_prelude_migration_records,
-            "prerequisite_migration": PREREQUISITE_MIGRATION_NAME,
-            "prerequisite_migration_recorded": prerequisite_migration_recorded,
-            "migration": MIGRATION_NAME,
-            "migration_recorded": migration_recorded,
-            "applied": False,
-        }
-        if not executor_is_superuser:
+        runtime_target = await _target_identity(
+            runtime_pool,
+            source="EOM funnel runtime",
+        )
+        if (
+            runtime_target.current_user != runtime_role
+            or runtime_target.session_user != runtime_role
+        ):
             raise RuntimeError(
-                "Configured DBA connection is not a PostgreSQL superuser; "
-                "refusing to run the privilege repair"
+                "EOM funnel runtime connection must use its direct configured login"
             )
-        if args.apply and migrations_table_exists and not migration_recorded:
-            await _require_role_admission_before_mutation(pool, runtime_role)
-            await _ensure_pgcrypto(pool)
-            await _apply_required_historical_prelude(
-                pool,
-                migration_pool=migration_pool,
-                run_migrations_fn=run_migrations_fn,
-            )
+        pool = await create_pool(database_url, schema_name=runtime_target.schema_name)
+        migration_pool = _RuntimeRoleMigrationPool(pool, runtime_role)
+        try:
+            await _attest_shared_database_lock(runtime_pool, pool)
             (
-                _,
-                _,
+                executor_is_superuser,
+                migrations_table_exists,
                 prerequisite_migration_recorded,
                 migration_recorded,
                 historical_prelude_migration_records,
-            ) = await _migration_state(pool)
-            result["historical_prelude_migrations"] = (
-                historical_prelude_migration_records
-            )
-        if args.apply and not prerequisite_migration_recorded:
-            raise RuntimeError(
-                f"Migration {PREREQUISITE_MIGRATION_NAME} is not recorded; "
-                "run the slim EOM bootstrap before the privilege repair"
-            )
-        if args.apply and not migration_recorded:
-            await run_migrations_fn(migration_pool, only=(MIGRATION_NAME,))
-            (
-                _,
-                _,
-                _,
-                migration_recorded,
-                historical_prelude_migration_records,
-            ) = await _migration_state(pool)
-            if not migration_recorded:
+            ) = await _migration_state(pool, expected_target=runtime_target)
+            result: dict[str, object] = {
+                "target": _safe_target_label(database_url),
+                "executor_is_superuser": executor_is_superuser,
+                "runtime_role": runtime_role,
+                "historical_prelude_migrations": historical_prelude_migration_records,
+                "prerequisite_migration": PREREQUISITE_MIGRATION_NAME,
+                "prerequisite_migration_recorded": prerequisite_migration_recorded,
+                "migration": MIGRATION_NAME,
+                "migration_recorded": migration_recorded,
+                "applied": False,
+            }
+            if not executor_is_superuser:
                 raise RuntimeError(
-                    "Migration runner returned without recording the EOM "
-                    "missed-call recovery privilege repair"
+                    "Configured DBA connection is not a PostgreSQL superuser; "
+                    "refusing to run the privilege repair"
                 )
-            result["migration_recorded"] = True
-            result["historical_prelude_migrations"] = (
-                historical_prelude_migration_records
-            )
-            result["applied"] = True
-        return result
+            if args.apply and migrations_table_exists and not migration_recorded:
+                await _require_role_admission_before_mutation(pool, runtime_role)
+                await _ensure_pgcrypto(pool)
+                await _apply_required_historical_prelude(
+                    pool,
+                    expected_target=runtime_target,
+                    migration_pool=migration_pool,
+                    run_migrations_fn=run_migrations_fn,
+                )
+                await _attest_shared_database_lock(runtime_pool, pool)
+                (
+                    _,
+                    _,
+                    prerequisite_migration_recorded,
+                    migration_recorded,
+                    historical_prelude_migration_records,
+                ) = await _migration_state(pool, expected_target=runtime_target)
+                result["historical_prelude_migrations"] = (
+                    historical_prelude_migration_records
+                )
+            if args.apply and not prerequisite_migration_recorded:
+                raise RuntimeError(
+                    f"Migration {PREREQUISITE_MIGRATION_NAME} is not recorded; "
+                    "run the slim EOM bootstrap before the privilege repair"
+                )
+            if args.apply and not migration_recorded:
+                await run_migrations_fn(migration_pool, only=(MIGRATION_NAME,))
+                await _attest_shared_database_lock(runtime_pool, pool)
+                (
+                    _,
+                    _,
+                    _,
+                    migration_recorded,
+                    historical_prelude_migration_records,
+                ) = await _migration_state(pool, expected_target=runtime_target)
+                if not migration_recorded:
+                    raise RuntimeError(
+                        "Migration runner returned without recording the EOM "
+                        "missed-call recovery privilege repair"
+                    )
+                result["migration_recorded"] = True
+                result["historical_prelude_migrations"] = (
+                    historical_prelude_migration_records
+                )
+                result["applied"] = True
+            return result
+        finally:
+            await pool.close()
     finally:
-        await pool.close()
+        await runtime_pool.close()
 
 
 async def _main(argv: list[str] | None = None) -> int:

--- a/scripts/apply_eom_missed_call_recovery_runtime_privileges.py
+++ b/scripts/apply_eom_missed_call_recovery_runtime_privileges.py
@@ -25,7 +25,10 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from atlas_brain.storage.migrations import run_migrations  # noqa: E402
+from atlas_brain.storage.migrations import (  # noqa: E402
+    PendingMigrationContentIntegrityError,
+    run_migrations,
+)
 
 
 DEFAULT_DSN_ENV = "ATLAS_EOM_MISSED_CALL_RECOVERY_DBA_DATABASE_URL"
@@ -164,9 +167,28 @@ async def _apply_required_historical_prelude(
 
     for _ in HISTORICAL_PRELUDE_MIGRATION_NAMES:
         _, _, _, _, before = await _migration_state(pool)
-        await run_migrations_fn(pool, only=HISTORICAL_PRELUDE_MIGRATION_NAMES)
+        try:
+            await run_migrations_fn(
+                pool,
+                only=HISTORICAL_PRELUDE_MIGRATION_NAMES,
+            )
+        except PendingMigrationContentIntegrityError:
+            # The generic runner intentionally commits one selected historical
+            # recovery, then raises while another evidence gap remains. Admit
+            # only that exact committed-progress stop; every no-progress
+            # integrity failure remains fail-closed.
+            _, _, _, _, after = await _migration_state(pool)
+            if not any(
+                not before[name] and after[name]
+                for name in HISTORICAL_PRELUDE_MIGRATION_NAMES
+            ):
+                raise
+            continue
         _, _, _, _, after = await _migration_state(pool)
-        if after == before:
+        if all(
+            after[name] == before[name]
+            for name in HISTORICAL_PRELUDE_MIGRATION_NAMES
+        ):
             return
 
 

--- a/scripts/apply_eom_missed_call_recovery_runtime_privileges.py
+++ b/scripts/apply_eom_missed_call_recovery_runtime_privileges.py
@@ -148,6 +148,94 @@ async def _ensure_pgcrypto(pool: Any) -> None:
         await connection.execute("CREATE EXTENSION IF NOT EXISTS pgcrypto")
 
 
+async def _require_role_admission_before_mutation(pool: Any, runtime_role: str) -> None:
+    """Fail closed before extension or prelude writes on an invalid role boundary.
+
+    Migration 393 repeats these admissions authoritatively inside its own
+    transaction. The runner needs the same read-only boundary before it creates
+    ``pgcrypto`` for a historical prelude that runs before 393.
+    """
+
+    async with pool.acquire() as connection:
+        admissions = await connection.fetchrow(
+            """
+            -- atlas:eom-missed-call-recovery-role-admission
+            SELECT
+                EXISTS (
+                    SELECT 1
+                      FROM pg_catalog.pg_roles AS guard_role
+                     WHERE guard_role.rolname = 'atlas_eom_handoff_owner'
+                       AND NOT guard_role.rolcanlogin
+                       AND NOT guard_role.rolinherit
+                       AND NOT guard_role.rolsuper
+                       AND NOT guard_role.rolcreaterole
+                       AND NOT guard_role.rolcreatedb
+                       AND NOT guard_role.rolreplication
+                       AND NOT guard_role.rolbypassrls
+                       AND NOT EXISTS (
+                           SELECT 1
+                             FROM pg_catalog.pg_roles AS member_role
+                            WHERE member_role.rolcanlogin
+                              AND NOT member_role.rolsuper
+                              AND pg_catalog.pg_has_role(
+                                  member_role.oid, guard_role.oid, 'MEMBER'
+                              )
+                       )
+                ) AS guard_role_ready,
+                EXISTS (
+                    SELECT 1
+                      FROM pg_catalog.pg_roles AS runtime_role_state
+                     WHERE runtime_role_state.rolname = $1
+                       AND runtime_role_state.rolcanlogin
+                       AND runtime_role_state.rolname <> 'atlas_nocodb'
+                       AND NOT runtime_role_state.rolsuper
+                       AND NOT runtime_role_state.rolcreaterole
+                       AND NOT runtime_role_state.rolcreatedb
+                       AND NOT runtime_role_state.rolreplication
+                       AND NOT runtime_role_state.rolbypassrls
+                       AND NOT EXISTS (
+                           SELECT 1
+                             FROM pg_catalog.pg_auth_members AS membership
+                             JOIN pg_catalog.pg_roles AS guard_role
+                               ON guard_role.oid = membership.roleid
+                            WHERE membership.member = runtime_role_state.oid
+                              AND guard_role.rolname = 'atlas_eom_handoff_owner'
+                       )
+                ) AS runtime_role_ready,
+                EXISTS (
+                    SELECT 1
+                      FROM pg_catalog.pg_roles AS nocodb_role
+                     WHERE nocodb_role.rolname = 'atlas_nocodb'
+                       AND nocodb_role.rolcanlogin
+                       AND NOT nocodb_role.rolsuper
+                       AND NOT nocodb_role.rolcreaterole
+                       AND NOT nocodb_role.rolcreatedb
+                       AND NOT nocodb_role.rolreplication
+                       AND NOT nocodb_role.rolbypassrls
+                       AND NOT nocodb_role.rolinherit
+                       AND NOT EXISTS (
+                           SELECT 1
+                             FROM pg_catalog.pg_auth_members AS membership
+                            WHERE membership.member = nocodb_role.oid
+                       )
+                ) AS nocodb_role_ready
+            """,
+            runtime_role,
+        )
+    if admissions is None or not all(
+        bool(admissions[name])
+        for name in (
+            "guard_role_ready",
+            "runtime_role_ready",
+            "nocodb_role_ready",
+        )
+    ):
+        raise RuntimeError(
+            "Guard/runtime/NocoDB role admission failed; refusing to create "
+            "pgcrypto or run historical recovery"
+        )
+
+
 async def _migration_state(
     pool: Any,
 ) -> tuple[bool, bool, bool, bool, dict[str, bool]]:
@@ -291,6 +379,7 @@ async def _run(
                 "refusing to run the privilege repair"
             )
         if args.apply and migrations_table_exists and not migration_recorded:
+            await _require_role_admission_before_mutation(pool, runtime_role)
             await _ensure_pgcrypto(pool)
             await _apply_required_historical_prelude(
                 pool,

--- a/scripts/apply_eom_missed_call_recovery_runtime_privileges.py
+++ b/scripts/apply_eom_missed_call_recovery_runtime_privileges.py
@@ -18,7 +18,7 @@ from collections.abc import Awaitable, Callable
 from pathlib import Path
 import sys
 from typing import Any
-from urllib.parse import urlsplit
+from urllib.parse import unquote, urlsplit
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -32,6 +32,8 @@ from atlas_brain.storage.migrations import (  # noqa: E402
 
 
 DEFAULT_DSN_ENV = "ATLAS_EOM_MISSED_CALL_RECOVERY_DBA_DATABASE_URL"
+DEFAULT_RUNTIME_DATABASE_URL_ENV = "ATLAS_EOM_FUNNEL_DB_CONNECTION_STRING"
+RUNTIME_ROLE_SETTING = "atlas.eom_missed_call_recovery_runtime_role"
 PREREQUISITE_MIGRATION_NAME = "389_eom_missed_call_recovery"
 MIGRATION_NAME = "393_eom_missed_call_recovery_runtime_privileges"
 HISTORICAL_PRELUDE_MIGRATION_NAMES: tuple[str, ...] = (
@@ -44,8 +46,7 @@ HISTORICAL_PRELUDE_MIGRATION_NAMES: tuple[str, ...] = (
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
-            "Preflight or apply the DBA-only EOM missed-call recovery "
-            "privilege repair."
+            "Preflight or apply the DBA-only EOM missed-call recovery privilege repair."
         )
     )
     parser.add_argument(
@@ -62,6 +63,15 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help=(
             "Apply an exact historical EOM recovery prelude if required, then "
             "run migration 393 after the read-only DBA preflight."
+        ),
+    )
+    parser.add_argument(
+        "--runtime-database-url-env",
+        default=DEFAULT_RUNTIME_DATABASE_URL_ENV,
+        help=(
+            "Environment variable holding the configured EOM funnel PostgreSQL "
+            "DSN; its username selects the runtime role granted by migration 393 "
+            f"(default: {DEFAULT_RUNTIME_DATABASE_URL_ENV})."
         ),
     )
     parser.add_argument(
@@ -85,6 +95,18 @@ def _safe_target_label(database_url: str) -> str:
         return "dsn=<configured>"
 
 
+def _runtime_role_from_database_url(database_url: str) -> str:
+    """Extract the configured EOM runtime login without retaining its DSN."""
+
+    try:
+        runtime_role = unquote(urlsplit(database_url).username or "").strip()
+    except ValueError as exc:
+        raise RuntimeError("Configured EOM runtime DSN is invalid") from exc
+    if not runtime_role:
+        raise RuntimeError("Configured EOM runtime DSN must include a username")
+    return runtime_role
+
+
 async def _create_pool(database_url: str) -> Any:
     try:
         import asyncpg
@@ -93,6 +115,37 @@ async def _create_pool(database_url: str) -> Any:
             "asyncpg is required to run the DBA migration preflight"
         ) from exc
     return await asyncpg.create_pool(dsn=database_url, min_size=1, max_size=1)
+
+
+class _RuntimeRoleMigrationPool:
+    """Bind the configured runtime role to every controlled migration session."""
+
+    def __init__(self, pool: Any, runtime_role: str) -> None:
+        self._pool = pool
+        self._runtime_role = runtime_role
+
+    async def acquire(self) -> Any:
+        connection = await self._pool.acquire()
+        try:
+            await connection.execute(
+                "SELECT pg_catalog.set_config($1, $2, FALSE)",
+                RUNTIME_ROLE_SETTING,
+                self._runtime_role,
+            )
+        except Exception:
+            await self._pool.release(connection)
+            raise
+        return connection
+
+    async def release(self, connection: Any) -> None:
+        await self._pool.release(connection)
+
+
+async def _ensure_pgcrypto(pool: Any) -> None:
+    """Establish the historical-prelude SHA-256 dependency under the DBA DSN."""
+
+    async with pool.acquire() as connection:
+        await connection.execute("CREATE EXTENSION IF NOT EXISTS pgcrypto")
 
 
 async def _migration_state(
@@ -154,6 +207,7 @@ async def _migration_state(
 async def _apply_required_historical_prelude(
     pool: Any,
     *,
+    migration_pool: Any,
     run_migrations_fn: Callable[..., Awaitable[None]],
 ) -> None:
     """Apply at most the three explicitly authorized historical EOM preludes.
@@ -169,7 +223,7 @@ async def _apply_required_historical_prelude(
         _, _, _, _, before = await _migration_state(pool)
         try:
             await run_migrations_fn(
-                pool,
+                migration_pool,
                 only=HISTORICAL_PRELUDE_MIGRATION_NAMES,
             )
         except PendingMigrationContentIntegrityError:
@@ -186,8 +240,7 @@ async def _apply_required_historical_prelude(
             continue
         _, _, _, _, after = await _migration_state(pool)
         if all(
-            after[name] == before[name]
-            for name in HISTORICAL_PRELUDE_MIGRATION_NAMES
+            after[name] == before[name] for name in HISTORICAL_PRELUDE_MIGRATION_NAMES
         ):
             return
 
@@ -201,11 +254,18 @@ async def _run(
     database_url = os.environ.get(args.database_url_env, "").strip()
     if not database_url:
         raise RuntimeError(
-            "Missing protected DBA DSN environment variable "
-            f"{args.database_url_env}"
+            f"Missing protected DBA DSN environment variable {args.database_url_env}"
         )
+    runtime_database_url = os.environ.get(args.runtime_database_url_env, "").strip()
+    if not runtime_database_url:
+        raise RuntimeError(
+            "Missing configured EOM runtime DSN environment variable "
+            f"{args.runtime_database_url_env}"
+        )
+    runtime_role = _runtime_role_from_database_url(runtime_database_url)
 
     pool = await create_pool(database_url)
+    migration_pool = _RuntimeRoleMigrationPool(pool, runtime_role)
     try:
         (
             executor_is_superuser,
@@ -217,6 +277,7 @@ async def _run(
         result: dict[str, object] = {
             "target": _safe_target_label(database_url),
             "executor_is_superuser": executor_is_superuser,
+            "runtime_role": runtime_role,
             "historical_prelude_migrations": historical_prelude_migration_records,
             "prerequisite_migration": PREREQUISITE_MIGRATION_NAME,
             "prerequisite_migration_recorded": prerequisite_migration_recorded,
@@ -230,8 +291,10 @@ async def _run(
                 "refusing to run the privilege repair"
             )
         if args.apply and migrations_table_exists and not migration_recorded:
+            await _ensure_pgcrypto(pool)
             await _apply_required_historical_prelude(
                 pool,
+                migration_pool=migration_pool,
                 run_migrations_fn=run_migrations_fn,
             )
             (
@@ -250,7 +313,7 @@ async def _run(
                 "run the slim EOM bootstrap before the privilege repair"
             )
         if args.apply and not migration_recorded:
-            await run_migrations_fn(pool, only=(MIGRATION_NAME,))
+            await run_migrations_fn(migration_pool, only=(MIGRATION_NAME,))
             (
                 _,
                 _,

--- a/scripts/apply_eom_missed_call_recovery_runtime_privileges.py
+++ b/scripts/apply_eom_missed_call_recovery_runtime_privileges.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Run the DBA-only EOM missed-call recovery privilege repair safely.
+
+The normal Atlas runtime must never be given the database authority required by
+migration 393. This command defaults to a read-only preflight and applies only
+the selected migration after an explicit ``--apply`` using a protected DBA DSN
+environment variable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+import sys
+from typing import Any
+from urllib.parse import urlsplit
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from atlas_brain.storage.migrations import run_migrations  # noqa: E402
+
+
+DEFAULT_DSN_ENV = "ATLAS_EOM_MISSED_CALL_RECOVERY_DBA_DATABASE_URL"
+MIGRATION_NAME = "393_eom_missed_call_recovery_runtime_privileges"
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Preflight or apply the DBA-only EOM missed-call recovery "
+            "privilege repair."
+        )
+    )
+    parser.add_argument(
+        "--database-url-env",
+        default=DEFAULT_DSN_ENV,
+        help=(
+            "Environment variable holding the protected DBA PostgreSQL DSN "
+            f"(default: {DEFAULT_DSN_ENV})."
+        ),
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Run migration 393 after the read-only DBA preflight.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the redacted preflight/result payload as JSON.",
+    )
+    return parser.parse_args(argv)
+
+
+def _safe_target_label(database_url: str) -> str:
+    """Return a target label that never includes credentials or query values."""
+
+    try:
+        parsed = urlsplit(database_url)
+        host = parsed.hostname or "connection-string"
+        port = f":{parsed.port}" if parsed.port else ""
+        database = parsed.path.lstrip("/") or "<database>"
+        return f"dsn={host}{port}/{database}"
+    except ValueError:
+        return "dsn=<configured>"
+
+
+async def _create_pool(database_url: str) -> Any:
+    try:
+        import asyncpg
+    except ImportError as exc:  # pragma: no cover - host dependency
+        raise RuntimeError(
+            "asyncpg is required to run the DBA migration preflight"
+        ) from exc
+    return await asyncpg.create_pool(dsn=database_url, min_size=1, max_size=1)
+
+
+async def _migration_state(pool: Any) -> tuple[bool, bool]:
+    """Return (executor_is_superuser, migration_recorded) without writes."""
+
+    async with pool.acquire() as connection:
+        executor_is_superuser = bool(
+            await connection.fetchval(
+                """
+                SELECT COALESCE((
+                    SELECT role.rolsuper
+                    FROM pg_roles AS role
+                    WHERE role.rolname = current_user
+                ), FALSE)
+                """
+            )
+        )
+        migrations_table_exists = bool(
+            await connection.fetchval(
+                "SELECT to_regclass('schema_migrations') IS NOT NULL"
+            )
+        )
+        migration_recorded = False
+        if migrations_table_exists:
+            migration_recorded = bool(
+                await connection.fetchval(
+                    "SELECT EXISTS (SELECT 1 FROM schema_migrations WHERE name = $1)",
+                    MIGRATION_NAME,
+                )
+            )
+    return executor_is_superuser, migration_recorded
+
+
+async def _run(
+    args: argparse.Namespace,
+    *,
+    create_pool: Callable[[str], Awaitable[Any]] = _create_pool,
+    run_migrations_fn: Callable[..., Awaitable[None]] = run_migrations,
+) -> dict[str, object]:
+    database_url = os.environ.get(args.database_url_env, "").strip()
+    if not database_url:
+        raise RuntimeError(
+            "Missing protected DBA DSN environment variable "
+            f"{args.database_url_env}"
+        )
+
+    pool = await create_pool(database_url)
+    try:
+        executor_is_superuser, migration_recorded = await _migration_state(pool)
+        result: dict[str, object] = {
+            "target": _safe_target_label(database_url),
+            "executor_is_superuser": executor_is_superuser,
+            "migration": MIGRATION_NAME,
+            "migration_recorded": migration_recorded,
+            "applied": False,
+        }
+        if not executor_is_superuser:
+            raise RuntimeError(
+                "Configured DBA connection is not a PostgreSQL superuser; "
+                "refusing to run the privilege repair"
+            )
+        if args.apply and not migration_recorded:
+            await run_migrations_fn(pool, only=(MIGRATION_NAME,))
+            _executor_is_superuser, migration_recorded = await _migration_state(pool)
+            if not migration_recorded:
+                raise RuntimeError(
+                    "Migration runner returned without recording the EOM "
+                    "missed-call recovery privilege repair"
+                )
+            result["migration_recorded"] = True
+            result["applied"] = True
+        return result
+    finally:
+        await pool.close()
+
+
+async def _main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    result = await _run(args)
+    if args.json:
+        print(json.dumps(result, sort_keys=True))
+    else:
+        action = "applied" if result["applied"] else "checked"
+        print(
+            f"{action} {result['migration']} on {result['target']}; "
+            f"recorded={result['migration_recorded']}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/scripts/apply_eom_missed_call_recovery_runtime_privileges.py
+++ b/scripts/apply_eom_missed_call_recovery_runtime_privileges.py
@@ -201,6 +201,16 @@ async def _require_role_admission_before_mutation(pool: Any, runtime_role: str) 
                             WHERE membership.member = runtime_role_state.oid
                               AND guard_role.rolname = 'atlas_eom_handoff_owner'
                        )
+                       AND NOT EXISTS (
+                           SELECT 1
+                             FROM pg_catalog.pg_roles AS delegating_login
+                            WHERE delegating_login.rolcanlogin
+                              AND NOT delegating_login.rolsuper
+                              AND delegating_login.oid <> runtime_role_state.oid
+                              AND pg_catalog.pg_has_role(
+                                  delegating_login.oid, runtime_role_state.oid, 'MEMBER'
+                              )
+                       )
                 ) AS runtime_role_ready,
                 EXISTS (
                     SELECT 1
@@ -217,6 +227,16 @@ async def _require_role_admission_before_mutation(pool: Any, runtime_role: str) 
                            SELECT 1
                              FROM pg_catalog.pg_auth_members AS membership
                             WHERE membership.member = nocodb_role.oid
+                       )
+                       AND NOT EXISTS (
+                           SELECT 1
+                             FROM pg_catalog.pg_roles AS delegating_login
+                            WHERE delegating_login.rolcanlogin
+                              AND NOT delegating_login.rolsuper
+                              AND delegating_login.oid <> nocodb_role.oid
+                              AND pg_catalog.pg_has_role(
+                                  delegating_login.oid, nocodb_role.oid, 'MEMBER'
+                              )
                        )
                 ) AS nocodb_role_ready
             """,

--- a/scripts/apply_eom_missed_call_recovery_runtime_privileges.py
+++ b/scripts/apply_eom_missed_call_recovery_runtime_privileges.py
@@ -28,6 +28,7 @@ from atlas_brain.storage.migrations import run_migrations  # noqa: E402
 
 
 DEFAULT_DSN_ENV = "ATLAS_EOM_MISSED_CALL_RECOVERY_DBA_DATABASE_URL"
+PREREQUISITE_MIGRATION_NAME = "389_eom_missed_call_recovery"
 MIGRATION_NAME = "393_eom_missed_call_recovery_runtime_privileges"
 
 
@@ -82,8 +83,8 @@ async def _create_pool(database_url: str) -> Any:
     return await asyncpg.create_pool(dsn=database_url, min_size=1, max_size=1)
 
 
-async def _migration_state(pool: Any) -> tuple[bool, bool]:
-    """Return (executor_is_superuser, migration_recorded) without writes."""
+async def _migration_state(pool: Any) -> tuple[bool, bool, bool]:
+    """Return executor, prerequisite, and repair ledger state without writes."""
 
     async with pool.acquire() as connection:
         executor_is_superuser = bool(
@@ -102,15 +103,26 @@ async def _migration_state(pool: Any) -> tuple[bool, bool]:
                 "SELECT to_regclass('schema_migrations') IS NOT NULL"
             )
         )
+        prerequisite_migration_recorded = False
         migration_recorded = False
         if migrations_table_exists:
+            prerequisite_migration_recorded = bool(
+                await connection.fetchval(
+                    "SELECT EXISTS (SELECT 1 FROM schema_migrations WHERE name = $1)",
+                    PREREQUISITE_MIGRATION_NAME,
+                )
+            )
             migration_recorded = bool(
                 await connection.fetchval(
                     "SELECT EXISTS (SELECT 1 FROM schema_migrations WHERE name = $1)",
                     MIGRATION_NAME,
                 )
             )
-    return executor_is_superuser, migration_recorded
+    return (
+        executor_is_superuser,
+        prerequisite_migration_recorded,
+        migration_recorded,
+    )
 
 
 async def _run(
@@ -128,10 +140,16 @@ async def _run(
 
     pool = await create_pool(database_url)
     try:
-        executor_is_superuser, migration_recorded = await _migration_state(pool)
+        (
+            executor_is_superuser,
+            prerequisite_migration_recorded,
+            migration_recorded,
+        ) = await _migration_state(pool)
         result: dict[str, object] = {
             "target": _safe_target_label(database_url),
             "executor_is_superuser": executor_is_superuser,
+            "prerequisite_migration": PREREQUISITE_MIGRATION_NAME,
+            "prerequisite_migration_recorded": prerequisite_migration_recorded,
             "migration": MIGRATION_NAME,
             "migration_recorded": migration_recorded,
             "applied": False,
@@ -141,9 +159,14 @@ async def _run(
                 "Configured DBA connection is not a PostgreSQL superuser; "
                 "refusing to run the privilege repair"
             )
+        if args.apply and not prerequisite_migration_recorded:
+            raise RuntimeError(
+                f"Migration {PREREQUISITE_MIGRATION_NAME} is not recorded; "
+                "run the slim EOM bootstrap before the privilege repair"
+            )
         if args.apply and not migration_recorded:
             await run_migrations_fn(pool, only=(MIGRATION_NAME,))
-            _executor_is_superuser, migration_recorded = await _migration_state(pool)
+            _, _, migration_recorded = await _migration_state(pool)
             if not migration_recorded:
                 raise RuntimeError(
                     "Migration runner returned without recording the EOM "
@@ -165,7 +188,8 @@ async def _main(argv: list[str] | None = None) -> int:
         action = "applied" if result["applied"] else "checked"
         print(
             f"{action} {result['migration']} on {result['target']}; "
-            f"recorded={result['migration_recorded']}"
+            f"recorded={result['migration_recorded']}; "
+            f"prerequisite_recorded={result['prerequisite_migration_recorded']}"
         )
     return 0
 

--- a/scripts/apply_eom_missed_call_recovery_runtime_privileges.py
+++ b/scripts/apply_eom_missed_call_recovery_runtime_privileges.py
@@ -2,9 +2,10 @@
 """Run the DBA-only EOM missed-call recovery privilege repair safely.
 
 The normal Atlas runtime must never be given the database authority required by
-migration 393. This command defaults to a read-only preflight and applies only
-the selected migration after an explicit ``--apply`` using a protected DBA DSN
-environment variable.
+migration 393 or its exact historical migration prerequisites. This command
+defaults to a read-only preflight. With ``--apply``, it first lets the existing
+historical selector apply only an attested EOM recovery prelude, then applies
+migration 393 after migration 389 is recorded, using a protected DBA DSN.
 """
 
 from __future__ import annotations
@@ -30,6 +31,11 @@ from atlas_brain.storage.migrations import run_migrations  # noqa: E402
 DEFAULT_DSN_ENV = "ATLAS_EOM_MISSED_CALL_RECOVERY_DBA_DATABASE_URL"
 PREREQUISITE_MIGRATION_NAME = "389_eom_missed_call_recovery"
 MIGRATION_NAME = "393_eom_missed_call_recovery_runtime_privileges"
+HISTORICAL_PRELUDE_MIGRATION_NAMES: tuple[str, ...] = (
+    "390_eom_won_loss_direct_sql_fence_recovery",
+    "391_eom_commercial_billing_run_fence_recovery",
+    "392_eom_commercial_billing_run_fence_schema_binding",
+)
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -50,7 +56,10 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--apply",
         action="store_true",
-        help="Run migration 393 after the read-only DBA preflight.",
+        help=(
+            "Apply an exact historical EOM recovery prelude if required, then "
+            "run migration 393 after the read-only DBA preflight."
+        ),
     )
     parser.add_argument(
         "--json",
@@ -83,8 +92,10 @@ async def _create_pool(database_url: str) -> Any:
     return await asyncpg.create_pool(dsn=database_url, min_size=1, max_size=1)
 
 
-async def _migration_state(pool: Any) -> tuple[bool, bool, bool]:
-    """Return executor, prerequisite, and repair ledger state without writes."""
+async def _migration_state(
+    pool: Any,
+) -> tuple[bool, bool, bool, bool, dict[str, bool]]:
+    """Return executor, ledger, and exact EOM migration state without writes."""
 
     async with pool.acquire() as connection:
         executor_is_superuser = bool(
@@ -105,6 +116,9 @@ async def _migration_state(pool: Any) -> tuple[bool, bool, bool]:
         )
         prerequisite_migration_recorded = False
         migration_recorded = False
+        historical_prelude_migration_records = {
+            name: False for name in HISTORICAL_PRELUDE_MIGRATION_NAMES
+        }
         if migrations_table_exists:
             prerequisite_migration_recorded = bool(
                 await connection.fetchval(
@@ -118,11 +132,42 @@ async def _migration_state(pool: Any) -> tuple[bool, bool, bool]:
                     MIGRATION_NAME,
                 )
             )
+            for historical_migration_name in HISTORICAL_PRELUDE_MIGRATION_NAMES:
+                historical_prelude_migration_records[historical_migration_name] = bool(
+                    await connection.fetchval(
+                        "SELECT EXISTS (SELECT 1 FROM schema_migrations WHERE name = $1)",
+                        historical_migration_name,
+                    )
+                )
     return (
         executor_is_superuser,
+        migrations_table_exists,
         prerequisite_migration_recorded,
         migration_recorded,
+        historical_prelude_migration_records,
     )
+
+
+async def _apply_required_historical_prelude(
+    pool: Any,
+    *,
+    run_migrations_fn: Callable[..., Awaitable[None]],
+) -> None:
+    """Apply at most the three explicitly authorized historical EOM preludes.
+
+    ``run_migrations`` deliberately commits one selected historical recovery per
+    invocation. Re-read the ledger after each invocation and stop once the
+    selector has no exact prelude to apply. This command never includes 389 in
+    its requested set, so normal bootstrap ownership remains with the slim EOM
+    runtime path.
+    """
+
+    for _ in HISTORICAL_PRELUDE_MIGRATION_NAMES:
+        _, _, _, _, before = await _migration_state(pool)
+        await run_migrations_fn(pool, only=HISTORICAL_PRELUDE_MIGRATION_NAMES)
+        _, _, _, _, after = await _migration_state(pool)
+        if after == before:
+            return
 
 
 async def _run(
@@ -142,12 +187,15 @@ async def _run(
     try:
         (
             executor_is_superuser,
+            migrations_table_exists,
             prerequisite_migration_recorded,
             migration_recorded,
+            historical_prelude_migration_records,
         ) = await _migration_state(pool)
         result: dict[str, object] = {
             "target": _safe_target_label(database_url),
             "executor_is_superuser": executor_is_superuser,
+            "historical_prelude_migrations": historical_prelude_migration_records,
             "prerequisite_migration": PREREQUISITE_MIGRATION_NAME,
             "prerequisite_migration_recorded": prerequisite_migration_recorded,
             "migration": MIGRATION_NAME,
@@ -159,6 +207,21 @@ async def _run(
                 "Configured DBA connection is not a PostgreSQL superuser; "
                 "refusing to run the privilege repair"
             )
+        if args.apply and migrations_table_exists and not migration_recorded:
+            await _apply_required_historical_prelude(
+                pool,
+                run_migrations_fn=run_migrations_fn,
+            )
+            (
+                _,
+                _,
+                prerequisite_migration_recorded,
+                migration_recorded,
+                historical_prelude_migration_records,
+            ) = await _migration_state(pool)
+            result["historical_prelude_migrations"] = (
+                historical_prelude_migration_records
+            )
         if args.apply and not prerequisite_migration_recorded:
             raise RuntimeError(
                 f"Migration {PREREQUISITE_MIGRATION_NAME} is not recorded; "
@@ -166,13 +229,22 @@ async def _run(
             )
         if args.apply and not migration_recorded:
             await run_migrations_fn(pool, only=(MIGRATION_NAME,))
-            _, _, migration_recorded = await _migration_state(pool)
+            (
+                _,
+                _,
+                _,
+                migration_recorded,
+                historical_prelude_migration_records,
+            ) = await _migration_state(pool)
             if not migration_recorded:
                 raise RuntimeError(
                     "Migration runner returned without recording the EOM "
                     "missed-call recovery privilege repair"
                 )
             result["migration_recorded"] = True
+            result["historical_prelude_migrations"] = (
+                historical_prelude_migration_records
+            )
             result["applied"] = True
         return result
     finally:
@@ -189,7 +261,8 @@ async def _main(argv: list[str] | None = None) -> int:
         print(
             f"{action} {result['migration']} on {result['target']}; "
             f"recorded={result['migration_recorded']}; "
-            f"prerequisite_recorded={result['prerequisite_migration_recorded']}"
+            f"prerequisite_recorded={result['prerequisite_migration_recorded']}; "
+            f"historical_preludes={result['historical_prelude_migrations']}"
         )
     return 0
 

--- a/scripts/apply_eom_missed_call_recovery_runtime_privileges.py
+++ b/scripts/apply_eom_missed_call_recovery_runtime_privileges.py
@@ -33,6 +33,7 @@ from atlas_brain.config import (  # noqa: E402
 from atlas_brain.eom_api.config import EOMFunnelConfig  # noqa: E402
 from atlas_brain.storage.migrations import (  # noqa: E402
     PendingMigrationContentIntegrityError,
+    _MIGRATIONS_ADVISORY_LOCK_KEY,
     run_migrations,
 )
 
@@ -238,6 +239,22 @@ async def _attest_shared_database_lock(runtime_pool: Any, dba_pool: Any) -> None
                         )
                 return
     raise RuntimeError("Could not reserve a fresh EOM funnel target-attestation lock")
+
+
+class _PinnedMigrationPool:
+    """Expose one transaction-pinned connection to the canonical runner."""
+
+    def __init__(self, connection: Any) -> None:
+        self._connection = connection
+
+    async def acquire(self) -> Any:
+        return self._connection
+
+    async def release(self, connection: Any) -> None:
+        if connection is not self._connection:
+            raise RuntimeError(
+                "Controlled migration attempted to release another connection"
+            )
 
 
 class _RuntimeRoleMigrationPool:
@@ -450,6 +467,59 @@ async def _migration_state(
     )
 
 
+async def _run_pinned_controlled_migration(
+    pool: Any,
+    *,
+    runtime_role: str,
+    run_migrations_fn: Callable[..., Awaitable[None]],
+) -> None:
+    """Run atomic migration 393 on one backend under the canonical lock.
+
+    Ordinary catalog runs remain transaction-free because some migrations use
+    concurrent DDL. Migration 393 is atomic bookkeeping, so this controlled
+    command can hold the canonical session lock inside one transaction and pin
+    the generic runner to that exact connection. That keeps the role setting,
+    lock, migration SQL, and receipt bookkeeping together under transaction
+    pooling; the outer unlock balances the generic runner's re-entrant lock.
+    """
+
+    async with pool.acquire() as connection:
+        while True:
+            lock_acquired = False
+            async with connection.transaction():
+                lock_acquired = bool(
+                    await connection.fetchval(
+                        "SELECT pg_catalog.pg_try_advisory_lock($1)",
+                        _MIGRATIONS_ADVISORY_LOCK_KEY,
+                    )
+                )
+                if lock_acquired:
+                    try:
+                        await run_migrations_fn(
+                            _RuntimeRoleMigrationPool(
+                                _PinnedMigrationPool(connection),
+                                runtime_role,
+                            ),
+                            only=(MIGRATION_NAME,),
+                        )
+                    finally:
+                        released = bool(
+                            await connection.fetchval(
+                                "SELECT pg_catalog.pg_advisory_unlock($1)",
+                                _MIGRATIONS_ADVISORY_LOCK_KEY,
+                            )
+                        )
+                        if not released:
+                            raise RuntimeError(
+                                "Controlled migration did not release its "
+                                "database serialization lock"
+                            )
+                    return
+            # Never wait inside a transaction: an ordinary migration might be
+            # waiting for that absence before its concurrent DDL can finish.
+            await asyncio.sleep(0.2)
+
+
 async def _apply_required_historical_prelude(
     pool: Any,
     *,
@@ -588,7 +658,11 @@ async def _run(
                     "run the slim EOM bootstrap before the privilege repair"
                 )
             if args.apply and not migration_recorded:
-                await run_migrations_fn(migration_pool, only=(MIGRATION_NAME,))
+                await _run_pinned_controlled_migration(
+                    pool,
+                    runtime_role=runtime_role,
+                    run_migrations_fn=run_migrations_fn,
+                )
                 await _attest_shared_database_lock(runtime_pool, pool)
                 (
                     _,

--- a/tests/test_eom_missed_call_privilege_runner.py
+++ b/tests/test_eom_missed_call_privilege_runner.py
@@ -56,6 +56,19 @@ class _Connection:
             return args[0] in self._state.recorded_migrations
         raise AssertionError(f"unexpected query: {query}")
 
+    async def fetchrow(self, query: str, *args: object) -> dict[str, bool]:
+        assert "atlas:eom-missed-call-recovery-role-admission" in query
+        assert args == ("atlas_funnel",)
+        self._state.role_admission_calls = getattr(
+            self._state, "role_admission_calls", []
+        )
+        self._state.role_admission_calls.append(args)
+        return {
+            "guard_role_ready": getattr(self._state, "guard_role_ready", True),
+            "runtime_role_ready": getattr(self._state, "runtime_role_ready", True),
+            "nocodb_role_ready": getattr(self._state, "nocodb_role_ready", True),
+        }
+
     async def execute(self, query: str, *args: object) -> None:
         self._state.executed = getattr(self._state, "executed", [])
         self._state.executed.append((query, args))
@@ -390,6 +403,48 @@ def test_privilege_runner_provisions_pgcrypto_before_historical_preludes(
         "migration",
         runner.HISTORICAL_PRELUDE_MIGRATION_NAMES,
     )
+    assert state.role_admission_calls == [("atlas_funnel",)]
+
+
+@pytest.mark.parametrize(
+    "invalid_admission",
+    ("guard_role_ready", "runtime_role_ready", "nocodb_role_ready"),
+)
+def test_privilege_runner_rejects_invalid_role_admission_before_pgcrypto(
+    monkeypatch,
+    invalid_admission: str,
+) -> None:
+    runner = _load_runner_module()
+    monkeypatch.setenv("TEST_EOM_DBA_DSN", "postgresql://example.test/atlas")
+    state = SimpleNamespace(
+        executor_is_superuser=True,
+        migrations_table_exists=True,
+        recorded_migrations={runner.PREREQUISITE_MIGRATION_NAME},
+    )
+    setattr(state, invalid_admission, False)
+    pool = _Pool(state)
+    calls: list[tuple[str, ...]] = []
+
+    async def create_pool(_database_url: str) -> _Pool:
+        return pool
+
+    async def run_migrations(_pool: object, *, only: tuple[str, ...]) -> None:
+        calls.append(only)
+
+    args = runner._parse_args(["--database-url-env", "TEST_EOM_DBA_DSN", "--apply"])
+    with pytest.raises(RuntimeError, match="role admission failed"):
+        asyncio.run(
+            runner._run(
+                args,
+                create_pool=create_pool,
+                run_migrations_fn=run_migrations,
+            )
+        )
+
+    assert state.role_admission_calls == [("atlas_funnel",)]
+    assert getattr(state, "executed", []) == []
+    assert calls == []
+    assert pool.closed is True
 
 
 def test_privilege_runner_continues_after_committed_historical_progress_stop(

--- a/tests/test_eom_missed_call_privilege_runner.py
+++ b/tests/test_eom_missed_call_privilege_runner.py
@@ -95,6 +95,9 @@ def test_privilege_runner_defaults_to_read_only_and_redacts_dsn(monkeypatch) -> 
     assert result == {
         "target": "dsn=example.test:5432/atlas",
         "executor_is_superuser": True,
+        "historical_prelude_migrations": {
+            name: False for name in runner.HISTORICAL_PRELUDE_MIGRATION_NAMES
+        },
         "prerequisite_migration": runner.PREREQUISITE_MIGRATION_NAME,
         "prerequisite_migration_recorded": False,
         "migration": runner.MIGRATION_NAME,
@@ -142,7 +145,10 @@ def test_privilege_runner_applies_only_the_recorded_repair(monkeypatch) -> None:
 
     async def run_migrations(observed_pool: object, *, only: tuple[str, ...]) -> None:
         calls.append((observed_pool, only))
-        state.recorded_migrations.add(runner.MIGRATION_NAME)
+        if only == (runner.MIGRATION_NAME,):
+            state.recorded_migrations.add(runner.MIGRATION_NAME)
+        else:
+            assert only == runner.HISTORICAL_PRELUDE_MIGRATION_NAMES
 
     args = runner._parse_args(
         ["--database-url-env", "TEST_EOM_DBA_DSN", "--apply"]
@@ -155,7 +161,10 @@ def test_privilege_runner_applies_only_the_recorded_repair(monkeypatch) -> None:
         )
     )
 
-    assert calls == [(pool, (runner.MIGRATION_NAME,))]
+    assert calls == [
+        (pool, runner.HISTORICAL_PRELUDE_MIGRATION_NAMES),
+        (pool, (runner.MIGRATION_NAME,)),
+    ]
     assert result["prerequisite_migration_recorded"] is True
     assert result["migration_recorded"] is True
     assert result["applied"] is True
@@ -200,13 +209,15 @@ def test_privilege_runner_refuses_apply_without_prerequisite_receipt(
         recorded_migrations=set(recorded_migrations),
     )
     pool = _Pool(state)
-    calls: list[object] = []
+    calls: list[tuple[str, ...]] = []
 
     async def create_pool(_database_url: str) -> _Pool:
         return pool
 
-    async def run_migrations(*_args: object, **_kwargs: object) -> None:
-        calls.append(object())
+    async def run_migrations(*_args: object, **kwargs: object) -> None:
+        only = kwargs["only"]
+        assert isinstance(only, tuple)
+        calls.append(only)
 
     args = runner._parse_args(
         ["--database-url-env", "TEST_EOM_DBA_DSN", "--apply"]
@@ -223,5 +234,66 @@ def test_privilege_runner_refuses_apply_without_prerequisite_receipt(
             )
         )
 
-    assert calls == []
+    expected_calls = (
+        []
+        if (
+            not migrations_table_exists
+            or runner.MIGRATION_NAME in recorded_migrations
+        )
+        else [runner.HISTORICAL_PRELUDE_MIGRATION_NAMES]
+    )
+    assert calls == expected_calls
+    assert (runner.MIGRATION_NAME,) not in calls
+    assert pool.closed is True
+
+
+def test_privilege_runner_applies_historical_preludes_before_privilege_repair(
+    monkeypatch,
+) -> None:
+    runner = _load_runner_module()
+    monkeypatch.setenv("TEST_EOM_DBA_DSN", "postgresql://example.test/atlas")
+    state = SimpleNamespace(
+        executor_is_superuser=True,
+        migrations_table_exists=True,
+        recorded_migrations={runner.PREREQUISITE_MIGRATION_NAME},
+    )
+    pool = _Pool(state)
+    calls: list[tuple[str, ...]] = []
+    prelude_names = iter(runner.HISTORICAL_PRELUDE_MIGRATION_NAMES)
+
+    async def create_pool(_database_url: str) -> _Pool:
+        return pool
+
+    async def run_migrations(_pool: object, *, only: tuple[str, ...]) -> None:
+        calls.append(only)
+        if only == runner.HISTORICAL_PRELUDE_MIGRATION_NAMES:
+            state.recorded_migrations.add(next(prelude_names))
+        elif only == (runner.MIGRATION_NAME,):
+            state.recorded_migrations.add(runner.MIGRATION_NAME)
+        else:  # pragma: no cover - regression guard for this controlled runner
+            raise AssertionError(f"unexpected migration selection: {only}")
+
+    args = runner._parse_args(
+        ["--database-url-env", "TEST_EOM_DBA_DSN", "--apply"]
+    )
+    result = asyncio.run(
+        runner._run(
+            args,
+            create_pool=create_pool,
+            run_migrations_fn=run_migrations,
+        )
+    )
+
+    assert calls == [
+        runner.HISTORICAL_PRELUDE_MIGRATION_NAMES,
+        runner.HISTORICAL_PRELUDE_MIGRATION_NAMES,
+        runner.HISTORICAL_PRELUDE_MIGRATION_NAMES,
+        (runner.MIGRATION_NAME,),
+    ]
+    assert result["historical_prelude_migrations"] == {
+        name: True for name in runner.HISTORICAL_PRELUDE_MIGRATION_NAMES
+    }
+    assert result["prerequisite_migration_recorded"] is True
+    assert result["migration_recorded"] is True
+    assert result["applied"] is True
     assert pool.closed is True

--- a/tests/test_eom_missed_call_privilege_runner.py
+++ b/tests/test_eom_missed_call_privilege_runner.py
@@ -79,6 +79,23 @@ class _Connection:
                 return False
             lock_state.advisory_lock_held = True
             return True
+        if "pg_try_advisory_lock" in query:
+            self._state.controlled_migration_lock_attempts = (
+                getattr(self._state, "controlled_migration_lock_attempts", 0) + 1
+            )
+            lock_results = getattr(
+                self._state,
+                "controlled_migration_lock_results",
+                [],
+            )
+            if lock_results:
+                return lock_results.pop(0)
+            return True
+        if "pg_advisory_unlock" in query:
+            self._state.controlled_migration_unlocks = (
+                getattr(self._state, "controlled_migration_unlocks", 0) + 1
+            )
+            return True
         if "rolsuper" in query:
             return self._state.executor_is_superuser
         if "to_regclass" in query:
@@ -280,12 +297,15 @@ def test_privilege_runner_applies_only_the_recorded_repair(monkeypatch) -> None:
         runner.HISTORICAL_PRELUDE_MIGRATION_NAMES,
         (runner.MIGRATION_NAME,),
     ]
-    assert all(
-        isinstance(observed_pool, runner._RuntimeRoleMigrationPool)
-        and observed_pool._pool is pool
-        and observed_pool._runtime_role == "atlas_funnel"
-        for observed_pool, _only in calls
-    )
+    historical_pool, _historical_only = calls[0]
+    assert isinstance(historical_pool, runner._RuntimeRoleMigrationPool)
+    assert historical_pool._pool is pool
+    assert historical_pool._runtime_role == "atlas_funnel"
+    controlled_pool, _controlled_only = calls[1]
+    assert isinstance(controlled_pool, runner._RuntimeRoleMigrationPool)
+    assert isinstance(controlled_pool._pool, runner._PinnedMigrationPool)
+    assert controlled_pool._pool._connection is pool._connection
+    assert controlled_pool._runtime_role == "atlas_funnel"
     assert result["prerequisite_migration_recorded"] is True
     assert result["migration_recorded"] is True
     assert result["applied"] is True
@@ -411,6 +431,87 @@ def test_privilege_runner_applies_historical_preludes_before_privilege_repair(
     assert result["migration_recorded"] is True
     assert result["applied"] is True
     assert pool.closed is True
+
+
+def test_privilege_runner_pins_393_role_setting_and_runner_connection(
+    monkeypatch,
+) -> None:
+    """A transaction-pooling proxy cannot split 393 across backends."""
+
+    runner = _load_runner_module()
+    lock_state = SimpleNamespace()
+    runtime_pool = _Pool(
+        SimpleNamespace(
+            schema_name="eom_canonical",
+            advisory_lock_state=lock_state,
+        )
+    )
+    dba_state = SimpleNamespace(
+        schema_name="eom_canonical",
+        executor_is_superuser=True,
+        migrations_table_exists=True,
+        recorded_migrations={
+            runner.PREREQUISITE_MIGRATION_NAME,
+            *runner.HISTORICAL_PRELUDE_MIGRATION_NAMES,
+        },
+        advisory_lock_state=lock_state,
+        controlled_migration_lock_results=[False, True],
+    )
+    dba_pool = _Pool(dba_state)
+    sleep_transaction_depths: list[int] = []
+    observed_migration_connections: list[object] = []
+
+    async def create_pool(
+        database_url: str,
+        *,
+        schema_name: str | None = None,
+    ) -> _Pool:
+        if database_url == TEST_RUNTIME_DSN:
+            assert schema_name is None
+            return runtime_pool
+        assert database_url == TEST_DBA_DSN
+        assert schema_name == "eom_canonical"
+        return dba_pool
+
+    async def sleep(_delay: float) -> None:
+        sleep_transaction_depths.append(dba_state.transaction_depth)
+
+    async def run_migrations(observed_pool: object, *, only: tuple[str, ...]) -> None:
+        if only == runner.HISTORICAL_PRELUDE_MIGRATION_NAMES:
+            return
+        assert only == (runner.MIGRATION_NAME,)
+        assert isinstance(observed_pool, runner._RuntimeRoleMigrationPool)
+        connection = await observed_pool.acquire()
+        observed_migration_connections.append(connection)
+        assert connection is dba_pool._connection
+        assert dba_state.transaction_depth == 1
+        await observed_pool.release(connection)
+        dba_state.recorded_migrations.add(runner.MIGRATION_NAME)
+
+    monkeypatch.setattr(runner.asyncio, "sleep", sleep)
+    result = asyncio.run(
+        runner._run(
+            runner._parse_args(["--apply"]),
+            create_pool=create_pool,
+            run_migrations_fn=run_migrations,
+            funnel_config_factory=lambda: SimpleNamespace(
+                db_connection_string=TEST_RUNTIME_DSN
+            ),
+        )
+    )
+
+    assert sleep_transaction_depths == [0]
+    assert observed_migration_connections == [dba_pool._connection]
+    assert dba_state.controlled_migration_lock_attempts == 2
+    assert dba_state.controlled_migration_unlocks == 1
+    assert (
+        "SELECT pg_catalog.set_config($1, $2, FALSE)",
+        (runner.RUNTIME_ROLE_SETTING, "atlas_funnel"),
+    ) in dba_state.executed
+    assert result["migration_recorded"] is True
+    assert result["applied"] is True
+    assert runtime_pool.closed is True
+    assert dba_pool.closed is True
 
 
 def test_privilege_runner_provisions_pgcrypto_before_historical_preludes(

--- a/tests/test_eom_missed_call_privilege_runner.py
+++ b/tests/test_eom_missed_call_privilege_runner.py
@@ -297,3 +297,107 @@ def test_privilege_runner_applies_historical_preludes_before_privilege_repair(
     assert result["migration_recorded"] is True
     assert result["applied"] is True
     assert pool.closed is True
+
+
+def test_privilege_runner_continues_after_committed_historical_progress_stop(
+    monkeypatch,
+) -> None:
+    """A committed prelude receipt authorizes retrying the exact selector."""
+
+    runner = _load_runner_module()
+    monkeypatch.setenv("TEST_EOM_DBA_DSN", "postgresql://example.test/atlas")
+    state = SimpleNamespace(
+        executor_is_superuser=True,
+        migrations_table_exists=True,
+        recorded_migrations={runner.PREREQUISITE_MIGRATION_NAME},
+    )
+    pool = _Pool(state)
+    calls: list[tuple[str, ...]] = []
+    prelude_names = iter(runner.HISTORICAL_PRELUDE_MIGRATION_NAMES)
+
+    async def create_pool(_database_url: str) -> _Pool:
+        return pool
+
+    async def run_migrations(_pool: object, *, only: tuple[str, ...]) -> None:
+        calls.append(only)
+        if only == runner.HISTORICAL_PRELUDE_MIGRATION_NAMES:
+            state.recorded_migrations.add(next(prelude_names))
+            if len(calls) < len(runner.HISTORICAL_PRELUDE_MIGRATION_NAMES):
+                raise runner.PendingMigrationContentIntegrityError(
+                    "next exact historical prelude remains"
+                )
+        elif only == (runner.MIGRATION_NAME,):
+            state.recorded_migrations.add(runner.MIGRATION_NAME)
+        else:  # pragma: no cover - regression guard for this controlled runner
+            raise AssertionError(f"unexpected migration selection: {only}")
+
+    args = runner._parse_args(
+        ["--database-url-env", "TEST_EOM_DBA_DSN", "--apply"]
+    )
+    result = asyncio.run(
+        runner._run(
+            args,
+            create_pool=create_pool,
+            run_migrations_fn=run_migrations,
+        )
+    )
+
+    assert calls == [
+        runner.HISTORICAL_PRELUDE_MIGRATION_NAMES,
+        runner.HISTORICAL_PRELUDE_MIGRATION_NAMES,
+        runner.HISTORICAL_PRELUDE_MIGRATION_NAMES,
+        (runner.MIGRATION_NAME,),
+    ]
+    assert result["historical_prelude_migrations"] == {
+        name: True for name in runner.HISTORICAL_PRELUDE_MIGRATION_NAMES
+    }
+    assert result["migration_recorded"] is True
+    assert pool.closed is True
+
+
+def test_privilege_runner_reraises_non_prelude_progress_stop(
+    monkeypatch,
+) -> None:
+    """Only a newly recorded authorized prelude may absorb the stop."""
+
+    runner = _load_runner_module()
+    monkeypatch.setenv("TEST_EOM_DBA_DSN", "postgresql://example.test/atlas")
+    state = SimpleNamespace(
+        executor_is_superuser=True,
+        migrations_table_exists=True,
+        recorded_migrations={runner.PREREQUISITE_MIGRATION_NAME},
+    )
+    pool = _Pool(state)
+    calls: list[tuple[str, ...]] = []
+
+    async def create_pool(_database_url: str) -> _Pool:
+        return pool
+
+    async def run_migrations(_pool: object, *, only: tuple[str, ...]) -> None:
+        calls.append(only)
+        assert only == runner.HISTORICAL_PRELUDE_MIGRATION_NAMES
+        # A concurrent/incorrectly selected non-prelude receipt is not the
+        # committed exact prelude that this controlled retry boundary admits.
+        state.recorded_migrations.add(runner.MIGRATION_NAME)
+        raise runner.PendingMigrationContentIntegrityError(
+            "historical prelude did not advance"
+        )
+
+    args = runner._parse_args(
+        ["--database-url-env", "TEST_EOM_DBA_DSN", "--apply"]
+    )
+    with pytest.raises(
+        runner.PendingMigrationContentIntegrityError,
+        match="historical prelude did not advance",
+    ):
+        asyncio.run(
+            runner._run(
+                args,
+                create_pool=create_pool,
+                run_migrations_fn=run_migrations,
+            )
+        )
+
+    assert calls == [runner.HISTORICAL_PRELUDE_MIGRATION_NAMES]
+    assert runner.MIGRATION_NAME in state.recorded_migrations
+    assert pool.closed is True

--- a/tests/test_eom_missed_call_privilege_runner.py
+++ b/tests/test_eom_missed_call_privilege_runner.py
@@ -13,6 +13,8 @@ import pytest
 
 ROOT = Path(__file__).resolve().parent.parent
 SCRIPT = ROOT / "scripts" / "apply_eom_missed_call_recovery_runtime_privileges.py"
+TEST_DBA_DSN = "postgresql://operator:test-only@example.test:5432/atlas"
+TEST_RUNTIME_DSN = "postgresql://atlas_funnel:test-only@example.test:5432/atlas"
 
 
 def _load_runner_module() -> ModuleType:
@@ -42,11 +44,41 @@ class _Acquire:
         return _connection().__await__()
 
 
+class _Transaction:
+    def __init__(self, connection: "_Connection") -> None:
+        self._connection = connection
+
+    async def __aenter__(self) -> "_Connection":
+        state = self._connection._state
+        state.transaction_depth = getattr(state, "transaction_depth", 0) + 1
+        return self._connection
+
+    async def __aexit__(self, *_args: object) -> None:
+        state = self._connection._state
+        state.transaction_depth -= 1
+        if state.transaction_depth == 0:
+            lock_state = getattr(state, "advisory_lock_state", state)
+            lock_state.advisory_lock_held = False
+        return None
+
+
 class _Connection:
     def __init__(self, state: SimpleNamespace) -> None:
         self._state = state
 
-    async def fetchval(self, query: str, *args: object) -> bool:
+    def transaction(self) -> _Transaction:
+        return _Transaction(self)
+
+    async def fetchval(self, query: str, *args: object) -> object:
+        if "pg_try_advisory_xact_lock" in query:
+            self._state.advisory_lock_attempts = (
+                getattr(self._state, "advisory_lock_attempts", 0) + 1
+            )
+            lock_state = getattr(self._state, "advisory_lock_state", self._state)
+            if getattr(lock_state, "advisory_lock_held", False):
+                return False
+            lock_state.advisory_lock_held = True
+            return True
         if "rolsuper" in query:
             return self._state.executor_is_superuser
         if "to_regclass" in query:
@@ -56,7 +88,15 @@ class _Connection:
             return args[0] in self._state.recorded_migrations
         raise AssertionError(f"unexpected query: {query}")
 
-    async def fetchrow(self, query: str, *args: object) -> dict[str, bool]:
+    async def fetchrow(self, query: str, *args: object) -> object:
+        if "current_schema() AS schema_name" in query:
+            return {
+                "schema_name": getattr(self._state, "schema_name", "public"),
+                "database_name": getattr(self._state, "database_name", "atlas"),
+                "database_oid": getattr(self._state, "database_oid", 16_384),
+                "current_user": getattr(self._state, "current_user", "atlas_funnel"),
+                "session_user": getattr(self._state, "session_user", "atlas_funnel"),
+            }
         assert "atlas:eom-missed-call-recovery-role-admission" in query
         assert args == ("atlas_funnel",)
         self._state.role_admission_calls = getattr(
@@ -94,15 +134,19 @@ class _Pool:
 @pytest.fixture(autouse=True)
 def _configured_runtime_dsn(monkeypatch) -> None:
     monkeypatch.setenv(
+        "ATLAS_EOM_MISSED_CALL_RECOVERY_DBA_DATABASE_URL",
+        TEST_DBA_DSN,
+    )
+    monkeypatch.setenv(
         "ATLAS_EOM_FUNNEL_DB_CONNECTION_STRING",
-        "postgresql://atlas_funnel:test-only@example.test:5432/atlas",
+        TEST_RUNTIME_DSN,
     )
 
 
 def test_privilege_runner_defaults_to_read_only_and_redacts_dsn(monkeypatch) -> None:
     runner = _load_runner_module()
     monkeypatch.setenv(
-        "TEST_EOM_DBA_DSN",
+        runner.DBA_DSN_ENV,
         "postgresql://operator:secret@example.test:5432/atlas?sslmode=require",
     )
     state = SimpleNamespace(
@@ -113,13 +157,13 @@ def test_privilege_runner_defaults_to_read_only_and_redacts_dsn(monkeypatch) -> 
     pool = _Pool(state)
     calls: list[object] = []
 
-    async def create_pool(_database_url: str) -> _Pool:
+    async def create_pool(_database_url: str, **_kwargs: object) -> _Pool:
         return pool
 
     async def run_migrations(*_args: object, **_kwargs: object) -> None:
         calls.append(object())
 
-    args = runner._parse_args(["--database-url-env", "TEST_EOM_DBA_DSN"])
+    args = runner._parse_args([])
     result = asyncio.run(
         runner._run(
             args,
@@ -147,7 +191,7 @@ def test_privilege_runner_defaults_to_read_only_and_redacts_dsn(monkeypatch) -> 
 
 def test_privilege_runner_requires_superuser_before_apply(monkeypatch) -> None:
     runner = _load_runner_module()
-    monkeypatch.setenv("TEST_EOM_DBA_DSN", "postgresql://example.test/atlas")
+    monkeypatch.setenv(runner.DBA_DSN_ENV, "postgresql://example.test/atlas")
     state = SimpleNamespace(
         executor_is_superuser=False,
         migrations_table_exists=True,
@@ -155,10 +199,10 @@ def test_privilege_runner_requires_superuser_before_apply(monkeypatch) -> None:
     )
     pool = _Pool(state)
 
-    async def create_pool(_database_url: str) -> _Pool:
+    async def create_pool(_database_url: str, **_kwargs: object) -> _Pool:
         return pool
 
-    args = runner._parse_args(["--database-url-env", "TEST_EOM_DBA_DSN", "--apply"])
+    args = runner._parse_args(["--apply"])
     with pytest.raises(RuntimeError, match="not a PostgreSQL superuser"):
         asyncio.run(runner._run(args, create_pool=create_pool))
     assert pool.closed is True
@@ -166,12 +210,19 @@ def test_privilege_runner_requires_superuser_before_apply(monkeypatch) -> None:
 
 def test_privilege_runner_rejects_missing_runtime_dsn(monkeypatch) -> None:
     runner = _load_runner_module()
-    monkeypatch.setenv("TEST_EOM_DBA_DSN", "postgresql://example.test/atlas")
+    monkeypatch.setenv(runner.DBA_DSN_ENV, "postgresql://example.test/atlas")
     monkeypatch.delenv("ATLAS_EOM_FUNNEL_DB_CONNECTION_STRING")
 
-    args = runner._parse_args(["--database-url-env", "TEST_EOM_DBA_DSN"])
-    with pytest.raises(RuntimeError, match="Missing configured EOM runtime DSN"):
-        asyncio.run(runner._run(args))
+    args = runner._parse_args([])
+    with pytest.raises(
+        RuntimeError, match="Missing EOM funnel runtime DSN configuration"
+    ):
+        asyncio.run(
+            runner._run(
+                args,
+                funnel_config_factory=lambda: SimpleNamespace(db_connection_string=""),
+            )
+        )
 
 
 def test_runtime_role_migration_pool_binds_the_configured_role() -> None:
@@ -197,7 +248,7 @@ def test_runtime_role_migration_pool_binds_the_configured_role() -> None:
 
 def test_privilege_runner_applies_only_the_recorded_repair(monkeypatch) -> None:
     runner = _load_runner_module()
-    monkeypatch.setenv("TEST_EOM_DBA_DSN", "postgresql://example.test/atlas")
+    monkeypatch.setenv(runner.DBA_DSN_ENV, "postgresql://example.test/atlas")
     state = SimpleNamespace(
         executor_is_superuser=True,
         migrations_table_exists=True,
@@ -206,7 +257,7 @@ def test_privilege_runner_applies_only_the_recorded_repair(monkeypatch) -> None:
     pool = _Pool(state)
     calls: list[tuple[object, tuple[str, ...]]] = []
 
-    async def create_pool(_database_url: str) -> _Pool:
+    async def create_pool(_database_url: str, **_kwargs: object) -> _Pool:
         return pool
 
     async def run_migrations(observed_pool: object, *, only: tuple[str, ...]) -> None:
@@ -216,7 +267,7 @@ def test_privilege_runner_applies_only_the_recorded_repair(monkeypatch) -> None:
         else:
             assert only == runner.HISTORICAL_PRELUDE_MIGRATION_NAMES
 
-    args = runner._parse_args(["--database-url-env", "TEST_EOM_DBA_DSN", "--apply"])
+    args = runner._parse_args(["--apply"])
     result = asyncio.run(
         runner._run(
             args,
@@ -272,7 +323,7 @@ def test_privilege_runner_refuses_apply_without_prerequisite_receipt(
     recorded_migrations: frozenset[str],
 ) -> None:
     runner = _load_runner_module()
-    monkeypatch.setenv("TEST_EOM_DBA_DSN", "postgresql://example.test/atlas")
+    monkeypatch.setenv(runner.DBA_DSN_ENV, "postgresql://example.test/atlas")
     state = SimpleNamespace(
         executor_is_superuser=True,
         migrations_table_exists=migrations_table_exists,
@@ -281,7 +332,7 @@ def test_privilege_runner_refuses_apply_without_prerequisite_receipt(
     pool = _Pool(state)
     calls: list[tuple[str, ...]] = []
 
-    async def create_pool(_database_url: str) -> _Pool:
+    async def create_pool(_database_url: str, **_kwargs: object) -> _Pool:
         return pool
 
     async def run_migrations(*_args: object, **kwargs: object) -> None:
@@ -289,7 +340,7 @@ def test_privilege_runner_refuses_apply_without_prerequisite_receipt(
         assert isinstance(only, tuple)
         calls.append(only)
 
-    args = runner._parse_args(["--database-url-env", "TEST_EOM_DBA_DSN", "--apply"])
+    args = runner._parse_args(["--apply"])
     with pytest.raises(
         RuntimeError,
         match="389_eom_missed_call_recovery is not recorded",
@@ -316,7 +367,7 @@ def test_privilege_runner_applies_historical_preludes_before_privilege_repair(
     monkeypatch,
 ) -> None:
     runner = _load_runner_module()
-    monkeypatch.setenv("TEST_EOM_DBA_DSN", "postgresql://example.test/atlas")
+    monkeypatch.setenv(runner.DBA_DSN_ENV, "postgresql://example.test/atlas")
     state = SimpleNamespace(
         executor_is_superuser=True,
         migrations_table_exists=True,
@@ -326,7 +377,7 @@ def test_privilege_runner_applies_historical_preludes_before_privilege_repair(
     calls: list[tuple[str, ...]] = []
     prelude_names = iter(runner.HISTORICAL_PRELUDE_MIGRATION_NAMES)
 
-    async def create_pool(_database_url: str) -> _Pool:
+    async def create_pool(_database_url: str, **_kwargs: object) -> _Pool:
         return pool
 
     async def run_migrations(_pool: object, *, only: tuple[str, ...]) -> None:
@@ -338,7 +389,7 @@ def test_privilege_runner_applies_historical_preludes_before_privilege_repair(
         else:  # pragma: no cover - regression guard for this controlled runner
             raise AssertionError(f"unexpected migration selection: {only}")
 
-    args = runner._parse_args(["--database-url-env", "TEST_EOM_DBA_DSN", "--apply"])
+    args = runner._parse_args(["--apply"])
     result = asyncio.run(
         runner._run(
             args,
@@ -366,7 +417,7 @@ def test_privilege_runner_provisions_pgcrypto_before_historical_preludes(
     monkeypatch,
 ) -> None:
     runner = _load_runner_module()
-    monkeypatch.setenv("TEST_EOM_DBA_DSN", "postgresql://example.test/atlas")
+    monkeypatch.setenv(runner.DBA_DSN_ENV, "postgresql://example.test/atlas")
     state = SimpleNamespace(
         executor_is_superuser=True,
         migrations_table_exists=True,
@@ -375,7 +426,7 @@ def test_privilege_runner_provisions_pgcrypto_before_historical_preludes(
     )
     pool = _Pool(state)
 
-    async def create_pool(_database_url: str) -> _Pool:
+    async def create_pool(_database_url: str, **_kwargs: object) -> _Pool:
         return pool
 
     async def run_migrations(_pool: object, *, only: tuple[str, ...]) -> None:
@@ -385,7 +436,7 @@ def test_privilege_runner_provisions_pgcrypto_before_historical_preludes(
         elif only == (runner.MIGRATION_NAME,):
             state.recorded_migrations.add(runner.MIGRATION_NAME)
 
-    args = runner._parse_args(["--database-url-env", "TEST_EOM_DBA_DSN", "--apply"])
+    args = runner._parse_args(["--apply"])
     asyncio.run(
         runner._run(
             args,
@@ -415,7 +466,7 @@ def test_privilege_runner_rejects_invalid_role_admission_before_pgcrypto(
     invalid_admission: str,
 ) -> None:
     runner = _load_runner_module()
-    monkeypatch.setenv("TEST_EOM_DBA_DSN", "postgresql://example.test/atlas")
+    monkeypatch.setenv(runner.DBA_DSN_ENV, "postgresql://example.test/atlas")
     state = SimpleNamespace(
         executor_is_superuser=True,
         migrations_table_exists=True,
@@ -425,13 +476,13 @@ def test_privilege_runner_rejects_invalid_role_admission_before_pgcrypto(
     pool = _Pool(state)
     calls: list[tuple[str, ...]] = []
 
-    async def create_pool(_database_url: str) -> _Pool:
+    async def create_pool(_database_url: str, **_kwargs: object) -> _Pool:
         return pool
 
     async def run_migrations(_pool: object, *, only: tuple[str, ...]) -> None:
         calls.append(only)
 
-    args = runner._parse_args(["--database-url-env", "TEST_EOM_DBA_DSN", "--apply"])
+    args = runner._parse_args(["--apply"])
     with pytest.raises(RuntimeError, match="role admission failed"):
         asyncio.run(
             runner._run(
@@ -453,7 +504,7 @@ def test_privilege_runner_continues_after_committed_historical_progress_stop(
     """A committed prelude receipt authorizes retrying the exact selector."""
 
     runner = _load_runner_module()
-    monkeypatch.setenv("TEST_EOM_DBA_DSN", "postgresql://example.test/atlas")
+    monkeypatch.setenv(runner.DBA_DSN_ENV, "postgresql://example.test/atlas")
     state = SimpleNamespace(
         executor_is_superuser=True,
         migrations_table_exists=True,
@@ -463,7 +514,7 @@ def test_privilege_runner_continues_after_committed_historical_progress_stop(
     calls: list[tuple[str, ...]] = []
     prelude_names = iter(runner.HISTORICAL_PRELUDE_MIGRATION_NAMES)
 
-    async def create_pool(_database_url: str) -> _Pool:
+    async def create_pool(_database_url: str, **_kwargs: object) -> _Pool:
         return pool
 
     async def run_migrations(_pool: object, *, only: tuple[str, ...]) -> None:
@@ -479,7 +530,7 @@ def test_privilege_runner_continues_after_committed_historical_progress_stop(
         else:  # pragma: no cover - regression guard for this controlled runner
             raise AssertionError(f"unexpected migration selection: {only}")
 
-    args = runner._parse_args(["--database-url-env", "TEST_EOM_DBA_DSN", "--apply"])
+    args = runner._parse_args(["--apply"])
     result = asyncio.run(
         runner._run(
             args,
@@ -507,7 +558,7 @@ def test_privilege_runner_reraises_non_prelude_progress_stop(
     """Only a newly recorded authorized prelude may absorb the stop."""
 
     runner = _load_runner_module()
-    monkeypatch.setenv("TEST_EOM_DBA_DSN", "postgresql://example.test/atlas")
+    monkeypatch.setenv(runner.DBA_DSN_ENV, "postgresql://example.test/atlas")
     state = SimpleNamespace(
         executor_is_superuser=True,
         migrations_table_exists=True,
@@ -516,7 +567,7 @@ def test_privilege_runner_reraises_non_prelude_progress_stop(
     pool = _Pool(state)
     calls: list[tuple[str, ...]] = []
 
-    async def create_pool(_database_url: str) -> _Pool:
+    async def create_pool(_database_url: str, **_kwargs: object) -> _Pool:
         return pool
 
     async def run_migrations(_pool: object, *, only: tuple[str, ...]) -> None:
@@ -529,7 +580,7 @@ def test_privilege_runner_reraises_non_prelude_progress_stop(
             "historical prelude did not advance"
         )
 
-    args = runner._parse_args(["--database-url-env", "TEST_EOM_DBA_DSN", "--apply"])
+    args = runner._parse_args(["--apply"])
     with pytest.raises(
         runner.PendingMigrationContentIntegrityError,
         match="historical prelude did not advance",
@@ -545,3 +596,328 @@ def test_privilege_runner_reraises_non_prelude_progress_stop(
     assert calls == [runner.HISTORICAL_PRELUDE_MIGRATION_NAMES]
     assert runner.MIGRATION_NAME in state.recorded_migrations
     assert pool.closed is True
+
+
+def test_create_pool_binds_the_attested_runtime_schema(monkeypatch) -> None:
+    """The controlled DBA pool must not depend on its DSN default search path."""
+
+    runner = _load_runner_module()
+    calls: list[dict[str, object]] = []
+    created_pool = object()
+
+    async def create_pool(**kwargs: object) -> object:
+        calls.append(dict(kwargs))
+        return created_pool
+
+    monkeypatch.setitem(
+        sys.modules, "asyncpg", SimpleNamespace(create_pool=create_pool)
+    )
+
+    runtime_pool = asyncio.run(runner._create_pool(TEST_RUNTIME_DSN))
+    dba_pool = asyncio.run(
+        runner._create_pool(TEST_DBA_DSN, schema_name="eom_canonical")
+    )
+
+    assert runtime_pool is created_pool
+    assert dba_pool is created_pool
+    assert calls == [
+        {
+            "dsn": TEST_RUNTIME_DSN,
+            "min_size": 1,
+            "max_size": 1,
+            "statement_cache_size": 0,
+        },
+        {
+            "dsn": TEST_DBA_DSN,
+            "min_size": 1,
+            "max_size": 1,
+            "statement_cache_size": 0,
+            "server_settings": {"search_path": '"eom_canonical", pg_catalog'},
+        },
+    ]
+
+
+@pytest.mark.parametrize("env_filename", (".env", ".env.local"))
+def test_typed_dba_config_loads_the_canonical_dsn_from_supported_env_file(
+    monkeypatch,
+    tmp_path: Path,
+    env_filename: str,
+) -> None:
+    runner = _load_runner_module()
+    monkeypatch.delenv(runner.DBA_DSN_ENV, raising=False)
+    monkeypatch.chdir(tmp_path)
+    env_file = tmp_path / env_filename
+    env_file.write_text(f"{runner.DBA_DSN_ENV}={TEST_DBA_DSN}\n", encoding="utf-8")
+
+    config = runner.EOMMissedCallRecoveryDBAConfig()
+
+    assert config.database_url.get_secret_value() == TEST_DBA_DSN
+    assert TEST_DBA_DSN not in repr(config)
+
+
+def test_privilege_runner_rejects_missing_typed_dba_dsn_before_pool(
+    monkeypatch,
+) -> None:
+    runner = _load_runner_module()
+    monkeypatch.delenv(runner.DBA_DSN_ENV, raising=False)
+    pool_calls: list[str] = []
+
+    async def create_pool(database_url: str, **_kwargs: object) -> _Pool:
+        pool_calls.append(database_url)
+        raise AssertionError("missing DBA DSN must fail before opening a pool")
+
+    with pytest.raises(
+        RuntimeError,
+        match=f"Missing protected DBA DSN configuration {runner.DBA_DSN_ENV}",
+    ):
+        asyncio.run(
+            runner._run(
+                runner._parse_args([]),
+                create_pool=create_pool,
+                config_factory=lambda: runner.EOMMissedCallRecoveryDBAConfig(
+                    _env_file=None
+                ),
+            )
+        )
+    assert pool_calls == []
+
+
+def test_privilege_runner_attests_matching_runtime_target_before_apply() -> None:
+    """A matching live runtime target reaches the existing controlled apply path."""
+
+    runner = _load_runner_module()
+    lock_state = SimpleNamespace()
+    runtime_pool = _Pool(
+        SimpleNamespace(
+            schema_name="eom_canonical",
+            advisory_lock_state=lock_state,
+        )
+    )
+    dba_state = SimpleNamespace(
+        schema_name="eom_canonical",
+        executor_is_superuser=True,
+        migrations_table_exists=True,
+        recorded_migrations={runner.PREREQUISITE_MIGRATION_NAME},
+        advisory_lock_state=lock_state,
+    )
+    dba_pool = _Pool(dba_state)
+    pool_calls: list[tuple[str, str | None]] = []
+    migration_calls: list[tuple[str, ...]] = []
+
+    async def create_pool(
+        database_url: str,
+        *,
+        schema_name: str | None = None,
+    ) -> _Pool:
+        pool_calls.append((database_url, schema_name))
+        if database_url == TEST_RUNTIME_DSN:
+            assert schema_name is None
+            return runtime_pool
+        assert database_url == TEST_DBA_DSN
+        assert schema_name == "eom_canonical"
+        return dba_pool
+
+    async def run_migrations(_pool: object, *, only: tuple[str, ...]) -> None:
+        migration_calls.append(only)
+        if only == (runner.MIGRATION_NAME,):
+            dba_state.recorded_migrations.add(runner.MIGRATION_NAME)
+        else:
+            assert only == runner.HISTORICAL_PRELUDE_MIGRATION_NAMES
+
+    result = asyncio.run(
+        runner._run(
+            runner._parse_args(["--apply"]),
+            create_pool=create_pool,
+            run_migrations_fn=run_migrations,
+            funnel_config_factory=lambda: SimpleNamespace(
+                db_connection_string=TEST_RUNTIME_DSN
+            ),
+        )
+    )
+
+    assert pool_calls == [
+        (TEST_RUNTIME_DSN, None),
+        (TEST_DBA_DSN, "eom_canonical"),
+    ]
+    assert migration_calls == [
+        runner.HISTORICAL_PRELUDE_MIGRATION_NAMES,
+        (runner.MIGRATION_NAME,),
+    ]
+    assert result["applied"] is True
+    assert runtime_pool.closed is True
+    assert dba_pool.closed is True
+
+
+def test_privilege_runner_rejects_non_direct_runtime_login_before_dba_pool() -> None:
+    runner = _load_runner_module()
+    runtime_pool = _Pool(
+        SimpleNamespace(
+            schema_name="eom_canonical",
+            current_user="other_runtime",
+            session_user="atlas_funnel",
+        )
+    )
+    pool_calls: list[tuple[str, str | None]] = []
+
+    async def create_pool(
+        database_url: str,
+        *,
+        schema_name: str | None = None,
+    ) -> _Pool:
+        pool_calls.append((database_url, schema_name))
+        assert database_url == TEST_RUNTIME_DSN
+        assert schema_name is None
+        return runtime_pool
+
+    with pytest.raises(
+        RuntimeError,
+        match="runtime connection must use its direct configured login",
+    ):
+        asyncio.run(
+            runner._run(
+                runner._parse_args(["--apply"]),
+                create_pool=create_pool,
+                funnel_config_factory=lambda: SimpleNamespace(
+                    db_connection_string=TEST_RUNTIME_DSN
+                ),
+            )
+        )
+
+    assert pool_calls == [(TEST_RUNTIME_DSN, None)]
+    assert runtime_pool.closed is True
+
+
+@pytest.mark.parametrize(
+    ("dba_schema_name", "dba_database_name", "dba_database_oid", "error"),
+    (
+        (
+            "other_schema",
+            "atlas",
+            16_384,
+            "did not resolve to the EOM funnel runtime schema",
+        ),
+        (
+            "eom_canonical",
+            "other_atlas",
+            16_384,
+            "does not target the EOM funnel runtime database",
+        ),
+        (
+            "eom_canonical",
+            "atlas",
+            16_385,
+            "does not target the EOM funnel runtime database",
+        ),
+    ),
+)
+def test_privilege_runner_rejects_dba_target_mismatch_before_mutation(
+    dba_schema_name: str,
+    dba_database_name: str,
+    dba_database_oid: int,
+    error: str,
+) -> None:
+    runner = _load_runner_module()
+    lock_state = SimpleNamespace()
+    runtime_pool = _Pool(
+        SimpleNamespace(
+            schema_name="eom_canonical",
+            advisory_lock_state=lock_state,
+        )
+    )
+    dba_state = SimpleNamespace(
+        schema_name=dba_schema_name,
+        database_name=dba_database_name,
+        database_oid=dba_database_oid,
+        advisory_lock_state=lock_state,
+    )
+    dba_pool = _Pool(dba_state)
+    migration_calls: list[object] = []
+
+    async def create_pool(
+        database_url: str,
+        *,
+        schema_name: str | None = None,
+    ) -> _Pool:
+        if database_url == TEST_RUNTIME_DSN:
+            assert schema_name is None
+            return runtime_pool
+        assert database_url == TEST_DBA_DSN
+        assert schema_name == "eom_canonical"
+        return dba_pool
+
+    async def run_migrations(*args: object, **_kwargs: object) -> None:
+        migration_calls.append(args)
+
+    with pytest.raises(RuntimeError, match=error):
+        asyncio.run(
+            runner._run(
+                runner._parse_args(["--apply"]),
+                create_pool=create_pool,
+                run_migrations_fn=run_migrations,
+                funnel_config_factory=lambda: SimpleNamespace(
+                    db_connection_string=TEST_RUNTIME_DSN
+                ),
+            )
+        )
+
+    assert getattr(dba_state, "executed", []) == []
+    assert migration_calls == []
+    assert runtime_pool.closed is True
+    assert dba_pool.closed is True
+
+
+def test_privilege_runner_rejects_same_named_clone_before_mutation() -> None:
+    """Name/OID equality alone is not enough when clusters do not share a lock."""
+
+    runner = _load_runner_module()
+    runtime_pool = _Pool(SimpleNamespace(schema_name="eom_canonical"))
+    dba_state = SimpleNamespace(
+        schema_name="eom_canonical",
+        executor_is_superuser=True,
+        migrations_table_exists=True,
+        recorded_migrations={runner.PREREQUISITE_MIGRATION_NAME},
+    )
+    dba_pool = _Pool(dba_state)
+    migration_calls: list[object] = []
+
+    async def create_pool(
+        database_url: str,
+        *,
+        schema_name: str | None = None,
+    ) -> _Pool:
+        if database_url == TEST_RUNTIME_DSN:
+            assert schema_name is None
+            return runtime_pool
+        assert database_url == TEST_DBA_DSN
+        assert schema_name == "eom_canonical"
+        return dba_pool
+
+    async def run_migrations(*args: object, **_kwargs: object) -> None:
+        migration_calls.append(args)
+
+    with pytest.raises(
+        RuntimeError,
+        match="does not share the EOM funnel runtime database",
+    ):
+        asyncio.run(
+            runner._run(
+                runner._parse_args(["--apply"]),
+                create_pool=create_pool,
+                run_migrations_fn=run_migrations,
+                funnel_config_factory=lambda: SimpleNamespace(
+                    db_connection_string=TEST_RUNTIME_DSN
+                ),
+            )
+        )
+
+    assert getattr(dba_state, "executed", []) == []
+    assert migration_calls == []
+    assert runtime_pool.closed is True
+    assert dba_pool.closed is True
+
+
+def test_privilege_runner_rejects_caller_selected_dsn_environment_name() -> None:
+    runner = _load_runner_module()
+
+    with pytest.raises(SystemExit):
+        runner._parse_args(["--database-url-env", "TEST_EOM_DBA_DSN"])

--- a/tests/test_eom_missed_call_privilege_runner.py
+++ b/tests/test_eom_missed_call_privilege_runner.py
@@ -1,0 +1,158 @@
+"""Unit proof for the controlled DBA migration entrypoint."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+from pathlib import Path
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = ROOT / "scripts" / "apply_eom_missed_call_recovery_runtime_privileges.py"
+
+
+def _load_runner_module() -> ModuleType:
+    module_name = "test_eom_missed_call_privilege_runner_script"
+    spec = importlib.util.spec_from_file_location(module_name, SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class _Acquire:
+    def __init__(self, connection: "_Connection") -> None:
+        self._connection = connection
+
+    async def __aenter__(self) -> "_Connection":
+        return self._connection
+
+    async def __aexit__(self, *_args: object) -> None:
+        return None
+
+
+class _Connection:
+    def __init__(self, state: SimpleNamespace) -> None:
+        self._state = state
+
+    async def fetchval(self, query: str, *_args: object) -> bool:
+        if "rolsuper" in query:
+            return self._state.executor_is_superuser
+        if "to_regclass" in query:
+            return self._state.migrations_table_exists
+        if "schema_migrations" in query:
+            return self._state.migration_recorded
+        raise AssertionError(f"unexpected query: {query}")
+
+
+class _Pool:
+    def __init__(self, state: SimpleNamespace) -> None:
+        self._connection = _Connection(state)
+        self.closed = False
+
+    def acquire(self) -> _Acquire:
+        return _Acquire(self._connection)
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def test_privilege_runner_defaults_to_read_only_and_redacts_dsn(monkeypatch) -> None:
+    runner = _load_runner_module()
+    monkeypatch.setenv(
+        "TEST_EOM_DBA_DSN",
+        "postgresql://operator:secret@example.test:5432/atlas?sslmode=require",
+    )
+    state = SimpleNamespace(
+        executor_is_superuser=True,
+        migrations_table_exists=True,
+        migration_recorded=False,
+    )
+    pool = _Pool(state)
+    calls: list[object] = []
+
+    async def create_pool(_database_url: str) -> _Pool:
+        return pool
+
+    async def run_migrations(*_args: object, **_kwargs: object) -> None:
+        calls.append(object())
+
+    args = runner._parse_args(["--database-url-env", "TEST_EOM_DBA_DSN"])
+    result = asyncio.run(
+        runner._run(
+            args,
+            create_pool=create_pool,
+            run_migrations_fn=run_migrations,
+        )
+    )
+
+    assert result == {
+        "target": "dsn=example.test:5432/atlas",
+        "executor_is_superuser": True,
+        "migration": runner.MIGRATION_NAME,
+        "migration_recorded": False,
+        "applied": False,
+    }
+    assert calls == []
+    assert pool.closed is True
+
+
+def test_privilege_runner_requires_superuser_before_apply(monkeypatch) -> None:
+    runner = _load_runner_module()
+    monkeypatch.setenv("TEST_EOM_DBA_DSN", "postgresql://example.test/atlas")
+    state = SimpleNamespace(
+        executor_is_superuser=False,
+        migrations_table_exists=True,
+        migration_recorded=False,
+    )
+    pool = _Pool(state)
+
+    async def create_pool(_database_url: str) -> _Pool:
+        return pool
+
+    args = runner._parse_args(
+        ["--database-url-env", "TEST_EOM_DBA_DSN", "--apply"]
+    )
+    with pytest.raises(RuntimeError, match="not a PostgreSQL superuser"):
+        asyncio.run(runner._run(args, create_pool=create_pool))
+    assert pool.closed is True
+
+
+def test_privilege_runner_applies_only_the_recorded_repair(monkeypatch) -> None:
+    runner = _load_runner_module()
+    monkeypatch.setenv("TEST_EOM_DBA_DSN", "postgresql://example.test/atlas")
+    state = SimpleNamespace(
+        executor_is_superuser=True,
+        migrations_table_exists=True,
+        migration_recorded=False,
+    )
+    pool = _Pool(state)
+    calls: list[tuple[object, tuple[str, ...]]] = []
+
+    async def create_pool(_database_url: str) -> _Pool:
+        return pool
+
+    async def run_migrations(observed_pool: object, *, only: tuple[str, ...]) -> None:
+        calls.append((observed_pool, only))
+        state.migration_recorded = True
+
+    args = runner._parse_args(
+        ["--database-url-env", "TEST_EOM_DBA_DSN", "--apply"]
+    )
+    result = asyncio.run(
+        runner._run(
+            args,
+            create_pool=create_pool,
+            run_migrations_fn=run_migrations,
+        )
+    )
+
+    assert calls == [(pool, (runner.MIGRATION_NAME,))]
+    assert result["migration_recorded"] is True
+    assert result["applied"] is True
+    assert pool.closed is True

--- a/tests/test_eom_missed_call_privilege_runner.py
+++ b/tests/test_eom_missed_call_privilege_runner.py
@@ -35,6 +35,12 @@ class _Acquire:
     async def __aexit__(self, *_args: object) -> None:
         return None
 
+    def __await__(self):
+        async def _connection() -> "_Connection":
+            return self._connection
+
+        return _connection().__await__()
+
 
 class _Connection:
     def __init__(self, state: SimpleNamespace) -> None:
@@ -50,6 +56,12 @@ class _Connection:
             return args[0] in self._state.recorded_migrations
         raise AssertionError(f"unexpected query: {query}")
 
+    async def execute(self, query: str, *args: object) -> None:
+        self._state.executed = getattr(self._state, "executed", [])
+        self._state.executed.append((query, args))
+        self._state.events = getattr(self._state, "events", [])
+        self._state.events.append(("execute", query, args))
+
 
 class _Pool:
     def __init__(self, state: SimpleNamespace) -> None:
@@ -59,8 +71,19 @@ class _Pool:
     def acquire(self) -> _Acquire:
         return _Acquire(self._connection)
 
+    async def release(self, connection: _Connection) -> None:
+        assert connection is self._connection
+
     async def close(self) -> None:
         self.closed = True
+
+
+@pytest.fixture(autouse=True)
+def _configured_runtime_dsn(monkeypatch) -> None:
+    monkeypatch.setenv(
+        "ATLAS_EOM_FUNNEL_DB_CONNECTION_STRING",
+        "postgresql://atlas_funnel:test-only@example.test:5432/atlas",
+    )
 
 
 def test_privilege_runner_defaults_to_read_only_and_redacts_dsn(monkeypatch) -> None:
@@ -95,6 +118,7 @@ def test_privilege_runner_defaults_to_read_only_and_redacts_dsn(monkeypatch) -> 
     assert result == {
         "target": "dsn=example.test:5432/atlas",
         "executor_is_superuser": True,
+        "runtime_role": "atlas_funnel",
         "historical_prelude_migrations": {
             name: False for name in runner.HISTORICAL_PRELUDE_MIGRATION_NAMES
         },
@@ -121,12 +145,41 @@ def test_privilege_runner_requires_superuser_before_apply(monkeypatch) -> None:
     async def create_pool(_database_url: str) -> _Pool:
         return pool
 
-    args = runner._parse_args(
-        ["--database-url-env", "TEST_EOM_DBA_DSN", "--apply"]
-    )
+    args = runner._parse_args(["--database-url-env", "TEST_EOM_DBA_DSN", "--apply"])
     with pytest.raises(RuntimeError, match="not a PostgreSQL superuser"):
         asyncio.run(runner._run(args, create_pool=create_pool))
     assert pool.closed is True
+
+
+def test_privilege_runner_rejects_missing_runtime_dsn(monkeypatch) -> None:
+    runner = _load_runner_module()
+    monkeypatch.setenv("TEST_EOM_DBA_DSN", "postgresql://example.test/atlas")
+    monkeypatch.delenv("ATLAS_EOM_FUNNEL_DB_CONNECTION_STRING")
+
+    args = runner._parse_args(["--database-url-env", "TEST_EOM_DBA_DSN"])
+    with pytest.raises(RuntimeError, match="Missing configured EOM runtime DSN"):
+        asyncio.run(runner._run(args))
+
+
+def test_runtime_role_migration_pool_binds_the_configured_role() -> None:
+    runner = _load_runner_module()
+    state = SimpleNamespace(
+        executor_is_superuser=True,
+        migrations_table_exists=True,
+        recorded_migrations=set(),
+    )
+    pool = _Pool(state)
+    migration_pool = runner._RuntimeRoleMigrationPool(pool, "atlas_funnel")
+
+    connection = asyncio.run(migration_pool.acquire())
+    asyncio.run(migration_pool.release(connection))
+
+    assert state.executed == [
+        (
+            "SELECT pg_catalog.set_config($1, $2, FALSE)",
+            (runner.RUNTIME_ROLE_SETTING, "atlas_funnel"),
+        )
+    ]
 
 
 def test_privilege_runner_applies_only_the_recorded_repair(monkeypatch) -> None:
@@ -150,9 +203,7 @@ def test_privilege_runner_applies_only_the_recorded_repair(monkeypatch) -> None:
         else:
             assert only == runner.HISTORICAL_PRELUDE_MIGRATION_NAMES
 
-    args = runner._parse_args(
-        ["--database-url-env", "TEST_EOM_DBA_DSN", "--apply"]
-    )
+    args = runner._parse_args(["--database-url-env", "TEST_EOM_DBA_DSN", "--apply"])
     result = asyncio.run(
         runner._run(
             args,
@@ -161,10 +212,16 @@ def test_privilege_runner_applies_only_the_recorded_repair(monkeypatch) -> None:
         )
     )
 
-    assert calls == [
-        (pool, runner.HISTORICAL_PRELUDE_MIGRATION_NAMES),
-        (pool, (runner.MIGRATION_NAME,)),
+    assert [only for _pool, only in calls] == [
+        runner.HISTORICAL_PRELUDE_MIGRATION_NAMES,
+        (runner.MIGRATION_NAME,),
     ]
+    assert all(
+        isinstance(observed_pool, runner._RuntimeRoleMigrationPool)
+        and observed_pool._pool is pool
+        and observed_pool._runtime_role == "atlas_funnel"
+        for observed_pool, _only in calls
+    )
     assert result["prerequisite_migration_recorded"] is True
     assert result["migration_recorded"] is True
     assert result["applied"] is True
@@ -219,9 +276,7 @@ def test_privilege_runner_refuses_apply_without_prerequisite_receipt(
         assert isinstance(only, tuple)
         calls.append(only)
 
-    args = runner._parse_args(
-        ["--database-url-env", "TEST_EOM_DBA_DSN", "--apply"]
-    )
+    args = runner._parse_args(["--database-url-env", "TEST_EOM_DBA_DSN", "--apply"])
     with pytest.raises(
         RuntimeError,
         match="389_eom_missed_call_recovery is not recorded",
@@ -236,10 +291,7 @@ def test_privilege_runner_refuses_apply_without_prerequisite_receipt(
 
     expected_calls = (
         []
-        if (
-            not migrations_table_exists
-            or runner.MIGRATION_NAME in recorded_migrations
-        )
+        if (not migrations_table_exists or runner.MIGRATION_NAME in recorded_migrations)
         else [runner.HISTORICAL_PRELUDE_MIGRATION_NAMES]
     )
     assert calls == expected_calls
@@ -273,9 +325,7 @@ def test_privilege_runner_applies_historical_preludes_before_privilege_repair(
         else:  # pragma: no cover - regression guard for this controlled runner
             raise AssertionError(f"unexpected migration selection: {only}")
 
-    args = runner._parse_args(
-        ["--database-url-env", "TEST_EOM_DBA_DSN", "--apply"]
-    )
+    args = runner._parse_args(["--database-url-env", "TEST_EOM_DBA_DSN", "--apply"])
     result = asyncio.run(
         runner._run(
             args,
@@ -297,6 +347,49 @@ def test_privilege_runner_applies_historical_preludes_before_privilege_repair(
     assert result["migration_recorded"] is True
     assert result["applied"] is True
     assert pool.closed is True
+
+
+def test_privilege_runner_provisions_pgcrypto_before_historical_preludes(
+    monkeypatch,
+) -> None:
+    runner = _load_runner_module()
+    monkeypatch.setenv("TEST_EOM_DBA_DSN", "postgresql://example.test/atlas")
+    state = SimpleNamespace(
+        executor_is_superuser=True,
+        migrations_table_exists=True,
+        recorded_migrations={runner.PREREQUISITE_MIGRATION_NAME},
+        events=[],
+    )
+    pool = _Pool(state)
+
+    async def create_pool(_database_url: str) -> _Pool:
+        return pool
+
+    async def run_migrations(_pool: object, *, only: tuple[str, ...]) -> None:
+        state.events.append(("migration", only))
+        if only == runner.HISTORICAL_PRELUDE_MIGRATION_NAMES:
+            state.recorded_migrations.add(runner.HISTORICAL_PRELUDE_MIGRATION_NAMES[0])
+        elif only == (runner.MIGRATION_NAME,):
+            state.recorded_migrations.add(runner.MIGRATION_NAME)
+
+    args = runner._parse_args(["--database-url-env", "TEST_EOM_DBA_DSN", "--apply"])
+    asyncio.run(
+        runner._run(
+            args,
+            create_pool=create_pool,
+            run_migrations_fn=run_migrations,
+        )
+    )
+
+    assert state.events[0] == (
+        "execute",
+        "CREATE EXTENSION IF NOT EXISTS pgcrypto",
+        (),
+    )
+    assert state.events[1] == (
+        "migration",
+        runner.HISTORICAL_PRELUDE_MIGRATION_NAMES,
+    )
 
 
 def test_privilege_runner_continues_after_committed_historical_progress_stop(
@@ -331,9 +424,7 @@ def test_privilege_runner_continues_after_committed_historical_progress_stop(
         else:  # pragma: no cover - regression guard for this controlled runner
             raise AssertionError(f"unexpected migration selection: {only}")
 
-    args = runner._parse_args(
-        ["--database-url-env", "TEST_EOM_DBA_DSN", "--apply"]
-    )
+    args = runner._parse_args(["--database-url-env", "TEST_EOM_DBA_DSN", "--apply"])
     result = asyncio.run(
         runner._run(
             args,
@@ -383,9 +474,7 @@ def test_privilege_runner_reraises_non_prelude_progress_stop(
             "historical prelude did not advance"
         )
 
-    args = runner._parse_args(
-        ["--database-url-env", "TEST_EOM_DBA_DSN", "--apply"]
-    )
+    args = runner._parse_args(["--database-url-env", "TEST_EOM_DBA_DSN", "--apply"])
     with pytest.raises(
         runner.PendingMigrationContentIntegrityError,
         match="historical prelude did not advance",

--- a/tests/test_eom_missed_call_privilege_runner.py
+++ b/tests/test_eom_missed_call_privilege_runner.py
@@ -40,13 +40,14 @@ class _Connection:
     def __init__(self, state: SimpleNamespace) -> None:
         self._state = state
 
-    async def fetchval(self, query: str, *_args: object) -> bool:
+    async def fetchval(self, query: str, *args: object) -> bool:
         if "rolsuper" in query:
             return self._state.executor_is_superuser
         if "to_regclass" in query:
             return self._state.migrations_table_exists
         if "schema_migrations" in query:
-            return self._state.migration_recorded
+            assert len(args) == 1
+            return args[0] in self._state.recorded_migrations
         raise AssertionError(f"unexpected query: {query}")
 
 
@@ -71,7 +72,7 @@ def test_privilege_runner_defaults_to_read_only_and_redacts_dsn(monkeypatch) -> 
     state = SimpleNamespace(
         executor_is_superuser=True,
         migrations_table_exists=True,
-        migration_recorded=False,
+        recorded_migrations=set(),
     )
     pool = _Pool(state)
     calls: list[object] = []
@@ -94,6 +95,8 @@ def test_privilege_runner_defaults_to_read_only_and_redacts_dsn(monkeypatch) -> 
     assert result == {
         "target": "dsn=example.test:5432/atlas",
         "executor_is_superuser": True,
+        "prerequisite_migration": runner.PREREQUISITE_MIGRATION_NAME,
+        "prerequisite_migration_recorded": False,
         "migration": runner.MIGRATION_NAME,
         "migration_recorded": False,
         "applied": False,
@@ -108,7 +111,7 @@ def test_privilege_runner_requires_superuser_before_apply(monkeypatch) -> None:
     state = SimpleNamespace(
         executor_is_superuser=False,
         migrations_table_exists=True,
-        migration_recorded=False,
+        recorded_migrations={runner.PREREQUISITE_MIGRATION_NAME},
     )
     pool = _Pool(state)
 
@@ -129,7 +132,7 @@ def test_privilege_runner_applies_only_the_recorded_repair(monkeypatch) -> None:
     state = SimpleNamespace(
         executor_is_superuser=True,
         migrations_table_exists=True,
-        migration_recorded=False,
+        recorded_migrations={runner.PREREQUISITE_MIGRATION_NAME},
     )
     pool = _Pool(state)
     calls: list[tuple[object, tuple[str, ...]]] = []
@@ -139,7 +142,7 @@ def test_privilege_runner_applies_only_the_recorded_repair(monkeypatch) -> None:
 
     async def run_migrations(observed_pool: object, *, only: tuple[str, ...]) -> None:
         calls.append((observed_pool, only))
-        state.migration_recorded = True
+        state.recorded_migrations.add(runner.MIGRATION_NAME)
 
     args = runner._parse_args(
         ["--database-url-env", "TEST_EOM_DBA_DSN", "--apply"]
@@ -153,6 +156,72 @@ def test_privilege_runner_applies_only_the_recorded_repair(monkeypatch) -> None:
     )
 
     assert calls == [(pool, (runner.MIGRATION_NAME,))]
+    assert result["prerequisite_migration_recorded"] is True
     assert result["migration_recorded"] is True
     assert result["applied"] is True
+    assert pool.closed is True
+
+
+@pytest.mark.parametrize(
+    ("migrations_table_exists", "recorded_migrations"),
+    [
+        (False, frozenset()),
+        (True, frozenset()),
+        (True, frozenset({"388_unrelated_migration"})),
+        (True, frozenset({"393_eom_missed_call_recovery_runtime_privileges"})),
+        (
+            True,
+            frozenset(
+                {
+                    "388_unrelated_migration",
+                    "393_eom_missed_call_recovery_runtime_privileges",
+                }
+            ),
+        ),
+    ],
+    ids=(
+        "no-ledger-table",
+        "empty-ledger",
+        "unrelated-receipt",
+        "repair-without-prerequisite",
+        "mixed-receipts-without-prerequisite",
+    ),
+)
+def test_privilege_runner_refuses_apply_without_prerequisite_receipt(
+    monkeypatch,
+    migrations_table_exists: bool,
+    recorded_migrations: frozenset[str],
+) -> None:
+    runner = _load_runner_module()
+    monkeypatch.setenv("TEST_EOM_DBA_DSN", "postgresql://example.test/atlas")
+    state = SimpleNamespace(
+        executor_is_superuser=True,
+        migrations_table_exists=migrations_table_exists,
+        recorded_migrations=set(recorded_migrations),
+    )
+    pool = _Pool(state)
+    calls: list[object] = []
+
+    async def create_pool(_database_url: str) -> _Pool:
+        return pool
+
+    async def run_migrations(*_args: object, **_kwargs: object) -> None:
+        calls.append(object())
+
+    args = runner._parse_args(
+        ["--database-url-env", "TEST_EOM_DBA_DSN", "--apply"]
+    )
+    with pytest.raises(
+        RuntimeError,
+        match="389_eom_missed_call_recovery is not recorded",
+    ):
+        asyncio.run(
+            runner._run(
+                args,
+                create_pool=create_pool,
+                run_migrations_fn=run_migrations,
+            )
+        )
+
+    assert calls == []
     assert pool.closed is True

--- a/tests/test_eom_missed_call_recovery.py
+++ b/tests/test_eom_missed_call_recovery.py
@@ -105,6 +105,12 @@ _TRUSTED_BRIDGE_FUNCTIONS = (
 _TRUSTED_APPEND_ONLY_FENCE_FUNCTION_SIGNATURES = (
     "prevent_eom_missed_call_operation_receipt_mutation()",
     "prevent_eom_missed_call_attempt_mutation()",
+    "prevent_eom_missed_call_sequence_event_mutation()",
+    "prevent_eom_missed_call_suppression_mutation()",
+)
+_TRUSTED_SCOPE_VALIDATOR_FUNCTION_SIGNATURES = (
+    "validate_eom_missed_call_contact_scope()",
+    "validate_eom_missed_call_sequence_scope()",
 )
 _TRUSTED_APPEND_ONLY_FENCE_FUNCTIONS = (
     (
@@ -117,6 +123,50 @@ _TRUSTED_APPEND_ONLY_FENCE_FUNCTIONS = (
         "prevent_eom_missed_call_attempt_mutation",
         "plpgsql",
     ),
+    (
+        "prevent_eom_missed_call_sequence_event_mutation()",
+        "prevent_eom_missed_call_sequence_event_mutation",
+        "plpgsql",
+    ),
+    (
+        "prevent_eom_missed_call_suppression_mutation()",
+        "prevent_eom_missed_call_suppression_mutation",
+        "plpgsql",
+    ),
+)
+_TRUSTED_GUARD_SUPPORT_FUNCTIONS = (
+    (
+        "validate_eom_missed_call_contact_scope()",
+        "validate_eom_missed_call_contact_scope",
+        "plpgsql",
+    ),
+    (
+        "validate_eom_missed_call_sequence_scope()",
+        "validate_eom_missed_call_sequence_scope",
+        "plpgsql",
+    ),
+    (
+        "eom_missed_call_has_proven_inbound_sms(JSONB)",
+        "eom_missed_call_has_proven_inbound_sms",
+        "sql",
+    ),
+)
+_TRUSTED_GUARD_FUNCTIONS = (
+    *_TRUSTED_BRIDGE_FUNCTIONS,
+    *_TRUSTED_APPEND_ONLY_FENCE_FUNCTIONS,
+    *_TRUSTED_GUARD_SUPPORT_FUNCTIONS,
+)
+_TRUSTED_GUARD_FUNCTION_SIGNATURES = tuple(
+    function_signature
+    for function_signature, _function_name, _language_name in _TRUSTED_GUARD_FUNCTIONS
+)
+_TRUSTED_DEFINER_FUNCTION_SIGNATURES = (
+    *_TRUSTED_BRIDGE_FUNCTION_SIGNATURES,
+    *_TRUSTED_SCOPE_VALIDATOR_FUNCTION_SIGNATURES,
+)
+_MUTABLE_EVIDENCE_FENCE_FUNCTION_SIGNATURES = (
+    "prevent_eom_missed_call_operation_receipt_mutation()",
+    "prevent_eom_missed_call_attempt_mutation()",
 )
 
 
@@ -226,11 +276,7 @@ def test_privilege_repair_trusted_function_bodies_match_migration_389_source() -
     assert repair.index(extension_install) < repair.index(
         "SELECT namespace_state.nspname"
     )
-    trusted_functions = (
-        *_TRUSTED_BRIDGE_FUNCTIONS,
-        *_TRUSTED_APPEND_ONLY_FENCE_FUNCTIONS,
-    )
-    for signature, function_name, language_name in trusted_functions:
+    for signature, function_name, language_name in _TRUSTED_GUARD_FUNCTIONS:
         function_match = re.search(
             rf"CREATE OR REPLACE FUNCTION {re.escape(function_name)}\b(.*?)"
             r"(?=\nCREATE OR REPLACE FUNCTION|\Z)",
@@ -239,7 +285,7 @@ def test_privilege_repair_trusted_function_bodies_match_migration_389_source() -
         )
         assert function_match is not None, function_name
         language_and_body_match = re.search(
-            r"LANGUAGE\s+([A-Za-z0-9_]+)(?:\s+STABLE)?\s+AS \$\$(.*?)\$\$;",
+            r"LANGUAGE\s+([A-Za-z0-9_]+)(?:\s+(?:STABLE|IMMUTABLE))?\s+AS \$\$(.*?)\$\$;",
             function_match.group(1),
             re.DOTALL,
         )
@@ -253,17 +299,33 @@ def test_privilege_repair_trusted_function_bodies_match_migration_389_source() -
         )
         assert expected_entry.search(repair), signature
 
-        if signature in _TRUSTED_APPEND_ONLY_FENCE_FUNCTION_SIGNATURES:
-            readiness_body = "E'" + (
-                language_and_body_match.group(2)
-                .replace("\\", "\\\\")
-                .replace("'", "''")
-                .replace("\n", "\\\\n")
-            ) + "'"
+        if signature in _MUTABLE_EVIDENCE_FENCE_FUNCTION_SIGNATURES:
+            readiness_body = (
+                "E'"
+                + (
+                    language_and_body_match.group(2)
+                    .replace("\\", "\\\\")
+                    .replace("'", "''")
+                    .replace("\n", "\\\\n")
+                )
+                + "'"
+            )
             assert signature in readiness
             assert readiness_body in readiness
     assert "language_state.lanname = 'plpgsql'" in readiness
-    assert "REVOKE ALL ON FUNCTION %I.%s FROM atlas" in repair
+    assert "REVOKE ALL ON FUNCTION %I.%s FROM %I" in repair
+    assert "pg_catalog.aclexplode(" in repair
+    assert "atlas.eom_missed_call_recovery_runtime_role" in repair
+    assert (
+        recovery_mod._MISSED_CALL_RECOVERY_GUARD_FUNCTION_SIGNATURES
+        == _TRUSTED_GUARD_FUNCTION_SIGNATURES
+    )
+    assert (
+        recovery_mod._MISSED_CALL_RECOVERY_DEFINER_FUNCTION_SIGNATURES
+        == _TRUSTED_DEFINER_FUNCTION_SIGNATURES
+    )
+    assert "COUNT(*) = cardinality($1::text[])" in readiness
+    assert "COUNT(*) = cardinality($2::text[])" in readiness
     assert (
         "AND NOT has_function_privilege(\n"
         "                                  current_user, procedure.oid, 'EXECUTE'\n"
@@ -350,6 +412,12 @@ async def _replace_append_only_fence_function(
         "prevent_eom_missed_call_attempt_mutation()": (
             "prevent_eom_missed_call_attempt_mutation"
         ),
+        "prevent_eom_missed_call_sequence_event_mutation()": (
+            "prevent_eom_missed_call_sequence_event_mutation"
+        ),
+        "prevent_eom_missed_call_suppression_mutation()": (
+            "prevent_eom_missed_call_suppression_mutation"
+        ),
     }
     function_name = function_names[function_signature]
     await connection.execute(
@@ -374,6 +442,58 @@ async def _tamper_append_only_fence_function(
     )
 
 
+async def _tamper_guard_function(
+    connection: Any,
+    *,
+    schema: str,
+    function_signature: str,
+) -> None:
+    """Replace one function that participates in the guarded recovery graph."""
+
+    if function_signature in _TRUSTED_BRIDGE_FUNCTION_SIGNATURES:
+        await _tamper_bridge_function(
+            connection,
+            schema=schema,
+            function_signature=function_signature,
+        )
+        return
+    if function_signature in _TRUSTED_APPEND_ONLY_FENCE_FUNCTION_SIGNATURES:
+        await _tamper_append_only_fence_function(
+            connection,
+            schema=schema,
+            function_signature=function_signature,
+        )
+        return
+
+    schema_ident = _quote_ident(schema)
+    definitions = {
+        "validate_eom_missed_call_contact_scope()": f"""
+            CREATE OR REPLACE FUNCTION {schema_ident}.validate_eom_missed_call_contact_scope()
+            RETURNS TRIGGER LANGUAGE plpgsql AS $$
+            BEGIN
+                RETURN NEW;
+            END;
+            $$;
+        """,
+        "validate_eom_missed_call_sequence_scope()": f"""
+            CREATE OR REPLACE FUNCTION {schema_ident}.validate_eom_missed_call_sequence_scope()
+            RETURNS TRIGGER LANGUAGE plpgsql AS $$
+            BEGIN
+                RETURN NEW;
+            END;
+            $$;
+        """,
+        "eom_missed_call_has_proven_inbound_sms(JSONB)": f"""
+            CREATE OR REPLACE FUNCTION {schema_ident}.eom_missed_call_has_proven_inbound_sms(
+                JSONB
+            ) RETURNS BOOLEAN LANGUAGE sql IMMUTABLE AS $$
+            SELECT TRUE;
+            $$;
+        """,
+    }
+    await connection.execute(definitions[function_signature])
+
+
 async def _restore_append_only_fence_function(
     connection: Any,
     *,
@@ -393,9 +513,7 @@ async def _restore_append_only_fence_function(
         schema=schema,
         function_signature=function_signature,
         body=(
-            "\nBEGIN\n"
-            f"    RAISE EXCEPTION '{messages[function_signature]}';\n"
-            "END;\n"
+            f"\nBEGIN\n    RAISE EXCEPTION '{messages[function_signature]}';\nEND;\n"
         ),
     )
 
@@ -475,8 +593,7 @@ async def _provision_privilege_repair_roles(connection: Any) -> None:
     )
     for member in guard_members:
         await connection.execute(
-            "REVOKE atlas_eom_handoff_owner FROM "
-            f"{_quote_ident(member['rolname'])}"
+            f"REVOKE atlas_eom_handoff_owner FROM {_quote_ident(member['rolname'])}"
         )
     database_name = await connection.fetchval("SELECT current_database()")
     await connection.execute(
@@ -673,6 +790,24 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
                 "WHERE extname = 'pgcrypto')"
             )
             await _provision_privilege_repair_roles(connection)
+            database_name = await connection.fetchval("SELECT current_database()")
+            await connection.execute(
+                f"CREATE ROLE {runtime_probe_ident} LOGIN NOINHERIT "
+                f"PASSWORD '{_RUNTIME_PROBE_PASSWORD}'"
+            )
+            runtime_role_created = True
+            await connection.execute(
+                f"GRANT CONNECT ON DATABASE {_quote_ident(database_name)} "
+                f"TO {runtime_probe_ident}"
+            )
+            await connection.execute(
+                f"GRANT USAGE ON SCHEMA {_quote_ident(schema)} TO {runtime_probe_ident}"
+            )
+            await connection.execute(
+                "SELECT pg_catalog.set_config("
+                "'atlas.eom_missed_call_recovery_runtime_role', $1, FALSE)",
+                runtime_probe_role,
+            )
             runtime_contact_id = await _insert_estimate_lead(
                 admin_pool,
                 email="runtime-privilege@example.test",
@@ -689,11 +824,11 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
             # because the table is being transferred from its old owner.
             await connection.execute(
                 f"GRANT DELETE ON TABLE {_quote_ident(schema)}."
-                "eom_missed_call_sequences TO atlas"
+                f"eom_missed_call_sequences TO {runtime_probe_ident}"
             )
             await connection.execute(
                 f"GRANT UPDATE (recipient_email) ON TABLE {_quote_ident(schema)}."
-                "eom_missed_call_sequences TO atlas"
+                f"eom_missed_call_sequences TO {runtime_probe_ident}"
             )
             await connection.execute(
                 f"GRANT SELECT (recipient_email) ON TABLE {_quote_ident(schema)}."
@@ -707,6 +842,21 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
             await connection.execute(
                 f"GRANT EXECUTE ON FUNCTION {_quote_ident(schema)}."
                 "cancel_eom_missed_call_sequences_for_contact(UUID, VARCHAR, VARCHAR) "
+                f"TO {runtime_probe_ident}"
+            )
+            await connection.execute(
+                f"GRANT EXECUTE ON FUNCTION {_quote_ident(schema)}."
+                "validate_eom_missed_call_contact_scope() "
+                f"TO {runtime_probe_ident}"
+            )
+            await connection.execute(
+                f"GRANT EXECUTE ON FUNCTION {_quote_ident(schema)}."
+                "cancel_eom_missed_call_sequences_for_contact(UUID, VARCHAR, VARCHAR) "
+                "TO atlas"
+            )
+            await connection.execute(
+                f"GRANT EXECUTE ON FUNCTION {_quote_ident(schema)}."
+                "validate_eom_missed_call_contact_scope() "
                 "TO atlas"
             )
             await connection.execute(
@@ -749,9 +899,38 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
                     "eom_missed_call_sequence_events",
                 ],
             )
-            assert {row["owner"] for row in table_rows} == {
-                "atlas_eom_handoff_owner"
-            }
+            assert {row["owner"] for row in table_rows} == {"atlas_eom_handoff_owner"}
+            for function_signature in _TRUSTED_GUARD_FUNCTION_SIGNATURES:
+                qualified_signature = f"{_quote_ident(schema)}.{function_signature}"
+                assert await connection.fetchval(
+                    """
+                    SELECT owner_role.rolname = 'atlas_eom_handoff_owner'
+                    FROM pg_catalog.pg_proc AS procedure
+                    JOIN pg_catalog.pg_roles AS owner_role
+                      ON owner_role.oid = procedure.proowner
+                    WHERE procedure.oid = pg_catalog.to_regprocedure($1::text)
+                    """,
+                    qualified_signature,
+                )
+            for function_signature in _TRUSTED_SCOPE_VALIDATOR_FUNCTION_SIGNATURES:
+                qualified_signature = f"{_quote_ident(schema)}.{function_signature}"
+                assert await connection.fetchval(
+                    """
+                    SELECT procedure.prosecdef
+                       AND COALESCE(
+                           procedure.proconfig @> ARRAY[
+                               format(
+                                   'search_path=pg_catalog, %I, pg_temp',
+                                   current_schema()
+                               )
+                           ],
+                           FALSE
+                       )
+                    FROM pg_catalog.pg_proc AS procedure
+                    WHERE procedure.oid = pg_catalog.to_regprocedure($1::text)
+                    """,
+                    qualified_signature,
+                )
 
             runtime_acl_rows = await connection.fetch(
                 """
@@ -761,7 +940,7 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
                 CROSS JOIN LATERAL aclexplode(relation.relacl) AS acl
                 WHERE namespace.nspname = current_schema()
                   AND relation.relname = ANY($1::text[])
-                  AND acl.grantee = (SELECT oid FROM pg_roles WHERE rolname = 'atlas')
+                  AND acl.grantee = (SELECT oid FROM pg_roles WHERE rolname = $2)
                 ORDER BY relation.relname, acl.privilege_type
                 """,
                 [
@@ -772,12 +951,11 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
                     "eom_missed_call_sequence_steps",
                     "eom_missed_call_sequence_events",
                 ],
+                runtime_probe_role,
             )
             runtime_acl: dict[str, set[str]] = {}
             for row in runtime_acl_rows:
-                runtime_acl.setdefault(row["relname"], set()).add(
-                    row["privilege_type"]
-                )
+                runtime_acl.setdefault(row["relname"], set()).add(row["privilege_type"])
             assert runtime_acl == {
                 "eom_missed_call_operation_receipts": {"INSERT", "SELECT", "UPDATE"},
                 "eom_missed_call_attempts": {"INSERT", "SELECT", "UPDATE"},
@@ -786,14 +964,39 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
                 "eom_missed_call_sequence_steps": {"INSERT", "SELECT", "UPDATE"},
                 "eom_missed_call_sequence_events": {"INSERT", "SELECT"},
             }
-            for function_signature in _TRUSTED_BRIDGE_FUNCTION_SIGNATURES:
+            for function_signature in _TRUSTED_DEFINER_FUNCTION_SIGNATURES:
                 qualified_signature = f"{_quote_ident(schema)}.{function_signature}"
                 assert not await connection.fetchval(
                     """
                     SELECT has_function_privilege(
-                        'atlas',
-                        pg_catalog.to_regprocedure($1::text),
+                        $1::text,
+                        pg_catalog.to_regprocedure($2::text),
                         'EXECUTE'
+                    )
+                    """,
+                    runtime_probe_role,
+                    qualified_signature,
+                )
+            for function_signature in _TRUSTED_DEFINER_FUNCTION_SIGNATURES:
+                qualified_signature = f"{_quote_ident(schema)}.{function_signature}"
+                assert not await connection.fetchval(
+                    """
+                    SELECT EXISTS (
+                        SELECT 1
+                        FROM pg_catalog.pg_proc AS procedure
+                        CROSS JOIN LATERAL pg_catalog.aclexplode(
+                            COALESCE(
+                                procedure.proacl,
+                                pg_catalog.acldefault('f', procedure.proowner)
+                            )
+                        ) AS function_acl
+                        WHERE procedure.oid = pg_catalog.to_regprocedure($1::text)
+                          AND function_acl.grantee = (
+                              SELECT oid
+                              FROM pg_catalog.pg_roles
+                              WHERE rolname = 'atlas'
+                          )
+                          AND function_acl.privilege_type = 'EXECUTE'
                     )
                     """,
                     qualified_signature,
@@ -809,10 +1012,12 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
                   AND relation.relname = ANY($1::text[])
                   AND attribute.attnum > 0
                   AND NOT attribute.attisdropped
-                  AND acl.grantee IN (
-                      0,
-                      (SELECT oid FROM pg_roles WHERE rolname = 'atlas'),
-                      (SELECT oid FROM pg_roles WHERE rolname = 'atlas_nocodb')
+                  AND acl.grantee = ANY(
+                      ARRAY[0::oid] || ARRAY(
+                          SELECT oid
+                          FROM pg_roles
+                          WHERE rolname = ANY($2::text[])
+                      )
                   )
                 """,
                 [
@@ -823,38 +1028,9 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
                     "eom_missed_call_sequence_steps",
                     "eom_missed_call_sequence_events",
                 ],
+                ["atlas", runtime_probe_role, "atlas_nocodb"],
             )
             assert stale_column_acl_rows == []
-
-            database_name = await connection.fetchval("SELECT current_database()")
-            await connection.execute(
-                f"CREATE ROLE {runtime_probe_ident} LOGIN NOINHERIT "
-                f"PASSWORD '{_RUNTIME_PROBE_PASSWORD}'"
-            )
-            runtime_role_created = True
-            await connection.execute(
-                f"GRANT CONNECT ON DATABASE {_quote_ident(database_name)} "
-                f"TO {runtime_probe_ident}"
-            )
-            await connection.execute(
-                f"GRANT USAGE ON SCHEMA {_quote_ident(schema)} TO {runtime_probe_ident}"
-            )
-            await connection.execute(
-                f"GRANT SELECT ON TABLE {_quote_ident(schema)}.contacts "
-                f"TO {runtime_probe_ident}"
-            )
-            for table_name, privileges in (
-                ("eom_missed_call_operation_receipts", "SELECT, INSERT, UPDATE"),
-                ("eom_missed_call_attempts", "SELECT, INSERT, UPDATE"),
-                ("eom_missed_call_contact_suppressions", "SELECT, INSERT"),
-                ("eom_missed_call_sequences", "SELECT, INSERT, UPDATE"),
-                ("eom_missed_call_sequence_steps", "SELECT, INSERT, UPDATE"),
-                ("eom_missed_call_sequence_events", "SELECT, INSERT"),
-            ):
-                await connection.execute(
-                    f"GRANT {privileges} ON TABLE {_quote_ident(schema)}."
-                    f"{_quote_ident(table_name)} TO {runtime_probe_ident}"
-                )
 
             runtime_connection = await asyncpg.connect(
                 database_url,
@@ -868,11 +1044,41 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
             assert await recovery_mod.missed_call_recovery_schema_ready(runtime_pool)
 
             await connection.execute(
+                f"ALTER FUNCTION {_quote_ident(schema)}."
+                "eom_missed_call_has_proven_inbound_sms(JSONB) "
+                f"OWNER TO {runtime_probe_ident}"
+            )
+            assert not await recovery_mod.missed_call_recovery_schema_ready(
+                runtime_pool
+            )
+            await connection.execute(
+                f"ALTER FUNCTION {_quote_ident(schema)}."
+                "eom_missed_call_has_proven_inbound_sms(JSONB) "
+                "OWNER TO atlas_eom_handoff_owner"
+            )
+            assert await recovery_mod.missed_call_recovery_schema_ready(runtime_pool)
+
+            await connection.execute(
+                f"ALTER FUNCTION {_quote_ident(schema)}."
+                "validate_eom_missed_call_contact_scope() SECURITY INVOKER"
+            )
+            assert not await recovery_mod.missed_call_recovery_schema_ready(
+                runtime_pool
+            )
+            await connection.execute(
+                f"ALTER FUNCTION {_quote_ident(schema)}."
+                "validate_eom_missed_call_contact_scope() SECURITY DEFINER"
+            )
+            assert await recovery_mod.missed_call_recovery_schema_ready(runtime_pool)
+
+            await connection.execute(
                 f"GRANT EXECUTE ON FUNCTION {_quote_ident(schema)}."
                 "cancel_eom_missed_call_sequences_for_contact(UUID, VARCHAR, VARCHAR) "
                 f"TO {runtime_probe_ident}"
             )
-            assert not await recovery_mod.missed_call_recovery_schema_ready(runtime_pool)
+            assert not await recovery_mod.missed_call_recovery_schema_ready(
+                runtime_pool
+            )
             await connection.execute(
                 f"REVOKE EXECUTE ON FUNCTION {_quote_ident(schema)}."
                 "cancel_eom_missed_call_sequences_for_contact(UUID, VARCHAR, VARCHAR) "
@@ -880,7 +1086,7 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
             )
             assert await recovery_mod.missed_call_recovery_schema_ready(runtime_pool)
 
-            for function_signature in _TRUSTED_APPEND_ONLY_FENCE_FUNCTION_SIGNATURES:
+            for function_signature in _MUTABLE_EVIDENCE_FENCE_FUNCTION_SIGNATURES:
                 await _tamper_append_only_fence_function(
                     connection,
                     schema=schema,
@@ -902,7 +1108,9 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
                 f"REVOKE INSERT ON TABLE {_quote_ident(schema)}."
                 f"eom_missed_call_sequence_events FROM {runtime_probe_ident}"
             )
-            assert not await recovery_mod.missed_call_recovery_schema_ready(runtime_pool)
+            assert not await recovery_mod.missed_call_recovery_schema_ready(
+                runtime_pool
+            )
             await connection.execute(
                 f"GRANT INSERT ON TABLE {_quote_ident(schema)}."
                 f"eom_missed_call_sequence_events TO {runtime_probe_ident}"
@@ -913,7 +1121,9 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
                 f"REVOKE UPDATE ON TABLE {_quote_ident(schema)}."
                 f"eom_missed_call_operation_receipts FROM {runtime_probe_ident}"
             )
-            assert not await recovery_mod.missed_call_recovery_schema_ready(runtime_pool)
+            assert not await recovery_mod.missed_call_recovery_schema_ready(
+                runtime_pool
+            )
             await connection.execute(
                 f"GRANT UPDATE ON TABLE {_quote_ident(schema)}."
                 f"eom_missed_call_operation_receipts TO {runtime_probe_ident}"
@@ -924,7 +1134,9 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
                 f"GRANT DELETE ON TABLE {_quote_ident(schema)}."
                 f"eom_missed_call_sequences TO {runtime_probe_ident}"
             )
-            assert not await recovery_mod.missed_call_recovery_schema_ready(runtime_pool)
+            assert not await recovery_mod.missed_call_recovery_schema_ready(
+                runtime_pool
+            )
             await connection.execute(
                 f"REVOKE DELETE ON TABLE {_quote_ident(schema)}."
                 f"eom_missed_call_sequences FROM {runtime_probe_ident}"
@@ -935,7 +1147,9 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
                 f"GRANT REFERENCES (recipient_email) ON TABLE {_quote_ident(schema)}."
                 "eom_missed_call_sequences TO atlas_nocodb"
             )
-            assert not await recovery_mod.missed_call_recovery_schema_ready(runtime_pool)
+            assert not await recovery_mod.missed_call_recovery_schema_ready(
+                runtime_pool
+            )
             await connection.execute(
                 f"REVOKE REFERENCES (recipient_email) ON TABLE {_quote_ident(schema)}."
                 "eom_missed_call_sequences FROM atlas_nocodb"
@@ -946,7 +1160,9 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
                 f"GRANT TRIGGER ON TABLE {_quote_ident(schema)}."
                 "eom_missed_call_sequences TO atlas_nocodb"
             )
-            assert not await recovery_mod.missed_call_recovery_schema_ready(runtime_pool)
+            assert not await recovery_mod.missed_call_recovery_schema_ready(
+                runtime_pool
+            )
             await connection.execute(
                 f"REVOKE TRIGGER ON TABLE {_quote_ident(schema)}."
                 "eom_missed_call_sequences FROM atlas_nocodb"
@@ -956,18 +1172,22 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
             await connection.execute(
                 f"GRANT atlas_eom_handoff_owner TO {runtime_probe_ident}"
             )
-            assert not await recovery_mod.missed_call_recovery_schema_ready(runtime_pool)
+            assert not await recovery_mod.missed_call_recovery_schema_ready(
+                runtime_pool
+            )
             await connection.execute(
                 f"REVOKE atlas_eom_handoff_owner FROM {runtime_probe_ident}"
             )
             assert await recovery_mod.missed_call_recovery_schema_ready(runtime_pool)
 
-            contact_id, _attempt_id, sequence_id = (
-                await _insert_active_sequence_for_privilege_probe(
-                    runtime_pool,
-                    email="runtime-privilege@example.test",
-                    contact_id=runtime_contact_id,
-                )
+            (
+                contact_id,
+                _attempt_id,
+                sequence_id,
+            ) = await _insert_active_sequence_for_privilege_probe(
+                runtime_pool,
+                email="runtime-privilege@example.test",
+                contact_id=runtime_contact_id,
             )
             receipt_key = _operation_key("runtime-receipt")
             await runtime_connection.execute(
@@ -1056,12 +1276,14 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
                     "SELECT recipient_email FROM eom_missed_call_sequences LIMIT 1"
                 )
 
-            _contact_change_id, _change_attempt_id, changed_sequence_id = (
-                await _insert_active_sequence_for_privilege_probe(
-                    runtime_pool,
-                    email="before-change@example.test",
-                    contact_id=contact_change_id,
-                )
+            (
+                _contact_change_id,
+                _change_attempt_id,
+                changed_sequence_id,
+            ) = await _insert_active_sequence_for_privilege_probe(
+                runtime_pool,
+                email="before-change@example.test",
+                contact_id=contact_change_id,
             )
             await nocodb_connection.execute(
                 "UPDATE contacts SET email = $2 WHERE id = $1",
@@ -1074,12 +1296,14 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
                 changed_sequence_id,
             )
 
-            _interaction_id, _interaction_attempt_id, interaction_sequence_id = (
-                await _insert_active_sequence_for_privilege_probe(
-                    runtime_pool,
-                    email="interaction@example.test",
-                    contact_id=interaction_id,
-                )
+            (
+                _interaction_id,
+                _interaction_attempt_id,
+                interaction_sequence_id,
+            ) = await _insert_active_sequence_for_privilege_probe(
+                runtime_pool,
+                email="interaction@example.test",
+                contact_id=interaction_id,
             )
             await nocodb_connection.execute(
                 """
@@ -1111,17 +1335,21 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("function_signature", _TRUSTED_BRIDGE_FUNCTION_SIGNATURES)
-async def test_privilege_repair_rejects_each_tampered_bridge_body(
+@pytest.mark.parametrize("function_signature", _TRUSTED_GUARD_FUNCTION_SIGNATURES)
+async def test_privilege_repair_rejects_each_tampered_guard_body(
     function_signature: str,
 ) -> None:
-    """No untrusted migration-389 bridge body may gain definer authority."""
+    """No altered function may enter the guard-owned recovery graph."""
 
     _database_url_or_skip()
     async with _test_store() as (admin_pool, schema):
         connection = admin_pool._connection
         await _provision_privilege_repair_roles(connection)
-        await _tamper_bridge_function(
+        await connection.execute(
+            "SELECT pg_catalog.set_config("
+            "'atlas.eom_missed_call_recovery_runtime_role', 'atlas', FALSE)"
+        )
+        await _tamper_guard_function(
             connection,
             schema=schema,
             function_signature=function_signature,
@@ -1156,7 +1384,7 @@ async def test_privilege_repair_rejects_each_tampered_bridge_body(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "function_signature", _TRUSTED_APPEND_ONLY_FENCE_FUNCTION_SIGNATURES
+    "function_signature", _MUTABLE_EVIDENCE_FENCE_FUNCTION_SIGNATURES
 )
 async def test_privilege_repair_rejects_each_tampered_append_only_fence_body(
     function_signature: str,
@@ -1167,6 +1395,10 @@ async def test_privilege_repair_rejects_each_tampered_append_only_fence_body(
     async with _test_store() as (admin_pool, schema):
         connection = admin_pool._connection
         await _provision_privilege_repair_roles(connection)
+        await connection.execute(
+            "SELECT pg_catalog.set_config("
+            "'atlas.eom_missed_call_recovery_runtime_role', 'atlas', FALSE)"
+        )
         await _tamper_append_only_fence_function(
             connection,
             schema=schema,
@@ -3102,7 +3334,9 @@ async def test_resume_and_cancel_keys_are_globally_bound_to_their_original_conta
 
 
 @pytest.mark.asyncio
-async def test_operator_route_reaches_persisted_call_and_status_state(monkeypatch) -> None:
+async def test_operator_route_reaches_persisted_call_and_status_state(
+    monkeypatch,
+) -> None:
     async with _test_store() as (pool, _schema):
         contact_id = await _insert_estimate_lead(pool)
         service = _service(pool, gateway=_FakeGateway())

--- a/tests/test_eom_missed_call_recovery.py
+++ b/tests/test_eom_missed_call_recovery.py
@@ -808,7 +808,13 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
     database_url = _database_url_or_skip()
     runtime_probe_role = f"eom_mc_runtime_{uuid4().hex[:16]}"
     runtime_probe_ident = _quote_ident(runtime_probe_role)
+    stale_group_role = f"eom_mc_stale_group_{uuid4().hex[:16]}"
+    stale_group_ident = _quote_ident(stale_group_role)
+    stale_login_role = f"eom_mc_stale_login_{uuid4().hex[:16]}"
+    stale_login_ident = _quote_ident(stale_login_role)
     runtime_role_created = False
+    stale_group_created = False
+    stale_login_created = False
     runtime_connection = None
     nocodb_connection = None
 
@@ -821,6 +827,15 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
             )
             await _provision_privilege_repair_roles(connection)
             database_name = await connection.fetchval("SELECT current_database()")
+            await connection.execute(
+                f"CREATE ROLE {stale_group_ident} NOLOGIN NOINHERIT"
+            )
+            stale_group_created = True
+            await connection.execute(f"CREATE ROLE {stale_login_ident} LOGIN INHERIT")
+            stale_login_created = True
+            await connection.execute(
+                f"GRANT {stale_group_ident} TO {stale_login_ident}"
+            )
             await connection.execute(
                 f"CREATE ROLE {runtime_probe_ident} LOGIN NOINHERIT "
                 f"PASSWORD '{_RUNTIME_PROBE_PASSWORD}'"
@@ -863,6 +878,18 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
             await connection.execute(
                 f"GRANT SELECT (recipient_email) ON TABLE {_quote_ident(schema)}."
                 "eom_missed_call_sequences TO atlas_nocodb"
+            )
+            await connection.execute(
+                f"GRANT SELECT ON TABLE {_quote_ident(schema)}."
+                f"eom_missed_call_attempts TO {stale_group_ident}"
+            )
+            await connection.execute(
+                f"GRANT SELECT (actor_name) ON TABLE {_quote_ident(schema)}."
+                f"eom_missed_call_attempts TO {stale_group_ident}"
+            )
+            await connection.execute(
+                f"GRANT SELECT (actor_name) ON TABLE {_quote_ident(schema)}."
+                "eom_missed_call_attempts TO atlas_eom_handoff_owner"
             )
             await connection.execute(
                 f"GRANT EXECUTE ON FUNCTION {_quote_ident(schema)}."
@@ -1003,6 +1030,60 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
                 "eom_missed_call_sequence_steps": {"INSERT", "SELECT", "UPDATE"},
                 "eom_missed_call_sequence_events": {"INSERT", "SELECT"},
             }
+            non_allowlisted_table_acl_rows = await connection.fetch(
+                """
+                SELECT relation.relname, COALESCE(grantee_role.rolname, 'PUBLIC')
+                FROM pg_class AS relation
+                JOIN pg_namespace AS namespace ON namespace.oid = relation.relnamespace
+                CROSS JOIN LATERAL aclexplode(
+                    COALESCE(
+                        relation.relacl,
+                        pg_catalog.acldefault('r', relation.relowner)
+                    )
+                ) AS acl
+                LEFT JOIN pg_roles AS grantee_role ON grantee_role.oid = acl.grantee
+                WHERE namespace.nspname = current_schema()
+                  AND relation.relname = ANY($1::text[])
+                  AND (
+                      acl.grantee = 0
+                      OR grantee_role.rolname NOT IN (
+                          'atlas_eom_handoff_owner', $2::text
+                      )
+                  )
+                """,
+                [
+                    "eom_missed_call_operation_receipts",
+                    "eom_missed_call_attempts",
+                    "eom_missed_call_contact_suppressions",
+                    "eom_missed_call_sequences",
+                    "eom_missed_call_sequence_steps",
+                    "eom_missed_call_sequence_events",
+                ],
+                runtime_probe_role,
+            )
+            assert non_allowlisted_table_acl_rows == []
+            assert not await connection.fetchval(
+                """
+                SELECT has_table_privilege(
+                    $1::text,
+                    to_regclass(format('%I.%I', $2::text, 'eom_missed_call_attempts')),
+                    'SELECT'
+                )
+                """,
+                stale_login_role,
+                schema,
+            )
+            assert not await connection.fetchval(
+                """
+                SELECT has_any_column_privilege(
+                    $1::text,
+                    to_regclass(format('%I.%I', $2::text, 'eom_missed_call_attempts')),
+                    'SELECT'
+                )
+                """,
+                stale_login_role,
+                schema,
+            )
             for function_signature in _TRUSTED_DEFINER_FUNCTION_SIGNATURES:
                 qualified_signature = f"{_quote_ident(schema)}.{function_signature}"
                 assert not await connection.fetchval(
@@ -1051,13 +1132,6 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
                   AND relation.relname = ANY($1::text[])
                   AND attribute.attnum > 0
                   AND NOT attribute.attisdropped
-                  AND acl.grantee = ANY(
-                      ARRAY[0::oid] || ARRAY(
-                          SELECT oid
-                          FROM pg_roles
-                          WHERE rolname = ANY($2::text[])
-                      )
-                  )
                 """,
                 [
                     "eom_missed_call_operation_receipts",
@@ -1067,7 +1141,6 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
                     "eom_missed_call_sequence_steps",
                     "eom_missed_call_sequence_events",
                 ],
-                ["atlas", runtime_probe_role, "atlas_nocodb"],
             )
             assert stale_column_acl_rows == []
 
@@ -1080,6 +1153,32 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
                 f"SET search_path TO {_quote_ident(schema)}, public"
             )
             runtime_pool = _ConnectionPool(runtime_connection)
+            assert await recovery_mod.missed_call_recovery_schema_ready(runtime_pool)
+
+            await connection.execute(
+                f"GRANT SELECT ON TABLE {_quote_ident(schema)}."
+                f"eom_missed_call_attempts TO {stale_group_ident}"
+            )
+            assert not await recovery_mod.missed_call_recovery_schema_ready(
+                runtime_pool
+            )
+            await connection.execute(
+                f"REVOKE SELECT ON TABLE {_quote_ident(schema)}."
+                f"eom_missed_call_attempts FROM {stale_group_ident}"
+            )
+            assert await recovery_mod.missed_call_recovery_schema_ready(runtime_pool)
+
+            await connection.execute(
+                f"GRANT SELECT (actor_name) ON TABLE {_quote_ident(schema)}."
+                f"eom_missed_call_attempts TO {stale_group_ident}"
+            )
+            assert not await recovery_mod.missed_call_recovery_schema_ready(
+                runtime_pool
+            )
+            await connection.execute(
+                f"REVOKE SELECT (actor_name) ON TABLE {_quote_ident(schema)}."
+                f"eom_missed_call_attempts FROM {stale_group_ident}"
+            )
             assert await recovery_mod.missed_call_recovery_schema_ready(runtime_pool)
 
             await connection.execute(
@@ -1371,6 +1470,15 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
             if runtime_role_created:
                 await connection.execute(f"DROP OWNED BY {runtime_probe_ident}")
                 await connection.execute(f"DROP ROLE {runtime_probe_ident}")
+            if stale_login_created:
+                await connection.execute(
+                    f"REVOKE {stale_group_ident} FROM {stale_login_ident}"
+                )
+                await connection.execute(f"DROP OWNED BY {stale_login_ident}")
+                await connection.execute(f"DROP ROLE {stale_login_ident}")
+            if stale_group_created:
+                await connection.execute(f"DROP OWNED BY {stale_group_ident}")
+                await connection.execute(f"DROP ROLE {stale_group_ident}")
 
 
 @pytest.mark.asyncio

--- a/tests/test_eom_missed_call_recovery.py
+++ b/tests/test_eom_missed_call_recovery.py
@@ -602,6 +602,36 @@ async def _provision_privilege_repair_roles(connection: Any) -> None:
 
 
 @asynccontextmanager
+async def _configured_unprivileged_runtime_probe_role(connection: Any, *, schema: str):
+    """Bind a disposable runtime login so migration 393 reaches its body checks."""
+
+    runtime_role = f"eom_mc_tamper_runtime_{uuid4().hex[:16]}"
+    runtime_role_ident = _quote_ident(runtime_role)
+    role_created = False
+    try:
+        database_name = await connection.fetchval("SELECT current_database()")
+        await connection.execute(f"CREATE ROLE {runtime_role_ident} LOGIN NOINHERIT")
+        role_created = True
+        await connection.execute(
+            f"GRANT CONNECT ON DATABASE {_quote_ident(database_name)} "
+            f"TO {runtime_role_ident}"
+        )
+        await connection.execute(
+            f"GRANT USAGE ON SCHEMA {_quote_ident(schema)} TO {runtime_role_ident}"
+        )
+        await connection.execute(
+            "SELECT pg_catalog.set_config("
+            "'atlas.eom_missed_call_recovery_runtime_role', $1, FALSE)",
+            runtime_role,
+        )
+        yield runtime_role
+    finally:
+        if role_created:
+            await connection.execute(f"DROP OWNED BY {runtime_role_ident}")
+            await connection.execute(f"DROP ROLE {runtime_role_ident}")
+
+
+@asynccontextmanager
 async def _test_store():
     database_url = _database_url_or_skip()
     schema = f"atlas_eom_missed_call_{uuid4().hex}"
@@ -1345,41 +1375,40 @@ async def test_privilege_repair_rejects_each_tampered_guard_body(
     async with _test_store() as (admin_pool, schema):
         connection = admin_pool._connection
         await _provision_privilege_repair_roles(connection)
-        await connection.execute(
-            "SELECT pg_catalog.set_config("
-            "'atlas.eom_missed_call_recovery_runtime_role', 'atlas', FALSE)"
-        )
-        await _tamper_guard_function(
-            connection,
-            schema=schema,
-            function_signature=function_signature,
-        )
-
-        with pytest.raises(
-            asyncpg.exceptions.RaiseError,
-            match="trusted migration-389 body",
+        async with _configured_unprivileged_runtime_probe_role(
+            connection, schema=schema
         ):
-            await connection.execute(_PRIVILEGE_REPAIR_MIGRATION.read_text())
+            await _tamper_guard_function(
+                connection,
+                schema=schema,
+                function_signature=function_signature,
+            )
 
-        qualified_signature = f"{_quote_ident(schema)}.{function_signature}"
-        assert not await connection.fetchval(
-            """
-            SELECT procedure.prosecdef
-            FROM pg_catalog.pg_proc AS procedure
-            WHERE procedure.oid = pg_catalog.to_regprocedure($1::text)
-            """,
-            qualified_signature,
-        )
-        assert await connection.fetchval(
-            """
-            SELECT owner_role.rolname <> 'atlas_eom_handoff_owner'
-            FROM pg_catalog.pg_proc AS procedure
-            JOIN pg_catalog.pg_roles AS owner_role
-              ON owner_role.oid = procedure.proowner
-            WHERE procedure.oid = pg_catalog.to_regprocedure($1::text)
-            """,
-            qualified_signature,
-        )
+            with pytest.raises(
+                asyncpg.exceptions.RaiseError,
+                match="trusted migration-389 body",
+            ):
+                await connection.execute(_PRIVILEGE_REPAIR_MIGRATION.read_text())
+
+            qualified_signature = f"{_quote_ident(schema)}.{function_signature}"
+            assert not await connection.fetchval(
+                """
+                SELECT procedure.prosecdef
+                FROM pg_catalog.pg_proc AS procedure
+                WHERE procedure.oid = pg_catalog.to_regprocedure($1::text)
+                """,
+                qualified_signature,
+            )
+            assert await connection.fetchval(
+                """
+                SELECT owner_role.rolname <> 'atlas_eom_handoff_owner'
+                FROM pg_catalog.pg_proc AS procedure
+                JOIN pg_catalog.pg_roles AS owner_role
+                  ON owner_role.oid = procedure.proowner
+                WHERE procedure.oid = pg_catalog.to_regprocedure($1::text)
+                """,
+                qualified_signature,
+            )
 
 
 @pytest.mark.asyncio
@@ -1395,38 +1424,38 @@ async def test_privilege_repair_rejects_each_tampered_append_only_fence_body(
     async with _test_store() as (admin_pool, schema):
         connection = admin_pool._connection
         await _provision_privilege_repair_roles(connection)
-        await connection.execute(
-            "SELECT pg_catalog.set_config("
-            "'atlas.eom_missed_call_recovery_runtime_role', 'atlas', FALSE)"
-        )
-        await _tamper_append_only_fence_function(
-            connection,
-            schema=schema,
-            function_signature=function_signature,
-        )
-
-        with pytest.raises(
-            asyncpg.exceptions.RaiseError,
-            match="append-only fence function .*trusted migration-389 body",
-        ):
-            await connection.execute(_PRIVILEGE_REPAIR_MIGRATION.read_text())
-
-        protected_table_name = (
-            "eom_missed_call_operation_receipts"
-            if "operation_receipt" in function_signature
-            else "eom_missed_call_attempts"
-        )
-        assert not await connection.fetchval(
-            """
-            SELECT has_table_privilege(
-                'atlas',
-                to_regclass(format('%I.%I', $1::text, $2::text)),
-                'UPDATE'
+        async with _configured_unprivileged_runtime_probe_role(
+            connection, schema=schema
+        ) as runtime_probe_role:
+            await _tamper_append_only_fence_function(
+                connection,
+                schema=schema,
+                function_signature=function_signature,
             )
-            """,
-            schema,
-            protected_table_name,
-        )
+
+            with pytest.raises(
+                asyncpg.exceptions.RaiseError,
+                match="append-only fence function .*trusted migration-389 body",
+            ):
+                await connection.execute(_PRIVILEGE_REPAIR_MIGRATION.read_text())
+
+            protected_table_name = (
+                "eom_missed_call_operation_receipts"
+                if "operation_receipt" in function_signature
+                else "eom_missed_call_attempts"
+            )
+            assert not await connection.fetchval(
+                """
+                SELECT has_table_privilege(
+                    $1::text,
+                    to_regclass(format('%I.%I', $2::text, $3::text)),
+                    'UPDATE'
+                )
+                """,
+                runtime_probe_role,
+                schema,
+                protected_table_name,
+            )
 
 
 @pytest.mark.asyncio

--- a/tests/test_eom_missed_call_recovery.py
+++ b/tests/test_eom_missed_call_recovery.py
@@ -263,6 +263,12 @@ def test_privilege_repair_trusted_function_bodies_match_migration_389_source() -
             assert signature in readiness
             assert readiness_body in readiness
     assert "language_state.lanname = 'plpgsql'" in readiness
+    assert "REVOKE ALL ON FUNCTION %I.%s FROM atlas" in repair
+    assert (
+        "AND NOT has_function_privilege(\n"
+        "                                  current_user, procedure.oid, 'EXECUTE'\n"
+        "                              )"
+    ) in readiness
 
 
 async def _tamper_bridge_function(
@@ -699,6 +705,11 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
                 "TO atlas_nocodb"
             )
             await connection.execute(
+                f"GRANT EXECUTE ON FUNCTION {_quote_ident(schema)}."
+                "cancel_eom_missed_call_sequences_for_contact(UUID, VARCHAR, VARCHAR) "
+                "TO atlas"
+            )
+            await connection.execute(
                 f"ALTER TABLE {_quote_ident(schema)}."
                 "eom_missed_call_operation_receipts DISABLE TRIGGER "
                 "trg_prevent_eom_missed_call_operation_receipt_mutation"
@@ -775,6 +786,18 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
                 "eom_missed_call_sequence_steps": {"INSERT", "SELECT", "UPDATE"},
                 "eom_missed_call_sequence_events": {"INSERT", "SELECT"},
             }
+            for function_signature in _TRUSTED_BRIDGE_FUNCTION_SIGNATURES:
+                qualified_signature = f"{_quote_ident(schema)}.{function_signature}"
+                assert not await connection.fetchval(
+                    """
+                    SELECT has_function_privilege(
+                        'atlas',
+                        pg_catalog.to_regprocedure($1::text),
+                        'EXECUTE'
+                    )
+                    """,
+                    qualified_signature,
+                )
             stale_column_acl_rows = await connection.fetch(
                 """
                 SELECT relation.relname, attribute.attname
@@ -842,6 +865,19 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
                 f"SET search_path TO {_quote_ident(schema)}, public"
             )
             runtime_pool = _ConnectionPool(runtime_connection)
+            assert await recovery_mod.missed_call_recovery_schema_ready(runtime_pool)
+
+            await connection.execute(
+                f"GRANT EXECUTE ON FUNCTION {_quote_ident(schema)}."
+                "cancel_eom_missed_call_sequences_for_contact(UUID, VARCHAR, VARCHAR) "
+                f"TO {runtime_probe_ident}"
+            )
+            assert not await recovery_mod.missed_call_recovery_schema_ready(runtime_pool)
+            await connection.execute(
+                f"REVOKE EXECUTE ON FUNCTION {_quote_ident(schema)}."
+                "cancel_eom_missed_call_sequences_for_contact(UUID, VARCHAR, VARCHAR) "
+                f"FROM {runtime_probe_ident}"
+            )
             assert await recovery_mod.missed_call_recovery_schema_ready(runtime_pool)
 
             for function_signature in _TRUSTED_APPEND_ONLY_FENCE_FUNCTION_SIGNATURES:

--- a/tests/test_eom_missed_call_recovery.py
+++ b/tests/test_eom_missed_call_recovery.py
@@ -55,6 +55,11 @@ DATABASE_URL_ENV = "ATLAS_MIGRATION_TEST_DATABASE_URL"
 _EOM_CONTEXT = "effingham_maids"
 _BOOKING_LINK = "https://calendar.app.google/eom-test-booking"
 _NOW = datetime(2026, 8, 21, 15, 0, tzinfo=timezone.utc)
+_NOCODB_TEST_PASSWORD = "test-only-missed-call-nocodb-password"
+_RUNTIME_PROBE_PASSWORD = "test-only-missed-call-runtime-password"
+_PRIVILEGE_REPAIR_MIGRATION = (
+    MIGRATIONS / "393_eom_missed_call_recovery_runtime_privileges.sql"
+)
 
 
 class _ConnectionPool:
@@ -140,6 +145,94 @@ async def _apply_schema(connection: Any, schema: str) -> None:
         "389_eom_missed_call_recovery.sql",
     ):
         await connection.execute((MIGRATIONS / name).read_text())
+
+
+def _quote_ident(identifier: str) -> str:
+    return '"' + identifier.replace('"', '""') + '"'
+
+
+async def _require_disposable_role_administration(connection: Any) -> None:
+    can_administer_roles = await connection.fetchval(
+        """
+        SELECT rolsuper OR rolcreaterole
+        FROM pg_roles
+        WHERE rolname = current_user
+        """
+    )
+    if not can_administer_roles:
+        pytest.skip("privilege migration proof requires disposable role administration")
+
+
+async def _provision_privilege_repair_roles(connection: Any) -> None:
+    """Create only disposable test-role state needed by migration 393."""
+
+    await _require_disposable_role_administration(connection)
+    await connection.execute(
+        """
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_roles WHERE rolname = 'atlas_eom_handoff_owner'
+            ) THEN
+                CREATE ROLE atlas_eom_handoff_owner NOLOGIN NOINHERIT;
+            END IF;
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_roles WHERE rolname = 'atlas_nocodb'
+            ) THEN
+                CREATE ROLE atlas_nocodb LOGIN NOINHERIT;
+            END IF;
+        END;
+        $$;
+        """
+    )
+    await connection.execute(
+        """
+        ALTER ROLE atlas_eom_handoff_owner
+            NOLOGIN NOINHERIT NOSUPERUSER NOCREATEDB NOCREATEROLE
+            NOREPLICATION NOBYPASSRLS
+        """
+    )
+    await connection.execute(
+        """
+        ALTER ROLE atlas_nocodb
+            LOGIN NOINHERIT NOSUPERUSER NOCREATEDB NOCREATEROLE
+            NOREPLICATION NOBYPASSRLS
+            PASSWORD 'test-only-missed-call-nocodb-password'
+        """
+    )
+    memberships = await connection.fetch(
+        """
+        SELECT granted_role.rolname
+        FROM pg_auth_members AS membership
+        JOIN pg_roles AS member_role ON member_role.oid = membership.member
+        JOIN pg_roles AS granted_role ON granted_role.oid = membership.roleid
+        WHERE member_role.rolname = 'atlas_nocodb'
+        """
+    )
+    for membership in memberships:
+        await connection.execute(
+            f"REVOKE {_quote_ident(membership['rolname'])} FROM atlas_nocodb"
+        )
+    guard_members = await connection.fetch(
+        """
+        SELECT member_role.rolname
+        FROM pg_roles AS member_role
+        JOIN pg_auth_members AS membership ON membership.member = member_role.oid
+        JOIN pg_roles AS guard_role ON guard_role.oid = membership.roleid
+        WHERE guard_role.rolname = 'atlas_eom_handoff_owner'
+          AND member_role.rolcanlogin
+          AND NOT member_role.rolsuper
+        """
+    )
+    for member in guard_members:
+        await connection.execute(
+            "REVOKE atlas_eom_handoff_owner FROM "
+            f"{_quote_ident(member['rolname'])}"
+        )
+    database_name = await connection.fetchval("SELECT current_database()")
+    await connection.execute(
+        f"GRANT CONNECT ON DATABASE {_quote_ident(database_name)} TO atlas_nocodb"
+    )
 
 
 @asynccontextmanager
@@ -234,6 +327,61 @@ async def _insert_estimate_lead(
     return contact_id
 
 
+async def _insert_active_sequence_for_privilege_probe(
+    pool: _ConnectionPool,
+    *,
+    email: str,
+) -> tuple[UUID, UUID, UUID]:
+    """Create minimal active state without calling a provider or public route."""
+
+    contact_id = uuid4()
+    attempt_id = uuid4()
+    sequence_id = uuid4()
+    now = datetime.now(timezone.utc) - timedelta(minutes=1)
+    operation_key = _operation_key("privilege-attempt")
+    fingerprint = f"{uuid4().hex}{uuid4().hex}"
+    await pool._connection.execute(
+        """
+        INSERT INTO contacts (
+            id, full_name, email, business_context_id, contact_type, status,
+            lead_stage, source, customer_type, created_at
+        ) VALUES ($1, 'Privilege Probe Lead', $2, $3, 'lead', 'active', 'new',
+                  'test', 'unknown', $4)
+        """,
+        contact_id,
+        email,
+        _EOM_CONTEXT,
+        now,
+    )
+    await pool._connection.execute(
+        """
+        INSERT INTO eom_missed_call_attempts (
+            id, contact_id, operation_key, request_fingerprint, actor_id,
+            actor_name, source, occurred_at
+        ) VALUES ($1, $2, $3, $4, 1, 'Privilege Probe', 'time_tracker', $5)
+        """,
+        attempt_id,
+        contact_id,
+        operation_key,
+        fingerprint,
+        now,
+    )
+    await pool._connection.execute(
+        """
+        INSERT INTO eom_missed_call_sequences (
+            id, contact_id, initiating_attempt_id, recipient_email, state,
+            created_at, updated_at
+        ) VALUES ($1, $2, $3, $4, 'active', $5, $5)
+        """,
+        sequence_id,
+        contact_id,
+        attempt_id,
+        email,
+        now,
+    )
+    return contact_id, attempt_id, sequence_id
+
+
 def _service(
     pool: _ConnectionPool,
     *,
@@ -252,6 +400,290 @@ def _service(
         now=lambda: clock["now"],
         email_history=history,
     )
+
+
+@pytest.mark.asyncio
+async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> None:
+    """Apply 393 in a disposable schema and exercise both restricted roles."""
+
+    database_url = _database_url_or_skip()
+    runtime_probe_role = f"eom_mc_runtime_{uuid4().hex[:16]}"
+    runtime_probe_ident = _quote_ident(runtime_probe_role)
+    runtime_role_created = False
+    runtime_connection = None
+    nocodb_connection = None
+
+    async with _test_store() as (admin_pool, schema):
+        connection = admin_pool._connection
+        try:
+            await _provision_privilege_repair_roles(connection)
+            # A repair must not preserve a prior broad application grant just
+            # because the table is being transferred from its old owner.
+            await connection.execute(
+                f"GRANT DELETE ON TABLE {_quote_ident(schema)}."
+                "eom_missed_call_sequences TO atlas"
+            )
+            await connection.execute(_PRIVILEGE_REPAIR_MIGRATION.read_text())
+
+            table_rows = await connection.fetch(
+                """
+                SELECT relation.relname, owner.rolname AS owner
+                FROM pg_class AS relation
+                JOIN pg_namespace AS namespace ON namespace.oid = relation.relnamespace
+                JOIN pg_roles AS owner ON owner.oid = relation.relowner
+                WHERE namespace.nspname = current_schema()
+                  AND relation.relname = ANY($1::text[])
+                ORDER BY relation.relname
+                """,
+                [
+                    "eom_missed_call_operation_receipts",
+                    "eom_missed_call_attempts",
+                    "eom_missed_call_contact_suppressions",
+                    "eom_missed_call_sequences",
+                    "eom_missed_call_sequence_steps",
+                    "eom_missed_call_sequence_events",
+                ],
+            )
+            assert {row["owner"] for row in table_rows} == {
+                "atlas_eom_handoff_owner"
+            }
+
+            runtime_acl_rows = await connection.fetch(
+                """
+                SELECT relation.relname, acl.privilege_type
+                FROM pg_class AS relation
+                JOIN pg_namespace AS namespace ON namespace.oid = relation.relnamespace
+                CROSS JOIN LATERAL aclexplode(relation.relacl) AS acl
+                WHERE namespace.nspname = current_schema()
+                  AND relation.relname = ANY($1::text[])
+                  AND acl.grantee = (SELECT oid FROM pg_roles WHERE rolname = 'atlas')
+                ORDER BY relation.relname, acl.privilege_type
+                """,
+                [
+                    "eom_missed_call_operation_receipts",
+                    "eom_missed_call_attempts",
+                    "eom_missed_call_contact_suppressions",
+                    "eom_missed_call_sequences",
+                    "eom_missed_call_sequence_steps",
+                    "eom_missed_call_sequence_events",
+                ],
+            )
+            runtime_acl: dict[str, set[str]] = {}
+            for row in runtime_acl_rows:
+                runtime_acl.setdefault(row["relname"], set()).add(
+                    row["privilege_type"]
+                )
+            assert runtime_acl == {
+                "eom_missed_call_operation_receipts": {"INSERT", "SELECT", "UPDATE"},
+                "eom_missed_call_attempts": {"INSERT", "SELECT", "UPDATE"},
+                "eom_missed_call_contact_suppressions": {"INSERT", "SELECT"},
+                "eom_missed_call_sequences": {"INSERT", "SELECT", "UPDATE"},
+                "eom_missed_call_sequence_steps": {"INSERT", "SELECT", "UPDATE"},
+                "eom_missed_call_sequence_events": {"INSERT", "SELECT"},
+            }
+
+            database_name = await connection.fetchval("SELECT current_database()")
+            await connection.execute(
+                f"CREATE ROLE {runtime_probe_ident} LOGIN NOINHERIT "
+                f"PASSWORD '{_RUNTIME_PROBE_PASSWORD}'"
+            )
+            runtime_role_created = True
+            await connection.execute(
+                f"GRANT CONNECT ON DATABASE {_quote_ident(database_name)} "
+                f"TO {runtime_probe_ident}"
+            )
+            await connection.execute(
+                f"GRANT USAGE ON SCHEMA {_quote_ident(schema)} TO {runtime_probe_ident}"
+            )
+            await connection.execute(
+                f"GRANT SELECT ON TABLE {_quote_ident(schema)}.contacts "
+                f"TO {runtime_probe_ident}"
+            )
+            for table_name, privileges in (
+                ("eom_missed_call_operation_receipts", "SELECT, INSERT, UPDATE"),
+                ("eom_missed_call_attempts", "SELECT, INSERT, UPDATE"),
+                ("eom_missed_call_contact_suppressions", "SELECT, INSERT"),
+                ("eom_missed_call_sequences", "SELECT, INSERT, UPDATE"),
+                ("eom_missed_call_sequence_steps", "SELECT, INSERT, UPDATE"),
+                ("eom_missed_call_sequence_events", "SELECT, INSERT"),
+            ):
+                await connection.execute(
+                    f"GRANT {privileges} ON TABLE {_quote_ident(schema)}."
+                    f"{_quote_ident(table_name)} TO {runtime_probe_ident}"
+                )
+
+            runtime_connection = await asyncpg.connect(
+                database_url,
+                user=runtime_probe_role,
+                password=_RUNTIME_PROBE_PASSWORD,
+            )
+            await runtime_connection.execute(
+                f"SET search_path TO {_quote_ident(schema)}, public"
+            )
+            runtime_pool = _ConnectionPool(runtime_connection)
+            assert await recovery_mod.missed_call_recovery_schema_ready(runtime_pool)
+
+            await connection.execute(
+                f"REVOKE INSERT ON TABLE {_quote_ident(schema)}."
+                f"eom_missed_call_sequence_events FROM {runtime_probe_ident}"
+            )
+            assert not await recovery_mod.missed_call_recovery_schema_ready(runtime_pool)
+            await connection.execute(
+                f"GRANT INSERT ON TABLE {_quote_ident(schema)}."
+                f"eom_missed_call_sequence_events TO {runtime_probe_ident}"
+            )
+            assert await recovery_mod.missed_call_recovery_schema_ready(runtime_pool)
+
+            await connection.execute(
+                f"REVOKE UPDATE ON TABLE {_quote_ident(schema)}."
+                f"eom_missed_call_operation_receipts FROM {runtime_probe_ident}"
+            )
+            assert not await recovery_mod.missed_call_recovery_schema_ready(runtime_pool)
+            await connection.execute(
+                f"GRANT UPDATE ON TABLE {_quote_ident(schema)}."
+                f"eom_missed_call_operation_receipts TO {runtime_probe_ident}"
+            )
+            assert await recovery_mod.missed_call_recovery_schema_ready(runtime_pool)
+
+            contact_id, _attempt_id, sequence_id = (
+                await _insert_active_sequence_for_privilege_probe(
+                    admin_pool,
+                    email="runtime-privilege@example.test",
+                )
+            )
+            receipt_key = _operation_key("runtime-receipt")
+            await connection.execute(
+                """
+                INSERT INTO eom_missed_call_operation_receipts (
+                    operation_key, contact_id, operation_kind, request_fingerprint
+                ) VALUES ($1, $2, 'no_answer', $3)
+                """,
+                receipt_key,
+                contact_id,
+                f"{uuid4().hex}{uuid4().hex}",
+            )
+            locked_receipt = await runtime_connection.fetchrow(
+                """
+                SELECT operation_key
+                FROM eom_missed_call_operation_receipts
+                WHERE operation_key = $1
+                FOR UPDATE
+                """,
+                receipt_key,
+            )
+            assert locked_receipt["operation_key"] == receipt_key
+            with pytest.raises(
+                asyncpg.exceptions.RaiseError,
+                match="eom_missed_call_operation_receipts is append-only",
+            ):
+                await runtime_connection.execute(
+                    """
+                    UPDATE eom_missed_call_operation_receipts
+                    SET operation_kind = 'resume'
+                    WHERE operation_key = $1
+                    """,
+                    receipt_key,
+                )
+            await runtime_connection.execute(
+                """
+                UPDATE eom_missed_call_sequences
+                SET updated_at = updated_at
+                WHERE id = $1
+                """,
+                sequence_id,
+            )
+            await runtime_connection.execute(
+                """
+                INSERT INTO eom_missed_call_sequence_events (
+                    sequence_id, event_type, actor_name, source, metadata
+                ) VALUES ($1, 'sequence_reused', 'Runtime Probe', 'time_tracker', '{}')
+                """,
+                sequence_id,
+            )
+
+            await connection.execute(
+                f"GRANT USAGE ON SCHEMA {_quote_ident(schema)} TO atlas_nocodb"
+            )
+            await connection.execute(
+                f"GRANT SELECT, UPDATE (email) ON TABLE {_quote_ident(schema)}.contacts "
+                "TO atlas_nocodb"
+            )
+            await connection.execute(
+                f"GRANT SELECT, INSERT ON TABLE {_quote_ident(schema)}."
+                "contact_interactions TO atlas_nocodb"
+            )
+            nocodb_connection = await asyncpg.connect(
+                database_url,
+                user="atlas_nocodb",
+                password=_NOCODB_TEST_PASSWORD,
+            )
+            await nocodb_connection.execute(
+                f"SET search_path TO {_quote_ident(schema)}, public"
+            )
+            with pytest.raises(asyncpg.exceptions.InsufficientPrivilegeError):
+                await nocodb_connection.fetchval(
+                    "SELECT COUNT(*) FROM eom_missed_call_sequences"
+                )
+            assert not await connection.fetchval(
+                """
+                SELECT has_function_privilege(
+                    'atlas_nocodb',
+                    to_regprocedure('cancel_eom_missed_call_sequences_for_contact(uuid, character varying, character varying)'),
+                    'EXECUTE'
+                )
+                """
+            )
+
+            contact_change_id, _change_attempt_id, changed_sequence_id = (
+                await _insert_active_sequence_for_privilege_probe(
+                    admin_pool,
+                    email="before-change@example.test",
+                )
+            )
+            await nocodb_connection.execute(
+                "UPDATE contacts SET email = $2 WHERE id = $1",
+                contact_change_id,
+                "after-change@example.test",
+            )
+            assert await connection.fetchval(
+                "SELECT state = 'cancelled' AND cancellation_reason = 'recipient_changed' "
+                "FROM eom_missed_call_sequences WHERE id = $1",
+                changed_sequence_id,
+            )
+
+            interaction_id, _interaction_attempt_id, interaction_sequence_id = (
+                await _insert_active_sequence_for_privilege_probe(
+                    admin_pool,
+                    email="interaction@example.test",
+                )
+            )
+            await nocodb_connection.execute(
+                """
+                INSERT INTO contact_interactions (
+                    id, contact_id, interaction_type, summary, intent, occurred_at,
+                    metadata, interaction_dedupe_key
+                ) VALUES (
+                    $1, $2, 'lead_response', 'NocoDB response', NULL,
+                    CURRENT_TIMESTAMP, '{}'::jsonb, $3
+                )
+                """,
+                uuid4(),
+                interaction_id,
+                f"nocodb-response-{uuid4().hex}",
+            )
+            assert await connection.fetchval(
+                "SELECT state = 'cancelled' AND cancellation_reason = 'lead_response' "
+                "FROM eom_missed_call_sequences WHERE id = $1",
+                interaction_sequence_id,
+            )
+        finally:
+            if nocodb_connection is not None:
+                await nocodb_connection.close()
+            if runtime_connection is not None:
+                await runtime_connection.close()
+            if runtime_role_created:
+                await connection.execute(f"DROP OWNED BY {runtime_probe_ident}")
+                await connection.execute(f"DROP ROLE {runtime_probe_ident}")
 
 
 @pytest.mark.asyncio

--- a/tests/test_eom_missed_call_recovery.py
+++ b/tests/test_eom_missed_call_recovery.py
@@ -8,8 +8,10 @@ schedule a real appointment.
 from __future__ import annotations
 
 import asyncio
+from hashlib import sha256
 import json
 import os
+import re
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
 from itertools import product
@@ -59,6 +61,46 @@ _NOCODB_TEST_PASSWORD = "test-only-missed-call-nocodb-password"
 _RUNTIME_PROBE_PASSWORD = "test-only-missed-call-runtime-password"
 _PRIVILEGE_REPAIR_MIGRATION = (
     MIGRATIONS / "393_eom_missed_call_recovery_runtime_privileges.sql"
+)
+_TRUSTED_BRIDGE_FUNCTION_SIGNATURES = (
+    "cancel_eom_missed_call_sequences_for_contact(UUID, VARCHAR, VARCHAR)",
+    "lock_eom_missed_call_interaction_contact()",
+    "eom_missed_call_effective_recipient(UUID, TEXT)",
+    "cancel_eom_missed_call_on_recipient_change(UUID)",
+    "cancel_eom_missed_call_on_contact_change()",
+    "cancel_eom_missed_call_on_interaction()",
+)
+_TRUSTED_BRIDGE_FUNCTIONS = (
+    (
+        "cancel_eom_missed_call_sequences_for_contact(UUID, VARCHAR, VARCHAR)",
+        "cancel_eom_missed_call_sequences_for_contact",
+        "plpgsql",
+    ),
+    (
+        "lock_eom_missed_call_interaction_contact()",
+        "lock_eom_missed_call_interaction_contact",
+        "plpgsql",
+    ),
+    (
+        "eom_missed_call_effective_recipient(UUID, TEXT)",
+        "eom_missed_call_effective_recipient",
+        "sql",
+    ),
+    (
+        "cancel_eom_missed_call_on_recipient_change(UUID)",
+        "cancel_eom_missed_call_on_recipient_change",
+        "plpgsql",
+    ),
+    (
+        "cancel_eom_missed_call_on_contact_change()",
+        "cancel_eom_missed_call_on_contact_change",
+        "plpgsql",
+    ),
+    (
+        "cancel_eom_missed_call_on_interaction()",
+        "cancel_eom_missed_call_on_interaction",
+        "plpgsql",
+    ),
 )
 
 
@@ -149,6 +191,98 @@ async def _apply_schema(connection: Any, schema: str) -> None:
 
 def _quote_ident(identifier: str) -> str:
     return '"' + identifier.replace('"', '""') + '"'
+
+
+def test_privilege_repair_trusted_bridge_hashes_match_migration_389_source() -> None:
+    """Keep 393's body allowlist tied to the immutable migration-389 source."""
+
+    source = (MIGRATIONS / "389_eom_missed_call_recovery.sql").read_text()
+    repair = _PRIVILEGE_REPAIR_MIGRATION.read_text()
+    for signature, function_name, language_name in _TRUSTED_BRIDGE_FUNCTIONS:
+        function_match = re.search(
+            rf"CREATE OR REPLACE FUNCTION {re.escape(function_name)}\b(.*?)"
+            r"(?=\nCREATE OR REPLACE FUNCTION|\Z)",
+            source,
+            re.DOTALL,
+        )
+        assert function_match is not None, function_name
+        language_and_body_match = re.search(
+            r"LANGUAGE\s+([A-Za-z0-9_]+)(?:\s+STABLE)?\s+AS \$\$(.*?)\$\$;",
+            function_match.group(1),
+            re.DOTALL,
+        )
+        assert language_and_body_match is not None, function_name
+        assert language_and_body_match.group(1) == language_name
+        body_sha256 = sha256(language_and_body_match.group(2).encode()).hexdigest()
+        expected_entry = re.compile(
+            rf"\(\s*'{re.escape(signature)}'\s*,\s*"
+            rf"'{language_name}'\s*,\s*'{body_sha256}'\s*\)",
+            re.DOTALL,
+        )
+        assert expected_entry.search(repair), signature
+
+
+async def _tamper_bridge_function(
+    connection: Any,
+    *,
+    schema: str,
+    function_signature: str,
+) -> None:
+    """Replace one bridge body while preserving its callable signature."""
+
+    schema_ident = _quote_ident(schema)
+    definitions = {
+        "cancel_eom_missed_call_sequences_for_contact(UUID, VARCHAR, VARCHAR)": f"""
+            CREATE OR REPLACE FUNCTION {schema_ident}.cancel_eom_missed_call_sequences_for_contact(
+                UUID, VARCHAR, VARCHAR
+            ) RETURNS VOID LANGUAGE plpgsql AS $$
+            BEGIN
+                RETURN;
+            END;
+            $$;
+        """,
+        "lock_eom_missed_call_interaction_contact()": f"""
+            CREATE OR REPLACE FUNCTION {schema_ident}.lock_eom_missed_call_interaction_contact()
+            RETURNS TRIGGER LANGUAGE plpgsql AS $$
+            BEGIN
+                RETURN NEW;
+            END;
+            $$;
+        """,
+        "eom_missed_call_effective_recipient(UUID, TEXT)": f"""
+            CREATE OR REPLACE FUNCTION {schema_ident}.eom_missed_call_effective_recipient(
+                UUID, TEXT
+            ) RETURNS TEXT LANGUAGE sql AS $$
+            SELECT 'tampered'::TEXT;
+            $$;
+        """,
+        "cancel_eom_missed_call_on_recipient_change(UUID)": f"""
+            CREATE OR REPLACE FUNCTION {schema_ident}.cancel_eom_missed_call_on_recipient_change(
+                UUID
+            ) RETURNS VOID LANGUAGE plpgsql AS $$
+            BEGIN
+                RETURN;
+            END;
+            $$;
+        """,
+        "cancel_eom_missed_call_on_contact_change()": f"""
+            CREATE OR REPLACE FUNCTION {schema_ident}.cancel_eom_missed_call_on_contact_change()
+            RETURNS TRIGGER LANGUAGE plpgsql AS $$
+            BEGIN
+                RETURN NEW;
+            END;
+            $$;
+        """,
+        "cancel_eom_missed_call_on_interaction()": f"""
+            CREATE OR REPLACE FUNCTION {schema_ident}.cancel_eom_missed_call_on_interaction()
+            RETURNS TRIGGER LANGUAGE plpgsql AS $$
+            BEGIN
+                RETURN NEW;
+            END;
+            $$;
+        """,
+    }
+    await connection.execute(definitions[function_signature])
 
 
 async def _require_disposable_role_administration(connection: Any) -> None:
@@ -803,6 +937,50 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
             if runtime_role_created:
                 await connection.execute(f"DROP OWNED BY {runtime_probe_ident}")
                 await connection.execute(f"DROP ROLE {runtime_probe_ident}")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("function_signature", _TRUSTED_BRIDGE_FUNCTION_SIGNATURES)
+async def test_privilege_repair_rejects_each_tampered_bridge_body(
+    function_signature: str,
+) -> None:
+    """No untrusted migration-389 bridge body may gain definer authority."""
+
+    _database_url_or_skip()
+    async with _test_store() as (admin_pool, schema):
+        connection = admin_pool._connection
+        await _provision_privilege_repair_roles(connection)
+        await _tamper_bridge_function(
+            connection,
+            schema=schema,
+            function_signature=function_signature,
+        )
+
+        with pytest.raises(
+            asyncpg.exceptions.RaiseError,
+            match="trusted migration-389 body",
+        ):
+            await connection.execute(_PRIVILEGE_REPAIR_MIGRATION.read_text())
+
+        qualified_signature = f"{_quote_ident(schema)}.{function_signature}"
+        assert not await connection.fetchval(
+            """
+            SELECT procedure.prosecdef
+            FROM pg_catalog.pg_proc AS procedure
+            WHERE procedure.oid = pg_catalog.to_regprocedure($1::text)
+            """,
+            qualified_signature,
+        )
+        assert await connection.fetchval(
+            """
+            SELECT owner_role.rolname <> 'atlas_eom_handoff_owner'
+            FROM pg_catalog.pg_proc AS procedure
+            JOIN pg_catalog.pg_roles AS owner_role
+              ON owner_role.oid = procedure.proowner
+            WHERE procedure.oid = pg_catalog.to_regprocedure($1::text)
+            """,
+            qualified_signature,
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_eom_missed_call_recovery.py
+++ b/tests/test_eom_missed_call_recovery.py
@@ -530,9 +530,7 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
                 FROM pg_attribute AS attribute
                 JOIN pg_class AS relation ON relation.oid = attribute.attrelid
                 JOIN pg_namespace AS namespace ON namespace.oid = relation.relnamespace
-                CROSS JOIN LATERAL aclexplode(
-                    COALESCE(attribute.attacl, ARRAY[]::aclitem[])
-                ) AS acl
+                CROSS JOIN LATERAL aclexplode(attribute.attacl) AS acl
                 WHERE namespace.nspname = current_schema()
                   AND relation.relname = ANY($1::text[])
                   AND attribute.attnum > 0

--- a/tests/test_eom_missed_call_recovery.py
+++ b/tests/test_eom_missed_call_recovery.py
@@ -49,6 +49,9 @@ from atlas_brain.templates.email.estimate_confirmation import (  # noqa: E402
 from atlas_brain.templates.email.missed_call_recovery import (  # noqa: E402
     render_missed_call_recovery_email,
 )
+from scripts.apply_eom_missed_call_recovery_runtime_privileges import (
+    _require_role_admission_before_mutation,
+)
 
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -59,6 +62,7 @@ _BOOKING_LINK = "https://calendar.app.google/eom-test-booking"
 _NOW = datetime(2026, 8, 21, 15, 0, tzinfo=timezone.utc)
 _NOCODB_TEST_PASSWORD = "test-only-missed-call-nocodb-password"
 _RUNTIME_PROBE_PASSWORD = "test-only-missed-call-runtime-password"
+_DELEGATED_LOGIN_PROBE_PASSWORD = "test-only-missed-call-delegated-login-password"
 _PRIVILEGE_REPAIR_MIGRATION = (
     MIGRATIONS / "393_eom_missed_call_recovery_runtime_privileges.sql"
 )
@@ -182,6 +186,10 @@ class _ConnectionPool:
     async def transaction(self):
         async with self._connection.transaction():
             yield self._connection
+
+    @asynccontextmanager
+    async def acquire(self):
+        yield self._connection
 
     async def fetch(self, *args: Any, **kwargs: Any) -> Any:
         return await self._connection.fetch(*args, **kwargs)
@@ -802,6 +810,155 @@ def _service(
 
 
 @pytest.mark.asyncio
+async def test_privilege_repair_rejects_delegated_admitted_logins_before_mutation() -> (
+    None
+):
+    """Block direct and transitive logins that can assume admitted identities."""
+
+    database_url = _database_url_or_skip()
+    runtime_role = f"eom_mc_delegated_runtime_{uuid4().hex[:16]}"
+    runtime_ident = _quote_ident(runtime_role)
+    delegated_login_role = f"eom_mc_delegated_login_{uuid4().hex[:16]}"
+    delegated_login_ident = _quote_ident(delegated_login_role)
+    delegated_group_role = f"eom_mc_delegated_group_{uuid4().hex[:16]}"
+    delegated_group_ident = _quote_ident(delegated_group_role)
+    runtime_role_created = False
+    delegated_login_created = False
+    delegated_group_created = False
+    delegated_login_connection = None
+
+    async with _test_store() as (admin_pool, schema):
+        connection = admin_pool._connection
+        try:
+            await _provision_privilege_repair_roles(connection)
+            database_name = await connection.fetchval("SELECT current_database()")
+            await connection.execute(
+                f"CREATE ROLE {runtime_ident} LOGIN NOINHERIT "
+                f"PASSWORD '{_RUNTIME_PROBE_PASSWORD}'"
+            )
+            runtime_role_created = True
+            await connection.execute(
+                f"GRANT CONNECT ON DATABASE {_quote_ident(database_name)} "
+                f"TO {runtime_ident}"
+            )
+            await connection.execute(
+                f"GRANT USAGE ON SCHEMA {_quote_ident(schema)} TO {runtime_ident}"
+            )
+            await connection.execute(
+                "SELECT pg_catalog.set_config("
+                "'atlas.eom_missed_call_recovery_runtime_role', $1, FALSE)",
+                runtime_role,
+            )
+            await connection.execute(
+                f"CREATE ROLE {delegated_login_ident} LOGIN NOINHERIT "
+                f"PASSWORD '{_DELEGATED_LOGIN_PROBE_PASSWORD}'"
+            )
+            delegated_login_created = True
+            await connection.execute(
+                f"GRANT CONNECT ON DATABASE {_quote_ident(database_name)} "
+                f"TO {delegated_login_ident}"
+            )
+            await connection.execute(
+                f"CREATE ROLE {delegated_group_ident} NOLOGIN NOINHERIT"
+            )
+            delegated_group_created = True
+            await connection.execute(
+                f"GRANT {delegated_group_ident} TO {delegated_login_ident}"
+            )
+            delegated_login_connection = await asyncpg.connect(
+                database_url,
+                user=delegated_login_role,
+                password=_DELEGATED_LOGIN_PROBE_PASSWORD,
+            )
+
+            async def assert_repair_has_not_mutated_privileges() -> None:
+                assert not await connection.fetchval(
+                    """
+                    SELECT procedure.prosecdef
+                    FROM pg_catalog.pg_proc AS procedure
+                    WHERE procedure.oid = pg_catalog.to_regprocedure($1::text)
+                    """,
+                    f"{_quote_ident(schema)}.validate_eom_missed_call_contact_scope()",
+                )
+                assert not await connection.fetchval(
+                    """
+                    SELECT has_table_privilege(
+                        $1::text,
+                        to_regclass(format('%I.%I', $2::text, $3::text)),
+                        'UPDATE'
+                    )
+                    """,
+                    runtime_role,
+                    schema,
+                    "eom_missed_call_operation_receipts",
+                )
+
+            for target_role, target_ident in (
+                (runtime_role, runtime_ident),
+                ("atlas_nocodb", "atlas_nocodb"),
+            ):
+                for _delegation_path, membership_grantee_ident in (
+                    ("direct", delegated_login_ident),
+                    ("transitive", delegated_group_ident),
+                ):
+                    await connection.execute(
+                        f"GRANT {target_ident} TO {membership_grantee_ident}"
+                    )
+                    try:
+                        assert await connection.fetchval(
+                            "SELECT pg_catalog.pg_has_role("
+                            "$1::name, $2::name, 'MEMBER')",
+                            delegated_login_role,
+                            target_role,
+                        )
+                        await delegated_login_connection.execute(
+                            f"SET ROLE {target_ident}"
+                        )
+                        assert (
+                            await delegated_login_connection.fetchval(
+                                "SELECT current_user"
+                            )
+                            == target_role
+                        )
+                        await delegated_login_connection.execute("RESET ROLE")
+                        with pytest.raises(
+                            asyncpg.exceptions.RaiseError,
+                            match="must be an unprivileged",
+                        ):
+                            await connection.execute(
+                                _PRIVILEGE_REPAIR_MIGRATION.read_text()
+                            )
+                        with pytest.raises(RuntimeError, match="role admission failed"):
+                            await _require_role_admission_before_mutation(
+                                admin_pool, runtime_role
+                            )
+                        await assert_repair_has_not_mutated_privileges()
+                    finally:
+                        await connection.execute(
+                            f"REVOKE {target_ident} FROM {membership_grantee_ident}"
+                        )
+                    await _require_role_admission_before_mutation(
+                        admin_pool, runtime_role
+                    )
+
+        finally:
+            if delegated_login_connection is not None:
+                await delegated_login_connection.close()
+            if delegated_group_created:
+                await connection.execute(
+                    f"REVOKE {delegated_group_ident} FROM {delegated_login_ident}"
+                )
+                await connection.execute(f"DROP OWNED BY {delegated_group_ident}")
+                await connection.execute(f"DROP ROLE {delegated_group_ident}")
+            if delegated_login_created:
+                await connection.execute(f"DROP OWNED BY {delegated_login_ident}")
+                await connection.execute(f"DROP ROLE {delegated_login_ident}")
+            if runtime_role_created:
+                await connection.execute(f"DROP OWNED BY {runtime_ident}")
+                await connection.execute(f"DROP ROLE {runtime_ident}")
+
+
+@pytest.mark.asyncio
 async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> None:
     """Apply 393 in a disposable schema and exercise both restricted roles."""
 
@@ -831,7 +988,7 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
                 f"CREATE ROLE {stale_group_ident} NOLOGIN NOINHERIT"
             )
             stale_group_created = True
-            await connection.execute(f"CREATE ROLE {stale_login_ident} LOGIN INHERIT")
+            await connection.execute(f"CREATE ROLE {stale_login_ident} LOGIN NOINHERIT")
             stale_login_created = True
             await connection.execute(
                 f"GRANT {stale_group_ident} TO {stale_login_ident}"
@@ -1205,6 +1362,24 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
 
             runtime_pool = _ConnectionPool(runtime_connection)
             assert await recovery_mod.missed_call_recovery_schema_ready(runtime_pool)
+            for target_ident, membership_grantee_ident in (
+                (runtime_probe_ident, stale_login_ident),
+                (runtime_probe_ident, stale_group_ident),
+                ("atlas_nocodb", stale_login_ident),
+                ("atlas_nocodb", stale_group_ident),
+            ):
+                await connection.execute(
+                    f"GRANT {target_ident} TO {membership_grantee_ident}"
+                )
+                assert not await recovery_mod.missed_call_recovery_schema_ready(
+                    runtime_pool
+                )
+                await connection.execute(
+                    f"REVOKE {target_ident} FROM {membership_grantee_ident}"
+                )
+                assert await recovery_mod.missed_call_recovery_schema_ready(
+                    runtime_pool
+                )
             assert await runtime_connection.fetchval(
                 "SELECT has_function_privilege("
                 "current_user, to_regprocedure("

--- a/tests/test_eom_missed_call_recovery.py
+++ b/tests/test_eom_missed_call_recovery.py
@@ -849,9 +849,54 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
                 f"GRANT USAGE ON SCHEMA {_quote_ident(schema)} TO {runtime_probe_ident}"
             )
             await connection.execute(
+                f"GRANT CREATE ON SCHEMA {_quote_ident(schema)} TO {runtime_probe_ident}"
+            )
+            await connection.execute(
                 "SELECT pg_catalog.set_config("
                 "'atlas.eom_missed_call_recovery_runtime_role', $1, FALSE)",
                 runtime_probe_role,
+            )
+            runtime_connection = await asyncpg.connect(
+                database_url,
+                user=runtime_probe_role,
+                password=_RUNTIME_PROBE_PASSWORD,
+            )
+            await runtime_connection.execute(
+                f"SET search_path TO {_quote_ident(schema)}, public"
+            )
+            await runtime_connection.execute(
+                """
+                CREATE FUNCTION eom_missed_call_effective_recipient(
+                    target_contact_id UUID,
+                    fallback_contact_email VARCHAR
+                ) RETURNS TEXT
+                LANGUAGE plpgsql
+                AS $body$
+                BEGIN
+                    PERFORM set_config(
+                        'atlas.eom_missed_call_recipient_overload_probe', current_user, FALSE
+                    );
+                    RETURN fallback_contact_email;
+                END;
+                $body$
+                """
+            )
+            await runtime_connection.execute(
+                """
+                CREATE FUNCTION cancel_eom_missed_call_sequences_for_contact(
+                    target_contact_id UUID,
+                    target_reason TEXT,
+                    target_source TEXT
+                ) RETURNS VOID
+                LANGUAGE plpgsql
+                AS $body$
+                BEGIN
+                    PERFORM set_config(
+                        'atlas.eom_missed_call_cancel_overload_probe', current_user, FALSE
+                    );
+                END;
+                $body$
+                """
             )
             runtime_contact_id = await _insert_estimate_lead(
                 admin_pool,
@@ -864,6 +909,20 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
             interaction_id = await _insert_estimate_lead(
                 admin_pool,
                 email="interaction@example.test",
+            )
+            overload_contact_id = uuid4()
+            await connection.execute(
+                """
+                INSERT INTO contacts (
+                    id, full_name, email, business_context_id, contact_type, status,
+                    lead_stage, source, customer_type, created_at
+                ) VALUES ($1, 'Overload Probe Lead', $2, $3, 'lead', 'active', 'new',
+                          'test', 'unknown', $4)
+                """,
+                overload_contact_id,
+                "overload-before@example.test",
+                _EOM_CONTEXT,
+                _NOW,
             )
             # A repair must not preserve a prior broad application grant just
             # because the table is being transferred from its old owner.
@@ -1144,16 +1203,49 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
             )
             assert stale_column_acl_rows == []
 
-            runtime_connection = await asyncpg.connect(
-                database_url,
-                user=runtime_probe_role,
-                password=_RUNTIME_PROBE_PASSWORD,
-            )
-            await runtime_connection.execute(
-                f"SET search_path TO {_quote_ident(schema)}, public"
-            )
             runtime_pool = _ConnectionPool(runtime_connection)
             assert await recovery_mod.missed_call_recovery_schema_ready(runtime_pool)
+            assert await runtime_connection.fetchval(
+                "SELECT has_function_privilege("
+                "current_user, to_regprocedure("
+                "'eom_missed_call_effective_recipient(uuid, character varying)'"
+                "), 'EXECUTE')"
+            )
+            assert await runtime_connection.fetchval(
+                "SELECT has_function_privilege("
+                "current_user, to_regprocedure("
+                "'cancel_eom_missed_call_sequences_for_contact(uuid, text, text)'"
+                "), 'EXECUTE')"
+            )
+            assert (
+                await runtime_connection.fetchval(
+                    "SELECT eom_missed_call_effective_recipient($1::UUID, $2::VARCHAR)",
+                    overload_contact_id,
+                    "runtime-overload@example.test",
+                )
+                == "runtime-overload@example.test"
+            )
+            assert (
+                await runtime_connection.fetchval(
+                    "SELECT current_setting("
+                    "'atlas.eom_missed_call_recipient_overload_probe', TRUE)"
+                )
+                == runtime_probe_role
+            )
+            await runtime_connection.execute(
+                "SELECT cancel_eom_missed_call_sequences_for_contact("
+                "$1::UUID, $2::TEXT, $3::TEXT)",
+                overload_contact_id,
+                "runtime_overload",
+                "runtime_probe",
+            )
+            assert (
+                await runtime_connection.fetchval(
+                    "SELECT current_setting("
+                    "'atlas.eom_missed_call_cancel_overload_probe', TRUE)"
+                )
+                == runtime_probe_role
+            )
 
             await connection.execute(
                 f"GRANT SELECT ON TABLE {_quote_ident(schema)}."
@@ -1381,7 +1473,7 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
                 f"GRANT USAGE ON SCHEMA {_quote_ident(schema)} TO atlas_nocodb"
             )
             await connection.execute(
-                f"GRANT SELECT, UPDATE (lead_stage) ON TABLE {_quote_ident(schema)}.contacts "
+                f"GRANT SELECT, UPDATE (lead_stage, email) ON TABLE {_quote_ident(schema)}.contacts "
                 "TO atlas_nocodb"
             )
             await connection.execute(
@@ -1413,6 +1505,40 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
                 await nocodb_connection.fetchval(
                     "SELECT recipient_email FROM eom_missed_call_sequences LIMIT 1"
                 )
+
+            (
+                _overload_contact_id,
+                _overload_attempt_id,
+                overload_sequence_id,
+            ) = await _insert_active_sequence_for_privilege_probe(
+                runtime_pool,
+                email="overload-before@example.test",
+                contact_id=overload_contact_id,
+            )
+            await nocodb_connection.execute(
+                "UPDATE contacts SET email = $2 WHERE id = $1",
+                overload_contact_id,
+                "overload-after@example.test",
+            )
+            assert (
+                await nocodb_connection.fetchval(
+                    "SELECT current_setting("
+                    "'atlas.eom_missed_call_recipient_overload_probe', TRUE)"
+                )
+                is None
+            )
+            assert (
+                await nocodb_connection.fetchval(
+                    "SELECT current_setting("
+                    "'atlas.eom_missed_call_cancel_overload_probe', TRUE)"
+                )
+                is None
+            )
+            assert await connection.fetchval(
+                "SELECT state = 'cancelled' AND cancellation_reason = 'recipient_changed' "
+                "FROM eom_missed_call_sequences WHERE id = $1",
+                overload_sequence_id,
+            )
 
             (
                 _contact_change_id,

--- a/tests/test_eom_missed_call_recovery.py
+++ b/tests/test_eom_missed_call_recovery.py
@@ -331,28 +331,31 @@ async def _insert_active_sequence_for_privilege_probe(
     pool: _ConnectionPool,
     *,
     email: str,
+    contact_id: UUID | None = None,
 ) -> tuple[UUID, UUID, UUID]:
     """Create minimal active state without calling a provider or public route."""
 
-    contact_id = uuid4()
+    should_create_contact = contact_id is None
+    contact_id = contact_id or uuid4()
     attempt_id = uuid4()
     sequence_id = uuid4()
     now = datetime.now(timezone.utc) - timedelta(minutes=1)
     operation_key = _operation_key("privilege-attempt")
     fingerprint = f"{uuid4().hex}{uuid4().hex}"
-    await pool._connection.execute(
-        """
-        INSERT INTO contacts (
-            id, full_name, email, business_context_id, contact_type, status,
-            lead_stage, source, customer_type, created_at
-        ) VALUES ($1, 'Privilege Probe Lead', $2, $3, 'lead', 'active', 'new',
-                  'test', 'unknown', $4)
-        """,
-        contact_id,
-        email,
-        _EOM_CONTEXT,
-        now,
-    )
+    if should_create_contact:
+        await pool._connection.execute(
+            """
+            INSERT INTO contacts (
+                id, full_name, email, business_context_id, contact_type, status,
+                lead_stage, source, customer_type, created_at
+            ) VALUES ($1, 'Privilege Probe Lead', $2, $3, 'lead', 'active', 'new',
+                      'test', 'unknown', $4)
+            """,
+            contact_id,
+            email,
+            _EOM_CONTEXT,
+            now,
+        )
     await pool._connection.execute(
         """
         INSERT INTO eom_missed_call_attempts (
@@ -417,11 +420,51 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
         connection = admin_pool._connection
         try:
             await _provision_privilege_repair_roles(connection)
+            runtime_contact_id = await _insert_estimate_lead(
+                admin_pool,
+                email="runtime-privilege@example.test",
+            )
+            contact_change_id = await _insert_estimate_lead(
+                admin_pool,
+                email="before-change@example.test",
+            )
+            interaction_id = await _insert_estimate_lead(
+                admin_pool,
+                email="interaction@example.test",
+            )
             # A repair must not preserve a prior broad application grant just
             # because the table is being transferred from its old owner.
             await connection.execute(
                 f"GRANT DELETE ON TABLE {_quote_ident(schema)}."
                 "eom_missed_call_sequences TO atlas"
+            )
+            await connection.execute(
+                f"GRANT UPDATE (recipient_email) ON TABLE {_quote_ident(schema)}."
+                "eom_missed_call_sequences TO atlas"
+            )
+            await connection.execute(
+                f"GRANT SELECT (recipient_email) ON TABLE {_quote_ident(schema)}."
+                "eom_missed_call_sequences TO atlas_nocodb"
+            )
+            await connection.execute(
+                f"GRANT EXECUTE ON FUNCTION {_quote_ident(schema)}."
+                "cancel_eom_missed_call_sequences_for_contact(UUID, VARCHAR, VARCHAR) "
+                "TO atlas_nocodb"
+            )
+            await connection.execute(
+                f"ALTER TABLE {_quote_ident(schema)}."
+                "eom_missed_call_operation_receipts DISABLE TRIGGER "
+                "trg_prevent_eom_missed_call_operation_receipt_mutation"
+            )
+            with pytest.raises(
+                asyncpg.exceptions.RaiseError,
+                match="append-only receipt and attempt triggers must be intact",
+            ):
+                await connection.execute(_PRIVILEGE_REPAIR_MIGRATION.read_text())
+            await connection.execute(
+                f"ALTER TABLE {_quote_ident(schema)}."
+                "eom_missed_call_operation_receipts ENABLE TRIGGER "
+                "trg_prevent_eom_missed_call_operation_receipt_mutation"
             )
             await connection.execute(_PRIVILEGE_REPAIR_MIGRATION.read_text())
 
@@ -481,6 +524,35 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
                 "eom_missed_call_sequence_steps": {"INSERT", "SELECT", "UPDATE"},
                 "eom_missed_call_sequence_events": {"INSERT", "SELECT"},
             }
+            stale_column_acl_rows = await connection.fetch(
+                """
+                SELECT relation.relname, attribute.attname
+                FROM pg_attribute AS attribute
+                JOIN pg_class AS relation ON relation.oid = attribute.attrelid
+                JOIN pg_namespace AS namespace ON namespace.oid = relation.relnamespace
+                CROSS JOIN LATERAL aclexplode(
+                    COALESCE(attribute.attacl, ARRAY[]::aclitem[])
+                ) AS acl
+                WHERE namespace.nspname = current_schema()
+                  AND relation.relname = ANY($1::text[])
+                  AND attribute.attnum > 0
+                  AND NOT attribute.attisdropped
+                  AND acl.grantee IN (
+                      0,
+                      (SELECT oid FROM pg_roles WHERE rolname = 'atlas'),
+                      (SELECT oid FROM pg_roles WHERE rolname = 'atlas_nocodb')
+                  )
+                """,
+                [
+                    "eom_missed_call_operation_receipts",
+                    "eom_missed_call_attempts",
+                    "eom_missed_call_contact_suppressions",
+                    "eom_missed_call_sequences",
+                    "eom_missed_call_sequence_steps",
+                    "eom_missed_call_sequence_events",
+                ],
+            )
+            assert stale_column_acl_rows == []
 
             database_name = await connection.fetchval("SELECT current_database()")
             await connection.execute(
@@ -545,14 +617,57 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
             )
             assert await recovery_mod.missed_call_recovery_schema_ready(runtime_pool)
 
+            await connection.execute(
+                f"GRANT DELETE ON TABLE {_quote_ident(schema)}."
+                f"eom_missed_call_sequences TO {runtime_probe_ident}"
+            )
+            assert not await recovery_mod.missed_call_recovery_schema_ready(runtime_pool)
+            await connection.execute(
+                f"REVOKE DELETE ON TABLE {_quote_ident(schema)}."
+                f"eom_missed_call_sequences FROM {runtime_probe_ident}"
+            )
+            assert await recovery_mod.missed_call_recovery_schema_ready(runtime_pool)
+
+            await connection.execute(
+                f"GRANT REFERENCES (recipient_email) ON TABLE {_quote_ident(schema)}."
+                "eom_missed_call_sequences TO atlas_nocodb"
+            )
+            assert not await recovery_mod.missed_call_recovery_schema_ready(runtime_pool)
+            await connection.execute(
+                f"REVOKE REFERENCES (recipient_email) ON TABLE {_quote_ident(schema)}."
+                "eom_missed_call_sequences FROM atlas_nocodb"
+            )
+            assert await recovery_mod.missed_call_recovery_schema_ready(runtime_pool)
+
+            await connection.execute(
+                f"GRANT TRIGGER ON TABLE {_quote_ident(schema)}."
+                "eom_missed_call_sequences TO atlas_nocodb"
+            )
+            assert not await recovery_mod.missed_call_recovery_schema_ready(runtime_pool)
+            await connection.execute(
+                f"REVOKE TRIGGER ON TABLE {_quote_ident(schema)}."
+                "eom_missed_call_sequences FROM atlas_nocodb"
+            )
+            assert await recovery_mod.missed_call_recovery_schema_ready(runtime_pool)
+
+            await connection.execute(
+                f"GRANT atlas_eom_handoff_owner TO {runtime_probe_ident}"
+            )
+            assert not await recovery_mod.missed_call_recovery_schema_ready(runtime_pool)
+            await connection.execute(
+                f"REVOKE atlas_eom_handoff_owner FROM {runtime_probe_ident}"
+            )
+            assert await recovery_mod.missed_call_recovery_schema_ready(runtime_pool)
+
             contact_id, _attempt_id, sequence_id = (
                 await _insert_active_sequence_for_privilege_probe(
-                    admin_pool,
+                    runtime_pool,
                     email="runtime-privilege@example.test",
+                    contact_id=runtime_contact_id,
                 )
             )
             receipt_key = _operation_key("runtime-receipt")
-            await connection.execute(
+            await runtime_connection.execute(
                 """
                 INSERT INTO eom_missed_call_operation_receipts (
                     operation_key, contact_id, operation_kind, request_fingerprint
@@ -633,11 +748,16 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
                 )
                 """
             )
+            with pytest.raises(asyncpg.exceptions.InsufficientPrivilegeError):
+                await nocodb_connection.fetchval(
+                    "SELECT recipient_email FROM eom_missed_call_sequences LIMIT 1"
+                )
 
-            contact_change_id, _change_attempt_id, changed_sequence_id = (
+            _contact_change_id, _change_attempt_id, changed_sequence_id = (
                 await _insert_active_sequence_for_privilege_probe(
-                    admin_pool,
+                    runtime_pool,
                     email="before-change@example.test",
+                    contact_id=contact_change_id,
                 )
             )
             await nocodb_connection.execute(
@@ -651,10 +771,11 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
                 changed_sequence_id,
             )
 
-            interaction_id, _interaction_attempt_id, interaction_sequence_id = (
+            _interaction_id, _interaction_attempt_id, interaction_sequence_id = (
                 await _insert_active_sequence_for_privilege_probe(
-                    admin_pool,
+                    runtime_pool,
                     email="interaction@example.test",
+                    contact_id=interaction_id,
                 )
             )
             await nocodb_connection.execute(
@@ -2591,10 +2712,18 @@ async def test_resume_and_cancel_keys_are_globally_bound_to_their_original_conta
 
 
 @pytest.mark.asyncio
-async def test_operator_route_reaches_persisted_call_and_status_state() -> None:
+async def test_operator_route_reaches_persisted_call_and_status_state(monkeypatch) -> None:
     async with _test_store() as (pool, _schema):
         contact_id = await _insert_estimate_lead(pool)
         service = _service(pool, gateway=_FakeGateway())
+
+        async def schema_ready() -> None:
+            return None
+
+        # This route fixture intentionally exercises the persisted handler on
+        # migration-389 shape only. The dedicated real-role test above settles
+        # the stricter 393 readiness predicate and ACL boundary.
+        monkeypatch.setattr(service, "require_schema_ready", schema_ready)
         app = FastAPI()
         app.include_router(funnel_mod.router, prefix="/api/v1")
         app.dependency_overrides[funnel_auth_mod.require_eom_funnel_api] = lambda: None

--- a/tests/test_eom_missed_call_recovery.py
+++ b/tests/test_eom_missed_call_recovery.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 from hashlib import sha256
+import importlib.util
 import json
 import os
 import re
@@ -16,6 +17,7 @@ from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
 from itertools import product
 from pathlib import Path
+import sys
 from types import SimpleNamespace
 from typing import Any
 from uuid import UUID, uuid4
@@ -49,12 +51,31 @@ from atlas_brain.templates.email.estimate_confirmation import (  # noqa: E402
 from atlas_brain.templates.email.missed_call_recovery import (  # noqa: E402
     render_missed_call_recovery_email,
 )
-from scripts.apply_eom_missed_call_recovery_runtime_privileges import (
-    _require_role_admission_before_mutation,
-)
 
 
 ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_privilege_runner() -> Any:
+    """Load the executable controlled runner without packaging ``scripts``."""
+
+    module_name = "test_eom_missed_call_recovery_privilege_runner"
+    spec = importlib.util.spec_from_file_location(
+        module_name,
+        ROOT / "scripts" / "apply_eom_missed_call_recovery_runtime_privileges.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_require_role_admission_before_mutation = (
+    _load_privilege_runner()._require_role_admission_before_mutation
+)
+
+
 MIGRATIONS = ROOT / "atlas_brain" / "storage" / "migrations"
 DATABASE_URL_ENV = "ATLAS_MIGRATION_TEST_DATABASE_URL"
 _EOM_CONTEXT = "effingham_maids"

--- a/tests/test_eom_missed_call_recovery.py
+++ b/tests/test_eom_missed_call_recovery.py
@@ -102,6 +102,22 @@ _TRUSTED_BRIDGE_FUNCTIONS = (
         "plpgsql",
     ),
 )
+_TRUSTED_APPEND_ONLY_FENCE_FUNCTION_SIGNATURES = (
+    "prevent_eom_missed_call_operation_receipt_mutation()",
+    "prevent_eom_missed_call_attempt_mutation()",
+)
+_TRUSTED_APPEND_ONLY_FENCE_FUNCTIONS = (
+    (
+        "prevent_eom_missed_call_operation_receipt_mutation()",
+        "prevent_eom_missed_call_operation_receipt_mutation",
+        "plpgsql",
+    ),
+    (
+        "prevent_eom_missed_call_attempt_mutation()",
+        "prevent_eom_missed_call_attempt_mutation",
+        "plpgsql",
+    ),
+)
 
 
 class _ConnectionPool:
@@ -193,11 +209,12 @@ def _quote_ident(identifier: str) -> str:
     return '"' + identifier.replace('"', '""') + '"'
 
 
-def test_privilege_repair_trusted_bridge_hashes_match_migration_389_source() -> None:
-    """Keep 393's body allowlist tied to the immutable migration-389 source."""
+def test_privilege_repair_trusted_function_bodies_match_migration_389_source() -> None:
+    """Keep 393/readiness body checks tied to immutable migration-389 source."""
 
     source = (MIGRATIONS / "389_eom_missed_call_recovery.sql").read_text()
     repair = _PRIVILEGE_REPAIR_MIGRATION.read_text()
+    readiness = (ROOT / "atlas_brain/services/eom_missed_call_recovery.py").read_text()
     extension_install = "EXECUTE 'CREATE EXTENSION IF NOT EXISTS pgcrypto';"
     assert extension_install in repair
     assert repair.index(extension_install) > repair.index(
@@ -209,7 +226,11 @@ def test_privilege_repair_trusted_bridge_hashes_match_migration_389_source() -> 
     assert repair.index(extension_install) < repair.index(
         "SELECT namespace_state.nspname"
     )
-    for signature, function_name, language_name in _TRUSTED_BRIDGE_FUNCTIONS:
+    trusted_functions = (
+        *_TRUSTED_BRIDGE_FUNCTIONS,
+        *_TRUSTED_APPEND_ONLY_FENCE_FUNCTIONS,
+    )
+    for signature, function_name, language_name in trusted_functions:
         function_match = re.search(
             rf"CREATE OR REPLACE FUNCTION {re.escape(function_name)}\b(.*?)"
             r"(?=\nCREATE OR REPLACE FUNCTION|\Z)",
@@ -231,6 +252,17 @@ def test_privilege_repair_trusted_bridge_hashes_match_migration_389_source() -> 
             re.DOTALL,
         )
         assert expected_entry.search(repair), signature
+
+        if signature in _TRUSTED_APPEND_ONLY_FENCE_FUNCTION_SIGNATURES:
+            readiness_body = "E'" + (
+                language_and_body_match.group(2)
+                .replace("\\", "\\\\")
+                .replace("'", "''")
+                .replace("\n", "\\\\n")
+            ) + "'"
+            assert signature in readiness
+            assert readiness_body in readiness
+    assert "language_state.lanname = 'plpgsql'" in readiness
 
 
 async def _tamper_bridge_function(
@@ -294,6 +326,72 @@ async def _tamper_bridge_function(
         """,
     }
     await connection.execute(definitions[function_signature])
+
+
+async def _replace_append_only_fence_function(
+    connection: Any,
+    *,
+    schema: str,
+    function_signature: str,
+    body: str,
+) -> None:
+    """Replace one bound append-only function without changing its OID."""
+
+    function_names = {
+        "prevent_eom_missed_call_operation_receipt_mutation()": (
+            "prevent_eom_missed_call_operation_receipt_mutation"
+        ),
+        "prevent_eom_missed_call_attempt_mutation()": (
+            "prevent_eom_missed_call_attempt_mutation"
+        ),
+    }
+    function_name = function_names[function_signature]
+    await connection.execute(
+        "CREATE OR REPLACE FUNCTION "
+        f"{_quote_ident(schema)}.{function_name}() "
+        "RETURNS TRIGGER LANGUAGE plpgsql AS $$"
+        f"{body}$$;"
+    )
+
+
+async def _tamper_append_only_fence_function(
+    connection: Any,
+    *,
+    schema: str,
+    function_signature: str,
+) -> None:
+    await _replace_append_only_fence_function(
+        connection,
+        schema=schema,
+        function_signature=function_signature,
+        body="\nBEGIN\n    RETURN NEW;\nEND;\n",
+    )
+
+
+async def _restore_append_only_fence_function(
+    connection: Any,
+    *,
+    schema: str,
+    function_signature: str,
+) -> None:
+    messages = {
+        "prevent_eom_missed_call_operation_receipt_mutation()": (
+            "eom_missed_call_operation_receipts is append-only"
+        ),
+        "prevent_eom_missed_call_attempt_mutation()": (
+            "eom_missed_call_attempts is append-only"
+        ),
+    }
+    await _replace_append_only_fence_function(
+        connection,
+        schema=schema,
+        function_signature=function_signature,
+        body=(
+            "\nBEGIN\n"
+            f"    RAISE EXCEPTION '{messages[function_signature]}';\n"
+            "END;\n"
+        ),
+    )
 
 
 async def _require_disposable_role_administration(connection: Any) -> None:
@@ -746,6 +844,24 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
             runtime_pool = _ConnectionPool(runtime_connection)
             assert await recovery_mod.missed_call_recovery_schema_ready(runtime_pool)
 
+            for function_signature in _TRUSTED_APPEND_ONLY_FENCE_FUNCTION_SIGNATURES:
+                await _tamper_append_only_fence_function(
+                    connection,
+                    schema=schema,
+                    function_signature=function_signature,
+                )
+                assert not await recovery_mod.missed_call_recovery_schema_ready(
+                    runtime_pool
+                )
+                await _restore_append_only_fence_function(
+                    connection,
+                    schema=schema,
+                    function_signature=function_signature,
+                )
+                assert await recovery_mod.missed_call_recovery_schema_ready(
+                    runtime_pool
+                )
+
             await connection.execute(
                 f"REVOKE INSERT ON TABLE {_quote_ident(schema)}."
                 f"eom_missed_call_sequence_events FROM {runtime_probe_ident}"
@@ -999,6 +1115,49 @@ async def test_privilege_repair_rejects_each_tampered_bridge_body(
             WHERE procedure.oid = pg_catalog.to_regprocedure($1::text)
             """,
             qualified_signature,
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "function_signature", _TRUSTED_APPEND_ONLY_FENCE_FUNCTION_SIGNATURES
+)
+async def test_privilege_repair_rejects_each_tampered_append_only_fence_body(
+    function_signature: str,
+) -> None:
+    """No altered append-only fence body may authorize runtime UPDATE grants."""
+
+    _database_url_or_skip()
+    async with _test_store() as (admin_pool, schema):
+        connection = admin_pool._connection
+        await _provision_privilege_repair_roles(connection)
+        await _tamper_append_only_fence_function(
+            connection,
+            schema=schema,
+            function_signature=function_signature,
+        )
+
+        with pytest.raises(
+            asyncpg.exceptions.RaiseError,
+            match="append-only fence function .*trusted migration-389 body",
+        ):
+            await connection.execute(_PRIVILEGE_REPAIR_MIGRATION.read_text())
+
+        protected_table_name = (
+            "eom_missed_call_operation_receipts"
+            if "operation_receipt" in function_signature
+            else "eom_missed_call_attempts"
+        )
+        assert not await connection.fetchval(
+            """
+            SELECT has_table_privilege(
+                'atlas',
+                to_regclass(format('%I.%I', $1::text, $2::text)),
+                'UPDATE'
+            )
+            """,
+            schema,
+            protected_table_name,
         )
 
 

--- a/tests/test_eom_missed_call_recovery.py
+++ b/tests/test_eom_missed_call_recovery.py
@@ -198,6 +198,17 @@ def test_privilege_repair_trusted_bridge_hashes_match_migration_389_source() -> 
 
     source = (MIGRATIONS / "389_eom_missed_call_recovery.sql").read_text()
     repair = _PRIVILEGE_REPAIR_MIGRATION.read_text()
+    extension_install = "EXECUTE 'CREATE EXTENSION IF NOT EXISTS pgcrypto';"
+    assert extension_install in repair
+    assert repair.index(extension_install) > repair.index(
+        "IF NOT executor_is_superuser THEN"
+    )
+    assert repair.index(extension_install) > repair.index(
+        "IF NOT nocodb_role_ready THEN"
+    )
+    assert repair.index(extension_install) < repair.index(
+        "SELECT namespace_state.nspname"
+    )
     for signature, function_name, language_name in _TRUSTED_BRIDGE_FUNCTIONS:
         function_match = re.search(
             rf"CREATE OR REPLACE FUNCTION {re.escape(function_name)}\b(.*?)"
@@ -553,6 +564,10 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
     async with _test_store() as (admin_pool, schema):
         connection = admin_pool._connection
         try:
+            assert not await connection.fetchval(
+                "SELECT EXISTS (SELECT 1 FROM pg_catalog.pg_extension "
+                "WHERE extname = 'pgcrypto')"
+            )
             await _provision_privilege_repair_roles(connection)
             runtime_contact_id = await _insert_estimate_lead(
                 admin_pool,
@@ -601,6 +616,10 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
                 "trg_prevent_eom_missed_call_operation_receipt_mutation"
             )
             await connection.execute(_PRIVILEGE_REPAIR_MIGRATION.read_text())
+            assert await connection.fetchval(
+                "SELECT EXISTS (SELECT 1 FROM pg_catalog.pg_extension "
+                "WHERE extname = 'pgcrypto')"
+            )
 
             table_rows = await connection.fetch(
                 """

--- a/tests/test_eom_missed_call_recovery.py
+++ b/tests/test_eom_missed_call_recovery.py
@@ -345,7 +345,7 @@ async def _tamper_bridge_function(
     definitions = {
         "cancel_eom_missed_call_sequences_for_contact(UUID, VARCHAR, VARCHAR)": f"""
             CREATE OR REPLACE FUNCTION {schema_ident}.cancel_eom_missed_call_sequences_for_contact(
-                UUID, VARCHAR, VARCHAR
+                target_contact_id UUID, target_reason VARCHAR, target_source VARCHAR
             ) RETURNS VOID LANGUAGE plpgsql AS $$
             BEGIN
                 RETURN;
@@ -362,14 +362,14 @@ async def _tamper_bridge_function(
         """,
         "eom_missed_call_effective_recipient(UUID, TEXT)": f"""
             CREATE OR REPLACE FUNCTION {schema_ident}.eom_missed_call_effective_recipient(
-                UUID, TEXT
+                target_contact_id UUID, fallback_contact_email TEXT
             ) RETURNS TEXT LANGUAGE sql AS $$
             SELECT 'tampered'::TEXT;
             $$;
         """,
         "cancel_eom_missed_call_on_recipient_change(UUID)": f"""
             CREATE OR REPLACE FUNCTION {schema_ident}.cancel_eom_missed_call_on_recipient_change(
-                UUID
+                target_contact_id UUID
             ) RETURNS VOID LANGUAGE plpgsql AS $$
             BEGIN
                 RETURN;
@@ -485,7 +485,7 @@ async def _tamper_guard_function(
         """,
         "eom_missed_call_has_proven_inbound_sms(JSONB)": f"""
             CREATE OR REPLACE FUNCTION {schema_ident}.eom_missed_call_has_proven_inbound_sms(
-                JSONB
+                candidate_metadata JSONB
             ) RETURNS BOOLEAN LANGUAGE sql IMMUTABLE AS $$
             SELECT TRUE;
             $$;
@@ -930,6 +930,15 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
                 ],
             )
             assert {row["owner"] for row in table_rows} == {"atlas_eom_handoff_owner"}
+            assert await connection.fetchval(
+                """
+                SELECT has_table_privilege(
+                    'atlas_eom_handoff_owner',
+                    to_regclass(format('%I.%I', current_schema(), 'eom_missed_call_attempts')),
+                    'SELECT'
+                )
+                """
+            )
             for function_signature in _TRUSTED_GUARD_FUNCTION_SIGNATURES:
                 qualified_signature = f"{_quote_ident(schema)}.{function_signature}"
                 assert await connection.fetchval(
@@ -1273,7 +1282,7 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
                 f"GRANT USAGE ON SCHEMA {_quote_ident(schema)} TO atlas_nocodb"
             )
             await connection.execute(
-                f"GRANT SELECT, UPDATE (email) ON TABLE {_quote_ident(schema)}.contacts "
+                f"GRANT SELECT, UPDATE (lead_stage) ON TABLE {_quote_ident(schema)}.contacts "
                 "TO atlas_nocodb"
             )
             await connection.execute(
@@ -1316,12 +1325,12 @@ async def test_privilege_repair_keeps_runtime_operable_and_nocodb_guarded() -> N
                 contact_id=contact_change_id,
             )
             await nocodb_connection.execute(
-                "UPDATE contacts SET email = $2 WHERE id = $1",
+                "UPDATE contacts SET lead_stage = $2 WHERE id = $1",
                 contact_change_id,
-                "after-change@example.test",
+                "qualified",
             )
             assert await connection.fetchval(
-                "SELECT state = 'cancelled' AND cancellation_reason = 'recipient_changed' "
+                "SELECT state = 'cancelled' AND cancellation_reason = 'lead_advanced' "
                 "FROM eom_missed_call_sequences WHERE id = $1",
                 changed_sequence_id,
             )

--- a/tests/test_eom_render_profile.py
+++ b/tests/test_eom_render_profile.py
@@ -689,10 +689,6 @@ def test_eom_missed_call_recovery_migration_helper_uses_funnel_curated_set():
         "351_eom_lead_lifecycle_events",
         "366_contacts_customer_type",
         "389_eom_missed_call_recovery",
-        "390_eom_won_loss_direct_sql_fence_recovery",
-        "391_eom_commercial_billing_run_fence_recovery",
-        "392_eom_commercial_billing_run_fence_schema_binding",
-        "393_eom_missed_call_recovery_runtime_privileges",
     )
 
 

--- a/tests/test_eom_render_profile.py
+++ b/tests/test_eom_render_profile.py
@@ -692,6 +692,7 @@ def test_eom_missed_call_recovery_migration_helper_uses_funnel_curated_set():
         "390_eom_won_loss_direct_sql_fence_recovery",
         "391_eom_commercial_billing_run_fence_recovery",
         "392_eom_commercial_billing_run_fence_schema_binding",
+        "393_eom_missed_call_recovery_runtime_privileges",
     )
 
 

--- a/tests/test_eom_render_profile.py
+++ b/tests/test_eom_render_profile.py
@@ -1823,7 +1823,7 @@ def test_eom_lifespan_closes_generic_database_when_funnel_close_fails(monkeypatc
     class _Pool:
         is_initialized = True
 
-        async def fetchval(self, query: str) -> bool:
+        async def fetchval(self, query: str, *_args: object) -> bool:
             events.append("datastore-check")
             return True
 
@@ -2224,7 +2224,7 @@ class _ReadyPool:
         self.queries = []
         self.closed = 0
 
-    async def fetchval(self, query):
+    async def fetchval(self, query, *_args):
         self.queries.append(query)
         return True
 

--- a/tests/test_migrations_runner.py
+++ b/tests/test_migrations_runner.py
@@ -1369,12 +1369,16 @@ async def test_generic_run_skips_controlled_dba_migration_until_explicitly_selec
     )
 
     assert CONTROLLED_DBA_MIGRATION_NAMES == {
-        "394_eom_first_clean_completion_receipts"
+        "393_eom_missed_call_recovery_runtime_privileges",
+        "394_eom_first_clean_completion_receipts",
     }
-    controlled_name = next(iter(CONTROLLED_DBA_MIGRATION_NAMES))
-    controlled_source = "SELECT 'controlled DBA migration'"
+    controlled_sources = {
+        controlled_name: f"SELECT '{controlled_name}'"
+        for controlled_name in CONTROLLED_DBA_MIGRATION_NAMES
+    }
     ordinary_source = "SELECT 'ordinary migration'"
-    (tmp_path / f"{controlled_name}.sql").write_text(controlled_source)
+    for controlled_name, controlled_source in controlled_sources.items():
+        (tmp_path / f"{controlled_name}.sql").write_text(controlled_source)
     (tmp_path / "395_ordinary_probe.sql").write_text(ordinary_source)
     pool = _SerializingPool(honor_lock=True)
     caplog.set_level(logging.INFO, logger="atlas.storage.migrations")
@@ -1382,17 +1386,28 @@ async def test_generic_run_skips_controlled_dba_migration_until_explicitly_selec
     await run_migrations(pool, migrations_dir=tmp_path)
 
     assert pool.applied_sql == [ordinary_source]
-    assert all(name != controlled_name for _version, name, _digest in pool.records)
-    assert "Skipping 1 controlled DBA migration" in caplog.text
-
-    await run_migrations(
-        pool,
-        migrations_dir=tmp_path,
-        only={controlled_name},
+    assert all(
+        name not in CONTROLLED_DBA_MIGRATION_NAMES
+        for _version, name, _digest in pool.records
     )
+    assert "Skipping 2 controlled DBA migration(s)" in caplog.text
 
-    assert pool.applied_sql == [ordinary_source, controlled_source]
-    assert any(name == controlled_name for _version, name, _digest in pool.records)
+    for controlled_name in sorted(CONTROLLED_DBA_MIGRATION_NAMES):
+        await run_migrations(
+            pool,
+            migrations_dir=tmp_path,
+            only={controlled_name},
+        )
+
+    assert pool.applied_sql == [
+        ordinary_source,
+        *(controlled_sources[name] for name in sorted(controlled_sources)),
+    ]
+    assert {
+        name
+        for _version, name, _digest in pool.records
+        if name in CONTROLLED_DBA_MIGRATION_NAMES
+    } == CONTROLLED_DBA_MIGRATION_NAMES
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md
Slice phase: Production hardening
Ownership lane: eom/missed-call-recovery-runtime-privileges

Migration 389 can leave missed-call recovery objects owned by its DBA executor while the configured EOM funnel runtime cannot use them. This forward-only repair establishes the guarded owner/ACL boundary, makes readiness reject privilege or trigger drift, and keeps the DBA-only repair outside normal runtime startup.

<!-- atlas-open-pr-wrapper: v1 -->

## Intentional

- Preserve migration 389 and recorded recovery evidence; repair only through the new recorded migration.
- Preserve existing `FOR UPDATE`, `--apply`, `--json`, redacted-result, and normal runtime behavior.
- Keep the protected DBA secret out of the ordinary Atlas runtime; only the controlled runner loads it.
- Keep routes, providers, delivery, billing, role memberships, historical migrations, the generic migration runner, and production database state unchanged.

## AI reconciliation

- Validate the complete role boundary before admitting the worker -- fixed-in: 38110ff097e619bc2d74b50689bdb7cbf66d2354; atlas_brain/services/eom_missed_call_recovery.py enforces the runtime, guard, and NocoDB boundary before recovery-worker admission.
- Clear every stale NocoDB ACL before installing definers -- fixed-in: 38110ff097e619bc2d74b50689bdb7cbf66d2354; atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql rebuilds recovery ACLs before guarded definer grants.
- Verify the append-only fences before granting UPDATE -- fixed-in: 38110ff097e619bc2d74b50689bdb7cbf66d2354; atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql attests the receipt and attempt fences before runtime UPDATE privileges.
- Separate the DBA repair from runtime migrations -- fixed-in: 38110ff097e619bc2d74b50689bdb7cbf66d2354; atlas_brain/main_eom.py excludes the DBA-only repair from normal EOM startup while scripts/apply_eom_missed_call_recovery_runtime_privileges.py owns the controlled path.
- Refuse repair until migration 389 is recorded -- fixed-in: 38110ff097e619bc2d74b50689bdb7cbf66d2354; scripts/apply_eom_missed_call_recovery_runtime_privileges.py requires the migration-389 ledger receipt before applying 393.
- Preserve historical recovery authorization during bootstrap -- fixed-in: 38110ff097e619bc2d74b50689bdb7cbf66d2354; scripts/apply_eom_missed_call_recovery_runtime_privileges.py applies the exact authorized historical prelude before the repair.
- Validate function bodies before granting definer authority -- fixed-in: 38110ff097e619bc2d74b50689bdb7cbf66d2354; atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql checks bridge body and language evidence before owner or definer elevation.
- Enroll the runner tests in EOM CI -- fixed-in: 38110ff097e619bc2d74b50689bdb7cbf66d2354; .github/workflows/atlas_eom_lead_pipeline_checks.yml includes tests/test_eom_missed_call_privilege_runner.py in the EOM test command.
- Provision pgcrypto before running migration 393 -- fixed-in: 38110ff097e619bc2d74b50689bdb7cbf66d2354; scripts/apply_eom_missed_call_recovery_runtime_privileges.py and atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql establish the prerequisite before digest checks.
- Retry after each committed historical prelude -- fixed-in: 38110ff097e619bc2d74b50689bdb7cbf66d2354; scripts/apply_eom_missed_call_recovery_runtime_privileges.py retries only after an authorized prelude receipt advances.
- Attest append-only trigger bodies before granting UPDATE -- fixed-in: 38110ff097e619bc2d74b50689bdb7cbf66d2354; atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql validates both trigger bodies before the update-grant path.
- Revoke runtime access to the definer helpers -- fixed-in: 38110ff097e619bc2d74b50689bdb7cbf66d2354; atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql removes non-guard direct EXECUTE grants and readiness rejects drift.
- Move all guard-critical functions to the isolated owner -- fixed-in: 38110ff097e619bc2d74b50689bdb7cbf66d2354; atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql transfers each attested bridge, fence, validator, and helper to the guard owner.
- Provision pgcrypto before applying historical preludes -- fixed-in: 38110ff097e619bc2d74b50689bdb7cbf66d2354; scripts/apply_eom_missed_call_recovery_runtime_privileges.py establishes pgcrypto through the admitted DBA pool before selecting historical preludes.
- Grant privileges to the configured runtime role -- fixed-in: 38110ff097e619bc2d74b50689bdb7cbf66d2354; scripts/apply_eom_missed_call_recovery_runtime_privileges.py binds the configured runtime login and migration 393 grants only that role.
- Validate role admissions before installing pgcrypto -- fixed-in: 38110ff097e619bc2d74b50689bdb7cbf66d2354; scripts/apply_eom_missed_call_recovery_runtime_privileges.py mirrors migration 393 role admissions before extension creation or a historical prelude.
- Use an unprivileged runtime in the tamper tests -- fixed-in: 38110ff097e619bc2d74b50689bdb7cbf66d2354; tests/test_eom_missed_call_recovery.py binds each tamper case to a disposable LOGIN NOINHERIT probe.
- Revoke recovery ACLs from every unauthorized role -- fixed-in: 38110ff097e619bc2d74b50689bdb7cbf66d2354; atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql rebuilds direct recovery ACLs while atlas_brain/services/eom_missed_call_recovery.py rejects non-allowlisted grants.
- Fix the migration-state tuple unpacking -- not-applicable: scripts/apply_eom_missed_call_recovery_runtime_privileges.py returns five values and every current caller binds five; tests/test_eom_missed_call_privilege_runner.py exercises the existing-ledger apply branch.
- Remove writable schemas from definer search paths -- fixed-in: 38110ff097e619bc2d74b50689bdb7cbf66d2354; atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql uses fixed, schema-qualified definitions before definer elevation.
- Reject roles that can assume the admitted logins -- fixed-in: f10985b2c5b634a975950fdd842c3f5d18ad8565; the migration, controlled runner, and worker readiness predicate reject unsafe direct or transitive non-superuser login delegation, with disposable-role proof in `tests/test_eom_missed_call_recovery.py`.
- Attest the runtime database before applying the DBA migration -- fixed-in: f10985b2c5b634a975950fdd842c3f5d18ad8565; `scripts/apply_eom_missed_call_recovery_runtime_privileges.py` records the runtime target, binds the DBA pool to its schema, requires cross-pool transaction-lock contention, and re-attests before and after migration work.
- Load the protected DSNs through typed settings -- fixed-in: f10985b2c5b634a975950fdd842c3f5d18ad8565; `atlas_brain/config.py` provides the protected `SecretStr` setting, while the runner uses that setting and `EOMFunnelConfig` instead of caller-selected environment-variable names.
- Reserve migration 393 from generic migration runs -- fixed-in: da6f299d6812f95899995497ac803f0f9cf1da05; `atlas_brain/storage/migrations/__init__.py` reserves 393 with the existing controlled DBA migration, and `tests/test_migrations_runner.py` proves generic startup skips both while explicit selection reaches either one.
- Pin migration 393 to one database backend -- fixed-in: da6f299d6812f95899995497ac803f0f9cf1da05; `scripts/apply_eom_missed_call_recovery_runtime_privileges.py` holds the canonical lock and runtime-role setting on one transaction-pinned connection, with focused retry and identity proof in `tests/test_eom_missed_call_privilege_runner.py`.
- Findings reviewed: yes.

## Fix-loop disposition preflight

- Root decision: Validate the complete role boundary before admitting the worker
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: atlas_brain/services/eom_missed_call_recovery.py, atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql, tests/test_eom_missed_call_recovery.py
- Max files: 13
- Parked hardening: none
- Source trace: worker admission -> readiness predicate -> catalog role and ACL boundary
- Upstream files: atlas_brain/services/eom_missed_call_recovery.py
- Fix strategy: upstream-root

- Root decision: Clear every stale NocoDB ACL before installing definers
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql, tests/test_eom_missed_call_recovery.py
- Max files: 13
- Parked hardening: none
- Source trace: direct NocoDB recovery access -> ACL rebuild -> guarded definer grant
- Upstream files: atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql
- Fix strategy: upstream-root

- Root decision: Verify the append-only fences before granting UPDATE
- Blocking predicate: data
- Disposition: fixed-in
- Allowed files: atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql, tests/test_eom_missed_call_recovery.py
- Max files: 13
- Parked hardening: none
- Source trace: runtime UPDATE grant -> append-only trigger fence -> source-body attestation
- Upstream files: atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql
- Fix strategy: upstream-root

- Root decision: Separate the DBA repair from runtime migrations
- Blocking predicate: ci
- Disposition: fixed-in
- Allowed files: atlas_brain/main_eom.py, scripts/apply_eom_missed_call_recovery_runtime_privileges.py, tests/test_eom_missed_call_privilege_runner.py
- Max files: 13
- Parked hardening: none
- Source trace: normal startup tuple -> DBA-only runner -> controlled migration repair
- Upstream files: atlas_brain/main_eom.py, scripts/apply_eom_missed_call_recovery_runtime_privileges.py
- Fix strategy: upstream-root

- Root decision: Refuse repair until migration 389 is recorded
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: scripts/apply_eom_missed_call_recovery_runtime_privileges.py, tests/test_eom_missed_call_privilege_runner.py
- Max files: 13
- Parked hardening: none
- Source trace: repair apply request -> migration ledger prerequisite -> migration 393 selection
- Upstream files: scripts/apply_eom_missed_call_recovery_runtime_privileges.py
- Fix strategy: upstream-root

- Root decision: Preserve historical recovery authorization during bootstrap
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: scripts/apply_eom_missed_call_recovery_runtime_privileges.py, tests/test_eom_missed_call_privilege_runner.py
- Max files: 13
- Parked hardening: none
- Source trace: legacy recovery evidence -> authorized historical prelude selector -> forward repair
- Upstream files: scripts/apply_eom_missed_call_recovery_runtime_privileges.py
- Fix strategy: upstream-root

- Root decision: Validate function bodies before granting definer authority
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql, tests/test_eom_missed_call_recovery.py
- Max files: 13
- Parked hardening: none
- Source trace: bridge function body -> pg_proc attestation -> definer authority change
- Upstream files: atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql
- Fix strategy: upstream-root

- Root decision: Enroll the runner tests in EOM CI
- Blocking predicate: ci
- Disposition: fixed-in
- Allowed files: .github/workflows/atlas_eom_lead_pipeline_checks.yml, tests/test_eom_missed_call_privilege_runner.py
- Max files: 13
- Parked hardening: none
- Source trace: runner change -> EOM workflow path filter -> focused runner pytest
- Upstream files: .github/workflows/atlas_eom_lead_pipeline_checks.yml
- Fix strategy: upstream-root

- Root decision: Provision pgcrypto before running migration 393
- Blocking predicate: ci
- Disposition: fixed-in
- Allowed files: scripts/apply_eom_missed_call_recovery_runtime_privileges.py, atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql, tests/test_eom_missed_call_recovery.py
- Max files: 13
- Parked hardening: none
- Source trace: bridge digest -> pgcrypto dependency -> migration 393 repair
- Upstream files: atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql
- Fix strategy: upstream-root

- Root decision: Retry after each committed historical prelude
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: scripts/apply_eom_missed_call_recovery_runtime_privileges.py, tests/test_eom_missed_call_privilege_runner.py
- Max files: 13
- Parked hardening: none
- Source trace: integrity progress stop -> migration ledger reread -> authorized retry
- Upstream files: scripts/apply_eom_missed_call_recovery_runtime_privileges.py
- Fix strategy: upstream-root

- Root decision: Attest append-only trigger bodies before granting UPDATE
- Blocking predicate: data
- Disposition: fixed-in
- Allowed files: atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql, atlas_brain/services/eom_missed_call_recovery.py, tests/test_eom_missed_call_recovery.py
- Max files: 13
- Parked hardening: none
- Source trace: runtime UPDATE grant -> fence function body -> trigger-body attestation
- Upstream files: atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql
- Fix strategy: upstream-root

- Root decision: Revoke runtime access to the definer helpers
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql, atlas_brain/services/eom_missed_call_recovery.py, tests/test_eom_missed_call_recovery.py
- Max files: 13
- Parked hardening: none
- Source trace: direct helper execute -> definer path -> terminal sequence mutation
- Upstream files: atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql
- Fix strategy: upstream-root

- Root decision: Move all guard-critical functions to the isolated owner
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql, atlas_brain/services/eom_missed_call_recovery.py, tests/test_eom_missed_call_recovery.py
- Max files: 13
- Parked hardening: none
- Source trace: bridge and fence functions -> guard ownership transfer -> readiness admission
- Upstream files: atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql
- Fix strategy: upstream-root

- Root decision: Provision pgcrypto before applying historical preludes
- Blocking predicate: ci
- Disposition: fixed-in
- Allowed files: scripts/apply_eom_missed_call_recovery_runtime_privileges.py, tests/test_eom_missed_call_privilege_runner.py
- Max files: 13
- Parked hardening: none
- Source trace: historical prelude -> pgcrypto dependency -> admitted DBA setup
- Upstream files: scripts/apply_eom_missed_call_recovery_runtime_privileges.py
- Fix strategy: upstream-root

- Root decision: Grant privileges to the configured runtime role
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: scripts/apply_eom_missed_call_recovery_runtime_privileges.py, atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql, tests/test_eom_missed_call_recovery.py
- Max files: 13
- Parked hardening: none
- Source trace: configured funnel login -> migration setting -> exact runtime ACL
- Upstream files: atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql
- Fix strategy: upstream-root

- Root decision: Validate role admissions before installing pgcrypto
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: scripts/apply_eom_missed_call_recovery_runtime_privileges.py, tests/test_eom_missed_call_privilege_runner.py
- Max files: 13
- Parked hardening: none
- Source trace: runner apply request -> catalog role admission -> pgcrypto creation
- Upstream files: scripts/apply_eom_missed_call_recovery_runtime_privileges.py
- Fix strategy: upstream-root

- Root decision: Use an unprivileged runtime in the tamper tests
- Blocking predicate: ci
- Disposition: fixed-in
- Allowed files: tests/test_eom_missed_call_recovery.py
- Max files: 13
- Parked hardening: none
- Source trace: tamper test setup -> disposable unprivileged login -> trusted-body assertion
- Upstream files: tests/test_eom_missed_call_recovery.py
- Fix strategy: upstream-root

- Root decision: Revoke recovery ACLs from every unauthorized role
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql, atlas_brain/services/eom_missed_call_recovery.py, tests/test_eom_missed_call_recovery.py
- Max files: 13
- Parked hardening: none
- Source trace: stale recovery ACL -> catalog ACL rebuild -> readiness allowlist check
- Upstream files: atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql
- Fix strategy: upstream-root

- Root decision: Fix the migration-state tuple unpacking
- Blocking predicate: not-blocking
- Disposition: not-applicable
- Allowed files: scripts/apply_eom_missed_call_recovery_runtime_privileges.py, tests/test_eom_missed_call_privilege_runner.py
- Max files: 13
- Parked hardening: none
- Source trace: migration state query -> five-value return tuple -> controlled apply decision
- Upstream files: scripts/apply_eom_missed_call_recovery_runtime_privileges.py
- Fix strategy: upstream-root

- Root decision: Remove writable schemas from definer search paths
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql, tests/test_eom_missed_call_recovery.py
- Max files: 13
- Parked hardening: none
- Source trace: definer search path -> helper lookup -> schema-qualified fixed path
- Upstream files: atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql
- Fix strategy: upstream-root

- Root decision: Reject roles that can assume the admitted logins
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: .github/workflows/atlas_eom_lead_pipeline_checks.yml, atlas_brain/config.py, atlas_brain/main_eom.py, atlas_brain/services/eom_missed_call_recovery.py, atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql, docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md, plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md, scripts/apply_eom_missed_call_recovery_runtime_privileges.py, tests/test_eom_missed_call_privilege_runner.py, tests/test_eom_missed_call_recovery.py, tests/test_eom_render_profile.py
- Max files: 13
- Parked hardening: none
- Source trace: delegated login -> role-admission query -> controlled migration and worker admission gate
- Upstream files: atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql, scripts/apply_eom_missed_call_recovery_runtime_privileges.py, atlas_brain/services/eom_missed_call_recovery.py
- Fix strategy: upstream-root

- Root decision: Attest the runtime database before applying the DBA migration
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: .github/workflows/atlas_eom_lead_pipeline_checks.yml, atlas_brain/config.py, atlas_brain/main_eom.py, atlas_brain/services/eom_missed_call_recovery.py, atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql, docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md, plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md, scripts/apply_eom_missed_call_recovery_runtime_privileges.py, tests/test_eom_missed_call_privilege_runner.py, tests/test_eom_missed_call_recovery.py, tests/test_eom_render_profile.py
- Max files: 13
- Parked hardening: none
- Source trace: DBA mutation target -> runtime identity record -> cross-pool advisory-lock target attestation
- Upstream files: scripts/apply_eom_missed_call_recovery_runtime_privileges.py, tests/test_eom_missed_call_privilege_runner.py
- Fix strategy: upstream-root

- Root decision: Load the protected DSNs through typed settings
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: .github/workflows/atlas_eom_lead_pipeline_checks.yml, atlas_brain/config.py, atlas_brain/main_eom.py, atlas_brain/services/eom_missed_call_recovery.py, atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql, docs/EOM_MISSED_CALL_RECOVERY_RUNBOOK.md, plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md, scripts/apply_eom_missed_call_recovery_runtime_privileges.py, tests/test_eom_missed_call_privilege_runner.py, tests/test_eom_missed_call_recovery.py, tests/test_eom_render_profile.py
- Max files: 13
- Parked hardening: none
- Source trace: protected DSN ingestion -> typed settings boundary -> controlled runner connection pools
- Upstream files: atlas_brain/config.py, scripts/apply_eom_missed_call_recovery_runtime_privileges.py, tests/test_eom_missed_call_privilege_runner.py
- Fix strategy: upstream-root

- Root decision: Reserve migration 393 from generic migration runs
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: atlas_brain/storage/migrations/__init__.py, plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md, tests/test_migrations_runner.py
- Max files: 13
- Parked hardening: none
- Source trace: unrestricted migration catalog -> controlled DBA reservation -> explicit selection only
- Upstream files: atlas_brain/storage/migrations/__init__.py
- Fix strategy: upstream-root

- Root decision: Pin migration 393 to one database backend
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: plans/PR-EOM-Missed-Call-Recovery-Runtime-Privileges.md, scripts/apply_eom_missed_call_recovery_runtime_privileges.py, tests/test_eom_missed_call_privilege_runner.py
- Max files: 13
- Parked hardening: none
- Source trace: runtime-role session setting -> transaction-pooling backend -> controlled migration and ledger receipt
- Upstream files: scripts/apply_eom_missed_call_recovery_runtime_privileges.py
- Fix strategy: upstream-root

## Deferred

- A production DBA applies the already-reviewed forward migration only after merge and the runbook’s read-only preflight; this source PR does not mutate a production target.

## Parked hardening

- None.

## Cold diff reconstruction

- `.github/workflows/atlas_eom_lead_pipeline_checks.yml` enrolls the controlled runner/migration proof in the EOM workflow.
- `atlas_brain/config.py`, the migration, service, and runner establish the guarded role/ACL boundary and the target-attested DBA execution path.
- `atlas_brain/storage/migrations/__init__.py` adds 393 to the controlled DBA catalog, changing generic-run eligibility but not the generic runner's selection or locking algorithm; `tests/test_migrations_runner.py` proves generic skip and explicit selection for both controlled names.
- The missed-call runner adds an explicit transaction-pinned connection for 393 only, while the focused runner test proves the busy-lock retry, role-setting install, and generic-adapter connection identity.
- The runbook and plan document the DBA-only rollout contract; runner, disposable-PostgreSQL, and render-profile tests exercise the changed behavior and regressions.
- Every changed path is listed in the plan scope and reconciliation allowlists; no routes, API schemas, generic migration-runner algorithm, dependency files, or production state are changed.

effect-trace: target attestation | the controlled runner opens the runtime pool first and validates the DBA pool’s live identity plus a shared transaction advisory lock | focused runner tests reject schema/database/OID mismatch and a same-named non-sharing clone before extension or migration calls.

effect-trace: generic migration reservation | `CONTROLLED_DBA_MIGRATION_NAMES` is the membership filter used by unrestricted generic runs | the migration-runner test proves 393 and 394 are skipped generically and each runs only when explicitly selected.

effect-trace: transaction-pooled migration binding | the controlled 393 helper holds one transaction and wraps that exact connection before the runtime-role `set_config` and generic migration call | the focused runner test observes a busy-lock sleep at depth zero, then the exact DBA connection at depth one with the setting installed.

boundary-probe: role/target admission | valid same-target execution reaches the existing controlled apply path; runtime delegated-session, mismatched schema/database/OID, and same-named clone paths reject before mutation.

## Verification

- Targeted runner and disposable PostgreSQL regression proofs passed on the committed head.
- Static lint, runner/test formatting, Python compilation, whitespace, plan sync, and strict guard-class closure checks passed locally.
- The full hosted workflow remains the required current-head integration proof after publication.

## Mechanical verification

- Command: pytest tests/test_eom_missed_call_privilege_runner.py -q - Result: 28 passed - Environment: local
- Command: pytest tests/test_eom_missed_call_recovery.py -q with the configured disposable PostgreSQL target - Result: 72 passed - Environment: local
- Command: ruff check atlas_brain/config.py scripts/apply_eom_missed_call_recovery_runtime_privileges.py tests/test_eom_missed_call_privilege_runner.py tests/test_eom_missed_call_recovery.py - Result: passed - Environment: local
- Command: ruff format --check scripts/apply_eom_missed_call_recovery_runtime_privileges.py tests/test_eom_missed_call_privilege_runner.py tests/test_eom_missed_call_recovery.py - Result: passed - Environment: local
- Command: python -m compileall -q atlas_brain/config.py scripts/apply_eom_missed_call_recovery_runtime_privileges.py tests/test_eom_missed_call_privilege_runner.py tests/test_eom_missed_call_recovery.py - Result: passed - Environment: local
- Command: git diff --check origin/main...HEAD - Result: passed - Environment: local

## Diff size

- Scope: 13 changed files, matching `Max files: 13` in the plan.

Diff-budget override: This forward-only privilege repair is one inseparable security boundary: the guarded migration, controlled DBA runner, fail-closed readiness predicate, workflow enrollment, and disposable PostgreSQL proof must change together to avoid an unrepaired or over-privileged runtime target.
