### PR TITLE
EOM: recover Atlas API liveness

### DIFF
--- a/config/atlas-api-healthcheck.service
+++ b/config/atlas-api-healthcheck.service
@@ -13,7 +13,6 @@ ExecStart=/usr/bin/python3 %h/.local/bin/atlas-api-healthcheck.py
 #   ATLAS_API_HEALTHCHECK_NTFY_TOPIC=<private-topic>
 EnvironmentFile=-%h/.config/atlas/atlas-api-healthcheck.env
 Environment=DISPLAY=:0
-Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus
 # 2 means an inactive provider was recovered and re-probed successfully.
 # 4 means the outcome is durable but its remote alert remains queued for retry.
 SuccessExitStatus=0 2 4

--- a/config/atlas-api-healthcheck.service
+++ b/config/atlas-api-healthcheck.service
@@ -15,4 +15,5 @@ EnvironmentFile=-%h/.config/atlas/atlas-api-healthcheck.env
 Environment=DISPLAY=:0
 Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus
 # 2 means an inactive provider was recovered and re-probed successfully.
-SuccessExitStatus=0 2
+# 4 means the outcome is durable but its remote alert remains queued for retry.
+SuccessExitStatus=0 2 4

--- a/config/atlas-api-healthcheck.service
+++ b/config/atlas-api-healthcheck.service
@@ -5,8 +5,9 @@ Description=Atlas API liveness recovery (lead intake and EOM provider)
 
 [Service]
 Type=oneshot
-# Install the source-managed, stdlib-only script outside the runtime worktree:
-#   install -m 755 scripts/atlas_api_healthcheck.py ~/.local/bin/atlas-api-healthcheck.py
+# Install, enable, and prove the source-managed monitor from the merged Atlas
+# checkout; the installer copies it outside the runtime worktree:
+#   python scripts/install_atlas_api_healthcheck.py --install
 ExecStart=/usr/bin/python3 %h/.local/bin/atlas-api-healthcheck.py
 # The private ntfy topic is deliberately supplied outside version control:
 #   ATLAS_API_HEALTHCHECK_NTFY_TOPIC=<private-topic>

--- a/config/atlas-api-healthcheck.service
+++ b/config/atlas-api-healthcheck.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Atlas API liveness recovery (lead intake and EOM provider)
+# This stays independent of atlas-api.service so it can recover that unit when
+# the application runtime is unavailable.
+
+[Service]
+Type=oneshot
+# Install the source-managed, stdlib-only script outside the runtime worktree:
+#   install -m 755 scripts/atlas_api_healthcheck.py ~/.local/bin/atlas-api-healthcheck.py
+ExecStart=/usr/bin/python3 %h/.local/bin/atlas-api-healthcheck.py
+# The private ntfy topic is deliberately supplied outside version control:
+#   ATLAS_API_HEALTHCHECK_NTFY_TOPIC=<private-topic>
+EnvironmentFile=-%h/.config/atlas/atlas-api-healthcheck.env
+Environment=DISPLAY=:0
+Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus
+# 2 means an inactive provider was recovered and re-probed successfully.
+SuccessExitStatus=0 2

--- a/config/atlas-api-healthcheck.timer
+++ b/config/atlas-api-healthcheck.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run Atlas API liveness recovery every five minutes
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/plans/PR-EOM-API-Liveness-Contract.md
+++ b/plans/PR-EOM-API-Liveness-Contract.md
@@ -389,5 +389,5 @@ notification exit diagnostics, as listed above.
 | `plans/PR-EOM-API-Liveness-Contract.md` | 393 |
 | `scripts/atlas_api_healthcheck.py` | 649 |
 | `scripts/install_atlas_api_healthcheck.py` | 482 |
-| `tests/test_atlas_api_healthcheck.py` | 1399 |
-| **Total** | **2952** |
+| `tests/test_atlas_api_healthcheck.py` | 1420 |
+| **Total** | **2973** |

--- a/plans/PR-EOM-API-Liveness-Contract.md
+++ b/plans/PR-EOM-API-Liveness-Contract.md
@@ -387,6 +387,36 @@ Notification delivery is at-least-once, not exactly-once.
   the full focused file, syntax/systemd/maturity/plan/diff checks, and the single
   managed full Unit Gate before push.
 
+### Contract revision: complete actor and producer closure
+
+- New evidence: ordinary termination signals can bypass installer rollback;
+  maintenance entry stops the provider before the marker is durably published;
+  the browser probe covers only one of two route-supported origins; maintenance
+  exit validates a service value it never uses; and the best-effort desktop
+  notifier can hold the serialized health cycle without a timeout.
+- Revised root cause: the execution model names transaction, producer, action,
+  and delivery boundaries but the implementation closes only one member of
+  several admitted sets. Catching one cancellation, probing one origin, and
+  separating numeric validation are partial closures rather than the complete
+  contract.
+- Revised required change surface: convert admitted `SIGTERM`/`SIGHUP` into the
+  installer rollback path and restore prior handlers; fsync maintenance-marker
+  publication before service stop and fsync its removal on maintenance exit;
+  probe every route-supported form
+  origin and pin the mirrored standalone set to the producer contract; validate
+  service only for actions that use it; and bound/handle desktop notification
+  timeout without changing primary ntfy acknowledgement semantics.
+- Revised explicit non-scope: do not admit `SIGKILL` or host power loss during
+  rollback, add application-runtime imports to the standalone monitor, change
+  route CORS policy, restart active-but-unhealthy processes, change notification
+  payloads, alter funnel business behavior, schemas, dependencies, or live
+  deployment.
+- Revised verification plan: focused termination-handler restoration/rollback,
+  durable-marker ordering/failure, all-origin request and second-origin failure,
+  action-specific service validation, desktop-timeout recovery, the full focused
+  file, syntax/systemd/maturity/plan/diff checks, and the single managed full
+  Unit Gate before push.
+
 ### Boundary-change enumeration
 
 The recovery decision is a system state boundary, not an open-input guard.
@@ -536,8 +566,8 @@ notification exit diagnostics, as listed above.
 |---|---:|
 | `config/atlas-api-healthcheck.service` | 18 |
 | `config/atlas-api-healthcheck.timer` | 10 |
-| `plans/PR-EOM-API-Liveness-Contract.md` | 543 |
-| `scripts/atlas_api_healthcheck.py` | 675 |
-| `scripts/install_atlas_api_healthcheck.py` | 579 |
-| `tests/test_atlas_api_healthcheck.py` | 1680 |
-| **Total** | **3505** |
+| `plans/PR-EOM-API-Liveness-Contract.md` | 573 |
+| `scripts/atlas_api_healthcheck.py` | 720 |
+| `scripts/install_atlas_api_healthcheck.py` | 601 |
+| `tests/test_atlas_api_healthcheck.py` | 1873 |
+| **Total** | **3795** |

--- a/plans/PR-EOM-API-Liveness-Contract.md
+++ b/plans/PR-EOM-API-Liveness-Contract.md
@@ -42,6 +42,7 @@ exceeds the normal diff target.
 
 Ownership lane: eom-provider-liveness
 Slice phase: Production hardening
+Max files: 6
 
 1. Replace the untracked alert-only health-check logic with a canonical
    installed-outside-the-runtime monitor that auto-recovers only an unexpected
@@ -96,7 +97,7 @@ Slice phase: Production hardening
 ### Contract revision: current-head review findings
 
 - New evidence: the enabled user timer still executes the legacy
-  `~/.local/bin/atlas-api-healthcheck.sh`; neither the new Python monitor nor
+  atlas-api-healthcheck.sh; neither the new Python monitor nor
   its notification environment file is installed. The current template only
   names an `install` command, so the source change has no deployment path.
   Separately, the monitor persists `next_state` after an undelivered transition
@@ -155,6 +156,22 @@ The recovery decision is a system state boundary, not an open-input guard.
   to enable an alerting timer until it can preserve a private topic.
 - Side-effect ordering: decide maintenance before any start; issue a start only
   after inactive evidence; record success only after the post-start probe.
+
+### Guard-closure declaration
+
+- `TOPIC_RE` is a CLOSED, DERIVED topic grammar: membership is evaluated from
+  the bounded ASCII grammar at `scripts/install_atlas_api_healthcheck.py:27,83-87`,
+  rather than copied from an operator-maintained list. The installer accepts only
+  a normalized string in that grammar; a missing or nonmatching value fails
+  before it writes copies or enables systemd, which is safer than directing an
+  alert to an unknown destination. The focused grammar-product test exercises
+  leading-token, body-family, length, and whitespace-wrapper boundaries against
+  an independent oracle.
+- `PENDING_ALERTS` is CLOSED and ENUMERATED by the three alert events that this
+  monitor can emit (`down`, `recovered`, and `auto-recovered`). An unrecognized
+  persisted notification record is not replayed; `pending_notification()`
+  discards it and the monitor recomputes the next state from the current
+  observation, so arbitrary stored values cannot choose a notification path.
 
 ### Files touched
 
@@ -219,8 +236,8 @@ Parked hardening: none.
 |---|---:|
 | `config/atlas-api-healthcheck.service` | 18 |
 | `config/atlas-api-healthcheck.timer` | 10 |
-| `plans/PR-EOM-API-Liveness-Contract.md` | 226 |
+| `plans/PR-EOM-API-Liveness-Contract.md` | 243 |
 | `scripts/atlas_api_healthcheck.py` | 345 |
 | `scripts/install_atlas_api_healthcheck.py` | 264 |
-| `tests/test_atlas_api_healthcheck.py` | 430 |
-| **Total** | **1293** |
+| `tests/test_atlas_api_healthcheck.py` | 473 |
+| **Total** | **1353** |

--- a/plans/PR-EOM-API-Liveness-Contract.md
+++ b/plans/PR-EOM-API-Liveness-Contract.md
@@ -359,6 +359,34 @@ Notification delivery is at-least-once, not exactly-once.
   the existing 67 focused cases, syntax/systemd/maturity/plan/diff checks, and
   the managed full Unit Gate before push.
 
+### Contract revision: installer preflight and deployed-copy identity closure
+
+- New evidence: notification-file decoding and missing-topic resolution still
+  happen after the prior timer may be stopped; a private symlink without a topic
+  is accepted and then replaced by a regular file; and read-only verification
+  treats a symlink or hard link to the checkout source as an installed copy when
+  its bytes match.
+- Revised root cause: installer admission is split across pre-mutation and
+  post-mutation phases, and deployment proof compares content without proving
+  namespace/inode independence. These are one transaction-boundary defect:
+  shapes that cannot be safely mutated or independently deployed are admitted
+  too late or accepted as proof.
+- Revised required change surface: build and validate the complete notification
+  update plan before any systemd query or mutation; convert malformed UTF-8 into
+  a fail-closed installer error; require an accepted notification symlink to be
+  private and already contain its valid topic; apply a precomputed payload only
+  to a regular destination; and make `--check` reject symlink destinations and
+  same-inode aliases even when bytes and executable mode match.
+- Revised explicit non-scope: do not change monitor recovery logic, systemd
+  commands or unit templates, topic grammar/value, regular-file migration
+  semantics, notification delivery, funnel routes, schemas, dependencies, or
+  live deployment.
+- Revised verification plan: focused malformed-UTF-8 preflight tests for both
+  configuration sources, private missing-topic symlink rejection, private
+  existing-topic preservation, symlink/hard-link deployment-proof rejection,
+  the full focused file, syntax/systemd/maturity/plan/diff checks, and the single
+  managed full Unit Gate before push.
+
 ### Boundary-change enumeration
 
 The recovery decision is a system state boundary, not an open-input guard.
@@ -508,8 +536,8 @@ notification exit diagnostics, as listed above.
 |---|---:|
 | `config/atlas-api-healthcheck.service` | 18 |
 | `config/atlas-api-healthcheck.timer` | 10 |
-| `plans/PR-EOM-API-Liveness-Contract.md` | 515 |
+| `plans/PR-EOM-API-Liveness-Contract.md` | 543 |
 | `scripts/atlas_api_healthcheck.py` | 675 |
-| `scripts/install_atlas_api_healthcheck.py` | 539 |
-| `tests/test_atlas_api_healthcheck.py` | 1646 |
-| **Total** | **3403** |
+| `scripts/install_atlas_api_healthcheck.py` | 579 |
+| `tests/test_atlas_api_healthcheck.py` | 1680 |
+| **Total** | **3505** |

--- a/plans/PR-EOM-API-Liveness-Contract.md
+++ b/plans/PR-EOM-API-Liveness-Contract.md
@@ -10,6 +10,11 @@ SIGTERM, and the Tailnet `/api` proxy consequently had no listener on port
 inactive unit for 84 consecutive runs, but its script only notified; it never
 restored the service. This is a production availability defect, so this is a
 small Production hardening slice justified by a real failed EOM provider path.
+The monitor program, its installed user-systemd units, the installer that
+activates those units, and the failure-path proof are indivisible: a program
+without deployment wiring cannot recover production, while wiring without the
+program and its regression coverage is unsafe. That is the reason this slice
+exceeds the normal diff target.
 
 ### Problem-derived contract
 
@@ -45,6 +50,9 @@ Slice phase: Production hardening
    automatically undone.
 3. Add executable regression coverage and source-managed unit templates that
    make the installation/configuration contract reviewable.
+4. Add an explicit post-merge installer/checker that activates the installed
+   user-systemd path and invokes it once without touching the live deployment
+   during PR review.
 
 ### Review Contract
 
@@ -63,19 +71,59 @@ Slice phase: Production hardening
      settled by
      `tests/test_atlas_api_healthcheck.py::test_active_unhealthy_service_alerts_without_restart`.
   5. The systemd template runs the installed copy outside the runtime worktree
-     and reads notification settings from a user-local environment file;
-     settled by `tests/test_atlas_api_healthcheck.py::test_service_template_uses_installed_script_and_private_environment`.
+   and reads notification settings from a user-local environment file;
+   settled by `tests/test_atlas_api_healthcheck.py::test_service_template_uses_installed_script_and_private_environment`.
+  6. The installer copies the reviewed monitor and both unit templates, enables
+   the timer, invokes the installed health service once, and can later verify
+   those deployed artifacts without writing; settled by
+   `tests/test_atlas_api_healthcheck.py::test_installer_deploys_source_and_invokes_enabled_timer_path`.
 - Reachability proof: On deployment, the timer invokes the installed monitor;
-  an unexpected inactive unit transitions to `systemctl --user start`, then an
-  OPTIONS request to the real `/api/v1/leads/intake` route returns 200/204.
-  Local tests exercise the same command/probe seam without stopping the live
-  provider.
-- Affected surfaces: source-managed standalone monitor, user-systemd
-  templates, notification/maintenance configuration, and their focused tests.
+  `python scripts/install_atlas_api_healthcheck.py --install` copies the source,
+  reloads user systemd, enables the timer, and invokes the installed health
+  service once. That service makes the real OPTIONS request to
+  `/api/v1/leads/intake`; `--check` subsequently verifies the installed copies,
+  private topic file, and enabled/active timer without writing. Local tests
+  exercise the same install command order and probe seam without stopping the
+  live provider.
+- Affected surfaces: source-managed standalone monitor, its explicit installer,
+  user-systemd templates, notification/maintenance configuration, and focused
+  tests.
 - Risk areas: unexpected clean stops, deliberate maintenance, failed start,
   failed re-probe, notification configuration absence, and keeping the monitor
   independent of the application worktree.
 - Reviewer rules triggered: R1, R2, R6, R11, R12, R14.
+
+### Contract revision: current-head review findings
+
+- New evidence: the enabled user timer still executes the legacy
+  `~/.local/bin/atlas-api-healthcheck.sh`; neither the new Python monitor nor
+  its notification environment file is installed. The current template only
+  names an `install` command, so the source change has no deployment path.
+  Separately, the monitor persists `next_state` after an undelivered transition
+  alert, which suppresses its retry, and it drops the details returned by a
+  failed `systemctl --user start` command.
+- Revised root cause: source-managed monitor files alone cannot change a
+  user-systemd deployment, and the alert state machine acknowledges a
+  notification before it knows that delivery succeeded.
+- Revised required change surface: add a narrowly scoped
+  `scripts/install_atlas_api_healthcheck.py` installer/checker that copies the
+  monitor and templates outside the runtime worktree, preserves or safely
+  migrates the private local notification topic without logging it, reloads and
+  enables the user timer, then invokes the installed health service once as the
+  deployment proof. Update the template invocation, make transition state
+  persist only when no alert is needed or delivery succeeds, carry bounded
+  sanitized start-failure detail into the observation, and add focused tests for
+  installation, timer/service activation, retry, and diagnostics.
+- Revised explicit non-scope: do not run the installer against the live user
+  systemd configuration in this PR; deployment remains a post-merge host
+  action. Do not change `atlas_brain`, funnel routes, CRM, migrations, tracker
+  APIs, Render/Tailnet topology, browser UI, active-but-unhealthy recovery, or
+  any notification destination.
+- Revised verification plan: unit-test source-to-installed-copy and expected
+  systemd command order in temporary paths, test the retry and failed-start
+  branches directly, run the focused monitor/installer tests and
+  `systemd-analyze verify`, and use the installer `--check` plus its initial
+  systemd service invocation as the post-merge deployment proof.
 
 ### Boundary-change enumeration
 
@@ -96,13 +144,15 @@ The recovery decision is a system state boundary, not an open-input guard.
 
 - Deployed/default config values: default service is `atlas-api.service`; default
   probe is local `OPTIONS /api/v1/leads/intake`; maintenance lock defaults under
-  the user Atlas config directory; notification topic comes only from the
-  user-local environment file.
+  the user Atlas config directory; the installer requires or safely migrates
+  the notification topic into the user-local environment file before enabling
+  the timer.
 - Explicit value probe: focused tests inject service, lock, and probe values.
 - Absent value probe: absent lock permits recovery; absent notification topic
   must not be committed or silently replaced with a public/default topic.
 - Default-session/default-context probe: the systemd template loads a missing
-  environment file optionally and the monitor uses its safe defaults.
+  environment file optionally for manual recovery, while the installer refuses
+  to enable an alerting timer until it can preserve a private topic.
 - Side-effect ordering: decide maintenance before any start; issue a start only
   after inactive evidence; record success only after the post-start probe.
 
@@ -112,6 +162,7 @@ The recovery decision is a system state boundary, not an open-input guard.
 - `config/atlas-api-healthcheck.timer`
 - `plans/PR-EOM-API-Liveness-Contract.md`
 - `scripts/atlas_api_healthcheck.py`
+- `scripts/install_atlas_api_healthcheck.py`
 - `tests/test_atlas_api_healthcheck.py`
 
 ## Mechanism
@@ -123,7 +174,10 @@ lock, it calls the existing user-systemd unit once and then runs the same
 lead-intake OPTIONS probe that the current monitor uses. It records and notifies
 only after the final outcome is known. The templates keep the timer independent
 of `atlas-api.service` and load the private notification topic from a local
-environment file rather than version control.
+environment file rather than version control. The companion installer copies
+the reviewed source and templates, migrates an existing private topic without
+printing it when necessary, reloads/enables user systemd, and invokes the
+installed service once; later `--check` is read-only.
 
 ## Intentional
 
@@ -134,6 +188,9 @@ environment file rather than version control.
   diagnosis and would widen this slice from the observed inactive-unit failure.
 - Do not commit the ntfy topic or read it from application configuration; it is
   a private notification credential and remains in a local environment file.
+- Do not consider an alert transition acknowledged until its ntfy push succeeds;
+  failed delivery records a pending transition so the next invocation retries
+  the same event.
 
 ## Deferred
 
@@ -143,9 +200,8 @@ environment file rather than version control.
 - A deployment-time authenticated, Render-origin funnel smoke is deferred until
   a supported provider hosting/network path is selected and can be tested.
 
-Parking predicate: network-topology changes, active-process recovery, and
-notification-delivery hardening are parked unless they block this inactive-unit
-recovery path.
+Parking predicate: network-topology changes and active-process recovery are
+parked unless they block this inactive-unit recovery path.
 
 Parked hardening: none.
 
@@ -161,9 +217,10 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `config/atlas-api-healthcheck.service` | 17 |
+| `config/atlas-api-healthcheck.service` | 18 |
 | `config/atlas-api-healthcheck.timer` | 10 |
-| `plans/PR-EOM-API-Liveness-Contract.md` | 169 |
-| `scripts/atlas_api_healthcheck.py` | 273 |
-| `tests/test_atlas_api_healthcheck.py` | 231 |
-| **Total** | **700** |
+| `plans/PR-EOM-API-Liveness-Contract.md` | 226 |
+| `scripts/atlas_api_healthcheck.py` | 345 |
+| `scripts/install_atlas_api_healthcheck.py` | 264 |
+| `tests/test_atlas_api_healthcheck.py` | 430 |
+| **Total** | **1293** |

--- a/plans/PR-EOM-API-Liveness-Contract.md
+++ b/plans/PR-EOM-API-Liveness-Contract.md
@@ -180,6 +180,10 @@ Max files: 6
 - After outbox persistence but before notification: the next cycle retries.
 - After successful notification but before acknowledgement persistence: a
   duplicate notification is admitted; silent loss is not.
+- After the installer stops the prior timer or replaces any installation file,
+  an operator `KeyboardInterrupt` runs the same rollback as an installation
+  failure and is then re-raised. `SIGKILL` remains outside the rollback boundary;
+  atomic file replacement still selects a complete prior or next file.
 - If state cannot be read, decoded, locked, or atomically written, the cycle
   fails before issuing a new recovery side effect. A SIGKILL cannot interrupt an
   atomic file replacement, although it can select either the prior or next
@@ -191,9 +195,9 @@ For every admitted interleaving: the monitor never starts an unloaded,
 transitional, failed, query-unknown, or maintenance-protected provider; every
 issued recovery start is preceded by durable intent; every derived alert is
 either durably queued or acknowledged after delivery; and installation is
-reported verified only when source bytes, private configuration, timer state,
-and systemd's loaded definitions agree. Notification delivery is at-least-once,
-not exactly-once.
+reported verified only when the provider proof is non-down and source bytes,
+private configuration, timer state, and systemd's loaded definitions agree.
+Notification delivery is at-least-once, not exactly-once.
 
 #### Closed-surface alternatives
 
@@ -231,6 +235,37 @@ not exactly-once.
   malformed HTTP at both boundaries, invalid numeric environment on both
   maintenance actions and the healthcheck path; syntax, systemd verification,
   focused maturity, plan sync, and diff audit. GitHub runs the full unit gate.
+
+### Contract revision: outcome precedence and installer cancellation
+
+- New evidence: notification delivery failure currently returns exit `4` for
+  both a healthy/recovered provider and a provider that remains down. Because
+  the systemd unit accepts exit `4`, the installer's service proof can therefore
+  succeed while the provider is unavailable. Separately, the installer mutates
+  timer and file state inside a transaction that catches `OSError` and
+  `RuntimeError`, but an operator `KeyboardInterrupt` bypasses rollback.
+- Revised root cause: the monitor collapses the provider observation and remote
+  alert-delivery result into one scalar without failure precedence, while the
+  installer transaction omits an admitted operator-cancellation exception from
+  its rollback boundary.
+- Revised required change surface: retain exit `3` whenever the current provider
+  outcome is down even if its alert remains queued; use exit `4` only when the
+  provider outcome is non-down and alert delivery remains pending; run the
+  existing installer rollback for `KeyboardInterrupt` and then re-raise the
+  cancellation; cover both outcome axes and cancellation after mutation in the
+  focused test file.
+- Revised explicit non-scope: do not change the systemd success-status set,
+  alert queue or retry semantics, timer cadence, notification destinations,
+  public CLI, dependencies, schemas, funnel/CRM behavior, or live deployment.
+  Non-finite recovery-interval validation and nonzero desktop `notify-send`
+  diagnostics are valid hardening but remain parked because neither blocks the
+  observed provider recovery proof. Do not add or change a workflow: the
+  existing every-PR Unit Gate escalates this config diff to the full unit suite.
+- Revised verification plan: focused regressions for down-plus-undelivered,
+  recovered-plus-undelivered, and installer `KeyboardInterrupt` rollback;
+  focused pytest and syntax checks; systemd unit verification; selector proof
+  that the PR runs the full Unit Gate; plan sync and diff audit. GitHub remains
+  the source of truth for the full Unit Gate.
 
 ### Boundary-change enumeration
 
@@ -324,11 +359,18 @@ back prior files/timer state on failure; later `--check` is read-only.
   this local liveness monitor, and this PR must not change that network boundary.
 - A deployment-time authenticated, Render-origin funnel smoke is deferred until
   a supported provider hosting/network path is selected and can be tested.
+- Rejecting non-finite recovery intervals is parked as configuration hardening;
+  ordinary numeric and negative-value validation remains unchanged, and this
+  does not alter the provider-result precedence required for installer proof.
+- Reporting a nonzero desktop `notify-send` return code is parked as secondary
+  observability hardening; desktop notification remains best-effort and remote
+  ntfy delivery plus provider outcome remain the operational contract.
 
 Parking predicate: network-topology changes and active-process recovery are
 parked unless they block this inactive-unit recovery path.
 
-Parked hardening: none.
+Parked hardening: non-finite recovery-interval validation and nonzero desktop
+notification exit diagnostics, as listed above.
 
 ## Verification
 
@@ -344,8 +386,8 @@ Parked hardening: none.
 |---|---:|
 | `config/atlas-api-healthcheck.service` | 19 |
 | `config/atlas-api-healthcheck.timer` | 10 |
-| `plans/PR-EOM-API-Liveness-Contract.md` | 351 |
-| `scripts/atlas_api_healthcheck.py` | 642 |
-| `scripts/install_atlas_api_healthcheck.py` | 472 |
-| `tests/test_atlas_api_healthcheck.py` | 1341 |
-| **Total** | **2835** |
+| `plans/PR-EOM-API-Liveness-Contract.md` | 393 |
+| `scripts/atlas_api_healthcheck.py` | 649 |
+| `scripts/install_atlas_api_healthcheck.py` | 482 |
+| `tests/test_atlas_api_healthcheck.py` | 1399 |
+| **Total** | **2952** |

--- a/plans/PR-EOM-API-Liveness-Contract.md
+++ b/plans/PR-EOM-API-Liveness-Contract.md
@@ -1,0 +1,169 @@
+# PR-EOM-API-Liveness-Contract
+
+## Why this slice exists
+
+The operator reported that the EOM funnel became unavailable after working
+earlier the same day. Live investigation found `atlas-api.service` cleanly
+stopped at 12:15 CDT; its `Restart=on-failure` policy did not restart a clean
+SIGTERM, and the Tailnet `/api` proxy consequently had no listener on port
+8012. The existing five-minute `atlas-api-healthcheck` timer detected the
+inactive unit for 84 consecutive runs, but its script only notified; it never
+restored the service. This is a production availability defect, so this is a
+small Production hardening slice justified by a real failed EOM provider path.
+
+### Problem-derived contract
+
+- Root cause: The source of truth for the existing standalone liveness monitor
+  is an untracked local shell script. It observes an inactive `atlas-api`
+  unit but has no recovery transition. A clean stop therefore persists until a
+  person manually starts the provider, even though the monitor has enough
+  evidence to distinguish an expected maintenance stop from an unexpected one.
+- Correct fix must touch/change: Add a source-managed, stdlib-only health-check
+  implementation plus its user-systemd service/timer templates. When the
+  provider is inactive and no explicit maintenance lock exists, the monitor
+  must start the existing unit, re-probe the existing lead-intake CORS route,
+  record/notify the outcome through the existing ntfy and desktop channels, and
+  remain installed outside the runtime worktree.
+  Add focused tests for the active, inactive/recovered, inactive/failed, and
+  maintenance-lock branches.
+- Must not change: Do not change `atlas_brain` funnel routes, authentication,
+  CRM lifecycle/storage, migrations, invoice behavior, EOM tracker APIs,
+  Render environment variables, Tailnet routing, browser UI, or the running
+  Atlas worktree. Do not automatically restart an *active but unhealthy*
+  process in this slice; preserve the existing alert-only behavior for that
+  distinct failure class.
+
+## Scope (this PR)
+
+Ownership lane: eom-provider-liveness
+Slice phase: Production hardening
+
+1. Replace the untracked alert-only health-check logic with a canonical
+   installed-outside-the-runtime monitor that auto-recovers only an unexpected
+   inactive `atlas-api.service`.
+2. Add a maintenance-lock contract so intentional maintenance is never
+   automatically undone.
+3. Add executable regression coverage and source-managed unit templates that
+   make the installation/configuration contract reviewable.
+
+### Review Contract
+
+- Acceptance criteria:
+  1. `run_healthcheck()` starts `atlas-api.service` exactly once when the
+     service is inactive, the maintenance lock is absent, and a subsequent
+     probe succeeds; settled by
+     `tests/test_atlas_api_healthcheck.py::test_inactive_service_is_started_and_reprobed`.
+  2. An existing maintenance lock prevents a start attempt and leaves an
+     inactive service explicitly recorded as maintenance; settled by
+     `tests/test_atlas_api_healthcheck.py::test_maintenance_lock_never_starts_service`.
+  3. A start that fails, or a start followed by a failed probe, remains a
+     visible down result rather than a false recovery; settled by the two
+     failed-recovery tests in `tests/test_atlas_api_healthcheck.py`.
+  4. An active but failed lead-intake probe does not restart the process;
+     settled by
+     `tests/test_atlas_api_healthcheck.py::test_active_unhealthy_service_alerts_without_restart`.
+  5. The systemd template runs the installed copy outside the runtime worktree
+     and reads notification settings from a user-local environment file;
+     settled by `tests/test_atlas_api_healthcheck.py::test_service_template_uses_installed_script_and_private_environment`.
+- Reachability proof: On deployment, the timer invokes the installed monitor;
+  an unexpected inactive unit transitions to `systemctl --user start`, then an
+  OPTIONS request to the real `/api/v1/leads/intake` route returns 200/204.
+  Local tests exercise the same command/probe seam without stopping the live
+  provider.
+- Affected surfaces: source-managed standalone monitor, user-systemd
+  templates, notification/maintenance configuration, and their focused tests.
+- Risk areas: unexpected clean stops, deliberate maintenance, failed start,
+  failed re-probe, notification configuration absence, and keeping the monitor
+  independent of the application worktree.
+- Reviewer rules triggered: R1, R2, R6, R11, R12, R14.
+
+### Boundary-change enumeration
+
+The recovery decision is a system state boundary, not an open-input guard.
+
+- Boundary path/seam: `run_healthcheck()` deciding whether to issue
+  `systemctl --user start`.
+- Replaced-path behaviors: inactive service previously notified only; it now
+  recovers only if maintenance is absent. Active/healthy remains no-op;
+  active/unhealthy remains alert-only.
+- Guard-relevant fields: unit active state, maintenance-lock path, start result,
+  and post-start CORS probe result.
+- Caller x input shape: timer invocation x active/healthy; timer x inactive/no
+  lock; timer x inactive/lock; timer x inactive/start failure; timer x
+  active/failed probe.
+
+### Deployed-config probing
+
+- Deployed/default config values: default service is `atlas-api.service`; default
+  probe is local `OPTIONS /api/v1/leads/intake`; maintenance lock defaults under
+  the user Atlas config directory; notification topic comes only from the
+  user-local environment file.
+- Explicit value probe: focused tests inject service, lock, and probe values.
+- Absent value probe: absent lock permits recovery; absent notification topic
+  must not be committed or silently replaced with a public/default topic.
+- Default-session/default-context probe: the systemd template loads a missing
+  environment file optionally and the monitor uses its safe defaults.
+- Side-effect ordering: decide maintenance before any start; issue a start only
+  after inactive evidence; record success only after the post-start probe.
+
+### Files touched
+
+- `config/atlas-api-healthcheck.service`
+- `config/atlas-api-healthcheck.timer`
+- `plans/PR-EOM-API-Liveness-Contract.md`
+- `scripts/atlas_api_healthcheck.py`
+- `tests/test_atlas_api_healthcheck.py`
+
+## Mechanism
+
+The monitor is a standalone Python program installed under `~/.local/bin`,
+not loaded from the Atlas runtime worktree. It checks the maintenance lock
+before observing or starting the unit. If the service is inactive without that
+lock, it calls the existing user-systemd unit once and then runs the same
+lead-intake OPTIONS probe that the current monitor uses. It records and notifies
+only after the final outcome is known. The templates keep the timer independent
+of `atlas-api.service` and load the private notification topic from a local
+environment file rather than version control.
+
+## Intentional
+
+- Do not rely on `Restart=always` as the root fix: an explicit systemd stop can
+  still suppress restart behavior, while the independent timer can recover the
+  observed inactive state.
+- Do not auto-restart an active-but-unhealthy provider. That needs a distinct
+  diagnosis and would widen this slice from the observed inactive-unit failure.
+- Do not commit the ntfy topic or read it from application configuration; it is
+  a private notification credential and remains in a local environment file.
+
+## Deferred
+
+- Render-to-Atlas reachability remains a separate deployment-topology slice.
+  The current `ATLAS_FUNNEL_BASE_URL` is not proven reachable from Render by
+  this local liveness monitor, and this PR must not change that network boundary.
+- A deployment-time authenticated, Render-origin funnel smoke is deferred until
+  a supported provider hosting/network path is selected and can be tested.
+
+Parking predicate: network-topology changes, active-process recovery, and
+notification-delivery hardening are parked unless they block this inactive-unit
+recovery path.
+
+Parked hardening: none.
+
+## Verification
+
+- `pytest tests/test_atlas_api_healthcheck.py -q`
+- `systemd-analyze verify config/atlas-api-healthcheck.service config/atlas-api-healthcheck.timer`
+- `python scripts/sync_pr_plan.py plans/PR-EOM-API-Liveness-Contract.md --check`
+- `bash scripts/push_pr.sh <body-file> -u origin HEAD` (runs the mechanical
+  local review bundle exactly once before push).
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `config/atlas-api-healthcheck.service` | 17 |
+| `config/atlas-api-healthcheck.timer` | 10 |
+| `plans/PR-EOM-API-Liveness-Contract.md` | 169 |
+| `scripts/atlas_api_healthcheck.py` | 273 |
+| `tests/test_atlas_api_healthcheck.py` | 231 |
+| **Total** | **700** |

--- a/plans/PR-EOM-API-Liveness-Contract.md
+++ b/plans/PR-EOM-API-Liveness-Contract.md
@@ -237,7 +237,7 @@ Parked hardening: none.
 | `config/atlas-api-healthcheck.service` | 18 |
 | `config/atlas-api-healthcheck.timer` | 10 |
 | `plans/PR-EOM-API-Liveness-Contract.md` | 243 |
-| `scripts/atlas_api_healthcheck.py` | 354 |
-| `scripts/install_atlas_api_healthcheck.py` | 264 |
-| `tests/test_atlas_api_healthcheck.py` | 516 |
-| **Total** | **1405** |
+| `scripts/atlas_api_healthcheck.py` | 415 |
+| `scripts/install_atlas_api_healthcheck.py` | 397 |
+| `tests/test_atlas_api_healthcheck.py` | 739 |
+| **Total** | **1822** |

--- a/plans/PR-EOM-API-Liveness-Contract.md
+++ b/plans/PR-EOM-API-Liveness-Contract.md
@@ -336,6 +336,29 @@ Notification delivery is at-least-once, not exactly-once.
   live/broken symlink rollback proof, followed by syntax, systemd, plan, diff,
   and the managed full Unit Gate before push.
 
+### Contract revision: notification-symlink referent safety
+
+- New evidence: `ensure_notification_topic()` follows an existing notification
+  environment symlink with `chmod(0600)` before service proof, while rollback
+  restores only the link entry. A failed installation can therefore leave the
+  managed target mode, ctime, and ACL mask changed even though the link and bytes
+  appear restored.
+- Revised root cause: the installer transaction snapshots destination namespace
+  entries but mutates a symlink referent outside that snapshot. Numeric-mode
+  restoration cannot reconstruct ctime or ACL side effects, so extending the
+  snapshot would still be lossy.
+- Revised required change surface: validate a notification symlink's followed
+  target mode before any systemd query or mutation; reject broken or group/world
+  accessible targets without reading or chmod; preserve an already-private
+  target/link without chmod; retain regular-file permission tightening; and
+  cover existing-topic, missing-topic, success, and failed-proof paths.
+- Revised explicit non-scope: do not change topic grammar, topic value, regular
+  destination behavior, source/unit paths, service/timer commands, recovery,
+  notification delivery, public CLI, schemas, dependencies, or live deployment.
+- Revised verification plan: focused symlink-target privacy and rollback tests,
+  the existing 67 focused cases, syntax/systemd/maturity/plan/diff checks, and
+  the managed full Unit Gate before push.
+
 ### Boundary-change enumeration
 
 The recovery decision is a system state boundary, not an open-input guard.
@@ -485,8 +508,8 @@ notification exit diagnostics, as listed above.
 |---|---:|
 | `config/atlas-api-healthcheck.service` | 18 |
 | `config/atlas-api-healthcheck.timer` | 10 |
-| `plans/PR-EOM-API-Liveness-Contract.md` | 492 |
+| `plans/PR-EOM-API-Liveness-Contract.md` | 515 |
 | `scripts/atlas_api_healthcheck.py` | 675 |
-| `scripts/install_atlas_api_healthcheck.py` | 524 |
-| `tests/test_atlas_api_healthcheck.py` | 1568 |
-| **Total** | **3287** |
+| `scripts/install_atlas_api_healthcheck.py` | 539 |
+| `tests/test_atlas_api_healthcheck.py` | 1646 |
+| **Total** | **3403** |

--- a/plans/PR-EOM-API-Liveness-Contract.md
+++ b/plans/PR-EOM-API-Liveness-Contract.md
@@ -205,6 +205,33 @@ not exactly-once.
   file plus `flock` is the smaller closed local surface; its admitted duplicate
   boundary is explicit above.
 
+### Contract revision: deployed boundary outcomes
+
+- New evidence: the systemd service accepts recovery exit `2` but rejects exit
+  `4`, even though exit `4` means the same recovery/observation is durably
+  recorded with only remote notification delivery pending. Separately,
+  `http.client.HTTPException` is outside both HTTP catch sets, and numeric
+  healthcheck environment defaults are converted before maintenance action
+  selection.
+- Revised root cause: the monitor classifies internal recovery and persistence
+  states, but its systemd, HTTP, and CLI boundaries do not preserve those
+  classifications. A queued alert is mistaken for failed recovery, malformed
+  HTTP escapes instead of becoming an existing failure outcome, and unrelated
+  healthcheck configuration can disable the supported maintenance boundary.
+- Revised required change surface: admit exit `4` as a successful systemd
+  oneshot completion while retaining its journal/outbox evidence; convert
+  `HTTPException` at probe and notification boundaries into the existing down
+  and undelivered outcomes; select maintenance mode before converting
+  healthcheck-only numeric settings; cover all three boundaries in the focused
+  suite.
+- Revised explicit non-scope: do not change exit-code meanings, outbox or retry
+  semantics, timer cadence, notification destination, installer transaction
+  behavior, funnel/CRM APIs, schemas, dependencies, or live deployment.
+- Revised verification plan: focused tests for queued-delivery service status,
+  malformed HTTP at both boundaries, invalid numeric environment on both
+  maintenance actions and the healthcheck path; syntax, systemd verification,
+  focused maturity, plan sync, and diff audit. GitHub runs the full unit gate.
+
 ### Boundary-change enumeration
 
 The recovery decision is a system state boundary, not an open-input guard.
@@ -315,10 +342,10 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `config/atlas-api-healthcheck.service` | 18 |
+| `config/atlas-api-healthcheck.service` | 19 |
 | `config/atlas-api-healthcheck.timer` | 10 |
-| `plans/PR-EOM-API-Liveness-Contract.md` | 324 |
-| `scripts/atlas_api_healthcheck.py` | 624 |
+| `plans/PR-EOM-API-Liveness-Contract.md` | 351 |
+| `scripts/atlas_api_healthcheck.py` | 642 |
 | `scripts/install_atlas_api_healthcheck.py` | 472 |
-| `tests/test_atlas_api_healthcheck.py` | 1262 |
-| **Total** | **2710** |
+| `tests/test_atlas_api_healthcheck.py` | 1341 |
+| **Total** | **2835** |

--- a/plans/PR-EOM-API-Liveness-Contract.md
+++ b/plans/PR-EOM-API-Liveness-Contract.md
@@ -237,7 +237,7 @@ Parked hardening: none.
 | `config/atlas-api-healthcheck.service` | 18 |
 | `config/atlas-api-healthcheck.timer` | 10 |
 | `plans/PR-EOM-API-Liveness-Contract.md` | 243 |
-| `scripts/atlas_api_healthcheck.py` | 345 |
+| `scripts/atlas_api_healthcheck.py` | 354 |
 | `scripts/install_atlas_api_healthcheck.py` | 264 |
-| `tests/test_atlas_api_healthcheck.py` | 473 |
-| **Total** | **1353** |
+| `tests/test_atlas_api_healthcheck.py` | 516 |
+| **Total** | **1405** |

--- a/plans/PR-EOM-API-Liveness-Contract.md
+++ b/plans/PR-EOM-API-Liveness-Contract.md
@@ -62,9 +62,10 @@ Max files: 6
      service is inactive, the maintenance lock is absent, and a subsequent
      probe succeeds; settled by
      `tests/test_atlas_api_healthcheck.py::test_inactive_service_is_started_and_reprobed`.
-  2. An existing maintenance lock prevents a start attempt and leaves an
-     inactive service explicitly recorded as maintenance; settled by
-     `tests/test_atlas_api_healthcheck.py::test_maintenance_lock_never_starts_service`.
+  2. An existing maintenance lock prevents a start attempt, and the supported
+     maintenance-entry command serializes marker creation plus service stop
+     against recovery; settled by the two maintenance tests in
+     `tests/test_atlas_api_healthcheck.py`.
   3. A start that fails, or a start followed by a failed probe, remains a
      visible down result rather than a false recovery; settled by the two
      failed-recovery tests in `tests/test_atlas_api_healthcheck.py`.
@@ -74,9 +75,10 @@ Max files: 6
   5. The systemd template runs the installed copy outside the runtime worktree
    and reads notification settings from a user-local environment file;
    settled by `tests/test_atlas_api_healthcheck.py::test_service_template_uses_installed_script_and_private_environment`.
-  6. The installer copies the reviewed monitor and both unit templates, enables
-   the timer, invokes the installed health service once, and can later verify
-   those deployed artifacts without writing; settled by
+  6. The installer copies the reviewed monitor and both unit templates, proves
+     the installed health service before enabling the timer, restores prior
+     files/timer state on failure, and can later verify the deployment without
+     writing; settled by
    `tests/test_atlas_api_healthcheck.py::test_installer_deploys_source_and_invokes_enabled_timer_path`.
 - Reachability proof: On deployment, the timer invokes the installed monitor;
   `python scripts/install_atlas_api_healthcheck.py --install` copies the source,
@@ -154,8 +156,9 @@ The recovery decision is a system state boundary, not an open-input guard.
 - Default-session/default-context probe: the systemd template loads a missing
   environment file optionally for manual recovery, while the installer refuses
   to enable an alerting timer until it can preserve a private topic.
-- Side-effect ordering: decide maintenance before any start; issue a start only
-  after inactive evidence; record success only after the post-start probe.
+- Side-effect ordering: supported maintenance entry and recovery share one
+  process lock; issue a start only after inactive evidence; prove installed
+  service behavior before timer enrollment.
 
 ### Guard-closure declaration
 
@@ -169,9 +172,9 @@ The recovery decision is a system state boundary, not an open-input guard.
   an independent oracle.
 - `PENDING_ALERTS` is CLOSED and ENUMERATED by the three alert events that this
   monitor can emit (`down`, `recovered`, and `auto-recovered`). An unrecognized
-  persisted notification record is not replayed; `pending_notification()`
-  discards it and the monitor recomputes the next state from the current
-  observation, so arbitrary stored values cannot choose a notification path.
+  persisted notification/state record resets safely; recognized pending events
+  remain queued while each run still derives state from the current observation,
+  so arbitrary stored values cannot choose or suppress a notification path.
 
 ### Files touched
 
@@ -185,16 +188,16 @@ The recovery decision is a system state boundary, not an open-input guard.
 ## Mechanism
 
 The monitor is a standalone Python program installed under `~/.local/bin`,
-not loaded from the Atlas runtime worktree. It checks the maintenance lock
-before observing or starting the unit. If the service is inactive without that
-lock, it calls the existing user-systemd unit once and then runs the same
+not loaded from the Atlas runtime worktree. Its supported maintenance command
+creates the marker and stops the service under the same lock used by recovery.
+If the service is inactive without that marker, it calls the existing unit and runs the same
 lead-intake OPTIONS probe that the current monitor uses. It records and notifies
 only after the final outcome is known. The templates keep the timer independent
 of `atlas-api.service` and load the private notification topic from a local
 environment file rather than version control. The companion installer copies
 the reviewed source and templates, migrates an existing private topic without
-printing it when necessary, reloads/enables user systemd, and invokes the
-installed service once; later `--check` is read-only.
+printing it, proves the installed service before enabling the timer, and rolls
+back prior files/timer state on failure; later `--check` is read-only.
 
 ## Intentional
 
@@ -236,8 +239,8 @@ Parked hardening: none.
 |---|---:|
 | `config/atlas-api-healthcheck.service` | 18 |
 | `config/atlas-api-healthcheck.timer` | 10 |
-| `plans/PR-EOM-API-Liveness-Contract.md` | 243 |
-| `scripts/atlas_api_healthcheck.py` | 415 |
+| `plans/PR-EOM-API-Liveness-Contract.md` | 246 |
+| `scripts/atlas_api_healthcheck.py` | 475 |
 | `scripts/install_atlas_api_healthcheck.py` | 397 |
-| `tests/test_atlas_api_healthcheck.py` | 739 |
-| **Total** | **1822** |
+| `tests/test_atlas_api_healthcheck.py` | 814 |
+| **Total** | **1960** |

--- a/plans/PR-EOM-API-Liveness-Contract.md
+++ b/plans/PR-EOM-API-Liveness-Contract.md
@@ -356,7 +356,7 @@ Notification delivery is at-least-once, not exactly-once.
   destination behavior, source/unit paths, service/timer commands, recovery,
   notification delivery, public CLI, schemas, dependencies, or live deployment.
 - Revised verification plan: focused symlink-target privacy and rollback tests,
-  the existing 67 focused cases, syntax/systemd/maturity/plan/diff checks, and
+  the complete focused test file, syntax/systemd/maturity/plan/diff checks, and
   the managed full Unit Gate before push.
 
 ### Contract revision: installer preflight and deployed-copy identity closure

--- a/plans/PR-EOM-API-Liveness-Contract.md
+++ b/plans/PR-EOM-API-Liveness-Contract.md
@@ -82,8 +82,8 @@ Max files: 6
    `tests/test_atlas_api_healthcheck.py::test_installer_deploys_source_and_invokes_enabled_timer_path`.
 - Reachability proof: On deployment, the timer invokes the installed monitor;
   `python scripts/install_atlas_api_healthcheck.py --install` copies the source,
-  reloads user systemd, enables the timer, and invokes the installed health
-  service once. That service makes the real OPTIONS request to
+  reloads user systemd, invokes the installed health service once, and enables
+  the timer only after that proof succeeds. That service makes the real OPTIONS request to
   `/api/v1/leads/intake`; `--check` subsequently verifies the installed copies,
   private topic file, and enabled/active timer without writing. Local tests
   exercise the same install command order and probe seam without stopping the
@@ -102,9 +102,9 @@ Max files: 6
   atlas-api-healthcheck.sh; neither the new Python monitor nor
   its notification environment file is installed. The current template only
   names an `install` command, so the source change has no deployment path.
-  Separately, the monitor persists `next_state` after an undelivered transition
-  alert, which suppresses its retry, and it drops the details returned by a
-  failed `systemctl --user start` command.
+  Separately, notification transitions need a crash-safe outbox rather than an
+  in-memory decision, and failed `systemctl --user start` details must remain
+  observable.
 - Revised root cause: source-managed monitor files alone cannot change a
   user-systemd deployment, and the alert state machine acknowledges a
   notification before it knows that delivery succeeded.
@@ -112,11 +112,10 @@ Max files: 6
   `scripts/install_atlas_api_healthcheck.py` installer/checker that copies the
   monitor and templates outside the runtime worktree, preserves or safely
   migrates the private local notification topic without logging it, reloads and
-  enables the user timer, then invokes the installed health service once as the
-  deployment proof. Update the template invocation, make transition state
-  persist only when no alert is needed or delivery succeeds, carry bounded
-  sanitized start-failure detail into the observation, and add focused tests for
-  installation, timer/service activation, retry, and diagnostics.
+  proves the installed health service, then enables the user timer. Persist each
+  transition in an atomic, fsynced outbox before delivery and acknowledge only
+  after success; carry bounded sanitized start-failure detail into the
+  observation; and test installation, rollback, crash-point retry, and diagnostics.
 - Revised explicit non-scope: do not run the installer against the live user
   systemd configuration in this PR; deployment remains a post-merge host
   action. Do not change `atlas_brain`, funnel routes, CRM, migrations, tracker
@@ -239,8 +238,8 @@ Parked hardening: none.
 |---|---:|
 | `config/atlas-api-healthcheck.service` | 18 |
 | `config/atlas-api-healthcheck.timer` | 10 |
-| `plans/PR-EOM-API-Liveness-Contract.md` | 246 |
-| `scripts/atlas_api_healthcheck.py` | 475 |
+| `plans/PR-EOM-API-Liveness-Contract.md` | 245 |
+| `scripts/atlas_api_healthcheck.py` | 506 |
 | `scripts/install_atlas_api_healthcheck.py` | 397 |
-| `tests/test_atlas_api_healthcheck.py` | 814 |
-| **Total** | **1960** |
+| `tests/test_atlas_api_healthcheck.py` | 852 |
+| **Total** | **2028** |

--- a/plans/PR-EOM-API-Liveness-Contract.md
+++ b/plans/PR-EOM-API-Liveness-Contract.md
@@ -293,6 +293,25 @@ Notification delivery is at-least-once, not exactly-once.
   syntax, systemd verification, plan sync, diff audit, and the existing managed
   full Unit Gate before push.
 
+### Contract revision: user-manager bus ownership
+
+- New evidence: the user-systemd unit hard-codes
+  `DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus`, although the installer
+  is not restricted to UID 1000 and every recovery command targets the invoking
+  user's service manager.
+- Revised root cause: deployment configuration overrides the manager-provided
+  user bus identity with an operator-specific UID, so a valid installation for
+  another UID can address the wrong or nonexistent bus.
+- Revised required change surface: remove the hard-coded bus override and prove
+  the unit contains no UID-specific runtime-bus path; let `systemctl --user`
+  resolve the invoking user's manager through its native runtime environment.
+- Revised explicit non-scope: do not change timer cadence, service commands,
+  installation paths, remote ntfy delivery, the best-effort DISPLAY hint, or
+  live deployment.
+- Revised verification plan: focused template assertion, native
+  `systemd-analyze verify`, syntax/diff/plan checks, and the managed full Unit
+  Gate before push.
+
 ### Boundary-change enumeration
 
 The recovery decision is a system state boundary, not an open-input guard.
@@ -410,10 +429,10 @@ notification exit diagnostics, as listed above.
 
 | File | LOC |
 |---|---:|
-| `config/atlas-api-healthcheck.service` | 19 |
+| `config/atlas-api-healthcheck.service` | 18 |
 | `config/atlas-api-healthcheck.timer` | 10 |
-| `plans/PR-EOM-API-Liveness-Contract.md` | 419 |
+| `plans/PR-EOM-API-Liveness-Contract.md` | 438 |
 | `scripts/atlas_api_healthcheck.py` | 675 |
 | `scripts/install_atlas_api_healthcheck.py` | 490 |
-| `tests/test_atlas_api_healthcheck.py` | 1510 |
-| **Total** | **3123** |
+| `tests/test_atlas_api_healthcheck.py` | 1511 |
+| **Total** | **3142** |

--- a/plans/PR-EOM-API-Liveness-Contract.md
+++ b/plans/PR-EOM-API-Liveness-Contract.md
@@ -239,7 +239,7 @@ Parked hardening: none.
 | `config/atlas-api-healthcheck.service` | 18 |
 | `config/atlas-api-healthcheck.timer` | 10 |
 | `plans/PR-EOM-API-Liveness-Contract.md` | 245 |
-| `scripts/atlas_api_healthcheck.py` | 506 |
-| `scripts/install_atlas_api_healthcheck.py` | 397 |
-| `tests/test_atlas_api_healthcheck.py` | 852 |
-| **Total** | **2028** |
+| `scripts/atlas_api_healthcheck.py` | 562 |
+| `scripts/install_atlas_api_healthcheck.py` | 402 |
+| `tests/test_atlas_api_healthcheck.py` | 971 |
+| **Total** | **2208** |

--- a/plans/PR-EOM-API-Liveness-Contract.md
+++ b/plans/PR-EOM-API-Liveness-Contract.md
@@ -92,9 +92,10 @@ Max files: 6
   user-systemd templates, notification/maintenance configuration, and focused
   tests.
 - Risk areas: unexpected clean stops, deliberate maintenance, failed start,
-  failed re-probe, notification configuration absence, and keeping the monitor
-  independent of the application worktree.
-- Reviewer rules triggered: R1, R2, R6, R11, R12, R14.
+  failed re-probe, notification configuration absence, transactional rollback,
+  concurrent maintenance/recovery actors, and keeping the monitor independent
+  of the application worktree.
+- Reviewer rules triggered: R1, R2, R6, R8, R11, R12, R14.
 
 ### Contract revision: current-head review findings
 
@@ -312,6 +313,29 @@ Notification delivery is at-least-once, not exactly-once.
   `systemd-analyze verify`, syntax/diff/plan checks, and the managed full Unit
   Gate before push.
 
+### Contract revision: complete decision inventory and symlink rollback
+
+- New evidence: the Review Contract omits R8 despite the hand-rolled lock,
+  crash-state, outbox, and rollback model; the closure declaration names only
+  two of the decision-driving memberships introduced by this slice; and file
+  snapshots follow live symlinks while treating broken symlinks as absent, so
+  rollback reconstructs a regular file or deletes the original link.
+- Revised root cause: the implementation and plan model values but not every
+  membership boundary or filesystem node type that those decisions consume.
+  The rollback snapshot therefore cannot reconstruct the pre-install namespace
+  entry, and the review contract cannot prove closure over all admitted states.
+- Revised required change surface: declare R8 and every decision-driving
+  membership with its closed/open status, source, and out-of-set direction;
+  snapshot symlink identity and its raw target before mutation; atomically
+  restore that link entry after a failed install; and prove existing and broken
+  relative symlinks survive a forced service-proof failure unchanged.
+- Revised explicit non-scope: do not change successful-install behavior,
+  source/destination paths, timer state semantics, provider recovery, CORS,
+  notification delivery, public CLI, schemas, dependencies, or live deployment.
+- Revised verification plan: focused out-of-set state tests and parameterized
+  live/broken symlink rollback proof, followed by syntax, systemd, plan, diff,
+  and the managed full Unit Gate before push.
+
 ### Boundary-change enumeration
 
 The recovery decision is a system state boundary, not an open-input guard.
@@ -347,19 +371,49 @@ The recovery decision is a system state boundary, not an open-input guard.
 
 ### Guard-closure declaration
 
-- `TOPIC_RE` is a CLOSED, DERIVED topic grammar: membership is evaluated from
-  the bounded ASCII grammar at `scripts/install_atlas_api_healthcheck.py:27,83-87`,
-  rather than copied from an operator-maintained list. The installer accepts only
-  a normalized string in that grammar; a missing or nonmatching value fails
-  before it writes copies or enables systemd, which is safer than directing an
-  alert to an unknown destination. The focused grammar-product test exercises
-  leading-token, body-family, length, and whitespace-wrapper boundaries against
-  an independent oracle.
+- `TOPIC_RE` and `LEGACY_TOPIC_RE` are CLOSED, DERIVED topic grammars:
+  membership is computed from the bounded ASCII grammar authored in
+  `scripts/install_atlas_api_healthcheck.py`; the legacy grammar additionally
+  derives the topic from the one supported shell assignment shape. Missing or
+  nonmatching input fails before copies or systemd enrollment, the safer side
+  because an unknown notification destination must not be used. The focused
+  grammar-product test exercises token, body, length, and wrapper boundaries
+  against an independent oracle.
 - `PENDING_ALERTS` is CLOSED and ENUMERATED by the three alert events that this
   monitor can emit (`down`, `recovered`, and `auto-recovered`). An unrecognized
-  persisted notification/state record resets safely; recognized pending events
-  remain queued while each run still derives state from the current observation,
-  so arbitrary stored values cannot choose or suppress a notification path.
+  persisted notification invalidates the stored document and resets to the safe
+  initial state; recognized events remain queued while each run still derives
+  state from the current observation, so arbitrary stored values cannot choose
+  or suppress a notification path.
+- The systemd response-key set (`LoadState`, `ActiveState`) is CLOSED and
+  ENUMERATED from the exact properties requested by `query_unit_state()`.
+  Unrequested keys are ignored and either missing required key returns a query
+  failure that becomes provider-down; incomplete systemd output cannot authorize
+  recovery.
+- The browser-ready probe memberships are CLOSED and ENUMERATED from the actual
+  public intake contract: HTTP 200/204, the canonical origin, POST, and
+  Content-Type. Any status or required CORS member outside those sets reports
+  the provider down, the safe side because an unusable browser route must not
+  prove deployment health.
+- `STATE_STATUSES` and the observation outcome vocabulary are CLOSED and
+  ENUMERATED by this monitor's persisted/runtime state machine. Unknown persisted
+  status invalidates the document and resets to the initial state; an unknown
+  runtime observation falls into the existing down outcome, so incompleteness
+  cannot manufacture health.
+- The legacy pending-record exit-code set is CLOSED and ENUMERATED from the
+  monitor's original durable outcomes (`EXIT_OK`, `EXIT_RECOVERED`, `EXIT_DOWN`).
+  Any other value invalidates the legacy document instead of being migrated.
+- The systemd `SuccessExitStatus` set is CLOSED and DERIVED from the current
+  monitor outcomes that mean the provider observation is durable and non-down:
+  ordinary health, successful recovery, and queued remote alert. Provider-down
+  remains outside the success set and therefore fails deployment proof.
+- Timer `ActiveState` membership is CLOSED and ENUMERATED by the three states
+  whose rollback meaning this installer defines (`active`, `inactive`, `failed`).
+  Timer `UnitFileState` membership is CLOSED and ENUMERATED by the four states it
+  can restore exactly (`disabled`, `enabled`, `enabled-runtime`, `static`); the
+  enabled subset is DERIVED from those accepted values at `TimerState.enabled`.
+  Any state outside either admitted set raises before installer mutation, while
+  a value outside the enabled subset remains not-enabled during read-only proof.
 
 ### Files touched
 
@@ -431,8 +485,8 @@ notification exit diagnostics, as listed above.
 |---|---:|
 | `config/atlas-api-healthcheck.service` | 18 |
 | `config/atlas-api-healthcheck.timer` | 10 |
-| `plans/PR-EOM-API-Liveness-Contract.md` | 438 |
+| `plans/PR-EOM-API-Liveness-Contract.md` | 492 |
 | `scripts/atlas_api_healthcheck.py` | 675 |
-| `scripts/install_atlas_api_healthcheck.py` | 490 |
-| `tests/test_atlas_api_healthcheck.py` | 1511 |
-| **Total** | **3142** |
+| `scripts/install_atlas_api_healthcheck.py` | 524 |
+| `tests/test_atlas_api_healthcheck.py` | 1568 |
+| **Total** | **3287** |

--- a/plans/PR-EOM-API-Liveness-Contract.md
+++ b/plans/PR-EOM-API-Liveness-Contract.md
@@ -267,6 +267,32 @@ Notification delivery is at-least-once, not exactly-once.
   that the PR runs the full Unit Gate; plan sync and diff audit. GitHub remains
   the source of truth for the full Unit Gate.
 
+### Contract revision: browser-ready probe and exact timer restoration
+
+- New evidence: the provider probe sends an OPTIONS preflight but treats a
+  200/204 status as healthy without verifying the route-owned CORS response
+  headers needed by the browser. Separately, installer rollback collapses
+  persistent `enabled` and temporary `enabled-runtime` timer states into one
+  boolean and always restores persistent enablement.
+- Revised root cause: both boundaries discard contract-bearing state after
+  reading it: the health probe drops preflight headers, and the installer drops
+  the systemd enablement class. Later decisions therefore prove or restore less
+  than the state they claim.
+- Revised required change surface: send the browser's Content-Type preflight
+  request and require the canonical origin, POST method, and Content-Type
+  allowance before reporting provider health; preserve disabled, persistent,
+  and runtime-only timer enablement distinctly and replay the exact enablement
+  form during rollback; cover missing/wrong/mixed CORS headers and runtime-only
+  rollback in the existing focused test file.
+- Revised explicit non-scope: do not change Atlas route CORS behavior, allowed
+  origins, the website request shape, service/timer templates, public CLI,
+  schemas, dependencies, notification behavior, or live deployment. Continue
+  to park non-finite intervals and desktop-notification diagnostics.
+- Revised verification plan: focused regression tests for valid and invalid
+  preflight response shapes plus persistent/runtime/disabled timer restoration;
+  syntax, systemd verification, plan sync, diff audit, and the existing managed
+  full Unit Gate before push.
+
 ### Boundary-change enumeration
 
 The recovery decision is a system state boundary, not an open-input guard.
@@ -386,8 +412,8 @@ notification exit diagnostics, as listed above.
 |---|---:|
 | `config/atlas-api-healthcheck.service` | 19 |
 | `config/atlas-api-healthcheck.timer` | 10 |
-| `plans/PR-EOM-API-Liveness-Contract.md` | 393 |
-| `scripts/atlas_api_healthcheck.py` | 649 |
-| `scripts/install_atlas_api_healthcheck.py` | 482 |
-| `tests/test_atlas_api_healthcheck.py` | 1420 |
-| **Total** | **2973** |
+| `plans/PR-EOM-API-Liveness-Contract.md` | 419 |
+| `scripts/atlas_api_healthcheck.py` | 675 |
+| `scripts/install_atlas_api_healthcheck.py` | 490 |
+| `tests/test_atlas_api_healthcheck.py` | 1510 |
+| **Total** | **3123** |

--- a/plans/PR-EOM-API-Liveness-Contract.md
+++ b/plans/PR-EOM-API-Liveness-Contract.md
@@ -127,6 +127,84 @@ Max files: 6
   `systemd-analyze verify`, and use the installer `--check` plus its initial
   systemd service invocation as the post-merge deployment proof.
 
+### Contract revision: closed systemd state and open-execution model
+
+- New evidence: `systemctl is-active` collapses every non-active result into one
+  boolean even though recovery is safe only for a loaded unit whose
+  `ActiveState` is exactly `inactive`. The installer likewise treats a missing
+  old healthcheck unit as a stop failure, while `--check` compares disk bytes
+  without proving that systemd loaded them.
+- Revised root cause: monitor, installer, and verifier do not share one explicit
+  systemd state model, and the contract describes sampled schedules rather than
+  the property that must survive every admitted interleaving.
+- Revised required change surface: query and parse `LoadState` plus
+  `ActiveState` once through the monitor-owned state model; recover only
+  `loaded/inactive`; surface absent, transitional, failed, incomplete, and query
+  error states without a start. Reuse that model to admit a clean install with
+  no old unit and to quiesce a loaded old unit. Require `NeedDaemonReload=no`
+  for both installed units before `--check` succeeds.
+- Revised explicit non-scope: do not add a supervisor, database, dependency,
+  schema, deployment write, active-but-unhealthy restart, or broader systemd
+  policy. The private topic, timer cadence, probe, and public CLI stay unchanged.
+  Out-of-band edits to the monitor state file and underlying filesystem or
+  storage corruption are also excluded; admitted state transitions are the
+  atomic, schema-validated writes made by this monitor.
+- Revised verification plan: exercise loaded/active, loaded/inactive,
+  not-found, transitional, query-failure, incomplete-response, clean-install,
+  unsupported-load-state, and daemon-reload-needed boundaries in the focused
+  test file. GitHub runs the full unit gate.
+
+#### Admitted actors and serialization
+
+1. The user-systemd timer or a manual healthcheck invocation runs one monitor
+   cycle. The oneshot service and `state.lock` serialize monitor cycles.
+2. The supported maintenance command holds the same lock while publishing the
+   marker and stopping `atlas-api.service`, so maintenance and recovery have a
+   total order.
+3. The installer first stops the timer, queries the old healthcheck unit, and
+   waits for a loaded old oneshot to stop before replacing files. A missing old
+   unit is the admitted clean-host state. Direct manual monitor launches during
+   installation are excluded; installation is a single-operator maintenance
+   action.
+4. The systemd user manager owns unit load/active state. The monitor and
+   installer act only on successfully parsed `LoadState`/`ActiveState` values;
+   query failures and non-admitted states fail closed.
+5. The remote ntfy service is an external at-least-once delivery consumer. It
+   cannot participate in the local atomic state write.
+
+#### Crash and cancellation boundaries
+
+- Before recovery-intent persistence: no start is issued.
+- After intent persistence but before/during start or re-probe: the next cycle
+  retains the intent and reconciles the explicit systemd state.
+- After outbox persistence but before notification: the next cycle retries.
+- After successful notification but before acknowledgement persistence: a
+  duplicate notification is admitted; silent loss is not.
+- If state cannot be read, decoded, locked, or atomically written, the cycle
+  fails before issuing a new recovery side effect. A SIGKILL cannot interrupt an
+  atomic file replacement, although it can select either the prior or next
+  complete state.
+
+#### Property invariant
+
+For every admitted interleaving: the monitor never starts an unloaded,
+transitional, failed, query-unknown, or maintenance-protected provider; every
+issued recovery start is preceded by durable intent; every derived alert is
+either durably queued or acknowledged after delivery; and installation is
+reported verified only when source bytes, private configuration, timer state,
+and systemd's loaded definitions agree. Notification delivery is at-least-once,
+not exactly-once.
+
+#### Closed-surface alternatives
+
+- `Restart=always` alone is rejected because an operator stop is intentionally
+  not restarted and it cannot encode the maintenance-marker boundary.
+- SQLite is rejected for this single-host, serialized record because it adds a
+  schema/migration surface while still being unable to atomically couple a
+  remote ntfy response with local acknowledgement. The mode-0600 atomic state
+  file plus `flock` is the smaller closed local surface; its admitted duplicate
+  boundary is explicit above.
+
 ### Boundary-change enumeration
 
 The recovery decision is a system state boundary, not an open-input guard.
@@ -136,11 +214,12 @@ The recovery decision is a system state boundary, not an open-input guard.
 - Replaced-path behaviors: inactive service previously notified only; it now
   recovers only if maintenance is absent. Active/healthy remains no-op;
   active/unhealthy remains alert-only.
-- Guard-relevant fields: unit active state, maintenance-lock path, start result,
-  and post-start CORS probe result.
-- Caller x input shape: timer invocation x active/healthy; timer x inactive/no
-  lock; timer x inactive/lock; timer x inactive/start failure; timer x
-  active/failed probe.
+- Guard-relevant fields: unit load state, unit active state, maintenance-lock
+  path, state-query result, start result, and post-start CORS probe result.
+- Caller x input shape: timer invocation x loaded-active/healthy; timer x
+  loaded-inactive/no lock; timer x loaded-inactive/lock; timer x not-found;
+  timer x transitional; timer x query failure; timer x loaded-inactive/start
+  failure; timer x loaded-active/failed probe.
 
 ### Deployed-config probing
 
@@ -238,8 +317,8 @@ Parked hardening: none.
 |---|---:|
 | `config/atlas-api-healthcheck.service` | 18 |
 | `config/atlas-api-healthcheck.timer` | 10 |
-| `plans/PR-EOM-API-Liveness-Contract.md` | 245 |
-| `scripts/atlas_api_healthcheck.py` | 562 |
-| `scripts/install_atlas_api_healthcheck.py` | 402 |
-| `tests/test_atlas_api_healthcheck.py` | 971 |
-| **Total** | **2208** |
+| `plans/PR-EOM-API-Liveness-Contract.md` | 324 |
+| `scripts/atlas_api_healthcheck.py` | 624 |
+| `scripts/install_atlas_api_healthcheck.py` | 472 |
+| `tests/test_atlas_api_healthcheck.py` | 1262 |
+| **Total** | **2710** |

--- a/scripts/atlas_api_healthcheck.py
+++ b/scripts/atlas_api_healthcheck.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 import fcntl
+import http.client
 import json
 import os
 import subprocess
@@ -183,7 +184,7 @@ def probe_lead_intake(probe_url: str, opener: Opener) -> tuple[bool, str]:
     try:
         with opener(request, timeout=8) as response:
             status = int(response.status)
-    except (urllib.error.URLError, OSError, ValueError) as exc:
+    except (urllib.error.URLError, http.client.HTTPException, OSError, ValueError) as exc:
         return False, f"lead-intake probe failed: {type(exc).__name__}"
     if status in (200, 204):
         return True, f"lead-intake probe returned HTTP {status}"
@@ -482,7 +483,7 @@ def publish(ntfy_url: str, topic: str, title: str, body: str, priority: str, tag
         try:
             with urllib.request.urlopen(request, timeout=15) as response:
                 delivered = 200 <= int(response.status) < 300
-        except (urllib.error.URLError, OSError, ValueError) as exc:
+        except (urllib.error.URLError, http.client.HTTPException, OSError, ValueError) as exc:
             print(f"WARNING alert delivery failed: {type(exc).__name__}")
     try:
         subprocess.run(
@@ -576,18 +577,42 @@ def _settings_from_args(argv: Sequence[str] | None) -> tuple[Settings, str]:
     parser.add_argument("--ntfy-topic", default=os.environ.get("ATLAS_API_HEALTHCHECK_NTFY_TOPIC", ""))
     parser.add_argument("--state-dir", default=os.environ.get("ATLAS_API_HEALTHCHECK_STATE_DIR", str(DEFAULT_STATE_DIR)))
     parser.add_argument("--maintenance-lock", default=os.environ.get("ATLAS_API_HEALTHCHECK_MAINTENANCE_LOCK", str(DEFAULT_MAINTENANCE_LOCK)))
-    parser.add_argument("--realert-every", type=int, default=int(os.environ.get("ATLAS_API_HEALTHCHECK_REALERT_EVERY", DEFAULT_REALERT_EVERY)))
-    parser.add_argument("--recovery-attempts", type=int, default=int(os.environ.get("ATLAS_API_HEALTHCHECK_RECOVERY_ATTEMPTS", DEFAULT_RECOVERY_ATTEMPTS)))
-    parser.add_argument("--recovery-interval-seconds", type=float, default=float(os.environ.get("ATLAS_API_HEALTHCHECK_RECOVERY_INTERVAL_SECONDS", DEFAULT_RECOVERY_INTERVAL_SECONDS)))
+    parser.add_argument("--realert-every", default=os.environ.get("ATLAS_API_HEALTHCHECK_REALERT_EVERY", str(DEFAULT_REALERT_EVERY)))
+    parser.add_argument("--recovery-attempts", default=os.environ.get("ATLAS_API_HEALTHCHECK_RECOVERY_ATTEMPTS", str(DEFAULT_RECOVERY_ATTEMPTS)))
+    parser.add_argument("--recovery-interval-seconds", default=os.environ.get("ATLAS_API_HEALTHCHECK_RECOVERY_INTERVAL_SECONDS", str(DEFAULT_RECOVERY_INTERVAL_SECONDS)))
     parser.add_argument("--no-alert", action="store_true")
     args = parser.parse_args(argv)
+    selected_action = (
+        "enter-maintenance"
+        if args.enter_maintenance
+        else "exit-maintenance"
+        if args.exit_maintenance
+        else "healthcheck"
+    )
     if not args.service.strip():
         raise ValueError("service must not be blank")
-    if args.realert_every < 0:
+    if selected_action == "healthcheck":
+        try:
+            realert_every = int(args.realert_every)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("realert-every must be an integer") from exc
+        try:
+            recovery_attempts = int(args.recovery_attempts)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("recovery-attempts must be an integer") from exc
+        try:
+            recovery_interval_seconds = float(args.recovery_interval_seconds)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("recovery-interval-seconds must be numeric") from exc
+    else:
+        realert_every = DEFAULT_REALERT_EVERY
+        recovery_attempts = DEFAULT_RECOVERY_ATTEMPTS
+        recovery_interval_seconds = DEFAULT_RECOVERY_INTERVAL_SECONDS
+    if realert_every < 0:
         raise ValueError("realert-every must not be negative")
-    if args.recovery_attempts < 1:
+    if recovery_attempts < 1:
         raise ValueError("recovery-attempts must be at least one")
-    if args.recovery_interval_seconds < 0:
+    if recovery_interval_seconds < 0:
         raise ValueError("recovery-interval-seconds must not be negative")
     settings = Settings(
         service=args.service,
@@ -596,17 +621,10 @@ def _settings_from_args(argv: Sequence[str] | None) -> tuple[Settings, str]:
         ntfy_topic=args.ntfy_topic,
         state_dir=Path(args.state_dir),
         maintenance_lock=Path(args.maintenance_lock),
-        realert_every=args.realert_every,
-        recovery_attempts=args.recovery_attempts,
-        recovery_interval_seconds=args.recovery_interval_seconds,
+        realert_every=realert_every,
+        recovery_attempts=recovery_attempts,
+        recovery_interval_seconds=recovery_interval_seconds,
         no_alert=args.no_alert,
-    )
-    selected_action = (
-        "enter-maintenance"
-        if args.enter_maintenance
-        else "exit-maintenance"
-        if args.exit_maintenance
-        else "healthcheck"
     )
     return settings, selected_action
 

--- a/scripts/atlas_api_healthcheck.py
+++ b/scripts/atlas_api_healthcheck.py
@@ -154,7 +154,14 @@ def probe_lead_intake(probe_url: str, opener: Opener) -> tuple[bool, str]:
     return False, f"lead-intake probe returned HTTP {status}"
 
 
-def observe(settings: Settings, runner: Runner, opener: Opener, sleeper: Callable[[float], None]) -> Observation:
+def observe(
+    settings: Settings,
+    runner: Runner,
+    opener: Opener,
+    sleeper: Callable[[float], None],
+    *,
+    before_start: Callable[[], None] | None = None,
+) -> Observation:
     """Observe the provider and recover only an inactive, non-maintenance unit."""
     if settings.maintenance_lock.exists():
         return Observation("maintenance", f"maintenance lock present: {settings.maintenance_lock}")
@@ -163,6 +170,8 @@ def observe(settings: Settings, runner: Runner, opener: Opener, sleeper: Callabl
         healthy, detail = probe_lead_intake(settings.probe_url, opener)
         return Observation("healthy" if healthy else "down", detail)
 
+    if before_start is not None:
+        before_start()
     started = runner(("systemctl", "--user", "start", settings.service))
     if started.returncode != 0:
         return Observation(
@@ -215,6 +224,15 @@ def _normalized_notification(value: object) -> dict[str, str] | None:
     return {"alert": alert, "detail": detail}
 
 
+def _normalized_recovery_intent(value: object) -> dict[str, str] | None:
+    if not isinstance(value, dict):
+        return None
+    service = value.get("service")
+    if not isinstance(service, str) or not service.strip():
+        return None
+    return {"service": service}
+
+
 def normalize_state(value: object) -> dict[str, object] | None:
     """Validate the persisted state and migrate the previous singular queue."""
     if not isinstance(value, dict):
@@ -222,9 +240,12 @@ def normalize_state(value: object) -> dict[str, object] | None:
 
     queued_value = value.get("pending_notifications")
     legacy_value = value.get("pending_notification")
+    recovery_value = value.get("recovery_intent")
     if queued_value is not None and legacy_value is not None:
         return None
     if legacy_value is not None:
+        if recovery_value is not None:
+            return None
         notification = _normalized_notification(legacy_value)
         next_state = _normalized_base_state(
             legacy_value.get("next_state") if isinstance(legacy_value, dict) else None
@@ -242,29 +263,34 @@ def normalize_state(value: object) -> dict[str, object] | None:
     state = _normalized_base_state(value)
     if state is None:
         return None
-    if queued_value is None:
-        return state
-    if not isinstance(queued_value, list):
-        return None
-    notifications: list[dict[str, str]] = []
-    for candidate in queued_value:
-        notification = _normalized_notification(candidate)
-        if notification is None:
+    if queued_value is not None:
+        if not isinstance(queued_value, list):
             return None
-        notifications.append(notification)
-    if notifications:
-        state["pending_notifications"] = notifications
+        notifications: list[dict[str, str]] = []
+        for candidate in queued_value:
+            notification = _normalized_notification(candidate)
+            if notification is None:
+                return None
+            notifications.append(notification)
+        if notifications:
+            state["pending_notifications"] = notifications
+    if recovery_value is not None:
+        recovery_intent = _normalized_recovery_intent(recovery_value)
+        if recovery_intent is None:
+            return None
+        state["recovery_intent"] = recovery_intent
     return state
 
 
 def read_state(path: Path) -> dict[str, object]:
-    if not path.exists():
-        return {}
     try:
         value = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        print(f"WARNING state read failed: {type(exc).__name__}", file=sys.stderr)
+    except FileNotFoundError:
         return {}
+    except OSError as exc:
+        raise RuntimeError(f"unable to read Atlas API health state at {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"unable to decode Atlas API health state at {path}") from exc
     normalized = normalize_state(value)
     if normalized is None:
         print("WARNING state schema is invalid; resetting monitor state", file=sys.stderr)
@@ -331,7 +357,9 @@ def decide_alert(previous: dict[str, object], observation: Observation, realert_
     if observation.status == "maintenance":
         return {"status": "maintenance", "consecutive": 0}, None, EXIT_OK
     if observation.status == "healthy":
-        alert = "recovered" if previous_status == "down" else None
+        alert = "auto-recovered" if recovery_intent_service(previous) is not None else None
+        if alert is None and previous_status == "down":
+            alert = "recovered"
         return {"status": "healthy", "consecutive": 0}, alert, EXIT_OK
     if observation.status == "recovered":
         return {"status": "healthy", "consecutive": 0}, "auto-recovered", EXIT_RECOVERED
@@ -360,6 +388,22 @@ def state_with_pending_notifications(
     if notifications:
         state["pending_notifications"] = notifications
     return state
+
+
+def state_with_recovery_intent(state: dict[str, object], service: str) -> dict[str, object]:
+    pending_state = dict(state)
+    pending_state.setdefault("status", "healthy")
+    pending_state.setdefault("consecutive", 0)
+    pending_state["recovery_intent"] = {"service": service}
+    return pending_state
+
+
+def recovery_intent_service(state: dict[str, object]) -> str | None:
+    intent = state.get("recovery_intent")
+    if not isinstance(intent, dict):
+        return None
+    service = intent.get("service")
+    return service if isinstance(service, str) and service.strip() else None
 
 
 def publish(ntfy_url: str, topic: str, title: str, body: str, priority: str, tags: str) -> bool:
@@ -415,12 +459,24 @@ def run_healthcheck(
     """Run one serialized observation/recovery/notification cycle."""
     state_path = settings.state_dir / "state.json"
     with serialized_monitor_state(settings):
-        observation = observe(settings, runner, opener, sleeper)
         previous = read_state(state_path)
+        observation = observe(
+            settings,
+            runner,
+            opener,
+            sleeper,
+            before_start=lambda: write_state(
+                state_path, state_with_recovery_intent(previous, settings.service)
+            ),
+        )
         next_state, alert, exit_code = decide_alert(previous, observation, settings.realert_every)
         notifications = pending_notifications(previous)
         if alert is not None:
-            notifications.append({"alert": alert, "detail": observation.detail})
+            detail = observation.detail
+            recovered_service = recovery_intent_service(previous)
+            if alert == "auto-recovered" and recovered_service is not None:
+                detail = f"auto-recovered {recovered_service}: {detail}"
+            notifications.append({"alert": alert, "detail": detail})
         append_log(settings.state_dir, f"{observation.status.upper()} {observation.detail}")
         print(f"{observation.status.upper()}: {observation.detail}")
 

--- a/scripts/atlas_api_healthcheck.py
+++ b/scripts/atlas_api_healthcheck.py
@@ -286,7 +286,7 @@ def read_state(path: Path) -> dict[str, object]:
     try:
         value = json.loads(path.read_text(encoding="utf-8"))
     except FileNotFoundError:
-        return {}
+        value = {}
     except OSError as exc:
         raise RuntimeError(f"unable to read Atlas API health state at {path}") from exc
     except json.JSONDecodeError as exc:

--- a/scripts/atlas_api_healthcheck.py
+++ b/scripts/atlas_api_healthcheck.py
@@ -32,6 +32,7 @@ EXIT_ALERT_UNDELIVERED = 4
 
 DEFAULT_SERVICE = "atlas-api.service"
 DEFAULT_PROBE_URL = "http://127.0.0.1:8012/api/v1/leads/intake"
+PROBE_ORIGIN = "https://effinghamofficemaids.com"
 DEFAULT_NTFY_URL = "https://ntfy.sh"
 DEFAULT_REALERT_EVERY = 6
 DEFAULT_RECOVERY_ATTEMPTS = 8
@@ -176,19 +177,44 @@ def probe_lead_intake(probe_url: str, opener: Opener) -> tuple[bool, str]:
     request = urllib.request.Request(
         probe_url,
         headers={
-            "Origin": "https://effinghamofficemaids.com",
+            "Origin": PROBE_ORIGIN,
             "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "Content-Type",
         },
         method="OPTIONS",
     )
     try:
         with opener(request, timeout=8) as response:
             status = int(response.status)
-    except (urllib.error.URLError, http.client.HTTPException, OSError, ValueError) as exc:
+            allow_origin = str(response.headers.get("Access-Control-Allow-Origin", "")).strip()
+            allow_methods = {
+                method.strip().upper()
+                for method in str(response.headers.get("Access-Control-Allow-Methods", "")).split(",")
+                if method.strip()
+            }
+            allow_headers = {
+                header.strip().lower()
+                for header in str(response.headers.get("Access-Control-Allow-Headers", "")).split(",")
+                if header.strip()
+            }
+    except (
+        urllib.error.URLError,
+        http.client.HTTPException,
+        AttributeError,
+        OSError,
+        TypeError,
+        ValueError,
+    ) as exc:
         return False, f"lead-intake probe failed: {type(exc).__name__}"
-    if status in (200, 204):
-        return True, f"lead-intake probe returned HTTP {status}"
-    return False, f"lead-intake probe returned HTTP {status}"
+    if status not in (200, 204):
+        return False, f"lead-intake probe returned HTTP {status}"
+    if allow_origin != PROBE_ORIGIN:
+        return False, f"lead-intake probe CORS origin mismatch at HTTP {status}"
+    if "POST" not in allow_methods:
+        return False, f"lead-intake probe CORS methods omit POST at HTTP {status}"
+    if "content-type" not in allow_headers:
+        return False, f"lead-intake probe CORS headers omit Content-Type at HTTP {status}"
+    return True, f"lead-intake probe returned browser-ready HTTP {status}"
 
 
 def observe(

--- a/scripts/atlas_api_healthcheck.py
+++ b/scripts/atlas_api_healthcheck.py
@@ -32,7 +32,10 @@ EXIT_ALERT_UNDELIVERED = 4
 
 DEFAULT_SERVICE = "atlas-api.service"
 DEFAULT_PROBE_URL = "http://127.0.0.1:8012/api/v1/leads/intake"
-PROBE_ORIGIN = "https://effinghamofficemaids.com"
+PROBE_ORIGINS = (
+    "https://effinghamofficemaids.com",
+    "https://www.effinghamofficemaids.com",
+)
 DEFAULT_NTFY_URL = "https://ntfy.sh"
 DEFAULT_REALERT_EVERY = 6
 DEFAULT_RECOVERY_ATTEMPTS = 8
@@ -42,6 +45,7 @@ DEFAULT_MAINTENANCE_LOCK = Path.home() / ".config" / "atlas" / "atlas-api.mainte
 PENDING_ALERTS = frozenset({"down", "recovered", "auto-recovered"})
 STATE_STATUSES = frozenset({"healthy", "down", "maintenance"})
 MAX_COMMAND_DETAIL = 240
+DESKTOP_NOTIFICATION_TIMEOUT_SECONDS = 3.0
 
 
 @dataclass(frozen=True)
@@ -140,17 +144,52 @@ def maintenance_is_active(path: Path) -> bool:
     return present
 
 
+def _durably_publish_maintenance_marker(path: Path) -> None:
+    descriptor: int | None = None
+    directory_descriptor: int | None = None
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        descriptor = os.open(
+            path,
+            os.O_WRONLY | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0),
+            0o600,
+        )
+        os.fchmod(descriptor, 0o600)
+        os.fsync(descriptor)
+        directory_descriptor = os.open(
+            path.parent, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+        )
+        os.fsync(directory_descriptor)
+    except OSError as exc:
+        raise RuntimeError(f"unable to durably create Atlas API maintenance lock at {path}") from exc
+    finally:
+        if directory_descriptor is not None:
+            os.close(directory_descriptor)
+        if descriptor is not None:
+            os.close(descriptor)
+
+
+def _durably_remove_maintenance_marker(path: Path) -> None:
+    directory_descriptor: int | None = None
+    try:
+        path.unlink(missing_ok=True)
+        if not path.parent.exists():
+            return
+        directory_descriptor = os.open(
+            path.parent, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+        )
+        os.fsync(directory_descriptor)
+    except OSError as exc:
+        raise RuntimeError(f"unable to durably remove Atlas API maintenance lock at {path}") from exc
+    finally:
+        if directory_descriptor is not None:
+            os.close(directory_descriptor)
+
+
 def enter_maintenance(settings: Settings, *, runner: Runner = _run) -> int:
     """Create the maintenance marker and stop the service under the monitor lock."""
     with serialized_monitor_state(settings):
-        try:
-            settings.maintenance_lock.parent.mkdir(parents=True, exist_ok=True)
-            settings.maintenance_lock.touch(mode=0o600, exist_ok=True)
-            settings.maintenance_lock.chmod(0o600)
-        except OSError as exc:
-            raise RuntimeError(
-                f"unable to create Atlas API maintenance lock at {settings.maintenance_lock}"
-            ) from exc
+        _durably_publish_maintenance_marker(settings.maintenance_lock)
         stopped = runner(("systemctl", "--user", "stop", settings.service))
         if stopped.returncode != 0:
             raise RuntimeError(
@@ -163,21 +202,18 @@ def enter_maintenance(settings: Settings, *, runner: Runner = _run) -> int:
 def exit_maintenance(settings: Settings) -> int:
     """Remove the maintenance marker under the same lock used by recovery."""
     with serialized_monitor_state(settings):
-        try:
-            settings.maintenance_lock.unlink(missing_ok=True)
-        except OSError as exc:
-            raise RuntimeError(
-                f"unable to remove Atlas API maintenance lock at {settings.maintenance_lock}"
-            ) from exc
+        _durably_remove_maintenance_marker(settings.maintenance_lock)
     print(f"MAINTENANCE CLEARED: {settings.maintenance_lock}")
     return EXIT_OK
 
 
-def probe_lead_intake(probe_url: str, opener: Opener) -> tuple[bool, str]:
+def _probe_lead_intake_origin(
+    probe_url: str, origin: str, opener: Opener
+) -> tuple[bool, str]:
     request = urllib.request.Request(
         probe_url,
         headers={
-            "Origin": PROBE_ORIGIN,
+            "Origin": origin,
             "Access-Control-Request-Method": "POST",
             "Access-Control-Request-Headers": "Content-Type",
         },
@@ -208,13 +244,21 @@ def probe_lead_intake(probe_url: str, opener: Opener) -> tuple[bool, str]:
         return False, f"lead-intake probe failed: {type(exc).__name__}"
     if status not in (200, 204):
         return False, f"lead-intake probe returned HTTP {status}"
-    if allow_origin != PROBE_ORIGIN:
+    if allow_origin != origin:
         return False, f"lead-intake probe CORS origin mismatch at HTTP {status}"
     if "POST" not in allow_methods:
         return False, f"lead-intake probe CORS methods omit POST at HTTP {status}"
     if "content-type" not in allow_headers:
         return False, f"lead-intake probe CORS headers omit Content-Type at HTTP {status}"
     return True, f"lead-intake probe returned browser-ready HTTP {status}"
+
+
+def probe_lead_intake(probe_url: str, opener: Opener) -> tuple[bool, str]:
+    for origin in PROBE_ORIGINS:
+        healthy, detail = _probe_lead_intake_origin(probe_url, origin, opener)
+        if not healthy:
+            return False, f"{origin}: {detail}"
+    return True, f"lead-intake probe returned browser-ready responses for {len(PROBE_ORIGINS)} origins"
 
 
 def observe(
@@ -524,8 +568,9 @@ def publish(ntfy_url: str, topic: str, title: str, body: str, priority: str, tag
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             check=False,
+            timeout=DESKTOP_NOTIFICATION_TIMEOUT_SECONDS,
         )
-    except OSError as exc:
+    except (OSError, subprocess.TimeoutExpired) as exc:
         print(f"WARNING desktop notification failed: {type(exc).__name__}", file=sys.stderr)
     return delivered
 
@@ -622,7 +667,7 @@ def _settings_from_args(argv: Sequence[str] | None) -> tuple[Settings, str]:
         if args.exit_maintenance
         else "healthcheck"
     )
-    if not args.service.strip():
+    if selected_action != "exit-maintenance" and not args.service.strip():
         raise ValueError("service must not be blank")
     if selected_action == "healthcheck":
         try:

--- a/scripts/atlas_api_healthcheck.py
+++ b/scripts/atlas_api_healthcheck.py
@@ -13,6 +13,7 @@ import json
 import os
 import subprocess
 import sys
+import tempfile
 import time
 import urllib.error
 import urllib.request
@@ -273,7 +274,38 @@ def read_state(path: Path) -> dict[str, object]:
 
 def write_state(path: Path, state: dict[str, object]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(state, sort_keys=True), encoding="utf-8")
+    payload = json.dumps(state, sort_keys=True).encode("utf-8")
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="wb",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            delete=False,
+        ) as handle:
+            temporary_path = Path(handle.name)
+            os.fchmod(handle.fileno(), 0o600)
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_path, path)
+        directory_fd = os.open(path.parent, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+        temporary_path = None
+    except OSError as exc:
+        raise RuntimeError(f"unable to atomically persist Atlas API health state at {path}") from exc
+    finally:
+        if temporary_path is not None and temporary_path.exists():
+            try:
+                temporary_path.unlink()
+            except OSError as exc:
+                print(
+                    f"WARNING state temporary cleanup failed: {type(exc).__name__}",
+                    file=sys.stderr,
+                )
 
 
 def append_log(state_dir: Path, message: str) -> bool:
@@ -395,8 +427,8 @@ def run_healthcheck(
         if not notifications:
             write_state(state_path, next_state)
             return exit_code
+        write_state(state_path, state_with_pending_notifications(next_state, notifications))
         if settings.no_alert:
-            write_state(state_path, state_with_pending_notifications(next_state, notifications))
             print("WARNING --no-alert: notifications queued for retry")
             return EXIT_ALERT_UNDELIVERED
 
@@ -405,14 +437,13 @@ def run_healthcheck(
                 notification["alert"], notification["detail"]
             )
             if not notifier(settings.ntfy_url, settings.ntfy_topic, title, body, priority, tags):
-                write_state(
-                    state_path,
-                    state_with_pending_notifications(next_state, notifications[index:]),
-                )
                 print("WARNING alert undelivered; transition remains queued for retry")
                 return EXIT_ALERT_UNDELIVERED
+            write_state(
+                state_path,
+                state_with_pending_notifications(next_state, notifications[index + 1 :]),
+            )
 
-        write_state(state_path, next_state)
         return exit_code
 
 

--- a/scripts/atlas_api_healthcheck.py
+++ b/scripts/atlas_api_healthcheck.py
@@ -36,6 +36,7 @@ DEFAULT_RECOVERY_INTERVAL_SECONDS = 1.0
 DEFAULT_STATE_DIR = Path(os.environ.get("XDG_STATE_HOME", Path.home() / ".local" / "state")) / "atlas-api-health"
 DEFAULT_MAINTENANCE_LOCK = Path.home() / ".config" / "atlas" / "atlas-api.maintenance"
 PENDING_ALERTS = frozenset({"down", "recovered", "auto-recovered"})
+STATE_STATUSES = frozenset({"healthy", "down", "maintenance"})
 MAX_COMMAND_DETAIL = 240
 
 
@@ -131,6 +132,79 @@ def observe(settings: Settings, runner: Runner, opener: Opener, sleeper: Callabl
     return Observation("down", f"auto-recovery did not restore {settings.service}: {last_detail}")
 
 
+def _normalized_base_state(value: object) -> dict[str, object] | None:
+    if value == {}:
+        return {}
+    if not isinstance(value, dict):
+        return None
+    status = value.get("status")
+    consecutive = value.get("consecutive")
+    if (
+        not isinstance(status, str)
+        or status not in STATE_STATUSES
+        or type(consecutive) is not int
+        or consecutive < 0
+    ):
+        return None
+    if status == "down" and consecutive < 1:
+        return None
+    if status != "down" and consecutive != 0:
+        return None
+    return {"status": status, "consecutive": consecutive}
+
+
+def _normalized_notification(value: object) -> dict[str, str] | None:
+    if not isinstance(value, dict):
+        return None
+    alert = value.get("alert")
+    detail = value.get("detail")
+    if not isinstance(alert, str) or alert not in PENDING_ALERTS or not isinstance(detail, str):
+        return None
+    return {"alert": alert, "detail": detail}
+
+
+def normalize_state(value: object) -> dict[str, object] | None:
+    """Validate the persisted state and migrate the previous singular queue."""
+    if not isinstance(value, dict):
+        return None
+
+    queued_value = value.get("pending_notifications")
+    legacy_value = value.get("pending_notification")
+    if queued_value is not None and legacy_value is not None:
+        return None
+    if legacy_value is not None:
+        notification = _normalized_notification(legacy_value)
+        next_state = _normalized_base_state(
+            legacy_value.get("next_state") if isinstance(legacy_value, dict) else None
+        )
+        exit_code = legacy_value.get("exit_code") if isinstance(legacy_value, dict) else None
+        if (
+            notification is None
+            or next_state is None
+            or type(exit_code) is not int
+            or exit_code not in {EXIT_OK, EXIT_RECOVERED, EXIT_DOWN}
+        ):
+            return None
+        return {**next_state, "pending_notifications": [notification]}
+
+    state = _normalized_base_state(value)
+    if state is None:
+        return None
+    if queued_value is None:
+        return state
+    if not isinstance(queued_value, list):
+        return None
+    notifications: list[dict[str, str]] = []
+    for candidate in queued_value:
+        notification = _normalized_notification(candidate)
+        if notification is None:
+            return None
+        notifications.append(notification)
+    if notifications:
+        state["pending_notifications"] = notifications
+    return state
+
+
 def read_state(path: Path) -> dict[str, object]:
     if not path.exists():
         return {}
@@ -139,7 +213,11 @@ def read_state(path: Path) -> dict[str, object]:
     except (OSError, json.JSONDecodeError) as exc:
         print(f"WARNING state read failed: {type(exc).__name__}", file=sys.stderr)
         return {}
-    return value if isinstance(value, dict) else {}
+    normalized = normalize_state(value)
+    if normalized is None:
+        print("WARNING state schema is invalid; resetting monitor state", file=sys.stderr)
+        return {}
+    return normalized
 
 
 def write_state(path: Path, state: dict[str, object]) -> None:
@@ -147,7 +225,7 @@ def write_state(path: Path, state: dict[str, object]) -> None:
     path.write_text(json.dumps(state, sort_keys=True), encoding="utf-8")
 
 
-def append_log(state_dir: Path, message: str) -> None:
+def append_log(state_dir: Path, message: str) -> bool:
     log_path = state_dir / "health.log"
     try:
         state_dir.mkdir(parents=True, exist_ok=True)
@@ -155,11 +233,18 @@ def append_log(state_dir: Path, message: str) -> None:
         with log_path.open("a", encoding="utf-8") as handle:
             handle.write(f"{stamp} {message}\n")
     except OSError as exc:
-        raise RuntimeError(f"unable to append Atlas API health log at {log_path}") from exc
+        print(
+            f"WARNING health log append failed at {log_path}: {type(exc).__name__}",
+            file=sys.stderr,
+        )
+        return False
+    return True
 
 
 def decide_alert(previous: dict[str, object], observation: Observation, realert_every: int) -> tuple[dict[str, object], str | None, int]:
-    previous_status = str(previous.get("status", "healthy"))
+    previous_status = previous.get("status", "healthy")
+    if not isinstance(previous_status, str) or previous_status not in STATE_STATUSES:
+        previous_status = "healthy"
     if observation.status == "maintenance":
         return {"status": "maintenance", "consecutive": 0}, None, EXIT_OK
     if observation.status == "healthy":
@@ -168,48 +253,29 @@ def decide_alert(previous: dict[str, object], observation: Observation, realert_
     if observation.status == "recovered":
         return {"status": "healthy", "consecutive": 0}, "auto-recovered", EXIT_RECOVERED
 
-    consecutive = int(previous.get("consecutive", 0)) + 1 if previous_status == "down" else 1
+    previous_consecutive = previous.get("consecutive", 0)
+    if type(previous_consecutive) is not int or previous_consecutive < 0:
+        previous_consecutive = 0
+    consecutive = previous_consecutive + 1 if previous_status == "down" else 1
     alert = "down" if previous_status != "down" else None
     if alert is None and realert_every > 0 and consecutive % realert_every == 0:
         alert = "down"
     return {"status": "down", "consecutive": consecutive}, alert, EXIT_DOWN
 
 
-def pending_notification(previous: dict[str, object]) -> tuple[str, str, dict[str, object], int] | None:
-    """Load an undelivered alert without treating its transition as acknowledged."""
-    value = previous.get("pending_notification")
-    if not isinstance(value, dict):
-        return None
-    alert = value.get("alert")
-    detail = value.get("detail")
-    next_state = value.get("next_state")
-    exit_code = value.get("exit_code")
-    if (
-        isinstance(alert, str)
-        and alert in PENDING_ALERTS
-        and isinstance(detail, str)
-        and isinstance(next_state, dict)
-        and exit_code in {EXIT_OK, EXIT_RECOVERED, EXIT_DOWN}
-    ):
-        return alert, detail, next_state, exit_code
-    return None
+def pending_notifications(state: dict[str, object]) -> list[dict[str, str]]:
+    value = state.get("pending_notifications", [])
+    if not isinstance(value, list):
+        return []
+    return [dict(item) for item in value if isinstance(item, dict)]
 
 
-def state_with_pending_notification(
-    previous: dict[str, object],
-    *,
-    alert: str,
-    detail: str,
-    next_state: dict[str, object],
-    exit_code: int,
+def state_with_pending_notifications(
+    next_state: dict[str, object], notifications: list[dict[str, str]]
 ) -> dict[str, object]:
-    state = dict(previous)
-    state["pending_notification"] = {
-        "alert": alert,
-        "detail": detail,
-        "next_state": next_state,
-        "exit_code": exit_code,
-    }
+    state = dict(next_state)
+    if notifications:
+        state["pending_notifications"] = notifications
     return state
 
 
@@ -275,37 +341,32 @@ def run_healthcheck(
         fcntl.flock(lock, fcntl.LOCK_EX)
         observation = observe(settings, runner, opener, sleeper)
         previous = read_state(state_path)
-        pending = pending_notification(previous)
-        if pending is None:
-            next_state, alert, exit_code = decide_alert(previous, observation, settings.realert_every)
-            alert_detail = observation.detail
-        else:
-            alert, alert_detail, next_state, exit_code = pending
+        next_state, alert, exit_code = decide_alert(previous, observation, settings.realert_every)
+        notifications = pending_notifications(previous)
+        if alert is not None:
+            notifications.append({"alert": alert, "detail": observation.detail})
         append_log(settings.state_dir, f"{observation.status.upper()} {observation.detail}")
         print(f"{observation.status.upper()}: {observation.detail}")
 
-        if alert is None:
+        if not notifications:
             write_state(state_path, next_state)
             return exit_code
         if settings.no_alert:
-            print(f"WARNING --no-alert: {alert} notification not sent and state left unchanged")
+            write_state(state_path, state_with_pending_notifications(next_state, notifications))
+            print("WARNING --no-alert: notifications queued for retry")
             return EXIT_ALERT_UNDELIVERED
 
-        title, body, priority, tags = alert_message(alert, alert_detail)
-        if not notifier(settings.ntfy_url, settings.ntfy_topic, title, body, priority, tags):
-            if pending is None:
+        for index, notification in enumerate(notifications):
+            title, body, priority, tags = alert_message(
+                notification["alert"], notification["detail"]
+            )
+            if not notifier(settings.ntfy_url, settings.ntfy_topic, title, body, priority, tags):
                 write_state(
                     state_path,
-                    state_with_pending_notification(
-                        previous,
-                        alert=alert,
-                        detail=alert_detail,
-                        next_state=next_state,
-                        exit_code=exit_code,
-                    ),
+                    state_with_pending_notifications(next_state, notifications[index:]),
                 )
-            print("WARNING alert undelivered; transition remains pending for retry")
-            return EXIT_ALERT_UNDELIVERED
+                print("WARNING alert undelivered; transition remains queued for retry")
+                return EXIT_ALERT_UNDELIVERED
 
         write_state(state_path, next_state)
         return exit_code

--- a/scripts/atlas_api_healthcheck.py
+++ b/scripts/atlas_api_healthcheck.py
@@ -452,6 +452,13 @@ def state_with_pending_notifications(
     return state
 
 
+def result_with_pending_alert(provider_exit_code: int) -> int:
+    """Keep a provider outage dominant over secondary alert delivery."""
+    if provider_exit_code == EXIT_DOWN:
+        return EXIT_DOWN
+    return EXIT_ALERT_UNDELIVERED
+
+
 def state_with_recovery_intent(state: dict[str, object], service: str) -> dict[str, object]:
     pending_state = dict(state)
     pending_state.setdefault("status", "healthy")
@@ -549,7 +556,7 @@ def run_healthcheck(
         print(f"{observation.status.upper()}: {observation.detail}")
         if settings.no_alert:
             print("WARNING --no-alert: notifications queued for retry")
-            return EXIT_ALERT_UNDELIVERED
+            return result_with_pending_alert(exit_code)
 
         for index, notification in enumerate(notifications):
             title, body, priority, tags = alert_message(
@@ -557,7 +564,7 @@ def run_healthcheck(
             )
             if not notifier(settings.ntfy_url, settings.ntfy_topic, title, body, priority, tags):
                 print("WARNING alert undelivered; transition remains queued for retry")
-                return EXIT_ALERT_UNDELIVERED
+                return result_with_pending_alert(exit_code)
             write_state(
                 state_path,
                 state_with_pending_notifications(next_state, notifications[index + 1 :]),

--- a/scripts/atlas_api_healthcheck.py
+++ b/scripts/atlas_api_healthcheck.py
@@ -35,6 +35,8 @@ DEFAULT_RECOVERY_ATTEMPTS = 8
 DEFAULT_RECOVERY_INTERVAL_SECONDS = 1.0
 DEFAULT_STATE_DIR = Path(os.environ.get("XDG_STATE_HOME", Path.home() / ".local" / "state")) / "atlas-api-health"
 DEFAULT_MAINTENANCE_LOCK = Path.home() / ".config" / "atlas" / "atlas-api.maintenance"
+PENDING_ALERTS = frozenset({"down", "recovered", "auto-recovered"})
+MAX_COMMAND_DETAIL = 240
 
 
 @dataclass(frozen=True)
@@ -64,6 +66,16 @@ Notifier = Callable[[str, str, str, str, str, str], bool]
 
 def _run(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
     return subprocess.run(command, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+def command_failure_detail(result: subprocess.CompletedProcess[str]) -> str:
+    """Return bounded diagnostic context without carrying terminal controls."""
+    text = " ".join(part for part in (result.stderr, result.stdout) if part)
+    text = "".join(character if character.isprintable() else " " for character in text)
+    text = " ".join(text.split())
+    if len(text) > MAX_COMMAND_DETAIL:
+        text = text[: MAX_COMMAND_DETAIL - 3] + "..."
+    return f"exit {result.returncode}: {text or 'no diagnostic output'}"
 
 
 def service_is_active(service: str, runner: Runner) -> bool:
@@ -100,7 +112,10 @@ def observe(settings: Settings, runner: Runner, opener: Opener, sleeper: Callabl
 
     started = runner(("systemctl", "--user", "start", settings.service))
     if started.returncode != 0:
-        return Observation("down", f"failed to start inactive unit {settings.service}")
+        return Observation(
+            "down",
+            f"failed to start inactive unit {settings.service} ({command_failure_detail(started)})",
+        )
 
     last_detail = f"started inactive unit {settings.service}; waiting for lead-intake probe"
     for attempt in range(settings.recovery_attempts):
@@ -155,6 +170,44 @@ def decide_alert(previous: dict[str, object], observation: Observation, realert_
     return {"status": "down", "consecutive": consecutive}, alert, EXIT_DOWN
 
 
+def pending_notification(previous: dict[str, object]) -> tuple[str, str, dict[str, object], int] | None:
+    """Load an undelivered alert without treating its transition as acknowledged."""
+    value = previous.get("pending_notification")
+    if not isinstance(value, dict):
+        return None
+    alert = value.get("alert")
+    detail = value.get("detail")
+    next_state = value.get("next_state")
+    exit_code = value.get("exit_code")
+    if (
+        isinstance(alert, str)
+        and alert in PENDING_ALERTS
+        and isinstance(detail, str)
+        and isinstance(next_state, dict)
+        and exit_code in {EXIT_OK, EXIT_RECOVERED, EXIT_DOWN}
+    ):
+        return alert, detail, next_state, exit_code
+    return None
+
+
+def state_with_pending_notification(
+    previous: dict[str, object],
+    *,
+    alert: str,
+    detail: str,
+    next_state: dict[str, object],
+    exit_code: int,
+) -> dict[str, object]:
+    state = dict(previous)
+    state["pending_notification"] = {
+        "alert": alert,
+        "detail": detail,
+        "next_state": next_state,
+        "exit_code": exit_code,
+    }
+    return state
+
+
 def publish(ntfy_url: str, topic: str, title: str, body: str, priority: str, tags: str) -> bool:
     """Deliver one alert without putting the private topic in a process argv."""
     delivered = False
@@ -184,17 +237,17 @@ def publish(ntfy_url: str, topic: str, title: str, body: str, priority: str, tag
     return delivered
 
 
-def alert_message(alert: str, observation: Observation) -> tuple[str, str, str, str]:
+def alert_message(alert: str, detail: str) -> tuple[str, str, str, str]:
     if alert == "auto-recovered":
         return (
             "atlas-api auto-recovered",
-            observation.detail,
+            detail,
             "urgent",
             "white_check_mark,warning",
         )
     if alert == "recovered":
-        return ("atlas-api recovered", observation.detail, "default", "white_check_mark")
-    return ("atlas-api DOWN", observation.detail, "urgent", "rotating_light,warning")
+        return ("atlas-api recovered", detail, "default", "white_check_mark")
+    return ("atlas-api DOWN", detail, "urgent", "rotating_light,warning")
 
 
 def run_healthcheck(
@@ -213,20 +266,39 @@ def run_healthcheck(
         fcntl.flock(lock, fcntl.LOCK_EX)
         observation = observe(settings, runner, opener, sleeper)
         previous = read_state(state_path)
-        next_state, alert, exit_code = decide_alert(previous, observation, settings.realert_every)
+        pending = pending_notification(previous)
+        if pending is None:
+            next_state, alert, exit_code = decide_alert(previous, observation, settings.realert_every)
+            alert_detail = observation.detail
+        else:
+            alert, alert_detail, next_state, exit_code = pending
         append_log(settings.state_dir, f"{observation.status.upper()} {observation.detail}")
         print(f"{observation.status.upper()}: {observation.detail}")
 
-        delivered = True
-        if alert and not settings.no_alert:
-            title, body, priority, tags = alert_message(alert, observation)
-            delivered = notifier(settings.ntfy_url, settings.ntfy_topic, title, body, priority, tags)
-        elif alert:
-            print(f"WARNING --no-alert: {alert} notification not sent")
+        if alert is None:
+            write_state(state_path, next_state)
+            return exit_code
+        if settings.no_alert:
+            print(f"WARNING --no-alert: {alert} notification not sent and state left unchanged")
+            return EXIT_ALERT_UNDELIVERED
+
+        title, body, priority, tags = alert_message(alert, alert_detail)
+        if not notifier(settings.ntfy_url, settings.ntfy_topic, title, body, priority, tags):
+            if pending is None:
+                write_state(
+                    state_path,
+                    state_with_pending_notification(
+                        previous,
+                        alert=alert,
+                        detail=alert_detail,
+                        next_state=next_state,
+                        exit_code=exit_code,
+                    ),
+                )
+            print("WARNING alert undelivered; transition remains pending for retry")
+            return EXIT_ALERT_UNDELIVERED
 
         write_state(state_path, next_state)
-        if alert and not settings.no_alert and not delivered:
-            return EXIT_ALERT_UNDELIVERED
         return exit_code
 
 

--- a/scripts/atlas_api_healthcheck.py
+++ b/scripts/atlas_api_healthcheck.py
@@ -62,6 +62,12 @@ class Observation:
     detail: str
 
 
+@dataclass(frozen=True)
+class UnitState:
+    load_state: str
+    active_state: str
+
+
 Runner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
 Opener = Callable[..., object]
 Notifier = Callable[[str, str, str, str, str, str], bool]
@@ -98,8 +104,38 @@ def serialized_monitor_state(settings: Settings) -> Iterator[TextIO]:
         yield lock
 
 
-def service_is_active(service: str, runner: Runner) -> bool:
-    return runner(("systemctl", "--user", "is-active", "--quiet", service)).returncode == 0
+def query_unit_state(service: str, runner: Runner) -> tuple[UnitState | None, str | None]:
+    command = (
+        "systemctl",
+        "--user",
+        "show",
+        "--property=LoadState",
+        "--property=ActiveState",
+        service,
+    )
+    result = runner(command)
+    if result.returncode != 0:
+        return None, f"unit-state query failed ({command_failure_detail(result)})"
+    fields: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        key, separator, value = line.partition("=")
+        if separator and key in {"LoadState", "ActiveState"}:
+            fields[key] = value.strip()
+    if not fields.get("LoadState") or not fields.get("ActiveState"):
+        return None, "unit-state query returned incomplete LoadState/ActiveState fields"
+    return UnitState(fields["LoadState"], fields["ActiveState"]), None
+
+
+def maintenance_is_active(path: Path) -> bool:
+    try:
+        path.stat()
+    except FileNotFoundError:
+        present = False
+    except OSError as exc:
+        raise RuntimeError(f"unable to inspect Atlas API maintenance lock at {path}") from exc
+    else:
+        present = True
+    return present
 
 
 def enter_maintenance(settings: Settings, *, runner: Runner = _run) -> int:
@@ -163,12 +199,26 @@ def observe(
     before_start: Callable[[], None] | None = None,
 ) -> Observation:
     """Observe the provider and recover only an inactive, non-maintenance unit."""
-    if settings.maintenance_lock.exists():
+    if maintenance_is_active(settings.maintenance_lock):
         return Observation("maintenance", f"maintenance lock present: {settings.maintenance_lock}")
 
-    if service_is_active(settings.service, runner):
+    unit_state, query_error = query_unit_state(settings.service, runner)
+    if unit_state is None:
+        return Observation("down", query_error or "unit-state query failed")
+    if unit_state.load_state != "loaded":
+        return Observation(
+            "down",
+            f"unit {settings.service} is not loaded (LoadState={unit_state.load_state})",
+        )
+    if unit_state.active_state == "active":
         healthy, detail = probe_lead_intake(settings.probe_url, opener)
         return Observation("healthy" if healthy else "down", detail)
+    if unit_state.active_state != "inactive":
+        return Observation(
+            "down",
+            f"unit {settings.service} is not eligible for recovery "
+            f"(ActiveState={unit_state.active_state})",
+        )
 
     if before_start is not None:
         before_start()
@@ -181,13 +231,24 @@ def observe(
 
     last_detail = f"started inactive unit {settings.service}; waiting for lead-intake probe"
     for attempt in range(settings.recovery_attempts):
-        if service_is_active(settings.service, runner):
+        unit_state, query_error = query_unit_state(settings.service, runner)
+        if unit_state is None:
+            last_detail = query_error or "unit-state query failed after start"
+        elif unit_state.load_state != "loaded":
+            last_detail = (
+                f"unit {settings.service} is not loaded after start "
+                f"(LoadState={unit_state.load_state})"
+            )
+        elif unit_state.active_state == "active":
             healthy, detail = probe_lead_intake(settings.probe_url, opener)
             if healthy:
                 return Observation("recovered", f"auto-recovered {settings.service}: {detail}")
             last_detail = detail
         else:
-            last_detail = f"unit {settings.service} is still inactive after start"
+            last_detail = (
+                f"unit {settings.service} is not active after start "
+                f"(ActiveState={unit_state.active_state})"
+            )
         if attempt + 1 < settings.recovery_attempts:
             sleeper(settings.recovery_interval_seconds)
     return Observation("down", f"auto-recovery did not restore {settings.service}: {last_detail}")
@@ -477,13 +538,14 @@ def run_healthcheck(
             if alert == "auto-recovered" and recovered_service is not None:
                 detail = f"auto-recovered {recovered_service}: {detail}"
             notifications.append({"alert": alert, "detail": detail})
-        append_log(settings.state_dir, f"{observation.status.upper()} {observation.detail}")
-        print(f"{observation.status.upper()}: {observation.detail}")
-
         if not notifications:
             write_state(state_path, next_state)
+            append_log(settings.state_dir, f"{observation.status.upper()} {observation.detail}")
+            print(f"{observation.status.upper()}: {observation.detail}")
             return exit_code
         write_state(state_path, state_with_pending_notifications(next_state, notifications))
+        append_log(settings.state_dir, f"{observation.status.upper()} {observation.detail}")
+        print(f"{observation.status.upper()}: {observation.detail}")
         if settings.no_alert:
             print("WARNING --no-alert: notifications queued for retry")
             return EXIT_ALERT_UNDELIVERED

--- a/scripts/atlas_api_healthcheck.py
+++ b/scripts/atlas_api_healthcheck.py
@@ -16,10 +16,11 @@ import sys
 import time
 import urllib.error
 import urllib.request
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Callable, Sequence
+from typing import Callable, Iterator, Sequence, TextIO
 
 
 EXIT_OK = 0
@@ -79,8 +80,58 @@ def command_failure_detail(result: subprocess.CompletedProcess[str]) -> str:
     return f"exit {result.returncode}: {text or 'no diagnostic output'}"
 
 
+@contextmanager
+def serialized_monitor_state(settings: Settings) -> Iterator[TextIO]:
+    """Serialize health cycles and supported maintenance transitions."""
+    lock_path = settings.state_dir / "state.lock"
+    try:
+        settings.state_dir.mkdir(parents=True, exist_ok=True)
+        lock_handle = lock_path.open("w", encoding="utf-8")
+    except OSError as exc:
+        raise RuntimeError(f"unable to open Atlas API health lock at {lock_path}") from exc
+    with lock_handle as lock:
+        try:
+            fcntl.flock(lock, fcntl.LOCK_EX)
+        except OSError as exc:
+            raise RuntimeError(f"unable to acquire Atlas API health lock at {lock_path}") from exc
+        yield lock
+
+
 def service_is_active(service: str, runner: Runner) -> bool:
     return runner(("systemctl", "--user", "is-active", "--quiet", service)).returncode == 0
+
+
+def enter_maintenance(settings: Settings, *, runner: Runner = _run) -> int:
+    """Create the maintenance marker and stop the service under the monitor lock."""
+    with serialized_monitor_state(settings):
+        try:
+            settings.maintenance_lock.parent.mkdir(parents=True, exist_ok=True)
+            settings.maintenance_lock.touch(mode=0o600, exist_ok=True)
+            settings.maintenance_lock.chmod(0o600)
+        except OSError as exc:
+            raise RuntimeError(
+                f"unable to create Atlas API maintenance lock at {settings.maintenance_lock}"
+            ) from exc
+        stopped = runner(("systemctl", "--user", "stop", settings.service))
+        if stopped.returncode != 0:
+            raise RuntimeError(
+                f"failed to stop {settings.service} for maintenance ({command_failure_detail(stopped)})"
+            )
+    print(f"MAINTENANCE: stopped {settings.service}; lock present at {settings.maintenance_lock}")
+    return EXIT_OK
+
+
+def exit_maintenance(settings: Settings) -> int:
+    """Remove the maintenance marker under the same lock used by recovery."""
+    with serialized_monitor_state(settings):
+        try:
+            settings.maintenance_lock.unlink(missing_ok=True)
+        except OSError as exc:
+            raise RuntimeError(
+                f"unable to remove Atlas API maintenance lock at {settings.maintenance_lock}"
+            ) from exc
+    print(f"MAINTENANCE CLEARED: {settings.maintenance_lock}")
+    return EXIT_OK
 
 
 def probe_lead_intake(probe_url: str, opener: Opener) -> tuple[bool, str]:
@@ -330,15 +381,8 @@ def run_healthcheck(
     sleeper: Callable[[float], None] = time.sleep,
 ) -> int:
     """Run one serialized observation/recovery/notification cycle."""
-    settings.state_dir.mkdir(parents=True, exist_ok=True)
     state_path = settings.state_dir / "state.json"
-    lock_path = settings.state_dir / "state.lock"
-    try:
-        lock_handle = lock_path.open("w", encoding="utf-8")
-    except OSError as exc:
-        raise RuntimeError(f"unable to open Atlas API health lock at {lock_path}") from exc
-    with lock_handle as lock:
-        fcntl.flock(lock, fcntl.LOCK_EX)
+    with serialized_monitor_state(settings):
         observation = observe(settings, runner, opener, sleeper)
         previous = read_state(state_path)
         next_state, alert, exit_code = decide_alert(previous, observation, settings.realert_every)
@@ -372,8 +416,11 @@ def run_healthcheck(
         return exit_code
 
 
-def _settings_from_args(argv: Sequence[str] | None) -> Settings:
+def _settings_from_args(argv: Sequence[str] | None) -> tuple[Settings, str]:
     parser = argparse.ArgumentParser(description=__doc__)
+    action = parser.add_mutually_exclusive_group()
+    action.add_argument("--enter-maintenance", action="store_true")
+    action.add_argument("--exit-maintenance", action="store_true")
     parser.add_argument("--service", default=os.environ.get("ATLAS_API_HEALTHCHECK_SERVICE", DEFAULT_SERVICE))
     parser.add_argument("--probe-url", default=os.environ.get("ATLAS_API_HEALTHCHECK_PROBE_URL", DEFAULT_PROBE_URL))
     parser.add_argument("--ntfy-url", default=os.environ.get("ATLAS_API_HEALTHCHECK_NTFY_URL", DEFAULT_NTFY_URL))
@@ -393,7 +440,7 @@ def _settings_from_args(argv: Sequence[str] | None) -> Settings:
         raise ValueError("recovery-attempts must be at least one")
     if args.recovery_interval_seconds < 0:
         raise ValueError("recovery-interval-seconds must not be negative")
-    return Settings(
+    settings = Settings(
         service=args.service,
         probe_url=args.probe_url,
         ntfy_url=args.ntfy_url,
@@ -405,10 +452,23 @@ def _settings_from_args(argv: Sequence[str] | None) -> Settings:
         recovery_interval_seconds=args.recovery_interval_seconds,
         no_alert=args.no_alert,
     )
+    selected_action = (
+        "enter-maintenance"
+        if args.enter_maintenance
+        else "exit-maintenance"
+        if args.exit_maintenance
+        else "healthcheck"
+    )
+    return settings, selected_action
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    return run_healthcheck(_settings_from_args(argv))
+    settings, action = _settings_from_args(argv)
+    if action == "enter-maintenance":
+        return enter_maintenance(settings)
+    if action == "exit-maintenance":
+        return exit_maintenance(settings)
+    return run_healthcheck(settings)
 
 
 if __name__ == "__main__":

--- a/scripts/atlas_api_healthcheck.py
+++ b/scripts/atlas_api_healthcheck.py
@@ -136,7 +136,8 @@ def read_state(path: Path) -> dict[str, object]:
         return {}
     try:
         value = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"WARNING state read failed: {type(exc).__name__}", file=sys.stderr)
         return {}
     return value if isinstance(value, dict) else {}
 
@@ -147,10 +148,14 @@ def write_state(path: Path, state: dict[str, object]) -> None:
 
 
 def append_log(state_dir: Path, message: str) -> None:
-    state_dir.mkdir(parents=True, exist_ok=True)
-    stamp = datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S%z")
-    with (state_dir / "health.log").open("a", encoding="utf-8") as handle:
-        handle.write(f"{stamp} {message}\n")
+    log_path = state_dir / "health.log"
+    try:
+        state_dir.mkdir(parents=True, exist_ok=True)
+        stamp = datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S%z")
+        with log_path.open("a", encoding="utf-8") as handle:
+            handle.write(f"{stamp} {message}\n")
+    except OSError as exc:
+        raise RuntimeError(f"unable to append Atlas API health log at {log_path}") from exc
 
 
 def decide_alert(previous: dict[str, object], observation: Observation, realert_every: int) -> tuple[dict[str, object], str | None, int]:
@@ -232,8 +237,8 @@ def publish(ntfy_url: str, topic: str, title: str, body: str, priority: str, tag
             stderr=subprocess.DEVNULL,
             check=False,
         )
-    except OSError:
-        pass
+    except OSError as exc:
+        print(f"WARNING desktop notification failed: {type(exc).__name__}", file=sys.stderr)
     return delivered
 
 
@@ -262,7 +267,11 @@ def run_healthcheck(
     settings.state_dir.mkdir(parents=True, exist_ok=True)
     state_path = settings.state_dir / "state.json"
     lock_path = settings.state_dir / "state.lock"
-    with lock_path.open("w", encoding="utf-8") as lock:
+    try:
+        lock_handle = lock_path.open("w", encoding="utf-8")
+    except OSError as exc:
+        raise RuntimeError(f"unable to open Atlas API health lock at {lock_path}") from exc
+    with lock_handle as lock:
         fcntl.flock(lock, fcntl.LOCK_EX)
         observation = observe(settings, runner, opener, sleeper)
         previous = read_state(state_path)

--- a/scripts/atlas_api_healthcheck.py
+++ b/scripts/atlas_api_healthcheck.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Monitor and recover an unexpectedly inactive local Atlas API service.
+
+This program is intentionally stdlib-only and is installed outside the Atlas
+runtime worktree. It can therefore observe the provider and attempt recovery
+even when a runtime worktree is stale, missing, or unable to start.
+"""
+from __future__ import annotations
+
+import argparse
+import fcntl
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Callable, Sequence
+
+
+EXIT_OK = 0
+EXIT_RECOVERED = 2
+EXIT_DOWN = 3
+EXIT_ALERT_UNDELIVERED = 4
+
+DEFAULT_SERVICE = "atlas-api.service"
+DEFAULT_PROBE_URL = "http://127.0.0.1:8012/api/v1/leads/intake"
+DEFAULT_NTFY_URL = "https://ntfy.sh"
+DEFAULT_REALERT_EVERY = 6
+DEFAULT_RECOVERY_ATTEMPTS = 8
+DEFAULT_RECOVERY_INTERVAL_SECONDS = 1.0
+DEFAULT_STATE_DIR = Path(os.environ.get("XDG_STATE_HOME", Path.home() / ".local" / "state")) / "atlas-api-health"
+DEFAULT_MAINTENANCE_LOCK = Path.home() / ".config" / "atlas" / "atlas-api.maintenance"
+
+
+@dataclass(frozen=True)
+class Settings:
+    service: str
+    probe_url: str
+    ntfy_url: str
+    ntfy_topic: str
+    state_dir: Path
+    maintenance_lock: Path
+    realert_every: int
+    recovery_attempts: int
+    recovery_interval_seconds: float
+    no_alert: bool
+
+
+@dataclass(frozen=True)
+class Observation:
+    status: str
+    detail: str
+
+
+Runner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
+Opener = Callable[..., object]
+Notifier = Callable[[str, str, str, str, str, str], bool]
+
+
+def _run(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+def service_is_active(service: str, runner: Runner) -> bool:
+    return runner(("systemctl", "--user", "is-active", "--quiet", service)).returncode == 0
+
+
+def probe_lead_intake(probe_url: str, opener: Opener) -> tuple[bool, str]:
+    request = urllib.request.Request(
+        probe_url,
+        headers={
+            "Origin": "https://effinghamofficemaids.com",
+            "Access-Control-Request-Method": "POST",
+        },
+        method="OPTIONS",
+    )
+    try:
+        with opener(request, timeout=8) as response:
+            status = int(response.status)
+    except (urllib.error.URLError, OSError, ValueError) as exc:
+        return False, f"lead-intake probe failed: {type(exc).__name__}"
+    if status in (200, 204):
+        return True, f"lead-intake probe returned HTTP {status}"
+    return False, f"lead-intake probe returned HTTP {status}"
+
+
+def observe(settings: Settings, runner: Runner, opener: Opener, sleeper: Callable[[float], None]) -> Observation:
+    """Observe the provider and recover only an inactive, non-maintenance unit."""
+    if settings.maintenance_lock.exists():
+        return Observation("maintenance", f"maintenance lock present: {settings.maintenance_lock}")
+
+    if service_is_active(settings.service, runner):
+        healthy, detail = probe_lead_intake(settings.probe_url, opener)
+        return Observation("healthy" if healthy else "down", detail)
+
+    started = runner(("systemctl", "--user", "start", settings.service))
+    if started.returncode != 0:
+        return Observation("down", f"failed to start inactive unit {settings.service}")
+
+    last_detail = f"started inactive unit {settings.service}; waiting for lead-intake probe"
+    for attempt in range(settings.recovery_attempts):
+        if service_is_active(settings.service, runner):
+            healthy, detail = probe_lead_intake(settings.probe_url, opener)
+            if healthy:
+                return Observation("recovered", f"auto-recovered {settings.service}: {detail}")
+            last_detail = detail
+        else:
+            last_detail = f"unit {settings.service} is still inactive after start"
+        if attempt + 1 < settings.recovery_attempts:
+            sleeper(settings.recovery_interval_seconds)
+    return Observation("down", f"auto-recovery did not restore {settings.service}: {last_detail}")
+
+
+def read_state(path: Path) -> dict[str, object]:
+    if not path.exists():
+        return {}
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def write_state(path: Path, state: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state, sort_keys=True), encoding="utf-8")
+
+
+def append_log(state_dir: Path, message: str) -> None:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S%z")
+    with (state_dir / "health.log").open("a", encoding="utf-8") as handle:
+        handle.write(f"{stamp} {message}\n")
+
+
+def decide_alert(previous: dict[str, object], observation: Observation, realert_every: int) -> tuple[dict[str, object], str | None, int]:
+    previous_status = str(previous.get("status", "healthy"))
+    if observation.status == "maintenance":
+        return {"status": "maintenance", "consecutive": 0}, None, EXIT_OK
+    if observation.status == "healthy":
+        alert = "recovered" if previous_status == "down" else None
+        return {"status": "healthy", "consecutive": 0}, alert, EXIT_OK
+    if observation.status == "recovered":
+        return {"status": "healthy", "consecutive": 0}, "auto-recovered", EXIT_RECOVERED
+
+    consecutive = int(previous.get("consecutive", 0)) + 1 if previous_status == "down" else 1
+    alert = "down" if previous_status != "down" else None
+    if alert is None and realert_every > 0 and consecutive % realert_every == 0:
+        alert = "down"
+    return {"status": "down", "consecutive": consecutive}, alert, EXIT_DOWN
+
+
+def publish(ntfy_url: str, topic: str, title: str, body: str, priority: str, tags: str) -> bool:
+    """Deliver one alert without putting the private topic in a process argv."""
+    delivered = False
+    if not topic.strip():
+        print("WARNING alert topic is not configured")
+    else:
+        request = urllib.request.Request(
+            f"{ntfy_url.rstrip('/')}/{topic}",
+            data=body.encode("utf-8"),
+            headers={"Title": title, "Priority": priority, "Tags": tags},
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=15) as response:
+                delivered = 200 <= int(response.status) < 300
+        except (urllib.error.URLError, OSError, ValueError) as exc:
+            print(f"WARNING alert delivery failed: {type(exc).__name__}")
+    try:
+        subprocess.run(
+            ("notify-send", "-u", "critical", title, body),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+    except OSError:
+        pass
+    return delivered
+
+
+def alert_message(alert: str, observation: Observation) -> tuple[str, str, str, str]:
+    if alert == "auto-recovered":
+        return (
+            "atlas-api auto-recovered",
+            observation.detail,
+            "urgent",
+            "white_check_mark,warning",
+        )
+    if alert == "recovered":
+        return ("atlas-api recovered", observation.detail, "default", "white_check_mark")
+    return ("atlas-api DOWN", observation.detail, "urgent", "rotating_light,warning")
+
+
+def run_healthcheck(
+    settings: Settings,
+    *,
+    runner: Runner = _run,
+    opener: Opener = urllib.request.urlopen,
+    notifier: Notifier = publish,
+    sleeper: Callable[[float], None] = time.sleep,
+) -> int:
+    """Run one serialized observation/recovery/notification cycle."""
+    settings.state_dir.mkdir(parents=True, exist_ok=True)
+    state_path = settings.state_dir / "state.json"
+    lock_path = settings.state_dir / "state.lock"
+    with lock_path.open("w", encoding="utf-8") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        observation = observe(settings, runner, opener, sleeper)
+        previous = read_state(state_path)
+        next_state, alert, exit_code = decide_alert(previous, observation, settings.realert_every)
+        append_log(settings.state_dir, f"{observation.status.upper()} {observation.detail}")
+        print(f"{observation.status.upper()}: {observation.detail}")
+
+        delivered = True
+        if alert and not settings.no_alert:
+            title, body, priority, tags = alert_message(alert, observation)
+            delivered = notifier(settings.ntfy_url, settings.ntfy_topic, title, body, priority, tags)
+        elif alert:
+            print(f"WARNING --no-alert: {alert} notification not sent")
+
+        write_state(state_path, next_state)
+        if alert and not settings.no_alert and not delivered:
+            return EXIT_ALERT_UNDELIVERED
+        return exit_code
+
+
+def _settings_from_args(argv: Sequence[str] | None) -> Settings:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--service", default=os.environ.get("ATLAS_API_HEALTHCHECK_SERVICE", DEFAULT_SERVICE))
+    parser.add_argument("--probe-url", default=os.environ.get("ATLAS_API_HEALTHCHECK_PROBE_URL", DEFAULT_PROBE_URL))
+    parser.add_argument("--ntfy-url", default=os.environ.get("ATLAS_API_HEALTHCHECK_NTFY_URL", DEFAULT_NTFY_URL))
+    parser.add_argument("--ntfy-topic", default=os.environ.get("ATLAS_API_HEALTHCHECK_NTFY_TOPIC", ""))
+    parser.add_argument("--state-dir", default=os.environ.get("ATLAS_API_HEALTHCHECK_STATE_DIR", str(DEFAULT_STATE_DIR)))
+    parser.add_argument("--maintenance-lock", default=os.environ.get("ATLAS_API_HEALTHCHECK_MAINTENANCE_LOCK", str(DEFAULT_MAINTENANCE_LOCK)))
+    parser.add_argument("--realert-every", type=int, default=int(os.environ.get("ATLAS_API_HEALTHCHECK_REALERT_EVERY", DEFAULT_REALERT_EVERY)))
+    parser.add_argument("--recovery-attempts", type=int, default=int(os.environ.get("ATLAS_API_HEALTHCHECK_RECOVERY_ATTEMPTS", DEFAULT_RECOVERY_ATTEMPTS)))
+    parser.add_argument("--recovery-interval-seconds", type=float, default=float(os.environ.get("ATLAS_API_HEALTHCHECK_RECOVERY_INTERVAL_SECONDS", DEFAULT_RECOVERY_INTERVAL_SECONDS)))
+    parser.add_argument("--no-alert", action="store_true")
+    args = parser.parse_args(argv)
+    if not args.service.strip():
+        raise ValueError("service must not be blank")
+    if args.realert_every < 0:
+        raise ValueError("realert-every must not be negative")
+    if args.recovery_attempts < 1:
+        raise ValueError("recovery-attempts must be at least one")
+    if args.recovery_interval_seconds < 0:
+        raise ValueError("recovery-interval-seconds must not be negative")
+    return Settings(
+        service=args.service,
+        probe_url=args.probe_url,
+        ntfy_url=args.ntfy_url,
+        ntfy_topic=args.ntfy_topic,
+        state_dir=Path(args.state_dir),
+        maintenance_lock=Path(args.maintenance_lock),
+        realert_every=args.realert_every,
+        recovery_attempts=args.recovery_attempts,
+        recovery_interval_seconds=args.recovery_interval_seconds,
+        no_alert=args.no_alert,
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    return run_healthcheck(_settings_from_args(argv))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/install_atlas_api_healthcheck.py
+++ b/scripts/install_atlas_api_healthcheck.py
@@ -59,8 +59,12 @@ class FileSnapshot:
 
 @dataclass(frozen=True)
 class TimerState:
-    enabled: bool
+    enablement: str
     active: bool
+
+    @property
+    def enabled(self) -> bool:
+        return self.enablement in {"enabled", "enabled-runtime"}
 
 
 Runner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
@@ -248,7 +252,7 @@ def _timer_state(runner: Runner) -> TimerState:
     if unit_state is None:
         raise RuntimeError(query_error or "cannot query existing health timer")
     if unit_state.load_state == "not-found":
-        return TimerState(enabled=False, active=False)
+        return TimerState(enablement="disabled", active=False)
     if unit_state.load_state != "loaded":
         raise RuntimeError(f"health timer has unsupported LoadState={unit_state.load_state}")
     if unit_state.active_state not in {"active", "inactive", "failed"}:
@@ -266,15 +270,14 @@ def _timer_state(runner: Runner) -> TimerState:
     if result.returncode != 0:
         raise RuntimeError(f"cannot query health timer enablement ({_command_detail(result)})")
     unit_file_state = result.stdout.strip().lower()
-    if unit_file_state in {"enabled", "enabled-runtime"}:
-        enabled = True
-    elif unit_file_state in {"disabled", "static"}:
-        enabled = False
-    else:
+    if unit_file_state not in {"disabled", "enabled", "enabled-runtime", "static"}:
         raise RuntimeError(
             f"health timer has unsupported UnitFileState={unit_file_state or 'empty'}"
         )
-    return TimerState(enabled=enabled, active=unit_state.active_state == "active")
+    return TimerState(
+        enablement=unit_file_state,
+        active=unit_state.active_state == "active",
+    )
 
 
 def _existing_health_service_is_loaded(runner: Runner) -> bool:
@@ -339,7 +342,12 @@ def _rollback_install(
         except RuntimeError as exc:
             errors.append(str(exc))
     run_rollback(("systemctl", "--user", "daemon-reload"), "cannot reload restored systemd files")
-    if timer_state.enabled:
+    if timer_state.enablement == "enabled-runtime":
+        run_rollback(
+            ("systemctl", "--user", "enable", "--runtime", TIMER_NAME),
+            "cannot restore runtime-enabled timer",
+        )
+    elif timer_state.enablement == "enabled":
         run_rollback(("systemctl", "--user", "enable", TIMER_NAME), "cannot restore enabled timer")
     if timer_state.active:
         run_rollback(("systemctl", "--user", "start", TIMER_NAME), "cannot restore active timer")

--- a/scripts/install_atlas_api_healthcheck.py
+++ b/scripts/install_atlas_api_healthcheck.py
@@ -140,6 +140,18 @@ def _topic_from_legacy_monitor(path: Path) -> str | None:
     return None
 
 
+def _private_notification_symlink(path: Path) -> bool:
+    if not path.is_symlink():
+        return False
+    try:
+        mode = stat.S_IMODE(path.stat().st_mode)
+    except OSError as exc:
+        raise RuntimeError(f"cannot inspect notification environment symlink target: {exc}") from exc
+    if mode & 0o077:
+        raise RuntimeError("notification environment symlink target is not private")
+    return True
+
+
 def _append_topic(path: Path, topic: str) -> None:
     try:
         existing = path.read_text(encoding="utf-8") if path.exists() else ""
@@ -151,9 +163,11 @@ def _append_topic(path: Path, topic: str) -> None:
 
 
 def ensure_notification_topic(paths: InstallPaths, environment: Mapping[str, str]) -> str:
+    private_symlink = _private_notification_symlink(paths.notification_env)
     existing = _topic_from_env_file(paths.notification_env)
     if existing is not None:
-        paths.notification_env.chmod(0o600)
+        if not private_symlink:
+            paths.notification_env.chmod(0o600)
         return "preserved private notification topic"
 
     candidate = environment.get(TOPIC_ENV, "")
@@ -394,6 +408,7 @@ def install(paths: InstallPaths, *, runner: Runner = _run, environment: Mapping[
     sources = _source_files(paths)
     destinations = [destination for _source, destination, _executable in sources]
     snapshots = [_snapshot_file(path) for path in (*destinations, paths.notification_env)]
+    _private_notification_symlink(paths.notification_env)
     previous_timer = _timer_state(runner)
     enrollment_attempted = False
     try:

--- a/scripts/install_atlas_api_healthcheck.py
+++ b/scripts/install_atlas_api_healthcheck.py
@@ -11,13 +11,15 @@ from __future__ import annotations
 import argparse
 import os
 import re
+import signal
 import stat
 import subprocess
 import sys
 import tempfile
 from dataclasses import dataclass
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Callable, Mapping, Sequence
+from typing import Callable, Iterator, Mapping, Sequence
 
 import atlas_api_healthcheck as healthcheck_runtime
 
@@ -80,6 +82,25 @@ Runner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
 
 def _run(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
     return subprocess.run(command, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+@contextmanager
+def _termination_signals_as_errors() -> Iterator[None]:
+    admitted = (signal.SIGTERM, signal.SIGHUP)
+    previous = {signum: signal.getsignal(signum) for signum in admitted}
+
+    def terminate(signum, _frame) -> None:
+        for admitted_signal in admitted:
+            signal.signal(admitted_signal, signal.SIG_IGN)
+        raise RuntimeError(f"installer received {signal.Signals(signum).name}")
+
+    try:
+        for signum in admitted:
+            signal.signal(signum, terminate)
+        yield
+    finally:
+        for signum, handler in previous.items():
+            signal.signal(signum, handler)
 
 
 def default_paths() -> InstallPaths:
@@ -447,60 +468,61 @@ def install(paths: InstallPaths, *, runner: Runner = _run, environment: Mapping[
     topic_plan = _notification_topic_plan(paths, environment)
     previous_timer = _timer_state(runner)
     enrollment_attempted = False
-    try:
-        if previous_timer.active:
+    with _termination_signals_as_errors():
+        try:
+            if previous_timer.active:
+                _run_required(
+                    runner,
+                    ("systemctl", "--user", "stop", TIMER_NAME),
+                    action="existing timer stop",
+                )
+            topic_message = ensure_notification_topic(paths, topic_plan)
+            messages = [topic_message]
+            if _existing_health_service_is_loaded(runner):
+                _run_required(
+                    runner,
+                    ("systemctl", "--user", "stop", SERVICE_NAME),
+                    action="existing health service stop",
+                )
+            for source, destination, executable in sources:
+                _write_copy(source, destination, executable=executable)
+                messages.append(f"wrote: {destination}")
+            _run_required(runner, ("systemctl", "--user", "daemon-reload"), action="systemd reload")
             _run_required(
                 runner,
-                ("systemctl", "--user", "stop", TIMER_NAME),
-                action="existing timer stop",
+                ("systemctl", "--user", "start", "--wait", SERVICE_NAME),
+                action="initial installed-monitor invocation",
             )
-        topic_message = ensure_notification_topic(paths, topic_plan)
-        messages = [topic_message]
-        if _existing_health_service_is_loaded(runner):
+            enrollment_attempted = True
             _run_required(
                 runner,
-                ("systemctl", "--user", "stop", SERVICE_NAME),
-                action="existing health service stop",
+                ("systemctl", "--user", "enable", "--now", TIMER_NAME),
+                action="timer enable",
             )
-        for source, destination, executable in sources:
-            _write_copy(source, destination, executable=executable)
-            messages.append(f"wrote: {destination}")
-        _run_required(runner, ("systemctl", "--user", "daemon-reload"), action="systemd reload")
-        _run_required(
-            runner,
-            ("systemctl", "--user", "start", "--wait", SERVICE_NAME),
-            action="initial installed-monitor invocation",
-        )
-        enrollment_attempted = True
-        _run_required(
-            runner,
-            ("systemctl", "--user", "enable", "--now", TIMER_NAME),
-            action="timer enable",
-        )
-        messages.append("proved installed health service and enabled timer")
-        return messages
-    except KeyboardInterrupt as exc:
-        rollback_errors = _rollback_install(
-            snapshots,
-            previous_timer,
-            runner,
-            enrollment_attempted=enrollment_attempted,
-        )
-        if rollback_errors:
-            exc.add_note(f"rollback failed: {'; '.join(rollback_errors)}")
-        raise
-    except (OSError, RuntimeError) as exc:
-        rollback_errors = _rollback_install(
-            snapshots,
-            previous_timer,
-            runner,
-            enrollment_attempted=enrollment_attempted,
-        )
-        if rollback_errors:
-            raise RuntimeError(
-                f"{exc}; rollback failed: {'; '.join(rollback_errors)}"
-            ) from exc
-        raise
+            messages.append("proved installed health service and enabled timer")
+            return messages
+        except KeyboardInterrupt as exc:
+            rollback_errors = _rollback_install(
+                snapshots,
+                previous_timer,
+                runner,
+                enrollment_attempted=enrollment_attempted,
+            )
+            if rollback_errors:
+                exc.add_note(f"rollback failed: {'; '.join(rollback_errors)}")
+            raise
+        except (OSError, RuntimeError) as exc:
+            rollback_errors = _rollback_install(
+                snapshots,
+                previous_timer,
+                runner,
+                enrollment_attempted=enrollment_attempted,
+            )
+            if rollback_errors:
+                raise RuntimeError(
+                    f"{exc}; rollback failed: {'; '.join(rollback_errors)}"
+                ) from exc
+            raise
 
 
 def _matches(source: Path, destination: Path, *, executable: bool) -> tuple[bool, str]:

--- a/scripts/install_atlas_api_healthcheck.py
+++ b/scripts/install_atlas_api_healthcheck.py
@@ -19,6 +19,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Mapping, Sequence
 
+import atlas_api_healthcheck as healthcheck_runtime
+
 
 SERVICE_NAME = "atlas-api-healthcheck.service"
 TIMER_NAME = "atlas-api-healthcheck.timer"
@@ -242,9 +244,70 @@ def _run_required(runner: Runner, command: Sequence[str], *, action: str) -> Non
 
 
 def _timer_state(runner: Runner) -> TimerState:
-    enabled = runner(("systemctl", "--user", "is-enabled", "--quiet", TIMER_NAME)).returncode == 0
-    active = runner(("systemctl", "--user", "is-active", "--quiet", TIMER_NAME)).returncode == 0
-    return TimerState(enabled=enabled, active=active)
+    unit_state, query_error = healthcheck_runtime.query_unit_state(TIMER_NAME, runner)
+    if unit_state is None:
+        raise RuntimeError(query_error or "cannot query existing health timer")
+    if unit_state.load_state == "not-found":
+        return TimerState(enabled=False, active=False)
+    if unit_state.load_state != "loaded":
+        raise RuntimeError(f"health timer has unsupported LoadState={unit_state.load_state}")
+    if unit_state.active_state not in {"active", "inactive", "failed"}:
+        raise RuntimeError(f"health timer has unsupported ActiveState={unit_state.active_state}")
+
+    command = (
+        "systemctl",
+        "--user",
+        "show",
+        "--property=UnitFileState",
+        "--value",
+        TIMER_NAME,
+    )
+    result = runner(command)
+    if result.returncode != 0:
+        raise RuntimeError(f"cannot query health timer enablement ({_command_detail(result)})")
+    unit_file_state = result.stdout.strip().lower()
+    if unit_file_state in {"enabled", "enabled-runtime"}:
+        enabled = True
+    elif unit_file_state in {"disabled", "static"}:
+        enabled = False
+    else:
+        raise RuntimeError(
+            f"health timer has unsupported UnitFileState={unit_file_state or 'empty'}"
+        )
+    return TimerState(enabled=enabled, active=unit_state.active_state == "active")
+
+
+def _existing_health_service_is_loaded(runner: Runner) -> bool:
+    unit_state, query_error = healthcheck_runtime.query_unit_state(SERVICE_NAME, runner)
+    if unit_state is None:
+        raise RuntimeError(query_error or "cannot query existing health service")
+    if unit_state.load_state == "not-found":
+        return False
+    if unit_state.load_state != "loaded":
+        raise RuntimeError(
+            f"existing health service has unsupported LoadState={unit_state.load_state}"
+        )
+    return True
+
+
+def _loaded_unit_is_current(unit: str, runner: Runner) -> tuple[bool, str]:
+    command = (
+        "systemctl",
+        "--user",
+        "show",
+        "--property=NeedDaemonReload",
+        "--value",
+        unit,
+    )
+    result = runner(command)
+    if result.returncode != 0:
+        return False, f"cannot query loaded definition for {unit} ({_command_detail(result)})"
+    needs_reload = result.stdout.strip().lower()
+    if needs_reload == "no":
+        return True, f"ok: loaded definition is current for {unit}"
+    if needs_reload == "yes":
+        return False, f"systemd requires daemon-reload for {unit}"
+    return False, f"invalid NeedDaemonReload state for {unit}: {needs_reload or 'empty'}"
 
 
 def _rollback_install(
@@ -300,11 +363,12 @@ def install(paths: InstallPaths, *, runner: Runner = _run, environment: Mapping[
             )
         topic_message = ensure_notification_topic(paths, environment)
         messages = [topic_message]
-        _run_required(
-            runner,
-            ("systemctl", "--user", "stop", SERVICE_NAME),
-            action="existing health service stop",
-        )
+        if _existing_health_service_is_loaded(runner):
+            _run_required(
+                runner,
+                ("systemctl", "--user", "stop", SERVICE_NAME),
+                action="existing health service stop",
+            )
         for source, destination, executable in sources:
             _write_copy(source, destination, executable=executable)
             messages.append(f"wrote: {destination}")
@@ -364,12 +428,18 @@ def check_install(paths: InstallPaths, *, runner: Runner = _run) -> tuple[bool, 
             checks.append((True, f"ok: private notification environment {paths.notification_env}"))
     except (OSError, RuntimeError) as exc:
         checks.append((False, str(exc)))
-    for command, label in (
-        (("systemctl", "--user", "is-enabled", "--quiet", TIMER_NAME), "timer is not enabled"),
-        (("systemctl", "--user", "is-active", "--quiet", TIMER_NAME), "timer is not active"),
-    ):
-        result = runner(command)
-        checks.append((result.returncode == 0, f"ok: {TIMER_NAME}" if result.returncode == 0 else label))
+    try:
+        timer_state = _timer_state(runner)
+        checks.append(
+            (timer_state.enabled, f"ok: {TIMER_NAME} is enabled" if timer_state.enabled else "timer is not enabled")
+        )
+        checks.append(
+            (timer_state.active, f"ok: {TIMER_NAME} is active" if timer_state.active else "timer is not active")
+        )
+    except RuntimeError as exc:
+        checks.append((False, str(exc)))
+    for unit in (SERVICE_NAME, TIMER_NAME):
+        checks.append(_loaded_unit_is_current(unit, runner))
     return all(passed for passed, _message in checks), [message for _passed, message in checks]
 
 

--- a/scripts/install_atlas_api_healthcheck.py
+++ b/scripts/install_atlas_api_healthcheck.py
@@ -300,6 +300,11 @@ def install(paths: InstallPaths, *, runner: Runner = _run, environment: Mapping[
             )
         topic_message = ensure_notification_topic(paths, environment)
         messages = [topic_message]
+        _run_required(
+            runner,
+            ("systemctl", "--user", "stop", SERVICE_NAME),
+            action="existing health service stop",
+        )
         for source, destination, executable in sources:
             _write_copy(source, destination, executable=executable)
             messages.append(f"wrote: {destination}")

--- a/scripts/install_atlas_api_healthcheck.py
+++ b/scripts/install_atlas_api_healthcheck.py
@@ -10,12 +10,13 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import stat
 import subprocess
 import sys
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-import re
 from typing import Callable, Mapping, Sequence
 
 
@@ -45,6 +46,19 @@ class InstallPaths:
     @property
     def notification_env(self) -> Path:
         return self.config_dir / "atlas-api-healthcheck.env"
+
+
+@dataclass(frozen=True)
+class FileSnapshot:
+    path: Path
+    payload: bytes | None
+    mode: int | None
+
+
+@dataclass(frozen=True)
+class TimerState:
+    enabled: bool
+    active: bool
 
 
 Runner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
@@ -125,9 +139,8 @@ def _append_topic(path: Path, topic: str) -> None:
     except OSError as exc:
         raise RuntimeError(f"cannot read notification environment file: {exc}") from exc
     separator = "" if not existing or existing.endswith("\n") else "\n"
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(f"{existing}{separator}{TOPIC_ENV}={topic}\n", encoding="utf-8")
-    path.chmod(0o600)
+    payload = f"{existing}{separator}{TOPIC_ENV}={topic}\n".encode("utf-8")
+    _atomic_write(path, payload, mode=0o600)
 
 
 def ensure_notification_topic(paths: InstallPaths, environment: Mapping[str, str]) -> str:
@@ -149,14 +162,68 @@ def ensure_notification_topic(paths: InstallPaths, environment: Mapping[str, str
     return "migrated private notification topic" if source == "legacy monitor" else "wrote private notification topic"
 
 
+def _atomic_write(destination: Path, payload: bytes, *, mode: int) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="wb",
+            dir=destination.parent,
+            prefix=f".{destination.name}.",
+            delete=False,
+        ) as handle:
+            temporary_path = Path(handle.name)
+            os.fchmod(handle.fileno(), mode)
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_path, destination)
+        temporary_path = None
+    except OSError as exc:
+        raise RuntimeError(f"cannot atomically write install destination {destination}") from exc
+    finally:
+        if temporary_path is not None and temporary_path.exists():
+            try:
+                temporary_path.unlink()
+            except OSError as exc:
+                print(
+                    f"WARNING cannot remove installer temporary file: {type(exc).__name__}",
+                    file=sys.stderr,
+                )
+
+
 def _write_copy(source: Path, destination: Path, *, executable: bool) -> None:
     try:
         payload = source.read_bytes()
     except OSError as exc:
         raise RuntimeError(f"cannot read install source {source}: {exc}") from exc
-    destination.parent.mkdir(parents=True, exist_ok=True)
-    destination.write_bytes(payload)
-    destination.chmod(0o755 if executable else 0o644)
+    _atomic_write(destination, payload, mode=0o755 if executable else 0o644)
+
+
+def _snapshot_file(path: Path) -> FileSnapshot:
+    if not path.exists():
+        return FileSnapshot(path=path, payload=None, mode=None)
+    if not path.is_file():
+        raise RuntimeError(f"install destination is not a regular file: {path}")
+    try:
+        return FileSnapshot(
+            path=path,
+            payload=path.read_bytes(),
+            mode=stat.S_IMODE(path.stat().st_mode),
+        )
+    except OSError as exc:
+        raise RuntimeError(f"cannot snapshot install destination {path}") from exc
+
+
+def _restore_file(snapshot: FileSnapshot) -> None:
+    if snapshot.payload is None:
+        try:
+            snapshot.path.unlink(missing_ok=True)
+        except OSError as exc:
+            raise RuntimeError(f"cannot remove new install destination {snapshot.path}") from exc
+        return
+    mode = snapshot.mode if snapshot.mode is not None else 0o600
+    _atomic_write(snapshot.path, snapshot.payload, mode=mode)
 
 
 def _command_detail(result: subprocess.CompletedProcess[str]) -> str:
@@ -174,28 +241,94 @@ def _run_required(runner: Runner, command: Sequence[str], *, action: str) -> Non
         raise RuntimeError(f"{action} failed ({_command_detail(result)})")
 
 
+def _timer_state(runner: Runner) -> TimerState:
+    enabled = runner(("systemctl", "--user", "is-enabled", "--quiet", TIMER_NAME)).returncode == 0
+    active = runner(("systemctl", "--user", "is-active", "--quiet", TIMER_NAME)).returncode == 0
+    return TimerState(enabled=enabled, active=active)
+
+
+def _rollback_install(
+    snapshots: Sequence[FileSnapshot],
+    timer_state: TimerState,
+    runner: Runner,
+    *,
+    enrollment_attempted: bool,
+) -> list[str]:
+    errors: list[str] = []
+
+    def run_rollback(command: Sequence[str], action: str) -> None:
+        try:
+            result = runner(command)
+        except OSError as exc:
+            errors.append(f"{action} ({type(exc).__name__})")
+            return
+        if result.returncode != 0:
+            errors.append(f"{action} ({_command_detail(result)})")
+
+    if enrollment_attempted:
+        run_rollback(
+            ("systemctl", "--user", "disable", "--now", TIMER_NAME),
+            "cannot remove failed timer enrollment",
+        )
+    for snapshot in snapshots:
+        try:
+            _restore_file(snapshot)
+        except RuntimeError as exc:
+            errors.append(str(exc))
+    run_rollback(("systemctl", "--user", "daemon-reload"), "cannot reload restored systemd files")
+    if timer_state.enabled:
+        run_rollback(("systemctl", "--user", "enable", TIMER_NAME), "cannot restore enabled timer")
+    if timer_state.active:
+        run_rollback(("systemctl", "--user", "start", TIMER_NAME), "cannot restore active timer")
+    return errors
+
+
 def install(paths: InstallPaths, *, runner: Runner = _run, environment: Mapping[str, str] | None = None) -> list[str]:
-    """Install the monitor, enable the timer, then invoke the installed service once."""
+    """Install and prove the monitor before enrolling its timer."""
     environment = os.environ if environment is None else environment
     sources = _source_files(paths)
-    topic_message = ensure_notification_topic(paths, environment)
-    messages = [topic_message]
-    for source, destination, executable in sources:
-        _write_copy(source, destination, executable=executable)
-        messages.append(f"wrote: {destination}")
-    _run_required(runner, ("systemctl", "--user", "daemon-reload"), action="systemd reload")
-    _run_required(
-        runner,
-        ("systemctl", "--user", "enable", "--now", TIMER_NAME),
-        action="timer enable",
-    )
-    _run_required(
-        runner,
-        ("systemctl", "--user", "start", "--wait", SERVICE_NAME),
-        action="initial installed-monitor invocation",
-    )
-    messages.append("enabled timer and invoked installed health service")
-    return messages
+    destinations = [destination for _source, destination, _executable in sources]
+    snapshots = [_snapshot_file(path) for path in (*destinations, paths.notification_env)]
+    previous_timer = _timer_state(runner)
+    enrollment_attempted = False
+    try:
+        if previous_timer.active:
+            _run_required(
+                runner,
+                ("systemctl", "--user", "stop", TIMER_NAME),
+                action="existing timer stop",
+            )
+        topic_message = ensure_notification_topic(paths, environment)
+        messages = [topic_message]
+        for source, destination, executable in sources:
+            _write_copy(source, destination, executable=executable)
+            messages.append(f"wrote: {destination}")
+        _run_required(runner, ("systemctl", "--user", "daemon-reload"), action="systemd reload")
+        _run_required(
+            runner,
+            ("systemctl", "--user", "start", "--wait", SERVICE_NAME),
+            action="initial installed-monitor invocation",
+        )
+        enrollment_attempted = True
+        _run_required(
+            runner,
+            ("systemctl", "--user", "enable", "--now", TIMER_NAME),
+            action="timer enable",
+        )
+        messages.append("proved installed health service and enabled timer")
+        return messages
+    except (OSError, RuntimeError) as exc:
+        rollback_errors = _rollback_install(
+            snapshots,
+            previous_timer,
+            runner,
+            enrollment_attempted=enrollment_attempted,
+        )
+        if rollback_errors:
+            raise RuntimeError(
+                f"{exc}; rollback failed: {'; '.join(rollback_errors)}"
+            ) from exc
+        raise
 
 
 def _matches(source: Path, destination: Path, *, executable: bool) -> tuple[bool, str]:

--- a/scripts/install_atlas_api_healthcheck.py
+++ b/scripts/install_atlas_api_healthcheck.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Install or verify the standalone Atlas API liveness monitor.
+
+Run this installer from a checked-out Atlas source tree after the liveness
+change is merged.  It deliberately installs the monitor outside the Atlas
+runtime worktree, reloads user systemd, enables its timer, and invokes the
+installed service once so deployment proves the actual systemd path.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import stat
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+import re
+from typing import Callable, Mapping, Sequence
+
+
+SERVICE_NAME = "atlas-api-healthcheck.service"
+TIMER_NAME = "atlas-api-healthcheck.timer"
+INSTALLED_MONITOR_NAME = "atlas-api-healthcheck.py"
+LEGACY_MONITOR_NAME = "atlas-api-healthcheck.sh"
+TOPIC_ENV = "ATLAS_API_HEALTHCHECK_NTFY_TOPIC"
+TOPIC_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,199}\Z")
+LEGACY_TOPIC_RE = re.compile(
+    r'^NTFY_TOPIC="\$\{ATLAS_HC_NTFY_TOPIC:-(?P<topic>[A-Za-z0-9][A-Za-z0-9._-]{0,199})\}"$'
+)
+
+
+@dataclass(frozen=True)
+class InstallPaths:
+    source_root: Path
+    bin_dir: Path
+    systemd_dir: Path
+    config_dir: Path
+    legacy_monitor: Path
+
+    @property
+    def installed_monitor(self) -> Path:
+        return self.bin_dir / INSTALLED_MONITOR_NAME
+
+    @property
+    def notification_env(self) -> Path:
+        return self.config_dir / "atlas-api-healthcheck.env"
+
+
+Runner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
+
+
+def _run(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+def default_paths() -> InstallPaths:
+    bin_dir = Path.home() / ".local" / "bin"
+    return InstallPaths(
+        source_root=Path(__file__).resolve().parents[1],
+        bin_dir=bin_dir,
+        systemd_dir=Path.home() / ".config" / "systemd" / "user",
+        config_dir=Path.home() / ".config" / "atlas",
+        legacy_monitor=bin_dir / LEGACY_MONITOR_NAME,
+    )
+
+
+def _source_files(paths: InstallPaths) -> tuple[tuple[Path, Path, bool], ...]:
+    monitor = paths.source_root / "scripts" / "atlas_api_healthcheck.py"
+    service = paths.source_root / "config" / SERVICE_NAME
+    timer = paths.source_root / "config" / TIMER_NAME
+    sources = (
+        (monitor, paths.installed_monitor, True),
+        (service, paths.systemd_dir / SERVICE_NAME, False),
+        (timer, paths.systemd_dir / TIMER_NAME, False),
+    )
+    missing = [str(source) for source, _destination, _executable in sources if not source.is_file()]
+    if missing:
+        raise RuntimeError("installer must run from an Atlas source checkout; missing " + ", ".join(missing))
+    return sources
+
+
+def _validated_topic(value: str, *, source: str) -> str:
+    topic = value.strip()
+    if not TOPIC_RE.fullmatch(topic):
+        raise RuntimeError(f"invalid notification topic from {source}")
+    return topic
+
+
+def _topic_from_env_file(path: Path) -> str | None:
+    if not path.exists():
+        return None
+    try:
+        values = [
+            line.partition("=")[2]
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line.partition("=")[0] == TOPIC_ENV
+        ]
+    except OSError as exc:
+        raise RuntimeError(f"cannot read notification environment file: {exc}") from exc
+    if not values:
+        return None
+    if len(values) != 1:
+        raise RuntimeError("notification environment file has multiple topic entries")
+    return _validated_topic(values[0], source="notification environment file")
+
+
+def _topic_from_legacy_monitor(path: Path) -> str | None:
+    if not path.is_file():
+        return None
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise RuntimeError(f"cannot read legacy monitor for topic migration: {exc}") from exc
+    for line in lines:
+        match = LEGACY_TOPIC_RE.fullmatch(line.strip())
+        if match:
+            return match.group("topic")
+    return None
+
+
+def _append_topic(path: Path, topic: str) -> None:
+    try:
+        existing = path.read_text(encoding="utf-8") if path.exists() else ""
+    except OSError as exc:
+        raise RuntimeError(f"cannot read notification environment file: {exc}") from exc
+    separator = "" if not existing or existing.endswith("\n") else "\n"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"{existing}{separator}{TOPIC_ENV}={topic}\n", encoding="utf-8")
+    path.chmod(0o600)
+
+
+def ensure_notification_topic(paths: InstallPaths, environment: Mapping[str, str]) -> str:
+    existing = _topic_from_env_file(paths.notification_env)
+    if existing is not None:
+        paths.notification_env.chmod(0o600)
+        return "preserved private notification topic"
+
+    candidate = environment.get(TOPIC_ENV, "")
+    source = "environment"
+    if not candidate.strip():
+        candidate = _topic_from_legacy_monitor(paths.legacy_monitor) or ""
+        source = "legacy monitor"
+    if not candidate.strip():
+        raise RuntimeError(
+            f"{TOPIC_ENV} is not configured; set it or retain a parseable legacy monitor before installation"
+        )
+    _append_topic(paths.notification_env, _validated_topic(candidate, source=source))
+    return "migrated private notification topic" if source == "legacy monitor" else "wrote private notification topic"
+
+
+def _write_copy(source: Path, destination: Path, *, executable: bool) -> None:
+    try:
+        payload = source.read_bytes()
+    except OSError as exc:
+        raise RuntimeError(f"cannot read install source {source}: {exc}") from exc
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_bytes(payload)
+    destination.chmod(0o755 if executable else 0o644)
+
+
+def _command_detail(result: subprocess.CompletedProcess[str]) -> str:
+    text = " ".join(part for part in (result.stderr, result.stdout) if part)
+    text = "".join(character if character.isprintable() else " " for character in text)
+    text = " ".join(text.split())
+    if len(text) > 240:
+        text = text[:237] + "..."
+    return f"exit {result.returncode}: {text or 'no diagnostic output'}"
+
+
+def _run_required(runner: Runner, command: Sequence[str], *, action: str) -> None:
+    result = runner(command)
+    if result.returncode != 0:
+        raise RuntimeError(f"{action} failed ({_command_detail(result)})")
+
+
+def install(paths: InstallPaths, *, runner: Runner = _run, environment: Mapping[str, str] | None = None) -> list[str]:
+    """Install the monitor, enable the timer, then invoke the installed service once."""
+    environment = os.environ if environment is None else environment
+    sources = _source_files(paths)
+    topic_message = ensure_notification_topic(paths, environment)
+    messages = [topic_message]
+    for source, destination, executable in sources:
+        _write_copy(source, destination, executable=executable)
+        messages.append(f"wrote: {destination}")
+    _run_required(runner, ("systemctl", "--user", "daemon-reload"), action="systemd reload")
+    _run_required(
+        runner,
+        ("systemctl", "--user", "enable", "--now", TIMER_NAME),
+        action="timer enable",
+    )
+    _run_required(
+        runner,
+        ("systemctl", "--user", "start", "--wait", SERVICE_NAME),
+        action="initial installed-monitor invocation",
+    )
+    messages.append("enabled timer and invoked installed health service")
+    return messages
+
+
+def _matches(source: Path, destination: Path, *, executable: bool) -> tuple[bool, str]:
+    if not destination.is_file():
+        return False, f"missing: {destination}"
+    try:
+        matches = source.read_bytes() == destination.read_bytes()
+    except OSError as exc:
+        return False, f"unreadable {destination}: {exc}"
+    if not matches:
+        return False, f"content drift: {destination}"
+    if executable and not os.access(destination, os.X_OK):
+        return False, f"not executable: {destination}"
+    return True, f"ok: {destination}"
+
+
+def check_install(paths: InstallPaths, *, runner: Runner = _run) -> tuple[bool, list[str]]:
+    """Read-only verification of the installed copies and enabled timer."""
+    checks = [_matches(source, destination, executable=executable) for source, destination, executable in _source_files(paths)]
+    try:
+        topic = _topic_from_env_file(paths.notification_env)
+        mode = stat.S_IMODE(paths.notification_env.stat().st_mode) if paths.notification_env.exists() else 0
+        if topic is None:
+            checks.append((False, f"missing notification topic: {paths.notification_env}"))
+        elif mode & 0o077:
+            checks.append((False, f"notification environment file is not private: {paths.notification_env}"))
+        else:
+            checks.append((True, f"ok: private notification environment {paths.notification_env}"))
+    except (OSError, RuntimeError) as exc:
+        checks.append((False, str(exc)))
+    for command, label in (
+        (("systemctl", "--user", "is-enabled", "--quiet", TIMER_NAME), "timer is not enabled"),
+        (("systemctl", "--user", "is-active", "--quiet", TIMER_NAME), "timer is not active"),
+    ):
+        result = runner(command)
+        checks.append((result.returncode == 0, f"ok: {TIMER_NAME}" if result.returncode == 0 else label))
+    return all(passed for passed, _message in checks), [message for _passed, message in checks]
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    action = parser.add_mutually_exclusive_group(required=True)
+    action.add_argument("--install", action="store_true", help="install, enable, and invoke the monitor")
+    action.add_argument("--check", action="store_true", help="verify installed monitor/timer without writing")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        if args.install:
+            messages = install(default_paths())
+            for message in messages:
+                print(message)
+            return 0
+        ok, messages = check_install(default_paths())
+        for message in messages:
+            print(message)
+        return 0 if ok else 1
+    except (OSError, RuntimeError, ValueError) as exc:
+        print(f"atlas-api-healthcheck installer: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/install_atlas_api_healthcheck.py
+++ b/scripts/install_atlas_api_healthcheck.py
@@ -55,6 +55,7 @@ class FileSnapshot:
     path: Path
     payload: bytes | None
     mode: int | None
+    symlink_target: str | None = None
 
 
 @dataclass(frozen=True)
@@ -207,6 +208,16 @@ def _write_copy(source: Path, destination: Path, *, executable: bool) -> None:
 
 
 def _snapshot_file(path: Path) -> FileSnapshot:
+    if path.is_symlink():
+        try:
+            return FileSnapshot(
+                path=path,
+                payload=None,
+                mode=None,
+                symlink_target=os.readlink(path),
+            )
+        except OSError as exc:
+            raise RuntimeError(f"cannot snapshot install destination {path}") from exc
     if not path.exists():
         return FileSnapshot(path=path, payload=None, mode=None)
     if not path.is_file():
@@ -222,6 +233,29 @@ def _snapshot_file(path: Path) -> FileSnapshot:
 
 
 def _restore_file(snapshot: FileSnapshot) -> None:
+    if snapshot.symlink_target is not None:
+        temporary_dir: tempfile.TemporaryDirectory[str] | None = None
+        try:
+            snapshot.path.parent.mkdir(parents=True, exist_ok=True)
+            temporary_dir = tempfile.TemporaryDirectory(
+                dir=snapshot.path.parent,
+                prefix=f".{snapshot.path.name}.link.",
+            )
+            temporary_link = Path(temporary_dir.name) / snapshot.path.name
+            os.symlink(snapshot.symlink_target, temporary_link)
+            os.replace(temporary_link, snapshot.path)
+        except OSError as exc:
+            raise RuntimeError(f"cannot restore install symlink {snapshot.path}") from exc
+        finally:
+            if temporary_dir is not None:
+                try:
+                    temporary_dir.cleanup()
+                except OSError as exc:
+                    print(
+                        f"WARNING cannot remove installer symlink staging directory: {type(exc).__name__}",
+                        file=sys.stderr,
+                    )
+        return
     if snapshot.payload is None:
         try:
             snapshot.path.unlink(missing_ok=True)

--- a/scripts/install_atlas_api_healthcheck.py
+++ b/scripts/install_atlas_api_healthcheck.py
@@ -68,6 +68,13 @@ class TimerState:
         return self.enablement in {"enabled", "enabled-runtime"}
 
 
+@dataclass(frozen=True)
+class NotificationTopicPlan:
+    payload: bytes | None
+    chmod_existing: bool
+    message: str
+
+
 Runner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
 
 
@@ -108,17 +115,21 @@ def _validated_topic(value: str, *, source: str) -> str:
     return topic
 
 
-def _topic_from_env_file(path: Path) -> str | None:
+def _read_optional_utf8(path: Path, *, label: str) -> str:
     if not path.exists():
-        return None
+        return ""
     try:
-        values = [
-            line.partition("=")[2]
-            for line in path.read_text(encoding="utf-8").splitlines()
-            if line.partition("=")[0] == TOPIC_ENV
-        ]
-    except OSError as exc:
-        raise RuntimeError(f"cannot read notification environment file: {exc}") from exc
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        raise RuntimeError(f"cannot read {label}: {type(exc).__name__}") from exc
+
+
+def _topic_from_env_text(text: str) -> str | None:
+    values = [
+        line.partition("=")[2]
+        for line in text.splitlines()
+        if line.partition("=")[0] == TOPIC_ENV
+    ]
     if not values:
         return None
     if len(values) != 1:
@@ -126,14 +137,17 @@ def _topic_from_env_file(path: Path) -> str | None:
     return _validated_topic(values[0], source="notification environment file")
 
 
+def _topic_from_env_file(path: Path) -> str | None:
+    return _topic_from_env_text(
+        _read_optional_utf8(path, label="notification environment file")
+    )
+
+
 def _topic_from_legacy_monitor(path: Path) -> str | None:
     if not path.is_file():
         return None
-    try:
-        lines = path.read_text(encoding="utf-8").splitlines()
-    except OSError as exc:
-        raise RuntimeError(f"cannot read legacy monitor for topic migration: {exc}") from exc
-    for line in lines:
+    text = _read_optional_utf8(path, label="legacy monitor for topic migration")
+    for line in text.splitlines():
         match = LEGACY_TOPIC_RE.fullmatch(line.strip())
         if match:
             return match.group("topic")
@@ -152,23 +166,28 @@ def _private_notification_symlink(path: Path) -> bool:
     return True
 
 
-def _append_topic(path: Path, topic: str) -> None:
-    try:
-        existing = path.read_text(encoding="utf-8") if path.exists() else ""
-    except OSError as exc:
-        raise RuntimeError(f"cannot read notification environment file: {exc}") from exc
+def _topic_payload(existing: str, topic: str) -> bytes:
     separator = "" if not existing or existing.endswith("\n") else "\n"
-    payload = f"{existing}{separator}{TOPIC_ENV}={topic}\n".encode("utf-8")
-    _atomic_write(path, payload, mode=0o600)
+    return f"{existing}{separator}{TOPIC_ENV}={topic}\n".encode("utf-8")
 
 
-def ensure_notification_topic(paths: InstallPaths, environment: Mapping[str, str]) -> str:
+def _notification_topic_plan(
+    paths: InstallPaths, environment: Mapping[str, str]
+) -> NotificationTopicPlan:
     private_symlink = _private_notification_symlink(paths.notification_env)
-    existing = _topic_from_env_file(paths.notification_env)
-    if existing is not None:
-        if not private_symlink:
-            paths.notification_env.chmod(0o600)
-        return "preserved private notification topic"
+    existing_text = _read_optional_utf8(
+        paths.notification_env, label="notification environment file"
+    )
+    if _topic_from_env_text(existing_text) is not None:
+        return NotificationTopicPlan(
+            payload=None,
+            chmod_existing=not private_symlink,
+            message="preserved private notification topic",
+        )
+    if private_symlink:
+        raise RuntimeError(
+            f"notification environment symlink must already contain {TOPIC_ENV}"
+        )
 
     candidate = environment.get(TOPIC_ENV, "")
     source = "environment"
@@ -179,8 +198,25 @@ def ensure_notification_topic(paths: InstallPaths, environment: Mapping[str, str
         raise RuntimeError(
             f"{TOPIC_ENV} is not configured; set it or retain a parseable legacy monitor before installation"
         )
-    _append_topic(paths.notification_env, _validated_topic(candidate, source=source))
-    return "migrated private notification topic" if source == "legacy monitor" else "wrote private notification topic"
+    topic = _validated_topic(candidate, source=source)
+    message = (
+        "migrated private notification topic"
+        if source == "legacy monitor"
+        else "wrote private notification topic"
+    )
+    return NotificationTopicPlan(
+        payload=_topic_payload(existing_text, topic),
+        chmod_existing=False,
+        message=message,
+    )
+
+
+def ensure_notification_topic(paths: InstallPaths, plan: NotificationTopicPlan) -> str:
+    if plan.payload is not None:
+        _atomic_write(paths.notification_env, plan.payload, mode=0o600)
+    elif plan.chmod_existing:
+        paths.notification_env.chmod(0o600)
+    return plan.message
 
 
 def _atomic_write(destination: Path, payload: bytes, *, mode: int) -> None:
@@ -408,7 +444,7 @@ def install(paths: InstallPaths, *, runner: Runner = _run, environment: Mapping[
     sources = _source_files(paths)
     destinations = [destination for _source, destination, _executable in sources]
     snapshots = [_snapshot_file(path) for path in (*destinations, paths.notification_env)]
-    _private_notification_symlink(paths.notification_env)
+    topic_plan = _notification_topic_plan(paths, environment)
     previous_timer = _timer_state(runner)
     enrollment_attempted = False
     try:
@@ -418,7 +454,7 @@ def install(paths: InstallPaths, *, runner: Runner = _run, environment: Mapping[
                 ("systemctl", "--user", "stop", TIMER_NAME),
                 action="existing timer stop",
             )
-        topic_message = ensure_notification_topic(paths, environment)
+        topic_message = ensure_notification_topic(paths, topic_plan)
         messages = [topic_message]
         if _existing_health_service_is_loaded(runner):
             _run_required(
@@ -468,9 +504,13 @@ def install(paths: InstallPaths, *, runner: Runner = _run, environment: Mapping[
 
 
 def _matches(source: Path, destination: Path, *, executable: bool) -> tuple[bool, str]:
+    if destination.is_symlink():
+        return False, f"not an independent regular-file copy: {destination}"
     if not destination.is_file():
         return False, f"missing: {destination}"
     try:
+        if source.samefile(destination):
+            return False, f"not an independent regular-file copy: {destination}"
         matches = source.read_bytes() == destination.read_bytes()
     except OSError as exc:
         return False, f"unreadable {destination}: {exc}"

--- a/scripts/install_atlas_api_healthcheck.py
+++ b/scripts/install_atlas_api_healthcheck.py
@@ -386,6 +386,16 @@ def install(paths: InstallPaths, *, runner: Runner = _run, environment: Mapping[
         )
         messages.append("proved installed health service and enabled timer")
         return messages
+    except KeyboardInterrupt as exc:
+        rollback_errors = _rollback_install(
+            snapshots,
+            previous_timer,
+            runner,
+            enrollment_attempted=enrollment_attempted,
+        )
+        if rollback_errors:
+            exc.add_note(f"rollback failed: {'; '.join(rollback_errors)}")
+        raise
     except (OSError, RuntimeError) as exc:
         rollback_errors = _rollback_install(
             snapshots,

--- a/tests/test_atlas_api_healthcheck.py
+++ b/tests/test_atlas_api_healthcheck.py
@@ -8,6 +8,7 @@ import os
 import string
 import subprocess
 import sys
+import threading
 from pathlib import Path
 
 import pytest
@@ -235,6 +236,80 @@ def test_maintenance_lock_never_starts_service(tmp_path):
     assert result == healthcheck.EXIT_OK
     assert _start_commands(runner) == []
     assert _state(settings) == {"consecutive": 0, "status": "maintenance"}
+
+
+def test_enter_maintenance_serializes_with_an_inflight_recovery(tmp_path):
+    settings = _settings(tmp_path)
+    first_status_read = threading.Event()
+    release_status_read = threading.Event()
+    maintenance_started = threading.Event()
+
+    class CoordinatedRunner:
+        def __init__(self):
+            self.active = False
+            self.commands: list[tuple[str, ...]] = []
+
+        def __call__(self, command):
+            command = tuple(command)
+            self.commands.append(command)
+            if "is-active" in command:
+                if not first_status_read.is_set():
+                    first_status_read.set()
+                    assert release_status_read.wait(timeout=2)
+                return subprocess.CompletedProcess(command, 0 if self.active else 3, "", "")
+            if "start" in command:
+                self.active = True
+            elif "stop" in command:
+                self.active = False
+            return subprocess.CompletedProcess(command, 0, "", "")
+
+    runner = CoordinatedRunner()
+    health_results: list[int] = []
+    maintenance_results: list[int] = []
+    health_thread = threading.Thread(
+        target=lambda: health_results.append(
+            healthcheck.run_healthcheck(
+                settings,
+                runner=runner,
+                opener=_opener(204),
+                notifier=lambda *args: True,
+                sleeper=lambda _: None,
+            )
+        )
+    )
+
+    def enter() -> None:
+        maintenance_started.set()
+        maintenance_results.append(healthcheck.enter_maintenance(settings, runner=runner))
+
+    maintenance_thread = threading.Thread(target=enter)
+    health_thread.start()
+    assert first_status_read.wait(timeout=1)
+    maintenance_thread.start()
+    assert maintenance_started.wait(timeout=1)
+    assert not settings.maintenance_lock.exists()
+    release_status_read.set()
+    health_thread.join(timeout=2)
+    maintenance_thread.join(timeout=2)
+
+    assert not health_thread.is_alive()
+    assert not maintenance_thread.is_alive()
+    assert health_results == [healthcheck.EXIT_RECOVERED]
+    assert maintenance_results == [healthcheck.EXIT_OK]
+    assert settings.maintenance_lock.exists()
+    assert not runner.active
+    assert runner.commands.index(("systemctl", "--user", "start", settings.service)) < runner.commands.index(
+        ("systemctl", "--user", "stop", settings.service)
+    )
+
+
+def test_exit_maintenance_removes_marker_under_monitor_lock(tmp_path):
+    settings = _settings(tmp_path)
+    settings.maintenance_lock.parent.mkdir(parents=True, exist_ok=True)
+    settings.maintenance_lock.touch()
+
+    assert healthcheck.exit_maintenance(settings) == healthcheck.EXIT_OK
+    assert not settings.maintenance_lock.exists()
 
 
 def test_failed_start_remains_a_visible_down_result(tmp_path):

--- a/tests/test_atlas_api_healthcheck.py
+++ b/tests/test_atlas_api_healthcheck.py
@@ -525,7 +525,7 @@ def test_undelivered_down_transition_is_retried(tmp_path):
     first = healthcheck.run_healthcheck(
         settings, runner=runner, opener=_opener(503), notifier=notifier, sleeper=lambda _: None
     )
-    assert first == healthcheck.EXIT_ALERT_UNDELIVERED
+    assert first == healthcheck.EXIT_DOWN
     assert _state(settings)["pending_notifications"][0]["alert"] == "down"
 
     second = healthcheck.run_healthcheck(
@@ -753,6 +753,21 @@ def test_missing_notification_configuration_does_not_block_recovery(tmp_path):
     assert _state(settings)["pending_notifications"][0]["alert"] == "auto-recovered"
 
 
+def test_failed_recovery_with_undelivered_alert_preserves_down_exit(tmp_path):
+    settings = _settings(tmp_path)
+
+    result = healthcheck.run_healthcheck(
+        settings,
+        runner=_Runner(active=False, start_returncode=1),
+        opener=_opener(204),
+        notifier=lambda *args: False,
+        sleeper=lambda _: None,
+    )
+
+    assert result == healthcheck.EXIT_DOWN
+    assert _state(settings)["pending_notifications"][0]["alert"] == "down"
+
+
 def test_no_alert_does_not_consume_a_transition(tmp_path):
     settings = _settings(tmp_path, no_alert=True)
 
@@ -764,7 +779,7 @@ def test_no_alert_does_not_consume_a_transition(tmp_path):
         sleeper=lambda _: None,
     )
 
-    assert result == healthcheck.EXIT_ALERT_UNDELIVERED
+    assert result == healthcheck.EXIT_DOWN
     assert _state(settings)["pending_notifications"][0]["alert"] == "down"
 
 
@@ -1299,6 +1314,49 @@ def test_installer_restores_files_and_timer_when_service_proof_fails(tmp_path):
     assert runner.timer_enabled
     assert runner.timer_active
     assert ("systemctl", "--user", "enable", "--now", installer.TIMER_NAME) not in runner.commands
+    assert runner.commands[-3:] == [
+        ("systemctl", "--user", "daemon-reload"),
+        ("systemctl", "--user", "enable", installer.TIMER_NAME),
+        ("systemctl", "--user", "start", installer.TIMER_NAME),
+    ]
+
+
+def test_installer_rolls_back_before_reraising_operator_cancellation(tmp_path):
+    paths = _install_paths(tmp_path)
+    paths.installed_monitor.parent.mkdir(parents=True, exist_ok=True)
+    paths.installed_monitor.write_bytes(b"previous-monitor")
+    paths.installed_monitor.chmod(0o700)
+    paths.notification_env.parent.mkdir(parents=True, exist_ok=True)
+    paths.notification_env.write_text(
+        f"{installer.TOPIC_ENV}=previous-private-topic\n", encoding="utf-8"
+    )
+    paths.notification_env.chmod(0o600)
+    runner = _InstallerRunner(timer_enabled=True, timer_active=True)
+    proof_command = (
+        "systemctl",
+        "--user",
+        "start",
+        "--wait",
+        installer.SERVICE_NAME,
+    )
+
+    def interrupting_runner(command):
+        if tuple(command) == proof_command:
+            runner.commands.append(proof_command)
+            raise KeyboardInterrupt
+        return runner(command)
+
+    with pytest.raises(KeyboardInterrupt):
+        installer.install(paths, runner=interrupting_runner, environment={})
+
+    assert paths.installed_monitor.read_bytes() == b"previous-monitor"
+    assert not (paths.systemd_dir / installer.SERVICE_NAME).exists()
+    assert not (paths.systemd_dir / installer.TIMER_NAME).exists()
+    assert paths.notification_env.read_text(encoding="utf-8") == (
+        f"{installer.TOPIC_ENV}=previous-private-topic\n"
+    )
+    assert runner.timer_enabled
+    assert runner.timer_active
     assert runner.commands[-3:] == [
         ("systemctl", "--user", "daemon-reload"),
         ("systemctl", "--user", "enable", installer.TIMER_NAME),

--- a/tests/test_atlas_api_healthcheck.py
+++ b/tests/test_atlas_api_healthcheck.py
@@ -2,8 +2,10 @@
 from __future__ import annotations
 
 import importlib.util
+import itertools
 import json
 import os
+import string
 import subprocess
 import sys
 from pathlib import Path
@@ -127,6 +129,47 @@ def _install_paths(tmp_path: Path) -> installer.InstallPaths:
         config_dir=tmp_path / "config",
         legacy_monitor=bin_dir / installer.LEGACY_MONITOR_NAME,
     )
+
+
+def _topic_grammar_oracle(value: str) -> bool:
+    normalized = value.strip()
+    allowed_leading = set(string.ascii_letters + string.digits)
+    allowed_body = allowed_leading | {".", "_", "-"}
+    return bool(
+        1 <= len(normalized) <= 200
+        and normalized[0] in allowed_leading
+        and all(character in allowed_body for character in normalized)
+    )
+
+
+def _topic_leading_tokens() -> str:
+    return string.ascii_letters + string.digits + "._-/ \u00e9"
+
+
+def _topic_body_families() -> str:
+    return string.ascii_letters + string.digits + "._-/ \u00e9"
+
+
+def _topic_wrappers() -> tuple[str, ...]:
+    return "", " ", "\n"
+
+
+def test_notification_topic_grammar_class_closure():
+    """Check the bounded topic grammar across token, family, and wrapper axes."""
+    for leading_token, body_family, length, wrapper in itertools.product(
+        _topic_leading_tokens(),
+        _topic_body_families(),
+        (0, 1, 2, 200, 201),
+        _topic_wrappers(),
+    ):
+        base = "" if length == 0 else leading_token + body_family * (length - 1)
+        candidate = f"{wrapper}{base}{wrapper}"
+        expected = _topic_grammar_oracle(candidate)
+        if expected:
+            assert installer._validated_topic(candidate, source="grammar property") == candidate.strip()
+        else:
+            with pytest.raises(RuntimeError):
+                installer._validated_topic(candidate, source="grammar property")
 
 
 def test_inactive_service_is_started_and_reprobed(tmp_path):

--- a/tests/test_atlas_api_healthcheck.py
+++ b/tests/test_atlas_api_healthcheck.py
@@ -51,21 +51,37 @@ class _Runner:
         start_returncode: int = 0,
         start_stdout: str = "",
         start_stderr: str = "",
+        load_state: str = "loaded",
+        active_state: str | None = None,
+        query_returncode: int = 0,
+        query_stdout: str | None = None,
+        query_stderr: str = "",
     ) -> None:
         self.active = active
+        self.load_state = load_state
+        self.active_state = active_state or ("active" if active else "inactive")
         self.start_returncode = start_returncode
         self.start_stdout = start_stdout
         self.start_stderr = start_stderr
+        self.query_returncode = query_returncode
+        self.query_stdout = query_stdout
+        self.query_stderr = query_stderr
         self.commands: list[tuple[str, ...]] = []
 
     def __call__(self, command):
         command = tuple(command)
         self.commands.append(command)
-        if "is-active" in command:
-            return subprocess.CompletedProcess(command, 0 if self.active else 3, "", "")
+        if "show" in command:
+            stdout = self.query_stdout
+            if stdout is None:
+                stdout = f"LoadState={self.load_state}\nActiveState={self.active_state}\n"
+            return subprocess.CompletedProcess(
+                command, self.query_returncode, stdout, self.query_stderr
+            )
         assert "start" in command
         if self.start_returncode == 0:
             self.active = True
+            self.active_state = "active"
         return subprocess.CompletedProcess(
             command,
             self.start_returncode,
@@ -81,10 +97,21 @@ class _InstallerRunner:
         failing_command: tuple[str, ...] | None = None,
         timer_enabled: bool = False,
         timer_active: bool = False,
+        timer_load_state: str = "loaded",
+        health_service_load_state: str = "loaded",
+        health_service_active_state: str = "inactive",
+        need_daemon_reload: dict[str, str] | None = None,
     ) -> None:
         self.failing_command = failing_command
         self.timer_enabled = timer_enabled
         self.timer_active = timer_active
+        self.timer_load_state = timer_load_state
+        self.health_service_load_state = health_service_load_state
+        self.health_service_active_state = health_service_active_state
+        self.need_daemon_reload = need_daemon_reload or {
+            installer.SERVICE_NAME: "no",
+            installer.TIMER_NAME: "no",
+        }
         self.commands: list[tuple[str, ...]] = []
 
     def __call__(self, command):
@@ -92,10 +119,26 @@ class _InstallerRunner:
         self.commands.append(command)
         if command == self.failing_command:
             return subprocess.CompletedProcess(command, 1, "", "unit\n\x1b[31mfailed")
-        if "is-enabled" in command:
-            return subprocess.CompletedProcess(command, 0 if self.timer_enabled else 1, "", "")
-        if "is-active" in command:
-            return subprocess.CompletedProcess(command, 0 if self.timer_active else 3, "", "")
+        if "show" in command and "--property=LoadState" in command:
+            if command[-1] == installer.TIMER_NAME:
+                load_state = self.timer_load_state
+                active_state = "active" if self.timer_active else "inactive"
+            else:
+                load_state = self.health_service_load_state
+                active_state = self.health_service_active_state
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                f"LoadState={load_state}\nActiveState={active_state}\n",
+                "",
+            )
+        if "show" in command and "--property=NeedDaemonReload" in command:
+            return subprocess.CompletedProcess(
+                command, 0, self.need_daemon_reload.get(command[-1], "") + "\n", ""
+            )
+        if "show" in command and "--property=UnitFileState" in command:
+            state = "enabled" if self.timer_enabled else "disabled"
+            return subprocess.CompletedProcess(command, 0, state + "\n", "")
         if command[2:4] == ("enable", "--now"):
             self.timer_enabled = True
             self.timer_active = True
@@ -238,6 +281,30 @@ def test_maintenance_lock_never_starts_service(tmp_path):
     assert _state(settings) == {"consecutive": 0, "status": "maintenance"}
 
 
+def test_unreadable_maintenance_lock_fails_before_query_or_start(tmp_path, monkeypatch):
+    settings = _settings(tmp_path)
+    runner = _Runner(active=False)
+    real_stat = Path.stat
+
+    def fail_only_for_maintenance(path):
+        if path == settings.maintenance_lock:
+            raise PermissionError("simulated unreadable maintenance marker")
+        return real_stat(path)
+
+    monkeypatch.setattr(Path, "stat", fail_only_for_maintenance)
+
+    with pytest.raises(RuntimeError, match="unable to inspect Atlas API maintenance lock"):
+        healthcheck.run_healthcheck(
+            settings,
+            runner=runner,
+            opener=_opener(204),
+            notifier=lambda *args: True,
+            sleeper=lambda _: None,
+        )
+
+    assert runner.commands == []
+
+
 def test_enter_maintenance_serializes_with_an_inflight_recovery(tmp_path):
     settings = _settings(tmp_path)
     first_status_read = threading.Event()
@@ -252,11 +319,14 @@ def test_enter_maintenance_serializes_with_an_inflight_recovery(tmp_path):
         def __call__(self, command):
             command = tuple(command)
             self.commands.append(command)
-            if "is-active" in command:
+            if "show" in command:
                 if not first_status_read.is_set():
                     first_status_read.set()
                     assert release_status_read.wait(timeout=2)
-                return subprocess.CompletedProcess(command, 0 if self.active else 3, "", "")
+                active_state = "active" if self.active else "inactive"
+                return subprocess.CompletedProcess(
+                    command, 0, f"LoadState=loaded\nActiveState={active_state}\n", ""
+                )
             if "start" in command:
                 self.active = True
             elif "stop" in command:
@@ -383,6 +453,46 @@ def test_active_unhealthy_service_alerts_without_restart(tmp_path):
     assert _state(settings) == {"consecutive": 1, "status": "down"}
 
 
+@pytest.mark.parametrize(
+    ("runner", "expected_detail"),
+    [
+        (
+            _Runner(active=False, load_state="not-found"),
+            "LoadState=not-found",
+        ),
+        (
+            _Runner(active=False, active_state="activating"),
+            "ActiveState=activating",
+        ),
+        (
+            _Runner(active=False, query_returncode=1, query_stderr="manager unavailable"),
+            "unit-state query failed",
+        ),
+        (
+            _Runner(active=False, query_stdout="LoadState=loaded\n"),
+            "incomplete LoadState/ActiveState",
+        ),
+    ],
+)
+def test_only_explicit_loaded_inactive_state_is_recoverable(
+    tmp_path, runner, expected_detail
+):
+    settings = _settings(tmp_path)
+    sent: list[tuple] = []
+
+    result = healthcheck.run_healthcheck(
+        settings,
+        runner=runner,
+        opener=_opener(204),
+        notifier=lambda *args: (sent.append(args), True)[1],
+        sleeper=lambda _: None,
+    )
+
+    assert result == healthcheck.EXIT_DOWN
+    assert _start_commands(runner) == []
+    assert expected_detail in sent[0][3]
+
+
 def test_undelivered_down_transition_is_retried(tmp_path):
     settings = _settings(tmp_path)
     runner = _Runner(active=True)
@@ -504,6 +614,35 @@ def test_recovery_outbox_is_persisted_before_a_delivery_crash(tmp_path):
     assert _state(settings) == {"consecutive": 0, "status": "healthy"}
 
 
+def test_recovery_outbox_is_persisted_before_console_output_crash(tmp_path, monkeypatch):
+    settings = _settings(tmp_path)
+
+    monkeypatch.setattr(
+        "builtins.print",
+        lambda *args, **kwargs: (_ for _ in ()).throw(BrokenPipeError("simulated console loss")),
+    )
+
+    with pytest.raises(BrokenPipeError, match="simulated console loss"):
+        healthcheck.run_healthcheck(
+            settings,
+            runner=_Runner(active=False),
+            opener=_opener(204),
+            notifier=lambda *args: True,
+            sleeper=lambda _: None,
+        )
+
+    assert _state(settings) == {
+        "status": "healthy",
+        "consecutive": 0,
+        "pending_notifications": [
+            {
+                "alert": "auto-recovered",
+                "detail": "auto-recovered atlas-api.service: lead-intake probe returned HTTP 204",
+            }
+        ],
+    }
+
+
 def test_recovery_intent_is_persisted_before_start_and_replayed_after_crash(tmp_path):
     settings = _settings(tmp_path)
     crashed_commands: list[tuple[str, ...]] = []
@@ -511,8 +650,10 @@ def test_recovery_intent_is_persisted_before_start_and_replayed_after_crash(tmp_
     def crash_after_start(command):
         command = tuple(command)
         crashed_commands.append(command)
-        if "is-active" in command:
-            return subprocess.CompletedProcess(command, 3, "", "")
+        if "show" in command:
+            return subprocess.CompletedProcess(
+                command, 0, "LoadState=loaded\nActiveState=inactive\n", ""
+            )
         raise SystemExit("simulated crash after systemd accepted start")
 
     with pytest.raises(SystemExit, match="simulated crash"):
@@ -797,8 +938,30 @@ def test_installer_deploys_source_and_invokes_enabled_timer_path(tmp_path):
     assert paths.notification_env.stat().st_mode & 0o077 == 0
     assert "test-private-topic" not in "\n".join(messages)
     assert runner.commands == [
-        ("systemctl", "--user", "is-enabled", "--quiet", installer.TIMER_NAME),
-        ("systemctl", "--user", "is-active", "--quiet", installer.TIMER_NAME),
+        (
+            "systemctl",
+            "--user",
+            "show",
+            "--property=LoadState",
+            "--property=ActiveState",
+            installer.TIMER_NAME,
+        ),
+        (
+            "systemctl",
+            "--user",
+            "show",
+            "--property=UnitFileState",
+            "--value",
+            installer.TIMER_NAME,
+        ),
+        (
+            "systemctl",
+            "--user",
+            "show",
+            "--property=LoadState",
+            "--property=ActiveState",
+            installer.SERVICE_NAME,
+        ),
         ("systemctl", "--user", "stop", installer.SERVICE_NAME),
         ("systemctl", "--user", "daemon-reload"),
         ("systemctl", "--user", "start", "--wait", installer.SERVICE_NAME),
@@ -810,8 +973,38 @@ def test_installer_deploys_source_and_invokes_enabled_timer_path(tmp_path):
     assert ok
     assert all(message.startswith("ok:") for message in check_messages)
     assert check_runner.commands == [
-        ("systemctl", "--user", "is-enabled", "--quiet", installer.TIMER_NAME),
-        ("systemctl", "--user", "is-active", "--quiet", installer.TIMER_NAME),
+        (
+            "systemctl",
+            "--user",
+            "show",
+            "--property=LoadState",
+            "--property=ActiveState",
+            installer.TIMER_NAME,
+        ),
+        (
+            "systemctl",
+            "--user",
+            "show",
+            "--property=UnitFileState",
+            "--value",
+            installer.TIMER_NAME,
+        ),
+        (
+            "systemctl",
+            "--user",
+            "show",
+            "--property=NeedDaemonReload",
+            "--value",
+            installer.SERVICE_NAME,
+        ),
+        (
+            "systemctl",
+            "--user",
+            "show",
+            "--property=NeedDaemonReload",
+            "--value",
+            installer.TIMER_NAME,
+        ),
     ]
 
 
@@ -824,10 +1017,108 @@ def test_installer_requires_private_topic_before_writing_or_enabling(tmp_path):
 
     assert not paths.installed_monitor.exists()
     assert runner.commands == [
-        ("systemctl", "--user", "is-enabled", "--quiet", installer.TIMER_NAME),
-        ("systemctl", "--user", "is-active", "--quiet", installer.TIMER_NAME),
+        (
+            "systemctl",
+            "--user",
+            "show",
+            "--property=LoadState",
+            "--property=ActiveState",
+            installer.TIMER_NAME,
+        ),
+        (
+            "systemctl",
+            "--user",
+            "show",
+            "--property=UnitFileState",
+            "--value",
+            installer.TIMER_NAME,
+        ),
         ("systemctl", "--user", "daemon-reload"),
     ]
+
+
+def test_clean_install_allows_an_absent_old_health_service(tmp_path):
+    paths = _install_paths(tmp_path)
+    runner = _InstallerRunner(
+        timer_load_state="not-found", health_service_load_state="not-found"
+    )
+
+    installer.install(
+        paths,
+        runner=runner,
+        environment={installer.TOPIC_ENV: "test-private-topic"},
+    )
+
+    assert ("systemctl", "--user", "stop", installer.SERVICE_NAME) not in runner.commands
+    assert (
+        "systemctl",
+        "--user",
+        "start",
+        "--wait",
+        installer.SERVICE_NAME,
+    ) in runner.commands
+    assert paths.installed_monitor.exists()
+
+
+def test_installer_rejects_an_unsupported_old_unit_load_state(tmp_path):
+    paths = _install_paths(tmp_path)
+    runner = _InstallerRunner(health_service_load_state="error")
+
+    with pytest.raises(RuntimeError, match="unsupported LoadState=error"):
+        installer.install(
+            paths,
+            runner=runner,
+            environment={installer.TOPIC_ENV: "test-private-topic"},
+        )
+
+    assert not paths.installed_monitor.exists()
+
+
+def test_installer_fails_closed_when_existing_timer_state_cannot_be_queried(tmp_path):
+    paths = _install_paths(tmp_path)
+    timer_query = (
+        "systemctl",
+        "--user",
+        "show",
+        "--property=LoadState",
+        "--property=ActiveState",
+        installer.TIMER_NAME,
+    )
+    runner = _InstallerRunner(failing_command=timer_query)
+
+    with pytest.raises(RuntimeError, match="unit-state query failed"):
+        installer.install(
+            paths,
+            runner=runner,
+            environment={installer.TOPIC_ENV: "test-private-topic"},
+        )
+
+    assert runner.commands == [timer_query]
+    assert not paths.installed_monitor.exists()
+
+
+def test_install_check_rejects_stale_loaded_unit_definitions(tmp_path):
+    paths = _install_paths(tmp_path)
+    installer.install(
+        paths,
+        runner=_InstallerRunner(
+            timer_load_state="not-found", health_service_load_state="not-found"
+        ),
+        environment={installer.TOPIC_ENV: "test-private-topic"},
+    )
+    check_runner = _InstallerRunner(
+        timer_enabled=True,
+        timer_active=True,
+        need_daemon_reload={
+            installer.SERVICE_NAME: "yes",
+            installer.TIMER_NAME: "no",
+        },
+    )
+
+    ok, messages = installer.check_install(paths, runner=check_runner)
+
+    assert not ok
+    assert f"systemd requires daemon-reload for {installer.SERVICE_NAME}" in messages
 
 
 def test_installer_quiesces_old_service_before_replacing_files(tmp_path, monkeypatch):

--- a/tests/test_atlas_api_healthcheck.py
+++ b/tests/test_atlas_api_healthcheck.py
@@ -1045,7 +1045,8 @@ def test_service_template_uses_installed_script_and_private_environment():
     assert "ExecStart=/usr/bin/python3 %h/.local/bin/atlas-api-healthcheck.py" in service
     assert "EnvironmentFile=-%h/.config/atlas/atlas-api-healthcheck.env" in service
     assert "Environment=DISPLAY=:0" in service
-    assert "Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus" in service
+    assert "DBUS_SESSION_BUS_ADDRESS=" not in service
+    assert "/run/user/1000" not in service
     assert "ATLAS_API_HEALTHCHECK_NTFY_TOPIC=<private-topic>" in service
     assert "eom-atlas-api-health-" not in service
     assert "SuccessExitStatus=0 2 4" in service

--- a/tests/test_atlas_api_healthcheck.py
+++ b/tests/test_atlas_api_healthcheck.py
@@ -35,8 +35,17 @@ _INSTALLER_SPEC.loader.exec_module(installer)
 
 
 class _Response:
-    def __init__(self, status: int) -> None:
+    def __init__(self, status: int, headers: dict[str, str] | None = None) -> None:
         self.status = status
+        self.headers = (
+            {
+                "Access-Control-Allow-Origin": healthcheck.PROBE_ORIGIN,
+                "Access-Control-Allow-Methods": "POST, OPTIONS",
+                "Access-Control-Allow-Headers": "Content-Type",
+            }
+            if headers is None
+            else headers
+        )
 
     def __enter__(self):
         return self
@@ -98,6 +107,7 @@ class _InstallerRunner:
         *,
         failing_command: tuple[str, ...] | None = None,
         timer_enabled: bool = False,
+        timer_runtime: bool = False,
         timer_active: bool = False,
         timer_load_state: str = "loaded",
         health_service_load_state: str = "loaded",
@@ -105,7 +115,8 @@ class _InstallerRunner:
         need_daemon_reload: dict[str, str] | None = None,
     ) -> None:
         self.failing_command = failing_command
-        self.timer_enabled = timer_enabled
+        self.timer_enabled = timer_enabled or timer_runtime
+        self.timer_runtime = timer_runtime
         self.timer_active = timer_active
         self.timer_load_state = timer_load_state
         self.health_service_load_state = health_service_load_state
@@ -139,16 +150,28 @@ class _InstallerRunner:
                 command, 0, self.need_daemon_reload.get(command[-1], "") + "\n", ""
             )
         if "show" in command and "--property=UnitFileState" in command:
-            state = "enabled" if self.timer_enabled else "disabled"
+            state = (
+                "enabled-runtime"
+                if self.timer_runtime
+                else "enabled"
+                if self.timer_enabled
+                else "disabled"
+            )
             return subprocess.CompletedProcess(command, 0, state + "\n", "")
         if command[2:4] == ("enable", "--now"):
             self.timer_enabled = True
+            self.timer_runtime = False
             self.timer_active = True
         elif command[2:4] == ("disable", "--now"):
             self.timer_enabled = False
+            self.timer_runtime = False
             self.timer_active = False
+        elif command[2:4] == ("enable", "--runtime"):
+            self.timer_enabled = True
+            self.timer_runtime = True
         elif command[2:] == ("enable", installer.TIMER_NAME):
             self.timer_enabled = True
+            self.timer_runtime = False
         elif command[2:] == ("start", installer.TIMER_NAME):
             self.timer_active = True
         elif command[2:] == ("stop", installer.TIMER_NAME):
@@ -173,11 +196,15 @@ def _settings(tmp_path: Path, **overrides):
     return healthcheck.Settings(**values)
 
 
-def _opener(status: int, seen: list | None = None):
+def _opener(
+    status: int,
+    seen: list | None = None,
+    headers: dict[str, str] | None = None,
+):
     def _open(request, *, timeout):
         if seen is not None:
             seen.append((request.method, request.headers, timeout))
-        return _Response(status)
+        return _Response(status, headers)
 
     return _open
 
@@ -260,9 +287,59 @@ def test_inactive_service_is_started_and_reprobed(tmp_path):
     assert _start_commands(runner) == [
         ("systemctl", "--user", "start", "atlas-api.service")
     ]
-    assert seen == [("OPTIONS", {"Origin": "https://effinghamofficemaids.com", "Access-control-request-method": "POST"}, 8)]
+    assert seen == [
+        (
+            "OPTIONS",
+            {
+                "Origin": healthcheck.PROBE_ORIGIN,
+                "Access-control-request-method": "POST",
+                "Access-control-request-headers": "Content-Type",
+            },
+            8,
+        )
+    ]
     assert sent[0][2] == "atlas-api auto-recovered"
     assert _state(settings) == {"consecutive": 0, "status": "healthy"}
+
+
+@pytest.mark.parametrize(
+    ("headers", "expected_detail"),
+    [
+        ({}, "CORS origin"),
+        (
+            {
+                "Access-Control-Allow-Origin": "https://example.invalid",
+                "Access-Control-Allow-Methods": "POST, OPTIONS",
+                "Access-Control-Allow-Headers": "Content-Type",
+            },
+            "CORS origin",
+        ),
+        (
+            {
+                "Access-Control-Allow-Origin": healthcheck.PROBE_ORIGIN,
+                "Access-Control-Allow-Methods": "OPTIONS",
+                "Access-Control-Allow-Headers": "Content-Type",
+            },
+            "POST",
+        ),
+        (
+            {
+                "Access-Control-Allow-Origin": healthcheck.PROBE_ORIGIN,
+                "Access-Control-Allow-Methods": "POST, OPTIONS",
+                "Access-Control-Allow-Headers": "X-Request-ID",
+            },
+            "Content-Type",
+        ),
+    ],
+)
+def test_probe_rejects_non_browser_ready_cors_responses(headers, expected_detail):
+    healthy, detail = healthcheck.probe_lead_intake(
+        "http://example.test/api/v1/leads/intake",
+        _opener(204, headers=headers),
+    )
+
+    assert not healthy
+    assert expected_detail in detail
 
 
 def test_maintenance_lock_never_starts_service(tmp_path):
@@ -616,7 +693,7 @@ def test_recovery_outbox_is_persisted_before_a_delivery_crash(tmp_path):
         "pending_notifications": [
             {
                 "alert": "auto-recovered",
-                "detail": "auto-recovered atlas-api.service: lead-intake probe returned HTTP 204",
+                "detail": "auto-recovered atlas-api.service: lead-intake probe returned browser-ready HTTP 204",
             }
         ],
     }
@@ -658,7 +735,7 @@ def test_recovery_outbox_is_persisted_before_console_output_crash(tmp_path, monk
         "pending_notifications": [
             {
                 "alert": "auto-recovered",
-                "detail": "auto-recovered atlas-api.service: lead-intake probe returned HTTP 204",
+                "detail": "auto-recovered atlas-api.service: lead-intake probe returned browser-ready HTTP 204",
             }
         ],
     }
@@ -1306,7 +1383,19 @@ def test_file_restore_preserves_a_falsy_zero_mode(tmp_path):
     assert destination.read_bytes() == b"previous"
 
 
-def test_installer_restores_files_and_timer_when_service_proof_fails(tmp_path):
+@pytest.mark.parametrize(
+    ("timer_runtime", "restore_enable_command"),
+    [
+        (False, ("systemctl", "--user", "enable", installer.TIMER_NAME)),
+        (
+            True,
+            ("systemctl", "--user", "enable", "--runtime", installer.TIMER_NAME),
+        ),
+    ],
+)
+def test_installer_restores_files_and_timer_when_service_proof_fails(
+    tmp_path, timer_runtime, restore_enable_command
+):
     paths = _install_paths(tmp_path)
     installed_files = [
         paths.installed_monitor,
@@ -1324,7 +1413,8 @@ def test_installer_restores_files_and_timer_when_service_proof_fails(tmp_path):
     previous_payloads = {path: path.read_bytes() for path in installed_files}
     runner = _InstallerRunner(
         failing_command=("systemctl", "--user", "start", "--wait", installer.SERVICE_NAME),
-        timer_enabled=True,
+        timer_enabled=not timer_runtime,
+        timer_runtime=timer_runtime,
         timer_active=True,
     )
 
@@ -1337,7 +1427,7 @@ def test_installer_restores_files_and_timer_when_service_proof_fails(tmp_path):
     assert ("systemctl", "--user", "enable", "--now", installer.TIMER_NAME) not in runner.commands
     assert runner.commands[-3:] == [
         ("systemctl", "--user", "daemon-reload"),
-        ("systemctl", "--user", "enable", installer.TIMER_NAME),
+        restore_enable_command,
         ("systemctl", "--user", "start", installer.TIMER_NAME),
     ]
 

--- a/tests/test_atlas_api_healthcheck.py
+++ b/tests/test_atlas_api_healthcheck.py
@@ -1211,25 +1211,29 @@ def test_installer_requires_private_topic_before_writing_or_enabling(tmp_path):
         installer.install(paths, runner=runner, environment={})
 
     assert not paths.installed_monitor.exists()
-    assert runner.commands == [
-        (
-            "systemctl",
-            "--user",
-            "show",
-            "--property=LoadState",
-            "--property=ActiveState",
-            installer.TIMER_NAME,
-        ),
-        (
-            "systemctl",
-            "--user",
-            "show",
-            "--property=UnitFileState",
-            "--value",
-            installer.TIMER_NAME,
-        ),
-        ("systemctl", "--user", "daemon-reload"),
-    ]
+    assert runner.commands == []
+
+
+@pytest.mark.parametrize("configuration_source", ["notification", "legacy"])
+def test_installer_rejects_malformed_utf8_before_systemd_or_mutation(
+    tmp_path, configuration_source
+):
+    paths = _install_paths(tmp_path)
+    target = (
+        paths.notification_env
+        if configuration_source == "notification"
+        else paths.legacy_monitor
+    )
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(b"\xff\xfe")
+    runner = _InstallerRunner(timer_active=True)
+
+    with pytest.raises(RuntimeError, match="UnicodeDecodeError"):
+        installer.install(paths, runner=runner, environment={})
+
+    assert runner.commands == []
+    assert runner.timer_active
+    assert target.read_bytes() == b"\xff\xfe"
 
 
 def test_clean_install_allows_an_absent_old_health_service(tmp_path):
@@ -1340,6 +1344,31 @@ def test_install_check_rejects_stale_loaded_unit_definitions(tmp_path):
     assert f"systemd requires daemon-reload for {installer.SERVICE_NAME}" in messages
 
 
+@pytest.mark.parametrize("link_kind", ["symlink", "hardlink"])
+def test_install_check_rejects_monitor_alias_to_checkout_source(tmp_path, link_kind):
+    paths = _install_paths(tmp_path)
+    installer.install(
+        paths,
+        runner=_InstallerRunner(
+            timer_load_state="not-found", health_service_load_state="not-found"
+        ),
+        environment={installer.TOPIC_ENV: "test-private-topic"},
+    )
+    source = REPO_ROOT / "scripts" / "atlas_api_healthcheck.py"
+    paths.installed_monitor.unlink()
+    if link_kind == "symlink":
+        paths.installed_monitor.symlink_to(source)
+    else:
+        os.link(source, paths.installed_monitor)
+
+    ok, messages = installer.check_install(
+        paths, runner=_InstallerRunner(timer_enabled=True, timer_active=True)
+    )
+
+    assert not ok
+    assert f"not an independent regular-file copy: {paths.installed_monitor}" in messages
+
+
 def test_installer_quiesces_old_service_before_replacing_files(tmp_path, monkeypatch):
     paths = _install_paths(tmp_path)
     events: list[tuple[str, ...]] = []
@@ -1381,7 +1410,8 @@ def test_installer_quiesces_old_service_before_replacing_files(tmp_path, monkeyp
 
 
 def test_topic_file_is_private_before_atomic_publish(tmp_path, monkeypatch):
-    destination = tmp_path / "config" / "atlas-api-healthcheck.env"
+    paths = _install_paths(tmp_path)
+    destination = paths.notification_env
     observed_modes: list[int] = []
     real_replace = installer.os.replace
 
@@ -1392,7 +1422,10 @@ def test_topic_file_is_private_before_atomic_publish(tmp_path, monkeypatch):
 
     monkeypatch.setattr(installer.os, "replace", inspect_replace)
 
-    installer._append_topic(destination, "test-private-topic")
+    plan = installer._notification_topic_plan(
+        paths, {installer.TOPIC_ENV: "test-private-topic"}
+    )
+    installer.ensure_notification_topic(paths, plan)
 
     assert observed_modes == [0o600]
     assert destination.stat().st_mode & 0o777 == 0o600
@@ -1543,7 +1576,9 @@ def test_installer_preserves_private_notification_symlink_without_chmod(
     assert stat.S_IMODE(target.stat().st_mode) == 0o600
 
 
-def test_failed_install_restores_missing_topic_symlink_without_changing_target(tmp_path):
+def test_installer_rejects_private_missing_topic_symlink_before_systemd_or_mutation(
+    tmp_path,
+):
     paths = _install_paths(tmp_path)
     paths.config_dir.mkdir(parents=True, exist_ok=True)
     target = paths.config_dir / "managed-healthcheck.env"
@@ -1551,11 +1586,9 @@ def test_failed_install_restores_missing_topic_symlink_without_changing_target(t
     target.write_text(original_payload, encoding="utf-8")
     target.chmod(0o600)
     paths.notification_env.symlink_to(target.name)
-    runner = _InstallerRunner(
-        failing_command=("systemctl", "--user", "start", "--wait", installer.SERVICE_NAME)
-    )
+    runner = _InstallerRunner(timer_active=True)
 
-    with pytest.raises(RuntimeError, match="initial installed-monitor invocation failed"):
+    with pytest.raises(RuntimeError, match="symlink must already contain"):
         installer.install(
             paths,
             runner=runner,
@@ -1566,6 +1599,7 @@ def test_failed_install_restores_missing_topic_symlink_without_changing_target(t
     assert os.readlink(paths.notification_env) == target.name
     assert target.read_text(encoding="utf-8") == original_payload
     assert stat.S_IMODE(target.stat().st_mode) == 0o600
+    assert runner.commands == []
 
 
 def test_installer_rolls_back_before_reraising_operator_cancellation(tmp_path):

--- a/tests/test_atlas_api_healthcheck.py
+++ b/tests/test_atlas_api_healthcheck.py
@@ -6,6 +6,7 @@ import http.client
 import itertools
 import json
 import os
+import shutil
 import string
 import subprocess
 import sys
@@ -972,6 +973,26 @@ def test_service_template_uses_installed_script_and_private_environment():
     assert "eom-atlas-api-health-" not in service
     assert "SuccessExitStatus=0 2 4" in service
     assert "OnUnitActiveSec=5min" in timer
+
+
+def test_systemd_templates_verify_when_systemd_analyze_is_available():
+    systemd_analyze = shutil.which("systemd-analyze")
+    if systemd_analyze is None:
+        pytest.skip("systemd-analyze is unavailable")
+
+    result = subprocess.run(
+        [
+            systemd_analyze,
+            "verify",
+            str(REPO_ROOT / "config" / installer.SERVICE_NAME),
+            str(REPO_ROOT / "config" / installer.TIMER_NAME),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
 
 
 @pytest.mark.parametrize(

--- a/tests/test_atlas_api_healthcheck.py
+++ b/tests/test_atlas_api_healthcheck.py
@@ -466,6 +466,44 @@ def test_pending_recovery_does_not_hide_a_current_outage(tmp_path):
     assert _state(settings) == {"consecutive": 1, "status": "down"}
 
 
+def test_recovery_outbox_is_persisted_before_a_delivery_crash(tmp_path):
+    settings = _settings(tmp_path)
+    runner = _Runner(active=False)
+
+    with pytest.raises(SystemExit, match="simulated crash"):
+        healthcheck.run_healthcheck(
+            settings,
+            runner=runner,
+            opener=_opener(204),
+            notifier=lambda *args: (_ for _ in ()).throw(SystemExit("simulated crash")),
+            sleeper=lambda _: None,
+        )
+
+    assert _state(settings) == {
+        "status": "healthy",
+        "consecutive": 0,
+        "pending_notifications": [
+            {
+                "alert": "auto-recovered",
+                "detail": "auto-recovered atlas-api.service: lead-intake probe returned HTTP 204",
+            }
+        ],
+    }
+
+    sent: list[tuple] = []
+    result = healthcheck.run_healthcheck(
+        settings,
+        runner=runner,
+        opener=_opener(204),
+        notifier=lambda *args: (sent.append(args), True)[1],
+        sleeper=lambda _: None,
+    )
+
+    assert result == healthcheck.EXIT_OK
+    assert sent[0][2] == "atlas-api auto-recovered"
+    assert _state(settings) == {"consecutive": 0, "status": "healthy"}
+
+
 def test_missing_notification_configuration_does_not_block_recovery(tmp_path):
     settings = _settings(tmp_path, ntfy_topic="")
     runner = _Runner(active=False)

--- a/tests/test_atlas_api_healthcheck.py
+++ b/tests/test_atlas_api_healthcheck.py
@@ -74,8 +74,16 @@ class _Runner:
 
 
 class _InstallerRunner:
-    def __init__(self, *, failing_command: tuple[str, ...] | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        failing_command: tuple[str, ...] | None = None,
+        timer_enabled: bool = False,
+        timer_active: bool = False,
+    ) -> None:
         self.failing_command = failing_command
+        self.timer_enabled = timer_enabled
+        self.timer_active = timer_active
         self.commands: list[tuple[str, ...]] = []
 
     def __call__(self, command):
@@ -83,6 +91,22 @@ class _InstallerRunner:
         self.commands.append(command)
         if command == self.failing_command:
             return subprocess.CompletedProcess(command, 1, "", "unit\n\x1b[31mfailed")
+        if "is-enabled" in command:
+            return subprocess.CompletedProcess(command, 0 if self.timer_enabled else 1, "", "")
+        if "is-active" in command:
+            return subprocess.CompletedProcess(command, 0 if self.timer_active else 3, "", "")
+        if command[2:4] == ("enable", "--now"):
+            self.timer_enabled = True
+            self.timer_active = True
+        elif command[2:4] == ("disable", "--now"):
+            self.timer_enabled = False
+            self.timer_active = False
+        elif command[2:] == ("enable", installer.TIMER_NAME):
+            self.timer_enabled = True
+        elif command[2:] == ("start", installer.TIMER_NAME):
+            self.timer_active = True
+        elif command[2:] == ("stop", installer.TIMER_NAME):
+            self.timer_active = False
         return subprocess.CompletedProcess(command, 0, "", "")
 
 
@@ -297,14 +321,14 @@ def test_undelivered_down_transition_is_retried(tmp_path):
         settings, runner=runner, opener=_opener(503), notifier=notifier, sleeper=lambda _: None
     )
     assert first == healthcheck.EXIT_ALERT_UNDELIVERED
-    assert _state(settings)["pending_notification"]["alert"] == "down"
+    assert _state(settings)["pending_notifications"][0]["alert"] == "down"
 
     second = healthcheck.run_healthcheck(
         settings, runner=runner, opener=_opener(503), notifier=notifier, sleeper=lambda _: None
     )
     assert second == healthcheck.EXIT_DOWN
     assert len(attempts) == 2
-    assert _state(settings) == {"consecutive": 1, "status": "down"}
+    assert _state(settings) == {"consecutive": 2, "status": "down"}
 
 
 def test_undelivered_recovery_transition_is_retried(tmp_path):
@@ -324,7 +348,7 @@ def test_undelivered_recovery_transition_is_retried(tmp_path):
         settings, runner=runner, opener=_opener(204), notifier=notifier, sleeper=lambda _: None
     )
     assert first == healthcheck.EXIT_ALERT_UNDELIVERED
-    assert _state(settings)["pending_notification"]["alert"] == "recovered"
+    assert _state(settings)["pending_notifications"][0]["alert"] == "recovered"
 
     second = healthcheck.run_healthcheck(
         settings, runner=runner, opener=_opener(204), notifier=notifier, sleeper=lambda _: None
@@ -332,6 +356,39 @@ def test_undelivered_recovery_transition_is_retried(tmp_path):
     assert second == healthcheck.EXIT_OK
     assert attempts[1][2] == "atlas-api recovered"
     assert _state(settings) == {"consecutive": 0, "status": "healthy"}
+
+
+def test_pending_recovery_does_not_hide_a_current_outage(tmp_path):
+    settings = _settings(tmp_path)
+    settings.state_dir.mkdir(parents=True)
+    (settings.state_dir / "state.json").write_text(
+        json.dumps(
+            {
+                "status": "healthy",
+                "consecutive": 0,
+                "pending_notifications": [
+                    {"alert": "auto-recovered", "detail": "earlier recovery"}
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    sent: list[tuple] = []
+
+    result = healthcheck.run_healthcheck(
+        settings,
+        runner=_Runner(active=False, start_returncode=1),
+        opener=_opener(204),
+        notifier=lambda *args: (sent.append(args), True)[1],
+        sleeper=lambda _: None,
+    )
+
+    assert result == healthcheck.EXIT_DOWN
+    assert [message[2] for message in sent] == [
+        "atlas-api auto-recovered",
+        "atlas-api DOWN",
+    ]
+    assert _state(settings) == {"consecutive": 1, "status": "down"}
 
 
 def test_missing_notification_configuration_does_not_block_recovery(tmp_path):
@@ -348,7 +405,7 @@ def test_missing_notification_configuration_does_not_block_recovery(tmp_path):
 
     assert result == healthcheck.EXIT_ALERT_UNDELIVERED
     assert len(_start_commands(runner)) == 1
-    assert _state(settings)["pending_notification"]["alert"] == "auto-recovered"
+    assert _state(settings)["pending_notifications"][0]["alert"] == "auto-recovered"
 
 
 def test_no_alert_does_not_consume_a_transition(tmp_path):
@@ -363,7 +420,7 @@ def test_no_alert_does_not_consume_a_transition(tmp_path):
     )
 
     assert result == healthcheck.EXIT_ALERT_UNDELIVERED
-    assert not (settings.state_dir / "state.json").exists()
+    assert _state(settings)["pending_notifications"][0]["alert"] == "down"
 
 
 def test_invalid_state_is_visible_before_monitor_resets_it(tmp_path, capsys):
@@ -374,12 +431,86 @@ def test_invalid_state_is_visible_before_monitor_resets_it(tmp_path, capsys):
     assert "WARNING state read failed: JSONDecodeError" in capsys.readouterr().err
 
 
-def test_health_log_failure_has_context(tmp_path):
+@pytest.mark.parametrize(
+    "value",
+    [
+        {"status": [], "consecutive": 0},
+        {"status": "down", "consecutive": "1"},
+        {
+            "status": "healthy",
+            "consecutive": 0,
+            "pending_notification": {
+                "alert": "recovered",
+                "detail": "old",
+                "next_state": {"status": "healthy", "consecutive": 0},
+                "exit_code": [],
+            },
+        },
+        {
+            "status": "healthy",
+            "consecutive": 0,
+            "pending_notifications": [{"alert": "unknown", "detail": "old"}],
+        },
+    ],
+)
+def test_malformed_state_shapes_reset_safely(tmp_path, capsys, value):
+    state_path = tmp_path / "state.json"
+    state_path.write_text(json.dumps(value), encoding="utf-8")
+
+    assert healthcheck.read_state(state_path) == {}
+    assert "WARNING state schema is invalid" in capsys.readouterr().err
+
+
+def test_previous_singular_pending_state_migrates_without_an_outer_status(tmp_path):
+    state_path = tmp_path / "state.json"
+    state_path.write_text(
+        json.dumps(
+            {
+                "pending_notification": {
+                    "alert": "down",
+                    "detail": "earlier outage",
+                    "next_state": {"status": "down", "consecutive": 1},
+                    "exit_code": healthcheck.EXIT_DOWN,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert healthcheck.read_state(state_path) == {
+        "status": "down",
+        "consecutive": 1,
+        "pending_notifications": [
+            {"alert": "down", "detail": "earlier outage"}
+        ],
+    }
+
+
+def test_health_log_failure_is_visible_but_best_effort(tmp_path, capsys):
     invalid_state_dir = tmp_path / "not-a-directory"
     invalid_state_dir.write_text("occupied", encoding="utf-8")
 
-    with pytest.raises(RuntimeError, match="unable to append Atlas API health log"):
-        healthcheck.append_log(invalid_state_dir, "DOWN test")
+    assert not healthcheck.append_log(invalid_state_dir, "DOWN test")
+    assert "WARNING health log append failed" in capsys.readouterr().err
+
+
+def test_health_log_failure_does_not_suppress_recovery_alert(tmp_path, capsys):
+    settings = _settings(tmp_path)
+    settings.state_dir.mkdir(parents=True)
+    (settings.state_dir / "health.log").mkdir()
+    sent: list[tuple] = []
+
+    result = healthcheck.run_healthcheck(
+        settings,
+        runner=_Runner(active=False),
+        opener=_opener(204),
+        notifier=lambda *args: (sent.append(args), True)[1],
+        sleeper=lambda _: None,
+    )
+
+    assert result == healthcheck.EXIT_RECOVERED
+    assert sent[0][2] == "atlas-api auto-recovered"
+    assert "WARNING health log append failed" in capsys.readouterr().err
 
 
 def test_health_lock_failure_has_context(tmp_path):
@@ -475,12 +606,14 @@ def test_installer_deploys_source_and_invokes_enabled_timer_path(tmp_path):
     assert paths.notification_env.stat().st_mode & 0o077 == 0
     assert "test-private-topic" not in "\n".join(messages)
     assert runner.commands == [
+        ("systemctl", "--user", "is-enabled", "--quiet", installer.TIMER_NAME),
+        ("systemctl", "--user", "is-active", "--quiet", installer.TIMER_NAME),
         ("systemctl", "--user", "daemon-reload"),
-        ("systemctl", "--user", "enable", "--now", installer.TIMER_NAME),
         ("systemctl", "--user", "start", "--wait", installer.SERVICE_NAME),
+        ("systemctl", "--user", "enable", "--now", installer.TIMER_NAME),
     ]
 
-    check_runner = _InstallerRunner()
+    check_runner = _InstallerRunner(timer_enabled=True, timer_active=True)
     ok, check_messages = installer.check_install(paths, runner=check_runner)
     assert ok
     assert all(message.startswith("ok:") for message in check_messages)
@@ -498,7 +631,97 @@ def test_installer_requires_private_topic_before_writing_or_enabling(tmp_path):
         installer.install(paths, runner=runner, environment={})
 
     assert not paths.installed_monitor.exists()
-    assert runner.commands == []
+    assert runner.commands == [
+        ("systemctl", "--user", "is-enabled", "--quiet", installer.TIMER_NAME),
+        ("systemctl", "--user", "is-active", "--quiet", installer.TIMER_NAME),
+        ("systemctl", "--user", "daemon-reload"),
+    ]
+
+
+def test_topic_file_is_private_before_atomic_publish(tmp_path, monkeypatch):
+    destination = tmp_path / "config" / "atlas-api-healthcheck.env"
+    observed_modes: list[int] = []
+    real_replace = installer.os.replace
+
+    def inspect_replace(source, target):
+        if Path(target) == destination:
+            observed_modes.append(Path(source).stat().st_mode & 0o777)
+        return real_replace(source, target)
+
+    monkeypatch.setattr(installer.os, "replace", inspect_replace)
+
+    installer._append_topic(destination, "test-private-topic")
+
+    assert observed_modes == [0o600]
+    assert destination.stat().st_mode & 0o777 == 0o600
+
+
+def test_file_restore_preserves_a_falsy_zero_mode(tmp_path):
+    destination = tmp_path / "restored"
+
+    installer._restore_file(
+        installer.FileSnapshot(path=destination, payload=b"previous", mode=0)
+    )
+
+    assert destination.stat().st_mode & 0o777 == 0
+    destination.chmod(0o600)
+    assert destination.read_bytes() == b"previous"
+
+
+def test_installer_restores_files_and_timer_when_service_proof_fails(tmp_path):
+    paths = _install_paths(tmp_path)
+    installed_files = [
+        paths.installed_monitor,
+        paths.systemd_dir / installer.SERVICE_NAME,
+        paths.systemd_dir / installer.TIMER_NAME,
+        paths.notification_env,
+    ]
+    for index, path in enumerate(installed_files):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(f"previous-{index}".encode("utf-8"))
+        path.chmod(0o600 if path == paths.notification_env else 0o644)
+    paths.notification_env.write_text(
+        f"{installer.TOPIC_ENV}=previous-private-topic\n", encoding="utf-8"
+    )
+    previous_payloads = {path: path.read_bytes() for path in installed_files}
+    runner = _InstallerRunner(
+        failing_command=("systemctl", "--user", "start", "--wait", installer.SERVICE_NAME),
+        timer_enabled=True,
+        timer_active=True,
+    )
+
+    with pytest.raises(RuntimeError, match="initial installed-monitor invocation failed"):
+        installer.install(paths, runner=runner, environment={})
+
+    assert {path: path.read_bytes() for path in installed_files} == previous_payloads
+    assert runner.timer_enabled
+    assert runner.timer_active
+    assert ("systemctl", "--user", "enable", "--now", installer.TIMER_NAME) not in runner.commands
+    assert runner.commands[-3:] == [
+        ("systemctl", "--user", "daemon-reload"),
+        ("systemctl", "--user", "enable", installer.TIMER_NAME),
+        ("systemctl", "--user", "start", installer.TIMER_NAME),
+    ]
+
+
+def test_installer_removes_partial_enrollment_when_timer_enable_fails(tmp_path):
+    paths = _install_paths(tmp_path)
+    runner = _InstallerRunner(
+        failing_command=("systemctl", "--user", "enable", "--now", installer.TIMER_NAME)
+    )
+
+    with pytest.raises(RuntimeError, match="timer enable failed"):
+        installer.install(
+            paths,
+            runner=runner,
+            environment={installer.TOPIC_ENV: "test-private-topic"},
+        )
+
+    assert not runner.timer_enabled
+    assert not runner.timer_active
+    assert not paths.installed_monitor.exists()
+    assert not paths.notification_env.exists()
+    assert ("systemctl", "--user", "disable", "--now", installer.TIMER_NAME) in runner.commands
 
 
 def test_installer_surfaces_sanitized_systemd_failure(tmp_path):

--- a/tests/test_atlas_api_healthcheck.py
+++ b/tests/test_atlas_api_healthcheck.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
+
+import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -16,6 +19,14 @@ healthcheck = importlib.util.module_from_spec(_SPEC)
 sys.modules["atlas_api_healthcheck"] = healthcheck
 assert _SPEC.loader is not None
 _SPEC.loader.exec_module(healthcheck)
+
+_INSTALLER_SPEC = importlib.util.spec_from_file_location(
+    "install_atlas_api_healthcheck", REPO_ROOT / "scripts" / "install_atlas_api_healthcheck.py"
+)
+installer = importlib.util.module_from_spec(_INSTALLER_SPEC)
+sys.modules["install_atlas_api_healthcheck"] = installer
+assert _INSTALLER_SPEC.loader is not None
+_INSTALLER_SPEC.loader.exec_module(installer)
 
 
 class _Response:
@@ -30,9 +41,18 @@ class _Response:
 
 
 class _Runner:
-    def __init__(self, *, active: bool, start_returncode: int = 0) -> None:
+    def __init__(
+        self,
+        *,
+        active: bool,
+        start_returncode: int = 0,
+        start_stdout: str = "",
+        start_stderr: str = "",
+    ) -> None:
         self.active = active
         self.start_returncode = start_returncode
+        self.start_stdout = start_stdout
+        self.start_stderr = start_stderr
         self.commands: list[tuple[str, ...]] = []
 
     def __call__(self, command):
@@ -43,7 +63,25 @@ class _Runner:
         assert "start" in command
         if self.start_returncode == 0:
             self.active = True
-        return subprocess.CompletedProcess(command, self.start_returncode, "", "")
+        return subprocess.CompletedProcess(
+            command,
+            self.start_returncode,
+            self.start_stdout,
+            self.start_stderr,
+        )
+
+
+class _InstallerRunner:
+    def __init__(self, *, failing_command: tuple[str, ...] | None = None) -> None:
+        self.failing_command = failing_command
+        self.commands: list[tuple[str, ...]] = []
+
+    def __call__(self, command):
+        command = tuple(command)
+        self.commands.append(command)
+        if command == self.failing_command:
+            return subprocess.CompletedProcess(command, 1, "", "unit\n\x1b[31mfailed")
+        return subprocess.CompletedProcess(command, 0, "", "")
 
 
 def _settings(tmp_path: Path, **overrides):
@@ -78,6 +116,17 @@ def _start_commands(runner: _Runner) -> list[tuple[str, ...]]:
 
 def _state(settings) -> dict:
     return json.loads((settings.state_dir / "state.json").read_text(encoding="utf-8"))
+
+
+def _install_paths(tmp_path: Path) -> installer.InstallPaths:
+    bin_dir = tmp_path / "bin"
+    return installer.InstallPaths(
+        source_root=REPO_ROOT,
+        bin_dir=bin_dir,
+        systemd_dir=tmp_path / "systemd",
+        config_dir=tmp_path / "config",
+        legacy_monitor=bin_dir / installer.LEGACY_MONITOR_NAME,
+    )
 
 
 def test_inactive_service_is_started_and_reprobed(tmp_path):
@@ -140,6 +189,24 @@ def test_failed_start_remains_a_visible_down_result(tmp_path):
     assert _state(settings) == {"consecutive": 1, "status": "down"}
 
 
+def test_failed_start_keeps_bounded_sanitized_diagnostics(tmp_path):
+    runner = _Runner(
+        active=False,
+        start_returncode=1,
+        start_stderr="unit failed\n\x1b[31m" + "x" * 400,
+    )
+
+    observation = healthcheck.observe(
+        _settings(tmp_path), runner, _opener(204), sleeper=lambda _: None
+    )
+
+    assert observation.status == "down"
+    assert "exit 1" in observation.detail
+    assert "\n" not in observation.detail
+    assert "\x1b" not in observation.detail
+    assert len(observation.detail) <= 320
+
+
 def test_failed_reprobe_after_start_remains_down(tmp_path):
     settings = _settings(tmp_path)
     runner = _Runner(active=False)
@@ -174,6 +241,56 @@ def test_active_unhealthy_service_alerts_without_restart(tmp_path):
     assert _state(settings) == {"consecutive": 1, "status": "down"}
 
 
+def test_undelivered_down_transition_is_retried(tmp_path):
+    settings = _settings(tmp_path)
+    runner = _Runner(active=True)
+    attempts: list[tuple] = []
+
+    def notifier(*args):
+        attempts.append(args)
+        return len(attempts) == 2
+
+    first = healthcheck.run_healthcheck(
+        settings, runner=runner, opener=_opener(503), notifier=notifier, sleeper=lambda _: None
+    )
+    assert first == healthcheck.EXIT_ALERT_UNDELIVERED
+    assert _state(settings)["pending_notification"]["alert"] == "down"
+
+    second = healthcheck.run_healthcheck(
+        settings, runner=runner, opener=_opener(503), notifier=notifier, sleeper=lambda _: None
+    )
+    assert second == healthcheck.EXIT_DOWN
+    assert len(attempts) == 2
+    assert _state(settings) == {"consecutive": 1, "status": "down"}
+
+
+def test_undelivered_recovery_transition_is_retried(tmp_path):
+    settings = _settings(tmp_path)
+    settings.state_dir.mkdir(parents=True)
+    (settings.state_dir / "state.json").write_text(
+        json.dumps({"consecutive": 2, "status": "down"}), encoding="utf-8"
+    )
+    runner = _Runner(active=True)
+    attempts: list[tuple] = []
+
+    def notifier(*args):
+        attempts.append(args)
+        return len(attempts) == 2
+
+    first = healthcheck.run_healthcheck(
+        settings, runner=runner, opener=_opener(204), notifier=notifier, sleeper=lambda _: None
+    )
+    assert first == healthcheck.EXIT_ALERT_UNDELIVERED
+    assert _state(settings)["pending_notification"]["alert"] == "recovered"
+
+    second = healthcheck.run_healthcheck(
+        settings, runner=runner, opener=_opener(204), notifier=notifier, sleeper=lambda _: None
+    )
+    assert second == healthcheck.EXIT_OK
+    assert attempts[1][2] == "atlas-api recovered"
+    assert _state(settings) == {"consecutive": 0, "status": "healthy"}
+
+
 def test_missing_notification_configuration_does_not_block_recovery(tmp_path):
     settings = _settings(tmp_path, ntfy_topic="")
     runner = _Runner(active=False)
@@ -188,7 +305,22 @@ def test_missing_notification_configuration_does_not_block_recovery(tmp_path):
 
     assert result == healthcheck.EXIT_ALERT_UNDELIVERED
     assert len(_start_commands(runner)) == 1
-    assert _state(settings) == {"consecutive": 0, "status": "healthy"}
+    assert _state(settings)["pending_notification"]["alert"] == "auto-recovered"
+
+
+def test_no_alert_does_not_consume_a_transition(tmp_path):
+    settings = _settings(tmp_path, no_alert=True)
+
+    result = healthcheck.run_healthcheck(
+        settings,
+        runner=_Runner(active=True),
+        opener=_opener(503),
+        notifier=lambda *args: (_ for _ in ()).throw(AssertionError("must not notify")),
+        sleeper=lambda _: None,
+    )
+
+    assert result == healthcheck.EXIT_ALERT_UNDELIVERED
+    assert not (settings.state_dir / "state.json").exists()
 
 
 def test_publish_preserves_the_desktop_notification_channel(monkeypatch):
@@ -229,3 +361,70 @@ def test_service_template_uses_installed_script_and_private_environment():
     assert "ATLAS_API_HEALTHCHECK_NTFY_TOPIC=<private-topic>" in service
     assert "eom-atlas-api-health-" not in service
     assert "OnUnitActiveSec=5min" in timer
+
+
+def test_installer_deploys_source_and_invokes_enabled_timer_path(tmp_path):
+    paths = _install_paths(tmp_path)
+    paths.legacy_monitor.parent.mkdir(parents=True)
+    paths.legacy_monitor.write_text(
+        'NTFY_TOPIC="${ATLAS_HC_NTFY_TOPIC:-test-private-topic}"\n', encoding="utf-8"
+    )
+    runner = _InstallerRunner()
+
+    messages = installer.install(paths, runner=runner, environment={})
+
+    assert paths.installed_monitor.read_bytes() == (
+        REPO_ROOT / "scripts" / "atlas_api_healthcheck.py"
+    ).read_bytes()
+    assert os.access(paths.installed_monitor, os.X_OK)
+    assert (paths.systemd_dir / installer.SERVICE_NAME).read_bytes() == (
+        REPO_ROOT / "config" / installer.SERVICE_NAME
+    ).read_bytes()
+    assert (paths.systemd_dir / installer.TIMER_NAME).read_bytes() == (
+        REPO_ROOT / "config" / installer.TIMER_NAME
+    ).read_bytes()
+    assert paths.notification_env.read_text(encoding="utf-8") == (
+        f"{installer.TOPIC_ENV}=test-private-topic\n"
+    )
+    assert paths.notification_env.stat().st_mode & 0o077 == 0
+    assert "test-private-topic" not in "\n".join(messages)
+    assert runner.commands == [
+        ("systemctl", "--user", "daemon-reload"),
+        ("systemctl", "--user", "enable", "--now", installer.TIMER_NAME),
+        ("systemctl", "--user", "start", "--wait", installer.SERVICE_NAME),
+    ]
+
+    check_runner = _InstallerRunner()
+    ok, check_messages = installer.check_install(paths, runner=check_runner)
+    assert ok
+    assert all(message.startswith("ok:") for message in check_messages)
+    assert check_runner.commands == [
+        ("systemctl", "--user", "is-enabled", "--quiet", installer.TIMER_NAME),
+        ("systemctl", "--user", "is-active", "--quiet", installer.TIMER_NAME),
+    ]
+
+
+def test_installer_requires_private_topic_before_writing_or_enabling(tmp_path):
+    paths = _install_paths(tmp_path)
+    runner = _InstallerRunner()
+
+    with pytest.raises(RuntimeError, match=installer.TOPIC_ENV):
+        installer.install(paths, runner=runner, environment={})
+
+    assert not paths.installed_monitor.exists()
+    assert runner.commands == []
+
+
+def test_installer_surfaces_sanitized_systemd_failure(tmp_path):
+    paths = _install_paths(tmp_path)
+    runner = _InstallerRunner(failing_command=("systemctl", "--user", "daemon-reload"))
+
+    with pytest.raises(RuntimeError, match="systemd reload failed") as error:
+        installer.install(
+            paths,
+            runner=runner,
+            environment={installer.TOPIC_ENV: "test-private-topic"},
+        )
+
+    assert "\n" not in str(error.value)
+    assert "\x1b" not in str(error.value)

--- a/tests/test_atlas_api_healthcheck.py
+++ b/tests/test_atlas_api_healthcheck.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import importlib.util
+import http.client
 import itertools
 import json
 import os
@@ -453,6 +454,25 @@ def test_active_unhealthy_service_alerts_without_restart(tmp_path):
     assert _state(settings) == {"consecutive": 1, "status": "down"}
 
 
+def test_http_protocol_failure_becomes_a_down_observation(tmp_path):
+    settings = _settings(tmp_path)
+    sent: list[tuple] = []
+
+    result = healthcheck.run_healthcheck(
+        settings,
+        runner=_Runner(active=True),
+        opener=lambda *args, **kwargs: (_ for _ in ()).throw(
+            http.client.BadStatusLine("malformed status")
+        ),
+        notifier=lambda *args: (sent.append(args), True)[1],
+        sleeper=lambda _: None,
+    )
+
+    assert result == healthcheck.EXIT_DOWN
+    assert "BadStatusLine" in sent[0][3]
+    assert _state(settings) == {"consecutive": 1, "status": "down"}
+
+
 @pytest.mark.parametrize(
     ("runner", "expected_detail"),
     [
@@ -886,6 +906,32 @@ def test_publish_reports_an_unavailable_desktop_notification(monkeypatch, capsys
     assert "WARNING desktop notification failed: FileNotFoundError" in capsys.readouterr().err
 
 
+def test_publish_treats_an_http_protocol_failure_as_undelivered(monkeypatch, capsys):
+    commands: list[tuple[str, ...]] = []
+
+    monkeypatch.setattr(
+        healthcheck.urllib.request,
+        "urlopen",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            http.client.BadStatusLine("malformed status")
+        ),
+    )
+    monkeypatch.setattr(
+        healthcheck.subprocess,
+        "run",
+        lambda command, **kwargs: (
+            commands.append(tuple(command)),
+            subprocess.CompletedProcess(command, 0),
+        )[1],
+    )
+
+    assert not healthcheck.publish(
+        "https://ntfy.test", "private-topic", "Title", "Body", "urgent", "warning"
+    )
+    assert "WARNING alert delivery failed: BadStatusLine" in capsys.readouterr().out
+    assert commands == [("notify-send", "-u", "critical", "Title", "Body")]
+
+
 def test_missing_ntfy_topic_still_preserves_desktop_notification(monkeypatch):
     commands: list[tuple[str, ...]] = []
 
@@ -909,7 +955,40 @@ def test_service_template_uses_installed_script_and_private_environment():
     assert "Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus" in service
     assert "ATLAS_API_HEALTHCHECK_NTFY_TOPIC=<private-topic>" in service
     assert "eom-atlas-api-health-" not in service
+    assert "SuccessExitStatus=0 2 4" in service
     assert "OnUnitActiveSec=5min" in timer
+
+
+@pytest.mark.parametrize(
+    ("argument", "expected_action"),
+    [
+        ("--enter-maintenance", "enter-maintenance"),
+        ("--exit-maintenance", "exit-maintenance"),
+    ],
+)
+def test_maintenance_actions_ignore_invalid_healthcheck_numeric_environment(
+    monkeypatch, argument, expected_action
+):
+    monkeypatch.setenv("ATLAS_API_HEALTHCHECK_REALERT_EVERY", "bad")
+    monkeypatch.setenv("ATLAS_API_HEALTHCHECK_RECOVERY_ATTEMPTS", "bad")
+    monkeypatch.setenv("ATLAS_API_HEALTHCHECK_RECOVERY_INTERVAL_SECONDS", "bad")
+
+    settings, action = healthcheck._settings_from_args([argument])
+
+    assert action == expected_action
+    assert settings.realert_every == healthcheck.DEFAULT_REALERT_EVERY
+    assert settings.recovery_attempts == healthcheck.DEFAULT_RECOVERY_ATTEMPTS
+    assert (
+        settings.recovery_interval_seconds
+        == healthcheck.DEFAULT_RECOVERY_INTERVAL_SECONDS
+    )
+
+
+def test_healthcheck_action_rejects_invalid_numeric_environment(monkeypatch):
+    monkeypatch.setenv("ATLAS_API_HEALTHCHECK_REALERT_EVERY", "bad")
+
+    with pytest.raises(ValueError, match="realert-every must be an integer"):
+        healthcheck._settings_from_args([])
 
 
 def test_installer_deploys_source_and_invokes_enabled_timer_path(tmp_path):

--- a/tests/test_atlas_api_healthcheck.py
+++ b/tests/test_atlas_api_healthcheck.py
@@ -366,6 +366,37 @@ def test_no_alert_does_not_consume_a_transition(tmp_path):
     assert not (settings.state_dir / "state.json").exists()
 
 
+def test_invalid_state_is_visible_before_monitor_resets_it(tmp_path, capsys):
+    state_path = tmp_path / "state.json"
+    state_path.write_text("not-json", encoding="utf-8")
+
+    assert healthcheck.read_state(state_path) == {}
+    assert "WARNING state read failed: JSONDecodeError" in capsys.readouterr().err
+
+
+def test_health_log_failure_has_context(tmp_path):
+    invalid_state_dir = tmp_path / "not-a-directory"
+    invalid_state_dir.write_text("occupied", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="unable to append Atlas API health log"):
+        healthcheck.append_log(invalid_state_dir, "DOWN test")
+
+
+def test_health_lock_failure_has_context(tmp_path):
+    settings = _settings(tmp_path)
+    settings.state_dir.mkdir(parents=True)
+    (settings.state_dir / "state.lock").mkdir()
+
+    with pytest.raises(RuntimeError, match="unable to open Atlas API health lock"):
+        healthcheck.run_healthcheck(
+            settings,
+            runner=_Runner(active=True),
+            opener=_opener(204),
+            notifier=lambda *args: True,
+            sleeper=lambda _: None,
+        )
+
+
 def test_publish_preserves_the_desktop_notification_channel(monkeypatch):
     commands: list[tuple[str, ...]] = []
 
@@ -378,6 +409,18 @@ def test_publish_preserves_the_desktop_notification_channel(monkeypatch):
 
     assert healthcheck.publish("https://ntfy.test", "private-topic", "Title", "Body", "urgent", "warning")
     assert commands == [("notify-send", "-u", "critical", "Title", "Body")]
+
+
+def test_publish_reports_an_unavailable_desktop_notification(monkeypatch, capsys):
+    monkeypatch.setattr(healthcheck.urllib.request, "urlopen", lambda *args, **kwargs: _Response(200))
+    monkeypatch.setattr(
+        healthcheck.subprocess,
+        "run",
+        lambda *args, **kwargs: (_ for _ in ()).throw(FileNotFoundError("notify-send")),
+    )
+
+    assert healthcheck.publish("https://ntfy.test", "private-topic", "Title", "Body", "urgent", "warning")
+    assert "WARNING desktop notification failed: FileNotFoundError" in capsys.readouterr().err
 
 
 def test_missing_ntfy_topic_still_preserves_desktop_notification(monkeypatch):

--- a/tests/test_atlas_api_healthcheck.py
+++ b/tests/test_atlas_api_healthcheck.py
@@ -7,6 +7,7 @@ import itertools
 import json
 import os
 import shutil
+import stat
 import string
 import subprocess
 import sys
@@ -1488,6 +1489,83 @@ def test_installer_failure_restores_live_and_broken_relative_symlinks(
         assert target.read_bytes() == original_target_payload
     else:
         assert not destination.exists()
+
+
+def test_installer_rejects_nonprivate_notification_symlink_before_systemd_or_mutation(
+    tmp_path,
+):
+    paths = _install_paths(tmp_path)
+    paths.config_dir.mkdir(parents=True, exist_ok=True)
+    target = paths.config_dir / "managed-healthcheck.env"
+    original_payload = f"{installer.TOPIC_ENV}=test-private-topic\n"
+    target.write_text(original_payload, encoding="utf-8")
+    target.chmod(0o640)
+    paths.notification_env.symlink_to(target.name)
+    runner = _InstallerRunner(timer_active=True)
+
+    with pytest.raises(RuntimeError, match="symlink target is not private"):
+        installer.install(paths, runner=runner, environment={})
+
+    assert runner.commands == []
+    assert paths.notification_env.is_symlink()
+    assert os.readlink(paths.notification_env) == target.name
+    assert target.read_text(encoding="utf-8") == original_payload
+    assert stat.S_IMODE(target.stat().st_mode) == 0o640
+
+
+@pytest.mark.parametrize("proof_fails", [False, True])
+def test_installer_preserves_private_notification_symlink_without_chmod(
+    tmp_path, proof_fails
+):
+    paths = _install_paths(tmp_path)
+    paths.config_dir.mkdir(parents=True, exist_ok=True)
+    target = paths.config_dir / "managed-healthcheck.env"
+    original_payload = f"{installer.TOPIC_ENV}=test-private-topic\n"
+    target.write_text(original_payload, encoding="utf-8")
+    target.chmod(0o600)
+    paths.notification_env.symlink_to(target.name)
+    failing_command = (
+        ("systemctl", "--user", "start", "--wait", installer.SERVICE_NAME)
+        if proof_fails
+        else None
+    )
+    runner = _InstallerRunner(failing_command=failing_command)
+
+    if proof_fails:
+        with pytest.raises(RuntimeError, match="initial installed-monitor invocation failed"):
+            installer.install(paths, runner=runner, environment={})
+    else:
+        installer.install(paths, runner=runner, environment={})
+
+    assert paths.notification_env.is_symlink()
+    assert os.readlink(paths.notification_env) == target.name
+    assert target.read_text(encoding="utf-8") == original_payload
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+
+
+def test_failed_install_restores_missing_topic_symlink_without_changing_target(tmp_path):
+    paths = _install_paths(tmp_path)
+    paths.config_dir.mkdir(parents=True, exist_ok=True)
+    target = paths.config_dir / "managed-healthcheck.env"
+    original_payload = "UNRELATED=value\n"
+    target.write_text(original_payload, encoding="utf-8")
+    target.chmod(0o600)
+    paths.notification_env.symlink_to(target.name)
+    runner = _InstallerRunner(
+        failing_command=("systemctl", "--user", "start", "--wait", installer.SERVICE_NAME)
+    )
+
+    with pytest.raises(RuntimeError, match="initial installed-monitor invocation failed"):
+        installer.install(
+            paths,
+            runner=runner,
+            environment={installer.TOPIC_ENV: "test-private-topic"},
+        )
+
+    assert paths.notification_env.is_symlink()
+    assert os.readlink(paths.notification_env) == target.name
+    assert target.read_text(encoding="utf-8") == original_payload
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
 
 
 def test_installer_rolls_back_before_reraising_operator_cancellation(tmp_path):

--- a/tests/test_atlas_api_healthcheck.py
+++ b/tests/test_atlas_api_healthcheck.py
@@ -504,6 +504,77 @@ def test_recovery_outbox_is_persisted_before_a_delivery_crash(tmp_path):
     assert _state(settings) == {"consecutive": 0, "status": "healthy"}
 
 
+def test_recovery_intent_is_persisted_before_start_and_replayed_after_crash(tmp_path):
+    settings = _settings(tmp_path)
+    crashed_commands: list[tuple[str, ...]] = []
+
+    def crash_after_start(command):
+        command = tuple(command)
+        crashed_commands.append(command)
+        if "is-active" in command:
+            return subprocess.CompletedProcess(command, 3, "", "")
+        raise SystemExit("simulated crash after systemd accepted start")
+
+    with pytest.raises(SystemExit, match="simulated crash"):
+        healthcheck.run_healthcheck(
+            settings,
+            runner=crash_after_start,
+            opener=_opener(204),
+            notifier=lambda *args: True,
+            sleeper=lambda _: None,
+        )
+
+    assert crashed_commands[-1] == ("systemctl", "--user", "start", settings.service)
+    assert _state(settings) == {
+        "status": "healthy",
+        "consecutive": 0,
+        "recovery_intent": {"service": settings.service},
+    }
+
+    sent: list[tuple] = []
+    result = healthcheck.run_healthcheck(
+        settings,
+        runner=_Runner(active=True),
+        opener=_opener(204),
+        notifier=lambda *args: (sent.append(args), True)[1],
+        sleeper=lambda _: None,
+    )
+
+    assert result == healthcheck.EXIT_OK
+    assert sent[0][2] == "atlas-api auto-recovered"
+    assert _state(settings) == {"status": "healthy", "consecutive": 0}
+
+
+def test_state_read_error_prevents_recovery_and_state_replacement(tmp_path, monkeypatch):
+    settings = _settings(tmp_path)
+    settings.state_dir.mkdir(parents=True)
+    state_path = settings.state_dir / "state.json"
+    original_payload = '{"status":"down","consecutive":1}'
+    state_path.write_text(original_payload, encoding="utf-8")
+    original_read_text = Path.read_text
+
+    def fail_state_read(path, *args, **kwargs):
+        if path == state_path:
+            raise OSError("transient read failure")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", fail_state_read)
+    runner = _Runner(active=False)
+
+    with pytest.raises(RuntimeError, match="unable to read Atlas API health state"):
+        healthcheck.run_healthcheck(
+            settings,
+            runner=runner,
+            opener=_opener(204),
+            notifier=lambda *args: True,
+            sleeper=lambda _: None,
+        )
+
+    assert runner.commands == []
+    with state_path.open(encoding="utf-8") as handle:
+        assert handle.read() == original_payload
+
+
 def test_missing_notification_configuration_does_not_block_recovery(tmp_path):
     settings = _settings(tmp_path, ntfy_topic="")
     runner = _Runner(active=False)
@@ -536,12 +607,14 @@ def test_no_alert_does_not_consume_a_transition(tmp_path):
     assert _state(settings)["pending_notifications"][0]["alert"] == "down"
 
 
-def test_invalid_state_is_visible_before_monitor_resets_it(tmp_path, capsys):
+def test_invalid_json_state_is_not_reset_or_replaced(tmp_path):
     state_path = tmp_path / "state.json"
     state_path.write_text("not-json", encoding="utf-8")
 
-    assert healthcheck.read_state(state_path) == {}
-    assert "WARNING state read failed: JSONDecodeError" in capsys.readouterr().err
+    with pytest.raises(RuntimeError, match="unable to decode Atlas API health state"):
+        healthcheck.read_state(state_path)
+
+    assert state_path.read_text(encoding="utf-8") == "not-json"
 
 
 @pytest.mark.parametrize(
@@ -563,6 +636,11 @@ def test_invalid_state_is_visible_before_monitor_resets_it(tmp_path, capsys):
             "status": "healthy",
             "consecutive": 0,
             "pending_notifications": [{"alert": "unknown", "detail": "old"}],
+        },
+        {
+            "status": "healthy",
+            "consecutive": 0,
+            "recovery_intent": {"service": ""},
         },
     ],
 )
@@ -721,6 +799,7 @@ def test_installer_deploys_source_and_invokes_enabled_timer_path(tmp_path):
     assert runner.commands == [
         ("systemctl", "--user", "is-enabled", "--quiet", installer.TIMER_NAME),
         ("systemctl", "--user", "is-active", "--quiet", installer.TIMER_NAME),
+        ("systemctl", "--user", "stop", installer.SERVICE_NAME),
         ("systemctl", "--user", "daemon-reload"),
         ("systemctl", "--user", "start", "--wait", installer.SERVICE_NAME),
         ("systemctl", "--user", "enable", "--now", installer.TIMER_NAME),
@@ -749,6 +828,46 @@ def test_installer_requires_private_topic_before_writing_or_enabling(tmp_path):
         ("systemctl", "--user", "is-active", "--quiet", installer.TIMER_NAME),
         ("systemctl", "--user", "daemon-reload"),
     ]
+
+
+def test_installer_quiesces_old_service_before_replacing_files(tmp_path, monkeypatch):
+    paths = _install_paths(tmp_path)
+    events: list[tuple[str, ...]] = []
+    runner = _InstallerRunner()
+    original_write_copy = installer._write_copy
+
+    def record_runner(command):
+        events.append(("command", *tuple(command)))
+        return runner(command)
+
+    def record_copy(source, destination, *, executable):
+        events.append(("copy", str(destination)))
+        return original_write_copy(source, destination, executable=executable)
+
+    monkeypatch.setattr(installer, "_write_copy", record_copy)
+
+    installer.install(
+        paths,
+        runner=record_runner,
+        environment={installer.TOPIC_ENV: "test-private-topic"},
+    )
+
+    stop_index = events.index(
+        ("command", "systemctl", "--user", "stop", installer.SERVICE_NAME)
+    )
+    first_copy_index = next(index for index, event in enumerate(events) if event[0] == "copy")
+    proof_index = events.index(
+        (
+            "command",
+            "systemctl",
+            "--user",
+            "start",
+            "--wait",
+            installer.SERVICE_NAME,
+        )
+    )
+
+    assert stop_index < first_copy_index < proof_index
 
 
 def test_topic_file_is_private_before_atomic_publish(tmp_path, monkeypatch):

--- a/tests/test_atlas_api_healthcheck.py
+++ b/tests/test_atlas_api_healthcheck.py
@@ -1,6 +1,7 @@
 """Regression coverage for the standalone Atlas API liveness monitor."""
 from __future__ import annotations
 
+import ast
 import importlib.util
 import http.client
 import itertools
@@ -40,7 +41,7 @@ class _Response:
         self.status = status
         self.headers = (
             {
-                "Access-Control-Allow-Origin": healthcheck.PROBE_ORIGIN,
+                "Access-Control-Allow-Origin": healthcheck.PROBE_ORIGINS[0],
                 "Access-Control-Allow-Methods": "POST, OPTIONS",
                 "Access-Control-Allow-Headers": "Content-Type",
             }
@@ -205,7 +206,14 @@ def _opener(
     def _open(request, *, timeout):
         if seen is not None:
             seen.append((request.method, request.headers, timeout))
-        return _Response(status, headers)
+        response_headers = headers
+        if response_headers is None:
+            response_headers = {
+                "Access-Control-Allow-Origin": request.get_header("Origin"),
+                "Access-Control-Allow-Methods": "POST, OPTIONS",
+                "Access-Control-Allow-Headers": "Content-Type",
+            }
+        return _Response(status, response_headers)
 
     return _open
 
@@ -292,12 +300,13 @@ def test_inactive_service_is_started_and_reprobed(tmp_path):
         (
             "OPTIONS",
             {
-                "Origin": healthcheck.PROBE_ORIGIN,
+                "Origin": origin,
                 "Access-control-request-method": "POST",
                 "Access-control-request-headers": "Content-Type",
             },
             8,
         )
+        for origin in healthcheck.PROBE_ORIGINS
     ]
     assert sent[0][2] == "atlas-api auto-recovered"
     assert _state(settings) == {"consecutive": 0, "status": "healthy"}
@@ -317,7 +326,7 @@ def test_inactive_service_is_started_and_reprobed(tmp_path):
         ),
         (
             {
-                "Access-Control-Allow-Origin": healthcheck.PROBE_ORIGIN,
+                "Access-Control-Allow-Origin": healthcheck.PROBE_ORIGINS[0],
                 "Access-Control-Allow-Methods": "OPTIONS",
                 "Access-Control-Allow-Headers": "Content-Type",
             },
@@ -325,7 +334,7 @@ def test_inactive_service_is_started_and_reprobed(tmp_path):
         ),
         (
             {
-                "Access-Control-Allow-Origin": healthcheck.PROBE_ORIGIN,
+                "Access-Control-Allow-Origin": healthcheck.PROBE_ORIGINS[0],
                 "Access-Control-Allow-Methods": "POST, OPTIONS",
                 "Access-Control-Allow-Headers": "X-Request-ID",
             },
@@ -341,6 +350,49 @@ def test_probe_rejects_non_browser_ready_cors_responses(headers, expected_detail
 
     assert not healthy
     assert expected_detail in detail
+
+
+def test_probe_origins_match_the_complete_lead_route_contract():
+    tree = ast.parse((REPO_ROOT / "atlas_brain" / "api" / "leads.py").read_text(encoding="utf-8"))
+    producer_origins = None
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(
+            isinstance(target, ast.Name) and target.id == "ALLOWED_FORM_ORIGINS"
+            for target in node.targets
+        ):
+            continue
+        assert isinstance(node.value, ast.Call)
+        producer_origins = frozenset(ast.literal_eval(node.value.args[0]))
+        break
+
+    assert producer_origins is not None
+    assert frozenset(healthcheck.PROBE_ORIGINS) == producer_origins
+
+
+def test_probe_fails_when_the_second_supported_origin_is_not_browser_ready():
+    seen_origins: list[str] = []
+
+    def opener(request, *, timeout):
+        origin = request.get_header("Origin")
+        seen_origins.append(origin)
+        headers = {
+            "Access-Control-Allow-Origin": origin,
+            "Access-Control-Allow-Methods": "POST, OPTIONS",
+            "Access-Control-Allow-Headers": "Content-Type",
+        }
+        if origin == healthcheck.PROBE_ORIGINS[1]:
+            headers["Access-Control-Allow-Origin"] = "https://example.invalid"
+        return _Response(204, headers)
+
+    healthy, detail = healthcheck.probe_lead_intake(
+        "http://example.test/api/v1/leads/intake", opener
+    )
+
+    assert not healthy
+    assert healthcheck.PROBE_ORIGINS[1] in detail
+    assert seen_origins == list(healthcheck.PROBE_ORIGINS)
 
 
 def test_maintenance_lock_never_starts_service(tmp_path):
@@ -460,6 +512,67 @@ def test_exit_maintenance_removes_marker_under_monitor_lock(tmp_path):
 
     assert healthcheck.exit_maintenance(settings) == healthcheck.EXIT_OK
     assert not settings.maintenance_lock.exists()
+
+
+def test_exit_maintenance_fsyncs_marker_removal(tmp_path, monkeypatch):
+    settings = _settings(tmp_path)
+    settings.maintenance_lock.parent.mkdir(parents=True, exist_ok=True)
+    settings.maintenance_lock.touch()
+    fsync_calls: list[int] = []
+    real_fsync = healthcheck.os.fsync
+
+    def record_fsync(descriptor):
+        fsync_calls.append(descriptor)
+        return real_fsync(descriptor)
+
+    monkeypatch.setattr(healthcheck.os, "fsync", record_fsync)
+
+    assert healthcheck.exit_maintenance(settings) == healthcheck.EXIT_OK
+    assert len(fsync_calls) == 1
+    assert not settings.maintenance_lock.exists()
+
+
+def test_enter_maintenance_fsyncs_marker_and_directory_before_service_stop(
+    tmp_path, monkeypatch
+):
+    settings = _settings(tmp_path)
+    events: list[str] = []
+    real_fsync = healthcheck.os.fsync
+
+    def record_fsync(descriptor):
+        events.append("fsync")
+        return real_fsync(descriptor)
+
+    def runner(command):
+        events.append("stop")
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(healthcheck.os, "fsync", record_fsync)
+
+    assert healthcheck.enter_maintenance(settings, runner=runner) == healthcheck.EXIT_OK
+    assert events == ["fsync", "fsync", "stop"]
+
+
+def test_enter_maintenance_does_not_stop_when_marker_fsync_fails(tmp_path, monkeypatch):
+    settings = _settings(tmp_path)
+    commands: list[tuple[str, ...]] = []
+
+    monkeypatch.setattr(
+        healthcheck.os,
+        "fsync",
+        lambda _descriptor: (_ for _ in ()).throw(OSError("simulated fsync failure")),
+    )
+
+    with pytest.raises(RuntimeError, match="durably create"):
+        healthcheck.enter_maintenance(
+            settings,
+            runner=lambda command: (
+                commands.append(tuple(command)),
+                subprocess.CompletedProcess(command, 0, "", ""),
+            )[1],
+        )
+
+    assert commands == []
 
 
 def test_failed_start_remains_a_visible_down_result(tmp_path):
@@ -694,7 +807,7 @@ def test_recovery_outbox_is_persisted_before_a_delivery_crash(tmp_path):
         "pending_notifications": [
             {
                 "alert": "auto-recovered",
-                "detail": "auto-recovered atlas-api.service: lead-intake probe returned browser-ready HTTP 204",
+                "detail": "auto-recovered atlas-api.service: lead-intake probe returned browser-ready responses for 2 origins",
             }
         ],
     }
@@ -736,7 +849,7 @@ def test_recovery_outbox_is_persisted_before_console_output_crash(tmp_path, monk
         "pending_notifications": [
             {
                 "alert": "auto-recovered",
-                "detail": "auto-recovered atlas-api.service: lead-intake probe returned browser-ready HTTP 204",
+                "detail": "auto-recovered atlas-api.service: lead-intake probe returned browser-ready responses for 2 origins",
             }
         ],
     }
@@ -1001,6 +1114,20 @@ def test_publish_reports_an_unavailable_desktop_notification(monkeypatch, capsys
     assert "WARNING desktop notification failed: FileNotFoundError" in capsys.readouterr().err
 
 
+def test_publish_bounds_a_hung_desktop_notification(monkeypatch, capsys):
+    monkeypatch.setattr(healthcheck.urllib.request, "urlopen", lambda *args, **kwargs: _Response(200))
+    monkeypatch.setattr(
+        healthcheck.subprocess,
+        "run",
+        lambda command, **kwargs: (_ for _ in ()).throw(
+            subprocess.TimeoutExpired(command, kwargs["timeout"])
+        ),
+    )
+
+    assert healthcheck.publish("https://ntfy.test", "private-topic", "Title", "Body", "urgent", "warning")
+    assert "WARNING desktop notification failed: TimeoutExpired" in capsys.readouterr().err
+
+
 def test_publish_treats_an_http_protocol_failure_as_undelivered(monkeypatch, capsys):
     commands: list[tuple[str, ...]] = []
 
@@ -1104,6 +1231,19 @@ def test_healthcheck_action_rejects_invalid_numeric_environment(monkeypatch):
     monkeypatch.setenv("ATLAS_API_HEALTHCHECK_REALERT_EVERY", "bad")
 
     with pytest.raises(ValueError, match="realert-every must be an integer"):
+        healthcheck._settings_from_args([])
+
+
+def test_exit_maintenance_ignores_blank_service_but_other_actions_reject_it(monkeypatch):
+    monkeypatch.setenv("ATLAS_API_HEALTHCHECK_SERVICE", "")
+
+    settings, action = healthcheck._settings_from_args(["--exit-maintenance"])
+    assert action == "exit-maintenance"
+    assert settings.service == ""
+
+    with pytest.raises(ValueError, match="service must not be blank"):
+        healthcheck._settings_from_args(["--enter-maintenance"])
+    with pytest.raises(ValueError, match="service must not be blank"):
         healthcheck._settings_from_args([])
 
 
@@ -1643,6 +1783,59 @@ def test_installer_rolls_back_before_reraising_operator_cancellation(tmp_path):
         ("systemctl", "--user", "enable", installer.TIMER_NAME),
         ("systemctl", "--user", "start", installer.TIMER_NAME),
     ]
+
+
+@pytest.mark.parametrize("termination_signal", [installer.signal.SIGTERM, installer.signal.SIGHUP])
+def test_installer_routes_termination_signals_through_rollback_and_restores_handlers(
+    tmp_path, monkeypatch, termination_signal
+):
+    paths = _install_paths(tmp_path)
+    paths.installed_monitor.parent.mkdir(parents=True, exist_ok=True)
+    paths.installed_monitor.write_bytes(b"previous-monitor")
+    paths.installed_monitor.chmod(0o700)
+    paths.notification_env.parent.mkdir(parents=True, exist_ok=True)
+    paths.notification_env.write_text(
+        f"{installer.TOPIC_ENV}=previous-private-topic\n", encoding="utf-8"
+    )
+    paths.notification_env.chmod(0o600)
+    runner = _InstallerRunner(timer_enabled=True, timer_active=True)
+    prior_handlers = {
+        installer.signal.SIGTERM: object(),
+        installer.signal.SIGHUP: object(),
+    }
+    current_handlers = dict(prior_handlers)
+
+    def fake_getsignal(signum):
+        return current_handlers[signum]
+
+    def fake_signal(signum, handler):
+        previous = current_handlers[signum]
+        current_handlers[signum] = handler
+        return previous
+
+    triggered = False
+
+    def terminating_runner(command):
+        nonlocal triggered
+        command = tuple(command)
+        if command == ("systemctl", "--user", "daemon-reload") and not triggered:
+            triggered = True
+            current_handlers[termination_signal](termination_signal, None)
+        return runner(command)
+
+    monkeypatch.setattr(installer.signal, "getsignal", fake_getsignal)
+    monkeypatch.setattr(installer.signal, "signal", fake_signal)
+
+    with pytest.raises(RuntimeError, match=installer.signal.Signals(termination_signal).name):
+        installer.install(paths, runner=terminating_runner, environment={})
+
+    assert paths.installed_monitor.read_bytes() == b"previous-monitor"
+    assert paths.notification_env.read_text(encoding="utf-8") == (
+        f"{installer.TOPIC_ENV}=previous-private-topic\n"
+    )
+    assert runner.timer_enabled
+    assert runner.timer_active
+    assert current_handlers == prior_handlers
 
 
 def test_installer_removes_partial_enrollment_when_timer_enable_fails(tmp_path):

--- a/tests/test_atlas_api_healthcheck.py
+++ b/tests/test_atlas_api_healthcheck.py
@@ -1,0 +1,231 @@
+"""Regression coverage for the standalone Atlas API liveness monitor."""
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+_SPEC = importlib.util.spec_from_file_location(
+    "atlas_api_healthcheck", REPO_ROOT / "scripts" / "atlas_api_healthcheck.py"
+)
+healthcheck = importlib.util.module_from_spec(_SPEC)
+sys.modules["atlas_api_healthcheck"] = healthcheck
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(healthcheck)
+
+
+class _Response:
+    def __init__(self, status: int) -> None:
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> bool:
+        return False
+
+
+class _Runner:
+    def __init__(self, *, active: bool, start_returncode: int = 0) -> None:
+        self.active = active
+        self.start_returncode = start_returncode
+        self.commands: list[tuple[str, ...]] = []
+
+    def __call__(self, command):
+        command = tuple(command)
+        self.commands.append(command)
+        if "is-active" in command:
+            return subprocess.CompletedProcess(command, 0 if self.active else 3, "", "")
+        assert "start" in command
+        if self.start_returncode == 0:
+            self.active = True
+        return subprocess.CompletedProcess(command, self.start_returncode, "", "")
+
+
+def _settings(tmp_path: Path, **overrides):
+    values = {
+        "service": "atlas-api.service",
+        "probe_url": "http://example.test/api/v1/leads/intake",
+        "ntfy_url": "https://ntfy.test",
+        "ntfy_topic": "private-topic",
+        "state_dir": tmp_path / "state",
+        "maintenance_lock": tmp_path / "atlas-api.maintenance",
+        "realert_every": 6,
+        "recovery_attempts": 1,
+        "recovery_interval_seconds": 0.0,
+        "no_alert": False,
+    }
+    values.update(overrides)
+    return healthcheck.Settings(**values)
+
+
+def _opener(status: int, seen: list | None = None):
+    def _open(request, *, timeout):
+        if seen is not None:
+            seen.append((request.method, request.headers, timeout))
+        return _Response(status)
+
+    return _open
+
+
+def _start_commands(runner: _Runner) -> list[tuple[str, ...]]:
+    return [command for command in runner.commands if "start" in command]
+
+
+def _state(settings) -> dict:
+    return json.loads((settings.state_dir / "state.json").read_text(encoding="utf-8"))
+
+
+def test_inactive_service_is_started_and_reprobed(tmp_path):
+    settings = _settings(tmp_path)
+    runner = _Runner(active=False)
+    sent: list[tuple] = []
+    seen: list = []
+
+    result = healthcheck.run_healthcheck(
+        settings,
+        runner=runner,
+        opener=_opener(204, seen),
+        notifier=lambda *args: (sent.append(args), True)[1],
+        sleeper=lambda _: None,
+    )
+
+    assert result == healthcheck.EXIT_RECOVERED
+    assert _start_commands(runner) == [
+        ("systemctl", "--user", "start", "atlas-api.service")
+    ]
+    assert seen == [("OPTIONS", {"Origin": "https://effinghamofficemaids.com", "Access-control-request-method": "POST"}, 8)]
+    assert sent[0][2] == "atlas-api auto-recovered"
+    assert _state(settings) == {"consecutive": 0, "status": "healthy"}
+
+
+def test_maintenance_lock_never_starts_service(tmp_path):
+    settings = _settings(tmp_path)
+    settings.maintenance_lock.touch()
+    runner = _Runner(active=False)
+
+    result = healthcheck.run_healthcheck(
+        settings,
+        runner=runner,
+        opener=_opener(204),
+        notifier=lambda *args: (_ for _ in ()).throw(AssertionError("must not notify")),
+        sleeper=lambda _: None,
+    )
+
+    assert result == healthcheck.EXIT_OK
+    assert _start_commands(runner) == []
+    assert _state(settings) == {"consecutive": 0, "status": "maintenance"}
+
+
+def test_failed_start_remains_a_visible_down_result(tmp_path):
+    settings = _settings(tmp_path)
+    runner = _Runner(active=False, start_returncode=1)
+    sent: list[tuple] = []
+
+    result = healthcheck.run_healthcheck(
+        settings,
+        runner=runner,
+        opener=_opener(204),
+        notifier=lambda *args: (sent.append(args), True)[1],
+        sleeper=lambda _: None,
+    )
+
+    assert result == healthcheck.EXIT_DOWN
+    assert len(_start_commands(runner)) == 1
+    assert sent[0][2] == "atlas-api DOWN"
+    assert _state(settings) == {"consecutive": 1, "status": "down"}
+
+
+def test_failed_reprobe_after_start_remains_down(tmp_path):
+    settings = _settings(tmp_path)
+    runner = _Runner(active=False)
+
+    result = healthcheck.run_healthcheck(
+        settings,
+        runner=runner,
+        opener=_opener(503),
+        notifier=lambda *args: True,
+        sleeper=lambda _: None,
+    )
+
+    assert result == healthcheck.EXIT_DOWN
+    assert len(_start_commands(runner)) == 1
+    assert _state(settings) == {"consecutive": 1, "status": "down"}
+
+
+def test_active_unhealthy_service_alerts_without_restart(tmp_path):
+    settings = _settings(tmp_path)
+    runner = _Runner(active=True)
+
+    result = healthcheck.run_healthcheck(
+        settings,
+        runner=runner,
+        opener=_opener(503),
+        notifier=lambda *args: True,
+        sleeper=lambda _: None,
+    )
+
+    assert result == healthcheck.EXIT_DOWN
+    assert _start_commands(runner) == []
+    assert _state(settings) == {"consecutive": 1, "status": "down"}
+
+
+def test_missing_notification_configuration_does_not_block_recovery(tmp_path):
+    settings = _settings(tmp_path, ntfy_topic="")
+    runner = _Runner(active=False)
+
+    result = healthcheck.run_healthcheck(
+        settings,
+        runner=runner,
+        opener=_opener(204),
+        notifier=lambda *args: False,
+        sleeper=lambda _: None,
+    )
+
+    assert result == healthcheck.EXIT_ALERT_UNDELIVERED
+    assert len(_start_commands(runner)) == 1
+    assert _state(settings) == {"consecutive": 0, "status": "healthy"}
+
+
+def test_publish_preserves_the_desktop_notification_channel(monkeypatch):
+    commands: list[tuple[str, ...]] = []
+
+    monkeypatch.setattr(healthcheck.urllib.request, "urlopen", lambda *args, **kwargs: _Response(200))
+    monkeypatch.setattr(
+        healthcheck.subprocess,
+        "run",
+        lambda command, **kwargs: (commands.append(tuple(command)), subprocess.CompletedProcess(command, 0))[1],
+    )
+
+    assert healthcheck.publish("https://ntfy.test", "private-topic", "Title", "Body", "urgent", "warning")
+    assert commands == [("notify-send", "-u", "critical", "Title", "Body")]
+
+
+def test_missing_ntfy_topic_still_preserves_desktop_notification(monkeypatch):
+    commands: list[tuple[str, ...]] = []
+
+    monkeypatch.setattr(
+        healthcheck.subprocess,
+        "run",
+        lambda command, **kwargs: (commands.append(tuple(command)), subprocess.CompletedProcess(command, 0))[1],
+    )
+
+    assert not healthcheck.publish("https://ntfy.test", "", "Title", "Body", "urgent", "warning")
+    assert commands == [("notify-send", "-u", "critical", "Title", "Body")]
+
+
+def test_service_template_uses_installed_script_and_private_environment():
+    service = (REPO_ROOT / "config" / "atlas-api-healthcheck.service").read_text(encoding="utf-8")
+    timer = (REPO_ROOT / "config" / "atlas-api-healthcheck.timer").read_text(encoding="utf-8")
+
+    assert "ExecStart=/usr/bin/python3 %h/.local/bin/atlas-api-healthcheck.py" in service
+    assert "EnvironmentFile=-%h/.config/atlas/atlas-api-healthcheck.env" in service
+    assert "Environment=DISPLAY=:0" in service
+    assert "Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus" in service
+    assert "ATLAS_API_HEALTHCHECK_NTFY_TOPIC=<private-topic>" in service
+    assert "eom-atlas-api-health-" not in service
+    assert "OnUnitActiveSec=5min" in timer

--- a/tests/test_atlas_api_healthcheck.py
+++ b/tests/test_atlas_api_healthcheck.py
@@ -875,6 +875,7 @@ def test_invalid_json_state_is_not_reset_or_replaced(tmp_path):
     "value",
     [
         {"status": [], "consecutive": 0},
+        {"status": "unknown", "consecutive": 0},
         {"status": "down", "consecutive": "1"},
         {
             "status": "healthy",
@@ -1290,6 +1291,30 @@ def test_installer_fails_closed_when_existing_timer_state_cannot_be_queried(tmp_
     assert not paths.installed_monitor.exists()
 
 
+@pytest.mark.parametrize(
+    ("active_state", "unit_file_state", "expected"),
+    [
+        ("activating", "disabled", "unsupported ActiveState=activating"),
+        ("inactive", "masked", "unsupported UnitFileState=masked"),
+    ],
+)
+def test_installer_rejects_timer_states_outside_the_restorable_sets(
+    active_state, unit_file_state, expected
+):
+    def runner(command):
+        if "--property=LoadState" in command:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                f"LoadState=loaded\nActiveState={active_state}\n",
+                "",
+            )
+        return subprocess.CompletedProcess(command, 0, unit_file_state + "\n", "")
+
+    with pytest.raises(RuntimeError, match=expected):
+        installer._timer_state(runner)
+
+
 def test_install_check_rejects_stale_loaded_unit_definitions(tmp_path):
     paths = _install_paths(tmp_path)
     installer.install(
@@ -1431,6 +1456,38 @@ def test_installer_restores_files_and_timer_when_service_proof_fails(
         restore_enable_command,
         ("systemctl", "--user", "start", installer.TIMER_NAME),
     ]
+
+
+@pytest.mark.parametrize("target_exists", [True, False])
+def test_installer_failure_restores_live_and_broken_relative_symlinks(
+    tmp_path, target_exists
+):
+    paths = _install_paths(tmp_path)
+    paths.legacy_monitor.parent.mkdir(parents=True, exist_ok=True)
+    paths.legacy_monitor.write_text(
+        'NTFY_TOPIC="${ATLAS_HC_NTFY_TOPIC:-test-private-topic}"\n', encoding="utf-8"
+    )
+    paths.systemd_dir.mkdir(parents=True, exist_ok=True)
+    target = paths.systemd_dir / "managed-healthcheck.service"
+    original_target_payload = b"managed-service"
+    if target_exists:
+        target.write_bytes(original_target_payload)
+    destination = paths.systemd_dir / installer.SERVICE_NAME
+    destination.symlink_to(target.name)
+    original_link_target = os.readlink(destination)
+    runner = _InstallerRunner(
+        failing_command=("systemctl", "--user", "start", "--wait", installer.SERVICE_NAME)
+    )
+
+    with pytest.raises(RuntimeError, match="initial installed-monitor invocation failed"):
+        installer.install(paths, runner=runner, environment={})
+
+    assert destination.is_symlink()
+    assert os.readlink(destination) == original_link_target
+    if target_exists:
+        assert target.read_bytes() == original_target_payload
+    else:
+        assert not destination.exists()
 
 
 def test_installer_rolls_back_before_reraising_operator_cancellation(tmp_path):


### PR DESCRIPTION
Plan: plans/PR-EOM-API-Liveness-Contract.md
Slice phase: Production hardening
Ownership lane: eom-provider-liveness

An enabled local Atlas provider can remain down indefinitely after a clean stop: its restart policy does not restart a clean SIGTERM, while the existing five-minute monitor only reports the outage. This slice makes that narrow, observed inactive-unit path self-recovering and keeps the recovery monitor independent of the application runtime it watches.

## Intentional

- Start only an inactive `atlas-api.service` when no explicit maintenance lock exists, then accept recovery only after the existing lead-intake OPTIONS probe succeeds.
- Keep an active-but-unhealthy provider alert-only; diagnosing/restarting that distinct failure class is intentionally not in this slice.
- Keep the monitor installed outside the Atlas runtime worktree and keep the private ntfy topic outside version control.

## AI reconciliation

- Enroll the monitor in a real deployment path fixed-in: `scripts/install_atlas_api_healthcheck.py:286-331` copies and proves the reviewed monitor/templates before enabling the timer, and `:250-283` restores the prior installation on failure; `tests/test_atlas_api_healthcheck.py:658,746,782` proves success and rollback paths.
- Retry undelivered state-transition alerts fixed-in: `scripts/atlas_api_healthcheck.py:349-362,407-448` persists a durable alert queue while advancing current observed state; `tests/test_atlas_api_healthcheck.py:386,409,436` covers down, recovery, and pending-plus-current transitions.
- Justify the 700-line diff-budget overage fixed-in: `plans/PR-EOM-API-Liveness-Contract.md:13-17` explains why the monitor, deployment wiring, and proof cannot be split; the override below records the same reason for the gate.
- Preserve the systemctl start failure details fixed-in: `scripts/atlas_api_healthcheck.py:82-89,252-257` carries bounded, control-safe command diagnostics into the observation; `tests/test_atlas_api_healthcheck.py:484-499` covers that failure path.
- Keep the new sensitive-path monitor within the scripts maturity contract fixed-in: `scripts/atlas_api_healthcheck.py:260-324,407-448` now makes fallback failures visible without suppressing notification/state handling; `tests/test_atlas_api_healthcheck.py:539-626` covers those error paths.
- Apply the current observation after replaying pending alerts fixed-in: `scripts/atlas_api_healthcheck.py:417-448` derives and persists the current state independently, appends any new transition to the durable queue, and returns the current observation result after delivery; `tests/test_atlas_api_healthcheck.py:436` proves an older recovery cannot hide a fresh outage.
- Create the topic file with private permissions initially fixed-in: `scripts/install_atlas_api_healthcheck.py:136-143,165-193` writes through a mode-0600 temporary file and atomically replaces the destination; `tests/test_atlas_api_healthcheck.py:716` observes the mode before publication.
- Validate the entire persisted state before using it fixed-in: `scripts/atlas_api_healthcheck.py:187-271` validates base state and every queued/legacy notification before decision logic, including migration of the previous singular format; `tests/test_atlas_api_healthcheck.py:539-599` covers varied malformed shapes and migration.
- Let alerts proceed when local logging fails fixed-in: `scripts/atlas_api_healthcheck.py:311-324,417-448` reports append failure to stderr and continues notification/state handling; `tests/test_atlas_api_healthcheck.py:610` proves a recovery alert still sends.
- Prove the service before enabling its timer fixed-in: `scripts/install_atlas_api_healthcheck.py:250-331` snapshots prior files/timer state, stops an active old timer, proves the installed service, enrolls only afterward, and rolls back any failure; `tests/test_atlas_api_healthcheck.py:746,782` covers pre-enrollment and partial-enrollment failure.
- Serialize maintenance admission with service recovery fixed-in: `scripts/atlas_api_healthcheck.py:84-135,407-448` makes supported maintenance entry create the marker and stop the service under the same lock as recovery; `tests/test_atlas_api_healthcheck.py:241` proves the reported interleaving ends in maintenance with the service stopped.
- Persist pending alerts before attempting delivery fixed-in: `scripts/atlas_api_healthcheck.py:275-317,417-448` atomically fsyncs the current state plus outbox before notifier execution and acknowledges only after success; `tests/test_atlas_api_healthcheck.py:469` simulates process exit at delivery and proves the recovery alert is replayed.
- Persist recovery intent before starting the service fixed-in: `scripts/atlas_api_healthcheck.py:157-175,236-298,353-405,451-503` loads durable state before observation, commits recovery intent before `systemctl start`, replays interrupted recovery as an auto-recovery, and fails closed on unreadable/undecodable state; `tests/test_atlas_api_healthcheck.py:507-575` covers the crash and transient-read boundaries.
- Stop an in-flight old monitor before proving the new copy fixed-in: `scripts/install_atlas_api_healthcheck.py:286-324` stops the existing oneshot before replacing files and then invokes the installed unit; `tests/test_atlas_api_healthcheck.py:799-805,833-870` proves the stop-copy-proof order.
- Allow clean installation when the unit is absent fixed-in: `scripts/install_atlas_api_healthcheck.py:280-290,349-400` treats `LoadState=not-found` as the explicit clean-host no-op while retaining fail-closed behavior for unsupported/query-error states; `tests/test_atlas_api_healthcheck.py:1040-1060` proves enrollment without an old-unit stop.
- Define the open-execution model in the contract fixed-in: `plans/PR-EOM-API-Liveness-Contract.md:130-206` names the admitted actors, serialization, crash/cancellation boundaries, invariant, excluded assumptions, and rejected closed-surface alternatives; `tests/test_atlas_api_healthcheck.py:284-373,579-686` proves the maintenance and crash boundaries.
- Distinguish inactivity from systemctl query failures fixed-in: `scripts/atlas_api_healthcheck.py:107-126,193-254` parses `LoadState`/`ActiveState`, starts only `loaded/inactive`, and surfaces all other/query-error states without a start; `tests/test_atlas_api_healthcheck.py:456-493` probes both error directions.
- Verify systemd loaded the installed unit files fixed-in: `scripts/install_atlas_api_healthcheck.py:293-310,417-443` requires `NeedDaemonReload=no` for the service and timer in addition to source bytes and typed timer state; `tests/test_atlas_api_healthcheck.py:971-1008,1104-1122` proves current definitions pass and stale definitions fail.
- Accept queued alerts during deployment proof fixed-in: `config/atlas-api-healthcheck.service:17-19` admits exit `4` as a successful oneshot completion because the observation and alert are already durable; `tests/test_atlas_api_healthcheck.py:948-959` pins the deployed unit contract while existing outbox tests prove retry remains observable.
- Convert HTTP protocol failures into down observations fixed-in: `scripts/atlas_api_healthcheck.py:175-191,471-497` catches the standard-library `HTTPException` class at both provider and ntfy boundaries; `tests/test_atlas_api_healthcheck.py:457-473,909-932` proves malformed responses become DOWN and undelivered outcomes.
- Decouple maintenance commands from probe configuration fixed-in: `scripts/atlas_api_healthcheck.py:569-629` selects the action before converting healthcheck-only numeric settings and uses safe internal values on maintenance paths; `tests/test_atlas_api_healthcheck.py:962-991` proves both maintenance actions remain available while the healthcheck path still rejects malformed settings.
- Preserve failed recovery in deployment proof fixed-in: `scripts/atlas_api_healthcheck.py:455-459,559,567` keeps provider-down exit `3` dominant when alert delivery remains queued while retaining exit `4` for non-down outcomes; `tests/test_atlas_api_healthcheck.py:516-563,739-783` proves down, healthy/recovered, and no-alert boundaries at current head `3ed213b64`.
- Roll back installation on operator cancellation fixed-in: `scripts/install_atlas_api_healthcheck.py:389-408` runs the existing file/timer rollback for `KeyboardInterrupt`, preserves rollback diagnostics, and re-raises cancellation; `tests/test_atlas_api_healthcheck.py:1345-1385` proves cancellation after replacement restores prior files and timer state at current head `3ed213b64`.
- Reject non-finite recovery intervals waived-out-of-scope: valid configuration hardening is parked in `plans/PR-EOM-API-Liveness-Contract.md` Deferred because finite values are not needed to close the observed provider-down/deployment-proof defect.
- Enroll the healthcheck regression suite in PR CI not-applicable: `.github/workflows/unit_gate.yml:18-20,93-142` runs on every PR and escalates unmapped config surfaces to `FULL`; `python scripts/select_impacted_tests.py --base origin/main` returned `FULL` for `config/atlas-api-healthcheck.service`. The narrower unit-template concern is fixed in the already-enrolled test file at `tests/test_atlas_api_healthcheck.py:978-997`, which invokes `systemd-analyze verify` when available.
- Report nonzero desktop notification exits waived-out-of-scope: secondary desktop-channel observability is parked in `plans/PR-EOM-API-Liveness-Contract.md` Deferred; remote ntfy delivery and provider outcome remain the current operational contract.
- Preserve runtime-only timer enablement on rollback fixed-in: `scripts/install_atlas_api_healthcheck.py:61-68,250-280,345-354` preserves the exact disabled/static, persistent-enabled, or runtime-enabled class and replays `enable --runtime` only for the runtime class; `tests/test_atlas_api_healthcheck.py:1383-1430` proves persistent and runtime rollback separately at current head `c42c3bb07`.
- Validate the preflight response, not only its status fixed-in: `scripts/atlas_api_healthcheck.py:35,176-218` sends the browser Content-Type preflight and requires the canonical origin plus POST and Content-Type allowances before health; `tests/test_atlas_api_healthcheck.py:258-346` proves the real request and missing/wrong/mixed response-header failures at current head `c42c3bb07`.
- Resolve the user bus from the invoking UID fixed-in: `config/atlas-api-healthcheck.service:8-18` no longer overrides `DBUS_SESSION_BUS_ADDRESS` with UID 1000, so the user manager supplies the invoking account's runtime bus; `tests/test_atlas_api_healthcheck.py:1045-1051` rejects any explicit bus override or UID-specific runtime path at current head `8b33c0e64`.
- Declare R8 in the Review Contract fixed-in: `plans/PR-EOM-API-Liveness-Contract.md:90-98` now declares transactional rollback and concurrent actors as risks and triggers R8 alongside R2 for the already-documented execution model at current head `844d15485`.
- Preserve symlink identity during installation rollback fixed-in: `scripts/install_atlas_api_healthcheck.py:53-58,210-266` snapshots the raw symlink target before following file semantics and atomically restores that namespace entry; `tests/test_atlas_api_healthcheck.py:1461-1490` proves both live and broken relative links plus the live target survive a forced service-proof failure at current head `844d15485`.
- Declare every decision-driving member set fixed-in: `plans/PR-EOM-API-Liveness-Contract.md:372-416` declares the closed/open status, membership source, and out-of-set direction for notification, systemd, browser-ready CORS, persisted/observation, exit, and timer memberships; `tests/test_atlas_api_healthcheck.py:874-907,1294-1315` proves unknown persisted and timer states take the declared safe paths at current head `844d15485`.
- Regenerate the squash commit contract fixed-in: the current diff is six files and 3,795 insertions at tip `734295e5d`; this body now cites the final tree and records `84 passed`.
- Preserve notification-symlink referent metadata fixed-in: `scripts/install_atlas_api_healthcheck.py:143-170,405-421` validates a symlink target as private before any systemd query and never chmods an accepted symlink target; `tests/test_atlas_api_healthcheck.py:1494-1568` proves nonprivate rejection before mutation plus private-target preservation across success and failed proof at current head `be7e54934`.
- Synchronize the final commit contract with the plan fixed-in: the synchronized plan table, current body, and final branch diff all record six files and 3,795 insertions at `734295e5d`, with regenerated current-tree recovery citations.
- Synchronize the final commit contract fixed-in: the final contract no longer carries the stale 3,142/3,287 counts or the shifted `scripts/atlas_api_healthcheck.py:156-183` recovery citation.
- Restore metadata changed through topic symlinks fixed-in: the installer validates notification-symlink target privacy before systemd work and avoids target-following chmod; `tests/test_atlas_api_healthcheck.py:1494-1568` covers rejection and preservation.
- Roll back on malformed UTF-8 configuration fixed-in: `scripts/install_atlas_api_healthcheck.py:118-154,174-219,441-457` converts both configuration-source decode failures into pre-systemd installer rejection; `tests/test_atlas_api_healthcheck.py:1217-1236` proves the active timer is untouched at current head `9f1e628a6`.
- Preserve a topic symlink when appending fixed-in: `scripts/install_atlas_api_healthcheck.py:157-219,441-457` admits a private notification symlink only when its valid topic already exists, so installation never replaces or writes through that link; `tests/test_atlas_api_healthcheck.py:1550-1602` covers success, proof failure, and missing-topic rejection.
- Regenerate the exact commit contract fixed-in: the synchronized plan, current body, and branch diff record six files and 3,505 insertions at `9f1e628a6`; the focused file records `75 passed`, and the cold reconstruction below uses final-tree citations.
- Verify an independent installed monitor copy fixed-in: `scripts/install_atlas_api_healthcheck.py:506-521` rejects symlink destinations and same-inode aliases before content/executable checks; `tests/test_atlas_api_healthcheck.py:1347-1369` proves both alias shapes fail `--check` at current head `9f1e628a6`.
- Route termination signals through installer rollback fixed-in: `scripts/install_atlas_api_healthcheck.py:88-103,462-525` converts admitted `SIGTERM`/`SIGHUP` into the existing rollback path, ignores repeats during rollback, and restores prior handlers; `tests/test_atlas_api_healthcheck.py:1789-1840` proves both signals restore prior files, timer state, and handlers at current head `734295e5d`.
- Regenerate the canonical commit contract fixed-in: the exact current contract records six files, 3,795 insertions, `84 passed`, and the final-tree cold reconstruction below at `734295e5d`.
- Probe every supported lead-form origin fixed-in: `scripts/atlas_api_healthcheck.py:35-39,210-261` requires browser-ready OPTIONS responses for both producer-supported origins; `tests/test_atlas_api_healthcheck.py:281-396` pins the mirrored standalone set to `atlas_brain/api/leads.py` and proves a second-origin regression fails health.
- Validate only configuration used by maintenance exit fixed-in: `scripts/atlas_api_healthcheck.py:647-707` skips service validation only for the service-free exit action; `tests/test_atlas_api_healthcheck.py:1212-1248` proves healthcheck/entry still reject blank service while exit remains available.
- Bound the best-effort desktop notification fixed-in: `scripts/atlas_api_healthcheck.py:48,548-575` applies a three-second timeout and handles `TimeoutExpired` without changing the primary ntfy result; `tests/test_atlas_api_healthcheck.py:1091-1129` covers success, unavailable, and timeout outcomes.
- Durably publish maintenance before stopping the service fixed-in: `scripts/atlas_api_healthcheck.py:147-207` fsyncs marker content and directory before stop and fsyncs removal on exit; `tests/test_atlas_api_healthcheck.py:508-576` proves ordering, failure-before-stop, and durable removal.

## Fix-loop disposition preflight

- Root decision: Declare R8 in the Review Contract
- Source trace: open-execution implementation -> prose-only R8 trigger -> incomplete review-rule declaration
- Upstream files: `plans/PR-EOM-API-Liveness-Contract.md`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`
- Max files: 6
- Parked hardening: none
- Root decision: Preserve symlink identity during installation rollback
- Source trace: symlink destination -> target-following file snapshot -> lossy regular-file or absent rollback
- Upstream files: `scripts/install_atlas_api_healthcheck.py`
- Fix strategy: upstream-root
- Blocking predicate: data
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`, `scripts/install_atlas_api_healthcheck.py`, `tests/test_atlas_api_healthcheck.py`
- Max files: 6
- Parked hardening: none
- Root decision: Declare every decision-driving member set
- Source trace: changed decision memberships -> partial closure declaration -> undispositioned out-of-set behavior
- Upstream files: `plans/PR-EOM-API-Liveness-Contract.md`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`, `tests/test_atlas_api_healthcheck.py`
- Max files: 6
- Parked hardening: none
- Root decision: Resolve the user bus from the invoking UID
- Source trace: user service template -> hard-coded UID 1000 bus -> wrong user manager on other accounts
- Upstream files: `config/atlas-api-healthcheck.service`
- Fix strategy: upstream-root
- Blocking predicate: claimed-mechanism
- Disposition: fixed-in
- Allowed files: `config/atlas-api-healthcheck.service`, `plans/PR-EOM-API-Liveness-Contract.md`, `tests/test_atlas_api_healthcheck.py`
- Max files: 6
- Parked hardening: none
- Root decision: Enroll the monitor in a real deployment path
- Source trace: review deployment finding -> config/atlas-api-healthcheck.service ExecStart -> missing source installer
- Upstream files: `config/atlas-api-healthcheck.service`, `config/atlas-api-healthcheck.timer`, `scripts/install_atlas_api_healthcheck.py`
- Fix strategy: upstream-root
- Blocking predicate: claimed-mechanism
- Disposition: fixed-in
- Allowed files: `config/atlas-api-healthcheck.service`, `config/atlas-api-healthcheck.timer`, `plans/PR-EOM-API-Liveness-Contract.md`, `scripts/atlas_api_healthcheck.py`, `scripts/install_atlas_api_healthcheck.py`, `tests/test_atlas_api_healthcheck.py`
- Max files: 6
- Parked hardening: none
- Root decision: Retry undelivered state-transition alerts
- Source trace: notification failure -> monitor state write -> suppressed retry
- Upstream files: `scripts/atlas_api_healthcheck.py`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`, `scripts/atlas_api_healthcheck.py`, `tests/test_atlas_api_healthcheck.py`
- Max files: 6
- Parked hardening: none
- Root decision: Justify the 700-line diff-budget overage
- Source trace: diff budget finding -> plan indivisibility rationale -> PR override marker
- Upstream files: `plans/PR-EOM-API-Liveness-Contract.md`
- Fix strategy: upstream-root
- Blocking predicate: ci
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`
- Max files: 6
- Parked hardening: none
- Root decision: Preserve the systemctl start failure details
- Source trace: failed systemctl start -> generic observation -> missing alert diagnostic
- Upstream files: `scripts/atlas_api_healthcheck.py`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`, `scripts/atlas_api_healthcheck.py`, `tests/test_atlas_api_healthcheck.py`
- Max files: 6
- Parked hardening: none
- Root decision: Keep the new sensitive-path monitor within the scripts maturity contract
- Source trace: hosted scripts maturity ratchet -> silent fallback and unguarded monitor I/O findings -> monitor error handling
- Upstream files: `scripts/atlas_api_healthcheck.py`
- Fix strategy: upstream-root
- Blocking predicate: ci
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`, `scripts/atlas_api_healthcheck.py`, `tests/test_atlas_api_healthcheck.py`
- Max files: 6
- Parked hardening: none
- Root decision: Apply the current observation after replaying pending alerts
- Source trace: pending alert replay -> current observation discarded -> stale state and exit result
- Upstream files: `scripts/atlas_api_healthcheck.py`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`, `scripts/atlas_api_healthcheck.py`, `tests/test_atlas_api_healthcheck.py`
- Max files: 6
- Parked hardening: none
- Root decision: Create the topic file with private permissions initially
- Source trace: absent topic file -> ordinary write creation -> chmod after credential exposure window
- Upstream files: `scripts/install_atlas_api_healthcheck.py`
- Fix strategy: upstream-root
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`, `scripts/install_atlas_api_healthcheck.py`, `tests/test_atlas_api_healthcheck.py`
- Max files: 6
- Parked hardening: none
- Root decision: Validate the entire persisted state before using it
- Source trace: persisted JSON -> partial field checks -> unhashable membership and unsafe integer conversion
- Upstream files: `scripts/atlas_api_healthcheck.py`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`, `scripts/atlas_api_healthcheck.py`, `tests/test_atlas_api_healthcheck.py`
- Max files: 6
- Parked hardening: none
- Root decision: Let alerts proceed when local logging fails
- Source trace: health log append -> uncaught filesystem error -> notifier and state write skipped
- Upstream files: `scripts/atlas_api_healthcheck.py`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`, `scripts/atlas_api_healthcheck.py`, `tests/test_atlas_api_healthcheck.py`
- Max files: 6
- Parked hardening: none
- Root decision: Prove the service before enabling its timer
- Source trace: installer writes -> timer enable -> service proof failure without rollback
- Upstream files: `scripts/install_atlas_api_healthcheck.py`
- Fix strategy: upstream-root
- Blocking predicate: claimed-mechanism
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`, `scripts/install_atlas_api_healthcheck.py`, `tests/test_atlas_api_healthcheck.py`
- Max files: 6
- Parked hardening: none
- Root decision: Serialize maintenance admission with service recovery
- Source trace: recovery lock -> one-time marker check -> out-of-band marker/stop race
- Upstream files: `scripts/atlas_api_healthcheck.py`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`, `scripts/atlas_api_healthcheck.py`, `tests/test_atlas_api_healthcheck.py`
- Max files: 6
- Parked hardening: none
- Root decision: Persist pending alerts before attempting delivery
- Source trace: current transition -> in-memory queue -> fallible notifier -> state write after failure
- Upstream files: `scripts/atlas_api_healthcheck.py`
- Fix strategy: upstream-root
- Blocking predicate: data
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`, `scripts/atlas_api_healthcheck.py`, `tests/test_atlas_api_healthcheck.py`
- Max files: 6
- Parked hardening: none
- Root decision: Persist recovery intent before starting the service
- Source trace: inactive service -> recovery start side effect -> crash before durable transition -> lost auto-recovery evidence
- Upstream files: `scripts/atlas_api_healthcheck.py`
- Fix strategy: upstream-root
- Blocking predicate: data
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`, `scripts/atlas_api_healthcheck.py`, `tests/test_atlas_api_healthcheck.py`
- Max files: 6
- Parked hardening: none
- Root decision: Stop an in-flight old monitor before proving the new copy
- Source trace: active old oneshot -> installer replaces files -> start waits on old process -> replacement accepted without execution
- Upstream files: `scripts/install_atlas_api_healthcheck.py`
- Fix strategy: upstream-root
- Blocking predicate: claimed-mechanism
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`, `scripts/install_atlas_api_healthcheck.py`, `tests/test_atlas_api_healthcheck.py`
- Max files: 6
- Parked hardening: none
- Root decision: Allow clean installation when the unit is absent
- Source trace: unconditional old-service stop -> clean host has no loaded unit -> installation aborts before copy
- Upstream files: `scripts/install_atlas_api_healthcheck.py`
- Fix strategy: upstream-root
- Blocking predicate: claimed-mechanism
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`, `scripts/install_atlas_api_healthcheck.py`, `tests/test_atlas_api_healthcheck.py`
- Max files: 6
- Parked hardening: none
- Root decision: Define the open-execution model in the contract
- Source trace: isolated crash tests -> no declared actor/interleaving invariant -> repeated one-sided review fixes
- Upstream files: `plans/PR-EOM-API-Liveness-Contract.md`
- Fix strategy: upstream-root
- Blocking predicate: data
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`
- Max files: 6
- Parked hardening: none
- Root decision: Distinguish inactivity from systemctl query failures
- Source trace: boolean is-active query -> query failure and transitional state appear inactive -> unsafe or false recovery
- Upstream files: `scripts/atlas_api_healthcheck.py`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`, `scripts/atlas_api_healthcheck.py`, `tests/test_atlas_api_healthcheck.py`
- Max files: 6
- Parked hardening: none
- Root decision: Verify systemd loaded the installed unit files
- Source trace: disk byte match plus active timer -> stale cached unit definition remains unobserved -> false deployment proof
- Upstream files: `scripts/install_atlas_api_healthcheck.py`
- Fix strategy: upstream-root
- Blocking predicate: claimed-mechanism
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`, `scripts/install_atlas_api_healthcheck.py`, `tests/test_atlas_api_healthcheck.py`
- Max files: 6
- Parked hardening: none
- Root decision: Accept queued alerts during deployment proof
- Source trace: durable undelivered alert -> exit 4 -> systemd marks proof failed -> installer rolls back working recovery
- Upstream files: `config/atlas-api-healthcheck.service`
- Fix strategy: upstream-root
- Blocking predicate: claimed-mechanism
- Disposition: fixed-in
- Allowed files: `config/atlas-api-healthcheck.service`, `plans/PR-EOM-API-Liveness-Contract.md`, `tests/test_atlas_api_healthcheck.py`
- Max files: 6
- Parked hardening: none
- Root decision: Convert HTTP protocol failures into down observations
- Source trace: malformed HTTP response -> uncaught HTTPException -> timer exits before durable DOWN or undelivered outcome
- Upstream files: `scripts/atlas_api_healthcheck.py`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`, `scripts/atlas_api_healthcheck.py`, `tests/test_atlas_api_healthcheck.py`
- Max files: 6
- Parked hardening: none
- Root decision: Decouple maintenance commands from probe configuration
- Source trace: eager numeric environment conversion -> action not yet selected -> supported maintenance command cannot run
- Upstream files: `scripts/atlas_api_healthcheck.py`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`, `scripts/atlas_api_healthcheck.py`, `tests/test_atlas_api_healthcheck.py`
- Max files: 6
- Parked hardening: none

- Root decision: Preserve failed recovery in deployment proof
- Source trace: failed recovery -> durable DOWN plus queued alert -> exit 4 -> systemd accepts failed provider proof
- Upstream files: `scripts/atlas_api_healthcheck.py`
- Fix strategy: upstream-root
- Blocking predicate: claimed-mechanism
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`, `scripts/atlas_api_healthcheck.py`, `tests/test_atlas_api_healthcheck.py`
- Max files: 6
- Parked hardening: none

- Root decision: Roll back installation on operator cancellation
- Source trace: timer/file mutation -> KeyboardInterrupt -> exception filter bypass -> stranded partial installation
- Upstream files: `scripts/install_atlas_api_healthcheck.py`
- Fix strategy: upstream-root
- Blocking predicate: data
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`, `scripts/install_atlas_api_healthcheck.py`, `tests/test_atlas_api_healthcheck.py`
- Max files: 6
- Parked hardening: none

- Root decision: Enroll the healthcheck regression suite in PR CI
- Source trace: every-PR Unit Gate -> config selector escalation to FULL -> enrolled focused test -> native systemd verification
- Upstream files: `tests/test_atlas_api_healthcheck.py`
- Fix strategy: upstream-root
- Blocking predicate: ci
- Disposition: not-applicable
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`, `tests/test_atlas_api_healthcheck.py`
- Max files: 6
- Parked hardening: none

- Root decision: Reject non-finite recovery intervals
- Source trace: nan/inf recovery interval -> sleep failure -> secondary configuration hardening outside the observed finite deployment path
- Upstream files: `plans/PR-EOM-API-Liveness-Contract.md`
- Fix strategy: symptom-only-deferred
- Symptom-Only Reason: finite production intervals already preserve the provider-down deployment proof; widening the CLI validator is adjacent hardening
- Follow-Up: `plans/PR-EOM-API-Liveness-Contract.md` Deferred parking record
- Blocking predicate: not-blocking
- Disposition: waived-out-of-scope
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`
- Max files: 6
- Parked hardening: non-finite recovery intervals

- Root decision: Report nonzero desktop notification exits
- Source trace: nonzero notify-send result -> secondary desktop channel diagnostic -> no change to remote alert retry or provider proof
- Upstream files: `plans/PR-EOM-API-Liveness-Contract.md`
- Fix strategy: symptom-only-deferred
- Symptom-Only Reason: desktop notification is best-effort and cannot change remote alert retry or the provider result consumed by installer proof
- Follow-Up: `plans/PR-EOM-API-Liveness-Contract.md` Deferred parking record
- Blocking predicate: not-blocking
- Disposition: waived-out-of-scope
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`
- Max files: 6
- Parked hardening: nonzero desktop notification exits

- Root decision: Preserve runtime-only timer enablement on rollback
- Source trace: enabled-runtime query -> boolean collapse -> persistent enable during rollback
- Upstream files: `scripts/install_atlas_api_healthcheck.py`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`, `scripts/install_atlas_api_healthcheck.py`, `tests/test_atlas_api_healthcheck.py`
- Max files: 6
- Parked hardening: none

- Root decision: Validate the preflight response, not only its status
- Source trace: OPTIONS 204 -> omitted/corrupt CORS headers -> browser POST remains blocked -> false healthy provider result
- Upstream files: `scripts/atlas_api_healthcheck.py`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`, `scripts/atlas_api_healthcheck.py`, `tests/test_atlas_api_healthcheck.py`
- Max files: 6
- Parked hardening: none

- Root decision: Synchronize the final commit contract with the plan
- Source trace: stale prior PR-body values -> current-head review claim -> exact tip commit and live body comparison
- Upstream files: `plans/PR-EOM-API-Liveness-Contract.md`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`
- Max files: 6
- Parked hardening: none

- Root decision: Synchronize the final commit contract
- Source trace: stale final-contract counts and shifted citations -> current committed tree -> regenerated exact evidence
- Upstream files: `plans/PR-EOM-API-Liveness-Contract.md`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`
- Max files: 6
- Parked hardening: none

- Root decision: Restore metadata changed through topic symlinks
- Source trace: notification environment symlink -> target-following chmod -> referent metadata escapes rollback
- Upstream files: `scripts/install_atlas_api_healthcheck.py`
- Fix strategy: upstream-root
- Blocking predicate: data
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`, `scripts/install_atlas_api_healthcheck.py`, `tests/test_atlas_api_healthcheck.py`
- Max files: 6
- Parked hardening: none

- Root decision: Regenerate the squash commit contract
- Source trace: stale PR-body citations and ephemeral review count -> final committed tree -> regenerated current-head evidence
- Upstream files: `plans/PR-EOM-API-Liveness-Contract.md`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`
- Max files: 6
- Parked hardening: none

- Root decision: Preserve notification-symlink referent metadata
- Source trace: existing notification symlink -> target-following chmod before proof -> rollback cannot restore referent metadata
- Upstream files: `scripts/install_atlas_api_healthcheck.py`
- Fix strategy: upstream-root
- Blocking predicate: data
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`, `scripts/install_atlas_api_healthcheck.py`, `tests/test_atlas_api_healthcheck.py`
- Max files: 6
- Parked hardening: none

- Root decision: Roll back on malformed UTF-8 configuration
- Source trace: malformed notification or legacy bytes -> post-stop decode failure -> rollback bypass
- Upstream files: `scripts/install_atlas_api_healthcheck.py`
- Fix strategy: upstream-root
- Blocking predicate: data
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`, `scripts/install_atlas_api_healthcheck.py`, `tests/test_atlas_api_healthcheck.py`
- Max files: 6
- Parked hardening: none

- Root decision: Preserve a topic symlink when appending
- Source trace: private missing-topic symlink -> atomic replacement at link path -> managed target detached
- Upstream files: `scripts/install_atlas_api_healthcheck.py`
- Fix strategy: upstream-root
- Blocking predicate: data
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`, `scripts/install_atlas_api_healthcheck.py`, `tests/test_atlas_api_healthcheck.py`
- Max files: 6
- Parked hardening: none

- Root decision: Regenerate the exact commit contract
- Source trace: stale synthetic squash evidence -> exact current tree -> regenerated verification, size, and citations
- Upstream files: `plans/PR-EOM-API-Liveness-Contract.md`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`
- Max files: 6
- Parked hardening: none

- Root decision: Verify an independent installed monitor copy
- Source trace: matching bytes through symlink or same inode -> false deployment proof -> runtime-worktree dependency
- Upstream files: `scripts/install_atlas_api_healthcheck.py`
- Fix strategy: upstream-root
- Blocking predicate: claimed-mechanism
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`, `scripts/install_atlas_api_healthcheck.py`, `tests/test_atlas_api_healthcheck.py`
- Max files: 6
- Parked hardening: none

- Root decision: Route termination signals through installer rollback
- Source trace: admitted termination signal -> default process exit -> transactional rollback bypass
- Upstream files: `scripts/install_atlas_api_healthcheck.py`
- Fix strategy: upstream-root
- Blocking predicate: data
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`, `scripts/install_atlas_api_healthcheck.py`, `tests/test_atlas_api_healthcheck.py`
- Max files: 6
- Parked hardening: none

- Root decision: Regenerate the canonical commit contract
- Source trace: stale synthetic contract -> exact current tree -> regenerated verification, size, and citations
- Upstream files: `plans/PR-EOM-API-Liveness-Contract.md`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`
- Max files: 6
- Parked hardening: none

- Root decision: Probe every supported lead-form origin
- Source trace: complete producer origin set -> single-origin standalone probe -> false healthy result
- Upstream files: `scripts/atlas_api_healthcheck.py`
- Fix strategy: upstream-root
- Blocking predicate: claimed-mechanism
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`, `scripts/atlas_api_healthcheck.py`, `tests/test_atlas_api_healthcheck.py`
- Max files: 6
- Parked hardening: none

- Root decision: Validate only configuration used by maintenance exit
- Source trace: exit-maintenance action -> unrelated service validation -> marker cannot be cleared
- Upstream files: `scripts/atlas_api_healthcheck.py`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`, `scripts/atlas_api_healthcheck.py`, `tests/test_atlas_api_healthcheck.py`
- Max files: 6
- Parked hardening: none

- Root decision: Bound the best-effort desktop notification
- Source trace: successful ntfy delivery -> unbounded notify-send -> serialized monitor lock held indefinitely
- Upstream files: `scripts/atlas_api_healthcheck.py`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`, `scripts/atlas_api_healthcheck.py`, `tests/test_atlas_api_healthcheck.py`
- Max files: 6
- Parked hardening: none

- Root decision: Durably publish maintenance before stopping the service
- Source trace: volatile marker creation -> service stop -> crash can erase maintenance intent
- Upstream files: `scripts/atlas_api_healthcheck.py`
- Fix strategy: upstream-root
- Blocking predicate: data
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-API-Liveness-Contract.md`, `scripts/atlas_api_healthcheck.py`, `tests/test_atlas_api_healthcheck.py`
- Max files: 6
- Parked hardening: none

## Deferred

- Render-to-Atlas reachability and an authenticated Render-origin funnel smoke remain a separate deployment-topology slice.
- Active-but-unhealthy process recovery remains deferred until that failure class is independently diagnosed.
- Non-finite recovery-interval validation remains parked configuration hardening; it does not change the provider-down result required by deployment proof.
- Nonzero desktop `notify-send` diagnostics remain parked best-effort observability hardening; remote alert retry and provider outcome remain authoritative.

## Parked hardening

- Non-finite recovery-interval validation and nonzero desktop notification exit diagnostics are explicitly parked in the plan Deferred section.

## Cold diff reconstruction

- `scripts/atlas_api_healthcheck.py:264-325` starts only an inactive, non-maintenance user service and accepts recovery only after all supported lead-form origins pass the browser-shaped OPTIONS contract; an active-but-unhealthy service remains alert-only.
- `scripts/atlas_api_healthcheck.py:97-207,591-644` serializes health and maintenance actors, durably publishes/removes maintenance intent, and persists recovery/alert state before their external effects.
- `scripts/atlas_api_healthcheck.py:328-464,485-545,591-644` validates/migrates persisted state, commits recovery intent before start, and uses a crash-safe ordered alert outbox while every run applies the current observation.
- `scripts/atlas_api_healthcheck.py:210-261` probes the apex and `www` producer origins and fails health on any status, origin, method, or header mismatch.
- `scripts/atlas_api_healthcheck.py:548-575` bounds both remote and best-effort desktop notification calls while preserving the remote-delivery result.
- `scripts/atlas_api_healthcheck.py:647-707` validates only action-used configuration, keeping maintenance exit available without weakening entry/healthcheck service validation.
- `scripts/install_atlas_api_healthcheck.py:88-103,462-525` installs temporary signal handlers for admitted termination paths, routes them through transactional rollback, and restores prior handlers afterward.
- `scripts/install_atlas_api_healthcheck.py:190-278,355-525` precomputes private notification publication before systemd work, atomically writes install artifacts, quiesces the old oneshot, proves the installed service before timer enrollment, and restores prior files/timer state on failure.
- `scripts/install_atlas_api_healthcheck.py:355-418,528-572` applies the same typed unit state to clean and existing hosts and makes `--check` require independent regular-file copies, enabled/active timer state, and current loaded unit definitions.
- `config/atlas-api-healthcheck.service:8-18` and `config/atlas-api-healthcheck.timer:4-10` define the installed standalone program and its five-minute user timer.
- `config/atlas-api-healthcheck.service:17-19` distinguishes a durable queued-alert outcome from provider/probe failure during systemd deployment proof.
- `scripts/install_atlas_api_healthcheck.py:64-70,355-385,421-459` retains the timer UnitFileState class and restores runtime-only enablement without making it persistent.
- `scripts/install_atlas_api_healthcheck.py:56-61,281-337` snapshots raw symlink targets and atomically restores the original live or broken link entry after installation failure.
- `scripts/install_atlas_api_healthcheck.py:139-240,462-480` rejects malformed input and broken, nonprivate, or missing-topic notification symlinks before systemd mutation while preserving accepted private links without chmod or replacement.
- `scripts/install_atlas_api_healthcheck.py:528-543` proves deployed artifacts are independent regular files before comparing content and executable mode.
- `plans/PR-EOM-API-Liveness-Contract.md:90-98,372-416` declares R8 and closes every decision-driving membership over its source and out-of-set behavior.
- `config/atlas-api-healthcheck.service:8-18` inherits the invoking user's systemd manager bus instead of forcing an operator-specific UID path.
- `tests/test_atlas_api_healthcheck.py:266-305,308-373,456-493,579-686,940-1008,1040-1122` covers recovery, serialized maintenance, typed systemd boundaries, crash-safe intent/outbox behavior, clean-host installation, loaded-definition verification, and fail-closed query handling.
- `tests/test_atlas_api_healthcheck.py:457-473,909-991` covers malformed HTTP at both network boundaries, queued-alert systemd success, both maintenance actions with invalid healthcheck environment, and ordinary healthcheck rejection.
- `tests/test_atlas_api_healthcheck.py:281-396,508-576,1091-1129,1212-1248` covers complete producer-origin probing, durable maintenance transitions, bounded desktop notification, and action-specific validation.
- `tests/test_atlas_api_healthcheck.py:1346-1739,1745-1840` covers pre-systemd configuration rejection, independent-copy proof, timer/file/symlink rollback, cancellation, and admitted termination signals.
- Every changed file traces to the plan contract; no funnel route, CRM, migration, tracker, Render, Tailnet, browser, or active runtime-worktree code changed.

## Verification

- Focused regression coverage passed for recovery, current-plus-pending notification state, malformed persistence, private atomic publication, and transactional deployment enrollment.
- `systemd-analyze` accepted both unit templates.
- The plan file is synchronized to the committed diff.

## Mechanical verification

- Command: `python -m py_compile scripts/atlas_api_healthcheck.py scripts/install_atlas_api_healthcheck.py tests/test_atlas_api_healthcheck.py` - Result: passed - Environment: local
- Command: `pytest tests/test_atlas_api_healthcheck.py -q` - Result: 84 passed - Environment: local
- Command: `python scripts/maturity_sweep_file_lane.py scripts/atlas_api_healthcheck.py scripts/install_atlas_api_healthcheck.py --tests-root tests --min-score 8 --sensitive-glob 'scripts/*.py'` - Result: passed - Environment: local
- Command: `systemd-analyze verify config/atlas-api-healthcheck.service config/atlas-api-healthcheck.timer` - Result: passed - Environment: local
- Command: `python scripts/sync_pr_plan.py plans/PR-EOM-API-Liveness-Contract.md --check` - Result: passed - Environment: local
- Command: `python scripts/select_impacted_tests.py --base origin/main` - Result: passed; selector returned `FULL` because the config service escalates to the full Unit Gate - Environment: local
- Command: `git diff --check` - Result: passed - Environment: local

## Diff size

Diff-budget override: The source-managed monitor, install/check path, user-systemd templates, migration-safe local topic handling, and failure/retry proof form one indivisible production recovery contract. Splitting them would publish an inactive artifact or leave the live timer on legacy alert-only code.

- 6 files changed, 3795 insertions.

<!-- atlas-open-pr-wrapper: v1 -->
