### PR TITLE
Build the Atlas Agent Operations Contract

### DIFF
--- a/.agent/capabilities.yaml
+++ b/.agent/capabilities.yaml
@@ -78,7 +78,7 @@ testing:
     status: available-with-explicit-disposable-database
     provider: pytest plus PostgreSQL 16
     command: ./ops test integration <focused-test-target>
-    authentication: ATLAS_MIGRATION_TEST_DATABASE_URL or ATLAS_RECEIVABLES_TEST_DATABASE_URL
+    authentication: one of ATLAS_MIGRATION_TEST_DATABASE_URL, ATLAS_RECEIVABLES_TEST_DATABASE_URL, or ATLAS_LEGACY_MONTHLY_AUTOINVOICE_WRITER_TEST_DATABASE_URL
     current_session_capable: false-until-a-disposable-url-is-exported
     mutation: destructive within the explicitly confirmed disposable database
     safe_verify: use the matching GitHub Actions workflow when no disposable local database is prepared
@@ -152,19 +152,21 @@ database:
   authentication: local PostgreSQL rules or ATLAS_DB_* environment variables
   current_session_capable: true
   access: ./ops db status
-  safe_query: ./ops db query "SELECT 1"
+  safe_inspection: ./ops db inspect connectivity
+  arbitrary_query: unavailable-until-a-privilege-restricted-inspection-role-exists
   migration_status: ./ops db migrations
   migrations:
     provider: custom SQL runner
     path: atlas_brain/storage/migrations
     invocation: automatic during full application startup
     warning: the full chain is not fresh-database applicable because later migrations depend on out-of-band product_metadata
-  mutation: query is read-only; app startup and integration tests can mutate
+  mutation: fixed inspections are read-only; app startup and integration tests can mutate
   likely_failures:
     - assuming root Docker Compose provides PostgreSQL
     - using Alembic even though Atlas uses its custom SQL runner
     - treating app startup as a read-only health check
     - using the live atlas database for integration tests
+    - assuming a READ ONLY transaction makes arbitrary SELECT functions non-mutating
   runbook: .agent/runbooks/database.md
 
 logs:

--- a/.agent/capabilities.yaml
+++ b/.agent/capabilities.yaml
@@ -6,7 +6,7 @@ project:
   verified_at: "2026-08-24"
   operational_entrypoint: ./ops doctor
   source_of_truth:
-    - ./ops runtime inspection
+    - ./ops doctor
     - executable configuration and current code
     - .agent/runbooks
     - README.md and CLAUDE.md only where they agree with the above
@@ -78,7 +78,7 @@ testing:
   integration:
     status: available-with-explicit-disposable-database
     provider: pytest plus PostgreSQL 16
-    command: ./ops test integration <focused-test-target>
+    command: ./ops test integration <tests/test_file.py[::node]> [pytest-options]
     authentication: one of ATLAS_MIGRATION_TEST_DATABASE_URL, ATLAS_RECEIVABLES_TEST_DATABASE_URL, or ATLAS_LEGACY_MONTHLY_AUTOINVOICE_WRITER_TEST_DATABASE_URL
     current_session_capable: false-until-a-disposable-url-is-exported
     mutation: destructive within the explicitly confirmed disposable database
@@ -86,6 +86,7 @@ testing:
     likely_failures:
       - pointing tests at the live atlas database
       - omitting ATLAS_CONFIRM_DISPOSABLE_TEST_DB=1
+      - omitting a concrete existing test file or passing a directory-wide target
       - running multiple DB-backed suites against one shared database
     runbook: .agent/runbooks/testing.md
 

--- a/.agent/capabilities.yaml
+++ b/.agent/capabilities.yaml
@@ -64,12 +64,13 @@ testing:
     command: ./ops test unit
     authentication: none
     current_session_capable: true
-    mutation: local test artifacts only; production providers are not required
+    mutation: local test artifacts only; inherited DATABASE_URL and *_DATABASE_URL values are removed before pytest, so database-backed tests skip
     safe_verify: ./ops test focused tests/test_agent_operations_contract.py -q
     likely_failures:
       - a worktree has no local .venv and must use the shared project venv or ATLAS_PYTHON
       - optional dependencies can cause collection errors
       - the full suite uses a committed known-failure baseline in CI
+      - use integration mode for database-backed proof; unit mode intentionally removes database URL credentials
   focused:
     status: verified
     command: ./ops test focused <pytest-target-and-args>

--- a/.agent/capabilities.yaml
+++ b/.agent/capabilities.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 project:
   name: Atlas
   repository: canfieldjuan/ATLAS
-  verified_at: "2026-08-24"
+  verified_at: "2026-08-25"
   operational_entrypoint: ./ops doctor
   source_of_truth:
     - ./ops doctor
@@ -80,12 +80,14 @@ testing:
     provider: pytest plus PostgreSQL 16
     command: ./ops test integration <tests/test_file.py[::node]> [pytest-options]
     authentication: exactly one of ATLAS_MIGRATION_TEST_DATABASE_URL, ATLAS_RECEIVABLES_TEST_DATABASE_URL, or ATLAS_LEGACY_MONTHLY_AUTOINVOICE_WRITER_TEST_DATABASE_URL
+    credential_isolation: pytest receives only the confirmed DSN, adapted to the selected canonical key, DATABASE_URL, EXTRACTED_DATABASE_URL, and ATLAS_DB_CONNECTION_STRING; other database credentials are removed
     current_session_capable: false-until-a-disposable-url-is-exported
     mutation: destructive within the explicitly confirmed disposable database
     safe_verify: use the matching GitHub Actions workflow when no disposable local database is prepared
     likely_failures:
       - pointing tests at the live atlas database
       - exporting multiple canonical test database URLs at once
+      - assuming an ambient generic or Atlas application database credential is passed through unchanged
       - omitting ATLAS_CONFIRM_DISPOSABLE_TEST_DB=1
       - omitting a concrete existing test file or passing a directory-wide target
       - running multiple DB-backed suites against one shared database

--- a/.agent/capabilities.yaml
+++ b/.agent/capabilities.yaml
@@ -1,0 +1,286 @@
+schema_version: 1
+
+project:
+  name: Atlas
+  repository: canfieldjuan/ATLAS
+  verified_at: "2026-08-24"
+  operational_entrypoint: ./ops doctor
+  source_of_truth:
+    - ./ops runtime inspection
+    - executable configuration and current code
+    - .agent/runbooks
+    - README.md and CLAUDE.md only where they agree with the above
+
+workspace:
+  normal_worktree:
+    status: verified
+    inspect: git status --short --branch
+    authentication: none
+    mutation: read-only
+    safe_verify: ./ops doctor
+  shared_root:
+    status: verified
+    path_hint: the parent of the worktree git common directory
+    purpose: holds shared ignored runtime state such as .env, .venv, and .vercel
+    warning: the shared Atlas root can report as bare and reject git status
+    runbook: .agent/runbooks/environment.md
+
+runtime:
+  brain:
+    status: verified
+    implementation: FastAPI served by uvicorn
+    code_entrypoint: atlas_brain.main:app
+    local_command: python -m uvicorn atlas_brain.main:app --host 127.0.0.1 --port 8001
+    production_provider: local systemd user service
+    production_service: atlas-api.service
+    production_health: http://127.0.0.1:8012/api/v1/ping
+    authentication: local user session and systemd user bus
+    current_session_capable: true
+    mutation: startup may run database migrations and enabled background work
+    safe_verify: ./ops deploy status
+    likely_failures:
+      - running from the shared bare root instead of a worktree
+      - missing or wrong systemd EnvironmentFiles
+      - database migration or writer-fence failure during startup
+      - optional LLM, ASR, or external provider unavailable
+    runbook: .agent/runbooks/environment.md
+  frontend_packages:
+    status: verified
+    provider: npm and Vite, with Expo for atlas-mobile
+    packages:
+      - atlas-ui
+      - atlas-intel-ui
+      - atlas-churn-ui
+      - atlas-admin-ui
+      - atlas-mobile
+      - portfolio-ui
+    safe_verify: ./ops test frontend atlas-churn-ui test
+    runbook: .agent/runbooks/testing.md
+
+testing:
+  unit:
+    status: verified
+    provider: pytest
+    command: ./ops test unit
+    authentication: none
+    current_session_capable: true
+    mutation: local test artifacts only; production providers are not required
+    safe_verify: ./ops test focused tests/test_agent_operations_contract.py -q
+    likely_failures:
+      - a worktree has no local .venv and must use the shared project venv or ATLAS_PYTHON
+      - optional dependencies can cause collection errors
+      - the full suite uses a committed known-failure baseline in CI
+  focused:
+    status: verified
+    command: ./ops test focused <pytest-target-and-args>
+    mutation: depends on the selected test
+  integration:
+    status: available-with-explicit-disposable-database
+    provider: pytest plus PostgreSQL 16
+    command: ./ops test integration <focused-test-target>
+    authentication: ATLAS_MIGRATION_TEST_DATABASE_URL or ATLAS_RECEIVABLES_TEST_DATABASE_URL
+    current_session_capable: false-until-a-disposable-url-is-exported
+    mutation: destructive within the explicitly confirmed disposable database
+    safe_verify: use the matching GitHub Actions workflow when no disposable local database is prepared
+    likely_failures:
+      - pointing tests at the live atlas database
+      - omitting ATLAS_CONFIRM_DISPOSABLE_TEST_DB=1
+      - running multiple DB-backed suites against one shared database
+    runbook: .agent/runbooks/testing.md
+
+ci:
+  status: verified
+  provider: GitHub Actions
+  repository: canfieldjuan/ATLAS
+  authentication: GitHub CLI keyring login with repo and workflow scopes
+  current_session_capable: true
+  mutation: inspection commands are read-only; rerun and dispatch are mutating
+  inspect: ./ops ci status
+  inspect_run: ./ops ci run <run-id> --log-failed
+  required_gate_registry: ci/gates.yml
+  safe_verify: gh workflow list --repo canfieldjuan/ATLAS
+  likely_failures:
+    - inspecting a stale run or a run for a different head SHA
+    - confusing advisory workflows with branch-required contexts
+    - assuming a skipped or runnerless job proves source failure
+  runbook: .agent/runbooks/ci.md
+
+deployment:
+  brain:
+    status: verified
+    provider: local systemd user service
+    service: atlas-api.service
+    source: detached runtime worktree
+    inspect: ./ops deploy status
+    deploy: manual guarded runtime-worktree cutover and systemd restart
+    current_session_capable: inspect-only
+    mutation: production-mutating; restart also invokes migration checks
+    staging: unavailable-no-service-discovered
+  frontend:
+    status: verified
+    provider: Vercel
+    project: atlas-churn-ui
+    build_config: vercel.json
+    build_source: atlas-churn-ui
+    inspect: ./ops deploy status
+    logs: ./ops logs frontend --since 1h
+    environment_inspect: ./ops env vercel
+    authentication: Vercel CLI login and ignored shared-root .vercel linkage
+    current_session_capable: true
+    mutation: inspect commands are read-only; vercel --prod is production-mutating
+    production: verified-ready-deployment-exists
+    preview: available-through-Vercel
+    staging: no-separate-named-environment-discovered
+    trigger: could-not-determine-no-tracked-GitHub-deploy-job-and-live-deployment-had-no-Git-metadata
+  render:
+    status: not-an-Atlas-deployment
+    provider: Render
+    authentication: CLI authenticated in the current session
+    current_session_capable: true
+    safe_verify: render services --output json
+    note: other workspace services exist, but no Atlas Brain service was identified
+  runbook: .agent/runbooks/deployment.md
+
+database:
+  status: verified
+  engine: PostgreSQL 16
+  provider: native local system service
+  host: 127.0.0.1
+  port: 5433
+  database: atlas
+  role: atlas
+  authentication: local PostgreSQL rules or ATLAS_DB_* environment variables
+  current_session_capable: true
+  access: ./ops db status
+  safe_query: ./ops db query "SELECT 1"
+  migration_status: ./ops db migrations
+  migrations:
+    provider: custom SQL runner
+    path: atlas_brain/storage/migrations
+    invocation: automatic during full application startup
+    warning: the full chain is not fresh-database applicable because later migrations depend on out-of-band product_metadata
+  mutation: query is read-only; app startup and integration tests can mutate
+  likely_failures:
+    - assuming root Docker Compose provides PostgreSQL
+    - using Alembic even though Atlas uses its custom SQL runner
+    - treating app startup as a read-only health check
+    - using the live atlas database for integration tests
+  runbook: .agent/runbooks/database.md
+
+logs:
+  brain:
+    status: verified
+    provider: journald
+    inspect: ./ops logs brain
+    authentication: local user journal access
+    current_session_capable: true
+    mutation: read-only
+  containers:
+    status: verified
+    provider: Docker
+    inspect: ./ops logs container <container-name>
+    authentication: Docker daemon access
+    current_session_capable: true
+    mutation: read-only
+  frontend:
+    status: verified
+    provider: Vercel runtime logs
+    inspect: ./ops logs frontend --since 1h
+    authentication: Vercel CLI login
+    current_session_capable: true
+    mutation: read-only
+    note: a static deployment can legitimately return no runtime log records
+  runbook: .agent/runbooks/logs.md
+
+environment:
+  status: verified
+  local_sources:
+    - worktree .env and .env.local when deliberately provisioned
+    - shared-root .env, .env.local, and .env.tailscale
+    - systemd EnvironmentFiles for atlas-api.service
+    - tracked subsystem .env.example files
+  inspect_keys_only: ./ops env keys
+  inspect_systemd_sources: ./ops env systemd
+  inspect_vercel_names: ./ops env vercel
+  authentication: filesystem permissions, systemd user bus, or Vercel login
+  mutation: read-only
+  warning: no root .env.example exists; never print, commit, or copy live values into a worktree
+  runbook: .agent/runbooks/environment.md
+
+containers:
+  status: verified
+  provider: Docker Engine with docker compose plugin
+  current_session_capable: true
+  compose_files:
+    root: docker-compose.yml
+    graph: docker-compose.graphiti.yml
+    home_assistant:
+      - docker-compose.ha.yml
+      - docker-compose.homeassistant.yml
+    cameras: docker-compose.wyze.yml
+  warning: root Compose has no postgres service and even status parsing requires ATLAS_NOCODB_DB_PASSWORD
+
+external_services:
+  required_or_active:
+    - PostgreSQL
+    - GitHub Actions
+    - Vercel for atlas-churn-ui
+    - Neo4j and Graphiti for graph memory
+    - NocoDB for the optional CRM admin UI
+  configured_or_optional:
+    - Ollama and vLLM
+    - Anthropic, OpenRouter, Groq, and Together AI
+    - Google Gmail and Calendar
+    - Stripe
+    - Resend and Amazon SES
+    - SignalWire and Twilio
+    - Home Assistant and MQTT
+    - Zendesk, Firecrawl, Apollo, and ntfy
+  rule: provider availability must be verified per operation; a config class or secret name is not proof of a live integration
+
+tools:
+  verified_at: "2026-08-24"
+  canonical:
+    git: available
+    gh: authenticated
+    python_project_venv: "3.12.3"
+    node: "26.7.0"
+    npm: "11.19.0"
+    docker: "29.7.2 daemon reachable"
+    docker_compose_plugin: available
+    psql: "16.15"
+    vercel: "50.26.1 authenticated"
+    render: "2.15.0 authenticated but not used for Atlas deployment"
+    systemctl: available
+    journalctl: available
+  available_not_canonical:
+    - uv
+    - pnpm
+    - yarn
+    - alembic
+  unavailable:
+    - docker-compose legacy binary
+    - flyctl
+    - railway
+    - gcloud
+    - aws
+    - az
+    - terraform
+    - kubectl
+  degraded:
+    ollama: CLI available but local server was unreachable
+
+repository_operations:
+  status: verified
+  provider: git and GitHub CLI
+  inspect: git status --short --branch
+  pr_status: gh pr list --state open
+  safe_verify: gh auth status
+  authentication: GitHub CLI keyring login
+  mutation: commits, pushes, comments, reviews, PR edits, and merges mutate state
+  required_process:
+    - AGENTS.md
+    - docs/SESSION_BOOTSTRAP.md
+    - session-scoped SESSION_STATE.*.local.md
+    - scripts/push_pr.sh
+    - scripts/open_pr.sh

--- a/.agent/capabilities.yaml
+++ b/.agent/capabilities.yaml
@@ -73,7 +73,10 @@ testing:
   focused:
     status: verified
     command: ./ops test focused <pytest-target-and-args>
+    credential_isolation: removes canonical, URL-shaped, Atlas application, libpq PG*, and disposable-confirmation database authority before pytest
     mutation: depends on the selected test
+    likely_failures:
+      - database-backed tests skip or fail without credentials; use guarded integration mode with an explicitly disposable database
   integration:
     status: available-with-explicit-disposable-database
     provider: pytest plus PostgreSQL 16

--- a/.agent/capabilities.yaml
+++ b/.agent/capabilities.yaml
@@ -79,14 +79,14 @@ testing:
     provider: pytest plus PostgreSQL 16
     command: ./ops test integration <tests/test_file.py[::node]> [pytest-options]
     authentication: exactly one of ATLAS_MIGRATION_TEST_DATABASE_URL, ATLAS_RECEIVABLES_TEST_DATABASE_URL, or ATLAS_LEGACY_MONTHLY_AUTOINVOICE_WRITER_TEST_DATABASE_URL
-    credential_isolation: pytest receives only the confirmed DSN, adapted to the selected canonical key, DATABASE_URL, EXTRACTED_DATABASE_URL, and ATLAS_DB_CONNECTION_STRING; other database credentials are removed
+    credential_isolation: pytest receives only the confirmed DSN, adapted to the selected canonical key, DATABASE_URL, EXTRACTED_DATABASE_URL, and ATLAS_DB_CONNECTION_STRING; inherited URL-shaped, Atlas application, and libpq PG* credentials are removed
     current_session_capable: false-until-a-disposable-url-is-exported
     mutation: destructive within the explicitly confirmed disposable database
     safe_verify: use the matching GitHub Actions workflow when no disposable local database is prepared
     likely_failures:
       - pointing tests at the live atlas database
       - exporting multiple canonical test database URLs at once
-      - assuming an ambient generic or Atlas application database credential is passed through unchanged
+      - assuming an ambient generic, Atlas application, or libpq PG* database credential is passed through unchanged
       - omitting ATLAS_CONFIRM_DISPOSABLE_TEST_DB=1
       - omitting a concrete existing test file or passing a directory-wide target
       - running multiple DB-backed suites against one shared database

--- a/.agent/capabilities.yaml
+++ b/.agent/capabilities.yaml
@@ -59,18 +59,17 @@ runtime:
 
 testing:
   unit:
-    status: verified
-    provider: pytest
-    command: ./ops test unit
+    status: hosted-only
+    provider: GitHub Actions running pytest
+    command: .github/workflows/unit_gate.yml
     authentication: none
-    current_session_capable: true
-    mutation: local test artifacts only; inherited DATABASE_URL and *_DATABASE_URL values are removed before pytest, so database-backed tests skip
-    safe_verify: ./ops test focused tests/test_agent_operations_contract.py -q
+    current_session_capable: inspect-only; local execution is intentionally disabled
+    mutation: hosted test artifacts only
+    safe_verify: ./ops ci status
     likely_failures:
-      - a worktree has no local .venv and must use the shared project venv or ATLAS_PYTHON
       - optional dependencies can cause collection errors
       - the full suite uses a committed known-failure baseline in CI
-      - use integration mode for database-backed proof; unit mode intentionally removes database URL credentials
+      - a local invocation is rejected by policy; use focused mode for narrow proof
   focused:
     status: verified
     command: ./ops test focused <pytest-target-and-args>

--- a/.agent/capabilities.yaml
+++ b/.agent/capabilities.yaml
@@ -20,7 +20,7 @@ workspace:
     safe_verify: ./ops doctor
   shared_root:
     status: verified
-    path_hint: the parent of the worktree git common directory
+    path_hint: the parent for a conventional .git common directory; otherwise the direct bare common directory
     purpose: holds shared ignored runtime state such as .env, .venv, and .vercel
     warning: the shared Atlas root can report as bare and reject git status
     runbook: .agent/runbooks/environment.md
@@ -79,12 +79,13 @@ testing:
     status: available-with-explicit-disposable-database
     provider: pytest plus PostgreSQL 16
     command: ./ops test integration <tests/test_file.py[::node]> [pytest-options]
-    authentication: one of ATLAS_MIGRATION_TEST_DATABASE_URL, ATLAS_RECEIVABLES_TEST_DATABASE_URL, or ATLAS_LEGACY_MONTHLY_AUTOINVOICE_WRITER_TEST_DATABASE_URL
+    authentication: exactly one of ATLAS_MIGRATION_TEST_DATABASE_URL, ATLAS_RECEIVABLES_TEST_DATABASE_URL, or ATLAS_LEGACY_MONTHLY_AUTOINVOICE_WRITER_TEST_DATABASE_URL
     current_session_capable: false-until-a-disposable-url-is-exported
     mutation: destructive within the explicitly confirmed disposable database
     safe_verify: use the matching GitHub Actions workflow when no disposable local database is prepared
     likely_failures:
       - pointing tests at the live atlas database
+      - exporting multiple canonical test database URLs at once
       - omitting ATLAS_CONFIRM_DISPOSABLE_TEST_DB=1
       - omitting a concrete existing test file or passing a directory-wide target
       - running multiple DB-backed suites against one shared database
@@ -154,6 +155,7 @@ database:
   authentication: local PostgreSQL rules or ATLAS_DB_* environment variables
   current_session_capable: true
   access: ./ops db status
+  configuration_selection: explicit ATLAS_OPS_ENV_FILES context, else worktree .env/.env.local, else shared-root .env/.env.local, else systemd EnvironmentFiles; exported process values win last
   safe_inspection: ./ops db inspect connectivity
   arbitrary_query: unavailable-until-a-privilege-restricted-inspection-role-exists
   migration_status: ./ops db migrations
@@ -168,6 +170,7 @@ database:
     - using Alembic even though Atlas uses its custom SQL runner
     - treating app startup as a read-only health check
     - using the live atlas database for integration tests
+    - merging inventory-only examples or an unrelated shared/systemd context into a deliberately provisioned worktree context
     - assuming a READ ONLY transaction makes arbitrary SELECT functions non-mutating
   runbook: .agent/runbooks/database.md
 
@@ -215,6 +218,8 @@ containers:
   status: verified
   provider: Docker Engine with docker compose plugin
   current_session_capable: true
+  inspect: ./ops status
+  safe_verify: docker info
   compose_files:
     root: docker-compose.yml
     graph: docker-compose.graphiti.yml
@@ -223,6 +228,9 @@ containers:
       - docker-compose.homeassistant.yml
     cameras: docker-compose.wyze.yml
   warning: root Compose has no postgres service and even status parsing requires ATLAS_NOCODB_DB_PASSWORD
+  likely_failures:
+    - Docker CLI installed but daemon stopped, unreachable, or denied
+    - a known container genuinely absent after daemon access succeeds
 
 external_services:
   required_or_active:

--- a/.agent/runbooks/ci.md
+++ b/.agent/runbooks/ci.md
@@ -1,0 +1,65 @@
+# CI and pull-request inspection
+
+Atlas uses GitHub Actions. The current GitHub CLI session is authenticated and
+can inspect the repository; inspection does not grant permission to rerun,
+dispatch, edit, push, review, or merge.
+
+## Fast inspection
+
+```bash
+./ops ci status
+./ops ci status 25
+./ops ci run <run-id>
+./ops ci run <run-id> --log-failed
+```
+
+For a PR, first establish exact ownership and head:
+
+```bash
+gh pr view <number> --repo canfieldjuan/ATLAS \
+  --json number,url,headRefName,headRefOid,baseRefName,state,isDraft
+gh pr checks <number> --repo canfieldjuan/ATLAS
+```
+
+Do not infer current status from a prior message, commit, or run. Match the PR
+head OID to the run head SHA and re-poll review/reconciliation immediately
+before a verdict or merge decision.
+
+## What is required
+
+`ci/gates.yml` is the machine-readable enforcement registry. At verification
+time its branch-required contexts include live reconciliation, secret scanning,
+baseline-growth protection, diff budget, plan admission, session lane, review
+contract, PR body contract, and Unit Gate. Read the registry live rather than
+copying this sentence into a decision; the set can change.
+
+Path-specific product/package workflows supplement those meta gates. A workflow
+being active does not mean it triggers on every diff. The Unit Gate runs on
+every PR and chooses impacted tests or the full non-integration/e2e suite;
+Repo-Wide Unit Backstop runs the full unit suite on schedule/on demand.
+
+The builder's local gate is `scripts/local_pr_review.sh`, normally invoked once
+by `scripts/push_pr.sh`/the managed pre-push hook. GitHub re-runs the trusted-base
+audit. Do not delete that duplication or run the same local bundle twice
+immediately before one push.
+
+## Actions that mutate CI or PR state
+
+The following are not discovery commands and are intentionally absent from
+`./ops`: workflow dispatch, run rerun/cancel/delete, PR comment/review/edit,
+push, merge, and branch protection changes. Follow `AGENTS.md`, the session
+state ownership guard, and the active PR contract before any of them.
+
+## Failure routing
+
+- Red required check: inspect the exact run and failed step; do not merge.
+- `steps: []` or failure before runner allocation: classify it as hosted
+  infrastructure/runner failure and compare local workflow-equivalent gates.
+- Check absent: inspect workflow path filters and `ci/gates.yml`; absence is not
+  green.
+- Advisory workflow red: report it separately from branch-required status, but
+  still assess whether it exposes a real security/data/deployment defect.
+- GitHub authentication fails: use `gh auth status`; do not re-login or replace
+  tokens without operator direction.
+- PR ownership guard fails: stop and ask the operator. Lane similarity is not
+  ownership.

--- a/.agent/runbooks/ci.md
+++ b/.agent/runbooks/ci.md
@@ -40,8 +40,10 @@ Repo-Wide Unit Backstop runs the full unit suite on schedule/on demand.
 
 The builder's local gate is `scripts/local_pr_review.sh`, normally invoked once
 by `scripts/push_pr.sh`/the managed pre-push hook. GitHub re-runs the trusted-base
-audit. Do not delete that duplication or run the same local bundle twice
-immediately before one push.
+audit. The local bundle runs mechanical checks only; it never launches the unit
+checker or pytest. `.github/workflows/unit_gate.yml` is the sole unit-gate
+runner. Do not delete the trusted audit duplication or run the same local bundle
+twice immediately before one push.
 
 ## Actions that mutate CI or PR state
 

--- a/.agent/runbooks/database.md
+++ b/.agent/runbooks/database.md
@@ -93,6 +93,11 @@ contain the same credential; they let current test consumers use their existing
 interface without inheriting a second database. The DSN is never placed in
 process arguments or output.
 
+`./ops test focused ...` uses the removal half of the same boundary without
+restoring any DSN. Database-backed focused targets therefore cannot inherit a
+stale credential; rerun the exact file/node through `./ops test integration ...`
+only after confirming a disposable database.
+
 Never point those variables at the live `atlas` database. Run only a focused
 database test target and do not run concurrent DB-backed suites against the
 same disposable database; many tests create/drop or rewrite shared objects.

--- a/.agent/runbooks/database.md
+++ b/.agent/runbooks/database.md
@@ -1,0 +1,83 @@
+# Database operations
+
+Use this runbook for PostgreSQL connectivity, bounded read-only queries,
+migration status, and database-backed tests.
+
+## Architecture and safe inspection
+
+Atlas uses native PostgreSQL 16 on `127.0.0.1:5433`, normally database `atlas`
+and role `atlas`. Root Docker Compose connects to this host service; it does not
+create PostgreSQL.
+
+```bash
+./ops db status
+./ops db query "SELECT 1"
+./ops db migrations
+```
+
+`./ops db query` accepts exactly one `SELECT`, `SHOW`, `TABLE`, or `VALUES`
+statement. It refuses write/DDL leads, `SELECT INTO`, row-locking selects, and
+multiple statements, then still runs the admitted SQL inside a PostgreSQL
+`READ ONLY` transaction with statement and lock timeouts. It uses exported
+`ATLAS_DB_*` variables or the same selected keys from discovered env files, but
+never prints credentials.
+
+The command is a write guard, not a data-privacy guard. Query only the columns
+and rows needed, add a `LIMIT`, and do not paste customer content or identifiers
+into chat or GitHub. There is intentionally no `./ops db write`.
+
+## Migrations
+
+Atlas does not use Alembic even though an `alembic` executable is installed.
+The canonical runner is `atlas_brain.storage.migrations.run_migrations`, backed
+by versioned SQL under `atlas_brain/storage/migrations/` and a
+`schema_migrations` ledger.
+
+The full FastAPI lifespan initializes the pool and invokes the migration check
+at startup. The runner holds a PostgreSQL advisory lock, re-snapshots the ledger
+under that lock, and applies pending files. Therefore a service restart is also
+a potential schema mutation.
+
+Do not manually run the full chain against a fresh database. The runner's code
+documents that migrations from `076` onward depend on an out-of-band
+`product_metadata` table that no packaged migration creates. Components that
+need one later prerequisite use the runner's bounded `only` mode. Never roll
+back or edit the live migration ledger during discovery.
+
+## Database-backed tests
+
+CI creates disposable PostgreSQL 16 service databases and supplies one of:
+
+- `ATLAS_MIGRATION_TEST_DATABASE_URL`
+- `ATLAS_RECEIVABLES_TEST_DATABASE_URL`
+- `ATLAS_LEGACY_MONTHLY_AUTOINVOICE_WRITER_TEST_DATABASE_URL`
+
+For local work, create or obtain a disposable database outside `./ops`, verify
+its exact name/host, then export only the matching test URL and acknowledge the
+boundary:
+
+```bash
+export ATLAS_MIGRATION_TEST_DATABASE_URL='postgresql://.../disposable_db'
+export ATLAS_CONFIRM_DISPOSABLE_TEST_DB=1
+./ops test integration tests/test_migrations_runner.py -q
+```
+
+Never point those variables at the live `atlas` database. Run only a focused
+database test target and do not run concurrent DB-backed suites against the
+same disposable database; many tests create/drop or rewrite shared objects.
+When no isolated local database is prepared, use the matching GitHub Actions
+workflow as the canonical proof.
+
+## Failure routing
+
+- `pg_isready` fails: check `systemctl status postgresql@16-main` and whether
+  port `5433` is listening; do not fall back to an unrelated `5432` database.
+- Readiness passes but the query fails: authentication or database selection is
+  wrong. Inspect key names with `./ops env keys`; never print the URL/password.
+- `schema_migrations` is absent: stop. The target is probably a fresh or wrong
+  database; do not “fix” it by applying the full chain.
+- Startup logs show a migration/writer fence: follow
+  `.agent/runbooks/deployment.md` and the specific product runbook. Do not
+  bypass the fence or edit the ledger.
+- NocoDB is unavailable: this does not mean PostgreSQL is down. NocoDB is an
+  optional browser UI and has its own unprivileged credential prerequisite.

--- a/.agent/runbooks/database.md
+++ b/.agent/runbooks/database.md
@@ -22,6 +22,25 @@ retains TLS, socket, and other connection parameters without appearing in a
 process argument. The fixed SQL still runs inside a PostgreSQL `READ ONLY`
 transaction with command, statement, and lock timeouts.
 
+## Configuration context and precedence
+
+Database inspection deliberately selects one application context instead of
+merging every file that `./ops env keys` inventories:
+
+1. `ATLAS_OPS_ENV_FILES`, when explicitly set, selects only those files in the
+   listed order.
+2. Otherwise, the presence of `.env` or `.env.local` in the current worktree
+   selects that pair, matching `DatabaseConfig` in that working directory.
+3. Without a worktree pair, the shared-root `.env`/`.env.local` pair is used.
+4. Systemd `EnvironmentFiles` are the final live-service fallback.
+5. Exported process values override the selected files.
+
+A present worktree context remains selected even when it omits database keys;
+do not silently fall through to shared production configuration. Tracked
+examples and `.env.tailscale` remain useful for key inventory, but they are not
+database value sources. Use `ATLAS_OPS_ENV_FILES` only to select an intentional
+context, never to concatenate unrelated environments.
+
 There is intentionally no arbitrary `./ops db query`: PostgreSQL permits
 functions with operational side effects inside a `READ ONLY` transaction. A
 generic query command is unavailable until Atlas has a privilege-restricted
@@ -55,8 +74,9 @@ CI creates disposable PostgreSQL 16 service databases and supplies one of:
 - `ATLAS_LEGACY_MONTHLY_AUTOINVOICE_WRITER_TEST_DATABASE_URL`
 
 For local work, create or obtain a disposable database outside `./ops`, verify
-its exact name/host, then export only the matching test URL and acknowledge the
-boundary:
+its exact name/host, then export exactly one matching test URL and acknowledge
+the boundary. Integration mode rejects both zero and multiple active canonical
+URLs before pytest starts:
 
 ```bash
 export ATLAS_MIGRATION_TEST_DATABASE_URL='postgresql://.../disposable_db'
@@ -75,7 +95,11 @@ workflow as the canonical proof.
 - `pg_isready` fails: check `systemctl status postgresql@16-main` and whether
   port `5433` is listening; do not fall back to an unrelated `5432` database.
 - Connectivity inspection fails: authentication or database selection is
-  wrong. Inspect key names with `./ops env keys`; never print the URL/password.
+  wrong. Inspect key names with `./ops env keys`; then verify the selected
+  context above without printing the URL/password.
+- Integration admission reports multiple URLs: unset every stale canonical
+  test URL except the one belonging to the focused suite; never guess which
+  disposable database should win.
 - `schema_migrations` is absent: stop. The target is probably a fresh or wrong
   database; do not “fix” it by applying the full chain.
 - Startup logs show a migration/writer fence: follow

--- a/.agent/runbooks/database.md
+++ b/.agent/runbooks/database.md
@@ -84,6 +84,14 @@ export ATLAS_CONFIRM_DISPOSABLE_TEST_DB=1
 ./ops test integration tests/test_migrations_runner.py -q
 ```
 
+After confirmation, `./ops` constructs a database-isolated child environment.
+It removes every inherited `DATABASE_URL`/`*_DATABASE_URL` and Atlas
+application database setting, then exposes the one confirmed DSN under the
+selected canonical key, `DATABASE_URL`, `EXTRACTED_DATABASE_URL`, and
+`ATLAS_DB_CONNECTION_STRING`. These aliases contain the same credential; they
+let current test consumers use their existing interface without inheriting a
+second database. The DSN is never placed in process arguments or output.
+
 Never point those variables at the live `atlas` database. Run only a focused
 database test target and do not run concurrent DB-backed suites against the
 same disposable database; many tests create/drop or rewrite shared objects.
@@ -100,6 +108,9 @@ workflow as the canonical proof.
 - Integration admission reports multiple URLs: unset every stale canonical
   test URL except the one belonging to the focused suite; never guess which
   disposable database should win.
+- A test needs another database interface: add an explicit adapter from the
+  already confirmed DSN and focused boundary proof; do not pass the parent
+  environment through or add a second credential.
 - `schema_migrations` is absent: stop. The target is probably a fresh or wrong
   database; do not “fix” it by applying the full chain.
 - Startup logs show a migration/writer fence: follow

--- a/.agent/runbooks/database.md
+++ b/.agent/runbooks/database.md
@@ -1,6 +1,6 @@
 # Database operations
 
-Use this runbook for PostgreSQL connectivity, bounded read-only queries,
+Use this runbook for PostgreSQL connectivity, fixed read-only inspections,
 migration status, and database-backed tests.
 
 ## Architecture and safe inspection
@@ -11,20 +11,22 @@ create PostgreSQL.
 
 ```bash
 ./ops db status
-./ops db query "SELECT 1"
+./ops db inspect connectivity
 ./ops db migrations
 ```
 
-`./ops db query` accepts exactly one `SELECT`, `SHOW`, `TABLE`, or `VALUES`
-statement. It refuses write/DDL leads, `SELECT INTO`, row-locking selects, and
-multiple statements, then still runs the admitted SQL inside a PostgreSQL
-`READ ONLY` transaction with statement and lock timeouts. It uses exported
-`ATLAS_DB_*` variables or the same selected keys from discovered env files, but
-never prints credentials.
+`./ops db inspect` accepts only the named, fixed `connectivity` and `migrations`
+inspections. It executes them through the project Python and Atlas's
+`DatabaseConfig`/asyncpg path, so a complete `ATLAS_DB_CONNECTION_STRING`
+retains TLS, socket, and other connection parameters without appearing in a
+process argument. The fixed SQL still runs inside a PostgreSQL `READ ONLY`
+transaction with command, statement, and lock timeouts.
 
-The command is a write guard, not a data-privacy guard. Query only the columns
-and rows needed, add a `LIMIT`, and do not paste customer content or identifiers
-into chat or GitHub. There is intentionally no `./ops db write`.
+There is intentionally no arbitrary `./ops db query`: PostgreSQL permits
+functions with operational side effects inside a `READ ONLY` transaction. A
+generic query command is unavailable until Atlas has a privilege-restricted
+inspection role. Do not paste customer content or identifiers into chat or
+GitHub, and do not substitute the live application role as an ad hoc read role.
 
 ## Migrations
 
@@ -72,7 +74,7 @@ workflow as the canonical proof.
 
 - `pg_isready` fails: check `systemctl status postgresql@16-main` and whether
   port `5433` is listening; do not fall back to an unrelated `5432` database.
-- Readiness passes but the query fails: authentication or database selection is
+- Connectivity inspection fails: authentication or database selection is
   wrong. Inspect key names with `./ops env keys`; never print the URL/password.
 - `schema_migrations` is absent: stop. The target is probably a fresh or wrong
   database; do not “fix” it by applying the full chain.

--- a/.agent/runbooks/database.md
+++ b/.agent/runbooks/database.md
@@ -85,12 +85,13 @@ export ATLAS_CONFIRM_DISPOSABLE_TEST_DB=1
 ```
 
 After confirmation, `./ops` constructs a database-isolated child environment.
-It removes every inherited `DATABASE_URL`/`*_DATABASE_URL` and Atlas
-application database setting, then exposes the one confirmed DSN under the
-selected canonical key, `DATABASE_URL`, `EXTRACTED_DATABASE_URL`, and
-`ATLAS_DB_CONNECTION_STRING`. These aliases contain the same credential; they
-let current test consumers use their existing interface without inheriting a
-second database. The DSN is never placed in process arguments or output.
+It removes every inherited `DATABASE_URL`/`*_DATABASE_URL`, uppercase libpq
+`PG*` variable, and Atlas application database setting, then exposes the one
+confirmed DSN under the selected canonical key, `DATABASE_URL`,
+`EXTRACTED_DATABASE_URL`, and `ATLAS_DB_CONNECTION_STRING`. These aliases
+contain the same credential; they let current test consumers use their existing
+interface without inheriting a second database. The DSN is never placed in
+process arguments or output.
 
 Never point those variables at the live `atlas` database. Run only a focused
 database test target and do not run concurrent DB-backed suites against the

--- a/.agent/runbooks/deployment.md
+++ b/.agent/runbooks/deployment.md
@@ -1,0 +1,103 @@
+# Deployment and status
+
+Atlas has multiple deployment surfaces. Never answer “where is Atlas deployed?”
+with one provider name.
+
+| Surface | Actual provider | Production-shaped target | Preview/staging |
+|---|---|---|---|
+| Brain API | local user `systemd` | `atlas-api.service`, detached runtime worktree, port `8012` | no separate backend staging service discovered |
+| Churn UI | Vercel | project `atlas-churn-ui`, root `vercel.json` | Vercel preview deployments; no named staging environment discovered |
+| Graph memory | Docker | `atlas-neo4j` + `atlas-graphiti-wrapper` | local containers only |
+| CRM browser | Docker | `atlas_nocodb` | local container only |
+
+Render CLI is authenticated in this machine's current workspace, but the live
+service inventory contains other products and no Atlas Brain service. Do not
+use Render for Atlas merely because the CLI is present.
+
+## Read-only status
+
+```bash
+./ops deploy status
+./ops status
+curl --fail --silent http://127.0.0.1:8012/api/v1/ping
+```
+
+`./ops deploy status` reads the systemd unit's current working directory and
+resolves that detached worktree's Git SHA. It also discovers and inspects the
+latest Vercel deployment. Re-run it immediately before any deployment claim;
+the runtime worktree and hosted deployment can drift independently from
+`origin/main`.
+
+For deeper, still read-only inspection:
+
+```bash
+systemctl --user show atlas-api \
+  --property=LoadState,ActiveState,SubState,WorkingDirectory,EnvironmentFiles
+vercel project inspect atlas-churn-ui
+vercel ls atlas-churn-ui
+./ops logs brain
+./ops logs frontend --since 1h
+```
+
+Vercel's ignored `.vercel/project.json` link exists in the shared Git root, not
+automatically in each worktree. `./ops` resolves that context. A direct
+`vercel env ls` from an unlinked worktree fails even when the account is logged
+in; use `./ops env vercel`.
+
+## How Brain deployment works
+
+The checked-in source of truth is GitHub, but the running Brain does not deploy
+automatically from a merge. The established production path is a guarded local
+runtime-worktree cutover:
+
+1. Fetch and identify the exact merged commit from `origin/main`.
+2. Create a fresh detached runtime worktree at that exact commit.
+3. Run the slice's targeted checks in that worktree.
+4. Preserve the user unit, then repoint only its `WorkingDirectory` to the new
+   runtime worktree.
+5. Run `systemctl --user daemon-reload` and restart `atlas-api.service`.
+6. Verify the ping/health route, the runtime worktree SHA, migration status,
+   and service logs.
+7. Keep the prior runtime worktree until rollback risk is closed.
+
+Steps 2-6 mutate production or local runtime state. They require an owned
+deployment arc and explicit operator authority; they are intentionally not
+wrapped by `./ops`. For the EOM API's exact health/auth/fence checks and
+rollback order, use `docs/EOM_FUNNEL_ENABLEMENT_RUNBOOK.md`.
+
+Starting or restarting the full app can apply pending migrations. A code
+rollback does not imply a migration rollback, and destructive schema rollback
+is not an orientation operation. Read `.agent/runbooks/database.md` first.
+
+## How frontend deployment works
+
+The root `vercel.json` installs and builds `atlas-churn-ui`, producing
+`atlas-churn-ui/dist`. A live production-target deployment was verified through
+the Vercel CLI. No tracked GitHub Actions workflow invokes Vercel deployment,
+and the inspected live deployment did not carry Git commit metadata, so the
+current trigger cannot be proven from this repository alone.
+
+`vercel --prod` from the linked root is the provider's direct production
+mutation, but it was not run during contract verification. Do not invoke it,
+fire a deploy hook, or change aliases merely to prove access. Confirm the exact
+project, diff, build, intended target, and operator authorization first.
+
+Other UI directories have their own `vercel.json` or package configuration and
+may belong to separate repositories/projects. The root Vercel link does not
+prove those surfaces deploy with `atlas-churn-ui`.
+
+## Rollback and failure routing
+
+- Brain service active but ping fails: inspect `./ops logs brain`, migration
+  fences, and the unit's exact working directory before restarting again.
+- Runtime SHA differs from `origin/main`: report both; do not silently repoint
+  production because a newer commit exists.
+- Vercel project inspection works but env listing fails: use the linked shared
+  root through `./ops env vercel`.
+- Vercel shows `ERROR`: inspect build logs with
+  `vercel inspect <deployment-url> --logs`; do not create another deployment as
+  a diagnostic retry.
+- Static Vercel runtime logs are empty: this can be normal. Inspect deployment
+  and build status instead.
+- A provider command asks to link/create/import a project: stop. Discovery must
+  not provision or reconfigure infrastructure.

--- a/.agent/runbooks/discovery-ledger.md
+++ b/.agent/runbooks/discovery-ledger.md
@@ -83,15 +83,18 @@ service, suggesting the database is container-owned.
 
 Finding:
 Root Compose defines no PostgreSQL service. Atlas uses native PostgreSQL 16 on
-port `5433`; the current session can run a read-only query and inspect the
-`schema_migrations` ledger.
+port `5433`; the current session can run fixed read-only connectivity and
+migration-ledger inspections through Atlas's application configuration path.
 
 Canonical method:
-Use `./ops db status`, `./ops db query`, and `./ops db migrations`.
+Use `./ops db status`, `./ops db inspect connectivity`, and
+`./ops db migrations`. Arbitrary SQL is intentionally unavailable until Atlas
+has a privilege-restricted inspection role; transaction read-only mode alone
+does not prevent side effects from invoked PostgreSQL functions.
 
 Verified:
-2026-08-24: `pg_isready` accepted the connection and a transaction marked
-`READ ONLY` returned database/role/recovery and migration-ledger metadata.
+2026-08-24: `./ops db inspect connectivity` and `./ops db migrations` succeeded
+through `DatabaseConfig`/asyncpg with fixed SQL inside `READ ONLY` transactions.
 
 Failure notes:
 Do not substitute a random `5432` instance, use live `atlas` for integration

--- a/.agent/runbooks/discovery-ledger.md
+++ b/.agent/runbooks/discovery-ledger.md
@@ -187,3 +187,33 @@ Verified:
 
 Failure notes:
 Installed/authenticated does not mean the tool/provider belongs to Atlas.
+
+## Dotenv database settings and unit-test isolation
+
+Problem:
+Hand-parsing selected `.env` assignments changes quoting, inline-comment,
+escape, and interpolation behavior, while a nominal unit command can inherit
+database URLs left exported after integration work.
+
+Finding:
+`DatabaseConfig` uses Pydantic settings backed by `python-dotenv`. Database
+inspection must decode selected values with that same parser before applying
+process-environment precedence. Several unmarked PostgreSQL tests activate from
+`DATABASE_URL` or `*_DATABASE_URL`, so pytest markers alone do not isolate unit
+mode from database writes.
+
+Canonical method:
+Use `./ops db inspect ...` for application-equivalent dotenv decoding. Use
+`./ops test unit` for database-credential-free unit execution and
+`./ops test integration ...` only with an explicitly confirmed disposable
+database.
+
+Verified:
+2026-08-24: focused boundary tests proved dotenv comments, escapes,
+interpolation, and process overrides, plus removal of current and novel
+database-URL-shaped variables from unit-mode children.
+
+Failure notes:
+Do not replace dotenv parsing with shell sourcing, and do not assume
+`-m "not integration"` excludes every database-writing test. Keep database
+URLs out of unit-mode subprocesses by construction.

--- a/.agent/runbooks/discovery-ledger.md
+++ b/.agent/runbooks/discovery-ledger.md
@@ -152,23 +152,33 @@ is not fresh-applicable because later files depend on out-of-band
 `product_metadata`. Database workflows create disposable PostgreSQL 16 services
 and pass test-specific URL variables. Local integration admission requires
 exactly one canonical test URL so stale credentials cannot compete for which
-destructive suite target pytest inherits.
+destructive suite target pytest inherits. Pytest receives an isolated child
+environment: ambient URL-shaped and Atlas application database settings are
+removed, and the one confirmed DSN is adapted to every supported current test
+interface.
 
 Canonical method:
 Inspect `atlas_brain/storage/migrations/__init__.py`, use
 `.agent/runbooks/database.md`, and prefer the matching GitHub Actions workflow
-unless a local disposable database is explicit.
+unless a local disposable database is explicit. Run database-backed tests only
+through `./ops test integration ...`; do not invoke pytest directly with an
+ambient database environment.
 
 Verified:
 2026-08-24: runner code, startup call path, workflow service definitions, test
 gates, and the live ledger were inspected. The focused 0/1/2/3 active-URL
 matrix admitted only one canonical variable and rejected every other
 cardinality before the pytest executor.
+2026-08-25: focused credential-isolation tests proved each canonical URL is the
+sole DSN exposed through the canonical, generic, and Atlas application
+interfaces; unconfirmed and novel database credentials do not reach argv or
+the child environment.
 
 Failure notes:
 A skipped DB test is not proof. Never apply the full chain to a fresh target as
 an exploratory action, and never leave multiple canonical integration URLs
-exported for one run.
+exported for one run. Do not bypass the isolated child environment with direct
+pytest when any database credential is present.
 
 ## Logs and CI
 

--- a/.agent/runbooks/discovery-ledger.md
+++ b/.agent/runbooks/discovery-ledger.md
@@ -217,3 +217,33 @@ Failure notes:
 Do not replace dotenv parsing with shell sourcing, and do not assume
 `-m "not integration"` excludes every database-writing test. Keep database
 URLs out of unit-mode subprocesses by construction.
+
+## Fresh-agent wrapper boundaries
+
+Problem:
+A fresh checkout is told to run `./ops doctor` before installing Python
+dependencies, configured health endpoints can contain credentials, and pytest
+falls back to broad collection when integration arguments do not name a file.
+
+Finding:
+Orientation must degrade an unavailable database probe without weakening
+explicit database commands. Health checks may consume a configured URL but must
+never echo it. Integration mode needs both disposable-database confirmation and
+a bounded file/node target; argument count alone is not a test boundary.
+
+Canonical method:
+Run `./ops doctor` before installation and treat an unavailable database line as
+an expected partial result. Run integration tests only as
+`./ops test integration tests/test_file.py[::node] [pytest-options]`; use
+`--option=value` for valued options.
+
+Verified:
+2026-08-24: focused boundary tests simulated missing `python-dotenv`, a
+credential-bearing configured health URL, option-only/directory/out-of-tree
+integration inputs, and valid file/node targets.
+
+Failure notes:
+Do not make `doctor` import application dependencies merely to orient a new
+agent. Do not print `ATLAS_OPS_BRAIN_URL`, even after a successful request. Do
+not bypass the bounded-target guard with direct pytest when database credentials
+are present.

--- a/.agent/runbooks/discovery-ledger.md
+++ b/.agent/runbooks/discovery-ledger.md
@@ -13,7 +13,8 @@ Finding:
 The shared root can be registered as bare/common state and reject `git status`.
 Dedicated worktrees under the repository's worktree locations are the editable
 contexts. Ignored `.env`, `.venv`, and `.vercel` state can remain at the shared
-root.
+root. Git may report that shared state as a conventional `.git` directory or as
+the bare common directory itself.
 
 Canonical method:
 Run `./ops doctor`, `git worktree list`, and work from the task's dedicated
@@ -21,11 +22,13 @@ worktree. `./ops` resolves the Git common directory for read-only shared state.
 
 Verified:
 2026-08-24: `git status` failed at the shared root; a fresh worktree from
-`origin/main` was clean and operational.
+`origin/main` was clean and operational. A focused resolver regression covers
+the conventional `.git`, direct bare-directory, and Git-command-failure shapes.
 
 Failure notes:
 Do not repair the shared root with reset/checkout/clean. Do not copy ignored
-secrets into the worktree.
+secrets into the worktree. Do not assume every successful common-dir path is
+named `.git`: only command failure falls back to the current repository root.
 
 ## Brain deployment
 

--- a/.agent/runbooks/discovery-ledger.md
+++ b/.agent/runbooks/discovery-ledger.md
@@ -157,6 +157,11 @@ environment: ambient URL-shaped, uppercase libpq `PG*`, and Atlas application
 database settings are removed, and the one confirmed DSN is adapted to every
 supported current test interface.
 
+The nominally narrow `focused` entrypoint is also a database-authority boundary,
+not merely a pytest selector. It removes the same credential classes and the
+disposable confirmation flag without restoring a DSN, so database-backed tests
+must enter through guarded integration mode.
+
 Canonical method:
 Inspect `atlas_brain/storage/migrations/__init__.py`, use
 `.agent/runbooks/database.md`, and prefer the matching GitHub Actions workflow
@@ -173,6 +178,9 @@ cardinality before the pytest executor.
 sole DSN exposed through the canonical, generic, and Atlas application
 interfaces; unconfirmed URL-shaped, application, current libpq, and novel `PG*`
 credentials do not reach argv or the child environment.
+2026-08-25: a focused-child regression failed before implementation because no
+explicit environment was passed, then passed with every database credential
+class absent and an unrelated canary preserved.
 
 Failure notes:
 A skipped DB test is not proof. Never apply the full chain to a fresh target as

--- a/.agent/runbooks/discovery-ledger.md
+++ b/.agent/runbooks/discovery-ledger.md
@@ -239,19 +239,20 @@ mode from database writes.
 
 Canonical method:
 Use `./ops db inspect ...` for application-equivalent dotenv decoding. Use
-`./ops test unit` for database-credential-free unit execution and
+focused local tests for database-credential-free proof and
 `./ops test integration ...` only with an explicitly confirmed disposable
-database.
+database. The full unit gate runs only in GitHub Actions.
 
 Verified:
 2026-08-24: focused boundary tests proved dotenv comments, escapes,
-interpolation, and process overrides, plus removal of current and novel
-database-URL-shaped variables from unit-mode children.
+interpolation, and process overrides. 2026-08-25: the local full-unit entrypoint
+was disabled in favor of the hosted unit gate.
 
 Failure notes:
 Do not replace dotenv parsing with shell sourcing, and do not assume
 `-m "not integration"` excludes every database-writing test. Keep database
-URLs out of unit-mode subprocesses by construction.
+URLs out of focused subprocesses and use the explicit integration boundary for
+database-backed proof.
 
 ## Fresh-agent wrapper boundaries
 
@@ -282,3 +283,31 @@ Do not make `doctor` import application dependencies merely to orient a new
 agent. Do not print `ATLAS_OPS_BRAIN_URL`, even after a successful request. Do
 not bypass the bounded-target guard with direct pytest when database credentials
 are present.
+
+## Hosted-only unit gate
+
+Problem:
+`scripts/local_pr_review.sh` contained a full local unit-gate mirror, so a push
+could leave a long-running pytest process even when the operator intended
+GitHub to own that expensive gate. `./ops test unit` exposed a second local
+full-suite path.
+
+Finding:
+An ambient `GITHUB_ACTIONS=true` convention was not a durable boundary. The
+local review entrypoint itself must be incapable of selecting, installing for,
+or executing unit-gate tests, and the stable operations command must fail
+closed instead of launching pytest.
+
+Canonical method:
+Use `./ops test focused <target> -q` for narrow local evidence. Push through
+`scripts/push_pr.sh`, then inspect `.github/workflows/unit_gate.yml` with
+`./ops ci status`; never run the full unit gate locally.
+
+Verified:
+2026-08-25: focused subprocess canaries proved local review does not invoke the
+selector/checker in selected, empty, full, failing, or missing-checker states,
+and `./ops test unit` rejects without invoking pytest.
+
+Failure notes:
+Do not restore a local mirror behind an environment flag. An agent needing a
+faster signal should narrow the focused target, not duplicate the hosted gate.

--- a/.agent/runbooks/discovery-ledger.md
+++ b/.agent/runbooks/discovery-ledger.md
@@ -1,0 +1,186 @@
+# Operational discovery ledger
+
+Only reusable discoveries belong here. Current values such as runtime SHAs and
+deployment IDs stay in live commands, not in this ledger.
+
+## Git worktree identity
+
+Problem:
+A fresh agent can enter `/home/juan-canfield/Desktop/Atlas`, see repository
+files, and assume it is a normal worktree.
+
+Finding:
+The shared root can be registered as bare/common state and reject `git status`.
+Dedicated worktrees under the repository's worktree locations are the editable
+contexts. Ignored `.env`, `.venv`, and `.vercel` state can remain at the shared
+root.
+
+Canonical method:
+Run `./ops doctor`, `git worktree list`, and work from the task's dedicated
+worktree. `./ops` resolves the Git common directory for read-only shared state.
+
+Verified:
+2026-08-24: `git status` failed at the shared root; a fresh worktree from
+`origin/main` was clean and operational.
+
+Failure notes:
+Do not repair the shared root with reset/checkout/clean. Do not copy ignored
+secrets into the worktree.
+
+## Brain deployment
+
+Problem:
+The installed Render CLI and checked-in Dockerfile make several deployment
+stories look plausible.
+
+Finding:
+The running Brain is `atlas-api.service`, a user systemd service whose
+`WorkingDirectory` points to a detached runtime worktree. Its ping route is on
+local port `8012`. Render's authenticated workspace had no Atlas Brain service.
+
+Canonical method:
+Use `./ops deploy status`, `./ops logs brain`, and the live systemd unit. For an
+authorized cutover, follow `.agent/runbooks/deployment.md` and the applicable
+product runbook.
+
+Verified:
+2026-08-24: systemd reported the unit active, the runtime worktree SHA resolved,
+and `GET /api/v1/ping` returned success.
+
+Failure notes:
+Do not infer deployment from a merged PR or from provider CLI availability.
+Restarting can run migrations.
+
+## Frontend deployment and Vercel linkage
+
+Problem:
+Vercel account authentication works in every worktree, but project-scoped env
+commands can still fail.
+
+Finding:
+The linked project is `atlas-churn-ui`; root `vercel.json` builds that package.
+The ignored `.vercel/project.json` link exists in the shared root, not fresh
+worktrees. A production-target READY deployment exists. No tracked GitHub
+workflow deploys it, and the inspected deployment had no Git metadata, so its
+trigger is not provable from this repository.
+
+Canonical method:
+Use `./ops deploy status`, `./ops env vercel`, and `./ops logs frontend`.
+
+Verified:
+2026-08-24: Vercel whoami/project/deployment/env/log access all succeeded when
+the correct linked context or explicit project was supplied.
+
+Failure notes:
+Do not run `vercel link`, `vercel --prod`, deploy hooks, or alias changes during
+discovery. An empty runtime log window is normal for a static deployment.
+
+## PostgreSQL location and safe access
+
+Problem:
+README and CLAUDE instructions tell agents to start a Compose `postgres`
+service, suggesting the database is container-owned.
+
+Finding:
+Root Compose defines no PostgreSQL service. Atlas uses native PostgreSQL 16 on
+port `5433`; the current session can run a read-only query and inspect the
+`schema_migrations` ledger.
+
+Canonical method:
+Use `./ops db status`, `./ops db query`, and `./ops db migrations`.
+
+Verified:
+2026-08-24: `pg_isready` accepted the connection and a transaction marked
+`READ ONLY` returned database/role/recovery and migration-ledger metadata.
+
+Failure notes:
+Do not substitute a random `5432` instance, use live `atlas` for integration
+tests, or use Alembic. Application startup invokes the custom migration runner.
+
+## Root Compose prerequisites
+
+Problem:
+Even a read-only-looking `docker compose ps` can fail before inspecting Docker.
+
+Finding:
+The root Compose file requires `ATLAS_NOCODB_DB_PASSWORD` during interpolation,
+even when the intended operation is status or another service.
+
+Canonical method:
+Use `./ops status` and targeted `docker inspect` / `./ops logs container` for
+discovery. Set the NocoDB credential only for an authorized Compose operation.
+
+Verified:
+2026-08-24: Docker daemon access succeeded while root `docker compose ps`
+failed at NocoDB interpolation with the variable absent.
+
+Failure notes:
+Do not weaken the required-variable expression merely to make status work.
+
+## Database migrations and test databases
+
+Problem:
+An installed `alembic` CLI and generic integration marker do not reveal Atlas's
+actual schema/test workflow.
+
+Finding:
+Atlas uses a custom SQL migration runner and `schema_migrations`. The full chain
+is not fresh-applicable because later files depend on out-of-band
+`product_metadata`. Database workflows create disposable PostgreSQL 16 services
+and pass test-specific URL variables.
+
+Canonical method:
+Inspect `atlas_brain/storage/migrations/__init__.py`, use
+`.agent/runbooks/database.md`, and prefer the matching GitHub Actions workflow
+unless a local disposable database is explicit.
+
+Verified:
+2026-08-24: runner code, startup call path, workflow service definitions, test
+gates, and the live ledger were inspected.
+
+Failure notes:
+A skipped DB test is not proof. Never apply the full chain to a fresh target as
+an exploratory action.
+
+## Logs and CI
+
+Problem:
+Agents can chase file logs, Compose logs, or stale GitHub runs without knowing
+which stream is canonical.
+
+Finding:
+Brain logs are in the user journal; container logs are in Docker; static UI
+runtime/build logs are in Vercel; CI is GitHub Actions with enforcement recorded
+in `ci/gates.yml`.
+
+Canonical method:
+Use `./ops logs ...`, `./ops ci status`, and `./ops ci run <id> --log-failed`.
+
+Verified:
+2026-08-24: journal metadata, Vercel log access, GitHub workflow inventory, and
+current run inspection succeeded.
+
+Failure notes:
+Logs may contain sensitive data. Always match CI branch/head SHA, and treat
+runnerless jobs separately from source-test failures.
+
+## Available tooling
+
+Problem:
+Agents waste time proposing installs before checking the workstation.
+
+Finding:
+Git/GitHub, Python/project venv, Node/npm, Docker, PostgreSQL clients, Vercel,
+Render, systemd/journal, curl, jq, uv, pnpm, yarn, and Alembic are present.
+Legacy `docker-compose` and the Fly/Railway/major-cloud/Terraform/Kubernetes
+CLIs were not found. Ollama CLI exists but its server was unavailable.
+
+Canonical method:
+Run `./ops doctor` and consult `.agent/capabilities.yaml`; install nothing as an
+orientation step.
+
+Verified:
+2026-08-24: command-path/version checks plus authenticated provider probes.
+
+Failure notes:
+Installed/authenticated does not mean the tool/provider belongs to Atlas.

--- a/.agent/runbooks/discovery-ledger.md
+++ b/.agent/runbooks/discovery-ledger.md
@@ -153,9 +153,9 @@ is not fresh-applicable because later files depend on out-of-band
 and pass test-specific URL variables. Local integration admission requires
 exactly one canonical test URL so stale credentials cannot compete for which
 destructive suite target pytest inherits. Pytest receives an isolated child
-environment: ambient URL-shaped and Atlas application database settings are
-removed, and the one confirmed DSN is adapted to every supported current test
-interface.
+environment: ambient URL-shaped, uppercase libpq `PG*`, and Atlas application
+database settings are removed, and the one confirmed DSN is adapted to every
+supported current test interface.
 
 Canonical method:
 Inspect `atlas_brain/storage/migrations/__init__.py`, use
@@ -171,8 +171,8 @@ matrix admitted only one canonical variable and rejected every other
 cardinality before the pytest executor.
 2026-08-25: focused credential-isolation tests proved each canonical URL is the
 sole DSN exposed through the canonical, generic, and Atlas application
-interfaces; unconfirmed and novel database credentials do not reach argv or
-the child environment.
+interfaces; unconfirmed URL-shaped, application, current libpq, and novel `PG*`
+credentials do not reach argv or the child environment.
 
 Failure notes:
 A skipped DB test is not proof. Never apply the full chain to a fresh target as

--- a/.agent/runbooks/discovery-ledger.md
+++ b/.agent/runbooks/discovery-ledger.md
@@ -88,20 +88,28 @@ Finding:
 Root Compose defines no PostgreSQL service. Atlas uses native PostgreSQL 16 on
 port `5433`; the current session can run fixed read-only connectivity and
 migration-ledger inspections through Atlas's application configuration path.
+Database inspection selects one configuration context: explicit override,
+worktree application files, shared-root application files, or systemd fallback;
+it does not merge every key-inventory source.
 
 Canonical method:
 Use `./ops db status`, `./ops db inspect connectivity`, and
 `./ops db migrations`. Arbitrary SQL is intentionally unavailable until Atlas
 has a privilege-restricted inspection role; transaction read-only mode alone
-does not prevent side effects from invoked PostgreSQL functions.
+does not prevent side effects from invoked PostgreSQL functions. Use
+`ATLAS_OPS_ENV_FILES` only for an intentional explicit context.
 
 Verified:
 2026-08-24: `./ops db inspect connectivity` and `./ops db migrations` succeeded
 through `DatabaseConfig`/asyncpg with fixed SQL inside `READ ONLY` transactions.
+Focused context-selection tests covered explicit, worktree, shared-root, and
+systemd sources; a live worktree probe selected only the shared-root `.env` and
+`.env.local` pair before connectivity succeeded.
 
 Failure notes:
 Do not substitute a random `5432` instance, use live `atlas` for integration
-tests, or use Alembic. Application startup invokes the custom migration runner.
+tests, merge worktree and live-service contexts, or use Alembic. Application
+startup invokes the custom migration runner.
 
 ## Root Compose prerequisites
 
@@ -110,18 +118,27 @@ Even a read-only-looking `docker compose ps` can fail before inspecting Docker.
 
 Finding:
 The root Compose file requires `ATLAS_NOCODB_DB_PASSWORD` during interpolation,
-even when the intended operation is status or another service.
+even when the intended operation is status or another service. Docker object
+absence is meaningful only after `docker info` proves the daemon/authentication
+boundary; otherwise inspect failures are provider unavailability, not absent
+containers.
 
 Canonical method:
-Use `./ops status` and targeted `docker inspect` / `./ops logs container` for
-discovery. Set the NocoDB credential only for an authorized Compose operation.
+Use `./ops status` for the daemon-first classification and targeted
+`docker inspect` / `./ops logs container` after it succeeds. Set the NocoDB
+credential only for an authorized Compose operation.
 
 Verified:
 2026-08-24: Docker daemon access succeeded while root `docker compose ps`
-failed at NocoDB interpolation with the variable absent.
+failed at NocoDB interpolation with the variable absent. Focused status tests
+covered CLI absence, offline mode, daemon failure, object absence/presence, and
+an empty successful inspect; live `./ops status` classified known objects after
+a successful daemon probe.
 
 Failure notes:
-Do not weaken the required-variable expression merely to make status work.
+Do not weaken the required-variable expression merely to make status work, and
+do not interpret a stopped/unreachable/permission-denied daemon as an inventory
+where every container is absent.
 
 ## Database migrations and test databases
 
@@ -133,7 +150,9 @@ Finding:
 Atlas uses a custom SQL migration runner and `schema_migrations`. The full chain
 is not fresh-applicable because later files depend on out-of-band
 `product_metadata`. Database workflows create disposable PostgreSQL 16 services
-and pass test-specific URL variables.
+and pass test-specific URL variables. Local integration admission requires
+exactly one canonical test URL so stale credentials cannot compete for which
+destructive suite target pytest inherits.
 
 Canonical method:
 Inspect `atlas_brain/storage/migrations/__init__.py`, use
@@ -142,11 +161,14 @@ unless a local disposable database is explicit.
 
 Verified:
 2026-08-24: runner code, startup call path, workflow service definitions, test
-gates, and the live ledger were inspected.
+gates, and the live ledger were inspected. The focused 0/1/2/3 active-URL
+matrix admitted only one canonical variable and rejected every other
+cardinality before the pytest executor.
 
 Failure notes:
 A skipped DB test is not proof. Never apply the full chain to a fresh target as
-an exploratory action.
+an exploratory action, and never leave multiple canonical integration URLs
+exported for one run.
 
 ## Logs and CI
 

--- a/.agent/runbooks/environment.md
+++ b/.agent/runbooks/environment.md
@@ -1,0 +1,109 @@
+# Environment and local runtime
+
+Use this runbook to orient a new worktree, find configuration without exposing
+it, and determine whether the Brain is already running.
+
+## First five minutes
+
+From a normal Atlas worktree:
+
+```bash
+./ops doctor
+./ops status
+./ops env keys
+```
+
+Read `.agent/capabilities.yaml` after the snapshot. It distinguishes verified,
+conditional, and unavailable operations. Do not use the old README/CLAUDE
+commands as evidence when they disagree with `./ops` or executable config.
+
+## Repository and worktree layout
+
+This checkout uses a shared Git root. The path commonly called
+`/home/juan-canfield/Desktop/Atlas` can be the common/bare root even though it
+contains files and ignored runtime state. `git status` can therefore fail there.
+Use a dedicated path listed by `git worktree list` for edits and tests.
+
+Ignored operational state such as `.env`, `.venv`, and `.vercel/project.json`
+may exist only in the shared root. A fresh worktree does not automatically get
+those files. `./ops` resolves the Git common directory so its read-only checks
+can find shared state without copying it into the branch.
+
+## Configuration sources
+
+Atlas settings read exported variables first and `.env` / `.env.local` in the
+process working directory otherwise. The live `atlas-api.service` injects
+absolute `EnvironmentFiles`, so its configuration is independent of the
+detached runtime worktree.
+
+Inspect names, never values:
+
+```bash
+./ops env keys
+./ops env keys --file /path/to/a/specific.env
+./ops env systemd
+./ops env vercel
+```
+
+`./ops env keys` parses assignment names without sourcing or evaluating the
+file. `./ops env vercel` must run through the linked shared-root context; it
+lists encrypted variable names and target environments, not values.
+
+Never use `cat`, `env`, `set`, `vercel env pull`, or debug tracing merely to
+learn whether a secret exists. Never copy the shared live `.env` into a
+worktree. A root `.env.example` does not exist; subsystem examples live under
+`atlas-ui/`, `atlas_video-processing/`, and `graphiti-wrapper/`.
+
+## Running the Brain
+
+The code entrypoint is `atlas_brain.main:app`. A direct development invocation
+is:
+
+```bash
+python -m uvicorn atlas_brain.main:app \
+  --host 127.0.0.1 --port 8001 \
+  --reload --reload-dir atlas_brain \
+  --reload-exclude data/postgres --reload-exclude 'data/postgres/**'
+```
+
+This is not a harmless smoke command. The FastAPI lifespan initializes the
+database, runs the custom migration check, and can start configured background
+services. Before starting it, use a deliberately prepared development
+environment and read `.agent/runbooks/database.md`. Do not load the shared
+production `.env` into an ad-hoc server.
+
+The current production-shaped Brain is the user unit `atlas-api.service`, not a
+Render service. Inspect it without restarting it:
+
+```bash
+./ops deploy status
+systemctl --user show atlas-api \
+  --property=LoadState,ActiveState,SubState,WorkingDirectory,EnvironmentFiles
+curl --fail --silent http://127.0.0.1:8012/api/v1/ping
+```
+
+## Containers and local dependencies
+
+Docker Engine and the Compose plugin are available. Root Compose packages the
+Brain and NocoDB but expects native PostgreSQL on host port `5433`; it does not
+define a `postgres` service. Graphiti/Neo4j use
+`docker-compose.graphiti.yml`.
+
+Even `docker compose ps` against the root file fails unless
+`ATLAS_NOCODB_DB_PASSWORD` is present because Compose evaluates the NocoDB
+required-variable expression before selecting a service. For read-only status,
+use `./ops status` or targeted `docker inspect` rather than weakening that
+guard.
+
+## Failure routing
+
+- `git status` says “must be run in a work tree”: run `git worktree list` and
+  move to the task's dedicated worktree.
+- A worktree lacks `.venv`: `./ops` uses the shared project venv when present;
+  set `ATLAS_PYTHON` to another verified interpreter if necessary.
+- Port `8012` is down: inspect `./ops deploy status` and `./ops logs brain`;
+  do not restart until deployment and migration impact are understood.
+- Ollama CLI exists but the server is unreachable: treat local-model features
+  as degraded; do not install or reconfigure Ollama as an orientation step.
+- A provider variable name exists: that proves configuration shape only, not
+  authentication or live provider health. Use the provider-specific safe check.

--- a/.agent/runbooks/logs.md
+++ b/.agent/runbooks/logs.md
@@ -1,0 +1,74 @@
+# Logs
+
+Log access is read-only but log contents can contain customer identifiers,
+request payload fragments, provider IDs, or error context. Retrieve the
+smallest useful window and do not paste raw logs into issues or chat.
+
+## Brain API
+
+The production-shaped Brain runs as the user service `atlas-api.service`, so
+journald is canonical:
+
+```bash
+./ops logs brain
+./ops logs brain --follow
+journalctl --user -u atlas-api --since '15 minutes ago' --no-pager
+```
+
+The default wrapper returns the last 100 lines. Use `--follow` only during an
+active, bounded observation; do not leave a polling process running.
+
+## Containers
+
+Use Docker logs by exact container name:
+
+```bash
+./ops logs container atlas-graphiti-wrapper
+./ops logs container atlas-neo4j
+./ops logs container atlas_nocodb
+```
+
+Targeted `docker logs` avoids the root Compose parsing prerequisite that makes
+even `docker compose ps/logs` fail when `ATLAS_NOCODB_DB_PASSWORD` is absent.
+Use `./ops status` to discover which known containers exist before reading.
+
+## Vercel frontend
+
+```bash
+./ops logs frontend --since 1h --limit 100
+./ops logs frontend --since 30m --limit 100 --follow
+```
+
+The root deployment is a static Vite site, so no runtime records can be a valid
+result. For build failure, use the deployment URL from `./ops deploy status`:
+
+```bash
+vercel inspect <deployment-url> --logs
+```
+
+Do not broaden a search to all account projects. The Atlas root project is
+`atlas-churn-ui`.
+
+## GitHub Actions
+
+```bash
+./ops ci status
+./ops ci run <run-id> --log-failed
+```
+
+Always match the run's branch and head SHA to the code under investigation.
+Workflow names recur across pushes, and a green older run is not current proof.
+
+## Failure routing
+
+- Journal access denied: verify the current user owns the user unit; do not use
+  `sudo journalctl` as an automatic bypass.
+- Container absent: inspect `docker ps` and the relevant Compose file; do not
+  start it just to make logs exist.
+- Vercel logs fail from a worktree: the ignored project link is shared-root
+  state; use `./ops`, which supplies the project and correct working directory.
+- GitHub logs show no job steps: treat runner/infrastructure allocation as a
+  separate failure class before changing source.
+- A log contains a secret or customer data: stop copying it, preserve only a
+  redacted evidence reference, and follow `docs/INCIDENT_RESPONSE.md` if
+  exposure is plausible.

--- a/.agent/runbooks/testing.md
+++ b/.agent/runbooks/testing.md
@@ -46,7 +46,9 @@ requires an existing Python file under `tests/` as the first target, an
 explicit test URL, and
 `ATLAS_CONFIRM_DISPOSABLE_TEST_DB=1` before it will run them. Follow
 `.agent/runbooks/database.md`. Do not use the live `atlas` database and do not
-run concurrent suites against one test database.
+run concurrent suites against one test database. Integration mode removes all
+inherited URL-shaped, Atlas application, and libpq `PG*` database credentials
+before adapting the confirmed disposable DSN to supported test interfaces.
 
 ```bash
 ./ops test integration tests/test_file.py::test_name -q

--- a/.agent/runbooks/testing.md
+++ b/.agent/runbooks/testing.md
@@ -1,0 +1,85 @@
+# Testing
+
+Use the narrowest command that settles the changed behavior, then run the
+repository's required mechanical gate before pushing.
+
+## Python tests
+
+The canonical runner is pytest. The shared project venv is preferred; `./ops`
+selects a worktree `.venv`, then the shared-root `.venv`, then the current
+interpreter. Override only with a verified executable:
+
+```bash
+ATLAS_PYTHON=/path/to/python ./ops test focused tests/test_file.py -q
+```
+
+Common commands:
+
+```bash
+# One file/node while iterating
+./ops test focused tests/test_file.py -q
+./ops test focused tests/test_file.py::test_name -q
+
+# Full non-integration/e2e suite
+./ops test unit
+
+# Mandatory mechanical PR bundle; run once through the push workflow
+./ops test local-review
+```
+
+The Unit Gate is branch-required and uses impacted-test selection plus the
+committed baseline. The scheduled Repo-Wide Unit Backstop runs the full
+non-integration/e2e suite. See `.github/workflows/unit_gate.yml`,
+`.github/workflows/repo_wide_unit_backstop.yml`, and
+`scripts/check_unit_gate.py`; a local green subset is not a claim that all CI
+passed.
+
+## Database and integration tests
+
+Integration tests can create, migrate, truncate, or drop objects. `./ops`
+requires a focused target, an explicit test URL, and
+`ATLAS_CONFIRM_DISPOSABLE_TEST_DB=1` before it will run them. Follow
+`.agent/runbooks/database.md`. Do not use the live `atlas` database and do not
+run concurrent suites against one test database.
+
+## Frontend tests
+
+Each frontend owns its package scripts. Discover them from `package.json`; do
+not assume every package has a generic `test` command.
+
+```bash
+./ops test frontend atlas-ui test
+./ops test frontend atlas-churn-ui test
+./ops test frontend atlas-intel-ui test:content-ops-input-display
+./ops test frontend portfolio-ui test:deflection-result
+```
+
+Install with the checked-in lockfile before first use in a fresh worktree:
+
+```bash
+cd <package>
+npm ci
+```
+
+`atlas-admin-ui` and `atlas-mobile` currently have no generic test script;
+build/lint or a feature-specific test is required instead of inventing one.
+
+## Extracted packages
+
+Changes under `extracted_*/` carry package gauntlets. The authoritative list is
+in `AGENTS.md` and the “Per-package validation gauntlets” section of
+`CLAUDE.md`. `extracted_content_pipeline` requires its validation, standalone
+import/audit, ASCII, and synchronization checks before push when applicable.
+
+## Failure routing
+
+- Pytest cannot import an optional dependency: verify the selected interpreter
+  and requirements before changing code or baselines.
+- A DB test skips: check the exact test-specific URL variable; a skip is not
+  integration proof.
+- A frontend has no `test` script: list scripts with
+  `jq -r '.scripts' <package>/package.json` and use the relevant named script.
+- Hosted CI is red: use `./ops ci run <id> --log-failed` and match the run's
+  head SHA before diagnosing source.
+- Before push, use `scripts/push_pr.sh`; do not run a duplicate manual local
+  review immediately before that wrapper.

--- a/.agent/runbooks/testing.md
+++ b/.agent/runbooks/testing.md
@@ -20,26 +20,24 @@ Common commands:
 ./ops test focused tests/test_file.py -q
 ./ops test focused tests/test_file.py::test_name -q
 
-# Full non-integration/e2e suite
-./ops test unit
+# Full non-integration/e2e suite: GitHub-only
+./ops ci status
 
 # Mandatory mechanical PR bundle; run once through the push workflow
 ./ops test local-review
 ```
 
-The Unit Gate is branch-required and uses impacted-test selection plus the
+The Unit Gate is branch-required, GitHub-only, and uses impacted-test selection plus the
 committed baseline. The scheduled Repo-Wide Unit Backstop runs the full
 non-integration/e2e suite. See `.github/workflows/unit_gate.yml`,
 `.github/workflows/repo_wide_unit_backstop.yml`, and
 `scripts/check_unit_gate.py`; a local green subset is not a claim that all CI
 passed.
 
-`./ops test unit` removes `DATABASE_URL` and every inherited
-`*_DATABASE_URL` from the pytest child environment, along with the disposable
-database confirmation flag. This keeps unmarked PostgreSQL tests in their skip
-path when credentials remain exported from an earlier integration run. Use
-`./ops test integration ...` for explicit database-backed proof; unrelated
-environment configuration is preserved in unit mode.
+`./ops test unit` fails closed with the hosted workflow location; it never
+starts pytest. Local agents use `./ops test focused ...` only for the narrow
+behavior they changed. Use `./ops test integration ...` for explicitly
+authorized database-backed proof.
 
 ## Database and integration tests
 

--- a/.agent/runbooks/testing.md
+++ b/.agent/runbooks/testing.md
@@ -27,6 +27,12 @@ Common commands:
 ./ops test local-review
 ```
 
+Focused mode preserves unrelated environment configuration but removes every
+canonical, URL-shaped, Atlas application, and libpq `PG*` database credential,
+plus `ATLAS_CONFIRM_DISPOSABLE_TEST_DB`, before pytest starts. A database-backed
+test must use the guarded integration entrypoint below; an exported stale URL
+never grants the focused command write authority.
+
 The Unit Gate is branch-required, GitHub-only, and uses impacted-test selection plus the
 committed baseline. The scheduled Repo-Wide Unit Backstop runs the full
 non-integration/e2e suite. See `.github/workflows/unit_gate.yml`,

--- a/.agent/runbooks/testing.md
+++ b/.agent/runbooks/testing.md
@@ -44,10 +44,19 @@ environment configuration is preserved in unit mode.
 ## Database and integration tests
 
 Integration tests can create, migrate, truncate, or drop objects. `./ops`
-requires a focused target, an explicit test URL, and
+requires an existing Python file under `tests/` as the first target, an
+explicit test URL, and
 `ATLAS_CONFIRM_DISPOSABLE_TEST_DB=1` before it will run them. Follow
 `.agent/runbooks/database.md`. Do not use the live `atlas` database and do not
 run concurrent suites against one test database.
+
+```bash
+./ops test integration tests/test_file.py::test_name -q
+```
+
+Directory, option-only, missing, and out-of-tree targets are rejected. Later
+arguments must be pytest option tokens; write valued options as
+`--option=value` so a second positional target cannot widen the run.
 
 ## Frontend tests
 

--- a/.agent/runbooks/testing.md
+++ b/.agent/runbooks/testing.md
@@ -34,6 +34,13 @@ non-integration/e2e suite. See `.github/workflows/unit_gate.yml`,
 `scripts/check_unit_gate.py`; a local green subset is not a claim that all CI
 passed.
 
+`./ops test unit` removes `DATABASE_URL` and every inherited
+`*_DATABASE_URL` from the pytest child environment, along with the disposable
+database confirmation flag. This keeps unmarked PostgreSQL tests in their skip
+path when credentials remain exported from an earlier integration run. Use
+`./ops test integration ...` for explicit database-backed proof; unrelated
+environment configuration is preserved in unit mode.
+
 ## Database and integration tests
 
 Integration tests can create, migrate, truncate, or drop objects. `./ops`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,19 @@ narrow / run scoped tests during iteration) that keep a session from
 compacting mid-work. A session that has drifted post-compaction gets the
 redirect prompt in that file.
 
+## Agent operations contract
+
+Operational ground truth lives in `.agent/capabilities.yaml` and
+`.agent/runbooks/`. Start with `./ops doctor`, then use the documented stable
+operation before rediscovering a provider-specific command. Inspect environment
+configuration by name only; production deploys, restarts, migrations, database
+writes, and provider mutations remain explicit manual operations.
+
+If you spend meaningful time discovering a reusable operational procedure, do
+not leave that knowledge only in the session. Update the corresponding `./ops`
+operation, capability record, runbook, or discovery-ledger entry and verify it
+before finishing.
+
 ---
 
 ## Review guidelines

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,10 @@ operation before rediscovering a provider-specific command. Inspect environment
 configuration by name only; production deploys, restarts, migrations, database
 writes, and provider mutations remain explicit manual operations.
 
+The full Python unit gate is GitHub-only. Never run it, its mirror, or the full
+non-integration suite locally; use `./ops test focused ...` for the narrow proof
+needed by a change and let `.github/workflows/unit_gate.yml` settle the gate.
+
 If you spend meaningful time discovering a reusable operational procedure, do
 not leave that knowledge only in the session. Update the corresponding `./ops`
 operation, capability record, runbook, or discovery-ledger entry and verify it

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,11 @@ active issue/accepted plan says so.
 
 ### Local Development (Recommended for fast iteration)
 
+Begin with `./ops doctor`, then read `.agent/capabilities.yaml` and the matching
+runbook under `.agent/runbooks/`. A full app start is mutating: the lifespan
+checks/applies database migrations and can start enabled background work. Use a
+deliberately prepared development environment, never the shared production env.
+
 ```bash
 # Activate virtual environment
 source .venv/bin/activate
@@ -94,10 +99,16 @@ ollama pull minimax-m2:cloud
 ollama run qwen3:14b "Hello"
 ```
 
-### Docker (Production)
+### Docker packaging (alternate/local)
+
+The current production-shaped Brain is `atlas-api.service` on a detached local
+runtime worktree, not this Compose project. Root Compose contains Brain and
+NocoDB only, expects native PostgreSQL on host port `5433`, and parses the
+required NocoDB password even for status/service selection.
 
 ```bash
-# Build and start the server (requires NVIDIA Container Toolkit)
+# Set ATLAS_NOCODB_DB_PASSWORD through an approved secret source first.
+# Build and start the containers (requires NVIDIA Container Toolkit)
 docker compose up --build -d
 
 # Restart after code changes (volumes mount atlas_brain/, so rebuild not always needed)
@@ -411,14 +422,15 @@ contact_interactions, appointments).  Atlas itself uses DatabaseCRMProvider
 (direct asyncpg) — NocoDB is purely a human-facing admin interface.
 
 ```bash
-# 1. Start Postgres + NocoDB
-docker compose up -d postgres nocodb
+# 1. Confirm native Postgres, then start NocoDB with its approved DB credential.
+./ops db status
+docker compose up -d nocodb
 
 # 2. Open the NocoDB UI
 open http://localhost:8090
 
-# 3. On first launch, create an account, then connect to the existing DB:
-#    Source: Postgres | Host: postgres | Port: 5432 | DB: atlas | User: atlas
+# 3. On first launch, create an account. Compose's NC_DB already targets:
+#    Host: host.docker.internal | Port: 5433 | DB: atlas | unprivileged NocoDB role
 ```
 
 The `contacts` table (created by migration `035_contacts.sql`) is the CRM schema.
@@ -1291,9 +1303,9 @@ pytest -m "not integration and not e2e"
 # Just one test file
 pytest tests/test_blog_post_postgres.py -v
 
-# Run integration tests (requires Postgres + Neo4j up)
-docker compose up -d postgres
-pytest -m integration
+# Run a focused integration test only against an explicit disposable DB.
+# See .agent/runbooks/database.md for the test URL and confirmation boundary.
+./ops test integration tests/<integration_test>.py -q
 
 # Single keyword filter
 pytest -k "campaign and not slow"
@@ -1434,7 +1446,7 @@ inside the directory. Python sub-services have their own `requirements*.txt`
 and Dockerfiles (`Dockerfile.graphiti`, `Dockerfile`).
 
 Compose files for sub-services:
-- `docker-compose.yml` — main brain + Postgres + NocoDB
+- `docker-compose.yml` — main brain + NocoDB; native Postgres is external on host port 5433
 - `docker-compose.graphiti.yml` — Neo4j + Graphiti wrapper (use `start-graphiti.sh`)
 - `docker-compose.ha.yml` / `docker-compose.homeassistant.yml` — Home Assistant
 - `docker-compose.wyze.yml` — Wyze cam bridge

--- a/README.md
+++ b/README.md
@@ -419,22 +419,34 @@ Dual-layer memory system:
 git clone https://github.com/canfieldjuan/ATLAS.git
 cd ATLAS
 
+# Inspect this machine, current services, provider auth, and safe next commands.
+./ops doctor
+
 python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
 
-cp .env.example .env   # Configure credentials
+# There is no root .env.example. Inspect names and follow the environment runbook.
+./ops env keys
 
 ollama pull qwen3:14b
-docker compose up -d postgres
+
+# Atlas expects native PostgreSQL on port 5433; Compose does not provide it.
+./ops db status
 
 # Dev server with hot reload
+# Warning: full app startup runs migration checks and configured background work.
 uvicorn atlas_brain.main:app \
   --host 0.0.0.0 --port 8001 \
   --reload --reload-dir atlas_brain \
   --reload-exclude 'data/postgres/**' \
   --ws-ping-interval 60 --ws-ping-timeout 120
 ```
+
+Read `.agent/runbooks/environment.md` and `.agent/runbooks/database.md` before
+loading configuration or starting the full app. The live production-shaped
+Brain uses `atlas-api.service`; inspect it with `./ops deploy status` rather
+than assuming Docker or a cloud provider owns it.
 
 ### ASR Server (for voice pipeline)
 

--- a/ops
+++ b/ops
@@ -207,22 +207,24 @@ def parse_env_keys(path: Path) -> list[str]:
     return sorted(keys)
 
 
-def parse_env_values(path: Path, allowed: set[str]) -> dict[str, str]:
-    """Read only selected dotenv assignments without executing the file."""
-    values: dict[str, str] = {}
+def parse_env_values(
+    path: Path,
+    allowed: set[str] | frozenset[str],
+) -> dict[str, str]:
+    """Decode selected assignments with the project's dotenv semantics."""
     try:
-        lines = path.read_text(encoding="utf-8").splitlines()
+        from dotenv import dotenv_values
+    except ImportError as exc:
+        raise OpsError("project Python is missing python-dotenv") from exc
+    try:
+        parsed = dotenv_values(path, encoding="utf-8")
     except (OSError, UnicodeError):
-        return values
-    for line in lines:
-        match = ENV_KEY_RE.match(line)
-        if not match or match.group("key") not in allowed:
-            continue
-        raw = line[match.end():].strip()
-        if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in ("'", '"'):
-            raw = raw[1:-1]
-        values[match.group("key")] = raw
-    return values
+        return {}
+    return {
+        key: value
+        for key, value in parsed.items()
+        if key in allowed and value is not None
+    }
 
 
 def database_runtime_environment() -> dict[str, str]:
@@ -645,6 +647,16 @@ def python_command() -> Path:
     return Path(sys.executable)
 
 
+def unit_test_environment() -> dict[str, str]:
+    """Remove inherited database URLs before nominal unit tests start."""
+    child_env = os.environ.copy()
+    for key in tuple(child_env):
+        if key == "DATABASE_URL" or key.endswith("_DATABASE_URL"):
+            child_env.pop(key)
+    child_env.pop("ATLAS_CONFIRM_DISPOSABLE_TEST_DB", None)
+    return child_env
+
+
 def test_command(args: list[str]) -> int:
     if not args:
         raise OpsError("usage: ./ops test {unit|focused|integration|frontend|local-review}")
@@ -662,6 +674,7 @@ def test_command(args: list[str]) -> int:
                 "-q", "--continue-on-collection-errors",
             ],
             cwd=root,
+            env=unit_test_environment(),
         )
     if action == "focused":
         if len(args) < 2:

--- a/ops
+++ b/ops
@@ -1,0 +1,879 @@
+#!/usr/bin/env python3
+"""Stable, read-only-first operational entrypoint for Atlas agents."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+from urllib.request import urlopen
+
+
+PROJECT = "Atlas"
+REPOSITORY = "canfieldjuan/ATLAS"
+SYSTEMD_UNIT = "atlas-api"
+VERCEL_PROJECT = "atlas-churn-ui"
+KNOWN_CONTAINERS = (
+    "atlas_brain",
+    "atlas_nocodb",
+    "atlas-neo4j",
+    "atlas-graphiti-wrapper",
+)
+ENV_KEY_RE = re.compile(
+    r"^\s*(?:export\s+)?(?P<key>[A-Za-z_][A-Za-z0-9_]*)\s*=",
+)
+SAFE_SQL_LEADS = frozenset(("select", "show", "table", "values"))
+
+
+class OpsError(RuntimeError):
+    """An actionable operational error safe to show to the caller."""
+
+
+def run(
+    args: list[str],
+    *,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+    timeout: int = 15,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            args,
+            cwd=cwd,
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return subprocess.CompletedProcess(args, 127, "", str(exc))
+
+
+def exec_command(args: list[str], *, cwd: Path | None = None) -> int:
+    try:
+        return subprocess.call(args, cwd=cwd)
+    except OSError as exc:
+        raise OpsError(str(exc)) from exc
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parent
+
+
+def worktree_root() -> Path | None:
+    result = run(
+        ["git", "-C", str(repo_root()), "rev-parse", "--show-toplevel"],
+        timeout=5,
+    )
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip()).resolve()
+
+
+def shared_root() -> Path:
+    result = run(
+        [
+            "git",
+            "-C",
+            str(repo_root()),
+            "rev-parse",
+            "--path-format=absolute",
+            "--git-common-dir",
+        ],
+        timeout=5,
+    )
+    if result.returncode != 0:
+        return repo_root()
+    common = Path(result.stdout.strip()).resolve()
+    return common.parent if common.name == ".git" else repo_root()
+
+
+def command_version(name: str) -> str | None:
+    if shutil.which(name) is None:
+        return None
+    options = {
+        "python": [sys.executable, "--version"],
+        "gh": ["gh", "--version"],
+        "render": ["render", "--version"],
+        "vercel": ["vercel", "--version"],
+    }
+    result = run(options.get(name, [name, "--version"]), timeout=5)
+    combined = "\n".join((result.stdout, result.stderr)).strip()
+    return combined.splitlines()[0] if combined else "available"
+
+
+def interpreter_version(path: Path) -> str:
+    result = run([str(path), "--version"], timeout=5)
+    combined = "\n".join((result.stdout, result.stderr)).strip()
+    return combined.splitlines()[0] if result.returncode == 0 and combined else "UNKNOWN"
+
+
+def status_line(label: str, state: str, detail: str = "") -> None:
+    suffix = f" ({detail})" if detail else ""
+    print(f"  {label}: {state}{suffix}")
+
+
+def offline() -> bool:
+    return os.environ.get("ATLAS_OPS_OFFLINE") == "1"
+
+
+def env_files() -> list[Path]:
+    override = os.environ.get("ATLAS_OPS_ENV_FILES")
+    if override is not None:
+        candidates = [Path(item).expanduser() for item in override.split(os.pathsep) if item]
+    else:
+        roots = [root for root in (worktree_root(), shared_root()) if root is not None]
+        candidates = []
+        for root in roots:
+            candidates.extend((root / ".env", root / ".env.local", root / ".env.tailscale"))
+        candidates.extend(
+            (
+                repo_root() / "atlas-ui/.env.example",
+                repo_root() / "atlas_video-processing/.env.example",
+                repo_root() / "graphiti-wrapper/.env.example",
+            )
+        )
+        if shutil.which("systemctl"):
+            result = run(
+                [
+                    "systemctl",
+                    "--user",
+                    "show",
+                    SYSTEMD_UNIT,
+                    "--property=EnvironmentFiles",
+                    "--value",
+                    "--no-pager",
+                ],
+                timeout=5,
+            )
+            if result.returncode == 0:
+                for line in result.stdout.splitlines():
+                    raw_path = line.strip().split(" ", 1)[0]
+                    if raw_path:
+                        candidates.append(Path(raw_path).expanduser())
+    unique: list[Path] = []
+    seen: set[Path] = set()
+    for candidate in candidates:
+        resolved = candidate.resolve(strict=False)
+        if resolved not in seen:
+            seen.add(resolved)
+            unique.append(resolved)
+    return unique
+
+
+def parse_env_keys(path: Path) -> list[str]:
+    keys: set[str] = set()
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeError):
+        return []
+    for line in lines:
+        match = ENV_KEY_RE.match(line)
+        if match:
+            keys.add(match.group("key"))
+    return sorted(keys)
+
+
+def parse_env_values(path: Path, allowed: set[str]) -> dict[str, str]:
+    """Read only selected dotenv assignments without executing the file."""
+    values: dict[str, str] = {}
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeError):
+        return values
+    for line in lines:
+        match = ENV_KEY_RE.match(line)
+        if not match or match.group("key") not in allowed:
+            continue
+        raw = line[match.end():].strip()
+        if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in ("'", '"'):
+            raw = raw[1:-1]
+        values[match.group("key")] = raw
+    return values
+
+
+def database_environment() -> dict[str, str]:
+    allowed = {
+        "ATLAS_DB_CONNECTION_STRING",
+        "ATLAS_DB_HOST",
+        "ATLAS_DB_PORT",
+        "ATLAS_DB_DATABASE",
+        "ATLAS_DB_USER",
+        "ATLAS_DB_PASSWORD",
+        "ATLAS_DB_SOCKET_PATH",
+    }
+    config: dict[str, str] = {}
+    for path in env_files():
+        config.update(parse_env_values(path, allowed))
+    for key in allowed:
+        if key in os.environ:
+            config[key] = os.environ[key]
+
+    child_env = os.environ.copy()
+    dsn = config.get("ATLAS_DB_CONNECTION_STRING", "").strip()
+    if dsn:
+        parsed = urlsplit(dsn)
+        if parsed.scheme not in ("postgres", "postgresql"):
+            raise OpsError("ATLAS_DB_CONNECTION_STRING is not a PostgreSQL URL")
+        if parsed.hostname:
+            child_env["PGHOST"] = parsed.hostname
+        if parsed.port:
+            child_env["PGPORT"] = str(parsed.port)
+        if parsed.path.lstrip("/"):
+            child_env["PGDATABASE"] = unquote(parsed.path.lstrip("/"))
+        if parsed.username:
+            child_env["PGUSER"] = unquote(parsed.username)
+        if parsed.password:
+            child_env["PGPASSWORD"] = unquote(parsed.password)
+    else:
+        child_env["PGHOST"] = config.get(
+            "ATLAS_DB_SOCKET_PATH",
+            config.get("ATLAS_DB_HOST", "127.0.0.1"),
+        )
+        child_env["PGPORT"] = config.get("ATLAS_DB_PORT", "5433")
+        child_env["PGDATABASE"] = config.get("ATLAS_DB_DATABASE", "atlas")
+        child_env["PGUSER"] = config.get("ATLAS_DB_USER", "atlas")
+        if config.get("ATLAS_DB_PASSWORD"):
+            child_env["PGPASSWORD"] = config["ATLAS_DB_PASSWORD"]
+    child_env["PGCONNECT_TIMEOUT"] = "5"
+    child_env["PGOPTIONS"] = (
+        "-c default_transaction_read_only=on "
+        "-c statement_timeout=5000 -c lock_timeout=1000"
+    )
+    return child_env
+
+
+def sanitize_sql(sql: str) -> str:
+    """Blank SQL strings/comments while retaining statement punctuation."""
+    out: list[str] = []
+    index = 0
+    state = "normal"
+    dollar_tag = ""
+    block_depth = 0
+    while index < len(sql):
+        char = sql[index]
+        pair = sql[index:index + 2]
+        if state == "normal":
+            if pair == "--":
+                state = "line-comment"
+                out.extend("  ")
+                index += 2
+                continue
+            if pair == "/*":
+                state = "block-comment"
+                block_depth = 1
+                out.extend("  ")
+                index += 2
+                continue
+            if char == "'":
+                state = "single"
+                out.append(" ")
+                index += 1
+                continue
+            if char == '"':
+                state = "double"
+                out.append(" ")
+                index += 1
+                continue
+            if char == "$":
+                match = re.match(r"\$[A-Za-z_][A-Za-z0-9_]*\$|\$\$", sql[index:])
+                if match:
+                    dollar_tag = match.group(0)
+                    state = "dollar"
+                    out.extend(" " * len(dollar_tag))
+                    index += len(dollar_tag)
+                    continue
+            out.append(char)
+            index += 1
+            continue
+        if state == "line-comment":
+            out.append("\n" if char == "\n" else " ")
+            if char == "\n":
+                state = "normal"
+            index += 1
+            continue
+        if state == "block-comment":
+            if pair == "/*":
+                block_depth += 1
+                out.extend("  ")
+                index += 2
+            elif pair == "*/":
+                block_depth -= 1
+                out.extend("  ")
+                index += 2
+                if block_depth == 0:
+                    state = "normal"
+            else:
+                out.append("\n" if char == "\n" else " ")
+                index += 1
+            continue
+        if state == "single":
+            if pair == "''":
+                out.extend("  ")
+                index += 2
+            elif char == "'":
+                out.append(" ")
+                state = "normal"
+                index += 1
+            elif char == "\\" and index + 1 < len(sql):
+                out.extend("  ")
+                index += 2
+            else:
+                out.append("\n" if char == "\n" else " ")
+                index += 1
+            continue
+        if state == "double":
+            if pair == '""':
+                out.extend("  ")
+                index += 2
+            elif char == '"':
+                out.append(" ")
+                state = "normal"
+                index += 1
+            else:
+                out.append("\n" if char == "\n" else " ")
+                index += 1
+            continue
+        if state == "dollar":
+            if sql.startswith(dollar_tag, index):
+                out.extend(" " * len(dollar_tag))
+                index += len(dollar_tag)
+                state = "normal"
+            else:
+                out.append("\n" if char == "\n" else " ")
+                index += 1
+    if state not in ("normal", "line-comment"):
+        raise OpsError("SQL contains an unterminated string or comment")
+    return "".join(out)
+
+
+def validate_read_only_sql(sql: str) -> tuple[bool, str]:
+    if not sql.strip():
+        return False, "query is empty"
+    if "\x00" in sql:
+        return False, "query contains a NUL byte"
+    try:
+        code = sanitize_sql(sql)
+    except OpsError as exc:
+        return False, str(exc)
+    statements = [part.strip() for part in code.split(";") if part.strip()]
+    if len(statements) != 1:
+        return False, "exactly one SQL statement is required"
+    lead_match = re.match(r"[A-Za-z]+", statements[0])
+    lead = lead_match.group(0).lower() if lead_match else ""
+    if lead not in SAFE_SQL_LEADS:
+        return False, "only SELECT, SHOW, TABLE, or VALUES statements are admitted"
+    if re.search(r"\binto\b", statements[0], re.IGNORECASE):
+        return False, "SELECT INTO is not read-only"
+    if re.search(
+        r"\bfor\s+(?:no\s+key\s+update|key\s+share|update|share)\b",
+        statements[0],
+        re.IGNORECASE,
+    ):
+        return False, "row-locking SELECT statements are not admitted"
+    return True, "ok"
+
+
+def psql_readonly_command(sql: str) -> list[str]:
+    return [
+        "psql",
+        "-X",
+        "-v",
+        "ON_ERROR_STOP=1",
+        "-P",
+        "pager=off",
+        "-c",
+        "BEGIN TRANSACTION READ ONLY;",
+        "-c",
+        sql,
+        "-c",
+        "ROLLBACK;",
+    ]
+
+
+def database_probe() -> tuple[str, str]:
+    if shutil.which("pg_isready") is None or shutil.which("psql") is None:
+        return "UNAVAILABLE", "install psql/pg_isready or use CI"
+    env = database_environment()
+    ready = run(["pg_isready", "-t", "3"], env=env, timeout=5)
+    if ready.returncode != 0:
+        return "FAIL", "PostgreSQL is not accepting connections"
+    query = run(psql_readonly_command("SELECT 1"), env=env, timeout=8)
+    if query.returncode != 0:
+        return "FAIL", "server reachable but query authentication failed"
+    return "OK", "read-only SELECT succeeded"
+
+
+def systemd_state() -> tuple[str, dict[str, str]]:
+    if shutil.which("systemctl") is None:
+        return "UNAVAILABLE", {}
+    result = run(
+        [
+            "systemctl",
+            "--user",
+            "show",
+            SYSTEMD_UNIT,
+            "--property=LoadState,ActiveState,SubState,WorkingDirectory",
+            "--no-pager",
+        ],
+        timeout=5,
+    )
+    values: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        if "=" in line:
+            key, value = line.split("=", 1)
+            values[key] = value
+    if result.returncode != 0 or values.get("LoadState") != "loaded":
+        return "UNAVAILABLE", values
+    state = "OK" if values.get("ActiveState") == "active" else "FAIL"
+    return state, values
+
+
+def auth_probe(command: list[str]) -> str:
+    if offline():
+        return "UNKNOWN"
+    if shutil.which(command[0]) is None:
+        return "UNAVAILABLE"
+    return "OK" if run(command, timeout=12).returncode == 0 else "FAIL"
+
+
+def docker_state() -> str:
+    if shutil.which("docker") is None:
+        return "UNAVAILABLE"
+    if offline():
+        return "UNKNOWN"
+    return "OK" if run(["docker", "info"], timeout=8).returncode == 0 else "FAIL"
+
+
+def brain_health() -> tuple[str, str]:
+    if offline():
+        return "UNKNOWN", "offline test mode"
+    configured = os.environ.get("ATLAS_OPS_BRAIN_URL")
+    urls = [configured] if configured else [
+        "http://127.0.0.1:8012/api/v1/ping",
+        "http://127.0.0.1:8000/api/v1/ping",
+        "http://127.0.0.1:8001/api/v1/ping",
+    ]
+    for url in urls:
+        if not url:
+            continue
+        try:
+            with urlopen(url, timeout=3) as response:  # noqa: S310 - fixed/local URL
+                if 200 <= response.status < 300:
+                    return "OK", url
+        except Exception:
+            continue
+    return "FAIL", "no configured/local ping endpoint responded"
+
+
+def print_git_snapshot() -> None:
+    root = worktree_root()
+    if root is None:
+        status_line("repository", str(shared_root()))
+        status_line("worktree", "UNAVAILABLE", "shared/bare root; use a dedicated worktree")
+        return
+    remote = run(["git", "-C", str(root), "remote", "get-url", "origin"], timeout=5)
+    branch = run(["git", "-C", str(root), "branch", "--show-current"], timeout=5)
+    state = run(["git", "-C", str(root), "status", "--porcelain"], timeout=5)
+    status_line("repository", remote.stdout.strip() if remote.returncode == 0 else str(root))
+    status_line("branch", branch.stdout.strip() or "detached")
+    status_line("working tree", "clean" if state.returncode == 0 and not state.stdout else "dirty")
+
+
+def doctor() -> int:
+    print("PROJECT")
+    status_line("name", PROJECT)
+    status_line("contract", ".agent/capabilities.yaml")
+    print("\nGIT")
+    print_git_snapshot()
+    print("\nRUNTIME")
+    status_line("shell Python", command_version("python") or "UNAVAILABLE")
+    project_python = python_command()
+    status_line("project Python", interpreter_version(project_python), str(project_python))
+    status_line("Node", command_version("node") or "UNAVAILABLE")
+    status_line("Docker daemon", docker_state())
+    service_state, service = systemd_state() if not offline() else ("UNKNOWN", {})
+    detail = service.get("WorkingDirectory", "")
+    status_line(f"{SYSTEMD_UNIT}.service", service_state, detail)
+    health_state, health_detail = brain_health()
+    status_line("Brain ping", health_state, health_detail)
+    print("\nTESTING")
+    status_line("Python unit", "available", "./ops test unit")
+    status_line("focused pytest", "available", "./ops test focused <target>")
+    status_line("integration", "guarded", "requires an explicit disposable DB URL")
+    print("\nDEPLOYMENT")
+    status_line("Brain", "local systemd", SYSTEMD_UNIT)
+    status_line("frontend provider", "Vercel", VERCEL_PROJECT)
+    status_line("Vercel authentication", auth_probe(["vercel", "whoami"]))
+    status_line("Render CLI", auth_probe(["render", "whoami", "--output", "json"]), "no Atlas service identified")
+    print("\nDATABASE")
+    db_state, db_detail = ("UNKNOWN", "offline test mode") if offline() else database_probe()
+    status_line("PostgreSQL", db_state, db_detail)
+    status_line("safe query", "available", './ops db query "SELECT 1"')
+    print("\nCI")
+    status_line("provider", "GitHub Actions")
+    status_line("GitHub authentication", auth_probe(["gh", "auth", "status"]))
+    status_line("status inspection", "available", "./ops ci status")
+    print("\nENVIRONMENT")
+    present = sum(1 for path in env_files() if path.is_file())
+    status_line("config sources", f"{present} readable", "./ops env keys never prints values")
+    print("\nUSEFUL COMMANDS")
+    for command in (
+        "./ops status",
+        "./ops test focused tests/<test_file>.py",
+        "./ops env keys",
+        './ops db query "SELECT 1"',
+        "./ops logs brain",
+        "./ops deploy status",
+        "./ops ci status",
+    ):
+        print(f"  {command}")
+    return 0
+
+
+def env_command(args: list[str]) -> int:
+    action = args[0] if args else "keys"
+    if action == "keys":
+        paths = env_files()
+        if len(args) == 3 and args[1] == "--file":
+            paths = [Path(args[2]).expanduser().resolve(strict=False)]
+        elif len(args) != 1:
+            raise OpsError("usage: ./ops env keys [--file PATH]")
+        found = False
+        for path in paths:
+            if not path.is_file():
+                continue
+            found = True
+            print(f"FILE {path}")
+            for key in parse_env_keys(path):
+                print(f"  {key}")
+        if not found:
+            print("No readable environment files found; exported variables may still be in use.")
+        return 0
+    if action == "systemd":
+        result = run(
+            ["systemctl", "--user", "show", SYSTEMD_UNIT, "--property=EnvironmentFiles", "--no-pager"],
+            timeout=5,
+        )
+        if result.returncode != 0:
+            raise OpsError("systemd environment-file inspection unavailable")
+        print(result.stdout.rstrip())
+        return 0
+    if action == "vercel":
+        link_root = shared_root()
+        if not (link_root / ".vercel/project.json").is_file():
+            raise OpsError("no linked Vercel project; use `vercel project inspect atlas-churn-ui`")
+        return exec_command(["vercel", "env", "ls"], cwd=link_root)
+    raise OpsError("usage: ./ops env {keys [--file PATH]|systemd|vercel}")
+
+
+def db_command(args: list[str]) -> int:
+    if not args:
+        raise OpsError("usage: ./ops db {status|query SQL|migrations}")
+    action = args[0]
+    if action == "status":
+        state, detail = database_probe()
+        status_line("database", state, detail)
+        return 0 if state == "OK" else 1
+    if action == "query":
+        if len(args) != 2:
+            raise OpsError('usage: ./ops db query "SELECT ..."')
+        allowed, reason = validate_read_only_sql(args[1])
+        if not allowed:
+            raise OpsError(f"query refused: {reason}")
+        return subprocess.call(psql_readonly_command(args[1]), env=database_environment())
+    if action == "migrations":
+        sql = (
+            "SELECT count(*) AS applied_count, max(version) AS latest_version "
+            "FROM schema_migrations"
+        )
+        return subprocess.call(psql_readonly_command(sql), env=database_environment())
+    if action in ("write", "migrate", "rollback", "drop"):
+        raise OpsError("mutating database operations are intentionally not exposed by ./ops")
+    raise OpsError("usage: ./ops db {status|query SQL|migrations}")
+
+
+def container_status() -> None:
+    if shutil.which("docker") is None:
+        status_line("containers", "UNAVAILABLE")
+        return
+    for name in KNOWN_CONTAINERS:
+        result = run(
+            ["docker", "inspect", "--format", "{{.State.Status}}", name],
+            timeout=5,
+        )
+        state = result.stdout.strip() if result.returncode == 0 else "absent"
+        status_line(name, state)
+
+
+def latest_vercel_deployment() -> dict[str, object] | None:
+    if shutil.which("vercel") is None or offline():
+        return None
+    listing = run(["vercel", "ls", VERCEL_PROJECT], cwd=shared_root(), timeout=20)
+    match = re.search(r"https://[^\s]+\.vercel\.app", listing.stdout)
+    if listing.returncode != 0 or match is None:
+        return None
+    inspected = run(
+        ["vercel", "inspect", match.group(0), "--format=json"],
+        cwd=shared_root(),
+        timeout=20,
+    )
+    if inspected.returncode != 0:
+        return None
+    try:
+        return json.loads(inspected.stdout)
+    except json.JSONDecodeError:
+        return None
+
+
+def deploy_status() -> int:
+    print("BRAIN")
+    state, values = systemd_state()
+    status_line("provider", "local systemd")
+    status_line("service", state, f"{SYSTEMD_UNIT}.service")
+    health_state, health_detail = brain_health()
+    status_line("health", health_state, health_detail)
+    runtime = values.get("WorkingDirectory", "")
+    if runtime:
+        head = run(["git", "-C", runtime, "rev-parse", "HEAD"], timeout=5)
+        status_line("runtime worktree", runtime)
+        status_line("runtime head", head.stdout.strip() if head.returncode == 0 else "UNKNOWN")
+    status_line("staging service", "UNAVAILABLE", "none discovered")
+    print("\nFRONTEND")
+    status_line("provider", "Vercel", VERCEL_PROJECT)
+    deployment = latest_vercel_deployment()
+    if deployment is None:
+        status_line("latest deployment", "UNKNOWN", "check Vercel auth/link/network")
+    else:
+        status_line("latest deployment", str(deployment.get("readyState", "UNKNOWN")))
+        status_line("target", str(deployment.get("target", "UNKNOWN")))
+        status_line("url", str(deployment.get("url", "UNKNOWN")))
+    print("\nNo deploy mutation is exposed by ./ops; read .agent/runbooks/deployment.md.")
+    return 0
+
+
+def logs_command(args: list[str]) -> int:
+    if not args:
+        raise OpsError("usage: ./ops logs {brain|container NAME|frontend [options]}")
+    surface = args[0]
+    if surface == "brain":
+        follow = args[1:] == ["--follow"]
+        if args[1:] not in ([], ["--follow"]):
+            raise OpsError("usage: ./ops logs brain [--follow]")
+        command = ["journalctl", "--user", "-u", SYSTEMD_UNIT, "-n", "100", "--no-pager"]
+        if follow:
+            command.extend(("--follow",))
+        return exec_command(command)
+    if surface == "container":
+        if len(args) not in (2, 3) or (len(args) == 3 and args[2] != "--follow"):
+            raise OpsError("usage: ./ops logs container NAME [--follow]")
+        command = ["docker", "logs", "--tail", "100"]
+        if len(args) == 3:
+            command.append("--follow")
+        command.append(args[1])
+        return exec_command(command)
+    if surface == "frontend":
+        since = "1h"
+        limit = "100"
+        follow = False
+        index = 1
+        while index < len(args):
+            if args[index] == "--follow":
+                follow = True
+                index += 1
+            elif args[index] in ("--since", "--limit") and index + 1 < len(args):
+                if args[index] == "--since":
+                    since = args[index + 1]
+                else:
+                    limit = args[index + 1]
+                index += 2
+            else:
+                raise OpsError("usage: ./ops logs frontend [--since 1h] [--limit N] [--follow]")
+        if not re.fullmatch(r"[0-9]+[mhd]", since):
+            raise OpsError("--since must be a relative interval such as 30m, 1h, or 1d")
+        if not limit.isdigit() or not 1 <= int(limit) <= 1000:
+            raise OpsError("--limit must be between 1 and 1000")
+        command = [
+            "vercel", "logs", "--project", VERCEL_PROJECT,
+            "--environment", "production", "--since", since,
+            "--limit", limit, "--no-branch",
+        ]
+        if follow:
+            command.append("--follow")
+        return exec_command(command, cwd=shared_root())
+    raise OpsError("usage: ./ops logs {brain|container NAME|frontend [options]}")
+
+
+def ci_command(args: list[str]) -> int:
+    action = args[0] if args else "status"
+    if action == "status":
+        limit = args[1] if len(args) == 2 else "10"
+        if len(args) > 2 or not limit.isdigit() or not 1 <= int(limit) <= 100:
+            raise OpsError("usage: ./ops ci status [LIMIT]")
+        return exec_command(
+            [
+                "gh", "run", "list", "--repo", REPOSITORY,
+                "--limit", limit,
+                "--json", "databaseId,workflowName,event,status,conclusion,headBranch,headSha,createdAt,url",
+            ],
+        )
+    if action == "run":
+        if len(args) not in (2, 3) or not args[1].isdigit():
+            raise OpsError("usage: ./ops ci run RUN_ID [--log-failed]")
+        command = ["gh", "run", "view", args[1], "--repo", REPOSITORY]
+        if len(args) == 3:
+            if args[2] != "--log-failed":
+                raise OpsError("usage: ./ops ci run RUN_ID [--log-failed]")
+            command.append("--log-failed")
+        return exec_command(command)
+    raise OpsError("usage: ./ops ci {status [LIMIT]|run RUN_ID [--log-failed]}")
+
+
+def python_command() -> Path:
+    override = os.environ.get("ATLAS_PYTHON")
+    if override:
+        return Path(override).expanduser()
+    root = worktree_root() or repo_root()
+    candidates = (root / ".venv/bin/python", shared_root() / ".venv/bin/python")
+    for candidate in candidates:
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return candidate
+    return Path(sys.executable)
+
+
+def test_command(args: list[str]) -> int:
+    if not args:
+        raise OpsError("usage: ./ops test {unit|focused|integration|frontend|local-review}")
+    root = worktree_root()
+    if root is None:
+        raise OpsError("tests require a normal worktree, not the shared/bare root")
+    action = args[0]
+    python = str(python_command())
+    if action == "unit":
+        if len(args) != 1:
+            raise OpsError("usage: ./ops test unit")
+        return exec_command(
+            [
+                python, "-m", "pytest", "tests/", "-m", "not integration and not e2e",
+                "-q", "--continue-on-collection-errors",
+            ],
+            cwd=root,
+        )
+    if action == "focused":
+        if len(args) < 2:
+            raise OpsError("usage: ./ops test focused <pytest target/args...>")
+        return exec_command([python, "-m", "pytest", *args[1:]], cwd=root)
+    if action == "integration":
+        if len(args) < 2:
+            raise OpsError("name a focused integration test target")
+        if not (
+            os.environ.get("ATLAS_MIGRATION_TEST_DATABASE_URL")
+            or os.environ.get("ATLAS_RECEIVABLES_TEST_DATABASE_URL")
+        ):
+            raise OpsError(
+                "integration tests require an explicit disposable "
+                "ATLAS_MIGRATION_TEST_DATABASE_URL or ATLAS_RECEIVABLES_TEST_DATABASE_URL"
+            )
+        if os.environ.get("ATLAS_CONFIRM_DISPOSABLE_TEST_DB") != "1":
+            raise OpsError("set ATLAS_CONFIRM_DISPOSABLE_TEST_DB=1 after verifying the DB is disposable")
+        return exec_command([python, "-m", "pytest", *args[1:]], cwd=root)
+    if action == "frontend":
+        if len(args) not in (2, 3):
+            raise OpsError("usage: ./ops test frontend PACKAGE [SCRIPT]")
+        package = args[1]
+        allowed = {
+            "atlas-ui", "atlas-intel-ui", "atlas-churn-ui",
+            "atlas-admin-ui", "atlas-mobile", "portfolio-ui",
+        }
+        if package not in allowed:
+            raise OpsError(f"unknown frontend package: {package}")
+        manifest = root / package / "package.json"
+        data = json.loads(manifest.read_text(encoding="utf-8"))
+        script = args[2] if len(args) == 3 else "test"
+        if script not in data.get("scripts", {}):
+            available = ", ".join(sorted(data.get("scripts", {})))
+            raise OpsError(f"{package} has no {script!r} script; available: {available}")
+        return exec_command(["npm", "run", script], cwd=manifest.parent)
+    if action == "local-review":
+        if len(args) != 1:
+            raise OpsError("usage: ./ops test local-review")
+        return exec_command(["bash", "scripts/local_pr_review.sh"], cwd=root)
+    raise OpsError("usage: ./ops test {unit|focused|integration|frontend|local-review}")
+
+
+def status_command() -> int:
+    deploy_status()
+    print("\nDATABASE")
+    state, detail = database_probe()
+    status_line("PostgreSQL", state, detail)
+    print("\nCONTAINERS")
+    container_status()
+    return 0
+
+
+def usage() -> None:
+    print(
+        """Usage: ./ops COMMAND [ARGS]
+
+Read-only discovery and inspection:
+  doctor
+  status
+  env {keys [--file PATH]|systemd|vercel}
+  db {status|query SQL|migrations}
+  deploy status
+  logs {brain|container NAME|frontend [--since 1h] [--limit N] [--follow]}
+  ci {status [LIMIT]|run RUN_ID [--log-failed]}
+
+Local/test execution:
+  test unit
+  test focused <pytest target/args...>
+  test integration <pytest target/args...>
+  test frontend PACKAGE [SCRIPT]
+  test local-review
+
+Production deploys, database writes, migrations, and restarts are intentionally
+not exposed. Read .agent/runbooks/ before performing them manually.
+"""
+    )
+
+
+def main(argv: list[str]) -> int:
+    if not argv or argv[0] in ("help", "--help", "-h"):
+        usage()
+        return 0
+    command, args = argv[0], argv[1:]
+    if command == "doctor":
+        if args:
+            raise OpsError("usage: ./ops doctor")
+        return doctor()
+    if command == "status":
+        if args:
+            raise OpsError("usage: ./ops status")
+        return status_command()
+    if command == "env":
+        return env_command(args)
+    if command == "db":
+        return db_command(args)
+    if command == "deploy" and args == ["status"]:
+        return deploy_status()
+    if command == "logs":
+        return logs_command(args)
+    if command == "ci":
+        return ci_command(args)
+    if command == "test":
+        return test_command(args)
+    raise OpsError(f"unknown command: {command}; run ./ops --help")
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main(sys.argv[1:]))
+    except OpsError as exc:
+        print(f"ops: {exc}", file=sys.stderr)
+        raise SystemExit(2)

--- a/ops
+++ b/ops
@@ -150,7 +150,44 @@ def offline() -> bool:
     return os.environ.get("ATLAS_OPS_OFFLINE") == "1"
 
 
+def unique_paths(candidates: list[Path]) -> list[Path]:
+    unique: list[Path] = []
+    seen: set[Path] = set()
+    for candidate in candidates:
+        resolved = candidate.resolve(strict=False)
+        if resolved not in seen:
+            seen.add(resolved)
+            unique.append(resolved)
+    return unique
+
+
+def systemd_env_files() -> list[Path]:
+    if shutil.which("systemctl") is None:
+        return []
+    result = run(
+        [
+            "systemctl",
+            "--user",
+            "show",
+            SYSTEMD_UNIT,
+            "--property=EnvironmentFiles",
+            "--value",
+            "--no-pager",
+        ],
+        timeout=5,
+    )
+    if result.returncode != 0:
+        return []
+    candidates = []
+    for line in result.stdout.splitlines():
+        raw_path = line.strip().split(" ", 1)[0]
+        if raw_path:
+            candidates.append(Path(raw_path).expanduser())
+    return unique_paths(candidates)
+
+
 def env_files() -> list[Path]:
+    """Return the broad, key-only environment-source inventory."""
     override = os.environ.get("ATLAS_OPS_ENV_FILES")
     if override is not None:
         candidates = [Path(item).expanduser() for item in override.split(os.pathsep) if item]
@@ -166,32 +203,30 @@ def env_files() -> list[Path]:
                 repo_root() / "graphiti-wrapper/.env.example",
             )
         )
-        if shutil.which("systemctl"):
-            result = run(
-                [
-                    "systemctl",
-                    "--user",
-                    "show",
-                    SYSTEMD_UNIT,
-                    "--property=EnvironmentFiles",
-                    "--value",
-                    "--no-pager",
-                ],
-                timeout=5,
-            )
-            if result.returncode == 0:
-                for line in result.stdout.splitlines():
-                    raw_path = line.strip().split(" ", 1)[0]
-                    if raw_path:
-                        candidates.append(Path(raw_path).expanduser())
-    unique: list[Path] = []
-    seen: set[Path] = set()
-    for candidate in candidates:
-        resolved = candidate.resolve(strict=False)
-        if resolved not in seen:
-            seen.add(resolved)
-            unique.append(resolved)
-    return unique
+        candidates.extend(systemd_env_files())
+    return unique_paths(candidates)
+
+
+def database_env_files() -> list[Path]:
+    """Select one application-equivalent database configuration context."""
+    override = os.environ.get("ATLAS_OPS_ENV_FILES")
+    if override is not None:
+        return unique_paths(
+            [Path(item).expanduser() for item in override.split(os.pathsep) if item]
+        )
+
+    seen_roots: set[Path] = set()
+    for root in (worktree_root(), shared_root()):
+        if root is None:
+            continue
+        resolved_root = root.resolve(strict=False)
+        if resolved_root in seen_roots:
+            continue
+        seen_roots.add(resolved_root)
+        candidates = [resolved_root / ".env", resolved_root / ".env.local"]
+        if any(path.is_file() for path in candidates):
+            return candidates
+    return systemd_env_files()
 
 
 def parse_env_keys(path: Path) -> list[str]:
@@ -230,7 +265,7 @@ def parse_env_values(
 def database_runtime_environment() -> dict[str, str]:
     """Pass DB configuration to the project interpreter without argv exposure."""
     config: dict[str, str] = {}
-    for path in env_files():
+    for path in database_env_files():
         config.update(parse_env_values(path, DATABASE_CONFIG_KEYS))
     for key in DATABASE_CONFIG_KEYS:
         if key in os.environ:
@@ -511,12 +546,21 @@ def container_status() -> None:
     if shutil.which("docker") is None:
         status_line("containers", "UNAVAILABLE")
         return
+    if offline():
+        status_line("containers", "UNKNOWN", "offline test mode")
+        return
+    if run(["docker", "info"], timeout=8).returncode != 0:
+        status_line("containers", "UNAVAILABLE", "Docker daemon/authentication unavailable")
+        return
     for name in KNOWN_CONTAINERS:
         result = run(
             ["docker", "inspect", "--format", "{{.State.Status}}", name],
             timeout=5,
         )
-        state = result.stdout.strip() if result.returncode == 0 else "absent"
+        if result.returncode != 0:
+            state = "absent"
+        else:
+            state = result.stdout.strip() or "UNKNOWN"
         status_line(name, state)
 
 
@@ -717,10 +761,18 @@ def test_command(args: list[str]) -> int:
         if len(args) < 2:
             raise OpsError("name a focused integration test target")
         validate_integration_target(root, args[1:])
-        if not any(os.environ.get(key) for key in TEST_DATABASE_URL_KEYS):
+        active_database_keys = [
+            key for key in TEST_DATABASE_URL_KEYS if os.environ.get(key)
+        ]
+        if len(active_database_keys) != 1:
+            detail = (
+                "none are set; use one of: " + ", ".join(TEST_DATABASE_URL_KEYS)
+                if not active_database_keys
+                else "multiple are set: " + ", ".join(active_database_keys)
+            )
             raise OpsError(
-                "integration tests require one explicit disposable test database URL; "
-                f"use one of: {', '.join(TEST_DATABASE_URL_KEYS)}"
+                "integration tests require exactly one explicit disposable test "
+                f"database URL; {detail}"
             )
         if os.environ.get("ATLAS_CONFIRM_DISPOSABLE_TEST_DB") != "1":
             raise OpsError(

--- a/ops
+++ b/ops
@@ -709,6 +709,29 @@ def unit_test_environment() -> dict[str, str]:
     return child_env
 
 
+def integration_test_environment(confirmed_key: str) -> dict[str, str]:
+    """Bind every supported DB interface to one confirmed disposable DSN."""
+    if confirmed_key not in TEST_DATABASE_URL_KEYS:
+        raise OpsError("unknown integration database credential")
+    confirmed_url = os.environ.get(confirmed_key)
+    if not confirmed_url:
+        raise OpsError("confirmed integration database credential is unavailable")
+
+    child_env = os.environ.copy()
+    for key in tuple(child_env):
+        if (
+            key == "DATABASE_URL"
+            or key.endswith("_DATABASE_URL")
+            or key in DATABASE_CONFIG_KEYS
+        ):
+            child_env.pop(key)
+    child_env[confirmed_key] = confirmed_url
+    child_env["DATABASE_URL"] = confirmed_url
+    child_env["EXTRACTED_DATABASE_URL"] = confirmed_url
+    child_env["ATLAS_DB_CONNECTION_STRING"] = confirmed_url
+    return child_env
+
+
 def validate_integration_target(root: Path, pytest_args: list[str]) -> None:
     target = pytest_args[0]
     file_target = target.partition("::")[0]
@@ -778,7 +801,12 @@ def test_command(args: list[str]) -> int:
             raise OpsError(
                 "set ATLAS_CONFIRM_DISPOSABLE_TEST_DB=1 after verifying the DB is disposable"
             )
-        return exec_command([python, "-m", "pytest", *args[1:]], cwd=root)
+        child_env = integration_test_environment(active_database_keys[0])
+        return exec_command(
+            [python, "-m", "pytest", *args[1:]],
+            cwd=root,
+            env=child_env,
+        )
     if action == "frontend":
         if len(args) not in (2, 3):
             raise OpsError("usage: ./ops test frontend PACKAGE [SCRIPT]")

--- a/ops
+++ b/ops
@@ -450,7 +450,7 @@ def doctor() -> int:
     health_state, health_detail = brain_health()
     status_line("Brain ping", health_state, health_detail)
     print("\nTESTING")
-    status_line("Python unit", "available", "./ops test unit")
+    status_line("Python unit gate", "GitHub-only", ".github/workflows/unit_gate.yml")
     status_line("focused pytest", "available", "./ops test focused <target>")
     status_line("integration", "guarded", "requires an explicit disposable DB URL")
     print("\nDEPLOYMENT")
@@ -699,16 +699,6 @@ def python_command() -> Path:
     return Path(sys.executable)
 
 
-def unit_test_environment() -> dict[str, str]:
-    """Remove inherited database URLs before nominal unit tests start."""
-    child_env = os.environ.copy()
-    for key in tuple(child_env):
-        if key == "DATABASE_URL" or key.endswith("_DATABASE_URL"):
-            child_env.pop(key)
-    child_env.pop("ATLAS_CONFIRM_DISPOSABLE_TEST_DB", None)
-    return child_env
-
-
 def integration_test_environment(confirmed_key: str) -> dict[str, str]:
     """Bind every supported DB interface to one confirmed disposable DSN."""
     if confirmed_key not in TEST_DATABASE_URL_KEYS:
@@ -768,13 +758,9 @@ def test_command(args: list[str]) -> int:
     if action == "unit":
         if len(args) != 1:
             raise OpsError("usage: ./ops test unit")
-        return exec_command(
-            [
-                python, "-m", "pytest", "tests/", "-m", "not integration and not e2e",
-                "-q", "--continue-on-collection-errors",
-            ],
-            cwd=root,
-            env=unit_test_environment(),
+        raise OpsError(
+            "the full unit gate is GitHub-only; inspect "
+            ".github/workflows/unit_gate.yml or use ./ops ci status"
         )
     if action == "focused":
         if len(args) < 2:
@@ -855,7 +841,7 @@ Read-only discovery and inspection:
   ci {status [LIMIT]|run RUN_ID [--log-failed]}
 
 Local/test execution:
-  test unit
+  test unit  # GitHub-only; prints the canonical hosted gate and exits
   test focused <pytest target/args...>
   test integration <pytest target/args...>
   test frontend PACKAGE [SCRIPT]

--- a/ops
+++ b/ops
@@ -118,7 +118,7 @@ def shared_root() -> Path:
     if result.returncode != 0:
         return repo_root()
     common = Path(result.stdout.strip()).resolve()
-    return common.parent if common.name == ".git" else repo_root()
+    return common.parent if common.name == ".git" else common
 
 
 def command_version(name: str) -> str | None:

--- a/ops
+++ b/ops
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import re
@@ -10,7 +11,6 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from urllib.parse import unquote, urlsplit
 from urllib.request import urlopen
 
 
@@ -27,7 +27,29 @@ KNOWN_CONTAINERS = (
 ENV_KEY_RE = re.compile(
     r"^\s*(?:export\s+)?(?P<key>[A-Za-z_][A-Za-z0-9_]*)\s*=",
 )
-SAFE_SQL_LEADS = frozenset(("select", "show", "table", "values"))
+DATABASE_CONFIG_KEYS = frozenset(
+    (
+        "ATLAS_DB_CONNECTION_STRING",
+        "ATLAS_DB_HOST",
+        "ATLAS_DB_PORT",
+        "ATLAS_DB_DATABASE",
+        "ATLAS_DB_USER",
+        "ATLAS_DB_PASSWORD",
+        "ATLAS_DB_SOCKET_PATH",
+    )
+)
+DATABASE_INSPECTIONS = {
+    "connectivity": "SELECT 1 AS ok",
+    "migrations": (
+        "SELECT count(*) AS applied_count, max(version) AS latest_version "
+        "FROM public.schema_migrations"
+    ),
+}
+TEST_DATABASE_URL_KEYS = (
+    "ATLAS_MIGRATION_TEST_DATABASE_URL",
+    "ATLAS_RECEIVABLES_TEST_DATABASE_URL",
+    "ATLAS_LEGACY_MONTHLY_AUTOINVOICE_WRITER_TEST_DATABASE_URL",
+)
 
 
 class OpsError(RuntimeError):
@@ -55,9 +77,14 @@ def run(
         return subprocess.CompletedProcess(args, 127, "", str(exc))
 
 
-def exec_command(args: list[str], *, cwd: Path | None = None) -> int:
+def exec_command(
+    args: list[str],
+    *,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+) -> int:
     try:
-        return subprocess.call(args, cwd=cwd)
+        return subprocess.call(args, cwd=cwd, env=env)
     except OSError as exc:
         raise OpsError(str(exc)) from exc
 
@@ -198,216 +225,91 @@ def parse_env_values(path: Path, allowed: set[str]) -> dict[str, str]:
     return values
 
 
-def database_environment() -> dict[str, str]:
-    allowed = {
-        "ATLAS_DB_CONNECTION_STRING",
-        "ATLAS_DB_HOST",
-        "ATLAS_DB_PORT",
-        "ATLAS_DB_DATABASE",
-        "ATLAS_DB_USER",
-        "ATLAS_DB_PASSWORD",
-        "ATLAS_DB_SOCKET_PATH",
-    }
+def database_runtime_environment() -> dict[str, str]:
+    """Pass DB configuration to the project interpreter without argv exposure."""
     config: dict[str, str] = {}
     for path in env_files():
-        config.update(parse_env_values(path, allowed))
-    for key in allowed:
+        config.update(parse_env_values(path, DATABASE_CONFIG_KEYS))
+    for key in DATABASE_CONFIG_KEYS:
         if key in os.environ:
             config[key] = os.environ[key]
 
     child_env = os.environ.copy()
-    dsn = config.get("ATLAS_DB_CONNECTION_STRING", "").strip()
-    if dsn:
-        parsed = urlsplit(dsn)
-        if parsed.scheme not in ("postgres", "postgresql"):
-            raise OpsError("ATLAS_DB_CONNECTION_STRING is not a PostgreSQL URL")
-        if parsed.hostname:
-            child_env["PGHOST"] = parsed.hostname
-        if parsed.port:
-            child_env["PGPORT"] = str(parsed.port)
-        if parsed.path.lstrip("/"):
-            child_env["PGDATABASE"] = unquote(parsed.path.lstrip("/"))
-        if parsed.username:
-            child_env["PGUSER"] = unquote(parsed.username)
-        if parsed.password:
-            child_env["PGPASSWORD"] = unquote(parsed.password)
-    else:
-        child_env["PGHOST"] = config.get(
-            "ATLAS_DB_SOCKET_PATH",
-            config.get("ATLAS_DB_HOST", "127.0.0.1"),
-        )
-        child_env["PGPORT"] = config.get("ATLAS_DB_PORT", "5433")
-        child_env["PGDATABASE"] = config.get("ATLAS_DB_DATABASE", "atlas")
-        child_env["PGUSER"] = config.get("ATLAS_DB_USER", "atlas")
-        if config.get("ATLAS_DB_PASSWORD"):
-            child_env["PGPASSWORD"] = config["ATLAS_DB_PASSWORD"]
-    child_env["PGCONNECT_TIMEOUT"] = "5"
-    child_env["PGOPTIONS"] = (
-        "-c default_transaction_read_only=on "
-        "-c statement_timeout=5000 -c lock_timeout=1000"
-    )
+    for key in DATABASE_CONFIG_KEYS:
+        child_env.pop(key, None)
+    child_env.update(config)
+    child_env["ATLAS_OPS_INTERNAL_DB_INSPECTION"] = "1"
     return child_env
 
 
-def sanitize_sql(sql: str) -> str:
-    """Blank SQL strings/comments while retaining statement punctuation."""
-    out: list[str] = []
-    index = 0
-    state = "normal"
-    dollar_tag = ""
-    block_depth = 0
-    while index < len(sql):
-        char = sql[index]
-        pair = sql[index:index + 2]
-        if state == "normal":
-            if pair == "--":
-                state = "line-comment"
-                out.extend("  ")
-                index += 2
-                continue
-            if pair == "/*":
-                state = "block-comment"
-                block_depth = 1
-                out.extend("  ")
-                index += 2
-                continue
-            if char == "'":
-                state = "single"
-                out.append(" ")
-                index += 1
-                continue
-            if char == '"':
-                state = "double"
-                out.append(" ")
-                index += 1
-                continue
-            if char == "$":
-                match = re.match(r"\$[A-Za-z_][A-Za-z0-9_]*\$|\$\$", sql[index:])
-                if match:
-                    dollar_tag = match.group(0)
-                    state = "dollar"
-                    out.extend(" " * len(dollar_tag))
-                    index += len(dollar_tag)
-                    continue
-            out.append(char)
-            index += 1
-            continue
-        if state == "line-comment":
-            out.append("\n" if char == "\n" else " ")
-            if char == "\n":
-                state = "normal"
-            index += 1
-            continue
-        if state == "block-comment":
-            if pair == "/*":
-                block_depth += 1
-                out.extend("  ")
-                index += 2
-            elif pair == "*/":
-                block_depth -= 1
-                out.extend("  ")
-                index += 2
-                if block_depth == 0:
-                    state = "normal"
-            else:
-                out.append("\n" if char == "\n" else " ")
-                index += 1
-            continue
-        if state == "single":
-            if pair == "''":
-                out.extend("  ")
-                index += 2
-            elif char == "'":
-                out.append(" ")
-                state = "normal"
-                index += 1
-            elif char == "\\" and index + 1 < len(sql):
-                out.extend("  ")
-                index += 2
-            else:
-                out.append("\n" if char == "\n" else " ")
-                index += 1
-            continue
-        if state == "double":
-            if pair == '""':
-                out.extend("  ")
-                index += 2
-            elif char == '"':
-                out.append(" ")
-                state = "normal"
-                index += 1
-            else:
-                out.append("\n" if char == "\n" else " ")
-                index += 1
-            continue
-        if state == "dollar":
-            if sql.startswith(dollar_tag, index):
-                out.extend(" " * len(dollar_tag))
-                index += len(dollar_tag)
-                state = "normal"
-            else:
-                out.append("\n" if char == "\n" else " ")
-                index += 1
-    if state not in ("normal", "line-comment"):
-        raise OpsError("SQL contains an unterminated string or comment")
-    return "".join(out)
+def database_inspection_command(name: str) -> list[str]:
+    if name not in DATABASE_INSPECTIONS:
+        raise OpsError(f"unknown database inspection: {name}")
+    return [str(python_command()), str(repo_root() / "ops"), "__db-inspect", name]
 
 
-def validate_read_only_sql(sql: str) -> tuple[bool, str]:
-    if not sql.strip():
-        return False, "query is empty"
-    if "\x00" in sql:
-        return False, "query contains a NUL byte"
+async def execute_database_inspection(name: str) -> int:
+    """Execute one fixed inspection through the same config path as Atlas."""
+    if name not in DATABASE_INSPECTIONS:
+        raise OpsError(f"unknown database inspection: {name}")
     try:
-        code = sanitize_sql(sql)
-    except OpsError as exc:
-        return False, str(exc)
-    statements = [part.strip() for part in code.split(";") if part.strip()]
-    if len(statements) != 1:
-        return False, "exactly one SQL statement is required"
-    lead_match = re.match(r"[A-Za-z]+", statements[0])
-    lead = lead_match.group(0).lower() if lead_match else ""
-    if lead not in SAFE_SQL_LEADS:
-        return False, "only SELECT, SHOW, TABLE, or VALUES statements are admitted"
-    if re.search(r"\binto\b", statements[0], re.IGNORECASE):
-        return False, "SELECT INTO is not read-only"
-    if re.search(
-        r"\bfor\s+(?:no\s+key\s+update|key\s+share|update|share)\b",
-        statements[0],
-        re.IGNORECASE,
-    ):
-        return False, "row-locking SELECT statements are not admitted"
-    return True, "ok"
+        import asyncpg
+        from atlas_brain.storage.config import DatabaseConfig
+    except ImportError as exc:
+        raise OpsError("project Python is missing asyncpg/database dependencies") from exc
+
+    config = DatabaseConfig(_env_file=None)
+    connection = None
+    try:
+        connection = await asyncpg.connect(
+            **config.connection_kwargs(command_timeout=5)
+        )
+        async with connection.transaction(readonly=True):
+            await connection.execute("SET LOCAL statement_timeout = '5s'")
+            await connection.execute("SET LOCAL lock_timeout = '1s'")
+            rows = await connection.fetch(DATABASE_INSPECTIONS[name])
+    except Exception as exc:
+        raise OpsError(f"database inspection failed ({type(exc).__name__})") from exc
+    finally:
+        if connection is not None:
+            try:
+                await connection.close()
+            except Exception as exc:
+                raise OpsError(
+                    f"database inspection cleanup failed ({type(exc).__name__})"
+                ) from exc
+
+    if rows:
+        columns = list(rows[0].keys())
+        print("\t".join(columns))
+        for row in rows:
+            print(
+                "\t".join(
+                    "" if row[column] is None else str(row[column])
+                    for column in columns
+                )
+            )
+    return 0
 
 
-def psql_readonly_command(sql: str) -> list[str]:
-    return [
-        "psql",
-        "-X",
-        "-v",
-        "ON_ERROR_STOP=1",
-        "-P",
-        "pager=off",
-        "-c",
-        "BEGIN TRANSACTION READ ONLY;",
-        "-c",
-        sql,
-        "-c",
-        "ROLLBACK;",
-    ]
+def run_database_inspection(
+    name: str,
+    *,
+    capture: bool = False,
+) -> int | subprocess.CompletedProcess[str]:
+    command = database_inspection_command(name)
+    env = database_runtime_environment()
+    if capture:
+        return run(command, env=env, timeout=10)
+    return exec_command(command, env=env)
 
 
 def database_probe() -> tuple[str, str]:
-    if shutil.which("pg_isready") is None or shutil.which("psql") is None:
-        return "UNAVAILABLE", "install psql/pg_isready or use CI"
-    env = database_environment()
-    ready = run(["pg_isready", "-t", "3"], env=env, timeout=5)
-    if ready.returncode != 0:
-        return "FAIL", "PostgreSQL is not accepting connections"
-    query = run(psql_readonly_command("SELECT 1"), env=env, timeout=8)
-    if query.returncode != 0:
-        return "FAIL", "server reachable but query authentication failed"
-    return "OK", "read-only SELECT succeeded"
+    result = run_database_inspection("connectivity", capture=True)
+    assert isinstance(result, subprocess.CompletedProcess)
+    if result.returncode != 0:
+        return "FAIL", "fixed connectivity inspection failed"
+    return "OK", "fixed connectivity inspection succeeded"
 
 
 def systemd_state() -> tuple[str, dict[str, str]]:
@@ -475,13 +377,12 @@ def brain_health() -> tuple[str, str]:
 def print_git_snapshot() -> None:
     root = worktree_root()
     if root is None:
-        status_line("repository", str(shared_root()))
+        status_line("repository", REPOSITORY)
         status_line("worktree", "UNAVAILABLE", "shared/bare root; use a dedicated worktree")
         return
-    remote = run(["git", "-C", str(root), "remote", "get-url", "origin"], timeout=5)
     branch = run(["git", "-C", str(root), "branch", "--show-current"], timeout=5)
     state = run(["git", "-C", str(root), "status", "--porcelain"], timeout=5)
-    status_line("repository", remote.stdout.strip() if remote.returncode == 0 else str(root))
+    status_line("repository", REPOSITORY)
     status_line("branch", branch.stdout.strip() or "detached")
     status_line("working tree", "clean" if state.returncode == 0 and not state.stdout else "dirty")
 
@@ -515,7 +416,7 @@ def doctor() -> int:
     print("\nDATABASE")
     db_state, db_detail = ("UNKNOWN", "offline test mode") if offline() else database_probe()
     status_line("PostgreSQL", db_state, db_detail)
-    status_line("safe query", "available", './ops db query "SELECT 1"')
+    status_line("fixed inspections", "available", "./ops db inspect connectivity")
     print("\nCI")
     status_line("provider", "GitHub Actions")
     status_line("GitHub authentication", auth_probe(["gh", "auth", "status"]))
@@ -528,7 +429,7 @@ def doctor() -> int:
         "./ops status",
         "./ops test focused tests/<test_file>.py",
         "./ops env keys",
-        './ops db query "SELECT 1"',
+        "./ops db inspect connectivity",
         "./ops logs brain",
         "./ops deploy status",
         "./ops ci status",
@@ -575,28 +476,25 @@ def env_command(args: list[str]) -> int:
 
 def db_command(args: list[str]) -> int:
     if not args:
-        raise OpsError("usage: ./ops db {status|query SQL|migrations}")
+        raise OpsError("usage: ./ops db {status|inspect NAME|migrations}")
     action = args[0]
     if action == "status":
         state, detail = database_probe()
         status_line("database", state, detail)
         return 0 if state == "OK" else 1
-    if action == "query":
+    if action == "inspect":
         if len(args) != 2:
-            raise OpsError('usage: ./ops db query "SELECT ..."')
-        allowed, reason = validate_read_only_sql(args[1])
-        if not allowed:
-            raise OpsError(f"query refused: {reason}")
-        return subprocess.call(psql_readonly_command(args[1]), env=database_environment())
+            raise OpsError("usage: ./ops db inspect {connectivity|migrations}")
+        result = run_database_inspection(args[1])
+        assert isinstance(result, int)
+        return result
     if action == "migrations":
-        sql = (
-            "SELECT count(*) AS applied_count, max(version) AS latest_version "
-            "FROM schema_migrations"
-        )
-        return subprocess.call(psql_readonly_command(sql), env=database_environment())
-    if action in ("write", "migrate", "rollback", "drop"):
-        raise OpsError("mutating database operations are intentionally not exposed by ./ops")
-    raise OpsError("usage: ./ops db {status|query SQL|migrations}")
+        result = run_database_inspection("migrations")
+        assert isinstance(result, int)
+        return result
+    if action in ("query", "write", "migrate", "rollback", "drop"):
+        raise OpsError("arbitrary SQL and mutating database operations are intentionally not exposed by ./ops")
+    raise OpsError("usage: ./ops db {status|inspect NAME|migrations}")
 
 
 def container_status() -> None:
@@ -772,16 +670,15 @@ def test_command(args: list[str]) -> int:
     if action == "integration":
         if len(args) < 2:
             raise OpsError("name a focused integration test target")
-        if not (
-            os.environ.get("ATLAS_MIGRATION_TEST_DATABASE_URL")
-            or os.environ.get("ATLAS_RECEIVABLES_TEST_DATABASE_URL")
-        ):
+        if not any(os.environ.get(key) for key in TEST_DATABASE_URL_KEYS):
             raise OpsError(
-                "integration tests require an explicit disposable "
-                "ATLAS_MIGRATION_TEST_DATABASE_URL or ATLAS_RECEIVABLES_TEST_DATABASE_URL"
+                "integration tests require one explicit disposable test database URL; "
+                f"use one of: {', '.join(TEST_DATABASE_URL_KEYS)}"
             )
         if os.environ.get("ATLAS_CONFIRM_DISPOSABLE_TEST_DB") != "1":
-            raise OpsError("set ATLAS_CONFIRM_DISPOSABLE_TEST_DB=1 after verifying the DB is disposable")
+            raise OpsError(
+                "set ATLAS_CONFIRM_DISPOSABLE_TEST_DB=1 after verifying the DB is disposable"
+            )
         return exec_command([python, "-m", "pytest", *args[1:]], cwd=root)
     if action == "frontend":
         if len(args) not in (2, 3):
@@ -825,7 +722,7 @@ Read-only discovery and inspection:
   doctor
   status
   env {keys [--file PATH]|systemd|vercel}
-  db {status|query SQL|migrations}
+  db {status|inspect {connectivity|migrations}|migrations}
   deploy status
   logs {brain|container NAME|frontend [--since 1h] [--limit N] [--follow]}
   ci {status [LIMIT]|run RUN_ID [--log-failed]}
@@ -868,6 +765,10 @@ def main(argv: list[str]) -> int:
         return ci_command(args)
     if command == "test":
         return test_command(args)
+    if command == "__db-inspect" and len(args) == 1:
+        if os.environ.get("ATLAS_OPS_INTERNAL_DB_INSPECTION") != "1":
+            raise OpsError("internal database inspection entrypoint is not public")
+        return asyncio.run(execute_database_inspection(args[0]))
     raise OpsError(f"unknown command: {command}; run ./ops --help")
 
 

--- a/ops
+++ b/ops
@@ -699,14 +699,8 @@ def python_command() -> Path:
     return Path(sys.executable)
 
 
-def integration_test_environment(confirmed_key: str) -> dict[str, str]:
-    """Bind every supported DB interface to one confirmed disposable DSN."""
-    if confirmed_key not in TEST_DATABASE_URL_KEYS:
-        raise OpsError("unknown integration database credential")
-    confirmed_url = os.environ.get(confirmed_key)
-    if not confirmed_url:
-        raise OpsError("confirmed integration database credential is unavailable")
-
+def database_free_test_environment() -> dict[str, str]:
+    """Remove every supported or open-class database authority from pytest."""
     child_env = os.environ.copy()
     for key in tuple(child_env):
         if (
@@ -716,6 +710,19 @@ def integration_test_environment(confirmed_key: str) -> dict[str, str]:
             or key in DATABASE_CONFIG_KEYS
         ):
             child_env.pop(key)
+    child_env.pop("ATLAS_CONFIRM_DISPOSABLE_TEST_DB", None)
+    return child_env
+
+
+def integration_test_environment(confirmed_key: str) -> dict[str, str]:
+    """Bind every supported DB interface to one confirmed disposable DSN."""
+    if confirmed_key not in TEST_DATABASE_URL_KEYS:
+        raise OpsError("unknown integration database credential")
+    confirmed_url = os.environ.get(confirmed_key)
+    if not confirmed_url:
+        raise OpsError("confirmed integration database credential is unavailable")
+
+    child_env = database_free_test_environment()
     child_env[confirmed_key] = confirmed_url
     child_env["DATABASE_URL"] = confirmed_url
     child_env["EXTRACTED_DATABASE_URL"] = confirmed_url
@@ -766,7 +773,11 @@ def test_command(args: list[str]) -> int:
     if action == "focused":
         if len(args) < 2:
             raise OpsError("usage: ./ops test focused <pytest target/args...>")
-        return exec_command([python, "-m", "pytest", *args[1:]], cwd=root)
+        return exec_command(
+            [python, "-m", "pytest", *args[1:]],
+            cwd=root,
+            env=database_free_test_environment(),
+        )
     if action == "integration":
         if len(args) < 2:
             raise OpsError("name a focused integration test target")

--- a/ops
+++ b/ops
@@ -307,7 +307,10 @@ def run_database_inspection(
 
 
 def database_probe() -> tuple[str, str]:
-    result = run_database_inspection("connectivity", capture=True)
+    try:
+        result = run_database_inspection("connectivity", capture=True)
+    except OpsError as exc:
+        return "UNAVAILABLE", str(exc)
     assert isinstance(result, subprocess.CompletedProcess)
     if result.returncode != 0:
         return "FAIL", "fixed connectivity inspection failed"
@@ -370,7 +373,12 @@ def brain_health() -> tuple[str, str]:
         try:
             with urlopen(url, timeout=3) as response:  # noqa: S310 - fixed/local URL
                 if 200 <= response.status < 300:
-                    return "OK", url
+                    detail = (
+                        "configured ping endpoint responded"
+                        if configured
+                        else "local ping endpoint responded"
+                    )
+                    return "OK", detail
         except Exception:
             continue
     return "FAIL", "no configured/local ping endpoint responded"
@@ -657,6 +665,31 @@ def unit_test_environment() -> dict[str, str]:
     return child_env
 
 
+def validate_integration_target(root: Path, pytest_args: list[str]) -> None:
+    target = pytest_args[0]
+    file_target = target.partition("::")[0]
+    try:
+        resolved = (root / file_target).resolve(strict=False)
+        resolved.relative_to((root / "tests").resolve())
+    except (OSError, ValueError):
+        resolved = Path()
+    if (
+        target.startswith("-")
+        or not file_target
+        or resolved.suffix != ".py"
+        or not resolved.is_file()
+    ):
+        raise OpsError(
+            "integration target must be an existing Python file under tests/ "
+            "(optionally followed by ::node)"
+        )
+    if any(not argument.startswith("-") for argument in pytest_args[1:]):
+        raise OpsError(
+            "additional integration arguments must be pytest option tokens; "
+            "use --option=value for options that take values"
+        )
+
+
 def test_command(args: list[str]) -> int:
     if not args:
         raise OpsError("usage: ./ops test {unit|focused|integration|frontend|local-review}")
@@ -683,6 +716,7 @@ def test_command(args: list[str]) -> int:
     if action == "integration":
         if len(args) < 2:
             raise OpsError("name a focused integration test target")
+        validate_integration_target(root, args[1:])
         if not any(os.environ.get(key) for key in TEST_DATABASE_URL_KEYS):
             raise OpsError(
                 "integration tests require one explicit disposable test database URL; "

--- a/ops
+++ b/ops
@@ -712,6 +712,7 @@ def integration_test_environment(confirmed_key: str) -> dict[str, str]:
         if (
             key == "DATABASE_URL"
             or key.endswith("_DATABASE_URL")
+            or key.startswith("PG")
             or key in DATABASE_CONFIG_KEYS
         ):
             child_env.pop(key)

--- a/plans/PR-Agent-Operations-Contract.md
+++ b/plans/PR-Agent-Operations-Contract.md
@@ -275,9 +275,9 @@ would leave an incomplete and unverified operational path between PRs.
 #### Integration credential closure declaration
 
 - Credential membership is **OPEN** for URL-shaped environment keys and
-  **CLOSED** for Atlas application database settings. Every `DATABASE_URL` and
-  `*_DATABASE_URL` key plus every `DATABASE_CONFIG_KEYS` member is removed from
-  the inherited child environment.
+  libpq's uppercase `PG*` class, and **CLOSED** for Atlas application database
+  settings. Every `DATABASE_URL`, `*_DATABASE_URL`, `PG*`, and
+  `DATABASE_CONFIG_KEYS` member is removed from the inherited child environment.
 - Exactly one canonical member of `TEST_DATABASE_URL_KEYS` is admitted. Its
   value is restored under that key and adapted to the two generic URL aliases
   and Atlas's connection-string key, so all supported current test consumers
@@ -307,6 +307,27 @@ would leave an incomplete and unverified operational path between PRs.
   Python/shell syntax, capability parsing, plan synchronization, and diff
   checks. Do not invoke the local unit gate or full unit suite; GitHub owns that
   result.
+
+### Contract revision 9
+
+- New current-head blocker: PostgreSQL's libpq interface can select a database
+  through inherited `PG*` variables even after every URL-shaped and Atlas
+  application credential is removed.
+- Revised root cause: the credential-isolation boundary enumerates application
+  and URL interfaces but leaves libpq's open environment-key class authorized,
+  so confirmation and subprocess authority can still describe different
+  databases.
+- Revised required change surface: remove the entire inherited uppercase `PG*`
+  class before restoring the one confirmed disposable DSN through the supported
+  URL/application aliases; add current and novel libpq canaries; update the
+  capability, database/testing runbooks, and discovery ledger.
+- Revised non-scope: do not change database configuration parsing, selected env
+  file error behavior, project-interpreter selection, pytest targets, hosted CI,
+  or the hosted-only unit-gate boundary.
+- Revised verification plan: rerun the single focused integration-environment
+  matrix, the focused operations-contract file, syntax/schema/plan/diff audits,
+  and the mechanical push. Do not run the local unit gate or a database-backed
+  test.
 
 ## Scope (this PR)
 
@@ -403,8 +424,8 @@ seam in the enumeration; otherwise write "N/A - no boundary change."
   shared/systemd context plus process override; Docker x CLI missing/offline/
   daemon unavailable/object absent/object present/empty successful inspect;
   integration credential execution x one confirmed canonical URL plus ambient
-  generic/novel/application database credentials and an unrelated environment
-  key.
+  generic/novel/application/libpq database credentials and an unrelated
+  environment key.
 
 ### Deployed-config probing
 
@@ -429,7 +450,7 @@ fallback changes; otherwise write "N/A - no guard/config boundary change."
   root to `/home/juan-canfield/Desktop/Atlas`.
 - Side-effect ordering: fixed inspection selection occurs before the database
   client receives SQL; the exact DSN remains in the child environment rather
-  than argv; unit-mode database URLs are removed before pytest starts; Git
+  than argv; local full-unit execution is unavailable; Git
   output selects the canonical identifier before printing; env rendering
   extracts keys before any output is produced; integration target validation
   and exact database-URL cardinality occur before the integration child
@@ -482,13 +503,20 @@ redaction, and command-boundary behavior without requiring live providers.
 - Provider deployment mutations remain operator-initiated; a future slice may
   add a separately consented, confirmation-gated deployment command if repeated
   operational evidence justifies it.
+- Selected dotenv decoding through the project interpreter is deferred as an
+  availability improvement; the current head's explicit database commands
+  remain read-only and the operator directed this pass to stop at blockers.
+- Fail-closed handling for unreadable selected database configuration is
+  deferred as read-only inspection hardening; it does not change the current
+  hosted-only unit boundary or disposable integration credential authority.
 
 Parking predicate: provider-specific conveniences, optional formatting, and
 additional mutating operations that are not required to answer the operator's
 fresh-agent questions are parked unless current verification proves they block
 the contract or create a security/data-safety defect.
 
-Parked hardening: none.
+Parked hardening: project-interpreter dotenv decoding and unreadable selected
+database-configuration rejection, as listed above.
 
 ## Verification
 
@@ -509,6 +537,9 @@ Parked hardening: none.
   across explicit/worktree/shared/systemd contexts, both shared-root path
   shapes, Docker CLI/offline/daemon/object states, and single-credential
   integration subprocess isolation across all 3 canonical URL keys.
+- Focused integration child-environment matrix - 3 passed; each canonical URL
+  case removes current libpq credentials and the novel `PGFUTURE_CREDENTIAL`
+  class member before pytest while preserving the unrelated canary.
 - Focused hosted-only unit boundary nodes across
   `tests/test_agent_operations_contract.py` and `tests/test_local_pr_review.py`
   - 9 passed; selected/empty/full/failing/missing checker states never invoke
@@ -551,18 +582,18 @@ Parked hardening: none.
 |---|---:|
 | `.agent/capabilities.yaml` | 299 |
 | `.agent/runbooks/ci.md` | 67 |
-| `.agent/runbooks/database.md` | 120 |
+| `.agent/runbooks/database.md` | 121 |
 | `.agent/runbooks/deployment.md` | 103 |
 | `.agent/runbooks/discovery-ledger.md` | 313 |
 | `.agent/runbooks/environment.md` | 109 |
 | `.agent/runbooks/logs.md` | 74 |
-| `.agent/runbooks/testing.md` | 99 |
+| `.agent/runbooks/testing.md` | 101 |
 | `AGENTS.md` | 17 |
 | `CLAUDE.md` | 32 |
 | `README.md` | 16 |
-| `ops` | 893 |
-| `plans/PR-Agent-Operations-Contract.md` | 568 |
+| `ops` | 894 |
+| `plans/PR-Agent-Operations-Contract.md` | 599 |
 | `scripts/local_pr_review.sh` | 132 |
-| `tests/test_agent_operations_contract.py` | 656 |
+| `tests/test_agent_operations_contract.py` | 675 |
 | `tests/test_local_pr_review.py` | 131 |
-| **Total** | **3629** |
+| **Total** | **3683** |

--- a/plans/PR-Agent-Operations-Contract.md
+++ b/plans/PR-Agent-Operations-Contract.md
@@ -83,6 +83,7 @@ would leave an incomplete and unverified operational path between PRs.
 
 Ownership lane: agent-operations
 Slice phase: workflow/process
+Max files: 14
 
 1. Establish one verified, versioned operational knowledge path for a fresh
    agent without replacing existing subsystem-specific runbooks.
@@ -249,6 +250,6 @@ Parked hardening: none.
 | `CLAUDE.md` | 32 |
 | `README.md` | 16 |
 | `ops` | 780 |
-| `plans/PR-Agent-Operations-Contract.md` | 254 |
+| `plans/PR-Agent-Operations-Contract.md` | 255 |
 | `tests/test_agent_operations_contract.py` | 258 |
-| **Total** | **2351** |
+| **Total** | **2352** |

--- a/plans/PR-Agent-Operations-Contract.md
+++ b/plans/PR-Agent-Operations-Contract.md
@@ -1,0 +1,222 @@
+# PR-Agent-Operations-Contract
+
+## Why this slice exists
+
+The operator explicitly requested a durable Agent Operations Contract after
+repeated sessions had to rediscover how Atlas runs, tests, reaches its database,
+and distinguishes local services from hosted frontends. Initial archaeology
+already found misleading operational paths: the root README names a missing
+root `.env.example`, tells agents to start an undefined Compose `postgres`
+service, and does not explain that the nominal repository root is a shared/bare
+Git root rather than a usable worktree. This is an operator-authorized process
+slice under `docs/CURRENT_PRODUCT_DISCIPLINE.md`; it removes a demonstrated
+workflow blocker and does not change product behavior.
+
+This contract is likely to exceed the normal 400-LOC target because the
+operator explicitly requires a machine-readable inventory, seven focused
+runbooks, a discovery ledger, fresh-agent instructions, an executable
+operations entrypoint, and verification coverage. Splitting those artifacts
+would leave an incomplete and unverified operational path between PRs.
+
+### Problem-derived contract
+
+- Root cause: Atlas operational knowledge is fragmented across prose, provider
+  configuration, scripts, local ignored state, and live CLI authentication;
+  some prominent prose has drifted from executable configuration. There is no
+  canonical capability record or stable read-only-first entrypoint, so each
+  agent must repeat provider, worktree, database, test, and log discovery.
+- Correct fix must touch/change: add a concise operational pointer to root
+  `AGENTS.md`; add `.agent/capabilities.yaml` plus environment, deployment,
+  database, testing, logs, CI, and discovery-ledger runbooks; add a thin `ops`
+  command whose doctor/status/env/database/deployment/log/CI/test surfaces
+  inspect reality without printing secrets or mutating production; and add
+  focused automated tests for the command's discovery and safety boundaries.
+- Must not change: Atlas runtime/API behavior, database schema or migrations,
+  application dependencies, CI/deployment configuration, provider resources,
+  customer-visible output, secrets, ignored environment files, and other
+  sessions' plans/branches/PRs.
+
+### Contract revision 1
+
+- New evidence: the executable root Compose file has no `postgres` service,
+  while both `README.md` and `CLAUDE.md` tell agents to run
+  `docker compose up -d postgres`; the README also names a missing root
+  `.env.example`. Leaving those entrypoints unchanged would preserve the exact
+  repeated-discovery trap this slice exists to remove.
+- Revised required change surface: update only the affected quick-start/testing
+  paragraphs in `README.md` and `CLAUDE.md` to route agents to the operations
+  contract and describe native PostgreSQL/disposable CI database reality.
+- Revised non-scope: no broad README/CLAUDE cleanup and no application,
+  provider, Compose, workflow, schema, or migration changes.
+- Revised verification plan: documentation contract tests assert the stale
+  root Compose commands and missing-template instruction are removed from the
+  affected operational sections.
+
+## Scope (this PR)
+
+Ownership lane: agent-operations
+Slice phase: operations contract
+
+1. Establish one verified, versioned operational knowledge path for a fresh
+   agent without replacing existing subsystem-specific runbooks.
+2. Provide a stable `./ops` discovery/inspection layer with explicit
+   read-only versus mutating boundaries and prove its local behavior with
+   focused tests plus safe live probes.
+
+### Review Contract
+
+- Acceptance criteria:
+  - `./ops doctor` runs from a normal worktree without provider mutation and
+    reports project, Git, runtime, test, deployment, database, CI, and useful
+    command status; settled by focused subprocess tests and a live invocation.
+  - `./ops env keys` emits variable names only, never values; settled by a
+    fixture containing a canary secret and an assertion that the canary never
+    appears in output.
+  - `./ops db query` admits only a single read-only SQL statement and also
+    starts a PostgreSQL read-only transaction; settled by boundary tests for a
+    SELECT and representative write/multi-statement inputs plus command
+    inspection.
+  - `.agent/capabilities.yaml` distinguishes verified, unavailable, and
+    authentication-dependent capabilities and records safe verification and
+    failure modes without secret values; settled by its checked-in contents
+    and YAML parsing.
+  - The runbooks answer all operator-requested operational questions and link
+    to existing subsystem-specific sources instead of duplicating them;
+    settled by the documentation contract test and cold reconstruction.
+  - Root `AGENTS.md` points fresh agents at the contract, `./ops doctor`, and
+    the continuous-learning rule; settled by the documentation contract test.
+- Reachability proof: run the real `./ops doctor`, `./ops env keys`,
+  `./ops db status`, `./ops deploy status`, `./ops ci status`, and focused test
+  entrypoints and observe their redacted terminal output/exit status.
+- Affected surfaces: root agent instructions, `.agent` operational metadata and
+  runbooks, the root `ops` command, and focused tests for those contracts.
+- Risk areas: secret disclosure, a nominally read-only database command
+  admitting writes, provider-specific assumptions, stale static claims, slow
+  or network-dependent doctor behavior, and accidental application/CI changes.
+- Reviewer rules triggered: R1, R2, R3, R5, R6, R10, R12, R13, R14.
+
+### Boundary-change enumeration
+
+Required when this diff changes a guard, validator, normalizer, resolver,
+router/classifier, or admission boundary. Name each changed boundary path or
+seam in the enumeration; otherwise write "N/A - no boundary change."
+
+- Boundary path/seam: `./ops db query` SQL admission and read-only execution;
+  `./ops env keys` secret-value suppression.
+- Replaced-path behaviors: N/A - no existing runtime path is replaced.
+- Guard-relevant fields: SQL first keyword, statement count/comment handling,
+  PostgreSQL read-only transaction options, environment assignment key/value
+  split, subprocess output redaction.
+- Caller x input shape: shell caller x SELECT/SHOW/TABLE/VALUES inputs;
+  shell caller x INSERT/UPDATE/DELETE/DDL/COPY/CALL/multi-statement inputs;
+  env files x blank/comment/export/quoted/canary-secret assignments.
+
+### Deployed-config probing
+
+Required for guard, validator, resolver, admission-boundary, or env/config
+fallback changes; otherwise write "N/A - no guard/config boundary change."
+
+- Deployed/default config values: database defaults come from
+  `atlas_brain/storage/config.py`; the linked Vercel project comes from ignored
+  `.vercel/project.json`; neither secret value is copied into version control.
+- Explicit value probe: tests pass explicit safe SQL and fixture env paths;
+  safe live probes use the current authenticated CLIs where available.
+- Absent value probe: doctor and status report UNKNOWN/unavailable when a CLI,
+  auth context, linked project, env file, or database is absent.
+- Default-session/default-context probe: run from the dedicated worktree, where
+  ignored environment/provider link files are absent, and from the shared root
+  context via explicit discovery only.
+- Side-effect ordering: input admission and read-only transaction setup occur
+  before the database client receives SQL; env rendering extracts keys before
+  any output is produced.
+
+### Files touched
+
+- `.agent/capabilities.yaml`
+- `.agent/runbooks/ci.md`
+- `.agent/runbooks/database.md`
+- `.agent/runbooks/deployment.md`
+- `.agent/runbooks/discovery-ledger.md`
+- `.agent/runbooks/environment.md`
+- `.agent/runbooks/logs.md`
+- `.agent/runbooks/testing.md`
+- `AGENTS.md`
+- `CLAUDE.md`
+- `README.md`
+- `ops`
+- `plans/PR-Agent-Operations-Contract.md`
+- `tests/test_agent_operations_contract.py`
+
+## Mechanism
+
+The YAML record stores evidence level, provider/tool, invocation,
+authentication, mutation class, safe verification, and failure notes for each
+capability. Focused runbooks explain prerequisites, safe procedures, and
+escalation paths while linking existing deep runbooks. The stdlib-only `ops`
+entrypoint discovers the repository/worktree and available tools at runtime,
+normalizes common read-only checks, keeps remote mutations out of status
+commands, and fails closed on database writes. Tests exercise its output,
+redaction, and command-boundary behavior without requiring live providers.
+
+## Intentional
+
+- Provider IDs discovered only from ignored local linkage are reported by live
+  inspection but are not copied into tracked files when a stable project name
+  or repository command is sufficient.
+- `ops` does not auto-source `.env` files, install tools, trigger deployments,
+  run migrations, or offer a generic database write command.
+- Existing product/subsystem runbooks remain canonical for their narrow flows;
+  the new layer links to them instead of rewriting them.
+
+## Deferred
+
+- Provider deployment mutations remain operator-initiated; a future slice may
+  add a separately consented, confirmation-gated deployment command if repeated
+  operational evidence justifies it.
+
+Parking predicate: provider-specific conveniences, optional formatting, and
+additional mutating operations that are not required to answer the operator's
+fresh-agent questions are parked unless current verification proves they block
+the contract or create a security/data-safety defect.
+
+Parked hardening: none.
+
+## Verification
+
+- `/home/juan-canfield/Desktop/Atlas/.venv/bin/python -m py_compile ops` - pass.
+- PyYAML `safe_load(.agent/capabilities.yaml)` - schema version `1` parsed.
+- `./ops test focused tests/test_agent_operations_contract.py -q` - 23 passed.
+- `./ops doctor` - pass; live systemd/Brain ping, Docker, Vercel, Render CLI,
+  PostgreSQL read-only query, GitHub auth, and environment-source discovery
+  reported without secret values.
+- `./ops status`, `./ops db status`, a live bounded read-only metadata query,
+  and `./ops db migrations` - pass.
+- `./ops env keys`, `./ops env systemd`, and `./ops env vercel` - pass;
+  names/sources only.
+- `./ops ci status 3`, `./ops logs brain`, targeted container logs, and
+  `./ops logs frontend --since 1h --limit 5` - pass; the static Vercel runtime
+  legitimately returned no records in that window.
+- `python scripts/sync_pr_plan.py --check plans/PR-Agent-Operations-Contract.md`
+  and `git diff --check` - pass after final sync.
+- Pending at commit time: mechanical local review and secret scan will run once
+  through `scripts/push_pr.sh` at push time.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.agent/capabilities.yaml` | 286 |
+| `.agent/runbooks/ci.md` | 65 |
+| `.agent/runbooks/database.md` | 83 |
+| `.agent/runbooks/deployment.md` | 103 |
+| `.agent/runbooks/discovery-ledger.md` | 186 |
+| `.agent/runbooks/environment.md` | 109 |
+| `.agent/runbooks/logs.md` | 74 |
+| `.agent/runbooks/testing.md` | 85 |
+| `AGENTS.md` | 13 |
+| `CLAUDE.md` | 32 |
+| `README.md` | 16 |
+| `ops` | 879 |
+| `plans/PR-Agent-Operations-Contract.md` | 222 |
+| `tests/test_agent_operations_contract.py` | 193 |
+| **Total** | **2346** |

--- a/plans/PR-Agent-Operations-Contract.md
+++ b/plans/PR-Agent-Operations-Contract.md
@@ -52,6 +52,33 @@ would leave an incomplete and unverified operational path between PRs.
   root Compose commands and missing-template instruction are removed from the
   affected operational sections.
 
+### Contract revision 2
+
+- New evidence: current-head review and code tracing proved four reachable
+  gaps in the new operations layer. PostgreSQL `READ ONLY` transactions still
+  admit operationally mutating functions invoked by arbitrary `SELECT`; DSN
+  decomposition drops libpq query parameters; the integration guard omits the
+  documented legacy monthly writer URL; and doctor prints a raw origin URL that
+  may contain HTTPS userinfo.
+- Revised root cause: the initial implementation treated SQL statement class,
+  decomposed connection coordinates, a sampled test-variable set, and a raw Git
+  remote as sufficient safety boundaries. Those are weaker than the contract's
+  no-mutation, exact-runtime, complete-canonical-set, and no-secret-output
+  requirements.
+- Revised required change surface: replace arbitrary SQL with named, fixed
+  database inspections executed through Atlas's own asyncpg configuration path;
+  pass the complete connection string through the child environment without
+  argv exposure; admit all three canonical disposable-test URL variables; print
+  only the canonical repository identifier; and update the capability/runbook
+  claims plus boundary tests for those decisions.
+- Revised non-scope: do not provision a database role, change application
+  database configuration, add dependencies, change migrations, expose raw SQL,
+  or touch provider/runtime configuration.
+- Revised verification plan: add negative proof that arbitrary queries are not
+  exposed, exact-DSN handoff/argv-secret tests, a complete-variable-set test,
+  credential-bearing-origin redaction proof, focused tests, live fixed
+  inspections, and the canonical guarded push review.
+
 ## Scope (this PR)
 
 Ownership lane: agent-operations
@@ -72,10 +99,10 @@ Slice phase: workflow/process
   - `./ops env keys` emits variable names only, never values; settled by a
     fixture containing a canary secret and an assertion that the canary never
     appears in output.
-  - `./ops db query` admits only a single read-only SQL statement and also
-    starts a PostgreSQL read-only transaction; settled by boundary tests for a
-    SELECT and representative write/multi-statement inputs plus command
-    inspection.
+  - `./ops db inspect` exposes only named, fixed inspections and arbitrary SQL
+    is unavailable until a privilege-restricted inspection role exists; settled
+    by the fixed registry, rejection tests, exact-DSN handoff proof, and live
+    connectivity/migration inspection.
   - `.agent/capabilities.yaml` distinguishes verified, unavailable, and
     authentication-dependent capabilities and records safe verification and
     failure modes without secret values; settled by its checked-in contents
@@ -101,14 +128,16 @@ Required when this diff changes a guard, validator, normalizer, resolver,
 router/classifier, or admission boundary. Name each changed boundary path or
 seam in the enumeration; otherwise write "N/A - no boundary change."
 
-- Boundary path/seam: `./ops db query` SQL admission and read-only execution;
+- Boundary path/seam: `./ops db inspect` named-inspection admission and
+  read-only execution; integration-test database-variable admission;
   `./ops env keys` secret-value suppression.
 - Replaced-path behaviors: N/A - no existing runtime path is replaced.
-- Guard-relevant fields: SQL first keyword, statement count/comment handling,
-  PostgreSQL read-only transaction options, environment assignment key/value
-  split, subprocess output redaction.
-- Caller x input shape: shell caller x SELECT/SHOW/TABLE/VALUES inputs;
-  shell caller x INSERT/UPDATE/DELETE/DDL/COPY/CALL/multi-statement inputs;
+- Guard-relevant fields: inspection name, complete PostgreSQL connection string,
+  the canonical disposable-test URL set, Git origin userinfo, environment
+  assignment key/value split, and subprocess output redaction.
+- Caller x input shape: shell caller x fixed connectivity/migrations names;
+  shell caller x arbitrary/unknown query names; test caller x each canonical
+  disposable database URL independently; Git origin x credential-bearing URL;
   env files x blank/comment/export/quoted/canary-secret assignments.
 
 ### Deployed-config probing
@@ -119,16 +148,18 @@ fallback changes; otherwise write "N/A - no guard/config boundary change."
 - Deployed/default config values: database defaults come from
   `atlas_brain/storage/config.py`; the linked Vercel project comes from ignored
   `.vercel/project.json`; neither secret value is copied into version control.
-- Explicit value probe: tests pass explicit safe SQL and fixture env paths;
+- Explicit value probe: tests pass fixed inspection names, a complete DSN with
+  TLS/socket parameters, each canonical disposable-test URL, and fixture env paths;
   safe live probes use the current authenticated CLIs where available.
 - Absent value probe: doctor and status report UNKNOWN/unavailable when a CLI,
   auth context, linked project, env file, or database is absent.
 - Default-session/default-context probe: run from the dedicated worktree, where
   ignored environment/provider link files are absent, and from the shared root
   context via explicit discovery only.
-- Side-effect ordering: input admission and read-only transaction setup occur
-  before the database client receives SQL; env rendering extracts keys before
-  any output is produced.
+- Side-effect ordering: fixed inspection selection occurs before the database
+  client receives SQL; the exact DSN remains in the child environment rather
+  than argv; Git output selects the canonical identifier before printing; env
+  rendering extracts keys before any output is produced.
 
 ### Files touched
 
@@ -185,12 +216,13 @@ Parked hardening: none.
 
 - `/home/juan-canfield/Desktop/Atlas/.venv/bin/python -m py_compile ops` - pass.
 - PyYAML `safe_load(.agent/capabilities.yaml)` - schema version `1` parsed.
-- `./ops test focused tests/test_agent_operations_contract.py -q` - 23 passed.
+- `./ops test focused tests/test_agent_operations_contract.py -q` - 16 passed.
+- `./ops test focused tests/test_eom_render_profile.py::test_database_config_prefers_connection_string_for_asyncpg_kwargs -q` - 1 passed.
 - `./ops doctor` - pass; live systemd/Brain ping, Docker, Vercel, Render CLI,
-  PostgreSQL read-only query, GitHub auth, and environment-source discovery
+  PostgreSQL fixed inspection, GitHub auth, and environment-source discovery
   reported without secret values.
-- `./ops status`, `./ops db status`, a live bounded read-only metadata query,
-  and `./ops db migrations` - pass.
+- `./ops db inspect connectivity` and `./ops db migrations` - pass through the
+  Atlas `DatabaseConfig`/asyncpg path.
 - `./ops env keys`, `./ops env systemd`, and `./ops env vercel` - pass;
   names/sources only.
 - `./ops ci status 3`, `./ops logs brain`, targeted container logs, and
@@ -198,25 +230,25 @@ Parked hardening: none.
   legitimately returned no records in that window.
 - `python scripts/sync_pr_plan.py --check plans/PR-Agent-Operations-Contract.md`
   and `git diff --check` - pass after final sync.
-- Pending at commit time: mechanical local review and secret scan will run once
-  through `scripts/push_pr.sh` at push time.
+- The original head's guarded push/local review and secret scan passed. The
+  current review-fix head will rerun the same guarded push before publication.
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
-| `.agent/capabilities.yaml` | 286 |
+| `.agent/capabilities.yaml` | 288 |
 | `.agent/runbooks/ci.md` | 65 |
-| `.agent/runbooks/database.md` | 83 |
+| `.agent/runbooks/database.md` | 85 |
 | `.agent/runbooks/deployment.md` | 103 |
-| `.agent/runbooks/discovery-ledger.md` | 186 |
+| `.agent/runbooks/discovery-ledger.md` | 189 |
 | `.agent/runbooks/environment.md` | 109 |
 | `.agent/runbooks/logs.md` | 74 |
 | `.agent/runbooks/testing.md` | 85 |
 | `AGENTS.md` | 13 |
 | `CLAUDE.md` | 32 |
 | `README.md` | 16 |
-| `ops` | 879 |
-| `plans/PR-Agent-Operations-Contract.md` | 222 |
-| `tests/test_agent_operations_contract.py` | 193 |
-| **Total** | **2346** |
+| `ops` | 780 |
+| `plans/PR-Agent-Operations-Contract.md` | 254 |
+| `tests/test_agent_operations_contract.py` | 258 |
+| **Total** | **2351** |

--- a/plans/PR-Agent-Operations-Contract.md
+++ b/plans/PR-Agent-Operations-Contract.md
@@ -329,6 +329,30 @@ would leave an incomplete and unverified operational path between PRs.
   and the mechanical push. Do not run the local unit gate or a database-backed
   test.
 
+### Contract revision 10
+
+- New current-head blocker: `./ops test focused` passes the ambient environment
+  directly to pytest, so any exported canonical, generic, Atlas application, or
+  libpq credential can activate a database-writing test without the disposable
+  confirmation and isolated child used by integration mode.
+- Revised root cause: database credential isolation exists only inside the
+  integration branch instead of at the common local pytest boundary. The
+  recommended focused entrypoint therefore has broader database authority than
+  the explicit destructive-test entrypoint.
+- Revised required change surface: factor one database-credential removal
+  helper over URL-shaped, uppercase `PG*`, Atlas application, and confirmation
+  keys; use its credential-free child for every focused pytest invocation; let
+  integration mode restore only the confirmed DSN aliases; add negative focused
+  child-environment proof and align the capability/testing/database/ledger
+  contract.
+- Revised non-scope: do not classify test targets, parse test source, change
+  pytest markers, run a database-backed test, rebase, or change Brain identity,
+  container inventory, Vercel linkage, hosted CI, APIs, schemas, or providers.
+- Revised verification plan: prove the focused-child regression fails before
+  implementation, then run the operations-contract test file, compile/schema/
+  plan/body/diff audits, and the mechanical push. Do not run the local unit gate
+  or a database-backed test.
+
 ## Scope (this PR)
 
 Ownership lane: agent-operations
@@ -375,6 +399,10 @@ Max files: 16
     canonical, generic, and Atlas application interfaces while every other
     database credential is absent; settled by child-environment and argv
     canary assertions without executing a database-backed test.
+  - Focused pytest receives no canonical, URL-shaped, Atlas application, libpq,
+    or disposable-confirmation database authority while unrelated environment
+    values remain available; settled by child-environment canaries without
+    executing a database-backed test.
   - Local PR review and `./ops test unit` cannot launch the unit gate; both
     direct agents to `.github/workflows/unit_gate.yml`, while focused tests
     remain locally available; settled by subprocess canaries that would fail if
@@ -509,14 +537,25 @@ redaction, and command-boundary behavior without requiring live providers.
 - Fail-closed handling for unreadable selected database configuration is
   deferred as read-only inspection hardening; it does not change the current
   hosted-only unit boundary or disposable integration credential authority.
+- Brain health payload identity validation is deferred as non-blocking status
+  accuracy hardening; no current-head evidence shows the configured endpoint is
+  serving an unrelated 2xx response.
+- Home Assistant and Wyze container enrollment in the aggregate status registry
+  is deferred as non-blocking inventory completeness; their tracked Compose
+  files remain directly inspectable.
+- Shared Vercel link identity validation is deferred as non-blocking provider
+  hardening; the current authenticated link was already verified during live
+  archaeology and no project mutation is exposed.
 
 Parking predicate: provider-specific conveniences, optional formatting, and
 additional mutating operations that are not required to answer the operator's
 fresh-agent questions are parked unless current verification proves they block
 the contract or create a security/data-safety defect.
 
-Parked hardening: project-interpreter dotenv decoding and unreadable selected
-database-configuration rejection, as listed above.
+Parked hardening: project-interpreter dotenv decoding, unreadable selected
+database-configuration rejection, Brain response identity, aggregate
+Home Assistant/Wyze status enrollment, and shared Vercel link identity, as
+listed above.
 
 ## Verification
 
@@ -532,7 +571,10 @@ database-configuration rejection, as listed above.
 - The integration credential-isolation regression failed before implementation
   in all 3 canonical cases because pytest received no explicit child
   environment.
-- `./ops test focused tests/test_agent_operations_contract.py -q` - 40 passed;
+- Focused-child database-authority regression failed before implementation with
+  `KeyError: 'env'`, proving focused mode supplied no explicit child environment;
+  it then passed after the shared removal helper was wired into focused mode.
+- `./ops test focused tests/test_agent_operations_contract.py -q` - 41 passed;
   the frozen pass covers integration URL counts 0/1/2/3, database selection
   across explicit/worktree/shared/systemd contexts, both shared-root path
   shapes, Docker CLI/offline/daemon/object states, and single-credential
@@ -580,20 +622,20 @@ database-configuration rejection, as listed above.
 
 | File | LOC |
 |---|---:|
-| `.agent/capabilities.yaml` | 299 |
+| `.agent/capabilities.yaml` | 302 |
 | `.agent/runbooks/ci.md` | 67 |
-| `.agent/runbooks/database.md` | 121 |
+| `.agent/runbooks/database.md` | 126 |
 | `.agent/runbooks/deployment.md` | 103 |
-| `.agent/runbooks/discovery-ledger.md` | 313 |
+| `.agent/runbooks/discovery-ledger.md` | 321 |
 | `.agent/runbooks/environment.md` | 109 |
 | `.agent/runbooks/logs.md` | 74 |
-| `.agent/runbooks/testing.md` | 101 |
+| `.agent/runbooks/testing.md` | 107 |
 | `AGENTS.md` | 17 |
 | `CLAUDE.md` | 32 |
 | `README.md` | 16 |
-| `ops` | 894 |
-| `plans/PR-Agent-Operations-Contract.md` | 599 |
+| `ops` | 905 |
+| `plans/PR-Agent-Operations-Contract.md` | 641 |
 | `scripts/local_pr_review.sh` | 132 |
-| `tests/test_agent_operations_contract.py` | 675 |
+| `tests/test_agent_operations_contract.py` | 723 |
 | `tests/test_local_pr_review.py` | 131 |
-| **Total** | **3683** |
+| **Total** | **3806** |

--- a/plans/PR-Agent-Operations-Contract.md
+++ b/plans/PR-Agent-Operations-Contract.md
@@ -163,6 +163,39 @@ would leave an incomplete and unverified operational path between PRs.
   to pytest. This closes the repo-wide fallback without inventing a general
   pytest parser.
 
+### Contract revision 5
+
+- New evidence: current-head review identified a second valid Git common-dir
+  shape. The live Atlas layout currently returns
+  `/home/juan-canfield/Desktop/Atlas/.git`, so the existing `.git`-parent branch
+  resolves shared state correctly; a linked worktree backed directly by a bare
+  common directory returns that directory itself, and the current fallback would
+  incorrectly select the worktree.
+- Revised root cause: the `ops` shared-root resolver distinguishes only a conventional `.git`
+  directory from failure and treats every other successful Git common-dir shape
+  as failure, conflating a bare common directory with an unavailable lookup.
+- Revised required change surface: return the parent for a conventional `.git`
+  common directory, return any other successfully resolved common directory
+  itself, preserve the repository-root fallback only for command failure, cover
+  all three outcomes in a focused resolver regression, and record the distinction
+  in the existing worktree-layout discovery entry.
+- Revised non-scope: do not change worktree discovery, copy shared ignored state,
+  alter Git configuration, add provider lookup behavior, or touch application,
+  database, deployment, CI, schema, or product code.
+- Revised verification plan: prove the bare-directory regression fails before
+  implementation, then run the focused operations-contract suite, compile,
+  plan/body/mechanical audits, and a live `ops` shared-root probe; GitHub retains
+  the full unit gate.
+
+#### Shared-root resolver closure declaration
+
+- Membership is **CLOSED** by Git command outcome and path shape: command failure
+  falls back to the checked-out repository root; a successful common directory
+  named `.git` resolves to its parent; every other successful absolute common
+  directory resolves to itself.
+- The regression covers each member directly, including the live Atlas
+  conventional `.git` shape and the alternate bare-directory shape.
+
 ## Scope (this PR)
 
 Ownership lane: agent-operations
@@ -217,13 +250,15 @@ seam in the enumeration; otherwise write "N/A - no boundary change."
   read-only execution; integration-test database-variable admission; unit-test
   database-environment isolation; integration-test target admission;
   dependency-free database status fallback; Brain health-detail redaction; and
-  `./ops env keys` secret-value suppression.
+  `./ops env keys` secret-value suppression; Git common-directory shared-root
+  resolution.
 - Replaced-path behaviors: N/A - no existing runtime path is replaced.
 - Guard-relevant fields: inspection name, complete PostgreSQL connection string,
   the canonical disposable-test URL set, open `*_DATABASE_URL` environment-key
   class, Git origin userinfo, environment assignment key/value split, and
   subprocess output redaction; configured Brain URL; integration target path,
-  node suffix, and trailing pytest arguments.
+  node suffix, trailing pytest arguments, Git lookup result, and common-dir
+  basename.
 - Caller x input shape: shell caller x fixed connectivity/migrations names;
   shell caller x arbitrary/unknown query names; test caller x each canonical
   disposable database URL independently; unit caller x current/novel database
@@ -231,7 +266,8 @@ seam in the enumeration; otherwise write "N/A - no boundary change."
   x blank/comment/export/quoted/escaped/interpolated/canary-secret assignments;
   fresh system Python x missing `python-dotenv`; configured Brain endpoint x
   credential-bearing URL; integration caller x file/node/option-only/directory/
-  missing/out-of-tree/additional-positional targets.
+  missing/out-of-tree/additional-positional targets; worktree x conventional
+  `.git`/direct bare common directory/Git lookup failure.
 
 ### Deployed-config probing
 
@@ -251,7 +287,8 @@ fallback changes; otherwise write "N/A - no guard/config boundary change."
   auth context, linked project, env file, or database is absent.
 - Default-session/default-context probe: run from the dedicated worktree, where
   ignored environment/provider link files are absent, and from the shared root
-  context via explicit discovery only.
+  context via explicit discovery only; the live worktree resolves its shared
+  root to `/home/juan-canfield/Desktop/Atlas`.
 - Side-effect ordering: fixed inspection selection occurs before the database
   client receives SQL; the exact DSN remains in the child environment rather
   than argv; unit-mode database URLs are removed before pytest starts; Git
@@ -320,7 +357,11 @@ Parked hardening: none.
 - The four new boundary regression groups failed before implementation with
   `10 failed`, covering missing dependency, configured-URL disclosure,
   unbounded integration targets, and the nonexistent capability command.
-- `./ops test focused tests/test_agent_operations_contract.py -q` - 29 passed.
+- The bare common-directory resolver regression failed before implementation
+  with `1 failed, 2 passed`; only the successful direct-bare member was wrong.
+- `./ops test focused tests/test_agent_operations_contract.py -q` - 32 passed.
+- Direct live `ops` shared-root probe -
+  `/home/juan-canfield/Desktop/Atlas` from the current linked worktree.
 - `./ops test focused tests/test_eom_render_profile.py::test_database_config_prefers_connection_string_for_asyncpg_kwargs -q` - 1 passed.
 - `./ops doctor` - pass; live systemd/Brain ping, Docker, Vercel, Render CLI,
   PostgreSQL fixed inspection, GitHub auth, and environment-source discovery
@@ -350,7 +391,7 @@ Parked hardening: none.
 | `.agent/runbooks/ci.md` | 65 |
 | `.agent/runbooks/database.md` | 85 |
 | `.agent/runbooks/deployment.md` | 103 |
-| `.agent/runbooks/discovery-ledger.md` | 249 |
+| `.agent/runbooks/discovery-ledger.md` | 252 |
 | `.agent/runbooks/environment.md` | 109 |
 | `.agent/runbooks/logs.md` | 74 |
 | `.agent/runbooks/testing.md` | 101 |
@@ -358,6 +399,6 @@ Parked hardening: none.
 | `CLAUDE.md` | 32 |
 | `README.md` | 16 |
 | `ops` | 827 |
-| `plans/PR-Agent-Operations-Contract.md` | 363 |
-| `tests/test_agent_operations_contract.py` | 468 |
-| **Total** | **2795** |
+| `plans/PR-Agent-Operations-Contract.md` | 404 |
+| `tests/test_agent_operations_contract.py` | 494 |
+| **Total** | **2865** |

--- a/plans/PR-Agent-Operations-Contract.md
+++ b/plans/PR-Agent-Operations-Contract.md
@@ -285,11 +285,34 @@ would leave an incomplete and unverified operational path between PRs.
 - Unknown future URL-shaped keys and every non-selected canonical key take the
   safe default and remain absent. Unrelated environment keys remain inherited.
 
+### Contract revision 8
+
+- New operator direction: the unit gate is GitHub-only because its local mirror
+  is too slow. A local pytest process survived the prior push/review path even
+  though the session intended to leave the full gate to GitHub.
+- Revised root cause: `scripts/local_pr_review.sh` still owns an executable
+  local unit-gate mirror, and `./ops test unit` still exposes the full local
+  suite as a normal operations command. The earlier convention depended on an
+  ambient `GITHUB_ACTIONS=true` override instead of making the boundary
+  structural.
+- Revised required change surface: remove the local-review unit-gate execution
+  path, make `./ops test unit` fail closed with the canonical hosted workflow,
+  retain focused local tests and all cheap mechanical review checks, update the
+  agent/testing/capability contract, and add focused subprocess proof that
+  neither local entrypoint launches the unit checker or pytest.
+- Revised non-scope: do not change the hosted unit workflow, its selection or
+  baseline logic, focused-test execution, integration execution, unrelated CI,
+  or any application behavior; do not diagnose or optimize the unit suite.
+- Revised verification plan: exercise only focused wrapper/operations tests,
+  Python/shell syntax, capability parsing, plan synchronization, and diff
+  checks. Do not invoke the local unit gate or full unit suite; GitHub owns that
+  result.
+
 ## Scope (this PR)
 
 Ownership lane: agent-operations
 Slice phase: workflow/process
-Max files: 14
+Max files: 16
 
 1. Establish one verified, versioned operational knowledge path for a fresh
    agent without replacing existing subsystem-specific runbooks.
@@ -331,12 +354,17 @@ Max files: 14
     canonical, generic, and Atlas application interfaces while every other
     database credential is absent; settled by child-environment and argv
     canary assertions without executing a database-backed test.
+  - Local PR review and `./ops test unit` cannot launch the unit gate; both
+    direct agents to `.github/workflows/unit_gate.yml`, while focused tests
+    remain locally available; settled by subprocess canaries that would fail if
+    the unit checker or pytest were invoked.
 - Reachability proof: run the real `./ops doctor`, `./ops env keys`,
   `./ops db status`, `./ops deploy status`, `./ops ci status`, and focused test
   entrypoints and observe their redacted terminal output/exit status.
 - Affected surfaces: root agent instructions, `.agent` operational metadata and
-  runbooks, the root `ops` command, and focused tests for those contracts.
-- Risk areas: secret disclosure, a nominally read-only database command
+  runbooks, the root `ops` command, the local PR-review wrapper, and focused
+  tests for those contracts.
+- Risk areas: secret disclosure, accidental local full-suite execution, a nominally read-only database command
   admitting writes, provider-specific assumptions, stale static claims, slow
   or network-dependent doctor behavior, and accidental application/CI changes.
 - Reviewer rules triggered: R1, R2, R3, R5, R6, R10, R12, R13, R14.
@@ -424,7 +452,9 @@ fallback changes; otherwise write "N/A - no guard/config boundary change."
 - `README.md`
 - `ops`
 - `plans/PR-Agent-Operations-Contract.md`
+- `scripts/local_pr_review.sh`
 - `tests/test_agent_operations_contract.py`
+- `tests/test_local_pr_review.py`
 
 ## Mechanism
 
@@ -479,6 +509,13 @@ Parked hardening: none.
   across explicit/worktree/shared/systemd contexts, both shared-root path
   shapes, Docker CLI/offline/daemon/object states, and single-credential
   integration subprocess isolation across all 3 canonical URL keys.
+- Focused hosted-only unit boundary nodes across
+  `tests/test_agent_operations_contract.py` and `tests/test_local_pr_review.py`
+  - 9 passed; selected/empty/full/failing/missing checker states never invoke
+  the local unit checker, and `./ops test unit` never invokes pytest.
+- `python -m py_compile ops tests/test_agent_operations_contract.py
+  tests/test_local_pr_review.py`, `bash -n scripts/local_pr_review.sh`, hosted-only
+  capability parsing, and `git diff --check` - pass.
 - Direct live `ops` shared-root probe -
   `/home/juan-canfield/Desktop/Atlas` from the current linked worktree.
 - `./ops test focused tests/test_eom_render_profile.py::test_database_config_prefers_connection_string_for_asyncpg_kwargs -q` - 1 passed.
@@ -504,25 +541,28 @@ Parked hardening: none.
 - `python scripts/sync_pr_plan.py --check plans/PR-Agent-Operations-Contract.md`
   and `git diff --check` - pass after final sync.
 - The original head's guarded push/local review and secret scan passed. The
-  current review-fix head will rerun the same guarded push before publication;
-  per operator direction, GitHub Actions owns the full unit gate.
+  hosted-only boundary head will rerun the guarded push before publication;
+  the local bundle can no longer launch pytest, and GitHub Actions owns the
+  full unit gate.
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
-| `.agent/capabilities.yaml` | 300 |
-| `.agent/runbooks/ci.md` | 65 |
+| `.agent/capabilities.yaml` | 299 |
+| `.agent/runbooks/ci.md` | 67 |
 | `.agent/runbooks/database.md` | 120 |
 | `.agent/runbooks/deployment.md` | 103 |
-| `.agent/runbooks/discovery-ledger.md` | 284 |
+| `.agent/runbooks/discovery-ledger.md` | 313 |
 | `.agent/runbooks/environment.md` | 109 |
 | `.agent/runbooks/logs.md` | 74 |
-| `.agent/runbooks/testing.md` | 101 |
-| `AGENTS.md` | 13 |
+| `.agent/runbooks/testing.md` | 99 |
+| `AGENTS.md` | 17 |
 | `CLAUDE.md` | 32 |
 | `README.md` | 16 |
-| `ops` | 907 |
-| `plans/PR-Agent-Operations-Contract.md` | 528 |
-| `tests/test_agent_operations_contract.py` | 674 |
-| **Total** | **3326** |
+| `ops` | 893 |
+| `plans/PR-Agent-Operations-Contract.md` | 568 |
+| `scripts/local_pr_review.sh` | 132 |
+| `tests/test_agent_operations_contract.py` | 656 |
+| `tests/test_local_pr_review.py` | 131 |
+| **Total** | **3629** |

--- a/plans/PR-Agent-Operations-Contract.md
+++ b/plans/PR-Agent-Operations-Contract.md
@@ -79,6 +79,49 @@ would leave an incomplete and unverified operational path between PRs.
   credential-bearing-origin redaction proof, focused tests, live fixed
   inspections, and the canonical guarded push review.
 
+### Contract revision 3
+
+- New evidence: current-head review found two reachable configuration-boundary
+  gaps. The database environment reader hand-parses assignments instead of
+  using the `python-dotenv` semantics that back `DatabaseConfig`, so quoting,
+  inline comments, escapes, and interpolation can produce a different value.
+  Unit mode also inherits all three canonical disposable-database URL
+  variables, allowing unmarked database-backed tests to write when a URL is
+  left exported from an earlier integration run.
+- Revised root cause: the operations layer preserved raw connection text and
+  pytest markers, but did not preserve the application's dotenv decoding or
+  isolate the unit-test child process from integration-only credentials.
+- Revised required change surface: parse selected database settings with the
+  same checked-in `python-dotenv` dependency used by Pydantic settings; retain
+  process-environment precedence and no-output/no-argv boundaries; remove every
+  inherited `DATABASE_URL` / `*_DATABASE_URL` plus the disposable-database
+  confirmation from unit-mode children; update capability/testing/ledger
+  claims; and add boundary regression tests.
+- Revised non-scope: do not source or execute shell files, print environment
+  values, alter `DatabaseConfig`, change pytest markers, add dependencies,
+  change integration-mode admission, or touch databases, schemas, CI, or
+  provider configuration.
+- Revised verification plan: focused tests prove dotenv quotes/comments,
+  escapes, and interpolation match `python-dotenv`; ambient environment still
+  wins; unit subprocesses omit every current and novel database-URL-shaped
+  variable while preserving unrelated environment; then run compile, plan
+  sync/audits, and the guarded push with GitHub retaining the full unit gate.
+
+#### Unit database-environment closure declaration
+
+- Membership is **OPEN** because parent-process environment names are not a
+  finite enum. Membership is **DERIVED** on every unit invocation from the
+  actual child-environment keys: `DATABASE_URL` and every key ending in
+  `_DATABASE_URL` belong to the database-URL class. This covers the three Atlas
+  integration URLs and the extracted/generic PostgreSQL test gates found under
+  `tests/` without copying a closed list into the decision.
+- Any recognized or novel database-URL-shaped key takes the safe default: it is
+  removed before pytest starts, because skipping an unintentionally live test
+  is safer than letting nominal unit mode write through inherited credentials.
+  Keys outside that syntactic class remain inherited so unrelated test/runtime
+  configuration is unchanged; integration mode retains its separate explicit
+  URL plus disposable-database confirmation gate.
+
 ## Scope (this PR)
 
 Ownership lane: agent-operations
@@ -130,16 +173,18 @@ router/classifier, or admission boundary. Name each changed boundary path or
 seam in the enumeration; otherwise write "N/A - no boundary change."
 
 - Boundary path/seam: `./ops db inspect` named-inspection admission and
-  read-only execution; integration-test database-variable admission;
-  `./ops env keys` secret-value suppression.
+  read-only execution; integration-test database-variable admission; unit-test
+  database-environment isolation; `./ops env keys` secret-value suppression.
 - Replaced-path behaviors: N/A - no existing runtime path is replaced.
 - Guard-relevant fields: inspection name, complete PostgreSQL connection string,
-  the canonical disposable-test URL set, Git origin userinfo, environment
-  assignment key/value split, and subprocess output redaction.
+  the canonical disposable-test URL set, open `*_DATABASE_URL` environment-key
+  class, Git origin userinfo, environment assignment key/value split, and
+  subprocess output redaction.
 - Caller x input shape: shell caller x fixed connectivity/migrations names;
   shell caller x arbitrary/unknown query names; test caller x each canonical
-  disposable database URL independently; Git origin x credential-bearing URL;
-  env files x blank/comment/export/quoted/canary-secret assignments.
+  disposable database URL independently; unit caller x current/novel database
+  URL keys plus an unrelated key; Git origin x credential-bearing URL; env files
+  x blank/comment/export/quoted/escaped/interpolated/canary-secret assignments.
 
 ### Deployed-config probing
 
@@ -150,8 +195,10 @@ fallback changes; otherwise write "N/A - no guard/config boundary change."
   `atlas_brain/storage/config.py`; the linked Vercel project comes from ignored
   `.vercel/project.json`; neither secret value is copied into version control.
 - Explicit value probe: tests pass fixed inspection names, a complete DSN with
-  TLS/socket parameters, each canonical disposable-test URL, and fixture env paths;
-  safe live probes use the current authenticated CLIs where available.
+  TLS/socket parameters, each canonical disposable-test URL, a novel
+  database-URL-shaped key, and fixture env paths with dotenv quoting/comments,
+  escapes, and interpolation; safe live probes use the current authenticated
+  CLIs where available.
 - Absent value probe: doctor and status report UNKNOWN/unavailable when a CLI,
   auth context, linked project, env file, or database is absent.
 - Default-session/default-context probe: run from the dedicated worktree, where
@@ -159,8 +206,9 @@ fallback changes; otherwise write "N/A - no guard/config boundary change."
   context via explicit discovery only.
 - Side-effect ordering: fixed inspection selection occurs before the database
   client receives SQL; the exact DSN remains in the child environment rather
-  than argv; Git output selects the canonical identifier before printing; env
-  rendering extracts keys before any output is produced.
+  than argv; unit-mode database URLs are removed before pytest starts; Git
+  output selects the canonical identifier before printing; env rendering
+  extracts keys before any output is produced.
 
 ### Files touched
 
@@ -217,13 +265,17 @@ Parked hardening: none.
 
 - `/home/juan-canfield/Desktop/Atlas/.venv/bin/python -m py_compile ops` - pass.
 - PyYAML `safe_load(.agent/capabilities.yaml)` - schema version `1` parsed.
-- `./ops test focused tests/test_agent_operations_contract.py -q` - 16 passed.
+- New dotenv/unit-isolation regression nodes failed before implementation with
+  undecoded dotenv text and a missing sanitized child environment.
+- `./ops test focused tests/test_agent_operations_contract.py -q` - 19 passed.
 - `./ops test focused tests/test_eom_render_profile.py::test_database_config_prefers_connection_string_for_asyncpg_kwargs -q` - 1 passed.
 - `./ops doctor` - pass; live systemd/Brain ping, Docker, Vercel, Render CLI,
   PostgreSQL fixed inspection, GitHub auth, and environment-source discovery
   reported without secret values.
 - `./ops db inspect connectivity` and `./ops db migrations` - pass through the
   Atlas `DatabaseConfig`/asyncpg path.
+- `./ops db inspect connectivity` - pass again after switching selected `.env`
+  decoding to `python-dotenv`.
 - `./ops env keys`, `./ops env systemd`, and `./ops env vercel` - pass;
   names/sources only.
 - `./ops ci status 3`, `./ops logs brain`, targeted container logs, and
@@ -232,24 +284,25 @@ Parked hardening: none.
 - `python scripts/sync_pr_plan.py --check plans/PR-Agent-Operations-Contract.md`
   and `git diff --check` - pass after final sync.
 - The original head's guarded push/local review and secret scan passed. The
-  current review-fix head will rerun the same guarded push before publication.
+  current review-fix head will rerun the same guarded push before publication;
+  per operator direction, GitHub Actions owns the full unit gate.
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
-| `.agent/capabilities.yaml` | 288 |
+| `.agent/capabilities.yaml` | 289 |
 | `.agent/runbooks/ci.md` | 65 |
 | `.agent/runbooks/database.md` | 85 |
 | `.agent/runbooks/deployment.md` | 103 |
-| `.agent/runbooks/discovery-ledger.md` | 189 |
+| `.agent/runbooks/discovery-ledger.md` | 219 |
 | `.agent/runbooks/environment.md` | 109 |
 | `.agent/runbooks/logs.md` | 74 |
-| `.agent/runbooks/testing.md` | 85 |
+| `.agent/runbooks/testing.md` | 92 |
 | `AGENTS.md` | 13 |
 | `CLAUDE.md` | 32 |
 | `README.md` | 16 |
-| `ops` | 780 |
-| `plans/PR-Agent-Operations-Contract.md` | 255 |
-| `tests/test_agent_operations_contract.py` | 258 |
-| **Total** | **2352** |
+| `ops` | 793 |
+| `plans/PR-Agent-Operations-Contract.md` | 308 |
+| `tests/test_agent_operations_contract.py` | 341 |
+| **Total** | **2539** |

--- a/plans/PR-Agent-Operations-Contract.md
+++ b/plans/PR-Agent-Operations-Contract.md
@@ -55,7 +55,7 @@ would leave an incomplete and unverified operational path between PRs.
 ## Scope (this PR)
 
 Ownership lane: agent-operations
-Slice phase: operations contract
+Slice phase: workflow/process
 
 1. Establish one verified, versioned operational knowledge path for a fresh
    agent without replacing existing subsystem-specific runbooks.

--- a/plans/PR-Agent-Operations-Contract.md
+++ b/plans/PR-Agent-Operations-Contract.md
@@ -196,6 +196,53 @@ would leave an incomplete and unverified operational path between PRs.
 - The regression covers each member directly, including the live Atlas
   conventional `.git` shape and the alternate bare-directory shape.
 
+### Contract revision 6
+
+- New evidence: one current-head review round exposed four finite classification
+  gaps. Integration admission accepts more than one destructive-test URL;
+  database inspection merges unrelated worktree, shared, example, and systemd
+  sources instead of selecting one application context; shared-root metadata
+  describes only the conventional `.git` shape; and container status reports
+  every Docker inspect failure as an absent object even when the daemon itself
+  is unavailable.
+- Revised root cause: the operational layer uses one-sided presence or ordered
+  accumulation where safety depends on explicit cardinality, precedence, or
+  provider state. Patching individual instances would leave the opposite
+  members of each same finite decision class undisposed.
+- Revised required change surface: require exactly one canonical integration
+  database URL; select one database file context in explicit override,
+  worktree, shared-root, then systemd-fallback order before applying process
+  environment precedence; describe conventional and direct-bare shared roots;
+  distinguish Docker CLI absence, offline mode, daemon unavailability, and
+  daemon-available object state; update the canonical database/ledger claims;
+  and cover every member with focused tests.
+- Revised non-scope: do not add more providers, containers, database variables,
+  environment formats, test modes, deployment behavior, CI changes, product
+  code, or adjacent hardening. This is one frozen pass over the four named
+  current-head threads; GitHub retains the full unit gate.
+- Revised verification plan: run only the focused operations-contract tests,
+  Python compile, YAML parse, plan sync/check, diff check, safe live doctor,
+  database status/inspection, and Docker status probes. Do not run the local
+  unit gate.
+
+#### Frozen-pass closure declarations
+
+- Integration database admission is **CLOSED** over 0, 1, or many active
+  members of `TEST_DATABASE_URL_KEYS`: only 1 proceeds; 0 and 2/3 reject before
+  pytest, naming keys but never values.
+- Database file context is **CLOSED** by precedence: an explicit
+  `ATLAS_OPS_ENV_FILES` list is one selected context; otherwise any worktree
+  `.env`/`.env.local` presence selects that application context, else the
+  shared-root pair, else systemd EnvironmentFiles. Tracked examples and
+  `.env.tailscale` remain inventory-only. Within a selected context later
+  files win, and exported process values win last.
+- Shared-root metadata is **CLOSED** over the resolver's successful path shapes:
+  conventional `.git` means its parent and a direct bare common directory
+  means that directory itself; command failure retains the repository fallback.
+- Docker container status is **CLOSED** over CLI missing, offline, daemon
+  unavailable, and daemon available. Only after a successful daemon probe can
+  an inspect miss mean `absent`; a successful empty inspect is `UNKNOWN`.
+
 ## Scope (this PR)
 
 Ownership lane: agent-operations
@@ -230,6 +277,14 @@ Max files: 14
     settled by the documentation contract test and cold reconstruction.
   - Root `AGENTS.md` points fresh agents at the contract, `./ops doctor`, and
     the continuous-learning rule; settled by the documentation contract test.
+  - Integration mode admits exactly one canonical disposable database URL and
+    rejects zero or many before pytest; settled by the 0/1/2/3 focused matrix.
+  - Database inspection selects one application-equivalent file context before
+    exported values override it; settled by explicit/worktree/shared/systemd
+    canary tests and the live selected-path probe.
+  - Container status proves Docker daemon access before classifying objects as
+    present or absent; settled by CLI/offline/daemon/object state tests and a
+    live `./ops status` invocation.
 - Reachability proof: run the real `./ops doctor`, `./ops env keys`,
   `./ops db status`, `./ops deploy status`, `./ops ci status`, and focused test
   entrypoints and observe their redacted terminal output/exit status.
@@ -251,7 +306,8 @@ seam in the enumeration; otherwise write "N/A - no boundary change."
   database-environment isolation; integration-test target admission;
   dependency-free database status fallback; Brain health-detail redaction; and
   `./ops env keys` secret-value suppression; Git common-directory shared-root
-  resolution.
+  resolution; selected database configuration context; integration database-URL
+  cardinality; and Docker daemon-versus-object state classification.
 - Replaced-path behaviors: N/A - no existing runtime path is replaced.
 - Guard-relevant fields: inspection name, complete PostgreSQL connection string,
   the canonical disposable-test URL set, open `*_DATABASE_URL` environment-key
@@ -267,7 +323,10 @@ seam in the enumeration; otherwise write "N/A - no boundary change."
   fresh system Python x missing `python-dotenv`; configured Brain endpoint x
   credential-bearing URL; integration caller x file/node/option-only/directory/
   missing/out-of-tree/additional-positional targets; worktree x conventional
-  `.git`/direct bare common directory/Git lookup failure.
+  `.git`/direct bare common directory/Git lookup failure; integration environment
+  x zero/one/two/three active canonical URLs; database source x explicit/worktree/
+  shared/systemd context plus process override; Docker x CLI missing/offline/
+  daemon unavailable/object absent/object present/empty successful inspect.
 
 ### Deployed-config probing
 
@@ -294,8 +353,9 @@ fallback changes; otherwise write "N/A - no guard/config boundary change."
   than argv; unit-mode database URLs are removed before pytest starts; Git
   output selects the canonical identifier before printing; env rendering
   extracts keys before any output is produced; integration target validation
-  occurs before pytest or database admission; health output selects a fixed
-  label rather than the configured URL.
+  and exact database-URL cardinality occur before pytest; Docker daemon access
+  is established before object inspection; health output selects a fixed label
+  rather than the configured URL.
 
 ### Files touched
 
@@ -359,13 +419,21 @@ Parked hardening: none.
   unbounded integration targets, and the nonexistent capability command.
 - The bare common-directory resolver regression failed before implementation
   with `1 failed, 2 passed`; only the successful direct-bare member was wrong.
-- `./ops test focused tests/test_agent_operations_contract.py -q` - 32 passed.
+- `./ops test focused tests/test_agent_operations_contract.py -q` - 40 passed;
+  the frozen pass covers integration URL counts 0/1/2/3, database selection
+  across explicit/worktree/shared/systemd contexts, both shared-root path
+  shapes, and Docker CLI/offline/daemon/object states.
 - Direct live `ops` shared-root probe -
   `/home/juan-canfield/Desktop/Atlas` from the current linked worktree.
 - `./ops test focused tests/test_eom_render_profile.py::test_database_config_prefers_connection_string_for_asyncpg_kwargs -q` - 1 passed.
 - `./ops doctor` - pass; live systemd/Brain ping, Docker, Vercel, Render CLI,
   PostgreSQL fixed inspection, GitHub auth, and environment-source discovery
   reported without secret values.
+- `./ops status` - pass after the daemon-first container change; the reachable
+  daemon reported present and absent known objects separately.
+- Live database-context path probe selected only the shared-root `.env` and
+  `.env.local` pair from this unprovisioned worktree; `./ops db status` and
+  `./ops db inspect connectivity` then passed without printing credentials.
 - `/usr/bin/python3 ./ops doctor` with `python-dotenv` unavailable - pass;
   database status reported `UNAVAILABLE` while the remaining snapshot completed.
 - `./ops db inspect connectivity` and `./ops db migrations` - pass through the
@@ -387,18 +455,18 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `.agent/capabilities.yaml` | 290 |
+| `.agent/capabilities.yaml` | 298 |
 | `.agent/runbooks/ci.md` | 65 |
-| `.agent/runbooks/database.md` | 85 |
+| `.agent/runbooks/database.md` | 109 |
 | `.agent/runbooks/deployment.md` | 103 |
-| `.agent/runbooks/discovery-ledger.md` | 252 |
+| `.agent/runbooks/discovery-ledger.md` | 274 |
 | `.agent/runbooks/environment.md` | 109 |
 | `.agent/runbooks/logs.md` | 74 |
 | `.agent/runbooks/testing.md` | 101 |
 | `AGENTS.md` | 13 |
 | `CLAUDE.md` | 32 |
 | `README.md` | 16 |
-| `ops` | 827 |
-| `plans/PR-Agent-Operations-Contract.md` | 404 |
-| `tests/test_agent_operations_contract.py` | 494 |
-| **Total** | **2865** |
+| `ops` | 879 |
+| `plans/PR-Agent-Operations-Contract.md` | 472 |
+| `tests/test_agent_operations_contract.py` | 654 |
+| **Total** | **3199** |

--- a/plans/PR-Agent-Operations-Contract.md
+++ b/plans/PR-Agent-Operations-Contract.md
@@ -122,6 +122,47 @@ would leave an incomplete and unverified operational path between PRs.
   configuration is unchanged; integration mode retains its separate explicit
   URL plus disposable-database confirmation gate.
 
+### Contract revision 4
+
+- New evidence: current-head review proved four bounded gaps in the operations
+  entrypoints. `doctor` aborts before dependencies are installed because its
+  database probe imports `python-dotenv`; a configured Brain health URL is
+  echoed after a successful probe; integration mode accepts option-only or
+  directory-wide pytest arguments; and the capability map names a nonexistent
+  runtime command.
+- Revised root cause: the operations layer did not preserve its orientation
+  command's dependency-free failure boundary, treated a credential-bearing URL
+  as safe status detail, checked only that integration arguments were nonempty,
+  and carried one unverified command label into the capability map.
+- Revised required change surface: make database status probing report an
+  unavailable dependency without aborting `doctor` while explicit database
+  commands retain actionable failure; report configured/local Brain endpoint
+  success without echoing the URL; require integration mode's first pytest
+  argument to resolve to an existing Python test file under `tests/`; replace
+  the nonexistent capability command; and add direct boundary regressions and
+  concise durable failure notes.
+- Revised non-scope: do not add a runtime command, install or vendor
+  dependencies, change database configuration, broaden pytest argument parsing,
+  change application health behavior, run integration tests, or touch CI,
+  provider, deployment, schema, or product code.
+- Revised verification plan: focused tests cover missing `python-dotenv`, a
+  canary-bearing configured health URL, option-only/directory/out-of-tree versus
+  file/node integration targets, and capability-command existence; then run
+  compile, plan/documentation audits, live dependency-free `doctor`, and the
+  guarded push while GitHub retains the full unit gate.
+
+#### Integration target closure declaration
+
+- Membership is **CLOSED** by the command grammar: the first argument after
+  `integration` is a path, optionally followed by a pytest `::node`, whose file
+  resolves under the repository's `tests/` directory, has a `.py` suffix, and
+  exists as a regular file. Later arguments must be pytest option tokens; use
+  `--option=value` when an option takes a value.
+- Empty, option-first, directory, missing, non-Python, and out-of-tree targets
+  take the safe default and are rejected before database credentials are handed
+  to pytest. This closes the repo-wide fallback without inventing a general
+  pytest parser.
+
 ## Scope (this PR)
 
 Ownership lane: agent-operations
@@ -174,17 +215,23 @@ seam in the enumeration; otherwise write "N/A - no boundary change."
 
 - Boundary path/seam: `./ops db inspect` named-inspection admission and
   read-only execution; integration-test database-variable admission; unit-test
-  database-environment isolation; `./ops env keys` secret-value suppression.
+  database-environment isolation; integration-test target admission;
+  dependency-free database status fallback; Brain health-detail redaction; and
+  `./ops env keys` secret-value suppression.
 - Replaced-path behaviors: N/A - no existing runtime path is replaced.
 - Guard-relevant fields: inspection name, complete PostgreSQL connection string,
   the canonical disposable-test URL set, open `*_DATABASE_URL` environment-key
   class, Git origin userinfo, environment assignment key/value split, and
-  subprocess output redaction.
+  subprocess output redaction; configured Brain URL; integration target path,
+  node suffix, and trailing pytest arguments.
 - Caller x input shape: shell caller x fixed connectivity/migrations names;
   shell caller x arbitrary/unknown query names; test caller x each canonical
   disposable database URL independently; unit caller x current/novel database
   URL keys plus an unrelated key; Git origin x credential-bearing URL; env files
-  x blank/comment/export/quoted/escaped/interpolated/canary-secret assignments.
+  x blank/comment/export/quoted/escaped/interpolated/canary-secret assignments;
+  fresh system Python x missing `python-dotenv`; configured Brain endpoint x
+  credential-bearing URL; integration caller x file/node/option-only/directory/
+  missing/out-of-tree/additional-positional targets.
 
 ### Deployed-config probing
 
@@ -197,8 +244,9 @@ fallback changes; otherwise write "N/A - no guard/config boundary change."
 - Explicit value probe: tests pass fixed inspection names, a complete DSN with
   TLS/socket parameters, each canonical disposable-test URL, a novel
   database-URL-shaped key, and fixture env paths with dotenv quoting/comments,
-  escapes, and interpolation; safe live probes use the current authenticated
-  CLIs where available.
+  escapes, and interpolation; tests also pass a credential-bearing configured
+  health URL and bounded/unbounded integration targets; safe live probes use the
+  current authenticated CLIs where available.
 - Absent value probe: doctor and status report UNKNOWN/unavailable when a CLI,
   auth context, linked project, env file, or database is absent.
 - Default-session/default-context probe: run from the dedicated worktree, where
@@ -208,7 +256,9 @@ fallback changes; otherwise write "N/A - no guard/config boundary change."
   client receives SQL; the exact DSN remains in the child environment rather
   than argv; unit-mode database URLs are removed before pytest starts; Git
   output selects the canonical identifier before printing; env rendering
-  extracts keys before any output is produced.
+  extracts keys before any output is produced; integration target validation
+  occurs before pytest or database admission; health output selects a fixed
+  label rather than the configured URL.
 
 ### Files touched
 
@@ -263,15 +313,20 @@ Parked hardening: none.
 
 ## Verification
 
-- `/home/juan-canfield/Desktop/Atlas/.venv/bin/python -m py_compile ops` - pass.
+- `python -m py_compile ops tests/test_agent_operations_contract.py` - pass.
 - PyYAML `safe_load(.agent/capabilities.yaml)` - schema version `1` parsed.
 - New dotenv/unit-isolation regression nodes failed before implementation with
   undecoded dotenv text and a missing sanitized child environment.
-- `./ops test focused tests/test_agent_operations_contract.py -q` - 19 passed.
+- The four new boundary regression groups failed before implementation with
+  `10 failed`, covering missing dependency, configured-URL disclosure,
+  unbounded integration targets, and the nonexistent capability command.
+- `./ops test focused tests/test_agent_operations_contract.py -q` - 29 passed.
 - `./ops test focused tests/test_eom_render_profile.py::test_database_config_prefers_connection_string_for_asyncpg_kwargs -q` - 1 passed.
 - `./ops doctor` - pass; live systemd/Brain ping, Docker, Vercel, Render CLI,
   PostgreSQL fixed inspection, GitHub auth, and environment-source discovery
   reported without secret values.
+- `/usr/bin/python3 ./ops doctor` with `python-dotenv` unavailable - pass;
+  database status reported `UNAVAILABLE` while the remaining snapshot completed.
 - `./ops db inspect connectivity` and `./ops db migrations` - pass through the
   Atlas `DatabaseConfig`/asyncpg path.
 - `./ops db inspect connectivity` - pass again after switching selected `.env`
@@ -291,18 +346,18 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `.agent/capabilities.yaml` | 289 |
+| `.agent/capabilities.yaml` | 290 |
 | `.agent/runbooks/ci.md` | 65 |
 | `.agent/runbooks/database.md` | 85 |
 | `.agent/runbooks/deployment.md` | 103 |
-| `.agent/runbooks/discovery-ledger.md` | 219 |
+| `.agent/runbooks/discovery-ledger.md` | 249 |
 | `.agent/runbooks/environment.md` | 109 |
 | `.agent/runbooks/logs.md` | 74 |
-| `.agent/runbooks/testing.md` | 92 |
+| `.agent/runbooks/testing.md` | 101 |
 | `AGENTS.md` | 13 |
 | `CLAUDE.md` | 32 |
 | `README.md` | 16 |
-| `ops` | 793 |
-| `plans/PR-Agent-Operations-Contract.md` | 308 |
-| `tests/test_agent_operations_contract.py` | 341 |
-| **Total** | **2539** |
+| `ops` | 827 |
+| `plans/PR-Agent-Operations-Contract.md` | 363 |
+| `tests/test_agent_operations_contract.py` | 468 |
+| **Total** | **2795** |

--- a/plans/PR-Agent-Operations-Contract.md
+++ b/plans/PR-Agent-Operations-Contract.md
@@ -243,6 +243,48 @@ would leave an incomplete and unverified operational path between PRs.
   unavailable, and daemon available. Only after a successful daemon probe can
   an inspect miss mean `absent`; a successful empty inspect is `UNKNOWN`.
 
+### Contract revision 7
+
+- New evidence: the exact-one canonical integration URL guard still hands
+  pytest the unfiltered parent environment. Current integration targets can
+  select `EXTRACTED_DATABASE_URL`, `DATABASE_URL`, or Atlas application
+  database settings instead of the confirmed canonical URL, and the cited
+  ticket-FAQ test applies migration SQL and performs writes/deletes through
+  that unconfirmed credential.
+- Revised root cause: integration admission validates credential cardinality
+  but does not bind subprocess authority to the credential that passed the
+  confirmation gate. Validation and execution therefore operate on different
+  database environments.
+- Revised required change surface: construct an integration-only child
+  environment that removes every inherited `DATABASE_URL`/`*_DATABASE_URL` and
+  Atlas application database setting, restores the single confirmed canonical
+  URL, and adapts that same value to `DATABASE_URL`,
+  `EXTRACTED_DATABASE_URL`, and `ATLAS_DB_CONNECTION_STRING`; pass that child
+  environment explicitly to pytest; update the capability/runbook/ledger
+  claims; and add negative proof that no unconfirmed credential reaches argv or
+  the child environment.
+- Revised non-scope: do not add target registries, parse test source, provision
+  databases, execute database-backed tests, alter pytest targets/markers,
+  change application configuration, add credentials, modify CI/provider/schema/
+  product code, or revisit earlier resolved review decisions.
+- Revised verification plan: prove the focused credential-isolation regression
+  fails before implementation, then run the focused operations-contract test
+  file, Python compile, YAML/plan/diff audits, and the guarded push with the
+  local full unit mirror skipped; GitHub owns the full unit gate.
+
+#### Integration credential closure declaration
+
+- Credential membership is **OPEN** for URL-shaped environment keys and
+  **CLOSED** for Atlas application database settings. Every `DATABASE_URL` and
+  `*_DATABASE_URL` key plus every `DATABASE_CONFIG_KEYS` member is removed from
+  the inherited child environment.
+- Exactly one canonical member of `TEST_DATABASE_URL_KEYS` is admitted. Its
+  value is restored under that key and adapted to the two generic URL aliases
+  and Atlas's connection-string key, so all supported current test consumers
+  receive one identical confirmed credential. No database value enters argv.
+- Unknown future URL-shaped keys and every non-selected canonical key take the
+  safe default and remain absent. Unrelated environment keys remain inherited.
+
 ## Scope (this PR)
 
 Ownership lane: agent-operations
@@ -285,6 +327,10 @@ Max files: 14
   - Container status proves Docker daemon access before classifying objects as
     present or absent; settled by CLI/offline/daemon/object state tests and a
     live `./ops status` invocation.
+  - Integration pytest receives one confirmed disposable credential across the
+    canonical, generic, and Atlas application interfaces while every other
+    database credential is absent; settled by child-environment and argv
+    canary assertions without executing a database-backed test.
 - Reachability proof: run the real `./ops doctor`, `./ops env keys`,
   `./ops db status`, `./ops deploy status`, `./ops ci status`, and focused test
   entrypoints and observe their redacted terminal output/exit status.
@@ -307,7 +353,8 @@ seam in the enumeration; otherwise write "N/A - no boundary change."
   dependency-free database status fallback; Brain health-detail redaction; and
   `./ops env keys` secret-value suppression; Git common-directory shared-root
   resolution; selected database configuration context; integration database-URL
-  cardinality; and Docker daemon-versus-object state classification.
+  cardinality and subprocess credential isolation; and Docker
+  daemon-versus-object state classification.
 - Replaced-path behaviors: N/A - no existing runtime path is replaced.
 - Guard-relevant fields: inspection name, complete PostgreSQL connection string,
   the canonical disposable-test URL set, open `*_DATABASE_URL` environment-key
@@ -326,7 +373,10 @@ seam in the enumeration; otherwise write "N/A - no boundary change."
   `.git`/direct bare common directory/Git lookup failure; integration environment
   x zero/one/two/three active canonical URLs; database source x explicit/worktree/
   shared/systemd context plus process override; Docker x CLI missing/offline/
-  daemon unavailable/object absent/object present/empty successful inspect.
+  daemon unavailable/object absent/object present/empty successful inspect;
+  integration credential execution x one confirmed canonical URL plus ambient
+  generic/novel/application database credentials and an unrelated environment
+  key.
 
 ### Deployed-config probing
 
@@ -340,8 +390,9 @@ fallback changes; otherwise write "N/A - no guard/config boundary change."
   TLS/socket parameters, each canonical disposable-test URL, a novel
   database-URL-shaped key, and fixture env paths with dotenv quoting/comments,
   escapes, and interpolation; tests also pass a credential-bearing configured
-  health URL and bounded/unbounded integration targets; safe live probes use the
-  current authenticated CLIs where available.
+  health URL, bounded/unbounded integration targets, and confirmed/unconfirmed
+  database credential canaries; safe live probes use the current authenticated
+  CLIs where available.
 - Absent value probe: doctor and status report UNKNOWN/unavailable when a CLI,
   auth context, linked project, env file, or database is absent.
 - Default-session/default-context probe: run from the dedicated worktree, where
@@ -353,9 +404,10 @@ fallback changes; otherwise write "N/A - no guard/config boundary change."
   than argv; unit-mode database URLs are removed before pytest starts; Git
   output selects the canonical identifier before printing; env rendering
   extracts keys before any output is produced; integration target validation
-  and exact database-URL cardinality occur before pytest; Docker daemon access
-  is established before object inspection; health output selects a fixed label
-  rather than the configured URL.
+  and exact database-URL cardinality occur before the integration child
+  environment is built, and that isolated environment is passed explicitly to
+  pytest; Docker daemon access is established before object inspection; health
+  output selects a fixed label rather than the configured URL.
 
 ### Files touched
 
@@ -419,10 +471,14 @@ Parked hardening: none.
   unbounded integration targets, and the nonexistent capability command.
 - The bare common-directory resolver regression failed before implementation
   with `1 failed, 2 passed`; only the successful direct-bare member was wrong.
+- The integration credential-isolation regression failed before implementation
+  in all 3 canonical cases because pytest received no explicit child
+  environment.
 - `./ops test focused tests/test_agent_operations_contract.py -q` - 40 passed;
   the frozen pass covers integration URL counts 0/1/2/3, database selection
   across explicit/worktree/shared/systemd contexts, both shared-root path
-  shapes, and Docker CLI/offline/daemon/object states.
+  shapes, Docker CLI/offline/daemon/object states, and single-credential
+  integration subprocess isolation across all 3 canonical URL keys.
 - Direct live `ops` shared-root probe -
   `/home/juan-canfield/Desktop/Atlas` from the current linked worktree.
 - `./ops test focused tests/test_eom_render_profile.py::test_database_config_prefers_connection_string_for_asyncpg_kwargs -q` - 1 passed.
@@ -455,18 +511,18 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `.agent/capabilities.yaml` | 298 |
+| `.agent/capabilities.yaml` | 300 |
 | `.agent/runbooks/ci.md` | 65 |
-| `.agent/runbooks/database.md` | 109 |
+| `.agent/runbooks/database.md` | 120 |
 | `.agent/runbooks/deployment.md` | 103 |
-| `.agent/runbooks/discovery-ledger.md` | 274 |
+| `.agent/runbooks/discovery-ledger.md` | 284 |
 | `.agent/runbooks/environment.md` | 109 |
 | `.agent/runbooks/logs.md` | 74 |
 | `.agent/runbooks/testing.md` | 101 |
 | `AGENTS.md` | 13 |
 | `CLAUDE.md` | 32 |
 | `README.md` | 16 |
-| `ops` | 879 |
-| `plans/PR-Agent-Operations-Contract.md` | 472 |
-| `tests/test_agent_operations_contract.py` | 654 |
-| **Total** | **3199** |
+| `ops` | 907 |
+| `plans/PR-Agent-Operations-Contract.md` | 528 |
+| `tests/test_agent_operations_contract.py` | 674 |
+| **Total** | **3326** |

--- a/scripts/local_pr_review.sh
+++ b/scripts/local_pr_review.sh
@@ -116,120 +116,6 @@ run_check() {
     fi
 }
 
-run_local_unit_gate_mirror() {
-    local tmp_dir
-    local base_baseline
-    local selected
-    local merge_base
-    local status
-    local -a unit_gate_env
-    local -a unit_gate_env_values
-    tmp_dir="$(mktemp -d)"
-    base_baseline="$tmp_dir/base_baseline.txt"
-    selected="$tmp_dir/selected.txt"
-    unit_gate_env=(-u ATLAS_CURRENT_PR_BODY_FILE -u ATLAS_CURRENT_PR_AUTHOR)
-    unit_gate_env_values=(
-        # A push performed by a gated test would otherwise re-enter the
-        # pre-push hook, which re-runs this script, which pushes again.
-        ATLAS_SKIP_LOCAL_PR_REVIEW=1
-        ATLAS_DB_CONNECTION_STRING=
-        ATLAS_DB_HOST=127.0.0.1
-        ATLAS_DB_PORT=1
-        ATLAS_DB_DATABASE=atlas
-        ATLAS_DB_USER=atlas
-        ATLAS_DB_PASSWORD=atlas_dev_password
-        ATLAS_DB_SOCKET_PATH=
-    )
-    while IFS= read -r git_env_var; do
-        [ -z "$git_env_var" ] && continue
-        unit_gate_env+=("-u" "$git_env_var")
-    done < <(git rev-parse --local-env-vars)
-    while IFS= read -r pytest_env_var; do
-        [ -z "$pytest_env_var" ] && continue
-        unit_gate_env+=("-u" "$pytest_env_var")
-    done < <(compgen -e PYTEST_)
-
-    if [ ! -f "$repo_root/scripts/check_unit_gate.py" ]; then
-        echo "scripts/check_unit_gate.py is absent from this PR head; local unit gate mirror cannot verify the required gate"
-        rm -rf "$tmp_dir"
-        return 1
-    fi
-    if [ ! -f "$script_root/scripts/check_unit_gate.py" ]; then
-        echo "trusted unit-gate checker unavailable; local unit gate mirror cannot verify the required gate"
-        rm -rf "$tmp_dir"
-        return 1
-    fi
-
-    if merge_base="$(git merge-base "$base_ref" HEAD 2>/dev/null)"; then
-        git show "${merge_base}:tests/unit_gate_baseline.txt" > "$base_baseline" 2>/dev/null || : > "$base_baseline"
-    else
-        git show "${base_ref}:tests/unit_gate_baseline.txt" > "$base_baseline" 2>/dev/null || : > "$base_baseline"
-    fi
-
-    if [ ! -f "$repo_root/scripts/select_impacted_tests.py" ]; then
-        echo "selector absent from this PR head; running FULL"
-        echo "FULL" > "$selected"
-    elif [ ! -f "$script_root/scripts/select_impacted_tests.py" ]; then
-        echo "trusted selector unavailable; running FULL"
-        echo "FULL" > "$selected"
-    else
-        # The unit gate workflow does not receive wrapper-only PR body env,
-        # Git hook-local env, or local pytest option overrides.
-        # Drop them so local pre-push mirrors CI.
-        env "${unit_gate_env[@]}" \
-            "$python_bin" "$script_root/scripts/select_impacted_tests.py" --base "$base_ref" > "$selected"
-        status=$?
-        if [ "$status" -ne 0 ]; then
-            echo "selector failed while choosing local unit-gate tests"
-            rm -rf "$tmp_dir"
-            return "$status"
-        fi
-    fi
-
-    if [ -f "$repo_root/requirements.unit_gate.txt" ]; then
-        echo "installing unit-gate test dependencies from requirements.unit_gate.txt"
-        "$python_bin" -m pip install -r "$repo_root/requirements.unit_gate.txt"
-    fi
-
-    echo "--- selection ---"
-    cat "$selected"
-
-    if [ "$(cat "$selected")" = "FULL" ]; then
-        echo "running the FULL suite (selection escalated)"
-        env "${unit_gate_env[@]}" \
-            "${unit_gate_env_values[@]}" \
-            "$python_bin" "$script_root/scripts/check_unit_gate.py" \
-            --baseline tests/unit_gate_baseline.txt \
-            --base-baseline "$base_baseline"
-        status=$?
-    elif [ ! -s "$selected" ]; then
-        echo "no test is reachable from the changed files; growth guard only"
-        env "${unit_gate_env[@]}" \
-            "${unit_gate_env_values[@]}" \
-            "$python_bin" "$script_root/scripts/check_unit_gate.py" \
-            --baseline tests/unit_gate_baseline.txt \
-            --base-baseline "$base_baseline" \
-            --growth-only
-        status=$?
-    else
-        mapfile -t selected_tests < "$selected"
-        echo "running ${#selected_tests[@]} impacted test file(s)"
-        env "${unit_gate_env[@]}" \
-            "${unit_gate_env_values[@]}" \
-            "$python_bin" "$script_root/scripts/check_unit_gate.py" \
-            --baseline tests/unit_gate_baseline.txt \
-            --base-baseline "$base_baseline" \
-            --selected-files "$selected" \
-            --pytest-args "${selected_tests[@]}" \
-                -m "not integration and not e2e" \
-                --continue-on-collection-errors -rfE --tb=no -q \
-                -p no:cacheprovider
-        status=$?
-    fi
-    rm -rf "$tmp_dir"
-    return "$status"
-}
-
 body_uses_docs_only_marker() {
     [ -n "$current_pr_body_file" ] || return 1
     [ -f "$current_pr_body_file" ] || return 1
@@ -392,21 +278,9 @@ fi
 
 run_check "git diff --check" git diff --check
 
-if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
-    echo
-    echo "==> Local unit gate mirror"
-    echo "    SKIP (GitHub Actions runs .github/workflows/unit_gate.yml as its own required check)"
-elif [ "$failures" -ne 0 ]; then
-    echo
-    echo "==> Local unit gate mirror"
-    echo "    SKIP ($failures earlier local review check(s) failed)"
-elif [ -f "$script_root/scripts/check_unit_gate.py" ] || git cat-file -e "$base:scripts/check_unit_gate.py" 2>/dev/null; then
-    run_check "Local unit gate mirror" run_local_unit_gate_mirror
-else
-    echo
-    echo "==> Local unit gate mirror"
-    echo "    SKIP (scripts/check_unit_gate.py not found)"
-fi
+echo
+echo "==> Unit gate"
+echo "    SKIP (GitHub Actions owns .github/workflows/unit_gate.yml; local review never runs the unit suite)"
 
 # Advisory only: nudge to archive merged plan docs once the plans/ root grows
 # past the threshold. Never affects the failure count -- archive_plans.py check

--- a/tests/test_agent_operations_contract.py
+++ b/tests/test_agent_operations_contract.py
@@ -22,6 +22,32 @@ database_inspection_command = OPS_MODULE["database_inspection_command"]
 database_runtime_environment = OPS_MODULE["database_runtime_environment"]
 
 
+@pytest.mark.parametrize(
+    ("returncode", "common_dir", "expected"),
+    (
+        (0, "/srv/atlas/.git", Path("/srv/atlas")),
+        (0, "/srv/Atlas", Path("/srv/Atlas")),
+        (1, "", Path("/workspace/atlas-worktree")),
+    ),
+)
+def test_shared_root_resolves_conventional_bare_and_failure_layouts(
+    returncode: int,
+    common_dir: str,
+    expected: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = Path("/workspace/atlas-worktree")
+
+    def fake_run(args: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args, returncode, f"{common_dir}\n", "")
+
+    function_globals = OPS_MODULE["shared_root"].__globals__
+    monkeypatch.setitem(function_globals, "repo_root", lambda: repo)
+    monkeypatch.setitem(function_globals, "run", fake_run)
+
+    assert OPS_MODULE["shared_root"]() == expected
+
+
 def test_database_surface_contains_only_fixed_inspections() -> None:
     assert DATABASE_INSPECTIONS == {
         "connectivity": "SELECT 1 AS ok",

--- a/tests/test_agent_operations_contract.py
+++ b/tests/test_agent_operations_contract.py
@@ -19,6 +19,7 @@ DATABASE_CONFIG_KEYS = OPS_MODULE["DATABASE_CONFIG_KEYS"]
 TEST_DATABASE_URL_KEYS = OPS_MODULE["TEST_DATABASE_URL_KEYS"]
 OpsError = OPS_MODULE["OpsError"]
 database_inspection_command = OPS_MODULE["database_inspection_command"]
+database_env_files = OPS_MODULE["database_env_files"]
 database_runtime_environment = OPS_MODULE["database_runtime_environment"]
 
 
@@ -159,6 +160,70 @@ def test_database_runtime_environment_overrides_dotenv(
     assert child_env["ATLAS_DB_HOST"] == "runtime.example"
 
 
+def test_database_file_context_prefers_worktree_over_shared_and_systemd(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    worktree = tmp_path / "worktree"
+    shared = tmp_path / "shared"
+    systemd = tmp_path / "systemd.env"
+    for path in (worktree, shared):
+        path.mkdir()
+    (worktree / ".env").write_text("ATLAS_DB_HOST=worktree.example\n", encoding="utf-8")
+    (shared / ".env").write_text("ATLAS_DB_HOST=shared.example\n", encoding="utf-8")
+    systemd.write_text("ATLAS_DB_HOST=systemd.example\n", encoding="utf-8")
+    monkeypatch.delenv("ATLAS_OPS_ENV_FILES", raising=False)
+    monkeypatch.delenv("ATLAS_DB_HOST", raising=False)
+    function_globals = database_env_files.__globals__
+    monkeypatch.setitem(function_globals, "worktree_root", lambda: worktree)
+    monkeypatch.setitem(function_globals, "shared_root", lambda: shared)
+    monkeypatch.setitem(function_globals, "systemd_env_files", lambda: [systemd])
+
+    selected = database_env_files()
+    child_env = database_runtime_environment()
+
+    assert selected == [worktree / ".env", worktree / ".env.local"]
+    assert child_env["ATLAS_DB_HOST"] == "worktree.example"
+
+
+def test_database_file_context_fallbacks_are_explicit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    worktree = tmp_path / "worktree"
+    shared = tmp_path / "shared"
+    systemd = tmp_path / "systemd.env"
+    for path in (worktree, shared):
+        path.mkdir()
+    (shared / ".env.local").write_text("ATLAS_DB_HOST=shared.example\n", encoding="utf-8")
+    systemd.write_text("ATLAS_DB_HOST=systemd.example\n", encoding="utf-8")
+    monkeypatch.delenv("ATLAS_OPS_ENV_FILES", raising=False)
+    function_globals = database_env_files.__globals__
+    monkeypatch.setitem(function_globals, "worktree_root", lambda: worktree)
+    monkeypatch.setitem(function_globals, "shared_root", lambda: shared)
+    monkeypatch.setitem(function_globals, "systemd_env_files", lambda: [systemd])
+
+    assert database_env_files() == [shared / ".env", shared / ".env.local"]
+
+    (shared / ".env.local").unlink()
+    assert database_env_files() == [systemd]
+
+
+def test_database_file_context_honors_explicit_override_order(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first = tmp_path / "first.env"
+    second = tmp_path / "second.env"
+    first.write_text("ATLAS_DB_HOST=first.example\n", encoding="utf-8")
+    second.write_text("ATLAS_DB_HOST=second.example\n", encoding="utf-8")
+    monkeypatch.setenv("ATLAS_OPS_ENV_FILES", os.pathsep.join((str(first), str(second))))
+    monkeypatch.delenv("ATLAS_DB_HOST", raising=False)
+
+    assert database_env_files() == [first, second]
+    assert database_runtime_environment()["ATLAS_DB_HOST"] == "second.example"
+
+
 def test_database_probe_degrades_when_project_dotenv_is_unavailable(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -265,6 +330,35 @@ def test_integration_guard_admits_each_canonical_database_variable(
     target = "tests/test_agent_operations_contract.py::test_doctor_runs_without_live_provider_access"
     assert OPS_MODULE["test_command"](["integration", target, "-q"]) == 0
     assert calls and calls[0][-2:] == [target, "-q"]
+
+
+@pytest.mark.parametrize("active_count", (0, 2, 3))
+def test_integration_guard_requires_exactly_one_database_variable(
+    active_count: int,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for key in TEST_DATABASE_URL_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    active_keys = TEST_DATABASE_URL_KEYS[:active_count]
+    for key in active_keys:
+        monkeypatch.setenv(key, f"postgresql://canary.invalid/{key.lower()}")
+    monkeypatch.setenv("ATLAS_CONFIRM_DISPOSABLE_TEST_DB", "1")
+    calls: list[list[str]] = []
+    function_globals = OPS_MODULE["test_command"].__globals__
+    monkeypatch.setitem(function_globals, "worktree_root", lambda: ROOT)
+    monkeypatch.setitem(
+        function_globals,
+        "exec_command",
+        lambda args, **_kwargs: calls.append(args) or 0,
+    )
+
+    with pytest.raises(OpsError, match="exactly one") as exc_info:
+        OPS_MODULE["test_command"](
+            ["integration", "tests/test_agent_operations_contract.py"]
+        )
+    assert calls == []
+    assert all(key in str(exc_info.value) for key in active_keys)
+    assert "postgresql://" not in str(exc_info.value)
 
 
 @pytest.mark.parametrize(
@@ -419,6 +513,68 @@ def test_doctor_runs_without_live_provider_access() -> None:
     assert "UNKNOWN" in result.stdout
 
 
+def test_container_status_stops_at_unavailable_daemon(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    commands: list[list[str]] = []
+    function_globals = OPS_MODULE["container_status"].__globals__
+    monkeypatch.setattr(function_globals["shutil"], "which", lambda _name: None)
+    OPS_MODULE["container_status"]()
+    assert "containers: UNAVAILABLE" in capsys.readouterr().out
+
+    def fake_run(args: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        commands.append(args)
+        return subprocess.CompletedProcess(args, 1, "", "daemon unavailable")
+
+    monkeypatch.delenv("ATLAS_OPS_OFFLINE", raising=False)
+    monkeypatch.setitem(function_globals, "run", fake_run)
+    monkeypatch.setattr(function_globals["shutil"], "which", lambda _name: "/usr/bin/docker")
+
+    OPS_MODULE["container_status"]()
+
+    output = capsys.readouterr().out
+    assert commands == [["docker", "info"]]
+    assert "containers: UNAVAILABLE" in output
+    assert "absent" not in output
+
+
+def test_container_status_classifies_offline_and_object_states(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    function_globals = OPS_MODULE["container_status"].__globals__
+    monkeypatch.setattr(function_globals["shutil"], "which", lambda _name: "/usr/bin/docker")
+    monkeypatch.setenv("ATLAS_OPS_OFFLINE", "1")
+    monkeypatch.setitem(
+        function_globals,
+        "run",
+        lambda *_args, **_kwargs: pytest.fail("offline status must not call Docker"),
+    )
+    OPS_MODULE["container_status"]()
+    assert "containers: UNKNOWN (offline test mode)" in capsys.readouterr().out
+
+    monkeypatch.delenv("ATLAS_OPS_OFFLINE", raising=False)
+    monkeypatch.setitem(function_globals, "KNOWN_CONTAINERS", ("running", "missing", "empty"))
+
+    def fake_run(args: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        if args == ["docker", "info"]:
+            return subprocess.CompletedProcess(args, 0, "ok", "")
+        name = args[-1]
+        if name == "running":
+            return subprocess.CompletedProcess(args, 0, "running\n", "")
+        if name == "empty":
+            return subprocess.CompletedProcess(args, 0, "", "")
+        return subprocess.CompletedProcess(args, 1, "", "not found")
+
+    monkeypatch.setitem(function_globals, "run", fake_run)
+    OPS_MODULE["container_status"]()
+    output = capsys.readouterr().out
+    assert "running: running" in output
+    assert "missing: absent" in output
+    assert "empty: UNKNOWN" in output
+
+
 def test_mutating_database_and_deployment_commands_are_not_exposed() -> None:
     for args in (("db", "write"), ("db", "migrate"), ("deploy", "production")):
         result = subprocess.run(
@@ -455,6 +611,10 @@ def test_capability_map_is_machine_readable_and_has_required_surfaces() -> None:
     assert capabilities["deployment"]["frontend"]["provider"] == "Vercel"
     assert "./ops doctor" in capabilities["project"]["source_of_truth"]
     assert "./ops runtime inspection" not in capabilities["project"]["source_of_truth"]
+    assert capabilities["workspace"]["shared_root"]["path_hint"] == (
+        "the parent for a conventional .git common directory; otherwise the "
+        "direct bare common directory"
+    )
 
 
 def test_fresh_agent_documentation_contract_is_complete() -> None:

--- a/tests/test_agent_operations_contract.py
+++ b/tests/test_agent_operations_contract.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import os
+import re
+import runpy
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+ROOT = Path(__file__).parents[1]
+OPS = ROOT / "ops"
+OPS_MODULE = runpy.run_path(str(OPS), run_name="atlas_ops_contract_test")
+validate_read_only_sql = OPS_MODULE["validate_read_only_sql"]
+psql_readonly_command = OPS_MODULE["psql_readonly_command"]
+
+
+@pytest.mark.parametrize(
+    "sql",
+    (
+        "SELECT 1",
+        "-- harmless comment\nSELECT ';' AS value;",
+        "SELECT $$semicolon ; in dollar quote$$",
+        "SELECT 1 /* ignored ; nested /* comment */ safely */;",
+        "SHOW transaction_read_only",
+        "TABLE schema_migrations",
+        "VALUES (1), (2)",
+    ),
+)
+def test_read_only_sql_admits_single_safe_statement(sql: str) -> None:
+    assert validate_read_only_sql(sql) == (True, "ok")
+
+
+@pytest.mark.parametrize(
+    "sql,reason_fragment",
+    (
+        ("", "empty"),
+        ("INSERT INTO audit_log VALUES (1)", "only SELECT"),
+        ("WITH changed AS (DELETE FROM x RETURNING *) SELECT * FROM changed", "only SELECT"),
+        ("SELECT 1; DELETE FROM contacts", "exactly one"),
+        ("SELECT * INTO copied_contacts FROM contacts", "SELECT INTO"),
+        ("SELECT * FROM contacts FOR UPDATE", "row-locking"),
+        ("SELECT 'unterminated", "unterminated"),
+        ("/* unterminated", "unterminated"),
+        ("\\copy contacts TO '/tmp/contacts'", "only SELECT"),
+    ),
+)
+def test_read_only_sql_rejects_write_and_ambiguous_boundaries(
+    sql: str,
+    reason_fragment: str,
+) -> None:
+    allowed, reason = validate_read_only_sql(sql)
+    assert allowed is False
+    assert reason_fragment in reason
+
+
+def test_psql_query_has_database_enforced_read_only_boundary() -> None:
+    command = psql_readonly_command("SELECT 1")
+    assert "BEGIN TRANSACTION READ ONLY;" in command
+    assert "ROLLBACK;" in command
+    assert command.index("BEGIN TRANSACTION READ ONLY;") < command.index("SELECT 1")
+    assert command.index("SELECT 1") < command.index("ROLLBACK;")
+
+
+def test_env_keys_never_emit_values_or_evaluate_file(tmp_path: Path) -> None:
+    canary = "never-print-this-secret-value"
+    side_effect = tmp_path / "must-not-exist"
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "# comment\n"
+        f"ATLAS_SECRET={canary}\n"
+        "export SAFE_NAME=present\n"
+        f"EVIL=$(touch {side_effect})\n",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["ATLAS_OPS_ENV_FILES"] = str(env_file)
+    env["ATLAS_OPS_OFFLINE"] = "1"
+    result = subprocess.run(
+        [str(OPS), "env", "keys"],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "ATLAS_SECRET" in result.stdout
+    assert "SAFE_NAME" in result.stdout
+    assert "EVIL" in result.stdout
+    assert canary not in result.stdout
+    assert not side_effect.exists()
+
+
+def test_doctor_runs_without_live_provider_access() -> None:
+    env = os.environ.copy()
+    env["ATLAS_OPS_OFFLINE"] = "1"
+    env["ATLAS_OPS_ENV_FILES"] = ""
+    result = subprocess.run(
+        [str(OPS), "doctor"],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    for heading in (
+        "PROJECT",
+        "GIT",
+        "RUNTIME",
+        "TESTING",
+        "DEPLOYMENT",
+        "DATABASE",
+        "CI",
+        "USEFUL COMMANDS",
+    ):
+        assert heading in result.stdout
+    assert "UNKNOWN" in result.stdout
+
+
+def test_mutating_database_and_deployment_commands_are_not_exposed() -> None:
+    for args in (("db", "write"), ("db", "migrate"), ("deploy", "production")):
+        result = subprocess.run(
+            [str(OPS), *args],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        assert result.returncode == 2
+        assert "intentionally" in result.stderr or "unknown command" in result.stderr
+
+
+def test_capability_map_is_machine_readable_and_has_required_surfaces() -> None:
+    capability_path = ROOT / ".agent/capabilities.yaml"
+    capabilities = yaml.safe_load(capability_path.read_text(encoding="utf-8"))
+    assert capabilities["schema_version"] == 1
+    for key in (
+        "runtime",
+        "testing",
+        "ci",
+        "deployment",
+        "database",
+        "logs",
+        "environment",
+        "external_services",
+        "tools",
+        "repository_operations",
+    ):
+        assert key in capabilities
+    assert capabilities["database"]["safe_query"].startswith("./ops db query")
+    assert capabilities["deployment"]["brain"]["provider"] == "local systemd user service"
+    assert capabilities["deployment"]["frontend"]["provider"] == "Vercel"
+
+
+def test_fresh_agent_documentation_contract_is_complete() -> None:
+    runbooks = ROOT / ".agent/runbooks"
+    required = (
+        "environment.md",
+        "deployment.md",
+        "database.md",
+        "testing.md",
+        "logs.md",
+        "ci.md",
+        "discovery-ledger.md",
+    )
+    for name in required:
+        text = (runbooks / name).read_text(encoding="utf-8")
+        assert "Failure" in text or "failure" in text
+
+    agents = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+    assert ".agent/capabilities.yaml" in agents
+    assert "./ops doctor" in agents
+    assert "do not leave that knowledge only in the session" in " ".join(agents.split())
+
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    claude = (ROOT / "CLAUDE.md").read_text(encoding="utf-8")
+    assert "cp .env.example .env" not in readme
+    assert "docker compose up -d postgres" not in readme
+    assert "docker compose up -d postgres" not in claude
+
+
+def test_operational_contract_contains_no_credential_bearing_urls() -> None:
+    files = [OPS, ROOT / ".agent/capabilities.yaml"]
+    files.extend((ROOT / ".agent/runbooks").glob("*.md"))
+    credential_url = re.compile(r"(?:postgres(?:ql)?|https?)://[^\s/:]+:[^\s/@]+@")
+    for path in files:
+        text = path.read_text(encoding="utf-8")
+        assert credential_url.search(text) is None, path
+        assert "gho_" not in text, path

--- a/tests/test_agent_operations_contract.py
+++ b/tests/test_agent_operations_contract.py
@@ -14,6 +14,7 @@ ROOT = Path(__file__).parents[1]
 OPS = ROOT / "ops"
 OPS_MODULE = runpy.run_path(str(OPS), run_name="atlas_ops_contract_test")
 DATABASE_INSPECTIONS = OPS_MODULE["DATABASE_INSPECTIONS"]
+DATABASE_CONFIG_KEYS = OPS_MODULE["DATABASE_CONFIG_KEYS"]
 TEST_DATABASE_URL_KEYS = OPS_MODULE["TEST_DATABASE_URL_KEYS"]
 database_inspection_command = OPS_MODULE["database_inspection_command"]
 database_runtime_environment = OPS_MODULE["database_runtime_environment"]
@@ -83,6 +84,53 @@ def test_database_runtime_preserves_exact_dsn_without_argv(
     assert all(dsn not in argument for argument in command)
 
 
+def test_database_runtime_uses_project_dotenv_semantics(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from atlas_brain.storage.config import DatabaseConfig
+
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "DB_USER=agent\n"
+        "DB_HOST=db.example\n"
+        'ATLAS_DB_CONNECTION_STRING="postgresql://${DB_USER}:pa\\\"ss@'
+        '${DB_HOST}/atlas?sslmode=require" # local database\n'
+        'ATLAS_DB_SOCKET_PATH="/var/run/postgresql\\tcluster"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("ATLAS_OPS_ENV_FILES", str(env_file))
+    for key in DATABASE_CONFIG_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+    child_env = database_runtime_environment()
+    application_config = DatabaseConfig(_env_file=env_file)
+
+    assert child_env["ATLAS_DB_CONNECTION_STRING"] == (
+        'postgresql://agent:pa"ss@db.example/atlas?sslmode=require'
+    )
+    assert child_env["ATLAS_DB_SOCKET_PATH"] == "/var/run/postgresql\tcluster"
+    assert (
+        child_env["ATLAS_DB_CONNECTION_STRING"]
+        == application_config.connection_string
+    )
+    assert child_env["ATLAS_DB_SOCKET_PATH"] == application_config.socket_path
+
+
+def test_database_runtime_environment_overrides_dotenv(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text("ATLAS_DB_HOST=file.example\n", encoding="utf-8")
+    monkeypatch.setenv("ATLAS_OPS_ENV_FILES", str(env_file))
+    monkeypatch.setenv("ATLAS_DB_HOST", "runtime.example")
+
+    child_env = database_runtime_environment()
+
+    assert child_env["ATLAS_DB_HOST"] == "runtime.example"
+
+
 def test_git_snapshot_never_reads_or_prints_raw_origin(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -126,6 +174,41 @@ def test_integration_guard_admits_each_canonical_database_variable(
 
     assert OPS_MODULE["test_command"](["integration", "tests/example.py", "-q"]) == 0
     assert calls and calls[0][-2:] == ["tests/example.py", "-q"]
+
+
+def test_unit_mode_removes_database_urls_from_child_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database_urls = (
+        *TEST_DATABASE_URL_KEYS,
+        "EXTRACTED_DATABASE_URL",
+        "DATABASE_URL",
+        "FUTURE_DATABASE_URL",
+    )
+    for key in database_urls:
+        monkeypatch.setenv(
+            key,
+            f"postgresql://disposable.invalid/{key.lower()}",
+        )
+    monkeypatch.setenv("ATLAS_CONFIRM_DISPOSABLE_TEST_DB", "1")
+    monkeypatch.setenv("ATLAS_UNIT_CANARY", "preserved")
+    calls: list[tuple[list[str], dict[str, object]]] = []
+
+    def fake_exec(args: list[str], **kwargs: object) -> int:
+        calls.append((args, kwargs))
+        return 0
+
+    function_globals = OPS_MODULE["test_command"].__globals__
+    monkeypatch.setitem(function_globals, "worktree_root", lambda: ROOT)
+    monkeypatch.setitem(function_globals, "exec_command", fake_exec)
+
+    assert OPS_MODULE["test_command"](["unit"]) == 0
+    assert calls
+    child_env = calls[0][1]["env"]
+    assert isinstance(child_env, dict)
+    assert all(key not in child_env for key in database_urls)
+    assert "ATLAS_CONFIRM_DISPOSABLE_TEST_DB" not in child_env
+    assert child_env["ATLAS_UNIT_CANARY"] == "preserved"
 
 
 def test_env_keys_never_emit_values_or_evaluate_file(tmp_path: Path) -> None:

--- a/tests/test_agent_operations_contract.py
+++ b/tests/test_agent_operations_contract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import builtins
 import os
 import re
 import runpy
@@ -16,6 +17,7 @@ OPS_MODULE = runpy.run_path(str(OPS), run_name="atlas_ops_contract_test")
 DATABASE_INSPECTIONS = OPS_MODULE["DATABASE_INSPECTIONS"]
 DATABASE_CONFIG_KEYS = OPS_MODULE["DATABASE_CONFIG_KEYS"]
 TEST_DATABASE_URL_KEYS = OPS_MODULE["TEST_DATABASE_URL_KEYS"]
+OpsError = OPS_MODULE["OpsError"]
 database_inspection_command = OPS_MODULE["database_inspection_command"]
 database_runtime_environment = OPS_MODULE["database_runtime_environment"]
 
@@ -131,6 +133,68 @@ def test_database_runtime_environment_overrides_dotenv(
     assert child_env["ATLAS_DB_HOST"] == "runtime.example"
 
 
+def test_database_probe_degrades_when_project_dotenv_is_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text("ATLAS_DB_HOST=localhost\n", encoding="utf-8")
+    monkeypatch.setenv("ATLAS_OPS_ENV_FILES", str(env_file))
+    for key in DATABASE_CONFIG_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    real_import = builtins.__import__
+
+    def import_without_dotenv(name: str, *args: object, **kwargs: object) -> object:
+        if name == "dotenv":
+            raise ImportError("dependency intentionally unavailable")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_dotenv)
+
+    assert OPS_MODULE["database_probe"]() == (
+        "UNAVAILABLE",
+        "project Python is missing python-dotenv",
+    )
+    with pytest.raises(OpsError, match="missing python-dotenv"):
+        database_runtime_environment()
+
+
+def test_brain_health_never_returns_the_configured_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    configured_url = (
+        "https://operator:canary-password@brain.example.invalid/api/v1/ping"
+        "?token=canary-secret#credential-fragment"
+    )
+    requested: list[str] = []
+
+    class FakeResponse:
+        status = 204
+
+        def __enter__(self) -> FakeResponse:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+    def fake_urlopen(url: str, **_kwargs: object) -> FakeResponse:
+        requested.append(url)
+        return FakeResponse()
+
+    function_globals = OPS_MODULE["brain_health"].__globals__
+    monkeypatch.setenv("ATLAS_OPS_BRAIN_URL", configured_url)
+    monkeypatch.delenv("ATLAS_OPS_OFFLINE", raising=False)
+    monkeypatch.setitem(function_globals, "urlopen", fake_urlopen)
+
+    state, detail = OPS_MODULE["brain_health"]()
+
+    assert state == "OK"
+    assert requested == [configured_url]
+    assert configured_url not in detail
+    assert "canary-password" not in detail
+    assert "canary-secret" not in detail
+
+
 def test_git_snapshot_never_reads_or_prints_raw_origin(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -172,8 +236,69 @@ def test_integration_guard_admits_each_canonical_database_variable(
     monkeypatch.setitem(function_globals, "worktree_root", lambda: ROOT)
     monkeypatch.setitem(function_globals, "exec_command", fake_exec)
 
-    assert OPS_MODULE["test_command"](["integration", "tests/example.py", "-q"]) == 0
-    assert calls and calls[0][-2:] == ["tests/example.py", "-q"]
+    target = "tests/test_agent_operations_contract.py::test_doctor_runs_without_live_provider_access"
+    assert OPS_MODULE["test_command"](["integration", target, "-q"]) == 0
+    assert calls and calls[0][-2:] == [target, "-q"]
+
+
+@pytest.mark.parametrize(
+    "target",
+    (
+        "-q",
+        ".",
+        "tests",
+        "tests/",
+        "README.md",
+        "tests/does_not_exist.py",
+        "../tests/test_agent_operations_contract.py",
+    ),
+)
+def test_integration_guard_rejects_unbounded_or_invalid_targets(
+    target: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        TEST_DATABASE_URL_KEYS[0],
+        "postgresql://disposable.invalid/atlas_test",
+    )
+    monkeypatch.setenv("ATLAS_CONFIRM_DISPOSABLE_TEST_DB", "1")
+    calls: list[list[str]] = []
+
+    function_globals = OPS_MODULE["test_command"].__globals__
+    monkeypatch.setitem(function_globals, "worktree_root", lambda: ROOT)
+    monkeypatch.setitem(
+        function_globals,
+        "exec_command",
+        lambda args, **_kwargs: calls.append(args) or 0,
+    )
+
+    with pytest.raises(OpsError, match="existing Python file under tests"):
+        OPS_MODULE["test_command"](["integration", target])
+    assert calls == []
+
+
+def test_integration_guard_rejects_additional_positional_targets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        TEST_DATABASE_URL_KEYS[0],
+        "postgresql://disposable.invalid/atlas_test",
+    )
+    monkeypatch.setenv("ATLAS_CONFIRM_DISPOSABLE_TEST_DB", "1")
+    calls: list[list[str]] = []
+    target = "tests/test_agent_operations_contract.py"
+
+    function_globals = OPS_MODULE["test_command"].__globals__
+    monkeypatch.setitem(function_globals, "worktree_root", lambda: ROOT)
+    monkeypatch.setitem(
+        function_globals,
+        "exec_command",
+        lambda args, **_kwargs: calls.append(args) or 0,
+    )
+
+    with pytest.raises(OpsError, match="pytest option tokens"):
+        OPS_MODULE["test_command"](["integration", target, "tests/"])
+    assert calls == []
 
 
 def test_unit_mode_removes_database_urls_from_child_environment(
@@ -302,6 +427,8 @@ def test_capability_map_is_machine_readable_and_has_required_surfaces() -> None:
     assert capabilities["database"]["arbitrary_query"].startswith("unavailable")
     assert capabilities["deployment"]["brain"]["provider"] == "local systemd user service"
     assert capabilities["deployment"]["frontend"]["provider"] == "Vercel"
+    assert "./ops doctor" in capabilities["project"]["source_of_truth"]
+    assert "./ops runtime inspection" not in capabilities["project"]["source_of_truth"]
 
 
 def test_fresh_agent_documentation_contract_is_complete() -> None:

--- a/tests/test_agent_operations_contract.py
+++ b/tests/test_agent_operations_contract.py
@@ -315,12 +315,19 @@ def test_integration_guard_admits_each_canonical_database_variable(
 ) -> None:
     for key in TEST_DATABASE_URL_KEYS:
         monkeypatch.delenv(key, raising=False)
-    monkeypatch.setenv(database_key, "postgresql://disposable.invalid/atlas_test")
+    confirmed_url = f"postgresql://confirmed.invalid/{database_key.lower()}"
+    unconfirmed_url = "postgresql://unconfirmed.invalid/must-not-reach-pytest"
+    monkeypatch.setenv(database_key, confirmed_url)
+    for key in ("DATABASE_URL", "EXTRACTED_DATABASE_URL", "FUTURE_DATABASE_URL"):
+        monkeypatch.setenv(key, unconfirmed_url)
+    for key in DATABASE_CONFIG_KEYS:
+        monkeypatch.setenv(key, unconfirmed_url)
     monkeypatch.setenv("ATLAS_CONFIRM_DISPOSABLE_TEST_DB", "1")
-    calls: list[list[str]] = []
+    monkeypatch.setenv("ATLAS_INTEGRATION_CANARY", "preserved")
+    calls: list[tuple[list[str], dict[str, object]]] = []
 
-    def fake_exec(args: list[str], **_kwargs: object) -> int:
-        calls.append(args)
+    def fake_exec(args: list[str], **kwargs: object) -> int:
+        calls.append((args, kwargs))
         return 0
 
     function_globals = OPS_MODULE["test_command"].__globals__
@@ -329,7 +336,20 @@ def test_integration_guard_admits_each_canonical_database_variable(
 
     target = "tests/test_agent_operations_contract.py::test_doctor_runs_without_live_provider_access"
     assert OPS_MODULE["test_command"](["integration", target, "-q"]) == 0
-    assert calls and calls[0][-2:] == [target, "-q"]
+    assert calls and calls[0][0][-2:] == [target, "-q"]
+    child_env = calls[0][1]["env"]
+    assert isinstance(child_env, dict)
+    assert child_env[database_key] == confirmed_url
+    assert child_env["DATABASE_URL"] == confirmed_url
+    assert child_env["EXTRACTED_DATABASE_URL"] == confirmed_url
+    assert child_env["ATLAS_DB_CONNECTION_STRING"] == confirmed_url
+    assert child_env["ATLAS_INTEGRATION_CANARY"] == "preserved"
+    assert "FUTURE_DATABASE_URL" not in child_env
+    for key in DATABASE_CONFIG_KEYS - {"ATLAS_DB_CONNECTION_STRING"}:
+        assert key not in child_env
+    assert unconfirmed_url not in child_env.values()
+    assert all(confirmed_url not in argument for argument in calls[0][0])
+    assert all(unconfirmed_url not in argument for argument in calls[0][0])
 
 
 @pytest.mark.parametrize("active_count", (0, 2, 3))

--- a/tests/test_agent_operations_contract.py
+++ b/tests/test_agent_operations_contract.py
@@ -320,6 +320,23 @@ def test_integration_guard_admits_each_canonical_database_variable(
     monkeypatch.setenv(database_key, confirmed_url)
     for key in ("DATABASE_URL", "EXTRACTED_DATABASE_URL", "FUTURE_DATABASE_URL"):
         monkeypatch.setenv(key, unconfirmed_url)
+    libpq_keys = (
+        "PGHOST",
+        "PGDATABASE",
+        "PGUSER",
+        "PGPASSWORD",
+        "PGPASSFILE",
+        "PGSERVICE",
+        "PGSERVICEFILE",
+        "PGSSLKEY",
+        "PGSSLCERT",
+        "PGSSLROOTCERT",
+        "PGCHANNELBINDING",
+        "PGTARGETSESSIONATTRS",
+        "PGFUTURE_CREDENTIAL",
+    )
+    for key in libpq_keys:
+        monkeypatch.setenv(key, unconfirmed_url)
     for key in DATABASE_CONFIG_KEYS:
         monkeypatch.setenv(key, unconfirmed_url)
     monkeypatch.setenv("ATLAS_CONFIRM_DISPOSABLE_TEST_DB", "1")
@@ -345,6 +362,8 @@ def test_integration_guard_admits_each_canonical_database_variable(
     assert child_env["ATLAS_DB_CONNECTION_STRING"] == confirmed_url
     assert child_env["ATLAS_INTEGRATION_CANARY"] == "preserved"
     assert "FUTURE_DATABASE_URL" not in child_env
+    assert all(key not in child_env for key in libpq_keys)
+    assert not any(key.startswith("PG") for key in child_env)
     for key in DATABASE_CONFIG_KEYS - {"ATLAS_DB_CONNECTION_STRING"}:
         assert key not in child_env
     assert unconfirmed_url not in child_env.values()

--- a/tests/test_agent_operations_contract.py
+++ b/tests/test_agent_operations_contract.py
@@ -13,55 +13,119 @@ import yaml
 ROOT = Path(__file__).parents[1]
 OPS = ROOT / "ops"
 OPS_MODULE = runpy.run_path(str(OPS), run_name="atlas_ops_contract_test")
-validate_read_only_sql = OPS_MODULE["validate_read_only_sql"]
-psql_readonly_command = OPS_MODULE["psql_readonly_command"]
+DATABASE_INSPECTIONS = OPS_MODULE["DATABASE_INSPECTIONS"]
+TEST_DATABASE_URL_KEYS = OPS_MODULE["TEST_DATABASE_URL_KEYS"]
+database_inspection_command = OPS_MODULE["database_inspection_command"]
+database_runtime_environment = OPS_MODULE["database_runtime_environment"]
+
+
+def test_database_surface_contains_only_fixed_inspections() -> None:
+    assert DATABASE_INSPECTIONS == {
+        "connectivity": "SELECT 1 AS ok",
+        "migrations": (
+            "SELECT count(*) AS applied_count, max(version) AS latest_version "
+            "FROM public.schema_migrations"
+        ),
+    }
+    for name in DATABASE_INSPECTIONS:
+        command = database_inspection_command(name)
+        assert command[-2:] == ["__db-inspect", name]
+        assert DATABASE_INSPECTIONS[name] not in command
 
 
 @pytest.mark.parametrize(
-    "sql",
+    "args",
     (
-        "SELECT 1",
-        "-- harmless comment\nSELECT ';' AS value;",
-        "SELECT $$semicolon ; in dollar quote$$",
-        "SELECT 1 /* ignored ; nested /* comment */ safely */;",
-        "SHOW transaction_read_only",
-        "TABLE schema_migrations",
-        "VALUES (1), (2)",
+        ("db", "query", "SELECT pg_terminate_backend(1)"),
+        ("db", "query", "SELECT 1"),
+        ("db", "inspect", "pg_terminate_backend"),
+        ("__db-inspect", "connectivity"),
     ),
 )
-def test_read_only_sql_admits_single_safe_statement(sql: str) -> None:
-    assert validate_read_only_sql(sql) == (True, "ok")
+def test_database_surface_rejects_arbitrary_sql(args: tuple[str, ...]) -> None:
+    result = subprocess.run(
+        [str(OPS), *args],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 2
+    assert any(
+        reason in result.stderr
+        for reason in (
+            "arbitrary SQL",
+            "unknown database inspection",
+            "internal database inspection entrypoint is not public",
+        )
+    )
 
 
-@pytest.mark.parametrize(
-    "sql,reason_fragment",
-    (
-        ("", "empty"),
-        ("INSERT INTO audit_log VALUES (1)", "only SELECT"),
-        ("WITH changed AS (DELETE FROM x RETURNING *) SELECT * FROM changed", "only SELECT"),
-        ("SELECT 1; DELETE FROM contacts", "exactly one"),
-        ("SELECT * INTO copied_contacts FROM contacts", "SELECT INTO"),
-        ("SELECT * FROM contacts FOR UPDATE", "row-locking"),
-        ("SELECT 'unterminated", "unterminated"),
-        ("/* unterminated", "unterminated"),
-        ("\\copy contacts TO '/tmp/contacts'", "only SELECT"),
-    ),
-)
-def test_read_only_sql_rejects_write_and_ambiguous_boundaries(
-    sql: str,
-    reason_fragment: str,
+def test_database_runtime_preserves_exact_dsn_without_argv(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    allowed, reason = validate_read_only_sql(sql)
-    assert allowed is False
-    assert reason_fragment in reason
+    dsn = (
+        "postgresql://agent:canary-password@db.example/atlas"
+        "?sslmode=require&host=%2Fvar%2Frun%2Fpostgresql"
+    )
+    env_file = tmp_path / ".env"
+    env_file.write_text(f"ATLAS_DB_CONNECTION_STRING={dsn}\n", encoding="utf-8")
+    monkeypatch.setenv("ATLAS_OPS_ENV_FILES", str(env_file))
+    for key in TEST_DATABASE_URL_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.delenv("ATLAS_DB_CONNECTION_STRING", raising=False)
+
+    child_env = database_runtime_environment()
+    command = database_inspection_command("connectivity")
+
+    assert child_env["ATLAS_DB_CONNECTION_STRING"] == dsn
+    assert all(dsn not in argument for argument in command)
 
 
-def test_psql_query_has_database_enforced_read_only_boundary() -> None:
-    command = psql_readonly_command("SELECT 1")
-    assert "BEGIN TRANSACTION READ ONLY;" in command
-    assert "ROLLBACK;" in command
-    assert command.index("BEGIN TRANSACTION READ ONLY;") < command.index("SELECT 1")
-    assert command.index("SELECT 1") < command.index("ROLLBACK;")
+def test_git_snapshot_never_reads_or_prints_raw_origin(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    commands: list[list[str]] = []
+
+    def fake_run(args: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        commands.append(args)
+        output = "main\n" if "--show-current" in args else ""
+        return subprocess.CompletedProcess(args, 0, output, "")
+
+    function_globals = OPS_MODULE["print_git_snapshot"].__globals__
+    monkeypatch.setitem(function_globals, "worktree_root", lambda: ROOT)
+    monkeypatch.setitem(function_globals, "run", fake_run)
+    OPS_MODULE["print_git_snapshot"]()
+
+    output = capsys.readouterr().out
+    assert "canfieldjuan/ATLAS" in output
+    assert "canary-token" not in output
+    assert all("get-url" not in command for command in commands)
+
+
+@pytest.mark.parametrize("database_key", TEST_DATABASE_URL_KEYS)
+def test_integration_guard_admits_each_canonical_database_variable(
+    database_key: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for key in TEST_DATABASE_URL_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv(database_key, "postgresql://disposable.invalid/atlas_test")
+    monkeypatch.setenv("ATLAS_CONFIRM_DISPOSABLE_TEST_DB", "1")
+    calls: list[list[str]] = []
+
+    def fake_exec(args: list[str], **_kwargs: object) -> int:
+        calls.append(args)
+        return 0
+
+    function_globals = OPS_MODULE["test_command"].__globals__
+    monkeypatch.setitem(function_globals, "worktree_root", lambda: ROOT)
+    monkeypatch.setitem(function_globals, "exec_command", fake_exec)
+
+    assert OPS_MODULE["test_command"](["integration", "tests/example.py", "-q"]) == 0
+    assert calls and calls[0][-2:] == ["tests/example.py", "-q"]
 
 
 def test_env_keys_never_emit_values_or_evaluate_file(tmp_path: Path) -> None:
@@ -151,7 +215,8 @@ def test_capability_map_is_machine_readable_and_has_required_surfaces() -> None:
         "repository_operations",
     ):
         assert key in capabilities
-    assert capabilities["database"]["safe_query"].startswith("./ops db query")
+    assert capabilities["database"]["safe_inspection"] == "./ops db inspect connectivity"
+    assert capabilities["database"]["arbitrary_query"].startswith("unavailable")
     assert capabilities["deployment"]["brain"]["provider"] == "local systemd user service"
     assert capabilities["deployment"]["frontend"]["provider"] == "Vercel"
 

--- a/tests/test_agent_operations_contract.py
+++ b/tests/test_agent_operations_contract.py
@@ -477,6 +477,54 @@ def test_unit_mode_is_github_only_and_never_launches_pytest(
     assert calls == []
 
 
+def test_focused_mode_removes_database_authority_from_child_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    unconfirmed = "postgresql://unconfirmed.invalid/must-not-reach-focused-pytest"
+    database_keys = {
+        *TEST_DATABASE_URL_KEYS,
+        *DATABASE_CONFIG_KEYS,
+        "DATABASE_URL",
+        "EXTRACTED_DATABASE_URL",
+        "FUTURE_DATABASE_URL",
+        "PGHOST",
+        "PGPASSWORD",
+        "PGSERVICEFILE",
+        "PGFUTURE_CREDENTIAL",
+    }
+    for key in database_keys:
+        monkeypatch.setenv(key, unconfirmed)
+    monkeypatch.setenv("ATLAS_CONFIRM_DISPOSABLE_TEST_DB", "1")
+    monkeypatch.setenv("ATLAS_FOCUSED_CANARY", "preserved")
+    calls: list[tuple[list[str], dict[str, object]]] = []
+
+    def fake_exec(args: list[str], **kwargs: object) -> int:
+        calls.append((args, kwargs))
+        return 0
+
+    function_globals = OPS_MODULE["test_command"].__globals__
+    monkeypatch.setitem(function_globals, "worktree_root", lambda: ROOT)
+    monkeypatch.setitem(function_globals, "exec_command", fake_exec)
+
+    target = "tests/test_agent_operations_contract.py::test_doctor_runs_without_live_provider_access"
+    assert OPS_MODULE["test_command"](["focused", target, "-q"]) == 0
+    assert calls and calls[0][0][-2:] == [target, "-q"]
+    child_env = calls[0][1]["env"]
+    assert isinstance(child_env, dict)
+    assert all(key not in child_env for key in database_keys)
+    assert not any(
+        key == "DATABASE_URL"
+        or key.endswith("_DATABASE_URL")
+        or key.startswith("PG")
+        or key in DATABASE_CONFIG_KEYS
+        for key in child_env
+    )
+    assert "ATLAS_CONFIRM_DISPOSABLE_TEST_DB" not in child_env
+    assert child_env["ATLAS_FOCUSED_CANARY"] == "preserved"
+    assert unconfirmed not in child_env.values()
+    assert all(unconfirmed not in argument for argument in calls[0][0])
+
+
 def test_env_keys_never_emit_values_or_evaluate_file(tmp_path: Path) -> None:
     canary = "never-print-this-secret-value"
     side_effect = tmp_path / "must-not-exist"

--- a/tests/test_agent_operations_contract.py
+++ b/tests/test_agent_operations_contract.py
@@ -441,39 +441,21 @@ def test_integration_guard_rejects_additional_positional_targets(
     assert calls == []
 
 
-def test_unit_mode_removes_database_urls_from_child_environment(
+def test_unit_mode_is_github_only_and_never_launches_pytest(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    database_urls = (
-        *TEST_DATABASE_URL_KEYS,
-        "EXTRACTED_DATABASE_URL",
-        "DATABASE_URL",
-        "FUTURE_DATABASE_URL",
-    )
-    for key in database_urls:
-        monkeypatch.setenv(
-            key,
-            f"postgresql://disposable.invalid/{key.lower()}",
-        )
-    monkeypatch.setenv("ATLAS_CONFIRM_DISPOSABLE_TEST_DB", "1")
-    monkeypatch.setenv("ATLAS_UNIT_CANARY", "preserved")
-    calls: list[tuple[list[str], dict[str, object]]] = []
-
-    def fake_exec(args: list[str], **kwargs: object) -> int:
-        calls.append((args, kwargs))
-        return 0
-
+    calls: list[list[str]] = []
     function_globals = OPS_MODULE["test_command"].__globals__
     monkeypatch.setitem(function_globals, "worktree_root", lambda: ROOT)
-    monkeypatch.setitem(function_globals, "exec_command", fake_exec)
+    monkeypatch.setitem(
+        function_globals,
+        "exec_command",
+        lambda args, **_kwargs: calls.append(args) or 0,
+    )
 
-    assert OPS_MODULE["test_command"](["unit"]) == 0
-    assert calls
-    child_env = calls[0][1]["env"]
-    assert isinstance(child_env, dict)
-    assert all(key not in child_env for key in database_urls)
-    assert "ATLAS_CONFIRM_DISPOSABLE_TEST_DB" not in child_env
-    assert child_env["ATLAS_UNIT_CANARY"] == "preserved"
+    with pytest.raises(OpsError, match="full unit gate is GitHub-only"):
+        OPS_MODULE["test_command"](["unit"])
+    assert calls == []
 
 
 def test_env_keys_never_emit_values_or_evaluate_file(tmp_path: Path) -> None:

--- a/tests/test_local_pr_review.py
+++ b/tests/test_local_pr_review.py
@@ -283,82 +283,32 @@ def test_local_pr_review_forwards_pr_author_to_pre_push_audit(tmp_path: Path) ->
     assert "--pr-author dependabot[bot]" in result.stdout
 
 
-def test_local_pr_review_runs_local_unit_gate_mirror(tmp_path: Path) -> None:
+def test_local_pr_review_never_runs_local_unit_gate(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     _write_fixture_repo(repo)
     _write_unit_gate_fixture(
         repo,
         selector_script="#!/usr/bin/env python3\nprint('tests/test_example.py')\n",
-        checker_script=(
-            "#!/usr/bin/env python3\n"
-            "import os\n"
-            "import sys\n"
-            "print('body env=' + str(os.environ.get('ATLAS_CURRENT_PR_BODY_FILE')))\n"
-            "print('git prefix env=' + str(os.environ.get('GIT_PREFIX')))\n"
-            "print('pytest addopts env=' + str(os.environ.get('PYTEST_ADDOPTS')))\n"
-            "print('pytest disable plugins env=' + str(os.environ.get('PYTEST_DISABLE_PLUGIN_AUTOLOAD')))\n"
-            "print('db connection env=' + str(os.environ.get('ATLAS_DB_CONNECTION_STRING')))\n"
-            "print('db host env=' + str(os.environ.get('ATLAS_DB_HOST')))\n"
-            "print('db port env=' + str(os.environ.get('ATLAS_DB_PORT')))\n"
-            "print('db database env=' + str(os.environ.get('ATLAS_DB_DATABASE')))\n"
-            "print('db user env=' + str(os.environ.get('ATLAS_DB_USER')))\n"
-            "print('db password env=' + str(os.environ.get('ATLAS_DB_PASSWORD')))\n"
-            "print('db socket env=' + str(os.environ.get('ATLAS_DB_SOCKET_PATH')))\n"
-            "print('unit gate args=' + ' '.join(sys.argv[1:]))\n"
-        ),
+        checker_script="#!/usr/bin/env python3\nimport sys\nprint('unit checker ran')\nsys.exit(9)\n",
     )
     (repo / "requirements.unit_gate.txt").write_text("scapy==2.7.0\n", encoding="utf-8")
     _git(repo, "add", "requirements.unit_gate.txt")
     _git(repo, "commit", "-m", "add unit gate test requirements")
-    fake_python = tmp_path / "fake-python"
-    _write_executable(
-        fake_python,
-        "#!/usr/bin/env bash\n"
-        "set -euo pipefail\n"
-        "if [ \"${1:-}\" = \"-m\" ] && [ \"${2:-}\" = \"pip\" ]; then\n"
-        "  shift 2\n"
-        "  printf 'unit gate deps install=%s\\n' \"$*\"\n"
-        "  exit 0\n"
-        "fi\n"
-        f"exec {sys.executable!r} \"$@\"\n",
-    )
 
     result = _run(
         repo,
         ["bash", "scripts/local_pr_review.sh"],
-        env={
-            "ATLAS_CURRENT_PR_BODY_FILE": "/tmp/body-from-wrapper.md",
-            "GIT_PREFIX": "from-hook/",
-            "GITHUB_ACTIONS": "false",
-            "PYTEST_ADDOPTS": "-k passing",
-            "PYTEST_DISABLE_PLUGIN_AUTOLOAD": "1",
-            "ATLAS_DB_SOCKET_PATH": "/tmp/dev-postgres.sock",
-            "PYTHON": str(fake_python),
-        },
+        env={"GITHUB_ACTIONS": "false"},
     )
 
-    stdout_lines = set(result.stdout.splitlines())
     assert result.returncode == 0, result.stdout + result.stderr
-    assert "Local unit gate mirror" in result.stdout
-    assert "unit gate deps install=install -r " + str(repo / "requirements.unit_gate.txt") in stdout_lines
-    assert "body env=None" in stdout_lines
-    assert "git prefix env=None" in stdout_lines
-    assert "pytest addopts env=None" in stdout_lines
-    assert "pytest disable plugins env=None" in stdout_lines
-    assert "db connection env=" in stdout_lines
-    assert "db host env=127.0.0.1" in stdout_lines
-    assert "db port env=1" in stdout_lines
-    assert "db database env=atlas" in stdout_lines
-    assert "db user env=atlas" in stdout_lines
-    assert "db password env=atlas_dev_password" in stdout_lines
-    assert "db socket env=" in stdout_lines
-    assert "running 1 impacted test file(s)" in result.stdout
-    assert "--selected-files" in result.stdout
-    assert "tests/test_example.py -m not integration and not e2e" in result.stdout
+    assert "GitHub Actions owns .github/workflows/unit_gate.yml" in result.stdout
+    assert "unit checker ran" not in result.stdout
+    assert "installing unit-gate test dependencies" not in result.stdout
     assert "local PR review passed" in result.stdout
 
 
-def test_local_pr_review_unit_gate_mirror_runs_growth_only_for_empty_selection(tmp_path: Path) -> None:
+def test_local_pr_review_ignores_empty_unit_selection_locally(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     _write_fixture_repo(repo)
     _write_unit_gate_fixture(repo, selector_script="#!/usr/bin/env python3\n")
@@ -366,13 +316,12 @@ def test_local_pr_review_unit_gate_mirror_runs_growth_only_for_empty_selection(t
     result = _run(repo, ["bash", "scripts/local_pr_review.sh"], env={"GITHUB_ACTIONS": "false"})
 
     assert result.returncode == 0, result.stdout + result.stderr
-    assert "no test is reachable from the changed files; growth guard only" in result.stdout
-    assert "--growth-only" in result.stdout
-    assert "--selected-files" not in result.stdout
+    assert "GitHub Actions owns .github/workflows/unit_gate.yml" in result.stdout
+    assert "no test is reachable from the changed files" not in result.stdout
     assert "local PR review passed" in result.stdout
 
 
-def test_local_pr_review_unit_gate_mirror_runs_full_selection(tmp_path: Path) -> None:
+def test_local_pr_review_ignores_full_unit_selection_locally(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     _write_fixture_repo(repo)
     _write_unit_gate_fixture(repo, selector_script="#!/usr/bin/env python3\nprint('FULL')\n")
@@ -380,13 +329,12 @@ def test_local_pr_review_unit_gate_mirror_runs_full_selection(tmp_path: Path) ->
     result = _run(repo, ["bash", "scripts/local_pr_review.sh"], env={"GITHUB_ACTIONS": "false"})
 
     assert result.returncode == 0, result.stdout + result.stderr
-    assert "running the FULL suite (selection escalated)" in result.stdout
-    assert "--growth-only" not in result.stdout
-    assert "--selected-files" not in result.stdout
+    assert "GitHub Actions owns .github/workflows/unit_gate.yml" in result.stdout
+    assert "running the FULL suite" not in result.stdout
     assert "local PR review passed" in result.stdout
 
 
-def test_local_pr_review_unit_gate_mirror_checker_failures_block_every_mode(tmp_path: Path) -> None:
+def test_local_pr_review_never_calls_unit_checker_in_any_selection_mode(tmp_path: Path) -> None:
     cases = {
         "selected": (
             "#!/usr/bin/env python3\nprint('tests/test_example.py')\n",
@@ -416,15 +364,14 @@ def test_local_pr_review_unit_gate_mirror_checker_failures_block_every_mode(tmp_
 
         result = _run(repo, ["bash", "scripts/local_pr_review.sh"], env={"GITHUB_ACTIONS": "false"})
 
-        assert result.returncode == 1, result.stdout + result.stderr
-        assert "Local unit gate mirror" in result.stdout
-        assert mode_message in result.stdout
-        assert args_fragment in result.stdout
-        assert "unit gate rejected:" in result.stdout
-        assert "1 local review check(s) failed" in result.stdout
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "GitHub Actions owns .github/workflows/unit_gate.yml" in result.stdout
+        assert mode_message not in result.stdout
+        assert args_fragment not in result.stdout
+        assert "unit gate rejected:" not in result.stdout
 
 
-def test_local_pr_review_unit_gate_mirror_propagates_selector_failure(tmp_path: Path) -> None:
+def test_local_pr_review_never_calls_failing_unit_selector(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     _write_fixture_repo(repo)
     _write_unit_gate_fixture(
@@ -435,14 +382,13 @@ def test_local_pr_review_unit_gate_mirror_propagates_selector_failure(tmp_path: 
 
     result = _run(repo, ["bash", "scripts/local_pr_review.sh"], env={"GITHUB_ACTIONS": "false"})
 
-    assert result.returncode == 1
-    assert "Local unit gate mirror" in result.stdout
-    assert "selector failed while choosing local unit-gate tests" in result.stdout
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "GitHub Actions owns .github/workflows/unit_gate.yml" in result.stdout
+    assert "selector failed" not in result.stdout
     assert "unit gate should not run" not in result.stdout
-    assert "1 local review check(s) failed" in result.stdout
 
 
-def test_local_pr_review_unit_gate_mirror_fails_when_checker_was_removed(tmp_path: Path) -> None:
+def test_local_pr_review_does_not_require_local_unit_checker(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     _write_fixture_repo(repo)
     _write_unit_gate_fixture(repo, selector_script="#!/usr/bin/env python3\nprint('FULL')\n")
@@ -452,14 +398,12 @@ def test_local_pr_review_unit_gate_mirror_fails_when_checker_was_removed(tmp_pat
 
     result = _run(repo, ["bash", "scripts/local_pr_review.sh"], env={"GITHUB_ACTIONS": "false"})
 
-    assert result.returncode == 1
-    assert "Local unit gate mirror" in result.stdout
-    assert "scripts/check_unit_gate.py is absent from this PR head" in result.stdout
-    assert "SKIP (scripts/check_unit_gate.py not found)" not in result.stdout
-    assert "1 local review check(s) failed" in result.stdout
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "GitHub Actions owns .github/workflows/unit_gate.yml" in result.stdout
+    assert "scripts/check_unit_gate.py is absent" not in result.stdout
 
 
-def test_local_pr_review_skips_unit_gate_mirror_in_github_actions(tmp_path: Path) -> None:
+def test_local_pr_review_defers_unit_gate_inside_github_actions(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     _write_fixture_repo(repo)
     _write_executable(
@@ -472,7 +416,7 @@ def test_local_pr_review_skips_unit_gate_mirror_in_github_actions(tmp_path: Path
     result = _run(repo, ["bash", "scripts/local_pr_review.sh"], env={"GITHUB_ACTIONS": "true"})
 
     assert result.returncode == 0, result.stdout + result.stderr
-    assert "SKIP (GitHub Actions runs .github/workflows/unit_gate.yml as its own required check)" in result.stdout
+    assert "GitHub Actions owns .github/workflows/unit_gate.yml" in result.stdout
     assert "should not run" not in result.stdout
     assert "local PR review passed" in result.stdout
 
@@ -807,12 +751,8 @@ def test_local_pr_review_skips_plans_advisory_when_absent(tmp_path: Path) -> Non
     assert "SKIP (scripts/archive_plans.py not found)" in result.stdout
 
 
-def test_local_pr_review_unit_gate_mirror_sets_recursion_guard(tmp_path: Path) -> None:
-    """The unit gate must run with ATLAS_SKIP_LOCAL_PR_REVIEW=1.
-
-    Without it, a push performed by a test inside the gated suite re-enters
-    the pre-push hook, which re-runs this script, which pushes again.
-    """
+def test_local_pr_review_does_not_launch_unit_gate_with_ambient_guard(tmp_path: Path) -> None:
+    """The hosted-only boundary must hold regardless of ambient guard state."""
     repo = tmp_path / "repo"
     _write_fixture_repo(repo)
     _write_unit_gate_fixture(
@@ -834,14 +774,15 @@ def test_local_pr_review_unit_gate_mirror_sets_recursion_guard(tmp_path: Path) -
     )
 
     assert result.returncode == 0, result.stdout + result.stderr
-    assert "skip local pr review env=1" in result.stdout.splitlines()
+    assert "GitHub Actions owns .github/workflows/unit_gate.yml" in result.stdout
+    assert "skip local pr review env=" not in result.stdout
 
 
 def test_conftest_preserves_the_recursion_guard() -> None:
     """conftest must keep ATLAS_SKIP_LOCAL_PR_REVIEW set for the suite.
 
     Dropping it would let a test that pushes into a repo with a managed
-    pre-push hook re-enter review -> unit gate -> pytest.
+    pre-push hook re-enter the local mechanical review path.
     """
     assert os.environ.get("ATLAS_SKIP_LOCAL_PR_REVIEW") == "1"
 
@@ -849,9 +790,9 @@ def test_conftest_preserves_the_recursion_guard() -> None:
 def test_recursion_guard_survives_a_real_pytest_launch() -> None:
     """Cover the checker -> pytest path, not just a stub that prints its env.
 
-    scripts/check_unit_gate.py launches pytest, which imports conftest. This
-    asserts the guard supplied by scripts/local_pr_review.sh is still set once
-    that import has happened -- the step a stub checker cannot exercise.
+    A focused pytest process imports conftest. This asserts the push-recursion
+    guard remains set there even though local review no longer launches the
+    unit checker.
     """
     result = subprocess.run(
         [


### PR DESCRIPTION
Plan: plans/PR-Agent-Operations-Contract.md
Slice phase: workflow/process
Ownership lane: agent-operations

Atlas operational knowledge was fragmented across stale prose, provider configuration, ignored local state, and authenticated CLIs. This slice establishes one verified, read-only-first operations contract without changing application behavior, provider resources, CI, or database state. The live archaeology also corrected two concrete entrypoint traps: root Compose does not provide PostgreSQL, and the repository has no root `.env.example`.

Diff-budget override: The operator-mandated contract is indivisible because the capability map, seven focused runbooks, discovery ledger, executable operations layer, fresh-agent pointers, and boundary tests must land together to provide a complete verified path.

## Intentional
- `./ops` exposes deployment inspection but no deployment mutation (`ops:535`).
- Database access exposes only fixed named inspections; arbitrary SQL remains unavailable until Atlas has a privilege-restricted inspection role (`ops:247`, `ops:479`).
- Complete database connection strings stay in the child environment and are consumed by Atlas's own `DatabaseConfig`/asyncpg path, never process argv (`ops:230`, `ops:253`).
- Environment inspection parses names without sourcing files or printing values (`ops:443`).
- Shared ignored `.env`, `.venv`, and Vercel linkage remain outside version control; the command discovers those sources at runtime.

## AI reconciliation
- Reject SELECT functions with operational side effects -- fixed-in: `ops:247`, `ops:253`, `tests/test_agent_operations_contract.py:23`
- Admit every documented integration database variable -- fixed-in: `ops:48`, `ops:686`, `tests/test_agent_operations_contract.py:157`
- Preserve PostgreSQL connection-string query parameters -- fixed-in: `ops:230`, `ops:253`, `tests/test_agent_operations_contract.py:65`
- Redact credentials from the Git remote snapshot -- fixed-in: `ops:379`, `tests/test_agent_operations_contract.py:134`
- Preserve dotenv parsing semantics for database settings -- fixed-in: `ops:210`, `ops:230`, `tests/test_agent_operations_contract.py:87`
- Keep database-backed tests out of unit mode -- fixed-in: `ops:650`, `ops:660`, `tests/test_agent_operations_contract.py:179`
- Keep doctor usable before dependencies are installed -- fixed-in: `c7914badd`, `ops:309`, `tests/test_agent_operations_contract.py:136`
- Redact credentials from configured health URLs -- fixed-in: `c7914badd`, `ops:361`, `tests/test_agent_operations_contract.py:162`
- Require a bounded integration-test target -- fixed-in: `c7914badd`, `ops:668`, `tests/test_agent_operations_contract.py:220`
- Replace the nonexistent runtime command -- fixed-in: `c7914badd`, `.agent/capabilities.yaml:9`, `tests/test_agent_operations_contract.py:410`
- Resolve bare common directories as the shared root -- fixed-in: `2bafd3da6`, `ops:106`, `tests/test_agent_operations_contract.py:25`
- Reject ambiguous integration database selections -- fixed-in: `0d49a4f92`, `ops:764`, `tests/test_agent_operations_contract.py:336`
- Honor the worktree database configuration precedence -- fixed-in: `0d49a4f92`, `ops:210`, `tests/test_agent_operations_contract.py:163`
- Describe direct bare common directories accurately -- fixed-in: `0d49a4f92`, `.agent/capabilities.yaml:23`, `tests/test_agent_operations_contract.py:611`
- Distinguish an unavailable Docker daemon from absent containers -- fixed-in: `0d49a4f92`, `ops:545`, `tests/test_agent_operations_contract.py:516`
- Sanitize unconfirmed database URLs before integration pytest -- fixed-in: `8700d73b4`, `ops:712`, `ops:804`, `tests/test_agent_operations_contract.py:312`
- Keep the unit gate GitHub-only -- fixed-in: `scripts/local_pr_review.sh`, `ops`, `tests/test_local_pr_review.py`, `tests/test_agent_operations_contract.py`
- Strip inherited libpq credentials before integration tests -- fixed-in: `d30849493`, `ops`, `tests/test_agent_operations_contract.py`, `.agent/runbooks/database.md`
- Parse dotenv files with the selected project interpreter -- waived-out-of-scope: non-blocking availability improvement parked in the plan Deferred section; no code change in the frozen pass
- Reject unreadable selected database configuration -- waived-out-of-scope: non-blocking read-only inspection hardening parked in the plan Deferred section; no code change in the frozen pass
- Route database-backed focused tests through the integration guard -- fixed-in: `8d6e59683`, `ops`, `tests/test_agent_operations_contract.py`, `.agent/runbooks/testing.md`, `.agent/runbooks/database.md`
- Verify the Brain response before reporting it healthy -- waived-out-of-scope: non-blocking status-accuracy hardening parked in the plan Deferred section; no code change in the frozen pass
- Include every tracked container in status -- waived-out-of-scope: non-blocking inventory completeness parked in the plan Deferred section; no code change in the frozen pass
- Verify the shared Vercel link before inspecting project state -- waived-out-of-scope: non-blocking provider hardening parked in the plan Deferred section; no code change in the frozen pass

## Fix-loop disposition preflight
- Root decision: Reject SELECT functions with operational side effects
- Source trace: advertised safe arbitrary SQL -> application-role function execution
- Upstream files: `ops`, `tests/test_agent_operations_contract.py`, `.agent/capabilities.yaml`, `.agent/runbooks/database.md`, `.agent/runbooks/discovery-ledger.md`
- Fix strategy: upstream-root
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: `.agent/capabilities.yaml`, `.agent/runbooks/ci.md`, `.agent/runbooks/database.md`, `.agent/runbooks/deployment.md`, `.agent/runbooks/discovery-ledger.md`, `.agent/runbooks/environment.md`, `.agent/runbooks/logs.md`, `.agent/runbooks/testing.md`, `AGENTS.md`, `CLAUDE.md`, `README.md`, `ops`, `plans/PR-Agent-Operations-Contract.md`, `tests/test_agent_operations_contract.py`
- Max files: 16
- Parked hardening: none

- Root decision: Reject ambiguous integration database selections
- Source trace: multiple active canonical URLs -> presence-only admission -> pytest inherits every destructive-test credential
- Upstream files: `ops`, `tests/test_agent_operations_contract.py`, `.agent/capabilities.yaml`, `.agent/runbooks/database.md`, `.agent/runbooks/discovery-ledger.md`, `plans/PR-Agent-Operations-Contract.md`
- Fix strategy: upstream-root
- Blocking predicate: data
- Disposition: fixed-in
- Allowed files: `.agent/capabilities.yaml`, `.agent/runbooks/ci.md`, `.agent/runbooks/database.md`, `.agent/runbooks/deployment.md`, `.agent/runbooks/discovery-ledger.md`, `.agent/runbooks/environment.md`, `.agent/runbooks/logs.md`, `.agent/runbooks/testing.md`, `AGENTS.md`, `CLAUDE.md`, `README.md`, `ops`, `plans/PR-Agent-Operations-Contract.md`, `tests/test_agent_operations_contract.py`
- Max files: 16
- Parked hardening: none

- Root decision: Honor the worktree database configuration precedence
- Source trace: deliberately provisioned worktree files -> broad source accumulation -> shared or systemd values overwrite the application context
- Upstream files: `ops`, `tests/test_agent_operations_contract.py`, `.agent/capabilities.yaml`, `.agent/runbooks/database.md`, `.agent/runbooks/discovery-ledger.md`, `plans/PR-Agent-Operations-Contract.md`
- Fix strategy: upstream-root
- Blocking predicate: data
- Disposition: fixed-in
- Allowed files: `.agent/capabilities.yaml`, `.agent/runbooks/ci.md`, `.agent/runbooks/database.md`, `.agent/runbooks/deployment.md`, `.agent/runbooks/discovery-ledger.md`, `.agent/runbooks/environment.md`, `.agent/runbooks/logs.md`, `.agent/runbooks/testing.md`, `AGENTS.md`, `CLAUDE.md`, `README.md`, `ops`, `plans/PR-Agent-Operations-Contract.md`, `tests/test_agent_operations_contract.py`
- Max files: 16
- Parked hardening: none

- Root decision: Describe direct bare common directories accurately
- Source trace: successful direct-bare common-directory resolution -> unconditional parent metadata -> future agents inspect the wrong shared state location
- Upstream files: `.agent/capabilities.yaml`, `tests/test_agent_operations_contract.py`, `plans/PR-Agent-Operations-Contract.md`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `.agent/capabilities.yaml`, `.agent/runbooks/ci.md`, `.agent/runbooks/database.md`, `.agent/runbooks/deployment.md`, `.agent/runbooks/discovery-ledger.md`, `.agent/runbooks/environment.md`, `.agent/runbooks/logs.md`, `.agent/runbooks/testing.md`, `AGENTS.md`, `CLAUDE.md`, `README.md`, `ops`, `plans/PR-Agent-Operations-Contract.md`, `tests/test_agent_operations_contract.py`
- Max files: 16
- Parked hardening: none

- Root decision: Distinguish an unavailable Docker daemon from absent containers
- Source trace: Docker CLI present but daemon unavailable -> failed object inspect -> every known container reported absent
- Upstream files: `ops`, `tests/test_agent_operations_contract.py`, `.agent/capabilities.yaml`, `.agent/runbooks/discovery-ledger.md`, `plans/PR-Agent-Operations-Contract.md`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `.agent/capabilities.yaml`, `.agent/runbooks/ci.md`, `.agent/runbooks/database.md`, `.agent/runbooks/deployment.md`, `.agent/runbooks/discovery-ledger.md`, `.agent/runbooks/environment.md`, `.agent/runbooks/logs.md`, `.agent/runbooks/testing.md`, `AGENTS.md`, `CLAUDE.md`, `README.md`, `ops`, `plans/PR-Agent-Operations-Contract.md`, `tests/test_agent_operations_contract.py`
- Max files: 16
- Parked hardening: none

- Root decision: Sanitize unconfirmed database URLs before integration pytest
- Source trace: exact-one canonical confirmation -> unfiltered parent environment -> generic or Atlas application database credential selected by a destructive focused test
- Upstream files: `ops`, `tests/test_agent_operations_contract.py`, `.agent/capabilities.yaml`, `.agent/runbooks/database.md`, `.agent/runbooks/discovery-ledger.md`, `plans/PR-Agent-Operations-Contract.md`
- Fix strategy: upstream-root
- Blocking predicate: data
- Disposition: fixed-in
- Allowed files: `.agent/capabilities.yaml`, `.agent/runbooks/ci.md`, `.agent/runbooks/database.md`, `.agent/runbooks/deployment.md`, `.agent/runbooks/discovery-ledger.md`, `.agent/runbooks/environment.md`, `.agent/runbooks/logs.md`, `.agent/runbooks/testing.md`, `AGENTS.md`, `CLAUDE.md`, `README.md`, `ops`, `plans/PR-Agent-Operations-Contract.md`, `tests/test_agent_operations_contract.py`
- Max files: 16
- Parked hardening: none

- Root decision: Keep the unit gate GitHub-only
- Source trace: guarded local push -> local review unit mirror -> long-running local pytest despite GitHub owning the required gate
- Upstream files: `scripts/local_pr_review.sh`, `ops`, `tests/test_local_pr_review.py`, `tests/test_agent_operations_contract.py`, `AGENTS.md`, `.agent/capabilities.yaml`, `.agent/runbooks/testing.md`, `.agent/runbooks/ci.md`, `.agent/runbooks/discovery-ledger.md`, `plans/PR-Agent-Operations-Contract.md`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `.agent/capabilities.yaml`, `.agent/runbooks/ci.md`, `.agent/runbooks/database.md`, `.agent/runbooks/deployment.md`, `.agent/runbooks/discovery-ledger.md`, `.agent/runbooks/environment.md`, `.agent/runbooks/logs.md`, `.agent/runbooks/testing.md`, `AGENTS.md`, `CLAUDE.md`, `README.md`, `ops`, `plans/PR-Agent-Operations-Contract.md`, `scripts/local_pr_review.sh`, `tests/test_agent_operations_contract.py`, `tests/test_local_pr_review.py`
- Max files: 16
- Parked hardening: none

- Root decision: Strip inherited libpq credentials before integration tests
- Source trace: confirmed disposable URL -> inherited libpq PG* environment -> selected test or subprocess can address an unconfirmed database
- Upstream files: `ops`, `tests/test_agent_operations_contract.py`, `.agent/capabilities.yaml`, `.agent/runbooks/database.md`, `.agent/runbooks/testing.md`, `.agent/runbooks/discovery-ledger.md`, `plans/PR-Agent-Operations-Contract.md`
- Fix strategy: upstream-root
- Blocking predicate: data
- Disposition: fixed-in
- Allowed files: `.agent/capabilities.yaml`, `.agent/runbooks/ci.md`, `.agent/runbooks/database.md`, `.agent/runbooks/deployment.md`, `.agent/runbooks/discovery-ledger.md`, `.agent/runbooks/environment.md`, `.agent/runbooks/logs.md`, `.agent/runbooks/testing.md`, `AGENTS.md`, `CLAUDE.md`, `README.md`, `ops`, `plans/PR-Agent-Operations-Contract.md`, `scripts/local_pr_review.sh`, `tests/test_agent_operations_contract.py`, `tests/test_local_pr_review.py`
- Max files: 16
- Parked hardening: none

- Root decision: Parse dotenv files with the selected project interpreter
- Source trace: fresh linked worktree -> wrapper interpreter lacks python-dotenv -> explicit read-only database inspection is unavailable despite a dependency-complete project interpreter
- Upstream files: `ops`, `.agent/runbooks/database.md`, `tests/test_agent_operations_contract.py`, `plans/PR-Agent-Operations-Contract.md`
- Fix strategy: symptom-only-deferred
- Symptom-only reason: availability hardening is not a merge blocker and the operator required a frozen blocker-only pass
- Follow-up: plan Deferred item for project-interpreter dotenv decoding when a product run proves the availability gap blocks work
- Blocking predicate: not-blocking
- Disposition: waived-out-of-scope
- Allowed files: `.agent/capabilities.yaml`, `.agent/runbooks/ci.md`, `.agent/runbooks/database.md`, `.agent/runbooks/deployment.md`, `.agent/runbooks/discovery-ledger.md`, `.agent/runbooks/environment.md`, `.agent/runbooks/logs.md`, `.agent/runbooks/testing.md`, `AGENTS.md`, `CLAUDE.md`, `README.md`, `ops`, `plans/PR-Agent-Operations-Contract.md`, `scripts/local_pr_review.sh`, `tests/test_agent_operations_contract.py`, `tests/test_local_pr_review.py`
- Max files: 16
- Parked hardening: plans/PR-Agent-Operations-Contract.md Deferred project-interpreter dotenv decoding item

- Root decision: Reject unreadable selected database configuration
- Source trace: unreadable selected env file -> empty parsed settings -> read-only inspection can fall back to a different default database
- Upstream files: `ops`, `.agent/runbooks/database.md`, `tests/test_agent_operations_contract.py`, `plans/PR-Agent-Operations-Contract.md`
- Fix strategy: symptom-only-deferred
- Symptom-only reason: read-only inspection hardening is not a merge blocker and the operator required a frozen blocker-only pass
- Follow-up: plan Deferred item for fail-closed unreadable selected database configuration after the current operations contract lands
- Blocking predicate: not-blocking
- Disposition: waived-out-of-scope
- Allowed files: `.agent/capabilities.yaml`, `.agent/runbooks/ci.md`, `.agent/runbooks/database.md`, `.agent/runbooks/deployment.md`, `.agent/runbooks/discovery-ledger.md`, `.agent/runbooks/environment.md`, `.agent/runbooks/logs.md`, `.agent/runbooks/testing.md`, `AGENTS.md`, `CLAUDE.md`, `README.md`, `ops`, `plans/PR-Agent-Operations-Contract.md`, `scripts/local_pr_review.sh`, `tests/test_agent_operations_contract.py`, `tests/test_local_pr_review.py`
- Max files: 16
- Parked hardening: plans/PR-Agent-Operations-Contract.md Deferred unreadable selected database configuration item

- Root decision: Route database-backed focused tests through the integration guard
- Source trace: focused pytest entrypoint -> ambient database credentials -> writing test bypasses disposable confirmation and integration child isolation
- Upstream files: `ops`, `tests/test_agent_operations_contract.py`, `.agent/capabilities.yaml`, `.agent/runbooks/testing.md`, `.agent/runbooks/database.md`, `.agent/runbooks/discovery-ledger.md`, `plans/PR-Agent-Operations-Contract.md`
- Fix strategy: upstream-root
- Blocking predicate: data
- Disposition: fixed-in
- Allowed files: `.agent/capabilities.yaml`, `.agent/runbooks/ci.md`, `.agent/runbooks/database.md`, `.agent/runbooks/deployment.md`, `.agent/runbooks/discovery-ledger.md`, `.agent/runbooks/environment.md`, `.agent/runbooks/logs.md`, `.agent/runbooks/testing.md`, `AGENTS.md`, `CLAUDE.md`, `README.md`, `ops`, `plans/PR-Agent-Operations-Contract.md`, `scripts/local_pr_review.sh`, `tests/test_agent_operations_contract.py`, `tests/test_local_pr_review.py`
- Max files: 16
- Parked hardening: none

- Root decision: Verify the Brain response before reporting it healthy
- Source trace: candidate Brain URL -> unrelated 2xx payload -> status probe can report a false-positive healthy service
- Upstream files: `ops`, `atlas_brain/api/health.py`, `tests/test_agent_operations_contract.py`, `plans/PR-Agent-Operations-Contract.md`
- Fix strategy: symptom-only-deferred
- Symptom-only reason: no current-head evidence shows an unrelated service at the configured endpoint, and the operator required blocker-only convergence
- Follow-up: plan Deferred Brain response identity item after an observed false-positive or operator-prioritized hardening slice
- Blocking predicate: not-blocking
- Disposition: waived-out-of-scope
- Allowed files: `.agent/capabilities.yaml`, `.agent/runbooks/ci.md`, `.agent/runbooks/database.md`, `.agent/runbooks/deployment.md`, `.agent/runbooks/discovery-ledger.md`, `.agent/runbooks/environment.md`, `.agent/runbooks/logs.md`, `.agent/runbooks/testing.md`, `AGENTS.md`, `CLAUDE.md`, `README.md`, `ops`, `plans/PR-Agent-Operations-Contract.md`, `scripts/local_pr_review.sh`, `tests/test_agent_operations_contract.py`, `tests/test_local_pr_review.py`
- Max files: 16
- Parked hardening: plans/PR-Agent-Operations-Contract.md Deferred Brain response identity item

- Root decision: Include every tracked container in status
- Source trace: aggregate container registry -> omitted Home Assistant and Wyze names -> status can omit running tracked dependencies
- Upstream files: `ops`, `docker-compose.ha.yml`, `docker-compose.wyze.yml`, `.agent/capabilities.yaml`, `plans/PR-Agent-Operations-Contract.md`
- Fix strategy: symptom-only-deferred
- Symptom-only reason: the tracked stacks remain directly inspectable and the operator required blocker-only convergence
- Follow-up: plan Deferred aggregate Home Assistant and Wyze status enrollment item
- Blocking predicate: not-blocking
- Disposition: waived-out-of-scope
- Allowed files: `.agent/capabilities.yaml`, `.agent/runbooks/ci.md`, `.agent/runbooks/database.md`, `.agent/runbooks/deployment.md`, `.agent/runbooks/discovery-ledger.md`, `.agent/runbooks/environment.md`, `.agent/runbooks/logs.md`, `.agent/runbooks/testing.md`, `AGENTS.md`, `CLAUDE.md`, `README.md`, `ops`, `plans/PR-Agent-Operations-Contract.md`, `scripts/local_pr_review.sh`, `tests/test_agent_operations_contract.py`, `tests/test_local_pr_review.py`
- Max files: 16
- Parked hardening: plans/PR-Agent-Operations-Contract.md Deferred aggregate container enrollment item

- Root decision: Verify the shared Vercel link before inspecting project state
- Source trace: shared ignored Vercel link -> existence-only admission -> project-scoped inspection can target unrelated metadata
- Upstream files: `ops`, `.agent/capabilities.yaml`, `.agent/runbooks/deployment.md`, `.agent/runbooks/environment.md`, `plans/PR-Agent-Operations-Contract.md`
- Fix strategy: symptom-only-deferred
- Symptom-only reason: the current authenticated project link was verified during archaeology and the operator required blocker-only convergence
- Follow-up: plan Deferred shared Vercel link identity item after observed drift or an operator-prioritized provider-hardening slice
- Blocking predicate: not-blocking
- Disposition: waived-out-of-scope
- Allowed files: `.agent/capabilities.yaml`, `.agent/runbooks/ci.md`, `.agent/runbooks/database.md`, `.agent/runbooks/deployment.md`, `.agent/runbooks/discovery-ledger.md`, `.agent/runbooks/environment.md`, `.agent/runbooks/logs.md`, `.agent/runbooks/testing.md`, `AGENTS.md`, `CLAUDE.md`, `README.md`, `ops`, `plans/PR-Agent-Operations-Contract.md`, `scripts/local_pr_review.sh`, `tests/test_agent_operations_contract.py`, `tests/test_local_pr_review.py`
- Max files: 16
- Parked hardening: plans/PR-Agent-Operations-Contract.md Deferred shared Vercel link identity item

- Root decision: Resolve bare common directories as the shared root
- Source trace: successful non-`.git` Git common-dir lookup -> fallback to current worktree -> shared ignored state unavailable
- Upstream files: `ops`, `tests/test_agent_operations_contract.py`, `.agent/runbooks/discovery-ledger.md`, `plans/PR-Agent-Operations-Contract.md`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `.agent/capabilities.yaml`, `.agent/runbooks/ci.md`, `.agent/runbooks/database.md`, `.agent/runbooks/deployment.md`, `.agent/runbooks/discovery-ledger.md`, `.agent/runbooks/environment.md`, `.agent/runbooks/logs.md`, `.agent/runbooks/testing.md`, `AGENTS.md`, `CLAUDE.md`, `README.md`, `ops`, `plans/PR-Agent-Operations-Contract.md`, `tests/test_agent_operations_contract.py`
- Max files: 16
- Parked hardening: none

- Root decision: Keep doctor usable before dependencies are installed
- Source trace: pre-install doctor -> database status probe -> missing python-dotenv import -> whole snapshot abort
- Upstream files: `ops`, `tests/test_agent_operations_contract.py`, `.agent/runbooks/discovery-ledger.md`, `plans/PR-Agent-Operations-Contract.md`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `.agent/capabilities.yaml`, `.agent/runbooks/ci.md`, `.agent/runbooks/database.md`, `.agent/runbooks/deployment.md`, `.agent/runbooks/discovery-ledger.md`, `.agent/runbooks/environment.md`, `.agent/runbooks/logs.md`, `.agent/runbooks/testing.md`, `AGENTS.md`, `CLAUDE.md`, `README.md`, `ops`, `plans/PR-Agent-Operations-Contract.md`, `tests/test_agent_operations_contract.py`
- Max files: 16
- Parked hardening: none

- Root decision: Redact credentials from configured health URLs
- Source trace: configured credential-bearing health URL -> successful request -> raw doctor status detail
- Upstream files: `ops`, `tests/test_agent_operations_contract.py`, `.agent/runbooks/discovery-ledger.md`, `plans/PR-Agent-Operations-Contract.md`
- Fix strategy: upstream-root
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: `.agent/capabilities.yaml`, `.agent/runbooks/ci.md`, `.agent/runbooks/database.md`, `.agent/runbooks/deployment.md`, `.agent/runbooks/discovery-ledger.md`, `.agent/runbooks/environment.md`, `.agent/runbooks/logs.md`, `.agent/runbooks/testing.md`, `AGENTS.md`, `CLAUDE.md`, `README.md`, `ops`, `plans/PR-Agent-Operations-Contract.md`, `tests/test_agent_operations_contract.py`
- Max files: 16
- Parked hardening: none

- Root decision: Require a bounded integration-test target
- Source trace: disposable database confirmation -> nonempty pytest argv -> option-only or directory-wide collection
- Upstream files: `ops`, `tests/test_agent_operations_contract.py`, `.agent/capabilities.yaml`, `.agent/runbooks/testing.md`, `.agent/runbooks/discovery-ledger.md`, `plans/PR-Agent-Operations-Contract.md`
- Fix strategy: upstream-root
- Blocking predicate: data
- Disposition: fixed-in
- Allowed files: `.agent/capabilities.yaml`, `.agent/runbooks/ci.md`, `.agent/runbooks/database.md`, `.agent/runbooks/deployment.md`, `.agent/runbooks/discovery-ledger.md`, `.agent/runbooks/environment.md`, `.agent/runbooks/logs.md`, `.agent/runbooks/testing.md`, `AGENTS.md`, `CLAUDE.md`, `README.md`, `ops`, `plans/PR-Agent-Operations-Contract.md`, `tests/test_agent_operations_contract.py`
- Max files: 16
- Parked hardening: none

- Root decision: Replace the nonexistent runtime command
- Source trace: capability-map source-of-truth command -> CLI dispatcher without runtime command
- Upstream files: `.agent/capabilities.yaml`, `tests/test_agent_operations_contract.py`, `plans/PR-Agent-Operations-Contract.md`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `.agent/capabilities.yaml`, `.agent/runbooks/ci.md`, `.agent/runbooks/database.md`, `.agent/runbooks/deployment.md`, `.agent/runbooks/discovery-ledger.md`, `.agent/runbooks/environment.md`, `.agent/runbooks/logs.md`, `.agent/runbooks/testing.md`, `AGENTS.md`, `CLAUDE.md`, `README.md`, `ops`, `plans/PR-Agent-Operations-Contract.md`, `tests/test_agent_operations_contract.py`
- Max files: 16
- Parked hardening: none

- Root decision: Preserve dotenv parsing semantics for database settings
- Source trace: valid dotenv assignment -> handwritten raw value extraction -> different DatabaseConfig input
- Upstream files: `ops`, `tests/test_agent_operations_contract.py`, `.agent/runbooks/discovery-ledger.md`, `plans/PR-Agent-Operations-Contract.md`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `.agent/capabilities.yaml`, `.agent/runbooks/ci.md`, `.agent/runbooks/database.md`, `.agent/runbooks/deployment.md`, `.agent/runbooks/discovery-ledger.md`, `.agent/runbooks/environment.md`, `.agent/runbooks/logs.md`, `.agent/runbooks/testing.md`, `AGENTS.md`, `CLAUDE.md`, `README.md`, `ops`, `plans/PR-Agent-Operations-Contract.md`, `tests/test_agent_operations_contract.py`
- Max files: 16
- Parked hardening: none

- Root decision: Keep database-backed tests out of unit mode
- Source trace: unit marker selector -> inherited environment -> unmarked PostgreSQL test gates
- Upstream files: `ops`, `tests/test_agent_operations_contract.py`, `.agent/capabilities.yaml`, `.agent/runbooks/testing.md`, `.agent/runbooks/discovery-ledger.md`, `plans/PR-Agent-Operations-Contract.md`
- Fix strategy: upstream-root
- Blocking predicate: data
- Disposition: fixed-in
- Allowed files: `.agent/capabilities.yaml`, `.agent/runbooks/ci.md`, `.agent/runbooks/database.md`, `.agent/runbooks/deployment.md`, `.agent/runbooks/discovery-ledger.md`, `.agent/runbooks/environment.md`, `.agent/runbooks/logs.md`, `.agent/runbooks/testing.md`, `AGENTS.md`, `CLAUDE.md`, `README.md`, `ops`, `plans/PR-Agent-Operations-Contract.md`, `tests/test_agent_operations_contract.py`
- Max files: 16
- Parked hardening: none

- Root decision: Admit every documented integration database variable
- Source trace: documented legacy test invocation -> sampled two-variable guard
- Upstream files: `ops`, `tests/test_agent_operations_contract.py`, `.agent/capabilities.yaml`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `.agent/capabilities.yaml`, `.agent/runbooks/ci.md`, `.agent/runbooks/database.md`, `.agent/runbooks/deployment.md`, `.agent/runbooks/discovery-ledger.md`, `.agent/runbooks/environment.md`, `.agent/runbooks/logs.md`, `.agent/runbooks/testing.md`, `AGENTS.md`, `CLAUDE.md`, `README.md`, `ops`, `plans/PR-Agent-Operations-Contract.md`, `tests/test_agent_operations_contract.py`
- Max files: 16
- Parked hardening: none

- Root decision: Preserve PostgreSQL connection-string query parameters
- Source trace: complete application DSN -> lossy psql environment decomposition
- Upstream files: `ops`, `tests/test_agent_operations_contract.py`, `.agent/runbooks/database.md`
- Fix strategy: upstream-root
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: `.agent/capabilities.yaml`, `.agent/runbooks/ci.md`, `.agent/runbooks/database.md`, `.agent/runbooks/deployment.md`, `.agent/runbooks/discovery-ledger.md`, `.agent/runbooks/environment.md`, `.agent/runbooks/logs.md`, `.agent/runbooks/testing.md`, `AGENTS.md`, `CLAUDE.md`, `README.md`, `ops`, `plans/PR-Agent-Operations-Contract.md`, `tests/test_agent_operations_contract.py`
- Max files: 16
- Parked hardening: none

- Root decision: Redact credentials from the Git remote snapshot
- Source trace: credential-bearing Git origin -> raw doctor repository output
- Upstream files: `ops`, `tests/test_agent_operations_contract.py`
- Fix strategy: upstream-root
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: `.agent/capabilities.yaml`, `.agent/runbooks/ci.md`, `.agent/runbooks/database.md`, `.agent/runbooks/deployment.md`, `.agent/runbooks/discovery-ledger.md`, `.agent/runbooks/environment.md`, `.agent/runbooks/logs.md`, `.agent/runbooks/testing.md`, `AGENTS.md`, `CLAUDE.md`, `README.md`, `ops`, `plans/PR-Agent-Operations-Contract.md`, `tests/test_agent_operations_contract.py`
- Max files: 16
- Parked hardening: none

## Deferred
- The frontend deployment trigger is recorded as could-not-determine: no tracked GitHub deploy job was found and the inspected live deployment had no Git metadata (`.agent/capabilities.yaml:134`).
- Ollama-dependent paths remain degraded while the configured local service is unreachable; no install or service mutation was attempted.
- Provider deployment mutations remain operator-initiated; no generic deploy, database-write, migration, or rollback command was added.
- Project-interpreter dotenv decoding is deferred as non-blocking availability hardening; no code change in this frozen pass.
- Fail-closed unreadable selected database configuration is deferred as non-blocking read-only inspection hardening; no code change in this frozen pass.
- Brain health payload identity validation is deferred as non-blocking status-accuracy hardening; no code change in this frozen pass.
- Home Assistant and Wyze aggregate status enrollment is deferred as non-blocking inventory completeness; no code change in this frozen pass.
- Shared Vercel link identity validation is deferred as non-blocking provider hardening; no code change in this frozen pass.

## Parked hardening
- Project-interpreter dotenv decoding, unreadable selected database-configuration rejection, Brain response identity, Home Assistant/Wyze aggregate status enrollment, and shared Vercel link identity, tracked in the plan Deferred section.

## Cold diff reconstruction
- Changed: `AGENTS.md:22` routes fresh agents to the durable contract and continuous-learning rule; `.agent/capabilities.yaml:3` records the verified inventory; `.agent/runbooks/environment.md:6`, `.agent/runbooks/deployment.md:17`, `.agent/runbooks/database.md:6`, `.agent/runbooks/testing.md:6`, `.agent/runbooks/logs.md:7`, and `.agent/runbooks/ci.md:7` provide task-oriented procedures; `.agent/runbooks/discovery-ledger.md:6` captures non-obvious discoveries.
- Changed: `ops` removes ambient URL-shaped, Atlas application, and uppercase libpq `PG*` credentials and adapts the one confirmed DSN to every supported test interface; the focused integration matrix covers all three canonical keys plus current/novel libpq, generic, application, argv, and unrelated-key boundaries; capability and database/testing/discovery runbooks record the invariant. Earlier context-selection, Docker, cardinality, and shared-root fixes remain unchanged.
- Changed: `ops` now builds focused pytest children through the same database-authority removal helper without restoring a DSN; the focused regression covers every credential class, the disposable confirmation flag, argv, and unrelated environment preservation. Database-backed proof therefore enters only through guarded integration mode.
- Changed: `scripts/local_pr_review.sh` removes the local unit-mirror implementation and always delegates the unit gate to GitHub; `ops` makes `test unit` fail closed; `AGENTS.md`, the capability map, testing/CI runbooks, and discovery ledger make the hosted-only rule durable; focused canary tests prove neither local entrypoint launches the checker or pytest.
- Changed: `README.md:416` and `CLAUDE.md:48` replace stale startup guidance with the verified operations path and native-PostgreSQL reality.
- Contract match: every changed path implements the Problem-derived contract and revisions through focused database-authority contract revision 10; the exact surface is enumerated in the plan's Boundary-change enumeration.
- Gaps: none. No runtime/API, schema/migration, dependency, workflow, provider, secret, or customer-visible behavior changed.

## Verification
- `python -m py_compile ops tests/test_agent_operations_contract.py` - pass.
- PyYAML `safe_load(.agent/capabilities.yaml)` - schema version 1 parsed.
- Fourth-round boundary regressions failed before implementation with 10 failures.
- Shared-root resolver regression failed before implementation with 1 failed and 2 passed.
- Integration credential-isolation regression failed before implementation in all 3 canonical cases because pytest received no explicit child environment.
- Focused database-authority regression failed before implementation with `KeyError: 'env'`, then passed after focused mode received the shared credential-free child.
- `./ops test focused tests/test_agent_operations_contract.py -q` - 41 passed.
- Focused integration child-environment matrix - 3 passed across every canonical URL with current and novel `PG*` canaries absent from the pytest child.
- Focused hosted-only unit boundary nodes across the operations and local-review contract tests - 9 passed.
- `python -m py_compile ops tests/test_agent_operations_contract.py tests/test_local_pr_review.py`, `bash -n scripts/local_pr_review.sh`, capability parsing, and `git diff --check` - pass.
- Direct live shared-root probe - `/home/juan-canfield/Desktop/Atlas`.
- `./ops test focused tests/test_eom_render_profile.py::test_database_config_prefers_connection_string_for_asyncpg_kwargs -q` - 1 passed.
- `./ops doctor` - pass; Git/runtime/tool availability and authenticated read-only providers inspected without emitting secrets.
- `/usr/bin/python3 ./ops doctor` with `python-dotenv` unavailable - pass; the database line reported `UNAVAILABLE` and the snapshot completed.
- `./ops db inspect connectivity` and `./ops db migrations` - pass through the live Atlas `DatabaseConfig`/asyncpg path.
- Boundary probe: focused mode removes canonical, generic, novel, application, libpq, and confirmation authority while preserving an unrelated canary; integration database counts 0/2/3 reject while each singleton passes and restores only the confirmed DSN aliases; database sources, Docker states, and both Git common-directory shapes remain covered.

## Mechanical verification
- Command: guarded `scripts/push_pr.sh` path - Result: pass; PR body, fix-loop preflight, plan/file/diff audits, cross-session drift, and `git diff --check` all passed - Environment: local
- Command: `python scripts/audit_plan_code_consistency.py plans/PR-Agent-Operations-Contract.md` - Result: pass; all 15 path claims resolve - Environment: local
- Command: `python scripts/sync_pr_plan.py plans/PR-Agent-Operations-Contract.md origin/main --check` - Result: pass; plan already in sync - Environment: local
- Command: `git diff --cached --check` before commit - Result: pass - Environment: local
- Skipped: local full unit gate - Reason: structurally disabled; GitHub Actions is the sole runner and focused local boundary tests passed.
- Skipped: hosted CI rerun - Reason: GitHub owns this post-push gate.

## Diff size
16 files, +3570 / -236

<!-- atlas-open-pr-wrapper: v1 -->
