### PR TITLE
Add database role topology preflight

### DIFF
--- a/.agent/runbooks/database.md
+++ b/.agent/runbooks/database.md
@@ -74,7 +74,8 @@ DSN argument and has no apply mode.
    `ATLAS_DB_*` application credentials. The normal runtime target continues to
    come only from `DatabaseConfig`; the command pins both connections in
    read-only repeatable-read transactions and rejects a missing DBA value, a
-   different database/schema/cluster, a switched `SET ROLE` session, or a
+   different database/schema/cluster, a DBA session that reuses the runtime
+   authenticated or effective identity, a switched `SET ROLE` session, or a
    non-superuser session before it reads the catalog.
 
 3. From the Atlas worktree that supplies the intended runtime configuration,
@@ -85,9 +86,11 @@ DSN argument and has no apply mode.
    ```
 
    It prints a redacted JSON receipt with target labels, role attributes and
-   membership options, database/schema ownership, per-object owner and ACL
-   records (including PostgreSQL defaults and column grants), plus RLS policy
-   role bindings. It never prints a password or DSN query values, but role and
+   complete reachable membership options (including referenced predefined
+   roles), database/schema ownership, per-object owner and ACL records
+   (including PostgreSQL defaults, column grants, and security-invoker view
+   state), plus RLS policy role bindings and deparsed `USING`/`WITH CHECK`
+   expressions. It never prints a password or DSN query values, but role and
    ownership metadata is still operationally sensitive: retain it in the
    protected cutover record rather than pasting it into public issues.
 

--- a/.agent/runbooks/database.md
+++ b/.agent/runbooks/database.md
@@ -71,12 +71,14 @@ DSN argument and has no apply mode.
 2. In a protected, operator-only environment, provide exactly one direct
    PostgreSQL-superuser DSN under
    `ATLAS_DATABASE_ROLE_TOPOLOGY_DBA_DATABASE_URL`. Do not reuse the normal
-   `ATLAS_DB_*` application credentials. The normal runtime target continues to
-   come only from `DatabaseConfig`; the command pins both connections in
-   read-only repeatable-read transactions and rejects a missing DBA value, a
-   different database/schema/cluster, a DBA session that reuses the runtime
-   authenticated or effective identity, a switched `SET ROLE` session, or a
-   non-superuser session before it reads the catalog.
+   `ATLAS_DB_*` application credentials. Export this protected value in the
+   command's process environment; the command intentionally ignores `.env` and
+   `.env.local`. The normal runtime target continues to come only from
+   `DatabaseConfig`; the command pins both connections in read-only
+   repeatable-read transactions and rejects a missing DBA value, a different
+   database/schema/cluster, a DBA session that reuses the runtime authenticated
+   or effective identity, a switched `SET ROLE` session, or a non-superuser
+   session before it reads the catalog.
 
 3. From the Atlas worktree that supplies the intended runtime configuration,
    run the fixed evidence command:

--- a/.agent/runbooks/database.md
+++ b/.agent/runbooks/database.md
@@ -47,6 +47,55 @@ generic query command is unavailable until Atlas has a privilege-restricted
 inspection role. Do not paste customer content or identifiers into chat or
 GitHub, and do not substitute the live application role as an ad hoc read role.
 
+## Role-topology evidence preflight
+
+This is a read-only prerequisite for a later least-privilege role cutover. It
+does not create roles, grant or revoke privileges, transfer ownership, run a
+migration, or restart Atlas. Keep the protected DBA DSN out of `.env`, service
+environment files, shell history, Git, chat, and GitHub. The command accepts no
+DSN argument and has no apply mode.
+
+1. Record the live/runtime relationship first:
+
+   ```bash
+   ./ops deploy status
+   git rev-parse HEAD
+   ```
+
+   A receipt describes only the target reached by its two connections. If the
+   running `atlas-api.service` revision differs from the source revision that a
+   future cutover would deploy, record that drift and do not use the receipt to
+   authorize a role change. Converge the deployment, then collect a new receipt
+   before the cutover review.
+
+2. In a protected, operator-only environment, provide exactly one direct
+   PostgreSQL-superuser DSN under
+   `ATLAS_DATABASE_ROLE_TOPOLOGY_DBA_DATABASE_URL`. Do not reuse the normal
+   `ATLAS_DB_*` application credentials. The normal runtime target continues to
+   come only from `DatabaseConfig`; the command rejects a missing DBA value, a
+   different database/schema/cluster, a switched `SET ROLE` session, or a
+   non-superuser session before it reads the catalog.
+
+3. From the Atlas worktree that supplies the intended runtime configuration,
+   run the fixed evidence command:
+
+   ```bash
+   python scripts/check_database_role_topology.py
+   ```
+
+   It prints a redacted JSON receipt with target labels, role attributes,
+   memberships, database/schema ownership, owner summaries, and effective ACL
+   summaries (including PostgreSQL defaults and column grants), plus RLS policy
+   role bindings. It never prints a password or DSN query values, but role and
+   ownership metadata is still operationally sensitive: retain it in the
+   protected cutover record rather than pasting it into public issues.
+
+4. A nonzero exit means there is no valid receipt. Fix the configuration or
+   target-attestation problem and rerun the read-only preflight; do not work
+   around it with `./ops db inspect`, ad hoc SQL, or a role mutation. A later
+   reviewed DBA-only slice owns any actual role, grant, ownership, migration,
+   or service-credential change.
+
 ## Unix-socket peer and loopback SCRAM cutover
 
 This is a production-mutating operation. Perform it only from an owned,

--- a/.agent/runbooks/database.md
+++ b/.agent/runbooks/database.md
@@ -72,7 +72,8 @@ DSN argument and has no apply mode.
    PostgreSQL-superuser DSN under
    `ATLAS_DATABASE_ROLE_TOPOLOGY_DBA_DATABASE_URL`. Do not reuse the normal
    `ATLAS_DB_*` application credentials. The normal runtime target continues to
-   come only from `DatabaseConfig`; the command rejects a missing DBA value, a
+   come only from `DatabaseConfig`; the command pins both connections in
+   read-only repeatable-read transactions and rejects a missing DBA value, a
    different database/schema/cluster, a switched `SET ROLE` session, or a
    non-superuser session before it reads the catalog.
 
@@ -83,9 +84,9 @@ DSN argument and has no apply mode.
    python scripts/check_database_role_topology.py
    ```
 
-   It prints a redacted JSON receipt with target labels, role attributes,
-   memberships, database/schema ownership, owner summaries, and effective ACL
-   summaries (including PostgreSQL defaults and column grants), plus RLS policy
+   It prints a redacted JSON receipt with target labels, role attributes and
+   membership options, database/schema ownership, per-object owner and ACL
+   records (including PostgreSQL defaults and column grants), plus RLS policy
    role bindings. It never prints a password or DSN query values, but role and
    ownership metadata is still operationally sensitive: retain it in the
    protected cutover record rather than pasting it into public issues.

--- a/.github/workflows/atlas_eom_lead_pipeline_checks.yml
+++ b/.github/workflows/atlas_eom_lead_pipeline_checks.yml
@@ -9,6 +9,7 @@ on:
       - ".github/workflows/atlas_eom_lead_pipeline_checks.yml"
       - "docker-compose.yml"
       - "scripts/eom_write_boundary_audit.py"
+      - "scripts/check_database_role_topology.py"
       - "atlas_brain/autonomous/tasks/gmail_digest.py"
       - "atlas_brain/config.py"
       - "atlas_brain/main.py"
@@ -97,6 +98,7 @@ on:
       - "tests/test_eom_missed_call_privilege_runner.py"
       - "tests/test_eom_first_clean_completion.py"
       - "tests/test_eom_first_clean_completion_dba_runner.py"
+      - "tests/test_database_role_topology_preflight.py"
       - "tests/test_eom_lead_conversion_integration.py"
       - "tests/test_eom_render_profile.py"
       - "tests/test_eom_public_onboarding.py"
@@ -124,6 +126,7 @@ on:
       - ".github/workflows/atlas_eom_lead_pipeline_checks.yml"
       - "docker-compose.yml"
       - "scripts/eom_write_boundary_audit.py"
+      - "scripts/check_database_role_topology.py"
       - "atlas_brain/autonomous/tasks/gmail_digest.py"
       - "atlas_brain/config.py"
       - "atlas_brain/main.py"
@@ -212,6 +215,7 @@ on:
       - "tests/test_eom_missed_call_privilege_runner.py"
       - "tests/test_eom_first_clean_completion.py"
       - "tests/test_eom_first_clean_completion_dba_runner.py"
+      - "tests/test_database_role_topology_preflight.py"
       - "tests/test_eom_lead_conversion_integration.py"
       - "tests/test_eom_render_profile.py"
       - "tests/test_eom_public_onboarding.py"
@@ -267,6 +271,7 @@ jobs:
       ATLAS_MIGRATION_TEST_DATABASE_URL: postgresql://atlas:atlas@localhost:5432/atlas_migration_tests
       ATLAS_EOM_FIRST_CLEAN_TEST_DATABASE_URL: postgresql://atlas:atlas@localhost:5433/atlas_eom_first_clean_tests
       ATLAS_EOM_FIRST_CLEAN_DBA_DATABASE_URL: postgresql://atlas_eom_test_dba:atlas-eom-test-dba@localhost:5433/atlas_eom_first_clean_tests
+      ATLAS_DATABASE_ROLE_TOPOLOGY_TEST_DBA_DATABASE_URL: postgresql://atlas:atlas@localhost:5432/atlas_migration_tests
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -337,6 +342,7 @@ jobs:
             tests/test_eom_missed_call_privilege_runner.py \
             tests/test_eom_first_clean_completion.py \
             tests/test_eom_first_clean_completion_dba_runner.py \
+            tests/test_database_role_topology_preflight.py \
             tests/test_eom_lead_conversion_integration.py \
             tests/test_eom_render_profile.py \
             tests/test_eom_funnel_capability_manifest.py \

--- a/atlas_brain/config.py
+++ b/atlas_brain/config.py
@@ -36,6 +36,9 @@ EOM_FIRST_CLEAN_COMPLETION_DBA_SCHEMA_ENV = (
 EOM_MISSED_CALL_RECOVERY_DBA_DATABASE_URL_ENV = (
     "ATLAS_EOM_MISSED_CALL_RECOVERY_DBA_DATABASE_URL"
 )
+DATABASE_ROLE_TOPOLOGY_DBA_DATABASE_URL_ENV = (
+    "ATLAS_DATABASE_ROLE_TOPOLOGY_DBA_DATABASE_URL"
+)
 _IMAP_PORT_ADAPTER = TypeAdapter(Annotated[int, Field(ge=1, le=65535)])
 _IMAP_SSL_ADAPTER = TypeAdapter(bool)
 
@@ -2600,6 +2603,27 @@ class EOMMissedCallRecoveryDBAConfig(BaseSettings):
         description=(
             "Protected PostgreSQL superuser DSN used only by the controlled "
             "EOM missed-call recovery privilege runner."
+        ),
+    )
+
+
+class DatabaseRoleTopologyDBAConfig(BaseSettings):
+    """Protected DBA-only configuration for the role-topology preflight.
+
+    The normal Atlas runtime does not instantiate this settings boundary. The
+    standalone evidence command is the only consumer of the privileged
+    connection it represents, and it performs no role or ownership mutation.
+    """
+
+    model_config = SettingsConfigDict(env_file=ENV_FILES, extra="ignore")
+
+    database_url: SecretStr = Field(
+        default=SecretStr(""),
+        validation_alias=AliasChoices(DATABASE_ROLE_TOPOLOGY_DBA_DATABASE_URL_ENV),
+        repr=False,
+        description=(
+            "Protected PostgreSQL superuser DSN used only by the read-only "
+            "database role-topology preflight."
         ),
     )
 

--- a/atlas_brain/config.py
+++ b/atlas_brain/config.py
@@ -2615,7 +2615,9 @@ class DatabaseRoleTopologyDBAConfig(BaseSettings):
     connection it represents, and it performs no role or ownership mutation.
     """
 
-    model_config = SettingsConfigDict(env_file=ENV_FILES, extra="ignore")
+    # This direct-superuser credential is intentionally process-environment
+    # only: a worktree dotenv file must not satisfy the preflight boundary.
+    model_config = SettingsConfigDict(env_file=None, extra="ignore")
 
     database_url: SecretStr = Field(
         default=SecretStr(""),

--- a/plans/PR-Postgres-Role-Topology-Preflight.md
+++ b/plans/PR-Postgres-Role-Topology-Preflight.md
@@ -366,5 +366,5 @@ Parked hardening: none.
 | `atlas_brain/config.py` | 24 |
 | `plans/PR-Postgres-Role-Topology-Preflight.md` | 370 |
 | `scripts/check_database_role_topology.py` | 810 |
-| `tests/test_database_role_topology_preflight.py` | 1028 |
-| **Total** | **2288** |
+| `tests/test_database_role_topology_preflight.py` | 1030 |
+| **Total** | **2290** |

--- a/plans/PR-Postgres-Role-Topology-Preflight.md
+++ b/plans/PR-Postgres-Role-Topology-Preflight.md
@@ -19,10 +19,11 @@ change production roles, ownership, credentials, or startup behavior.
 
 This slice intentionally exceeds the 400-LOC soft cap. Its typed privileged
 configuration, two-target admission checks, fixed catalog projection,
-fail-closed boundary fixtures, and operator procedure are one atomic safety
-surface: splitting them would either publish an unverified privileged reader
-or leave the operator without a usable, documented receipt. It does not carry
-the later role/grant/ownership cutover, which remains a separate slice.
+fail-closed boundary fixtures, disposable PostgreSQL 16 integration proof, and
+operator procedure are one atomic safety surface: splitting them would either
+publish an unverified privileged reader or leave the operator without a usable,
+documented receipt. It does not carry the later role/grant/ownership cutover,
+which remains a separate slice.
 
 ### Problem-derived contract
 
@@ -41,8 +42,9 @@ the later role/grant/ownership cutover, which remains a separate slice.
   2. Add a fixed-query, read-only preflight that opens the normal runtime
      target and the DBA target, proves that both reach the same PostgreSQL
      database/cluster, rejects an insufficient DBA identity, and reports the
-     role, membership, database-owner, schema-owner, relation-owner, and ACL
-     facts needed for a later cutover without customer rows or credentials.
+     role, membership, database-owner, schema-owner, and per-object ownership
+     and ACL facts needed for a later cutover without customer rows or
+     credentials.
   3. Add focused unit coverage for successful target attestation and each
      fail-closed admission path; prove every connection enters a read-only
      transaction and no apply/mutation path exists.
@@ -60,6 +62,45 @@ the later role/grant/ownership cutover, which remains a separate slice.
      maintenance-script refactor.
   4. Do not expose a generic SQL runner, print DSNs/passwords, or add a
      production role change disguised as a preflight.
+
+### Contract revision — current-head review findings
+
+New evidence:
+
+- The fixed membership projection records only `admin_option`, while PostgreSQL
+  16 stores distinct `inherit_option` and `set_option` authority on each
+  membership edge.
+- Runtime identity, DBA identity, lock attestation, and the catalog projection
+  currently use separate acquired transactions. A receipt needs one pinned
+  runtime connection and one pinned DBA connection, with the DBA catalog facts
+  taken from the same stable snapshot that passed attestation.
+- Relation/function owner and ACL records, column grants, and RLS-policy roles
+  are aggregated into counts, losing the object identity required to design a
+  least-privilege cutover.
+- The focused unit double checks query routing but does not execute the catalog
+  SQL through PostgreSQL 16.
+
+Revised required change surface:
+
+1. Record each PostgreSQL 16 membership row's grantor and `admin_option`,
+   `inherit_option`, and `set_option` fields.
+2. Pin target identity, shared-lock attestation, and all catalog reads to the
+   same acquired runtime/DBA connections, in read-only repeatable-read
+   transactions, before rendering a receipt.
+3. Replace lossy object-level counts with stable relation, function, column,
+   and policy identities alongside their owner, ACL, and RLS metadata.
+4. Add a disposable PostgreSQL 16 integration test that seeds only test roles,
+   objects, grants, and a policy; invokes the real command through asyncpg; and
+   is enrolled in its PostgreSQL-backed GitHub workflow.
+
+Revised non-scope:
+
+- The command remains evidence-only. No production database action is added.
+  The integration fixture may create and tear down only uniquely named roles,
+  schema objects, grants, and policies inside the disposable GitHub PostgreSQL
+  16 service; it must never receive a production or operator DSN.
+- Normal startup, `DatabaseConfig`, `DatabasePool`, migrations, EOM funnel
+  behavior, APIs, and role topology remain outside this revision.
 
 ## Scope (this PR)
 
@@ -142,11 +183,11 @@ Required because this slice adds a DBA-only configuration boundary.
   command does not maintain a copied role or object inventory.
 - The projection classes are **CLOSED for this slice**: target identity, role
   attributes, membership edges, current-database ownership/ACL, non-system
-  schema ownership/ACL, relation and function owner/effective-ACL summaries
-  with row-security and security-definer flags, explicit column-ACL and
-  row-security-policy role summaries, and explicit default-ACL overrides. Their
-  canonical definition is this problem-derived contract and the static query
-  constants in the command.
+  schema ownership/ACL, per-object relation and function ownership/effective
+  ACL records with row-security and security-definer flags, explicit
+  column-ACL and row-security-policy role records, and explicit default-ACL
+  overrides. Their canonical definition is this problem-derived contract and
+  the static query constants in the command.
 - Catalog classes outside that closed projection, plus `pg_*` and
   `information_schema` objects, are deliberately not interpreted as permission
   to proceed. Incomplete, malformed, mismatched, or unrecognized evidence
@@ -157,6 +198,7 @@ Required because this slice adds a DBA-only configuration boundary.
 ### Files touched
 
 - `.agent/runbooks/database.md`
+- `.github/workflows/atlas_eom_lead_pipeline_checks.yml`
 - `atlas_brain/config.py`
 - `plans/PR-Postgres-Role-Topology-Preflight.md`
 - `scripts/check_database_role_topology.py`
@@ -167,18 +209,20 @@ Required because this slice adds a DBA-only configuration boundary.
 The command uses the ordinary `DatabaseConfig` only to open the same runtime
 target that Atlas would use. A separate typed `SecretStr` DBA configuration is
 loaded only inside the command. It opens bounded, statement-cache-free pools,
-attests that the runtime and DBA sessions name the same database/schema and
+pins one runtime and one DBA connection in read-only repeatable-read
+transactions, attests that those sessions name the same database/schema and
 share a transaction-scoped advisory-lock namespace, then verifies the DBA
-session is a superuser before reading a fixed catalog projection.
+session is a superuser before reading a fixed catalog projection from that same
+DBA transaction.
 
 The projection contains no business rows and no DSN text. It reports only
-database/current-schema ownership, relevant roles and memberships, protected
-EOM guard isolation, runtime privilege flags, relation/sequence/function owner
-summaries with row-security and security-definer flags, and effective ACL
-summaries (including PostgreSQL defaults, explicit column grants, and RLS policy
-role bindings) needed to design the next role-separation slice. The JSON
-renderer redacts targets to host/port/database labels and never serializes a
-`SecretStr` value.
+database/current-schema ownership, relevant roles and PostgreSQL 16 membership
+options, protected EOM guard isolation, runtime privilege flags, per-object
+relation/sequence/function ownership with row-security and security-definer
+flags, and effective ACL records (including PostgreSQL defaults, explicit
+column grants, and RLS policy role bindings) needed to design the next
+role-separation slice. The JSON renderer redacts targets to host/port/database
+labels and never serializes a `SecretStr` value.
 
 The command has no `--apply` option and never calls `execute` for DDL/DML. It
 does not extend `./ops db inspect`, so the ordinary operator surface remains
@@ -224,22 +268,23 @@ Parked hardening: none.
   tests/test_database_role_topology_preflight.py atlas_brain/config.py`;
   `./ops test focused tests/test_database_role_topology_preflight.py
   tests/test_agent_operations_contract.py
-  tests/test_eom_first_clean_completion_dba_runner.py -q` (`137 passed`);
+  tests/test_eom_first_clean_completion_dba_runner.py -q` (`140 passed, 1
+  skipped`);
   `bash scripts/check_ascii_python.sh`; `git diff --cached --check`;
   `python scripts/sync_pr_plan.py --check
   plans/PR-Postgres-Role-Topology-Preflight.md origin/main`; and
   `python scripts/audit_plan_doc.py
   plans/PR-Postgres-Role-Topology-Preflight.md`.
+- The real PostgreSQL 16 command test skips locally unless the explicitly named,
+  loopback-only disposable DBA test DSN is present. The EOM PostgreSQL workflow
+  supplies that service and runs the test; it must pass there before merge.
 - Not locally runnable: `gitleaks protect --staged --redact --verbose` because
   the executable is absent in this worktree environment. Do not bypass it; the
   required CI secret scan remains the release gate.
-- Passed after the first commit: `python scripts/audit_plan_doc_files_touched.py
-  plans/PR-Postgres-Role-Topology-Preflight.md origin/main` and
-  `python scripts/audit_plan_doc_diff_size.py
-  plans/PR-Postgres-Role-Topology-Preflight.md origin/main` (the plan's five
-  files and `1757` LOC match `origin/main...HEAD`).
-- Passed before push: the local PR-review wrapper completed successfully with
-  its isolated session-state file and the current PR body.
+- Passed after the current follow-up commit: the plan-file and diff-size audits
+  agree that the six declared files and `2136` LOC match `origin/main...HEAD`.
+- Pending before the current branch update: the local PR-review wrapper with
+  its isolated session-state file and current PR body.
 - No production database role/configuration/deployment action is part of local
   verification. A real receipt is deferred until a protected DBA DSN is
   provisioned and the deployed runtime has converged.
@@ -248,9 +293,10 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `.agent/runbooks/database.md` | 49 |
+| `.agent/runbooks/database.md` | 50 |
+| `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 6 |
 | `atlas_brain/config.py` | 24 |
-| `plans/PR-Postgres-Role-Topology-Preflight.md` | 256 |
-| `scripts/check_database_role_topology.py` | 761 |
-| `tests/test_database_role_topology_preflight.py` | 667 |
-| **Total** | **1757** |
+| `plans/PR-Postgres-Role-Topology-Preflight.md` | 302 |
+| `scripts/check_database_role_topology.py` | 783 |
+| `tests/test_database_role_topology_preflight.py` | 971 |
+| **Total** | **2136** |

--- a/plans/PR-Postgres-Role-Topology-Preflight.md
+++ b/plans/PR-Postgres-Role-Topology-Preflight.md
@@ -455,5 +455,5 @@ Parked hardening: none.
 | `atlas_brain/config.py` | 26 |
 | `plans/PR-Postgres-Role-Topology-Preflight.md` | 459 |
 | `scripts/check_database_role_topology.py` | 848 |
-| `tests/test_database_role_topology_preflight.py` | 1209 |
-| **Total** | **2603** |
+| `tests/test_database_role_topology_preflight.py` | 1216 |
+| **Total** | **2610** |

--- a/plans/PR-Postgres-Role-Topology-Preflight.md
+++ b/plans/PR-Postgres-Role-Topology-Preflight.md
@@ -166,6 +166,54 @@ Must not change:
   or privileges, add a migration, change normal runtime configuration, or
   broaden the disposable test target beyond its loopback-only guard.
 
+### Contract revision — authoritative privilege semantics and independent DBA identity
+
+Root cause:
+
+- The fixed receipt records named RLS policies and direct membership grants, but
+  omits the policy expressions and view-invoker state that route a privilege
+  decision through an authenticated role. It also reports a direct grant to a
+  predefined PostgreSQL role while dropping the predefined-role memberships
+  through which that role inherits authority. The result is a topology snapshot
+  that can understate the effective authority a later cutover must preserve.
+- The admission boundary proves that the two connections reach one target and
+  that the DBA session is a direct superuser, but it does not reject two
+  sessions authenticated as the same PostgreSQL principal. That contradicts the
+  command's separate DBA-identity requirement and lets a copied application
+  superuser configuration produce an apparently independently attested receipt.
+
+Required change surface:
+
+1. Extend the fixed relation and RLS-policy projections with the catalog fields
+   that control execution identity: security-invoker view state plus deparsed
+   `USING` and `WITH CHECK` policy expressions. Preserve the fixed-query,
+   JSON-scalar, redacted receipt boundary.
+2. Replace the one-hop `pg_` membership filter with a fixed recursive closure
+   from every reported non-system role through its granted roles. Emit the
+   closure's referenced role records and membership edges, including reachable
+   predefined roles, in deterministic order.
+3. Reject a runtime and DBA session that share either authenticated or effective
+   PostgreSQL identity before the shared-lock probe or any catalog read.
+4. Extend the controlled unit doubles and the disposable PostgreSQL 16 test to
+   prove all three conditions: a role-sensitive policy plus a
+   security-invoker view appear in the real receipt, a predefined-role chain is
+   retained, and same-principal admission fails before catalog access. The test
+   fixture must revoke every added predefined-role membership before dropping
+   its temporary runtime role.
+5. Update the database runbook's command contract to state the new fail-closed
+   same-principal check and the added evidence classes.
+
+Must not change:
+
+- Do not create, alter, grant, revoke, drop, or assume a production PostgreSQL
+  role; the standalone command remains read-only and has no mutation path.
+- Do not change `DatabaseConfig`, `DatabasePool`, application startup,
+  migrations, EOM behavior, existing role names, production credentials, or
+  deployment state.
+- Do not expose policy business rows, DSNs, passwords, generic SQL input, or a
+  role-cutover mechanism. The disposable PostgreSQL 16 fixture remains the
+  only test code allowed to create and clean up uniquely named test topology.
+
 ## Scope (this PR)
 
 Ownership lane: eom-crm/runtime-security
@@ -186,9 +234,10 @@ Max files: 6
   1. With an explicit valid DBA DSN and matching runtime/DBA identity, the
      command returns a redacted receipt containing only fixed catalog fields;
      settled by `tests/test_database_role_topology_preflight.py`.
-  2. With the DBA DSN absent, a runtime/DBA database or cluster mismatch, or a
-     non-superuser DBA session, the command raises before any catalog report;
-     settled by focused unit tests in the same file.
+  2. With the DBA DSN absent, a runtime/DBA database or cluster mismatch, a
+     reused runtime/DBA authenticated or effective identity, or a non-superuser
+     DBA session, the command raises before any catalog report; settled by
+     focused unit tests in the same file.
   3. Both connections execute inside read-only transactions and the command has
      no `--apply`/mutation branch; settled by its controlled test doubles and
      direct inspection of the command's connection flow.
@@ -201,9 +250,10 @@ Max files: 6
   JSON evidence receipt or a fail-closed error before catalog reporting.
 - Affected surfaces: typed DBA-only config, the new preflight script, focused
   test fixtures, and the database runbook. No runtime service caller is added.
-- Risk areas: credential redaction, target confusion, cross-cluster false
-  attestation, insufficient inspection authority, read-only enforcement,
-  current production/runtime drift, and accidental role/DDL mutation.
+- Risk areas: credential redaction, target confusion, runtime/DBA identity
+  reuse, cross-cluster false attestation, insufficient inspection authority,
+  read-only enforcement, current production/runtime drift, and accidental
+  role/DDL mutation.
 - Reviewer rules triggered: R1, R2, R3, R4, R6, R8, R10, R11, R12, R13, R14.
 
 ### Boundary-change enumeration
@@ -219,9 +269,9 @@ The preflight is an admission boundary for a privileged catalog receipt.
   session role; DBA database name/OID/current schema/current and session role;
   advisory-lock contention; DBA superuser status.
 - Caller x input shape: absent DBA configuration -> reject before connect;
-  explicit DBA DSN + matching runtime target -> fixed read-only report;
-  explicit DBA DSN + target mismatch/non-superuser session -> reject before
-  report.
+  explicit DBA DSN + matching independent runtime target -> fixed read-only
+  report; explicit DBA DSN + target mismatch, reused identity, or non-superuser
+  session -> reject before report.
 
 ### Deployed-config probing
 
@@ -234,8 +284,9 @@ Required because this slice adds a DBA-only configuration boundary.
   command uses it only for the dedicated DBA pool.
 - Absent value probe: a test proves missing/blank DBA DSN prevents pool creation.
 - Default-session/default-context probe: tests distinguish a direct runtime
-  session from a `SET ROLE`/mismatched session and prove runtime/DBA target
-  attestation uses both database identity and one advisory-lock namespace.
+  session from a `SET ROLE`/mismatched session, reject a reused runtime/DBA
+  authenticated or effective identity, and prove target attestation uses both
+  database identity and one advisory-lock namespace.
 - Side-effect ordering: all identity/config admissions precede catalog report
   construction; every catalog query runs inside `readonly=True` transactions;
   the command contains no mutation path.
@@ -247,17 +298,20 @@ Required because this slice adds a DBA-only configuration boundary.
   **DERIVED** on every command invocation from fixed `pg_catalog` queries; the
   command does not maintain a copied role or object inventory.
 - The projection classes are **CLOSED for this slice**: target identity, role
-  attributes, membership edges, current-database ownership/ACL, non-system
-  schema ownership/ACL, per-object relation and function ownership/effective
-  ACL records with row-security and security-definer flags, explicit
-  column-ACL and row-security-policy role records, and explicit default-ACL
+  attributes, each reported non-system role's reachable membership closure
+  (including referenced predefined-role records), current-database
+  ownership/ACL, non-system schema ownership/ACL, per-object relation and
+  function ownership/effective ACL records with row-security,
+  security-invoker, and security-definer flags, explicit column-ACL and
+  row-security-policy role/expression records, and explicit default-ACL
   overrides. Their canonical definition is this problem-derived contract and
   the static query constants in the command.
 - Catalog classes outside that closed projection, plus `pg_*` and
-  `information_schema` objects, are deliberately not interpreted as permission
-  to proceed. Incomplete, malformed, mismatched, or unrecognized evidence
-  fails to produce a receipt that can authorize a cutover; that is the safe
-  side because this command never changes authority and a later cutover remains
+  `information_schema` objects other than the reachable predefined-role
+  membership closure, are deliberately not interpreted as permission to
+  proceed. Incomplete, malformed, mismatched, or unrecognized evidence fails
+  to produce a receipt that can authorize a cutover; that is the safe side
+  because this command never changes authority and a later cutover remains
   blocked on a reviewed, complete receipt.
 
 ### Files touched
@@ -277,17 +331,19 @@ loaded only inside the command. It opens bounded, statement-cache-free pools,
 pins one runtime and one DBA connection in read-only repeatable-read
 transactions, attests that those sessions name the same database/schema and
 share a transaction-scoped advisory-lock namespace, then verifies the DBA
-session is a superuser before reading a fixed catalog projection from that same
-DBA transaction.
+session is a direct superuser with a different authenticated and effective
+identity before reading a fixed catalog projection from that same DBA
+transaction.
 
 The projection contains no business rows and no DSN text. It reports only
 database/current-schema ownership, relevant roles and PostgreSQL 16 membership
-options, protected EOM guard isolation, runtime privilege flags, per-object
-relation/sequence/function ownership with row-security and security-definer
-flags, and effective ACL records (including PostgreSQL defaults, explicit
-column grants, and RLS policy role bindings) needed to design the next
-role-separation slice. The JSON renderer redacts targets to host/port/database
-labels and never serializes a `SecretStr` value.
+options through each non-system role's reachable predefined-role closure,
+protected EOM guard isolation, runtime privilege flags, per-object
+relation/sequence/function ownership with row-security, security-invoker, and
+security-definer flags, and effective ACL records (including PostgreSQL
+defaults, explicit column grants, and deparsed RLS policy bindings/expressions)
+needed to design the next role-separation slice. The JSON renderer redacts
+targets to host/port/database labels and never serializes a `SecretStr` value.
 
 The command has no `--apply` option and never calls `execute` for DDL/DML. It
 does not extend `./ops db inspect`, so the ordinary operator surface remains
@@ -329,16 +385,17 @@ Parked hardening: none.
 
 ## Verification
 
-- Passed locally after the compatibility, cleanup, and provenance corrections:
+- Passed locally after the compatibility, cleanup, provenance, and
+  privilege-semantics corrections:
   `python3.11 -m py_compile
   tests/test_database_role_topology_preflight.py`; `python -m py_compile
   scripts/check_database_role_topology.py
   tests/test_database_role_topology_preflight.py atlas_brain/config.py`;
   `./ops test focused tests/test_database_role_topology_preflight.py -q`
-  (`20 passed, 1 skipped`); `./ops test focused
+  (`22 passed, 1 skipped`); `./ops test focused
   tests/test_database_role_topology_preflight.py
   tests/test_agent_operations_contract.py
-  tests/test_eom_first_clean_completion_dba_runner.py -q` (`142 passed, 1
+  tests/test_eom_first_clean_completion_dba_runner.py -q` (`144 passed, 1
   skipped`); and `bash scripts/check_ascii_python.sh`.
 - Not locally runnable: `python3.11 -m pytest
   tests/test_database_role_topology_preflight.py -q` because that isolated
@@ -361,10 +418,10 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `.agent/runbooks/database.md` | 50 |
+| `.agent/runbooks/database.md` | 53 |
 | `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 6 |
 | `atlas_brain/config.py` | 24 |
-| `plans/PR-Postgres-Role-Topology-Preflight.md` | 370 |
-| `scripts/check_database_role_topology.py` | 810 |
-| `tests/test_database_role_topology_preflight.py` | 1030 |
-| **Total** | **2290** |
+| `plans/PR-Postgres-Role-Topology-Preflight.md` | 427 |
+| `scripts/check_database_role_topology.py` | 848 |
+| `tests/test_database_role_topology_preflight.py` | 1174 |
+| **Total** | **2532** |

--- a/plans/PR-Postgres-Role-Topology-Preflight.md
+++ b/plans/PR-Postgres-Role-Topology-Preflight.md
@@ -130,6 +130,42 @@ Must not change:
   disposable database fixture's role/ACL/policy topology, workflow service
   topology, runtime configuration, or any production behavior.
 
+### Contract revision — ACL grantor provenance and disposable cleanup
+
+New evidence:
+
+- Every ACL projection emits its grantee and privilege but omits
+  `aclexplode(...).grantor`, so the receipt cannot distinguish a direct owner
+  grant from a delegated grant that disappears when an intermediate grantor is
+  revoked.
+- The disposable integration fixture grants the temporary runtime role
+  `USAGE` on `public`, but does not revoke that persistent schema ACL before
+  it drops the role.
+
+Root cause:
+
+- The role-topology receipt preserves object identity but not the provenance of
+  ACL authority, and the test fixture leaves one cross-schema dependency owned
+  by its temporary role.
+
+Required change surface:
+
+1. Add stable grantor OID and role-name fields to database, schema, relation,
+   function, column, and default-ACL records, and include those identities in
+   deterministic ordering.
+2. Extend the unit fixture and source-closure assertion for every ACL
+   projection; seed one delegated relation grant in the disposable PostgreSQL
+   16 test and assert its grantor OID/name in the real receipt.
+3. Reset any switched test role and revoke the temporary runtime role's
+   `public` schema `USAGE` before dropping it, so the integration fixture
+   proves cleanup rather than retaining a privilege dependency.
+
+Must not change:
+
+- Do not make the standalone command mutate a database, alter production roles
+  or privileges, add a migration, change normal runtime configuration, or
+  broaden the disposable test target beyond its loopback-only guard.
+
 ## Scope (this PR)
 
 Ownership lane: eom-crm/runtime-security
@@ -293,7 +329,8 @@ Parked hardening: none.
 
 ## Verification
 
-- Passed locally after the Python 3.11 correction: `python3.11 -m py_compile
+- Passed locally after the compatibility, cleanup, and provenance corrections:
+  `python3.11 -m py_compile
   tests/test_database_role_topology_preflight.py`; `python -m py_compile
   scripts/check_database_role_topology.py
   tests/test_database_role_topology_preflight.py atlas_brain/config.py`;
@@ -327,7 +364,7 @@ Parked hardening: none.
 | `.agent/runbooks/database.md` | 50 |
 | `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 6 |
 | `atlas_brain/config.py` | 24 |
-| `plans/PR-Postgres-Role-Topology-Preflight.md` | 333 |
-| `scripts/check_database_role_topology.py` | 783 |
-| `tests/test_database_role_topology_preflight.py` | 985 |
-| **Total** | **2181** |
+| `plans/PR-Postgres-Role-Topology-Preflight.md` | 370 |
+| `scripts/check_database_role_topology.py` | 810 |
+| `tests/test_database_role_topology_preflight.py` | 1028 |
+| **Total** | **2288** |

--- a/plans/PR-Postgres-Role-Topology-Preflight.md
+++ b/plans/PR-Postgres-Role-Topology-Preflight.md
@@ -1,0 +1,256 @@
+# PR-Postgres-Role-Topology-Preflight
+
+## Why this slice exists
+
+The operator asked to begin the deferred least-privilege database-role work
+from `PR-Postgres-Loopback-Scram-Hardening`. That prior slice deliberately did
+not alter role topology. Current source still routes the application pool,
+generic migration runner, and fixed operations inspection through the same
+`DatabaseConfig` connection path. A direct ownership/privilege cutover without
+an independently target-attested catalog receipt could alter the wrong database
+or break the EOM guard-owned namespace.
+
+This is a production-hardening prerequisite, not the role cutover itself. It
+adds a controlled, read-only evidence command that compares the configured
+runtime target with a separately configured DBA connection and emits only the
+catalog facts a later role-design slice needs. The currently deployed
+`atlas-api.service` is behind current `origin/main`, so this slice must not
+change production roles, ownership, credentials, or startup behavior.
+
+This slice intentionally exceeds the 400-LOC soft cap. Its typed privileged
+configuration, two-target admission checks, fixed catalog projection,
+fail-closed boundary fixtures, and operator procedure are one atomic safety
+surface: splitting them would either publish an unverified privileged reader
+or leave the operator without a usable, documented receipt. It does not carry
+the later role/grant/ownership cutover, which remains a separate slice.
+
+### Problem-derived contract
+
+- Root cause: Atlas has no independent, target-attested role-topology
+  inspection path. `DatabasePool` initializes with
+  `DatabaseConfig.connection_kwargs()`, the application lifespan passes that
+  pool to the generic migration runner, and `./ops db inspect` opens a
+  read-only connection from the same `DatabaseConfig`. As a result, source
+  alone cannot establish the live role graph required before separating runtime
+  DML, migration DDL, and inspection authority. A role/ownership change made
+  from that ambiguity could invalidate the existing EOM no-login guard boundary.
+- Correct fix must touch/change:
+  1. Add a typed, secret-redacted DBA-only configuration boundary that is
+     instantiated only by a new preflight command, never by normal Atlas
+     startup.
+  2. Add a fixed-query, read-only preflight that opens the normal runtime
+     target and the DBA target, proves that both reach the same PostgreSQL
+     database/cluster, rejects an insufficient DBA identity, and reports the
+     role, membership, database-owner, schema-owner, relation-owner, and ACL
+     facts needed for a later cutover without customer rows or credentials.
+  3. Add focused unit coverage for successful target attestation and each
+     fail-closed admission path; prove every connection enters a read-only
+     transaction and no apply/mutation path exists.
+  4. Document the command as evidence-only in the database runbook, including
+     the prerequisite that the live runtime revision must be converged before
+     any later role cutover.
+- Must not change:
+  1. Do not create, alter, grant, revoke, drop, or assume PostgreSQL roles;
+     do not change database/schema/object ownership or ACLs.
+  2. Do not change `DatabaseConfig`, `DatabasePool`, generic migration startup,
+     EOM funnel connection behavior, application role name `atlas`, the
+     existing `atlas_eom_handoff_owner` guard, or NocoDB privileges.
+  3. Do not add a migration, service restart, deployment action, runtime
+     credential, user-facing behavior, API, schema, dependency, or historical
+     maintenance-script refactor.
+  4. Do not expose a generic SQL runner, print DSNs/passwords, or add a
+     production role change disguised as a preflight.
+
+## Scope (this PR)
+
+Ownership lane: eom-crm/runtime-security
+Slice phase: Production hardening
+
+1. Add a fail-closed, read-only catalog receipt that establishes the live
+   PostgreSQL role/ownership topology before any authority separation is
+   attempted.
+2. Add a standalone `scripts/check_database_role_topology.py` command that is
+   evidence-only and defaults to a redacted JSON receipt.
+3. Add a typed `DatabaseRoleTopologyDBAConfig` used only by that command.
+4. Add focused fixture tests and a database-runbook entry for the command.
+
+### Review Contract
+
+- Acceptance criteria:
+  1. With an explicit valid DBA DSN and matching runtime/DBA identity, the
+     command returns a redacted receipt containing only fixed catalog fields;
+     settled by `tests/test_database_role_topology_preflight.py`.
+  2. With the DBA DSN absent, a runtime/DBA database or cluster mismatch, or a
+     non-superuser DBA session, the command raises before any catalog report;
+     settled by focused unit tests in the same file.
+  3. Both connections execute inside read-only transactions and the command has
+     no `--apply`/mutation branch; settled by its controlled test doubles and
+     direct inspection of the command's connection flow.
+  4. Normal `DatabaseConfig` startup/migration behavior is unchanged; settled
+     by unchanged `atlas_brain/storage/config.py`,
+     `atlas_brain/storage/database.py`, and `atlas_brain/main.py` plus the
+     focused regression suite.
+- Reachability proof: `python scripts/check_database_role_topology.py` is the
+  real operator entrypoint. Its observable result is a redacted, fixed-shape
+  JSON evidence receipt or a fail-closed error before catalog reporting.
+- Affected surfaces: typed DBA-only config, the new preflight script, focused
+  test fixtures, and the database runbook. No runtime service caller is added.
+- Risk areas: credential redaction, target confusion, cross-cluster false
+  attestation, insufficient inspection authority, read-only enforcement,
+  current production/runtime drift, and accidental role/DDL mutation.
+- Reviewer rules triggered: R1, R2, R3, R4, R6, R8, R10, R11, R12, R13, R14.
+
+### Boundary-change enumeration
+
+The preflight is an admission boundary for a privileged catalog receipt.
+
+- Boundary path/seam: `scripts/check_database_role_topology.py` admits the
+  runtime target and configured DBA target before it reads catalog facts.
+- Replaced-path behaviors: no prior role-topology command exists; generic
+  `./ops db inspect` remains restricted to connectivity/migration-count
+  queries and is not widened.
+- Guard-relevant fields: runtime database name/OID/current schema/current and
+  session role; DBA database name/OID/current schema/current and session role;
+  advisory-lock contention; DBA superuser status.
+- Caller x input shape: absent DBA configuration -> reject before connect;
+  explicit DBA DSN + matching runtime target -> fixed read-only report;
+  explicit DBA DSN + target mismatch/non-superuser session -> reject before
+  report.
+
+### Deployed-config probing
+
+Required because this slice adds a DBA-only configuration boundary.
+
+- Deployed/default config values: the normal runtime keeps its current
+  `DatabaseConfig` selection. The new DBA DSN is absent by default and the
+  command must fail closed when absent.
+- Explicit value probe: a test injects a valid typed DBA DSN and proves the
+  command uses it only for the dedicated DBA pool.
+- Absent value probe: a test proves missing/blank DBA DSN prevents pool creation.
+- Default-session/default-context probe: tests distinguish a direct runtime
+  session from a `SET ROLE`/mismatched session and prove runtime/DBA target
+  attestation uses both database identity and one advisory-lock namespace.
+- Side-effect ordering: all identity/config admissions precede catalog report
+  construction; every catalog query runs inside `readonly=True` transactions;
+  the command contains no mutation path.
+
+### Catalog-projection closure
+
+- The catalog row set is **OPEN**: roles, membership edges, non-system schemas,
+  objects, and ACL entries can change after this PR. Their membership is
+  **DERIVED** on every command invocation from fixed `pg_catalog` queries; the
+  command does not maintain a copied role or object inventory.
+- The projection classes are **CLOSED for this slice**: target identity, role
+  attributes, membership edges, current-database ownership/ACL, non-system
+  schema ownership/ACL, relation and function owner/effective-ACL summaries
+  with row-security and security-definer flags, explicit column-ACL and
+  row-security-policy role summaries, and explicit default-ACL overrides. Their
+  canonical definition is this problem-derived contract and the static query
+  constants in the command.
+- Catalog classes outside that closed projection, plus `pg_*` and
+  `information_schema` objects, are deliberately not interpreted as permission
+  to proceed. Incomplete, malformed, mismatched, or unrecognized evidence
+  fails to produce a receipt that can authorize a cutover; that is the safe
+  side because this command never changes authority and a later cutover remains
+  blocked on a reviewed, complete receipt.
+
+### Files touched
+
+- `.agent/runbooks/database.md`
+- `atlas_brain/config.py`
+- `plans/PR-Postgres-Role-Topology-Preflight.md`
+- `scripts/check_database_role_topology.py`
+- `tests/test_database_role_topology_preflight.py`
+
+## Mechanism
+
+The command uses the ordinary `DatabaseConfig` only to open the same runtime
+target that Atlas would use. A separate typed `SecretStr` DBA configuration is
+loaded only inside the command. It opens bounded, statement-cache-free pools,
+attests that the runtime and DBA sessions name the same database/schema and
+share a transaction-scoped advisory-lock namespace, then verifies the DBA
+session is a superuser before reading a fixed catalog projection.
+
+The projection contains no business rows and no DSN text. It reports only
+database/current-schema ownership, relevant roles and memberships, protected
+EOM guard isolation, runtime privilege flags, relation/sequence/function owner
+summaries with row-security and security-definer flags, and effective ACL
+summaries (including PostgreSQL defaults, explicit column grants, and RLS policy
+role bindings) needed to design the next role-separation slice. The JSON
+renderer redacts targets to host/port/database labels and never serializes a
+`SecretStr` value.
+
+The command has no `--apply` option and never calls `execute` for DDL/DML. It
+does not extend `./ops db inspect`, so the ordinary operator surface remains
+two fixed low-privilege queries instead of becoming a privileged catalog shell.
+
+## Intentional
+
+- A superuser DBA connection is intentionally required for a complete role and
+  ownership receipt; a normal application connection can be insufficient and
+  would make a false-complete report unsafe.
+- The preflight does not create the future inspection role. Creating roles,
+  transferring ownership, and changing runtime migration behavior are the
+  next controlled DBA slice after this receipt is collected and reviewed.
+- The current role name `atlas` remains a report field, not a newly enforced
+  global requirement. Existing EOM completion code has a stricter `atlas`
+  readiness invariant that remains unchanged.
+- Historical scripts that connect with `db_settings.dsn` remain untouched; they
+  are a separately deferred maintenance-runner refactor, not a reason to widen
+  this evidence command.
+
+## Deferred
+
+- Controlled role-topology cutover: create separate runtime, migration, and
+  inspection authorities; enumerate every application and maintenance caller;
+  transfer ownership only after a reviewed preflight receipt and deployed-code
+  convergence.
+- Runtime migration behavior: remove generic DDL from application startup and
+  replace it with a controlled migration deployment path plus readiness fence.
+- Historical maintenance-script refactoring into a supported operations runner.
+- Cross-host PostgreSQL authentication and TLS policy.
+- Deployment convergence: the running `atlas-api.service` must reach a revision
+  containing the current socket/guard code before any production role change.
+
+Parking predicate: any role, ownership, grant, service credential, migration,
+or deployment mutation is parked by default. This slice owns only the
+evidence-gathering command required to make those later changes safe.
+
+Parked hardening: none.
+
+## Verification
+
+- Passed locally: `python -m py_compile scripts/check_database_role_topology.py
+  tests/test_database_role_topology_preflight.py atlas_brain/config.py`;
+  `./ops test focused tests/test_database_role_topology_preflight.py
+  tests/test_agent_operations_contract.py
+  tests/test_eom_first_clean_completion_dba_runner.py -q` (`137 passed`);
+  `bash scripts/check_ascii_python.sh`; `git diff --cached --check`;
+  `python scripts/sync_pr_plan.py --check
+  plans/PR-Postgres-Role-Topology-Preflight.md origin/main`; and
+  `python scripts/audit_plan_doc.py
+  plans/PR-Postgres-Role-Topology-Preflight.md`.
+- Not locally runnable: `gitleaks protect --staged --redact --verbose` because
+  the executable is absent in this worktree environment. Do not bypass it; the
+  required CI secret scan remains the release gate.
+- Passed after the first commit: `python scripts/audit_plan_doc_files_touched.py
+  plans/PR-Postgres-Role-Topology-Preflight.md origin/main` and
+  `python scripts/audit_plan_doc_diff_size.py
+  plans/PR-Postgres-Role-Topology-Preflight.md origin/main` (the plan's five
+  files and `1757` LOC match `origin/main...HEAD`).
+- Passed before push: the local PR-review wrapper completed successfully with
+  its isolated session-state file and the current PR body.
+- No production database role/configuration/deployment action is part of local
+  verification. A real receipt is deferred until a protected DBA DSN is
+  provisioned and the deployed runtime has converged.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.agent/runbooks/database.md` | 49 |
+| `atlas_brain/config.py` | 24 |
+| `plans/PR-Postgres-Role-Topology-Preflight.md` | 256 |
+| `scripts/check_database_role_topology.py` | 761 |
+| `tests/test_database_role_topology_preflight.py` | 667 |
+| **Total** | **1757** |

--- a/plans/PR-Postgres-Role-Topology-Preflight.md
+++ b/plans/PR-Postgres-Role-Topology-Preflight.md
@@ -102,6 +102,34 @@ Revised non-scope:
 - Normal startup, `DatabaseConfig`, `DatabasePool`, migrations, EOM funnel
   behavior, APIs, and role topology remain outside this revision.
 
+### Contract revision — Python 3.11 test-collection compatibility
+
+New evidence:
+
+- The disposable-test identifier helper embeds escaped quote literals in an
+  f-string expression. GitHub's pinned Python 3.11 parser rejects that form
+  during test collection, before the PostgreSQL integration test can run.
+
+Root cause:
+
+- The test-only identifier helper relies on newer f-string grammar rather than
+  the Python 3.11 grammar the enrolled workflow runs.
+
+Required change surface:
+
+1. Replace only the helper's f-string expression with Python-3.11-compatible
+   string concatenation while retaining doubled-double-quote identifier
+   escaping.
+2. Add a direct focused assertion for ordinary and embedded-double-quote
+   identifiers, and run the focused file through the available Python 3.11
+   interpreter before push.
+
+Must not change:
+
+- Do not change the standalone preflight command, its fixed catalog SQL, the
+  disposable database fixture's role/ACL/policy topology, workflow service
+  topology, runtime configuration, or any production behavior.
+
 ## Scope (this PR)
 
 Ownership lane: eom-crm/runtime-security
@@ -265,27 +293,29 @@ Parked hardening: none.
 
 ## Verification
 
-- Passed locally: `python -m py_compile scripts/check_database_role_topology.py
+- Passed locally after the Python 3.11 correction: `python3.11 -m py_compile
+  tests/test_database_role_topology_preflight.py`; `python -m py_compile
+  scripts/check_database_role_topology.py
   tests/test_database_role_topology_preflight.py atlas_brain/config.py`;
-  `./ops test focused tests/test_database_role_topology_preflight.py
+  `./ops test focused tests/test_database_role_topology_preflight.py -q`
+  (`20 passed, 1 skipped`); `./ops test focused
+  tests/test_database_role_topology_preflight.py
   tests/test_agent_operations_contract.py
-  tests/test_eom_first_clean_completion_dba_runner.py -q` (`140 passed, 1
-  skipped`);
-  `bash scripts/check_ascii_python.sh`; `git diff --cached --check`;
-  `python scripts/sync_pr_plan.py --check
-  plans/PR-Postgres-Role-Topology-Preflight.md origin/main`; and
-  `python scripts/audit_plan_doc.py
-  plans/PR-Postgres-Role-Topology-Preflight.md`.
+  tests/test_eom_first_clean_completion_dba_runner.py -q` (`142 passed, 1
+  skipped`); and `bash scripts/check_ascii_python.sh`.
+- Not locally runnable: `python3.11 -m pytest
+  tests/test_database_role_topology_preflight.py -q` because that isolated
+  Python 3.11 interpreter has no `pytest` module. This is not bypassed; the
+  enrolled GitHub Python 3.11 workflow remains the execution gate.
 - The real PostgreSQL 16 command test skips locally unless the explicitly named,
   loopback-only disposable DBA test DSN is present. The EOM PostgreSQL workflow
   supplies that service and runs the test; it must pass there before merge.
 - Not locally runnable: `gitleaks protect --staged --redact --verbose` because
   the executable is absent in this worktree environment. Do not bypass it; the
   required CI secret scan remains the release gate.
-- Passed after the current follow-up commit: the plan-file and diff-size audits
-  agree that the six declared files and `2137` LOC match `origin/main...HEAD`.
-- Pending before the current branch update: the local PR-review wrapper with
-  its isolated session-state file and current PR body.
+- Pending after the current branch update: rerun the plan-file/diff-size audits
+  and local PR-review wrapper with its isolated session-state file and current
+  PR body.
 - No production database role/configuration/deployment action is part of local
   verification. A real receipt is deferred until a protected DBA DSN is
   provisioned and the deployed runtime has converged.
@@ -297,7 +327,7 @@ Parked hardening: none.
 | `.agent/runbooks/database.md` | 50 |
 | `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 6 |
 | `atlas_brain/config.py` | 24 |
-| `plans/PR-Postgres-Role-Topology-Preflight.md` | 303 |
+| `plans/PR-Postgres-Role-Topology-Preflight.md` | 333 |
 | `scripts/check_database_role_topology.py` | 783 |
-| `tests/test_database_role_topology_preflight.py` | 971 |
-| **Total** | **2137** |
+| `tests/test_database_role_topology_preflight.py` | 985 |
+| **Total** | **2181** |

--- a/plans/PR-Postgres-Role-Topology-Preflight.md
+++ b/plans/PR-Postgres-Role-Topology-Preflight.md
@@ -106,6 +106,7 @@ Revised non-scope:
 
 Ownership lane: eom-crm/runtime-security
 Slice phase: Production hardening
+Max files: 6
 
 1. Add a fail-closed, read-only catalog receipt that establishes the live
    PostgreSQL role/ownership topology before any authority separation is
@@ -282,7 +283,7 @@ Parked hardening: none.
   the executable is absent in this worktree environment. Do not bypass it; the
   required CI secret scan remains the release gate.
 - Passed after the current follow-up commit: the plan-file and diff-size audits
-  agree that the six declared files and `2136` LOC match `origin/main...HEAD`.
+  agree that the six declared files and `2137` LOC match `origin/main...HEAD`.
 - Pending before the current branch update: the local PR-review wrapper with
   its isolated session-state file and current PR body.
 - No production database role/configuration/deployment action is part of local
@@ -296,7 +297,7 @@ Parked hardening: none.
 | `.agent/runbooks/database.md` | 50 |
 | `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 6 |
 | `atlas_brain/config.py` | 24 |
-| `plans/PR-Postgres-Role-Topology-Preflight.md` | 302 |
+| `plans/PR-Postgres-Role-Topology-Preflight.md` | 303 |
 | `scripts/check_database_role_topology.py` | 783 |
 | `tests/test_database_role_topology_preflight.py` | 971 |
-| **Total** | **2136** |
+| **Total** | **2137** |

--- a/plans/PR-Postgres-Role-Topology-Preflight.md
+++ b/plans/PR-Postgres-Role-Topology-Preflight.md
@@ -214,6 +214,38 @@ Must not change:
   role-cutover mechanism. The disposable PostgreSQL 16 fixture remains the
   only test code allowed to create and clean up uniquely named test topology.
 
+### Contract revision — process-environment-only DBA credential
+
+Root cause:
+
+- The topology command invokes `DatabaseRoleTopologyDBAConfig()` with its
+  default settings source. That settings class currently includes the shared
+  `.env` and `.env.local` files, so an absent process environment variable can
+  silently resolve to a stale privileged DBA DSN from a worktree file. The
+  command's missing-configuration guard therefore does not actually mean that
+  the operator supplied the protected credential for this invocation.
+
+Required change surface:
+
+1. Make `DatabaseRoleTopologyDBAConfig` read its privileged DSN from the
+   process environment only; it must not read either shared dotenv file while
+   preserving the existing environment-variable name, `SecretStr` redaction,
+   and empty-value fail-closed behavior.
+2. Add default-constructor and command-entry tests from a temporary working
+   directory containing both dotenv files. With the process variable absent,
+   both tests must prove the key is ignored and the command fails before it
+   opens either database pool.
+3. State the process-environment-only requirement in the database runbook so
+   operators do not store the DBA credential in the worktree dotenv files.
+
+Must not change:
+
+- Do not change `ENV_FILES`, `DatabaseConfig`, any other settings class, normal
+  application startup, the database URL environment-variable name, or the
+  standalone command's fixed-query/read-only database behavior.
+- Do not read, write, migrate, or rotate a production credential as part of
+  this change. Test-only dotenv files may contain only a synthetic DSN.
+
 ## Scope (this PR)
 
 Ownership lane: eom-crm/runtime-security
@@ -385,14 +417,14 @@ Parked hardening: none.
 
 ## Verification
 
-- Passed locally after the compatibility, cleanup, provenance, and
-  privilege-semantics corrections:
+- Passed locally after the compatibility, cleanup, provenance,
+  privilege-semantics, and dotenv-boundary corrections:
   `python3.11 -m py_compile
   tests/test_database_role_topology_preflight.py`; `python -m py_compile
   scripts/check_database_role_topology.py
   tests/test_database_role_topology_preflight.py atlas_brain/config.py`;
   `./ops test focused tests/test_database_role_topology_preflight.py -q`
-  (`22 passed, 1 skipped`); `./ops test focused
+  (`23 passed, 1 skipped`); `./ops test focused
   tests/test_database_role_topology_preflight.py
   tests/test_agent_operations_contract.py
   tests/test_eom_first_clean_completion_dba_runner.py -q` (`144 passed, 1
@@ -418,10 +450,10 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `.agent/runbooks/database.md` | 53 |
+| `.agent/runbooks/database.md` | 55 |
 | `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 6 |
-| `atlas_brain/config.py` | 24 |
-| `plans/PR-Postgres-Role-Topology-Preflight.md` | 427 |
+| `atlas_brain/config.py` | 26 |
+| `plans/PR-Postgres-Role-Topology-Preflight.md` | 459 |
 | `scripts/check_database_role_topology.py` | 848 |
-| `tests/test_database_role_topology_preflight.py` | 1174 |
-| **Total** | **2532** |
+| `tests/test_database_role_topology_preflight.py` | 1209 |
+| **Total** | **2603** |

--- a/plans/PR-Postgres-Role-Topology-Preflight.md
+++ b/plans/PR-Postgres-Role-Topology-Preflight.md
@@ -407,9 +407,9 @@ Parked hardening: none.
 - Not locally runnable: `gitleaks protect --staged --redact --verbose` because
   the executable is absent in this worktree environment. Do not bypass it; the
   required CI secret scan remains the release gate.
-- Pending after the current branch update: rerun the plan-file/diff-size audits
-  and local PR-review wrapper with its isolated session-state file and current
-  PR body.
+- Current-head plan-file/diff-size audits and the local PR-review wrapper pass
+  with the synchronized PR body. GitHub remains the required full-unit,
+  PostgreSQL-16, and secret-scan execution authority.
 - No production database role/configuration/deployment action is part of local
   verification. A real receipt is deferred until a protected DBA DSN is
   provisioned and the deployed runtime has converged.

--- a/scripts/check_database_role_topology.py
+++ b/scripts/check_database_role_topology.py
@@ -96,7 +96,20 @@ _DATABASE_OWNER_QUERY = """
      )
 """
 
-_ROLES_QUERY = """
+_REPORTED_ROLE_CLOSURE_CTE = """
+    WITH RECURSIVE reported_role_closure(role_oid) AS (
+        SELECT role.oid
+          FROM pg_catalog.pg_roles AS role
+         WHERE role.rolname !~ '^pg_'
+        UNION
+        SELECT membership.roleid
+          FROM pg_catalog.pg_auth_members AS membership
+          JOIN reported_role_closure AS member_closure
+            ON member_closure.role_oid = membership.member
+    )
+"""
+
+_ROLES_QUERY = _REPORTED_ROLE_CLOSURE_CTE + """
     SELECT role.rolname AS role_name,
            role.rolcanlogin AS can_login,
            role.rolsuper AS is_superuser,
@@ -106,19 +119,12 @@ _ROLES_QUERY = """
            role.rolreplication AS can_replicate,
            role.rolbypassrls AS bypasses_row_security
       FROM pg_catalog.pg_roles AS role
-     WHERE role.rolname !~ '^pg_'
-        OR EXISTS (
-            SELECT 1
-              FROM pg_catalog.pg_auth_members AS membership
-              JOIN pg_catalog.pg_roles AS member_role
-                ON member_role.oid = membership.member
-             WHERE membership.roleid = role.oid
-               AND member_role.rolname !~ '^pg_'
-        )
-     ORDER BY role.rolname
+      JOIN reported_role_closure AS role_closure
+        ON role_closure.role_oid = role.oid
+     ORDER BY role.rolname, role.oid
 """
 
-_ROLE_MEMBERSHIPS_QUERY = """
+_ROLE_MEMBERSHIPS_QUERY = _REPORTED_ROLE_CLOSURE_CTE + """
     SELECT membership.oid AS membership_oid,
            granted_role.rolname AS granted_role,
            member_role.rolname AS member_role,
@@ -129,12 +135,14 @@ _ROLE_MEMBERSHIPS_QUERY = """
       FROM pg_catalog.pg_auth_members AS membership
       JOIN pg_catalog.pg_roles AS granted_role
         ON granted_role.oid = membership.roleid
+      JOIN reported_role_closure AS granted_closure
+        ON granted_closure.role_oid = granted_role.oid
       JOIN pg_catalog.pg_roles AS member_role
         ON member_role.oid = membership.member
+      JOIN reported_role_closure AS member_closure
+        ON member_closure.role_oid = member_role.oid
       JOIN pg_catalog.pg_roles AS grantor_role
         ON grantor_role.oid = membership.grantor
-     WHERE granted_role.rolname !~ '^pg_'
-        OR member_role.rolname !~ '^pg_'
      ORDER BY granted_role.rolname, member_role.rolname, grantor_role.rolname,
               membership.oid
 """
@@ -157,7 +165,9 @@ _RELATION_OWNERS_QUERY = """
            relation.relkind::text AS relation_kind,
            owner_role.rolname AS owner_role,
            relation.relrowsecurity AS row_security_enabled,
-           relation.relforcerowsecurity AS row_security_forced
+           relation.relforcerowsecurity AS row_security_forced,
+           COALESCE(relation.reloptions, ARRAY[]::text[])
+               @> ARRAY['security_invoker=true']::text[] AS is_security_invoker
       FROM pg_catalog.pg_class AS relation
       JOIN pg_catalog.pg_namespace AS namespace
         ON namespace.oid = relation.relnamespace
@@ -257,6 +267,8 @@ _RELATION_ACL_QUERY = """
            relation.relkind::text AS relation_kind,
            relation.relrowsecurity AS row_security_enabled,
            relation.relforcerowsecurity AS row_security_forced,
+           COALESCE(relation.reloptions, ARRAY[]::text[])
+               @> ARRAY['security_invoker=true']::text[] AS is_security_invoker,
            acl.grantor AS grantor_role_oid,
            grantor_role.rolname AS grantor_role,
            COALESCE(grantee_role.rolname, 'PUBLIC') AS grantee_role,
@@ -367,6 +379,10 @@ _ROW_SECURITY_POLICIES_QUERY = """
            relation.relkind::text AS relation_kind,
            policy.polcmd::text AS command,
            policy.polpermissive AS is_permissive,
+           pg_catalog.pg_get_expr(policy.polqual, policy.polrelid)
+               AS using_expression,
+           pg_catalog.pg_get_expr(policy.polwithcheck, policy.polrelid)
+               AS with_check_expression,
            policy.oid AS policy_oid,
            policy.polname AS policy_name,
            COALESCE(role.rolname, 'PUBLIC') AS role_name,
@@ -578,6 +594,24 @@ def _require_direct_dba_superuser(target: _TargetIdentity) -> None:
         )
 
 
+def _require_independent_dba_identity(
+    runtime_target: _TargetIdentity,
+    dba_target: _TargetIdentity,
+) -> None:
+    """Reject a DBA session that reuses the runtime authentication context."""
+
+    if runtime_target.session_user == dba_target.session_user:
+        raise PreflightError(
+            "Configured DBA connection must not reuse the Atlas runtime "
+            "authenticated identity"
+        )
+    if runtime_target.current_user == dba_target.current_user:
+        raise PreflightError(
+            "Configured DBA connection must not reuse the Atlas runtime "
+            "effective identity"
+        )
+
+
 async def _attest_shared_database_lock(
     runtime_connection: Any,
     dba_connection: Any,
@@ -766,6 +800,10 @@ async def _run(
                             )
                             _require_matching_target(runtime_target, dba_target)
                             _require_direct_dba_superuser(dba_target)
+                            _require_independent_dba_identity(
+                                runtime_target,
+                                dba_target,
+                            )
                             await _attest_shared_database_lock(
                                 runtime_connection,
                                 dba_connection,

--- a/scripts/check_database_role_topology.py
+++ b/scripts/check_database_role_topology.py
@@ -193,6 +193,8 @@ _DATABASE_ACL_QUERY = """
                WHEN database_catalog.datacl IS NULL THEN 'default'
                ELSE 'explicit'
            END AS acl_source,
+           acl.grantor AS grantor_role_oid,
+           grantor_role.rolname AS grantor_role,
            COALESCE(grantee_role.rolname, 'PUBLIC') AS grantee_role,
            acl.privilege_type AS privilege_type,
            acl.is_grantable AS is_grantable
@@ -205,12 +207,15 @@ _DATABASE_ACL_QUERY = """
       ) AS acl
       LEFT JOIN pg_catalog.pg_roles AS grantee_role
         ON grantee_role.oid = acl.grantee
+      LEFT JOIN pg_catalog.pg_roles AS grantor_role
+        ON grantor_role.oid = acl.grantor
      WHERE database_catalog.oid = (
          SELECT oid
            FROM pg_catalog.pg_database
           WHERE datname = pg_catalog.current_database()
      )
-     ORDER BY acl_source, grantee_role, acl.privilege_type, acl.is_grantable
+     ORDER BY acl_source, grantor_role.rolname, acl.grantor, grantee_role,
+              acl.privilege_type, acl.is_grantable
 """
 
 _SCHEMA_ACL_QUERY = """
@@ -219,6 +224,8 @@ _SCHEMA_ACL_QUERY = """
                ELSE 'explicit'
            END AS acl_source,
            namespace.nspname AS schema_name,
+           acl.grantor AS grantor_role_oid,
+           grantor_role.rolname AS grantor_role,
            COALESCE(grantee_role.rolname, 'PUBLIC') AS grantee_role,
            acl.privilege_type AS privilege_type,
            acl.is_grantable AS is_grantable
@@ -231,10 +238,12 @@ _SCHEMA_ACL_QUERY = """
       ) AS acl
       LEFT JOIN pg_catalog.pg_roles AS grantee_role
         ON grantee_role.oid = acl.grantee
+      LEFT JOIN pg_catalog.pg_roles AS grantor_role
+        ON grantor_role.oid = acl.grantor
      WHERE namespace.nspname !~ '^pg_'
        AND namespace.nspname <> 'information_schema'
-     ORDER BY acl_source, namespace.nspname, grantee_role, acl.privilege_type,
-              acl.is_grantable
+     ORDER BY acl_source, namespace.nspname, grantor_role.rolname, acl.grantor,
+              grantee_role, acl.privilege_type, acl.is_grantable
 """
 
 _RELATION_ACL_QUERY = """
@@ -248,6 +257,8 @@ _RELATION_ACL_QUERY = """
            relation.relkind::text AS relation_kind,
            relation.relrowsecurity AS row_security_enabled,
            relation.relforcerowsecurity AS row_security_forced,
+           acl.grantor AS grantor_role_oid,
+           grantor_role.rolname AS grantor_role,
            COALESCE(grantee_role.rolname, 'PUBLIC') AS grantee_role,
            acl.privilege_type AS privilege_type,
            acl.is_grantable AS is_grantable
@@ -268,12 +279,15 @@ _RELATION_ACL_QUERY = """
       ) AS acl
       LEFT JOIN pg_catalog.pg_roles AS grantee_role
         ON grantee_role.oid = acl.grantee
+      LEFT JOIN pg_catalog.pg_roles AS grantor_role
+        ON grantor_role.oid = acl.grantor
      WHERE namespace.nspname !~ '^pg_'
        AND namespace.nspname <> 'information_schema'
        AND relation.relkind IN ('r', 'p', 'v', 'm', 'S', 'f')
      ORDER BY acl_source, namespace.nspname, relation.relname, relation.oid,
               relation.relrowsecurity, relation.relforcerowsecurity,
-              grantee_role, acl.privilege_type, acl.is_grantable
+              grantor_role.rolname, acl.grantor, grantee_role,
+              acl.privilege_type, acl.is_grantable
 """
 
 _FUNCTION_ACL_QUERY = """
@@ -288,6 +302,8 @@ _FUNCTION_ACL_QUERY = """
            pg_catalog.pg_get_function_identity_arguments(procedure.oid)
                AS identity_arguments,
            procedure.prosecdef AS is_security_definer,
+           acl.grantor AS grantor_role_oid,
+           grantor_role.rolname AS grantor_role,
            COALESCE(grantee_role.rolname, 'PUBLIC') AS grantee_role,
            acl.privilege_type AS privilege_type,
            acl.is_grantable AS is_grantable
@@ -302,10 +318,12 @@ _FUNCTION_ACL_QUERY = """
       ) AS acl
       LEFT JOIN pg_catalog.pg_roles AS grantee_role
         ON grantee_role.oid = acl.grantee
+      LEFT JOIN pg_catalog.pg_roles AS grantor_role
+        ON grantor_role.oid = acl.grantor
      WHERE namespace.nspname !~ '^pg_'
        AND namespace.nspname <> 'information_schema'
      ORDER BY acl_source, namespace.nspname, procedure.proname, procedure.oid,
-              procedure.prosecdef, grantee_role,
+              procedure.prosecdef, grantor_role.rolname, acl.grantor, grantee_role,
               acl.privilege_type, acl.is_grantable
 """
 
@@ -317,6 +335,8 @@ _COLUMN_ACL_QUERY = """
            relation.relkind::text AS relation_kind,
            column_attribute.attnum AS column_number,
            column_attribute.attname AS column_name,
+           acl.grantor AS grantor_role_oid,
+           grantor_role.rolname AS grantor_role,
            COALESCE(grantee_role.rolname, 'PUBLIC') AS grantee_role,
            acl.privilege_type AS privilege_type,
            acl.is_grantable AS is_grantable
@@ -328,13 +348,15 @@ _COLUMN_ACL_QUERY = """
       CROSS JOIN LATERAL pg_catalog.aclexplode(column_attribute.attacl) AS acl
       LEFT JOIN pg_catalog.pg_roles AS grantee_role
         ON grantee_role.oid = acl.grantee
+      LEFT JOIN pg_catalog.pg_roles AS grantor_role
+        ON grantor_role.oid = acl.grantor
      WHERE namespace.nspname !~ '^pg_'
        AND namespace.nspname <> 'information_schema'
        AND relation.relkind IN ('r', 'p', 'v', 'm', 'f')
        AND column_attribute.attnum > 0
        AND NOT column_attribute.attisdropped
      ORDER BY namespace.nspname, relation.relname, relation.oid,
-              column_attribute.attnum, grantee_role,
+              column_attribute.attnum, grantor_role.rolname, acl.grantor, grantee_role,
               acl.privilege_type, acl.is_grantable
 """
 
@@ -373,6 +395,8 @@ _DEFAULT_ACL_QUERY = """
            COALESCE(namespace.nspname, '<database>') AS schema_name,
            owner_role.rolname AS owner_role,
            default_acl.defaclobjtype::text AS object_type,
+           acl.grantor AS grantor_role_oid,
+           grantor_role.rolname AS grantor_role,
            COALESCE(grantee_role.rolname, 'PUBLIC') AS grantee_role,
            acl.privilege_type AS privilege_type,
            acl.is_grantable AS is_grantable
@@ -384,13 +408,16 @@ _DEFAULT_ACL_QUERY = """
       CROSS JOIN LATERAL pg_catalog.aclexplode(default_acl.defaclacl) AS acl
       LEFT JOIN pg_catalog.pg_roles AS grantee_role
         ON grantee_role.oid = acl.grantee
+      LEFT JOIN pg_catalog.pg_roles AS grantor_role
+        ON grantor_role.oid = acl.grantor
      WHERE namespace.nspname IS NULL
         OR (
             namespace.nspname !~ '^pg_'
             AND namespace.nspname <> 'information_schema'
         )
-     ORDER BY default_acl.oid, schema_name, owner_role, object_type, grantee_role,
-              acl.privilege_type, acl.is_grantable
+     ORDER BY default_acl.oid, schema_name, owner_role, object_type,
+              grantor_role.rolname, acl.grantor, grantee_role, acl.privilege_type,
+              acl.is_grantable
 """
 
 

--- a/scripts/check_database_role_topology.py
+++ b/scripts/check_database_role_topology.py
@@ -119,17 +119,24 @@ _ROLES_QUERY = """
 """
 
 _ROLE_MEMBERSHIPS_QUERY = """
-    SELECT granted_role.rolname AS granted_role,
+    SELECT membership.oid AS membership_oid,
+           granted_role.rolname AS granted_role,
            member_role.rolname AS member_role,
-           membership.admin_option AS admin_option
+           grantor_role.rolname AS grantor_role,
+           membership.admin_option AS admin_option,
+           membership.inherit_option AS inherit_option,
+           membership.set_option AS set_option
       FROM pg_catalog.pg_auth_members AS membership
       JOIN pg_catalog.pg_roles AS granted_role
         ON granted_role.oid = membership.roleid
       JOIN pg_catalog.pg_roles AS member_role
         ON member_role.oid = membership.member
+      JOIN pg_catalog.pg_roles AS grantor_role
+        ON grantor_role.oid = membership.grantor
      WHERE granted_role.rolname !~ '^pg_'
         OR member_role.rolname !~ '^pg_'
-     ORDER BY granted_role.rolname, member_role.rolname
+     ORDER BY granted_role.rolname, member_role.rolname, grantor_role.rolname,
+              membership.oid
 """
 
 _SCHEMA_OWNERS_QUERY = """
@@ -143,13 +150,14 @@ _SCHEMA_OWNERS_QUERY = """
      ORDER BY namespace.nspname
 """
 
-_RELATION_OWNER_SUMMARY_QUERY = """
+_RELATION_OWNERS_QUERY = """
     SELECT namespace.nspname AS schema_name,
+           relation.oid AS relation_oid,
+           relation.relname AS relation_name,
            relation.relkind::text AS relation_kind,
            owner_role.rolname AS owner_role,
            relation.relrowsecurity AS row_security_enabled,
-           relation.relforcerowsecurity AS row_security_forced,
-           count(*)::bigint AS object_count
+           relation.relforcerowsecurity AS row_security_forced
       FROM pg_catalog.pg_class AS relation
       JOIN pg_catalog.pg_namespace AS namespace
         ON namespace.oid = relation.relnamespace
@@ -158,17 +166,18 @@ _RELATION_OWNER_SUMMARY_QUERY = """
      WHERE namespace.nspname !~ '^pg_'
        AND namespace.nspname <> 'information_schema'
        AND relation.relkind IN ('r', 'p', 'v', 'm', 'S', 'f')
-     GROUP BY namespace.nspname, relation.relkind, owner_role.rolname,
-              relation.relrowsecurity, relation.relforcerowsecurity
-     ORDER BY namespace.nspname, relation.relkind, owner_role.rolname,
-              relation.relrowsecurity, relation.relforcerowsecurity
+     ORDER BY namespace.nspname, relation.relname, relation.oid
 """
 
-_FUNCTION_OWNER_SUMMARY_QUERY = """
+_FUNCTION_OWNERS_QUERY = """
     SELECT namespace.nspname AS schema_name,
+           procedure.oid AS function_oid,
+           procedure.proname AS function_name,
+           procedure.prokind::text AS function_kind,
+           pg_catalog.pg_get_function_identity_arguments(procedure.oid)
+               AS identity_arguments,
            owner_role.rolname AS owner_role,
-           procedure.prosecdef AS is_security_definer,
-           count(*)::bigint AS function_count
+           procedure.prosecdef AS is_security_definer
       FROM pg_catalog.pg_proc AS procedure
       JOIN pg_catalog.pg_namespace AS namespace
         ON namespace.oid = procedure.pronamespace
@@ -176,8 +185,7 @@ _FUNCTION_OWNER_SUMMARY_QUERY = """
         ON owner_role.oid = procedure.proowner
      WHERE namespace.nspname !~ '^pg_'
        AND namespace.nspname <> 'information_schema'
-     GROUP BY namespace.nspname, owner_role.rolname, procedure.prosecdef
-     ORDER BY namespace.nspname, owner_role.rolname, procedure.prosecdef
+     ORDER BY namespace.nspname, procedure.proname, procedure.oid
 """
 
 _DATABASE_ACL_QUERY = """
@@ -229,19 +237,20 @@ _SCHEMA_ACL_QUERY = """
               acl.is_grantable
 """
 
-_RELATION_ACL_SUMMARY_QUERY = """
+_RELATION_ACL_QUERY = """
     SELECT CASE
                WHEN relation.relacl IS NULL THEN 'default'
                ELSE 'explicit'
            END AS acl_source,
            namespace.nspname AS schema_name,
+           relation.oid AS relation_oid,
+           relation.relname AS relation_name,
            relation.relkind::text AS relation_kind,
            relation.relrowsecurity AS row_security_enabled,
            relation.relforcerowsecurity AS row_security_forced,
            COALESCE(grantee_role.rolname, 'PUBLIC') AS grantee_role,
            acl.privilege_type AS privilege_type,
-           acl.is_grantable AS is_grantable,
-           count(*)::bigint AS object_count
+           acl.is_grantable AS is_grantable
       FROM pg_catalog.pg_class AS relation
       JOIN pg_catalog.pg_namespace AS namespace
         ON namespace.oid = relation.relnamespace
@@ -262,25 +271,26 @@ _RELATION_ACL_SUMMARY_QUERY = """
      WHERE namespace.nspname !~ '^pg_'
        AND namespace.nspname <> 'information_schema'
        AND relation.relkind IN ('r', 'p', 'v', 'm', 'S', 'f')
-     GROUP BY relation.relacl IS NULL, namespace.nspname, relation.relkind,
-              relation.relrowsecurity, relation.relforcerowsecurity,
-              grantee_role, acl.privilege_type, acl.is_grantable
-     ORDER BY acl_source, namespace.nspname, relation.relkind,
+     ORDER BY acl_source, namespace.nspname, relation.relname, relation.oid,
               relation.relrowsecurity, relation.relforcerowsecurity,
               grantee_role, acl.privilege_type, acl.is_grantable
 """
 
-_FUNCTION_ACL_SUMMARY_QUERY = """
+_FUNCTION_ACL_QUERY = """
     SELECT CASE
                WHEN procedure.proacl IS NULL THEN 'default'
                ELSE 'explicit'
            END AS acl_source,
            namespace.nspname AS schema_name,
+           procedure.oid AS function_oid,
+           procedure.proname AS function_name,
+           procedure.prokind::text AS function_kind,
+           pg_catalog.pg_get_function_identity_arguments(procedure.oid)
+               AS identity_arguments,
            procedure.prosecdef AS is_security_definer,
            COALESCE(grantee_role.rolname, 'PUBLIC') AS grantee_role,
            acl.privilege_type AS privilege_type,
-           acl.is_grantable AS is_grantable,
-           count(*)::bigint AS function_count
+           acl.is_grantable AS is_grantable
       FROM pg_catalog.pg_proc AS procedure
       JOIN pg_catalog.pg_namespace AS namespace
         ON namespace.oid = procedure.pronamespace
@@ -294,21 +304,22 @@ _FUNCTION_ACL_SUMMARY_QUERY = """
         ON grantee_role.oid = acl.grantee
      WHERE namespace.nspname !~ '^pg_'
        AND namespace.nspname <> 'information_schema'
-     GROUP BY procedure.proacl IS NULL, namespace.nspname,
-              procedure.prosecdef, grantee_role, acl.privilege_type,
-              acl.is_grantable
-     ORDER BY acl_source, namespace.nspname, procedure.prosecdef, grantee_role,
+     ORDER BY acl_source, namespace.nspname, procedure.proname, procedure.oid,
+              procedure.prosecdef, grantee_role,
               acl.privilege_type, acl.is_grantable
 """
 
-_COLUMN_ACL_SUMMARY_QUERY = """
+_COLUMN_ACL_QUERY = """
     SELECT 'explicit_column' AS acl_source,
            namespace.nspname AS schema_name,
+           relation.oid AS relation_oid,
+           relation.relname AS relation_name,
            relation.relkind::text AS relation_kind,
+           column_attribute.attnum AS column_number,
+           column_attribute.attname AS column_name,
            COALESCE(grantee_role.rolname, 'PUBLIC') AS grantee_role,
            acl.privilege_type AS privilege_type,
-           acl.is_grantable AS is_grantable,
-           count(*)::bigint AS column_count
+           acl.is_grantable AS is_grantable
       FROM pg_catalog.pg_attribute AS column_attribute
       JOIN pg_catalog.pg_class AS relation
         ON relation.oid = column_attribute.attrelid
@@ -322,19 +333,22 @@ _COLUMN_ACL_SUMMARY_QUERY = """
        AND relation.relkind IN ('r', 'p', 'v', 'm', 'f')
        AND column_attribute.attnum > 0
        AND NOT column_attribute.attisdropped
-     GROUP BY namespace.nspname, relation.relkind, grantee_role,
-              acl.privilege_type, acl.is_grantable
-     ORDER BY namespace.nspname, relation.relkind, grantee_role,
+     ORDER BY namespace.nspname, relation.relname, relation.oid,
+              column_attribute.attnum, grantee_role,
               acl.privilege_type, acl.is_grantable
 """
 
-_ROW_SECURITY_POLICY_SUMMARY_QUERY = """
+_ROW_SECURITY_POLICIES_QUERY = """
     SELECT namespace.nspname AS schema_name,
+           relation.oid AS relation_oid,
+           relation.relname AS relation_name,
            relation.relkind::text AS relation_kind,
            policy.polcmd::text AS command,
            policy.polpermissive AS is_permissive,
+           policy.oid AS policy_oid,
+           policy.polname AS policy_name,
            COALESCE(role.rolname, 'PUBLIC') AS role_name,
-           count(*)::bigint AS policy_count
+           policy_role.role_oid AS role_oid
       FROM pg_catalog.pg_policy AS policy
       JOIN pg_catalog.pg_class AS relation
         ON relation.oid = policy.polrelid
@@ -350,14 +364,13 @@ _ROW_SECURITY_POLICY_SUMMARY_QUERY = """
         ON role.oid = policy_role.role_oid
      WHERE namespace.nspname !~ '^pg_'
        AND namespace.nspname <> 'information_schema'
-     GROUP BY namespace.nspname, relation.relkind, policy.polcmd,
-              policy.polpermissive, role.rolname
-     ORDER BY namespace.nspname, relation.relkind, policy.polcmd,
-              policy.polpermissive, role_name
+     ORDER BY namespace.nspname, relation.relname, relation.oid, policy.polname,
+              policy.oid, role_name, policy_role.role_oid
 """
 
-_DEFAULT_ACL_SUMMARY_QUERY = """
-    SELECT COALESCE(namespace.nspname, '<database>') AS schema_name,
+_DEFAULT_ACL_QUERY = """
+    SELECT default_acl.oid AS default_acl_oid,
+           COALESCE(namespace.nspname, '<database>') AS schema_name,
            owner_role.rolname AS owner_role,
            default_acl.defaclobjtype::text AS object_type,
            COALESCE(grantee_role.rolname, 'PUBLIC') AS grantee_role,
@@ -376,7 +389,7 @@ _DEFAULT_ACL_SUMMARY_QUERY = """
             namespace.nspname !~ '^pg_'
             AND namespace.nspname <> 'information_schema'
         )
-     ORDER BY schema_name, owner_role, object_type, grantee_role,
+     ORDER BY default_acl.oid, schema_name, owner_role, object_type, grantee_role,
               acl.privilege_type, acl.is_grantable
 """
 
@@ -478,12 +491,10 @@ async def _create_pool(connection_kwargs: Mapping[str, object]) -> Any:
     return await asyncpg.create_pool(**pool_kwargs)
 
 
-async def _target_identity(pool: Any, *, source: str) -> _TargetIdentity:
-    """Read one session's database/schema/role identity in a read-only tx."""
+async def _target_identity(connection: Any, *, source: str) -> _TargetIdentity:
+    """Read one pinned session's database/schema/role identity."""
 
-    async with pool.acquire() as connection:
-        async with connection.transaction(readonly=True):
-            row = await connection.fetchrow(_TARGET_IDENTITY_QUERY)
+    row = await connection.fetchrow(_TARGET_IDENTITY_QUERY)
     if row is None:
         raise PreflightError(f"Missing or invalid database identity from {source}")
     return _TargetIdentity(
@@ -540,35 +551,34 @@ def _require_direct_dba_superuser(target: _TargetIdentity) -> None:
         )
 
 
-async def _attest_shared_database_lock(runtime_pool: Any, dba_pool: Any) -> None:
-    """Prove both pools contend on one live database-cluster lock namespace."""
+async def _attest_shared_database_lock(
+    runtime_connection: Any,
+    dba_connection: Any,
+) -> None:
+    """Prove pinned runtime and DBA sessions share one lock namespace."""
 
     for _attempt in range(3):
         lock_key = secrets.randbits(63)
-        async with runtime_pool.acquire() as runtime_connection:
-            async with runtime_connection.transaction(readonly=True):
-                runtime_acquired = bool(
-                    await runtime_connection.fetchval(
-                        "SELECT pg_catalog.pg_try_advisory_xact_lock($1)",
-                        lock_key,
-                    )
-                )
-                if not runtime_acquired:
-                    continue
-                async with dba_pool.acquire() as dba_connection:
-                    async with dba_connection.transaction(readonly=True):
-                        dba_acquired = bool(
-                            await dba_connection.fetchval(
-                                "SELECT pg_catalog.pg_try_advisory_xact_lock($1)",
-                                lock_key,
-                            )
-                        )
-                if dba_acquired:
-                    raise PreflightError(
-                        "Configured DBA connection does not share the Atlas "
-                        "runtime database cluster"
-                    )
-                return
+        runtime_acquired = bool(
+            await runtime_connection.fetchval(
+                "SELECT pg_catalog.pg_try_advisory_xact_lock($1)",
+                lock_key,
+            )
+        )
+        if not runtime_acquired:
+            continue
+        dba_acquired = bool(
+            await dba_connection.fetchval(
+                "SELECT pg_catalog.pg_try_advisory_xact_lock($1)",
+                lock_key,
+            )
+        )
+        if dba_acquired:
+            raise PreflightError(
+                "Configured DBA connection does not share the Atlas "
+                "runtime database cluster"
+            )
+        return
     raise PreflightError(
         "Could not reserve a fresh runtime target-attestation advisory lock"
     )
@@ -601,26 +611,22 @@ def _json_catalog_row(row: object, *, source: str) -> dict[str, object]:
     }
 
 
-async def _catalog_receipt(pool: Any) -> dict[str, object]:
-    """Return the fixed catalog facts required for later role design only."""
+async def _catalog_receipt(connection: Any) -> dict[str, object]:
+    """Return fixed catalog facts from the DBA connection that passed admission."""
 
-    async with pool.acquire() as connection:
-        async with connection.transaction(readonly=True):
-            database_owner = await connection.fetchrow(_DATABASE_OWNER_QUERY)
-            roles = await connection.fetch(_ROLES_QUERY)
-            memberships = await connection.fetch(_ROLE_MEMBERSHIPS_QUERY)
-            schemas = await connection.fetch(_SCHEMA_OWNERS_QUERY)
-            relation_owners = await connection.fetch(_RELATION_OWNER_SUMMARY_QUERY)
-            function_owners = await connection.fetch(_FUNCTION_OWNER_SUMMARY_QUERY)
-            database_acl = await connection.fetch(_DATABASE_ACL_QUERY)
-            schema_acl = await connection.fetch(_SCHEMA_ACL_QUERY)
-            relation_acl = await connection.fetch(_RELATION_ACL_SUMMARY_QUERY)
-            function_acl = await connection.fetch(_FUNCTION_ACL_SUMMARY_QUERY)
-            column_acl = await connection.fetch(_COLUMN_ACL_SUMMARY_QUERY)
-            row_security_policies = await connection.fetch(
-                _ROW_SECURITY_POLICY_SUMMARY_QUERY
-            )
-            default_acl = await connection.fetch(_DEFAULT_ACL_SUMMARY_QUERY)
+    database_owner = await connection.fetchrow(_DATABASE_OWNER_QUERY)
+    roles = await connection.fetch(_ROLES_QUERY)
+    memberships = await connection.fetch(_ROLE_MEMBERSHIPS_QUERY)
+    schemas = await connection.fetch(_SCHEMA_OWNERS_QUERY)
+    relation_owners = await connection.fetch(_RELATION_OWNERS_QUERY)
+    function_owners = await connection.fetch(_FUNCTION_OWNERS_QUERY)
+    database_acl = await connection.fetch(_DATABASE_ACL_QUERY)
+    schema_acl = await connection.fetch(_SCHEMA_ACL_QUERY)
+    relation_acl = await connection.fetch(_RELATION_ACL_QUERY)
+    function_acl = await connection.fetch(_FUNCTION_ACL_QUERY)
+    column_acl = await connection.fetch(_COLUMN_ACL_QUERY)
+    row_security_policies = await connection.fetch(_ROW_SECURITY_POLICIES_QUERY)
+    default_acl = await connection.fetch(_DEFAULT_ACL_QUERY)
 
     if database_owner is None:
         raise PreflightError("Catalog receipt is missing the current database owner")
@@ -641,11 +647,11 @@ async def _catalog_receipt(pool: Any) -> dict[str, object]:
             _json_catalog_row(row, source="schema owners")
             for row in schemas
         ],
-        "relation_owner_summary": [
+        "relation_owners": [
             _json_catalog_row(row, source="relation owners")
             for row in relation_owners
         ],
-        "function_owner_summary": [
+        "function_owners": [
             _json_catalog_row(row, source="function owners")
             for row in function_owners
         ],
@@ -657,23 +663,23 @@ async def _catalog_receipt(pool: Any) -> dict[str, object]:
             _json_catalog_row(row, source="schema ACL")
             for row in schema_acl
         ],
-        "relation_acl_summary": [
+        "relation_acl": [
             _json_catalog_row(row, source="relation ACL")
             for row in relation_acl
         ],
-        "function_acl_summary": [
+        "function_acl": [
             _json_catalog_row(row, source="function ACL")
             for row in function_acl
         ],
-        "column_acl_summary": [
+        "column_acl": [
             _json_catalog_row(row, source="column ACL")
             for row in column_acl
         ],
-        "row_security_policy_summary": [
+        "row_security_policies": [
             _json_catalog_row(row, source="row security policy")
             for row in row_security_policies
         ],
-        "default_acl_summary": [
+        "default_acl": [
             _json_catalog_row(row, source="default ACL")
             for row in default_acl
         ],
@@ -711,27 +717,43 @@ async def _run(
     runtime_config = runtime_config_factory()
     runtime_pool = await create_pool(_runtime_connection_kwargs(runtime_config))
     try:
-        runtime_target = await _target_identity(runtime_pool, source="Atlas runtime")
         dba_pool = await create_pool({"dsn": dba_database_url})
         try:
-            dba_target = await _target_identity(
-                dba_pool,
-                source="configured DBA connection",
-            )
-            _require_matching_target(runtime_target, dba_target)
-            _require_direct_dba_superuser(dba_target)
-            await _attest_shared_database_lock(runtime_pool, dba_pool)
-            catalog = await _catalog_receipt(dba_pool)
-            return {
-                "receipt_version": RECEIPT_VERSION,
-                "mode": "read-only",
-                "runtime_target": _runtime_target_label(runtime_config),
-                "dba_target": _safe_target_label(dba_database_url),
-                "target_attested": True,
-                "runtime_session": _identity_receipt(runtime_target),
-                "dba_session": _identity_receipt(dba_target),
-                "catalog": catalog,
-            }
+            async with runtime_pool.acquire() as runtime_connection:
+                async with dba_pool.acquire() as dba_connection:
+                    async with runtime_connection.transaction(
+                        isolation="repeatable_read",
+                        readonly=True,
+                    ):
+                        runtime_target = await _target_identity(
+                            runtime_connection,
+                            source="Atlas runtime",
+                        )
+                        async with dba_connection.transaction(
+                            isolation="repeatable_read",
+                            readonly=True,
+                        ):
+                            dba_target = await _target_identity(
+                                dba_connection,
+                                source="configured DBA connection",
+                            )
+                            _require_matching_target(runtime_target, dba_target)
+                            _require_direct_dba_superuser(dba_target)
+                            await _attest_shared_database_lock(
+                                runtime_connection,
+                                dba_connection,
+                            )
+                            catalog = await _catalog_receipt(dba_connection)
+                            return {
+                                "receipt_version": RECEIPT_VERSION,
+                                "mode": "read-only",
+                                "runtime_target": _runtime_target_label(runtime_config),
+                                "dba_target": _safe_target_label(dba_database_url),
+                                "target_attested": True,
+                                "runtime_session": _identity_receipt(runtime_target),
+                                "dba_session": _identity_receipt(dba_target),
+                                "catalog": catalog,
+                            }
         finally:
             await dba_pool.close()
     finally:

--- a/scripts/check_database_role_topology.py
+++ b/scripts/check_database_role_topology.py
@@ -1,0 +1,761 @@
+#!/usr/bin/env python3
+"""Produce a fixed, read-only PostgreSQL role-topology evidence receipt.
+
+This command is a preflight for a later least-privilege role cutover. It never
+creates roles, changes grants or ownership, runs migrations, or exposes a
+generic SQL interface. It compares the normal Atlas runtime target with a
+separately configured DBA target before reading a fixed catalog projection.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import secrets
+import sys
+from typing import Any
+from urllib.parse import urlsplit
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from atlas_brain.config import (  # noqa: E402
+    DATABASE_ROLE_TOPOLOGY_DBA_DATABASE_URL_ENV,
+    DatabaseRoleTopologyDBAConfig,
+)
+from atlas_brain.storage.config import DatabaseConfig  # noqa: E402
+
+
+DBA_DSN_ENV = DATABASE_ROLE_TOPOLOGY_DBA_DATABASE_URL_ENV
+RECEIPT_VERSION = "database-role-topology-preflight.v1"
+_READ_ONLY_SERVER_SETTINGS = {"default_transaction_read_only": "on"}
+
+
+class PreflightError(RuntimeError):
+    """A safe, operator-actionable admission failure before a receipt exists."""
+
+
+@dataclass(frozen=True)
+class _TargetIdentity:
+    """One session's target and authenticated PostgreSQL identity."""
+
+    schema_name: str
+    database_name: str
+    database_oid: int
+    current_user: str
+    session_user: str
+    current_user_is_superuser: bool
+
+    @property
+    def database_identity(self) -> tuple[str, int]:
+        """Return the database identity that must match before catalog access."""
+
+        return (self.database_name, self.database_oid)
+
+    @property
+    def uses_direct_superuser_login(self) -> bool:
+        """Return whether the active session is a direct superuser login."""
+
+        return (
+            self.current_user == self.session_user
+            and self.current_user_is_superuser
+        )
+
+
+_TARGET_IDENTITY_QUERY = """
+    SELECT pg_catalog.current_schema() AS schema_name,
+           pg_catalog.current_database() AS database_name,
+           CURRENT_USER AS current_user,
+           SESSION_USER AS session_user,
+           COALESCE((
+               SELECT role.rolsuper
+                 FROM pg_catalog.pg_roles AS role
+                WHERE role.rolname = CURRENT_USER
+           ), FALSE) AS current_user_is_superuser,
+           (
+               SELECT database_catalog.oid
+                 FROM pg_catalog.pg_database AS database_catalog
+                WHERE database_catalog.datname = pg_catalog.current_database()
+           ) AS database_oid
+"""
+
+_DATABASE_OWNER_QUERY = """
+    SELECT database_catalog.datname AS database_name,
+           pg_catalog.pg_get_userbyid(database_catalog.datdba) AS owner_role
+      FROM pg_catalog.pg_database AS database_catalog
+     WHERE database_catalog.oid = (
+         SELECT oid
+           FROM pg_catalog.pg_database
+          WHERE datname = pg_catalog.current_database()
+     )
+"""
+
+_ROLES_QUERY = """
+    SELECT role.rolname AS role_name,
+           role.rolcanlogin AS can_login,
+           role.rolsuper AS is_superuser,
+           role.rolinherit AS inherits_privileges,
+           role.rolcreaterole AS can_create_roles,
+           role.rolcreatedb AS can_create_databases,
+           role.rolreplication AS can_replicate,
+           role.rolbypassrls AS bypasses_row_security
+      FROM pg_catalog.pg_roles AS role
+     WHERE role.rolname !~ '^pg_'
+        OR EXISTS (
+            SELECT 1
+              FROM pg_catalog.pg_auth_members AS membership
+              JOIN pg_catalog.pg_roles AS member_role
+                ON member_role.oid = membership.member
+             WHERE membership.roleid = role.oid
+               AND member_role.rolname !~ '^pg_'
+        )
+     ORDER BY role.rolname
+"""
+
+_ROLE_MEMBERSHIPS_QUERY = """
+    SELECT granted_role.rolname AS granted_role,
+           member_role.rolname AS member_role,
+           membership.admin_option AS admin_option
+      FROM pg_catalog.pg_auth_members AS membership
+      JOIN pg_catalog.pg_roles AS granted_role
+        ON granted_role.oid = membership.roleid
+      JOIN pg_catalog.pg_roles AS member_role
+        ON member_role.oid = membership.member
+     WHERE granted_role.rolname !~ '^pg_'
+        OR member_role.rolname !~ '^pg_'
+     ORDER BY granted_role.rolname, member_role.rolname
+"""
+
+_SCHEMA_OWNERS_QUERY = """
+    SELECT namespace.nspname AS schema_name,
+           owner_role.rolname AS owner_role
+      FROM pg_catalog.pg_namespace AS namespace
+      JOIN pg_catalog.pg_roles AS owner_role
+        ON owner_role.oid = namespace.nspowner
+     WHERE namespace.nspname !~ '^pg_'
+       AND namespace.nspname <> 'information_schema'
+     ORDER BY namespace.nspname
+"""
+
+_RELATION_OWNER_SUMMARY_QUERY = """
+    SELECT namespace.nspname AS schema_name,
+           relation.relkind::text AS relation_kind,
+           owner_role.rolname AS owner_role,
+           relation.relrowsecurity AS row_security_enabled,
+           relation.relforcerowsecurity AS row_security_forced,
+           count(*)::bigint AS object_count
+      FROM pg_catalog.pg_class AS relation
+      JOIN pg_catalog.pg_namespace AS namespace
+        ON namespace.oid = relation.relnamespace
+      JOIN pg_catalog.pg_roles AS owner_role
+        ON owner_role.oid = relation.relowner
+     WHERE namespace.nspname !~ '^pg_'
+       AND namespace.nspname <> 'information_schema'
+       AND relation.relkind IN ('r', 'p', 'v', 'm', 'S', 'f')
+     GROUP BY namespace.nspname, relation.relkind, owner_role.rolname,
+              relation.relrowsecurity, relation.relforcerowsecurity
+     ORDER BY namespace.nspname, relation.relkind, owner_role.rolname,
+              relation.relrowsecurity, relation.relforcerowsecurity
+"""
+
+_FUNCTION_OWNER_SUMMARY_QUERY = """
+    SELECT namespace.nspname AS schema_name,
+           owner_role.rolname AS owner_role,
+           procedure.prosecdef AS is_security_definer,
+           count(*)::bigint AS function_count
+      FROM pg_catalog.pg_proc AS procedure
+      JOIN pg_catalog.pg_namespace AS namespace
+        ON namespace.oid = procedure.pronamespace
+      JOIN pg_catalog.pg_roles AS owner_role
+        ON owner_role.oid = procedure.proowner
+     WHERE namespace.nspname !~ '^pg_'
+       AND namespace.nspname <> 'information_schema'
+     GROUP BY namespace.nspname, owner_role.rolname, procedure.prosecdef
+     ORDER BY namespace.nspname, owner_role.rolname, procedure.prosecdef
+"""
+
+_DATABASE_ACL_QUERY = """
+    SELECT CASE
+               WHEN database_catalog.datacl IS NULL THEN 'default'
+               ELSE 'explicit'
+           END AS acl_source,
+           COALESCE(grantee_role.rolname, 'PUBLIC') AS grantee_role,
+           acl.privilege_type AS privilege_type,
+           acl.is_grantable AS is_grantable
+      FROM pg_catalog.pg_database AS database_catalog
+      CROSS JOIN LATERAL pg_catalog.aclexplode(
+          COALESCE(
+              database_catalog.datacl,
+              pg_catalog.acldefault('d', database_catalog.datdba)
+          )
+      ) AS acl
+      LEFT JOIN pg_catalog.pg_roles AS grantee_role
+        ON grantee_role.oid = acl.grantee
+     WHERE database_catalog.oid = (
+         SELECT oid
+           FROM pg_catalog.pg_database
+          WHERE datname = pg_catalog.current_database()
+     )
+     ORDER BY acl_source, grantee_role, acl.privilege_type, acl.is_grantable
+"""
+
+_SCHEMA_ACL_QUERY = """
+    SELECT CASE
+               WHEN namespace.nspacl IS NULL THEN 'default'
+               ELSE 'explicit'
+           END AS acl_source,
+           namespace.nspname AS schema_name,
+           COALESCE(grantee_role.rolname, 'PUBLIC') AS grantee_role,
+           acl.privilege_type AS privilege_type,
+           acl.is_grantable AS is_grantable
+      FROM pg_catalog.pg_namespace AS namespace
+      CROSS JOIN LATERAL pg_catalog.aclexplode(
+          COALESCE(
+              namespace.nspacl,
+              pg_catalog.acldefault('n', namespace.nspowner)
+          )
+      ) AS acl
+      LEFT JOIN pg_catalog.pg_roles AS grantee_role
+        ON grantee_role.oid = acl.grantee
+     WHERE namespace.nspname !~ '^pg_'
+       AND namespace.nspname <> 'information_schema'
+     ORDER BY acl_source, namespace.nspname, grantee_role, acl.privilege_type,
+              acl.is_grantable
+"""
+
+_RELATION_ACL_SUMMARY_QUERY = """
+    SELECT CASE
+               WHEN relation.relacl IS NULL THEN 'default'
+               ELSE 'explicit'
+           END AS acl_source,
+           namespace.nspname AS schema_name,
+           relation.relkind::text AS relation_kind,
+           relation.relrowsecurity AS row_security_enabled,
+           relation.relforcerowsecurity AS row_security_forced,
+           COALESCE(grantee_role.rolname, 'PUBLIC') AS grantee_role,
+           acl.privilege_type AS privilege_type,
+           acl.is_grantable AS is_grantable,
+           count(*)::bigint AS object_count
+      FROM pg_catalog.pg_class AS relation
+      JOIN pg_catalog.pg_namespace AS namespace
+        ON namespace.oid = relation.relnamespace
+      CROSS JOIN LATERAL pg_catalog.aclexplode(
+          COALESCE(
+              relation.relacl,
+              pg_catalog.acldefault(
+                  CASE
+                      WHEN relation.relkind = 'S' THEN 'S'::"char"
+                      ELSE 'r'::"char"
+                  END,
+                  relation.relowner
+              )
+          )
+      ) AS acl
+      LEFT JOIN pg_catalog.pg_roles AS grantee_role
+        ON grantee_role.oid = acl.grantee
+     WHERE namespace.nspname !~ '^pg_'
+       AND namespace.nspname <> 'information_schema'
+       AND relation.relkind IN ('r', 'p', 'v', 'm', 'S', 'f')
+     GROUP BY relation.relacl IS NULL, namespace.nspname, relation.relkind,
+              relation.relrowsecurity, relation.relforcerowsecurity,
+              grantee_role, acl.privilege_type, acl.is_grantable
+     ORDER BY acl_source, namespace.nspname, relation.relkind,
+              relation.relrowsecurity, relation.relforcerowsecurity,
+              grantee_role, acl.privilege_type, acl.is_grantable
+"""
+
+_FUNCTION_ACL_SUMMARY_QUERY = """
+    SELECT CASE
+               WHEN procedure.proacl IS NULL THEN 'default'
+               ELSE 'explicit'
+           END AS acl_source,
+           namespace.nspname AS schema_name,
+           procedure.prosecdef AS is_security_definer,
+           COALESCE(grantee_role.rolname, 'PUBLIC') AS grantee_role,
+           acl.privilege_type AS privilege_type,
+           acl.is_grantable AS is_grantable,
+           count(*)::bigint AS function_count
+      FROM pg_catalog.pg_proc AS procedure
+      JOIN pg_catalog.pg_namespace AS namespace
+        ON namespace.oid = procedure.pronamespace
+      CROSS JOIN LATERAL pg_catalog.aclexplode(
+          COALESCE(
+              procedure.proacl,
+              pg_catalog.acldefault('f', procedure.proowner)
+          )
+      ) AS acl
+      LEFT JOIN pg_catalog.pg_roles AS grantee_role
+        ON grantee_role.oid = acl.grantee
+     WHERE namespace.nspname !~ '^pg_'
+       AND namespace.nspname <> 'information_schema'
+     GROUP BY procedure.proacl IS NULL, namespace.nspname,
+              procedure.prosecdef, grantee_role, acl.privilege_type,
+              acl.is_grantable
+     ORDER BY acl_source, namespace.nspname, procedure.prosecdef, grantee_role,
+              acl.privilege_type, acl.is_grantable
+"""
+
+_COLUMN_ACL_SUMMARY_QUERY = """
+    SELECT 'explicit_column' AS acl_source,
+           namespace.nspname AS schema_name,
+           relation.relkind::text AS relation_kind,
+           COALESCE(grantee_role.rolname, 'PUBLIC') AS grantee_role,
+           acl.privilege_type AS privilege_type,
+           acl.is_grantable AS is_grantable,
+           count(*)::bigint AS column_count
+      FROM pg_catalog.pg_attribute AS column_attribute
+      JOIN pg_catalog.pg_class AS relation
+        ON relation.oid = column_attribute.attrelid
+      JOIN pg_catalog.pg_namespace AS namespace
+        ON namespace.oid = relation.relnamespace
+      CROSS JOIN LATERAL pg_catalog.aclexplode(column_attribute.attacl) AS acl
+      LEFT JOIN pg_catalog.pg_roles AS grantee_role
+        ON grantee_role.oid = acl.grantee
+     WHERE namespace.nspname !~ '^pg_'
+       AND namespace.nspname <> 'information_schema'
+       AND relation.relkind IN ('r', 'p', 'v', 'm', 'f')
+       AND column_attribute.attnum > 0
+       AND NOT column_attribute.attisdropped
+     GROUP BY namespace.nspname, relation.relkind, grantee_role,
+              acl.privilege_type, acl.is_grantable
+     ORDER BY namespace.nspname, relation.relkind, grantee_role,
+              acl.privilege_type, acl.is_grantable
+"""
+
+_ROW_SECURITY_POLICY_SUMMARY_QUERY = """
+    SELECT namespace.nspname AS schema_name,
+           relation.relkind::text AS relation_kind,
+           policy.polcmd::text AS command,
+           policy.polpermissive AS is_permissive,
+           COALESCE(role.rolname, 'PUBLIC') AS role_name,
+           count(*)::bigint AS policy_count
+      FROM pg_catalog.pg_policy AS policy
+      JOIN pg_catalog.pg_class AS relation
+        ON relation.oid = policy.polrelid
+      JOIN pg_catalog.pg_namespace AS namespace
+        ON namespace.oid = relation.relnamespace
+      CROSS JOIN LATERAL unnest(
+          COALESCE(
+              NULLIF(policy.polroles, ARRAY[]::oid[]),
+              ARRAY[0::oid]
+          )
+      ) AS policy_role(role_oid)
+      LEFT JOIN pg_catalog.pg_roles AS role
+        ON role.oid = policy_role.role_oid
+     WHERE namespace.nspname !~ '^pg_'
+       AND namespace.nspname <> 'information_schema'
+     GROUP BY namespace.nspname, relation.relkind, policy.polcmd,
+              policy.polpermissive, role.rolname
+     ORDER BY namespace.nspname, relation.relkind, policy.polcmd,
+              policy.polpermissive, role_name
+"""
+
+_DEFAULT_ACL_SUMMARY_QUERY = """
+    SELECT COALESCE(namespace.nspname, '<database>') AS schema_name,
+           owner_role.rolname AS owner_role,
+           default_acl.defaclobjtype::text AS object_type,
+           COALESCE(grantee_role.rolname, 'PUBLIC') AS grantee_role,
+           acl.privilege_type AS privilege_type,
+           acl.is_grantable AS is_grantable
+      FROM pg_catalog.pg_default_acl AS default_acl
+      JOIN pg_catalog.pg_roles AS owner_role
+        ON owner_role.oid = default_acl.defaclrole
+      LEFT JOIN pg_catalog.pg_namespace AS namespace
+        ON namespace.oid = default_acl.defaclnamespace
+      CROSS JOIN LATERAL pg_catalog.aclexplode(default_acl.defaclacl) AS acl
+      LEFT JOIN pg_catalog.pg_roles AS grantee_role
+        ON grantee_role.oid = acl.grantee
+     WHERE namespace.nspname IS NULL
+        OR (
+            namespace.nspname !~ '^pg_'
+            AND namespace.nspname <> 'information_schema'
+        )
+     ORDER BY schema_name, owner_role, object_type, grantee_role,
+              acl.privilege_type, acl.is_grantable
+"""
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse the intentionally argument-free, evidence-only command surface."""
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Print a fixed, read-only PostgreSQL database role-topology receipt."
+        )
+    )
+    return parser.parse_args(argv)
+
+
+def _require_text(value: object, *, source: str) -> str:
+    """Require a non-empty catalog text field without interpolating it into SQL."""
+
+    if not isinstance(value, str) or not value.strip():
+        raise PreflightError(f"Missing or invalid {source}")
+    return value
+
+
+def _require_database_oid(value: object, *, source: str) -> int:
+    """Require one positive PostgreSQL database OID."""
+
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise PreflightError(f"Missing or invalid {source}")
+    return value
+
+
+def _require_bool(value: object, *, source: str) -> bool:
+    """Require a catalog boolean instead of coercing an ambiguous value."""
+
+    if not isinstance(value, bool):
+        raise PreflightError(f"Missing or invalid {source}")
+    return value
+
+
+def _safe_target_label(database_url: str) -> str:
+    """Render a target label without credentials or connection query values."""
+
+    try:
+        parsed = urlsplit(database_url)
+        host = parsed.hostname or "connection-string"
+        port = f":{parsed.port}" if parsed.port else ""
+        database = parsed.path.lstrip("/") or "<database>"
+        return f"dsn={host}{port}/{database}"
+    except ValueError:
+        return "dsn=<configured>"
+
+
+def _runtime_target_label(config: object) -> str:
+    """Use DatabaseConfig's safe label, never reconstructing a raw DSN."""
+
+    target_label = getattr(config, "target_label", "")
+    if isinstance(target_label, str) and target_label.strip():
+        return target_label
+    return "configured-runtime-target"
+
+
+def _runtime_connection_kwargs(config: object) -> dict[str, object]:
+    """Get normal runtime kwargs without changing normal runtime configuration."""
+
+    connection_kwargs = getattr(config, "connection_kwargs", None)
+    if not callable(connection_kwargs):
+        raise PreflightError("Runtime database configuration is unavailable")
+    values = connection_kwargs()
+    if not isinstance(values, Mapping):
+        raise PreflightError("Runtime database configuration is invalid")
+    return dict(values)
+
+
+async def _create_pool(connection_kwargs: Mapping[str, object]) -> Any:
+    """Open one bounded PostgreSQL pool with read-only defaults enforced."""
+
+    try:
+        import asyncpg
+    except ImportError as exc:  # pragma: no cover - host dependency
+        raise PreflightError(
+            "asyncpg is required to run the database role-topology preflight"
+        ) from exc
+
+    pool_kwargs = dict(connection_kwargs)
+    configured_settings = pool_kwargs.pop("server_settings", {})
+    if not isinstance(configured_settings, Mapping):
+        raise PreflightError("Runtime database server settings are invalid")
+    pool_kwargs.update(
+        {
+            "min_size": 1,
+            "max_size": 1,
+            "statement_cache_size": 0,
+            "server_settings": {
+                **dict(configured_settings),
+                **_READ_ONLY_SERVER_SETTINGS,
+            },
+        }
+    )
+    return await asyncpg.create_pool(**pool_kwargs)
+
+
+async def _target_identity(pool: Any, *, source: str) -> _TargetIdentity:
+    """Read one session's database/schema/role identity in a read-only tx."""
+
+    async with pool.acquire() as connection:
+        async with connection.transaction(readonly=True):
+            row = await connection.fetchrow(_TARGET_IDENTITY_QUERY)
+    if row is None:
+        raise PreflightError(f"Missing or invalid database identity from {source}")
+    return _TargetIdentity(
+        schema_name=_require_text(
+            row["schema_name"], source=f"current schema from {source}"
+        ),
+        database_name=_require_text(
+            row["database_name"], source=f"database name from {source}"
+        ),
+        database_oid=_require_database_oid(
+            row["database_oid"], source=f"database OID from {source}"
+        ),
+        current_user=_require_text(
+            row["current_user"], source=f"current user from {source}"
+        ),
+        session_user=_require_text(
+            row["session_user"], source=f"session user from {source}"
+        ),
+        current_user_is_superuser=_require_bool(
+            row["current_user_is_superuser"],
+            source=f"superuser status from {source}",
+        ),
+    )
+
+
+def _require_matching_target(
+    runtime_target: _TargetIdentity,
+    dba_target: _TargetIdentity,
+) -> None:
+    """Reject a DBA pool that is not the exact configured runtime target."""
+
+    if dba_target.database_identity != runtime_target.database_identity:
+        raise PreflightError(
+            "Configured DBA connection does not target the Atlas runtime database"
+        )
+    if dba_target.schema_name != runtime_target.schema_name:
+        raise PreflightError(
+            "Configured DBA connection does not resolve to the Atlas runtime schema"
+        )
+
+
+def _require_direct_dba_superuser(target: _TargetIdentity) -> None:
+    """Require a direct superuser session, not a weaker or switched role."""
+
+    if target.uses_direct_superuser_login:
+        return
+    if target.current_user != target.session_user:
+        raise PreflightError(
+            "Configured DBA connection must use a direct DBA login, not SET ROLE"
+        )
+    if not target.current_user_is_superuser:
+        raise PreflightError(
+            "Configured DBA connection is not a PostgreSQL superuser"
+        )
+
+
+async def _attest_shared_database_lock(runtime_pool: Any, dba_pool: Any) -> None:
+    """Prove both pools contend on one live database-cluster lock namespace."""
+
+    for _attempt in range(3):
+        lock_key = secrets.randbits(63)
+        async with runtime_pool.acquire() as runtime_connection:
+            async with runtime_connection.transaction(readonly=True):
+                runtime_acquired = bool(
+                    await runtime_connection.fetchval(
+                        "SELECT pg_catalog.pg_try_advisory_xact_lock($1)",
+                        lock_key,
+                    )
+                )
+                if not runtime_acquired:
+                    continue
+                async with dba_pool.acquire() as dba_connection:
+                    async with dba_connection.transaction(readonly=True):
+                        dba_acquired = bool(
+                            await dba_connection.fetchval(
+                                "SELECT pg_catalog.pg_try_advisory_xact_lock($1)",
+                                lock_key,
+                            )
+                        )
+                if dba_acquired:
+                    raise PreflightError(
+                        "Configured DBA connection does not share the Atlas "
+                        "runtime database cluster"
+                    )
+                return
+    raise PreflightError(
+        "Could not reserve a fresh runtime target-attestation advisory lock"
+    )
+
+
+def _json_catalog_value(value: object, *, source: str) -> object:
+    """Keep the receipt strictly JSON scalar data from fixed catalog queries."""
+
+    if value is None or isinstance(value, (bool, int, str)):
+        return value
+    raise PreflightError(f"Catalog receipt contained an invalid value from {source}")
+
+
+def _json_catalog_row(row: object, *, source: str) -> dict[str, object]:
+    """Convert one static catalog result to a safe JSON object."""
+
+    try:
+        values = dict(row)
+    except (TypeError, ValueError) as exc:
+        raise PreflightError(
+            f"Catalog receipt contained an invalid row from {source}"
+        ) from exc
+    if any(not isinstance(key, str) for key in values):
+        raise PreflightError(
+            f"Catalog receipt contained an invalid row from {source}"
+        )
+    return {
+        key: _json_catalog_value(value, source=source)
+        for key, value in values.items()
+    }
+
+
+async def _catalog_receipt(pool: Any) -> dict[str, object]:
+    """Return the fixed catalog facts required for later role design only."""
+
+    async with pool.acquire() as connection:
+        async with connection.transaction(readonly=True):
+            database_owner = await connection.fetchrow(_DATABASE_OWNER_QUERY)
+            roles = await connection.fetch(_ROLES_QUERY)
+            memberships = await connection.fetch(_ROLE_MEMBERSHIPS_QUERY)
+            schemas = await connection.fetch(_SCHEMA_OWNERS_QUERY)
+            relation_owners = await connection.fetch(_RELATION_OWNER_SUMMARY_QUERY)
+            function_owners = await connection.fetch(_FUNCTION_OWNER_SUMMARY_QUERY)
+            database_acl = await connection.fetch(_DATABASE_ACL_QUERY)
+            schema_acl = await connection.fetch(_SCHEMA_ACL_QUERY)
+            relation_acl = await connection.fetch(_RELATION_ACL_SUMMARY_QUERY)
+            function_acl = await connection.fetch(_FUNCTION_ACL_SUMMARY_QUERY)
+            column_acl = await connection.fetch(_COLUMN_ACL_SUMMARY_QUERY)
+            row_security_policies = await connection.fetch(
+                _ROW_SECURITY_POLICY_SUMMARY_QUERY
+            )
+            default_acl = await connection.fetch(_DEFAULT_ACL_SUMMARY_QUERY)
+
+    if database_owner is None:
+        raise PreflightError("Catalog receipt is missing the current database owner")
+    return {
+        "database_owner": _json_catalog_row(
+            database_owner,
+            source="database owner",
+        ),
+        "roles": [
+            _json_catalog_row(row, source="roles")
+            for row in roles
+        ],
+        "memberships": [
+            _json_catalog_row(row, source="role memberships")
+            for row in memberships
+        ],
+        "schema_owners": [
+            _json_catalog_row(row, source="schema owners")
+            for row in schemas
+        ],
+        "relation_owner_summary": [
+            _json_catalog_row(row, source="relation owners")
+            for row in relation_owners
+        ],
+        "function_owner_summary": [
+            _json_catalog_row(row, source="function owners")
+            for row in function_owners
+        ],
+        "database_acl": [
+            _json_catalog_row(row, source="database ACL")
+            for row in database_acl
+        ],
+        "schema_acl": [
+            _json_catalog_row(row, source="schema ACL")
+            for row in schema_acl
+        ],
+        "relation_acl_summary": [
+            _json_catalog_row(row, source="relation ACL")
+            for row in relation_acl
+        ],
+        "function_acl_summary": [
+            _json_catalog_row(row, source="function ACL")
+            for row in function_acl
+        ],
+        "column_acl_summary": [
+            _json_catalog_row(row, source="column ACL")
+            for row in column_acl
+        ],
+        "row_security_policy_summary": [
+            _json_catalog_row(row, source="row security policy")
+            for row in row_security_policies
+        ],
+        "default_acl_summary": [
+            _json_catalog_row(row, source="default ACL")
+            for row in default_acl
+        ],
+    }
+
+
+def _identity_receipt(target: _TargetIdentity) -> dict[str, object]:
+    """Render only non-secret session facts from a target identity."""
+
+    return {
+        "schema_name": target.schema_name,
+        "database_name": target.database_name,
+        "database_oid": target.database_oid,
+        "current_user": target.current_user,
+        "session_user": target.session_user,
+        "current_user_is_superuser": target.current_user_is_superuser,
+    }
+
+
+async def _run(
+    *,
+    create_pool: Callable[[Mapping[str, object]], Awaitable[Any]] = _create_pool,
+    dba_config_factory: Callable[[], DatabaseRoleTopologyDBAConfig] = (
+        DatabaseRoleTopologyDBAConfig
+    ),
+    runtime_config_factory: Callable[[], DatabaseConfig] = DatabaseConfig,
+) -> dict[str, object]:
+    """Attest both targets and return a role-topology receipt or fail closed."""
+
+    dba_config = dba_config_factory()
+    dba_database_url = dba_config.database_url.get_secret_value().strip()
+    if not dba_database_url:
+        raise PreflightError(f"Missing protected DBA DSN configuration {DBA_DSN_ENV}")
+
+    runtime_config = runtime_config_factory()
+    runtime_pool = await create_pool(_runtime_connection_kwargs(runtime_config))
+    try:
+        runtime_target = await _target_identity(runtime_pool, source="Atlas runtime")
+        dba_pool = await create_pool({"dsn": dba_database_url})
+        try:
+            dba_target = await _target_identity(
+                dba_pool,
+                source="configured DBA connection",
+            )
+            _require_matching_target(runtime_target, dba_target)
+            _require_direct_dba_superuser(dba_target)
+            await _attest_shared_database_lock(runtime_pool, dba_pool)
+            catalog = await _catalog_receipt(dba_pool)
+            return {
+                "receipt_version": RECEIPT_VERSION,
+                "mode": "read-only",
+                "runtime_target": _runtime_target_label(runtime_config),
+                "dba_target": _safe_target_label(dba_database_url),
+                "target_attested": True,
+                "runtime_session": _identity_receipt(runtime_target),
+                "dba_session": _identity_receipt(dba_target),
+                "catalog": catalog,
+            }
+        finally:
+            await dba_pool.close()
+    finally:
+        await runtime_pool.close()
+
+
+async def _main(argv: list[str] | None = None) -> int:
+    """Run the fixed preflight and print either a receipt or a safe failure."""
+
+    _parse_args(argv)
+    try:
+        receipt = await _run()
+    except PreflightError as exc:
+        print(f"Database role-topology preflight failed: {exc}", file=sys.stderr)
+        return 2
+    except Exception:  # pragma: no cover - protects credential-bearing drivers
+        print(
+            "Database role-topology preflight failed before producing a receipt.",
+            file=sys.stderr,
+        )
+        return 2
+    print(json.dumps(receipt, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/tests/test_database_role_topology_preflight.py
+++ b/tests/test_database_role_topology_preflight.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 import asyncio
 import importlib.util
 import json
+import os
 from pathlib import Path
+import subprocess
 import sys
 from types import ModuleType, SimpleNamespace
+from urllib.parse import quote, urlsplit, urlunsplit
+from uuid import uuid4
 
 import pytest
 
@@ -38,12 +42,20 @@ class _Acquire:
 
 
 class _Transaction:
-    def __init__(self, state: SimpleNamespace, *, readonly: bool) -> None:
+    def __init__(
+        self,
+        state: SimpleNamespace,
+        *,
+        readonly: bool,
+        isolation: str | None,
+    ) -> None:
         self._state = state
         self._readonly = readonly
+        self._isolation = isolation
 
     async def __aenter__(self) -> None:
         self._state.readonly_transactions.append(self._readonly)
+        self._state.transaction_isolations.append(self._isolation)
         self._state.transaction_depth += 1
         return None
 
@@ -56,8 +68,13 @@ class _Connection:
     def __init__(self, state: SimpleNamespace) -> None:
         self._state = state
 
-    def transaction(self, *, readonly: bool = False) -> _Transaction:
-        return _Transaction(self._state, readonly=readonly)
+    def transaction(
+        self,
+        *,
+        readonly: bool = False,
+        isolation: str | None = None,
+    ) -> _Transaction:
+        return _Transaction(self._state, readonly=readonly, isolation=isolation)
 
     def _require_readonly_transaction(self) -> None:
         if self._state.transaction_depth < 1:
@@ -95,11 +112,11 @@ class _Connection:
         self._require_readonly_transaction()
         self._state.catalog_fetches += 1
         if "procedure.proacl" in query:
-            return self._state.catalog["function_acl_summary"]
+            return self._state.catalog["function_acl"]
         if "pg_catalog.pg_attribute AS column_attribute" in query:
-            return self._state.catalog["column_acl_summary"]
+            return self._state.catalog["column_acl"]
         if "pg_catalog.pg_policy AS policy" in query:
-            return self._state.catalog["row_security_policy_summary"]
+            return self._state.catalog["row_security_policies"]
         if "pg_catalog.pg_roles AS role" in query:
             return self._state.catalog["roles"]
         if "pg_catalog.pg_auth_members AS membership" in query:
@@ -107,17 +124,17 @@ class _Connection:
         if "namespace.nspowner" in query:
             return self._state.catalog["schema_owners"]
         if "relation.relowner" in query:
-            return self._state.catalog["relation_owner_summary"]
+            return self._state.catalog["relation_owners"]
         if "pg_catalog.pg_proc AS procedure" in query:
-            return self._state.catalog["function_owner_summary"]
+            return self._state.catalog["function_owners"]
         if "database_catalog.datacl" in query:
             return self._state.catalog["database_acl"]
         if "namespace.nspacl" in query:
             return self._state.catalog["schema_acl"]
         if "relation.relacl" in query:
-            return self._state.catalog["relation_acl_summary"]
+            return self._state.catalog["relation_acl"]
         if "pg_catalog.pg_default_acl" in query:
-            return self._state.catalog["default_acl_summary"]
+            return self._state.catalog["default_acl"]
         raise AssertionError(f"unexpected fetch query: {query}")
 
     async def execute(self, *_args: object) -> None:
@@ -127,9 +144,11 @@ class _Connection:
 class _Pool:
     def __init__(self, state: SimpleNamespace) -> None:
         self._connection = _Connection(state)
+        self.acquire_calls = 0
         self.closed = False
 
     def acquire(self) -> _Acquire:
+        self.acquire_calls += 1
         return _Acquire(self._connection)
 
     async def close(self) -> None:
@@ -152,30 +171,38 @@ def _catalog() -> dict[str, list[dict[str, object]]]:
         ],
         "memberships": [
             {
+                "membership_oid": 20_001,
                 "granted_role": "atlas_eom_handoff_owner",
                 "member_role": "atlas",
+                "grantor_role": "postgres",
                 "admin_option": False,
+                "inherit_option": False,
+                "set_option": True,
             }
         ],
         "schema_owners": [
             {"schema_name": "public", "owner_role": "atlas_eom_handoff_owner"}
         ],
-        "relation_owner_summary": [
+        "relation_owners": [
             {
                 "schema_name": "public",
+                "relation_oid": 20_002,
+                "relation_name": "work_log",
                 "relation_kind": "r",
                 "owner_role": "atlas_eom_handoff_owner",
                 "row_security_enabled": True,
                 "row_security_forced": False,
-                "object_count": 2,
             }
         ],
-        "function_owner_summary": [
+        "function_owners": [
             {
                 "schema_name": "public",
+                "function_oid": 20_003,
+                "function_name": "write_log",
+                "function_kind": "f",
+                "identity_arguments": "employee_id bigint",
                 "owner_role": "atlas_eom_handoff_owner",
                 "is_security_definer": True,
-                "function_count": 1,
             }
         ],
         "database_acl": [
@@ -195,52 +222,63 @@ def _catalog() -> dict[str, list[dict[str, object]]]:
                 "is_grantable": False,
             }
         ],
-        "relation_acl_summary": [
+        "relation_acl": [
             {
                 "acl_source": "explicit",
                 "schema_name": "public",
+                "relation_oid": 20_002,
+                "relation_name": "work_log",
                 "relation_kind": "r",
                 "row_security_enabled": True,
                 "row_security_forced": False,
                 "grantee_role": "atlas",
                 "privilege_type": "SELECT",
                 "is_grantable": False,
-                "object_count": 2,
             }
         ],
-        "function_acl_summary": [
+        "function_acl": [
             {
                 "acl_source": "default",
                 "schema_name": "public",
+                "function_oid": 20_003,
+                "function_name": "write_log",
+                "function_kind": "f",
+                "identity_arguments": "employee_id bigint",
                 "is_security_definer": True,
                 "grantee_role": "PUBLIC",
                 "privilege_type": "EXECUTE",
                 "is_grantable": False,
-                "function_count": 1,
             }
         ],
-        "column_acl_summary": [
+        "column_acl": [
             {
                 "acl_source": "explicit_column",
                 "schema_name": "public",
+                "relation_oid": 20_002,
+                "relation_name": "work_log",
                 "relation_kind": "r",
+                "column_number": 2,
+                "column_name": "hours_worked",
                 "grantee_role": "atlas",
                 "privilege_type": "UPDATE",
                 "is_grantable": False,
-                "column_count": 1,
             }
         ],
-        "row_security_policy_summary": [
+        "row_security_policies": [
             {
                 "schema_name": "public",
+                "relation_oid": 20_002,
+                "relation_name": "work_log",
                 "relation_kind": "r",
                 "command": "r",
                 "is_permissive": True,
+                "policy_oid": 20_004,
+                "policy_name": "atlas_work_log_read",
                 "role_name": "atlas",
-                "policy_count": 1,
+                "role_oid": 20_005,
             }
         ],
-        "default_acl_summary": [],
+        "default_acl": [],
     }
 
 
@@ -255,6 +293,7 @@ def _state(**overrides: object) -> SimpleNamespace:
         "advisory_lock_available": True,
         "advisory_lock_attempts": 0,
         "readonly_transactions": [],
+        "transaction_isolations": [],
         "transaction_depth": 0,
         "catalog_fetches": 0,
         "database_owner": "atlas_eom_handoff_owner",
@@ -335,7 +374,7 @@ def test_dba_config_uses_redacted_secret_boundary(
     assert "dba-secret" not in repr(config)
 
 
-def test_preflight_returns_redacted_receipt_and_uses_only_readonly_transactions(
+def test_preflight_returns_redacted_snapshot_from_pinned_readonly_connections(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     runner = _load_preflight_module()
@@ -375,14 +414,18 @@ def test_preflight_returns_redacted_receipt_and_uses_only_readonly_transactions(
         "owner_role": "atlas_eom_handoff_owner",
     }
     assert receipt["catalog"]["roles"] == dba_state.catalog["roles"]
-    assert receipt["catalog"]["function_acl_summary"] == dba_state.catalog[
-        "function_acl_summary"
+    assert receipt["catalog"]["memberships"] == dba_state.catalog["memberships"]
+    assert receipt["catalog"]["relation_owners"] == dba_state.catalog[
+        "relation_owners"
     ]
-    assert receipt["catalog"]["column_acl_summary"] == dba_state.catalog[
-        "column_acl_summary"
+    assert receipt["catalog"]["function_acl"] == dba_state.catalog[
+        "function_acl"
     ]
-    assert receipt["catalog"]["row_security_policy_summary"] == dba_state.catalog[
-        "row_security_policy_summary"
+    assert receipt["catalog"]["column_acl"] == dba_state.catalog[
+        "column_acl"
+    ]
+    assert receipt["catalog"]["row_security_policies"] == dba_state.catalog[
+        "row_security_policies"
     ]
     assert "dba-secret" not in rendered
     assert "runtime-secret" not in rendered
@@ -400,10 +443,14 @@ def test_preflight_returns_redacted_receipt_and_uses_only_readonly_transactions(
     ]
     assert runtime_pool.closed is True
     assert dba_pool.closed is True
+    assert runtime_pool.acquire_calls == 1
+    assert dba_pool.acquire_calls == 1
     assert runtime_state.readonly_transactions
     assert dba_state.readonly_transactions
     assert all(runtime_state.readonly_transactions)
     assert all(dba_state.readonly_transactions)
+    assert runtime_state.transaction_isolations == ["repeatable_read"]
+    assert dba_state.transaction_isolations == ["repeatable_read"]
 
 
 @pytest.mark.parametrize("database_url", ("", "   "))
@@ -513,14 +560,24 @@ def test_preflight_rejects_every_target_identity_mismatch_before_report(
 def test_target_identity_rejects_an_ambiguous_catalog_superuser_flag() -> None:
     runner = _load_preflight_module()
     state = _state(current_user_is_superuser="true")
+    pool = _Pool(state)
+
+    async def read_identity() -> object:
+        async with pool.acquire() as connection:
+            async with connection.transaction(
+                isolation="repeatable_read",
+                readonly=True,
+            ):
+                return await runner._target_identity(connection, source="test target")
 
     with pytest.raises(
         runner.PreflightError,
         match="Missing or invalid superuser status from test target",
     ):
-        asyncio.run(runner._target_identity(_Pool(state), source="test target"))
+        asyncio.run(read_identity())
 
     assert state.readonly_transactions == [True]
+    assert state.transaction_isolations == ["repeatable_read"]
 
 
 def test_catalog_row_rejects_an_unexpected_column_key() -> None:
@@ -644,10 +701,16 @@ def test_preflight_has_no_apply_or_mutation_command_surface() -> None:
     assert "--apply" not in source
     assert ".execute(" not in source
     assert "readonly=True" in source
+    assert 'isolation="repeatable_read"' in source
     assert "acldefault('d'" in source
     assert "acldefault('n'" in source
     assert "acldefault('f'" in source
     assert "NULLIF(policy.polroles, ARRAY[]::oid[])" in source
+    assert "membership.inherit_option" in source
+    assert "membership.set_option" in source
+    assert "relation.relname AS relation_name" in source
+    assert "policy.polname AS policy_name" in source
+    assert "count(*)::bigint" not in source
 
 
 def test_main_does_not_render_an_unexpected_driver_message(
@@ -665,3 +728,244 @@ def test_main_does_not_render_an_unexpected_driver_message(
     captured = capsys.readouterr()
     assert "driver-secret" not in captured.err
     assert "failed before producing a receipt" in captured.err
+
+
+_ROLE_TOPOLOGY_TEST_DBA_DSN_ENV = (
+    "ATLAS_DATABASE_ROLE_TOPOLOGY_TEST_DBA_DATABASE_URL"
+)
+
+
+def _disposable_role_topology_dba_dsn() -> str:
+    """Return the explicitly provisioned PostgreSQL 16 test target only."""
+
+    database_url = os.environ.get(_ROLE_TOPOLOGY_TEST_DBA_DSN_ENV, "").strip()
+    if not database_url:
+        pytest.skip(
+            "set ATLAS_DATABASE_ROLE_TOPOLOGY_TEST_DBA_DATABASE_URL to run "
+            "the disposable PostgreSQL 16 role-topology integration test"
+        )
+    try:
+        return _require_disposable_role_topology_dba_dsn(database_url)
+    except ValueError as exc:
+        pytest.fail(str(exc))
+
+
+def _require_disposable_role_topology_dba_dsn(database_url: str) -> str:
+    """Reject a non-test or remote database before the fixture can mutate it."""
+
+    parsed = urlsplit(database_url)
+    database_name = parsed.path.lstrip("/")
+    if not database_name.endswith(("_test", "_tests")):
+        raise ValueError("role-topology integration requires a disposable test database")
+    if parsed.hostname not in {"localhost", "127.0.0.1", "::1"}:
+        raise ValueError("role-topology integration requires a loopback database host")
+    if not parsed.hostname or not parsed.username:
+        raise ValueError("role-topology integration requires a complete disposable DBA DSN")
+    return database_url
+
+
+@pytest.mark.parametrize(
+    ("database_url", "message"),
+    (
+        ("postgresql://atlas:atlas@localhost:5432/atlas", "disposable test database"),
+        (
+            "postgresql://atlas:atlas@example.test:5432/atlas_migration_tests",
+            "loopback database host",
+        ),
+        ("postgresql://localhost:5432/atlas_migration_tests", "complete disposable DBA DSN"),
+    ),
+)
+def test_disposable_role_topology_dsn_rejects_non_test_targets(
+    database_url: str,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        _require_disposable_role_topology_dba_dsn(database_url)
+
+
+def _quoted_identifier(value: str) -> str:
+    return f'"{value.replace("\"", "\"\"")}"'
+
+
+def _runtime_dsn_from_dba_dsn(
+    dba_database_url: str,
+    *,
+    runtime_role: str,
+    runtime_password: str,
+) -> str:
+    """Build a test-only runtime login URL without changing the DBA target."""
+
+    parsed = urlsplit(dba_database_url)
+    assert parsed.hostname is not None
+    host = parsed.hostname
+    if ":" in host:
+        host = f"[{host}]"
+    port = f":{parsed.port}" if parsed.port else ""
+    netloc = (
+        f"{quote(runtime_role, safe='')}:{quote(runtime_password, safe='')}"
+        f"@{host}{port}"
+    )
+    return urlunsplit((parsed.scheme, netloc, parsed.path, parsed.query, ""))
+
+
+@pytest.mark.integration
+def test_role_topology_preflight_executes_fixed_queries_against_postgresql_16() -> None:
+    """Exercise the real command against a sealed disposable PostgreSQL target."""
+
+    asyncpg = pytest.importorskip("asyncpg")
+    dba_database_url = _disposable_role_topology_dba_dsn()
+    suffix = uuid4().hex
+    schema_name = f"role_topology_{suffix}"
+    runtime_role = f"role_topology_runtime_{suffix}"
+    granted_role = f"role_topology_granted_{suffix}"
+    relation_name = "work_log"
+    function_name = "write_log"
+    policy_name = "read_work_log"
+    runtime_password = f"runtime-{suffix}"
+    schema = _quoted_identifier(schema_name)
+    runtime = _quoted_identifier(runtime_role)
+    granted = _quoted_identifier(granted_role)
+    relation = f"{schema}.{_quoted_identifier(relation_name)}"
+    function = f"{schema}.{_quoted_identifier(function_name)}(employee_id bigint)"
+    policy = _quoted_identifier(policy_name)
+
+    async def exercise() -> dict[str, object]:
+        connection = await asyncpg.connect(dba_database_url)
+        runtime_created = False
+        granted_created = False
+        try:
+            await connection.execute(
+                f"CREATE ROLE {runtime} LOGIN PASSWORD "
+                f"'{runtime_password}' INHERIT NOSUPERUSER NOCREATEDB "
+                "NOCREATEROLE NOREPLICATION NOBYPASSRLS"
+            )
+            runtime_created = True
+            await connection.execute(f"CREATE ROLE {granted} NOLOGIN")
+            granted_created = True
+            await connection.execute(
+                f"GRANT {granted} TO {runtime} WITH ADMIN FALSE, "
+                "INHERIT FALSE, SET TRUE"
+            )
+            await connection.execute(f"GRANT USAGE ON SCHEMA public TO {runtime}")
+            await connection.execute(f"CREATE SCHEMA {schema}")
+            await connection.execute(
+                f"CREATE TABLE {relation} (row_id bigint, hours_worked integer)"
+            )
+            await connection.execute(f"ALTER TABLE {relation} ENABLE ROW LEVEL SECURITY")
+            await connection.execute(
+                f"CREATE POLICY {policy} ON {relation} FOR SELECT TO {runtime} "
+                "USING (true)"
+            )
+            await connection.execute(f"GRANT USAGE ON SCHEMA {schema} TO {runtime}")
+            await connection.execute(f"GRANT SELECT ON {relation} TO {runtime}")
+            await connection.execute(
+                f"GRANT UPDATE (hours_worked) ON {relation} TO {runtime}"
+            )
+            await connection.execute(
+                f"CREATE FUNCTION {function} RETURNS bigint LANGUAGE sql "
+                "SECURITY DEFINER AS $$ SELECT employee_id $$"
+            )
+            await connection.execute(f"GRANT EXECUTE ON FUNCTION {function} TO {runtime}")
+
+            environment = dict(os.environ)
+            environment["ATLAS_DB_CONNECTION_STRING"] = _runtime_dsn_from_dba_dsn(
+                dba_database_url,
+                runtime_role=runtime_role,
+                runtime_password=runtime_password,
+            )
+            environment["ATLAS_DATABASE_ROLE_TOPOLOGY_DBA_DATABASE_URL"] = (
+                dba_database_url
+            )
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT)],
+                cwd=ROOT,
+                env=environment,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            assert result.returncode == 0, result.stderr
+            return json.loads(result.stdout)
+        finally:
+            await connection.execute(f"DROP SCHEMA IF EXISTS {schema} CASCADE")
+            if runtime_created and granted_created:
+                await connection.execute(f"REVOKE {granted} FROM {runtime}")
+            if runtime_created:
+                await connection.execute(f"DROP ROLE {runtime}")
+            if granted_created:
+                await connection.execute(f"DROP ROLE {granted}")
+            await connection.close()
+
+    receipt = asyncio.run(exercise())
+    catalog = receipt["catalog"]
+    membership = next(
+        row
+        for row in catalog["memberships"]
+        if row["granted_role"] == granted_role and row["member_role"] == runtime_role
+    )
+    assert isinstance(membership["membership_oid"], int)
+    assert isinstance(membership["grantor_role"], str)
+    assert membership["admin_option"] is False
+    assert membership["inherit_option"] is False
+    assert membership["set_option"] is True
+
+    relation_owner = next(
+        row
+        for row in catalog["relation_owners"]
+        if row["schema_name"] == schema_name
+        and row["relation_name"] == relation_name
+    )
+    assert isinstance(relation_owner["relation_oid"], int)
+
+    relation_acl = next(
+        row
+        for row in catalog["relation_acl"]
+        if row["schema_name"] == schema_name
+        and row["relation_name"] == relation_name
+        and row["grantee_role"] == runtime_role
+        and row["privilege_type"] == "SELECT"
+    )
+    assert isinstance(relation_acl["relation_oid"], int)
+
+    column_acl = next(
+        row
+        for row in catalog["column_acl"]
+        if row["schema_name"] == schema_name
+        and row["relation_name"] == relation_name
+        and row["column_name"] == "hours_worked"
+        and row["grantee_role"] == runtime_role
+        and row["privilege_type"] == "UPDATE"
+    )
+    assert isinstance(column_acl["relation_oid"], int)
+    assert isinstance(column_acl["column_number"], int)
+
+    function_acl = next(
+        row
+        for row in catalog["function_acl"]
+        if row["schema_name"] == schema_name
+        and row["function_name"] == function_name
+        and row["grantee_role"] == runtime_role
+        and row["privilege_type"] == "EXECUTE"
+    )
+    assert isinstance(function_acl["function_oid"], int)
+    assert function_acl["identity_arguments"] == "employee_id bigint"
+
+    function_owner = next(
+        row
+        for row in catalog["function_owners"]
+        if row["schema_name"] == schema_name
+        and row["function_name"] == function_name
+    )
+    assert isinstance(function_owner["function_oid"], int)
+    assert function_owner["identity_arguments"] == "employee_id bigint"
+
+    policy_row = next(
+        row
+        for row in catalog["row_security_policies"]
+        if row["schema_name"] == schema_name
+        and row["relation_name"] == relation_name
+        and row["policy_name"] == policy_name
+        and row["role_name"] == runtime_role
+    )
+    assert isinstance(policy_row["policy_oid"], int)
+    assert isinstance(policy_row["relation_oid"], int)

--- a/tests/test_database_role_topology_preflight.py
+++ b/tests/test_database_role_topology_preflight.py
@@ -530,6 +530,41 @@ def test_preflight_rejects_missing_or_blank_dba_dsn_before_opening_a_pool(
         )
 
 
+def test_default_dba_config_ignores_worktree_dotenv_and_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A stale worktree dotenv value cannot satisfy the protected DSN boundary."""
+
+    runner = _load_preflight_module()
+    monkeypatch.delenv(runner.DBA_DSN_ENV, raising=False)
+    monkeypatch.chdir(tmp_path)
+    dotenv_value = "postgresql://dotenv-test:synthetic@example.test:5432/atlas"
+    (tmp_path / ".env").write_text(f"{runner.DBA_DSN_ENV}={dotenv_value}\n")
+    (tmp_path / ".env.local").write_text(f"{runner.DBA_DSN_ENV}={dotenv_value}\n")
+
+    assert runner.DatabaseRoleTopologyDBAConfig().database_url.get_secret_value() == ""
+
+    pool_calls: list[object] = []
+
+    async def create_pool(connection_kwargs: object) -> _Pool:
+        pool_calls.append(connection_kwargs)
+        raise AssertionError("dotenv-only DBA config must prevent pool creation")
+
+    with pytest.raises(
+        runner.PreflightError,
+        match=f"Missing protected DBA DSN configuration {runner.DBA_DSN_ENV}",
+    ):
+        asyncio.run(
+            runner._run(
+                create_pool=create_pool,
+                runtime_config_factory=_RuntimeConfig,
+            )
+        )
+
+    assert pool_calls == []
+
+
 def test_preflight_rejects_database_mismatch_before_catalog_reporting(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_database_role_topology_preflight.py
+++ b/tests/test_database_role_topology_preflight.py
@@ -1,0 +1,667 @@
+"""Unit proof for the fixed, read-only database role-topology preflight."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+from pathlib import Path
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = ROOT / "scripts" / "check_database_role_topology.py"
+
+
+def _load_preflight_module() -> ModuleType:
+    module_name = "test_database_role_topology_preflight_script"
+    spec = importlib.util.spec_from_file_location(module_name, SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class _Acquire:
+    def __init__(self, connection: "_Connection") -> None:
+        self._connection = connection
+
+    async def __aenter__(self) -> "_Connection":
+        return self._connection
+
+    async def __aexit__(self, *_args: object) -> None:
+        return None
+
+
+class _Transaction:
+    def __init__(self, state: SimpleNamespace, *, readonly: bool) -> None:
+        self._state = state
+        self._readonly = readonly
+
+    async def __aenter__(self) -> None:
+        self._state.readonly_transactions.append(self._readonly)
+        self._state.transaction_depth += 1
+        return None
+
+    async def __aexit__(self, *_args: object) -> None:
+        self._state.transaction_depth -= 1
+        return None
+
+
+class _Connection:
+    def __init__(self, state: SimpleNamespace) -> None:
+        self._state = state
+
+    def transaction(self, *, readonly: bool = False) -> _Transaction:
+        return _Transaction(self._state, readonly=readonly)
+
+    def _require_readonly_transaction(self) -> None:
+        if self._state.transaction_depth < 1:
+            raise AssertionError("preflight query escaped its transaction")
+        if not self._state.readonly_transactions[-1]:
+            raise AssertionError("preflight query escaped read-only mode")
+
+    async def fetchrow(self, query: str) -> object:
+        self._require_readonly_transaction()
+        if "current_schema() AS schema_name" in query:
+            return {
+                "schema_name": self._state.schema_name,
+                "database_name": self._state.database_name,
+                "database_oid": self._state.database_oid,
+                "current_user": self._state.current_user,
+                "session_user": self._state.session_user,
+                "current_user_is_superuser": self._state.current_user_is_superuser,
+            }
+        if "database_catalog.datname AS database_name" in query:
+            self._state.catalog_fetches += 1
+            return {
+                "database_name": self._state.database_name,
+                "owner_role": self._state.database_owner,
+            }
+        raise AssertionError(f"unexpected fetchrow query: {query}")
+
+    async def fetchval(self, query: str, *_args: object) -> object:
+        self._require_readonly_transaction()
+        if "pg_try_advisory_xact_lock" in query:
+            self._state.advisory_lock_attempts += 1
+            return self._state.advisory_lock_available
+        raise AssertionError(f"unexpected fetchval query: {query}")
+
+    async def fetch(self, query: str) -> list[dict[str, object]]:
+        self._require_readonly_transaction()
+        self._state.catalog_fetches += 1
+        if "procedure.proacl" in query:
+            return self._state.catalog["function_acl_summary"]
+        if "pg_catalog.pg_attribute AS column_attribute" in query:
+            return self._state.catalog["column_acl_summary"]
+        if "pg_catalog.pg_policy AS policy" in query:
+            return self._state.catalog["row_security_policy_summary"]
+        if "pg_catalog.pg_roles AS role" in query:
+            return self._state.catalog["roles"]
+        if "pg_catalog.pg_auth_members AS membership" in query:
+            return self._state.catalog["memberships"]
+        if "namespace.nspowner" in query:
+            return self._state.catalog["schema_owners"]
+        if "relation.relowner" in query:
+            return self._state.catalog["relation_owner_summary"]
+        if "pg_catalog.pg_proc AS procedure" in query:
+            return self._state.catalog["function_owner_summary"]
+        if "database_catalog.datacl" in query:
+            return self._state.catalog["database_acl"]
+        if "namespace.nspacl" in query:
+            return self._state.catalog["schema_acl"]
+        if "relation.relacl" in query:
+            return self._state.catalog["relation_acl_summary"]
+        if "pg_catalog.pg_default_acl" in query:
+            return self._state.catalog["default_acl_summary"]
+        raise AssertionError(f"unexpected fetch query: {query}")
+
+    async def execute(self, *_args: object) -> None:
+        raise AssertionError("read-only preflight must not execute a mutation")
+
+
+class _Pool:
+    def __init__(self, state: SimpleNamespace) -> None:
+        self._connection = _Connection(state)
+        self.closed = False
+
+    def acquire(self) -> _Acquire:
+        return _Acquire(self._connection)
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _catalog() -> dict[str, list[dict[str, object]]]:
+    return {
+        "roles": [
+            {
+                "role_name": "atlas",
+                "can_login": True,
+                "is_superuser": False,
+                "inherits_privileges": True,
+                "can_create_roles": False,
+                "can_create_databases": False,
+                "can_replicate": False,
+                "bypasses_row_security": False,
+            }
+        ],
+        "memberships": [
+            {
+                "granted_role": "atlas_eom_handoff_owner",
+                "member_role": "atlas",
+                "admin_option": False,
+            }
+        ],
+        "schema_owners": [
+            {"schema_name": "public", "owner_role": "atlas_eom_handoff_owner"}
+        ],
+        "relation_owner_summary": [
+            {
+                "schema_name": "public",
+                "relation_kind": "r",
+                "owner_role": "atlas_eom_handoff_owner",
+                "row_security_enabled": True,
+                "row_security_forced": False,
+                "object_count": 2,
+            }
+        ],
+        "function_owner_summary": [
+            {
+                "schema_name": "public",
+                "owner_role": "atlas_eom_handoff_owner",
+                "is_security_definer": True,
+                "function_count": 1,
+            }
+        ],
+        "database_acl": [
+            {
+                "acl_source": "explicit",
+                "grantee_role": "atlas",
+                "privilege_type": "CONNECT",
+                "is_grantable": False,
+            }
+        ],
+        "schema_acl": [
+            {
+                "acl_source": "explicit",
+                "schema_name": "public",
+                "grantee_role": "atlas",
+                "privilege_type": "USAGE",
+                "is_grantable": False,
+            }
+        ],
+        "relation_acl_summary": [
+            {
+                "acl_source": "explicit",
+                "schema_name": "public",
+                "relation_kind": "r",
+                "row_security_enabled": True,
+                "row_security_forced": False,
+                "grantee_role": "atlas",
+                "privilege_type": "SELECT",
+                "is_grantable": False,
+                "object_count": 2,
+            }
+        ],
+        "function_acl_summary": [
+            {
+                "acl_source": "default",
+                "schema_name": "public",
+                "is_security_definer": True,
+                "grantee_role": "PUBLIC",
+                "privilege_type": "EXECUTE",
+                "is_grantable": False,
+                "function_count": 1,
+            }
+        ],
+        "column_acl_summary": [
+            {
+                "acl_source": "explicit_column",
+                "schema_name": "public",
+                "relation_kind": "r",
+                "grantee_role": "atlas",
+                "privilege_type": "UPDATE",
+                "is_grantable": False,
+                "column_count": 1,
+            }
+        ],
+        "row_security_policy_summary": [
+            {
+                "schema_name": "public",
+                "relation_kind": "r",
+                "command": "r",
+                "is_permissive": True,
+                "role_name": "atlas",
+                "policy_count": 1,
+            }
+        ],
+        "default_acl_summary": [],
+    }
+
+
+def _state(**overrides: object) -> SimpleNamespace:
+    values: dict[str, object] = {
+        "schema_name": "public",
+        "database_name": "atlas",
+        "database_oid": 16_384,
+        "current_user": "atlas",
+        "session_user": "atlas",
+        "current_user_is_superuser": False,
+        "advisory_lock_available": True,
+        "advisory_lock_attempts": 0,
+        "readonly_transactions": [],
+        "transaction_depth": 0,
+        "catalog_fetches": 0,
+        "database_owner": "atlas_eom_handoff_owner",
+        "catalog": _catalog(),
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+class _RuntimeConfig:
+    target_label = "dsn=runtime.example.test:5432/atlas"
+
+    def connection_kwargs(self) -> dict[str, object]:
+        return {
+            "host": "runtime.example.test",
+            "port": 5432,
+            "database": "atlas",
+            "user": "atlas",
+            "password": "runtime-secret",
+        }
+
+
+def _dba_config(runner: ModuleType, monkeypatch: pytest.MonkeyPatch) -> object:
+    monkeypatch.setenv(
+        runner.DBA_DSN_ENV,
+        "postgresql://operator:dba-secret@example.test:5432/atlas?sslmode=require",
+    )
+    return runner.DatabaseRoleTopologyDBAConfig(_env_file=None)
+
+
+def test_create_pool_enforces_readonly_defaults_and_disables_statement_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _load_preflight_module()
+    calls: list[dict[str, object]] = []
+    created_pool = object()
+
+    async def create_pool(**kwargs: object) -> object:
+        calls.append(dict(kwargs))
+        return created_pool
+
+    monkeypatch.setitem(sys.modules, "asyncpg", SimpleNamespace(create_pool=create_pool))
+
+    pool = asyncio.run(
+        runner._create_pool(
+            {
+                "dsn": "postgresql://operator:secret@example.test/atlas",
+                "server_settings": {
+                    "search_path": "public",
+                    "default_transaction_read_only": "off",
+                },
+            }
+        )
+    )
+
+    assert pool is created_pool
+    assert calls == [
+        {
+            "dsn": "postgresql://operator:secret@example.test/atlas",
+            "min_size": 1,
+            "max_size": 1,
+            "statement_cache_size": 0,
+            "server_settings": {
+                "search_path": "public",
+                "default_transaction_read_only": "on",
+            },
+        }
+    ]
+
+
+def test_dba_config_uses_redacted_secret_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _load_preflight_module()
+    config = _dba_config(runner, monkeypatch)
+
+    assert config.database_url.get_secret_value().endswith("sslmode=require")
+    assert "dba-secret" not in repr(config)
+
+
+def test_preflight_returns_redacted_receipt_and_uses_only_readonly_transactions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _load_preflight_module()
+    runtime_state = _state()
+    dba_state = _state(
+        current_user="postgres",
+        session_user="postgres",
+        current_user_is_superuser=True,
+        advisory_lock_available=False,
+    )
+    runtime_pool = _Pool(runtime_state)
+    dba_pool = _Pool(dba_state)
+    pool_kwargs: list[dict[str, object]] = []
+
+    async def create_pool(connection_kwargs: object) -> _Pool:
+        pool_kwargs.append(dict(connection_kwargs))
+        return runtime_pool if len(pool_kwargs) == 1 else dba_pool
+
+    receipt = asyncio.run(
+        runner._run(
+            create_pool=create_pool,
+            dba_config_factory=lambda: _dba_config(runner, monkeypatch),
+            runtime_config_factory=_RuntimeConfig,
+        )
+    )
+
+    rendered = json.dumps(receipt, sort_keys=True)
+    assert receipt["receipt_version"] == runner.RECEIPT_VERSION
+    assert receipt["mode"] == "read-only"
+    assert receipt["target_attested"] is True
+    assert receipt["runtime_target"] == "dsn=runtime.example.test:5432/atlas"
+    assert receipt["dba_target"] == "dsn=example.test:5432/atlas"
+    assert receipt["runtime_session"]["current_user"] == "atlas"
+    assert receipt["dba_session"]["current_user"] == "postgres"
+    assert receipt["catalog"]["database_owner"] == {
+        "database_name": "atlas",
+        "owner_role": "atlas_eom_handoff_owner",
+    }
+    assert receipt["catalog"]["roles"] == dba_state.catalog["roles"]
+    assert receipt["catalog"]["function_acl_summary"] == dba_state.catalog[
+        "function_acl_summary"
+    ]
+    assert receipt["catalog"]["column_acl_summary"] == dba_state.catalog[
+        "column_acl_summary"
+    ]
+    assert receipt["catalog"]["row_security_policy_summary"] == dba_state.catalog[
+        "row_security_policy_summary"
+    ]
+    assert "dba-secret" not in rendered
+    assert "runtime-secret" not in rendered
+    assert pool_kwargs == [
+        {
+            "host": "runtime.example.test",
+            "port": 5432,
+            "database": "atlas",
+            "user": "atlas",
+            "password": "runtime-secret",
+        },
+        {
+            "dsn": "postgresql://operator:dba-secret@example.test:5432/atlas?sslmode=require"
+        },
+    ]
+    assert runtime_pool.closed is True
+    assert dba_pool.closed is True
+    assert runtime_state.readonly_transactions
+    assert dba_state.readonly_transactions
+    assert all(runtime_state.readonly_transactions)
+    assert all(dba_state.readonly_transactions)
+
+
+@pytest.mark.parametrize("database_url", ("", "   "))
+def test_preflight_rejects_missing_or_blank_dba_dsn_before_opening_a_pool(
+    database_url: str,
+) -> None:
+    runner = _load_preflight_module()
+
+    async def create_pool(_connection_kwargs: object) -> _Pool:
+        raise AssertionError("missing DBA config must prevent pool creation")
+
+    with pytest.raises(
+        runner.PreflightError,
+        match=f"Missing protected DBA DSN configuration {runner.DBA_DSN_ENV}",
+    ):
+        asyncio.run(
+            runner._run(
+                create_pool=create_pool,
+                dba_config_factory=lambda: runner.DatabaseRoleTopologyDBAConfig(
+                    database_url=database_url,
+                    _env_file=None,
+                ),
+                runtime_config_factory=_RuntimeConfig,
+            )
+        )
+
+
+def test_preflight_rejects_database_mismatch_before_catalog_reporting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _load_preflight_module()
+    runtime_pool = _Pool(_state())
+    dba_state = _state(
+        database_name="atlas_clone",
+        current_user="postgres",
+        session_user="postgres",
+        current_user_is_superuser=True,
+    )
+    dba_pool = _Pool(dba_state)
+    calls = 0
+
+    async def create_pool(_connection_kwargs: object) -> _Pool:
+        nonlocal calls
+        calls += 1
+        return runtime_pool if calls == 1 else dba_pool
+
+    with pytest.raises(
+        runner.PreflightError,
+        match="does not target the Atlas runtime database",
+    ):
+        asyncio.run(
+            runner._run(
+                create_pool=create_pool,
+                dba_config_factory=lambda: _dba_config(runner, monkeypatch),
+                runtime_config_factory=_RuntimeConfig,
+            )
+        )
+
+    assert runtime_pool.closed is True
+    assert dba_pool.closed is True
+    assert dba_state.catalog_fetches == 0
+    assert all(dba_state.readonly_transactions)
+
+
+@pytest.mark.parametrize(
+    ("dba_overrides", "message"),
+    (
+        ({"database_oid": 16_385}, "does not target the Atlas runtime database"),
+        ({"schema_name": "operations"}, "does not resolve to the Atlas runtime schema"),
+    ),
+)
+def test_preflight_rejects_every_target_identity_mismatch_before_report(
+    monkeypatch: pytest.MonkeyPatch,
+    dba_overrides: dict[str, object],
+    message: str,
+) -> None:
+    runner = _load_preflight_module()
+    runtime_pool = _Pool(_state())
+    dba_state = _state(
+        current_user="postgres",
+        session_user="postgres",
+        current_user_is_superuser=True,
+        **dba_overrides,
+    )
+    dba_pool = _Pool(dba_state)
+    calls = 0
+
+    async def create_pool(_connection_kwargs: object) -> _Pool:
+        nonlocal calls
+        calls += 1
+        return runtime_pool if calls == 1 else dba_pool
+
+    with pytest.raises(runner.PreflightError, match=message):
+        asyncio.run(
+            runner._run(
+                create_pool=create_pool,
+                dba_config_factory=lambda: _dba_config(runner, monkeypatch),
+                runtime_config_factory=_RuntimeConfig,
+            )
+        )
+
+    assert dba_state.catalog_fetches == 0
+    assert dba_state.advisory_lock_attempts == 0
+    assert all(dba_state.readonly_transactions)
+
+
+def test_target_identity_rejects_an_ambiguous_catalog_superuser_flag() -> None:
+    runner = _load_preflight_module()
+    state = _state(current_user_is_superuser="true")
+
+    with pytest.raises(
+        runner.PreflightError,
+        match="Missing or invalid superuser status from test target",
+    ):
+        asyncio.run(runner._target_identity(_Pool(state), source="test target"))
+
+    assert state.readonly_transactions == [True]
+
+
+def test_catalog_row_rejects_an_unexpected_column_key() -> None:
+    runner = _load_preflight_module()
+
+    with pytest.raises(
+        runner.PreflightError,
+        match="Catalog receipt contained an invalid row from test catalog",
+    ):
+        runner._json_catalog_row({1: "value"}, source="test catalog")
+
+
+def test_preflight_rejects_a_switched_or_non_superuser_dba_session_before_report(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _load_preflight_module()
+    runtime_pool = _Pool(_state())
+    dba_state = _state(
+        current_user="atlas",
+        session_user="postgres",
+        current_user_is_superuser=True,
+    )
+    dba_pool = _Pool(dba_state)
+    calls = 0
+
+    async def create_pool(_connection_kwargs: object) -> _Pool:
+        nonlocal calls
+        calls += 1
+        return runtime_pool if calls == 1 else dba_pool
+
+    with pytest.raises(
+        runner.PreflightError,
+        match="must use a direct DBA login, not SET ROLE",
+    ):
+        asyncio.run(
+            runner._run(
+                create_pool=create_pool,
+                dba_config_factory=lambda: _dba_config(runner, monkeypatch),
+                runtime_config_factory=_RuntimeConfig,
+            )
+        )
+
+    assert dba_state.catalog_fetches == 0
+    assert dba_state.advisory_lock_attempts == 0
+    assert all(dba_state.readonly_transactions)
+
+
+def test_preflight_rejects_non_superuser_dba_session_before_report(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _load_preflight_module()
+    runtime_pool = _Pool(_state())
+    dba_state = _state(current_user="operator", session_user="operator")
+    dba_pool = _Pool(dba_state)
+    calls = 0
+
+    async def create_pool(_connection_kwargs: object) -> _Pool:
+        nonlocal calls
+        calls += 1
+        return runtime_pool if calls == 1 else dba_pool
+
+    with pytest.raises(
+        runner.PreflightError,
+        match="Configured DBA connection is not a PostgreSQL superuser",
+    ):
+        asyncio.run(
+            runner._run(
+                create_pool=create_pool,
+                dba_config_factory=lambda: _dba_config(runner, monkeypatch),
+                runtime_config_factory=_RuntimeConfig,
+            )
+        )
+
+    assert dba_state.catalog_fetches == 0
+    assert dba_state.advisory_lock_attempts == 0
+    assert all(dba_state.readonly_transactions)
+
+
+def test_preflight_rejects_a_target_that_does_not_share_the_lock_namespace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _load_preflight_module()
+    runtime_pool = _Pool(_state())
+    dba_state = _state(
+        current_user="postgres",
+        session_user="postgres",
+        current_user_is_superuser=True,
+        advisory_lock_available=True,
+    )
+    dba_pool = _Pool(dba_state)
+    calls = 0
+
+    async def create_pool(_connection_kwargs: object) -> _Pool:
+        nonlocal calls
+        calls += 1
+        return runtime_pool if calls == 1 else dba_pool
+
+    with pytest.raises(
+        runner.PreflightError,
+        match="does not share the Atlas runtime database cluster",
+    ):
+        asyncio.run(
+            runner._run(
+                create_pool=create_pool,
+                dba_config_factory=lambda: _dba_config(runner, monkeypatch),
+                runtime_config_factory=_RuntimeConfig,
+            )
+    )
+
+    assert dba_state.catalog_fetches == 0
+    assert all(runtime_pool._connection._state.readonly_transactions)
+    assert all(dba_state.readonly_transactions)
+
+
+def test_preflight_has_no_apply_or_mutation_command_surface() -> None:
+    runner = _load_preflight_module()
+    source = SCRIPT.read_text(encoding="utf-8")
+
+    with pytest.raises(SystemExit):
+        runner._parse_args(["--apply"])
+    assert "--apply" not in source
+    assert ".execute(" not in source
+    assert "readonly=True" in source
+    assert "acldefault('d'" in source
+    assert "acldefault('n'" in source
+    assert "acldefault('f'" in source
+    assert "NULLIF(policy.polroles, ARRAY[]::oid[])" in source
+
+
+def test_main_does_not_render_an_unexpected_driver_message(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    runner = _load_preflight_module()
+
+    async def fail_with_sensitive_driver_message() -> dict[str, object]:
+        raise ValueError("postgresql://operator:driver-secret@example.test/atlas")
+
+    monkeypatch.setattr(runner, "_run", fail_with_sensitive_driver_message)
+
+    assert asyncio.run(runner._main([])) == 2
+    captured = capsys.readouterr()
+    assert "driver-secret" not in captured.err
+    assert "failed before producing a receipt" in captured.err

--- a/tests/test_database_role_topology_preflight.py
+++ b/tests/test_database_role_topology_preflight.py
@@ -540,6 +540,7 @@ def test_default_dba_config_ignores_worktree_dotenv_and_fails_closed(
     monkeypatch.delenv(runner.DBA_DSN_ENV, raising=False)
     monkeypatch.chdir(tmp_path)
     dotenv_value = "postgresql://dotenv-test:synthetic@example.test:5432/atlas"
+    process_value = "postgresql://process-test:synthetic@example.test:5432/atlas"
     (tmp_path / ".env").write_text(f"{runner.DBA_DSN_ENV}={dotenv_value}\n")
     (tmp_path / ".env.local").write_text(f"{runner.DBA_DSN_ENV}={dotenv_value}\n")
 
@@ -563,6 +564,12 @@ def test_default_dba_config_ignores_worktree_dotenv_and_fails_closed(
         )
 
     assert pool_calls == []
+
+    monkeypatch.setenv(runner.DBA_DSN_ENV, process_value)
+    assert (
+        runner.DatabaseRoleTopologyDBAConfig().database_url.get_secret_value()
+        == process_value
+    )
 
 
 def test_preflight_rejects_database_mismatch_before_catalog_reporting(

--- a/tests/test_database_role_topology_preflight.py
+++ b/tests/test_database_role_topology_preflight.py
@@ -208,6 +208,8 @@ def _catalog() -> dict[str, list[dict[str, object]]]:
         "database_acl": [
             {
                 "acl_source": "explicit",
+                "grantor_role_oid": 20_010,
+                "grantor_role": "postgres",
                 "grantee_role": "atlas",
                 "privilege_type": "CONNECT",
                 "is_grantable": False,
@@ -217,6 +219,8 @@ def _catalog() -> dict[str, list[dict[str, object]]]:
             {
                 "acl_source": "explicit",
                 "schema_name": "public",
+                "grantor_role_oid": 20_010,
+                "grantor_role": "postgres",
                 "grantee_role": "atlas",
                 "privilege_type": "USAGE",
                 "is_grantable": False,
@@ -231,6 +235,8 @@ def _catalog() -> dict[str, list[dict[str, object]]]:
                 "relation_kind": "r",
                 "row_security_enabled": True,
                 "row_security_forced": False,
+                "grantor_role_oid": 20_006,
+                "grantor_role": "atlas_eom_handoff_owner",
                 "grantee_role": "atlas",
                 "privilege_type": "SELECT",
                 "is_grantable": False,
@@ -245,6 +251,8 @@ def _catalog() -> dict[str, list[dict[str, object]]]:
                 "function_kind": "f",
                 "identity_arguments": "employee_id bigint",
                 "is_security_definer": True,
+                "grantor_role_oid": 20_006,
+                "grantor_role": "atlas_eom_handoff_owner",
                 "grantee_role": "PUBLIC",
                 "privilege_type": "EXECUTE",
                 "is_grantable": False,
@@ -259,6 +267,8 @@ def _catalog() -> dict[str, list[dict[str, object]]]:
                 "relation_kind": "r",
                 "column_number": 2,
                 "column_name": "hours_worked",
+                "grantor_role_oid": 20_006,
+                "grantor_role": "atlas_eom_handoff_owner",
                 "grantee_role": "atlas",
                 "privilege_type": "UPDATE",
                 "is_grantable": False,
@@ -708,6 +718,16 @@ def test_preflight_has_no_apply_or_mutation_command_surface() -> None:
     assert "NULLIF(policy.polroles, ARRAY[]::oid[])" in source
     assert "membership.inherit_option" in source
     assert "membership.set_option" in source
+    acl_queries = (
+        runner._DATABASE_ACL_QUERY,
+        runner._SCHEMA_ACL_QUERY,
+        runner._RELATION_ACL_QUERY,
+        runner._FUNCTION_ACL_QUERY,
+        runner._COLUMN_ACL_QUERY,
+        runner._DEFAULT_ACL_QUERY,
+    )
+    assert all("acl.grantor AS grantor_role_oid" in query for query in acl_queries)
+    assert all("grantor_role.rolname AS grantor_role" in query for query in acl_queries)
     assert "relation.relname AS relation_name" in source
     assert "policy.polname AS policy_name" in source
     assert "count(*)::bigint" not in source
@@ -832,6 +852,7 @@ def test_role_topology_preflight_executes_fixed_queries_against_postgresql_16() 
     schema_name = f"role_topology_{suffix}"
     runtime_role = f"role_topology_runtime_{suffix}"
     granted_role = f"role_topology_granted_{suffix}"
+    grantor_role = f"role_topology_grantor_{suffix}"
     relation_name = "work_log"
     function_name = "write_log"
     policy_name = "read_work_log"
@@ -839,14 +860,16 @@ def test_role_topology_preflight_executes_fixed_queries_against_postgresql_16() 
     schema = _quoted_identifier(schema_name)
     runtime = _quoted_identifier(runtime_role)
     granted = _quoted_identifier(granted_role)
+    grantor = _quoted_identifier(grantor_role)
     relation = f"{schema}.{_quoted_identifier(relation_name)}"
     function = f"{schema}.{_quoted_identifier(function_name)}(employee_id bigint)"
     policy = _quoted_identifier(policy_name)
 
-    async def exercise() -> dict[str, object]:
+    async def exercise() -> tuple[dict[str, object], int]:
         connection = await asyncpg.connect(dba_database_url)
         runtime_created = False
         granted_created = False
+        grantor_created = False
         try:
             await connection.execute(
                 f"CREATE ROLE {runtime} LOGIN PASSWORD "
@@ -856,6 +879,8 @@ def test_role_topology_preflight_executes_fixed_queries_against_postgresql_16() 
             runtime_created = True
             await connection.execute(f"CREATE ROLE {granted} NOLOGIN")
             granted_created = True
+            await connection.execute(f"CREATE ROLE {grantor} NOLOGIN")
+            grantor_created = True
             await connection.execute(
                 f"GRANT {granted} TO {runtime} WITH ADMIN FALSE, "
                 "INHERIT FALSE, SET TRUE"
@@ -865,13 +890,24 @@ def test_role_topology_preflight_executes_fixed_queries_against_postgresql_16() 
             await connection.execute(
                 f"CREATE TABLE {relation} (row_id bigint, hours_worked integer)"
             )
+            await connection.execute(f"GRANT USAGE ON SCHEMA {schema} TO {grantor}")
+            await connection.execute(
+                f"GRANT SELECT ON {relation} TO {grantor} WITH GRANT OPTION"
+            )
+            await connection.execute(f"SET ROLE {grantor}")
+            await connection.execute(f"GRANT SELECT ON {relation} TO {runtime}")
+            await connection.execute("RESET ROLE")
+            grantor_role_oid = await connection.fetchval(
+                "SELECT oid FROM pg_catalog.pg_roles WHERE rolname = $1",
+                grantor_role,
+            )
+            assert isinstance(grantor_role_oid, int)
             await connection.execute(f"ALTER TABLE {relation} ENABLE ROW LEVEL SECURITY")
             await connection.execute(
                 f"CREATE POLICY {policy} ON {relation} FOR SELECT TO {runtime} "
                 "USING (true)"
             )
             await connection.execute(f"GRANT USAGE ON SCHEMA {schema} TO {runtime}")
-            await connection.execute(f"GRANT SELECT ON {relation} TO {runtime}")
             await connection.execute(
                 f"GRANT UPDATE (hours_worked) ON {relation} TO {runtime}"
             )
@@ -899,18 +935,23 @@ def test_role_topology_preflight_executes_fixed_queries_against_postgresql_16() 
                 check=False,
             )
             assert result.returncode == 0, result.stderr
-            return json.loads(result.stdout)
+            return json.loads(result.stdout), grantor_role_oid
         finally:
+            await connection.execute("RESET ROLE")
             await connection.execute(f"DROP SCHEMA IF EXISTS {schema} CASCADE")
+            if runtime_created:
+                await connection.execute(f"REVOKE USAGE ON SCHEMA public FROM {runtime}")
             if runtime_created and granted_created:
                 await connection.execute(f"REVOKE {granted} FROM {runtime}")
             if runtime_created:
                 await connection.execute(f"DROP ROLE {runtime}")
             if granted_created:
                 await connection.execute(f"DROP ROLE {granted}")
+            if grantor_created:
+                await connection.execute(f"DROP ROLE {grantor}")
             await connection.close()
 
-    receipt = asyncio.run(exercise())
+    receipt, grantor_role_oid = asyncio.run(exercise())
     catalog = receipt["catalog"]
     membership = next(
         row
@@ -940,6 +981,8 @@ def test_role_topology_preflight_executes_fixed_queries_against_postgresql_16() 
         and row["privilege_type"] == "SELECT"
     )
     assert isinstance(relation_acl["relation_oid"], int)
+    assert relation_acl["grantor_role"] == grantor_role
+    assert relation_acl["grantor_role_oid"] == grantor_role_oid
 
     column_acl = next(
         row

--- a/tests/test_database_role_topology_preflight.py
+++ b/tests/test_database_role_topology_preflight.py
@@ -784,7 +784,21 @@ def test_disposable_role_topology_dsn_rejects_non_test_targets(
 
 
 def _quoted_identifier(value: str) -> str:
-    return f'"{value.replace("\"", "\"\"")}"'
+    return '"' + value.replace('"', '""') + '"'
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    (
+        ("work_log", '"work_log"'),
+        ('work"log', '"work""log"'),
+    ),
+)
+def test_quoted_identifier_uses_postgresql_double_quote_escaping(
+    value: str,
+    expected: str,
+) -> None:
+    assert _quoted_identifier(value) == expected
 
 
 def _runtime_dsn_from_dba_dsn(

--- a/tests/test_database_role_topology_preflight.py
+++ b/tests/test_database_role_topology_preflight.py
@@ -940,7 +940,9 @@ def test_role_topology_preflight_executes_fixed_queries_against_postgresql_16() 
             await connection.execute("RESET ROLE")
             await connection.execute(f"DROP SCHEMA IF EXISTS {schema} CASCADE")
             if runtime_created:
-                await connection.execute(f"REVOKE USAGE ON SCHEMA public FROM {runtime}")
+                await connection.execute(
+                    f"REVOKE USAGE ON SCHEMA public FROM {runtime}"
+                )
             if runtime_created and granted_created:
                 await connection.execute(f"REVOKE {granted} FROM {runtime}")
             if runtime_created:

--- a/tests/test_database_role_topology_preflight.py
+++ b/tests/test_database_role_topology_preflight.py
@@ -117,10 +117,10 @@ class _Connection:
             return self._state.catalog["column_acl"]
         if "pg_catalog.pg_policy AS policy" in query:
             return self._state.catalog["row_security_policies"]
-        if "pg_catalog.pg_roles AS role" in query:
-            return self._state.catalog["roles"]
-        if "pg_catalog.pg_auth_members AS membership" in query:
+        if "SELECT membership.oid AS membership_oid" in query:
             return self._state.catalog["memberships"]
+        if "SELECT role.rolname AS role_name" in query:
+            return self._state.catalog["roles"]
         if "namespace.nspowner" in query:
             return self._state.catalog["schema_owners"]
         if "relation.relowner" in query:
@@ -167,7 +167,27 @@ def _catalog() -> dict[str, list[dict[str, object]]]:
                 "can_create_databases": False,
                 "can_replicate": False,
                 "bypasses_row_security": False,
-            }
+            },
+            {
+                "role_name": "pg_monitor",
+                "can_login": False,
+                "is_superuser": False,
+                "inherits_privileges": True,
+                "can_create_roles": False,
+                "can_create_databases": False,
+                "can_replicate": False,
+                "bypasses_row_security": False,
+            },
+            {
+                "role_name": "pg_read_all_settings",
+                "can_login": False,
+                "is_superuser": False,
+                "inherits_privileges": True,
+                "can_create_roles": False,
+                "can_create_databases": False,
+                "can_replicate": False,
+                "bypasses_row_security": False,
+            },
         ],
         "memberships": [
             {
@@ -178,7 +198,25 @@ def _catalog() -> dict[str, list[dict[str, object]]]:
                 "admin_option": False,
                 "inherit_option": False,
                 "set_option": True,
-            }
+            },
+            {
+                "membership_oid": 20_007,
+                "granted_role": "pg_monitor",
+                "member_role": "atlas",
+                "grantor_role": "postgres",
+                "admin_option": False,
+                "inherit_option": True,
+                "set_option": True,
+            },
+            {
+                "membership_oid": 20_008,
+                "granted_role": "pg_read_all_settings",
+                "member_role": "pg_monitor",
+                "grantor_role": "postgres",
+                "admin_option": False,
+                "inherit_option": True,
+                "set_option": True,
+            },
         ],
         "schema_owners": [
             {"schema_name": "public", "owner_role": "atlas_eom_handoff_owner"}
@@ -192,6 +230,7 @@ def _catalog() -> dict[str, list[dict[str, object]]]:
                 "owner_role": "atlas_eom_handoff_owner",
                 "row_security_enabled": True,
                 "row_security_forced": False,
+                "is_security_invoker": False,
             }
         ],
         "function_owners": [
@@ -235,6 +274,7 @@ def _catalog() -> dict[str, list[dict[str, object]]]:
                 "relation_kind": "r",
                 "row_security_enabled": True,
                 "row_security_forced": False,
+                "is_security_invoker": False,
                 "grantor_role_oid": 20_006,
                 "grantor_role": "atlas_eom_handoff_owner",
                 "grantee_role": "atlas",
@@ -282,6 +322,8 @@ def _catalog() -> dict[str, list[dict[str, object]]]:
                 "relation_kind": "r",
                 "command": "r",
                 "is_permissive": True,
+                "using_expression": "(CURRENT_USER = 'atlas'::name)",
+                "with_check_expression": "(CURRENT_USER = 'atlas'::name)",
                 "policy_oid": 20_004,
                 "policy_name": "atlas_work_log_read",
                 "role_name": "atlas",
@@ -666,6 +708,64 @@ def test_preflight_rejects_non_superuser_dba_session_before_report(
     assert all(dba_state.readonly_transactions)
 
 
+@pytest.mark.parametrize(
+    ("runtime_overrides", "message"),
+    (
+        (
+            {
+                "current_user": "postgres",
+                "session_user": "postgres",
+                "current_user_is_superuser": True,
+            },
+            "authenticated identity",
+        ),
+        (
+            {
+                "current_user": "postgres",
+                "session_user": "atlas_runtime_login",
+                "current_user_is_superuser": True,
+            },
+            "effective identity",
+        ),
+    ),
+)
+def test_preflight_rejects_reused_runtime_and_dba_identity_before_catalog_reporting(
+    monkeypatch: pytest.MonkeyPatch,
+    runtime_overrides: dict[str, object],
+    message: str,
+) -> None:
+    runner = _load_preflight_module()
+    runtime_state = _state(**runtime_overrides)
+    dba_state = _state(
+        current_user="postgres",
+        session_user="postgres",
+        current_user_is_superuser=True,
+    )
+    runtime_pool = _Pool(runtime_state)
+    dba_pool = _Pool(dba_state)
+    calls = 0
+
+    async def create_pool(_connection_kwargs: object) -> _Pool:
+        nonlocal calls
+        calls += 1
+        return runtime_pool if calls == 1 else dba_pool
+
+    with pytest.raises(runner.PreflightError, match=message):
+        asyncio.run(
+            runner._run(
+                create_pool=create_pool,
+                dba_config_factory=lambda: _dba_config(runner, monkeypatch),
+                runtime_config_factory=_RuntimeConfig,
+            )
+        )
+
+    assert dba_state.catalog_fetches == 0
+    assert runtime_state.advisory_lock_attempts == 0
+    assert dba_state.advisory_lock_attempts == 0
+    assert all(runtime_state.readonly_transactions)
+    assert all(dba_state.readonly_transactions)
+
+
 def test_preflight_rejects_a_target_that_does_not_share_the_lock_namespace(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -718,6 +818,13 @@ def test_preflight_has_no_apply_or_mutation_command_surface() -> None:
     assert "NULLIF(policy.polroles, ARRAY[]::oid[])" in source
     assert "membership.inherit_option" in source
     assert "membership.set_option" in source
+    assert "WITH RECURSIVE reported_role_closure(role_oid)" in source
+    assert "JOIN reported_role_closure AS granted_closure" in source
+    assert "JOIN reported_role_closure AS member_closure" in source
+    assert "pg_catalog.pg_get_expr(policy.polqual, policy.polrelid)" in source
+    assert "pg_catalog.pg_get_expr(policy.polwithcheck, policy.polrelid)" in source
+    assert "security_invoker=true" in runner._RELATION_OWNERS_QUERY
+    assert "security_invoker=true" in runner._RELATION_ACL_QUERY
     acl_queries = (
         runner._DATABASE_ACL_QUERY,
         runner._SCHEMA_ACL_QUERY,
@@ -854,6 +961,7 @@ def test_role_topology_preflight_executes_fixed_queries_against_postgresql_16() 
     granted_role = f"role_topology_granted_{suffix}"
     grantor_role = f"role_topology_grantor_{suffix}"
     relation_name = "work_log"
+    view_name = "work_log_view"
     function_name = "write_log"
     policy_name = "read_work_log"
     runtime_password = f"runtime-{suffix}"
@@ -862,6 +970,7 @@ def test_role_topology_preflight_executes_fixed_queries_against_postgresql_16() 
     granted = _quoted_identifier(granted_role)
     grantor = _quoted_identifier(grantor_role)
     relation = f"{schema}.{_quoted_identifier(relation_name)}"
+    view = f"{schema}.{_quoted_identifier(view_name)}"
     function = f"{schema}.{_quoted_identifier(function_name)}(employee_id bigint)"
     policy = _quoted_identifier(policy_name)
 
@@ -881,6 +990,7 @@ def test_role_topology_preflight_executes_fixed_queries_against_postgresql_16() 
             granted_created = True
             await connection.execute(f"CREATE ROLE {grantor} NOLOGIN")
             grantor_created = True
+            await connection.execute(f"GRANT pg_monitor TO {runtime}")
             await connection.execute(
                 f"GRANT {granted} TO {runtime} WITH ADMIN FALSE, "
                 "INHERIT FALSE, SET TRUE"
@@ -889,6 +999,10 @@ def test_role_topology_preflight_executes_fixed_queries_against_postgresql_16() 
             await connection.execute(f"CREATE SCHEMA {schema}")
             await connection.execute(
                 f"CREATE TABLE {relation} (row_id bigint, hours_worked integer)"
+            )
+            await connection.execute(
+                f"CREATE VIEW {view} WITH (security_invoker = true) AS "
+                f"SELECT row_id, hours_worked FROM {relation}"
             )
             await connection.execute(f"GRANT USAGE ON SCHEMA {schema} TO {grantor}")
             await connection.execute(
@@ -904,8 +1018,9 @@ def test_role_topology_preflight_executes_fixed_queries_against_postgresql_16() 
             assert isinstance(grantor_role_oid, int)
             await connection.execute(f"ALTER TABLE {relation} ENABLE ROW LEVEL SECURITY")
             await connection.execute(
-                f"CREATE POLICY {policy} ON {relation} FOR SELECT TO {runtime} "
-                "USING (true)"
+                f"CREATE POLICY {policy} ON {relation} FOR ALL TO {runtime} "
+                f"USING (CURRENT_USER = '{runtime_role}'::name) "
+                f"WITH CHECK (CURRENT_USER = '{runtime_role}'::name)"
             )
             await connection.execute(f"GRANT USAGE ON SCHEMA {schema} TO {runtime}")
             await connection.execute(
@@ -943,6 +1058,7 @@ def test_role_topology_preflight_executes_fixed_queries_against_postgresql_16() 
                 await connection.execute(
                     f"REVOKE USAGE ON SCHEMA public FROM {runtime}"
                 )
+                await connection.execute(f"REVOKE pg_monitor FROM {runtime}")
             if runtime_created and granted_created:
                 await connection.execute(f"REVOKE {granted} FROM {runtime}")
             if runtime_created:
@@ -965,6 +1081,21 @@ def test_role_topology_preflight_executes_fixed_queries_against_postgresql_16() 
     assert membership["admin_option"] is False
     assert membership["inherit_option"] is False
     assert membership["set_option"] is True
+    predefined_membership = next(
+        row
+        for row in catalog["memberships"]
+        if row["granted_role"] == "pg_monitor" and row["member_role"] == runtime_role
+    )
+    assert predefined_membership["grantor_role"]
+    predefined_chain = next(
+        row
+        for row in catalog["memberships"]
+        if row["granted_role"] == "pg_read_all_settings"
+        and row["member_role"] == "pg_monitor"
+    )
+    assert predefined_chain["grantor_role"]
+    role_names = {row["role_name"] for row in catalog["roles"]}
+    assert {"pg_monitor", "pg_read_all_settings"} <= role_names
 
     relation_owner = next(
         row
@@ -973,6 +1104,14 @@ def test_role_topology_preflight_executes_fixed_queries_against_postgresql_16() 
         and row["relation_name"] == relation_name
     )
     assert isinstance(relation_owner["relation_oid"], int)
+
+    security_invoker_view = next(
+        row
+        for row in catalog["relation_owners"]
+        if row["schema_name"] == schema_name and row["relation_name"] == view_name
+    )
+    assert security_invoker_view["relation_kind"] == "v"
+    assert security_invoker_view["is_security_invoker"] is True
 
     relation_acl = next(
         row
@@ -1028,3 +1167,8 @@ def test_role_topology_preflight_executes_fixed_queries_against_postgresql_16() 
     )
     assert isinstance(policy_row["policy_oid"], int)
     assert isinstance(policy_row["relation_oid"], int)
+    for expression_name in ("using_expression", "with_check_expression"):
+        expression = policy_row[expression_name]
+        assert isinstance(expression, str)
+        assert "CURRENT_USER" in expression
+        assert runtime_role in expression


### PR DESCRIPTION
Plan: plans/PR-Postgres-Role-Topology-Preflight.md
Slice phase: Production hardening
Ownership lane: eom-crm/runtime-security

Adds a standalone, read-only PostgreSQL role-topology receipt so a later
least-privilege role cutover is based on target-attested live catalog evidence,
not the normal runtime connection path. It makes no role, grant, ownership,
migration, credential, service, or deployment change outside the disposable
PostgreSQL 16 integration fixture.

## Intentional

- The dedicated DBA configuration is `SecretStr`-backed and instantiated only
  by the standalone command; normal Atlas startup remains unchanged.
- The topology-specific DBA DSN is read only from the direct command process
  environment; worktree `.env` and `.env.local` files cannot satisfy it.
- The command keeps each runtime and DBA identity read, cross-target lock
  attestation, and DBA catalog projection on pinned read-only repeatable-read
  connections before emitting a receipt.
- The receipt follows each reported non-system role through reachable predefined
  PostgreSQL role memberships and records security-invoker view state plus RLS
  `USING`/`WITH CHECK` expressions needed for a later authority cutover.
- A direct-superuser DBA session must also have a different authenticated and
  effective PostgreSQL identity from the runtime session; equal identities fail
  before the lock probe or catalog reads.
- The focused PostgreSQL 16 test creates uniquely named roles, schema, ACLs,
  and policy only in the workflow's loopback disposable database, then removes
  them in its fixture cleanup.
- `./ops db inspect` remains the existing fixed low-privilege inspection
  surface; this PR does not add a generic SQL runner.

## AI reconciliation

- Include all PostgreSQL 16 membership options fixed-in: `scripts/check_database_role_topology.py:127-148` emits membership OID, grantor, admin, inherit, and set options; `tests/test_database_role_topology_preflight.py:952-1083` creates and asserts a non-inherited, settable grant against PostgreSQL 16.
- Pin attestation and catalog reads to one database session fixed-in: `scripts/check_database_role_topology.py:763-820` holds each acquired connection in a read-only repeatable-read transaction through identity, lock, and catalog reads; `tests/test_database_role_topology_preflight.py:408-484` asserts one acquire per pool and the selected isolation level.
- Preserve object identity in privilege evidence fixed-in: `scripts/check_database_role_topology.py:161-180,259-407` projects relation/function/policy object identity rather than aggregate counts; `tests/test_database_role_topology_preflight.py:1072-1174` asserts those identities from the real receipt.
- Execute catalog SQL against PostgreSQL in tests fixed-in: `tests/test_database_role_topology_preflight.py:952-1174` invokes the command against a disposable PostgreSQL 16 target; `.github/workflows/atlas_eom_lead_pipeline_checks.yml:270-345` provides that target and enrolls the test.
- Rewrite the quoting helper for Python 3.11 fixed-in: `tests/test_database_role_topology_preflight.py:914-929` uses concatenation outside an f-string expression and directly proves PostgreSQL identifier quote escaping.
- Revoke the persistent public-schema grant during cleanup fixed-in: `tests/test_database_role_topology_preflight.py:1054-1070` resets the test role and revokes its `public` schema usage before it drops the temporary runtime role.
- Preserve grantor provenance across ACL projections fixed-in: `scripts/check_database_role_topology.py:201-431` records grantor OID/name across every ACL projection; `tests/test_database_role_topology_preflight.py:952-1126` seeds and asserts a delegated relation grant in PostgreSQL 16.
- Capture privilege-routing semantics in the receipt fixed-in: `scripts/check_database_role_topology.py:161-180,259-303,375-407` records security-invoker state and deparsed RLS expressions; `tests/test_database_role_topology_preflight.py:1003-1024,1108-1114,1160-1174` seeds and asserts them through PostgreSQL 16.
- Retain inherited predefined-role membership edges fixed-in: `scripts/check_database_role_topology.py:99-148` derives a recursive closure from each non-system role; `tests/test_database_role_topology_preflight.py:993-997,1061-1063,1084-1098` proves `pg_monitor` and its `pg_read_all_settings` edge are retained and cleaned up.
- Reject reuse of the runtime identity for DBA attestation fixed-in: `scripts/check_database_role_topology.py:597-612,801-811` rejects equal authenticated or effective identities before lock/catalog access; `tests/test_database_role_topology_preflight.py:711-766` probes both rejection directions.
- Prevent loading the DBA credential from dotenv files fixed-in: `atlas_brain/config.py:2618-2620` disables dotenv loading only for the topology DBA settings boundary; `tests/test_database_role_topology_preflight.py:533-571` proves both stale dotenv files are ignored, the default command fails before any pool opens, and a direct process value still loads.

## Fix-loop disposition preflight

### Include all PostgreSQL 16 membership options

- Root decision: Include all PostgreSQL 16 membership options
- Source trace: `pg_auth_members` membership attributes -> the receipt omitted inherit and set options -> capability evidence was incomplete.
- Upstream files: `scripts/check_database_role_topology.py`, `tests/test_database_role_topology_preflight.py`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `scripts/check_database_role_topology.py`, `tests/test_database_role_topology_preflight.py`, `plans/PR-Postgres-Role-Topology-Preflight.md`
- Max files: 6
- Parked hardening: none

### Pin attestation and catalog reads to one database session

- Root decision: Pin attestation and catalog reads to one database session
- Source trace: independently acquired pool connections -> target admission and catalog evidence could observe different sessions -> target attestation was not pinned.
- Upstream files: `scripts/check_database_role_topology.py`, `tests/test_database_role_topology_preflight.py`
- Fix strategy: upstream-root
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: `scripts/check_database_role_topology.py`, `tests/test_database_role_topology_preflight.py`
- Max files: 6
- Parked hardening: none

### Preserve object identity in privilege evidence

- Root decision: Preserve object identity in privilege evidence
- Source trace: aggregated catalog counts -> distinct objects shared one summary -> the receipt lost object identity.
- Upstream files: `scripts/check_database_role_topology.py`, `tests/test_database_role_topology_preflight.py`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `scripts/check_database_role_topology.py`, `tests/test_database_role_topology_preflight.py`, `.agent/runbooks/database.md`
- Max files: 6
- Parked hardening: none

### Execute catalog SQL against PostgreSQL in tests

- Root decision: Execute catalog SQL against PostgreSQL in tests
- Source trace: SQL-substring fake -> catalog SQL was not parsed by PostgreSQL 16 -> query compatibility lacked executable proof.
- Upstream files: `tests/test_database_role_topology_preflight.py`, `.github/workflows/atlas_eom_lead_pipeline_checks.yml`
- Fix strategy: upstream-root
- Blocking predicate: ci
- Disposition: fixed-in
- Allowed files: `tests/test_database_role_topology_preflight.py`, `.github/workflows/atlas_eom_lead_pipeline_checks.yml`, `atlas_brain/config.py`
- Max files: 6
- Parked hardening: none

### Rewrite the quoting helper for Python 3.11

- Root decision: Rewrite the quoting helper for Python 3.11
- Source trace: escaped literals inside an f-string expression -> Python 3.11 rejects collection -> the enrolled integration suite cannot start.
- Upstream files: `tests/test_database_role_topology_preflight.py`
- Fix strategy: upstream-root
- Blocking predicate: ci
- Disposition: fixed-in
- Allowed files: `tests/test_database_role_topology_preflight.py`, `plans/PR-Postgres-Role-Topology-Preflight.md`
- Max files: 6
- Parked hardening: none

### Revoke the persistent public-schema grant during cleanup

- Root decision: Revoke the persistent public-schema grant during cleanup
- Source trace: test fixture grants public-schema usage -> fixture drops the temporary role without revoking that ACL -> PostgreSQL retains a role dependency.
- Upstream files: `tests/test_database_role_topology_preflight.py`
- Fix strategy: upstream-root
- Blocking predicate: ci
- Disposition: fixed-in
- Allowed files: `tests/test_database_role_topology_preflight.py`, `plans/PR-Postgres-Role-Topology-Preflight.md`
- Max files: 6
- Parked hardening: none

### Preserve grantor provenance across ACL projections

- Root decision: Preserve grantor provenance across ACL projections
- Source trace: `aclexplode` grantor field -> ACL receipt omitted the delegating role -> direct and delegated authority were indistinguishable.
- Upstream files: `scripts/check_database_role_topology.py`, `tests/test_database_role_topology_preflight.py`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `scripts/check_database_role_topology.py`, `tests/test_database_role_topology_preflight.py`, `plans/PR-Postgres-Role-Topology-Preflight.md`
- Max files: 6
- Parked hardening: none

### Capture privilege-routing semantics in the receipt

- Root decision: Capture privilege-routing semantics in the receipt
- Source trace: RLS policy names and target roles without expressions, plus view records without security-invoker state -> role-sensitive authorization paths were indistinguishable -> the receipt could not safely inform a role cutover.
- Upstream files: `scripts/check_database_role_topology.py`, `tests/test_database_role_topology_preflight.py`, `.agent/runbooks/database.md`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `scripts/check_database_role_topology.py`, `tests/test_database_role_topology_preflight.py`, `.agent/runbooks/database.md`, `plans/PR-Postgres-Role-Topology-Preflight.md`
- Max files: 6
- Parked hardening: none

### Retain inherited predefined-role membership edges

- Root decision: Retain inherited predefined-role membership edges
- Source trace: one-hop non-system membership filter -> `pg_` role-to-role edges were omitted -> a direct predefined-role grant understated effective runtime authority.
- Upstream files: `scripts/check_database_role_topology.py`, `tests/test_database_role_topology_preflight.py`, `.agent/runbooks/database.md`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `scripts/check_database_role_topology.py`, `tests/test_database_role_topology_preflight.py`, `.agent/runbooks/database.md`, `plans/PR-Postgres-Role-Topology-Preflight.md`
- Max files: 6
- Parked hardening: none

### Reject reuse of the runtime identity for DBA attestation

- Root decision: Reject reuse of the runtime identity for DBA attestation
- Source trace: matching target plus direct-superuser DBA admission -> same authenticated or effective runtime/DBA identity still emitted `target_attested: true` -> the claimed independent DBA boundary was not enforced.
- Upstream files: `scripts/check_database_role_topology.py`, `tests/test_database_role_topology_preflight.py`, `.agent/runbooks/database.md`
- Fix strategy: upstream-root
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: `scripts/check_database_role_topology.py`, `tests/test_database_role_topology_preflight.py`, `.agent/runbooks/database.md`, `plans/PR-Postgres-Role-Topology-Preflight.md`
- Max files: 6
- Parked hardening: none

### Prevent loading the DBA credential from dotenv files

- Root decision: Prevent loading the DBA credential from dotenv files
- Source trace: default topology DBA settings source -> shared worktree dotenv files could supply the privileged DSN -> the missing-process-variable fail-closed admission was bypassable.
- Upstream files: `atlas_brain/config.py`, `tests/test_database_role_topology_preflight.py`, `.agent/runbooks/database.md`
- Fix strategy: upstream-root
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: `atlas_brain/config.py`, `tests/test_database_role_topology_preflight.py`, `.agent/runbooks/database.md`, `plans/PR-Postgres-Role-Topology-Preflight.md`
- Max files: 6
- Parked hardening: none

## Deferred

- The controlled role/grant/ownership cutover, runtime migration decoupling,
  maintenance-runner refactor, cross-host TLS, and deployment convergence stay
  in the follow-up slices named by the plan.

## Parked hardening

- None for this evidence-only slice. A real receipt and later privilege changes
  remain blocked until a protected DBA DSN is provisioned and production has
  converged to the intended source revision.

## Cold diff reconstruction

- The six-file diff adds an isolated `SecretStr` configuration boundary,
  standalone fixed-query reader, disposable PostgreSQL 16 test, workflow
  enrollment, runbook, and plan. The command uses `.fetch*` only; the test
  fixture's `.execute` calls create and clean uniquely named disposable test
  objects.
- The command's actual receipt contains membership grant option evidence at
  `scripts/check_database_role_topology.py:99-148`, including the recursive
  reachable predefined-role closure; it records security-invoker and RLS
  policy-expression semantics at `:161-180`, `:259-303`, and `:375-407`; and
  it rejects reused runtime/DBA identities at `:597-612` before the pinned
  read-only admission/catalog flow at `:763-820`.
- The topology DBA settings boundary explicitly sets `env_file=None` at
  `atlas_brain/config.py:2618-2620`; the default-constructor/command probe at
  `tests/test_database_role_topology_preflight.py:533-571` places the key in
  both dotenv files, proves no pool is opened without a process value, and
  proves a direct process value remains accepted.
- No application `DatabaseConfig`, database pool, startup, migration runner,
  funnel, API, or UI file is in the changed-path set. Production database
  configuration and PostgreSQL privileges remain untouched.
- Contract comparison: every new change traces to the plan's authoritative
  privilege-semantics, independent-identity, or process-environment-only
  credential contract; the changed-path set is still the declared six files.
  No gap or out-of-contract file is known from the current-head reconstruction.

## Boundary and effect evidence

- boundary-probe: `tests/test_database_role_topology_preflight.py:711-766`
  drives both equal `session_user` and equal `current_user` / different
  `session_user` cases; each raises before either the advisory-lock probe or
  catalog fetch, while the normal distinct `atlas`/`postgres` fixture remains
  the passing receipt path at `:408-484`.
- effect-trace: independent-identity rejection | the controlling predicate is
  `scripts/check_database_role_topology.py:597-612` | `_run` calls it at
  `:801-811` before lock attestation and `_catalog_receipt`.
- effect-trace: reachable predefined-role evidence | the controlling projection
  is the recursive CTE and closure joins at
  `scripts/check_database_role_topology.py:99-148` | the PostgreSQL 16 fixture
  seeds `pg_monitor` at `tests/test_database_role_topology_preflight.py:993-997`
  and observes both the direct grant and `pg_read_all_settings` edge at
  `:1084-1098`.
- effect-trace: identity-sensitive object evidence | the controlling fields are
  relation `reloptions` and `pg_get_expr` at
  `scripts/check_database_role_topology.py:161-180,259-303,375-407` | the real
  fixture creates a security-invoker view and role-sensitive policy at
  `tests/test_database_role_topology_preflight.py:1003-1024` and asserts their
  rendered fields at `:1108-1114,1160-1174`.
- boundary-probe: `tests/test_database_role_topology_preflight.py:533-571`
  exercises both sides of the credential source boundary: a missing process
  variable with the key in both dotenv files fails before any pool opens, while
  a direct process variable is returned by the same default constructor.
- effect-trace: process-environment-only DBA credential | the controlling
  setting is `SettingsConfigDict(env_file=None)` at
  `atlas_brain/config.py:2618-2620` | the default command calls that class at
  `scripts/check_database_role_topology.py:763-776`, and the boundary probe
  confirms the missing-config guard is reached rather than a dotenv fallback.

## Verification

- Local static, focused, and plan-contract checks are rerun from this head
  before push. The real PostgreSQL 16 command test skips locally unless the
  explicitly named loopback-only disposable test DSN is present; the enrolled
  EOM workflow must run it before merge.
- No production receipt was attempted. The protected DBA DSN is intentionally
  absent locally, and the command has no production mutation path.
- The local `gitleaks` executable is absent. This is not bypassed; the
  required CI secret-scan context remains a merge gate.

## Mechanical verification

- Command: python3.11 -m py_compile atlas_brain/config.py scripts/check_database_role_topology.py tests/test_database_role_topology_preflight.py - Result: passed - Environment: local
- Command: python -m py_compile scripts/check_database_role_topology.py tests/test_database_role_topology_preflight.py atlas_brain/config.py - Result: passed - Environment: local
- Command: ./ops test focused tests/test_database_role_topology_preflight.py -q - Result: 23 passed, 1 skipped - Environment: local
- Command: ./ops test focused tests/test_database_role_topology_preflight.py tests/test_agent_operations_contract.py tests/test_eom_first_clean_completion_dba_runner.py -q - Result: 145 passed, 1 skipped - Environment: local
- Command: bash scripts/check_ascii_python.sh - Result: passed - Environment: local
- Command: git diff --check origin/main...HEAD - Result: passed - Environment: local
- Command: python scripts/audit_plan_doc.py plans/PR-Postgres-Role-Topology-Preflight.md - Result: passed - Environment: local
- Command: python scripts/audit_plan_doc_files_touched.py plans/PR-Postgres-Role-Topology-Preflight.md origin/main - Result: passed - Environment: local
- Command: python scripts/audit_plan_doc_diff_size.py plans/PR-Postgres-Role-Topology-Preflight.md origin/main - Result: passed - Environment: local
- Command: python scripts/audit_plan_code_consistency.py --base-ref origin/main plans/PR-Postgres-Role-Topology-Preflight.md - Result: passed - Environment: local
- Command: python scripts/sync_pr_plan.py --check plans/PR-Postgres-Role-Topology-Preflight.md origin/main - Result: passed - Environment: local
- Skipped: python3.11 -m pytest tests/test_database_role_topology_preflight.py -q - Reason: the isolated local Python 3.11 interpreter has no pytest module; the GitHub Python 3.11 workflow remains required.
- Skipped: gitleaks protect --staged --redact --verbose - Reason: the executable is not installed locally; required CI secret scanning is not waived.

## Diff size

6 files, +2610 / -0.

Diff-budget override: The typed privileged configuration, dual-target
attestation, fixed per-object catalog projection, disposable PostgreSQL 16
execution proof, fail-closed test harness, workflow enrollment, and operator
procedure form one safety boundary; splitting them would publish an unverified
privileged reader or leave no usable evidence receipt.

<!-- atlas-open-pr-wrapper: v1 -->
