### PR TITLE
Harden Atlas PostgreSQL loopback authentication

### DIFF
--- a/.agent/runbooks/database.md
+++ b/.agent/runbooks/database.md
@@ -209,10 +209,37 @@ break-glass path.
    DSN deliberately takes precedence over `ATLAS_DB_SOCKET_PATH`, so this
    cutover must stop if one is effective. Do not remove or rewrite a full DSN as
    part of this procedure; that needs a separate configuration-migration slice.
-   Set `EFFECTIVE_DB_ENV_FILE` to that one effective file, confirm it is one of
-   the paths in `SERVICE_ENV_FILES`, and add exactly this non-secret setting
-   with `sudoedit "$EFFECTIVE_DB_ENV_FILE"`; do not copy or print the rest of
-   any file:
+
+   This procedure supports only a **new** socket setting. Before any edit, stop
+   if any selected service file already assigns `ATLAS_DB_SOCKET_PATH`, including
+   an empty or different value. Do not replace, remove, or preserve an existing
+   assignment here: its original behavior needs a separate configuration
+   migration with an exact restoration receipt.
+
+   ```bash
+   while IFS= read -r service_env_file; do
+     [ -n "$service_env_file" ] || continue
+     if ! sudo test -r "$service_env_file"; then
+       printf '%s\n' 'service EnvironmentFile is unreadable; do not add a socket setting' >&2
+       exit 1
+     fi
+     if sudo grep -Eq '^[[:space:]]*(export[[:space:]]+)?ATLAS_DB_SOCKET_PATH[[:space:]]*=' "$service_env_file"; then
+       printf '%s\n' 'pre-existing ATLAS_DB_SOCKET_PATH found; use a separate configuration migration' >&2
+       exit 1
+     else
+       grep_status=$?
+       if [ "$grep_status" -ne 1 ]; then
+         printf '%s\n' 'could not inspect service EnvironmentFile; do not add a socket setting' >&2
+         exit 1
+       fi
+     fi
+   done < <(printf '%s\n' "$SERVICE_ENV_FILES" | tr ':' '\n')
+   ```
+
+   Set `EFFECTIVE_DB_ENV_FILE` to the final file in service-file order, confirm
+   it is one of the paths in `SERVICE_ENV_FILES`, and add exactly this non-secret
+   setting with `sudoedit "$EFFECTIVE_DB_ENV_FILE"`; do not copy or print the
+   rest of any file:
 
    ```bash
    EFFECTIVE_DB_ENV_FILE='/absolute/path/to/the-effective.service.env'

--- a/.agent/runbooks/database.md
+++ b/.agent/runbooks/database.md
@@ -84,7 +84,7 @@ break-glass path.
    sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -At -c \
      "SELECT count(*) FROM pg_stat_replication;"
    sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -At -F '|' -c \
-     "SELECT type, address, netmask, auth_method \
+     "SELECT type, database, user_name, address, netmask, auth_method \
       FROM pg_hba_file_rules \
       WHERE auth_method = 'trust' \
       ORDER BY line_number;"
@@ -95,10 +95,10 @@ break-glass path.
    identity-map file is `/etc/postgresql/16/main/pg_ident.conf`, and the socket
    directory is `/var/run/postgresql`. Stop if the live results differ; derive
    the map/rules from the returned topology rather than copying these values
-   blindly. The final query must show exactly four `host` trust rows: two for
-   `127.0.0.1` and two for `::1`, one application and one replication row for
-   each address. Stop if any other trust row exists; this runbook does not
-   generalize a different HBA topology.
+   blindly. The final query must show exactly four `host` trust rows: two
+   `{all}` application rows and two `{replication}` rows, one for each of
+   `127.0.0.1` and `::1`. Stop if any other trust row exists; this runbook does
+   not generalize a different HBA topology.
 
    Set `SERVICE_ENV_FILES` to the absolute `EnvironmentFiles` paths printed by
    `./ops env systemd`, joined with `:` in that same order. Use this shell-local
@@ -234,17 +234,24 @@ break-glass path.
         count(*) FILTER ( \
           WHERE type = 'host' \
             AND address IN ('127.0.0.1', '::1') \
+            AND database = ARRAY['all']::text[] \
             AND auth_method = 'scram-sha-256' \
-        ) AS loopback_scram_rules, \
+        ) AS application_loopback_scram_rules, \
+        count(*) FILTER ( \
+          WHERE type = 'host' \
+            AND address IN ('127.0.0.1', '::1') \
+            AND database = ARRAY['replication']::text[] \
+            AND auth_method = 'scram-sha-256' \
+        ) AS replication_loopback_scram_rules, \
         count(*) FILTER (WHERE auth_method = 'trust') AS remaining_trust_rules, \
         count(*) FILTER (WHERE error IS NOT NULL) AS hba_errors \
       FROM pg_hba_file_rules;"
    ```
 
-   The query must return `4|0|0`: all four recorded loopback host rules use
-   SCRAM, no trust rule remains, and PostgreSQL loaded the file without errors.
-   Otherwise restore the saved files and stop. Then repeat the service,
-   `service_db_inspect`, and authenticated CRM proofs from step 3.
+   The query must return `2|2|0|0`: both application and replication channels
+   use SCRAM on IPv4 and IPv6, no trust rule remains, and PostgreSQL loaded the
+   file without errors. Otherwise restore the saved files and stop. Then repeat
+   the service, `service_db_inspect`, and authenticated CRM proofs from step 3.
 
 5. Verify both sides of the new boundary. The passwordless TCP probe must fail;
    the retained `postgres` socket peer probe must succeed:

--- a/.agent/runbooks/database.md
+++ b/.agent/runbooks/database.md
@@ -47,6 +47,153 @@ generic query command is unavailable until Atlas has a privilege-restricted
 inspection role. Do not paste customer content or identifiers into chat or
 GitHub, and do not substitute the live application role as an ad hoc read role.
 
+## Unix-socket peer and loopback SCRAM cutover
+
+This is a production-mutating operation. Perform it only from an owned,
+merged-and-deployed hardening slice. A Brain restart can run migration checks;
+read the migration section below first. Do not add a database password or a
+systemd credential for this cutover: the service is a non-root user service,
+and the correct boundary is the operating-system identity already available to
+PostgreSQL over its Unix socket.
+
+The source revision for this runbook makes
+`DatabaseConfig.connection_kwargs()` honour `ATLAS_DB_SOCKET_PATH`. That is
+required before changing the live setting: the generic pool and fixed
+`./ops db inspect` path both call that method. The service will connect as the
+existing `atlas` PostgreSQL role through `/var/run/postgresql` on port `5433`.
+`pg_ident.conf` maps only the actual service OS account to that role, and an
+HBA rule scoped to database `atlas` and role `atlas` selects peer
+authentication. The existing `postgres` Unix-socket peer rule remains the
+break-glass path.
+
+1. Revalidate the exact deployed source, service identity, PostgreSQL paths,
+   active local clients, and current health. Do not print `.env` values or a
+   database URL:
+
+   ```bash
+   ./ops deploy status
+   ./ops db inspect connectivity
+   id -un
+   sudo -u postgres psql -d atlas -At -F '|' -c \
+     "SHOW hba_file; SHOW ident_file; SHOW unix_socket_directories;"
+   sudo -u postgres psql -d atlas -At -F '|' -c \
+     "SELECT application_name, usename, client_addr, state \
+      FROM pg_stat_activity \
+      WHERE client_addr IN ('127.0.0.1'::inet, '::1'::inet);"
+   sudo -u postgres psql -d atlas -At -c \
+     "SELECT count(*) FROM pg_stat_replication;"
+   ```
+
+   For the current single-user deployment, the service account is
+   `juan-canfield`, the HBA file is `/etc/postgresql/16/main/pg_hba.conf`, the
+   identity-map file is `/etc/postgresql/16/main/pg_ident.conf`, and the socket
+   directory is `/var/run/postgresql`. Stop if the live results differ; derive
+   the map/rules from the returned topology rather than copying these values
+   blindly.
+
+2. Preserve only the two PostgreSQL authentication files before editing them:
+
+   ```bash
+   if sudo test -e /etc/postgresql/16/main/pg_hba.conf.pre-atlas-peer \
+     || sudo test -e /etc/postgresql/16/main/pg_ident.conf.pre-atlas-peer; then
+     printf '%s\n' 'existing peer-cutover backup found; inspect it before retrying' >&2
+     exit 1
+   fi
+   sudo cp --preserve=mode,ownership,timestamps /etc/postgresql/16/main/pg_hba.conf \
+     /etc/postgresql/16/main/pg_hba.conf.pre-atlas-peer
+   sudo cp --preserve=mode,ownership,timestamps /etc/postgresql/16/main/pg_ident.conf \
+     /etc/postgresql/16/main/pg_ident.conf.pre-atlas-peer
+   ```
+
+   Then add this exact map with `sudoedit /etc/postgresql/16/main/pg_ident.conf`:
+
+   ```text
+   atlas_app    juan-canfield    atlas
+   ```
+
+   Add this exact rule with `sudoedit /etc/postgresql/16/main/pg_hba.conf`
+   **above** the generic `local   all   all   peer` rule. Do not change the
+   existing `local   all   postgres   peer` rule:
+
+   ```text
+   local   atlas   atlas                         peer map=atlas_app
+   ```
+
+   ```bash
+   sudo systemctl reload postgresql@16-main
+   sudo -u postgres psql -d atlas -At -c \
+     "SELECT count(*) FROM pg_hba_file_rules WHERE error IS NOT NULL;"
+   ```
+
+   The final query must return `0`; otherwise restore both saved files and
+   reload PostgreSQL before continuing. The service still uses TCP at this
+   point, so a valid scoped peer rule can be proved without removing the
+   existing path.
+
+3. In the shared application configuration read by `atlas-api.service`, add
+   exactly this non-secret setting with an editor; do not copy or print the
+   rest of the file:
+
+   ```text
+   ATLAS_DB_SOCKET_PATH=/var/run/postgresql
+   ```
+
+   Restart the user service, then prove that the application has changed its
+   real connection path before any TCP trust rule is removed:
+
+   ```bash
+   systemctl --user restart atlas-api.service
+   ./ops deploy status
+   ./ops db inspect connectivity
+   ```
+
+   Perform one read-only authenticated EOM CRM Contacts-page refresh. A health
+   response alone is insufficient: the generic pool can initialize lazily, so
+   the CRM read proves the application data path. If either proof fails,
+   restore the two saved PostgreSQL files, remove only the exact non-secret
+   setting just added, reload PostgreSQL, and restart `atlas-api.service`.
+
+4. Only after the socket-peer proof succeeds, replace **all four** loopback
+   TCP `trust` entries in `pg_hba.conf` with `scram-sha-256` using `sudoedit`:
+
+   ```text
+   host    all             all             127.0.0.1/32            scram-sha-256
+   host    all             all             ::1/128                 scram-sha-256
+   host    replication     all             127.0.0.1/32            scram-sha-256
+   host    replication     all             ::1/128                 scram-sha-256
+   ```
+
+   Do not alter any non-loopback rule. Reload PostgreSQL and repeat the
+   service, fixed-inspection, and authenticated CRM proofs from step 3.
+
+5. Verify both sides of the new boundary. The passwordless TCP probe must fail;
+   the retained `postgres` socket peer probe must succeed:
+
+   ```bash
+   if env -u PGPASSWORD -u ATLAS_DB_PASSWORD PGPASSFILE=/dev/null \
+     psql -w -h 127.0.0.1 -p 5433 -U atlas -d atlas -Atc 'SELECT 1'; then
+     printf '%s\n' 'unexpected passwordless loopback TCP access' >&2
+     exit 1
+   fi
+   sudo -u postgres psql -d atlas -Atc 'SELECT current_user'
+   ```
+
+   The second command must print `postgres`. The first must reject
+   authentication without prompting. Do not use an existing `.pgpass` file or
+   a secret-bearing shell environment as a substitute test.
+
+6. If a step fails after the HBA conversion, restore both saved authentication
+   files, reload PostgreSQL, and restart `atlas-api.service`. If the service
+   still cannot reconnect, remove only the added `ATLAS_DB_SOCKET_PATH` line
+   from shared configuration and restart again. Re-run the fixed inspection and
+   CRM read before declaring rollback complete. Do not edit roles, passwords,
+   migration ledger rows, or database data as part of rollback.
+
+`./ops db inspect` remains fixed-query-only. It already selects the same
+socket-path configuration as the application and uses a `READ ONLY`
+transaction. This cutover does not create a generic command runner or expose a
+credential.
+
 ## Migrations
 
 Atlas does not use Alembic even though an `alembic` executable is installed.

--- a/.agent/runbooks/database.md
+++ b/.agent/runbooks/database.md
@@ -233,25 +233,74 @@ break-glass path.
      "SELECT \
         count(*) FILTER ( \
           WHERE type = 'host' \
-            AND address IN ('127.0.0.1', '::1') \
             AND database = ARRAY['all']::text[] \
+            AND user_name = ARRAY['all']::text[] \
+            AND address = '127.0.0.1' \
+            AND netmask = '255.255.255.255' \
             AND auth_method = 'scram-sha-256' \
-        ) AS application_loopback_scram_rules, \
+        ) AS application_ipv4_scram_rule, \
+        count(*) FILTER ( \
+          WHERE type = 'host' \
+            AND database = ARRAY['all']::text[] \
+            AND user_name = ARRAY['all']::text[] \
+            AND address = '::1' \
+            AND netmask = 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff' \
+            AND auth_method = 'scram-sha-256' \
+        ) AS application_ipv6_scram_rule, \
+        count(*) FILTER ( \
+          WHERE type = 'host' \
+            AND database = ARRAY['replication']::text[] \
+            AND user_name = ARRAY['all']::text[] \
+            AND address = '127.0.0.1' \
+            AND netmask = '255.255.255.255' \
+            AND auth_method = 'scram-sha-256' \
+        ) AS replication_ipv4_scram_rule, \
+        count(*) FILTER ( \
+          WHERE type = 'host' \
+            AND database = ARRAY['replication']::text[] \
+            AND user_name = ARRAY['all']::text[] \
+            AND address = '::1' \
+            AND netmask = 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff' \
+            AND auth_method = 'scram-sha-256' \
+        ) AS replication_ipv6_scram_rule, \
         count(*) FILTER ( \
           WHERE type = 'host' \
             AND address IN ('127.0.0.1', '::1') \
-            AND database = ARRAY['replication']::text[] \
-            AND auth_method = 'scram-sha-256' \
-        ) AS replication_loopback_scram_rules, \
+            AND NOT ( \
+              (database = ARRAY['all']::text[] \
+               AND user_name = ARRAY['all']::text[] \
+               AND address = '127.0.0.1' \
+               AND netmask = '255.255.255.255' \
+               AND auth_method = 'scram-sha-256') \
+              OR (database = ARRAY['all']::text[] \
+                  AND user_name = ARRAY['all']::text[] \
+                  AND address = '::1' \
+                  AND netmask = 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff' \
+                  AND auth_method = 'scram-sha-256') \
+              OR (database = ARRAY['replication']::text[] \
+                  AND user_name = ARRAY['all']::text[] \
+                  AND address = '127.0.0.1' \
+                  AND netmask = '255.255.255.255' \
+                  AND auth_method = 'scram-sha-256') \
+              OR (database = ARRAY['replication']::text[] \
+                  AND user_name = ARRAY['all']::text[] \
+                  AND address = '::1' \
+                  AND netmask = 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff' \
+                  AND auth_method = 'scram-sha-256') \
+            ) \
+        ) AS unexpected_loopback_host_rules, \
         count(*) FILTER (WHERE auth_method = 'trust') AS remaining_trust_rules, \
         count(*) FILTER (WHERE error IS NOT NULL) AS hba_errors \
       FROM pg_hba_file_rules;"
    ```
 
-   The query must return `2|2|0|0`: both application and replication channels
-   use SCRAM on IPv4 and IPv6, no trust rule remains, and PostgreSQL loaded the
-   file without errors. Otherwise restore the saved files and stop. Then repeat
-   the service, `service_db_inspect`, and authenticated CRM proofs from step 3.
+   The query must return `1|1|1|1|0|0|0`: one exact application IPv4 rule, one
+   exact application IPv6 rule, one exact replication IPv4 rule, one exact
+   replication IPv6 rule, no unexpected loopback host rule, no trust rule, and
+   no parser error. If any field differs, do not proceed: follow step 6 exactly
+   so the restored HBA/ident files are reloaded before the procedure stops. Then
+   repeat the service, `service_db_inspect`, and authenticated CRM proofs from
+   step 3.
 
 5. Verify both sides of the new boundary. The passwordless TCP probe must fail;
    the retained `postgres` socket peer probe must succeed:
@@ -270,12 +319,14 @@ break-glass path.
    authentication without prompting. Do not use an existing `.pgpass` file or
    a secret-bearing shell environment as a substitute test.
 
-6. If a step fails after the HBA conversion, first remove only the added
-   `ATLAS_DB_SOCKET_PATH` line from the effective service configuration. Then
-   restore both saved authentication files, reload PostgreSQL, and restart
-   `atlas-api.service` once. Re-run `service_db_inspect` and the CRM read before
-   declaring rollback complete. Do not edit roles, passwords, migration ledger
-   rows, or database data as part of rollback.
+6. If the loaded-HBA receipt or any later step fails after the HBA conversion,
+   first remove only the added `ATLAS_DB_SOCKET_PATH` line from the effective
+   service configuration. Then restore both saved authentication files and
+   reload PostgreSQL before stopping or restarting anything else. Restart
+   `atlas-api.service` once only after that reload. Re-run
+   `service_db_inspect` and the CRM read before declaring rollback complete. Do
+   not edit roles, passwords, migration ledger rows, or database data as part of
+   rollback.
 
 `service_db_inspect` remains fixed-query-only. It explicitly selects the same
 service configuration as the application and uses a `READ ONLY` transaction.

--- a/.agent/runbooks/database.md
+++ b/.agent/runbooks/database.md
@@ -248,7 +248,7 @@ break-glass path.
    sudo systemctl reload postgresql@16-main
    sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -At -c \
      "WITH intended_peer_rule AS ( \
-        SELECT line_number \
+        SELECT rule_number \
         FROM pg_hba_file_rules \
         WHERE error IS NULL \
           AND type = 'local' \
@@ -258,10 +258,10 @@ break-glass path.
           AND options = ARRAY['map=atlas_app']::text[] \
       ), \
       preceding_local_rules AS ( \
-        SELECT rules.line_number \
+        SELECT rules.rule_number \
         FROM pg_hba_file_rules AS rules \
         JOIN intended_peer_rule AS intended \
-          ON rules.line_number < intended.line_number \
+          ON rules.rule_number < intended.rule_number \
         WHERE rules.error IS NULL \
           AND rules.type = 'local' \
           AND NOT ( \
@@ -288,7 +288,8 @@ break-glass path.
    The final query must return `0|1|1|0|1|0`: no HBA parser error, exactly one
    intended `atlas_app | juan-canfield | atlas` mapping, no additional
    `atlas_app` mapping, no identity-map error, exactly one loaded
-   `local atlas atlas peer map=atlas_app` rule, and no preceding local rule
+   `local atlas atlas peer map=atlas_app` rule, and no preceding local rule in
+   loaded `rule_number` order
    other than the retained `local all postgres peer` recovery rule. Otherwise
    restore both saved files and reload PostgreSQL before continuing. The service
    still uses TCP at this point, so a valid scoped peer rule can be proved

--- a/.agent/runbooks/database.md
+++ b/.agent/runbooks/database.md
@@ -147,6 +147,9 @@ break-glass path.
        END { exit(found ? 0 : 1) }
      ' "$1"
    }
+   service_db_has_socket_assignment() {
+     sudo grep -Eqi '^[[:space:]]*(export[[:space:]]+)?ATLAS_DB_SOCKET_PATH[[:space:]]*=' "$1"
+   }
    service_db_require_canonical_keys() {
      saw_service_env=0
      while IFS= read -r service_env_file; do
@@ -171,6 +174,22 @@ break-glass path.
        printf '%s\n' 'no service EnvironmentFiles selected; do not inspect a fallback context' >&2
        return 1
      fi
+   }
+   service_db_require_no_socket_assignments() {
+     service_db_require_canonical_keys || return 1
+     while IFS= read -r service_env_file; do
+       [ -n "$service_env_file" ] || continue
+       if service_db_has_socket_assignment "$service_env_file"; then
+         printf '%s\n' 'ATLAS_DB_SOCKET_PATH assignment remains; do not continue' >&2
+         return 1
+       else
+         socket_status=$?
+         if [ "$socket_status" -ne 1 ]; then
+           printf '%s\n' 'could not inspect service EnvironmentFile socket assignments; do not continue' >&2
+           return 1
+         fi
+       fi
+     done < <(printf '%s\n' "$SERVICE_ENV_FILES" | tr ':' '\n')
    }
    service_db_inspect() {
      service_db_require_canonical_keys || return 1
@@ -247,46 +266,25 @@ break-glass path.
    this point, so a valid scoped peer rule can be proved without removing the
    existing path.
 
-3. Re-run `service_db_require_canonical_keys`; it rejects an empty service-file
-   set and any case-variant `ATLAS_DB_*` key before either fixed inspection or
-   this edit step can use a different configuration from `atlas-api.service`.
-   Then, in the effective service configuration selected by `SERVICE_ENV_FILES`,
-   use `./ops env keys --file <each service file>` and an editor to identify the
-   final canonical `ATLAS_DB_*` assignment in service-file order. Verify that
-   the effective `ATLAS_DB_CONNECTION_STRING` is absent or empty. A nonblank
-   full DSN deliberately takes precedence over `ATLAS_DB_SOCKET_PATH`, so this
-   cutover must stop if one is effective. Do not remove or rewrite a full DSN as
-   part of this procedure; that needs a separate configuration-migration slice.
+3. Re-run `service_db_require_no_socket_assignments`; it rejects an empty
+   service-file set, any case-variant `ATLAS_DB_*` key, and every existing
+   socket assignment before either fixed inspection or this edit step can use a
+   different configuration from `atlas-api.service`. Then, in the effective
+   service configuration selected by `SERVICE_ENV_FILES`, use `./ops env keys
+   --file <each service file>` and an editor to identify the final canonical
+   `ATLAS_DB_*` assignment in service-file order. Verify that the effective
+   `ATLAS_DB_CONNECTION_STRING` is absent or empty. A nonblank full DSN
+   deliberately takes precedence over `ATLAS_DB_SOCKET_PATH`, so this cutover
+   must stop if one is effective. Do not remove or rewrite a full DSN as part of
+   this procedure; that needs a separate configuration-migration slice.
 
    ```bash
-   service_db_require_canonical_keys || exit 1
+   service_db_require_no_socket_assignments || exit 1
    ```
 
-   This procedure supports only a **new** socket setting. Before any edit, stop
-   if any selected service file already assigns `ATLAS_DB_SOCKET_PATH` in any
-   case variant, including an empty or different value. Do not replace, remove,
-   or preserve an existing assignment here: its original behavior needs a
-   separate configuration migration with an exact restoration receipt.
-
-   ```bash
-   while IFS= read -r service_env_file; do
-     [ -n "$service_env_file" ] || continue
-     if ! sudo test -r "$service_env_file"; then
-       printf '%s\n' 'service EnvironmentFile is unreadable; do not add a socket setting' >&2
-       exit 1
-     fi
-     if sudo grep -Eqi '^[[:space:]]*(export[[:space:]]+)?ATLAS_DB_SOCKET_PATH[[:space:]]*=' "$service_env_file"; then
-       printf '%s\n' 'pre-existing ATLAS_DB_SOCKET_PATH found; use a separate configuration migration' >&2
-       exit 1
-     else
-       grep_status=$?
-       if [ "$grep_status" -ne 1 ]; then
-         printf '%s\n' 'could not inspect service EnvironmentFile; do not add a socket setting' >&2
-         exit 1
-       fi
-     fi
-   done < <(printf '%s\n' "$SERVICE_ENV_FILES" | tr ':' '\n')
-   ```
+   This procedure supports only a **new** socket setting. Do not replace,
+   remove, or preserve an existing assignment here: its original behavior needs
+   a separate configuration migration with an exact restoration receipt.
 
    Set `EFFECTIVE_DB_ENV_FILE` to the final file in service-file order, confirm
    it is one of the paths in `SERVICE_ENV_FILES`, and add exactly this non-secret
@@ -304,9 +302,9 @@ break-glass path.
 
    Define this shell-local rollback helper before the restart. It is the only
    rollback path after the socket setting exists; when it opens the editor,
-   remove only the exact `ATLAS_DB_SOCKET_PATH=/var/run/postgresql` line just
-   added, save, and exit before the function restores the two authentication
-   files:
+   remove the added `ATLAS_DB_SOCKET_PATH` assignment entirely without changing
+   any other database key. The helper refuses to restore authentication while
+   any case-variant socket assignment remains in any selected service file:
 
    ```bash
    rollback_peer_cutover() {
@@ -315,10 +313,7 @@ break-glass path.
        *) printf '%s\n' 'effective database environment file is not a service EnvironmentFile' >&2; return 1 ;;
      esac
      sudoedit "$EFFECTIVE_DB_ENV_FILE" || return 1
-     if sudo grep -Eq '^[[:space:]]*ATLAS_DB_SOCKET_PATH=/var/run/postgresql[[:space:]]*$' "$EFFECTIVE_DB_ENV_FILE"; then
-       printf '%s\n' 'remove only the added ATLAS_DB_SOCKET_PATH line before rollback can continue' >&2
-       return 1
-     fi
+     service_db_require_no_socket_assignments || return 1
      sudo cp --preserve=mode,ownership,timestamps /etc/postgresql/16/main/pg_hba.conf.pre-atlas-peer \
        /etc/postgresql/16/main/pg_hba.conf || return 1
      sudo cp --preserve=mode,ownership,timestamps /etc/postgresql/16/main/pg_ident.conf.pre-atlas-peer \

--- a/.agent/runbooks/database.md
+++ b/.agent/runbooks/database.md
@@ -123,8 +123,8 @@ break-glass path.
    `./ops env systemd`, joined with `:` in that same order. Use this shell-local
    helper for every fixed inspection in this cutover. It selects the service's
    configuration without printing values. The inspector also removes every
-   case variant of known Atlas database settings, so an inherited lower- or
-   mixed-case alias cannot override those files:
+   case variant of every Atlas database setting it can consume, so an inherited
+   lower- or mixed-case alias cannot override those files:
 
    ```bash
    SERVICE_ENV_FILES='/absolute/first.service.env:/absolute/second.service.env'

--- a/.agent/runbooks/database.md
+++ b/.agent/runbooks/database.md
@@ -134,6 +134,18 @@ break-glass path.
    edit an included HBA file. The `atlas_app` identity-map query must return no
    rows before editing: do not reuse a pre-existing map name.
 
+   `eom-write-boundary-audit.timer` is a repository-owned hourly one-shot
+   database client. It is normally absent from both live inventory queries, so
+   its absence is not evidence that it has no TCP dependency. Before any HBA
+   backup or authentication edit, require its installed script to match this
+   deployed source, its timer/service identity to be live, and its unit or
+   user-manager environment to contain no `ATLAS_EOM_AUDIT_ATLAS_DSN` override
+   or `EnvironmentFile`. The source default is the passwordless
+   `/var/run/postgresql` socket route and clears inherited libpq target
+   selectors before invoking `psql`; an override needs its own owner-verified
+   socket or SCRAM migration rather than being silently accepted here. The
+   checks retain environment text only in shell variables and never print it.
+
    Set `SERVICE_ENV_FILES` to the absolute `EnvironmentFiles` paths printed by
    `./ops env systemd`, joined with `:` in that same order. Use this shell-local
    helper for every fixed inspection in this cutover. It selects the service's
@@ -142,8 +154,65 @@ break-glass path.
    lower- or mixed-case alias cannot override those files:
 
    ```bash
+   EOM_AUDIT_REPOSITORY_ROOT="$(git rev-parse --show-toplevel)" || exit 1
+   EOM_AUDIT_SOURCE="$EOM_AUDIT_REPOSITORY_ROOT/scripts/eom_write_boundary_audit.py"
+   EOM_AUDIT_INSTALLED="$HOME/.local/bin/eom-write-boundary-audit.py"
+   EOM_AUDIT_SERVICE='eom-write-boundary-audit.service'
+   EOM_AUDIT_TIMER='eom-write-boundary-audit.timer'
    SERVICE_ENV_FILES='/absolute/first.service.env:/absolute/second.service.env'
    EFFECTIVE_DB_ENV_FILE="${SERVICE_ENV_FILES##*:}"
+   eom_audit_environment_has_dsn_override() {
+     case "$1" in
+       *'ATLAS_EOM_AUDIT_ATLAS_DSN='*) return 0 ;;
+       *) return 1 ;;
+     esac
+   }
+   eom_audit_require_socket_default() {
+     if ! test -r "$EOM_AUDIT_SOURCE" || ! cmp -s "$EOM_AUDIT_SOURCE" "$EOM_AUDIT_INSTALLED"; then
+       printf '%s\n' 'installed EOM audit script does not match deployed source; install it before cutover' >&2
+       return 1
+     fi
+     if ! systemctl --user is-enabled --quiet "$EOM_AUDIT_TIMER" \
+       || ! systemctl --user is-active --quiet "$EOM_AUDIT_TIMER"; then
+       printf '%s\n' 'EOM audit timer is not enabled and active; do not remove loopback trust' >&2
+       return 1
+     fi
+     eom_audit_exec_start="$(systemctl --user show "$EOM_AUDIT_SERVICE" \
+       --property=LoadState,ExecStart --value)" || {
+       printf '%s\n' 'could not inspect EOM audit service identity; do not remove loopback trust' >&2
+       return 1
+     }
+     case "$eom_audit_exec_start" in
+       *"$EOM_AUDIT_INSTALLED"*) ;;
+       *)
+         printf '%s\n' 'EOM audit service does not execute the admitted installed script; do not remove loopback trust' >&2
+         return 1
+         ;;
+     esac
+     eom_audit_environment_files="$(systemctl --user show "$EOM_AUDIT_SERVICE" \
+       --property=EnvironmentFiles --value)" || {
+       printf '%s\n' 'could not inspect EOM audit service environment files; do not remove loopback trust' >&2
+       return 1
+     }
+     if [ -n "$eom_audit_environment_files" ]; then
+       printf '%s\n' 'EOM audit service uses an EnvironmentFile; inventory its transport separately before cutover' >&2
+       return 1
+     fi
+     eom_audit_service_environment="$(systemctl --user show "$EOM_AUDIT_SERVICE" \
+       --property=Environment --value)" || {
+       printf '%s\n' 'could not inspect EOM audit service environment; do not remove loopback trust' >&2
+       return 1
+     }
+     eom_audit_manager_environment="$(systemctl --user show-environment)" || {
+       printf '%s\n' 'could not inspect EOM audit manager environment; do not remove loopback trust' >&2
+       return 1
+     }
+     if eom_audit_environment_has_dsn_override "$eom_audit_service_environment" \
+       || eom_audit_environment_has_dsn_override "$eom_audit_manager_environment"; then
+       printf '%s\n' 'EOM audit DSN override found; migrate and prove it separately before cutover' >&2
+       return 1
+     fi
+   }
    service_db_has_case_variant_key() {
      sudo awk '
        BEGIN { found = 0 }
@@ -274,6 +343,7 @@ break-glass path.
        ATLAS_OPS_ENV_FILES="$SERVICE_ENV_FILES" \
        ./ops db inspect connectivity
    }
+   eom_audit_require_socket_default || exit 1
    service_db_require_new_socket_configuration || exit 1
    service_db_inspect
    ```
@@ -285,7 +355,8 @@ break-glass path.
    backup, HBA/identity edit, or PostgreSQL reload. It rejects an empty
    service-file set, any case-variant `ATLAS_DB_*` key, every existing socket
    assignment, and every nonblank complete-DSN assignment without printing a
-   value. A complete DSN deliberately takes precedence over
+   value. The dormant monitor admission must also succeed before the first
+   backup, HBA/identity edit, or PostgreSQL reload. A complete DSN deliberately takes precedence over
    `ATLAS_DB_SOCKET_PATH`; do not remove or rewrite one as part of this
    procedure. That needs a separate configuration-migration slice.
 
@@ -365,9 +436,11 @@ break-glass path.
    `local atlas atlas peer map=atlas_app` rule, and no preceding local rule in
    loaded `rule_number` order
    other than the retained `local all postgres peer` recovery rule. Otherwise
-   restore both saved files and reload PostgreSQL before continuing. The service
+   restore both saved files and reload PostgreSQL before continuing. `atlas-api`
    still uses TCP at this point, so a valid scoped peer rule can be proved
-   without removing the existing path.
+   without removing the existing path. The separately admitted audit monitor is
+   not yet its socket receipt; obtain that receipt after the application restart
+   and before loopback trust is replaced.
 
 3. The pre-mutation admission receipt derives and validates
    `EFFECTIVE_DB_ENV_FILE` as the final selected service file before any
@@ -457,13 +530,47 @@ break-glass path.
      "SELECT application_name, usename, client_addr, state, sync_state \
       FROM pg_stat_replication \
       WHERE client_addr IN ('127.0.0.1'::inet, '::1'::inet);"
+   EOM_AUDIT_DRY_RUN_DIR="$(mktemp -d)" || {
+     printf '%s\n' 'could not create EOM audit dry-run state directory; rollback required' >&2
+     rollback_peer_cutover
+     exit 1
+   }
+   EOM_AUDIT_DRY_RUN_OUTPUT="$("$EOM_AUDIT_INSTALLED" \
+     --state-dir "$EOM_AUDIT_DRY_RUN_DIR" \
+     --ntfy-topic cutover-dry-run \
+     --no-alert)"
+   EOM_AUDIT_DRY_RUN_STATUS=$?
+   rm -rf -- "$EOM_AUDIT_DRY_RUN_DIR" || {
+     printf '%s\n' 'could not remove EOM audit dry-run state directory; rollback required' >&2
+     rollback_peer_cutover
+     exit 1
+   }
+   case "$EOM_AUDIT_DRY_RUN_OUTPUT" in
+     *'COULD NOT MEASURE'*)
+       printf '%s\n' 'EOM audit could not measure through its default socket route; rollback required' >&2
+       rollback_peer_cutover
+       exit 1
+       ;;
+   esac
+   case "$EOM_AUDIT_DRY_RUN_STATUS" in
+     0|2) ;;
+     *)
+       printf '%s\n' 'EOM audit dry run exited unexpectedly; rollback required' >&2
+       rollback_peer_cutover
+       exit 1
+       ;;
+   esac
    ```
 
    The immediate transport receipt must return `1|1`: the CRM read created at
    least one qualifying `atlas`/`atlas` client backend, and every qualifying
    backend has a null `client_addr` (a Unix socket). Do not accept one socket
    row while another qualifying backend is TCP; that would not prove the
-   restarted application uses the socket. Compare the rows with the loopback
+   restarted application uses the socket. The EOM audit dry run must not report
+   `COULD NOT MEASURE`; its `--no-alert` invocation intentionally leaves no
+   notification or persistent alert-state change. Exit `0` means the audit was
+   clean and exit `2` means it measured a boundary breach; either is a transport
+   receipt. Any other exit is a failure. Compare the rows with the loopback
    clients from step 1. The fixed inspection must also succeed only after that
    transport proof. If any proof fails, remove only the exact non-secret setting
    just added, restore the two saved PostgreSQL files, reload PostgreSQL, and
@@ -473,13 +580,16 @@ break-glass path.
    Before step 4, reconcile every client identity in the union of the initial
    and final inventories. Each must have either a post-restart Unix-socket
    backend receipt or a separate, owner-verified SCRAM reconnect receipt for
-   that client. A TCP session that disappeared between snapshots is not a
-   receipt; stop and obtain one before conversion. Both final inventories must
-   also be empty. A remaining loopback TCP client, including a replication
-   client, is a stop condition even if it has a future SCRAM receipt: move that
-   client to the Unix socket or complete its separate migration and disconnect
-   it before re-running this cutover. Do not create a new credential or remove
-   HBA trust while any row or receipt remains unresolved.
+   that client. Record the audit monitor's source-match/no-override admission
+   and dry-run transport receipt alongside that union: its scheduled absence
+   from both snapshots is admissible only with both receipts. A TCP session that
+   disappeared between snapshots is not a receipt; stop and obtain one before
+   conversion. Both final inventories must also be empty. A remaining loopback
+   TCP client, including a replication client, is a stop condition even if it
+   has a future SCRAM receipt: move that client to the Unix socket or complete
+   its separate migration and disconnect it before re-running this cutover. Do
+   not create a new credential or remove HBA trust while any row or receipt
+   remains unresolved.
 
 4. Only after the socket-peer proof succeeds, replace **all four** loopback
    TCP `trust` entries in `pg_hba.conf` with `scram-sha-256` using `sudoedit`:

--- a/.agent/runbooks/database.md
+++ b/.agent/runbooks/database.md
@@ -78,11 +78,12 @@ break-glass path.
    sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -At -F '|' -c \
      "SHOW hba_file; SHOW ident_file; SHOW unix_socket_directories;"
    sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -At -F '|' -c \
-     "SELECT application_name, usename, client_addr, state \
+     "SELECT backend_start, application_name, usename, datname, backend_type, \
+             client_addr, state \
       FROM pg_stat_activity \
       WHERE client_addr IN ('127.0.0.1'::inet, '::1'::inet);"
    sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -At -F '|' -c \
-     "SELECT application_name, usename, client_addr, state, sync_state \
+     "SELECT backend_start, application_name, usename, client_addr, state, sync_state \
       FROM pg_stat_replication \
       WHERE client_addr IN ('127.0.0.1'::inet, '::1'::inet);"
    sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -At -F '|' -c \
@@ -96,6 +97,16 @@ break-glass path.
       WHERE auth_method = 'trust' \
       ORDER BY line_number;"
    ```
+
+   Record every row from those two inventory queries in the cutover record as
+   the **initial loopback-client inventory**. Keep its source
+   (`pg_stat_activity` or `pg_stat_replication`), `backend_start`, application,
+   user, database or replication state, address, and state/sync state. These
+   are not diagnostic snapshots: every client identity observed here must later
+   receive a Unix-socket or separately owner-verified SCRAM reconnect receipt
+   before HBA conversion, even if its TCP session subsequently disappears. Do
+   not infer that two rows are the same client from an application name or role
+   alone; the owner must bind each initial row to its later receipt in the record.
 
    For the current single-user deployment, the service account is
    `juan-canfield`, the HBA file is `/etc/postgresql/16/main/pg_hba.conf`, the
@@ -279,11 +290,17 @@ break-glass path.
    exact non-secret setting just added, restore the two saved PostgreSQL files,
    reload PostgreSQL, and restart `atlas-api.service`.
 
-   Before step 4, both final loopback inventories must be empty. A remaining
-   loopback TCP client, including a replication client, is a stop condition:
-   move that client to the Unix socket or complete a separate, owner-verified
-   SCRAM reconnect migration before re-running this cutover. Do not create a
-   new credential or remove HBA trust while any such row remains.
+   Record those two later queries as the **final loopback-client inventory**.
+   Before step 4, reconcile every client identity in the union of the initial
+   and final inventories. Each must have either a post-restart Unix-socket
+   backend receipt or a separate, owner-verified SCRAM reconnect receipt for
+   that client. A TCP session that disappeared between snapshots is not a
+   receipt; stop and obtain one before conversion. Both final inventories must
+   also be empty. A remaining loopback TCP client, including a replication
+   client, is a stop condition even if it has a future SCRAM receipt: move that
+   client to the Unix socket or complete its separate migration and disconnect
+   it before re-running this cutover. Do not create a new credential or remove
+   HBA trust while any row or receipt remains unresolved.
 
 4. Only after the socket-peer proof succeeds, replace **all four** loopback
    TCP `trust` entries in `pg_hba.conf` with `scram-sha-256` using `sudoedit`:
@@ -300,6 +317,29 @@ break-glass path.
    authenticated CRM proofs from step 3:
 
    ```bash
+   sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -At -F '|' -c \
+     "WITH hba AS ( \
+        SELECT *, \
+          CASE \
+            WHEN address IS NULL OR netmask IS NULL THEN TRUE \
+            WHEN NOT pg_input_is_valid(address, 'inet') \
+              OR NOT pg_input_is_valid(netmask, 'inet') THEN TRUE \
+            WHEN family(address::inet) <> family(netmask::inet) THEN TRUE \
+            WHEN family(address::inet) = 4 THEN \
+              host(address::inet & netmask::inet) \
+                = host('127.0.0.1'::inet & netmask::inet) \
+            WHEN family(address::inet) = 6 THEN \
+              host(address::inet & netmask::inet) \
+                = host('::1'::inet & netmask::inet) \
+            ELSE TRUE \
+          END AS covers_loopback \
+        FROM pg_hba_file_rules \
+      ) \
+      SELECT count(*) FILTER ( \
+        WHERE type <> 'local' \
+          AND covers_loopback \
+      ) AS loopback_network_rule_count \
+      FROM hba;"
    sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -At -F '|' -c \
      "SELECT \
         count(*) FILTER ( \
@@ -365,10 +405,14 @@ break-glass path.
       FROM pg_hba_file_rules;"
    ```
 
-   The query must return `1|1|1|1|0|0|0`: one exact application IPv4 rule, one
-   exact application IPv6 rule, one exact replication IPv4 rule, one exact
-   replication IPv6 rule, no unexpected loopback host rule, no trust rule, and
-   no parser error. If any field differs, do not proceed: run
+   The first query must return `4`: it derives every non-local HBA rule whose
+   network can cover either loopback endpoint. This count fails closed for a
+   broader subnet, `hostssl`/other host type, an unparseable address form, or a
+   family mismatch. The second query must return `1|1|1|1|0|0|0`: one exact
+   application IPv4 rule, one exact application IPv6 rule, one exact replication
+   IPv4 rule, one exact replication IPv6 rule, no unexpected endpoint-equal host
+   rule, no trust rule, and no parser error. If either receipt differs, do not
+   proceed: run
    `rollback_peer_cutover` immediately so the restored HBA/ident files are
    reloaded before the procedure stops. Then repeat the service,
    `service_db_inspect`, and authenticated CRM proofs from step 3.

--- a/.agent/runbooks/database.md
+++ b/.agent/runbooks/database.md
@@ -165,6 +165,33 @@ break-glass path.
    service_db_has_socket_assignment() {
      sudo grep -Eqi '^[[:space:]]*(export[[:space:]]+)?ATLAS_DB_SOCKET_PATH[[:space:]]*=' "$1"
    }
+   service_db_has_nonempty_connection_string_assignment() {
+     sudo awk '
+       BEGIN { found = 0 }
+       {
+         line = $0
+         sub(/^[[:space:]]*/, "", line)
+         sub(/^export[[:space:]]+/, "", line)
+         if (line !~ /^ATLAS_DB_CONNECTION_STRING[[:space:]]*=/) {
+           next
+         }
+         sub(/^ATLAS_DB_CONNECTION_STRING[[:space:]]*=/, "", line)
+         sub(/^[[:space:]]*/, "", line)
+         if (line ~ /^#/) {
+           line = ""
+         } else {
+           sub(/[[:space:]]+#.*/, "", line)
+           sub(/[[:space:]]*$/, "", line)
+         }
+         if (line == "" || line == "\"\"" || line == sprintf("%c%c", 39, 39)) {
+           next
+         }
+         found = 1
+         exit
+       }
+       END { exit(found ? 0 : 1) }
+     ' "$1"
+   }
    service_db_require_canonical_keys() {
      saw_service_env=0
      while IFS= read -r service_env_file; do
@@ -206,6 +233,22 @@ break-glass path.
        fi
      done < <(printf '%s\n' "$SERVICE_ENV_FILES" | tr ':' '\n')
    }
+   service_db_require_new_socket_configuration() {
+     service_db_require_no_socket_assignments || return 1
+     while IFS= read -r service_env_file; do
+       [ -n "$service_env_file" ] || continue
+       if service_db_has_nonempty_connection_string_assignment "$service_env_file"; then
+         printf '%s\n' 'nonblank ATLAS_DB_CONNECTION_STRING assignment found; use a separate configuration migration' >&2
+         return 1
+       else
+         connection_string_status=$?
+         if [ "$connection_string_status" -ne 1 ]; then
+           printf '%s\n' 'could not inspect service EnvironmentFile connection-string assignments; do not continue' >&2
+           return 1
+         fi
+       fi
+     done < <(printf '%s\n' "$SERVICE_ENV_FILES" | tr ':' '\n')
+   }
    service_db_inspect() {
      service_db_require_canonical_keys || return 1
      env -u ATLAS_DB_ENABLED \
@@ -223,17 +266,23 @@ break-glass path.
        ATLAS_OPS_ENV_FILES="$SERVICE_ENV_FILES" \
        ./ops db inspect connectivity
    }
+   service_db_require_new_socket_configuration || exit 1
    service_db_inspect
    ```
 
    Do not run a bare `./ops db inspect connectivity` in this procedure: a
    worktree `.env` takes precedence over the service files. If the service has
    no readable `EnvironmentFiles`, stop rather than substituting a worktree or
-   shared configuration.
+   shared configuration. The admission command must succeed before the first
+   backup, HBA/identity edit, or PostgreSQL reload. It rejects an empty
+   service-file set, any case-variant `ATLAS_DB_*` key, every existing socket
+   assignment, and every nonblank complete-DSN assignment without printing a
+   value. A complete DSN deliberately takes precedence over
+   `ATLAS_DB_SOCKET_PATH`; do not remove or rewrite one as part of this
+   procedure. That needs a separate configuration-migration slice.
 
-2. The source receipt above proves every loopback `trust` rule this procedure
-   will replace lives in the top-level HBA file, so preserve only the two
-   PostgreSQL authentication files before editing them:
+2. Only after both the source and service-configuration receipts succeed,
+   preserve the two PostgreSQL authentication files before editing them:
 
    ```bash
    if sudo test -e /etc/postgresql/16/main/pg_hba.conf.pre-atlas-peer \
@@ -312,25 +361,10 @@ break-glass path.
    still uses TCP at this point, so a valid scoped peer rule can be proved
    without removing the existing path.
 
-3. Re-run `service_db_require_no_socket_assignments`; it rejects an empty
-   service-file set, any case-variant `ATLAS_DB_*` key, and every existing
-   socket assignment before either fixed inspection or this edit step can use a
-   different configuration from `atlas-api.service`. Then, in the effective
-   service configuration selected by `SERVICE_ENV_FILES`, use `./ops env keys
-   --file <each service file>` and an editor to identify the final canonical
-   `ATLAS_DB_*` assignment in service-file order. Verify that the effective
-   `ATLAS_DB_CONNECTION_STRING` is absent or empty. A nonblank full DSN
-   deliberately takes precedence over `ATLAS_DB_SOCKET_PATH`, so this cutover
-   must stop if one is effective. Do not remove or rewrite a full DSN as part of
-   this procedure; that needs a separate configuration-migration slice.
-
-   ```bash
-   service_db_require_no_socket_assignments || exit 1
-   ```
-
-   This procedure supports only a **new** socket setting. Do not replace,
-   remove, or preserve an existing assignment here: its original behavior needs
-   a separate configuration migration with an exact restoration receipt.
+3. The pre-mutation admission receipt means this procedure supports only a
+   **new** socket setting. Do not replace, remove, or preserve an existing
+   socket assignment or complete DSN here: its original behavior needs a
+   separate configuration migration with an exact restoration receipt.
 
    Set `EFFECTIVE_DB_ENV_FILE` to the final file in service-file order, confirm
    it is one of the paths in `SERVICE_ENV_FILES`, and add exactly this non-secret
@@ -482,7 +516,24 @@ break-glass path.
       ) AS loopback_network_rule_count \
       FROM hba;"
    sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -At -F '|' -c \
-     "SELECT \
+     "WITH hba AS ( \
+        SELECT *, \
+          CASE \
+            WHEN address IS NULL OR netmask IS NULL THEN TRUE \
+            WHEN NOT pg_input_is_valid(address, 'inet') \
+              OR NOT pg_input_is_valid(netmask, 'inet') THEN TRUE \
+            WHEN family(address::inet) <> family(netmask::inet) THEN TRUE \
+            WHEN family(address::inet) = 4 THEN \
+              host(address::inet & netmask::inet) \
+                = host('127.0.0.1'::inet & netmask::inet) \
+            WHEN family(address::inet) = 6 THEN \
+              host(address::inet & netmask::inet) \
+                = host('::1'::inet & netmask::inet) \
+            ELSE TRUE \
+          END AS covers_loopback \
+        FROM pg_hba_file_rules \
+      ) \
+      SELECT \
         count(*) FILTER ( \
           WHERE type = 'host' \
             AND database = ARRAY['all']::text[] \
@@ -548,7 +599,7 @@ break-glass path.
             AND covers_loopback \
             AND file_name IS DISTINCT FROM '/etc/postgresql/16/main/pg_hba.conf' \
         ) AS loopback_rules_outside_backup \
-      FROM pg_hba_file_rules;"
+      FROM hba;"
    ```
 
    The first query must return `4`: it derives every non-local HBA rule whose

--- a/.agent/runbooks/database.md
+++ b/.agent/runbooks/database.md
@@ -129,13 +129,18 @@ break-glass path.
    ```bash
    SERVICE_ENV_FILES='/absolute/first.service.env:/absolute/second.service.env'
    service_db_inspect() {
-     env -u ATLAS_DB_CONNECTION_STRING \
+     env -u ATLAS_DB_ENABLED \
+       -u ATLAS_DB_CONNECTION_STRING \
        -u ATLAS_DB_HOST \
        -u ATLAS_DB_PORT \
        -u ATLAS_DB_DATABASE \
        -u ATLAS_DB_USER \
        -u ATLAS_DB_PASSWORD \
+       -u ATLAS_DB_MIN_POOL_SIZE \
+       -u ATLAS_DB_MAX_POOL_SIZE \
        -u ATLAS_DB_SOCKET_PATH \
+       -u ATLAS_DB_CONNECT_TIMEOUT \
+       -u ATLAS_DB_COMMAND_TIMEOUT \
        ATLAS_OPS_ENV_FILES="$SERVICE_ENV_FILES" \
        ./ops db inspect connectivity
    }

--- a/.agent/runbooks/database.md
+++ b/.agent/runbooks/database.md
@@ -192,11 +192,49 @@ break-glass path.
    DSN deliberately takes precedence over `ATLAS_DB_SOCKET_PATH`, so this
    cutover must stop if one is effective. Do not remove or rewrite a full DSN as
    part of this procedure; that needs a separate configuration-migration slice.
-   Then add exactly this non-secret setting to the file that supplies the
-   effective database configuration; do not copy or print the rest of any file:
+   Set `EFFECTIVE_DB_ENV_FILE` to that one effective file, confirm it is one of
+   the paths in `SERVICE_ENV_FILES`, and add exactly this non-secret setting
+   with `sudoedit "$EFFECTIVE_DB_ENV_FILE"`; do not copy or print the rest of
+   any file:
+
+   ```bash
+   EFFECTIVE_DB_ENV_FILE='/absolute/path/to/the-effective.service.env'
+   sudoedit "$EFFECTIVE_DB_ENV_FILE"
+   ```
 
    ```text
    ATLAS_DB_SOCKET_PATH=/var/run/postgresql
+   ```
+
+   Define this shell-local rollback helper before the restart. It is the only
+   rollback path after the socket setting exists; when it opens the editor,
+   remove only the exact `ATLAS_DB_SOCKET_PATH=/var/run/postgresql` line just
+   added, save, and exit before the function restores the two authentication
+   files:
+
+   ```bash
+   rollback_peer_cutover() {
+     case ":$SERVICE_ENV_FILES:" in
+       *":$EFFECTIVE_DB_ENV_FILE:"*) ;;
+       *) printf '%s\n' 'effective database environment file is not a service EnvironmentFile' >&2; return 1 ;;
+     esac
+     sudoedit "$EFFECTIVE_DB_ENV_FILE" || return 1
+     if sudo grep -Eq '^[[:space:]]*ATLAS_DB_SOCKET_PATH=/var/run/postgresql[[:space:]]*$' "$EFFECTIVE_DB_ENV_FILE"; then
+       printf '%s\n' 'remove only the added ATLAS_DB_SOCKET_PATH line before rollback can continue' >&2
+       return 1
+     fi
+     sudo cp --preserve=mode,ownership,timestamps /etc/postgresql/16/main/pg_hba.conf.pre-atlas-peer \
+       /etc/postgresql/16/main/pg_hba.conf || return 1
+     sudo cp --preserve=mode,ownership,timestamps /etc/postgresql/16/main/pg_ident.conf.pre-atlas-peer \
+       /etc/postgresql/16/main/pg_ident.conf || return 1
+     sudo systemctl reload postgresql@16-main || return 1
+     if [ "$(sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -At -F '|' -c 'SELECT count(*) FILTER (WHERE auth_method = '\''trust'\''), count(*) FILTER (WHERE error IS NOT NULL) FROM pg_hba_file_rules;')" != '4|0' ]; then
+       printf '%s\n' 'restored HBA receipt was not 4|0; do not restart atlas-api' >&2
+       return 1
+     fi
+     systemctl --user restart atlas-api.service || return 1
+     service_db_inspect
+   }
    ```
 
    Restart the user service, then prove that the application has changed its
@@ -330,10 +368,10 @@ break-glass path.
    The query must return `1|1|1|1|0|0|0`: one exact application IPv4 rule, one
    exact application IPv6 rule, one exact replication IPv4 rule, one exact
    replication IPv6 rule, no unexpected loopback host rule, no trust rule, and
-   no parser error. If any field differs, do not proceed: follow step 6 exactly
-   so the restored HBA/ident files are reloaded before the procedure stops. Then
-   repeat the service, `service_db_inspect`, and authenticated CRM proofs from
-   step 3.
+   no parser error. If any field differs, do not proceed: run
+   `rollback_peer_cutover` immediately so the restored HBA/ident files are
+   reloaded before the procedure stops. Then repeat the service,
+   `service_db_inspect`, and authenticated CRM proofs from step 3.
 
 5. Verify both sides of the new boundary. The passwordless TCP probe must fail;
    the retained `postgres` socket peer probe must succeed:
@@ -342,6 +380,7 @@ break-glass path.
    if env -u PGPASSWORD -u ATLAS_DB_PASSWORD PGPASSFILE=/dev/null \
      psql -w -h 127.0.0.1 -p 5433 -U atlas -d atlas -Atc 'SELECT 1'; then
      printf '%s\n' 'unexpected passwordless loopback TCP access' >&2
+     rollback_peer_cutover
      exit 1
    fi
    sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -Atc \
@@ -352,14 +391,13 @@ break-glass path.
    authentication without prompting. Do not use an existing `.pgpass` file or
    a secret-bearing shell environment as a substitute test.
 
-6. If the loaded-HBA receipt or any later step fails after the HBA conversion,
-   first remove only the added `ATLAS_DB_SOCKET_PATH` line from the effective
-   service configuration. Then restore both saved authentication files and
-   reload PostgreSQL before stopping or restarting anything else. Restart
-   `atlas-api.service` once only after that reload. Re-run
-   `service_db_inspect` and the CRM read before declaring rollback complete. Do
-   not edit roles, passwords, migration ledger rows, or database data as part of
-   rollback.
+6. `rollback_peer_cutover` is mandatory when the loaded-HBA receipt, the
+   passwordless TCP probe, or any later proof fails after HBA conversion. It
+   removes only the added socket setting through `sudoedit`, restores and
+   reloads HBA/ident, proves the restored `4|0` HBA receipt, then restarts
+   `atlas-api.service` and re-runs fixed inspection. After it succeeds, re-run
+   the CRM read before declaring rollback complete. Do not edit roles,
+   passwords, migration ledger rows, or database data as part of rollback.
 
 `service_db_inspect` remains fixed-query-only. It explicitly selects the same
 service configuration as the application and uses a `READ ONLY` transaction.

--- a/.agent/runbooks/database.md
+++ b/.agent/runbooks/database.md
@@ -67,12 +67,13 @@ authentication. The existing `postgres` Unix-socket peer rule remains the
 break-glass path.
 
 1. Revalidate the exact deployed source, service identity, PostgreSQL paths,
-   active local clients, and current health. Do not print `.env` values or a
+   active local clients, and current health. Record the service
+   `EnvironmentFiles` in their printed order. Do not print `.env` values or a
    database URL:
 
    ```bash
    ./ops deploy status
-   ./ops db inspect connectivity
+   ./ops env systemd
    id -un
    sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -At -F '|' -c \
      "SHOW hba_file; SHOW ident_file; SHOW unix_socket_directories;"
@@ -82,6 +83,11 @@ break-glass path.
       WHERE client_addr IN ('127.0.0.1'::inet, '::1'::inet);"
    sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -At -c \
      "SELECT count(*) FROM pg_stat_replication;"
+   sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -At -F '|' -c \
+     "SELECT type, address, netmask, auth_method \
+      FROM pg_hba_file_rules \
+      WHERE auth_method = 'trust' \
+      ORDER BY line_number;"
    ```
 
    For the current single-user deployment, the service account is
@@ -89,7 +95,37 @@ break-glass path.
    identity-map file is `/etc/postgresql/16/main/pg_ident.conf`, and the socket
    directory is `/var/run/postgresql`. Stop if the live results differ; derive
    the map/rules from the returned topology rather than copying these values
-   blindly.
+   blindly. The final query must show exactly four `host` trust rows: two for
+   `127.0.0.1` and two for `::1`, one application and one replication row for
+   each address. Stop if any other trust row exists; this runbook does not
+   generalize a different HBA topology.
+
+   Set `SERVICE_ENV_FILES` to the absolute `EnvironmentFiles` paths printed by
+   `./ops env systemd`, joined with `:` in that same order. Use this shell-local
+   helper for every fixed inspection in this cutover. It selects the service's
+   configuration without printing values and removes ad hoc Atlas database
+   variables that would otherwise override those files:
+
+   ```bash
+   SERVICE_ENV_FILES='/absolute/first.service.env:/absolute/second.service.env'
+   service_db_inspect() {
+     env -u ATLAS_DB_CONNECTION_STRING \
+       -u ATLAS_DB_HOST \
+       -u ATLAS_DB_PORT \
+       -u ATLAS_DB_DATABASE \
+       -u ATLAS_DB_USER \
+       -u ATLAS_DB_PASSWORD \
+       -u ATLAS_DB_SOCKET_PATH \
+       ATLAS_OPS_ENV_FILES="$SERVICE_ENV_FILES" \
+       ./ops db inspect connectivity
+   }
+   service_db_inspect
+   ```
+
+   Do not run a bare `./ops db inspect connectivity` in this procedure: a
+   worktree `.env` takes precedence over the service files. If the service has
+   no readable `EnvironmentFiles`, stop rather than substituting a worktree or
+   shared configuration.
 
 2. Preserve only the two PostgreSQL authentication files before editing them:
 
@@ -130,13 +166,15 @@ break-glass path.
    point, so a valid scoped peer rule can be proved without removing the
    existing path.
 
-3. In the shared application configuration read by `atlas-api.service`, use an
-   editor to verify that `ATLAS_DB_CONNECTION_STRING` is absent or empty. A
-   nonblank full DSN deliberately takes precedence over
-   `ATLAS_DB_SOCKET_PATH`, so this cutover must stop if one is effective. Do
-   not remove or rewrite a full DSN as part of this procedure; that needs a
-   separate configuration-migration slice. Then add exactly this non-secret
-   setting; do not copy or print the rest of the file:
+3. In the effective service configuration selected by `SERVICE_ENV_FILES`, use
+   `./ops env keys --file <each service file>` and an editor to identify the
+   final `ATLAS_DB_*` assignment in service-file order. Verify that the
+   effective `ATLAS_DB_CONNECTION_STRING` is absent or empty. A nonblank full
+   DSN deliberately takes precedence over `ATLAS_DB_SOCKET_PATH`, so this
+   cutover must stop if one is effective. Do not remove or rewrite a full DSN as
+   part of this procedure; that needs a separate configuration-migration slice.
+   Then add exactly this non-secret setting to the file that supplies the
+   effective database configuration; do not copy or print the rest of any file:
 
    ```text
    ATLAS_DB_SOCKET_PATH=/var/run/postgresql
@@ -165,7 +203,7 @@ break-glass path.
         AND datname = 'atlas' \
         AND backend_type = 'client backend' \
       ORDER BY backend_start;"
-   ./ops db inspect connectivity
+   service_db_inspect
    ```
 
    At least one backend with a `backend_start` after the just-issued service
@@ -186,8 +224,27 @@ break-glass path.
    host    replication     all             ::1/128                 scram-sha-256
    ```
 
-   Do not alter any non-loopback rule. Reload PostgreSQL and repeat the
-   service, fixed-inspection, and authenticated CRM proofs from step 3.
+   Do not alter any non-loopback rule. Reload PostgreSQL, then verify the
+   loaded rule set before repeating the service, fixed-inspection, and
+   authenticated CRM proofs from step 3:
+
+   ```bash
+   sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -At -F '|' -c \
+     "SELECT \
+        count(*) FILTER ( \
+          WHERE type = 'host' \
+            AND address IN ('127.0.0.1', '::1') \
+            AND auth_method = 'scram-sha-256' \
+        ) AS loopback_scram_rules, \
+        count(*) FILTER (WHERE auth_method = 'trust') AS remaining_trust_rules, \
+        count(*) FILTER (WHERE error IS NOT NULL) AS hba_errors \
+      FROM pg_hba_file_rules;"
+   ```
+
+   The query must return `4|0|0`: all four recorded loopback host rules use
+   SCRAM, no trust rule remains, and PostgreSQL loaded the file without errors.
+   Otherwise restore the saved files and stop. Then repeat the service,
+   `service_db_inspect`, and authenticated CRM proofs from step 3.
 
 5. Verify both sides of the new boundary. The passwordless TCP probe must fail;
    the retained `postgres` socket peer probe must succeed:
@@ -207,16 +264,15 @@ break-glass path.
    a secret-bearing shell environment as a substitute test.
 
 6. If a step fails after the HBA conversion, first remove only the added
-   `ATLAS_DB_SOCKET_PATH` line from shared configuration. Then restore both
-   saved authentication files, reload PostgreSQL, and restart
-   `atlas-api.service` once. Re-run the fixed inspection and CRM read before
+   `ATLAS_DB_SOCKET_PATH` line from the effective service configuration. Then
+   restore both saved authentication files, reload PostgreSQL, and restart
+   `atlas-api.service` once. Re-run `service_db_inspect` and the CRM read before
    declaring rollback complete. Do not edit roles, passwords, migration ledger
    rows, or database data as part of rollback.
 
-`./ops db inspect` remains fixed-query-only. It already selects the same
-socket-path configuration as the application and uses a `READ ONLY`
-transaction. This cutover does not create a generic command runner or expose a
-credential.
+`service_db_inspect` remains fixed-query-only. It explicitly selects the same
+service configuration as the application and uses a `READ ONLY` transaction.
+This cutover does not create a generic command runner or expose a credential.
 
 ## Migrations
 

--- a/.agent/runbooks/database.md
+++ b/.agent/runbooks/database.md
@@ -92,10 +92,22 @@ break-glass path.
       WHERE map_name = 'atlas_app' \
       ORDER BY line_number;"
    sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -At -F '|' -c \
-     "SELECT type, database, user_name, address, netmask, auth_method \
+     "SELECT rule_number, file_name, line_number, type, database, user_name, \
+             address, netmask, auth_method \
       FROM pg_hba_file_rules \
       WHERE auth_method = 'trust' \
-      ORDER BY line_number;"
+      ORDER BY rule_number;"
+   if [ "$(sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -At -F '|' -c \
+     "SELECT count(*) FILTER (WHERE auth_method = 'trust'), \
+             count(*) FILTER ( \
+               WHERE auth_method = 'trust' \
+                 AND file_name IS DISTINCT FROM '/etc/postgresql/16/main/pg_hba.conf' \
+             ), \
+             count(*) FILTER (WHERE error IS NOT NULL) \
+      FROM pg_hba_file_rules;")" != '4|0|0' ]; then
+     printf '%s\n' 'trust HBA source receipt was not 4|0|0; do not edit the top-level file' >&2
+     exit 1
+   fi
    ```
 
    Record every row from those two inventory queries in the cutover record as
@@ -115,9 +127,12 @@ break-glass path.
    the map/rules from the returned topology rather than copying these values
    blindly. The final query must show exactly four `host` trust rows: two
    `{all}` application rows and two `{replication}` rows, one for each of
-   `127.0.0.1` and `::1`. Stop if any other trust row exists; this runbook does
-   not generalize a different HBA topology. The `atlas_app` identity-map query
-   must return no rows before editing: do not reuse a pre-existing map name.
+   `127.0.0.1` and `::1`. The immediately preceding HBA source receipt must be
+   `4|0|0`: four trust rows, none sourced outside
+   `/etc/postgresql/16/main/pg_hba.conf`, and no parser error. Stop if any
+   value differs; this runbook does not generalize a different HBA topology or
+   edit an included HBA file. The `atlas_app` identity-map query must return no
+   rows before editing: do not reuse a pre-existing map name.
 
    Set `SERVICE_ENV_FILES` to the absolute `EnvironmentFiles` paths printed by
    `./ops env systemd`, joined with `:` in that same order. Use this shell-local
@@ -216,7 +231,9 @@ break-glass path.
    no readable `EnvironmentFiles`, stop rather than substituting a worktree or
    shared configuration.
 
-2. Preserve only the two PostgreSQL authentication files before editing them:
+2. The source receipt above proves every loopback `trust` rule this procedure
+   will replace lives in the top-level HBA file, so preserve only the two
+   PostgreSQL authentication files before editing them:
 
    ```bash
    if sudo test -e /etc/postgresql/16/main/pg_hba.conf.pre-atlas-peer \
@@ -348,8 +365,8 @@ break-glass path.
      sudo cp --preserve=mode,ownership,timestamps /etc/postgresql/16/main/pg_ident.conf.pre-atlas-peer \
        /etc/postgresql/16/main/pg_ident.conf || return 1
      sudo systemctl reload postgresql@16-main || return 1
-     if [ "$(sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -At -F '|' -c 'SELECT count(*) FILTER (WHERE auth_method = '\''trust'\''), count(*) FILTER (WHERE error IS NOT NULL) FROM pg_hba_file_rules;')" != '4|0' ]; then
-       printf '%s\n' 'restored HBA receipt was not 4|0; do not restart atlas-api' >&2
+     if [ "$(sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -At -F '|' -c 'SELECT count(*) FILTER (WHERE auth_method = '\''trust'\''), count(*) FILTER (WHERE auth_method = '\''trust'\'' AND file_name IS DISTINCT FROM '\''/etc/postgresql/16/main/pg_hba.conf'\''), count(*) FILTER (WHERE error IS NOT NULL) FROM pg_hba_file_rules;')" != '4|0|0' ]; then
+       printf '%s\n' 'restored HBA receipt was not 4|0|0; do not restart atlas-api' >&2
        return 1
      fi
      systemctl --user restart atlas-api.service || return 1
@@ -380,6 +397,19 @@ break-glass path.
         AND datname = 'atlas' \
         AND backend_type = 'client backend' \
       ORDER BY backend_start;"
+   sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -At -F '|' -c \
+     "WITH atlas_backends AS ( \
+        SELECT client_addr \
+        FROM pg_stat_activity \
+        WHERE usename = 'atlas' \
+          AND datname = 'atlas' \
+          AND backend_type = 'client backend' \
+      ) \
+      SELECT \
+        CASE WHEN count(*) > 0 THEN 1 ELSE 0 END, \
+        CASE WHEN count(*) FILTER (WHERE client_addr IS NULL) = count(*) \
+          THEN 1 ELSE 0 END \
+      FROM atlas_backends;"
    service_db_inspect
    sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -At -F '|' -c \
      "SELECT application_name, usename, client_addr, state \
@@ -391,13 +421,15 @@ break-glass path.
       WHERE client_addr IN ('127.0.0.1'::inet, '::1'::inet);"
    ```
 
-   At least one backend with a `backend_start` after the just-issued service
-   restart must show `<unix>` for `client_addr`; compare the rows with the
-   loopback clients from step 1 and stop if the service's backend cannot be
-   identified as a Unix socket connection. The fixed inspection must also
-   succeed only after that transport proof. If any proof fails, remove only the
-   exact non-secret setting just added, restore the two saved PostgreSQL files,
-   reload PostgreSQL, and restart `atlas-api.service`.
+   The immediate transport receipt must return `1|1`: the CRM read created at
+   least one qualifying `atlas`/`atlas` client backend, and every qualifying
+   backend has a null `client_addr` (a Unix socket). Do not accept one socket
+   row while another qualifying backend is TCP; that would not prove the
+   restarted application uses the socket. Compare the rows with the loopback
+   clients from step 1. The fixed inspection must also succeed only after that
+   transport proof. If any proof fails, remove only the exact non-secret setting
+   just added, restore the two saved PostgreSQL files, reload PostgreSQL, and
+   restart `atlas-api.service`.
 
    Record those two later queries as the **final loopback-client inventory**.
    Before step 4, reconcile every client identity in the union of the initial
@@ -510,19 +542,24 @@ break-glass path.
             ) \
         ) AS unexpected_loopback_host_rules, \
         count(*) FILTER (WHERE auth_method = 'trust') AS remaining_trust_rules, \
-        count(*) FILTER (WHERE error IS NOT NULL) AS hba_errors \
+        count(*) FILTER (WHERE error IS NOT NULL) AS hba_errors, \
+        count(*) FILTER ( \
+          WHERE type <> 'local' \
+            AND covers_loopback \
+            AND file_name IS DISTINCT FROM '/etc/postgresql/16/main/pg_hba.conf' \
+        ) AS loopback_rules_outside_backup \
       FROM pg_hba_file_rules;"
    ```
 
    The first query must return `4`: it derives every non-local HBA rule whose
    network can cover either loopback endpoint. This count fails closed for a
    broader subnet, `hostssl`/other host type, an unparseable address form, or a
-   family mismatch. The second query must return `1|1|1|1|0|0|0`: one exact
+   family mismatch. The second query must return `1|1|1|1|0|0|0|0`: one exact
    application IPv4 rule, one exact application IPv6 rule, one exact replication
    IPv4 rule, one exact replication IPv6 rule, no unexpected endpoint-equal host
-   rule, no trust rule, and no parser error. If either receipt differs, do not
-   proceed: run
-   `rollback_peer_cutover` immediately so the restored HBA/ident files are
+   rule, no trust rule, no parser error, and no loopback rule sourced outside
+   the backed-up top-level HBA file. If either receipt differs, do not proceed:
+   run `rollback_peer_cutover` immediately so the restored HBA/ident files are
    reloaded before the procedure stops. Then repeat the service,
    `service_db_inspect`, and authenticated CRM proofs from step 3.
 
@@ -547,7 +584,7 @@ break-glass path.
 6. `rollback_peer_cutover` is mandatory when the loaded-HBA receipt, the
    passwordless TCP probe, or any later proof fails after HBA conversion. It
    removes only the added socket setting through `sudoedit`, restores and
-   reloads HBA/ident, proves the restored `4|0` HBA receipt, then restarts
+   reloads HBA/ident, proves the restored `4|0|0` HBA receipt, then restarts
    `atlas-api.service` and re-runs fixed inspection. After it succeeds, re-run
    the CRM read before declaring rollback complete. Do not edit roles,
    passwords, migration ledger rows, or database data as part of rollback.

--- a/.agent/runbooks/database.md
+++ b/.agent/runbooks/database.md
@@ -327,9 +327,19 @@ break-glass path.
      ' "$1"
    }
    service_db_require_canonical_keys() {
+     if [ -z "$SERVICE_ENV_FILES" ]; then
+       printf '%s\n' 'no service EnvironmentFiles selected; do not inspect a fallback context' >&2
+       return 1
+     fi
      saw_service_env=0
      while IFS= read -r service_env_file; do
-       [ -n "$service_env_file" ] || continue
+       case "$service_env_file" in
+         /*) ;;
+         *)
+           printf '%s\n' 'service EnvironmentFile must be a nonempty absolute path; do not inspect it' >&2
+           return 1
+           ;;
+       esac
        saw_service_env=1
        if ! sudo test -r "$service_env_file"; then
          printf '%s\n' 'service EnvironmentFile is unreadable; do not inspect it' >&2
@@ -368,6 +378,14 @@ break-glass path.
      done < <(printf '%s\n' "$SERVICE_ENV_FILES" | tr ':' '\n')
    }
    service_db_require_effective_env_file() {
+     service_db_require_canonical_keys || return 1
+     case "$EFFECTIVE_DB_ENV_FILE" in
+       /*) ;;
+       *)
+         printf '%s\n' 'effective database environment file must be a nonempty absolute path' >&2
+         return 1
+         ;;
+     esac
      case ":$SERVICE_ENV_FILES:" in
        *":$EFFECTIVE_DB_ENV_FILE:"*) ;;
        *) printf '%s\n' 'effective database environment file is not a service EnvironmentFile' >&2; return 1 ;;

--- a/.agent/runbooks/database.md
+++ b/.agent/runbooks/database.md
@@ -247,7 +247,31 @@ break-glass path.
    ```bash
    sudo systemctl reload postgresql@16-main
    sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -At -c \
-     "SELECT \
+     "WITH intended_peer_rule AS ( \
+        SELECT line_number \
+        FROM pg_hba_file_rules \
+        WHERE error IS NULL \
+          AND type = 'local' \
+          AND database = ARRAY['atlas']::text[] \
+          AND user_name = ARRAY['atlas']::text[] \
+          AND auth_method = 'peer' \
+          AND options = ARRAY['map=atlas_app']::text[] \
+      ), \
+      preceding_local_rules AS ( \
+        SELECT rules.line_number \
+        FROM pg_hba_file_rules AS rules \
+        JOIN intended_peer_rule AS intended \
+          ON rules.line_number < intended.line_number \
+        WHERE rules.error IS NULL \
+          AND rules.type = 'local' \
+          AND NOT ( \
+            rules.database = ARRAY['all']::text[] \
+            AND rules.user_name = ARRAY['postgres']::text[] \
+            AND rules.auth_method = 'peer' \
+            AND COALESCE(rules.options, ARRAY[]::text[]) = ARRAY[]::text[] \
+          ) \
+      ) \
+      SELECT \
         (SELECT count(*) FROM pg_hba_file_rules WHERE error IS NOT NULL), \
         count(*) FILTER ( \
           WHERE map_name = 'atlas_app' \
@@ -255,16 +279,20 @@ break-glass path.
             AND pg_username = 'atlas' \
         ), \
         count(*) FILTER (WHERE map_name = 'atlas_app'), \
-        count(*) FILTER (WHERE error IS NOT NULL) \
+        count(*) FILTER (WHERE error IS NOT NULL), \
+        (SELECT count(*) FROM intended_peer_rule), \
+        (SELECT count(*) FROM preceding_local_rules) \
       FROM pg_ident_file_mappings;"
    ```
 
-   The final query must return `0|1|1|0`: no HBA parser error, exactly one
+   The final query must return `0|1|1|0|1|0`: no HBA parser error, exactly one
    intended `atlas_app | juan-canfield | atlas` mapping, no additional
-   `atlas_app` mapping, and no identity-map error. Otherwise restore both saved
-   files and reload PostgreSQL before continuing. The service still uses TCP at
-   this point, so a valid scoped peer rule can be proved without removing the
-   existing path.
+   `atlas_app` mapping, no identity-map error, exactly one loaded
+   `local atlas atlas peer map=atlas_app` rule, and no preceding local rule
+   other than the retained `local all postgres peer` recovery rule. Otherwise
+   restore both saved files and reload PostgreSQL before continuing. The service
+   still uses TCP at this point, so a valid scoped peer rule can be proved
+   without removing the existing path.
 
 3. Re-run `service_db_require_no_socket_assignments`; it rejects an empty
    service-file set, any case-variant `ATLAS_DB_*` key, and every existing

--- a/.agent/runbooks/database.md
+++ b/.agent/runbooks/database.md
@@ -143,6 +143,7 @@ break-glass path.
 
    ```bash
    SERVICE_ENV_FILES='/absolute/first.service.env:/absolute/second.service.env'
+   EFFECTIVE_DB_ENV_FILE="${SERVICE_ENV_FILES##*:}"
    service_db_has_case_variant_key() {
      sudo awk '
        BEGIN { found = 0 }
@@ -233,7 +234,14 @@ break-glass path.
        fi
      done < <(printf '%s\n' "$SERVICE_ENV_FILES" | tr ':' '\n')
    }
+   service_db_require_effective_env_file() {
+     case ":$SERVICE_ENV_FILES:" in
+       *":$EFFECTIVE_DB_ENV_FILE:"*) ;;
+       *) printf '%s\n' 'effective database environment file is not a service EnvironmentFile' >&2; return 1 ;;
+     esac
+   }
    service_db_require_new_socket_configuration() {
+     service_db_require_effective_env_file || return 1
      service_db_require_no_socket_assignments || return 1
      while IFS= read -r service_env_file; do
        [ -n "$service_env_file" ] || continue
@@ -361,18 +369,17 @@ break-glass path.
    still uses TCP at this point, so a valid scoped peer rule can be proved
    without removing the existing path.
 
-3. The pre-mutation admission receipt means this procedure supports only a
+3. The pre-mutation admission receipt derives and validates
+   `EFFECTIVE_DB_ENV_FILE` as the final selected service file before any
+   authentication edit. This procedure supports only a
    **new** socket setting. Do not replace, remove, or preserve an existing
    socket assignment or complete DSN here: its original behavior needs a
    separate configuration migration with an exact restoration receipt.
 
-   Set `EFFECTIVE_DB_ENV_FILE` to the final file in service-file order, confirm
-   it is one of the paths in `SERVICE_ENV_FILES`, and add exactly this non-secret
-   setting with `sudoedit "$EFFECTIVE_DB_ENV_FILE"`; do not copy or print the
-   rest of any file:
+   Add exactly this non-secret setting with `sudoedit "$EFFECTIVE_DB_ENV_FILE"`;
+   do not copy or print the rest of that file:
 
    ```bash
-   EFFECTIVE_DB_ENV_FILE='/absolute/path/to/the-effective.service.env'
    sudoedit "$EFFECTIVE_DB_ENV_FILE"
    ```
 
@@ -388,10 +395,7 @@ break-glass path.
 
    ```bash
    rollback_peer_cutover() {
-     case ":$SERVICE_ENV_FILES:" in
-       *":$EFFECTIVE_DB_ENV_FILE:"*) ;;
-       *) printf '%s\n' 'effective database environment file is not a service EnvironmentFile' >&2; return 1 ;;
-     esac
+     service_db_require_effective_env_file || return 1
      sudoedit "$EFFECTIVE_DB_ENV_FILE" || return 1
      service_db_require_no_socket_assignments || return 1
      sudo cp --preserve=mode,ownership,timestamps /etc/postgresql/16/main/pg_hba.conf.pre-atlas-peer \

--- a/.agent/runbooks/database.md
+++ b/.agent/runbooks/database.md
@@ -211,10 +211,10 @@ break-glass path.
    part of this procedure; that needs a separate configuration-migration slice.
 
    This procedure supports only a **new** socket setting. Before any edit, stop
-   if any selected service file already assigns `ATLAS_DB_SOCKET_PATH`, including
-   an empty or different value. Do not replace, remove, or preserve an existing
-   assignment here: its original behavior needs a separate configuration
-   migration with an exact restoration receipt.
+   if any selected service file already assigns `ATLAS_DB_SOCKET_PATH` in any
+   case variant, including an empty or different value. Do not replace, remove,
+   or preserve an existing assignment here: its original behavior needs a
+   separate configuration migration with an exact restoration receipt.
 
    ```bash
    while IFS= read -r service_env_file; do
@@ -223,7 +223,7 @@ break-glass path.
        printf '%s\n' 'service EnvironmentFile is unreadable; do not add a socket setting' >&2
        exit 1
      fi
-     if sudo grep -Eq '^[[:space:]]*(export[[:space:]]+)?ATLAS_DB_SOCKET_PATH[[:space:]]*=' "$service_env_file"; then
+     if sudo grep -Eqi '^[[:space:]]*(export[[:space:]]+)?ATLAS_DB_SOCKET_PATH[[:space:]]*=' "$service_env_file"; then
        printf '%s\n' 'pre-existing ATLAS_DB_SOCKET_PATH found; use a separate configuration migration' >&2
        exit 1
      else

--- a/.agent/runbooks/database.md
+++ b/.agent/runbooks/database.md
@@ -128,7 +128,52 @@ break-glass path.
 
    ```bash
    SERVICE_ENV_FILES='/absolute/first.service.env:/absolute/second.service.env'
+   service_db_has_case_variant_key() {
+     sudo awk '
+       BEGIN { found = 0 }
+       {
+         line = $0
+         sub(/^[[:space:]]*/, "", line)
+         sub(/^export[[:space:]]+/, "", line)
+         if (line ~ /^[A-Za-z_][A-Za-z0-9_]*[[:space:]]*=/) {
+           key = line
+           sub(/[[:space:]]*=.*/, "", key)
+           if (tolower(key) ~ /^atlas_db_/ && key != toupper(key)) {
+             found = 1
+             exit
+           }
+         }
+       }
+       END { exit(found ? 0 : 1) }
+     ' "$1"
+   }
+   service_db_require_canonical_keys() {
+     saw_service_env=0
+     while IFS= read -r service_env_file; do
+       [ -n "$service_env_file" ] || continue
+       saw_service_env=1
+       if ! sudo test -r "$service_env_file"; then
+         printf '%s\n' 'service EnvironmentFile is unreadable; do not inspect it' >&2
+         return 1
+       fi
+       if service_db_has_case_variant_key "$service_env_file"; then
+         printf '%s\n' 'case-variant ATLAS_DB_* key found; normalize it before inspection' >&2
+         return 1
+       else
+         case_variant_status=$?
+         if [ "$case_variant_status" -ne 1 ]; then
+           printf '%s\n' 'could not inspect service EnvironmentFile keys; do not inspect it' >&2
+           return 1
+         fi
+       fi
+     done < <(printf '%s\n' "$SERVICE_ENV_FILES" | tr ':' '\n')
+     if [ "$saw_service_env" -ne 1 ]; then
+       printf '%s\n' 'no service EnvironmentFiles selected; do not inspect a fallback context' >&2
+       return 1
+     fi
+   }
    service_db_inspect() {
+     service_db_require_canonical_keys || return 1
      env -u ATLAS_DB_ENABLED \
        -u ATLAS_DB_CONNECTION_STRING \
        -u ATLAS_DB_HOST \
@@ -202,13 +247,20 @@ break-glass path.
    this point, so a valid scoped peer rule can be proved without removing the
    existing path.
 
-3. In the effective service configuration selected by `SERVICE_ENV_FILES`, use
-   `./ops env keys --file <each service file>` and an editor to identify the
-   final `ATLAS_DB_*` assignment in service-file order. Verify that the
-   effective `ATLAS_DB_CONNECTION_STRING` is absent or empty. A nonblank full
-   DSN deliberately takes precedence over `ATLAS_DB_SOCKET_PATH`, so this
+3. Re-run `service_db_require_canonical_keys`; it rejects an empty service-file
+   set and any case-variant `ATLAS_DB_*` key before either fixed inspection or
+   this edit step can use a different configuration from `atlas-api.service`.
+   Then, in the effective service configuration selected by `SERVICE_ENV_FILES`,
+   use `./ops env keys --file <each service file>` and an editor to identify the
+   final canonical `ATLAS_DB_*` assignment in service-file order. Verify that
+   the effective `ATLAS_DB_CONNECTION_STRING` is absent or empty. A nonblank
+   full DSN deliberately takes precedence over `ATLAS_DB_SOCKET_PATH`, so this
    cutover must stop if one is effective. Do not remove or rewrite a full DSN as
    part of this procedure; that needs a separate configuration-migration slice.
+
+   ```bash
+   service_db_require_canonical_keys || exit 1
+   ```
 
    This procedure supports only a **new** socket setting. Before any edit, stop
    if any selected service file already assigns `ATLAS_DB_SOCKET_PATH` in any

--- a/.agent/runbooks/database.md
+++ b/.agent/runbooks/database.md
@@ -74,13 +74,13 @@ break-glass path.
    ./ops deploy status
    ./ops db inspect connectivity
    id -un
-   sudo -u postgres psql -d atlas -At -F '|' -c \
+   sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -At -F '|' -c \
      "SHOW hba_file; SHOW ident_file; SHOW unix_socket_directories;"
-   sudo -u postgres psql -d atlas -At -F '|' -c \
+   sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -At -F '|' -c \
      "SELECT application_name, usename, client_addr, state \
       FROM pg_stat_activity \
       WHERE client_addr IN ('127.0.0.1'::inet, '::1'::inet);"
-   sudo -u postgres psql -d atlas -At -c \
+   sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -At -c \
      "SELECT count(*) FROM pg_stat_replication;"
    ```
 
@@ -121,7 +121,7 @@ break-glass path.
 
    ```bash
    sudo systemctl reload postgresql@16-main
-   sudo -u postgres psql -d atlas -At -c \
+   sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -At -c \
      "SELECT count(*) FROM pg_hba_file_rules WHERE error IS NOT NULL;"
    ```
 
@@ -130,9 +130,13 @@ break-glass path.
    point, so a valid scoped peer rule can be proved without removing the
    existing path.
 
-3. In the shared application configuration read by `atlas-api.service`, add
-   exactly this non-secret setting with an editor; do not copy or print the
-   rest of the file:
+3. In the shared application configuration read by `atlas-api.service`, use an
+   editor to verify that `ATLAS_DB_CONNECTION_STRING` is absent or empty. A
+   nonblank full DSN deliberately takes precedence over
+   `ATLAS_DB_SOCKET_PATH`, so this cutover must stop if one is effective. Do
+   not remove or rewrite a full DSN as part of this procedure; that needs a
+   separate configuration-migration slice. Then add exactly this non-secret
+   setting; do not copy or print the rest of the file:
 
    ```text
    ATLAS_DB_SOCKET_PATH=/var/run/postgresql
@@ -144,14 +148,33 @@ break-glass path.
    ```bash
    systemctl --user restart atlas-api.service
    ./ops deploy status
-   ./ops db inspect connectivity
    ```
 
    Perform one read-only authenticated EOM CRM Contacts-page refresh. A health
    response alone is insufficient: the generic pool can initialize lazily, so
-   the CRM read proves the application data path. If either proof fails,
-   restore the two saved PostgreSQL files, remove only the exact non-secret
-   setting just added, reload PostgreSQL, and restart `atlas-api.service`.
+   the CRM read proves the application data path. Immediately after that
+   refresh, before running the fixed inspector, observe the application's
+   PostgreSQL backends:
+
+   ```bash
+   sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -At -F '|' -c \
+     "SELECT backend_start, usename, datname, \
+             COALESCE(client_addr::text, '<unix>'), state \
+      FROM pg_stat_activity \
+      WHERE usename = 'atlas' \
+        AND datname = 'atlas' \
+        AND backend_type = 'client backend' \
+      ORDER BY backend_start;"
+   ./ops db inspect connectivity
+   ```
+
+   At least one backend with a `backend_start` after the just-issued service
+   restart must show `<unix>` for `client_addr`; compare the rows with the
+   loopback clients from step 1 and stop if the service's backend cannot be
+   identified as a Unix socket connection. The fixed inspection must also
+   succeed only after that transport proof. If any proof fails, remove only the
+   exact non-secret setting just added, restore the two saved PostgreSQL files,
+   reload PostgreSQL, and restart `atlas-api.service`.
 
 4. Only after the socket-peer proof succeeds, replace **all four** loopback
    TCP `trust` entries in `pg_hba.conf` with `scram-sha-256` using `sudoedit`:
@@ -175,19 +198,20 @@ break-glass path.
      printf '%s\n' 'unexpected passwordless loopback TCP access' >&2
      exit 1
    fi
-   sudo -u postgres psql -d atlas -Atc 'SELECT current_user'
+   sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -Atc \
+     'SELECT current_user'
    ```
 
    The second command must print `postgres`. The first must reject
    authentication without prompting. Do not use an existing `.pgpass` file or
    a secret-bearing shell environment as a substitute test.
 
-6. If a step fails after the HBA conversion, restore both saved authentication
-   files, reload PostgreSQL, and restart `atlas-api.service`. If the service
-   still cannot reconnect, remove only the added `ATLAS_DB_SOCKET_PATH` line
-   from shared configuration and restart again. Re-run the fixed inspection and
-   CRM read before declaring rollback complete. Do not edit roles, passwords,
-   migration ledger rows, or database data as part of rollback.
+6. If a step fails after the HBA conversion, first remove only the added
+   `ATLAS_DB_SOCKET_PATH` line from shared configuration. Then restore both
+   saved authentication files, reload PostgreSQL, and restart
+   `atlas-api.service` once. Re-run the fixed inspection and CRM read before
+   declaring rollback complete. Do not edit roles, passwords, migration ledger
+   rows, or database data as part of rollback.
 
 `./ops db inspect` remains fixed-query-only. It already selects the same
 socket-path configuration as the application and uses a `READ ONLY`

--- a/.agent/runbooks/database.md
+++ b/.agent/runbooks/database.md
@@ -122,8 +122,9 @@ break-glass path.
    Set `SERVICE_ENV_FILES` to the absolute `EnvironmentFiles` paths printed by
    `./ops env systemd`, joined with `:` in that same order. Use this shell-local
    helper for every fixed inspection in this cutover. It selects the service's
-   configuration without printing values and removes ad hoc Atlas database
-   variables that would otherwise override those files:
+   configuration without printing values. The inspector also removes every
+   case variant of known Atlas database settings, so an inherited lower- or
+   mixed-case alias cannot override those files:
 
    ```bash
    SERVICE_ENV_FILES='/absolute/first.service.env:/absolute/second.service.env'

--- a/.agent/runbooks/database.md
+++ b/.agent/runbooks/database.md
@@ -81,8 +81,15 @@ break-glass path.
      "SELECT application_name, usename, client_addr, state \
       FROM pg_stat_activity \
       WHERE client_addr IN ('127.0.0.1'::inet, '::1'::inet);"
-   sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -At -c \
-     "SELECT count(*) FROM pg_stat_replication;"
+   sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -At -F '|' -c \
+     "SELECT application_name, usename, client_addr, state, sync_state \
+      FROM pg_stat_replication \
+      WHERE client_addr IN ('127.0.0.1'::inet, '::1'::inet);"
+   sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -At -F '|' -c \
+     "SELECT map_name, sys_name, pg_username, error \
+      FROM pg_ident_file_mappings \
+      WHERE map_name = 'atlas_app' \
+      ORDER BY line_number;"
    sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -At -F '|' -c \
      "SELECT type, database, user_name, address, netmask, auth_method \
       FROM pg_hba_file_rules \
@@ -98,7 +105,8 @@ break-glass path.
    blindly. The final query must show exactly four `host` trust rows: two
    `{all}` application rows and two `{replication}` rows, one for each of
    `127.0.0.1` and `::1`. Stop if any other trust row exists; this runbook does
-   not generalize a different HBA topology.
+   not generalize a different HBA topology. The `atlas_app` identity-map query
+   must return no rows before editing: do not reuse a pre-existing map name.
 
    Set `SERVICE_ENV_FILES` to the absolute `EnvironmentFiles` paths printed by
    `./ops env systemd`, joined with `:` in that same order. Use this shell-local
@@ -158,12 +166,23 @@ break-glass path.
    ```bash
    sudo systemctl reload postgresql@16-main
    sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -At -c \
-     "SELECT count(*) FROM pg_hba_file_rules WHERE error IS NOT NULL;"
+     "SELECT \
+        (SELECT count(*) FROM pg_hba_file_rules WHERE error IS NOT NULL), \
+        count(*) FILTER ( \
+          WHERE map_name = 'atlas_app' \
+            AND sys_name = 'juan-canfield' \
+            AND pg_username = 'atlas' \
+        ), \
+        count(*) FILTER (WHERE map_name = 'atlas_app'), \
+        count(*) FILTER (WHERE error IS NOT NULL) \
+      FROM pg_ident_file_mappings;"
    ```
 
-   The final query must return `0`; otherwise restore both saved files and
-   reload PostgreSQL before continuing. The service still uses TCP at this
-   point, so a valid scoped peer rule can be proved without removing the
+   The final query must return `0|1|1|0`: no HBA parser error, exactly one
+   intended `atlas_app | juan-canfield | atlas` mapping, no additional
+   `atlas_app` mapping, and no identity-map error. Otherwise restore both saved
+   files and reload PostgreSQL before continuing. The service still uses TCP at
+   this point, so a valid scoped peer rule can be proved without removing the
    existing path.
 
 3. In the effective service configuration selected by `SERVICE_ENV_FILES`, use
@@ -204,6 +223,14 @@ break-glass path.
         AND backend_type = 'client backend' \
       ORDER BY backend_start;"
    service_db_inspect
+   sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -At -F '|' -c \
+     "SELECT application_name, usename, client_addr, state \
+      FROM pg_stat_activity \
+      WHERE client_addr IN ('127.0.0.1'::inet, '::1'::inet);"
+   sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -At -F '|' -c \
+     "SELECT application_name, usename, client_addr, state, sync_state \
+      FROM pg_stat_replication \
+      WHERE client_addr IN ('127.0.0.1'::inet, '::1'::inet);"
    ```
 
    At least one backend with a `backend_start` after the just-issued service
@@ -213,6 +240,12 @@ break-glass path.
    succeed only after that transport proof. If any proof fails, remove only the
    exact non-secret setting just added, restore the two saved PostgreSQL files,
    reload PostgreSQL, and restart `atlas-api.service`.
+
+   Before step 4, both final loopback inventories must be empty. A remaining
+   loopback TCP client, including a replication client, is a stop condition:
+   move that client to the Unix socket or complete a separate, owner-verified
+   SCRAM reconnect migration before re-running this cutover. Do not create a
+   new credential or remove HBA trust while any such row remains.
 
 4. Only after the socket-peer proof succeeds, replace **all four** loopback
    TCP `trust` entries in `pg_hba.conf` with `scram-sha-256` using `sudoedit`:

--- a/.agent/runbooks/database.md
+++ b/.agent/runbooks/database.md
@@ -170,6 +170,12 @@ break-glass path.
        *) return 1 ;;
      esac
    }
+   eom_audit_environment_has_psql_bin_override() {
+     case "$1" in
+       *'ATLAS_EOM_AUDIT_PSQL_BIN='*) return 0 ;;
+       *) return 1 ;;
+     esac
+   }
    eom_audit_require_unit_contract() {
      if ! systemctl --user is-enabled --quiet "$EOM_AUDIT_TIMER" \
        || ! systemctl --user is-active --quiet "$EOM_AUDIT_TIMER"; then
@@ -221,10 +227,23 @@ break-glass path.
        printf '%s\n' 'EOM audit DSN override found; migrate and prove it separately before cutover' >&2
        return 1
      fi
+     if eom_audit_environment_has_psql_bin_override "$eom_audit_service_environment" \
+       || eom_audit_environment_has_psql_bin_override "$eom_audit_manager_environment"; then
+       printf '%s\n' 'EOM audit psql executable override found; remove it before cutover' >&2
+       return 1
+     fi
+   }
+   eom_audit_require_stage_inputs() {
+     if ! test -f "$EOM_AUDIT_SOURCE" || ! test -r "$EOM_AUDIT_SOURCE" \
+       || ! test -f "$EOM_AUDIT_INSTALLED" || ! test -r "$EOM_AUDIT_INSTALLED"; then
+       printf '%s\n' 'EOM audit source or installed script is unreadable; do not remove loopback trust' >&2
+       return 1
+     fi
    }
    eom_audit_require_socket_default() {
      eom_audit_require_unit_contract || return 1
-     if ! test -r "$EOM_AUDIT_SOURCE" || ! cmp -s "$EOM_AUDIT_SOURCE" "$EOM_AUDIT_INSTALLED"; then
+     eom_audit_require_stage_inputs || return 1
+     if ! cmp -s "$EOM_AUDIT_SOURCE" "$EOM_AUDIT_INSTALLED"; then
        printf '%s\n' 'installed EOM audit script does not match deployed source; stage it after peer authentication' >&2
        return 1
      fi
@@ -234,6 +253,7 @@ break-glass path.
        printf '%s\n' 'pre-peer EOM audit source backup already exists; inspect it before retrying' >&2
        return 1
      fi
+     eom_audit_require_stage_inputs || return 1
      if ! cp --preserve=mode,ownership,timestamps "$EOM_AUDIT_INSTALLED" "$EOM_AUDIT_PRE_PEER_SOURCE"; then
        printf '%s\n' 'could not preserve the pre-peer EOM audit source; do not replace it' >&2
        return 1
@@ -388,6 +408,7 @@ break-glass path.
        ./ops db inspect connectivity
    }
    eom_audit_require_unit_contract || exit 1
+   eom_audit_require_stage_inputs || exit 1
    service_db_require_new_socket_configuration || exit 1
    service_db_inspect
    ```
@@ -399,13 +420,15 @@ break-glass path.
    backup, HBA/identity edit, or PostgreSQL reload. It rejects an empty
    service-file set, any case-variant `ATLAS_DB_*` key, every existing socket
    assignment, and every nonblank complete-DSN assignment without printing a
-   value. The dormant monitor admission must also succeed before the first
-   backup, HBA/identity edit, or PostgreSQL reload. A complete DSN deliberately takes precedence over
+   value. The dormant monitor admission and source-stage input receipt must
+   also succeed before the first backup, HBA/identity edit, or PostgreSQL
+   reload. A complete DSN deliberately takes precedence over
    `ATLAS_DB_SOCKET_PATH`; do not remove or rewrite one as part of this
    procedure. That needs a separate configuration-migration slice.
 
-2. Only after the timer-contract and service-configuration receipts succeed,
-   preserve the two PostgreSQL authentication files before editing them:
+2. Only after the timer-contract, source-stage, and service-configuration
+   receipts succeed, preserve the two PostgreSQL authentication files before
+   editing them:
 
    ```bash
    if sudo test -e /etc/postgresql/16/main/pg_hba.conf.pre-atlas-peer \
@@ -593,7 +616,8 @@ break-glass path.
      rollback_peer_cutover
      exit 1
    }
-   EOM_AUDIT_DRY_RUN_OUTPUT="$(env -u ATLAS_EOM_AUDIT_ATLAS_DSN "$EOM_AUDIT_INSTALLED" \
+   EOM_AUDIT_DRY_RUN_OUTPUT="$(env -u ATLAS_EOM_AUDIT_ATLAS_DSN \
+     -u ATLAS_EOM_AUDIT_PSQL_BIN "$EOM_AUDIT_INSTALLED" \
      --state-dir "$EOM_AUDIT_DRY_RUN_DIR" \
      --ntfy-topic cutover-dry-run \
      --no-alert)"

--- a/.agent/runbooks/database.md
+++ b/.agent/runbooks/database.md
@@ -137,14 +137,16 @@ break-glass path.
    `eom-write-boundary-audit.timer` is a repository-owned hourly one-shot
    database client. It is normally absent from both live inventory queries, so
    its absence is not evidence that it has no TCP dependency. Before any HBA
-   backup or authentication edit, require its installed script to match this
-   deployed source, its timer/service identity to be live, and its unit or
-   user-manager environment to contain no `ATLAS_EOM_AUDIT_ATLAS_DSN` override
-   or `EnvironmentFile`. The source default is the passwordless
-   `/var/run/postgresql` socket route and clears inherited libpq target
-   selectors before invoking `psql`; an override needs its own owner-verified
-   socket or SCRAM migration rather than being silently accepted here. The
-   checks retain environment text only in shell variables and never print it.
+   backup or authentication edit, admit its exact target-free timer command,
+   active timer/service identity, and no unit/user-manager
+   `ATLAS_EOM_AUDIT_ATLAS_DSN` override or `EnvironmentFile`. Do **not** require
+   the installed source to be the new socket default yet: it would run before
+   the peer map is loaded. After the map/rule succeeds, this procedure stages
+   the current source atomically, retains the old installed copy for rollback,
+   then obtains the socket receipt. The source-owned default clears inherited
+   libpq settings; an explicit override retains its owner-managed TLS/libpq
+   behavior and needs its own verified socket or SCRAM migration. The checks
+   retain environment text only in shell variables and never print it.
 
    Set `SERVICE_ENV_FILES` to the absolute `EnvironmentFiles` paths printed by
    `./ops env systemd`, joined with `:` in that same order. Use this shell-local
@@ -157,6 +159,7 @@ break-glass path.
    EOM_AUDIT_REPOSITORY_ROOT="$(git rev-parse --show-toplevel)" || exit 1
    EOM_AUDIT_SOURCE="$EOM_AUDIT_REPOSITORY_ROOT/scripts/eom_write_boundary_audit.py"
    EOM_AUDIT_INSTALLED="$HOME/.local/bin/eom-write-boundary-audit.py"
+   EOM_AUDIT_PRE_PEER_SOURCE="$EOM_AUDIT_INSTALLED.pre-atlas-peer"
    EOM_AUDIT_SERVICE='eom-write-boundary-audit.service'
    EOM_AUDIT_TIMER='eom-write-boundary-audit.timer'
    SERVICE_ENV_FILES='/absolute/first.service.env:/absolute/second.service.env'
@@ -167,11 +170,7 @@ break-glass path.
        *) return 1 ;;
      esac
    }
-   eom_audit_require_socket_default() {
-     if ! test -r "$EOM_AUDIT_SOURCE" || ! cmp -s "$EOM_AUDIT_SOURCE" "$EOM_AUDIT_INSTALLED"; then
-       printf '%s\n' 'installed EOM audit script does not match deployed source; install it before cutover' >&2
-       return 1
-     fi
+   eom_audit_require_unit_contract() {
      if ! systemctl --user is-enabled --quiet "$EOM_AUDIT_TIMER" \
        || ! systemctl --user is-active --quiet "$EOM_AUDIT_TIMER"; then
        printf '%s\n' 'EOM audit timer is not enabled and active; do not remove loopback trust' >&2
@@ -183,12 +182,22 @@ break-glass path.
        return 1
      }
      case "$eom_audit_exec_start" in
-       *"$EOM_AUDIT_INSTALLED"*) ;;
+       *'argv[]='*'argv[]='*)
+         printf '%s\n' 'EOM audit service has multiple effective commands; do not remove loopback trust' >&2
+         return 1
+         ;;
+       *'argv[]='*) ;;
        *)
-         printf '%s\n' 'EOM audit service does not execute the admitted installed script; do not remove loopback trust' >&2
+         printf '%s\n' 'could not parse EOM audit service command; do not remove loopback trust' >&2
          return 1
          ;;
      esac
+     eom_audit_argv="${eom_audit_exec_start#*argv[]=}"
+     eom_audit_argv="${eom_audit_argv%% ;*}"
+     if [ "$eom_audit_argv" != "/usr/bin/python3 $EOM_AUDIT_INSTALLED" ]; then
+       printf '%s\n' 'EOM audit service command is not the admitted target-free argv; do not remove loopback trust' >&2
+       return 1
+     fi
      eom_audit_environment_files="$(systemctl --user show "$EOM_AUDIT_SERVICE" \
        --property=EnvironmentFiles --value)" || {
        printf '%s\n' 'could not inspect EOM audit service environment files; do not remove loopback trust' >&2
@@ -212,6 +221,41 @@ break-glass path.
        printf '%s\n' 'EOM audit DSN override found; migrate and prove it separately before cutover' >&2
        return 1
      fi
+   }
+   eom_audit_require_socket_default() {
+     eom_audit_require_unit_contract || return 1
+     if ! test -r "$EOM_AUDIT_SOURCE" || ! cmp -s "$EOM_AUDIT_SOURCE" "$EOM_AUDIT_INSTALLED"; then
+       printf '%s\n' 'installed EOM audit script does not match deployed source; stage it after peer authentication' >&2
+       return 1
+     fi
+   }
+   eom_audit_stage_socket_source() {
+     if test -e "$EOM_AUDIT_PRE_PEER_SOURCE"; then
+       printf '%s\n' 'pre-peer EOM audit source backup already exists; inspect it before retrying' >&2
+       return 1
+     fi
+     if ! cp --preserve=mode,ownership,timestamps "$EOM_AUDIT_INSTALLED" "$EOM_AUDIT_PRE_PEER_SOURCE"; then
+       printf '%s\n' 'could not preserve the pre-peer EOM audit source; do not replace it' >&2
+       return 1
+     fi
+     eom_audit_stage="$(mktemp "$EOM_AUDIT_INSTALLED.stage.XXXXXX")" || {
+       printf '%s\n' 'could not create staged EOM audit source; do not replace it' >&2
+       return 1
+     }
+     if ! install -m 755 "$EOM_AUDIT_SOURCE" "$eom_audit_stage" \
+       || ! mv -f "$eom_audit_stage" "$EOM_AUDIT_INSTALLED"; then
+       rm -f -- "$eom_audit_stage"
+       cp --preserve=mode,ownership,timestamps "$EOM_AUDIT_PRE_PEER_SOURCE" "$EOM_AUDIT_INSTALLED" || return 1
+       printf '%s\n' 'could not stage the socket-default EOM audit source; restored the prior source' >&2
+       return 1
+     fi
+     eom_audit_require_socket_default
+   }
+   eom_audit_restore_pre_peer_source() {
+     if ! test -e "$EOM_AUDIT_PRE_PEER_SOURCE"; then
+       return 0
+     fi
+     cp --preserve=mode,ownership,timestamps "$EOM_AUDIT_PRE_PEER_SOURCE" "$EOM_AUDIT_INSTALLED"
    }
    service_db_has_case_variant_key() {
      sudo awk '
@@ -343,7 +387,7 @@ break-glass path.
        ATLAS_OPS_ENV_FILES="$SERVICE_ENV_FILES" \
        ./ops db inspect connectivity
    }
-   eom_audit_require_socket_default || exit 1
+   eom_audit_require_unit_contract || exit 1
    service_db_require_new_socket_configuration || exit 1
    service_db_inspect
    ```
@@ -360,7 +404,7 @@ break-glass path.
    `ATLAS_DB_SOCKET_PATH`; do not remove or rewrite one as part of this
    procedure. That needs a separate configuration-migration slice.
 
-2. Only after both the source and service-configuration receipts succeed,
+2. Only after the timer-contract and service-configuration receipts succeed,
    preserve the two PostgreSQL authentication files before editing them:
 
    ```bash
@@ -468,6 +512,7 @@ break-glass path.
 
    ```bash
    rollback_peer_cutover() {
+     eom_audit_restore_pre_peer_source || return 1
      service_db_require_effective_env_file || return 1
      sudoedit "$EFFECTIVE_DB_ENV_FILE" || return 1
      service_db_require_no_socket_assignments || return 1
@@ -482,6 +527,19 @@ break-glass path.
      fi
      systemctl --user restart atlas-api.service || return 1
      service_db_inspect
+   }
+   ```
+
+   Stage the socket-default monitor only after the previous peer-map/HBA receipt
+   succeeded and the rollback helper exists. If staging cannot preserve or
+   install the source, invoke that helper so the old source is restored before
+   the peer authentication files are restored:
+
+   ```bash
+   eom_audit_stage_socket_source || {
+     printf '%s\n' 'could not stage the EOM audit socket source; rollback required' >&2
+     rollback_peer_cutover
+     exit 1
    }
    ```
 
@@ -535,7 +593,7 @@ break-glass path.
      rollback_peer_cutover
      exit 1
    }
-   EOM_AUDIT_DRY_RUN_OUTPUT="$("$EOM_AUDIT_INSTALLED" \
+   EOM_AUDIT_DRY_RUN_OUTPUT="$(env -u ATLAS_EOM_AUDIT_ATLAS_DSN "$EOM_AUDIT_INSTALLED" \
      --state-dir "$EOM_AUDIT_DRY_RUN_DIR" \
      --ntfy-topic cutover-dry-run \
      --no-alert)"

--- a/atlas_brain/storage/config.py
+++ b/atlas_brain/storage/config.py
@@ -5,7 +5,7 @@ Configuration is loaded from environment variables with sensible defaults.
 """
 
 from typing import Optional
-from urllib.parse import urlsplit
+from urllib.parse import quote, urlsplit
 
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -83,7 +83,7 @@ class DatabaseConfig(BaseSettings):
             # Unix socket connection (lowest latency)
             return (
                 f"postgresql://{self.user}:{self.password}@/{self.database}"
-                f"?host={self.socket_path}&port={self.port}"
+                f"?host={quote(self.socket_path, safe='/')}&port={self.port}"
             )
         else:
             # TCP connection

--- a/atlas_brain/storage/config.py
+++ b/atlas_brain/storage/config.py
@@ -102,7 +102,9 @@ class DatabaseConfig(BaseSettings):
             except ValueError:
                 return "dsn=<connection-string>"
         if self.socket_path:
-            return f"socket={self.socket_path}, db={self.database}"
+            return (
+                f"socket={self.socket_path}, port={self.port}, db={self.database}"
+            )
         return f"host={self.host}, port={self.port}, db={self.database}"
 
     def connection_kwargs(

--- a/atlas_brain/storage/config.py
+++ b/atlas_brain/storage/config.py
@@ -81,7 +81,10 @@ class DatabaseConfig(BaseSettings):
             return self.connection_string.strip()
         if self.socket_path:
             # Unix socket connection (lowest latency)
-            return f"postgresql://{self.user}:{self.password}@/{self.database}?host={self.socket_path}"
+            return (
+                f"postgresql://{self.user}:{self.password}@/{self.database}"
+                f"?host={self.socket_path}&port={self.port}"
+            )
         else:
             # TCP connection
             return f"postgresql://{self.user}:{self.password}@{self.host}:{self.port}/{self.database}"
@@ -122,7 +125,7 @@ class DatabaseConfig(BaseSettings):
                 **timeout_kwargs,
             }
         return {
-            "host": self.host,
+            "host": self.socket_path or self.host,
             "port": self.port,
             "database": self.database,
             "user": self.user,

--- a/config/eom-write-boundary-audit.service
+++ b/config/eom-write-boundary-audit.service
@@ -18,6 +18,8 @@ Type=oneshot
 #
 # Absolute path, and no systemd %-specifiers in the command: an unescaped % in a
 # unit file silently produced a wrong SHA-256 digest once already.
+# Keep this effective argv target-free. The peer-socket cutover runbook admits
+# this exact command before it stages the installed socket-default source.
 ExecStart=/usr/bin/python3 /home/juan-canfield/.local/bin/eom-write-boundary-audit.py
 # notify-send needs a display for the desktop popup; the ntfy push does not.
 Environment=DISPLAY=:0

--- a/docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md
+++ b/docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md
@@ -38,11 +38,11 @@ bytes verified, and the read-only preflight continues to report that mismatch.
 
    - `verified` and `legacy_unverified` can proceed under the normal runner
      policy. Legacy null hashes remain visible; they are not silently repaired.
-   - `unresolved_drift` with a matching known record may be admissible only when
-     every entry in `known_reconciliation_evidence` for that reported name is
-     `attested`, there is no `missing_source`, and there are no additional
-     mismatched names. The preflight still exits 2 to preserve forensic truth;
-     do not treat exit 2 alone as approval.
+   - `unresolved_drift` may be admissible only when every reported mismatched
+     **and** missing-source name has matching known reconciliation evidence,
+     every reported evidence entry is `attested`, and no unknown or
+     non-attested discrepancy remains. The preflight still exits 2 to preserve
+     forensic truth; do not treat exit 2 alone as approval.
    - Any unknown mismatch, missing source, a known record that is currently
      reported as mismatched but has absent/non-attested evidence, target
      mismatch, or `could_not_determine` result is a stop condition. Do not

--- a/docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md
+++ b/docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md
@@ -43,11 +43,11 @@ bytes verified, and the read-only preflight continues to report that mismatch.
      every reported evidence entry is `attested`, and no unknown or
      non-attested discrepancy remains. The preflight still exits 2 to preserve
      forensic truth; do not treat exit 2 alone as approval.
-   - Any unknown mismatch, missing source, a known record that is currently
-     reported as mismatched but has absent/non-attested evidence, target
-     mismatch, or `could_not_determine` result is a stop condition. Do not
-     probe a known reconciliation that is not an active mismatch as a reason to
-     stop an otherwise clean target.
+   - Any unknown discrepancy; any reported mismatch or missing-source item
+     without matching, currently attested evidence; target mismatch; or a
+     `could_not_determine` result is a stop condition. Do not probe a known
+     reconciliation that is not an active mismatch as a reason to stop an
+     otherwise clean target.
 
 4. Deploy the admission-policy release to every Atlas process that can invoke
    `run_migrations()` before adding a later migration-bearing release. This

--- a/ops
+++ b/ops
@@ -29,13 +29,18 @@ ENV_KEY_RE = re.compile(
 )
 DATABASE_CONFIG_KEYS = frozenset(
     (
+        "ATLAS_DB_ENABLED",
         "ATLAS_DB_CONNECTION_STRING",
         "ATLAS_DB_HOST",
         "ATLAS_DB_PORT",
         "ATLAS_DB_DATABASE",
         "ATLAS_DB_USER",
         "ATLAS_DB_PASSWORD",
+        "ATLAS_DB_MIN_POOL_SIZE",
+        "ATLAS_DB_MAX_POOL_SIZE",
         "ATLAS_DB_SOCKET_PATH",
+        "ATLAS_DB_CONNECT_TIMEOUT",
+        "ATLAS_DB_COMMAND_TIMEOUT",
     )
 )
 DATABASE_CONFIG_KEY_CASEFOLDS = frozenset(

--- a/ops
+++ b/ops
@@ -38,6 +38,9 @@ DATABASE_CONFIG_KEYS = frozenset(
         "ATLAS_DB_SOCKET_PATH",
     )
 )
+DATABASE_CONFIG_KEY_CASEFOLDS = frozenset(
+    key.casefold() for key in DATABASE_CONFIG_KEYS
+)
 DATABASE_INSPECTIONS = {
     "connectivity": "SELECT 1 AS ok",
     "migrations": (
@@ -272,8 +275,11 @@ def database_runtime_environment() -> dict[str, str]:
             config[key] = os.environ[key]
 
     child_env = os.environ.copy()
-    for key in DATABASE_CONFIG_KEYS:
-        child_env.pop(key, None)
+    # BaseSettings resolves environment variable names case-insensitively.  Keep
+    # only canonical file values and exact-uppercase runtime overrides.
+    for key in tuple(child_env):
+        if key.casefold() in DATABASE_CONFIG_KEY_CASEFOLDS:
+            child_env.pop(key)
     child_env.update(config)
     child_env["ATLAS_OPS_INTERNAL_DB_INSPECTION"] = "1"
     return child_env

--- a/plans/PR-Postgres-Loopback-Scram-Hardening.md
+++ b/plans/PR-Postgres-Loopback-Scram-Hardening.md
@@ -74,8 +74,8 @@ leave its restart procedure with contradictory integrity instructions.
    the service. The procedure must stop on unresolved or remaining loopback TCP
    clients and prove the loaded peer map has exactly the intended mapping. The fixed
    inspection must explicitly select the ordered `atlas-api.service`
-   `EnvironmentFiles` while excluding every case variant of ad hoc known
-   `ATLAS_DB_*` overrides.
+   `EnvironmentFiles` while the helper clears every exact-uppercase
+   `ATLAS_DB_*` override and `ops` excludes every lower/mixed-case variant.
 4. Correct `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` to require matching,
    currently attested evidence for every raw mismatch **and** missing-source
    item while preserving the raw report and its forensic nonzero exit.
@@ -191,7 +191,8 @@ Max files: 7
   - The fixed inspector uses only the service `EnvironmentFiles`, in service
     order, and removes every case variant of every consumed `ATLAS_DB_*` value
     before it constructs `DatabaseConfig`; exact-uppercase runtime keys preserve
-    the documented override behavior.
+    the generic documented override behavior, while the service-pinned helper
+    explicitly unsets all of them before its proof.
   - The cutover reconciles every client observed in both initial and final
     loopback TCP/replication inventories to a Unix-socket or verified-SCRAM
     receipt, requires no remaining final client, and requires an exact loaded
@@ -247,9 +248,10 @@ Max files: 7
   inherited database override admitted. Every lower- or mixed-case matching
   alias is removed before `DatabaseConfig` loads the child environment, while
   unrelated keys remain unchanged; this fails closed against inspecting a
-  shadowed target or applying a shadowed timeout. A regression pins the
-  membership equality so a new `DatabaseConfig` field cannot silently escape
-  the scrub set.
+  shadowed target or applying a shadowed timeout. The service-pinned helper
+  clears every canonical key before it invokes the inspector, so it admits no
+  inherited database override. A regression pins the membership equality so a
+  new `DatabaseConfig` field cannot silently escape the scrub set.
 
 ### Files touched
 
@@ -311,6 +313,8 @@ blocks the socket-peer path.
   'database_runtime_environment'` — 3 passed, 40 deselected (local); proves
   the canonical override, case-variant rejection, and complete key-set closure.
 - `bash scripts/check_ascii_python.sh` — passed (local).
+- `service_db_inspect` shell block extracted from
+  `.agent/runbooks/database.md` and checked with `bash -n` — passed (local).
 - `git diff --check` — passed (local).
 - `python scripts/sync_pr_plan.py
   plans/PR-Postgres-Loopback-Scram-Hardening.md --check` — passed (local).
@@ -331,14 +335,14 @@ blocks the socket-peer path.
 
 | File | LOC |
 |---|---:|
-| `.agent/runbooks/database.md` | 401 |
+| `.agent/runbooks/database.md` | 406 |
 | `atlas_brain/storage/config.py` | 11 |
 | `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` | 20 |
 | `ops` | 15 |
-| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 346 |
+| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 350 |
 | `tests/test_agent_operations_contract.py` | 50 |
 | `tests/test_eom_render_profile.py` | 61 |
-| **Total** | **904** |
+| **Total** | **913** |
 
 ## Diff budget
 

--- a/plans/PR-Postgres-Loopback-Scram-Hardening.md
+++ b/plans/PR-Postgres-Loopback-Scram-Hardening.md
@@ -4,33 +4,24 @@
 
 The authorized EOM recovery exposed two deferred operational defects.
 
-PostgreSQL currently accepts every TCP connection from `127.0.0.1` and `::1`
-with `trust`, including connections requested as the `postgres` superuser.
-Atlas defaults to the `atlas` database role without a password. Although
-`DatabaseConfig` exposes `ATLAS_DB_SOCKET_PATH`, the live pool and fixed
-`./ops db inspect` path call `connection_kwargs()`, which currently ignores
-that setting and always selects the TCP host/port. The deployed application
-cannot move from TCP `trust` to Unix-socket peer authentication merely by
-setting the existing environment variable.
+Loopback TCP `trust` accepts unauthenticated connections as every role,
+including `postgres`. Atlas defaults to `atlas` without a password, and its
+live pool/fixed inspection call `connection_kwargs()`, which ignores the
+existing `ATLAS_DB_SOCKET_PATH`. The deployed application therefore cannot
+move to Unix-socket peer authentication by setting that variable alone.
 
-The recovery also emitted a migration-content-integrity warning. The runner
-deliberately reports raw `missing_source` and `mismatched` historical evidence
-even when matching, attested reconciliation records admit a pending migration.
-The runbook previously described that admissible state as requiring no
-`missing_source` records, contradicting the runner.
+The same recovery reported raw `missing_source` and `mismatched` evidence even
+when matching, attested reconciliations admit a pending migration. The runbook
+incorrectly said that admissible state could contain no `missing_source`.
 
 ### Problem-derived contract
 
 #### Root cause
 
-- The local database boundary is too broad: loopback TCP `trust` lets a local
-  process request any database role without authentication.
-- The intended peer-auth replacement is ineffective because
-  `DatabaseConfig.connection_kwargs()` ignores `socket_path`; the generic pool
-  and fixed inspection use those kwargs rather than `DatabaseConfig.dsn`.
-- The migration runbook conflates raw forensic reporting with admission. The
-  runner admits known mismatches and missing sources only after current
-  attestation; it does not erase or suppress their raw report.
+- Loopback TCP `trust` lets a local process request any database role.
+- `connection_kwargs()` ignores `socket_path`, while the pool and fixed
+  inspection call it rather than `DatabaseConfig.dsn`.
+- The migration runbook confuses raw forensic output with attested admission.
 
 #### Required change surface
 
@@ -42,21 +33,16 @@ The runbook previously described that admissible state as requiring no
      socket rather than loopback TCP.
 2. Update focused `DatabaseConfig` tests in
    `tests/test_eom_render_profile.py` to pin both socket-path forms and the
-   existing TCP/complete-DSN precedence behavior.
-3. Replace the provisional credential/SCRAM procedure in
-   `.agent/runbooks/database.md` with the peer procedure: configure the
-   non-secret socket-path setting, map the actual `atlas-api` OS user to the
-   existing `atlas` PostgreSQL role in `pg_ident.conf`, add a specific
-   socket-peer HBA rule, prove the service/inspection/CRM path, then replace
-   all loopback TCP `trust` rules with `scram-sha-256`. Preserve the existing
-   Unix-socket `postgres` peer recovery path and a rollback sequence.
+   existing TCP/complete-DSN precedence behavior, then assert the actual pool
+   and raw-connection callers receive the socket kwargs.
+3. Replace the provisional credential/SCRAM procedure with non-secret socket
+   configuration, an exact `atlas-api` OS-user → `atlas` peer map, staged
+   service/inspection/CRM proof, loopback-SCRAM replacement, and rollback.
 4. Correct `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` to require matching,
    currently attested evidence for every raw mismatch **and** missing-source
    item while preserving the raw report and its forensic nonzero exit.
-5. Remove the unviable, uncommitted systemd encrypted-credential experiment
-   and its tests. The running service is a non-root user service; this host
-   cannot provision a protected credential to that manager without a plaintext
-   secret fallback, so it is not a valid solution.
+5. Remove the unviable, uncommitted encrypted-credential experiment and tests;
+   it would require an unsupported plaintext-secret fallback.
 
 #### Explicit non-scope
 
@@ -72,20 +58,16 @@ The runbook previously described that admissible state as requiring no
 
 #### Assumptions and blockers
 
-- `atlas-api.service` runs as local user `juan-canfield` and PostgreSQL's
-  socket directory is `/var/run/postgresql`; the runbook requires a fresh
-  check of both just before cutover.
-- PostgreSQL accepts the `atlas_app` identity map and no live local TCP
-  replication client depends on loopback `trust`; the cutover requires an
-  activity/replication probe before changing those rules.
-- HBA/ident/shared-configuration changes are an owned, post-merge controlled
-  operation. They require deployment of the source revision containing the
-  socket-kwargs correction first.
+- The service user is `juan-canfield` and the socket is `/var/run/postgresql`;
+  recheck both immediately before cutover.
+- Recheck the peer map and local replication activity before changing HBA.
+- HBA/ident/shared configuration changes occur only after this source revision
+  is deployed.
 
 #### Verification plan
 
-- Focused regression: socket `dsn` and `connection_kwargs()` assertions plus
-  existing TCP and complete-DSN assertions.
+- Focused regression: socket `dsn` and `connection_kwargs()` assertions,
+  existing TCP and complete-DSN assertions, and the pool/raw caller seam.
 - Cheap local gates: focused test target, `bash scripts/check_ascii_python.sh`,
   `git diff --check`, and `python scripts/sync_pr_plan.py ... --check`.
 - GitHub remains the complete unit gate.
@@ -140,32 +122,20 @@ Max files: 5
 
 ## Mechanism
 
-`DatabaseConfig` already owns the socket-path setting. Its split connection
-path will consistently translate it into the asyncpg socket host plus the
-configured port. No password is added: the post-merge server-side identity map
-lets the `atlas-api` OS user authenticate as the existing `atlas` role with
-peer authentication. The socket setting is a non-secret shared application
-configuration value, which `atlas-api` and `./ops` already read.
+`DatabaseConfig` now carries its existing socket path and port into asyncpg.
+No password is added: the post-merge identity map lets `atlas-api` authenticate
+as `atlas` over peer. The map/rule are proved while TCP remains available;
+only then do all loopback `trust` entries become `scram-sha-256`.
 
-The HBA sequence is staged. The exact `pg_ident.conf` mapping and specific HBA
-rule are added and proved while current TCP rules remain available. Only after
-the service genuinely uses the socket do all IPv4/IPv6 loopback TCP `trust`
-rules change to `scram-sha-256`. This removes uncredentialed cross-user local
-impersonation without a plaintext credential mechanism.
-
-The migration-runbook change is documentation only. Raw discrepancies stay
-visible and retain the existing forensic nonzero status; the document now
-describes the runner's actual pending-admission condition.
+The migration-runbook change is documentation only: raw discrepancies stay
+visible and retain their forensic nonzero status.
 
 ## Intentional
 
-- Raw migration mismatch/error logging and preflight exit semantics remain
-  unchanged.
-- `ops` source code remains unchanged: it already carries
-  `ATLAS_DB_SOCKET_PATH` to the fixed inspection child.
-- Existing app database role, database ownership, and non-loopback access
-  remain unchanged.
-- The endpoint-level CRM read is production verification, not a new feature.
+- Raw migration reporting/exit semantics, database role/ownership, and
+  non-loopback access remain unchanged.
+- `ops` already carries `ATLAS_DB_SOCKET_PATH`; CRM read is production proof,
+  not a feature.
 
 ## Deferred
 
@@ -181,7 +151,7 @@ blocks the socket-peer path.
 ## Verification
 
 - Pending before push: `./ops test focused tests/test_eom_render_profile.py -q
-  -k 'database_config'`.
+  -k 'database_config or database_pool_uses_configured_connection_kwargs'`.
 - Pending before push: `bash scripts/check_ascii_python.sh`.
 - Pending before push: `git diff --check`.
 - Pending before push: `python scripts/sync_pr_plan.py
@@ -198,6 +168,6 @@ blocks the socket-peer path.
 | `.agent/runbooks/database.md` | 147 |
 | `atlas_brain/storage/config.py` | 7 |
 | `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` | 10 |
-| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 203 |
-| `tests/test_eom_render_profile.py` | 31 |
-| **Total** | **398** |
+| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 173 |
+| `tests/test_eom_render_profile.py` | 51 |
+| **Total** | **388** |

--- a/plans/PR-Postgres-Loopback-Scram-Hardening.md
+++ b/plans/PR-Postgres-Loopback-Scram-Hardening.md
@@ -36,6 +36,10 @@ leave its restart procedure with contradictory integrity instructions.
   pre-existing case-variant assignment in any selected service file has no
   baseline receipt; deleting or overriding it during rollback could change the
   service's original connection path.
+- `DatabaseConfig` accepts case-variant database keys while the fixed inspector
+  previously selected only canonical service-file keys; an alias or empty file
+  list could therefore make fixed inspection use a fallback/different target
+  from `atlas-api.service` before the cutover safety checks run.
 - `DatabaseConfig` resolves environment names case-insensitively, but `ops`
   previously removed only a subset of canonical uppercase database keys. A
   lower- or mixed-case inherited alias for any setting the inspector consumes
@@ -83,7 +87,10 @@ leave its restart procedure with contradictory integrity instructions.
    must reject a pre-existing case-variant `ATLAS_DB_SOCKET_PATH` in every
    selected service file before adding its single reversible assignment, and
    regressions must pin the helper's unset set to every `DatabaseConfig` field
-   and its precondition's positive/negative matching boundaries.
+   and its precondition's positive/negative matching boundaries. The helper
+   must refuse an empty file set and any noncanonical-cased `ATLAS_DB_*` key
+   before fixed inspection, so the full-DSN gate applies to the same source as
+   the service.
 4. Correct `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` to require matching,
    currently attested evidence for every raw mismatch **and** missing-source
    item while preserving the raw report and its forensic nonzero exit.
@@ -207,6 +214,10 @@ Max files: 7
     file is a stop condition; this cutover adds exactly one new assignment only
     after the absence precondition, so rollback never rewrites an earlier
     configuration.
+  - Before fixed inspection or an edit, every selected service file must be
+    readable, the selected set must be nonempty, and all `ATLAS_DB_*` keys must
+    be canonical uppercase. This makes the `ops` configuration parser and the
+    service's case-insensitive `DatabaseConfig` agree without exposing values.
   - The cutover reconciles every client observed in both initial and final
     loopback TCP/replication inventories to a Unix-socket or verified-SCRAM
     receipt, requires no remaining final client, and requires an exact loaded
@@ -261,6 +272,13 @@ Max files: 7
   unreadable files or any empty, different, or matching-value assignment stop
   before editing. The safe default is a separate configuration migration with
   an exact baseline receipt, not an implicit overwrite or rollback rewrite.
+- **Service configuration aliases — CLOSED / DERIVED before inspection.**
+  Membership is each parsed `ATLAS_DB_*` assignment in the ordered selected
+  `EnvironmentFiles`. Every file must be readable, the set must be nonempty,
+  and every key must be canonical uppercase; lower/mixed variants stop before
+  fixed inspection or the full-DSN precondition. The safe default is to
+  normalize configuration in a separate migration, not to inspect a fallback
+  or choose between alias collisions.
 - **Database environment-key aliases — CLOSED / DERIVED for fixed inspection.**
   Membership is every canonical `ATLAS_DB_*` setting consumed by
   `DatabaseConfig`, listed as `DATABASE_CONFIG_KEYS` in `ops`; its case-folded
@@ -330,15 +348,17 @@ blocks the socket-peer path.
   database_file_context_honors_explicit_override_order'` — 2 passed, 39
   deselected (local).
 - `./ops test focused tests/test_agent_operations_contract.py -q -k
-  'database_runtime_environment or service_db_inspect'` — 9 passed, 40
+  'database_runtime_environment or service_db_inspect'` — 17 passed, 40
   deselected (local); proves the canonical override, case-variant rejection,
-  complete key-set closure, the service-helper unset-set closure, and the
-  socket precondition's case-variant/near-miss boundary.
-- `./ops test focused tests/test_agent_operations_contract.py -q` — 49 passed
+  complete key-set closure, the service-helper unset-set closure, socket and
+  full-DSN alias/near-miss boundaries, empty-service-set rejection, and that
+  the preflight prevents a lower-case DSN from reaching `ops`.
+- `./ops test focused tests/test_agent_operations_contract.py -q` — 57 passed
   (local).
 - `bash scripts/check_ascii_python.sh` — passed (local).
-- `service_db_inspect` and the pre-existing-socket guard blocks extracted from
-  `.agent/runbooks/database.md` and checked with `bash -n` — passed (local).
+- `service_db_inspect`, canonical-key, and pre-existing-socket guard blocks
+  extracted from `.agent/runbooks/database.md` and checked with `bash -n` —
+  passed (local).
 - `git diff --check` — passed (local).
 - `python scripts/sync_pr_plan.py
   plans/PR-Postgres-Loopback-Scram-Hardening.md origin/main --check` — passed
@@ -360,14 +380,14 @@ blocks the socket-peer path.
 
 | File | LOC |
 |---|---:|
-| `.agent/runbooks/database.md` | 433 |
+| `.agent/runbooks/database.md` | 485 |
 | `atlas_brain/storage/config.py` | 11 |
 | `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` | 20 |
 | `ops` | 15 |
-| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 375 |
-| `tests/test_agent_operations_contract.py` | 95 |
+| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 395 |
+| `tests/test_agent_operations_contract.py` | 213 |
 | `tests/test_eom_render_profile.py` | 61 |
-| **Total** | **1010** |
+| **Total** | **1200** |
 
 ## Diff budget
 

--- a/plans/PR-Postgres-Loopback-Scram-Hardening.md
+++ b/plans/PR-Postgres-Loopback-Scram-Hardening.md
@@ -118,6 +118,11 @@ leave its restart procedure with contradictory integrity instructions.
   configured connection and command timeouts, although the prior `create_pool`
   call omitted both options; a long-running existing rebuild can therefore fail
   solely from this transport refactor.
+- The colon-delimited service environment-file list silently skips empty
+  members, while the effective-target sentinel treats an empty derived final
+  member as present. A trailing delimiter can therefore pass pre-mutation
+  admission, fail only at `sudoedit`, and block the rollback before it restores
+  authentication files.
 - The migration runbook confuses raw forensic output with attested admission.
 
 #### Required change surface
@@ -164,9 +169,10 @@ leave its restart procedure with contradictory integrity instructions.
    query must define its own derived loopback-coverage relation before it
    consumes that relation.
    The effective environment file must be derived from the ordered selected
-   service-file list and have its membership validated by the same pre-mutation
-   gate and rollback path; no manual file selection may occur after
-   authentication edits.
+   service-file list and have its nonempty absolute-path form and membership
+   validated by the same pre-mutation gate and rollback path. Every selected
+   list member must also be nonempty and absolute; no manual file selection may
+   occur after authentication edits.
    The loaded peer receipt must also require exactly one intended local HBA rule
    and no preceding local rule except the retained `postgres` recovery rule.
    It must require at least one qualifying post-restart `atlas` backend and a
@@ -253,7 +259,9 @@ leave its restart procedure with contradictory integrity instructions.
   configuration-admission command precedes the first HBA backup, and prove each
   final HBA receipt independently defines `covers_loopback`.
 - It must also prove the derived effective file passes only when it belongs to
-  the ordered selected service-file list and stops before the gate otherwise.
+  the ordered selected service-file list and stops before the gate otherwise,
+  including when a leading, middle, or trailing delimiter creates an empty
+  member or a relative member appears in the list.
 - Monitor regressions must prove both default-socket selection and preserved
   explicit-override selection, including hostile inherited `PG*` settings, and
   the runbook guard must reject service and user-manager DSN and executable
@@ -317,8 +325,8 @@ Max files: 12
      socket path or a nonblank complete DSN, so rollback removes only an
      assignment created by this cutover. Each final HBA receipt is independently
      executable with its own loopback-coverage relation, and the effective
-     environment file is derived and membership-checked before any authentication
-     mutation.
+     environment file is derived and its nonempty absolute form and membership
+     are checked before any authentication mutation.
   5. The migration runbook accurately distinguishes raw forensic output from
      attested admission without changing runner behavior.
 - Reachability proof: `atlas_brain/storage/database.py` initializes the pool
@@ -367,9 +375,10 @@ Max files: 12
     comment-only assignments remain admissible; a literal or expansion-shaped
     value requires a separate configuration migration.
   - The effective environment-file target is derived as the final selected
-    service file and must remain a member of that exact ordered list before
-    either the new-socket gate or rollback proceeds; an unlisted target stops
-    rather than creating a stray assignment.
+   service file and must be a nonempty absolute member of that exact ordered
+   list before either the new-socket gate or rollback proceeds; a leading,
+   middle, or trailing empty member, relative member, or unlisted target stops
+   rather than creating a stray assignment.
   - Before fixed inspection or an edit, every selected service file must be
     readable, the selected set must be nonempty, and all `ATLAS_DB_*` keys must
     be canonical uppercase. This makes the `ops` configuration parser and the
@@ -460,12 +469,12 @@ Max files: 12
   least one member and null `client_addr` for every member; any TCP member or an
   empty set stops the cutover.
 - **Service environment-file list — CLOSED / DERIVED for the selected service
-  unit.** Membership is the ordered `EnvironmentFiles` output of `./ops env
-  systemd`. The effective target is derived from the final member, then the
-  same membership predicate gates new-socket admission and rollback. An absent,
-  unreadable, or unlisted effective configuration file stops fixed inspection
-  and HBA mutation, the safer side over inspecting or changing a guessed
-  database target.
+  unit.** Membership is the ordered, nonempty absolute `EnvironmentFiles`
+  output of `./ops env systemd`. The effective target is derived from the final
+  member, then the same list validation and membership predicate gate new-socket
+  admission and rollback. An empty, relative, absent, unreadable, or unlisted
+  effective configuration file stops fixed inspection and HBA mutation, the
+  safer side over inspecting or changing a guessed database target.
 - **Pre-existing socket-path assignments — CLOSED / DERIVED before cutover.**
   Membership is every case-variant assignment matching `ATLAS_DB_SOCKET_PATH`
   in the ordered selected `EnvironmentFiles`. The only admitted set is empty;
@@ -537,8 +546,10 @@ only then do all loopback `trust` entries become `scram-sha-256`.
 
 The fixed inspector keeps its existing source-selection semantics. The runbook
 uses its documented explicit environment-file override in the exact service
-order; `ops` discards case-insensitive aliases for known database settings, so
-the read-only proof observes the same database target as `atlas-api.service`.
+order; it validates every selected member and the derived final target as a
+nonempty absolute path before either admission or rollback, and `ops` discards
+case-insensitive aliases for known database settings, so the read-only proof
+observes the same database target as `atlas-api.service`.
 
 The independent EOM audit monitor gains a source-owned passwordless socket
 default without importing or depending on `atlas-api`. The cutover first
@@ -590,11 +601,12 @@ blocks the socket-peer path.
 
 - `./ops test focused tests/test_eom_write_boundary_audit.py
   tests/test_agent_operations_contract.py tests/test_eom_render_profile.py -q`
-  — 197 passed, 2 skipped (local). This covers the source-owned default versus
+  — 203 passed, 2 skipped (local). This covers the source-owned default versus
   explicit TLS/libpq behavior, exact timer argv and service/user-manager
   executable-override boundaries, readable and unreadable source-stage inputs,
-  post-peer source staging and rollback restoration, and both typed maintenance
-  caller seams.
+  post-peer source staging and rollback restoration, nonempty absolute
+  service-environment list members and rollback-before-edit, and both typed
+  maintenance caller seams.
 - `bash scripts/check_ascii_python.sh` — passed (local).
 - `python scripts/check_guard_class_closure.py --base origin/main --strict` —
   passed (local advisory guard-closure lint).
@@ -631,19 +643,19 @@ blocks the socket-peer path.
 
 | File | LOC |
 |---|---:|
-| `.agent/runbooks/database.md` | 793 |
+| `.agent/runbooks/database.md` | 811 |
 | `atlas_brain/storage/config.py` | 13 |
 | `config/eom-write-boundary-audit.service` | 2 |
 | `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` | 20 |
 | `ops` | 15 |
-| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 651 |
+| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 663 |
 | `scripts/backfill_community_buying_stage_defaults.py` | 8 |
 | `scripts/eom_write_boundary_audit.py` | 59 |
 | `scripts/rebuild_blog_charts.py` | 16 |
-| `tests/test_agent_operations_contract.py` | 795 |
+| `tests/test_agent_operations_contract.py` | 888 |
 | `tests/test_eom_render_profile.py` | 122 |
 | `tests/test_eom_write_boundary_audit.py` | 112 |
-| **Total** | **2606** |
+| **Total** | **2729** |
 
 ## Diff budget
 

--- a/plans/PR-Postgres-Loopback-Scram-Hardening.md
+++ b/plans/PR-Postgres-Loopback-Scram-Hardening.md
@@ -44,6 +44,10 @@ leave its restart procedure with contradictory integrity instructions.
   file. A surviving case- or spacing-variant could keep the service on peer
   authentication after its identity map was restored, while fixed inspection
   would not necessarily observe that residual configuration.
+- The peer-map receipt proved only that `atlas_app` exists; it did not prove the
+  loaded `local atlas atlas peer map=atlas_app` rule is first among applicable
+  local HBA rules. A preceding map or broad peer rule could therefore authorize
+  a different OS account while the intended map and parser receipts still pass.
 - `DatabaseConfig` resolves environment names case-insensitively, but `ops`
   previously removed only a subset of canonical uppercase database keys. A
   lower- or mixed-case inherited alias for any setting the inspector consumes
@@ -97,6 +101,8 @@ leave its restart procedure with contradictory integrity instructions.
    the service. A shared no-socket-assignment guard must gate both the initial
    edit and rollback across every selected service file, including case and
    spacing variants, before rollback restores HBA/identity configuration.
+   The loaded peer receipt must also require exactly one intended local HBA rule
+   and no preceding local rule except the retained `postgres` recovery rule.
 4. Correct `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` to require matching,
    currently attested evidence for every raw mismatch **and** missing-source
    item while preserving the raw report and its forensic nonzero exit.
@@ -227,6 +233,10 @@ Max files: 7
   - The same full-service-file socket-assignment guard gates both adding and
     rollback. It permits restored HBA/identity configuration only after no
     canonical, case-variant, or spacing-variant socket assignment remains.
+  - Before socket configuration, the loaded HBA receipt proves that exactly one
+    intended local peer-map rule exists and no local rule that could supersede
+    it precedes it; only the retained `postgres` recovery rule is admitted
+    before the intended rule.
   - The cutover reconciles every client observed in both initial and final
     loopback TCP/replication inventories to a Unix-socket or verified-SCRAM
     receipt, requires no remaining final client, and requires an exact loaded
@@ -294,6 +304,12 @@ Max files: 7
   admitted set is empty. A remaining assignment stops before HBA/identity
   restore; the safe default is to remove only the cutover-created assignment or
   use a separate configuration migration with an exact baseline receipt.
+- **Peer-HBA precedence — CLOSED / DERIVED before socket configuration.**
+  Membership is the ordered loaded `local` HBA rows preceding the exact
+  `atlas | atlas | peer | map=atlas_app` row. The receipt admits exactly one
+  intended row and only the `all | postgres | peer` recovery row before it;
+  every other preceding local rule stops the cutover for a separate HBA-policy
+  migration.
 - **Database environment-key aliases — CLOSED / DERIVED for fixed inspection.**
   Membership is every canonical `ATLAS_DB_*` setting consumed by
   `DatabaseConfig`, listed as `DATABASE_CONFIG_KEYS` in `ops`; its case-folded
@@ -365,17 +381,22 @@ blocks the socket-peer path.
 - `./ops test focused tests/test_agent_operations_contract.py -q -k
   'database_runtime_environment or service_db_inspect or
   service_db_case_variant_preflight or service_db_no_socket_guard or
-  rollback_refuses'` — 21 passed, 40 deselected (local); proves the canonical
-  override, case-variant rejection, complete key-set closure, the service-helper
-  unset-set closure, socket/full-DSN alias and near-miss boundaries,
-  empty-service-set rejection, and that a surviving spacing-variant socket
-  assignment cannot reach HBA restoration.
-- `./ops test focused tests/test_agent_operations_contract.py -q` — 61 passed
+  rollback_refuses or peer_hba_receipt'` — 22 passed, 40 deselected (local);
+  proves the canonical override, case-variant rejection, complete key-set
+  closure, the service-helper unset-set closure, socket/full-DSN alias and
+  near-miss boundaries, empty-service-set rejection, a surviving spacing-variant
+  socket assignment cannot reach HBA restoration, and the loaded peer-HBA
+  receipt requires the intended rule/precedence predicate.
+- `./ops test focused tests/test_agent_operations_contract.py -q` — 62 passed
   (local).
 - `bash scripts/check_ascii_python.sh` — passed (local).
 - `service_db_inspect`, canonical-key/no-socket, and rollback guard blocks
   extracted from `.agent/runbooks/database.md` and checked with `bash -n` —
   passed (local).
+- The read-only loaded peer-HBA receipt returned `0|0|0|0|0|0` against the
+  pre-cutover state, proving its negative boundary; the synthetic receipt
+  returned `accepted|1|0` and `blocked|1|1` for the retained recovery-only and
+  competing-local-rule cases, respectively (local).
 - `git diff --check` — passed (local).
 - `python scripts/sync_pr_plan.py
   plans/PR-Postgres-Loopback-Scram-Hardening.md origin/main --check` — passed
@@ -397,14 +418,14 @@ blocks the socket-peer path.
 
 | File | LOC |
 |---|---:|
-| `.agent/runbooks/database.md` | 480 |
+| `.agent/runbooks/database.md` | 508 |
 | `atlas_brain/storage/config.py` | 11 |
 | `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` | 20 |
 | `ops` | 15 |
-| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 412 |
-| `tests/test_agent_operations_contract.py` | 278 |
+| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 433 |
+| `tests/test_agent_operations_contract.py` | 290 |
 | `tests/test_eom_render_profile.py` | 61 |
-| **Total** | **1277** |
+| **Total** | **1338** |
 
 ## Diff budget
 

--- a/plans/PR-Postgres-Loopback-Scram-Hardening.md
+++ b/plans/PR-Postgres-Loopback-Scram-Hardening.md
@@ -40,6 +40,10 @@ leave its restart procedure with contradictory integrity instructions.
   previously selected only canonical service-file keys; an alias or empty file
   list could therefore make fixed inspection use a fallback/different target
   from `atlas-api.service` before the cutover safety checks run.
+- Rollback previously checked only one exact socket-assignment spelling in one
+  file. A surviving case- or spacing-variant could keep the service on peer
+  authentication after its identity map was restored, while fixed inspection
+  would not necessarily observe that residual configuration.
 - `DatabaseConfig` resolves environment names case-insensitively, but `ops`
   previously removed only a subset of canonical uppercase database keys. A
   lower- or mixed-case inherited alias for any setting the inspector consumes
@@ -90,7 +94,9 @@ leave its restart procedure with contradictory integrity instructions.
    and its precondition's positive/negative matching boundaries. The helper
    must refuse an empty file set and any noncanonical-cased `ATLAS_DB_*` key
    before fixed inspection, so the full-DSN gate applies to the same source as
-   the service.
+   the service. A shared no-socket-assignment guard must gate both the initial
+   edit and rollback across every selected service file, including case and
+   spacing variants, before rollback restores HBA/identity configuration.
 4. Correct `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` to require matching,
    currently attested evidence for every raw mismatch **and** missing-source
    item while preserving the raw report and its forensic nonzero exit.
@@ -218,6 +224,9 @@ Max files: 7
     readable, the selected set must be nonempty, and all `ATLAS_DB_*` keys must
     be canonical uppercase. This makes the `ops` configuration parser and the
     service's case-insensitive `DatabaseConfig` agree without exposing values.
+  - The same full-service-file socket-assignment guard gates both adding and
+    rollback. It permits restored HBA/identity configuration only after no
+    canonical, case-variant, or spacing-variant socket assignment remains.
   - The cutover reconciles every client observed in both initial and final
     loopback TCP/replication inventories to a Unix-socket or verified-SCRAM
     receipt, requires no remaining final client, and requires an exact loaded
@@ -279,6 +288,12 @@ Max files: 7
   fixed inspection or the full-DSN precondition. The safe default is to
   normalize configuration in a separate migration, not to inspect a fallback
   or choose between alias collisions.
+- **Rollback socket assignments — CLOSED / DERIVED before HBA restore.**
+  Membership is every case-variant `ATLAS_DB_SOCKET_PATH` assignment in every
+  ordered selected `EnvironmentFile`, regardless of value or spacing. The only
+  admitted set is empty. A remaining assignment stops before HBA/identity
+  restore; the safe default is to remove only the cutover-created assignment or
+  use a separate configuration migration with an exact baseline receipt.
 - **Database environment-key aliases — CLOSED / DERIVED for fixed inspection.**
   Membership is every canonical `ATLAS_DB_*` setting consumed by
   `DatabaseConfig`, listed as `DATABASE_CONFIG_KEYS` in `ops`; its case-folded
@@ -348,15 +363,17 @@ blocks the socket-peer path.
   database_file_context_honors_explicit_override_order'` — 2 passed, 39
   deselected (local).
 - `./ops test focused tests/test_agent_operations_contract.py -q -k
-  'database_runtime_environment or service_db_inspect'` — 17 passed, 40
-  deselected (local); proves the canonical override, case-variant rejection,
-  complete key-set closure, the service-helper unset-set closure, socket and
-  full-DSN alias/near-miss boundaries, empty-service-set rejection, and that
-  the preflight prevents a lower-case DSN from reaching `ops`.
-- `./ops test focused tests/test_agent_operations_contract.py -q` — 57 passed
+  'database_runtime_environment or service_db_inspect or
+  service_db_case_variant_preflight or service_db_no_socket_guard or
+  rollback_refuses'` — 21 passed, 40 deselected (local); proves the canonical
+  override, case-variant rejection, complete key-set closure, the service-helper
+  unset-set closure, socket/full-DSN alias and near-miss boundaries,
+  empty-service-set rejection, and that a surviving spacing-variant socket
+  assignment cannot reach HBA restoration.
+- `./ops test focused tests/test_agent_operations_contract.py -q` — 61 passed
   (local).
 - `bash scripts/check_ascii_python.sh` — passed (local).
-- `service_db_inspect`, canonical-key, and pre-existing-socket guard blocks
+- `service_db_inspect`, canonical-key/no-socket, and rollback guard blocks
   extracted from `.agent/runbooks/database.md` and checked with `bash -n` —
   passed (local).
 - `git diff --check` — passed (local).
@@ -380,14 +397,14 @@ blocks the socket-peer path.
 
 | File | LOC |
 |---|---:|
-| `.agent/runbooks/database.md` | 485 |
+| `.agent/runbooks/database.md` | 480 |
 | `atlas_brain/storage/config.py` | 11 |
 | `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` | 20 |
 | `ops` | 15 |
-| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 395 |
-| `tests/test_agent_operations_contract.py` | 213 |
+| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 412 |
+| `tests/test_agent_operations_contract.py` | 278 |
 | `tests/test_eom_render_profile.py` | 61 |
-| **Total** | **1200** |
+| **Total** | **1277** |
 
 ## Diff budget
 

--- a/plans/PR-Postgres-Loopback-Scram-Hardening.md
+++ b/plans/PR-Postgres-Loopback-Scram-Hardening.md
@@ -82,6 +82,15 @@ leave its restart procedure with contradictory integrity instructions.
 - The effective service file was manually selected after authentication edits
   and only checked during rollback, so a mistyped or unlisted path could create
   a stray socket assignment that the rollback path refuses to remove.
+- The loopback-client inventory sees only current PostgreSQL sessions. The
+  repository-owned `eom-write-boundary-audit.timer` is an hourly one-shot and
+  can be absent from both snapshots while its source default still selects
+  loopback TCP, so its database path could be lost during trust removal without
+  any client receipt.
+- Its libpq helper begins with the inherited process environment, so ambient
+  `PG*` settings can survive a socket-default change and make the monitor's
+  effective transport depend on user-manager state rather than the admitted
+  source URI.
 - The migration runbook confuses raw forensic output with attested admission.
 
 #### Required change surface
@@ -148,6 +157,16 @@ leave its restart procedure with contradictory integrity instructions.
    proves the selected service file wins for both target and timeout settings,
    plus a closure test that fails when a future `DatabaseConfig` field is not
    added to that scrub set.
+7. Move the standalone EOM write-boundary monitor's source default to a
+   passwordless encoded Unix-socket URI, decode that URI host before passing it
+   to libpq, clear inherited `PG*` libpq settings before applying that URI,
+   preserve explicit monitor-DSN override behavior, and add focused monitor
+   tests. The cutover runbook must inventory this dormant scheduled
+   client before HBA mutation by requiring an installed-source match, an active
+   timer/service identity, no `EnvironmentFile`, and no unit/user-manager DSN
+   override without printing environment values; after peer configuration it must dry-run the
+   installed monitor with no alert/state mutation and reject an unreadable
+   socket route before trust replacement.
 
 #### Explicit non-scope
 
@@ -160,6 +179,10 @@ leave its restart procedure with contradictory integrity instructions.
   fixed read-only statements, refactor arbitrary maintenance scripts, add
   dependencies, or make runtime-routing changes.
 - Do not change the `postgres` Unix-socket peer break-glass rule.
+- Do not change the EOM audit's signals, alert delivery, timer cadence, state
+  semantics, unit configuration, or any monitor override value; an explicit
+  monitor DSN remains supported but is outside this cutover until separately
+  migrated and proved.
 
 #### Assumptions and blockers
 
@@ -168,6 +191,10 @@ leave its restart procedure with contradictory integrity instructions.
 - Recheck the peer map and local replication activity before changing HBA.
 - HBA/ident/shared configuration changes occur only after this source revision
   is deployed.
+- The deployed audit unit executes the documented installed script path and no
+  `EnvironmentFile` or `ATLAS_EOM_AUDIT_ATLAS_DSN` value is inherited from its
+  unit or user manager; otherwise the cutover stops rather than inferring its
+  transport.
 
 #### Verification plan
 
@@ -189,6 +216,10 @@ leave its restart procedure with contradictory integrity instructions.
   final HBA receipt independently defines `covers_loopback`.
 - It must also prove the derived effective file passes only when it belongs to
   the ordered selected service-file list and stops before the gate otherwise.
+- Monitor regressions must prove both default-socket selection and preserved
+  explicit-override selection, including hostile inherited `PG*` settings, and
+  the runbook guard must reject service and user-manager DSN overrides plus a
+  stale installed monitor copy before the first HBA backup.
 - GitHub remains the complete unit gate.
 - Post-merge proof while existing TCP trust remains: deploy source; configure
   `ATLAS_DB_SOCKET_PATH` only when no complete DSN overrides it; add/reload the
@@ -197,8 +228,9 @@ leave its restart procedure with contradictory integrity instructions.
   Unix-socket backend,
   fixed inspection selected from the service `EnvironmentFiles`, the exclusive
   loaded identity map, a Unix-socket or separately verified SCRAM receipt for
-  every client observed in either inventory, and no remaining loopback TCP or
-  replication client.
+  every client observed in either inventory, the dormant audit monitor's
+  installed-source/no-override admission and no-alert socket dry-run receipt,
+  and no remaining loopback TCP or replication client.
 - Only then replace every loopback TCP `trust` rule with `scram-sha-256`,
   reload PostgreSQL, prove the derived loopback-network receipt is `4` and the
   exact loaded-HBA result is `1|1|1|1|0|0|0|0` (one exact application IPv4,
@@ -213,7 +245,7 @@ leave its restart procedure with contradictory integrity instructions.
 
 Ownership lane: eom-crm/runtime-security
 Slice phase: production hardening
-Max files: 7
+Max files: 9
 
 ### Review contract
 
@@ -228,7 +260,12 @@ Max files: 7
      because both already call `connection_kwargs()`, and the fixed inspector
      admits only selected service values or exact-uppercase runtime database
      overrides rather than case-variant inherited aliases.
-  4. The operational procedure rejects an overriding complete DSN, authenticates
+  4. The operational procedure rejects an overriding complete DSN, independently
+     admits the dormant EOM audit monitor's installed source, service/timer
+     identity, no `EnvironmentFile`, and no-override default socket route before
+     HBA mutation, then
+     records its no-alert socket dry-run receipt before trust replacement,
+     authenticates
      the specific service OS account as `atlas` over the Unix socket before
      removing loopback `trust`, proves the exclusive loaded identity map,
      requires every qualifying post-restart backend to use a Unix socket, gives
@@ -252,13 +289,15 @@ Max files: 7
   the corrected socket port as well.
 - Affected surfaces: `DatabaseConfig` DSN/asyncpg construction and target
   labels; `DatabasePool`; the fixed `./ops db inspect` environment-selection
-  seam; PostgreSQL HBA/ident operational procedure; migration target
+  seam; the standalone EOM write-boundary monitor's libpq environment
+  construction; PostgreSQL HBA/ident operational procedure; migration target
   confirmation; and the authenticated EOM CRM read used as production proof.
 - Risk areas: local role impersonation over loopback TCP, wrong-cluster
   inspection, service/inspector configuration skew, HBA parser failure,
   an overbroad peer map, active local client disconnect, duplicated/missing
   IPv4/IPv6/replication tuples, unreloaded failed HBA restoration,
-  startup-migration availability, and rollback recovery.
+  dormant scheduled-client disconnect, startup-migration availability, and
+  rollback recovery.
 - Reviewer rules triggered: R1, R2, R3, R11, R12, R14.
 - Boundary-change enumeration:
   - `socket_path=None` continues to produce TCP host/port kwargs.
@@ -269,6 +308,12 @@ Max files: 7
     query value; asyncpg kwargs retain the original filesystem path.
   - The socket target label includes that port, so confirmation cannot conflate
     same-directory, same-database clusters on distinct ports.
+  - The standalone audit's absent monitor-DSN default selects the encoded Unix
+    socket host and no password; its libpq environment decodes that host to the
+    filesystem path and clears every inherited `PG*` setting first. An explicit
+    `ATLAS_EOM_AUDIT_ATLAS_DSN` still wins for the monitor itself, but it stops
+    this peer cutover until separately migrated and proved rather than becoming
+    an unobserved TCP dependency.
   - The fixed inspector uses only the service `EnvironmentFiles`, in service
     order, and removes every case variant of every consumed `ATLAS_DB_*` value
     before it constructs `DatabaseConfig`; exact-uppercase runtime keys preserve
@@ -300,8 +345,10 @@ Max files: 7
   - The cutover reconciles every client observed in both initial and final
     loopback TCP/replication inventories to a Unix-socket or verified-SCRAM
     receipt, requires every qualifying post-restart `atlas` backend to be a
-    Unix socket, requires no remaining final client, and requires an exact loaded
-    `atlas_app | juan-canfield | atlas` identity map before HBA replacement.
+    Unix socket, requires the known dormant audit monitor's independent
+    installed-source/no-override and dry-run receipt, requires no remaining
+    final client, and requires an exact loaded `atlas_app | juan-canfield |
+    atlas` identity map before HBA replacement.
   - The post-conversion HBA receipt derives every non-local rule whose network
     can cover either loopback endpoint, then requires one exact SCRAM tuple for
     each application/replication IPv4/IPv6 channel, no unexpected endpoint-equal
@@ -346,6 +393,25 @@ Max files: 7
   client that disappears or newly appears, stops the cutover until it has a
   Unix-socket or separately verified SCRAM reconnect receipt; an empty final
   snapshot alone is not an admissible default.
+- **EOM audit scheduled client — CLOSED / DERIVED before trust removal.**
+  Membership is the one repository-owned `eom-write-boundary-audit.service`
+  reached by its active hourly timer, its installed script at the documented
+  path, any service `EnvironmentFile`, and any unit or user-manager
+  `ATLAS_EOM_AUDIT_ATLAS_DSN` assignment.
+  The admitted member has a byte-identical installed script, expected service
+  executable, active enabled timer, no `EnvironmentFile`, no override in either
+  environment source, an explicit-source-owned libpq target, and a post-peer
+  no-alert dry run that does not report `COULD NOT MEASURE`.
+  A clean result (`0`) and a measured boundary breach (`2`) both prove its
+  socket transport; an absent timer, stale script, different executable,
+  override, unreadable measurement, or other exit stops before HBA replacement.
+- **Inherited libpq settings — OPEN / DERIVED per monitor invocation.**
+  Membership is every inherited environment key with the `PG` prefix, derived
+  by `psql_environment()` from the process environment. The safe default is to
+  remove every member, then derive the only admitted libpq settings from the
+  parsed monitor DSN (including its explicit `options` and `sslmode` query
+  values). A setting absent from that URI cannot silently select another target;
+  non-`PG` process environment remains available to locate and run `psql`.
 - **Post-restart Atlas transport — CLOSED / DERIVED before trust removal.**
   Membership is every `pg_stat_activity` client backend for user/database
   `atlas` after the authenticated CRM read. The only admitted receipt has at
@@ -411,8 +477,10 @@ Max files: 7
 - `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`
 - `ops`
 - `plans/PR-Postgres-Loopback-Scram-Hardening.md`
+- `scripts/eom_write_boundary_audit.py`
 - `tests/test_agent_operations_contract.py`
 - `tests/test_eom_render_profile.py`
+- `tests/test_eom_write_boundary_audit.py`
 
 ## Mechanism
 
@@ -427,6 +495,15 @@ uses its documented explicit environment-file override in the exact service
 order; `ops` discards case-insensitive aliases for known database settings, so
 the read-only proof observes the same database target as `atlas-api.service`.
 
+The independent EOM audit monitor now defaults to the same passwordless socket
+transport through libpq without importing or depending on `atlas-api`. Before
+the cutover can rely on that source default, the runbook proves the installed
+standalone copy is current and has no hidden DSN override; its dry run is
+measurement-only and cannot consume an alert transition. Its subprocess
+environment removes every inherited `PG*` setting before the source URI is
+parsed, so a user-manager `PGHOSTADDR`, service profile, or unlisted libpq
+configuration cannot silently turn the socket receipt back into TCP.
+
 The migration-runbook change is documentation only: raw discrepancies stay
 visible and retain their forensic nonzero status.
 
@@ -440,6 +517,9 @@ visible and retain their forensic nonzero status.
   its existing explicit override, while its inspection child now strips
   case-variant inherited database aliases rather than changing normal worktree
   selection behavior.
+- The EOM audit's timer, signals, notification delivery, state persistence, and
+  explicit DSN override precedence remain unchanged; only its absent-override
+  default moves to the socket.
 
 ## Deferred
 
@@ -461,28 +541,22 @@ blocks the socket-peer path.
   'database_file_context_prefers_worktree_over_shared_and_systemd or
   database_file_context_honors_explicit_override_order'` — 2 passed, 39
   deselected (local).
+- `./ops test focused tests/test_eom_write_boundary_audit.py -q -k 'socket or
+  dsn or libpq_target'` — 5 passed, 29 deselected (local); proves the monitor's
+  default socket URI decodes into a libpq filesystem host, hostile inherited
+  target selectors are scrubbed, and an explicit DSN still wins.
 - `./ops test focused tests/test_agent_operations_contract.py -q -k
-  'database_runtime_environment or service_db_inspect or
-  service_db_case_variant_preflight or service_db_no_socket_guard or
-  effective_env_file or new_socket_configuration or final_hba_receipt or
-  admits_new_socket_configuration_before_hba_mutation or rollback_refuses or
-  peer_hba_receipt or qualifying_atlas_backends or hba_sources'` — 15 passed,
-  60 deselected (local);
-  proves the canonical override, case-variant rejection, complete key-set
-  closure, the service-helper unset-set closure, socket/full-DSN alias and
-  near-miss boundaries, empty-service-set rejection, a nonblank complete DSN
-  stops before the first HBA backup, a selected versus unlisted effective file
-  boundary gates both cutover and rollback, a surviving spacing-variant socket
-  assignment cannot reach HBA restoration, each final HBA receipt defines its
-  own loopback CTE, the transport receipt requires every qualifying Atlas backend
-  to use the socket, the HBA source receipt gates top-level backup/rollback, and
-  the loaded peer-HBA receipt requires the intended rule/precedence predicate.
-- `./ops test focused tests/test_agent_operations_contract.py -q` — 75 passed
-  (local).
+  'dormant_eom_audit or admits_the_dormant'` — 9 passed, 75 deselected (local);
+  proves the dormant-client admission is before HBA backup and rejects a stale
+  installed copy, disabled/inactive timer, unexpected executable, an
+  `EnvironmentFile`, or either service or user-manager DSN override.
+- `./ops test focused tests/test_eom_write_boundary_audit.py
+  tests/test_agent_operations_contract.py -q` — 116 passed, 2 skipped (local);
+  covers the full current monitor and operations-contract suite.
 - `bash scripts/check_ascii_python.sh` — passed (local).
-- `service_db_inspect`, effective-file, new-socket-admission, canonical-key/no-socket, and rollback guard blocks
-  extracted from `.agent/runbooks/database.md` and checked with `bash -n` —
-  passed (local).
+- The initial admission block and the post-restart audit dry-run block extracted
+  from `.agent/runbooks/database.md` and checked with `bash -n` — passed
+  (local).
 - The read-only loaded peer-HBA receipt returned `0|0|0|0|0|0` against the
   pre-cutover state, proving its negative boundary; the synthetic receipt
   returned `accepted|1|0` and `blocked|1|1` for the retained recovery-only and
@@ -516,14 +590,16 @@ blocks the socket-peer path.
 
 | File | LOC |
 |---|---:|
-| `.agent/runbooks/database.md` | 601 |
+| `.agent/runbooks/database.md` | 711 |
 | `atlas_brain/storage/config.py` | 13 |
 | `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` | 20 |
 | `ops` | 15 |
-| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 531 |
-| `tests/test_agent_operations_contract.py` | 458 |
+| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 607 |
+| `scripts/eom_write_boundary_audit.py` | 22 |
+| `tests/test_agent_operations_contract.py` | 558 |
 | `tests/test_eom_render_profile.py` | 84 |
-| **Total** | **1722** |
+| `tests/test_eom_write_boundary_audit.py` | 83 |
+| **Total** | **2113** |
 
 ## Diff budget
 

--- a/plans/PR-Postgres-Loopback-Scram-Hardening.md
+++ b/plans/PR-Postgres-Loopback-Scram-Hardening.md
@@ -79,6 +79,9 @@ leave its restart procedure with contradictory integrity instructions.
 - Service-file admission for a pre-existing socket assignment or nonblank
   complete DSN was deferred until after backup, peer-map/HBA edits, and reload,
   so a rejected configuration could leave partial authentication state live.
+- The effective service file was manually selected after authentication edits
+  and only checked during rollback, so a mistyped or unlisted path could create
+  a stray socket assignment that the rollback path refuses to remove.
 - The migration runbook confuses raw forensic output with attested admission.
 
 #### Required change surface
@@ -124,6 +127,10 @@ leave its restart procedure with contradictory integrity instructions.
    HBA/identity backup, edit, or reload. Each independent post-conversion HBA
    query must define its own derived loopback-coverage relation before it
    consumes that relation.
+   The effective environment file must be derived from the ordered selected
+   service-file list and have its membership validated by the same pre-mutation
+   gate and rollback path; no manual file selection may occur after
+   authentication edits.
    The loaded peer receipt must also require exactly one intended local HBA rule
    and no preceding local rule except the retained `postgres` recovery rule.
    It must require at least one qualifying post-restart `atlas` backend and a
@@ -180,6 +187,8 @@ leave its restart procedure with contradictory integrity instructions.
   assignments pass while literal and expansion-shaped values stop, prove the
   configuration-admission command precedes the first HBA backup, and prove each
   final HBA receipt independently defines `covers_loopback`.
+- It must also prove the derived effective file passes only when it belongs to
+  the ordered selected service-file list and stops before the gate otherwise.
 - GitHub remains the complete unit gate.
 - Post-merge proof while existing TCP trust remains: deploy source; configure
   `ATLAS_DB_SOCKET_PATH` only when no complete DSN overrides it; add/reload the
@@ -231,7 +240,9 @@ Max files: 7
      any HBA/identity mutation when any selected service file already assigns the
      socket path or a nonblank complete DSN, so rollback removes only an
      assignment created by this cutover. Each final HBA receipt is independently
-     executable with its own loopback-coverage relation.
+     executable with its own loopback-coverage relation, and the effective
+     environment file is derived and membership-checked before any authentication
+     mutation.
   5. The migration runbook accurately distinguishes raw forensic output from
      attested admission without changing runner behavior.
 - Reachability proof: `atlas_brain/storage/database.py` initializes the pool
@@ -271,6 +282,10 @@ Max files: 7
     stop condition before authentication mutation. Empty, quoted-empty, and
     comment-only assignments remain admissible; a literal or expansion-shaped
     value requires a separate configuration migration.
+  - The effective environment-file target is derived as the final selected
+    service file and must remain a member of that exact ordered list before
+    either the new-socket gate or rollback proceeds; an unlisted target stops
+    rather than creating a stray assignment.
   - Before fixed inspection or an edit, every selected service file must be
     readable, the selected set must be nonempty, and all `ATLAS_DB_*` keys must
     be canonical uppercase. This makes the `ops` configuration parser and the
@@ -338,9 +353,11 @@ Max files: 7
   empty set stops the cutover.
 - **Service environment-file list — CLOSED / DERIVED for the selected service
   unit.** Membership is the ordered `EnvironmentFiles` output of `./ops env
-  systemd`. An absent, unreadable, or unlisted effective configuration file
-  stops fixed inspection and HBA mutation, the safer side over inspecting or
-  changing a guessed database target.
+  systemd`. The effective target is derived from the final member, then the
+  same membership predicate gates new-socket admission and rollback. An absent,
+  unreadable, or unlisted effective configuration file stops fixed inspection
+  and HBA mutation, the safer side over inspecting or changing a guessed
+  database target.
 - **Pre-existing socket-path assignments — CLOSED / DERIVED before cutover.**
   Membership is every case-variant assignment matching `ATLAS_DB_SOCKET_PATH`
   in the ordered selected `EnvironmentFiles`. The only admitted set is empty;
@@ -447,22 +464,23 @@ blocks the socket-peer path.
 - `./ops test focused tests/test_agent_operations_contract.py -q -k
   'database_runtime_environment or service_db_inspect or
   service_db_case_variant_preflight or service_db_no_socket_guard or
-  new_socket_configuration or final_hba_receipt or
+  effective_env_file or new_socket_configuration or final_hba_receipt or
   admits_new_socket_configuration_before_hba_mutation or rollback_refuses or
-  peer_hba_receipt or qualifying_atlas_backends or hba_sources'` — 13 passed,
+  peer_hba_receipt or qualifying_atlas_backends or hba_sources'` — 15 passed,
   60 deselected (local);
   proves the canonical override, case-variant rejection, complete key-set
   closure, the service-helper unset-set closure, socket/full-DSN alias and
   near-miss boundaries, empty-service-set rejection, a nonblank complete DSN
-  stops before the first HBA backup, a surviving spacing-variant socket
+  stops before the first HBA backup, a selected versus unlisted effective file
+  boundary gates both cutover and rollback, a surviving spacing-variant socket
   assignment cannot reach HBA restoration, each final HBA receipt defines its
   own loopback CTE, the transport receipt requires every qualifying Atlas backend
   to use the socket, the HBA source receipt gates top-level backup/rollback, and
   the loaded peer-HBA receipt requires the intended rule/precedence predicate.
-- `./ops test focused tests/test_agent_operations_contract.py -q` — 73 passed
+- `./ops test focused tests/test_agent_operations_contract.py -q` — 75 passed
   (local).
 - `bash scripts/check_ascii_python.sh` — passed (local).
-- `service_db_inspect`, new-socket-admission, canonical-key/no-socket, and rollback guard blocks
+- `service_db_inspect`, effective-file, new-socket-admission, canonical-key/no-socket, and rollback guard blocks
   extracted from `.agent/runbooks/database.md` and checked with `bash -n` —
   passed (local).
 - The read-only loaded peer-HBA receipt returned `0|0|0|0|0|0` against the
@@ -498,14 +516,14 @@ blocks the socket-peer path.
 
 | File | LOC |
 |---|---:|
-| `.agent/runbooks/database.md` | 597 |
+| `.agent/runbooks/database.md` | 601 |
 | `atlas_brain/storage/config.py` | 13 |
 | `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` | 20 |
 | `ops` | 15 |
-| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 513 |
-| `tests/test_agent_operations_contract.py` | 424 |
+| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 531 |
+| `tests/test_agent_operations_contract.py` | 458 |
 | `tests/test_eom_render_profile.py` | 84 |
-| **Total** | **1666** |
+| **Total** | **1722** |
 
 ## Diff budget
 

--- a/plans/PR-Postgres-Loopback-Scram-Hardening.md
+++ b/plans/PR-Postgres-Loopback-Scram-Hardening.md
@@ -96,10 +96,11 @@ incorrectly said that admissible state could contain no `missing_source`.
   health, an authenticated EOM CRM read, the application's Unix-socket backend,
   and fixed inspection selected from the service `EnvironmentFiles`.
 - Only then replace every loopback TCP `trust` rule with `scram-sha-256`,
-  reload PostgreSQL, prove the loaded HBA result is `4|0|0` (four loopback
-  SCRAM rows, zero trust rows, zero parser errors), repeat the proofs, prove
-  passwordless TCP rejection, and prove `sudo -u postgres psql -h
-  /var/run/postgresql -p 5433 -d atlas -Atc 'SELECT current_user'` succeeds.
+  reload PostgreSQL, prove the loaded HBA result is `2|2|0|0` (two application
+  and two replication loopback SCRAM rows, zero trust rows, zero parser
+  errors), repeat the proofs, prove passwordless TCP rejection, and prove
+  `sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -Atc 'SELECT
+  current_user'` succeeds.
 
 ## Scope (this PR)
 
@@ -147,9 +148,9 @@ Max files: 5
   - The fixed inspector uses only the service `EnvironmentFiles`, in service
     order, and removes ad hoc `ATLAS_DB_*` values before it constructs
     `DatabaseConfig`.
-  - The post-conversion HBA receipt requires four loopback SCRAM rows, no
-    remaining trust row, and no parser error before an IPv4-only negative probe
-    can be treated as sufficient.
+  - The post-conversion HBA receipt requires two application and two
+    replication loopback SCRAM rows, no remaining trust row, and no parser
+    error before an IPv4-only negative probe can be treated as sufficient.
   - Cutover order is peer proof before removal of any trust rule; rollback
     restores TCP configuration before restarting the application.
 
@@ -222,12 +223,12 @@ blocks the socket-peer path.
 
 | File | LOC |
 |---|---:|
-| `.agent/runbooks/database.md` | 227 |
+| `.agent/runbooks/database.md` | 234 |
 | `atlas_brain/storage/config.py` | 11 |
 | `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` | 20 |
-| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 238 |
+| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 239 |
 | `tests/test_eom_render_profile.py` | 60 |
-| **Total** | **556** |
+| **Total** | **564** |
 
 ## Diff budget
 

--- a/plans/PR-Postgres-Loopback-Scram-Hardening.md
+++ b/plans/PR-Postgres-Loopback-Scram-Hardening.md
@@ -54,8 +54,17 @@ leave its restart procedure with contradictory integrity instructions.
   could therefore override the selected service configuration in its subprocess.
 - A socket target label omits its configured port even though the port selects
   the socket filename and the migration receipt confirms that label exactly.
+- A socket path is interpolated raw into the direct-DSN query string while the
+  pool path passes it as a raw asyncpg host, so URI delimiters can make the two
+  supported connection forms select different targets.
 - A successful service or inspector connection is not socket proof while a
   complete DSN retains deliberate precedence over split configuration.
+- The transport receipt accepts one socket connection among all qualifying
+  `atlas`/`atlas` backends, so it can pass while another qualifying backend
+  remains on TCP.
+- The HBA procedure backs up only the top-level file but did not prove the
+  loopback rules it edits originate there; an included source could survive
+  rollback.
 - A final-only loopback-client inventory can lose a client observed at preflight
   before it is proved Unix-socket or SCRAM-ready, and a peer-map insertion
   without an exact loaded-map receipt can retain a broader OS-account
@@ -72,6 +81,8 @@ leave its restart procedure with contradictory integrity instructions.
    forms and its log-safe target label honour `socket_path` and the configured
    PostgreSQL port:
    - `dsn` includes the socket host and port for direct asyncpg callers.
+   - The socket-host query value is URI-encoded so its decoded value remains
+     identical to the asyncpg keyword host for delimiter-containing paths.
    - `connection_kwargs()` uses the socket directory as `host`, retaining the
      configured port, so `DatabasePool` and `./ops db inspect` reach the Unix
      socket rather than loopback TCP.
@@ -79,8 +90,9 @@ leave its restart procedure with contradictory integrity instructions.
      distinguishes same-directory, same-database PostgreSQL clusters.
 2. Update focused `DatabaseConfig` tests in
    `tests/test_eom_render_profile.py` to pin both socket-path forms, distinct
-   socket ports, and the existing TCP/complete-DSN precedence behavior, then
-   assert the actual pool and raw-connection callers receive the socket kwargs.
+   socket ports, a delimiter-containing socket path, and the existing
+   TCP/complete-DSN precedence behavior, then assert the actual pool and
+   raw-connection callers receive the socket kwargs.
 3. Replace the provisional credential/SCRAM procedure with non-secret socket
    configuration, an exact `atlas-api` OS-user → `atlas` peer map, staged
    service/CRM/backend-transport/inspection proof, reconciled initial/final
@@ -103,6 +115,10 @@ leave its restart procedure with contradictory integrity instructions.
    spacing variants, before rollback restores HBA/identity configuration.
    The loaded peer receipt must also require exactly one intended local HBA rule
    and no preceding local rule except the retained `postgres` recovery rule.
+   It must require at least one qualifying post-restart `atlas` backend and a
+   null `client_addr` for every such backend before trust removal, and it must
+   stop before mutation unless every loopback trust rule is sourced from the
+   one top-level HBA file that rollback backs up and restores.
 4. Correct `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` to require matching,
    currently attested evidence for every raw mismatch **and** missing-source
    item while preserving the raw report and its forensic nonzero exit.
@@ -138,8 +154,9 @@ leave its restart procedure with contradictory integrity instructions.
 #### Verification plan
 
 - Focused regression: socket `dsn` and `connection_kwargs()` assertions,
-  distinct socket target-label assertions, existing TCP and complete-DSN
-  assertions, and the pool/raw caller seam.
+  including a delimiter-containing socket path, distinct socket target-label
+  assertions, existing TCP and complete-DSN assertions, and the pool/raw caller
+  seam.
 - Adjacent configuration-context regression: a worktree file remains the
   default inspector context, while an ordered `ATLAS_OPS_ENV_FILES` override
   selects the intended service configuration and lower/mixed-case inherited
@@ -152,16 +169,18 @@ leave its restart procedure with contradictory integrity instructions.
 - Post-merge proof while existing TCP trust remains: deploy source; configure
   `ATLAS_DB_SOCKET_PATH` only when no complete DSN overrides it; add/reload the
   exact identity map and specific peer HBA rule; restart `atlas-api`; prove
-  health, an authenticated EOM CRM read, the application's Unix-socket backend,
+  health, an authenticated EOM CRM read, every qualifying application's
+  Unix-socket backend,
   fixed inspection selected from the service `EnvironmentFiles`, the exclusive
   loaded identity map, a Unix-socket or separately verified SCRAM receipt for
   every client observed in either inventory, and no remaining loopback TCP or
   replication client.
 - Only then replace every loopback TCP `trust` rule with `scram-sha-256`,
   reload PostgreSQL, prove the derived loopback-network receipt is `4` and the
-  exact loaded-HBA result is `1|1|1|1|0|0|0` (one exact application IPv4,
+  exact loaded-HBA result is `1|1|1|1|0|0|0|0` (one exact application IPv4,
   application IPv6, replication IPv4, and replication IPv6 SCRAM tuple; zero
-  unexpected endpoint-equal host rules, trust rows, and parser errors), repeat
+  unexpected endpoint-equal host rules, trust rows, parser errors, and
+  loopback rules outside the backed-up top-level source), repeat
   the proofs, prove passwordless TCP rejection, and prove
   `sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -Atc 'SELECT
   current_user'` succeeds.
@@ -176,8 +195,9 @@ Max files: 7
 
 - Acceptance criteria:
   1. A configured socket path reaches the configured PostgreSQL socket port in
-     both `DatabaseConfig.dsn` and `connection_kwargs()`, and that port appears
-     in its log-safe exact-target label.
+     both `DatabaseConfig.dsn` and `connection_kwargs()`, URI delimiters round
+     trip identically through the DSN host query, and that port appears in its
+     log-safe exact-target label.
   2. Complete DSNs retain their precedence; non-socket split settings retain
      existing TCP kwargs.
   3. `DatabasePool` and fixed `./ops db inspect` inherit the corrected path
@@ -186,11 +206,13 @@ Max files: 7
      overrides rather than case-variant inherited aliases.
   4. The operational procedure rejects an overriding complete DSN, authenticates
      the specific service OS account as `atlas` over the Unix socket before
-     removing loopback `trust`, proves the exclusive loaded identity map, gives
+     removing loopback `trust`, proves the exclusive loaded identity map,
+     requires every qualifying post-restart backend to use a Unix socket, gives
      every initial/final loopback client a Unix-socket or verified-SCRAM receipt,
      leaves no TCP client, derives every loopback-covering HBA network rule,
      proves every exact tuple, retains `postgres` peer recovery, and reloads
-     restored TCP authentication before a rollback restart. It also stops before
+     restored TCP authentication before a rollback restart. It also proves every
+     loopback rule it edits is in the backed-up top-level HBA file, and stops before
      editing when any selected service file already assigns the socket path, so
      rollback removes only an assignment created by this cutover.
   5. The migration runbook accurately distinguishes raw forensic output from
@@ -215,6 +237,8 @@ Max files: 7
   - `connection_string` continues to win over split socket/TCP settings.
   - `socket_path` replaces only the host, retaining the configured port needed
     to select PostgreSQL's socket filename.
+  - A socket path containing URI delimiters is encoded only in `dsn`'s host
+    query value; asyncpg kwargs retain the original filesystem path.
   - The socket target label includes that port, so confirmation cannot conflate
     same-directory, same-database clusters on distinct ports.
   - The fixed inspector uses only the service `EnvironmentFiles`, in service
@@ -239,12 +263,14 @@ Max files: 7
     before the intended rule.
   - The cutover reconciles every client observed in both initial and final
     loopback TCP/replication inventories to a Unix-socket or verified-SCRAM
-    receipt, requires no remaining final client, and requires an exact loaded
+    receipt, requires every qualifying post-restart `atlas` backend to be a
+    Unix socket, requires no remaining final client, and requires an exact loaded
     `atlas_app | juan-canfield | atlas` identity map before HBA replacement.
   - The post-conversion HBA receipt derives every non-local rule whose network
     can cover either loopback endpoint, then requires one exact SCRAM tuple for
     each application/replication IPv4/IPv6 channel, no unexpected endpoint-equal
-    host rule, no remaining trust row, and no parser error before an IPv4-only
+    host rule, no remaining trust row, no parser error, and no loopback source
+    outside the backed-up file before an IPv4-only
     negative probe can be treated as sufficient.
   - Cutover order is peer proof before removal of any trust rule; rollback
     restores and reloads TCP authentication before restarting the application.
@@ -259,15 +285,18 @@ Max files: 7
   existing order; a nonblank DSN is outside the socket-proof-admissible subset
   and stops this cutover rather than allowing HBA mutation.
 - **Loopback HBA topology — CLOSED / DERIVED at cutover.** Membership comes
-  from every non-local live `pg_hba_file_rules` record on the declared socket
-  and port, not the four examples in this plan. A derived network predicate
+  from every non-local live `pg_hba_file_rules` record and its `file_name` on
+  the declared socket and port, not the four examples in this plan. A derived
+  network predicate
   includes an address/netmask rule when it can cover either loopback endpoint
   and treats null, unparseable, or family-mismatched forms as candidates. The
   procedure admits exactly four candidates, each one exact
   application/replication IPv4/IPv6 tuple with the declared user, netmask, and
   SCRAM method. A missing, duplicate, broader, TLS-specific, or unlisted rule
   fails closed to no HBA change because an unknown authentication path is less
-  safe than a deferred hardening run.
+  safe than a deferred hardening run. Before mutation, every trust rule must
+  come from the top-level source the procedure backs up; the post-conversion
+  receipt applies the same source check to every loopback rule.
 - **`atlas_app` peer-map membership — CLOSED / DERIVED at reload.** Membership
   comes from `pg_ident_file_mappings`; exactly one
   `atlas_app | juan-canfield | atlas` tuple and no mapping error is admitted.
@@ -280,6 +309,11 @@ Max files: 7
   client that disappears or newly appears, stops the cutover until it has a
   Unix-socket or separately verified SCRAM reconnect receipt; an empty final
   snapshot alone is not an admissible default.
+- **Post-restart Atlas transport — CLOSED / DERIVED before trust removal.**
+  Membership is every `pg_stat_activity` client backend for user/database
+  `atlas` after the authenticated CRM read. The only admitted receipt has at
+  least one member and null `client_addr` for every member; any TCP member or an
+  empty set stops the cutover.
 - **Service environment-file list — CLOSED / DERIVED for the selected service
   unit.** Membership is the ordered `EnvironmentFiles` output of `./ops env
   systemd`. An absent, unreadable, or unlisted effective configuration file
@@ -336,7 +370,8 @@ Max files: 7
 
 ## Mechanism
 
-`DatabaseConfig` now carries its existing socket path and port into asyncpg.
+`DatabaseConfig` now carries its existing socket path and port into asyncpg,
+encoding the direct-DSN host query without changing the raw asyncpg kwargs.
 No password is added: the post-merge identity map lets `atlas-api` authenticate
 as `atlas` over peer. The map/rule are proved while TCP remains available;
 only then do all loopback `trust` entries become `scram-sha-256`.
@@ -374,7 +409,7 @@ blocks the socket-peer path.
 ## Verification
 
 - `./ops test focused tests/test_eom_render_profile.py -q -k 'database_config
-  or database_pool_uses_configured_connection_kwargs'` — 4 passed, 61
+  or database_pool_uses_configured_connection_kwargs'` — 5 passed, 61
   deselected (local).
 - `./ops test focused tests/test_agent_operations_contract.py -q -k
   'database_file_context_prefers_worktree_over_shared_and_systemd or
@@ -383,13 +418,16 @@ blocks the socket-peer path.
 - `./ops test focused tests/test_agent_operations_contract.py -q -k
   'database_runtime_environment or service_db_inspect or
   service_db_case_variant_preflight or service_db_no_socket_guard or
-  rollback_refuses or peer_hba_receipt'` — 22 passed, 40 deselected (local);
+  rollback_refuses or peer_hba_receipt or qualifying_atlas_backends or
+  hba_sources'` — 25 passed, 40 deselected (local);
   proves the canonical override, case-variant rejection, complete key-set
   closure, the service-helper unset-set closure, socket/full-DSN alias and
   near-miss boundaries, empty-service-set rejection, a surviving spacing-variant
-  socket assignment cannot reach HBA restoration, and the loaded peer-HBA
-  receipt requires the intended rule/precedence predicate.
-- `./ops test focused tests/test_agent_operations_contract.py -q` — 62 passed
+  socket assignment cannot reach HBA restoration, the transport receipt requires
+  every qualifying Atlas backend to use the socket, the HBA source receipt gates
+  top-level backup/rollback, and the loaded peer-HBA receipt requires the
+  intended rule/precedence predicate.
+- `./ops test focused tests/test_agent_operations_contract.py -q` — 65 passed
   (local).
 - `bash scripts/check_ascii_python.sh` — passed (local).
 - `service_db_inspect`, canonical-key/no-socket, and rollback guard blocks
@@ -410,6 +448,9 @@ blocks the socket-peer path.
   `4|0`: four loopback-network candidates and zero unexpected candidates; a
   synthetic broader subnet, `hostssl` rule, and non-IP form each became a
   candidate while the current remote `/12` rule did not (local).
+- The read-only HBA source receipt returned `4|0|0`; the transport predicate
+  returned `socket_only|1|1` and `mixed|1|0` against synthetic socket-only and
+  mixed candidates (local).
 - Guarded `scripts/push_pr.sh` local PR review — passed; GitHub owns the full
   unit gate.
 - Post-merge: follow the exact peer-socket cutover/rollback procedure in
@@ -420,14 +461,14 @@ blocks the socket-peer path.
 
 | File | LOC |
 |---|---:|
-| `.agent/runbooks/database.md` | 509 |
-| `atlas_brain/storage/config.py` | 11 |
+| `.agent/runbooks/database.md` | 546 |
+| `atlas_brain/storage/config.py` | 13 |
 | `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` | 20 |
 | `ops` | 15 |
-| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 435 |
-| `tests/test_agent_operations_contract.py` | 292 |
-| `tests/test_eom_render_profile.py` | 61 |
-| **Total** | **1343** |
+| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 476 |
+| `tests/test_agent_operations_contract.py` | 350 |
+| `tests/test_eom_render_profile.py` | 84 |
+| **Total** | **1504** |
 
 ## Diff budget
 

--- a/plans/PR-Postgres-Loopback-Scram-Hardening.md
+++ b/plans/PR-Postgres-Loopback-Scram-Hardening.md
@@ -91,6 +91,22 @@ leave its restart procedure with contradictory integrity instructions.
   `PG*` settings can survive a socket-default change and make the monitor's
   effective transport depend on user-manager state rather than the admitted
   source URI.
+- The monitor admission checks only whether effective `ExecStart` contains the
+  installed script path. A drop-in can add `--atlas-dsn` or another
+  target-affecting argument while passing that check, so its manual default
+  dry-run can prove a different connection from the timer's scheduled command.
+- Requiring an installed copy of the new socket-default source before the peer
+  map/rule is loaded creates a rollout window in which the active timer runs as
+  `juan-canfield` but the generic peer rule cannot authenticate it as `atlas`.
+  A later rollback would also strand that new source if it restored the old HBA
+  and identity files without restoring the pre-cutover installed monitor.
+- Clearing every inherited libpq setting for an explicit owner-provided audit
+  DSN removes non-target TLS inputs such as root/client certificate paths that
+  the prior monitor preserved, regressing supported explicit-DSN deployments.
+- Two repository-owned typed maintenance callers construct asyncpg targets from
+  `db_settings.host` directly rather than the corrected socket-aware
+  `connection_kwargs()`/`dsn` seams, so they remain TCP clients after loopback
+  trust is removed.
 - The migration runbook confuses raw forensic output with attested admission.
 
 #### Required change surface
@@ -157,16 +173,23 @@ leave its restart procedure with contradictory integrity instructions.
    proves the selected service file wins for both target and timeout settings,
    plus a closure test that fails when a future `DatabaseConfig` field is not
    added to that scrub set.
-7. Move the standalone EOM write-boundary monitor's source default to a
+7. Move the standalone EOM write-boundary monitor's source-owned default to a
    passwordless encoded Unix-socket URI, decode that URI host before passing it
-   to libpq, clear inherited `PG*` libpq settings before applying that URI,
-   preserve explicit monitor-DSN override behavior, and add focused monitor
-   tests. The cutover runbook must inventory this dormant scheduled
-   client before HBA mutation by requiring an installed-source match, an active
-   timer/service identity, no `EnvironmentFile`, and no unit/user-manager DSN
-   override without printing environment values; after peer configuration it must dry-run the
-   installed monitor with no alert/state mutation and reject an unreadable
-   socket route before trust replacement.
+   to libpq, and clear inherited `PG*` libpq settings only for that default.
+   Explicit monitor DSNs retain their pre-existing owner-supplied libpq/TLS
+   environment behavior. The cutover runbook must admit the dormant scheduled
+   client before HBA mutation using its exact effective Python/script argv, an
+   active timer/service identity, no `EnvironmentFile`, and no unit/user-manager
+   DSN override without printing environment values. It must stage the new
+   installed monitor only after the scoped peer map/rule is loaded, retain a
+   restorable pre-cutover copy through the cutover, and dry-run the admitted
+   source with no alert/state mutation before trust replacement. Regression
+   tests must cover the command-argument, source-stage/rollback, default-versus-
+   explicit-libpq, and unreadable-route boundaries.
+8. Route every repository-owned typed `DatabaseConfig` maintenance caller that
+   still passes `db_settings.host` directly through `connection_kwargs()` while
+   retaining its current command-timeout/pool-size intent, and pin those two
+   caller seams with socket-path regressions.
 
 #### Explicit non-scope
 
@@ -180,9 +203,8 @@ leave its restart procedure with contradictory integrity instructions.
   dependencies, or make runtime-routing changes.
 - Do not change the `postgres` Unix-socket peer break-glass rule.
 - Do not change the EOM audit's signals, alert delivery, timer cadence, state
-  semantics, unit configuration, or any monitor override value; an explicit
-  monitor DSN remains supported but is outside this cutover until separately
-  migrated and proved.
+  semantics, or any monitor override value; an explicit monitor DSN remains
+  supported but is outside this cutover until separately migrated and proved.
 
 #### Assumptions and blockers
 
@@ -245,7 +267,7 @@ leave its restart procedure with contradictory integrity instructions.
 
 Ownership lane: eom-crm/runtime-security
 Slice phase: production hardening
-Max files: 9
+Max files: 12
 
 ### Review contract
 
@@ -398,20 +420,23 @@ Max files: 9
   reached by its active hourly timer, its installed script at the documented
   path, any service `EnvironmentFile`, and any unit or user-manager
   `ATLAS_EOM_AUDIT_ATLAS_DSN` assignment.
-  The admitted member has a byte-identical installed script, expected service
-  executable, active enabled timer, no `EnvironmentFile`, no override in either
-  environment source, an explicit-source-owned libpq target, and a post-peer
-  no-alert dry run that does not report `COULD NOT MEASURE`.
+  The admitted member has an exact effective Python/script argv with no extra
+  target-affecting argument, active enabled timer, no `EnvironmentFile`, no
+  override in either environment source, a byte-identical installed source only
+  after the peer map/rule is live, an explicit-source-owned libpq target, and a
+  post-peer no-alert dry run that does not report `COULD NOT MEASURE`. The
+  pre-cutover installed source remains restorable until the cutover is closed.
   A clean result (`0`) and a measured boundary breach (`2`) both prove its
   socket transport; an absent timer, stale script, different executable,
   override, unreadable measurement, or other exit stops before HBA replacement.
-- **Inherited libpq settings — OPEN / DERIVED per monitor invocation.**
+- **Inherited libpq settings — CLOSED / DERIVED per monitor invocation.**
   Membership is every inherited environment key with the `PG` prefix, derived
-  by `psql_environment()` from the process environment. The safe default is to
-  remove every member, then derive the only admitted libpq settings from the
-  parsed monitor DSN (including its explicit `options` and `sslmode` query
-  values). A setting absent from that URI cannot silently select another target;
-  non-`PG` process environment remains available to locate and run `psql`.
+  by `psql_environment()` from the process environment. The source-owned
+  default removes every member, then derives the only admitted libpq settings
+  from its parsed URI. An explicit audit DSN keeps its prior owner-controlled
+  inherited libpq/TLS behavior and is rejected from this socket cutover by the
+  unit/user-manager override admission; non-`PG` process environment remains
+  available to locate and run `psql`.
 - **Post-restart Atlas transport — CLOSED / DERIVED before trust removal.**
   Membership is every `pg_stat_activity` client backend for user/database
   `atlas` after the authenticated CRM read. The only admitted receipt has at
@@ -474,10 +499,13 @@ Max files: 9
 
 - `.agent/runbooks/database.md`
 - `atlas_brain/storage/config.py`
+- `config/eom-write-boundary-audit.service`
 - `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`
 - `ops`
 - `plans/PR-Postgres-Loopback-Scram-Hardening.md`
+- `scripts/backfill_community_buying_stage_defaults.py`
 - `scripts/eom_write_boundary_audit.py`
+- `scripts/rebuild_blog_charts.py`
 - `tests/test_agent_operations_contract.py`
 - `tests/test_eom_render_profile.py`
 - `tests/test_eom_write_boundary_audit.py`
@@ -495,14 +523,20 @@ uses its documented explicit environment-file override in the exact service
 order; `ops` discards case-insensitive aliases for known database settings, so
 the read-only proof observes the same database target as `atlas-api.service`.
 
-The independent EOM audit monitor now defaults to the same passwordless socket
-transport through libpq without importing or depending on `atlas-api`. Before
-the cutover can rely on that source default, the runbook proves the installed
-standalone copy is current and has no hidden DSN override; its dry run is
-measurement-only and cannot consume an alert transition. Its subprocess
-environment removes every inherited `PG*` setting before the source URI is
-parsed, so a user-manager `PGHOSTADDR`, service profile, or unlisted libpq
-configuration cannot silently turn the socket receipt back into TCP.
+The independent EOM audit monitor gains a source-owned passwordless socket
+default without importing or depending on `atlas-api`. The cutover first
+proves the timer's exact target-free command and no hidden DSN override while
+the prior monitor remains live over TCP; after the scoped peer map/rule is
+loaded it atomically stages the installed source, retains a rollback copy, and
+then takes a measurement-only socket receipt. Its subprocess removes every
+inherited `PG*` setting only for the source-owned default, while explicit
+owner-provided DSNs retain their existing libpq/TLS inputs and remain excluded
+from this socket cutover.
+
+The two typed maintenance scripts that bypassed the shared connection seam now
+use `DatabaseConfig.connection_kwargs()` with their existing timeout/pool-size
+intent, so the same configured socket reaches application and maintenance
+callers.
 
 The migration-runbook change is documentation only: raw discrepancies stay
 visible and retain their forensic nonzero status.
@@ -518,8 +552,9 @@ visible and retain their forensic nonzero status.
   case-variant inherited database aliases rather than changing normal worktree
   selection behavior.
 - The EOM audit's timer, signals, notification delivery, state persistence, and
-  explicit DSN override precedence remain unchanged; only its absent-override
-  default moves to the socket.
+  explicit DSN override precedence remain unchanged; only its source-owned
+  absent-override default moves to the socket after peer authentication is
+  staged.
 
 ## Deferred
 
@@ -534,29 +569,14 @@ blocks the socket-peer path.
 
 ## Verification
 
-- `./ops test focused tests/test_eom_render_profile.py -q -k 'database_config
-  or database_pool_uses_configured_connection_kwargs'` — 5 passed, 61
-  deselected (local).
-- `./ops test focused tests/test_agent_operations_contract.py -q -k
-  'database_file_context_prefers_worktree_over_shared_and_systemd or
-  database_file_context_honors_explicit_override_order'` — 2 passed, 39
-  deselected (local).
-- `./ops test focused tests/test_eom_write_boundary_audit.py -q -k 'socket or
-  dsn or libpq_target'` — 5 passed, 29 deselected (local); proves the monitor's
-  default socket URI decodes into a libpq filesystem host, hostile inherited
-  target selectors are scrubbed, and an explicit DSN still wins.
-- `./ops test focused tests/test_agent_operations_contract.py -q -k
-  'dormant_eom_audit or admits_the_dormant'` — 9 passed, 75 deselected (local);
-  proves the dormant-client admission is before HBA backup and rejects a stale
-  installed copy, disabled/inactive timer, unexpected executable, an
-  `EnvironmentFile`, or either service or user-manager DSN override.
 - `./ops test focused tests/test_eom_write_boundary_audit.py
-  tests/test_agent_operations_contract.py -q` — 116 passed, 2 skipped (local);
-  covers the full current monitor and operations-contract suite.
+  tests/test_agent_operations_contract.py tests/test_eom_render_profile.py -q`
+  — 190 passed, 2 skipped (local). This covers the source-owned default versus
+  explicit TLS/libpq behavior, exact timer argv boundaries, post-peer source
+  staging and rollback restoration, and both typed maintenance caller seams.
 - `bash scripts/check_ascii_python.sh` — passed (local).
-- The initial admission block and the post-restart audit dry-run block extracted
-  from `.agent/runbooks/database.md` and checked with `bash -n` — passed
-  (local).
+- `python scripts/check_guard_class_closure.py --base origin/main --strict` —
+  passed (local advisory guard-closure lint).
 - The read-only loaded peer-HBA receipt returned `0|0|0|0|0|0` against the
   pre-cutover state, proving its negative boundary; the synthetic receipt
   returned `accepted|1|0` and `blocked|1|1` for the retained recovery-only and
@@ -590,16 +610,19 @@ blocks the socket-peer path.
 
 | File | LOC |
 |---|---:|
-| `.agent/runbooks/database.md` | 711 |
+| `.agent/runbooks/database.md` | 769 |
 | `atlas_brain/storage/config.py` | 13 |
+| `config/eom-write-boundary-audit.service` | 2 |
 | `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` | 20 |
 | `ops` | 15 |
-| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 607 |
-| `scripts/eom_write_boundary_audit.py` | 22 |
-| `tests/test_agent_operations_contract.py` | 558 |
-| `tests/test_eom_render_profile.py` | 84 |
-| `tests/test_eom_write_boundary_audit.py` | 83 |
-| **Total** | **2113** |
+| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 630 |
+| `scripts/backfill_community_buying_stage_defaults.py` | 8 |
+| `scripts/eom_write_boundary_audit.py` | 59 |
+| `scripts/rebuild_blog_charts.py` | 6 |
+| `tests/test_agent_operations_contract.py` | 718 |
+| `tests/test_eom_render_profile.py` | 99 |
+| `tests/test_eom_write_boundary_audit.py` | 112 |
+| **Total** | **2451** |
 
 ## Diff budget
 

--- a/plans/PR-Postgres-Loopback-Scram-Hardening.md
+++ b/plans/PR-Postgres-Loopback-Scram-Hardening.md
@@ -32,6 +32,10 @@ leave its restart procedure with contradictory integrity instructions.
   inspection call it rather than `DatabaseConfig.dsn`.
 - A bare fixed inspection can select a worktree `.env` instead of the
   service's `EnvironmentFiles`, even when the worktree omits database keys.
+- The cutover rollback assumes that it created `ATLAS_DB_SOCKET_PATH`, but a
+  pre-existing assignment in any selected service file has no baseline receipt;
+  deleting or overriding it during rollback could change the service's original
+  connection path.
 - `DatabaseConfig` resolves environment names case-insensitively, but `ops`
   previously removed only a subset of canonical uppercase database keys. A
   lower- or mixed-case inherited alias for any setting the inspector consumes
@@ -75,7 +79,10 @@ leave its restart procedure with contradictory integrity instructions.
    clients and prove the loaded peer map has exactly the intended mapping. The fixed
    inspection must explicitly select the ordered `atlas-api.service`
    `EnvironmentFiles` while the helper clears every exact-uppercase
-   `ATLAS_DB_*` override and `ops` excludes every lower/mixed-case variant.
+   `ATLAS_DB_*` override and `ops` excludes every lower/mixed-case variant. It
+   must reject a pre-existing `ATLAS_DB_SOCKET_PATH` in every selected service
+   file before adding its single reversible assignment, and a static regression
+   must pin the helper's unset set to every `DatabaseConfig` field.
 4. Correct `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` to require matching,
    currently attested evidence for every raw mismatch **and** missing-source
    item while preserving the raw report and its forensic nonzero exit.
@@ -163,7 +170,9 @@ Max files: 7
      every initial/final loopback client a Unix-socket or verified-SCRAM receipt,
      leaves no TCP client, derives every loopback-covering HBA network rule,
      proves every exact tuple, retains `postgres` peer recovery, and reloads
-     restored TCP authentication before a rollback restart.
+     restored TCP authentication before a rollback restart. It also stops before
+     editing when any selected service file already assigns the socket path, so
+     rollback removes only an assignment created by this cutover.
   5. The migration runbook accurately distinguishes raw forensic output from
      attested admission without changing runner behavior.
 - Reachability proof: `atlas_brain/storage/database.py` initializes the pool
@@ -193,6 +202,9 @@ Max files: 7
     before it constructs `DatabaseConfig`; exact-uppercase runtime keys preserve
     the generic documented override behavior, while the service-pinned helper
     explicitly unsets all of them before its proof.
+  - A pre-existing socket-path assignment in any selected service file is a
+    stop condition; this cutover adds exactly one new assignment only after the
+    absence precondition, so rollback never rewrites an earlier configuration.
   - The cutover reconciles every client observed in both initial and final
     loopback TCP/replication inventories to a Unix-socket or verified-SCRAM
     receipt, requires no remaining final client, and requires an exact loaded
@@ -241,6 +253,12 @@ Max files: 7
   systemd`. An absent, unreadable, or unlisted effective configuration file
   stops fixed inspection and HBA mutation, the safer side over inspecting or
   changing a guessed database target.
+- **Pre-existing socket-path assignments — CLOSED / DERIVED before cutover.**
+  Membership is every assignment matching `ATLAS_DB_SOCKET_PATH` in the ordered
+  selected `EnvironmentFiles`. The only admitted set is empty; unreadable files
+  or any empty, different, or matching-value assignment stop before editing.
+  The safe default is a separate configuration migration with an exact baseline
+  receipt, not an implicit overwrite or rollback rewrite.
 - **Database environment-key aliases — CLOSED / DERIVED for fixed inspection.**
   Membership is every canonical `ATLAS_DB_*` setting consumed by
   `DatabaseConfig`, listed as `DATABASE_CONFIG_KEYS` in `ops`; its case-folded
@@ -310,8 +328,11 @@ blocks the socket-peer path.
   database_file_context_honors_explicit_override_order'` — 2 passed, 39
   deselected (local).
 - `./ops test focused tests/test_agent_operations_contract.py -q -k
-  'database_runtime_environment'` — 3 passed, 40 deselected (local); proves
-  the canonical override, case-variant rejection, and complete key-set closure.
+  'database_runtime_environment or service_db_inspect'` — 4 passed, 40
+  deselected (local); proves the canonical override, case-variant rejection,
+  complete key-set closure, and the service-helper unset-set closure.
+- `./ops test focused tests/test_agent_operations_contract.py -q` — 44 passed
+  (local).
 - `bash scripts/check_ascii_python.sh` — passed (local).
 - `service_db_inspect` shell block extracted from
   `.agent/runbooks/database.md` and checked with `bash -n` — passed (local).
@@ -335,14 +356,14 @@ blocks the socket-peer path.
 
 | File | LOC |
 |---|---:|
-| `.agent/runbooks/database.md` | 406 |
+| `.agent/runbooks/database.md` | 433 |
 | `atlas_brain/storage/config.py` | 11 |
 | `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` | 20 |
 | `ops` | 15 |
-| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 350 |
-| `tests/test_agent_operations_contract.py` | 50 |
+| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 371 |
+| `tests/test_agent_operations_contract.py` | 63 |
 | `tests/test_eom_render_profile.py` | 61 |
-| **Total** | **913** |
+| **Total** | **974** |
 
 ## Diff budget
 

--- a/plans/PR-Postgres-Loopback-Scram-Hardening.md
+++ b/plans/PR-Postgres-Loopback-Scram-Hardening.md
@@ -14,6 +14,15 @@ The same recovery reported raw `missing_source` and `mismatched` evidence even
 when matching, attested reconciliations admit a pending migration. The runbook
 incorrectly said that admissible state could contain no `missing_source`.
 
+This PR intentionally exceeds the normal diff budget because the configuration
+and caller seams, deployment cutover/rollback procedure, and plan evidence are
+one deployment-safety boundary. The migration-integrity correction must ship
+with that same restart procedure: `atlas-api` startup runs migration checks,
+and the former guidance stopped an operator on a raw `missing_source` state
+that the runtime admits when matching current attestation exists. Splitting
+either side would publish the socket transition without its proof/rollback or
+leave its restart procedure with contradictory integrity instructions.
+
 ### Problem-derived contract
 
 #### Root cause
@@ -23,6 +32,10 @@ incorrectly said that admissible state could contain no `missing_source`.
   inspection call it rather than `DatabaseConfig.dsn`.
 - A bare fixed inspection can select a worktree `.env` instead of the
   service's `EnvironmentFiles`, even when the worktree omits database keys.
+- `DatabaseConfig` resolves environment names case-insensitively, but `ops`
+  previously removed only canonical uppercase database keys. A lower- or
+  mixed-case inherited alias could therefore override the selected service
+  configuration in the inspector subprocess.
 - A socket target label omits its configured port even though the port selects
   the socket filename and the migration receipt confirms that label exactly.
 - A successful service or inspector connection is not socket proof while a
@@ -61,12 +74,17 @@ incorrectly said that admissible state could contain no `missing_source`.
    the service. The procedure must stop on unresolved or remaining loopback TCP
    clients and prove the loaded peer map has exactly the intended mapping. The fixed
    inspection must explicitly select the ordered `atlas-api.service`
-   `EnvironmentFiles` while excluding ad hoc `ATLAS_DB_*` overrides.
+   `EnvironmentFiles` while excluding every case variant of ad hoc known
+   `ATLAS_DB_*` overrides.
 4. Correct `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` to require matching,
    currently attested evidence for every raw mismatch **and** missing-source
    item while preserving the raw report and its forensic nonzero exit.
 5. Exclude the unviable encrypted-credential experiment from this PR; it would
    require an unsupported plaintext-secret fallback.
+6. Update `ops` to admit only canonical uppercase runtime database overrides,
+   remove every case-insensitive known-database-key alias before its inspection
+   child constructs `DatabaseConfig`, and add a regression that proves the
+   selected service file wins in that child.
 
 #### Explicit non-scope
 
@@ -95,7 +113,8 @@ incorrectly said that admissible state could contain no `missing_source`.
   assertions, and the pool/raw caller seam.
 - Adjacent configuration-context regression: a worktree file remains the
   default inspector context, while an ordered `ATLAS_OPS_ENV_FILES` override
-  selects the intended service configuration.
+  selects the intended service configuration and lower/mixed-case inherited
+  database aliases cannot supersede it in the inspection child.
 - Cheap local gates: focused test target, `bash scripts/check_ascii_python.sh`,
   `git diff --check`, and `python scripts/sync_pr_plan.py ... --check`.
 - GitHub remains the complete unit gate.
@@ -120,7 +139,7 @@ incorrectly said that admissible state could contain no `missing_source`.
 
 Ownership lane: eom-crm/runtime-security
 Slice phase: production hardening
-Max files: 5
+Max files: 7
 
 ### Review contract
 
@@ -131,7 +150,9 @@ Max files: 5
   2. Complete DSNs retain their precedence; non-socket split settings retain
      existing TCP kwargs.
   3. `DatabasePool` and fixed `./ops db inspect` inherit the corrected path
-     because both already call `connection_kwargs()`.
+     because both already call `connection_kwargs()`, and the fixed inspector
+     admits only selected service values or exact-uppercase runtime database
+     overrides rather than case-variant inherited aliases.
   4. The operational procedure rejects an overriding complete DSN, authenticates
      the specific service OS account as `atlas` over the Unix socket before
      removing loopback `trust`, proves the exclusive loaded identity map, gives
@@ -164,8 +185,9 @@ Max files: 5
   - The socket target label includes that port, so confirmation cannot conflate
     same-directory, same-database clusters on distinct ports.
   - The fixed inspector uses only the service `EnvironmentFiles`, in service
-    order, and removes ad hoc `ATLAS_DB_*` values before it constructs
-    `DatabaseConfig`.
+    order, and removes every case variant of known `ATLAS_DB_*` values before
+    it constructs `DatabaseConfig`; exact-uppercase runtime keys preserve the
+    documented override behavior.
   - The cutover reconciles every client observed in both initial and final
     loopback TCP/replication inventories to a Unix-socket or verified-SCRAM
     receipt, requires no remaining final client, and requires an exact loaded
@@ -214,13 +236,22 @@ Max files: 5
   systemd`. An absent, unreadable, or unlisted effective configuration file
   stops fixed inspection and HBA mutation, the safer side over inspecting or
   changing a guessed database target.
+- **Database environment-key aliases — CLOSED / DERIVED for fixed inspection.**
+  Membership is the canonical `DATABASE_CONFIG_KEYS` set in `ops`; its
+  case-folded form is derived from that set. An exact-uppercase environment key
+  is the only inherited database override admitted. Every lower- or mixed-case
+  matching alias is removed before `DatabaseConfig` loads the child environment,
+  while unrelated keys remain unchanged; this fails closed against inspecting a
+  shadowed target.
 
 ### Files touched
 
 - `.agent/runbooks/database.md`
 - `atlas_brain/storage/config.py`
 - `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`
+- `ops`
 - `plans/PR-Postgres-Loopback-Scram-Hardening.md`
+- `tests/test_agent_operations_contract.py`
 - `tests/test_eom_render_profile.py`
 
 ## Mechanism
@@ -231,9 +262,9 @@ as `atlas` over peer. The map/rule are proved while TCP remains available;
 only then do all loopback `trust` entries become `scram-sha-256`.
 
 The fixed inspector keeps its existing source-selection semantics. The runbook
-uses its documented explicit environment-file override, in the exact service
-order and without inherited database settings, so the read-only proof observes
-the same database target as `atlas-api.service`.
+uses its documented explicit environment-file override in the exact service
+order; `ops` discards case-insensitive aliases for known database settings, so
+the read-only proof observes the same database target as `atlas-api.service`.
 
 The migration-runbook change is documentation only: raw discrepancies stay
 visible and retain their forensic nonzero status.
@@ -244,8 +275,10 @@ visible and retain their forensic nonzero status.
   non-loopback access remain unchanged.
 - `ops` already carries `ATLAS_DB_SOCKET_PATH`; CRM read is production proof,
   not a feature.
-- `ops` context-selection code remains unchanged; the cutover invokes its
-  existing explicit override rather than changing normal worktree behavior.
+- `ops` context-selection precedence remains unchanged; the cutover invokes
+  its existing explicit override, while its inspection child now strips
+  case-variant inherited database aliases rather than changing normal worktree
+  selection behavior.
 
 ## Deferred
 
@@ -267,6 +300,9 @@ blocks the socket-peer path.
   'database_file_context_prefers_worktree_over_shared_and_systemd or
   database_file_context_honors_explicit_override_order'` — 2 passed, 39
   deselected (local).
+- `./ops test focused tests/test_agent_operations_contract.py -q -k
+  'database_runtime_environment'` — 2 passed, 40 deselected (local); proves
+  both the canonical override and case-variant rejection boundaries.
 - `bash scripts/check_ascii_python.sh` — passed (local).
 - `git diff --check` — passed (local).
 - `python scripts/sync_pr_plan.py
@@ -288,17 +324,16 @@ blocks the socket-peer path.
 
 | File | LOC |
 |---|---:|
-| `.agent/runbooks/database.md` | 400 |
+| `.agent/runbooks/database.md` | 401 |
 | `atlas_brain/storage/config.py` | 11 |
 | `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` | 20 |
-| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 304 |
+| `ops` | 10 |
+| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 339 |
+| `tests/test_agent_operations_contract.py` | 36 |
 | `tests/test_eom_render_profile.py` | 61 |
-| **Total** | **796** |
+| **Total** | **878** |
 
 ## Diff budget
 
-Diff-budget override: the socket construction, caller-seam evidence, exact
-target identity, and staged peer/SCRAM procedure are one deployment-safety
-boundary; splitting them would publish either executable configuration without
-its safe cutover/rollback proof or a procedure that refers to unavailable
-behavior.
+The complete over-budget rationale is in **Why this slice exists**. This
+footer is retained only as the plan's diff-budget marker.

--- a/plans/PR-Postgres-Loopback-Scram-Hardening.md
+++ b/plans/PR-Postgres-Loopback-Scram-Hardening.md
@@ -169,6 +169,38 @@ Max files: 5
   - Cutover order is peer proof before removal of any trust rule; rollback
     restores and reloads TCP authentication before restarting the application.
 
+### Boundary-set closure declaration
+
+- **`DatabaseConfig` connection-construction branches — CLOSED / DERIVED.**
+  Membership is the three ordered outcomes in
+  `atlas_brain/storage/config.py:80-136`: a nonblank complete DSN, a blank DSN
+  with `socket_path`, or a blank DSN without `socket_path`. No fourth
+  construction path exists. Any setting combination resolves through that
+  existing order; a nonblank DSN is outside the socket-proof-admissible subset
+  and stops this cutover rather than allowing HBA mutation.
+- **Loopback HBA topology — CLOSED / DERIVED at cutover.** Membership comes
+  from the live `pg_hba_file_rules` receipt on the declared socket and port, not
+  the four examples in this plan. The procedure admits exactly one loaded
+  application/replication IPv4/IPv6 tuple with the declared user, netmask, and
+  SCRAM method. A missing, duplicate, or unlisted loopback rule fails closed to
+  no HBA change because an unknown authentication path is less safe than a
+  deferred hardening run.
+- **`atlas_app` peer-map membership — CLOSED / DERIVED at reload.** Membership
+  comes from `pg_ident_file_mappings`; exactly one
+  `atlas_app | juan-canfield | atlas` tuple and no mapping error is admitted.
+  Any extra, missing, malformed, or unrecognized mapping stops before HBA
+  replacement because it could broaden local role impersonation.
+- **Loopback-client inventory — OPEN / DERIVED at observation time.**
+  `pg_stat_activity` and `pg_stat_replication` supply every current TCP
+  loopback client; application names and client identities are not enumerated.
+  Any observed member, including a new unrecognized client, stops the cutover
+  until it moves to a socket or completes a separately verified SCRAM migration.
+- **Service environment-file list — CLOSED / DERIVED for the selected service
+  unit.** Membership is the ordered `EnvironmentFiles` output of `./ops env
+  systemd`. An absent, unreadable, or unlisted effective configuration file
+  stops fixed inspection and HBA mutation, the safer side over inspecting or
+  changing a guessed database target.
+
 ### Files touched
 
 - `.agent/runbooks/database.md`
@@ -238,12 +270,12 @@ blocks the socket-peer path.
 
 | File | LOC |
 |---|---:|
-| `.agent/runbooks/database.md` | 318 |
+| `.agent/runbooks/database.md` | 356 |
 | `atlas_brain/storage/config.py` | 11 |
 | `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` | 20 |
-| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 254 |
-| `tests/test_eom_render_profile.py` | 60 |
-| **Total** | **663** |
+| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 286 |
+| `tests/test_eom_render_profile.py` | 61 |
+| **Total** | **734** |
 
 ## Diff budget
 

--- a/plans/PR-Postgres-Loopback-Scram-Hardening.md
+++ b/plans/PR-Postgres-Loopback-Scram-Hardening.md
@@ -100,6 +100,13 @@ leave its restart procedure with contradictory integrity instructions.
   `juan-canfield` but the generic peer rule cannot authenticate it as `atlas`.
   A later rollback would also strand that new source if it restored the old HBA
   and identity files without restoring the pre-cutover installed monitor.
+- The dormant-monitor admission rejects a scheduled DSN override but not its
+  environment-selected `psql` executable, so the operator-shell dry run can
+  prove a different binary from the one the next timer run invokes.
+- That admission also reaches the first HBA/identity backup without verifying
+  that both the installed monitor and the source it must stage are readable.
+  A predictable staging failure is therefore discovered only after
+  authentication mutation and leaves retry-blocking pre-peer backups behind.
 - Clearing every inherited libpq setting for an explicit owner-provided audit
   DSN removes non-target TLS inputs such as root/client certificate paths that
   the prior monitor preserved, regressing supported explicit-DSN deployments.
@@ -107,6 +114,10 @@ leave its restart procedure with contradictory integrity instructions.
   `db_settings.host` directly rather than the corrected socket-aware
   `connection_kwargs()`/`dsn` seams, so they remain TCP clients after loopback
   trust is removed.
+- Routing the chart rebuild through `connection_kwargs()` also injects its
+  configured connection and command timeouts, although the prior `create_pool`
+  call omitted both options; a long-running existing rebuild can therefore fail
+  solely from this transport refactor.
 - The migration runbook confuses raw forensic output with attested admission.
 
 #### Required change surface
@@ -180,16 +191,20 @@ leave its restart procedure with contradictory integrity instructions.
    environment behavior. The cutover runbook must admit the dormant scheduled
    client before HBA mutation using its exact effective Python/script argv, an
    active timer/service identity, no `EnvironmentFile`, and no unit/user-manager
-   DSN override without printing environment values. It must stage the new
-   installed monitor only after the scoped peer map/rule is loaded, retain a
-   restorable pre-cutover copy through the cutover, and dry-run the admitted
-   source with no alert/state mutation before trust replacement. Regression
-   tests must cover the command-argument, source-stage/rollback, default-versus-
-   explicit-libpq, and unreadable-route boundaries.
+   DSN or `psql`-executable override without printing environment values, and
+   verify both source-stage inputs are readable before the first authentication
+   backup. It must stage the new installed monitor only after the scoped peer
+   map/rule is loaded, retain a restorable pre-cutover copy through the cutover,
+   and dry-run the admitted source with no alert/state mutation before trust
+   replacement. Regression tests must cover the command-argument,
+   environment-executable, source-stage/rollback, default-versus-explicit-
+   libpq, and unreadable-route boundaries.
 8. Route every repository-owned typed `DatabaseConfig` maintenance caller that
    still passes `db_settings.host` directly through `connection_kwargs()` while
-   retaining its current command-timeout/pool-size intent, and pin those two
-   caller seams with socket-path regressions.
+   retaining its current command-timeout/pool-size intent. In particular, the
+   chart-rebuild pool must omit the connection and command timeout options just
+   as it did before this transport change, while retaining its existing pool
+   bounds. Pin those two caller seams with socket-path regressions.
 
 #### Explicit non-scope
 
@@ -213,10 +228,11 @@ leave its restart procedure with contradictory integrity instructions.
 - Recheck the peer map and local replication activity before changing HBA.
 - HBA/ident/shared configuration changes occur only after this source revision
   is deployed.
-- The deployed audit unit executes the documented installed script path and no
-  `EnvironmentFile` or `ATLAS_EOM_AUDIT_ATLAS_DSN` value is inherited from its
-  unit or user manager; otherwise the cutover stops rather than inferring its
-  transport.
+- The deployed audit unit executes the documented installed script path, both
+  source-stage files are readable, and no `EnvironmentFile`,
+  `ATLAS_EOM_AUDIT_ATLAS_DSN`, or `ATLAS_EOM_AUDIT_PSQL_BIN` value is inherited
+  from its unit or user manager; otherwise the cutover stops rather than
+  inferring its transport or executable.
 
 #### Verification plan
 
@@ -240,8 +256,9 @@ leave its restart procedure with contradictory integrity instructions.
   the ordered selected service-file list and stops before the gate otherwise.
 - Monitor regressions must prove both default-socket selection and preserved
   explicit-override selection, including hostile inherited `PG*` settings, and
-  the runbook guard must reject service and user-manager DSN overrides plus a
-  stale installed monitor copy before the first HBA backup.
+  the runbook guard must reject service and user-manager DSN and executable
+  overrides plus a missing source or installed monitor before the first HBA
+  backup.
 - GitHub remains the complete unit gate.
 - Post-merge proof while existing TCP trust remains: deploy source; configure
   `ATLAS_DB_SOCKET_PATH` only when no complete DSN overrides it; add/reload the
@@ -283,9 +300,9 @@ Max files: 12
      admits only selected service values or exact-uppercase runtime database
      overrides rather than case-variant inherited aliases.
   4. The operational procedure rejects an overriding complete DSN, independently
-     admits the dormant EOM audit monitor's installed source, service/timer
-     identity, no `EnvironmentFile`, and no-override default socket route before
-     HBA mutation, then
+     admits the dormant EOM audit monitor's readable source and installed copy,
+     service/timer identity, no `EnvironmentFile`, and no DSN or executable
+     override on its default socket route before HBA mutation, then
      records its no-alert socket dry-run receipt before trust replacement,
      authenticates
      the specific service OS account as `atlas` over the Unix socket before
@@ -525,18 +542,19 @@ the read-only proof observes the same database target as `atlas-api.service`.
 
 The independent EOM audit monitor gains a source-owned passwordless socket
 default without importing or depending on `atlas-api`. The cutover first
-proves the timer's exact target-free command and no hidden DSN override while
-the prior monitor remains live over TCP; after the scoped peer map/rule is
-loaded it atomically stages the installed source, retains a rollback copy, and
-then takes a measurement-only socket receipt. Its subprocess removes every
-inherited `PG*` setting only for the source-owned default, while explicit
-owner-provided DSNs retain their existing libpq/TLS inputs and remain excluded
-from this socket cutover.
+proves the timer's exact target-free command, readable staging inputs, and no
+hidden DSN or executable override while the prior monitor remains live over
+TCP; after the scoped peer map/rule is loaded it atomically stages the installed
+source, retains a rollback copy, and then takes a measurement-only socket
+receipt. Its subprocess removes every inherited `PG*` setting only for the
+source-owned default, while explicit owner-provided DSNs retain their existing
+libpq/TLS inputs and remain excluded from this socket cutover.
 
 The two typed maintenance scripts that bypassed the shared connection seam now
 use `DatabaseConfig.connection_kwargs()` with their existing timeout/pool-size
 intent, so the same configured socket reaches application and maintenance
-callers.
+callers. The chart rebuild retains its previous no-explicit-timeout pool
+behavior while it adopts only the corrected target construction.
 
 The migration-runbook change is documentation only: raw discrepancies stay
 visible and retain their forensic nonzero status.
@@ -554,7 +572,8 @@ visible and retain their forensic nonzero status.
 - The EOM audit's timer, signals, notification delivery, state persistence, and
   explicit DSN override precedence remain unchanged; only its source-owned
   absent-override default moves to the socket after peer authentication is
-  staged.
+  staged. The scheduled cutover rejects rather than repurposes unit- or
+  manager-level executable overrides.
 
 ## Deferred
 
@@ -571,9 +590,11 @@ blocks the socket-peer path.
 
 - `./ops test focused tests/test_eom_write_boundary_audit.py
   tests/test_agent_operations_contract.py tests/test_eom_render_profile.py -q`
-  — 190 passed, 2 skipped (local). This covers the source-owned default versus
-  explicit TLS/libpq behavior, exact timer argv boundaries, post-peer source
-  staging and rollback restoration, and both typed maintenance caller seams.
+  — 197 passed, 2 skipped (local). This covers the source-owned default versus
+  explicit TLS/libpq behavior, exact timer argv and service/user-manager
+  executable-override boundaries, readable and unreadable source-stage inputs,
+  post-peer source staging and rollback restoration, and both typed maintenance
+  caller seams.
 - `bash scripts/check_ascii_python.sh` — passed (local).
 - `python scripts/check_guard_class_closure.py --base origin/main --strict` —
   passed (local advisory guard-closure lint).
@@ -610,19 +631,19 @@ blocks the socket-peer path.
 
 | File | LOC |
 |---|---:|
-| `.agent/runbooks/database.md` | 769 |
+| `.agent/runbooks/database.md` | 793 |
 | `atlas_brain/storage/config.py` | 13 |
 | `config/eom-write-boundary-audit.service` | 2 |
 | `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` | 20 |
 | `ops` | 15 |
-| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 630 |
+| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 651 |
 | `scripts/backfill_community_buying_stage_defaults.py` | 8 |
 | `scripts/eom_write_boundary_audit.py` | 59 |
-| `scripts/rebuild_blog_charts.py` | 6 |
-| `tests/test_agent_operations_contract.py` | 718 |
-| `tests/test_eom_render_profile.py` | 99 |
+| `scripts/rebuild_blog_charts.py` | 16 |
+| `tests/test_agent_operations_contract.py` | 795 |
+| `tests/test_eom_render_profile.py` | 122 |
 | `tests/test_eom_write_boundary_audit.py` | 112 |
-| **Total** | **2451** |
+| **Total** | **2606** |
 
 ## Diff budget
 

--- a/plans/PR-Postgres-Loopback-Scram-Hardening.md
+++ b/plans/PR-Postgres-Loopback-Scram-Hardening.md
@@ -27,8 +27,9 @@ incorrectly said that admissible state could contain no `missing_source`.
   the socket filename and the migration receipt confirms that label exactly.
 - A successful service or inspector connection is not socket proof while a
   complete DSN retains deliberate precedence over split configuration.
-- A manual four-rule HBA conversion needs a loaded-rule postcondition; one
-  IPv4 application probe cannot prove the IPv6 and replication channels.
+- A manual four-rule HBA conversion needs an exact loaded-tuple postcondition
+  and active-file rollback; aggregate counts can mask duplicated/missing
+  channels, and a disk-only restore leaves partial HBA rules active.
 - The migration runbook confuses raw forensic output with attested admission.
 
 #### Required change surface
@@ -49,10 +50,11 @@ incorrectly said that admissible state could contain no `missing_source`.
 3. Replace the provisional credential/SCRAM procedure with non-secret socket
    configuration, an exact `atlas-api` OS-user → `atlas` peer map, staged
    service/CRM/backend-transport/inspection proof, loopback-SCRAM replacement,
-   a loaded-HBA assertion for all four loopback rules, and a rollback that
-   restores TCP settings before restarting the service. The fixed inspection
-   must explicitly select the ordered `atlas-api.service` `EnvironmentFiles`
-   while excluding ad hoc `ATLAS_DB_*` overrides.
+   an exact loaded-HBA assertion for all four loopback tuples, and a rollback
+   that restores TCP settings and reloads the restored HBA before restarting
+   the service. The fixed inspection must explicitly select the ordered
+   `atlas-api.service` `EnvironmentFiles` while excluding ad hoc `ATLAS_DB_*`
+   overrides.
 4. Correct `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` to require matching,
    currently attested evidence for every raw mismatch **and** missing-source
    item while preserving the raw report and its forensic nonzero exit.
@@ -96,8 +98,9 @@ incorrectly said that admissible state could contain no `missing_source`.
   health, an authenticated EOM CRM read, the application's Unix-socket backend,
   and fixed inspection selected from the service `EnvironmentFiles`.
 - Only then replace every loopback TCP `trust` rule with `scram-sha-256`,
-  reload PostgreSQL, prove the loaded HBA result is `2|2|0|0` (two application
-  and two replication loopback SCRAM rows, zero trust rows, zero parser
+  reload PostgreSQL, prove the loaded HBA result is `1|1|1|1|0|0|0` (one exact
+  application IPv4, application IPv6, replication IPv4, and replication IPv6
+  SCRAM tuple; zero unexpected loopback host rules, trust rows, and parser
   errors), repeat the proofs, prove passwordless TCP rejection, and prove
   `sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -Atc 'SELECT
   current_user'` succeeds.
@@ -120,8 +123,9 @@ Max files: 5
      because both already call `connection_kwargs()`.
   4. The operational procedure rejects an overriding complete DSN, authenticates
      the specific service OS account as `atlas` over the Unix socket before
-     removing loopback `trust`, retains `postgres` peer recovery, and restores
-     TCP settings before a rollback restart.
+     removing loopback `trust`, proves every exact loopback HBA tuple, retains
+     `postgres` peer recovery, and reloads restored TCP authentication before a
+     rollback restart.
   5. The migration runbook accurately distinguishes raw forensic output from
      attested admission without changing runner behavior.
 - Reachability proof: `atlas_brain/storage/database.py` initializes the pool
@@ -135,8 +139,8 @@ Max files: 5
   confirmation; and the authenticated EOM CRM read used as production proof.
 - Risk areas: local role impersonation over loopback TCP, wrong-cluster
   inspection, service/inspector configuration skew, HBA parser failure,
-  IPv6/replication trust left behind, startup-migration availability, and
-  rollback recovery.
+  duplicated/missing IPv4/IPv6/replication tuples, unreloaded failed HBA
+  restoration, startup-migration availability, and rollback recovery.
 - Reviewer rules triggered: R1, R2, R3, R11, R12, R14.
 - Boundary-change enumeration:
   - `socket_path=None` continues to produce TCP host/port kwargs.
@@ -148,11 +152,12 @@ Max files: 5
   - The fixed inspector uses only the service `EnvironmentFiles`, in service
     order, and removes ad hoc `ATLAS_DB_*` values before it constructs
     `DatabaseConfig`.
-  - The post-conversion HBA receipt requires two application and two
-    replication loopback SCRAM rows, no remaining trust row, and no parser
-    error before an IPv4-only negative probe can be treated as sufficient.
+  - The post-conversion HBA receipt requires one exact SCRAM tuple for each
+    application/replication IPv4/IPv6 channel, no unexpected loopback host
+    rule, no remaining trust row, and no parser error before an IPv4-only
+    negative probe can be treated as sufficient.
   - Cutover order is peer proof before removal of any trust rule; rollback
-    restores TCP configuration before restarting the application.
+    restores and reloads TCP authentication before restarting the application.
 
 ### Files touched
 
@@ -223,12 +228,12 @@ blocks the socket-peer path.
 
 | File | LOC |
 |---|---:|
-| `.agent/runbooks/database.md` | 234 |
+| `.agent/runbooks/database.md` | 285 |
 | `atlas_brain/storage/config.py` | 11 |
 | `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` | 20 |
-| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 239 |
+| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 244 |
 | `tests/test_eom_render_profile.py` | 60 |
-| **Total** | **564** |
+| **Total** | **620** |
 
 ## Diff budget
 

--- a/plans/PR-Postgres-Loopback-Scram-Hardening.md
+++ b/plans/PR-Postgres-Loopback-Scram-Hardening.md
@@ -27,6 +27,9 @@ incorrectly said that admissible state could contain no `missing_source`.
   the socket filename and the migration receipt confirms that label exactly.
 - A successful service or inspector connection is not socket proof while a
   complete DSN retains deliberate precedence over split configuration.
+- A loopback-client inventory without a stop condition can strand an active
+  local client after HBA conversion, and a peer-map insertion without an exact
+  loaded-map receipt can retain a broader OS-account authorization.
 - A manual four-rule HBA conversion needs an exact loaded-tuple postcondition
   and active-file rollback; aggregate counts can mask duplicated/missing
   channels, and a disk-only restore leaves partial HBA rules active.
@@ -52,9 +55,10 @@ incorrectly said that admissible state could contain no `missing_source`.
    service/CRM/backend-transport/inspection proof, loopback-SCRAM replacement,
    an exact loaded-HBA assertion for all four loopback tuples, and a rollback
    that restores TCP settings and reloads the restored HBA before restarting
-   the service. The fixed inspection must explicitly select the ordered
-   `atlas-api.service` `EnvironmentFiles` while excluding ad hoc `ATLAS_DB_*`
-   overrides.
+   the service. The procedure must stop on remaining loopback TCP clients and
+   prove the loaded peer map has exactly the intended mapping. The fixed
+   inspection must explicitly select the ordered `atlas-api.service`
+   `EnvironmentFiles` while excluding ad hoc `ATLAS_DB_*` overrides.
 4. Correct `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` to require matching,
    currently attested evidence for every raw mismatch **and** missing-source
    item while preserving the raw report and its forensic nonzero exit.
@@ -96,7 +100,8 @@ incorrectly said that admissible state could contain no `missing_source`.
   `ATLAS_DB_SOCKET_PATH` only when no complete DSN overrides it; add/reload the
   exact identity map and specific peer HBA rule; restart `atlas-api`; prove
   health, an authenticated EOM CRM read, the application's Unix-socket backend,
-  and fixed inspection selected from the service `EnvironmentFiles`.
+  fixed inspection selected from the service `EnvironmentFiles`, the exclusive
+  loaded identity map, and no remaining loopback TCP or replication client.
 - Only then replace every loopback TCP `trust` rule with `scram-sha-256`,
   reload PostgreSQL, prove the loaded HBA result is `1|1|1|1|0|0|0` (one exact
   application IPv4, application IPv6, replication IPv4, and replication IPv6
@@ -123,9 +128,10 @@ Max files: 5
      because both already call `connection_kwargs()`.
   4. The operational procedure rejects an overriding complete DSN, authenticates
      the specific service OS account as `atlas` over the Unix socket before
-     removing loopback `trust`, proves every exact loopback HBA tuple, retains
-     `postgres` peer recovery, and reloads restored TCP authentication before a
-     rollback restart.
+     removing loopback `trust`, proves the exclusive loaded identity map and no
+     remaining loopback TCP client, proves every exact loopback HBA tuple,
+     retains `postgres` peer recovery, and reloads restored TCP authentication
+     before a rollback restart.
   5. The migration runbook accurately distinguishes raw forensic output from
      attested admission without changing runner behavior.
 - Reachability proof: `atlas_brain/storage/database.py` initializes the pool
@@ -139,8 +145,9 @@ Max files: 5
   confirmation; and the authenticated EOM CRM read used as production proof.
 - Risk areas: local role impersonation over loopback TCP, wrong-cluster
   inspection, service/inspector configuration skew, HBA parser failure,
-  duplicated/missing IPv4/IPv6/replication tuples, unreloaded failed HBA
-  restoration, startup-migration availability, and rollback recovery.
+  an overbroad peer map, active local client disconnect, duplicated/missing
+  IPv4/IPv6/replication tuples, unreloaded failed HBA restoration,
+  startup-migration availability, and rollback recovery.
 - Reviewer rules triggered: R1, R2, R3, R11, R12, R14.
 - Boundary-change enumeration:
   - `socket_path=None` continues to produce TCP host/port kwargs.
@@ -152,6 +159,9 @@ Max files: 5
   - The fixed inspector uses only the service `EnvironmentFiles`, in service
     order, and removes ad hoc `ATLAS_DB_*` values before it constructs
     `DatabaseConfig`.
+  - The cutover requires no remaining loopback TCP/replication client and an
+    exact loaded `atlas_app | juan-canfield | atlas` identity map before HBA
+    replacement.
   - The post-conversion HBA receipt requires one exact SCRAM tuple for each
     application/replication IPv4/IPv6 channel, no unexpected loopback host
     rule, no remaining trust row, and no parser error before an IPv4-only
@@ -228,12 +238,12 @@ blocks the socket-peer path.
 
 | File | LOC |
 |---|---:|
-| `.agent/runbooks/database.md` | 285 |
+| `.agent/runbooks/database.md` | 318 |
 | `atlas_brain/storage/config.py` | 11 |
 | `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` | 20 |
-| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 244 |
+| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 254 |
 | `tests/test_eom_render_profile.py` | 60 |
-| **Total** | **620** |
+| **Total** | **663** |
 
 ## Diff budget
 

--- a/plans/PR-Postgres-Loopback-Scram-Hardening.md
+++ b/plans/PR-Postgres-Loopback-Scram-Hardening.md
@@ -21,23 +21,31 @@ incorrectly said that admissible state could contain no `missing_source`.
 - Loopback TCP `trust` lets a local process request any database role.
 - `connection_kwargs()` ignores `socket_path`, while the pool and fixed
   inspection call it rather than `DatabaseConfig.dsn`.
+- A socket target label omits its configured port even though the port selects
+  the socket filename and the migration receipt confirms that label exactly.
+- A successful service or inspector connection is not socket proof while a
+  complete DSN retains deliberate precedence over split configuration.
 - The migration runbook confuses raw forensic output with attested admission.
 
 #### Required change surface
 
 1. Update `atlas_brain/storage/config.py` so both connection construction
-   forms honour `socket_path` and the configured PostgreSQL port:
+   forms and its log-safe target label honour `socket_path` and the configured
+   PostgreSQL port:
    - `dsn` includes the socket host and port for direct asyncpg callers.
    - `connection_kwargs()` uses the socket directory as `host`, retaining the
      configured port, so `DatabasePool` and `./ops db inspect` reach the Unix
      socket rather than loopback TCP.
+   - `target_label` includes the socket port so exact-target confirmation
+     distinguishes same-directory, same-database PostgreSQL clusters.
 2. Update focused `DatabaseConfig` tests in
-   `tests/test_eom_render_profile.py` to pin both socket-path forms and the
-   existing TCP/complete-DSN precedence behavior, then assert the actual pool
-   and raw-connection callers receive the socket kwargs.
+   `tests/test_eom_render_profile.py` to pin both socket-path forms, distinct
+   socket ports, and the existing TCP/complete-DSN precedence behavior, then
+   assert the actual pool and raw-connection callers receive the socket kwargs.
 3. Replace the provisional credential/SCRAM procedure with non-secret socket
    configuration, an exact `atlas-api` OS-user → `atlas` peer map, staged
-   service/inspection/CRM proof, loopback-SCRAM replacement, and rollback.
+   service/CRM/backend-transport/inspection proof, loopback-SCRAM replacement,
+   and a rollback that restores TCP settings before restarting the service.
 4. Correct `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` to require matching,
    currently attested evidence for every raw mismatch **and** missing-source
    item while preserving the raw report and its forensic nonzero exit.
@@ -67,17 +75,20 @@ incorrectly said that admissible state could contain no `missing_source`.
 #### Verification plan
 
 - Focused regression: socket `dsn` and `connection_kwargs()` assertions,
-  existing TCP and complete-DSN assertions, and the pool/raw caller seam.
+  distinct socket target-label assertions, existing TCP and complete-DSN
+  assertions, and the pool/raw caller seam.
 - Cheap local gates: focused test target, `bash scripts/check_ascii_python.sh`,
   `git diff --check`, and `python scripts/sync_pr_plan.py ... --check`.
 - GitHub remains the complete unit gate.
 - Post-merge proof while existing TCP trust remains: deploy source; configure
-  `ATLAS_DB_SOCKET_PATH`; add/reload the exact identity map and specific peer
-  HBA rule; restart `atlas-api`; prove health, fixed inspection, and an
-  authenticated EOM CRM read.
+  `ATLAS_DB_SOCKET_PATH` only when no complete DSN overrides it; add/reload the
+  exact identity map and specific peer HBA rule; restart `atlas-api`; prove
+  health, an authenticated EOM CRM read, the application's Unix-socket backend,
+  and fixed inspection.
 - Only then replace every loopback TCP `trust` rule with `scram-sha-256`,
   reload PostgreSQL, repeat the proofs, prove passwordless TCP rejection, and
-  prove `sudo -u postgres psql -d atlas -Atc 'SELECT current_user'` succeeds.
+  prove `sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -Atc
+  'SELECT current_user'` succeeds.
 
 ## Scope (this PR)
 
@@ -89,14 +100,16 @@ Max files: 5
 
 - Acceptance criteria:
   1. A configured socket path reaches the configured PostgreSQL socket port in
-     both `DatabaseConfig.dsn` and `connection_kwargs()`.
+     both `DatabaseConfig.dsn` and `connection_kwargs()`, and that port appears
+     in its log-safe exact-target label.
   2. Complete DSNs retain their precedence; non-socket split settings retain
      existing TCP kwargs.
   3. `DatabasePool` and fixed `./ops db inspect` inherit the corrected path
      because both already call `connection_kwargs()`.
-  4. The operational procedure authenticates the specific service OS account
-     as `atlas` over the Unix socket before removing loopback `trust`, retains
-     `postgres` peer recovery, and has a rollback order.
+  4. The operational procedure rejects an overriding complete DSN, authenticates
+     the specific service OS account as `atlas` over the Unix socket before
+     removing loopback `trust`, retains `postgres` peer recovery, and restores
+     TCP settings before a rollback restart.
   5. The migration runbook accurately distinguishes raw forensic output from
      attested admission without changing runner behavior.
 - Reachability proof: `atlas_brain/storage/database.py` initializes the pool
@@ -109,8 +122,10 @@ Max files: 5
   - `connection_string` continues to win over split socket/TCP settings.
   - `socket_path` replaces only the host, retaining the configured port needed
     to select PostgreSQL's socket filename.
+  - The socket target label includes that port, so confirmation cannot conflate
+    same-directory, same-database clusters on distinct ports.
   - Cutover order is peer proof before removal of any trust rule; rollback
-    restores saved HBA/ident/config state before restarting the application.
+    restores TCP configuration before restarting the application.
 
 ### Files touched
 
@@ -165,9 +180,9 @@ blocks the socket-peer path.
 
 | File | LOC |
 |---|---:|
-| `.agent/runbooks/database.md` | 147 |
-| `atlas_brain/storage/config.py` | 7 |
-| `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` | 10 |
-| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 173 |
-| `tests/test_eom_render_profile.py` | 51 |
-| **Total** | **388** |
+| `.agent/runbooks/database.md` | 171 |
+| `atlas_brain/storage/config.py` | 11 |
+| `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` | 20 |
+| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 188 |
+| `tests/test_eom_render_profile.py` | 60 |
+| **Total** | **450** |

--- a/plans/PR-Postgres-Loopback-Scram-Hardening.md
+++ b/plans/PR-Postgres-Loopback-Scram-Hardening.md
@@ -73,6 +73,12 @@ leave its restart procedure with contradictory integrity instructions.
   derived coverage over every non-local rule that can match loopback, and
   active-file rollback; endpoint-only counts can miss a broader subnet or
   TLS-specific rule, while a disk-only restore leaves partial HBA rules active.
+- The final exact-tuple HBA receipt consumes `covers_loopback` from a CTE that
+  was scoped to the preceding, separate `psql` command, so PostgreSQL cannot
+  evaluate the source-boundary column in the final receipt.
+- Service-file admission for a pre-existing socket assignment or nonblank
+  complete DSN was deferred until after backup, peer-map/HBA edits, and reload,
+  so a rejected configuration could leave partial authentication state live.
 - The migration runbook confuses raw forensic output with attested admission.
 
 #### Required change surface
@@ -113,6 +119,11 @@ leave its restart procedure with contradictory integrity instructions.
    the service. A shared no-socket-assignment guard must gate both the initial
    edit and rollback across every selected service file, including case and
    spacing variants, before rollback restores HBA/identity configuration.
+   A combined new-socket admission gate must also reject every selected service
+   file with a nonblank complete-DSN assignment, and must run before the first
+   HBA/identity backup, edit, or reload. Each independent post-conversion HBA
+   query must define its own derived loopback-coverage relation before it
+   consumes that relation.
    The loaded peer receipt must also require exactly one intended local HBA rule
    and no preceding local rule except the retained `postgres` recovery rule.
    It must require at least one qualifying post-restart `atlas` backend and a
@@ -165,6 +176,10 @@ leave its restart procedure with contradictory integrity instructions.
   current `DatabaseConfig` fields.
 - Cheap local gates: focused test target, `bash scripts/check_ascii_python.sh`,
   `git diff --check`, and `python scripts/sync_pr_plan.py ... --check`.
+- Guard boundary coverage must prove empty and quoted-empty complete-DSN
+  assignments pass while literal and expansion-shaped values stop, prove the
+  configuration-admission command precedes the first HBA backup, and prove each
+  final HBA receipt independently defines `covers_loopback`.
 - GitHub remains the complete unit gate.
 - Post-merge proof while existing TCP trust remains: deploy source; configure
   `ATLAS_DB_SOCKET_PATH` only when no complete DSN overrides it; add/reload the
@@ -213,8 +228,10 @@ Max files: 7
      proves every exact tuple, retains `postgres` peer recovery, and reloads
      restored TCP authentication before a rollback restart. It also proves every
      loopback rule it edits is in the backed-up top-level HBA file, and stops before
-     editing when any selected service file already assigns the socket path, so
-     rollback removes only an assignment created by this cutover.
+     any HBA/identity mutation when any selected service file already assigns the
+     socket path or a nonblank complete DSN, so rollback removes only an
+     assignment created by this cutover. Each final HBA receipt is independently
+     executable with its own loopback-coverage relation.
   5. The migration runbook accurately distinguishes raw forensic output from
      attested admission without changing runner behavior.
 - Reachability proof: `atlas_brain/storage/database.py` initializes the pool
@@ -247,9 +264,13 @@ Max files: 7
     the generic documented override behavior, while the service-pinned helper
     explicitly unsets all of them before its proof.
   - A pre-existing case-variant socket-path assignment in any selected service
-    file is a stop condition; this cutover adds exactly one new assignment only
-    after the absence precondition, so rollback never rewrites an earlier
-    configuration.
+   file is a stop condition; this cutover adds exactly one new assignment only
+   after the absence precondition, so rollback never rewrites an earlier
+   configuration.
+  - A nonblank complete-DSN assignment in any selected service file is also a
+    stop condition before authentication mutation. Empty, quoted-empty, and
+    comment-only assignments remain admissible; a literal or expansion-shaped
+    value requires a separate configuration migration.
   - Before fixed inspection or an edit, every selected service file must be
     readable, the selected set must be nonempty, and all `ATLAS_DB_*` keys must
     be canonical uppercase. This makes the `ops` configuration parser and the
@@ -270,7 +291,8 @@ Max files: 7
     can cover either loopback endpoint, then requires one exact SCRAM tuple for
     each application/replication IPv4/IPv6 channel, no unexpected endpoint-equal
     host rule, no remaining trust row, no parser error, and no loopback source
-    outside the backed-up file before an IPv4-only
+    outside the backed-up file. Each receipt carries its own `hba` CTE so it can
+    execute independently before an IPv4-only
     negative probe can be treated as sufficient.
   - Cutover order is peer proof before removal of any trust rule; rollback
     restores and reloads TCP authentication before restarting the application.
@@ -332,6 +354,13 @@ Max files: 7
   fixed inspection or the full-DSN precondition. The safe default is to
   normalize configuration in a separate migration, not to inspect a fallback
   or choose between alias collisions.
+- **Complete-DSN admission — CLOSED / DERIVED before HBA mutation.** Membership
+  is every canonical `ATLAS_DB_CONNECTION_STRING` assignment in the ordered
+  selected `EnvironmentFiles`. The only admitted values are absent, empty,
+  quoted-empty, or comment-only; any literal or expansion-shaped value stops
+  before backup or reload because complete-DSN precedence could bypass the new
+  socket setting. The safe default is a separate configuration migration, not a
+  partial peer-authentication edit.
 - **Rollback socket assignments — CLOSED / DERIVED before HBA restore.**
   Membership is every case-variant `ATLAS_DB_SOCKET_PATH` assignment in every
   ordered selected `EnvironmentFile`, regardless of value or spacing. The only
@@ -418,19 +447,22 @@ blocks the socket-peer path.
 - `./ops test focused tests/test_agent_operations_contract.py -q -k
   'database_runtime_environment or service_db_inspect or
   service_db_case_variant_preflight or service_db_no_socket_guard or
-  rollback_refuses or peer_hba_receipt or qualifying_atlas_backends or
-  hba_sources'` — 25 passed, 40 deselected (local);
+  new_socket_configuration or final_hba_receipt or
+  admits_new_socket_configuration_before_hba_mutation or rollback_refuses or
+  peer_hba_receipt or qualifying_atlas_backends or hba_sources'` — 13 passed,
+  60 deselected (local);
   proves the canonical override, case-variant rejection, complete key-set
   closure, the service-helper unset-set closure, socket/full-DSN alias and
-  near-miss boundaries, empty-service-set rejection, a surviving spacing-variant
-  socket assignment cannot reach HBA restoration, the transport receipt requires
-  every qualifying Atlas backend to use the socket, the HBA source receipt gates
-  top-level backup/rollback, and the loaded peer-HBA receipt requires the
-  intended rule/precedence predicate.
-- `./ops test focused tests/test_agent_operations_contract.py -q` — 65 passed
+  near-miss boundaries, empty-service-set rejection, a nonblank complete DSN
+  stops before the first HBA backup, a surviving spacing-variant socket
+  assignment cannot reach HBA restoration, each final HBA receipt defines its
+  own loopback CTE, the transport receipt requires every qualifying Atlas backend
+  to use the socket, the HBA source receipt gates top-level backup/rollback, and
+  the loaded peer-HBA receipt requires the intended rule/precedence predicate.
+- `./ops test focused tests/test_agent_operations_contract.py -q` — 73 passed
   (local).
 - `bash scripts/check_ascii_python.sh` — passed (local).
-- `service_db_inspect`, canonical-key/no-socket, and rollback guard blocks
+- `service_db_inspect`, new-socket-admission, canonical-key/no-socket, and rollback guard blocks
   extracted from `.agent/runbooks/database.md` and checked with `bash -n` —
   passed (local).
 - The read-only loaded peer-HBA receipt returned `0|0|0|0|0|0` against the
@@ -451,6 +483,11 @@ blocks the socket-peer path.
 - The read-only HBA source receipt returned `4|0|0`; the transport predicate
   returned `socket_only|1|1` and `mixed|1|0` against synthetic socket-only and
   mixed candidates (local).
+- The exact final post-conversion HBA receipt executed read-only against the
+  pre-conversion topology and returned `0|0|0|0|4|4|0|0`; that is intentionally
+  not the cutover acceptance value, but proves the independently scoped
+  `covers_loopback` query reaches PostgreSQL without a missing-column error
+  (local).
 - Guarded `scripts/push_pr.sh` local PR review — passed; GitHub owns the full
   unit gate.
 - Post-merge: follow the exact peer-socket cutover/rollback procedure in
@@ -461,14 +498,14 @@ blocks the socket-peer path.
 
 | File | LOC |
 |---|---:|
-| `.agent/runbooks/database.md` | 546 |
+| `.agent/runbooks/database.md` | 597 |
 | `atlas_brain/storage/config.py` | 13 |
 | `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` | 20 |
 | `ops` | 15 |
-| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 476 |
-| `tests/test_agent_operations_contract.py` | 350 |
+| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 513 |
+| `tests/test_agent_operations_contract.py` | 424 |
 | `tests/test_eom_render_profile.py` | 84 |
-| **Total** | **1504** |
+| **Total** | **1666** |
 
 ## Diff budget
 

--- a/plans/PR-Postgres-Loopback-Scram-Hardening.md
+++ b/plans/PR-Postgres-Loopback-Scram-Hardening.md
@@ -41,8 +41,8 @@ incorrectly said that admissible state could contain no `missing_source`.
 4. Correct `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` to require matching,
    currently attested evidence for every raw mismatch **and** missing-source
    item while preserving the raw report and its forensic nonzero exit.
-5. Remove the unviable, uncommitted encrypted-credential experiment and tests;
-   it would require an unsupported plaintext-secret fallback.
+5. Exclude the unviable encrypted-credential experiment from this PR; it would
+   require an unsupported plaintext-secret fallback.
 
 #### Explicit non-scope
 

--- a/plans/PR-Postgres-Loopback-Scram-Hardening.md
+++ b/plans/PR-Postgres-Loopback-Scram-Hardening.md
@@ -21,10 +21,14 @@ incorrectly said that admissible state could contain no `missing_source`.
 - Loopback TCP `trust` lets a local process request any database role.
 - `connection_kwargs()` ignores `socket_path`, while the pool and fixed
   inspection call it rather than `DatabaseConfig.dsn`.
+- A bare fixed inspection can select a worktree `.env` instead of the
+  service's `EnvironmentFiles`, even when the worktree omits database keys.
 - A socket target label omits its configured port even though the port selects
   the socket filename and the migration receipt confirms that label exactly.
 - A successful service or inspector connection is not socket proof while a
   complete DSN retains deliberate precedence over split configuration.
+- A manual four-rule HBA conversion needs a loaded-rule postcondition; one
+  IPv4 application probe cannot prove the IPv6 and replication channels.
 - The migration runbook confuses raw forensic output with attested admission.
 
 #### Required change surface
@@ -45,7 +49,10 @@ incorrectly said that admissible state could contain no `missing_source`.
 3. Replace the provisional credential/SCRAM procedure with non-secret socket
    configuration, an exact `atlas-api` OS-user → `atlas` peer map, staged
    service/CRM/backend-transport/inspection proof, loopback-SCRAM replacement,
-   and a rollback that restores TCP settings before restarting the service.
+   a loaded-HBA assertion for all four loopback rules, and a rollback that
+   restores TCP settings before restarting the service. The fixed inspection
+   must explicitly select the ordered `atlas-api.service` `EnvironmentFiles`
+   while excluding ad hoc `ATLAS_DB_*` overrides.
 4. Correct `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` to require matching,
    currently attested evidence for every raw mismatch **and** missing-source
    item while preserving the raw report and its forensic nonzero exit.
@@ -77,6 +84,9 @@ incorrectly said that admissible state could contain no `missing_source`.
 - Focused regression: socket `dsn` and `connection_kwargs()` assertions,
   distinct socket target-label assertions, existing TCP and complete-DSN
   assertions, and the pool/raw caller seam.
+- Adjacent configuration-context regression: a worktree file remains the
+  default inspector context, while an ordered `ATLAS_OPS_ENV_FILES` override
+  selects the intended service configuration.
 - Cheap local gates: focused test target, `bash scripts/check_ascii_python.sh`,
   `git diff --check`, and `python scripts/sync_pr_plan.py ... --check`.
 - GitHub remains the complete unit gate.
@@ -84,11 +94,12 @@ incorrectly said that admissible state could contain no `missing_source`.
   `ATLAS_DB_SOCKET_PATH` only when no complete DSN overrides it; add/reload the
   exact identity map and specific peer HBA rule; restart `atlas-api`; prove
   health, an authenticated EOM CRM read, the application's Unix-socket backend,
-  and fixed inspection.
+  and fixed inspection selected from the service `EnvironmentFiles`.
 - Only then replace every loopback TCP `trust` rule with `scram-sha-256`,
-  reload PostgreSQL, repeat the proofs, prove passwordless TCP rejection, and
-  prove `sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -Atc
-  'SELECT current_user'` succeeds.
+  reload PostgreSQL, prove the loaded HBA result is `4|0|0` (four loopback
+  SCRAM rows, zero trust rows, zero parser errors), repeat the proofs, prove
+  passwordless TCP rejection, and prove `sudo -u postgres psql -h
+  /var/run/postgresql -p 5433 -d atlas -Atc 'SELECT current_user'` succeeds.
 
 ## Scope (this PR)
 
@@ -117,6 +128,15 @@ Max files: 5
   `DatabaseConfig(_env_file=None)` and passes those kwargs to its fixed asyncpg
   inspection. Direct maintenance scripts that call `db_settings.dsn` receive
   the corrected socket port as well.
+- Affected surfaces: `DatabaseConfig` DSN/asyncpg construction and target
+  labels; `DatabasePool`; the fixed `./ops db inspect` environment-selection
+  seam; PostgreSQL HBA/ident operational procedure; migration target
+  confirmation; and the authenticated EOM CRM read used as production proof.
+- Risk areas: local role impersonation over loopback TCP, wrong-cluster
+  inspection, service/inspector configuration skew, HBA parser failure,
+  IPv6/replication trust left behind, startup-migration availability, and
+  rollback recovery.
+- Reviewer rules triggered: R1, R2, R3, R11, R12, R14.
 - Boundary-change enumeration:
   - `socket_path=None` continues to produce TCP host/port kwargs.
   - `connection_string` continues to win over split socket/TCP settings.
@@ -124,6 +144,12 @@ Max files: 5
     to select PostgreSQL's socket filename.
   - The socket target label includes that port, so confirmation cannot conflate
     same-directory, same-database clusters on distinct ports.
+  - The fixed inspector uses only the service `EnvironmentFiles`, in service
+    order, and removes ad hoc `ATLAS_DB_*` values before it constructs
+    `DatabaseConfig`.
+  - The post-conversion HBA receipt requires four loopback SCRAM rows, no
+    remaining trust row, and no parser error before an IPv4-only negative probe
+    can be treated as sufficient.
   - Cutover order is peer proof before removal of any trust rule; rollback
     restores TCP configuration before restarting the application.
 
@@ -142,6 +168,11 @@ No password is added: the post-merge identity map lets `atlas-api` authenticate
 as `atlas` over peer. The map/rule are proved while TCP remains available;
 only then do all loopback `trust` entries become `scram-sha-256`.
 
+The fixed inspector keeps its existing source-selection semantics. The runbook
+uses its documented explicit environment-file override, in the exact service
+order and without inherited database settings, so the read-only proof observes
+the same database target as `atlas-api.service`.
+
 The migration-runbook change is documentation only: raw discrepancies stay
 visible and retain their forensic nonzero status.
 
@@ -151,6 +182,8 @@ visible and retain their forensic nonzero status.
   non-loopback access remain unchanged.
 - `ops` already carries `ATLAS_DB_SOCKET_PATH`; CRM read is production proof,
   not a feature.
+- `ops` context-selection code remains unchanged; the cutover invokes its
+  existing explicit override rather than changing normal worktree behavior.
 
 ## Deferred
 
@@ -165,24 +198,41 @@ blocks the socket-peer path.
 
 ## Verification
 
-- Pending before push: `./ops test focused tests/test_eom_render_profile.py -q
-  -k 'database_config or database_pool_uses_configured_connection_kwargs'`.
-- Pending before push: `bash scripts/check_ascii_python.sh`.
-- Pending before push: `git diff --check`.
-- Pending before push: `python scripts/sync_pr_plan.py
-  plans/PR-Postgres-Loopback-Scram-Hardening.md --check`.
-- Pending before push: cold diff / contract audit and normal PR mechanical
-  review helpers.
+- `./ops test focused tests/test_eom_render_profile.py -q -k 'database_config
+  or database_pool_uses_configured_connection_kwargs'` — 4 passed, 61
+  deselected (local).
+- `./ops test focused tests/test_agent_operations_contract.py -q -k
+  'database_file_context_prefers_worktree_over_shared_and_systemd or
+  database_file_context_honors_explicit_override_order'` — 2 passed, 39
+  deselected (local).
+- `bash scripts/check_ascii_python.sh` — passed (local).
+- `git diff --check` — passed (local).
+- `python scripts/sync_pr_plan.py
+  plans/PR-Postgres-Loopback-Scram-Hardening.md --check` — passed (local).
+- `python scripts/audit_pr_body.py --base-ref origin/main
+  tmp/pr-body-postgres-loopback-peer-hardening.md` and the reconciliation/fix
+  loop auditors — passed (local).
+- Guarded `scripts/push_pr.sh` local PR review — passed; GitHub owns the full
+  unit gate.
 - Post-merge: follow the exact peer-socket cutover/rollback procedure in
-  `.agent/runbooks/database.md`; GitHub Actions remains the complete unit gate.
+  `.agent/runbooks/database.md`; do not remove HBA trust until service-pinned
+  inspection, CRM, transport, and loaded-HBA proofs all succeed.
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
-| `.agent/runbooks/database.md` | 171 |
+| `.agent/runbooks/database.md` | 227 |
 | `atlas_brain/storage/config.py` | 11 |
 | `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` | 20 |
-| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 188 |
+| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 238 |
 | `tests/test_eom_render_profile.py` | 60 |
-| **Total** | **450** |
+| **Total** | **556** |
+
+## Diff budget
+
+Diff-budget override: the socket construction, caller-seam evidence, exact
+target identity, and staged peer/SCRAM procedure are one deployment-safety
+boundary; splitting them would publish either executable configuration without
+its safe cutover/rollback proof or a procedure that refers to unavailable
+behavior.

--- a/plans/PR-Postgres-Loopback-Scram-Hardening.md
+++ b/plans/PR-Postgres-Loopback-Scram-Hardening.md
@@ -27,12 +27,14 @@ incorrectly said that admissible state could contain no `missing_source`.
   the socket filename and the migration receipt confirms that label exactly.
 - A successful service or inspector connection is not socket proof while a
   complete DSN retains deliberate precedence over split configuration.
-- A loopback-client inventory without a stop condition can strand an active
-  local client after HBA conversion, and a peer-map insertion without an exact
-  loaded-map receipt can retain a broader OS-account authorization.
-- A manual four-rule HBA conversion needs an exact loaded-tuple postcondition
-  and active-file rollback; aggregate counts can mask duplicated/missing
-  channels, and a disk-only restore leaves partial HBA rules active.
+- A final-only loopback-client inventory can lose a client observed at preflight
+  before it is proved Unix-socket or SCRAM-ready, and a peer-map insertion
+  without an exact loaded-map receipt can retain a broader OS-account
+  authorization.
+- A manual four-rule HBA conversion needs an exact loaded-tuple postcondition,
+  derived coverage over every non-local rule that can match loopback, and
+  active-file rollback; endpoint-only counts can miss a broader subnet or
+  TLS-specific rule, while a disk-only restore leaves partial HBA rules active.
 - The migration runbook confuses raw forensic output with attested admission.
 
 #### Required change surface
@@ -52,11 +54,12 @@ incorrectly said that admissible state could contain no `missing_source`.
    assert the actual pool and raw-connection callers receive the socket kwargs.
 3. Replace the provisional credential/SCRAM procedure with non-secret socket
    configuration, an exact `atlas-api` OS-user → `atlas` peer map, staged
-   service/CRM/backend-transport/inspection proof, loopback-SCRAM replacement,
-   an exact loaded-HBA assertion for all four loopback tuples, and a rollback
+   service/CRM/backend-transport/inspection proof, reconciled initial/final
+   loopback-client inventories, loopback-SCRAM replacement, a derived
+   loaded-HBA coverage assertion plus exact four-tuple proof, and a rollback
    that restores TCP settings and reloads the restored HBA before restarting
-   the service. The procedure must stop on remaining loopback TCP clients and
-   prove the loaded peer map has exactly the intended mapping. The fixed
+   the service. The procedure must stop on unresolved or remaining loopback TCP
+   clients and prove the loaded peer map has exactly the intended mapping. The fixed
    inspection must explicitly select the ordered `atlas-api.service`
    `EnvironmentFiles` while excluding ad hoc `ATLAS_DB_*` overrides.
 4. Correct `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` to require matching,
@@ -101,12 +104,15 @@ incorrectly said that admissible state could contain no `missing_source`.
   exact identity map and specific peer HBA rule; restart `atlas-api`; prove
   health, an authenticated EOM CRM read, the application's Unix-socket backend,
   fixed inspection selected from the service `EnvironmentFiles`, the exclusive
-  loaded identity map, and no remaining loopback TCP or replication client.
+  loaded identity map, a Unix-socket or separately verified SCRAM receipt for
+  every client observed in either inventory, and no remaining loopback TCP or
+  replication client.
 - Only then replace every loopback TCP `trust` rule with `scram-sha-256`,
-  reload PostgreSQL, prove the loaded HBA result is `1|1|1|1|0|0|0` (one exact
-  application IPv4, application IPv6, replication IPv4, and replication IPv6
-  SCRAM tuple; zero unexpected loopback host rules, trust rows, and parser
-  errors), repeat the proofs, prove passwordless TCP rejection, and prove
+  reload PostgreSQL, prove the derived loopback-network receipt is `4` and the
+  exact loaded-HBA result is `1|1|1|1|0|0|0` (one exact application IPv4,
+  application IPv6, replication IPv4, and replication IPv6 SCRAM tuple; zero
+  unexpected endpoint-equal host rules, trust rows, and parser errors), repeat
+  the proofs, prove passwordless TCP rejection, and prove
   `sudo -u postgres psql -h /var/run/postgresql -p 5433 -d atlas -Atc 'SELECT
   current_user'` succeeds.
 
@@ -128,10 +134,11 @@ Max files: 5
      because both already call `connection_kwargs()`.
   4. The operational procedure rejects an overriding complete DSN, authenticates
      the specific service OS account as `atlas` over the Unix socket before
-     removing loopback `trust`, proves the exclusive loaded identity map and no
-     remaining loopback TCP client, proves every exact loopback HBA tuple,
-     retains `postgres` peer recovery, and reloads restored TCP authentication
-     before a rollback restart.
+     removing loopback `trust`, proves the exclusive loaded identity map, gives
+     every initial/final loopback client a Unix-socket or verified-SCRAM receipt,
+     leaves no TCP client, derives every loopback-covering HBA network rule,
+     proves every exact tuple, retains `postgres` peer recovery, and reloads
+     restored TCP authentication before a rollback restart.
   5. The migration runbook accurately distinguishes raw forensic output from
      attested admission without changing runner behavior.
 - Reachability proof: `atlas_brain/storage/database.py` initializes the pool
@@ -159,12 +166,14 @@ Max files: 5
   - The fixed inspector uses only the service `EnvironmentFiles`, in service
     order, and removes ad hoc `ATLAS_DB_*` values before it constructs
     `DatabaseConfig`.
-  - The cutover requires no remaining loopback TCP/replication client and an
-    exact loaded `atlas_app | juan-canfield | atlas` identity map before HBA
-    replacement.
-  - The post-conversion HBA receipt requires one exact SCRAM tuple for each
-    application/replication IPv4/IPv6 channel, no unexpected loopback host
-    rule, no remaining trust row, and no parser error before an IPv4-only
+  - The cutover reconciles every client observed in both initial and final
+    loopback TCP/replication inventories to a Unix-socket or verified-SCRAM
+    receipt, requires no remaining final client, and requires an exact loaded
+    `atlas_app | juan-canfield | atlas` identity map before HBA replacement.
+  - The post-conversion HBA receipt derives every non-local rule whose network
+    can cover either loopback endpoint, then requires one exact SCRAM tuple for
+    each application/replication IPv4/IPv6 channel, no unexpected endpoint-equal
+    host rule, no remaining trust row, and no parser error before an IPv4-only
     negative probe can be treated as sufficient.
   - Cutover order is peer proof before removal of any trust rule; rollback
     restores and reloads TCP authentication before restarting the application.
@@ -179,22 +188,27 @@ Max files: 5
   existing order; a nonblank DSN is outside the socket-proof-admissible subset
   and stops this cutover rather than allowing HBA mutation.
 - **Loopback HBA topology — CLOSED / DERIVED at cutover.** Membership comes
-  from the live `pg_hba_file_rules` receipt on the declared socket and port, not
-  the four examples in this plan. The procedure admits exactly one loaded
+  from every non-local live `pg_hba_file_rules` record on the declared socket
+  and port, not the four examples in this plan. A derived network predicate
+  includes an address/netmask rule when it can cover either loopback endpoint
+  and treats null, unparseable, or family-mismatched forms as candidates. The
+  procedure admits exactly four candidates, each one exact
   application/replication IPv4/IPv6 tuple with the declared user, netmask, and
-  SCRAM method. A missing, duplicate, or unlisted loopback rule fails closed to
-  no HBA change because an unknown authentication path is less safe than a
-  deferred hardening run.
+  SCRAM method. A missing, duplicate, broader, TLS-specific, or unlisted rule
+  fails closed to no HBA change because an unknown authentication path is less
+  safe than a deferred hardening run.
 - **`atlas_app` peer-map membership — CLOSED / DERIVED at reload.** Membership
   comes from `pg_ident_file_mappings`; exactly one
   `atlas_app | juan-canfield | atlas` tuple and no mapping error is admitted.
   Any extra, missing, malformed, or unrecognized mapping stops before HBA
   replacement because it could broaden local role impersonation.
-- **Loopback-client inventory — OPEN / DERIVED at observation time.**
+- **Loopback-client inventory — OPEN / DERIVED at both observation times.**
   `pg_stat_activity` and `pg_stat_replication` supply every current TCP
-  loopback client; application names and client identities are not enumerated.
-  Any observed member, including a new unrecognized client, stops the cutover
-  until it moves to a socket or completes a separately verified SCRAM migration.
+  loopback client at initial and final observation; application names and client
+  identities are not enumerated. Every member of their union, including a
+  client that disappears or newly appears, stops the cutover until it has a
+  Unix-socket or separately verified SCRAM reconnect receipt; an empty final
+  snapshot alone is not an admissible default.
 - **Service environment-file list — CLOSED / DERIVED for the selected service
   unit.** Membership is the ordered `EnvironmentFiles` output of `./ops env
   systemd`. An absent, unreadable, or unlisted effective configuration file
@@ -260,6 +274,10 @@ blocks the socket-peer path.
 - `python scripts/audit_pr_body.py --base-ref origin/main
   tmp/pr-body-postgres-loopback-peer-hardening.md` and the reconciliation/fix
   loop auditors — passed (local).
+- Read-only derived-HBA probe against the current `trust` topology returned
+  `4|0`: four loopback-network candidates and zero unexpected candidates; a
+  synthetic broader subnet, `hostssl` rule, and non-IP form each became a
+  candidate while the current remote `/12` rule did not (local).
 - Guarded `scripts/push_pr.sh` local PR review — passed; GitHub owns the full
   unit gate.
 - Post-merge: follow the exact peer-socket cutover/rollback procedure in
@@ -270,12 +288,12 @@ blocks the socket-peer path.
 
 | File | LOC |
 |---|---:|
-| `.agent/runbooks/database.md` | 356 |
+| `.agent/runbooks/database.md` | 400 |
 | `atlas_brain/storage/config.py` | 11 |
 | `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` | 20 |
-| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 286 |
+| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 304 |
 | `tests/test_eom_render_profile.py` | 61 |
-| **Total** | **734** |
+| **Total** | **796** |
 
 ## Diff budget
 

--- a/plans/PR-Postgres-Loopback-Scram-Hardening.md
+++ b/plans/PR-Postgres-Loopback-Scram-Hardening.md
@@ -1,0 +1,203 @@
+# PR-Postgres-Loopback-Peer-Hardening
+
+## Why this slice exists
+
+The authorized EOM recovery exposed two deferred operational defects.
+
+PostgreSQL currently accepts every TCP connection from `127.0.0.1` and `::1`
+with `trust`, including connections requested as the `postgres` superuser.
+Atlas defaults to the `atlas` database role without a password. Although
+`DatabaseConfig` exposes `ATLAS_DB_SOCKET_PATH`, the live pool and fixed
+`./ops db inspect` path call `connection_kwargs()`, which currently ignores
+that setting and always selects the TCP host/port. The deployed application
+cannot move from TCP `trust` to Unix-socket peer authentication merely by
+setting the existing environment variable.
+
+The recovery also emitted a migration-content-integrity warning. The runner
+deliberately reports raw `missing_source` and `mismatched` historical evidence
+even when matching, attested reconciliation records admit a pending migration.
+The runbook previously described that admissible state as requiring no
+`missing_source` records, contradicting the runner.
+
+### Problem-derived contract
+
+#### Root cause
+
+- The local database boundary is too broad: loopback TCP `trust` lets a local
+  process request any database role without authentication.
+- The intended peer-auth replacement is ineffective because
+  `DatabaseConfig.connection_kwargs()` ignores `socket_path`; the generic pool
+  and fixed inspection use those kwargs rather than `DatabaseConfig.dsn`.
+- The migration runbook conflates raw forensic reporting with admission. The
+  runner admits known mismatches and missing sources only after current
+  attestation; it does not erase or suppress their raw report.
+
+#### Required change surface
+
+1. Update `atlas_brain/storage/config.py` so both connection construction
+   forms honour `socket_path` and the configured PostgreSQL port:
+   - `dsn` includes the socket host and port for direct asyncpg callers.
+   - `connection_kwargs()` uses the socket directory as `host`, retaining the
+     configured port, so `DatabasePool` and `./ops db inspect` reach the Unix
+     socket rather than loopback TCP.
+2. Update focused `DatabaseConfig` tests in
+   `tests/test_eom_render_profile.py` to pin both socket-path forms and the
+   existing TCP/complete-DSN precedence behavior.
+3. Replace the provisional credential/SCRAM procedure in
+   `.agent/runbooks/database.md` with the peer procedure: configure the
+   non-secret socket-path setting, map the actual `atlas-api` OS user to the
+   existing `atlas` PostgreSQL role in `pg_ident.conf`, add a specific
+   socket-peer HBA rule, prove the service/inspection/CRM path, then replace
+   all loopback TCP `trust` rules with `scram-sha-256`. Preserve the existing
+   Unix-socket `postgres` peer recovery path and a rollback sequence.
+4. Correct `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` to require matching,
+   currently attested evidence for every raw mismatch **and** missing-source
+   item while preserving the raw report and its forensic nonzero exit.
+5. Remove the unviable, uncommitted systemd encrypted-credential experiment
+   and its tests. The running service is a non-root user service; this host
+   cannot provision a protected credential to that manager without a plaintext
+   secret fallback, so it is not a valid solution.
+
+#### Explicit non-scope
+
+- Do not alter application APIs, CRM/customer behavior, email, payroll,
+  billing, schemas, migrations, migration-ledger rows, historical migration
+  source bytes, or database data.
+- Do not change database roles, role privileges, network/non-loopback HBA
+  rules, PostgreSQL ownership, or add an application password/credential.
+- Do not introduce a generic SQL interface, alter `./ops db inspect`'s two
+  fixed read-only statements, refactor arbitrary maintenance scripts, add
+  dependencies, or make runtime-routing changes.
+- Do not change the `postgres` Unix-socket peer break-glass rule.
+
+#### Assumptions and blockers
+
+- `atlas-api.service` runs as local user `juan-canfield` and PostgreSQL's
+  socket directory is `/var/run/postgresql`; the runbook requires a fresh
+  check of both just before cutover.
+- PostgreSQL accepts the `atlas_app` identity map and no live local TCP
+  replication client depends on loopback `trust`; the cutover requires an
+  activity/replication probe before changing those rules.
+- HBA/ident/shared-configuration changes are an owned, post-merge controlled
+  operation. They require deployment of the source revision containing the
+  socket-kwargs correction first.
+
+#### Verification plan
+
+- Focused regression: socket `dsn` and `connection_kwargs()` assertions plus
+  existing TCP and complete-DSN assertions.
+- Cheap local gates: focused test target, `bash scripts/check_ascii_python.sh`,
+  `git diff --check`, and `python scripts/sync_pr_plan.py ... --check`.
+- GitHub remains the complete unit gate.
+- Post-merge proof while existing TCP trust remains: deploy source; configure
+  `ATLAS_DB_SOCKET_PATH`; add/reload the exact identity map and specific peer
+  HBA rule; restart `atlas-api`; prove health, fixed inspection, and an
+  authenticated EOM CRM read.
+- Only then replace every loopback TCP `trust` rule with `scram-sha-256`,
+  reload PostgreSQL, repeat the proofs, prove passwordless TCP rejection, and
+  prove `sudo -u postgres psql -d atlas -Atc 'SELECT current_user'` succeeds.
+
+## Scope (this PR)
+
+Ownership lane: eom-crm/runtime-security
+Slice phase: production hardening
+Max files: 5
+
+### Review contract
+
+- Acceptance criteria:
+  1. A configured socket path reaches the configured PostgreSQL socket port in
+     both `DatabaseConfig.dsn` and `connection_kwargs()`.
+  2. Complete DSNs retain their precedence; non-socket split settings retain
+     existing TCP kwargs.
+  3. `DatabasePool` and fixed `./ops db inspect` inherit the corrected path
+     because both already call `connection_kwargs()`.
+  4. The operational procedure authenticates the specific service OS account
+     as `atlas` over the Unix socket before removing loopback `trust`, retains
+     `postgres` peer recovery, and has a rollback order.
+  5. The migration runbook accurately distinguishes raw forensic output from
+     attested admission without changing runner behavior.
+- Reachability proof: `atlas_brain/storage/database.py` initializes the pool
+  and raw connections from `db_settings.connection_kwargs()`; `ops` creates
+  `DatabaseConfig(_env_file=None)` and passes those kwargs to its fixed asyncpg
+  inspection. Direct maintenance scripts that call `db_settings.dsn` receive
+  the corrected socket port as well.
+- Boundary-change enumeration:
+  - `socket_path=None` continues to produce TCP host/port kwargs.
+  - `connection_string` continues to win over split socket/TCP settings.
+  - `socket_path` replaces only the host, retaining the configured port needed
+    to select PostgreSQL's socket filename.
+  - Cutover order is peer proof before removal of any trust rule; rollback
+    restores saved HBA/ident/config state before restarting the application.
+
+### Files touched
+
+- `.agent/runbooks/database.md`
+- `atlas_brain/storage/config.py`
+- `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`
+- `plans/PR-Postgres-Loopback-Scram-Hardening.md`
+- `tests/test_eom_render_profile.py`
+
+## Mechanism
+
+`DatabaseConfig` already owns the socket-path setting. Its split connection
+path will consistently translate it into the asyncpg socket host plus the
+configured port. No password is added: the post-merge server-side identity map
+lets the `atlas-api` OS user authenticate as the existing `atlas` role with
+peer authentication. The socket setting is a non-secret shared application
+configuration value, which `atlas-api` and `./ops` already read.
+
+The HBA sequence is staged. The exact `pg_ident.conf` mapping and specific HBA
+rule are added and proved while current TCP rules remain available. Only after
+the service genuinely uses the socket do all IPv4/IPv6 loopback TCP `trust`
+rules change to `scram-sha-256`. This removes uncredentialed cross-user local
+impersonation without a plaintext credential mechanism.
+
+The migration-runbook change is documentation only. Raw discrepancies stay
+visible and retain the existing forensic nonzero status; the document now
+describes the runner's actual pending-admission condition.
+
+## Intentional
+
+- Raw migration mismatch/error logging and preflight exit semantics remain
+  unchanged.
+- `ops` source code remains unchanged: it already carries
+  `ATLAS_DB_SOCKET_PATH` to the fixed inspection child.
+- Existing app database role, database ownership, and non-loopback access
+  remain unchanged.
+- The endpoint-level CRM read is production verification, not a new feature.
+
+## Deferred
+
+- Least-privilege database-role redesign (separate application ownership,
+  migration DDL, and inspection authority).
+- Refactoring historical maintenance scripts into a supported operations runner.
+- Cross-host PostgreSQL authentication policy and TLS posture.
+
+Parking predicate: role topology, maintenance-script ownership, or non-local
+database access gets a new slice only when it blocks a future capability. None
+blocks the socket-peer path.
+
+## Verification
+
+- Pending before push: `./ops test focused tests/test_eom_render_profile.py -q
+  -k 'database_config'`.
+- Pending before push: `bash scripts/check_ascii_python.sh`.
+- Pending before push: `git diff --check`.
+- Pending before push: `python scripts/sync_pr_plan.py
+  plans/PR-Postgres-Loopback-Scram-Hardening.md --check`.
+- Pending before push: cold diff / contract audit and normal PR mechanical
+  review helpers.
+- Post-merge: follow the exact peer-socket cutover/rollback procedure in
+  `.agent/runbooks/database.md`; GitHub Actions remains the complete unit gate.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.agent/runbooks/database.md` | 147 |
+| `atlas_brain/storage/config.py` | 7 |
+| `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` | 10 |
+| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 203 |
+| `tests/test_eom_render_profile.py` | 31 |
+| **Total** | **398** |

--- a/plans/PR-Postgres-Loopback-Scram-Hardening.md
+++ b/plans/PR-Postgres-Loopback-Scram-Hardening.md
@@ -33,9 +33,9 @@ leave its restart procedure with contradictory integrity instructions.
 - A bare fixed inspection can select a worktree `.env` instead of the
   service's `EnvironmentFiles`, even when the worktree omits database keys.
 - The cutover rollback assumes that it created `ATLAS_DB_SOCKET_PATH`, but a
-  pre-existing assignment in any selected service file has no baseline receipt;
-  deleting or overriding it during rollback could change the service's original
-  connection path.
+  pre-existing case-variant assignment in any selected service file has no
+  baseline receipt; deleting or overriding it during rollback could change the
+  service's original connection path.
 - `DatabaseConfig` resolves environment names case-insensitively, but `ops`
   previously removed only a subset of canonical uppercase database keys. A
   lower- or mixed-case inherited alias for any setting the inspector consumes
@@ -80,9 +80,10 @@ leave its restart procedure with contradictory integrity instructions.
    inspection must explicitly select the ordered `atlas-api.service`
    `EnvironmentFiles` while the helper clears every exact-uppercase
    `ATLAS_DB_*` override and `ops` excludes every lower/mixed-case variant. It
-   must reject a pre-existing `ATLAS_DB_SOCKET_PATH` in every selected service
-   file before adding its single reversible assignment, and a static regression
-   must pin the helper's unset set to every `DatabaseConfig` field.
+   must reject a pre-existing case-variant `ATLAS_DB_SOCKET_PATH` in every
+   selected service file before adding its single reversible assignment, and
+   regressions must pin the helper's unset set to every `DatabaseConfig` field
+   and its precondition's positive/negative matching boundaries.
 4. Correct `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` to require matching,
    currently attested evidence for every raw mismatch **and** missing-source
    item while preserving the raw report and its forensic nonzero exit.
@@ -202,9 +203,10 @@ Max files: 7
     before it constructs `DatabaseConfig`; exact-uppercase runtime keys preserve
     the generic documented override behavior, while the service-pinned helper
     explicitly unsets all of them before its proof.
-  - A pre-existing socket-path assignment in any selected service file is a
-    stop condition; this cutover adds exactly one new assignment only after the
-    absence precondition, so rollback never rewrites an earlier configuration.
+  - A pre-existing case-variant socket-path assignment in any selected service
+    file is a stop condition; this cutover adds exactly one new assignment only
+    after the absence precondition, so rollback never rewrites an earlier
+    configuration.
   - The cutover reconciles every client observed in both initial and final
     loopback TCP/replication inventories to a Unix-socket or verified-SCRAM
     receipt, requires no remaining final client, and requires an exact loaded
@@ -254,11 +256,11 @@ Max files: 7
   stops fixed inspection and HBA mutation, the safer side over inspecting or
   changing a guessed database target.
 - **Pre-existing socket-path assignments — CLOSED / DERIVED before cutover.**
-  Membership is every assignment matching `ATLAS_DB_SOCKET_PATH` in the ordered
-  selected `EnvironmentFiles`. The only admitted set is empty; unreadable files
-  or any empty, different, or matching-value assignment stop before editing.
-  The safe default is a separate configuration migration with an exact baseline
-  receipt, not an implicit overwrite or rollback rewrite.
+  Membership is every case-variant assignment matching `ATLAS_DB_SOCKET_PATH`
+  in the ordered selected `EnvironmentFiles`. The only admitted set is empty;
+  unreadable files or any empty, different, or matching-value assignment stop
+  before editing. The safe default is a separate configuration migration with
+  an exact baseline receipt, not an implicit overwrite or rollback rewrite.
 - **Database environment-key aliases — CLOSED / DERIVED for fixed inspection.**
   Membership is every canonical `ATLAS_DB_*` setting consumed by
   `DatabaseConfig`, listed as `DATABASE_CONFIG_KEYS` in `ops`; its case-folded
@@ -328,17 +330,19 @@ blocks the socket-peer path.
   database_file_context_honors_explicit_override_order'` — 2 passed, 39
   deselected (local).
 - `./ops test focused tests/test_agent_operations_contract.py -q -k
-  'database_runtime_environment or service_db_inspect'` — 4 passed, 40
+  'database_runtime_environment or service_db_inspect'` — 9 passed, 40
   deselected (local); proves the canonical override, case-variant rejection,
-  complete key-set closure, and the service-helper unset-set closure.
-- `./ops test focused tests/test_agent_operations_contract.py -q` — 44 passed
+  complete key-set closure, the service-helper unset-set closure, and the
+  socket precondition's case-variant/near-miss boundary.
+- `./ops test focused tests/test_agent_operations_contract.py -q` — 49 passed
   (local).
 - `bash scripts/check_ascii_python.sh` — passed (local).
-- `service_db_inspect` shell block extracted from
+- `service_db_inspect` and the pre-existing-socket guard blocks extracted from
   `.agent/runbooks/database.md` and checked with `bash -n` — passed (local).
 - `git diff --check` — passed (local).
 - `python scripts/sync_pr_plan.py
-  plans/PR-Postgres-Loopback-Scram-Hardening.md --check` — passed (local).
+  plans/PR-Postgres-Loopback-Scram-Hardening.md origin/main --check` — passed
+  (local).
 - `python scripts/audit_pr_body.py --base-ref origin/main
   tmp/pr-body-postgres-loopback-peer-hardening.md` and the reconciliation/fix
   loop auditors — passed (local).
@@ -360,10 +364,10 @@ blocks the socket-peer path.
 | `atlas_brain/storage/config.py` | 11 |
 | `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` | 20 |
 | `ops` | 15 |
-| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 371 |
-| `tests/test_agent_operations_contract.py` | 63 |
+| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 375 |
+| `tests/test_agent_operations_contract.py` | 95 |
 | `tests/test_eom_render_profile.py` | 61 |
-| **Total** | **974** |
+| **Total** | **1010** |
 
 ## Diff budget
 

--- a/plans/PR-Postgres-Loopback-Scram-Hardening.md
+++ b/plans/PR-Postgres-Loopback-Scram-Hardening.md
@@ -306,7 +306,9 @@ Max files: 7
   use a separate configuration migration with an exact baseline receipt.
 - **Peer-HBA precedence — CLOSED / DERIVED before socket configuration.**
   Membership is the ordered loaded `local` HBA rows preceding the exact
-  `atlas | atlas | peer | map=atlas_app` row. The receipt admits exactly one
+  `atlas | atlas | peer | map=atlas_app` row, ordered by
+  `pg_hba_file_rules.rule_number` rather than source-local `line_number`. The
+  receipt admits exactly one
   intended row and only the `all | postgres | peer` recovery row before it;
   every other preceding local rule stops the cutover for a separate HBA-policy
   migration.
@@ -418,14 +420,14 @@ blocks the socket-peer path.
 
 | File | LOC |
 |---|---:|
-| `.agent/runbooks/database.md` | 508 |
+| `.agent/runbooks/database.md` | 509 |
 | `atlas_brain/storage/config.py` | 11 |
 | `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` | 20 |
 | `ops` | 15 |
-| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 433 |
-| `tests/test_agent_operations_contract.py` | 290 |
+| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 435 |
+| `tests/test_agent_operations_contract.py` | 292 |
 | `tests/test_eom_render_profile.py` | 61 |
-| **Total** | **1338** |
+| **Total** | **1343** |
 
 ## Diff budget
 

--- a/plans/PR-Postgres-Loopback-Scram-Hardening.md
+++ b/plans/PR-Postgres-Loopback-Scram-Hardening.md
@@ -33,9 +33,9 @@ leave its restart procedure with contradictory integrity instructions.
 - A bare fixed inspection can select a worktree `.env` instead of the
   service's `EnvironmentFiles`, even when the worktree omits database keys.
 - `DatabaseConfig` resolves environment names case-insensitively, but `ops`
-  previously removed only canonical uppercase database keys. A lower- or
-  mixed-case inherited alias could therefore override the selected service
-  configuration in the inspector subprocess.
+  previously removed only a subset of canonical uppercase database keys. A
+  lower- or mixed-case inherited alias for any setting the inspector consumes
+  could therefore override the selected service configuration in its subprocess.
 - A socket target label omits its configured port even though the port selects
   the socket filename and the migration receipt confirms that label exactly.
 - A successful service or inspector connection is not socket proof while a
@@ -82,9 +82,9 @@ leave its restart procedure with contradictory integrity instructions.
 5. Exclude the unviable encrypted-credential experiment from this PR; it would
    require an unsupported plaintext-secret fallback.
 6. Update `ops` to admit only canonical uppercase runtime database overrides,
-   remove every case-insensitive known-database-key alias before its inspection
-   child constructs `DatabaseConfig`, and add a regression that proves the
-   selected service file wins in that child.
+   remove every case-insensitive alias for every `DatabaseConfig` setting before
+   its inspection child constructs that configuration, and add a regression that
+   proves the selected service file wins for both target and timeout settings.
 
 #### Explicit non-scope
 
@@ -114,7 +114,8 @@ leave its restart procedure with contradictory integrity instructions.
 - Adjacent configuration-context regression: a worktree file remains the
   default inspector context, while an ordered `ATLAS_OPS_ENV_FILES` override
   selects the intended service configuration and lower/mixed-case inherited
-  database aliases cannot supersede it in the inspection child.
+  aliases for every consumed database setting cannot supersede it in the
+  inspection child.
 - Cheap local gates: focused test target, `bash scripts/check_ascii_python.sh`,
   `git diff --check`, and `python scripts/sync_pr_plan.py ... --check`.
 - GitHub remains the complete unit gate.
@@ -185,9 +186,9 @@ Max files: 7
   - The socket target label includes that port, so confirmation cannot conflate
     same-directory, same-database clusters on distinct ports.
   - The fixed inspector uses only the service `EnvironmentFiles`, in service
-    order, and removes every case variant of known `ATLAS_DB_*` values before
-    it constructs `DatabaseConfig`; exact-uppercase runtime keys preserve the
-    documented override behavior.
+    order, and removes every case variant of every consumed `ATLAS_DB_*` value
+    before it constructs `DatabaseConfig`; exact-uppercase runtime keys preserve
+    the documented override behavior.
   - The cutover reconciles every client observed in both initial and final
     loopback TCP/replication inventories to a Unix-socket or verified-SCRAM
     receipt, requires no remaining final client, and requires an exact loaded
@@ -237,12 +238,13 @@ Max files: 7
   stops fixed inspection and HBA mutation, the safer side over inspecting or
   changing a guessed database target.
 - **Database environment-key aliases — CLOSED / DERIVED for fixed inspection.**
-  Membership is the canonical `DATABASE_CONFIG_KEYS` set in `ops`; its
-  case-folded form is derived from that set. An exact-uppercase environment key
-  is the only inherited database override admitted. Every lower- or mixed-case
-  matching alias is removed before `DatabaseConfig` loads the child environment,
-  while unrelated keys remain unchanged; this fails closed against inspecting a
-  shadowed target.
+  Membership is every canonical `ATLAS_DB_*` setting consumed by
+  `DatabaseConfig`, listed as `DATABASE_CONFIG_KEYS` in `ops`; its case-folded
+  form is derived from that set. An exact-uppercase environment key is the only
+  inherited database override admitted. Every lower- or mixed-case matching
+  alias is removed before `DatabaseConfig` loads the child environment, while
+  unrelated keys remain unchanged; this fails closed against inspecting a
+  shadowed target or applying a shadowed timeout.
 
 ### Files touched
 
@@ -327,11 +329,11 @@ blocks the socket-peer path.
 | `.agent/runbooks/database.md` | 401 |
 | `atlas_brain/storage/config.py` | 11 |
 | `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` | 20 |
-| `ops` | 10 |
-| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 339 |
-| `tests/test_agent_operations_contract.py` | 36 |
+| `ops` | 15 |
+| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 341 |
+| `tests/test_agent_operations_contract.py` | 42 |
 | `tests/test_eom_render_profile.py` | 61 |
-| **Total** | **878** |
+| **Total** | **891** |
 
 ## Diff budget
 

--- a/plans/PR-Postgres-Loopback-Scram-Hardening.md
+++ b/plans/PR-Postgres-Loopback-Scram-Hardening.md
@@ -84,7 +84,9 @@ leave its restart procedure with contradictory integrity instructions.
 6. Update `ops` to admit only canonical uppercase runtime database overrides,
    remove every case-insensitive alias for every `DatabaseConfig` setting before
    its inspection child constructs that configuration, and add a regression that
-   proves the selected service file wins for both target and timeout settings.
+   proves the selected service file wins for both target and timeout settings,
+   plus a closure test that fails when a future `DatabaseConfig` field is not
+   added to that scrub set.
 
 #### Explicit non-scope
 
@@ -115,7 +117,8 @@ leave its restart procedure with contradictory integrity instructions.
   default inspector context, while an ordered `ATLAS_OPS_ENV_FILES` override
   selects the intended service configuration and lower/mixed-case inherited
   aliases for every consumed database setting cannot supersede it in the
-  inspection child.
+  inspection child; the `DATABASE_CONFIG_KEYS` set must exactly match the
+  current `DatabaseConfig` fields.
 - Cheap local gates: focused test target, `bash scripts/check_ascii_python.sh`,
   `git diff --check`, and `python scripts/sync_pr_plan.py ... --check`.
 - GitHub remains the complete unit gate.
@@ -244,7 +247,9 @@ Max files: 7
   inherited database override admitted. Every lower- or mixed-case matching
   alias is removed before `DatabaseConfig` loads the child environment, while
   unrelated keys remain unchanged; this fails closed against inspecting a
-  shadowed target or applying a shadowed timeout.
+  shadowed target or applying a shadowed timeout. A regression pins the
+  membership equality so a new `DatabaseConfig` field cannot silently escape
+  the scrub set.
 
 ### Files touched
 
@@ -303,8 +308,8 @@ blocks the socket-peer path.
   database_file_context_honors_explicit_override_order'` — 2 passed, 39
   deselected (local).
 - `./ops test focused tests/test_agent_operations_contract.py -q -k
-  'database_runtime_environment'` — 2 passed, 40 deselected (local); proves
-  both the canonical override and case-variant rejection boundaries.
+  'database_runtime_environment'` — 3 passed, 40 deselected (local); proves
+  the canonical override, case-variant rejection, and complete key-set closure.
 - `bash scripts/check_ascii_python.sh` — passed (local).
 - `git diff --check` — passed (local).
 - `python scripts/sync_pr_plan.py
@@ -330,10 +335,10 @@ blocks the socket-peer path.
 | `atlas_brain/storage/config.py` | 11 |
 | `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` | 20 |
 | `ops` | 15 |
-| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 341 |
-| `tests/test_agent_operations_contract.py` | 42 |
+| `plans/PR-Postgres-Loopback-Scram-Hardening.md` | 346 |
+| `tests/test_agent_operations_contract.py` | 50 |
 | `tests/test_eom_render_profile.py` | 61 |
-| **Total** | **891** |
+| **Total** | **904** |
 
 ## Diff budget
 

--- a/scripts/backfill_community_buying_stage_defaults.py
+++ b/scripts/backfill_community_buying_stage_defaults.py
@@ -61,13 +61,7 @@ def _should_downgrade(row: dict[str, Any]) -> bool:
 
 async def _run(limit: int, apply: bool) -> None:
     conn = await asyncpg.connect(
-        host=db_settings.host,
-        port=db_settings.port,
-        database=db_settings.database,
-        user=db_settings.user,
-        password=db_settings.password,
-        timeout=db_settings.connect_timeout,
-        command_timeout=60,
+        **db_settings.connection_kwargs(command_timeout=60),
     )
     try:
         rows = await conn.fetch(

--- a/scripts/eom_write_boundary_audit.py
+++ b/scripts/eom_write_boundary_audit.py
@@ -95,10 +95,12 @@ DEFAULT_REALERT_EVERY = 24  # hourly cadence -> re-alert once a day while open
 # below; libpq receives the filesystem path rather than a TCP hostname.
 DEFAULT_ATLAS_DSN = "postgresql://atlas@%2Fvar%2Frun%2Fpostgresql:5433/atlas"
 
-# `psql_environment` must make the URI, rather than an inherited service-manager
-# setting, authoritative for the monitor's database target.  Clear every libpq
-# setting, then add back only values parsed from the monitor's DSN; this avoids
-# leaving an unenumerated selector such as PGHOSTADDR or PGSERVICE in effect.
+# The source-owned default must make its URI, rather than an inherited
+# service-manager setting, authoritative for the monitor's database target.
+# It clears every libpq setting before adding back only DSN-derived values, so
+# an unenumerated selector such as PGHOSTADDR or PGSERVICE cannot take effect.
+# Explicit owner-provided DSNs deliberately retain their inherited libpq/TLS
+# configuration.
 
 @dataclass(frozen=True)
 class Signal:
@@ -165,20 +167,32 @@ SELECT
 """
 
 
-def psql_environment(dsn: str) -> dict[str, str]:
+def psql_environment(
+    dsn: str,
+    *,
+    source_owned_default: bool = False,
+) -> dict[str, str]:
     """Connection settings for a psql subprocess, passed by environment.
 
     Never as an argument: /proc/<pid>/cmdline is world-readable on this
     deployment, so a DSN in argv hands the database password to any local
     account for the life of the process. /proc/<pid>/environ is readable only
     by the owner, which is why libpq supports these variables at all.
+
+    The source-owned default must not inherit a user-manager libpq target such
+    as ``PGHOSTADDR`` or ``PGSERVICE``. Explicit owner-provided DSNs retain the
+    monitor's previous libpq behavior, including TLS certificate inputs that
+    are intentionally not encoded in a URI.
     """
     parsed = urlsplit(dsn)
-    env = {
-        key: value
-        for key, value in os.environ.items()
-        if not key.startswith("PG")
-    }
+    if source_owned_default:
+        env = {
+            key: value
+            for key, value in os.environ.items()
+            if not key.startswith("PG")
+        }
+    else:
+        env = dict(os.environ)
     if parsed.username:
         env["PGUSER"] = unquote(parsed.username)
     if parsed.password:
@@ -255,10 +269,15 @@ def _parse_counts(raw: str, expected: int) -> tuple[list[int] | None, str | None
     return counts, None
 
 
-def query_atlas(psql_bin: str, dsn: str) -> tuple[list[int] | None, str | None]:
+def query_atlas(
+    psql_bin: str,
+    dsn: str,
+    *,
+    source_owned_default: bool = False,
+) -> tuple[list[int] | None, str | None]:
     raw, error = _run(
         [psql_bin, "-A", "-t", "-F", "|", "-v", "ON_ERROR_STOP=1", "-c", _atlas_sql()],
-        env=psql_environment(dsn),
+        env=psql_environment(dsn, source_owned_default=source_owned_default),
     )
     if error:
         return None, error
@@ -425,10 +444,7 @@ def publish(ntfy_url: str, topic: str, title: str, body: str, priority: str, tag
 
 def main(argv: Sequence[str] | None = None, *, notifier: Callable[..., None] = publish) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "--atlas-dsn",
-        default=os.environ.get("ATLAS_EOM_AUDIT_ATLAS_DSN", DEFAULT_ATLAS_DSN),
-    )
+    parser.add_argument("--atlas-dsn")
     parser.add_argument("--psql-bin", default=os.environ.get("ATLAS_EOM_AUDIT_PSQL_BIN", "psql"))
     parser.add_argument("--state-dir", default=os.environ.get("ATLAS_EOM_AUDIT_STATE_DIR", str(DEFAULT_STATE_DIR)))
     parser.add_argument("--ntfy-url", default=os.environ.get("ATLAS_EOM_AUDIT_NTFY_URL", DEFAULT_NTFY_URL))
@@ -436,6 +452,11 @@ def main(argv: Sequence[str] | None = None, *, notifier: Callable[..., None] = p
     parser.add_argument("--realert-every", type=int, default=int(os.environ.get("ATLAS_EOM_AUDIT_REALERT_EVERY", DEFAULT_REALERT_EVERY)))
     parser.add_argument("--no-alert", action="store_true", help="measure and print without notifying")
     args = parser.parse_args(argv)
+    configured_dsn = args.atlas_dsn
+    if configured_dsn is None and "ATLAS_EOM_AUDIT_ATLAS_DSN" in os.environ:
+        configured_dsn = os.environ["ATLAS_EOM_AUDIT_ATLAS_DSN"]
+    source_owned_default = configured_dsn is None
+    args.atlas_dsn = DEFAULT_ATLAS_DSN if source_owned_default else configured_dsn
     validate_settings(args.realert_every, args.ntfy_topic)
 
     state_path = Path(args.state_dir) / "state.json"
@@ -457,7 +478,13 @@ def main(argv: Sequence[str] | None = None, *, notifier: Callable[..., None] = p
         # measure breach and publish first -- and A would afterwards take the
         # lock and overwrite the state with its stale clean reading, cancelling
         # the alert that had already gone out.
-        result = build_signals(query_atlas(args.psql_bin, args.atlas_dsn))
+        result = build_signals(
+            query_atlas(
+                args.psql_bin,
+                args.atlas_dsn,
+                source_owned_default=source_owned_default,
+            )
+        )
         print(result.report())
         return _decide_and_notify(args, result, state_path, notifier)
 

--- a/scripts/eom_write_boundary_audit.py
+++ b/scripts/eom_write_boundary_audit.py
@@ -89,7 +89,16 @@ DEFAULT_NTFY_TOPIC = ""
 DEFAULT_NTFY_URL = "https://ntfy.sh"
 DEFAULT_REALERT_EVERY = 24  # hourly cadence -> re-alert once a day while open
 
+# The monitor is an independent scheduled client.  It must keep a passwordless
+# route when the production cutover replaces loopback TCP trust with SCRAM.
+# PostgreSQL URI socket hosts are percent-encoded, then decoded into PGHOST
+# below; libpq receives the filesystem path rather than a TCP hostname.
+DEFAULT_ATLAS_DSN = "postgresql://atlas@%2Fvar%2Frun%2Fpostgresql:5433/atlas"
 
+# `psql_environment` must make the URI, rather than an inherited service-manager
+# setting, authoritative for the monitor's database target.  Clear every libpq
+# setting, then add back only values parsed from the monitor's DSN; this avoids
+# leaving an unenumerated selector such as PGHOSTADDR or PGSERVICE in effect.
 
 @dataclass(frozen=True)
 class Signal:
@@ -165,13 +174,17 @@ def psql_environment(dsn: str) -> dict[str, str]:
     by the owner, which is why libpq supports these variables at all.
     """
     parsed = urlsplit(dsn)
-    env = dict(os.environ)
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("PG")
+    }
     if parsed.username:
         env["PGUSER"] = unquote(parsed.username)
     if parsed.password:
         env["PGPASSWORD"] = unquote(parsed.password)
     if parsed.hostname:
-        env["PGHOST"] = parsed.hostname
+        env["PGHOST"] = unquote(parsed.hostname)
     if parsed.port:
         env["PGPORT"] = str(parsed.port)
     database = parsed.path.lstrip("/")
@@ -412,7 +425,10 @@ def publish(ntfy_url: str, topic: str, title: str, body: str, priority: str, tag
 
 def main(argv: Sequence[str] | None = None, *, notifier: Callable[..., None] = publish) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--atlas-dsn", default=os.environ.get("ATLAS_EOM_AUDIT_ATLAS_DSN", "postgresql://atlas:atlas@localhost:5433/atlas"))
+    parser.add_argument(
+        "--atlas-dsn",
+        default=os.environ.get("ATLAS_EOM_AUDIT_ATLAS_DSN", DEFAULT_ATLAS_DSN),
+    )
     parser.add_argument("--psql-bin", default=os.environ.get("ATLAS_EOM_AUDIT_PSQL_BIN", "psql"))
     parser.add_argument("--state-dir", default=os.environ.get("ATLAS_EOM_AUDIT_STATE_DIR", str(DEFAULT_STATE_DIR)))
     parser.add_argument("--ntfy-url", default=os.environ.get("ATLAS_EOM_AUDIT_NTFY_URL", DEFAULT_NTFY_URL))

--- a/scripts/rebuild_blog_charts.py
+++ b/scripts/rebuild_blog_charts.py
@@ -22,15 +22,25 @@ logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 logger = logging.getLogger(__name__)
 
 
+def _rebuild_pool_connection_kwargs(connection_kwargs: dict[str, object]) -> dict[str, object]:
+    """Keep the normalized target while preserving this script's pool defaults."""
+    return {
+        key: value
+        for key, value in connection_kwargs.items()
+        if key not in {"timeout", "command_timeout"}
+    }
+
+
 async def main(limit: int, dry_run: bool, topic_type_filter: str | None):
     from atlas_brain.storage.config import db_settings
 
     import asyncpg
 
+    pool_kwargs = _rebuild_pool_connection_kwargs(db_settings.connection_kwargs())
     pool = await asyncpg.create_pool(
         min_size=2,
         max_size=4,
-        **db_settings.connection_kwargs(),
+        **pool_kwargs,
     )
 
     from atlas_brain.autonomous.tasks.b2b_blog_post_generation import (

--- a/scripts/rebuild_blog_charts.py
+++ b/scripts/rebuild_blog_charts.py
@@ -28,13 +28,9 @@ async def main(limit: int, dry_run: bool, topic_type_filter: str | None):
     import asyncpg
 
     pool = await asyncpg.create_pool(
-        host=db_settings.host,
-        port=db_settings.port,
-        database=db_settings.database,
-        user=db_settings.user,
-        password=db_settings.password,
         min_size=2,
         max_size=4,
+        **db_settings.connection_kwargs(),
     )
 
     from atlas_brain.autonomous.tasks.b2b_blog_post_generation import (

--- a/tests/test_agent_operations_contract.py
+++ b/tests/test_agent_operations_contract.py
@@ -156,7 +156,7 @@ def test_runbook_admits_new_socket_configuration_before_hba_mutation() -> None:
 def test_runbook_admits_the_dormant_eom_audit_before_hba_mutation() -> None:
     runbook = (ROOT / ".agent/runbooks/database.md").read_text(encoding="utf-8")
 
-    admission = "eom_audit_require_socket_default || exit 1"
+    admission = "eom_audit_require_unit_contract || exit 1"
     first_hba_backup = (
         "sudo cp --preserve=mode,ownership,timestamps /etc/postgresql/16/main/pg_hba.conf"
     )
@@ -164,9 +164,11 @@ def test_runbook_admits_the_dormant_eom_audit_before_hba_mutation() -> None:
     assert runbook.count(admission) == 1
     assert runbook.index(admission) < runbook.index(first_hba_backup)
     assert "cmp -s \"$EOM_AUDIT_SOURCE\" \"$EOM_AUDIT_INSTALLED\"" in runbook
+    assert "eom_audit_stage_socket_source || {" in runbook
     assert "--property=EnvironmentFiles --value" in runbook
     assert "systemctl --user show-environment" in runbook
     assert "ATLAS_EOM_AUDIT_ATLAS_DSN=" in runbook
+    assert 'EOM_AUDIT_DRY_RUN_OUTPUT="$(env -u ATLAS_EOM_AUDIT_ATLAS_DSN' in runbook
     assert "--no-alert" in runbook
     assert "COULD NOT MEASURE" in runbook
     assert "0|2" in runbook
@@ -210,6 +212,22 @@ def _run_runbook_function(
     )
 
 
+def _eom_audit_systemctl_stub() -> str:
+    return (
+        "systemctl() {\n"
+        "  case \"$*\" in\n"
+        "    *'is-enabled --quiet'*) [ \"$EOM_AUDIT_TEST_TIMER_ENABLED\" = true ] ;;\n"
+        "    *'is-active --quiet'*) [ \"$EOM_AUDIT_TEST_TIMER_ACTIVE\" = true ] ;;\n"
+        "    *'--property=LoadState,ExecStart --value'*) printf '%s\\n' \"$EOM_AUDIT_TEST_EXEC_START\" ;;\n"
+        "    *'--property=EnvironmentFiles --value'*) printf '%s\\n' \"$EOM_AUDIT_TEST_ENVIRONMENT_FILES\" ;;\n"
+        "    *'--property=Environment --value'*) printf '%s\\n' \"$EOM_AUDIT_TEST_SERVICE_ENV\" ;;\n"
+        "    *show-environment*) printf '%s\\n' \"$EOM_AUDIT_TEST_MANAGER_ENV\" ;;\n"
+        "    *) return 97 ;;\n"
+        "  esac\n"
+        "}"
+    )
+
+
 @pytest.mark.parametrize(
     ("effective_is_selected", "expected_returncode"),
     ((True, 0), (False, 1)),
@@ -243,45 +261,82 @@ def test_service_db_effective_env_file_must_be_selected_before_cutover(
         "service_environment",
         "manager_environment",
         "environment_files",
-        "copies_match",
         "timer_enabled",
         "timer_active",
-        "exec_matches",
-        "expected_returncode",
+        "exec_variant",
+        "expected_error",
     ),
     (
-        ("", "", "", True, True, True, True, 0),
-        ("ATLAS_EOM_AUDIT_ATLAS_DSN=postgresql://tcp.example/atlas", "", "", True, True, True, True, 1),
-        ("", "ATLAS_EOM_AUDIT_ATLAS_DSN=postgresql://tcp.example/atlas", "", True, True, True, True, 1),
-        ("", "", "/secure/eom-audit.env", True, True, True, True, 1),
-        ("", "", "", False, True, True, True, 1),
-        ("", "", "", True, False, True, True, 1),
-        ("", "", "", True, True, False, True, 1),
-        ("", "", "", True, True, True, False, 1),
+        ("", "", "", True, True, "exact", None),
+        (
+            "ATLAS_EOM_AUDIT_ATLAS_DSN=postgresql://tcp.example/atlas",
+            "",
+            "",
+            True,
+            True,
+            "exact",
+            "EOM audit DSN override found",
+        ),
+        (
+            "",
+            "ATLAS_EOM_AUDIT_ATLAS_DSN=postgresql://tcp.example/atlas",
+            "",
+            True,
+            True,
+            "exact",
+            "EOM audit DSN override found",
+        ),
+        ("", "", "/secure/eom-audit.env", True, True, "exact", "EnvironmentFile"),
+        ("", "", "", False, True, "exact", "not enabled and active"),
+        ("", "", "", True, False, "exact", "not enabled and active"),
+        ("", "", "", True, True, "atlas_dsn", "admitted target-free argv"),
+        ("", "", "", True, True, "psql_bin", "admitted target-free argv"),
+        ("", "", "", True, True, "multiple", "multiple effective commands"),
+        ("", "", "", True, True, "unparseable", "could not parse EOM audit service command"),
     ),
 )
-def test_dormant_eom_audit_admission_rejects_transport_overrides_and_stale_install(
+def test_dormant_eom_audit_admission_rejects_transport_overrides_and_extra_commands(
     tmp_path: Path,
     service_environment: str,
     manager_environment: str,
     environment_files: str,
-    copies_match: bool,
     timer_enabled: bool,
     timer_active: bool,
-    exec_matches: bool,
-    expected_returncode: int,
+    exec_variant: str,
+    expected_error: str | None,
 ) -> None:
     runbook = (ROOT / ".agent/runbooks/database.md").read_text(encoding="utf-8")
     source = tmp_path / "eom_write_boundary_audit.py"
     installed = tmp_path / "eom-write-boundary-audit.py"
     source.write_text("source\n", encoding="utf-8")
-    installed.write_text("source\n" if copies_match else "stale\n", encoding="utf-8")
+    installed.write_text("stale\n", encoding="utf-8")
+    canonical_argv = f"/usr/bin/python3 {installed}"
+    if exec_variant == "exact":
+        exec_start = f"{{ path=/usr/bin/python3 ; argv[]={canonical_argv} ; ignore_errors=no ; }}"
+    elif exec_variant == "atlas_dsn":
+        exec_start = (
+            "{ path=/usr/bin/python3 ; argv[]="
+            f"{canonical_argv} --atlas-dsn postgresql://tcp.example/atlas ; ignore_errors=no ; }}"
+        )
+    elif exec_variant == "psql_bin":
+        exec_start = (
+            "{ path=/usr/bin/python3 ; argv[]="
+            f"{canonical_argv} --psql-bin /tmp/psql ; ignore_errors=no ; }}"
+        )
+    elif exec_variant == "multiple":
+        exec_start = (
+            "{ path=/usr/bin/python3 ; argv[]="
+            f"{canonical_argv} ; argv[]=/usr/bin/true ; ignore_errors=no ; }}"
+        )
+    else:
+        assert exec_variant == "unparseable"
+        exec_start = f"loaded {installed}"
 
     result = _run_runbook_function(
         runbook,
         (
             "eom_audit_environment_has_dsn_override",
-            "eom_audit_require_socket_default",
+            "eom_audit_require_unit_contract",
         ),
         shell_stubs=(
             f"EOM_AUDIT_SOURCE={str(source)!r}",
@@ -293,30 +348,133 @@ def test_dormant_eom_audit_admission_rejects_transport_overrides_and_stale_insta
             f"EOM_AUDIT_TEST_ENVIRONMENT_FILES={environment_files!r}",
             f"EOM_AUDIT_TEST_TIMER_ENABLED={str(timer_enabled).lower()}",
             f"EOM_AUDIT_TEST_TIMER_ACTIVE={str(timer_active).lower()}",
-            f"EOM_AUDIT_TEST_EXEC_START={'loaded ' + str(installed) if exec_matches else 'loaded /other/eom-write-boundary-audit.py'!r}",
-            "systemctl() {\n"
-            "  case \"$*\" in\n"
-            "    *'is-enabled --quiet'*) [ \"$EOM_AUDIT_TEST_TIMER_ENABLED\" = true ] ;;\n"
-            "    *'is-active --quiet'*) [ \"$EOM_AUDIT_TEST_TIMER_ACTIVE\" = true ] ;;\n"
-            "    *'--property=LoadState,ExecStart --value'*) printf '%s\\n' \"$EOM_AUDIT_TEST_EXEC_START\" ;;\n"
-            "    *'--property=EnvironmentFiles --value'*) printf '%s\\n' \"$EOM_AUDIT_TEST_ENVIRONMENT_FILES\" ;;\n"
-            "    *'--property=Environment --value'*) printf '%s\\n' \"$EOM_AUDIT_TEST_SERVICE_ENV\" ;;\n"
-            "    *show-environment*) printf '%s\\n' \"$EOM_AUDIT_TEST_MANAGER_ENV\" ;;\n"
-            "    *) return 97 ;;\n"
-            "  esac\n"
-            "}",
+            f"EOM_AUDIT_TEST_EXEC_START={exec_start!r}",
+            _eom_audit_systemctl_stub(),
+        ),
+    )
+
+    assert result.returncode == (0 if expected_error is None else 1)
+    if expected_error is not None:
+        assert expected_error in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("installed_content", "expected_returncode"),
+    (("source\n", 0), ("stale\n", 1)),
+)
+def test_eom_audit_socket_default_requires_the_staged_source(
+    tmp_path: Path,
+    installed_content: str,
+    expected_returncode: int,
+) -> None:
+    runbook = (ROOT / ".agent/runbooks/database.md").read_text(encoding="utf-8")
+    source = tmp_path / "eom_write_boundary_audit.py"
+    installed = tmp_path / "eom-write-boundary-audit.py"
+    source.write_text("source\n", encoding="utf-8")
+    installed.write_text(installed_content, encoding="utf-8")
+    exec_start = (
+        "{ path=/usr/bin/python3 ; argv[]="
+        f"/usr/bin/python3 {installed} ; ignore_errors=no ; }}"
+    )
+
+    result = _run_runbook_function(
+        runbook,
+        (
+            "eom_audit_environment_has_dsn_override",
+            "eom_audit_require_unit_contract",
+            "eom_audit_require_socket_default",
+        ),
+        shell_stubs=(
+            f"EOM_AUDIT_SOURCE={str(source)!r}",
+            f"EOM_AUDIT_INSTALLED={str(installed)!r}",
+            "EOM_AUDIT_SERVICE='eom-write-boundary-audit.service'",
+            "EOM_AUDIT_TIMER='eom-write-boundary-audit.timer'",
+            "EOM_AUDIT_TEST_SERVICE_ENV=''",
+            "EOM_AUDIT_TEST_MANAGER_ENV=''",
+            "EOM_AUDIT_TEST_ENVIRONMENT_FILES=''",
+            "EOM_AUDIT_TEST_TIMER_ENABLED=true",
+            "EOM_AUDIT_TEST_TIMER_ACTIVE=true",
+            f"EOM_AUDIT_TEST_EXEC_START={exec_start!r}",
+            _eom_audit_systemctl_stub(),
         ),
     )
 
     assert result.returncode == expected_returncode
     if expected_returncode:
-        assert (
-            "EOM audit DSN override found" in result.stderr
-            or "EOM audit service uses an EnvironmentFile" in result.stderr
-            or "installed EOM audit script does not match deployed source" in result.stderr
-            or "EOM audit timer is not enabled and active" in result.stderr
-            or "EOM audit service does not execute the admitted installed script" in result.stderr
-        )
+        assert "stage it after peer authentication" in result.stderr
+
+
+def test_eom_audit_source_stage_and_rollback_restore_the_pre_peer_copy(
+    tmp_path: Path,
+) -> None:
+    runbook = (ROOT / ".agent/runbooks/database.md").read_text(encoding="utf-8")
+    source = tmp_path / "eom_write_boundary_audit.py"
+    installed = tmp_path / "eom-write-boundary-audit.py"
+    backup = tmp_path / "eom-write-boundary-audit.py.pre-atlas-peer"
+    source.write_text("socket-default\n", encoding="utf-8")
+    installed.write_text("pre-peer\n", encoding="utf-8")
+    exec_start = (
+        "{ path=/usr/bin/python3 ; argv[]="
+        f"/usr/bin/python3 {installed} ; ignore_errors=no ; }}"
+    )
+    shell_stubs = (
+        f"EOM_AUDIT_SOURCE={str(source)!r}",
+        f"EOM_AUDIT_INSTALLED={str(installed)!r}",
+        f"EOM_AUDIT_PRE_PEER_SOURCE={str(backup)!r}",
+        "EOM_AUDIT_SERVICE='eom-write-boundary-audit.service'",
+        "EOM_AUDIT_TIMER='eom-write-boundary-audit.timer'",
+        "EOM_AUDIT_TEST_SERVICE_ENV=''",
+        "EOM_AUDIT_TEST_MANAGER_ENV=''",
+        "EOM_AUDIT_TEST_ENVIRONMENT_FILES=''",
+        "EOM_AUDIT_TEST_TIMER_ENABLED=true",
+        "EOM_AUDIT_TEST_TIMER_ACTIVE=true",
+        f"EOM_AUDIT_TEST_EXEC_START={exec_start!r}",
+        _eom_audit_systemctl_stub(),
+    )
+
+    stage = _run_runbook_function(
+        runbook,
+        (
+            "eom_audit_environment_has_dsn_override",
+            "eom_audit_require_unit_contract",
+            "eom_audit_require_socket_default",
+            "eom_audit_stage_socket_source",
+        ),
+        shell_stubs=shell_stubs,
+    )
+
+    assert stage.returncode == 0, stage.stderr
+    assert installed.read_text(encoding="utf-8") == "socket-default\n"
+    assert backup.read_text(encoding="utf-8") == "pre-peer\n"
+
+    restore = _run_runbook_function(
+        runbook,
+        ("eom_audit_restore_pre_peer_source",),
+        shell_stubs=(
+            f"EOM_AUDIT_INSTALLED={str(installed)!r}",
+            f"EOM_AUDIT_PRE_PEER_SOURCE={str(backup)!r}",
+        ),
+    )
+
+    assert restore.returncode == 0, restore.stderr
+    assert installed.read_text(encoding="utf-8") == "pre-peer\n"
+
+
+def test_runbook_stages_and_restores_the_audit_source_on_the_peer_side_of_cutover() -> None:
+    runbook = (ROOT / ".agent/runbooks/database.md").read_text(encoding="utf-8")
+    peer_receipt = "The final query must return `0|1|1|0|1|0`"
+    stage = "eom_audit_stage_socket_source || {"
+    rollback = runbook.split("rollback_peer_cutover() {", maxsplit=1)[1].split(
+        "\n   }", maxsplit=1
+    )[0]
+
+    assert runbook.index(peer_receipt) < runbook.index(stage)
+    assert runbook.index(stage) < runbook.index(
+        "systemctl --user restart atlas-api.service", runbook.index(stage)
+    )
+    assert rollback.index("eom_audit_restore_pre_peer_source || return 1") < rollback.index(
+        "sudo cp --preserve=mode,ownership,timestamps /etc/postgresql/16/main/pg_hba.conf.pre-atlas-peer"
+    )
 
 
 @pytest.mark.parametrize(
@@ -497,6 +655,7 @@ def test_rollback_refuses_a_surviving_socket_assignment_before_hba_restore(
             "service_db_require_canonical_keys",
             "service_db_require_no_socket_assignments",
             "service_db_require_effective_env_file",
+            "eom_audit_restore_pre_peer_source",
             "rollback_peer_cutover",
         ),
         service_env_files=str(env_file),
@@ -526,6 +685,7 @@ def test_rollback_refuses_an_hba_source_mismatch_before_service_restart(
             "service_db_require_canonical_keys",
             "service_db_require_no_socket_assignments",
             "service_db_require_effective_env_file",
+            "eom_audit_restore_pre_peer_source",
             "rollback_peer_cutover",
         ),
         service_env_files=str(env_file),

--- a/tests/test_agent_operations_contract.py
+++ b/tests/test_agent_operations_contract.py
@@ -94,7 +94,9 @@ def test_peer_hba_receipt_requires_the_intended_first_applicable_rule() -> None:
     assert "database = ARRAY['atlas']::text[]" in runbook
     assert "user_name = ARRAY['atlas']::text[]" in runbook
     assert "options = ARRAY['map=atlas_app']::text[]" in runbook
-    assert "ON rules.line_number < intended.line_number" in runbook
+    assert "SELECT rule_number" in runbook
+    assert "ON rules.rule_number < intended.rule_number" in runbook
+    assert "ON rules.line_number < intended.line_number" not in runbook
     assert "rules.user_name = ARRAY['postgres']::text[]" in runbook
     assert "0|1|1|0|1|0" in runbook
 

--- a/tests/test_agent_operations_contract.py
+++ b/tests/test_agent_operations_contract.py
@@ -123,6 +123,34 @@ def test_runbook_refuses_hba_sources_outside_the_backed_up_file() -> None:
     assert "loopback_rules_outside_backup" in runbook
 
 
+def test_runbook_defines_loopback_cte_in_each_final_hba_receipt() -> None:
+    runbook = (ROOT / ".agent/runbooks/database.md").read_text(encoding="utf-8")
+    final_receipts = runbook.split("4. Only after the socket-peer proof succeeds", 1)[1].split(
+        "The first query must return `4`", 1
+    )[0]
+
+    standalone_receipts = re.findall(
+        r'"WITH hba AS .*?FROM hba;"', final_receipts, flags=re.DOTALL
+    )
+
+    assert len(standalone_receipts) == 2
+    assert all("END AS covers_loopback" in receipt for receipt in standalone_receipts)
+    assert "loopback_rules_outside_backup" in standalone_receipts[1]
+
+
+def test_runbook_admits_new_socket_configuration_before_hba_mutation() -> None:
+    runbook = (ROOT / ".agent/runbooks/database.md").read_text(encoding="utf-8")
+
+    admission = "service_db_require_new_socket_configuration || exit 1"
+    first_hba_backup = (
+        "sudo cp --preserve=mode,ownership,timestamps /etc/postgresql/16/main/pg_hba.conf"
+    )
+
+    assert runbook.count(admission) == 1
+    assert runbook.index(admission) < runbook.index(first_hba_backup)
+    assert "nonblank ATLAS_DB_CONNECTION_STRING assignment found" in runbook
+
+
 def _run_runbook_function(
     runbook: str,
     function_names: tuple[str, ...],
@@ -271,6 +299,52 @@ def test_service_db_no_socket_guard_checks_every_selected_file(
     )
 
     assert result.returncode == expected_returncode
+
+
+@pytest.mark.parametrize(
+    ("assignment", "expected_returncode", "expected_stderr"),
+    (
+        ("ATLAS_DB_CONNECTION_STRING=\n", 0, ""),
+        ('ATLAS_DB_CONNECTION_STRING="" # intentionally empty\n', 0, ""),
+        ("ATLAS_DB_CONNECTION_STRING=''\n", 0, ""),
+        ("ATLAS_DB_CONNECTION_STRING= # intentionally empty\n", 0, ""),
+        (
+            "ATLAS_DB_CONNECTION_STRING=postgresql://db.example/atlas\n",
+            1,
+            "nonblank ATLAS_DB_CONNECTION_STRING assignment found",
+        ),
+        (
+            "ATLAS_DB_CONNECTION_STRING=${ATLAS_DATABASE_URL}\n",
+            1,
+            "nonblank ATLAS_DB_CONNECTION_STRING assignment found",
+        ),
+    ),
+)
+def test_new_socket_configuration_admission_rejects_nonempty_complete_dsn(
+    tmp_path: Path,
+    assignment: str,
+    expected_returncode: int,
+    expected_stderr: str,
+) -> None:
+    runbook = (ROOT / ".agent/runbooks/database.md").read_text(encoding="utf-8")
+    env_file = tmp_path / "atlas-api.env"
+    env_file.write_text(assignment, encoding="utf-8")
+
+    result = _run_runbook_function(
+        runbook,
+        (
+            "service_db_has_case_variant_key",
+            "service_db_has_socket_assignment",
+            "service_db_has_nonempty_connection_string_assignment",
+            "service_db_require_canonical_keys",
+            "service_db_require_no_socket_assignments",
+            "service_db_require_new_socket_configuration",
+        ),
+        service_env_files=str(env_file),
+    )
+
+    assert result.returncode == expected_returncode
+    assert expected_stderr in result.stderr
 
 
 def test_rollback_refuses_a_surviving_socket_assignment_before_hba_restore(

--- a/tests/test_agent_operations_contract.py
+++ b/tests/test_agent_operations_contract.py
@@ -160,6 +160,42 @@ def test_database_runtime_environment_overrides_dotenv(
     assert child_env["ATLAS_DB_HOST"] == "runtime.example"
 
 
+def test_database_runtime_environment_ignores_case_variant_database_overrides(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from atlas_brain.storage.config import DatabaseConfig
+
+    file_dsn = "postgresql://file.example:5433/atlas"
+    shadow_dsn = "postgresql://shadow.example:5433/shadow"
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        f"ATLAS_DB_CONNECTION_STRING={file_dsn}\nATLAS_DB_HOST=file.example\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("ATLAS_OPS_ENV_FILES", str(env_file))
+    monkeypatch.setenv("atlas_db_connection_string", shadow_dsn)
+    monkeypatch.setenv("AtLaS_Db_HoSt", "shadow.example")
+    for key in DATABASE_CONFIG_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+    child_env = database_runtime_environment()
+
+    assert child_env["ATLAS_DB_CONNECTION_STRING"] == file_dsn
+    assert child_env["ATLAS_DB_HOST"] == "file.example"
+    assert "atlas_db_connection_string" not in child_env
+    assert "AtLaS_Db_HoSt" not in child_env
+    with monkeypatch.context() as child_process:
+        for key in tuple(os.environ):
+            child_process.delenv(key, raising=False)
+        for key, value in child_env.items():
+            child_process.setenv(key, value)
+        application_config = DatabaseConfig(_env_file=None)
+
+    assert application_config.connection_string == file_dsn
+    assert application_config.host == "file.example"
+
+
 def test_database_file_context_prefers_worktree_over_shared_and_systemd(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_agent_operations_contract.py
+++ b/tests/test_agent_operations_contract.py
@@ -246,7 +246,11 @@ def test_service_db_effective_env_file_must_be_selected_before_cutover(
 
     result = _run_runbook_function(
         runbook,
-        ("service_db_require_effective_env_file",),
+        (
+            "service_db_has_case_variant_key",
+            "service_db_require_canonical_keys",
+            "service_db_require_effective_env_file",
+        ),
         service_env_files=str(selected_env_file),
         shell_stubs=(f"EFFECTIVE_DB_ENV_FILE={str(effective_env_file)!r}",),
     )
@@ -254,6 +258,60 @@ def test_service_db_effective_env_file_must_be_selected_before_cutover(
     assert result.returncode == expected_returncode
     if not effective_is_selected:
         assert "effective database environment file is not a service EnvironmentFile" in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("list_shape", "expected_error"),
+    (
+        ("valid", None),
+        ("trailing_empty", "service EnvironmentFile must be a nonempty absolute path"),
+        ("leading_empty", "service EnvironmentFile must be a nonempty absolute path"),
+        ("middle_empty", "service EnvironmentFile must be a nonempty absolute path"),
+        ("relative", "service EnvironmentFile must be a nonempty absolute path"),
+    ),
+)
+def test_service_db_effective_env_file_rejects_empty_or_relative_list_members(
+    tmp_path: Path,
+    list_shape: str,
+    expected_error: str | None,
+) -> None:
+    runbook = (ROOT / ".agent/runbooks/database.md").read_text(encoding="utf-8")
+    first = tmp_path / "first.env"
+    second = tmp_path / "second.env"
+    first.write_text("ATLAS_DB_HOST=first.example\n", encoding="utf-8")
+    second.write_text("ATLAS_DB_HOST=second.example\n", encoding="utf-8")
+
+    if list_shape == "valid":
+        service_env_files = str(first)
+        effective_env_file = str(first)
+    elif list_shape == "trailing_empty":
+        service_env_files = f"{first}:"
+        effective_env_file = ""
+    elif list_shape == "leading_empty":
+        service_env_files = f":{first}"
+        effective_env_file = str(first)
+    elif list_shape == "middle_empty":
+        service_env_files = f"{first}::{second}"
+        effective_env_file = str(second)
+    else:
+        assert list_shape == "relative"
+        service_env_files = "relative.env"
+        effective_env_file = "relative.env"
+
+    result = _run_runbook_function(
+        runbook,
+        (
+            "service_db_has_case_variant_key",
+            "service_db_require_canonical_keys",
+            "service_db_require_effective_env_file",
+        ),
+        service_env_files=service_env_files,
+        shell_stubs=(f"EFFECTIVE_DB_ENV_FILE={effective_env_file!r}",),
+    )
+
+    assert result.returncode == (0 if expected_error is None else 1)
+    if expected_error is not None:
+        assert expected_error in result.stderr
 
 
 @pytest.mark.parametrize(
@@ -745,6 +803,41 @@ def test_rollback_refuses_a_surviving_socket_assignment_before_hba_restore(
     assert result.returncode == 1
     assert "ATLAS_DB_SOCKET_PATH assignment remains" in result.stderr
     assert "unexpected env invocation" not in result.stderr
+
+
+def test_rollback_rejects_empty_environment_file_members_before_sudoedit(
+    tmp_path: Path,
+) -> None:
+    runbook = (ROOT / ".agent/runbooks/database.md").read_text(encoding="utf-8")
+    env_file = tmp_path / "atlas-api.env"
+    env_file.write_text("ATLAS_DB_HOST=canonical.example\n", encoding="utf-8")
+
+    result = _run_runbook_function(
+        runbook,
+        (
+            "service_db_has_case_variant_key",
+            "service_db_require_canonical_keys",
+            "service_db_require_effective_env_file",
+            "eom_audit_restore_pre_peer_source",
+            "rollback_peer_cutover",
+        ),
+        service_env_files=f"{env_file}:",
+        shell_stubs=(
+            "sudoedit() { printf '%s\\n' 'unexpected sudoedit' >&2; return 99; }",
+            (
+                "sudo() { "
+                "if [ \"$1\" = 'cp' ]; then printf '%s\\n' 'unexpected HBA restore' >&2; return 99; fi; "
+                "\"$@\"; "
+                "}"
+            ),
+            "EFFECTIVE_DB_ENV_FILE=''",
+        ),
+    )
+
+    assert result.returncode == 1
+    assert "service EnvironmentFile must be a nonempty absolute path" in result.stderr
+    assert "unexpected sudoedit" not in result.stderr
+    assert "unexpected HBA restore" not in result.stderr
 
 
 def test_rollback_refuses_an_hba_source_mismatch_before_service_restart(

--- a/tests/test_agent_operations_contract.py
+++ b/tests/test_agent_operations_contract.py
@@ -81,9 +81,10 @@ def test_service_db_inspect_clears_every_database_config_key() -> None:
     )
 
     assert cleared_keys == DATABASE_CONFIG_KEYS
-    assert "pre-existing ATLAS_DB_SOCKET_PATH found" in runbook
+    assert "ATLAS_DB_SOCKET_PATH assignment remains; do not continue" in runbook
     assert "sudo grep -Eqi" in runbook
     assert "service_db_require_canonical_keys || return 1" in helper
+    assert "service_db_require_no_socket_assignments || return 1" in runbook
 
 
 def _run_runbook_function(
@@ -92,6 +93,7 @@ def _run_runbook_function(
     *,
     argument: Path | None = None,
     service_env_files: str | None = None,
+    shell_stubs: tuple[str, ...] = (),
 ) -> subprocess.CompletedProcess[str]:
     functions = []
     for function_name in function_names:
@@ -108,6 +110,7 @@ def _run_runbook_function(
             f"SERVICE_ENV_FILES={service_env_files!r}"
             if service_env_files is not None
             else "",
+            *shell_stubs,
             call,
         )
     )
@@ -201,6 +204,68 @@ def test_service_db_inspect_preflight_controls_ops_invocation(
 
     assert result.returncode == expected_returncode
     assert expected_stderr in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("assignment", "expected_returncode"),
+    (
+        ("ATLAS_DB_HOST=canonical.example\n", 0),
+        ("ATLAS_DB_SOCKET_PATH = /var/run/postgresql\n", 1),
+        ("ATLAS_DB_SOCKET_PATH_BACKUP=/var/run/postgresql\n", 0),
+    ),
+)
+def test_service_db_no_socket_guard_checks_every_selected_file(
+    tmp_path: Path,
+    assignment: str,
+    expected_returncode: int,
+) -> None:
+    runbook = (ROOT / ".agent/runbooks/database.md").read_text(encoding="utf-8")
+    env_file = tmp_path / "atlas-api.env"
+    env_file.write_text(assignment, encoding="utf-8")
+
+    result = _run_runbook_function(
+        runbook,
+        (
+            "service_db_has_case_variant_key",
+            "service_db_has_socket_assignment",
+            "service_db_require_canonical_keys",
+            "service_db_require_no_socket_assignments",
+        ),
+        service_env_files=str(env_file),
+    )
+
+    assert result.returncode == expected_returncode
+
+
+def test_rollback_refuses_a_surviving_socket_assignment_before_hba_restore(
+    tmp_path: Path,
+) -> None:
+    runbook = (ROOT / ".agent/runbooks/database.md").read_text(encoding="utf-8")
+    env_file = tmp_path / "atlas-api.env"
+    env_file.write_text(
+        "ATLAS_DB_SOCKET_PATH = /var/run/postgresql\n",
+        encoding="utf-8",
+    )
+
+    result = _run_runbook_function(
+        runbook,
+        (
+            "service_db_has_case_variant_key",
+            "service_db_has_socket_assignment",
+            "service_db_require_canonical_keys",
+            "service_db_require_no_socket_assignments",
+            "rollback_peer_cutover",
+        ),
+        service_env_files=str(env_file),
+        shell_stubs=(
+            "sudoedit() { return 0; }",
+            f"EFFECTIVE_DB_ENV_FILE={str(env_file)!r}",
+        ),
+    )
+
+    assert result.returncode == 1
+    assert "ATLAS_DB_SOCKET_PATH assignment remains" in result.stderr
+    assert "unexpected env invocation" not in result.stderr
 
 
 @pytest.mark.parametrize(

--- a/tests/test_agent_operations_contract.py
+++ b/tests/test_agent_operations_contract.py
@@ -101,6 +101,28 @@ def test_peer_hba_receipt_requires_the_intended_first_applicable_rule() -> None:
     assert "0|1|1|0|1|0" in runbook
 
 
+def test_runbook_requires_all_qualifying_atlas_backends_to_use_the_socket() -> None:
+    runbook = (ROOT / ".agent/runbooks/database.md").read_text(encoding="utf-8")
+
+    assert "WITH atlas_backends AS" in runbook
+    assert "CASE WHEN count(*) > 0 THEN 1 ELSE 0 END" in runbook
+    assert "count(*) FILTER (WHERE client_addr IS NULL) = count(*)" in runbook
+    assert "The immediate transport receipt must return `1|1`" in runbook
+    assert "At least one backend with a `backend_start`" not in runbook
+
+
+def test_runbook_refuses_hba_sources_outside_the_backed_up_file() -> None:
+    runbook = (ROOT / ".agent/runbooks/database.md").read_text(encoding="utf-8")
+
+    top_level_hba = "/etc/postgresql/16/main/pg_hba.conf"
+    assert "SELECT rule_number, file_name, line_number, type" in runbook
+    assert f"file_name IS DISTINCT FROM '{top_level_hba}'" in runbook
+    assert "trust HBA source receipt was not 4|0|0" in runbook
+    assert "restored HBA receipt was not 4|0|0" in runbook
+    assert "1|1|1|1|0|0|0|0" in runbook
+    assert "loopback_rules_outside_backup" in runbook
+
+
 def _run_runbook_function(
     runbook: str,
     function_names: tuple[str, ...],
@@ -280,6 +302,42 @@ def test_rollback_refuses_a_surviving_socket_assignment_before_hba_restore(
     assert result.returncode == 1
     assert "ATLAS_DB_SOCKET_PATH assignment remains" in result.stderr
     assert "unexpected env invocation" not in result.stderr
+
+
+def test_rollback_refuses_an_hba_source_mismatch_before_service_restart(
+    tmp_path: Path,
+) -> None:
+    runbook = (ROOT / ".agent/runbooks/database.md").read_text(encoding="utf-8")
+    env_file = tmp_path / "atlas-api.env"
+    env_file.write_text("ATLAS_DB_HOST=canonical.example\n", encoding="utf-8")
+
+    result = _run_runbook_function(
+        runbook,
+        (
+            "service_db_has_case_variant_key",
+            "service_db_has_socket_assignment",
+            "service_db_require_canonical_keys",
+            "service_db_require_no_socket_assignments",
+            "rollback_peer_cutover",
+        ),
+        service_env_files=str(env_file),
+        shell_stubs=(
+            "sudoedit() { return 0; }",
+            (
+                "sudo() { "
+                "if [ \"$1\" = '-u' ]; then printf '%s\\n' '4|1|0'; return 0; fi; "
+                "if [ \"$1\" = 'cp' ] || [ \"$1\" = 'systemctl' ]; then return 0; fi; "
+                "\"$@\"; "
+                "}"
+            ),
+            "systemctl() { printf '%s\\n' 'unexpected user restart' >&2; return 99; }",
+            f"EFFECTIVE_DB_ENV_FILE={str(env_file)!r}",
+        ),
+    )
+
+    assert result.returncode == 1
+    assert "restored HBA receipt was not 4|0|0" in result.stderr
+    assert "unexpected user restart" not in result.stderr
 
 
 @pytest.mark.parametrize(

--- a/tests/test_agent_operations_contract.py
+++ b/tests/test_agent_operations_contract.py
@@ -83,6 +83,124 @@ def test_service_db_inspect_clears_every_database_config_key() -> None:
     assert cleared_keys == DATABASE_CONFIG_KEYS
     assert "pre-existing ATLAS_DB_SOCKET_PATH found" in runbook
     assert "sudo grep -Eqi" in runbook
+    assert "service_db_require_canonical_keys || return 1" in helper
+
+
+def _run_runbook_function(
+    runbook: str,
+    function_names: tuple[str, ...],
+    *,
+    argument: Path | None = None,
+    service_env_files: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    functions = []
+    for function_name in function_names:
+        function_body = runbook.split(f"{function_name}() {{", maxsplit=1)[1].split(
+            "\n   }", maxsplit=1
+        )[0]
+        functions.append(f"{function_name}() {{{function_body}\n}}")
+    call = f'{function_names[-1]} "$1"' if argument is not None else function_names[-1]
+    script = "\n".join(
+        (
+            'sudo() { "$@"; }',
+            *functions,
+            "env() { printf '%s\\n' 'unexpected env invocation' >&2; return 99; }",
+            f"SERVICE_ENV_FILES={service_env_files!r}"
+            if service_env_files is not None
+            else "",
+            call,
+        )
+    )
+    command = ["bash", "-c", script, "runbook-test"]
+    if argument is not None:
+        command.append(str(argument))
+    return subprocess.run(
+        command,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.parametrize(
+    ("assignment", "expected_returncode"),
+    (
+        ("ATLAS_DB_HOST=canonical.example\n", 1),
+        ("ATLAS_DB_SOCKET_PATH_BACKUP=/var/run/postgresql\n", 1),
+        ("atlas_db_connection_string=postgresql://shadow.example/atlas\n", 0),
+        ("AtLaS_Db_SoCkEt_PaTh=/var/run/postgresql\n", 0),
+        ("export atLaS_dB_CoNnEcT_tImEoUt=0.01\n", 0),
+    ),
+)
+def test_service_db_case_variant_preflight_matches_database_aliases(
+    tmp_path: Path,
+    assignment: str,
+    expected_returncode: int,
+) -> None:
+    runbook = (ROOT / ".agent/runbooks/database.md").read_text(encoding="utf-8")
+    env_file = tmp_path / "atlas-api.env"
+    env_file.write_text(assignment, encoding="utf-8")
+
+    result = _run_runbook_function(
+        runbook,
+        ("service_db_has_case_variant_key",),
+        argument=env_file,
+    )
+
+    assert result.returncode == expected_returncode
+
+
+def test_service_db_inspect_rejects_empty_service_environment_file_set() -> None:
+    runbook = (ROOT / ".agent/runbooks/database.md").read_text(encoding="utf-8")
+
+    result = _run_runbook_function(
+        runbook,
+        (
+            "service_db_has_case_variant_key",
+            "service_db_require_canonical_keys",
+            "service_db_inspect",
+        ),
+        service_env_files="",
+    )
+
+    assert result.returncode == 1
+    assert "no service EnvironmentFiles selected" in result.stderr
+    assert "unexpected env invocation" not in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("assignment", "expected_returncode", "expected_stderr"),
+    (
+        ("ATLAS_DB_HOST=canonical.example\n", 99, "unexpected env invocation"),
+        (
+            "atlas_db_connection_string=postgresql://shadow.example/atlas\n",
+            1,
+            "case-variant ATLAS_DB_* key found",
+        ),
+    ),
+)
+def test_service_db_inspect_preflight_controls_ops_invocation(
+    tmp_path: Path,
+    assignment: str,
+    expected_returncode: int,
+    expected_stderr: str,
+) -> None:
+    runbook = (ROOT / ".agent/runbooks/database.md").read_text(encoding="utf-8")
+    env_file = tmp_path / "atlas-api.env"
+    env_file.write_text(assignment, encoding="utf-8")
+
+    result = _run_runbook_function(
+        runbook,
+        (
+            "service_db_has_case_variant_key",
+            "service_db_require_canonical_keys",
+            "service_db_inspect",
+        ),
+        service_env_files=str(env_file),
+    )
+
+    assert result.returncode == expected_returncode
+    assert expected_stderr in result.stderr
 
 
 @pytest.mark.parametrize(

--- a/tests/test_agent_operations_contract.py
+++ b/tests/test_agent_operations_contract.py
@@ -142,11 +142,13 @@ def test_runbook_admits_new_socket_configuration_before_hba_mutation() -> None:
     runbook = (ROOT / ".agent/runbooks/database.md").read_text(encoding="utf-8")
 
     admission = "service_db_require_new_socket_configuration || exit 1"
+    effective_file_derivation = 'EFFECTIVE_DB_ENV_FILE="${SERVICE_ENV_FILES##*:}"'
     first_hba_backup = (
         "sudo cp --preserve=mode,ownership,timestamps /etc/postgresql/16/main/pg_hba.conf"
     )
 
     assert runbook.count(admission) == 1
+    assert runbook.index(effective_file_derivation) < runbook.index(admission)
     assert runbook.index(admission) < runbook.index(first_hba_backup)
     assert "nonblank ATLAS_DB_CONNECTION_STRING assignment found" in runbook
 
@@ -187,6 +189,34 @@ def _run_runbook_function(
         capture_output=True,
         text=True,
     )
+
+
+@pytest.mark.parametrize(
+    ("effective_is_selected", "expected_returncode"),
+    ((True, 0), (False, 1)),
+)
+def test_service_db_effective_env_file_must_be_selected_before_cutover(
+    tmp_path: Path,
+    effective_is_selected: bool,
+    expected_returncode: int,
+) -> None:
+    runbook = (ROOT / ".agent/runbooks/database.md").read_text(encoding="utf-8")
+    selected_env_file = tmp_path / "atlas-api.env"
+    selected_env_file.write_text("ATLAS_DB_HOST=canonical.example\n", encoding="utf-8")
+    effective_env_file = (
+        selected_env_file if effective_is_selected else tmp_path / "outside.env"
+    )
+
+    result = _run_runbook_function(
+        runbook,
+        ("service_db_require_effective_env_file",),
+        service_env_files=str(selected_env_file),
+        shell_stubs=(f"EFFECTIVE_DB_ENV_FILE={str(effective_env_file)!r}",),
+    )
+
+    assert result.returncode == expected_returncode
+    if not effective_is_selected:
+        assert "effective database environment file is not a service EnvironmentFile" in result.stderr
 
 
 @pytest.mark.parametrize(
@@ -338,9 +368,11 @@ def test_new_socket_configuration_admission_rejects_nonempty_complete_dsn(
             "service_db_has_nonempty_connection_string_assignment",
             "service_db_require_canonical_keys",
             "service_db_require_no_socket_assignments",
+            "service_db_require_effective_env_file",
             "service_db_require_new_socket_configuration",
         ),
         service_env_files=str(env_file),
+        shell_stubs=(f"EFFECTIVE_DB_ENV_FILE={str(env_file)!r}",),
     )
 
     assert result.returncode == expected_returncode
@@ -364,6 +396,7 @@ def test_rollback_refuses_a_surviving_socket_assignment_before_hba_restore(
             "service_db_has_socket_assignment",
             "service_db_require_canonical_keys",
             "service_db_require_no_socket_assignments",
+            "service_db_require_effective_env_file",
             "rollback_peer_cutover",
         ),
         service_env_files=str(env_file),
@@ -392,6 +425,7 @@ def test_rollback_refuses_an_hba_source_mismatch_before_service_restart(
             "service_db_has_socket_assignment",
             "service_db_require_canonical_keys",
             "service_db_require_no_socket_assignments",
+            "service_db_require_effective_env_file",
             "rollback_peer_cutover",
         ),
         service_env_files=str(env_file),

--- a/tests/test_agent_operations_contract.py
+++ b/tests/test_agent_operations_contract.py
@@ -87,6 +87,18 @@ def test_service_db_inspect_clears_every_database_config_key() -> None:
     assert "service_db_require_no_socket_assignments || return 1" in runbook
 
 
+def test_peer_hba_receipt_requires_the_intended_first_applicable_rule() -> None:
+    runbook = (ROOT / ".agent/runbooks/database.md").read_text(encoding="utf-8")
+
+    assert "WITH intended_peer_rule AS" in runbook
+    assert "database = ARRAY['atlas']::text[]" in runbook
+    assert "user_name = ARRAY['atlas']::text[]" in runbook
+    assert "options = ARRAY['map=atlas_app']::text[]" in runbook
+    assert "ON rules.line_number < intended.line_number" in runbook
+    assert "rules.user_name = ARRAY['postgres']::text[]" in runbook
+    assert "0|1|1|0|1|0" in runbook
+
+
 def _run_runbook_function(
     runbook: str,
     function_names: tuple[str, ...],

--- a/tests/test_agent_operations_contract.py
+++ b/tests/test_agent_operations_contract.py
@@ -82,6 +82,38 @@ def test_service_db_inspect_clears_every_database_config_key() -> None:
 
     assert cleared_keys == DATABASE_CONFIG_KEYS
     assert "pre-existing ATLAS_DB_SOCKET_PATH found" in runbook
+    assert "sudo grep -Eqi" in runbook
+
+
+@pytest.mark.parametrize(
+    ("assignment", "expected_returncode"),
+    (
+        ("ATLAS_DB_SOCKET_PATH=/var/run/postgresql\n", 0),
+        ("atlas_db_socket_path=/var/run/postgresql\n", 0),
+        ("export AtLaS_Db_SoCkEt_PaTh = /var/run/postgresql\n", 0),
+        ("ATLAS_DB_SOCKET_PATH_BACKUP=/var/run/postgresql\n", 1),
+        ("ATLAS_DB_SOCKET_PATH\n", 1),
+    ),
+)
+def test_service_db_inspect_socket_precondition_matches_case_variants_only(
+    tmp_path: Path,
+    assignment: str,
+    expected_returncode: int,
+) -> None:
+    runbook = (ROOT / ".agent/runbooks/database.md").read_text(encoding="utf-8")
+    match = re.search(r"sudo grep -Eqi '([^']+)'", runbook)
+    assert match is not None
+
+    env_file = tmp_path / "atlas-api.env"
+    env_file.write_text(assignment, encoding="utf-8")
+    result = subprocess.run(
+        ["grep", "-Eqi", match.group(1), str(env_file)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == expected_returncode
 
 
 @pytest.mark.parametrize(

--- a/tests/test_agent_operations_contract.py
+++ b/tests/test_agent_operations_contract.py
@@ -286,6 +286,24 @@ def test_service_db_effective_env_file_must_be_selected_before_cutover(
             "exact",
             "EOM audit DSN override found",
         ),
+        (
+            "ATLAS_EOM_AUDIT_PSQL_BIN=/missing/psql",
+            "",
+            "",
+            True,
+            True,
+            "exact",
+            "EOM audit psql executable override found",
+        ),
+        (
+            "",
+            "ATLAS_EOM_AUDIT_PSQL_BIN=/missing/psql",
+            "",
+            True,
+            True,
+            "exact",
+            "EOM audit psql executable override found",
+        ),
         ("", "", "/secure/eom-audit.env", True, True, "exact", "EnvironmentFile"),
         ("", "", "", False, True, "exact", "not enabled and active"),
         ("", "", "", True, False, "exact", "not enabled and active"),
@@ -295,7 +313,7 @@ def test_service_db_effective_env_file_must_be_selected_before_cutover(
         ("", "", "", True, True, "unparseable", "could not parse EOM audit service command"),
     ),
 )
-def test_dormant_eom_audit_admission_rejects_transport_overrides_and_extra_commands(
+def test_dormant_eom_audit_admission_rejects_transport_or_executable_overrides_and_extra_commands(
     tmp_path: Path,
     service_environment: str,
     manager_environment: str,
@@ -336,6 +354,7 @@ def test_dormant_eom_audit_admission_rejects_transport_overrides_and_extra_comma
         runbook,
         (
             "eom_audit_environment_has_dsn_override",
+            "eom_audit_environment_has_psql_bin_override",
             "eom_audit_require_unit_contract",
         ),
         shell_stubs=(
@@ -356,6 +375,51 @@ def test_dormant_eom_audit_admission_rejects_transport_overrides_and_extra_comma
     assert result.returncode == (0 if expected_error is None else 1)
     if expected_error is not None:
         assert expected_error in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("source_mode", "installed_mode", "expected_returncode"),
+    (
+        (0o600, 0o600, 0),
+        (None, 0o600, 1),
+        (0o600, None, 1),
+        (0o000, 0o600, 1),
+        (0o600, 0o000, 1),
+    ),
+)
+def test_eom_audit_admission_requires_both_stage_inputs_before_cutover(
+    tmp_path: Path,
+    source_mode: int | None,
+    installed_mode: int | None,
+    expected_returncode: int,
+) -> None:
+    runbook = (ROOT / ".agent/runbooks/database.md").read_text(encoding="utf-8")
+    source = tmp_path / "eom_write_boundary_audit.py"
+    installed = tmp_path / "eom-write-boundary-audit.py"
+    if source_mode is not None:
+        source.write_text("source\n", encoding="utf-8")
+        source.chmod(source_mode)
+    if installed_mode is not None:
+        installed.write_text("installed\n", encoding="utf-8")
+        installed.chmod(installed_mode)
+
+    try:
+        result = _run_runbook_function(
+            runbook,
+            ("eom_audit_require_stage_inputs",),
+            shell_stubs=(
+                f"EOM_AUDIT_SOURCE={str(source)!r}",
+                f"EOM_AUDIT_INSTALLED={str(installed)!r}",
+            ),
+        )
+    finally:
+        for path in (source, installed):
+            if path.exists():
+                path.chmod(0o600)
+
+    assert result.returncode == expected_returncode
+    if expected_returncode:
+        assert "source or installed script is unreadable" in result.stderr
 
 
 @pytest.mark.parametrize(
@@ -381,7 +445,9 @@ def test_eom_audit_socket_default_requires_the_staged_source(
         runbook,
         (
             "eom_audit_environment_has_dsn_override",
+            "eom_audit_environment_has_psql_bin_override",
             "eom_audit_require_unit_contract",
+            "eom_audit_require_stage_inputs",
             "eom_audit_require_socket_default",
         ),
         shell_stubs=(
@@ -436,7 +502,9 @@ def test_eom_audit_source_stage_and_rollback_restore_the_pre_peer_copy(
         runbook,
         (
             "eom_audit_environment_has_dsn_override",
+            "eom_audit_environment_has_psql_bin_override",
             "eom_audit_require_unit_contract",
+            "eom_audit_require_stage_inputs",
             "eom_audit_require_socket_default",
             "eom_audit_stage_socket_source",
         ),
@@ -467,13 +535,22 @@ def test_runbook_stages_and_restores_the_audit_source_on_the_peer_side_of_cutove
     rollback = runbook.split("rollback_peer_cutover() {", maxsplit=1)[1].split(
         "\n   }", maxsplit=1
     )[0]
+    stage_input_admission = "eom_audit_require_stage_inputs || exit 1"
+    first_hba_backup = (
+        "sudo cp --preserve=mode,ownership,timestamps /etc/postgresql/16/main/pg_hba.conf"
+    )
 
+    assert runbook.index(stage_input_admission) < runbook.index(first_hba_backup)
     assert runbook.index(peer_receipt) < runbook.index(stage)
     assert runbook.index(stage) < runbook.index(
         "systemctl --user restart atlas-api.service", runbook.index(stage)
     )
     assert rollback.index("eom_audit_restore_pre_peer_source || return 1") < rollback.index(
         "sudo cp --preserve=mode,ownership,timestamps /etc/postgresql/16/main/pg_hba.conf.pre-atlas-peer"
+    )
+    assert (
+        'env -u ATLAS_EOM_AUDIT_ATLAS_DSN \\\n     -u ATLAS_EOM_AUDIT_PSQL_BIN "$EOM_AUDIT_INSTALLED"'
+        in runbook
     )
 
 

--- a/tests/test_agent_operations_contract.py
+++ b/tests/test_agent_operations_contract.py
@@ -170,12 +170,15 @@ def test_database_runtime_environment_ignores_case_variant_database_overrides(
     shadow_dsn = "postgresql://shadow.example:5433/shadow"
     env_file = tmp_path / ".env"
     env_file.write_text(
-        f"ATLAS_DB_CONNECTION_STRING={file_dsn}\nATLAS_DB_HOST=file.example\n",
+        f"ATLAS_DB_CONNECTION_STRING={file_dsn}\n"
+        "ATLAS_DB_HOST=file.example\n"
+        "ATLAS_DB_CONNECT_TIMEOUT=7.5\n",
         encoding="utf-8",
     )
     monkeypatch.setenv("ATLAS_OPS_ENV_FILES", str(env_file))
     monkeypatch.setenv("atlas_db_connection_string", shadow_dsn)
     monkeypatch.setenv("AtLaS_Db_HoSt", "shadow.example")
+    monkeypatch.setenv("AtLaS_Db_Connect_Timeout", "0.01")
     for key in DATABASE_CONFIG_KEYS:
         monkeypatch.delenv(key, raising=False)
 
@@ -183,8 +186,10 @@ def test_database_runtime_environment_ignores_case_variant_database_overrides(
 
     assert child_env["ATLAS_DB_CONNECTION_STRING"] == file_dsn
     assert child_env["ATLAS_DB_HOST"] == "file.example"
+    assert child_env["ATLAS_DB_CONNECT_TIMEOUT"] == "7.5"
     assert "atlas_db_connection_string" not in child_env
     assert "AtLaS_Db_HoSt" not in child_env
+    assert "AtLaS_Db_Connect_Timeout" not in child_env
     with monkeypatch.context() as child_process:
         for key in tuple(os.environ):
             child_process.delenv(key, raising=False)
@@ -194,6 +199,7 @@ def test_database_runtime_environment_ignores_case_variant_database_overrides(
 
     assert application_config.connection_string == file_dsn
     assert application_config.host == "file.example"
+    assert application_config.connect_timeout == 7.5
 
 
 def test_database_file_context_prefers_worktree_over_shared_and_systemd(

--- a/tests/test_agent_operations_contract.py
+++ b/tests/test_agent_operations_contract.py
@@ -71,6 +71,19 @@ def test_database_runtime_environment_covers_every_database_config_key() -> None
     )
 
 
+def test_service_db_inspect_clears_every_database_config_key() -> None:
+    runbook = (ROOT / ".agent/runbooks/database.md").read_text(encoding="utf-8")
+    helper = runbook.split("service_db_inspect() {", maxsplit=1)[1].split(
+        "\n   }", maxsplit=1
+    )[0]
+    cleared_keys = set(
+        re.findall(r"(?m)^\s*(?:env\s+)?-u\s+(ATLAS_DB_[A-Z_]+)\s+\\$", helper)
+    )
+
+    assert cleared_keys == DATABASE_CONFIG_KEYS
+    assert "pre-existing ATLAS_DB_SOCKET_PATH found" in runbook
+
+
 @pytest.mark.parametrize(
     "args",
     (

--- a/tests/test_agent_operations_contract.py
+++ b/tests/test_agent_operations_contract.py
@@ -63,6 +63,14 @@ def test_database_surface_contains_only_fixed_inspections() -> None:
         assert DATABASE_INSPECTIONS[name] not in command
 
 
+def test_database_runtime_environment_covers_every_database_config_key() -> None:
+    from atlas_brain.storage.config import DatabaseConfig
+
+    assert DATABASE_CONFIG_KEYS == frozenset(
+        f"ATLAS_DB_{field_name.upper()}" for field_name in DatabaseConfig.model_fields
+    )
+
+
 @pytest.mark.parametrize(
     "args",
     (

--- a/tests/test_agent_operations_contract.py
+++ b/tests/test_agent_operations_contract.py
@@ -153,6 +153,25 @@ def test_runbook_admits_new_socket_configuration_before_hba_mutation() -> None:
     assert "nonblank ATLAS_DB_CONNECTION_STRING assignment found" in runbook
 
 
+def test_runbook_admits_the_dormant_eom_audit_before_hba_mutation() -> None:
+    runbook = (ROOT / ".agent/runbooks/database.md").read_text(encoding="utf-8")
+
+    admission = "eom_audit_require_socket_default || exit 1"
+    first_hba_backup = (
+        "sudo cp --preserve=mode,ownership,timestamps /etc/postgresql/16/main/pg_hba.conf"
+    )
+
+    assert runbook.count(admission) == 1
+    assert runbook.index(admission) < runbook.index(first_hba_backup)
+    assert "cmp -s \"$EOM_AUDIT_SOURCE\" \"$EOM_AUDIT_INSTALLED\"" in runbook
+    assert "--property=EnvironmentFiles --value" in runbook
+    assert "systemctl --user show-environment" in runbook
+    assert "ATLAS_EOM_AUDIT_ATLAS_DSN=" in runbook
+    assert "--no-alert" in runbook
+    assert "COULD NOT MEASURE" in runbook
+    assert "0|2" in runbook
+
+
 def _run_runbook_function(
     runbook: str,
     function_names: tuple[str, ...],
@@ -217,6 +236,87 @@ def test_service_db_effective_env_file_must_be_selected_before_cutover(
     assert result.returncode == expected_returncode
     if not effective_is_selected:
         assert "effective database environment file is not a service EnvironmentFile" in result.stderr
+
+
+@pytest.mark.parametrize(
+    (
+        "service_environment",
+        "manager_environment",
+        "environment_files",
+        "copies_match",
+        "timer_enabled",
+        "timer_active",
+        "exec_matches",
+        "expected_returncode",
+    ),
+    (
+        ("", "", "", True, True, True, True, 0),
+        ("ATLAS_EOM_AUDIT_ATLAS_DSN=postgresql://tcp.example/atlas", "", "", True, True, True, True, 1),
+        ("", "ATLAS_EOM_AUDIT_ATLAS_DSN=postgresql://tcp.example/atlas", "", True, True, True, True, 1),
+        ("", "", "/secure/eom-audit.env", True, True, True, True, 1),
+        ("", "", "", False, True, True, True, 1),
+        ("", "", "", True, False, True, True, 1),
+        ("", "", "", True, True, False, True, 1),
+        ("", "", "", True, True, True, False, 1),
+    ),
+)
+def test_dormant_eom_audit_admission_rejects_transport_overrides_and_stale_install(
+    tmp_path: Path,
+    service_environment: str,
+    manager_environment: str,
+    environment_files: str,
+    copies_match: bool,
+    timer_enabled: bool,
+    timer_active: bool,
+    exec_matches: bool,
+    expected_returncode: int,
+) -> None:
+    runbook = (ROOT / ".agent/runbooks/database.md").read_text(encoding="utf-8")
+    source = tmp_path / "eom_write_boundary_audit.py"
+    installed = tmp_path / "eom-write-boundary-audit.py"
+    source.write_text("source\n", encoding="utf-8")
+    installed.write_text("source\n" if copies_match else "stale\n", encoding="utf-8")
+
+    result = _run_runbook_function(
+        runbook,
+        (
+            "eom_audit_environment_has_dsn_override",
+            "eom_audit_require_socket_default",
+        ),
+        shell_stubs=(
+            f"EOM_AUDIT_SOURCE={str(source)!r}",
+            f"EOM_AUDIT_INSTALLED={str(installed)!r}",
+            "EOM_AUDIT_SERVICE='eom-write-boundary-audit.service'",
+            "EOM_AUDIT_TIMER='eom-write-boundary-audit.timer'",
+            f"EOM_AUDIT_TEST_SERVICE_ENV={service_environment!r}",
+            f"EOM_AUDIT_TEST_MANAGER_ENV={manager_environment!r}",
+            f"EOM_AUDIT_TEST_ENVIRONMENT_FILES={environment_files!r}",
+            f"EOM_AUDIT_TEST_TIMER_ENABLED={str(timer_enabled).lower()}",
+            f"EOM_AUDIT_TEST_TIMER_ACTIVE={str(timer_active).lower()}",
+            f"EOM_AUDIT_TEST_EXEC_START={'loaded ' + str(installed) if exec_matches else 'loaded /other/eom-write-boundary-audit.py'!r}",
+            "systemctl() {\n"
+            "  case \"$*\" in\n"
+            "    *'is-enabled --quiet'*) [ \"$EOM_AUDIT_TEST_TIMER_ENABLED\" = true ] ;;\n"
+            "    *'is-active --quiet'*) [ \"$EOM_AUDIT_TEST_TIMER_ACTIVE\" = true ] ;;\n"
+            "    *'--property=LoadState,ExecStart --value'*) printf '%s\\n' \"$EOM_AUDIT_TEST_EXEC_START\" ;;\n"
+            "    *'--property=EnvironmentFiles --value'*) printf '%s\\n' \"$EOM_AUDIT_TEST_ENVIRONMENT_FILES\" ;;\n"
+            "    *'--property=Environment --value'*) printf '%s\\n' \"$EOM_AUDIT_TEST_SERVICE_ENV\" ;;\n"
+            "    *show-environment*) printf '%s\\n' \"$EOM_AUDIT_TEST_MANAGER_ENV\" ;;\n"
+            "    *) return 97 ;;\n"
+            "  esac\n"
+            "}",
+        ),
+    )
+
+    assert result.returncode == expected_returncode
+    if expected_returncode:
+        assert (
+            "EOM audit DSN override found" in result.stderr
+            or "EOM audit service uses an EnvironmentFile" in result.stderr
+            or "installed EOM audit script does not match deployed source" in result.stderr
+            or "EOM audit timer is not enabled and active" in result.stderr
+            or "EOM audit service does not execute the admitted installed script" in result.stderr
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_eom_render_profile.py
+++ b/tests/test_eom_render_profile.py
@@ -919,6 +919,37 @@ def test_database_config_preserves_split_host_port_kwargs_without_connection_str
     assert config.connection_kwargs(command_timeout=60)["command_timeout"] == 60
 
 
+def test_database_config_uses_socket_path_for_dsn_and_asyncpg_kwargs():
+    from atlas_brain.storage.config import DatabaseConfig
+
+    config = DatabaseConfig(
+        connection_string=" ",
+        host="postgres.internal",
+        port=6543,
+        database="atlas_prod",
+        user="atlas_user",
+        password="atlas_pass",
+        socket_path="/var/run/postgresql",
+        connect_timeout=5.0,
+        command_timeout=17.0,
+    )
+
+    assert config.dsn == (
+        "postgresql://atlas_user:atlas_pass@/atlas_prod"
+        "?host=/var/run/postgresql&port=6543"
+    )
+    assert config.connection_kwargs() == {
+        "host": "/var/run/postgresql",
+        "port": 6543,
+        "database": "atlas_prod",
+        "user": "atlas_user",
+        "password": "atlas_pass",
+        "timeout": 5.0,
+        "command_timeout": 17.0,
+    }
+    assert config.connection_kwargs(command_timeout=60)["command_timeout"] == 60
+
+
 def test_database_pool_uses_configured_connection_kwargs(monkeypatch):
     from atlas_brain.storage.config import DatabaseConfig
     from atlas_brain.storage import database

--- a/tests/test_eom_render_profile.py
+++ b/tests/test_eom_render_profile.py
@@ -948,6 +948,15 @@ def test_database_config_uses_socket_path_for_dsn_and_asyncpg_kwargs():
         "command_timeout": 17.0,
     }
     assert config.connection_kwargs(command_timeout=60)["command_timeout"] == 60
+    assert config.target_label == (
+        "socket=/var/run/postgresql, port=6543, db=atlas_prod"
+    )
+
+    same_socket_other_port = config.model_copy(update={"port": 6544})
+    assert same_socket_other_port.target_label == (
+        "socket=/var/run/postgresql, port=6544, db=atlas_prod"
+    )
+    assert same_socket_other_port.target_label != config.target_label
 
 
 def test_database_pool_uses_configured_connection_kwargs(monkeypatch):

--- a/tests/test_eom_render_profile.py
+++ b/tests/test_eom_render_profile.py
@@ -870,6 +870,7 @@ def test_database_config_prefers_connection_string_for_asyncpg_kwargs():
         database="atlas",
         user="atlas",
         password="split-secret",
+        socket_path="/var/run/postgresql",
         connect_timeout=7.0,
         command_timeout=11.0,
     )

--- a/tests/test_eom_render_profile.py
+++ b/tests/test_eom_render_profile.py
@@ -954,7 +954,6 @@ def test_database_pool_uses_configured_connection_kwargs(monkeypatch):
     from atlas_brain.storage.config import DatabaseConfig
     from atlas_brain.storage import database
 
-    dsn = "postgresql://atlas_eom:secret@atlas-eom-postgres:5432/atlas_eom"
     calls: dict[str, dict[str, object]] = {}
 
     class _FakePool:
@@ -971,7 +970,12 @@ def test_database_pool_uses_configured_connection_kwargs(monkeypatch):
 
     config = DatabaseConfig(
         enabled=True,
-        connection_string=dsn,
+        connection_string="",
+        socket_path="/var/run/postgresql",
+        port=5433,
+        database="atlas",
+        user="atlas",
+        password="",
         min_pool_size=1,
         max_pool_size=3,
         connect_timeout=4.0,
@@ -994,14 +998,22 @@ def test_database_pool_uses_configured_connection_kwargs(monkeypatch):
         database.db_settings = original_settings
 
     assert calls["create_pool"] == {
-        "dsn": dsn,
+        "host": "/var/run/postgresql",
+        "port": 5433,
+        "database": "atlas",
+        "user": "atlas",
+        "password": "",
         "timeout": 4.0,
         "command_timeout": 9.0,
         "min_size": 1,
         "max_size": 3,
     }
     assert calls["connect"] == {
-        "dsn": dsn,
+        "host": "/var/run/postgresql",
+        "port": 5433,
+        "database": "atlas",
+        "user": "atlas",
+        "password": "",
         "timeout": 4.0,
         "command_timeout": 60,
     }

--- a/tests/test_eom_render_profile.py
+++ b/tests/test_eom_render_profile.py
@@ -960,6 +960,21 @@ def test_database_config_uses_socket_path_for_dsn_and_asyncpg_kwargs():
     assert same_socket_other_port.target_label != config.target_label
 
 
+def test_typed_maintenance_scripts_use_socket_aware_database_kwargs():
+    repo_root = Path(__file__).resolve().parents[1]
+    backfill = (repo_root / "scripts/backfill_community_buying_stage_defaults.py").read_text(
+        encoding="utf-8"
+    )
+    rebuild = (repo_root / "scripts/rebuild_blog_charts.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "db_settings.host" not in backfill
+    assert "db_settings.connection_kwargs(command_timeout=60)" in backfill
+    assert "db_settings.host" not in rebuild
+    assert "db_settings.connection_kwargs()" in rebuild
+
+
 def test_database_config_percent_encodes_socket_path_in_dsn_query():
     from urllib.parse import parse_qs, urlsplit
 

--- a/tests/test_eom_render_profile.py
+++ b/tests/test_eom_render_profile.py
@@ -2,6 +2,7 @@ import asyncio
 import hashlib
 import json
 import os
+import runpy
 import string
 import subprocess
 import sys
@@ -973,6 +974,28 @@ def test_typed_maintenance_scripts_use_socket_aware_database_kwargs():
     assert "db_settings.connection_kwargs(command_timeout=60)" in backfill
     assert "db_settings.host" not in rebuild
     assert "db_settings.connection_kwargs()" in rebuild
+    assert "min_size=2" in rebuild
+    assert "max_size=4" in rebuild
+
+    rebuild_module = runpy.run_path(str(repo_root / "scripts/rebuild_blog_charts.py"))
+    pool_kwargs = rebuild_module["_rebuild_pool_connection_kwargs"](
+        {
+            "host": "/var/run/postgresql",
+            "port": 5433,
+            "database": "atlas",
+            "user": "atlas",
+            "password": "secret",
+            "timeout": 10.0,
+            "command_timeout": 30.0,
+        }
+    )
+    assert pool_kwargs == {
+        "host": "/var/run/postgresql",
+        "port": 5433,
+        "database": "atlas",
+        "user": "atlas",
+        "password": "secret",
+    }
 
 
 def test_database_config_percent_encodes_socket_path_in_dsn_query():

--- a/tests/test_eom_render_profile.py
+++ b/tests/test_eom_render_profile.py
@@ -960,6 +960,29 @@ def test_database_config_uses_socket_path_for_dsn_and_asyncpg_kwargs():
     assert same_socket_other_port.target_label != config.target_label
 
 
+def test_database_config_percent_encodes_socket_path_in_dsn_query():
+    from urllib.parse import parse_qs, urlsplit
+
+    from atlas_brain.storage.config import DatabaseConfig
+
+    socket_path = "/tmp/atlas&cluster?primary"
+    config = DatabaseConfig(
+        connection_string="",
+        port=6543,
+        database="atlas_prod",
+        user="atlas_user",
+        password="atlas_pass",
+        socket_path=socket_path,
+    )
+
+    assert config.dsn == (
+        "postgresql://atlas_user:atlas_pass@/atlas_prod"
+        "?host=/tmp/atlas%26cluster%3Fprimary&port=6543"
+    )
+    assert parse_qs(urlsplit(config.dsn).query)["host"] == [socket_path]
+    assert config.connection_kwargs()["host"] == socket_path
+
+
 def test_database_pool_uses_configured_connection_kwargs(monkeypatch):
     from atlas_brain.storage.config import DatabaseConfig
     from atlas_brain.storage import database

--- a/tests/test_eom_write_boundary_audit.py
+++ b/tests/test_eom_write_boundary_audit.py
@@ -221,12 +221,15 @@ def test_main_stays_silent_and_exits_zero_when_clean(monkeypatch, tmp_path):
 def test_main_uses_the_passwordless_socket_default_without_a_dsn_override(
     monkeypatch, tmp_path
 ):
-    captured: list[str] = []
+    captured: list[tuple[str, bool]] = []
     monkeypatch.delenv("ATLAS_EOM_AUDIT_ATLAS_DSN", raising=False)
     monkeypatch.setattr(
         audit,
         "query_atlas",
-        lambda _psql_bin, dsn: (captured.append(dsn), ([0, 0, 0], None))[1],
+        lambda _psql_bin, dsn, *, source_owned_default: (
+            captured.append((dsn, source_owned_default)),
+            ([0, 0, 0], None),
+        )[1],
     )
 
     code = audit.main(
@@ -234,17 +237,20 @@ def test_main_uses_the_passwordless_socket_default_without_a_dsn_override(
     )
 
     assert code == 0
-    assert captured == [audit.DEFAULT_ATLAS_DSN]
+    assert captured == [(audit.DEFAULT_ATLAS_DSN, True)]
 
 
 def test_main_preserves_an_explicit_audit_dsn_override(monkeypatch, tmp_path):
     override = "postgresql://audit@localhost:5433/atlas"
-    captured: list[str] = []
+    captured: list[tuple[str, bool]] = []
     monkeypatch.setenv("ATLAS_EOM_AUDIT_ATLAS_DSN", override)
     monkeypatch.setattr(
         audit,
         "query_atlas",
-        lambda _psql_bin, dsn: (captured.append(dsn), ([0, 0, 0], None))[1],
+        lambda _psql_bin, dsn, *, source_owned_default: (
+            captured.append((dsn, source_owned_default)),
+            ([0, 0, 0], None),
+        )[1],
     )
 
     code = audit.main(
@@ -252,7 +258,7 @@ def test_main_preserves_an_explicit_audit_dsn_override(monkeypatch, tmp_path):
     )
 
     assert code == 0
-    assert captured == [override]
+    assert captured == [(override, False)]
 
 
 def test_an_undelivered_alert_does_not_advance_state(monkeypatch, tmp_path):
@@ -565,7 +571,10 @@ def test_credentials_are_passed_by_environment_not_argv(monkeypatch):
 def test_default_socket_dsn_decodes_its_unix_host_for_libpq(monkeypatch):
     monkeypatch.delenv("PGPASSWORD", raising=False)
 
-    env = audit.psql_environment(audit.DEFAULT_ATLAS_DSN)
+    env = audit.psql_environment(
+        audit.DEFAULT_ATLAS_DSN,
+        source_owned_default=True,
+    )
 
     assert env["PGUSER"] == "atlas"
     assert env["PGHOST"] == "/var/run/postgresql"
@@ -594,7 +603,10 @@ def test_default_socket_dsn_scrubs_all_inherited_libpq_target_settings(monkeypat
     for key, value in inherited.items():
         monkeypatch.setenv(key, value)
 
-    env = audit.psql_environment(audit.DEFAULT_ATLAS_DSN)
+    env = audit.psql_environment(
+        audit.DEFAULT_ATLAS_DSN,
+        source_owned_default=True,
+    )
 
     assert env["PGHOST"] == "/var/run/postgresql"
     assert env["PGPORT"] == "5433"
@@ -606,6 +618,23 @@ def test_default_socket_dsn_scrubs_all_inherited_libpq_target_settings(monkeypat
         "PGPORT",
         "PGUSER",
     }
+
+
+def test_explicit_audit_dsn_preserves_inherited_tls_inputs(monkeypatch):
+    inherited_tls = {
+        "PGSSLROOTCERT": "/secure/root.crt",
+        "PGSSLCERT": "/secure/client.crt",
+        "PGSSLKEY": "/secure/client.key",
+    }
+    for key, value in inherited_tls.items():
+        monkeypatch.setenv(key, value)
+
+    env = audit.psql_environment(
+        "postgresql://audit@db.example:5433/atlas?sslmode=verify-full",
+    )
+
+    assert {key: env[key] for key in inherited_tls} == inherited_tls
+    assert env["PGSSLMODE"] == "verify-full"
 
 
 def test_search_path_options_travel_as_pgoptions():

--- a/tests/test_eom_write_boundary_audit.py
+++ b/tests/test_eom_write_boundary_audit.py
@@ -218,6 +218,43 @@ def test_main_stays_silent_and_exits_zero_when_clean(monkeypatch, tmp_path):
     assert sent == []
 
 
+def test_main_uses_the_passwordless_socket_default_without_a_dsn_override(
+    monkeypatch, tmp_path
+):
+    captured: list[str] = []
+    monkeypatch.delenv("ATLAS_EOM_AUDIT_ATLAS_DSN", raising=False)
+    monkeypatch.setattr(
+        audit,
+        "query_atlas",
+        lambda _psql_bin, dsn: (captured.append(dsn), ([0, 0, 0], None))[1],
+    )
+
+    code = audit.main(
+        ["--state-dir", str(tmp_path), "--ntfy-topic", "t", "--no-alert"],
+    )
+
+    assert code == 0
+    assert captured == [audit.DEFAULT_ATLAS_DSN]
+
+
+def test_main_preserves_an_explicit_audit_dsn_override(monkeypatch, tmp_path):
+    override = "postgresql://audit@localhost:5433/atlas"
+    captured: list[str] = []
+    monkeypatch.setenv("ATLAS_EOM_AUDIT_ATLAS_DSN", override)
+    monkeypatch.setattr(
+        audit,
+        "query_atlas",
+        lambda _psql_bin, dsn: (captured.append(dsn), ([0, 0, 0], None))[1],
+    )
+
+    code = audit.main(
+        ["--state-dir", str(tmp_path), "--ntfy-topic", "t", "--no-alert"],
+    )
+
+    assert code == 0
+    assert captured == [override]
+
+
 def test_an_undelivered_alert_does_not_advance_state(monkeypatch, tmp_path):
     """A failed push must not record the breach as notified.
 
@@ -523,6 +560,52 @@ def test_credentials_are_passed_by_environment_not_argv(monkeypatch):
     assert captured["env"]["PGPORT"] == "5433"
     assert captured["env"]["PGDATABASE"] == "db"
     assert captured["env"]["PGSSLMODE"] == "require"
+
+
+def test_default_socket_dsn_decodes_its_unix_host_for_libpq(monkeypatch):
+    monkeypatch.delenv("PGPASSWORD", raising=False)
+
+    env = audit.psql_environment(audit.DEFAULT_ATLAS_DSN)
+
+    assert env["PGUSER"] == "atlas"
+    assert env["PGHOST"] == "/var/run/postgresql"
+    assert env["PGPORT"] == "5433"
+    assert env["PGDATABASE"] == "atlas"
+    assert "PGPASSWORD" not in env
+
+
+def test_default_socket_dsn_scrubs_all_inherited_libpq_target_settings(monkeypatch):
+    inherited = {
+        "PGHOST": "localhost",
+        "PGHOSTADDR": "127.0.0.1",
+        "PGPORT": "6543",
+        "PGDATABASE": "wrong_database",
+        "PGUSER": "wrong_user",
+        "PGPASSWORD": "wrong_password",
+        "PGPASSFILE": "/tmp/wrong-passfile",
+        "PGSERVICE": "wrong-service",
+        "PGSERVICEFILE": "/tmp/wrong-service-file",
+        "PGAPPNAME": "wrong-application-name",
+        "PGOPTIONS": "-c search_path=wrong_schema",
+        "PGSSLMODE": "require",
+        "PGTARGETSESSIONATTRS": "read-write",
+        "PGLOADBALANCEHOSTS": "random",
+    }
+    for key, value in inherited.items():
+        monkeypatch.setenv(key, value)
+
+    env = audit.psql_environment(audit.DEFAULT_ATLAS_DSN)
+
+    assert env["PGHOST"] == "/var/run/postgresql"
+    assert env["PGPORT"] == "5433"
+    assert env["PGDATABASE"] == "atlas"
+    assert env["PGUSER"] == "atlas"
+    assert {key for key in env if key.startswith("PG")} == {
+        "PGDATABASE",
+        "PGHOST",
+        "PGPORT",
+        "PGUSER",
+    }
 
 
 def test_search_path_options_travel_as_pgoptions():


### PR DESCRIPTION
Plan: plans/PR-Postgres-Loopback-Scram-Hardening.md
Slice phase: Production hardening
Ownership lane: eom-crm/runtime-security

The existing socket configuration was descriptive but ineffective for the live asyncpg pool: `connection_kwargs()` still selected TCP, leaving the application dependent on broad loopback `trust`. This slice makes the established socket setting reach every supported connection construction path, documents a staged peer/HBA cutover, and corrects the migration-admission wording without changing its forensic behavior.

## Intentional

- Make `DatabaseConfig` use a configured Unix-socket directory and configured port in direct DSNs, asyncpg kwargs, and exact-target labels, and prove pool/raw callers receive them.
- Preserve complete-DSN precedence and ordinary split TCP settings.
- Replace the unsupported credential experiment with a staged socket-peer procedure that rejects an overriding complete DSN, proves the service transport, and restores TCP configuration before any rollback restart.
- Correct the migration runbook: attested `missing_source` entries can be admissible, while raw drift reporting and its nonzero exit remain intact.
- Make the fixed inspector reject lower- and mixed-case inherited aliases for every `DatabaseConfig` setting while preserving the documented exact-uppercase override behavior.
- Refuse service-pinned inspection and the edit step when no service file is selected or any selected file contains a noncanonical-cased `ATLAS_DB_*` key, so its proof cannot diverge from `atlas-api.service`.
- Refuse the cutover before any edit when a selected service file already assigns any case variant of `ATLAS_DB_SOCKET_PATH`, so rollback removes only the assignment this procedure created.
- Use that same full-service-file socket-assignment guard before rollback restores HBA or identity configuration.
- Require the loaded peer-HBA receipt to prove the exact intended local rule is first applicable in loaded `rule_number` order, preserving only the `postgres` recovery peer rule ahead of it.
- Percent-encode only the socket-directory value when it is placed in the generated DSN query, while retaining the raw directory in asyncpg connection kwargs.
- Require every qualifying `atlas` user/database client backend observed after restart to use the Unix socket, not merely one such backend.
- Stop before backup, edit, reload, rollback restart, or final cutover acceptance if any edited trust or loopback HBA rule is loaded from outside the backed-up top-level HBA file.
- Make each final HBA receipt independently define the derived `covers_loopback` relation it consumes.
- Gate a new socket cutover on the absence of both an existing socket assignment and a nonblank complete DSN before any HBA/identity backup, edit, or reload.
- Derive and validate the effective service file before authentication edits, then reuse that exact membership rule in rollback.
- Move only the absent-override EOM write-boundary monitor default to the passwordless PostgreSQL socket; clear inherited `PG*` libpq settings only for that source-owned default, while preserving explicit override TLS/libpq behavior and the timer, alert, and state contracts.
- Diff-budget override: the configuration/caller seams, cutover/rollback procedure, and plan evidence are one deployment-safety boundary. The migration-integrity correction ships with the same restart procedure because `atlas-api` startup runs migration checks and the former guidance stopped an operator on a raw state that matching current attestation admits; splitting either side would publish socket hardening without proof/rollback or a contradictory restart procedure.

## AI reconciliation

- Pin every privileged psql probe to port 5433 -- fixed-in: `cbc4b0b43` updates `.agent/runbooks/database.md` to pin the preflight, HBA-validation, and break-glass probes to `/var/run/postgresql` and port `5433`.
- Qualify the remaining missing-source stop condition -- fixed-in: `cbc4b0b43` makes `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md` stop only for a mismatch or missing-source item without matching, currently attested evidence.
- Verify the application is actually using the socket -- fixed-in: `cbc4b0b43` makes `.agent/runbooks/database.md` reject an overriding full DSN and require a post-restart `pg_stat_activity.client_addr` Unix-socket observation after the authenticated CRM read.
- Include the socket port in target labels -- fixed-in: `cbc4b0b43` updates `atlas_brain/storage/config.py` and `tests/test_eom_render_profile.py` so same-directory socket targets on distinct ports have distinct exact-target labels.
- Restore TCP configuration before restarting rollback -- fixed-in: `cbc4b0b43` makes `.agent/runbooks/database.md` remove the added socket setting before restoring HBA/ident and restarting `atlas-api.service`.
- Finalize the mandatory plan evidence -- fixed-in: `04af030e24d4672ae6eb4ed931b41f70cfb73c6f` adds the required affected surfaces, risk areas, reviewer rules, and actual command/pass-count verification to `plans/PR-Postgres-Loopback-Scram-Hardening.md`.
- Pin the inspector to the service configuration -- fixed-in: `04af030e24d4672ae6eb4ed931b41f70cfb73c6f` makes `.agent/runbooks/database.md` select ordered `atlas-api.service` environment files while removing inherited `ATLAS_DB_*` overrides.
- Verify every loopback trust rule was removed -- fixed-in: `b4962704ba834b4d6f89b157e077975e6f230962` makes `.agent/runbooks/database.md` require a loaded-HBA `1|1|1|1|0|0|0` receipt for every exact application/replication IPv4/IPv6 tuple before the boundary is accepted.
- Validate each exact loopback HBA channel -- fixed-in: `b4962704ba834b4d6f89b157e077975e6f230962` makes `.agent/runbooks/database.md` count each exact address, database, user, netmask, and SCRAM tuple while rejecting unexpected loopback host rules.
- Reload PostgreSQL after restoring failed HBA edits -- fixed-in: `b4962704ba834b4d6f89b157e077975e6f230962` routes a failed loaded-HBA receipt through rollback that restores and reloads HBA/ident before it stops or restarts the service.
- Gate the cutover on every active loopback client -- fixed-in: `bef35690c9f29d29054c6fd97c9330a7224a0913` makes `.agent/runbooks/database.md` stop before HBA replacement while any TCP loopback or replication client remains.
- Verify the loaded peer identity map is exclusive -- fixed-in: `bef35690c9f29d29054c6fd97c9330a7224a0913` makes `.agent/runbooks/database.md` require exactly one loaded `atlas_app | juan-canfield | atlas` mapping and no mapping/HBA error.
- Declare closure for the enumerated boundary sets -- fixed-in: `fe7a61bc48b1e9db2957055c7e252275f8e269c8` adds closed/open membership, source, and safe-default declarations for each decision-driving set in `plans/PR-Postgres-Loopback-Scram-Hardening.md`.
- Test complete-DSN precedence with a configured socket -- fixed-in: `fe7a61bc48b1e9db2957055c7e252275f8e269c8` configures `socket_path` alongside a complete DSN in `tests/test_eom_render_profile.py` and asserts the DSN, kwargs, and target label still select it.
- Route a successful passwordless probe through rollback -- fixed-in: `fe7a61bc48b1e9db2957055c7e252275f8e269c8` routes the unexpected-success branch through `rollback_peer_cutover` before exit, including HBA/ident reload and the restored-HBA receipt.
- Reconcile every initially observed loopback client -- fixed-in: `db8cf126b60949589973e9da6725f52a02ca0589` records both client inventories and requires a Unix-socket or owner-verified SCRAM receipt for every observed client before HBA conversion.
- Reject every HBA rule whose network covers loopback -- fixed-in: `db8cf126b60949589973e9da6725f52a02ca0589` derives every non-local `pg_hba_file_rules` network that covers either loopback endpoint and requires exactly the four intended candidates before accepting the existing exact-tuple receipt.
- Clear case-insensitive database overrides before inspection -- fixed-in: `28fe8ec8435b3d88fd7589f1dc0be77a86ae0cfd` updates `.agent/runbooks/database.md`, `ops`, and `tests/test_agent_operations_contract.py` so the service helper clears every canonical override and `ops` clears all lower/mixed-case aliases before `DatabaseConfig` loads.
- Clear every database override in the service probe -- fixed-in: `28fe8ec8435b3d88fd7589f1dc0be77a86ae0cfd` expands `service_db_inspect` in `.agent/runbooks/database.md` from seven target keys to all twelve `DatabaseConfig` settings, so exact-uppercase inherited timeouts and pool settings cannot override the selected service files.
- Reject pre-existing socket assignments before cutover -- fixed-in: `5624d66864731e6609f310b9c941447bb077687a` makes `.agent/runbooks/database.md` inspect every selected service EnvironmentFile and stop before an edit when any assigns `ATLAS_DB_SOCKET_PATH`; the static regression also pins the service helper's unset set to every `DatabaseConfig` field.
- Reject case-variant pre-existing socket settings -- fixed-in: `56abd4e815d29092875928d5b98f577d3a40fff1` makes the service-pinned helper reject an empty file set and every lower/mixed-case `ATLAS_DB_*` key before it invokes `ops`, so case-variant DSNs cannot bypass the full-DSN gate; the shell harness proves both the reject path and canonical path reachability.
- Reject every surviving socket assignment during rollback -- fixed-in: `82eb3b5d666dc2bc37ad8a6b0d38779d6915098e` refactors the runbook to use one case-insensitive, all-selected-file socket-assignment guard before both adding and rollback; the rollback harness proves a spacing-variant residual stops before HBA restoration.
- Verify the loaded peer HBA rule and its precedence -- fixed-in: `791e8ea8eb10733e2cba0c7f9aa38a2598467788` makes the loaded receipt require exactly one `local atlas atlas peer map=atlas_app` row and no preceding local row except `local all postgres peer`, compared in loaded `rule_number` order.
- Use HBA rule numbers to check precedence -- fixed-in: `791e8ea8eb10733e2cba0c7f9aa38a2598467788` replaces source-local `line_number` with `pg_hba_file_rules.rule_number` in both sides of the receipt predicate, so included HBA files are checked in PostgreSQL authentication order.
- Require every post-restart Atlas backend to use the socket -- fixed-in: `2a2ce747bcb9468b3a46dbe6de6f760519c9c610` makes the post-restart receipt require a nonempty qualifying `atlas` user/database client set and prove every member has `client_addr IS NULL`.
- Percent-encode the socket path in generated DSNs -- fixed-in: `2a2ce747bcb9468b3a46dbe6de6f760519c9c610` encodes URI query delimiters in the socket directory while the asyncpg kwargs retain the original path.
- Back up every HBA file modified by the cutover -- fixed-in: `2a2ce747bcb9468b3a46dbe6de6f760519c9c610` makes preflight, rollback, and final HBA receipts reject any edited trust or loopback rule sourced outside the backed-up top-level HBA file.
- Define covers_loopback in the final HBA receipt -- fixed-in: `c68413b74a55ada631a8b21e6838cc8ea01027f9` gives the exact-tuple receipt its own `hba` CTE, so its source-boundary predicate is in the same PostgreSQL statement as `covers_loopback`.
- Run configuration gates before authentication edits -- fixed-in: `c68413b74a55ada631a8b21e6838cc8ea01027f9` makes the new-socket admission reject selected-file socket assignments and nonblank complete DSNs before any HBA/identity backup, edit, or reload.
- Validate the effective file before editing it -- fixed-in: `b3e799eb37c5a187cb74dc2652730f7abe6967e6` derives the final selected service file, validates its membership in the pre-mutation gate, and reuses that predicate in rollback.
- Put the complete overage rationale in Why -- fixed-in: `8673c26fbc59d6c228cf0de8aba2267069ad78e9` adds the complete indivisibility rationale to `plans/PR-Postgres-Loopback-Scram-Hardening.md` under `Why this slice exists`.
- Inventory dormant loopback clients before replacing trust -- fixed-in: `bc3fd211f6bb222c511d7e68bbfc9203f6819c0e` moves the scheduled EOM audit's absent-override default to a Unix socket and clears inherited `PG*` libpq settings in `scripts/eom_write_boundary_audit.py`; `.agent/runbooks/database.md` admits its installed source/timer/no-override state before HBA mutation and obtains a no-alert transport receipt before trust replacement, with regressions in `tests/test_eom_write_boundary_audit.py` and `tests/test_agent_operations_contract.py`.
- Reject command-line DSN overrides in the timer unit -- fixed-in: `.agent/runbooks/database.md` now requires the exact effective Python/script argv and `tests/test_agent_operations_contract.py` rejects `--atlas-dsn`, alternate executable flags, multiple commands, and unparseable output.
- Preserve TLS inputs for explicit audit DSNs -- fixed-in: `scripts/eom_write_boundary_audit.py` clears inherited `PG*` settings only for its source-owned default, while `tests/test_eom_write_boundary_audit.py` proves inherited root/client certificate paths survive an explicit DSN.
- Stage peer authentication before switching the monitor default -- fixed-in: `.agent/runbooks/database.md` admits the timer contract before HBA mutation, stages the installed socket source after the loaded peer-map receipt, and restores the pre-peer copy before rollback restores HBA; `tests/test_agent_operations_contract.py` pins both ordering and restoration.
- Route typed maintenance callers through socket-aware kwargs -- fixed-in: `scripts/backfill_community_buying_stage_defaults.py` and `scripts/rebuild_blog_charts.py` now delegate their targets to `DatabaseConfig.connection_kwargs()`, pinned by `tests/test_eom_render_profile.py`.
- Pin the timer's psql executable before cutover -- fixed-in: `17fd0cac72cd7705cde7488875c69f7bde759f70` makes `.agent/runbooks/database.md` reject `ATLAS_EOM_AUDIT_PSQL_BIN` from either the unit or user-manager environment, and clears that selector from the operator dry run so it cannot prove a different binary.
- Preserve the rebuild's existing command-timeout behavior -- fixed-in: `17fd0cac72cd7705cde7488875c69f7bde759f70` filters the connection and command timeout keys injected by `connection_kwargs()` while retaining the chart rebuild's normalized target and existing pool bounds.
- Validate monitor sources before authentication edits -- fixed-in: `17fd0cac72cd7705cde7488875c69f7bde759f70` requires regular readable source and installed monitor files before the first HBA backup, while retaining the post-peer staging and rollback order.
- Reject an empty effective environment-file target -- fixed-in: `eaddaa91e6c406d0238c1f1e21d00b135592bbfa` makes `.agent/runbooks/database.md` reject leading, middle, and trailing empty members plus relative paths before new-socket admission or rollback can reach `sudoedit`; `tests/test_agent_operations_contract.py` proves the trailing-delimiter path makes no edit or HBA restore attempt.

All findings fixed or waived: yes.

## Fix-loop disposition preflight

- Root decision: Pin every privileged psql probe to port 5433
- Source trace: unpinned privileged psql probe -> PostgreSQL default or another local cluster -> HBA, replication, or recovery proof targets the wrong instance.
- Upstream files: `.agent/runbooks/database.md`, `atlas_brain/storage/config.py`, `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `tests/test_eom_render_profile.py`
- Fix strategy: upstream-root
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: `.agent/runbooks/database.md`, `atlas_brain/storage/config.py`, `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`, `ops`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `tests/test_agent_operations_contract.py`, `tests/test_eom_render_profile.py`
- Max files: 12
- Parked hardening: none

- Root decision: Verify the loaded peer HBA rule and its precedence
- Source trace: identity-map count proves only that `atlas_app` exists -> preceding local HBA rule can select another map or broad peer path -> service/socket proof succeeds through a different authorization boundary -> claimed exclusive peer identity is not established.
- Upstream files: `.agent/runbooks/database.md`, `tests/test_agent_operations_contract.py`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`
- Fix strategy: upstream-root
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: `.agent/runbooks/database.md`, `atlas_brain/storage/config.py`, `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`, `ops`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `tests/test_agent_operations_contract.py`, `tests/test_eom_render_profile.py`
- Max files: 12
- Parked hardening: none

- Root decision: Use HBA rule numbers to check precedence
- Source trace: source-local `line_number` comparison -> included HBA file can be evaluated before the intended rule despite its local line being greater -> competing local peer path is omitted from the receipt -> claimed exclusive peer identity is not established.
- Upstream files: `.agent/runbooks/database.md`, `tests/test_agent_operations_contract.py`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`
- Fix strategy: upstream-root
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: `.agent/runbooks/database.md`, `atlas_brain/storage/config.py`, `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`, `ops`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `tests/test_agent_operations_contract.py`, `tests/test_eom_render_profile.py`
- Max files: 12
- Parked hardening: none

- Root decision: Require every post-restart Atlas backend to use the socket
- Source trace: one qualifying Unix-socket row -> another qualifying `atlas` client remains on TCP -> service proof appears to pass -> trust removal strands the TCP client.
- Upstream files: `.agent/runbooks/database.md`, `tests/test_agent_operations_contract.py`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`
- Fix strategy: upstream-root
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: `.agent/runbooks/database.md`, `atlas_brain/storage/config.py`, `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`, `ops`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `tests/test_agent_operations_contract.py`, `tests/test_eom_render_profile.py`
- Max files: 12
- Parked hardening: none

- Root decision: Percent-encode the socket path in generated DSNs
- Source trace: raw socket path in a URI query -> delimiter splits or changes the parsed host -> direct DSN callers diverge from raw asyncpg kwargs -> connection target mismatch.
- Upstream files: `atlas_brain/storage/config.py`, `tests/test_eom_render_profile.py`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `.agent/runbooks/database.md`, `atlas_brain/storage/config.py`, `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`, `ops`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `tests/test_agent_operations_contract.py`, `tests/test_eom_render_profile.py`
- Max files: 12
- Parked hardening: none

- Root decision: Back up every HBA file modified by the cutover
- Source trace: HBA source omitted from the receipt -> included-file trust or loopback rule is edited -> top-level backup excludes the source -> rollback cannot restore the authentication boundary.
- Upstream files: `.agent/runbooks/database.md`, `tests/test_agent_operations_contract.py`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`
- Fix strategy: upstream-root
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: `.agent/runbooks/database.md`, `atlas_brain/storage/config.py`, `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`, `ops`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `tests/test_agent_operations_contract.py`, `tests/test_eom_render_profile.py`
- Max files: 12
- Parked hardening: none

- Root decision: Define covers_loopback in the final HBA receipt
- Source trace: `covers_loopback` exists only in the first `psql` command -> the separate exact-tuple command references a nonexistent column -> PostgreSQL rejects the final source-boundary receipt -> the cutover cannot verify its post-conversion state.
- Upstream files: `.agent/runbooks/database.md`, `tests/test_agent_operations_contract.py`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`
- Fix strategy: upstream-root
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: `.agent/runbooks/database.md`, `atlas_brain/storage/config.py`, `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`, `ops`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `tests/test_agent_operations_contract.py`, `tests/test_eom_render_profile.py`
- Max files: 12
- Parked hardening: none

- Root decision: Run configuration gates before authentication edits
- Source trace: selected service-file socket assignment or nonblank complete DSN -> backup, peer-map/HBA edit, and reload occur before the admission check -> the procedure stops with partial authentication state live -> the claimed stop-before-edit boundary is false.
- Upstream files: `.agent/runbooks/database.md`, `tests/test_agent_operations_contract.py`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`
- Fix strategy: upstream-root
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: `.agent/runbooks/database.md`, `atlas_brain/storage/config.py`, `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`, `ops`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `tests/test_agent_operations_contract.py`, `tests/test_eom_render_profile.py`
- Max files: 12
- Parked hardening: none

- Root decision: Validate the effective file before editing it
- Source trace: manually chosen effective path -> no membership proof before `sudoedit` -> socket setting can be written outside the selected service files -> transport proof fails and rollback refuses its late membership check -> partial peer-authentication state and stray setting remain.
- Upstream files: `.agent/runbooks/database.md`, `tests/test_agent_operations_contract.py`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`
- Fix strategy: upstream-root
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: `.agent/runbooks/database.md`, `atlas_brain/storage/config.py`, `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`, `ops`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `tests/test_agent_operations_contract.py`, `tests/test_eom_render_profile.py`
- Max files: 12
- Parked hardening: none

- Root decision: Reject every surviving socket assignment during rollback
- Source trace: rollback's exact single-file/value check -> a case- or spacing-variant socket assignment survives -> peer identity map/HBA restore removes its authentication path -> service can restart with a residual peer target and fixed inspection can prove a different path.
- Upstream files: `.agent/runbooks/database.md`, `tests/test_agent_operations_contract.py`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`
- Fix strategy: upstream-root
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: `.agent/runbooks/database.md`, `atlas_brain/storage/config.py`, `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`, `ops`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `tests/test_agent_operations_contract.py`, `tests/test_eom_render_profile.py`
- Max files: 12
- Parked hardening: none

- Root decision: Qualify the remaining missing-source stop condition
- Source trace: attested missing-source admission rule -> unqualified later stop condition -> contradictory operator decision for the same migration receipt.
- Upstream files: `.agent/runbooks/database.md`, `atlas_brain/storage/config.py`, `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `tests/test_eom_render_profile.py`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `.agent/runbooks/database.md`, `atlas_brain/storage/config.py`, `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`, `ops`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `tests/test_agent_operations_contract.py`, `tests/test_eom_render_profile.py`
- Max files: 12
- Parked hardening: none

- Root decision: Verify the application is actually using the socket
- Source trace: complete DSN precedence -> service and inspector can remain on loopback TCP -> HBA trust removal strands the application.
- Upstream files: `.agent/runbooks/database.md`, `atlas_brain/storage/config.py`, `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `tests/test_eom_render_profile.py`
- Fix strategy: upstream-root
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: `.agent/runbooks/database.md`, `atlas_brain/storage/config.py`, `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`, `ops`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `tests/test_agent_operations_contract.py`, `tests/test_eom_render_profile.py`
- Max files: 12
- Parked hardening: none

- Root decision: Include the socket port in target labels
- Source trace: socket target label omits port -> exact migration-target confirmation conflates distinct same-directory clusters -> attestation can target the wrong database instance.
- Upstream files: `.agent/runbooks/database.md`, `atlas_brain/storage/config.py`, `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `tests/test_eom_render_profile.py`
- Fix strategy: upstream-root
- Blocking predicate: data
- Disposition: fixed-in
- Allowed files: `.agent/runbooks/database.md`, `atlas_brain/storage/config.py`, `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`, `ops`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `tests/test_agent_operations_contract.py`, `tests/test_eom_render_profile.py`
- Max files: 12
- Parked hardening: none

- Root decision: Restore TCP configuration before restarting rollback
- Source trace: rollback restores pre-cutover HBA and identity map -> socket peer loses its map -> restart before removing socket configuration cannot reconnect.
- Upstream files: `.agent/runbooks/database.md`, `atlas_brain/storage/config.py`, `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `tests/test_eom_render_profile.py`
- Fix strategy: upstream-root
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: `.agent/runbooks/database.md`, `atlas_brain/storage/config.py`, `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`, `ops`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `tests/test_agent_operations_contract.py`, `tests/test_eom_render_profile.py`
- Max files: 12
- Parked hardening: none

- Root decision: Finalize the mandatory plan evidence
- Source trace: incomplete review contract and stale pending verification -> reviewer cannot establish scope or reproduce current proof -> security cutover evidence is not auditable.
- Upstream files: `plans/PR-Postgres-Loopback-Scram-Hardening.md`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `.agent/runbooks/database.md`, `atlas_brain/storage/config.py`, `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`, `ops`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `tests/test_agent_operations_contract.py`, `tests/test_eom_render_profile.py`
- Max files: 12
- Parked hardening: none

- Root decision: Pin the inspector to the service configuration
- Source trace: worktree environment-file precedence -> bare fixed inspection can use a different database target than atlas-api.service -> TCP-to-SCRAM conversion can strand the inspector or prove the wrong path.
- Upstream files: `ops`, `.agent/runbooks/database.md`, and `plans/PR-Postgres-Loopback-Scram-Hardening.md`
- Fix strategy: upstream-root
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: `.agent/runbooks/database.md`, `atlas_brain/storage/config.py`, `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`, `ops`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `tests/test_agent_operations_contract.py`, `tests/test_eom_render_profile.py`
- Max files: 12
- Parked hardening: none

- Root decision: Verify every loopback trust rule was removed
- Source trace: four independent HBA rules -> one IPv4 application probe -> IPv6 or replication trust can remain unnoticed after the claimed hardening.
- Upstream files: `.agent/runbooks/database.md` and `plans/PR-Postgres-Loopback-Scram-Hardening.md`
- Fix strategy: upstream-root
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: `.agent/runbooks/database.md`, `atlas_brain/storage/config.py`, `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`, `ops`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `tests/test_agent_operations_contract.py`, `tests/test_eom_render_profile.py`
- Max files: 12
- Parked hardening: none

- Root decision: Validate each exact loopback HBA channel
- Source trace: aggregated HBA counts -> duplicate IPv4 or wrong user/netmask can satisfy the receipt -> IPv6 or replication behavior is not proved after reload.
- Upstream files: `.agent/runbooks/database.md` and `plans/PR-Postgres-Loopback-Scram-Hardening.md`
- Fix strategy: upstream-root
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: `.agent/runbooks/database.md`, `atlas_brain/storage/config.py`, `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`, `ops`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `tests/test_agent_operations_contract.py`, `tests/test_eom_render_profile.py`
- Max files: 12
- Parked hardening: none

- Root decision: Reload PostgreSQL after restoring failed HBA edits
- Source trace: disk-only HBA restore -> PostgreSQL continues enforcing partial loaded rules -> rollback appearance diverges from active authentication state.
- Upstream files: `.agent/runbooks/database.md` and `plans/PR-Postgres-Loopback-Scram-Hardening.md`
- Fix strategy: upstream-root
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: `.agent/runbooks/database.md`, `atlas_brain/storage/config.py`, `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`, `ops`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `tests/test_agent_operations_contract.py`, `tests/test_eom_render_profile.py`
- Max files: 12
- Parked hardening: none

- Root decision: Gate the cutover on every active loopback client
- Source trace: inventory-only loopback activity/replication probes -> an active TCP client can reconnect after trust removal without a password -> security or availability regression after a superficially successful cutover.
- Upstream files: `.agent/runbooks/database.md` and `plans/PR-Postgres-Loopback-Scram-Hardening.md`
- Fix strategy: upstream-root
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: `.agent/runbooks/database.md`, `atlas_brain/storage/config.py`, `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`, `ops`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `tests/test_agent_operations_contract.py`, `tests/test_eom_render_profile.py`
- Max files: 12
- Parked hardening: none

- Root decision: Verify the loaded peer identity map is exclusive
- Source trace: append-only `atlas_app` map insertion -> a prior broad map can still authorize another OS account as `atlas` -> peer boundary is not exclusive.
- Upstream files: `.agent/runbooks/database.md` and `plans/PR-Postgres-Loopback-Scram-Hardening.md`
- Fix strategy: upstream-root
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: `.agent/runbooks/database.md`, `atlas_brain/storage/config.py`, `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`, `ops`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `tests/test_agent_operations_contract.py`, `tests/test_eom_render_profile.py`
- Max files: 12
- Parked hardening: none

- Root decision: Declare closure for the enumerated boundary sets
- Source trace: enumerated configuration, HBA, identity-map, client, and service-environment sets -> no declared membership source or handling of unlisted members -> reviewer and operator cannot prove that the cutover rejects a changed topology.
- Upstream files: `plans/PR-Postgres-Loopback-Scram-Hardening.md`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `.agent/runbooks/database.md`, `atlas_brain/storage/config.py`, `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`, `ops`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `tests/test_agent_operations_contract.py`, `tests/test_eom_render_profile.py`
- Max files: 12
- Parked hardening: none

- Root decision: Test complete-DSN precedence with a configured socket
- Source trace: complete-DSN test without a socket plus socket test without a complete DSN -> both-nonblank configuration state lacks regression coverage -> a precedence regression can bypass the socket cutover boundary.
- Upstream files: `atlas_brain/storage/config.py`, `tests/test_eom_render_profile.py`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`
- Fix strategy: upstream-root
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: `.agent/runbooks/database.md`, `atlas_brain/storage/config.py`, `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`, `ops`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `tests/test_agent_operations_contract.py`, `tests/test_eom_render_profile.py`
- Max files: 12
- Parked hardening: none

- Root decision: Route a successful passwordless probe through rollback
- Source trace: unexpected passwordless TCP success -> direct exit -> active HBA/identity-map state remains after a failed boundary probe -> the procedure can leave the intended security transition unrolled back.
- Upstream files: `.agent/runbooks/database.md`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`
- Fix strategy: upstream-root
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: `.agent/runbooks/database.md`, `atlas_brain/storage/config.py`, `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`, `ops`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `tests/test_agent_operations_contract.py`, `tests/test_eom_render_profile.py`
- Max files: 12
- Parked hardening: none

- Root decision: Reconcile every initially observed loopback client
- Source trace: initial TCP client inventory -> client disconnects before final snapshot -> final-empty gate admits an unproven future reconnect -> post-conversion authentication can strand the client.
- Upstream files: `.agent/runbooks/database.md`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`
- Fix strategy: upstream-root
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: `.agent/runbooks/database.md`, `atlas_brain/storage/config.py`, `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`, `ops`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `tests/test_agent_operations_contract.py`, `tests/test_eom_render_profile.py`
- Max files: 12
- Parked hardening: none

- Root decision: Reject every HBA rule whose network covers loopback
- Source trace: endpoint-equal `host` predicate -> a broader subnet, TLS-specific host type, or non-IP form can match loopback without entering the exact-tuple receipt -> conversion can accept a different active authentication rule.
- Upstream files: `.agent/runbooks/database.md`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`
- Fix strategy: upstream-root
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: `.agent/runbooks/database.md`, `atlas_brain/storage/config.py`, `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`, `ops`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `tests/test_agent_operations_contract.py`, `tests/test_eom_render_profile.py`
- Max files: 12
- Parked hardening: none

- Root decision: Clear case-insensitive database overrides before inspection
- Source trace: service helper leaves an inherited canonical non-target setting or Pydantic Settings accepts a lower/mixed-case alias -> fixed inspector constructs `DatabaseConfig` with a shadow target or timeout instead of the selected service configuration.
- Upstream files: `ops`, `tests/test_agent_operations_contract.py`, `.agent/runbooks/database.md`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`
- Fix strategy: upstream-root
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: `.agent/runbooks/database.md`, `atlas_brain/storage/config.py`, `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`, `ops`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `tests/test_agent_operations_contract.py`, `tests/test_eom_render_profile.py`
- Max files: 12
- Parked hardening: none

- Root decision: Put the complete overage rationale in Why
- Source trace: over-budget multi-surface cutover -> rationale outside required `Why this slice exists` section -> budget exception omits the migration-integrity restart coupling -> plan cannot establish the complete indivisible safety boundary.
- Upstream files: `plans/PR-Postgres-Loopback-Scram-Hardening.md`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `.agent/runbooks/database.md`, `atlas_brain/storage/config.py`, `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`, `ops`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `tests/test_agent_operations_contract.py`, `tests/test_eom_render_profile.py`
- Max files: 12
- Parked hardening: none

- Root decision: Clear every database override in the service probe
- Source trace: partial `env -u` service helper -> inherited canonical non-target setting such as `ATLAS_DB_CONNECT_TIMEOUT` -> `ops` deliberately honors exact-uppercase overrides -> service-pinned inspection can use a shadow timeout instead of the selected `EnvironmentFiles`.
- Upstream files: `.agent/runbooks/database.md`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `.agent/runbooks/database.md`, `atlas_brain/storage/config.py`, `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`, `ops`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `tests/test_agent_operations_contract.py`, `tests/test_eom_render_profile.py`
- Max files: 12
- Parked hardening: none

- Root decision: Reject pre-existing socket assignments before cutover
- Source trace: cutover adds a socket setting -> a prior assignment has no baseline receipt -> rollback can delete or override configuration the cutover did not create -> service reconnects through an unproved path after peer mapping/HBA changes.
- Upstream files: `.agent/runbooks/database.md`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `tests/test_agent_operations_contract.py`
- Fix strategy: upstream-root
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: `.agent/runbooks/database.md`, `atlas_brain/storage/config.py`, `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`, `ops`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `tests/test_agent_operations_contract.py`, `tests/test_eom_render_profile.py`
- Max files: 12
- Parked hardening: pre-existing socket configuration migration with an exact baseline/restore receipt

- Root decision: Reject case-variant pre-existing socket settings
- Source trace: `DatabaseConfig` consumes case-insensitive environment keys while the fixed inspector selects only canonical service-file keys -> a lower/mixed-case alias or an empty selected-file set can make proof use a fallback/different target -> case-variant socket or full-DSN configuration bypasses the cutover's claimed source-of-truth boundary.
- Upstream files: `.agent/runbooks/database.md`, `tests/test_agent_operations_contract.py`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`
- Fix strategy: upstream-root
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: `.agent/runbooks/database.md`, `atlas_brain/storage/config.py`, `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`, `ops`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `tests/test_agent_operations_contract.py`, `tests/test_eom_render_profile.py`
- Max files: 12
- Parked hardening: none

- Root decision: Inventory dormant loopback clients before replacing trust
- Source trace: live `pg_stat_activity`/`pg_stat_replication` snapshots omit an idle hourly one-shot -> its old TCP default has no socket/SCRAM receipt -> loopback trust removal can strand the repository-owned monitor on its next run.
- Upstream files: `.agent/runbooks/database.md`, `scripts/eom_write_boundary_audit.py`, `tests/test_agent_operations_contract.py`, `tests/test_eom_write_boundary_audit.py`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`
- Fix strategy: upstream-root
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: `.agent/runbooks/database.md`, `atlas_brain/storage/config.py`, `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md`, `ops`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `scripts/eom_write_boundary_audit.py`, `tests/test_agent_operations_contract.py`, `tests/test_eom_render_profile.py`, `tests/test_eom_write_boundary_audit.py`
- Max files: 12
- Parked hardening: explicit EOM audit DSN overrides need a separate owner-verified socket or SCRAM migration receipt

- Root decision: Reject command-line DSN overrides in the timer unit
- Source trace: substring-based scheduled `ExecStart` admission -> a drop-in adds `--atlas-dsn` or another target-affecting option -> the manual default dry run proves a different connection than the timer -> loopback trust can be removed without a receipt for the scheduled target.
- Upstream files: `.agent/runbooks/database.md`, `config/eom-write-boundary-audit.service`, `tests/test_agent_operations_contract.py`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`
- Fix strategy: upstream-root
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: `.agent/runbooks/database.md`, `config/eom-write-boundary-audit.service`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `tests/test_agent_operations_contract.py`
- Max files: 12
- Parked hardening: none

- Root decision: Preserve TLS inputs for explicit audit DSNs
- Source trace: blanket inherited-`PG*` scrub -> explicit owner DSN loses `PGSSLROOTCERT`, `PGSSLCERT`, or `PGSSLKEY` -> a supported certificate-authenticated monitor cannot connect -> the cutover regresses an explicit owner route outside its socket migration.
- Upstream files: `scripts/eom_write_boundary_audit.py`, `tests/test_eom_write_boundary_audit.py`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `scripts/eom_write_boundary_audit.py`, `tests/test_eom_write_boundary_audit.py`
- Max files: 12
- Parked hardening: explicit audit DSN transport migration remains owner-verified outside this socket cutover

- Root decision: Stage peer authentication before switching the monitor default
- Source trace: installed source switches to socket before the scoped peer map/HBA rule is loaded -> the active timer runs as `juan-canfield` through generic peer -> PostgreSQL cannot authenticate it as `atlas` -> the monitor is stranded before the cutover proof, and rollback can strand it again without source restoration.
- Upstream files: `.agent/runbooks/database.md`, `tests/test_agent_operations_contract.py`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`
- Fix strategy: upstream-root
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: `.agent/runbooks/database.md`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `tests/test_agent_operations_contract.py`
- Max files: 12
- Parked hardening: none

- Root decision: Route typed maintenance callers through socket-aware kwargs
- Source trace: typed maintenance callers construct asyncpg targets from `db_settings.host` -> configured socket path is bypassed -> scripts remain TCP clients after loopback trust is removed -> maintenance jobs can be stranded despite the shared connection seam.
- Upstream files: `scripts/backfill_community_buying_stage_defaults.py`, `scripts/rebuild_blog_charts.py`, `tests/test_eom_render_profile.py`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `scripts/backfill_community_buying_stage_defaults.py`, `scripts/rebuild_blog_charts.py`, `tests/test_eom_render_profile.py`
- Max files: 12
- Parked hardening: historic maintenance-script refactoring remains outside this targeted connection-seam repair

- Root decision: Pin the timer's psql executable before cutover
- Source trace: unit or user-manager `ATLAS_EOM_AUDIT_PSQL_BIN` -> scheduled script chooses an unchecked executable -> operator-shell dry run can select a different binary -> trust can be removed while the timer cannot measure.
- Upstream files: `.agent/runbooks/database.md`, `tests/test_agent_operations_contract.py`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`
- Fix strategy: upstream-root
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: `.agent/runbooks/database.md`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `scripts/rebuild_blog_charts.py`, `tests/test_agent_operations_contract.py`, `tests/test_eom_render_profile.py`
- Max files: 12
- Parked hardening: none

- Root decision: Preserve the rebuild's existing command-timeout behavior
- Source trace: socket-aware `connection_kwargs()` -> injected connection and command timeout keys -> previous unbounded-by-config pool query behavior changes -> long-running maintenance rebuild can fail without a requested behavior change.
- Upstream files: `scripts/rebuild_blog_charts.py`, `tests/test_eom_render_profile.py`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `.agent/runbooks/database.md`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `scripts/rebuild_blog_charts.py`, `tests/test_agent_operations_contract.py`, `tests/test_eom_render_profile.py`
- Max files: 12
- Parked hardening: none

- Root decision: Validate monitor sources before authentication edits
- Source trace: missing or unreadable source/installed monitor -> stage fails only after HBA backup and authentication edit -> rollback restores live files but leaves retry-blocking pre-peer backups -> a predictable precondition becomes a post-mutation failure.
- Upstream files: `.agent/runbooks/database.md`, `tests/test_agent_operations_contract.py`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`
- Fix strategy: upstream-root
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: `.agent/runbooks/database.md`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `scripts/rebuild_blog_charts.py`, `tests/test_agent_operations_contract.py`, `tests/test_eom_render_profile.py`
- Max files: 12
- Parked hardening: none

- Root decision: Reject an empty effective environment-file target
- Source trace: colon-delimited service EnvironmentFiles -> empty member or trailing delimiter -> derived final target is empty -> sentinel membership admits `::` -> HBA edit occurs before `sudoedit` fails -> rollback repeats the empty edit and cannot restore authentication.
- Upstream files: `.agent/runbooks/database.md`, `tests/test_agent_operations_contract.py`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`
- Fix strategy: upstream-root
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: `.agent/runbooks/database.md`, `plans/PR-Postgres-Loopback-Scram-Hardening.md`, `tests/test_agent_operations_contract.py`
- Max files: 12
- Parked hardening: none

## Deferred

- Least-privilege role separation, historic maintenance-script refactoring, and cross-host PostgreSQL/TLS policy remain outside this source slice.

## Parked hardening

- No parked item blocks the socket-peer cutover. The runbook requires a fresh activity/replication probe and production connection proof before HBA mutation.

## Cold diff reconstruction

- `atlas_brain/storage/config.py:77-136` makes the already-declared socket path select the socket host while retaining its port for both connection forms and exact-target label; no credential, role, or API behavior is added.
- `tests/test_eom_render_profile.py:862-1030` pins complete-DSN-over-socket precedence, socket DSN/kwargs output, distinct socket target labels, and both asyncpg pool creation and raw connections; adjacent TCP behavior remains covered.
- `.agent/runbooks/database.md` adds a service-file admission gate before the first HBA/identity backup; it derives the final selected effective file, proves its membership, rejects empty/case-variant configuration, every socket assignment, and every nonblank complete DSN without printing values, then uses the same membership predicate in rollback. It also gives the final exact-tuple HBA receipt its own `hba` CTE, so `covers_loopback` and the source-boundary predicate execute in one PostgreSQL statement. The existing client-inventory and HBA receipt behaviors remain otherwise intact.
- `docs/MIGRATION_CONTENT_INTEGRITY_RUNBOOK.md:41-50` consistently admits only matching, currently attested mismatch/missing-source evidence; migration code and ledger data are untouched.
- `ops:30-285` lists every `DatabaseConfig` setting, derives their case-folds, strips every matching inherited alias from the fixed-inspection child environment, then restores selected file values and exact-uppercase runtime overrides.
- `tests/test_agent_operations_contract.py` proves the key-set closure, service-helper unset-set closure, the independently scoped HBA receipts, pre-backup admission ordering, selected versus unlisted effective-file boundaries, and empty/quoted-empty/comment-only versus literal/expansion-shaped complete-DSN boundaries, alongside the pre-existing socket, rollback, transport, and HBA source/precedence checks.
- `scripts/eom_write_boundary_audit.py:168-210,270-279,443-485` clears inherited libpq values only when `main()` selected the source-owned default, preserves them for an explicit audit DSN, and passes that mode through the real `query_atlas()` invocation.
- `.agent/runbooks/database.md:167-256,410-411,619-623` rejects both DSN and psql-executable selectors from the unit or user-manager environment, requires regular readable source and installed monitor inputs before the first HBA backup and before staging, retains post-peer staging/rollback ordering, and clears the executable selector from the documented dry run.
- `.agent/runbooks/database.md:329-393` rejects an empty or relative selected `EnvironmentFiles` member and verifies the derived effective target before its membership sentinel; both new-socket admission and rollback call this guard before any edit.
- `config/eom-write-boundary-audit.service:21-23` documents the canonical target-free argv that the runbook admits; it does not change the systemd command, timer, or monitor configuration.
- `scripts/backfill_community_buying_stage_defaults.py:62-65` retains its explicit 60-second command timeout while delegating target selection to `connection_kwargs()`; `scripts/rebuild_blog_charts.py:25-44` retains its pool sizes and pre-existing absence of explicit connection/command timeouts while using that same socket-aware seam.
- `tests/test_eom_write_boundary_audit.py:221-265,586-637`, `tests/test_agent_operations_contract.py:263-314,808-840`, and `tests/test_eom_render_profile.py:963-998` prove default/explicit libpq boundaries, unit and manager executable-override rejection, readable/missing/unreadable stage-input boundaries, leading/middle/trailing-empty and relative environment-file rejection, rollback-before-edit, source-stage/restore behavior, and the rebuild timeout filter.
- `plans/PR-Postgres-Loopback-Scram-Hardening.md` records the root causes, required pre-mutation, effective-file, and independent-query boundaries, verification evidence, deferred work, and exact changed-file budget.
- Contract match: the full `origin/main...HEAD` diff is limited to the twelve paths declared in the plan; the current three-file repair is limited to the service-environment list and effective-target admission root above.
- Gaps: none found. No API, schema, data, alert/state, timer cadence, live PostgreSQL/HBA action, or user-facing behavior changed.

## Verification

- `./ops test focused tests/test_eom_write_boundary_audit.py tests/test_agent_operations_contract.py tests/test_eom_render_profile.py -q` passed locally with `203 passed, 2 skipped`; it includes the service/user-manager executable, missing/unreadable stage-input, rebuild-timeout, malformed service-environment-list, and rollback-before-edit boundaries.
- `bash scripts/pre_push_audit.sh --repo-root "$PWD" --script-root "$PWD" --pr-author juan-canfield`, `git diff --check`, and strict guard-class closure checks passed locally after the repair.
- Focused configuration regression passed: socket DSN/kwargs, existing TCP and complete-DSN cases, plus the pool/raw caller seam.
- Focused operations-context regression passed: worktree precedence and explicit service-environment override order.
- Focused database-environment regression passed: exact-uppercase overrides remain admitted, while lower/mixed-case target and timeout aliases are absent from the inspection child and cannot change the resulting `DatabaseConfig`; a field-set equality regression prevents a future alias gap.
- The exact final HBA receipt executed read-only before cutover and returned `0|0|0|0|4|4|0|0`, proving the new statement-scoped `covers_loopback` relation reaches PostgreSQL. This is intentionally not the post-conversion acceptance receipt, which remains `1|1|1|1|0|0|0|0`.
- The read-only loaded-map receipt returned `0|0|0|0` before cutover, and the loopback inventory exposed two idle `atlas` TCP sessions; the runbook now requires the exact map receipt and zero remaining TCP loopback/replication rows before HBA replacement.
- The installed asyncpg parser reads `port` before `host` query settings and constructs a Unix socket when the host begins with `/`; local source evidence is in `asyncpg/connect_utils.py:353-361,637-642`.
- The direct live socket probe is intentionally deferred to the post-merge runbook: the `postgres` OS account cannot execute the project virtualenv, and system Python lacks asyncpg. No HBA rule is changed until the deployed application, fixed inspection, and authenticated CRM read prove the socket path.
- The independent EOM audit monitor is not a live-snapshot client by design. The source, unit, and no-override preflight is therefore coupled to an installed no-alert run after peer setup; it accepts only a clean (`0`) or measured-breach (`2`) monitor result and rejects an unreadable socket route before trust removal.
- The service-pinned preflight now derives the final selected effective file and rejects an empty file set, an unlisted effective path, every noncanonical `ATLAS_DB_*` alias, every existing socket assignment, and every nonblank complete DSN before it creates an HBA/identity backup. Empty, quoted-empty, and comment-only complete-DSN assignments pass; literal and expansion-shaped values stop. Rollback reuses the effective-file membership predicate.
- The read-only live HBA view exposes loaded `rule_number` values `1`, `2`, and `5` for source `line_number` values `118`, `123`, and `130`; the receipt now uses the loaded-order field, not the source-file field.
- The effective-file, new-socket-admission, rollback helper, and negative-probe blocks pass `bash -n`; the restored-HBA receipt uses the same read-only `pg_hba_file_rules` count that the helper requires before an `atlas-api.service` restart.
- The derived network query itself returned `4` against the live pre-conversion topology; its trust-parameterized cross-check returned `4|0`, and synthetic broad, TLS-specific, and non-IP candidates all fell on the fail-closed side.
- GitHub remains the complete unit gate.

## Mechanical verification

- Command: `./ops test focused tests/test_eom_write_boundary_audit.py tests/test_agent_operations_contract.py tests/test_eom_render_profile.py -q` - Result: pass (`197 passed, 2 skipped`) - Environment: local
- Command: `bash scripts/pre_push_audit.sh --repo-root "$PWD" --script-root "$PWD" --pr-author juan-canfield` - Result: pass - Environment: local
- Command: `./ops test focused tests/test_eom_render_profile.py -q -k 'database_config or database_pool_uses_configured_connection_kwargs'` - Result: pass (5 passed, 61 deselected) - Environment: local
- Command: `./ops test focused tests/test_agent_operations_contract.py -q -k 'database_file_context_prefers_worktree_over_shared_and_systemd or database_file_context_honors_explicit_override_order'` - Result: pass (2 passed, 39 deselected) - Environment: local
- Command: `./ops test focused tests/test_agent_operations_contract.py -q -k 'effective_env_file or new_socket_configuration or final_hba_receipt or admits_new_socket_configuration_before_hba_mutation or rollback_refuses or peer_hba_receipt or qualifying_atlas_backends or hba_sources'` - Result: pass (15 passed, 60 deselected) - Environment: local
- Command: `./ops test focused tests/test_agent_operations_contract.py -q` - Result: pass (75 passed) - Environment: local
- Command: `bash scripts/check_ascii_python.sh` - Result: pass - Environment: local
- Command: extracted `service_db_inspect`, effective-file, new-socket-admission, canonical-key/no-socket, and rollback shell blocks through `bash -n` - Result: pass - Environment: local
- Command: extracted pre-existing-socket guard through `bash -n` - Result: pass - Environment: local
- Command: `python scripts/sync_pr_plan.py plans/PR-Postgres-Loopback-Scram-Hardening.md origin/main --check` - Result: pass - Environment: local
- Command: `git diff --check` - Result: pass - Environment: local
- Command: extracted `rollback_peer_cutover` and negative-probe shell blocks through `bash -n` - Result: pass - Environment: local
- Command: extracted inventory/HBA/probe shell blocks through `bash -n`, then executed the read-only derived network receipt - Result: pass (`4`) - Environment: local
- Command: read-only HBA-source receipt - Result: pass (`4|0|0`) - Environment: local
- Command: synthetic qualified-client transport boundary - Result: pass (`mixed|1|0`; `socket_only|1|1`) - Environment: local
- Command: exact final post-conversion HBA receipt against the pre-conversion topology - Result: pass (query executed: `0|0|0|0|4|4|0|0`; intentionally not the post-conversion acceptance value) - Environment: local
- Command: `./ops test focused tests/test_eom_write_boundary_audit.py -q -k 'socket or dsn or libpq_target'` - Result: pass (5 passed, 29 deselected) - Environment: local
- Command: `./ops test focused tests/test_agent_operations_contract.py -q -k 'dormant_eom_audit or admits_the_dormant'` - Result: pass (9 passed, 75 deselected) - Environment: local
- Command: `./ops test focused tests/test_eom_write_boundary_audit.py tests/test_agent_operations_contract.py -q` - Result: pass (116 passed, 2 skipped) - Environment: local
- Command: `python scripts/check_guard_class_closure.py --base origin/main --strict` - Result: pass - Environment: local
- Command: `./ops test focused tests/test_eom_write_boundary_audit.py tests/test_agent_operations_contract.py tests/test_eom_render_profile.py -q` - Result: pass (190 passed, 2 skipped) - Environment: local
- Command: `bash scripts/check_ascii_python.sh && python scripts/check_guard_class_closure.py --base origin/main --strict && git diff --check origin/main` - Result: pass - Environment: local
- Command: `python scripts/sync_pr_plan.py plans/PR-Postgres-Loopback-Scram-Hardening.md origin/main --check` - Result: pass - Environment: local
- Command: `python scripts/audit_pr_body.py --base-ref origin/main tmp/pr-body-postgres-loopback-peer-hardening.md && python scripts/audit_fix_loop_disposition.py --repo-root . --base-ref origin/main --current-pr-body-file tmp/pr-body-postgres-loopback-peer-hardening.md` - Result: pass - Environment: local
- Command: `./ops test focused tests/test_eom_write_boundary_audit.py tests/test_agent_operations_contract.py tests/test_eom_render_profile.py -q` - Result: pass (`203 passed, 2 skipped`) - Environment: local
- Command: `git diff --check`, `bash scripts/check_ascii_python.sh`, `python scripts/check_guard_class_closure.py --base origin/main --strict`, and `python scripts/sync_pr_plan.py plans/PR-Postgres-Loopback-Scram-Hardening.md origin/main --check` - Result: pass - Environment: local
- Skipped: direct asyncpg socket connection as the PostgreSQL OS account | Reason: project virtualenv traversal is denied and the system interpreter lacks asyncpg; the runbook requires the real post-merge proof before HBA changes.

## Diff size

- 12 files, 2729 changed lines; synchronized by `scripts/sync_pr_plan.py`.

<!-- atlas-open-pr-wrapper: v1 -->
