### PR TITLE
EOM: add versioned Terms authority

### DIFF
--- a/.agent/capabilities.yaml
+++ b/.agent/capabilities.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 project:
   name: Atlas
   repository: canfieldjuan/ATLAS
-  verified_at: "2026-08-25"
+  verified_at: "2026-08-27"
   operational_entrypoint: ./ops doctor
   source_of_truth:
     - ./ops doctor
@@ -166,8 +166,19 @@ database:
   migrations:
     provider: custom SQL runner
     path: atlas_brain/storage/migrations
-    invocation: automatic during full application startup
+    invocation: automatic during full application startup except migrations registered as controlled DBA-only
     warning: the full chain is not fresh-database applicable because later migrations depend on out-of-band product_metadata
+  controlled_migrations:
+    eom_terms_authority:
+      status: guarded-preflight-and-apply
+      migration: 396_eom_terms_authority
+      preflight: ./ops db controlled eom-terms-authority preflight
+      apply: ./ops db controlled eom-terms-authority apply
+      implementation: scripts/apply_eom_terms_authority_schema.py
+      authentication: protected direct PostgreSQL-superuser DSN plus canonical EOM funnel runtime configuration
+      current_session_capable: false-until-the-protected-DBA-configuration-is-exported
+      mutation: preflight is read-only; apply creates guard-owned Terms authority objects and records migration 396
+      rollback: stop Terms writers and consumers, retain immutable history and the migration record, and follow .agent/runbooks/database.md
   mutation: fixed inspections are read-only; app startup and integration tests can mutate
   likely_failures:
     - assuming root Docker Compose provides PostgreSQL

--- a/.agent/runbooks/database.md
+++ b/.agent/runbooks/database.md
@@ -47,6 +47,73 @@ generic query command is unavailable until Atlas has a privilege-restricted
 inspection role. Do not paste customer content or identifiers into chat or
 GitHub, and do not substitute the live application role as an ad hoc read role.
 
+## EOM Terms authority migration
+
+Migration `396_eom_terms_authority` is deliberately excluded from automatic
+startup migrations. It creates the immutable Terms-version authority under the
+existing no-login EOM guard owner, so it must be applied through the one fixed
+`./ops` operation below. Generic `./ops db migrate`, arbitrary SQL, and direct
+use of the shared migration runner are not substitutes.
+
+1. Use a normal worktree at the exact merged release intended for deployment.
+   Confirm its revision and the currently running revision first. If they do
+   not describe the intended rollout, stop rather than applying a schema for a
+   different release:
+
+   ```bash
+   git rev-parse HEAD
+   ./ops deploy status
+   ```
+
+2. In an operator-only process environment, provide
+   `ATLAS_EOM_FIRST_CLEAN_COMPLETION_DBA_DATABASE_URL` as a direct PostgreSQL
+   superuser DSN and `ATLAS_EOM_FIRST_CLEAN_COMPLETION_DBA_SCHEMA` as the exact
+   EOM funnel schema. Keep both out of Git, chat, shell history, and service
+   environment files. The runtime target must come from that worktree's
+   canonical `ATLAS_EOM_FUNNEL_DB_CONNECTION_STRING` context. The command
+   rejects a missing or elevated runtime identity, mismatched database,
+   schema, or live cluster, a non-superuser DBA, an unsafe guard role, and any
+   migration outside its fixed allowlist.
+
+3. Run the read-only preflight. Its JSON target is redacted. A nonzero exit or
+   an unexpected target means the migration is not authorized; fix the
+   configuration and rerun instead of bypassing a guard:
+
+   ```bash
+   ./ops db controlled eom-terms-authority preflight
+   ```
+
+4. After recording the preflight with the release receipt, run the explicitly
+   named apply operation once, then repeat the preflight. The runner pins the
+   canonical migration lock, DDL, and migration ledger write to one database
+   transaction; `migration_recorded` must be true before the Terms routes are
+   deployed or restarted:
+
+   ```bash
+   ./ops db controlled eom-terms-authority apply
+   ./ops db controlled eom-terms-authority preflight
+   ```
+
+5. Deploy the application only after that receipt. A failure before the
+   migration transaction commits leaves no partial authority; investigate the
+   reported target or database error and rerun the preflight.
+
+Post-deployment application rollback is retention-only. Stop Terms write
+callers and downstream invitation/acceptance consumers first, then roll the
+application back. Retain both guard-owned tables, all guard functions and
+triggers, the runtime grants, stored versions, and the `schema_migrations`
+record. The prior release does not use these additive objects; do not drop,
+truncate, delete, disable, or unrecord them merely because code is rolled back.
+Roll forward with a reviewed migration or service fix.
+
+If rollback is responding to suspected runtime-credential or application
+compromise, stop every Atlas process using the runtime credential before a DBA
+revokes the Terms tables' runtime INSERT/UPDATE privileges as a separately
+reviewed containment action. Preserve SELECT-only audit access and all stored
+history. Do not use that emergency revoke for a routine application rollback:
+it intentionally makes Terms readiness fail closed until a reviewed repair
+restores the exact grants.
+
 ## Role-topology evidence preflight
 
 This is a read-only prerequisite for a later least-privilege role cutover. It

--- a/.github/workflows/atlas_eom_lead_pipeline_checks.yml
+++ b/.github/workflows/atlas_eom_lead_pipeline_checks.yml
@@ -35,6 +35,7 @@ on:
       - "atlas_brain/services/eom_onboarding_drafts.py"
       - "atlas_brain/services/eom_missed_call_recovery.py"
       - "atlas_brain/services/eom_first_clean_completion.py"
+      - "atlas_brain/services/eom_terms_authority.py"
       - "atlas_brain/services/eom_public_onboarding_tokens.py"
       - "atlas_brain/templates/email/__init__.py"
       - "atlas_brain/templates/email/estimate_confirmation.py"
@@ -80,8 +81,10 @@ on:
       - "atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql"
       - "atlas_brain/storage/migrations/394_eom_first_clean_completion_receipts.sql"
       - "atlas_brain/storage/migrations/395_eom_post_clean_onboarding_candidates.sql"
+      - "atlas_brain/storage/migrations/396_eom_terms_authority.sql"
       - "atlas_brain/storage/migrations/reconciliation.py"
       - "scripts/apply_eom_first_clean_completion_schema.py"
+      - "scripts/apply_eom_terms_authority_schema.py"
       - "atlas_brain/tools/calendar.py"
       - "atlas_brain/tools/scheduling.py"
       - "tests/test_ack_commercial_templates.py"
@@ -99,6 +102,7 @@ on:
       - "tests/test_eom_missed_call_privilege_runner.py"
       - "tests/test_eom_first_clean_completion.py"
       - "tests/test_eom_first_clean_completion_dba_runner.py"
+      - "tests/test_eom_terms_authority.py"
       - "tests/test_database_role_topology_preflight.py"
       - "tests/test_eom_lead_conversion_integration.py"
       - "tests/test_eom_render_profile.py"
@@ -153,6 +157,7 @@ on:
       - "atlas_brain/services/eom_onboarding_drafts.py"
       - "atlas_brain/services/eom_missed_call_recovery.py"
       - "atlas_brain/services/eom_first_clean_completion.py"
+      - "atlas_brain/services/eom_terms_authority.py"
       - "atlas_brain/services/eom_public_onboarding_tokens.py"
       - "atlas_brain/templates/email/__init__.py"
       - "atlas_brain/templates/email/estimate_confirmation.py"
@@ -198,8 +203,10 @@ on:
       - "atlas_brain/storage/migrations/393_eom_missed_call_recovery_runtime_privileges.sql"
       - "atlas_brain/storage/migrations/394_eom_first_clean_completion_receipts.sql"
       - "atlas_brain/storage/migrations/395_eom_post_clean_onboarding_candidates.sql"
+      - "atlas_brain/storage/migrations/396_eom_terms_authority.sql"
       - "atlas_brain/storage/migrations/reconciliation.py"
       - "scripts/apply_eom_first_clean_completion_schema.py"
+      - "scripts/apply_eom_terms_authority_schema.py"
       - "atlas_brain/tools/calendar.py"
       - "atlas_brain/tools/scheduling.py"
       - "tests/test_ack_commercial_templates.py"
@@ -217,6 +224,7 @@ on:
       - "tests/test_eom_missed_call_privilege_runner.py"
       - "tests/test_eom_first_clean_completion.py"
       - "tests/test_eom_first_clean_completion_dba_runner.py"
+      - "tests/test_eom_terms_authority.py"
       - "tests/test_database_role_topology_preflight.py"
       - "tests/test_eom_lead_conversion_integration.py"
       - "tests/test_eom_render_profile.py"
@@ -344,6 +352,7 @@ jobs:
             tests/test_eom_missed_call_privilege_runner.py \
             tests/test_eom_first_clean_completion.py \
             tests/test_eom_first_clean_completion_dba_runner.py \
+            tests/test_eom_terms_authority.py \
             tests/test_database_role_topology_preflight.py \
             tests/test_eom_lead_conversion_integration.py \
             tests/test_eom_render_profile.py \

--- a/atlas_brain/eom_api/funnel.py
+++ b/atlas_brain/eom_api/funnel.py
@@ -9,7 +9,16 @@ from datetime import datetime
 from typing import Annotated, Any, Literal, Mapping
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, status
+from fastapi import (
+    APIRouter,
+    Depends,
+    Header,
+    HTTPException,
+    Query,
+    Request,
+    Response,
+    status,
+)
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -54,6 +63,10 @@ from ..services.eom_missed_call_recovery import (
 from ..services.eom_first_clean_completion import (
     EOMFirstCleanCompletionError,
     EOMFirstCleanCompletionService,
+)
+from ..services.eom_terms_authority import (
+    EOMTermsAuthority,
+    EOMTermsAuthorityError,
 )
 from ..services.eom_public_onboarding_tokens import (
     AuthenticatedEOMPublicOnboardingToken,
@@ -194,6 +207,36 @@ class EOMPostCleanOnboardingCandidateResponse(BaseModel):
     cursor: str | None = None
     has_more: bool = Field(serialization_alias="hasMore")
     next_cursor: str | None = Field(default=None, serialization_alias="nextCursor")
+
+
+class EOMTermsVersionCreateRequest(BaseModel):
+    """One exact bilingual residential/commercial Terms release candidate."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    version_label: object = Field(alias="versionLabel")
+    material_change: object = Field(alias="materialChange")
+    documents: object
+
+
+class EOMTermsVersionResponse(BaseModel):
+    """Closed private projection of one Atlas Terms version."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    version_id: UUID = Field(alias="versionId")
+    version_label: str = Field(alias="versionLabel")
+    status: Literal["draft", "published"]
+    material_change: bool = Field(alias="materialChange")
+    documents: dict[str, Any]
+    content_hash: str = Field(alias="contentHash")
+    created_by_id: int = Field(alias="createdById")
+    created_by_name: str = Field(alias="createdByName")
+    created_at: datetime = Field(alias="createdAt")
+    published_by_id: int | None = Field(default=None, alias="publishedById")
+    published_by_name: str | None = Field(default=None, alias="publishedByName")
+    published_at: datetime | None = Field(default=None, alias="publishedAt")
+    idempotent: bool
 
 
 class EOMPublicOnboardingSessionRequest(BaseModel):
@@ -710,6 +753,19 @@ def _first_clean_completion_dependency(
 
         pool = get_db_pool()
     return EOMFirstCleanCompletionService(pool=pool)
+
+
+def _terms_authority_dependency(request: Request) -> EOMTermsAuthority:
+    """Bind Terms state to the same canonical funnel database."""
+
+    pool_factory = getattr(request.app.state, "eom_funnel_terms_pool", None)
+    if callable(pool_factory):
+        pool = pool_factory()
+    else:
+        from ..storage.database import get_db_pool
+
+        pool = get_db_pool()
+    return EOMTermsAuthority(pool=pool)
 
 
 def _authenticated_public_onboarding_token(
@@ -2015,6 +2071,92 @@ async def list_eom_public_onboarding_issued_links(
         has_more=has_more,
         next_cursor=next_cursor,
     )
+
+
+def _terms_error(exc: EOMTermsAuthorityError) -> HTTPException:
+    return HTTPException(
+        status_code=exc.status_code,
+        detail={"code": exc.code, "message": str(exc)},
+    )
+
+
+@router.post(
+    "/terms/versions",
+    response_model=EOMTermsVersionResponse,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(require_eom_funnel_api)],
+)
+async def create_eom_terms_version(
+    payload: EOMTermsVersionCreateRequest,
+    response: Response,
+    actor: dict[str, object] = Depends(require_eom_funnel_actor),
+    authority: EOMTermsAuthority = Depends(_terms_authority_dependency),
+) -> EOMTermsVersionResponse:
+    """Store one reviewed-but-unpublished Terms snapshot."""
+
+    try:
+        result = await authority.create_draft(
+            version_label=payload.version_label,
+            material_change=payload.material_change,
+            documents=payload.documents,
+            actor_id=actor["id"],
+            actor_name=actor["name"],
+        )
+    except EOMTermsAuthorityError as exc:
+        raise _terms_error(exc) from exc
+    response.status_code = (
+        status.HTTP_200_OK
+        if bool(result["idempotent"])
+        else status.HTTP_201_CREATED
+    )
+    return EOMTermsVersionResponse.model_validate(result)
+
+
+@router.post(
+    "/terms/versions/{version_id}/publish",
+    response_model=EOMTermsVersionResponse,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(require_eom_funnel_api)],
+)
+async def publish_eom_terms_version(
+    version_id: UUID,
+    response: Response,
+    actor: dict[str, object] = Depends(require_eom_funnel_actor),
+    authority: EOMTermsAuthority = Depends(_terms_authority_dependency),
+) -> EOMTermsVersionResponse:
+    """Publish an immutable snapshot and select it as current."""
+
+    try:
+        result = await authority.publish(
+            version_id=version_id,
+            actor_id=actor["id"],
+            actor_name=actor["name"],
+        )
+    except EOMTermsAuthorityError as exc:
+        raise _terms_error(exc) from exc
+    response.status_code = (
+        status.HTTP_200_OK
+        if bool(result["idempotent"])
+        else status.HTTP_201_CREATED
+    )
+    return EOMTermsVersionResponse.model_validate(result)
+
+
+@router.get(
+    "/terms/current",
+    response_model=EOMTermsVersionResponse,
+    dependencies=[Depends(require_eom_funnel_api)],
+)
+async def get_current_eom_terms_version(
+    authority: EOMTermsAuthority = Depends(_terms_authority_dependency),
+) -> EOMTermsVersionResponse:
+    """Return the exact current published snapshot without changing state."""
+
+    try:
+        result = await authority.get_current()
+    except EOMTermsAuthorityError as exc:
+        raise _terms_error(exc) from exc
+    return EOMTermsVersionResponse.model_validate(result)
 
 
 @router.get(

--- a/atlas_brain/main_eom.py
+++ b/atlas_brain/main_eom.py
@@ -318,4 +318,5 @@ app.include_router(receivables_router, prefix="/api/v1")
 app.state.eom_funnel_crm_provider = get_eom_funnel_crm_provider
 app.state.eom_funnel_missed_call_recovery_pool = get_eom_funnel_db_pool
 app.state.eom_funnel_first_clean_completion_pool = get_eom_funnel_db_pool
+app.state.eom_funnel_terms_pool = get_eom_funnel_db_pool
 app.include_router(funnel_router, prefix="/api/v1")

--- a/atlas_brain/services/eom_terms_authority.py
+++ b/atlas_brain/services/eom_terms_authority.py
@@ -875,6 +875,7 @@ class EOMTermsAuthority:
                     "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
                     _PUBLICATION_LOCK_KEY,
                 )
+                publication_timestamp = await conn.fetchval("SELECT clock_timestamp()")
                 row = await conn.fetchrow(
                     "SELECT * FROM eom_terms_versions WHERE id = $1 FOR UPDATE",
                     parsed_version_id,
@@ -896,30 +897,33 @@ class EOMTermsAuthority:
                     SET status = 'published',
                         published_by_id = $2,
                         published_by_name = $3,
-                        published_at = CURRENT_TIMESTAMP
+                        published_at = $4
                     WHERE id = $1 AND status = 'draft'
                     RETURNING *
                     """,
                     parsed_version_id,
                     parsed_actor_id,
                     parsed_actor_name,
+                    publication_timestamp,
                 )
                 if row is None:
                     raise EOMTermsConflictError("Terms version could not be published")
                 await conn.execute(
                     """
                     INSERT INTO eom_terms_current_version (
-                        singleton, version_id, selected_by_id, selected_by_name
-                    ) VALUES (TRUE, $1, $2, $3)
+                        singleton, version_id, selected_by_id, selected_by_name,
+                        selected_at
+                    ) VALUES (TRUE, $1, $2, $3, $4)
                     ON CONFLICT (singleton) DO UPDATE
                     SET version_id = EXCLUDED.version_id,
                         selected_by_id = EXCLUDED.selected_by_id,
                         selected_by_name = EXCLUDED.selected_by_name,
-                        selected_at = CURRENT_TIMESTAMP
+                        selected_at = EXCLUDED.selected_at
                     """,
                     parsed_version_id,
                     parsed_actor_id,
                     parsed_actor_name,
+                    publication_timestamp,
                 )
                 return _version_result(row, idempotent=False)
         except EOMTermsAuthorityError:

--- a/atlas_brain/services/eom_terms_authority.py
+++ b/atlas_brain/services/eom_terms_authority.py
@@ -1,0 +1,467 @@
+"""Versioned, immutable Terms authority for Effingham Office Maids."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from datetime import datetime, timezone
+from typing import Any, Mapping
+from uuid import UUID, uuid4
+
+import asyncpg
+
+
+EOM_TERMS_AUDIENCES = ("residential", "commercial")
+EOM_TERMS_LOCALES = ("en", "es")
+EOM_TERMS_DOCUMENT_FIELDS = (
+    "terms",
+    "servicesWeCannotProvide",
+    "additionalWorkAcknowledgement",
+)
+_VERSION_LABEL_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+_MAX_SECTION_LENGTH = 100_000
+_MAX_ACTOR_NAME_LENGTH = 128
+_MAX_SIGNED_BIGINT = 2**63 - 1
+_PUBLICATION_LOCK_KEY = "eom-terms-current-version"
+
+
+class EOMTermsAuthorityError(Exception):
+    """Base class for stable private-API failures."""
+
+    status_code = 409
+    code = "eom_terms_authority_error"
+
+
+class EOMTermsValidationError(EOMTermsAuthorityError):
+    status_code = 422
+    code = "invalid_eom_terms_request"
+
+
+class EOMTermsConflictError(EOMTermsAuthorityError):
+    status_code = 409
+    code = "eom_terms_conflict"
+
+
+class EOMTermsNotFoundError(EOMTermsAuthorityError):
+    status_code = 404
+    code = "eom_terms_not_found"
+
+
+class EOMTermsUnavailableError(EOMTermsAuthorityError):
+    status_code = 503
+    code = "eom_terms_unavailable"
+
+
+def _uuid(value: object) -> UUID:
+    if isinstance(value, UUID):
+        return value
+    try:
+        return UUID(str(value))
+    except (TypeError, ValueError, AttributeError) as exc:
+        raise EOMTermsValidationError("Terms version id is invalid") from exc
+
+
+def _version_label(value: object) -> str:
+    if not isinstance(value, str):
+        raise EOMTermsValidationError("Terms version label is invalid")
+    normalized = value.strip()
+    if not _VERSION_LABEL_PATTERN.fullmatch(normalized):
+        raise EOMTermsValidationError("Terms version label is invalid")
+    return normalized
+
+
+def _actor(actor_id: object, actor_name: object) -> tuple[int, str]:
+    if (
+        isinstance(actor_id, bool)
+        or not isinstance(actor_id, int)
+        or actor_id <= 0
+        or actor_id > _MAX_SIGNED_BIGINT
+    ):
+        raise EOMTermsValidationError("Authenticated actor is invalid")
+    if not isinstance(actor_name, str):
+        raise EOMTermsValidationError("Authenticated actor is invalid")
+    normalized_name = actor_name.strip()
+    if (
+        not normalized_name
+        or len(normalized_name) > _MAX_ACTOR_NAME_LENGTH
+        or "\x00" in normalized_name
+        or any(0xD800 <= ord(char) <= 0xDFFF for char in normalized_name)
+    ):
+        raise EOMTermsValidationError("Authenticated actor is invalid")
+    return actor_id, normalized_name
+
+
+def _closed_mapping(
+    value: object, expected: tuple[str, ...], label: str
+) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping) or set(value) != set(expected):
+        raise EOMTermsValidationError(
+            f"{label} must contain exactly: {', '.join(expected)}"
+        )
+    return value
+
+
+def _section(value: object, label: str) -> str:
+    if not isinstance(value, str):
+        raise EOMTermsValidationError(f"{label} must be text")
+    normalized = value.strip()
+    if (
+        not normalized
+        or len(normalized) > _MAX_SECTION_LENGTH
+        or "\x00" in normalized
+        or any(0xD800 <= ord(char) <= 0xDFFF for char in normalized)
+    ):
+        raise EOMTermsValidationError(f"{label} is invalid")
+    return normalized
+
+
+def normalize_eom_terms_documents(
+    documents: object,
+) -> dict[str, dict[str, dict[str, str]]]:
+    """Admit one exact audience x locale x section bundle."""
+
+    audiences = _closed_mapping(documents, EOM_TERMS_AUDIENCES, "documents")
+    normalized: dict[str, dict[str, dict[str, str]]] = {}
+    for audience in EOM_TERMS_AUDIENCES:
+        locales = _closed_mapping(audiences[audience], EOM_TERMS_LOCALES, audience)
+        normalized[audience] = {}
+        for locale in EOM_TERMS_LOCALES:
+            fields = _closed_mapping(
+                locales[locale],
+                EOM_TERMS_DOCUMENT_FIELDS,
+                f"{audience}.{locale}",
+            )
+            normalized[audience][locale] = {
+                field: _section(fields[field], f"{audience}.{locale}.{field}")
+                for field in EOM_TERMS_DOCUMENT_FIELDS
+            }
+    return normalized
+
+
+def canonical_eom_terms_documents(
+    documents: object,
+) -> tuple[dict[str, dict[str, dict[str, str]]], str, str]:
+    normalized = normalize_eom_terms_documents(documents)
+    serialized = json.dumps(
+        normalized,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return (
+        normalized,
+        serialized,
+        hashlib.sha256(serialized.encode("utf-8")).hexdigest(),
+    )
+
+
+def _documents_from_row(value: object) -> dict[str, dict[str, dict[str, str]]]:
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise EOMTermsUnavailableError(
+                "Stored Terms documents are invalid"
+            ) from exc
+    try:
+        return normalize_eom_terms_documents(value)
+    except EOMTermsValidationError as exc:
+        raise EOMTermsUnavailableError("Stored Terms documents are invalid") from exc
+
+
+def _iso(value: object) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, datetime) or value.tzinfo is None:
+        raise EOMTermsUnavailableError("Stored Terms timestamp is invalid")
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _version_result(row: Mapping[str, Any], *, idempotent: bool) -> dict[str, Any]:
+    documents = _documents_from_row(row["documents"])
+    _, _, calculated_hash = canonical_eom_terms_documents(documents)
+    stored_hash = row["content_hash"]
+    if not isinstance(stored_hash, str) or stored_hash != calculated_hash:
+        raise EOMTermsUnavailableError("Stored Terms content hash is invalid")
+    return {
+        "versionId": str(row["id"]),
+        "versionLabel": str(row["version_label"]),
+        "status": str(row["status"]),
+        "materialChange": bool(row["material_change"]),
+        "documents": documents,
+        "contentHash": stored_hash,
+        "createdById": int(row["created_by_id"]),
+        "createdByName": str(row["created_by_name"]),
+        "createdAt": _iso(row["created_at"]),
+        "publishedById": (
+            int(row["published_by_id"])
+            if row.get("published_by_id") is not None
+            else None
+        ),
+        "publishedByName": row.get("published_by_name"),
+        "publishedAt": _iso(row.get("published_at")),
+        "idempotent": idempotent,
+    }
+
+
+async def eom_terms_authority_schema_ready(pool: Any) -> bool:
+    try:
+        return bool(
+            await pool.fetchval(
+                """
+                SELECT to_regclass('eom_terms_versions') IS NOT NULL
+                   AND to_regclass('eom_terms_current_version') IS NOT NULL
+                   AND (
+                       SELECT COUNT(*) = 5
+                         FROM pg_trigger AS guard_trigger
+                        WHERE NOT guard_trigger.tgisinternal
+                          AND guard_trigger.tgenabled = 'O'
+                          AND (
+                              (
+                                  guard_trigger.tgrelid =
+                                      to_regclass('eom_terms_versions')
+                                  AND guard_trigger.tgname IN (
+                                      'trg_protect_eom_terms_version',
+                                      'trg_protect_eom_terms_version_truncate'
+                                  )
+                              )
+                              OR (
+                                  guard_trigger.tgrelid =
+                                      to_regclass('eom_terms_current_version')
+                                  AND guard_trigger.tgname IN (
+                                      'trg_require_published_eom_terms_current_version',
+                                      'trg_prevent_eom_terms_current_delete',
+                                      'trg_prevent_eom_terms_current_truncate'
+                                  )
+                              )
+                          )
+                   )
+                   AND (
+                       SELECT COUNT(DISTINCT indexed_attribute.attname) = 2
+                         FROM pg_index AS unique_index
+                         JOIN pg_attribute AS indexed_attribute
+                           ON indexed_attribute.attrelid = unique_index.indrelid
+                          AND indexed_attribute.attnum = unique_index.indkey[0]
+                          AND NOT indexed_attribute.attisdropped
+                        WHERE unique_index.indrelid =
+                                  to_regclass('eom_terms_versions')
+                          AND unique_index.indisunique
+                          AND unique_index.indisvalid
+                          AND unique_index.indpred IS NULL
+                          AND unique_index.indexprs IS NULL
+                          AND unique_index.indnkeyatts = 1
+                          AND unique_index.indnatts = 1
+                          AND indexed_attribute.attname IN ('id', 'version_label')
+                   )
+                   AND (
+                       SELECT COUNT(DISTINCT indexed_attribute.attname) = 2
+                         FROM pg_index AS unique_index
+                         JOIN pg_attribute AS indexed_attribute
+                           ON indexed_attribute.attrelid = unique_index.indrelid
+                          AND indexed_attribute.attnum = unique_index.indkey[0]
+                          AND NOT indexed_attribute.attisdropped
+                        WHERE unique_index.indrelid =
+                                  to_regclass('eom_terms_current_version')
+                          AND unique_index.indisunique
+                          AND unique_index.indisvalid
+                          AND unique_index.indpred IS NULL
+                          AND unique_index.indexprs IS NULL
+                          AND unique_index.indnkeyatts = 1
+                          AND unique_index.indnatts = 1
+                          AND indexed_attribute.attname IN (
+                              'singleton', 'version_id'
+                          )
+                   )
+                   AND EXISTS (
+                       SELECT 1
+                         FROM pg_constraint AS foreign_key
+                        WHERE foreign_key.contype = 'f'
+                          AND foreign_key.conrelid =
+                              to_regclass('eom_terms_current_version')
+                          AND foreign_key.confrelid =
+                              to_regclass('eom_terms_versions')
+                          AND foreign_key.conkey = ARRAY[
+                              (SELECT attnum FROM pg_attribute
+                                WHERE attrelid = foreign_key.conrelid
+                                  AND attname = 'version_id'
+                                  AND NOT attisdropped)
+                          ]::smallint[]
+                          AND foreign_key.confkey = ARRAY[
+                              (SELECT attnum FROM pg_attribute
+                                WHERE attrelid = foreign_key.confrelid
+                                  AND attname = 'id'
+                                  AND NOT attisdropped)
+                          ]::smallint[]
+                          AND foreign_key.confdeltype = 'r'
+                          AND foreign_key.convalidated
+                          AND NOT foreign_key.condeferrable
+                   )
+                """
+            )
+        )
+    except Exception:
+        return False
+
+
+class EOMTermsAuthority:
+    """Own Terms draft identity, publication serialization, and current reads."""
+
+    def __init__(self, *, pool: Any) -> None:
+        self._pool = pool
+
+    @property
+    def pool(self) -> Any:
+        if not bool(getattr(self._pool, "is_initialized", True)):
+            raise EOMTermsUnavailableError("Terms database is unavailable")
+        return self._pool
+
+    async def require_schema_ready(self) -> None:
+        if not await eom_terms_authority_schema_ready(self.pool):
+            raise EOMTermsUnavailableError("Terms authority schema is unavailable")
+
+    async def create_draft(
+        self,
+        *,
+        version_label: object,
+        material_change: object,
+        documents: object,
+        actor_id: object,
+        actor_name: object,
+    ) -> dict[str, Any]:
+        label = _version_label(version_label)
+        if not isinstance(material_change, bool):
+            raise EOMTermsValidationError("materialChange must be boolean")
+        _, serialized, content_hash = canonical_eom_terms_documents(documents)
+        parsed_actor_id, parsed_actor_name = _actor(actor_id, actor_name)
+        await self.require_schema_ready()
+        try:
+            async with self.pool.transaction() as conn:
+                row = await conn.fetchrow(
+                    """
+                    INSERT INTO eom_terms_versions (
+                        id, version_label, material_change, documents,
+                        content_hash, created_by_id, created_by_name
+                    ) VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7)
+                    ON CONFLICT (version_label) DO NOTHING
+                    RETURNING *
+                    """,
+                    uuid4(),
+                    label,
+                    material_change,
+                    serialized,
+                    content_hash,
+                    parsed_actor_id,
+                    parsed_actor_name,
+                )
+                if row is not None:
+                    return _version_result(row, idempotent=False)
+                row = await conn.fetchrow(
+                    "SELECT * FROM eom_terms_versions WHERE version_label = $1",
+                    label,
+                )
+                if row is None:
+                    raise EOMTermsUnavailableError("Terms draft is unavailable")
+                if (
+                    str(row["content_hash"]) != content_hash
+                    or bool(row["material_change"]) is not material_change
+                    or _documents_from_row(row["documents"])
+                    != normalize_eom_terms_documents(documents)
+                ):
+                    raise EOMTermsConflictError(
+                        "Terms version label belongs to different content"
+                    )
+                return _version_result(row, idempotent=True)
+        except EOMTermsAuthorityError:
+            raise
+        except (asyncpg.PostgresError, OSError, TimeoutError) as exc:
+            raise EOMTermsUnavailableError("Terms draft could not be stored") from exc
+
+    async def publish(
+        self,
+        *,
+        version_id: object,
+        actor_id: object,
+        actor_name: object,
+    ) -> dict[str, Any]:
+        parsed_version_id = _uuid(version_id)
+        parsed_actor_id, parsed_actor_name = _actor(actor_id, actor_name)
+        await self.require_schema_ready()
+        try:
+            async with self.pool.transaction() as conn:
+                await conn.execute(
+                    "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+                    _PUBLICATION_LOCK_KEY,
+                )
+                row = await conn.fetchrow(
+                    "SELECT * FROM eom_terms_versions WHERE id = $1 FOR UPDATE",
+                    parsed_version_id,
+                )
+                if row is None:
+                    raise EOMTermsNotFoundError("Terms version was not found")
+                current_id = await conn.fetchval(
+                    "SELECT version_id FROM eom_terms_current_version WHERE singleton"
+                )
+                if str(row["status"]) == "published":
+                    if current_id == parsed_version_id:
+                        return _version_result(row, idempotent=True)
+                    raise EOMTermsConflictError(
+                        "Published Terms version is not the current version"
+                    )
+                row = await conn.fetchrow(
+                    """
+                    UPDATE eom_terms_versions
+                    SET status = 'published',
+                        published_by_id = $2,
+                        published_by_name = $3,
+                        published_at = CURRENT_TIMESTAMP
+                    WHERE id = $1 AND status = 'draft'
+                    RETURNING *
+                    """,
+                    parsed_version_id,
+                    parsed_actor_id,
+                    parsed_actor_name,
+                )
+                if row is None:
+                    raise EOMTermsConflictError("Terms version could not be published")
+                await conn.execute(
+                    """
+                    INSERT INTO eom_terms_current_version (
+                        singleton, version_id, selected_by_id, selected_by_name
+                    ) VALUES (TRUE, $1, $2, $3)
+                    ON CONFLICT (singleton) DO UPDATE
+                    SET version_id = EXCLUDED.version_id,
+                        selected_by_id = EXCLUDED.selected_by_id,
+                        selected_by_name = EXCLUDED.selected_by_name,
+                        selected_at = CURRENT_TIMESTAMP
+                    """,
+                    parsed_version_id,
+                    parsed_actor_id,
+                    parsed_actor_name,
+                )
+                return _version_result(row, idempotent=False)
+        except EOMTermsAuthorityError:
+            raise
+        except (asyncpg.PostgresError, OSError, TimeoutError) as exc:
+            raise EOMTermsUnavailableError(
+                "Terms version could not be published"
+            ) from exc
+
+    async def get_current(self) -> dict[str, Any]:
+        await self.require_schema_ready()
+        try:
+            row = await self.pool.fetchrow(
+                """
+                SELECT version.*
+                FROM eom_terms_current_version AS selected
+                JOIN eom_terms_versions AS version ON version.id = selected.version_id
+                WHERE selected.singleton AND version.status = 'published'
+                """
+            )
+        except (asyncpg.PostgresError, OSError, TimeoutError) as exc:
+            raise EOMTermsUnavailableError(
+                "Current Terms version is unavailable"
+            ) from exc
+        if row is None:
+            raise EOMTermsNotFoundError("Current Terms version was not found")
+        return _version_result(row, idempotent=True)

--- a/atlas_brain/services/eom_terms_authority.py
+++ b/atlas_brain/services/eom_terms_authority.py
@@ -352,7 +352,7 @@ async def eom_terms_authority_schema_ready(pool: Any) -> bool:
                           ]
                    )
                    AND (
-                       SELECT COUNT(*) = 5
+                       SELECT COUNT(*) = 4
                           AND BOOL_AND(
                               guard_trigger.tgenabled = 'O'
                               AND (
@@ -607,7 +607,7 @@ async def eom_terms_authority_schema_ready(pool: Any) -> bool:
                           )
                    )
                    AND (
-                       SELECT COUNT(*) = 5
+                       SELECT COUNT(*) = 4
                          FROM pg_attribute AS attribute
                         WHERE attribute.attrelid = boundary.versions_oid
                           AND attribute.attname IN (
@@ -643,7 +643,7 @@ async def eom_terms_authority_schema_ready(pool: Any) -> bool:
                           )
                    )
                    AND (
-                       SELECT COUNT(*) = 4
+                       SELECT COUNT(*) = 5
                          FROM pg_attribute AS attribute
                         WHERE attribute.attrelid = boundary.current_oid
                           AND attribute.attname IN (

--- a/atlas_brain/services/eom_terms_authority.py
+++ b/atlas_brain/services/eom_terms_authority.py
@@ -607,7 +607,7 @@ async def eom_terms_authority_schema_ready(pool: Any) -> bool:
                           )
                    )
                    AND (
-                       SELECT COUNT(*) = 4
+                       SELECT COUNT(*) = 5
                          FROM pg_attribute AS attribute
                         WHERE attribute.attrelid = boundary.versions_oid
                           AND attribute.attname IN (
@@ -650,7 +650,7 @@ async def eom_terms_authority_schema_ready(pool: Any) -> bool:
                               'singleton',
                               'version_id',
                               'selected_by_id',
-                              'selected_by_name'
+                              'selected_by_name', 'selected_at'
                           )
                           AND has_column_privilege(
                               current_user,
@@ -669,7 +669,7 @@ async def eom_terms_authority_schema_ready(pool: Any) -> bool:
                               'singleton',
                               'version_id',
                               'selected_by_id',
-                              'selected_by_name'
+                              'selected_by_name', 'selected_at'
                           )
                           AND has_column_privilege(
                               current_user,

--- a/atlas_brain/services/eom_terms_authority.py
+++ b/atlas_brain/services/eom_terms_authority.py
@@ -352,7 +352,7 @@ async def eom_terms_authority_schema_ready(pool: Any) -> bool:
                           ]
                    )
                    AND (
-                       SELECT COUNT(*) = 4
+                       SELECT COUNT(*) = 5
                           AND BOOL_AND(
                               guard_trigger.tgenabled = 'O'
                               AND (

--- a/atlas_brain/services/eom_terms_authority.py
+++ b/atlas_brain/services/eom_terms_authority.py
@@ -206,35 +206,265 @@ def _version_result(row: Mapping[str, Any], *, idempotent: bool) -> dict[str, An
 
 
 async def eom_terms_authority_schema_ready(pool: Any) -> bool:
+    """Return whether the connected runtime has the exact guarded boundary."""
+
     try:
         return bool(
             await pool.fetchval(
                 """
-                SELECT to_regclass('eom_terms_versions') IS NOT NULL
-                   AND to_regclass('eom_terms_current_version') IS NOT NULL
+                WITH boundary AS (
+                    SELECT pg_catalog.current_schema() AS schema_name,
+                           to_regclass(format(
+                               '%I.eom_terms_versions',
+                               pg_catalog.current_schema()
+                           )) AS versions_oid,
+                           to_regclass(format(
+                               '%I.eom_terms_current_version',
+                               pg_catalog.current_schema()
+                           )) AS current_oid,
+                           to_regprocedure(format(
+                               '%I.protect_eom_terms_version()',
+                               pg_catalog.current_schema()
+                           )) AS protect_version_oid,
+                           to_regprocedure(format(
+                               '%I.require_published_eom_terms_current_version()',
+                               pg_catalog.current_schema()
+                           )) AS require_current_oid,
+                           to_regprocedure(format(
+                               '%I.prevent_eom_terms_current_removal()',
+                               pg_catalog.current_schema()
+                           )) AS prevent_current_removal_oid,
+                           (
+                               SELECT oid
+                                 FROM pg_roles
+                                WHERE rolname = 'atlas'
+                           ) AS runtime_oid,
+                           (
+                               SELECT oid
+                                 FROM pg_roles
+                                WHERE rolname = 'atlas_eom_handoff_owner'
+                           ) AS guard_oid
+                )
+                SELECT boundary.versions_oid IS NOT NULL
+                   AND boundary.current_oid IS NOT NULL
+                   AND current_user = 'atlas'
+                   AND session_user = 'atlas'
+                   AND EXISTS (
+                       SELECT 1
+                         FROM pg_roles AS runtime_role
+                        WHERE runtime_role.oid = boundary.runtime_oid
+                          AND runtime_role.rolcanlogin
+                          AND NOT runtime_role.rolsuper
+                          AND NOT runtime_role.rolcreaterole
+                          AND NOT runtime_role.rolcreatedb
+                          AND NOT runtime_role.rolreplication
+                          AND NOT runtime_role.rolbypassrls
+                          AND NOT EXISTS (
+                              SELECT 1
+                                FROM pg_database AS database
+                               WHERE database.datname = current_database()
+                                 AND database.datdba = runtime_role.oid
+                          )
+                          AND NOT EXISTS (
+                              SELECT 1
+                                FROM pg_roles AS elevated_role
+                               WHERE elevated_role.oid <> runtime_role.oid
+                                 AND (
+                                     elevated_role.rolsuper
+                                     OR elevated_role.rolcreaterole
+                                     OR elevated_role.rolcreatedb
+                                     OR elevated_role.rolreplication
+                                     OR elevated_role.rolbypassrls
+                                 )
+                                 AND pg_has_role(
+                                     runtime_role.oid,
+                                     elevated_role.oid,
+                                     'MEMBER'
+                                 )
+                          )
+                   )
+                   AND EXISTS (
+                       SELECT 1
+                         FROM pg_roles AS guard_role
+                        WHERE guard_role.oid = boundary.guard_oid
+                          AND NOT guard_role.rolcanlogin
+                          AND NOT guard_role.rolinherit
+                          AND NOT guard_role.rolsuper
+                          AND NOT guard_role.rolcreaterole
+                          AND NOT guard_role.rolcreatedb
+                          AND NOT guard_role.rolreplication
+                          AND NOT guard_role.rolbypassrls
+                   )
+                   AND NOT EXISTS (
+                       SELECT 1
+                         FROM pg_stat_activity AS activity
+                        WHERE activity.usesysid = boundary.guard_oid
+                          AND activity.datid = (
+                              SELECT database.oid
+                                FROM pg_database AS database
+                               WHERE database.datname = current_database()
+                          )
+                   )
+                   AND NOT EXISTS (
+                       SELECT 1
+                         FROM pg_roles AS member_role
+                        WHERE member_role.rolcanlogin
+                          AND NOT member_role.rolsuper
+                          AND pg_has_role(
+                              member_role.oid,
+                              boundary.guard_oid,
+                              'MEMBER'
+                          )
+                   )
+                   AND EXISTS (
+                       SELECT 1
+                         FROM pg_namespace AS namespace
+                        WHERE namespace.nspname = boundary.schema_name
+                          AND namespace.nspowner = boundary.guard_oid
+                   )
+                   AND (
+                       SELECT COUNT(*) = 2
+                         FROM pg_class AS relation
+                        WHERE relation.oid IN (
+                                  boundary.versions_oid,
+                                  boundary.current_oid
+                              )
+                          AND relation.relkind = 'r'
+                          AND relation.relowner = boundary.guard_oid
+                   )
+                   AND (
+                       SELECT COUNT(*) = 3
+                         FROM pg_proc AS protected_function
+                        WHERE protected_function.oid IN (
+                                  boundary.protect_version_oid,
+                                  boundary.require_current_oid,
+                                  boundary.prevent_current_removal_oid
+                              )
+                          AND protected_function.pronargs = 0
+                          AND protected_function.proowner = boundary.guard_oid
+                          AND NOT protected_function.prosecdef
+                          AND protected_function.prorettype = 'trigger'::regtype
+                          AND protected_function.proconfig = ARRAY[
+                              format(
+                                  'search_path=pg_catalog, %I, pg_temp',
+                                  boundary.schema_name
+                              )
+                          ]
+                   )
                    AND (
                        SELECT COUNT(*) = 5
+                          AND BOOL_AND(
+                              guard_trigger.tgenabled = 'O'
+                              AND (
+                                  (
+                                      guard_trigger.tgrelid =
+                                          boundary.versions_oid
+                                      AND guard_trigger.tgfoid =
+                                          boundary.protect_version_oid
+                                      AND guard_trigger.tgname IN (
+                                          'trg_protect_eom_terms_version',
+                                          'trg_protect_eom_terms_version_truncate'
+                                      )
+                                  )
+                                  OR (
+                                      guard_trigger.tgrelid =
+                                          boundary.current_oid
+                                      AND guard_trigger.tgfoid =
+                                          boundary.require_current_oid
+                                      AND guard_trigger.tgname =
+                                          'trg_require_published_eom_terms_current_version'
+                                  )
+                                  OR (
+                                      guard_trigger.tgrelid =
+                                          boundary.current_oid
+                                      AND guard_trigger.tgfoid =
+                                          boundary.prevent_current_removal_oid
+                                      AND guard_trigger.tgname IN (
+                                          'trg_prevent_eom_terms_current_delete',
+                                          'trg_prevent_eom_terms_current_truncate'
+                                      )
+                                  )
+                              )
+                          )
                          FROM pg_trigger AS guard_trigger
                         WHERE NOT guard_trigger.tgisinternal
-                          AND guard_trigger.tgenabled = 'O'
-                          AND (
-                              (
-                                  guard_trigger.tgrelid =
-                                      to_regclass('eom_terms_versions')
-                                  AND guard_trigger.tgname IN (
-                                      'trg_protect_eom_terms_version',
-                                      'trg_protect_eom_terms_version_truncate'
-                                  )
-                              )
-                              OR (
-                                  guard_trigger.tgrelid =
-                                      to_regclass('eom_terms_current_version')
-                                  AND guard_trigger.tgname IN (
-                                      'trg_require_published_eom_terms_current_version',
-                                      'trg_prevent_eom_terms_current_delete',
-                                      'trg_prevent_eom_terms_current_truncate'
-                                  )
-                              )
+                          AND guard_trigger.tgrelid IN (
+                              boundary.versions_oid,
+                              boundary.current_oid
+                          )
+                   )
+                   AND NOT EXISTS (
+                       SELECT 1
+                         FROM (
+                             VALUES
+                                 ('eom_terms_versions',
+                                  'pk_eom_terms_versions', 'p'),
+                                 ('eom_terms_versions',
+                                  'uq_eom_terms_version_label', 'u'),
+                                 ('eom_terms_versions',
+                                  'ck_eom_terms_context', 'c'),
+                                 ('eom_terms_versions',
+                                  'ck_eom_terms_version_label', 'c'),
+                                 ('eom_terms_versions',
+                                  'ck_eom_terms_status', 'c'),
+                                 ('eom_terms_versions',
+                                  'ck_eom_terms_documents_object', 'c'),
+                                 ('eom_terms_versions',
+                                  'ck_eom_terms_content_hash', 'c'),
+                                 ('eom_terms_versions',
+                                  'ck_eom_terms_creator', 'c'),
+                                 ('eom_terms_versions',
+                                  'ck_eom_terms_publication', 'c'),
+                                 ('eom_terms_current_version',
+                                  'pk_eom_terms_current_version', 'p'),
+                                 ('eom_terms_current_version',
+                                  'ck_eom_terms_current_singleton', 'c'),
+                                 ('eom_terms_current_version',
+                                  'uq_eom_terms_current_version', 'u'),
+                                 ('eom_terms_current_version',
+                                  'fk_eom_terms_current_version', 'f'),
+                                 ('eom_terms_current_version',
+                                  'ck_eom_terms_current_selector_id', 'c'),
+                                 ('eom_terms_current_version',
+                                  'ck_eom_terms_current_selector_name', 'c')
+                         ) AS expected_constraint(
+                             relation_name,
+                             constraint_name,
+                             constraint_type
+                         )
+                        WHERE NOT EXISTS (
+                            SELECT 1
+                              FROM pg_constraint AS actual_constraint
+                             WHERE actual_constraint.conrelid = to_regclass(
+                                       format(
+                                           '%I.%I',
+                                           boundary.schema_name,
+                                           expected_constraint.relation_name
+                                       )
+                                   )
+                               AND actual_constraint.conname =
+                                   expected_constraint.constraint_name
+                               AND actual_constraint.contype::text =
+                                   expected_constraint.constraint_type
+                               AND actual_constraint.convalidated
+                        )
+                   )
+                   AND (
+                       SELECT COUNT(DISTINCT indexed_attribute.attname) = 2
+                         FROM pg_index AS unique_index
+                         JOIN pg_attribute AS indexed_attribute
+                           ON indexed_attribute.attrelid = unique_index.indrelid
+                          AND indexed_attribute.attnum = unique_index.indkey[0]
+                          AND NOT indexed_attribute.attisdropped
+                        WHERE unique_index.indrelid = boundary.versions_oid
+                          AND unique_index.indisunique
+                          AND unique_index.indisvalid
+                          AND unique_index.indpred IS NULL
+                          AND unique_index.indexprs IS NULL
+                          AND unique_index.indnkeyatts = 1
+                          AND unique_index.indnatts = 1
+                          AND indexed_attribute.attname IN (
+                              'id', 'version_label'
                           )
                    )
                    AND (
@@ -244,25 +474,7 @@ async def eom_terms_authority_schema_ready(pool: Any) -> bool:
                            ON indexed_attribute.attrelid = unique_index.indrelid
                           AND indexed_attribute.attnum = unique_index.indkey[0]
                           AND NOT indexed_attribute.attisdropped
-                        WHERE unique_index.indrelid =
-                                  to_regclass('eom_terms_versions')
-                          AND unique_index.indisunique
-                          AND unique_index.indisvalid
-                          AND unique_index.indpred IS NULL
-                          AND unique_index.indexprs IS NULL
-                          AND unique_index.indnkeyatts = 1
-                          AND unique_index.indnatts = 1
-                          AND indexed_attribute.attname IN ('id', 'version_label')
-                   )
-                   AND (
-                       SELECT COUNT(DISTINCT indexed_attribute.attname) = 2
-                         FROM pg_index AS unique_index
-                         JOIN pg_attribute AS indexed_attribute
-                           ON indexed_attribute.attrelid = unique_index.indrelid
-                          AND indexed_attribute.attnum = unique_index.indkey[0]
-                          AND NOT indexed_attribute.attisdropped
-                        WHERE unique_index.indrelid =
-                                  to_regclass('eom_terms_current_version')
+                        WHERE unique_index.indrelid = boundary.current_oid
                           AND unique_index.indisunique
                           AND unique_index.indisvalid
                           AND unique_index.indpred IS NULL
@@ -277,26 +489,296 @@ async def eom_terms_authority_schema_ready(pool: Any) -> bool:
                        SELECT 1
                          FROM pg_constraint AS foreign_key
                         WHERE foreign_key.contype = 'f'
-                          AND foreign_key.conrelid =
-                              to_regclass('eom_terms_current_version')
-                          AND foreign_key.confrelid =
-                              to_regclass('eom_terms_versions')
+                          AND foreign_key.conrelid = boundary.current_oid
+                          AND foreign_key.confrelid = boundary.versions_oid
                           AND foreign_key.conkey = ARRAY[
-                              (SELECT attnum FROM pg_attribute
-                                WHERE attrelid = foreign_key.conrelid
-                                  AND attname = 'version_id'
-                                  AND NOT attisdropped)
+                              (
+                                  SELECT attnum
+                                    FROM pg_attribute
+                                   WHERE attrelid = boundary.current_oid
+                                     AND attname = 'version_id'
+                                     AND NOT attisdropped
+                              )
                           ]::smallint[]
                           AND foreign_key.confkey = ARRAY[
-                              (SELECT attnum FROM pg_attribute
-                                WHERE attrelid = foreign_key.confrelid
-                                  AND attname = 'id'
-                                  AND NOT attisdropped)
+                              (
+                                  SELECT attnum
+                                    FROM pg_attribute
+                                   WHERE attrelid = boundary.versions_oid
+                                     AND attname = 'id'
+                                     AND NOT attisdropped
+                              )
                           ]::smallint[]
                           AND foreign_key.confdeltype = 'r'
                           AND foreign_key.convalidated
                           AND NOT foreign_key.condeferrable
                    )
+                   AND has_schema_privilege(
+                       current_user, boundary.schema_name, 'USAGE'
+                   )
+                   AND has_table_privilege(
+                       current_user, boundary.versions_oid, 'SELECT'
+                   )
+                   AND has_table_privilege(
+                       current_user, boundary.current_oid, 'SELECT'
+                   )
+                   AND NOT has_table_privilege(
+                       current_user, boundary.versions_oid, 'INSERT'
+                   )
+                   AND NOT has_table_privilege(
+                       current_user, boundary.versions_oid, 'UPDATE'
+                   )
+                   AND NOT has_table_privilege(
+                       current_user, boundary.current_oid, 'INSERT'
+                   )
+                   AND NOT has_table_privilege(
+                       current_user, boundary.current_oid, 'UPDATE'
+                   )
+                   AND NOT has_table_privilege(
+                       current_user, boundary.versions_oid, 'DELETE'
+                   )
+                   AND NOT has_table_privilege(
+                       current_user, boundary.versions_oid, 'TRUNCATE'
+                   )
+                   AND NOT has_table_privilege(
+                       current_user, boundary.versions_oid, 'REFERENCES'
+                   )
+                   AND NOT has_any_column_privilege(
+                       current_user, boundary.versions_oid, 'REFERENCES'
+                   )
+                   AND NOT has_table_privilege(
+                       current_user, boundary.versions_oid, 'TRIGGER'
+                   )
+                   AND NOT has_table_privilege(
+                       current_user, boundary.current_oid, 'DELETE'
+                   )
+                   AND NOT has_table_privilege(
+                       current_user, boundary.current_oid, 'TRUNCATE'
+                   )
+                   AND NOT has_table_privilege(
+                       current_user, boundary.current_oid, 'REFERENCES'
+                   )
+                   AND NOT has_any_column_privilege(
+                       current_user, boundary.current_oid, 'REFERENCES'
+                   )
+                   AND NOT has_table_privilege(
+                       current_user, boundary.current_oid, 'TRIGGER'
+                   )
+                   AND (
+                       SELECT COUNT(*) = 7
+                         FROM pg_attribute AS attribute
+                        WHERE attribute.attrelid = boundary.versions_oid
+                          AND attribute.attname IN (
+                              'id',
+                              'version_label',
+                              'material_change',
+                              'documents',
+                              'content_hash',
+                              'created_by_id',
+                              'created_by_name'
+                          )
+                          AND has_column_privilege(
+                              current_user,
+                              boundary.versions_oid,
+                              attribute.attnum,
+                              'INSERT'
+                          )
+                   )
+                   AND NOT EXISTS (
+                       SELECT 1
+                         FROM pg_attribute AS attribute
+                        WHERE attribute.attrelid = boundary.versions_oid
+                          AND attribute.attnum > 0
+                          AND NOT attribute.attisdropped
+                          AND attribute.attname NOT IN (
+                              'id',
+                              'version_label',
+                              'material_change',
+                              'documents',
+                              'content_hash',
+                              'created_by_id',
+                              'created_by_name'
+                          )
+                          AND has_column_privilege(
+                              current_user,
+                              boundary.versions_oid,
+                              attribute.attnum,
+                              'INSERT'
+                          )
+                   )
+                   AND (
+                       SELECT COUNT(*) = 4
+                         FROM pg_attribute AS attribute
+                        WHERE attribute.attrelid = boundary.versions_oid
+                          AND attribute.attname IN (
+                              'status',
+                              'published_by_id',
+                              'published_by_name',
+                              'published_at'
+                          )
+                          AND has_column_privilege(
+                              current_user,
+                              boundary.versions_oid,
+                              attribute.attnum,
+                              'UPDATE'
+                          )
+                   )
+                   AND NOT EXISTS (
+                       SELECT 1
+                         FROM pg_attribute AS attribute
+                        WHERE attribute.attrelid = boundary.versions_oid
+                          AND attribute.attnum > 0
+                          AND NOT attribute.attisdropped
+                          AND attribute.attname NOT IN (
+                              'status',
+                              'published_by_id',
+                              'published_by_name',
+                              'published_at'
+                          )
+                          AND has_column_privilege(
+                              current_user,
+                              boundary.versions_oid,
+                              attribute.attnum,
+                              'UPDATE'
+                          )
+                   )
+                   AND (
+                       SELECT COUNT(*) = 4
+                         FROM pg_attribute AS attribute
+                        WHERE attribute.attrelid = boundary.current_oid
+                          AND attribute.attname IN (
+                              'singleton',
+                              'version_id',
+                              'selected_by_id',
+                              'selected_by_name'
+                          )
+                          AND has_column_privilege(
+                              current_user,
+                              boundary.current_oid,
+                              attribute.attnum,
+                              'INSERT'
+                          )
+                   )
+                   AND NOT EXISTS (
+                       SELECT 1
+                         FROM pg_attribute AS attribute
+                        WHERE attribute.attrelid = boundary.current_oid
+                          AND attribute.attnum > 0
+                          AND NOT attribute.attisdropped
+                          AND attribute.attname NOT IN (
+                              'singleton',
+                              'version_id',
+                              'selected_by_id',
+                              'selected_by_name'
+                          )
+                          AND has_column_privilege(
+                              current_user,
+                              boundary.current_oid,
+                              attribute.attnum,
+                              'INSERT'
+                          )
+                   )
+                   AND (
+                       SELECT COUNT(*) = 4
+                         FROM pg_attribute AS attribute
+                        WHERE attribute.attrelid = boundary.current_oid
+                          AND attribute.attname IN (
+                              'version_id',
+                              'selected_by_id',
+                              'selected_by_name',
+                              'selected_at'
+                          )
+                          AND has_column_privilege(
+                              current_user,
+                              boundary.current_oid,
+                              attribute.attnum,
+                              'UPDATE'
+                          )
+                   )
+                   AND NOT EXISTS (
+                       SELECT 1
+                         FROM pg_attribute AS attribute
+                        WHERE attribute.attrelid = boundary.current_oid
+                          AND attribute.attnum > 0
+                          AND NOT attribute.attisdropped
+                          AND attribute.attname NOT IN (
+                              'version_id',
+                              'selected_by_id',
+                              'selected_by_name',
+                              'selected_at'
+                          )
+                          AND has_column_privilege(
+                              current_user,
+                              boundary.current_oid,
+                              attribute.attnum,
+                              'UPDATE'
+                          )
+                   )
+                   AND NOT has_function_privilege(
+                       current_user,
+                       boundary.protect_version_oid,
+                       'EXECUTE'
+                   )
+                   AND NOT has_function_privilege(
+                       current_user,
+                       boundary.require_current_oid,
+                       'EXECUTE'
+                   )
+                   AND NOT has_function_privilege(
+                       current_user,
+                       boundary.prevent_current_removal_oid,
+                       'EXECUTE'
+                   )
+                   AND NOT EXISTS (
+                       SELECT 1
+                         FROM pg_class AS relation
+                         CROSS JOIN LATERAL aclexplode(
+                             relation.relacl
+                         ) AS acl
+                        WHERE relation.oid IN (
+                                  boundary.versions_oid,
+                                  boundary.current_oid
+                              )
+                          AND (
+                              acl.grantee NOT IN (
+                                  boundary.runtime_oid,
+                                  boundary.guard_oid
+                              )
+                              OR acl.is_grantable
+                          )
+                   )
+                   AND NOT EXISTS (
+                       SELECT 1
+                         FROM pg_attribute AS attribute
+                         CROSS JOIN LATERAL aclexplode(
+                             attribute.attacl
+                         ) AS acl
+                        WHERE attribute.attrelid IN (
+                                  boundary.versions_oid,
+                                  boundary.current_oid
+                              )
+                          AND (
+                              acl.grantee <> boundary.runtime_oid
+                              OR acl.is_grantable
+                          )
+                   )
+                   AND NOT EXISTS (
+                       SELECT 1
+                         FROM pg_proc AS protected_function
+                         CROSS JOIN LATERAL aclexplode(
+                             protected_function.proacl
+                         ) AS acl
+                        WHERE protected_function.oid IN (
+                                  boundary.protect_version_oid,
+                                  boundary.require_current_oid,
+                                  boundary.prevent_current_removal_oid
+                              )
+                          AND (
+                              acl.grantee <> boundary.guard_oid
+                              OR acl.is_grantable
+                          )
+                   )
+                  FROM boundary
                 """
             )
         )

--- a/atlas_brain/storage/migrations/396_eom_terms_authority.sql
+++ b/atlas_brain/storage/migrations/396_eom_terms_authority.sql
@@ -409,7 +409,7 @@ BEGIN
         schema_name
     );
     EXECUTE format(
-        'GRANT INSERT (singleton, version_id, selected_by_id, selected_by_name) '
+        'GRANT INSERT (singleton, version_id, selected_by_id, selected_by_name, selected_at) '
         || 'ON TABLE %I.eom_terms_current_version TO atlas',
         schema_name
     );

--- a/atlas_brain/storage/migrations/396_eom_terms_authority.sql
+++ b/atlas_brain/storage/migrations/396_eom_terms_authority.sql
@@ -1,0 +1,145 @@
+-- atlas: atomic-bookkeeping
+-- Immutable, bilingual EOM Terms releases. This migration stores no customer
+-- acceptance and seeds no Terms content; later invitation/acceptance slices
+-- reference the published version selected by the singleton pointer.
+
+CREATE TABLE IF NOT EXISTS eom_terms_versions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    business_context_id VARCHAR(64) NOT NULL DEFAULT 'effingham_maids',
+    version_label VARCHAR(64) NOT NULL UNIQUE,
+    status VARCHAR(16) NOT NULL DEFAULT 'draft',
+    material_change BOOLEAN NOT NULL,
+    documents JSONB NOT NULL,
+    content_hash VARCHAR(64) NOT NULL,
+    created_by_id BIGINT NOT NULL,
+    created_by_name VARCHAR(128) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    published_by_id BIGINT,
+    published_by_name VARCHAR(128),
+    published_at TIMESTAMPTZ,
+    CONSTRAINT ck_eom_terms_context
+        CHECK (business_context_id = 'effingham_maids'),
+    CONSTRAINT ck_eom_terms_version_label
+        CHECK (version_label ~ '^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$'),
+    CONSTRAINT ck_eom_terms_status
+        CHECK (status IN ('draft', 'published')),
+    CONSTRAINT ck_eom_terms_documents_object
+        CHECK (jsonb_typeof(documents) = 'object'),
+    CONSTRAINT ck_eom_terms_content_hash
+        CHECK (content_hash ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT ck_eom_terms_creator
+        CHECK (created_by_id > 0 AND length(btrim(created_by_name)) > 0),
+    CONSTRAINT ck_eom_terms_publication
+        CHECK (
+            (status = 'draft'
+                AND published_by_id IS NULL
+                AND published_by_name IS NULL
+                AND published_at IS NULL)
+            OR
+            (status = 'published'
+                AND published_by_id > 0
+                AND length(btrim(published_by_name)) > 0
+                AND published_at IS NOT NULL)
+        )
+);
+
+CREATE TABLE IF NOT EXISTS eom_terms_current_version (
+    singleton BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (singleton),
+    version_id UUID NOT NULL UNIQUE
+        REFERENCES eom_terms_versions(id) ON DELETE RESTRICT,
+    selected_by_id BIGINT NOT NULL CHECK (selected_by_id > 0),
+    selected_by_name VARCHAR(128) NOT NULL
+        CHECK (length(btrim(selected_by_name)) > 0),
+    selected_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE OR REPLACE FUNCTION protect_eom_terms_version()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF TG_OP = 'TRUNCATE' THEN
+        RAISE EXCEPTION 'EOM Terms version history is append-only';
+    END IF;
+    IF OLD.status = 'published' THEN
+        RAISE EXCEPTION 'Published EOM Terms versions are immutable';
+    END IF;
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+    IF NEW.status = 'draft' THEN
+        RAISE EXCEPTION 'EOM Terms drafts cannot be edited; create a new version';
+    END IF;
+    IF NEW.id IS DISTINCT FROM OLD.id
+       OR NEW.business_context_id IS DISTINCT FROM OLD.business_context_id
+       OR NEW.version_label IS DISTINCT FROM OLD.version_label
+       OR NEW.material_change IS DISTINCT FROM OLD.material_change
+       OR NEW.documents IS DISTINCT FROM OLD.documents
+       OR NEW.content_hash IS DISTINCT FROM OLD.content_hash
+       OR NEW.created_by_id IS DISTINCT FROM OLD.created_by_id
+       OR NEW.created_by_name IS DISTINCT FROM OLD.created_by_name
+       OR NEW.created_at IS DISTINCT FROM OLD.created_at THEN
+        RAISE EXCEPTION 'Publishing EOM Terms cannot rewrite draft content';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_protect_eom_terms_version
+    ON eom_terms_versions;
+CREATE TRIGGER trg_protect_eom_terms_version
+    BEFORE UPDATE OR DELETE ON eom_terms_versions
+    FOR EACH ROW EXECUTE FUNCTION protect_eom_terms_version();
+
+DROP TRIGGER IF EXISTS trg_protect_eom_terms_version_truncate
+    ON eom_terms_versions;
+CREATE TRIGGER trg_protect_eom_terms_version_truncate
+    BEFORE TRUNCATE ON eom_terms_versions
+    FOR EACH STATEMENT EXECUTE FUNCTION protect_eom_terms_version();
+
+CREATE OR REPLACE FUNCTION require_published_eom_terms_current_version()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM eom_terms_versions AS version
+        WHERE version.id = NEW.version_id
+          AND version.status = 'published'
+    ) THEN
+        RAISE EXCEPTION 'Current EOM Terms version must be published';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_require_published_eom_terms_current_version
+    ON eom_terms_current_version;
+CREATE TRIGGER trg_require_published_eom_terms_current_version
+    BEFORE INSERT OR UPDATE ON eom_terms_current_version
+    FOR EACH ROW EXECUTE FUNCTION require_published_eom_terms_current_version();
+
+CREATE OR REPLACE FUNCTION prevent_eom_terms_current_removal()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION 'Current EOM Terms authority cannot be removed';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_prevent_eom_terms_current_truncate
+    ON eom_terms_current_version;
+CREATE TRIGGER trg_prevent_eom_terms_current_truncate
+    BEFORE TRUNCATE ON eom_terms_current_version
+    FOR EACH STATEMENT EXECUTE FUNCTION prevent_eom_terms_current_removal();
+
+DROP TRIGGER IF EXISTS trg_prevent_eom_terms_current_delete
+    ON eom_terms_current_version;
+CREATE TRIGGER trg_prevent_eom_terms_current_delete
+    BEFORE DELETE ON eom_terms_current_version
+    FOR EACH ROW EXECUTE FUNCTION prevent_eom_terms_current_removal();
+
+CREATE INDEX IF NOT EXISTS idx_eom_terms_versions_created
+    ON eom_terms_versions (created_at DESC, id DESC);

--- a/atlas_brain/storage/migrations/396_eom_terms_authority.sql
+++ b/atlas_brain/storage/migrations/396_eom_terms_authority.sql
@@ -8,6 +8,13 @@
 -- trigger functions that make published history immutable. Apply this through
 -- the dedicated Terms-authority preflight/apply command, never ordinary Atlas
 -- startup migrations.
+--
+-- Post-deployment rollback: stop the Terms write routes and every consumer
+-- before rolling the application back. Retain the guard-owned tables,
+-- functions, triggers, grants, and migration record as legal/audit history;
+-- do not drop, truncate, delete, or unrecord them. The complete operational
+-- sequence and security-containment exception live in
+-- .agent/runbooks/database.md under "EOM Terms authority migration".
 
 DO $$
 DECLARE

--- a/atlas_brain/storage/migrations/396_eom_terms_authority.sql
+++ b/atlas_brain/storage/migrations/396_eom_terms_authority.sql
@@ -2,11 +2,148 @@
 -- Immutable, bilingual EOM Terms releases. This migration stores no customer
 -- acceptance and seeds no Terms content; later invitation/acceptance slices
 -- reference the published version selected by the singleton pointer.
+--
+-- This is a controlled DBA-only migration. The direct Atlas runtime must be
+-- able to create drafts and publish them, but it must not own the relations or
+-- trigger functions that make published history immutable. Apply this through
+-- the dedicated Terms-authority preflight/apply command, never ordinary Atlas
+-- startup migrations.
 
-CREATE TABLE IF NOT EXISTS eom_terms_versions (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+DO $$
+DECLARE
+    schema_name TEXT := current_schema();
+    executor_is_superuser BOOLEAN;
+    runtime_role_ready BOOLEAN;
+    guard_role_ready BOOLEAN;
+BEGIN
+    SELECT COALESCE(role.rolsuper, FALSE)
+      INTO executor_is_superuser
+      FROM pg_roles AS role
+     WHERE role.rolname = current_user;
+    IF NOT executor_is_superuser THEN
+        RAISE EXCEPTION
+            'database administrator must run 396_eom_terms_authority';
+    END IF;
+
+    SELECT EXISTS (
+        SELECT 1
+          FROM pg_roles AS runtime_role
+         WHERE runtime_role.rolname = 'atlas'
+           AND runtime_role.rolcanlogin
+           AND NOT runtime_role.rolsuper
+           AND NOT runtime_role.rolcreaterole
+           AND NOT runtime_role.rolcreatedb
+           AND NOT runtime_role.rolreplication
+           AND NOT runtime_role.rolbypassrls
+           AND NOT EXISTS (
+               SELECT 1
+                 FROM pg_database AS database
+                WHERE database.datname = current_database()
+                  AND database.datdba = runtime_role.oid
+           )
+           AND NOT EXISTS (
+               SELECT 1
+                 FROM pg_roles AS elevated_role
+                WHERE elevated_role.oid <> runtime_role.oid
+                  AND (
+                      elevated_role.rolsuper
+                      OR elevated_role.rolcreaterole
+                      OR elevated_role.rolcreatedb
+                      OR elevated_role.rolreplication
+                      OR elevated_role.rolbypassrls
+                  )
+                  AND pg_has_role(
+                      runtime_role.oid, elevated_role.oid, 'MEMBER'
+                  )
+           )
+    )
+      INTO runtime_role_ready;
+    IF NOT runtime_role_ready THEN
+        RAISE EXCEPTION
+            'atlas must be an unprivileged login runtime role before running 396_eom_terms_authority';
+    END IF;
+
+    SELECT EXISTS (
+        SELECT 1
+          FROM pg_roles AS guard_role
+         WHERE guard_role.rolname = 'atlas_eom_handoff_owner'
+           AND NOT guard_role.rolcanlogin
+           AND NOT guard_role.rolinherit
+           AND NOT guard_role.rolsuper
+           AND NOT guard_role.rolcreaterole
+           AND NOT guard_role.rolcreatedb
+           AND NOT guard_role.rolreplication
+           AND NOT guard_role.rolbypassrls
+    )
+      INTO guard_role_ready;
+    IF NOT guard_role_ready THEN
+        RAISE EXCEPTION
+            'atlas_eom_handoff_owner must already be the isolated no-login EOM guard role before running 396_eom_terms_authority';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+          FROM pg_stat_activity AS activity
+          JOIN pg_roles AS guard_role
+            ON guard_role.rolname = 'atlas_eom_handoff_owner'
+         WHERE activity.usesysid = guard_role.oid
+           AND activity.datid = (
+               SELECT database.oid
+                 FROM pg_database AS database
+                WHERE database.datname = current_database()
+           )
+    ) THEN
+        RAISE EXCEPTION
+            'atlas_eom_handoff_owner must have no live sessions before running 396_eom_terms_authority';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+          FROM pg_roles AS member_role
+          JOIN pg_roles AS guard_role
+            ON guard_role.rolname = 'atlas_eom_handoff_owner'
+         WHERE member_role.rolcanlogin
+           AND NOT member_role.rolsuper
+           AND pg_has_role(member_role.oid, guard_role.oid, 'MEMBER')
+    ) THEN
+        RAISE EXCEPTION
+            'no non-superuser login may retain membership in atlas_eom_handoff_owner';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+          FROM pg_namespace AS namespace
+         WHERE namespace.nspname = schema_name
+           AND namespace.nspowner = (
+               SELECT oid
+                 FROM pg_roles
+                WHERE rolname = 'atlas_eom_handoff_owner'
+           )
+    ) THEN
+        RAISE EXCEPTION
+            'the EOM funnel schema must already be owned by atlas_eom_handoff_owner; apply the guarded EOM schema boundary before 396_eom_terms_authority';
+    END IF;
+
+    IF to_regclass(format('%I.eom_terms_versions', schema_name)) IS NOT NULL
+       OR to_regclass(format('%I.eom_terms_current_version', schema_name)) IS NOT NULL
+       OR to_regprocedure(format('%I.protect_eom_terms_version()', schema_name))
+            IS NOT NULL
+       OR to_regprocedure(format(
+            '%I.require_published_eom_terms_current_version()', schema_name
+          )) IS NOT NULL
+       OR to_regprocedure(format(
+            '%I.prevent_eom_terms_current_removal()', schema_name
+          )) IS NOT NULL THEN
+        RAISE EXCEPTION
+            'refusing to adopt a pre-existing EOM Terms authority object';
+    END IF;
+END;
+$$;
+
+CREATE TABLE eom_terms_versions (
+    id UUID CONSTRAINT pk_eom_terms_versions PRIMARY KEY DEFAULT gen_random_uuid(),
     business_context_id VARCHAR(64) NOT NULL DEFAULT 'effingham_maids',
-    version_label VARCHAR(64) NOT NULL UNIQUE,
+    version_label VARCHAR(64) NOT NULL,
     status VARCHAR(16) NOT NULL DEFAULT 'draft',
     material_change BOOLEAN NOT NULL,
     documents JSONB NOT NULL,
@@ -17,6 +154,7 @@ CREATE TABLE IF NOT EXISTS eom_terms_versions (
     published_by_id BIGINT,
     published_by_name VARCHAR(128),
     published_at TIMESTAMPTZ,
+    CONSTRAINT uq_eom_terms_version_label UNIQUE (version_label),
     CONSTRAINT ck_eom_terms_context
         CHECK (business_context_id = 'effingham_maids'),
     CONSTRAINT ck_eom_terms_version_label
@@ -43,19 +181,27 @@ CREATE TABLE IF NOT EXISTS eom_terms_versions (
         )
 );
 
-CREATE TABLE IF NOT EXISTS eom_terms_current_version (
-    singleton BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (singleton),
-    version_id UUID NOT NULL UNIQUE
+CREATE TABLE eom_terms_current_version (
+    singleton BOOLEAN NOT NULL DEFAULT TRUE,
+    version_id UUID NOT NULL,
+    selected_by_id BIGINT NOT NULL,
+    selected_by_name VARCHAR(128) NOT NULL,
+    selected_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT pk_eom_terms_current_version PRIMARY KEY (singleton),
+    CONSTRAINT ck_eom_terms_current_singleton CHECK (singleton),
+    CONSTRAINT uq_eom_terms_current_version UNIQUE (version_id),
+    CONSTRAINT fk_eom_terms_current_version
+        FOREIGN KEY (version_id)
         REFERENCES eom_terms_versions(id) ON DELETE RESTRICT,
-    selected_by_id BIGINT NOT NULL CHECK (selected_by_id > 0),
-    selected_by_name VARCHAR(128) NOT NULL
-        CHECK (length(btrim(selected_by_name)) > 0),
-    selected_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    CONSTRAINT ck_eom_terms_current_selector_id CHECK (selected_by_id > 0),
+    CONSTRAINT ck_eom_terms_current_selector_name
+        CHECK (length(btrim(selected_by_name)) > 0)
 );
 
-CREATE OR REPLACE FUNCTION protect_eom_terms_version()
+CREATE FUNCTION protect_eom_terms_version()
 RETURNS TRIGGER
 LANGUAGE plpgsql
+SECURITY INVOKER
 AS $$
 BEGIN
     IF TG_OP = 'TRUNCATE' THEN
@@ -85,21 +231,18 @@ BEGIN
 END;
 $$;
 
-DROP TRIGGER IF EXISTS trg_protect_eom_terms_version
-    ON eom_terms_versions;
 CREATE TRIGGER trg_protect_eom_terms_version
     BEFORE UPDATE OR DELETE ON eom_terms_versions
     FOR EACH ROW EXECUTE FUNCTION protect_eom_terms_version();
 
-DROP TRIGGER IF EXISTS trg_protect_eom_terms_version_truncate
-    ON eom_terms_versions;
 CREATE TRIGGER trg_protect_eom_terms_version_truncate
     BEFORE TRUNCATE ON eom_terms_versions
     FOR EACH STATEMENT EXECUTE FUNCTION protect_eom_terms_version();
 
-CREATE OR REPLACE FUNCTION require_published_eom_terms_current_version()
+CREATE FUNCTION require_published_eom_terms_current_version()
 RETURNS TRIGGER
 LANGUAGE plpgsql
+SECURITY INVOKER
 AS $$
 BEGIN
     IF NOT EXISTS (
@@ -114,32 +257,159 @@ BEGIN
 END;
 $$;
 
-DROP TRIGGER IF EXISTS trg_require_published_eom_terms_current_version
-    ON eom_terms_current_version;
 CREATE TRIGGER trg_require_published_eom_terms_current_version
     BEFORE INSERT OR UPDATE ON eom_terms_current_version
     FOR EACH ROW EXECUTE FUNCTION require_published_eom_terms_current_version();
 
-CREATE OR REPLACE FUNCTION prevent_eom_terms_current_removal()
+CREATE FUNCTION prevent_eom_terms_current_removal()
 RETURNS TRIGGER
 LANGUAGE plpgsql
+SECURITY INVOKER
 AS $$
 BEGIN
     RAISE EXCEPTION 'Current EOM Terms authority cannot be removed';
 END;
 $$;
 
-DROP TRIGGER IF EXISTS trg_prevent_eom_terms_current_truncate
-    ON eom_terms_current_version;
 CREATE TRIGGER trg_prevent_eom_terms_current_truncate
     BEFORE TRUNCATE ON eom_terms_current_version
     FOR EACH STATEMENT EXECUTE FUNCTION prevent_eom_terms_current_removal();
 
-DROP TRIGGER IF EXISTS trg_prevent_eom_terms_current_delete
-    ON eom_terms_current_version;
 CREATE TRIGGER trg_prevent_eom_terms_current_delete
     BEFORE DELETE ON eom_terms_current_version
     FOR EACH ROW EXECUTE FUNCTION prevent_eom_terms_current_removal();
 
-CREATE INDEX IF NOT EXISTS idx_eom_terms_versions_created
+CREATE INDEX idx_eom_terms_versions_created
     ON eom_terms_versions (created_at DESC, id DESC);
+
+DO $$
+DECLARE
+    schema_name TEXT := current_schema();
+    table_name TEXT;
+    function_name TEXT;
+    grantee_name TEXT;
+BEGIN
+    FOREACH function_name IN ARRAY ARRAY[
+        'protect_eom_terms_version',
+        'require_published_eom_terms_current_version',
+        'prevent_eom_terms_current_removal'
+    ]
+    LOOP
+        EXECUTE format(
+            'ALTER FUNCTION %I.%I() RESET ALL', schema_name, function_name
+        );
+        EXECUTE format(
+            'ALTER FUNCTION %I.%I() SET search_path TO pg_catalog, %I, pg_temp',
+            schema_name,
+            function_name,
+            schema_name
+        );
+        EXECUTE format(
+            'ALTER FUNCTION %I.%I() OWNER TO atlas_eom_handoff_owner',
+            schema_name,
+            function_name
+        );
+    END LOOP;
+
+    FOREACH table_name IN ARRAY ARRAY[
+        'eom_terms_versions',
+        'eom_terms_current_version'
+    ]
+    LOOP
+        EXECUTE format(
+            'ALTER TABLE %I.%I OWNER TO atlas_eom_handoff_owner',
+            schema_name,
+            table_name
+        );
+        EXECUTE format(
+            'REVOKE ALL PRIVILEGES ON TABLE %I.%I FROM PUBLIC',
+            schema_name,
+            table_name
+        );
+        FOR grantee_name IN
+            SELECT DISTINCT grantee_role.rolname
+              FROM pg_class AS relation
+              JOIN pg_namespace AS namespace
+                ON namespace.oid = relation.relnamespace
+              CROSS JOIN LATERAL aclexplode(
+                  COALESCE(relation.relacl, ARRAY[]::aclitem[])
+              ) AS acl
+              JOIN pg_roles AS grantee_role ON grantee_role.oid = acl.grantee
+             WHERE namespace.nspname = schema_name
+               AND relation.relname = table_name
+               AND grantee_role.rolname <> 'atlas_eom_handoff_owner'
+        LOOP
+            EXECUTE format(
+                'REVOKE ALL PRIVILEGES ON TABLE %I.%I FROM %I',
+                schema_name,
+                table_name,
+                grantee_name
+            );
+        END LOOP;
+    END LOOP;
+
+    FOREACH function_name IN ARRAY ARRAY[
+        'protect_eom_terms_version',
+        'require_published_eom_terms_current_version',
+        'prevent_eom_terms_current_removal'
+    ]
+    LOOP
+        EXECUTE format(
+            'REVOKE ALL PRIVILEGES ON FUNCTION %I.%I() FROM PUBLIC',
+            schema_name,
+            function_name
+        );
+        FOR grantee_name IN
+            SELECT DISTINCT grantee_role.rolname
+              FROM pg_proc AS protected_function
+              JOIN pg_namespace AS namespace
+                ON namespace.oid = protected_function.pronamespace
+              CROSS JOIN LATERAL aclexplode(
+                  COALESCE(protected_function.proacl, ARRAY[]::aclitem[])
+              ) AS acl
+              JOIN pg_roles AS grantee_role ON grantee_role.oid = acl.grantee
+             WHERE namespace.nspname = schema_name
+               AND protected_function.proname = function_name
+               AND protected_function.pronargs = 0
+               AND grantee_role.rolname <> 'atlas_eom_handoff_owner'
+        LOOP
+            EXECUTE format(
+                'REVOKE ALL PRIVILEGES ON FUNCTION %I.%I() FROM %I',
+                schema_name,
+                function_name,
+                grantee_name
+            );
+        END LOOP;
+    END LOOP;
+
+    EXECUTE format(
+        'GRANT SELECT ON TABLE %I.eom_terms_versions TO atlas',
+        schema_name
+    );
+    EXECUTE format(
+        'GRANT INSERT (id, version_label, material_change, documents, '
+        || 'content_hash, created_by_id, created_by_name) '
+        || 'ON TABLE %I.eom_terms_versions TO atlas',
+        schema_name
+    );
+    EXECUTE format(
+        'GRANT UPDATE (status, published_by_id, published_by_name, published_at) '
+        || 'ON TABLE %I.eom_terms_versions TO atlas',
+        schema_name
+    );
+    EXECUTE format(
+        'GRANT SELECT ON TABLE %I.eom_terms_current_version TO atlas',
+        schema_name
+    );
+    EXECUTE format(
+        'GRANT INSERT (singleton, version_id, selected_by_id, selected_by_name) '
+        || 'ON TABLE %I.eom_terms_current_version TO atlas',
+        schema_name
+    );
+    EXECUTE format(
+        'GRANT UPDATE (version_id, selected_by_id, selected_by_name, selected_at) '
+        || 'ON TABLE %I.eom_terms_current_version TO atlas',
+        schema_name
+    );
+END;
+$$;

--- a/atlas_brain/storage/migrations/__init__.py
+++ b/atlas_brain/storage/migrations/__init__.py
@@ -24,6 +24,7 @@ CONTROLLED_DBA_MIGRATION_NAMES = frozenset(
     {
         "393_eom_missed_call_recovery_runtime_privileges",
         "394_eom_first_clean_completion_receipts",
+        "396_eom_terms_authority",
     }
 )
 

--- a/ops
+++ b/ops
@@ -53,6 +53,9 @@ DATABASE_INSPECTIONS = {
         "FROM public.schema_migrations"
     ),
 }
+CONTROLLED_DATABASE_OPERATIONS = {
+    "eom-terms-authority": "apply_eom_terms_authority_schema.py",
+}
 TEST_DATABASE_URL_KEYS = (
     "ATLAS_MIGRATION_TEST_DATABASE_URL",
     "ATLAS_RECEIVABLES_TEST_DATABASE_URL",
@@ -352,6 +355,30 @@ def run_database_inspection(
     return exec_command(command, env=env)
 
 
+def run_controlled_database_operation(name: str, mode: str) -> int:
+    """Dispatch one allowlisted preflight/apply script from a real worktree."""
+
+    script_name = CONTROLLED_DATABASE_OPERATIONS.get(name)
+    if script_name is None:
+        raise OpsError(f"unknown controlled database operation: {name}")
+    if mode not in ("preflight", "apply"):
+        raise OpsError(f"usage: ./ops db controlled {name} {{preflight|apply}}")
+    root = worktree_root()
+    if root is None:
+        raise OpsError(
+            "controlled database operations require a normal worktree, "
+            "not the shared/bare root"
+        )
+    command = [
+        str(python_command()),
+        str(root / "scripts" / script_name),
+        "--json",
+    ]
+    if mode == "apply":
+        command.append("--apply")
+    return exec_command(command, cwd=root)
+
+
 def database_probe() -> tuple[str, str]:
     try:
         result = run_database_inspection("connectivity", capture=True)
@@ -532,7 +559,9 @@ def env_command(args: list[str]) -> int:
 
 def db_command(args: list[str]) -> int:
     if not args:
-        raise OpsError("usage: ./ops db {status|inspect NAME|migrations}")
+        raise OpsError(
+            "usage: ./ops db {status|inspect NAME|migrations|controlled NAME MODE}"
+        )
     action = args[0]
     if action == "status":
         state, detail = database_probe()
@@ -548,9 +577,17 @@ def db_command(args: list[str]) -> int:
         result = run_database_inspection("migrations")
         assert isinstance(result, int)
         return result
+    if action == "controlled":
+        if len(args) != 3:
+            raise OpsError(
+                "usage: ./ops db controlled eom-terms-authority {preflight|apply}"
+            )
+        return run_controlled_database_operation(args[1], args[2])
     if action in ("query", "write", "migrate", "rollback", "drop"):
         raise OpsError("arbitrary SQL and mutating database operations are intentionally not exposed by ./ops")
-    raise OpsError("usage: ./ops db {status|inspect NAME|migrations}")
+    raise OpsError(
+        "usage: ./ops db {status|inspect NAME|migrations|controlled NAME MODE}"
+    )
 
 
 def container_status() -> None:
@@ -863,6 +900,9 @@ Read-only discovery and inspection:
   logs {brain|container NAME|frontend [--since 1h] [--limit N] [--follow]}
   ci {status [LIMIT]|run RUN_ID [--log-failed]}
 
+Guarded database changes:
+  db controlled eom-terms-authority {preflight|apply}
+
 Local/test execution:
   test unit  # GitHub-only; prints the canonical hosted gate and exits
   test focused <pytest target/args...>
@@ -870,8 +910,9 @@ Local/test execution:
   test frontend PACKAGE [SCRIPT]
   test local-review
 
-Production deploys, database writes, migrations, and restarts are intentionally
-not exposed. Read .agent/runbooks/ before performing them manually.
+Other production deploys, database writes, migrations, and restarts are
+intentionally not exposed. Read .agent/runbooks/ before using the one guarded
+controlled-migration operation above or performing another change manually.
 """
     )
 

--- a/plans/PR-EOM-Terms-Authority.md
+++ b/plans/PR-EOM-Terms-Authority.md
@@ -1,0 +1,190 @@
+# PR-EOM-Terms-Authority
+
+## Why this slice exists
+
+Issue #2156 and the operator's current-session decisions require Terms to be a
+universal, versioned customer obligation that is independent from the existing
+welcome/profile onboarding token and from the later recurring-residential card
+flow. Atlas currently has no canonical Terms document/version authority, so a
+consumer cannot name the exact English/Spanish residential/commercial snapshot
+that was reviewed, published, or later accepted.
+
+This is the first provider slice of the accepted onboarding-separation arc. It
+adds only the private Atlas authority needed to author, review, publish, and
+read an exact Terms version. Invitations, acceptance records, readiness,
+Tracker/Website consumers, first-clean money state, and Stripe remain later
+vertical slices. The source PDFs were inspected directly; their refined
+bilingual copy is deliberately not seeded or published by this PR.
+
+Diff-budget override: the schema guard, immutable publication service, private
+HTTP boundary, and focused adversarial proof form one provider contract;
+splitting them would merge either unreachable storage or an unguarded
+legal-version API.
+
+### Problem-derived contract
+
+- Root cause: the code treats onboarding drafts/tokens as customer-handoff
+  state, but no immutable, audience-specific, bilingual Terms version exists.
+  Without that authority, later invitations and acceptances could only point to
+  mutable prose or an ambiguous "current terms" claim.
+- Correct fix must touch/change: add a guarded Atlas migration for immutable
+  published versions plus the singleton current-version pointer; add one
+  service that validates the closed four-document bundle, hashes it
+  canonically, creates/replays drafts, publishes/replays versions under a
+  serialized transaction, and reads the current version; expose those actions
+  through authenticated, actor-attributed private funnel routes; add focused
+  model/service/route/migration tests.
+- Must not change: no welcome draft, existing public-onboarding token, email,
+  Customer/Site handoff, first-clean completion/candidate, payment, Stripe,
+  calendar, Tracker, Website, employee timekeeping, commercial billing, or
+  deployed Terms content behavior changes. No Terms row is seeded and no
+  customer-facing content is published by deployment.
+
+## Scope (this PR)
+
+Ownership lane: eom-onboarding-terms
+Slice phase: Terms authority
+
+1. Persist draft/published Terms versions containing exactly residential and
+   commercial documents in English and Spanish, each with Terms body, Services
+   We Cannot Provide body, and the separate additional-work acknowledgment.
+2. Canonically hash the complete bundle, make published versions immutable,
+   and serialize publication through one current-version pointer.
+3. Add authenticated private create, publish, and current-version endpoints
+   with actor evidence and idempotent unchanged retries.
+4. Prove the real FastAPI entrypoint returns the stored draft/current snapshot
+   and rejects malformed, conflicting, missing-schema, malformed stored, and
+   non-current replay inputs.
+
+### Review Contract
+
+- Acceptance criteria:
+  - `tests/test_eom_terms_authority.py` proves only the exact
+    residential/commercial x en/es bundle reaches storage; missing, extra,
+    blank, oversized, and surrogate-bearing fields fail before a write.
+  - `EOMTermsAuthority.create_draft` returns the existing row only when the
+    normalized payload hash and material-change flag match; the same label with
+    different content returns a conflict.
+  - `EOMTermsAuthority.publish` locks the target/current state, permits only a
+    draft or the already-current published version, and an unchanged retry
+    returns the same version without another state transition.
+  - migration 396 prevents UPDATE/DELETE of a published version and prevents
+    the current pointer from referencing a draft or being removed.
+  - route tests exercise `POST /api/v1/eom-funnel/terms/versions`,
+    `POST /api/v1/eom-funnel/terms/versions/{id}/publish`, and
+    `GET /api/v1/eom-funnel/terms/current` through the real router with service
+    authentication and actor attribution.
+  - the diff contains no seed INSERT and touches no existing onboarding,
+    completion, money, calendar, or delivery implementation.
+- Reachability proof: the mounted EOM FastAPI router is called by an ASGI client;
+  the observable effects are a closed draft response, a published/current
+  response, and stable API errors for rejected boundaries.
+- Affected surfaces: migration chain, new Terms authority service, private EOM
+  funnel API models/dependency/routes, focused tests.
+- Risk areas: mutable published content, ambiguous document bundles, hash
+  instability, duplicate labels, concurrent publication, missing schema,
+  authorization/actor omission, accidental customer-visible publication.
+- Reviewer rules triggered: R1, R2, R3, R4, R6, R7, R9, R10, R11, R14.
+
+### Boundary-change enumeration
+
+- Boundary path/seam: private authenticated Terms draft creation, publication,
+  and current-version read.
+- Replaced-path behaviors: none; this is additive and existing onboarding paths
+  remain authoritative for their current profile/handoff behavior.
+- Guard-relevant fields: versionLabel, materialChange, residential/commercial,
+  en/es, terms, servicesWeCannotProvide,
+  additionalWorkAcknowledgement, actor id/name, version UUID.
+- Caller x input shape: Tracker/private service bearer plus actor headers x one
+  exact four-document JSON bundle; private bearer without actor is admitted
+  only for the read route.
+
+### Deployed-config probing
+
+- Deployed/default config values: existing EOM funnel API service bearer only;
+  no new environment value or fallback.
+- Explicit value probe: authenticated create/publish/current route tests.
+- Absent value probe: missing service bearer and missing actor tests retain the
+  existing fail-closed dependencies.
+- Default-session/default-context probe: every row is fixed to
+  `effingham_maids`; no caller-supplied tenant is accepted.
+- Side-effect ordering: validation and canonical hashing precede the
+  transaction; publication changes the version to published before updating
+  the locked current pointer; neither route sends mail or calls a provider.
+
+### Files touched
+
+- `atlas_brain/eom_api/funnel.py`
+- `atlas_brain/services/eom_terms_authority.py`
+- `atlas_brain/storage/migrations/396_eom_terms_authority.sql`
+- `plans/PR-EOM-Terms-Authority.md`
+- `tests/test_eom_terms_authority.py`
+
+## Mechanism
+
+Migration 396 stores the complete closed document bundle as JSONB beside a
+canonical SHA-256 hash and actor evidence. Draft rows may transition once to
+published; a trigger then makes them append-only. A singleton pointer selects
+the current published version without rewriting history. The service owns all
+normalization, replay, conflict, and transaction behavior. The funnel routes
+only validate/reproject the private HTTP contract and map typed service errors.
+
+## Intentional
+
+- The source PDFs are evidence for later copy authoring, not seed data. Exact
+  refined English and Spanish copy still requires operator approval.
+- No IP address, device fingerprint, invitation token, signature, acceptance,
+  readiness, email, or card state is added in this authority-only slice.
+- Every published version is retained. Publishing a new version moves only the
+  current pointer; it does not mutate the prior published row.
+- The bundle is one version across both audiences and both languages so a
+  single version/hash identifies the complete approved release.
+
+## Deferred
+
+- EOM Terms invitations, acceptances, executed-copy delivery, material-version
+  readiness, and manual-existing-customer invitations: next Atlas Terms slice.
+- Tracker proxy, Website Onboarding tab/public bilingual acceptance page, and
+  admin readiness UI: subsequent consumer slices.
+- Structured one-time/recurring service plan, exact first-clean balance/payment
+  allocation, and recurring-residential Stripe SetupIntent: later accepted
+  slices in issue #2156.
+- Exact refined bilingual Terms publication: blocked on operator approval of
+  the complete customer-visible copy.
+
+Parking predicate: findings that require invitations, delivery, public-page,
+payment, Stripe, or another new mechanism are parked into their accepted
+follow-up slice unless they prove this authority stores or publishes false
+state.
+
+Parked hardening: none.
+
+## Verification
+
+- PASS: `./ops test focused tests/test_eom_terms_authority.py -q` (27 passed).
+- PASS: `./ops test focused tests/test_migrations_runner.py -q` (117 passed,
+  1 environment-gated test skipped).
+- PASS: adjacent `tests/test_eom_public_onboarding.py` (41 passed) and
+  `tests/test_eom_first_clean_completion.py` (14 passed, 74 disposable-DB tests
+  skipped by focused-mode credential isolation).
+- PASS: targeted Ruff lint/format and Python compilation for changed Python.
+- PASS: migration 396 and the authority service were exercised against an
+  isolated PostgreSQL 16 container. Draft/replay/publish/current succeeded;
+  published edits, publish-time content rewrites, draft pointer selection, and
+  current-pointer deletion/truncation failed; disabling either a row or
+  statement integrity trigger made schema readiness fail. The throwaway
+  container was then removed.
+- Pending before push: plan sync, diff check, and `scripts/push_pr.sh` mechanical
+  local review bundle.
+- Hosted full Unit Gate remains GitHub-only under `.agent/capabilities.yaml`.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `atlas_brain/eom_api/funnel.py` | 144 |
+| `atlas_brain/services/eom_terms_authority.py` | 467 |
+| `atlas_brain/storage/migrations/396_eom_terms_authority.sql` | 145 |
+| `plans/PR-EOM-Terms-Authority.md` | 190 |
+| `tests/test_eom_terms_authority.py` | 541 |
+| **Total** | **1487** |

--- a/plans/PR-EOM-Terms-Authority.md
+++ b/plans/PR-EOM-Terms-Authority.md
@@ -43,7 +43,7 @@ legal-version API.
 ## Scope (this PR)
 
 Ownership lane: eom-onboarding-terms
-Slice phase: Terms authority
+Slice phase: Vertical slice
 
 1. Persist draft/published Terms versions containing exactly residential and
    commercial documents in English and Spanish, each with Terms body, Services

--- a/plans/PR-EOM-Terms-Authority.md
+++ b/plans/PR-EOM-Terms-Authority.md
@@ -49,6 +49,7 @@ legal-version API.
 
 Ownership lane: eom-onboarding-terms
 Slice phase: Vertical slice
+Max files: 12
 
 1. Persist draft/published Terms versions containing exactly residential and
    commercial documents in English and Spanish, each with Terms body, Services
@@ -238,10 +239,10 @@ Parked hardening: none.
 | `atlas_brain/services/eom_terms_authority.py` | 949 |
 | `atlas_brain/storage/migrations/396_eom_terms_authority.sql` | 415 |
 | `atlas_brain/storage/migrations/__init__.py` | 1 |
-| `plans/PR-EOM-Terms-Authority.md` | 247 |
+| `plans/PR-EOM-Terms-Authority.md` | 248 |
 | `scripts/apply_eom_first_clean_completion_schema.py` | 55 |
 | `scripts/apply_eom_terms_authority_schema.py` | 42 |
 | `tests/test_eom_first_clean_completion_dba_runner.py` | 44 |
 | `tests/test_eom_terms_authority.py` | 1007 |
 | `tests/test_migrations_runner.py` | 3 |
-| **Total** | **2917** |
+| **Total** | **2918** |

--- a/plans/PR-EOM-Terms-Authority.md
+++ b/plans/PR-EOM-Terms-Authority.md
@@ -273,4 +273,4 @@ Parked hardening: none.
 | `tests/test_eom_first_clean_completion_dba_runner.py` | 44 |
 | `tests/test_eom_terms_authority.py` | 1053 |
 | `tests/test_migrations_runner.py` | 3 |
-| **Total** | **3205** |
+| **Total** | **3206** |

--- a/plans/PR-EOM-Terms-Authority.md
+++ b/plans/PR-EOM-Terms-Authority.md
@@ -155,11 +155,18 @@ Slice phase: Vertical slice
 
 ### Files touched
 
+- `.github/workflows/atlas_eom_lead_pipeline_checks.yml`
 - `atlas_brain/eom_api/funnel.py`
+- `atlas_brain/main_eom.py`
 - `atlas_brain/services/eom_terms_authority.py`
 - `atlas_brain/storage/migrations/396_eom_terms_authority.sql`
+- `atlas_brain/storage/migrations/__init__.py`
 - `plans/PR-EOM-Terms-Authority.md`
+- `scripts/apply_eom_first_clean_completion_schema.py`
+- `scripts/apply_eom_terms_authority_schema.py`
+- `tests/test_eom_first_clean_completion_dba_runner.py`
 - `tests/test_eom_terms_authority.py`
+- `tests/test_migrations_runner.py`
 
 ## Mechanism
 
@@ -231,10 +238,10 @@ Parked hardening: none.
 | `atlas_brain/services/eom_terms_authority.py` | 949 |
 | `atlas_brain/storage/migrations/396_eom_terms_authority.sql` | 415 |
 | `atlas_brain/storage/migrations/__init__.py` | 1 |
-| `plans/PR-EOM-Terms-Authority.md` | 238 |
+| `plans/PR-EOM-Terms-Authority.md` | 247 |
 | `scripts/apply_eom_first_clean_completion_schema.py` | 55 |
 | `scripts/apply_eom_terms_authority_schema.py` | 42 |
 | `tests/test_eom_first_clean_completion_dba_runner.py` | 44 |
-| `tests/test_eom_terms_authority.py` | 947 |
+| `tests/test_eom_terms_authority.py` | 1007 |
 | `tests/test_migrations_runner.py` | 3 |
-| **Total** | **2848** |
+| **Total** | **2917** |

--- a/plans/PR-EOM-Terms-Authority.md
+++ b/plans/PR-EOM-Terms-Authority.md
@@ -36,9 +36,12 @@ legal-version API.
   search path, constraints, and runtime privilege shape; add one service that
   validates the closed four-document bundle, hashes it canonically,
   creates/replays drafts, publishes/replays versions under the execution model
-  below, and reads the current version; bind the private routes to the slim EOM
-  funnel pool; add real-entrypoint and disposable-PostgreSQL tests enrolled in
-  the EOM workflow, plus focused validator/route coverage.
+  below using one post-lock timestamp, and reads the current version; bind the
+  private routes to the slim EOM funnel pool; expose the controlled migration
+  through one allowlisted `./ops` preflight/apply operation with capability and
+  rollback documentation; add real-entrypoint and disposable-PostgreSQL tests
+  enrolled in the EOM workflow, plus focused validator/route/operations
+  coverage.
 - Must not change: no welcome draft, existing public-onboarding token, email,
   Customer/Site handoff, first-clean completion/candidate, payment, Stripe,
   calendar, Tracker, Website, employee timekeeping, commercial billing, or
@@ -49,7 +52,7 @@ legal-version API.
 
 Ownership lane: eom-onboarding-terms
 Slice phase: Vertical slice
-Max files: 12
+Max files: 16
 
 1. Persist draft/published Terms versions containing exactly residential and
    commercial documents in English and Spanish, each with Terms body, Services
@@ -61,6 +64,8 @@ Max files: 12
 4. Prove the real FastAPI entrypoint returns the stored draft/current snapshot
    and rejects malformed, conflicting, missing-schema, malformed stored, and
    non-current replay inputs.
+5. Make the controlled migration discoverable and safely operable through the
+   repository's canonical `./ops` surface, including retention-first rollback.
 
 ### Review Contract
 
@@ -73,7 +78,9 @@ Max files: 12
     different content returns a conflict.
   - `EOMTermsAuthority.publish` locks the target/current state, permits only a
     draft or the already-current published version, and an unchanged retry
-    returns the same version without another state transition.
+    returns the same version without another state transition. A wall-clock
+    timestamp captured after the advisory lock is used for both the immutable
+    publication row and current-pointer selection.
   - controlled migration 396 leaves both relations and all three guard
     functions owned by `atlas_eom_handoff_owner`; the direct `atlas` login has
     only table SELECT plus the exact column INSERT/UPDATE privileges the
@@ -90,16 +97,22 @@ Max files: 12
   - a disposable-PostgreSQL test runs the actual migration as DBA and the
     service as the direct unprivileged `atlas` login, including concurrency,
     rollback, trigger, ownership, and ACL probes.
+  - `./ops db controlled eom-terms-authority preflight|apply` dispatches only
+    the pinned migration-396 runner from a normal worktree; the capability map
+    and database runbook name the same commands and require retained history on
+    application rollback.
   - the diff contains no seed INSERT and touches no existing onboarding,
     completion, money, calendar, or delivery implementation.
 - Reachability proof: the mounted EOM FastAPI router is called by an ASGI client;
   the observable effects are a closed draft response, a published/current
   response, and stable API errors for rejected boundaries.
 - Affected surfaces: migration chain, new Terms authority service, private EOM
-  funnel API models/dependency/routes, focused tests.
+  funnel API models/dependency/routes, guarded operations contract, focused
+  tests.
 - Risk areas: mutable published content, ambiguous document bundles, hash
-  instability, duplicate labels, concurrent publication, missing schema,
-  authorization/actor omission, accidental customer-visible publication.
+  instability, duplicate labels, concurrent publication/timestamp ordering,
+  missing schema, operational apply/rollback ambiguity, authorization/actor
+  omission, accidental customer-visible publication.
 - Reviewer rules triggered: R1, R2, R3, R4, R6, R7, R8, R9, R10, R11, R14.
 
 ### Publication execution model
@@ -111,12 +124,14 @@ Max files: 12
   by every Terms publication; correctness does not depend on a weaker
   isolation level.
 - While holding that lock, the service row-locks the target version, reads the
-  singleton pointer, performs at most one content-preserving draft-to-published
-  transition, and then selects that version as current. Commit is the
-  linearization point for this service path. Its invariant is: the singleton
-  points to the last lock-ordered authority publication; every earlier
-  published row remains immutable history; an authority publish cannot commit
-  its version transition without its pointer update.
+  wall clock once, row-locks the target version, reads the singleton pointer,
+  performs at most one content-preserving draft-to-published transition, and
+  then selects that version as current with that same timestamp. Commit is the
+  linearization point for this service path. Its invariant is: publication and
+  selection timestamps follow lock order, the singleton points to the last
+  lock-ordered authority publication, every earlier published row remains
+  immutable history, and an authority publish cannot commit its version
+  transition without its pointer update.
 - Duplicate requests for the current published version replay without a write.
   A late retry for a published version already superseded by another committed
   publication conflicts rather than rewinding the pointer. Distinct concurrent
@@ -156,16 +171,20 @@ Max files: 12
 
 ### Files touched
 
+- `.agent/capabilities.yaml`
+- `.agent/runbooks/database.md`
 - `.github/workflows/atlas_eom_lead_pipeline_checks.yml`
 - `atlas_brain/eom_api/funnel.py`
 - `atlas_brain/main_eom.py`
 - `atlas_brain/services/eom_terms_authority.py`
 - `atlas_brain/storage/migrations/396_eom_terms_authority.sql`
 - `atlas_brain/storage/migrations/__init__.py`
+- `ops`
 - `plans/PR-EOM-Terms-Authority.md`
 - `scripts/apply_eom_first_clean_completion_schema.py`
 - `scripts/apply_eom_terms_authority_schema.py`
 - `tests/test_eom_first_clean_completion_dba_runner.py`
+- `tests/test_agent_operations_contract.py`
 - `tests/test_eom_terms_authority.py`
 - `tests/test_migrations_runner.py`
 
@@ -174,9 +193,12 @@ Max files: 12
 Migration 396 stores the complete closed document bundle as JSONB beside a
 canonical SHA-256 hash and actor evidence. Draft rows may transition once to
 published; a trigger then makes them append-only. A singleton pointer selects
-the current published version without rewriting history. The service owns all
+the current published version without rewriting history, using the same
+post-lock wall-clock timestamp as the publication. The service owns all
 normalization, replay, conflict, and transaction behavior. The funnel routes
 only validate/reproject the private HTTP contract and map typed service errors.
+The canonical `./ops` command exposes only the dedicated migration-396
+preflight/apply wrapper and points operators to the retention-first runbook.
 
 ## Intentional
 
@@ -186,6 +208,8 @@ only validate/reproject the private HTTP contract and map typed service errors.
   readiness, email, or card state is added in this authority-only slice.
 - Every published version is retained. Publishing a new version moves only the
   current pointer; it does not mutate the prior published row.
+- Application rollback retains the migration, guarded objects, runtime grants,
+  and every stored version; destructive schema rollback is forbidden.
 - The bundle is one version across both audiences and both languages so a
   single version/hash identifies the complete approved release.
 
@@ -210,8 +234,8 @@ Parked hardening: none.
 
 ## Verification
 
-- PASS: focused Terms suite without disposable credentials (28 passed, 1
-  environment-gated test skipped).
+- PASS: current focused Terms plus guarded-operations contract probes (31
+  passed, 1 environment-gated test skipped).
 - PASS: the same Terms suite against isolated PostgreSQL 16 (29 passed; no
   skip), controlled DBA-runner suite (21 passed), and migration-runner suite
   (117 passed, 1 unrelated environment-gated test skipped).
@@ -225,24 +249,28 @@ Parked hardening: none.
   retry conflict; rollback after the version transition but before pointer
   selection; DBA trigger execution; and readiness failure while a trigger is
   disabled.
-- Pending before push: clean-tree `./ops test local-review`, mechanical push,
-  hosted reconciliation, and resolution of the four review threads.
+- Pending for this review follow-up: clean-tree `./ops test local-review`,
+  mechanical push, current-head hosted checks, and review reconciliation.
 - Hosted full Unit Gate remains GitHub-only under `.agent/capabilities.yaml`.
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
+| `.agent/capabilities.yaml` | 15 |
+| `.agent/runbooks/database.md` | 67 |
 | `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 9 |
 | `atlas_brain/eom_api/funnel.py` | 144 |
 | `atlas_brain/main_eom.py` | 1 |
-| `atlas_brain/services/eom_terms_authority.py` | 949 |
-| `atlas_brain/storage/migrations/396_eom_terms_authority.sql` | 415 |
+| `atlas_brain/services/eom_terms_authority.py` | 953 |
+| `atlas_brain/storage/migrations/396_eom_terms_authority.sql` | 422 |
 | `atlas_brain/storage/migrations/__init__.py` | 1 |
-| `plans/PR-EOM-Terms-Authority.md` | 248 |
+| `ops` | 49 |
+| `plans/PR-EOM-Terms-Authority.md` | 276 |
 | `scripts/apply_eom_first_clean_completion_schema.py` | 55 |
 | `scripts/apply_eom_terms_authority_schema.py` | 42 |
+| `tests/test_agent_operations_contract.py` | 71 |
 | `tests/test_eom_first_clean_completion_dba_runner.py` | 44 |
-| `tests/test_eom_terms_authority.py` | 1007 |
+| `tests/test_eom_terms_authority.py` | 1053 |
 | `tests/test_migrations_runner.py` | 3 |
-| **Total** | **2918** |
+| **Total** | **3205** |

--- a/plans/PR-EOM-Terms-Authority.md
+++ b/plans/PR-EOM-Terms-Authority.md
@@ -25,15 +25,20 @@ legal-version API.
 
 - Root cause: the code treats onboarding drafts/tokens as customer-handoff
   state, but no immutable, audience-specific, bilingual Terms version exists.
-  Without that authority, later invitations and acceptances could only point to
-  mutable prose or an ambiguous "current terms" claim.
-- Correct fix must touch/change: add a guarded Atlas migration for immutable
-  published versions plus the singleton current-version pointer; add one
-  service that validates the closed four-document bundle, hashes it
-  canonically, creates/replays drafts, publishes/replays versions under a
-  serialized transaction, and reads the current version; expose those actions
-  through authenticated, actor-attributed private funnel routes; add focused
-  model/service/route/migration tests.
+  A version owned by the mutable application role would not be immutable, and a
+  route bound to the global Atlas pool would not be canonical when the slim EOM
+  funnel uses its dedicated database. Without one guarded authority on that
+  exact database, later acceptances could point to mutable prose or an
+  ambiguous "current terms" claim.
+- Correct fix must touch/change: add a controlled-DBA Atlas migration that binds
+  the version tables/functions to the existing no-login EOM guard owner and
+  grants the runtime only required DML; attest ownership, trigger identity,
+  search path, constraints, and runtime privilege shape; add one service that
+  validates the closed four-document bundle, hashes it canonically,
+  creates/replays drafts, publishes/replays versions under the execution model
+  below, and reads the current version; bind the private routes to the slim EOM
+  funnel pool; add real-entrypoint and disposable-PostgreSQL tests enrolled in
+  the EOM workflow, plus focused validator/route coverage.
 - Must not change: no welcome draft, existing public-onboarding token, email,
   Customer/Site handoff, first-clean completion/candidate, payment, Stripe,
   calendar, Tracker, Website, employee timekeeping, commercial billing, or
@@ -68,12 +73,22 @@ Slice phase: Vertical slice
   - `EOMTermsAuthority.publish` locks the target/current state, permits only a
     draft or the already-current published version, and an unchanged retry
     returns the same version without another state transition.
+  - controlled migration 396 leaves both relations and all three guard
+    functions owned by `atlas_eom_handoff_owner`; the direct `atlas` login has
+    only table SELECT plus the exact column INSERT/UPDATE privileges the
+    service needs.
   - migration 396 prevents UPDATE/DELETE of a published version and prevents
-    the current pointer from referencing a draft or being removed.
+    the current pointer from referencing a draft or being removed; runtime SQL
+    cannot disable or replace those guard-owned triggers/functions.
   - route tests exercise `POST /api/v1/eom-funnel/terms/versions`,
     `POST /api/v1/eom-funnel/terms/versions/{id}/publish`, and
     `GET /api/v1/eom-funnel/terms/current` through the real router with service
     authentication and actor attribution.
+  - the slim `main_eom` app binds the Terms dependency to
+    `get_eom_funnel_db_pool`; a real entrypoint test pins that wiring.
+  - a disposable-PostgreSQL test runs the actual migration as DBA and the
+    service as the direct unprivileged `atlas` login, including concurrency,
+    rollback, trigger, ownership, and ACL probes.
   - the diff contains no seed INSERT and touches no existing onboarding,
     completion, money, calendar, or delivery implementation.
 - Reachability proof: the mounted EOM FastAPI router is called by an ASGI client;
@@ -84,7 +99,33 @@ Slice phase: Vertical slice
 - Risk areas: mutable published content, ambiguous document bundles, hash
   instability, duplicate labels, concurrent publication, missing schema,
   authorization/actor omission, accidental customer-visible publication.
-- Reviewer rules triggered: R1, R2, R3, R4, R6, R7, R9, R10, R11, R14.
+- Reviewer rules triggered: R1, R2, R3, R4, R6, R7, R8, R9, R10, R11, R14.
+
+### Publication execution model
+
+- PostgreSQL is the closed execution surface. Draft creation linearizes on the
+  unique version-label constraint. Publication runs in one database transaction
+  at the connection's configured isolation level (the service does not
+  override it) and first acquires one transaction-scoped advisory lock shared
+  by every Terms publication; correctness does not depend on a weaker
+  isolation level.
+- While holding that lock, the service row-locks the target version, reads the
+  singleton pointer, performs at most one content-preserving draft-to-published
+  transition, and then selects that version as current. Commit is the
+  linearization point for this service path. Its invariant is: the singleton
+  points to the last lock-ordered authority publication; every earlier
+  published row remains immutable history; an authority publish cannot commit
+  its version transition without its pointer update.
+- Duplicate requests for the current published version replay without a write.
+  A late retry for a published version already superseded by another committed
+  publication conflicts rather than rewinding the pointer. Distinct concurrent
+  publications serialize; both may remain published history and the one whose
+  lock-ordered transaction commits last is current.
+- Validation failures happen before the transaction. Database errors,
+  cancellation, process death, or connection loss before COMMIT release the
+  transaction-scoped lock and roll back both version and pointer changes. A
+  response lost after COMMIT is safe to retry under the replay/conflict rules
+  above. There is no lease, expiry, background worker, or cross-database write.
 
 ### Boundary-change enumeration
 
@@ -161,30 +202,39 @@ Parked hardening: none.
 
 ## Verification
 
-- PASS: `./ops test focused tests/test_eom_terms_authority.py -q` (27 passed).
-- PASS: `./ops test focused tests/test_migrations_runner.py -q` (117 passed,
-  1 environment-gated test skipped).
-- PASS: adjacent `tests/test_eom_public_onboarding.py` (41 passed) and
-  `tests/test_eom_first_clean_completion.py` (14 passed, 74 disposable-DB tests
-  skipped by focused-mode credential isolation).
-- PASS: targeted Ruff lint/format and Python compilation for changed Python.
-- PASS: migration 396 and the authority service were exercised against an
-  isolated PostgreSQL 16 container. Draft/replay/publish/current succeeded;
-  published edits, publish-time content rewrites, draft pointer selection, and
-  current-pointer deletion/truncation failed; disabling either a row or
-  statement integrity trigger made schema readiness fail. The throwaway
-  container was then removed.
-- Pending before push: plan sync, diff check, and `scripts/push_pr.sh` mechanical
-  local review bundle.
+- PASS: focused Terms suite without disposable credentials (28 passed, 1
+  environment-gated test skipped).
+- PASS: the same Terms suite against isolated PostgreSQL 16 (29 passed; no
+  skip), controlled DBA-runner suite (21 passed), and migration-runner suite
+  (117 passed, 1 unrelated environment-gated test skipped).
+- PASS: adjacent EOM render-profile and capability-manifest suites (76 passed).
+- PASS: targeted Ruff lint, canonical formatting for the new/rewritten Python,
+  Python compilation, and `git diff --check`.
+- PASS: the real database proof applies migration 396 as DBA and calls the
+  service as direct unprivileged `atlas`. It covers owner/ACL/function
+  attestation; runtime trigger-replacement denial; immutable updates; draft
+  pointer rejection; duplicate and distinct concurrent publications; stale
+  retry conflict; rollback after the version transition but before pointer
+  selection; DBA trigger execution; and readiness failure while a trigger is
+  disabled.
+- Pending before push: clean-tree `./ops test local-review`, mechanical push,
+  hosted reconciliation, and resolution of the four review threads.
 - Hosted full Unit Gate remains GitHub-only under `.agent/capabilities.yaml`.
 
 ## Estimated diff size
 
 | File | LOC |
 |---|---:|
+| `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 9 |
 | `atlas_brain/eom_api/funnel.py` | 144 |
-| `atlas_brain/services/eom_terms_authority.py` | 467 |
-| `atlas_brain/storage/migrations/396_eom_terms_authority.sql` | 145 |
-| `plans/PR-EOM-Terms-Authority.md` | 190 |
-| `tests/test_eom_terms_authority.py` | 541 |
-| **Total** | **1487** |
+| `atlas_brain/main_eom.py` | 1 |
+| `atlas_brain/services/eom_terms_authority.py` | 949 |
+| `atlas_brain/storage/migrations/396_eom_terms_authority.sql` | 415 |
+| `atlas_brain/storage/migrations/__init__.py` | 1 |
+| `plans/PR-EOM-Terms-Authority.md` | 238 |
+| `scripts/apply_eom_first_clean_completion_schema.py` | 55 |
+| `scripts/apply_eom_terms_authority_schema.py` | 42 |
+| `tests/test_eom_first_clean_completion_dba_runner.py` | 44 |
+| `tests/test_eom_terms_authority.py` | 947 |
+| `tests/test_migrations_runner.py` | 3 |
+| **Total** | **2848** |

--- a/scripts/apply_eom_first_clean_completion_schema.py
+++ b/scripts/apply_eom_first_clean_completion_schema.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-"""Run the DBA-only EOM first-clean completion schema safely.
+"""Run one approved DBA-only EOM guarded schema migration safely.
 
 The normal Atlas runtime must never gain the authority needed to create a
 foreign key to the guard-owned handoff table or to own immutable completion
-evidence. This command defaults to a read-only preflight and applies only
-migration 394 after an explicit ``--apply`` using a protected typed DBA DSN
-configuration.
+or Terms evidence. This command defaults to a read-only preflight and applies
+only the selected allowlisted migration after an explicit ``--apply`` using a
+protected typed DBA DSN configuration.
 """
 
 from __future__ import annotations
@@ -42,6 +42,8 @@ DBA_DSN_ENV = EOM_FIRST_CLEAN_COMPLETION_DBA_DATABASE_URL_ENV
 DBA_SCHEMA_ENV = EOM_FIRST_CLEAN_COMPLETION_DBA_SCHEMA_ENV
 FUNNEL_DSN_ENV = "ATLAS_EOM_FUNNEL_DB_CONNECTION_STRING"
 MIGRATION_NAME = "394_eom_first_clean_completion_receipts"
+TERMS_AUTHORITY_MIGRATION_NAME = "396_eom_terms_authority"
+CONTROLLED_MIGRATION_NAMES = frozenset({MIGRATION_NAME, TERMS_AUTHORITY_MIGRATION_NAME})
 
 
 @dataclass(frozen=True)
@@ -86,14 +88,18 @@ class _PinnedMigrationPool:
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description=(
-            "Preflight or apply the DBA-only EOM first-clean completion schema."
-        )
+        description="Preflight or apply one approved DBA-only EOM schema migration."
     )
     parser.add_argument(
         "--apply",
         action="store_true",
-        help="Run migration 394 after the read-only DBA preflight.",
+        help="Run the selected migration after the read-only DBA preflight.",
+    )
+    parser.add_argument(
+        "--migration",
+        choices=sorted(CONTROLLED_MIGRATION_NAMES),
+        default=MIGRATION_NAME,
+        help="Allowlisted controlled migration to preflight or apply.",
     )
     parser.add_argument(
         "--json",
@@ -269,6 +275,7 @@ async def _migration_state(
     pool: Any,
     *,
     expected_target: _TargetIdentity,
+    migration_name: str,
 ) -> tuple[bool, bool]:
     """Return executor/migration state after re-attesting its full target."""
 
@@ -307,7 +314,7 @@ async def _migration_state(
             migration_recorded = bool(
                 await connection.fetchval(
                     "SELECT EXISTS (SELECT 1 FROM schema_migrations WHERE name = $1)",
-                    MIGRATION_NAME,
+                    migration_name,
                 )
             )
     return executor_is_superuser, migration_recorded
@@ -316,17 +323,19 @@ async def _migration_state(
 async def _run_pinned_controlled_migration(
     pool: Any,
     *,
+    migration_name: str,
     run_migrations_fn: Callable[..., Awaitable[None]],
 ) -> None:
-    """Run 394 under the canonical lock on one explicit database transaction.
+    """Run one allowlisted migration in the canonical pinned transaction.
 
     ``run_migrations`` uses a session advisory lock because ordinary catalog
-    runs can contain ``CREATE INDEX CONCURRENTLY``. Migration 394 is atomic and
-    cannot contain concurrent DDL, so the controlled runner can first acquire
-    that same lock inside an explicit transaction, then pin the canonical
-    runner to that connection. A transaction-pooling proxy consequently keeps
-    the lock, migration SQL, and bookkeeping on one backend; the outer release
-    removes the extra re-entrant session lock before the transaction ends.
+    runs can contain ``CREATE INDEX CONCURRENTLY``. Every migration admitted by
+    this controlled runner is atomic and cannot contain concurrent DDL, so the
+    runner can first acquire that same lock inside an explicit transaction,
+    then pin the canonical runner to that connection. A transaction-pooling
+    proxy consequently keeps the lock, migration SQL, and bookkeeping on one
+    backend; the outer release removes the extra re-entrant session lock before
+    the transaction ends.
     """
 
     async with pool.acquire() as connection:
@@ -343,7 +352,7 @@ async def _run_pinned_controlled_migration(
                     try:
                         await run_migrations_fn(
                             _PinnedMigrationPool(connection),
-                            only=(MIGRATION_NAME,),
+                            only=(migration_name,),
                         )
                     finally:
                         released = bool(
@@ -373,6 +382,9 @@ async def _run(
     ),
     funnel_config_factory: Callable[[], EOMFunnelConfig] = EOMFunnelConfig,
 ) -> dict[str, object]:
+    migration_name = str(args.migration)
+    if migration_name not in CONTROLLED_MIGRATION_NAMES:
+        raise RuntimeError("Refusing a non-allowlisted controlled EOM migration")
     config = config_factory()
     database_url = config.database_url.get_secret_value().strip()
     if not database_url:
@@ -405,33 +417,36 @@ async def _run(
             executor_is_superuser, migration_recorded = await _migration_state(
                 pool,
                 expected_target=runtime_target,
+                migration_name=migration_name,
             )
             result: dict[str, object] = {
                 "target": _safe_target_label(database_url, schema_name=schema_name),
                 "executor_is_superuser": executor_is_superuser,
-                "migration": MIGRATION_NAME,
+                "migration": migration_name,
                 "migration_recorded": migration_recorded,
                 "applied": False,
             }
             if not executor_is_superuser:
                 raise RuntimeError(
                     "Configured DBA connection is not a PostgreSQL superuser; "
-                    "refusing to run the first-clean completion schema migration"
+                    "refusing to run the controlled EOM schema migration"
                 )
             if args.apply and not migration_recorded:
                 await _run_pinned_controlled_migration(
                     pool,
+                    migration_name=migration_name,
                     run_migrations_fn=run_migrations_fn,
                 )
                 await _attest_shared_database_lock(runtime_pool, pool)
                 _executor_is_superuser, migration_recorded = await _migration_state(
                     pool,
                     expected_target=runtime_target,
+                    migration_name=migration_name,
                 )
                 if not migration_recorded:
                     raise RuntimeError(
                         "Migration runner returned without recording the EOM "
-                        "first-clean completion schema"
+                        "controlled schema"
                     )
                 result["migration_recorded"] = True
                 result["applied"] = True

--- a/scripts/apply_eom_terms_authority_schema.py
+++ b/scripts/apply_eom_terms_authority_schema.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Preflight or apply controlled EOM Terms-authority migration 396."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+
+from apply_eom_first_clean_completion_schema import (
+    TERMS_AUTHORITY_MIGRATION_NAME,
+    _main,
+)
+
+
+def _terms_argv(argv: list[str]) -> list[str]:
+    """Pin the shared controlled runner to the Terms migration."""
+
+    parser = argparse.ArgumentParser(
+        description="Preflight or apply controlled EOM Terms-authority schema."
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply migration 396 after the read-only DBA preflight.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the redacted preflight/result payload as JSON.",
+    )
+    args = parser.parse_args(argv)
+    forwarded = ["--migration", TERMS_AUTHORITY_MIGRATION_NAME]
+    if args.apply:
+        forwarded.append("--apply")
+    if args.json:
+        forwarded.append("--json")
+    return forwarded
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main(_terms_argv(sys.argv[1:]))))

--- a/tests/test_agent_operations_contract.py
+++ b/tests/test_agent_operations_contract.py
@@ -17,10 +17,12 @@ OPS_MODULE = runpy.run_path(str(OPS), run_name="atlas_ops_contract_test")
 DATABASE_INSPECTIONS = OPS_MODULE["DATABASE_INSPECTIONS"]
 DATABASE_CONFIG_KEYS = OPS_MODULE["DATABASE_CONFIG_KEYS"]
 TEST_DATABASE_URL_KEYS = OPS_MODULE["TEST_DATABASE_URL_KEYS"]
+CONTROLLED_DATABASE_OPERATIONS = OPS_MODULE["CONTROLLED_DATABASE_OPERATIONS"]
 OpsError = OPS_MODULE["OpsError"]
 database_inspection_command = OPS_MODULE["database_inspection_command"]
 database_env_files = OPS_MODULE["database_env_files"]
 database_runtime_environment = OPS_MODULE["database_runtime_environment"]
+run_controlled_database_operation = OPS_MODULE["run_controlled_database_operation"]
 
 
 @pytest.mark.parametrize(
@@ -61,6 +63,62 @@ def test_database_surface_contains_only_fixed_inspections() -> None:
         command = database_inspection_command(name)
         assert command[-2:] == ["__db-inspect", name]
         assert DATABASE_INSPECTIONS[name] not in command
+
+
+def test_terms_authority_is_the_only_guarded_database_operation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert CONTROLLED_DATABASE_OPERATIONS == {
+        "eom-terms-authority": "apply_eom_terms_authority_schema.py"
+    }
+    root = Path("/workspace/atlas-terms-release")
+    calls: list[tuple[list[str], Path | None]] = []
+    function_globals = run_controlled_database_operation.__globals__
+    monkeypatch.setitem(function_globals, "worktree_root", lambda: root)
+    monkeypatch.setitem(
+        function_globals, "python_command", lambda: Path("/venv/python")
+    )
+
+    def fake_exec_command(
+        args: list[str], *, cwd: Path | None = None, **_kwargs: object
+    ) -> int:
+        calls.append((args, cwd))
+        return 0
+
+    monkeypatch.setitem(function_globals, "exec_command", fake_exec_command)
+
+    assert run_controlled_database_operation("eom-terms-authority", "preflight") == 0
+    assert run_controlled_database_operation("eom-terms-authority", "apply") == 0
+    expected_prefix = [
+        "/venv/python",
+        str(root / "scripts/apply_eom_terms_authority_schema.py"),
+        "--json",
+    ]
+    assert calls == [
+        (expected_prefix, root),
+        ([*expected_prefix, "--apply"], root),
+    ]
+    with pytest.raises(OpsError, match="unknown controlled database operation"):
+        run_controlled_database_operation("other", "preflight")
+    with pytest.raises(OpsError, match=r"\{preflight\|apply\}"):
+        run_controlled_database_operation("eom-terms-authority", "other")
+    monkeypatch.setitem(function_globals, "worktree_root", lambda: None)
+    with pytest.raises(OpsError, match="normal worktree"):
+        run_controlled_database_operation("eom-terms-authority", "preflight")
+
+    dispatched: list[tuple[str, str]] = []
+    db_command = OPS_MODULE["db_command"]
+    monkeypatch.setitem(
+        db_command.__globals__,
+        "run_controlled_database_operation",
+        lambda name, mode: dispatched.append((name, mode)) or 0,
+    )
+    assert db_command(["controlled", "eom-terms-authority", "preflight"]) == 0
+    assert db_command(["controlled", "eom-terms-authority", "apply"]) == 0
+    assert dispatched == [
+        ("eom-terms-authority", "preflight"),
+        ("eom-terms-authority", "apply"),
+    ]
 
 
 def test_database_runtime_environment_covers_every_database_config_key() -> None:
@@ -1564,6 +1622,19 @@ def test_capability_map_is_machine_readable_and_has_required_surfaces() -> None:
         assert key in capabilities
     assert capabilities["database"]["safe_inspection"] == "./ops db inspect connectivity"
     assert capabilities["database"]["arbitrary_query"].startswith("unavailable")
+    terms_migration = capabilities["database"]["controlled_migrations"][
+        "eom_terms_authority"
+    ]
+    assert terms_migration["preflight"] == (
+        "./ops db controlled eom-terms-authority preflight"
+    )
+    assert terms_migration["apply"] == "./ops db controlled eom-terms-authority apply"
+    database_runbook = (ROOT / ".agent/runbooks/database.md").read_text(
+        encoding="utf-8"
+    )
+    assert terms_migration["preflight"] in database_runbook
+    assert terms_migration["apply"] in database_runbook
+    assert "Post-deployment application rollback is retention-only" in database_runbook
     assert capabilities["deployment"]["brain"]["provider"] == "local systemd user service"
     assert capabilities["deployment"]["frontend"]["provider"] == "Vercel"
     assert "./ops doctor" in capabilities["project"]["source_of_truth"]

--- a/tests/test_eom_first_clean_completion_dba_runner.py
+++ b/tests/test_eom_first_clean_completion_dba_runner.py
@@ -15,6 +15,7 @@ from pydantic import ValidationError
 
 ROOT = Path(__file__).resolve().parent.parent
 SCRIPT = ROOT / "scripts" / "apply_eom_first_clean_completion_schema.py"
+TERMS_SCRIPT = ROOT / "scripts" / "apply_eom_terms_authority_schema.py"
 
 
 def _load_runner_module() -> ModuleType:
@@ -24,6 +25,19 @@ def _load_runner_module() -> ModuleType:
     module = importlib.util.module_from_spec(spec)
     sys.modules[module_name] = module
     spec.loader.exec_module(module)
+    return module
+
+
+def _load_terms_runner_module() -> ModuleType:
+    module_name = "test_eom_terms_authority_dba_runner_script"
+    spec = importlib.util.spec_from_file_location(module_name, TERMS_SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(TERMS_SCRIPT.parent))
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.pop(0)
     return module
 
 
@@ -274,8 +288,16 @@ def test_runner_rejects_non_superuser_before_apply(monkeypatch) -> None:
     assert dba_pool.closed is True
 
 
+@pytest.mark.parametrize(
+    "migration_name",
+    [
+        "394_eom_first_clean_completion_receipts",
+        "396_eom_terms_authority",
+    ],
+)
 def test_runner_applies_only_its_named_migration_in_pinned_transaction(
     monkeypatch,
+    migration_name: str,
 ) -> None:
     runner = _load_runner_module()
     runtime_database_url = "postgresql://runtime@example.test/atlas"
@@ -316,7 +338,7 @@ def test_runner_applies_only_its_named_migration_in_pinned_transaction(
 
     monkeypatch.setattr(runner.asyncio, "sleep", sleep)
 
-    args = runner._parse_args(["--apply"])
+    args = runner._parse_args(["--apply", "--migration", migration_name])
     result = asyncio.run(
         runner._run(
             args,
@@ -331,7 +353,7 @@ def test_runner_applies_only_its_named_migration_in_pinned_transaction(
         )
     )
 
-    assert [only for _pool, only in calls] == [(runner.MIGRATION_NAME,)]
+    assert [only for _pool, only in calls] == [(migration_name,)]
     assert result["migration_recorded"] is True
     assert result["applied"] is True
     assert runtime_pool.closed is True
@@ -342,6 +364,24 @@ def test_runner_applies_only_its_named_migration_in_pinned_transaction(
     assert state.migration_lock_unlocks == 1
     assert state.migration_lock_depth == 0
     assert sleep_delays == [0.2]
+
+
+def test_terms_entrypoint_pins_migration_396() -> None:
+    terms_runner = _load_terms_runner_module()
+
+    argv = terms_runner._terms_argv(["--apply", "--json"])
+    assert argv == [
+        "--migration",
+        "396_eom_terms_authority",
+        "--apply",
+        "--json",
+    ]
+    shared_runner = sys.modules[terms_runner._main.__module__]
+    assert shared_runner._parse_args(argv).migration == "396_eom_terms_authority"
+    with pytest.raises(SystemExit):
+        terms_runner._terms_argv(
+            ["--migration=394_eom_first_clean_completion_receipts"]
+        )
 
 
 def test_runner_rejects_missing_typed_dsn_before_pool(monkeypatch) -> None:

--- a/tests/test_eom_terms_authority.py
+++ b/tests/test_eom_terms_authority.py
@@ -1,0 +1,541 @@
+"""Focused proof for the private EOM Terms version authority."""
+
+from __future__ import annotations
+
+import json
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from atlas_brain.eom_api import funnel as funnel_mod
+from atlas_brain.eom_api import funnel_auth as funnel_auth_mod
+from atlas_brain.eom_api.config import EOMFunnelConfig
+from atlas_brain.services.eom_terms_authority import (
+    EOMTermsAuthority,
+    EOMTermsConflictError,
+    EOMTermsNotFoundError,
+    EOMTermsUnavailableError,
+    EOMTermsValidationError,
+    canonical_eom_terms_documents,
+    eom_terms_authority_schema_ready,
+    normalize_eom_terms_documents,
+)
+
+
+_NOW = datetime(2026, 8, 27, 21, 0, tzinfo=timezone.utc)
+_VERSION_ID = UUID("11111111-1111-4111-8111-111111111111")
+_SERVICE = funnel_auth_mod.generate_eom_funnel_service_token()
+_MIGRATION = (
+    Path(__file__).resolve().parent.parent
+    / "atlas_brain/storage/migrations/396_eom_terms_authority.sql"
+)
+
+
+def _documents(marker: str = "approved") -> dict[str, Any]:
+    return {
+        audience: {
+            locale: {
+                "terms": f"{marker} {audience} {locale} terms",
+                "servicesWeCannotProvide": f"{marker} {audience} {locale} services",
+                "additionalWorkAcknowledgement": (
+                    f"{marker} {audience} {locale} additional work"
+                ),
+            }
+            for locale in ("en", "es")
+        }
+        for audience in ("residential", "commercial")
+    }
+
+
+def _row(
+    *,
+    status: str = "draft",
+    documents: object | None = None,
+    material_change: bool = True,
+) -> dict[str, Any]:
+    normalized, serialized, digest = canonical_eom_terms_documents(
+        documents if documents is not None else _documents()
+    )
+    return {
+        "id": _VERSION_ID,
+        "version_label": "2026.1",
+        "status": status,
+        "material_change": material_change,
+        "documents": serialized,
+        "content_hash": digest,
+        "created_by_id": 7,
+        "created_by_name": "Juan",
+        "created_at": _NOW,
+        "published_by_id": 7 if status == "published" else None,
+        "published_by_name": "Juan" if status == "published" else None,
+        "published_at": _NOW if status == "published" else None,
+        "normalized": normalized,
+    }
+
+
+class _Pool:
+    is_initialized = True
+
+    def __init__(self, connection: Any, *, current_row: dict[str, Any] | None = None):
+        self.connection = connection
+        self.current_row = current_row
+
+    async def fetchval(self, *_args: Any, **_kwargs: Any) -> bool:
+        return True
+
+    async def fetchrow(self, *_args: Any, **_kwargs: Any) -> Any:
+        return self.current_row
+
+    @asynccontextmanager
+    async def transaction(self):
+        yield self.connection
+
+
+class _SchemaProbePool:
+    def __init__(self, result: object) -> None:
+        self.result = result
+        self.query = ""
+
+    async def fetchval(self, query: str) -> object:
+        self.query = query
+        return self.result
+
+
+class _CreateConnection:
+    def __init__(
+        self,
+        *,
+        inserted: dict[str, Any] | None,
+        existing: dict[str, Any] | None = None,
+    ) -> None:
+        self.inserted = inserted
+        self.existing = existing
+        self.calls: list[str] = []
+
+    async def fetchrow(self, query: str, *_args: Any) -> Any:
+        self.calls.append(query)
+        if "INSERT INTO eom_terms_versions" in query:
+            return self.inserted
+        return self.existing
+
+
+class _PublishConnection:
+    def __init__(self, source: dict[str, Any], *, current_id: UUID | None = None):
+        self.source = source
+        self.current_id = current_id
+        self.calls: list[str] = []
+
+    async def execute(self, query: str, *_args: Any) -> str:
+        self.calls.append(query)
+        return "OK"
+
+    async def fetchval(self, query: str, *_args: Any) -> UUID | None:
+        self.calls.append(query)
+        return self.current_id
+
+    async def fetchrow(self, query: str, *_args: Any) -> Any:
+        self.calls.append(query)
+        if query.lstrip().startswith("SELECT"):
+            return self.source
+        if "UPDATE eom_terms_versions" in query:
+            return _row(status="published")
+        raise AssertionError(f"Unexpected query: {query}")
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda value: value.pop("commercial"),
+        lambda value: value.update({"other": {}}),
+        lambda value: value["residential"].pop("es"),
+        lambda value: value["residential"]["en"].pop("terms"),
+        lambda value: value["residential"]["en"].update({"other": "x"}),
+        lambda value: value["residential"]["en"].update({"terms": " "}),
+        lambda value: value["residential"]["en"].update({"terms": "bad\x00text"}),
+        lambda value: value["residential"]["en"].update({"terms": 7}),
+        lambda value: value["residential"]["en"].update({"terms": "\ud800"}),
+        lambda value: value["residential"]["en"].update({"terms": "x" * 100_001}),
+    ],
+)
+def test_document_boundary_rejects_every_incomplete_or_extra_shape(mutate: Any) -> None:
+    documents = _documents()
+    mutate(documents)
+    with pytest.raises(EOMTermsValidationError):
+        normalize_eom_terms_documents(documents)
+
+
+def test_document_section_accepts_exact_length_boundary() -> None:
+    documents = _documents()
+    documents["residential"]["en"]["terms"] = "x" * 100_000
+    normalized = normalize_eom_terms_documents(documents)
+    assert len(normalized["residential"]["en"]["terms"]) == 100_000
+
+
+def test_canonical_hash_is_independent_of_mapping_order() -> None:
+    documents = _documents()
+    reversed_documents = dict(reversed(documents.items()))
+    normalized, _, digest = canonical_eom_terms_documents(documents)
+    normalized_reversed, _, reversed_digest = canonical_eom_terms_documents(
+        reversed_documents
+    )
+    assert normalized_reversed == normalized
+    assert reversed_digest == digest
+
+
+@pytest.mark.asyncio
+async def test_create_draft_writes_one_normalized_snapshot() -> None:
+    connection = _CreateConnection(inserted=_row())
+    result = await EOMTermsAuthority(pool=_Pool(connection)).create_draft(
+        version_label=" 2026.1 ",
+        material_change=True,
+        documents=_documents(),
+        actor_id=7,
+        actor_name=" Juan ",
+    )
+    assert result["versionId"] == str(_VERSION_ID)
+    assert result["status"] == "draft"
+    assert result["idempotent"] is False
+    assert len(connection.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_create_draft_replays_only_identical_content() -> None:
+    existing = _row()
+    connection = _CreateConnection(inserted=None, existing=existing)
+    authority = EOMTermsAuthority(pool=_Pool(connection))
+    replay = await authority.create_draft(
+        version_label="2026.1",
+        material_change=True,
+        documents=_documents(),
+        actor_id=7,
+        actor_name="Juan",
+    )
+    assert replay["idempotent"] is True
+
+    with pytest.raises(EOMTermsConflictError):
+        await authority.create_draft(
+            version_label="2026.1",
+            material_change=True,
+            documents=_documents("different"),
+            actor_id=7,
+            actor_name="Juan",
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_draft_accepts_false_but_rejects_non_boolean_material_flag() -> (
+    None
+):
+    accepted_connection = _CreateConnection(inserted=_row(material_change=False))
+    accepted = await EOMTermsAuthority(pool=_Pool(accepted_connection)).create_draft(
+        version_label="2026.1",
+        material_change=False,
+        documents=_documents(),
+        actor_id=7,
+        actor_name="Juan",
+    )
+    assert accepted["materialChange"] is False
+
+    rejected_connection = _CreateConnection(inserted=_row())
+    with pytest.raises(EOMTermsValidationError, match="must be boolean"):
+        await EOMTermsAuthority(pool=_Pool(rejected_connection)).create_draft(
+            version_label="2026.1",
+            material_change=0,
+            documents=_documents(),
+            actor_id=7,
+            actor_name="Juan",
+        )
+    assert rejected_connection.calls == []
+
+
+@pytest.mark.asyncio
+async def test_publish_serializes_before_selecting_current_version() -> None:
+    connection = _PublishConnection(_row())
+    result = await EOMTermsAuthority(pool=_Pool(connection)).publish(
+        version_id=_VERSION_ID,
+        actor_id=7,
+        actor_name="Juan",
+    )
+    assert result["status"] == "published"
+    assert result["idempotent"] is False
+    assert "pg_advisory_xact_lock" in connection.calls[0]
+    assert "FOR UPDATE" in connection.calls[1]
+    assert "eom_terms_current_version" in connection.calls[-1]
+
+
+@pytest.mark.asyncio
+async def test_publish_replays_only_when_version_is_still_current() -> None:
+    published = _row(status="published")
+    replay_connection = _PublishConnection(published, current_id=_VERSION_ID)
+    replay = await EOMTermsAuthority(pool=_Pool(replay_connection)).publish(
+        version_id=_VERSION_ID,
+        actor_id=7,
+        actor_name="Juan",
+    )
+    assert replay["idempotent"] is True
+    assert not any(
+        "UPDATE eom_terms_versions" in call for call in replay_connection.calls
+    )
+
+    stale_connection = _PublishConnection(published, current_id=uuid4())
+    with pytest.raises(EOMTermsConflictError):
+        await EOMTermsAuthority(pool=_Pool(stale_connection)).publish(
+            version_id=_VERSION_ID,
+            actor_id=7,
+            actor_name="Juan",
+        )
+
+
+@pytest.mark.asyncio
+async def test_current_read_fails_closed_without_schema_or_pointer() -> None:
+    class _NoSchemaPool:
+        is_initialized = True
+
+        async def fetchval(self, *_args: Any, **_kwargs: Any) -> bool:
+            return False
+
+    with pytest.raises(EOMTermsUnavailableError):
+        await EOMTermsAuthority(pool=_NoSchemaPool()).get_current()
+
+    with pytest.raises(EOMTermsNotFoundError):
+        await EOMTermsAuthority(pool=_Pool(connection=None)).get_current()
+
+
+@pytest.mark.asyncio
+async def test_schema_guard_requires_relations_triggers_unique_keys_and_fk() -> None:
+    ready_pool = _SchemaProbePool(True)
+    missing_boundary_pool = _SchemaProbePool(False)
+
+    assert await eom_terms_authority_schema_ready(ready_pool) is True
+    assert await eom_terms_authority_schema_ready(missing_boundary_pool) is False
+    for expected_boundary in (
+        "eom_terms_versions",
+        "eom_terms_current_version",
+        "trg_protect_eom_terms_version",
+        "trg_protect_eom_terms_version_truncate",
+        "trg_require_published_eom_terms_current_version",
+        "trg_prevent_eom_terms_current_delete",
+        "trg_prevent_eom_terms_current_truncate",
+        "pg_index",
+        "pg_constraint",
+        "foreign_key.confdeltype = 'r'",
+    ):
+        assert expected_boundary in ready_pool.query
+
+
+@pytest.mark.asyncio
+async def test_current_read_rejects_documents_that_do_not_match_stored_hash() -> None:
+    corrupt_row = _row(status="published")
+    corrupt_row["content_hash"] = "0" * 64
+    with pytest.raises(EOMTermsUnavailableError, match="content hash"):
+        await EOMTermsAuthority(
+            pool=_Pool(connection=None, current_row=corrupt_row)
+        ).get_current()
+
+
+class _RouteAuthority:
+    def __init__(self, *, idempotent: bool = False) -> None:
+        self.draft = _row()
+        self.published = _row(status="published")
+        self.idempotent = idempotent
+
+    async def create_draft(self, **_kwargs: Any) -> dict[str, Any]:
+        return _api_result(self.draft, idempotent=self.idempotent)
+
+    async def publish(self, **_kwargs: Any) -> dict[str, Any]:
+        return _api_result(self.published, idempotent=self.idempotent)
+
+    async def get_current(self) -> dict[str, Any]:
+        return _api_result(self.published, idempotent=True)
+
+
+class _MalformedRouteAuthority(_RouteAuthority):
+    async def create_draft(self, **_kwargs: Any) -> dict[str, Any]:
+        result = await super().create_draft(**_kwargs)
+        result["unexpected"] = "must not escape"
+        return result
+
+
+class _ConflictRouteAuthority(_RouteAuthority):
+    async def create_draft(self, **_kwargs: Any) -> dict[str, Any]:
+        raise EOMTermsConflictError("Terms version label belongs to different content")
+
+
+def _api_result(row: dict[str, Any], *, idempotent: bool) -> dict[str, Any]:
+    documents = json.loads(row["documents"])
+    return {
+        "versionId": str(row["id"]),
+        "versionLabel": row["version_label"],
+        "status": row["status"],
+        "materialChange": row["material_change"],
+        "documents": documents,
+        "contentHash": row["content_hash"],
+        "createdById": row["created_by_id"],
+        "createdByName": row["created_by_name"],
+        "createdAt": row["created_at"].isoformat(),
+        "publishedById": row["published_by_id"],
+        "publishedByName": row["published_by_name"],
+        "publishedAt": (
+            row["published_at"].isoformat() if row["published_at"] else None
+        ),
+        "idempotent": idempotent,
+    }
+
+
+def _app(authority: Any) -> FastAPI:
+    app = FastAPI()
+    app.include_router(funnel_mod.router, prefix="/api/v1")
+    app.dependency_overrides[funnel_auth_mod.get_eom_funnel_api_config] = lambda: (
+        EOMFunnelConfig(
+            api_enabled=True,
+            service_token_sha256=_SERVICE.sha256,
+        )
+    )
+    app.dependency_overrides[funnel_mod._terms_authority_dependency] = lambda: authority
+    return app
+
+
+def _headers(*, actor: bool = True) -> dict[str, str]:
+    headers = {"Authorization": f"Bearer {_SERVICE.token}"}
+    if actor:
+        headers.update({"X-EOM-Actor": "Juan", "X-EOM-Actor-ID": "7"})
+    return headers
+
+
+@pytest.mark.asyncio
+async def test_private_routes_create_publish_and_read_current_version() -> None:
+    app = _app(_RouteAuthority())
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        created = await client.post(
+            "/api/v1/eom-funnel/terms/versions",
+            headers=_headers(),
+            json={
+                "versionLabel": "2026.1",
+                "materialChange": True,
+                "documents": _documents(),
+            },
+        )
+        published = await client.post(
+            f"/api/v1/eom-funnel/terms/versions/{_VERSION_ID}/publish",
+            headers=_headers(),
+        )
+        current = await client.get(
+            "/api/v1/eom-funnel/terms/current", headers=_headers(actor=False)
+        )
+
+    assert created.status_code == 201
+    assert created.json()["status"] == "draft"
+    assert published.status_code == 201
+    assert published.json()["status"] == "published"
+    assert current.status_code == 200
+    assert current.json()["versionId"] == str(_VERSION_ID)
+
+
+@pytest.mark.asyncio
+async def test_create_route_still_requires_actor_evidence() -> None:
+    app = _app(_RouteAuthority())
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        response = await client.post(
+            "/api/v1/eom-funnel/terms/versions",
+            headers=_headers(actor=False),
+            json={
+                "versionLabel": "2026.1",
+                "materialChange": True,
+                "documents": _documents(),
+            },
+        )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_private_terms_routes_require_service_bearer() -> None:
+    app = _app(_RouteAuthority())
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        response = await client.get("/api/v1/eom-funnel/terms/current")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_unchanged_create_and_publish_replays_return_200() -> None:
+    app = _app(_RouteAuthority(idempotent=True))
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        created = await client.post(
+            "/api/v1/eom-funnel/terms/versions",
+            headers=_headers(),
+            json={
+                "versionLabel": "2026.1",
+                "materialChange": True,
+                "documents": _documents(),
+            },
+        )
+        published = await client.post(
+            f"/api/v1/eom-funnel/terms/versions/{_VERSION_ID}/publish",
+            headers=_headers(),
+        )
+    assert created.status_code == 200
+    assert published.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_create_route_does_not_bypass_closed_response_projection() -> None:
+    app = _app(_MalformedRouteAuthority())
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app, raise_app_exceptions=False),
+        base_url="http://testserver",
+    ) as client:
+        response = await client.post(
+            "/api/v1/eom-funnel/terms/versions",
+            headers=_headers(),
+            json={
+                "versionLabel": "2026.1",
+                "materialChange": True,
+                "documents": _documents(),
+            },
+        )
+    assert response.status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_create_route_maps_typed_service_conflict() -> None:
+    app = _app(_ConflictRouteAuthority())
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        response = await client.post(
+            "/api/v1/eom-funnel/terms/versions",
+            headers=_headers(),
+            json={
+                "versionLabel": "2026.1",
+                "materialChange": True,
+                "documents": _documents(),
+            },
+        )
+    assert response.status_code == 409
+    assert response.json()["detail"] == {
+        "code": "eom_terms_conflict",
+        "message": "Terms version label belongs to different content",
+    }
+
+
+def test_migration_guards_published_history_and_seeds_no_terms_content() -> None:
+    migration = _MIGRATION.read_text()
+    assert "OLD.status = 'published'" in migration
+    assert "Current EOM Terms version must be published" in migration
+    assert "BEFORE TRUNCATE ON eom_terms_versions" in migration
+    assert "Publishing EOM Terms cannot rewrite draft content" in migration
+    assert "BEFORE DELETE ON eom_terms_current_version" in migration
+    assert "INSERT INTO eom_terms_versions" not in migration

--- a/tests/test_eom_terms_authority.py
+++ b/tests/test_eom_terms_authority.py
@@ -1050,4 +1050,5 @@ def test_migration_guards_published_history_and_seeds_no_terms_content() -> None
     assert "BEFORE DELETE ON eom_terms_current_version" in migration
     assert "Post-deployment rollback" in migration
     assert "Retain the guard-owned tables" in migration
+    assert "selected_by_name, selected_at) " in migration
     assert "INSERT INTO eom_terms_versions" not in migration

--- a/tests/test_eom_terms_authority.py
+++ b/tests/test_eom_terms_authority.py
@@ -284,17 +284,23 @@ class _PublishConnection:
         self.source = source
         self.current_id = current_id
         self.calls: list[str] = []
+        self.arguments: list[tuple[str, tuple[Any, ...]]] = []
 
-    async def execute(self, query: str, *_args: Any) -> str:
+    async def execute(self, query: str, *args: Any) -> str:
         self.calls.append(query)
+        self.arguments.append((query, args))
         return "OK"
 
-    async def fetchval(self, query: str, *_args: Any) -> UUID | None:
+    async def fetchval(self, query: str, *args: Any) -> object:
         self.calls.append(query)
+        self.arguments.append((query, args))
+        if "clock_timestamp" in query:
+            return _NOW
         return self.current_id
 
-    async def fetchrow(self, query: str, *_args: Any) -> Any:
+    async def fetchrow(self, query: str, *args: Any) -> Any:
         self.calls.append(query)
+        self.arguments.append((query, args))
         if query.lstrip().startswith("SELECT"):
             return self.source
         if "UPDATE eom_terms_versions" in query:
@@ -419,8 +425,21 @@ async def test_publish_serializes_before_selecting_current_version() -> None:
     assert result["status"] == "published"
     assert result["idempotent"] is False
     assert "pg_advisory_xact_lock" in connection.calls[0]
-    assert "FOR UPDATE" in connection.calls[1]
+    assert "clock_timestamp" in connection.calls[1]
+    assert "FOR UPDATE" in connection.calls[2]
     assert "eom_terms_current_version" in connection.calls[-1]
+    version_update_args = next(
+        args
+        for query, args in connection.arguments
+        if "UPDATE eom_terms_versions" in query
+    )
+    current_update_args = next(
+        args
+        for query, args in connection.arguments
+        if "INSERT INTO eom_terms_current_version" in query
+    )
+    assert version_update_args[3] == _NOW
+    assert current_update_args[3] == _NOW
 
 
 @pytest.mark.asyncio
@@ -661,6 +680,31 @@ async def test_real_postgres_enforces_guard_concurrency_and_rollback() -> None:
         assert len(publication_order) == 2
         current = await authority.get_current()
         assert UUID(current["versionId"]) == publication_order[-1]
+        async with pool.raw_pool.acquire() as timestamp_connection:
+            publication_rows = await timestamp_connection.fetch(
+                """
+                SELECT id, published_at
+                FROM eom_terms_versions
+                WHERE id = ANY($1::uuid[])
+                """,
+                distinct_versions,
+            )
+            selected_row = await timestamp_connection.fetchrow(
+                """
+                SELECT version_id, selected_at
+                FROM eom_terms_current_version
+                WHERE singleton
+                """
+            )
+        published_at = {
+            UUID(str(row["id"])): row["published_at"] for row in publication_rows
+        }
+        lock_ordered_timestamps = [
+            published_at[version_id] for version_id in publication_order
+        ]
+        assert lock_ordered_timestamps == sorted(lock_ordered_timestamps)
+        assert UUID(str(selected_row["version_id"])) == publication_order[-1]
+        assert selected_row["selected_at"] == published_at[publication_order[-1]]
         assert (
             await pool.fetchval(
                 """
@@ -1004,4 +1048,6 @@ def test_migration_guards_published_history_and_seeds_no_terms_content() -> None
     assert "BEFORE TRUNCATE ON eom_terms_versions" in migration
     assert "Publishing EOM Terms cannot rewrite draft content" in migration
     assert "BEFORE DELETE ON eom_terms_current_version" in migration
+    assert "Post-deployment rollback" in migration
+    assert "Retain the guard-owned tables" in migration
     assert "INSERT INTO eom_terms_versions" not in migration

--- a/tests/test_eom_terms_authority.py
+++ b/tests/test_eom_terms_authority.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
+import os
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 from uuid import UUID, uuid4
 
+import asyncpg
 import httpx
 import pytest
 from fastapi import FastAPI
@@ -35,6 +38,8 @@ _MIGRATION = (
     Path(__file__).resolve().parent.parent
     / "atlas_brain/storage/migrations/396_eom_terms_authority.sql"
 )
+_RUNTIME_DATABASE_URL_ENV = "ATLAS_EOM_FIRST_CLEAN_TEST_DATABASE_URL"
+_DBA_DATABASE_URL_ENV = "ATLAS_EOM_FIRST_CLEAN_DBA_DATABASE_URL"
 
 
 def _documents(marker: str = "approved") -> dict[str, Any]:
@@ -105,6 +110,155 @@ class _SchemaProbePool:
     async def fetchval(self, query: str) -> object:
         self.query = query
         return self.result
+
+
+class _AsyncpgAuthorityPool:
+    """Expose the service pool protocol over a real asyncpg pool."""
+
+    is_initialized = True
+
+    def __init__(self, pool: Any) -> None:
+        self.raw_pool = pool
+
+    @asynccontextmanager
+    async def transaction(self):
+        async with self.raw_pool.acquire() as connection:
+            async with connection.transaction():
+                yield connection
+
+    async def fetchval(self, *args: Any, **kwargs: Any) -> Any:
+        async with self.raw_pool.acquire() as connection:
+            return await connection.fetchval(*args, **kwargs)
+
+    async def fetchrow(self, *args: Any, **kwargs: Any) -> Any:
+        async with self.raw_pool.acquire() as connection:
+            return await connection.fetchrow(*args, **kwargs)
+
+
+class _FailBeforeCurrentConnection:
+    """Inject one failure after publication UPDATE but before pointer UPSERT."""
+
+    def __init__(self, connection: Any) -> None:
+        self._connection = connection
+
+    async def execute(self, query: str, *args: Any) -> Any:
+        if "INSERT INTO eom_terms_current_version" in query:
+            raise OSError("injected pointer-write failure")
+        return await self._connection.execute(query, *args)
+
+    async def fetchval(self, query: str, *args: Any) -> Any:
+        return await self._connection.fetchval(query, *args)
+
+    async def fetchrow(self, query: str, *args: Any) -> Any:
+        return await self._connection.fetchrow(query, *args)
+
+
+class _FailBeforeCurrentPool(_AsyncpgAuthorityPool):
+    @asynccontextmanager
+    async def transaction(self):
+        async with self.raw_pool.acquire() as connection:
+            async with connection.transaction():
+                yield _FailBeforeCurrentConnection(connection)
+
+
+class _RecordingCurrentConnection:
+    """Record successful current-pointer writes while holding the DB lock."""
+
+    def __init__(self, connection: Any, publication_order: list[UUID]) -> None:
+        self._connection = connection
+        self._publication_order = publication_order
+
+    async def execute(self, query: str, *args: Any) -> Any:
+        result = await self._connection.execute(query, *args)
+        if "INSERT INTO eom_terms_current_version" in query:
+            self._publication_order.append(UUID(str(args[0])))
+        return result
+
+    async def fetchval(self, query: str, *args: Any) -> Any:
+        return await self._connection.fetchval(query, *args)
+
+    async def fetchrow(self, query: str, *args: Any) -> Any:
+        return await self._connection.fetchrow(query, *args)
+
+
+class _RecordingCurrentPool(_AsyncpgAuthorityPool):
+    def __init__(self, pool: Any, publication_order: list[UUID]) -> None:
+        super().__init__(pool)
+        self._publication_order = publication_order
+
+    @asynccontextmanager
+    async def transaction(self):
+        async with self.raw_pool.acquire() as connection:
+            async with connection.transaction():
+                yield _RecordingCurrentConnection(
+                    connection,
+                    self._publication_order,
+                )
+
+
+def _database_url_or_skip(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        pytest.skip(f"{name} is not configured")
+    return value
+
+
+async def _provision_terms_guard(dba_connection: Any) -> None:
+    await dba_connection.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1 FROM pg_roles
+                WHERE rolname = 'atlas_eom_handoff_owner'
+            ) THEN
+                ALTER ROLE atlas_eom_handoff_owner
+                    NOLOGIN NOINHERIT NOSUPERUSER NOCREATEDB NOCREATEROLE
+                    NOREPLICATION NOBYPASSRLS;
+            ELSE
+                CREATE ROLE atlas_eom_handoff_owner
+                    NOLOGIN NOINHERIT NOSUPERUSER NOCREATEDB NOCREATEROLE
+                    NOREPLICATION NOBYPASSRLS;
+            END IF;
+        END;
+        $$;
+        """
+    )
+    await dba_connection.execute("REVOKE atlas_eom_handoff_owner FROM atlas")
+
+
+@asynccontextmanager
+async def _real_terms_store():
+    runtime_url = _database_url_or_skip(_RUNTIME_DATABASE_URL_ENV)
+    dba_url = _database_url_or_skip(_DBA_DATABASE_URL_ENV)
+    schema = f"atlas_eom_terms_{uuid4().hex}"
+    dba_connection = await asyncpg.connect(dba_url)
+    runtime_pool = None
+    try:
+        await _provision_terms_guard(dba_connection)
+        await dba_connection.execute(
+            f'CREATE SCHEMA "{schema}" AUTHORIZATION atlas_eom_handoff_owner'
+        )
+        await dba_connection.execute(
+            f'GRANT USAGE, CREATE ON SCHEMA "{schema}" TO atlas'
+        )
+        await dba_connection.execute(f'SET search_path TO "{schema}", pg_catalog')
+        await dba_connection.execute(_MIGRATION.read_text())
+        runtime_pool = await asyncpg.create_pool(
+            runtime_url,
+            min_size=1,
+            max_size=5,
+            statement_cache_size=0,
+            server_settings={"search_path": f'"{schema}", pg_catalog'},
+        )
+        yield _AsyncpgAuthorityPool(runtime_pool), dba_connection, schema
+    finally:
+        if runtime_pool is not None:
+            await runtime_pool.close()
+        try:
+            await dba_connection.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        finally:
+            await dba_connection.close()
 
 
 class _CreateConnection:
@@ -327,6 +481,318 @@ async def test_schema_guard_requires_relations_triggers_unique_keys_and_fk() -> 
         "foreign_key.confdeltype = 'r'",
     ):
         assert expected_boundary in ready_pool.query
+
+
+def test_slim_eom_profile_binds_terms_to_canonical_funnel_pool() -> None:
+    from atlas_brain import main_eom
+
+    assert main_eom.app.state.eom_funnel_terms_pool is main_eom.get_eom_funnel_db_pool
+
+
+@pytest.mark.asyncio
+async def test_real_postgres_enforces_guard_concurrency_and_rollback() -> None:
+    async with _real_terms_store() as (pool, dba_connection, schema):
+        authority = EOMTermsAuthority(pool=pool)
+
+        assert await eom_terms_authority_schema_ready(pool) is True
+        assert await pool.fetchval("SELECT COUNT(*) FROM eom_terms_versions") == 0
+        relation_owners = await dba_connection.fetch(
+            """
+            SELECT relation.relname, owner.rolname AS owner
+            FROM pg_class AS relation
+            JOIN pg_roles AS owner ON owner.oid = relation.relowner
+            WHERE relation.oid IN (
+                'eom_terms_versions'::regclass,
+                'eom_terms_current_version'::regclass
+            )
+            """
+        )
+        assert {
+            (str(row["relname"]), str(row["owner"])) for row in relation_owners
+        } == {
+            ("eom_terms_versions", "atlas_eom_handoff_owner"),
+            ("eom_terms_current_version", "atlas_eom_handoff_owner"),
+        }
+        assert (
+            await pool.fetchval(
+                """
+            SELECT NOT has_table_privilege(
+                       current_user, 'eom_terms_versions', 'UPDATE'
+                   )
+               AND NOT has_table_privilege(
+                       current_user, 'eom_terms_versions', 'INSERT'
+                   )
+               AND has_column_privilege(
+                       current_user, 'eom_terms_versions', 'status', 'UPDATE'
+                   )
+               AND NOT has_column_privilege(
+                       current_user, 'eom_terms_versions', 'documents', 'UPDATE'
+                   )
+               AND NOT has_function_privilege(
+                       current_user,
+                       'protect_eom_terms_version()'::regprocedure,
+                       'EXECUTE'
+                   )
+            """
+            )
+            is True
+        )
+
+        first = await authority.create_draft(
+            version_label="2026.1",
+            material_change=True,
+            documents=_documents("first"),
+            actor_id=7,
+            actor_name="Juan",
+        )
+        first_id = UUID(first["versionId"])
+        published = await authority.publish(
+            version_id=first_id,
+            actor_id=7,
+            actor_name="Juan",
+        )
+        assert published["status"] == "published"
+        assert published["idempotent"] is False
+
+        async with pool.raw_pool.acquire() as runtime_connection:
+            with pytest.raises(
+                asyncpg.PostgresError,
+                match="Published EOM Terms versions are immutable",
+            ):
+                await runtime_connection.execute(
+                    """
+                    UPDATE eom_terms_versions
+                    SET published_by_name = 'tampered'
+                    WHERE id = $1
+                    """,
+                    first_id,
+                )
+            with pytest.raises(asyncpg.InsufficientPrivilegeError):
+                await runtime_connection.execute(
+                    """
+                    ALTER TABLE eom_terms_versions
+                    DISABLE TRIGGER trg_protect_eom_terms_version
+                    """
+                )
+            with pytest.raises(asyncpg.InsufficientPrivilegeError):
+                await runtime_connection.execute(
+                    """
+                    CREATE OR REPLACE FUNCTION protect_eom_terms_version()
+                    RETURNS TRIGGER LANGUAGE plpgsql AS $$
+                    BEGIN
+                        RETURN NEW;
+                    END;
+                    $$
+                    """
+                )
+            with pytest.raises(asyncpg.InsufficientPrivilegeError):
+                await runtime_connection.execute(
+                    "DELETE FROM eom_terms_current_version"
+                )
+            with pytest.raises(asyncpg.InsufficientPrivilegeError):
+                await runtime_connection.execute("TRUNCATE eom_terms_versions")
+
+        duplicate = await authority.create_draft(
+            version_label="2026.2",
+            material_change=False,
+            documents=_documents("duplicate"),
+            actor_id=7,
+            actor_name="Juan",
+        )
+        duplicate_id = UUID(duplicate["versionId"])
+        async with pool.raw_pool.acquire() as runtime_connection:
+            with pytest.raises(
+                asyncpg.PostgresError,
+                match="Current EOM Terms version must be published",
+            ):
+                await runtime_connection.execute(
+                    """
+                    UPDATE eom_terms_current_version
+                    SET version_id = $1
+                    WHERE singleton
+                    """,
+                    duplicate_id,
+                )
+
+        duplicate_results = await asyncio.gather(
+            authority.publish(
+                version_id=duplicate_id,
+                actor_id=7,
+                actor_name="Juan",
+            ),
+            authority.publish(
+                version_id=duplicate_id,
+                actor_id=7,
+                actor_name="Juan",
+            ),
+        )
+        assert sorted(result["idempotent"] for result in duplicate_results) == [
+            False,
+            True,
+        ]
+
+        distinct_versions = []
+        for suffix in ("3", "4"):
+            created = await authority.create_draft(
+                version_label=f"2026.{suffix}",
+                material_change=True,
+                documents=_documents(f"distinct-{suffix}"),
+                actor_id=7,
+                actor_name="Juan",
+            )
+            distinct_versions.append(UUID(created["versionId"]))
+
+        publication_order: list[UUID] = []
+        recording_authority = EOMTermsAuthority(
+            pool=_RecordingCurrentPool(pool.raw_pool, publication_order)
+        )
+
+        async def publish_recorded(version_id: UUID) -> dict[str, Any]:
+            return await recording_authority.publish(
+                version_id=version_id,
+                actor_id=7,
+                actor_name="Juan",
+            )
+
+        distinct_results = await asyncio.gather(
+            *(publish_recorded(version_id) for version_id in distinct_versions)
+        )
+        assert all(result["status"] == "published" for result in distinct_results)
+        assert len(publication_order) == 2
+        current = await authority.get_current()
+        assert UUID(current["versionId"]) == publication_order[-1]
+        assert (
+            await pool.fetchval(
+                """
+            SELECT COUNT(*)
+            FROM eom_terms_versions
+            WHERE id = ANY($1::uuid[]) AND status = 'published'
+            """,
+                distinct_versions,
+            )
+            == 2
+        )
+        with pytest.raises(EOMTermsConflictError):
+            await authority.publish(
+                version_id=publication_order[0],
+                actor_id=7,
+                actor_name="Juan",
+            )
+
+        rollback_draft = await authority.create_draft(
+            version_label="2026.rollback",
+            material_change=True,
+            documents=_documents("rollback"),
+            actor_id=7,
+            actor_name="Juan",
+        )
+        rollback_id = UUID(rollback_draft["versionId"])
+        current_before_failure = await pool.fetchval(
+            "SELECT version_id FROM eom_terms_current_version WHERE singleton"
+        )
+        failing_authority = EOMTermsAuthority(
+            pool=_FailBeforeCurrentPool(pool.raw_pool)
+        )
+        with pytest.raises(
+            EOMTermsUnavailableError,
+            match="could not be published",
+        ):
+            await failing_authority.publish(
+                version_id=rollback_id,
+                actor_id=7,
+                actor_name="Juan",
+            )
+        assert (
+            await pool.fetchval(
+                "SELECT status FROM eom_terms_versions WHERE id = $1",
+                rollback_id,
+            )
+            == "draft"
+        )
+        assert (
+            await pool.fetchval(
+                "SELECT version_id FROM eom_terms_current_version WHERE singleton"
+            )
+            == current_before_failure
+        )
+
+        rewrite_probe = await authority.create_draft(
+            version_label="2026.rewrite",
+            material_change=True,
+            documents=_documents("rewrite"),
+            actor_id=7,
+            actor_name="Juan",
+        )
+        with pytest.raises(
+            asyncpg.PostgresError,
+            match="Publishing EOM Terms cannot rewrite draft content",
+        ):
+            await dba_connection.execute(
+                """
+                UPDATE eom_terms_versions
+                SET status = 'published',
+                    published_by_id = 7,
+                    published_by_name = 'Juan',
+                    published_at = CURRENT_TIMESTAMP,
+                    documents = '{"tampered": true}'::jsonb
+                WHERE id = $1
+                """,
+                UUID(rewrite_probe["versionId"]),
+            )
+        with pytest.raises(
+            asyncpg.PostgresError,
+            match="Current EOM Terms authority cannot be removed",
+        ):
+            await dba_connection.execute("DELETE FROM eom_terms_current_version")
+        with pytest.raises(
+            asyncpg.PostgresError,
+            match=(
+                "EOM Terms version history is append-only"
+                "|Current EOM Terms authority cannot be removed"
+            ),
+        ):
+            await dba_connection.execute(
+                "TRUNCATE eom_terms_versions, eom_terms_current_version"
+            )
+
+        await dba_connection.execute(
+            """
+            ALTER TABLE eom_terms_versions
+            DISABLE TRIGGER trg_protect_eom_terms_version
+            """
+        )
+        assert await eom_terms_authority_schema_ready(pool) is False
+        await dba_connection.execute(
+            """
+            ALTER TABLE eom_terms_versions
+            ENABLE TRIGGER trg_protect_eom_terms_version
+            """
+        )
+        assert await eom_terms_authority_schema_ready(pool) is True
+
+        await dba_connection.execute(
+            "GRANT DELETE ON TABLE eom_terms_versions TO atlas"
+        )
+        assert await eom_terms_authority_schema_ready(pool) is False
+        await dba_connection.execute(
+            "REVOKE DELETE ON TABLE eom_terms_versions FROM atlas"
+        )
+        assert await eom_terms_authority_schema_ready(pool) is True
+
+        await dba_connection.execute(
+            """
+            ALTER FUNCTION protect_eom_terms_version()
+            SET search_path TO pg_catalog
+            """
+        )
+        assert await eom_terms_authority_schema_ready(pool) is False
+        await dba_connection.execute(
+            f"""
+            ALTER FUNCTION protect_eom_terms_version()
+            SET search_path TO pg_catalog, "{schema}", pg_temp
+            """
+        )
+        assert await eom_terms_authority_schema_ready(pool) is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_migrations_runner.py
+++ b/tests/test_migrations_runner.py
@@ -1371,6 +1371,7 @@ async def test_generic_run_skips_controlled_dba_migration_until_explicitly_selec
     assert CONTROLLED_DBA_MIGRATION_NAMES == {
         "393_eom_missed_call_recovery_runtime_privileges",
         "394_eom_first_clean_completion_receipts",
+        "396_eom_terms_authority",
     }
     controlled_sources = {
         controlled_name: f"SELECT '{controlled_name}'"
@@ -1390,7 +1391,7 @@ async def test_generic_run_skips_controlled_dba_migration_until_explicitly_selec
         name not in CONTROLLED_DBA_MIGRATION_NAMES
         for _version, name, _digest in pool.records
     )
-    assert "Skipping 2 controlled DBA migration(s)" in caplog.text
+    assert "Skipping 3 controlled DBA migration(s)" in caplog.text
 
     for controlled_name in sorted(CONTROLLED_DBA_MIGRATION_NAMES):
         await run_migrations(


### PR DESCRIPTION
Plan: plans/PR-EOM-Terms-Authority.md
Slice phase: Vertical slice
Ownership lane: eom-onboarding-terms

Issue #2156 needs Terms to become a universal, versioned obligation separate
from welcome/profile onboarding and later recurring-residential card setup.
This provider slice creates the private Atlas authority only; it publishes no
customer copy and produces no invitation, acceptance, email, payment, or Stripe
effect.

Diff-budget override: The controlled schema guard, immutable publication
service, private HTTP boundary, slim-database binding, and real PostgreSQL proof
form one provider contract. Splitting them would merge unreachable storage, a
runtime-tamperable legal boundary, or an unproved concurrency model.

## Intentional

- One version contains the exact residential/commercial x English/Spanish
  bundle, including Terms, unavailable-services, and additional-work sections.
- Draft identity is label-idempotent; identical retries replay, while changed
  content conflicts.
- Publication is transactionally serialized; published content is immutable;
  the singleton current pointer can reference only a published version.
- Migration 396 is DBA-controlled. The no-login EOM guard owns the relations
  and trigger functions; direct runtime Atlas receives only exact column DML.
- The slim EOM app binds Terms to its canonical funnel database.
- The private API requires the existing EOM service bearer; create/publish also
  require actor evidence.
- No Terms content is seeded or customer-visible by this deployment.

## AI reconciliation

- Bind the Terms authority to the slim funnel database — fixed-in: 1689ceb12 adds the real main_eom override and entrypoint test.
- Exercise the migration guards against PostgreSQL — fixed-in: 1689ceb12 adds an enrolled disposable-PostgreSQL migration, trigger, ACL, concurrency, and rollback proof.
- Move immutable Terms objects out of runtime ownership — fixed-in: 1689ceb12 makes migration 396 DBA-controlled, transfers objects to the no-login guard, minimizes DML, and attests the complete boundary.
- Define the publication execution model before merge — fixed-in: 1689ceb12 documents it and proves same-version replay, distinct-version serialization, stale retry conflict, and pre-pointer rollback.
- Document the post-deployment rollback procedure — fixed-in: 8370f868c adds retention-first migration guidance and the complete operator stop, rollback, and security-containment sequence.
- Timestamp publication after acquiring the lock — fixed-in: 8370f868c captures one wall-clock timestamp after serialization and uses it for both publication and current selection, with ordering proof.
- Enroll the controlled migration in the ops surface — fixed-in: 8370f868c adds the allowlisted `./ops` preflight/apply command, capability entry, runbook, and boundary tests.
- Grant INSERT on the pointer timestamp — fixed-in: 11cb8a3b2 grants and attests the `selected_at` column now written by the serialized publication transaction, with the exact five-column INSERT and five-trigger readiness counts.

## Fix-loop disposition preflight

- Root decision: Bind the Terms authority to the slim funnel database —
- Source trace: Terms route dependency fallback -> real slim EOM application pool binding
- Upstream files: `atlas_brain/main_eom.py`
- Fix strategy: upstream-root
- Blocking predicate: claimed-mechanism
- Disposition: fixed-in
- Allowed files: `atlas_brain/eom_api/funnel.py`, `atlas_brain/main_eom.py`, `tests/test_eom_terms_authority.py`
- Max files: 16
- Parked hardening: none

- Root decision: Exercise the migration guards against PostgreSQL —
- Source trace: substring assertions -> actual DBA migration and runtime PostgreSQL behavior
- Upstream files: `atlas_brain/storage/migrations/396_eom_terms_authority.sql`, `tests/test_eom_terms_authority.py`
- Fix strategy: upstream-root
- Blocking predicate: claimed-mechanism
- Disposition: fixed-in
- Allowed files: `.github/workflows/atlas_eom_lead_pipeline_checks.yml`, `atlas_brain/storage/migrations/396_eom_terms_authority.sql`, `tests/test_eom_terms_authority.py`
- Max files: 16
- Parked hardening: none

- Root decision: Move immutable Terms objects out of runtime ownership —
- Source trace: runtime-owned trigger objects -> controlled DBA migration and no-login guard ownership
- Upstream files: `atlas_brain/storage/migrations/396_eom_terms_authority.sql`, `atlas_brain/services/eom_terms_authority.py`
- Fix strategy: upstream-root
- Blocking predicate: security
- Disposition: fixed-in
- Allowed files: `atlas_brain/services/eom_terms_authority.py`, `atlas_brain/storage/migrations/396_eom_terms_authority.sql`, `atlas_brain/storage/migrations/__init__.py`, `scripts/apply_eom_first_clean_completion_schema.py`, `scripts/apply_eom_terms_authority_schema.py`, `tests/test_eom_first_clean_completion_dba_runner.py`, `tests/test_migrations_runner.py`
- Max files: 16
- Parked hardening: none

- Root decision: Define the publication execution model before merge —
- Source trace: unproved publish ordering and rollback -> documented lock transaction model and real concurrency probes
- Upstream files: `atlas_brain/services/eom_terms_authority.py`, `tests/test_eom_terms_authority.py`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `plans/PR-EOM-Terms-Authority.md`, `atlas_brain/services/eom_terms_authority.py`, `tests/test_eom_terms_authority.py`
- Max files: 16
- Parked hardening: none

- Root decision: Document the post-deployment rollback procedure —
- Source trace: committed guard-owned schema without rollback instructions -> retention-first migration and database runbook procedure
- Upstream files: `atlas_brain/storage/migrations/396_eom_terms_authority.sql`, `.agent/runbooks/database.md`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `.agent/runbooks/database.md`, `atlas_brain/storage/migrations/396_eom_terms_authority.sql`, `plans/PR-EOM-Terms-Authority.md`
- Max files: 16
- Parked hardening: none

- Root decision: Timestamp publication after acquiring the lock —
- Source trace: transaction-start CURRENT_TIMESTAMP -> one post-advisory-lock wall-clock value shared by both writes
- Upstream files: `atlas_brain/services/eom_terms_authority.py`, `tests/test_eom_terms_authority.py`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `atlas_brain/services/eom_terms_authority.py`, `tests/test_eom_terms_authority.py`, `plans/PR-EOM-Terms-Authority.md`
- Max files: 16
- Parked hardening: none

- Root decision: Enroll the controlled migration in the ops surface —
- Source trace: source-only migration wrapper -> canonical allowlisted ./ops command and machine-readable operator contract
- Upstream files: `ops`, `.agent/capabilities.yaml`, `.agent/runbooks/database.md`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `.agent/capabilities.yaml`, `.agent/runbooks/database.md`, `ops`, `tests/test_agent_operations_contract.py`, `plans/PR-EOM-Terms-Authority.md`
- Max files: 16
- Parked hardening: none

- Root decision: Grant INSERT on the pointer timestamp —
- Source trace: explicit `selected_at` pointer insert -> matching runtime column privilege and readiness attestation
- Upstream files: `atlas_brain/services/eom_terms_authority.py`, `atlas_brain/storage/migrations/396_eom_terms_authority.sql`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `atlas_brain/services/eom_terms_authority.py`, `atlas_brain/storage/migrations/396_eom_terms_authority.sql`, `tests/test_eom_terms_authority.py`, `plans/PR-EOM-Terms-Authority.md`
- Max files: 16
- Parked hardening: none

## Deferred

- Invitations, acceptances, executed-copy delivery, material-version
  reacceptance, readiness, and initial-customer invitations remain the next
  Atlas Terms slice.
- Tracker proxy, Website Onboarding tab/public acceptance page, and admin
  readiness UI remain consumer slices.
- First-clean balance/payment and recurring-residential hosted Stripe setup
  remain later #2156 slices.
- Exact bilingual customer-facing copy remains unseeded pending operator
  approval.

## Parked hardening

- None. Invitation, acceptance, delivery, payment, Stripe, and UI mechanisms
  are separate accepted slices, not omissions from this authority contract.

## Cold diff reconstruction

- Confirmed: migration 396 rejects an untrusted runtime/schema topology and
  pre-existing lookalikes before creating state
  (`atlas_brain/storage/migrations/396_eom_terms_authority.sql:6`,
  `atlas_brain/storage/migrations/396_eom_terms_authority.sql:12`).
- Confirmed: the two version/current relations and three SECURITY INVOKER guard
  functions are transferred to `atlas_eom_handoff_owner`; Atlas receives table
  SELECT plus only the insert/update columns used by the service
  (`atlas_brain/storage/migrations/396_eom_terms_authority.sql:143`,
  `atlas_brain/storage/migrations/396_eom_terms_authority.sql:184`,
  `atlas_brain/storage/migrations/396_eom_terms_authority.sql:204`,
  `atlas_brain/storage/migrations/396_eom_terms_authority.sql:308`,
  `atlas_brain/storage/migrations/396_eom_terms_authority.sql:320`,
  `atlas_brain/storage/migrations/396_eom_terms_authority.sql:386`).
- Confirmed: readiness now attests the direct runtime/guard roles, schema/table
  and function ownership, fixed function search paths, exact trigger-function
  linkage, required constraints, and effective ACL shape before serving
  (`atlas_brain/services/eom_terms_authority.py:208`).
- Confirmed: the service admits only the exact audience/locale/section bundle,
  hashes canonical JSON, validates stored rows against that hash, creates or
  replays a draft by label, serializes publication, and reads only the current
  published row (`atlas_brain/services/eom_terms_authority.py:119`,
  `atlas_brain/services/eom_terms_authority.py:142`,
  `atlas_brain/services/eom_terms_authority.py:805`,
  `atlas_brain/services/eom_terms_authority.py:862`,
  `atlas_brain/services/eom_terms_authority.py:932`).
- Confirmed: closed bearer-protected routes expose create/publish/current, both
  writes require actor evidence, and `main_eom` overrides the dependency with
  the slim funnel pool (`atlas_brain/eom_api/funnel.py:2089`,
  `atlas_brain/eom_api/funnel.py:2121`,
  `atlas_brain/eom_api/funnel.py:2150`,
  `atlas_brain/main_eom.py:321`).
- Confirmed: migration 396 is excluded from ordinary startup, has a dedicated
  pinned DBA entrypoint, and its real PostgreSQL test is enrolled in the EOM
  workflow (`atlas_brain/storage/migrations/__init__.py:23`,
  `scripts/apply_eom_first_clean_completion_schema.py:45`,
  `scripts/apply_eom_terms_authority_schema.py:33`,
  `.github/workflows/atlas_eom_lead_pipeline_checks.yml:355`,
  `tests/test_eom_terms_authority.py:493`).
- Confirmed: publication captures one wall-clock value after the advisory lock
  and writes it to both the immutable version and current selector
  (`atlas_brain/services/eom_terms_authority.py:874`).
- Confirmed: the canonical operations surface exposes only the pinned Terms
  preflight/apply command, with matching capability and retention-first runbook
  entries (`ops:355`, `.agent/capabilities.yaml:171`,
  `.agent/runbooks/database.md:50`).
- Contradicted: the diff contains no Terms seed and no customer invitation,
  acceptance, delivery, payment, Stripe, calendar, Tracker, Website, or
  employee-timekeeping implementation.
- Could not determine: deployed schema state remains unchanged until the
  controlled migration is applied to the deployed slim EOM database.

## Verification

- effect-trace: private POST -> closed request -> validation/canonical hash ->
  guarded version row; publish POST -> transaction advisory lock -> locked
  version/current state -> immutable transition -> published-only pointer ->
  commit; private GET -> current join -> stored-hash verification -> closed
  response.
- boundary-probe: complete documents pass; missing, extra, blank, NUL,
  surrogate, non-text, and over-limit fields fail; exact max length passes;
  false materialChange passes while numeric zero fails.
- boundary-probe: direct runtime can use only required DML and cannot disable a
  trigger, replace a guard function, mutate a published row, delete current
  authority, or truncate history. Injected trigger, ACL, and function-search-
  path drift each make readiness fail closed.
- concurrency/failure: two concurrent publishes of one draft produce one
  transition plus one replay; two distinct drafts serialize and current equals
  the last lock-ordered pointer write; a superseded retry conflicts; injected
  failure after version UPDATE but before pointer UPSERT rolls back both.
- deployment order: Atlas controlled migration/provider first; no consumer is
  included.

## Mechanical verification

- Command: `python -m pytest tests/test_eom_terms_authority.py -q` with disposable PostgreSQL DSNs - Result: 29 passed - Environment: local
- Command: current-head disposable PostgreSQL guard/concurrency/rollback probe - Result: 1 passed in 0.49s - Environment: local
- Command: `./ops test focused tests/test_eom_terms_authority.py -q` - Result: 28 passed, 1 skipped - Environment: local
- Command: focused Terms plus guarded-operations contract probes - Result: 31 passed, 1 skipped - Environment: local
- Command: `./ops test focused tests/test_eom_first_clean_completion_dba_runner.py -q` - Result: 21 passed - Environment: local
- Command: `./ops test focused tests/test_migrations_runner.py -q` - Result: 117 passed, 1 skipped - Environment: local
- Command: adjacent EOM render-profile and capability-manifest suites - Result: 76 passed - Environment: local
- Command: targeted Ruff lint, new/rewritten-file format check, `py_compile`, and `git diff --check` - Result: passed - Environment: local
- Command: `ATLAS_SESSION_STATE_FILE=SESSION_STATE.codex-eom-onboarding-20260827.local.md ./ops test local-review` - Result: passed - Environment: local
- Command: `docker stop atlas-eom-terms-2504-postgres` - Result: passed; the disposable container and synthetic schemas were removed - Environment: local
- Skipped: full local Unit Gate - Reason: repository policy assigns it to GitHub.

## Diff size

16 files, +3176 / -30

<!-- atlas-open-pr-wrapper: v1 -->
