### PR TITLE
Add EOM Terms invitation and acceptance authority

### DIFF
--- a/.agent/capabilities.yaml
+++ b/.agent/capabilities.yaml
@@ -179,6 +179,17 @@ database:
       current_session_capable: false-until-the-protected-DBA-configuration-is-exported
       mutation: preflight is read-only; apply creates guard-owned Terms authority objects and records migration 396
       rollback: stop Terms writers and consumers, retain immutable history and the migration record, and follow .agent/runbooks/database.md
+    eom_terms_acceptance:
+      status: guarded-preflight-and-apply
+      migration: 397_eom_terms_acceptance
+      predecessor: 396_eom_terms_authority
+      preflight: ./ops db controlled eom-terms-acceptance preflight
+      apply: ./ops db controlled eom-terms-acceptance apply
+      implementation: scripts/apply_eom_terms_acceptance_schema.py
+      authentication: protected direct PostgreSQL-superuser DSN plus canonical EOM funnel runtime configuration
+      current_session_capable: false-until-the-protected-DBA-configuration-is-exported
+      mutation: preflight is read-only; apply creates guard-owned Terms invitation, acceptance, and delivery evidence and records migration 397
+      rollback: stop Terms invitation and acceptance callers, retain all legal and delivery history plus the migration record, and follow .agent/runbooks/database.md
   mutation: fixed inspections are read-only; app startup and integration tests can mutate
   likely_failures:
     - assuming root Docker Compose provides PostgreSQL

--- a/.agent/runbooks/database.md
+++ b/.agent/runbooks/database.md
@@ -114,6 +114,56 @@ history. Do not use that emergency revoke for a routine application rollback:
 it intentionally makes Terms readiness fail closed until a reviewed repair
 restores the exact grants.
 
+## EOM Terms acceptance migration
+
+Migration `397_eom_terms_acceptance` is also excluded from automatic startup.
+It adds customer-bound invitation metadata, immutable acceptance evidence, and
+content-stable delivery records under the same no-login EOM guard owner. It
+depends on a recorded migration `396_eom_terms_authority`; the fixed runner
+rejects preflight and apply when that predecessor is absent.
+
+1. Use the exact merged release worktree intended for deployment and compare it
+   to the running revision:
+
+   ```bash
+   git rev-parse HEAD
+   ./ops deploy status
+   ```
+
+2. Supply the same operator-only protected DBA DSN and exact schema variables
+   described above. Do not put them in Git, chat, shell history, or a service
+   environment file. Confirm migration 396 first, then run the read-only 397
+   preflight:
+
+   ```bash
+   ./ops db controlled eom-terms-authority preflight
+   ./ops db controlled eom-terms-acceptance preflight
+   ```
+
+3. After recording both target receipts, apply 397 once and immediately repeat
+   its preflight. `migration_recorded` must be true before deploying or
+   restarting any invitation, token-session, acceptance, readiness, revocation,
+   or delivery-reconciliation route:
+
+   ```bash
+   ./ops db controlled eom-terms-acceptance apply
+   ./ops db controlled eom-terms-acceptance preflight
+   ```
+
+4. Keep invitation issuance disabled until the application release and its
+   Tracker consumer are deployed. Applying the schema creates no Terms content,
+   invitation, acceptance, email, scheduler, or customer mutation by itself.
+
+Post-deployment application rollback is retention-only. Stop every Terms
+invitation and acceptance caller first, then roll application code back while
+retaining migrations 396 and 397, all guard-owned relations/functions/triggers,
+their grants, and every stored row. Never delete, truncate, disable, rewrite, or
+unrecord legal or delivery evidence as an application rollback mechanism. A
+credential-compromise response may revoke runtime write grants only as a
+separately reviewed DBA containment action after all affected Atlas processes
+are stopped; preserve read-only audit access and roll forward with a reviewed
+repair.
+
 ## Role-topology evidence preflight
 
 This is a read-only prerequisite for a later least-privilege role cutover. It

--- a/.github/workflows/atlas_eom_lead_pipeline_checks.yml
+++ b/.github/workflows/atlas_eom_lead_pipeline_checks.yml
@@ -36,6 +36,7 @@ on:
       - "atlas_brain/services/eom_missed_call_recovery.py"
       - "atlas_brain/services/eom_first_clean_completion.py"
       - "atlas_brain/services/eom_terms_authority.py"
+      - "atlas_brain/services/eom_terms_acceptance.py"
       - "atlas_brain/services/eom_public_onboarding_tokens.py"
       - "atlas_brain/templates/email/__init__.py"
       - "atlas_brain/templates/email/estimate_confirmation.py"
@@ -82,9 +83,11 @@ on:
       - "atlas_brain/storage/migrations/394_eom_first_clean_completion_receipts.sql"
       - "atlas_brain/storage/migrations/395_eom_post_clean_onboarding_candidates.sql"
       - "atlas_brain/storage/migrations/396_eom_terms_authority.sql"
+      - "atlas_brain/storage/migrations/397_eom_terms_acceptance.sql"
       - "atlas_brain/storage/migrations/reconciliation.py"
       - "scripts/apply_eom_first_clean_completion_schema.py"
       - "scripts/apply_eom_terms_authority_schema.py"
+      - "scripts/apply_eom_terms_acceptance_schema.py"
       - "atlas_brain/tools/calendar.py"
       - "atlas_brain/tools/scheduling.py"
       - "tests/test_ack_commercial_templates.py"
@@ -103,6 +106,7 @@ on:
       - "tests/test_eom_first_clean_completion.py"
       - "tests/test_eom_first_clean_completion_dba_runner.py"
       - "tests/test_eom_terms_authority.py"
+      - "tests/test_eom_terms_acceptance.py"
       - "tests/test_database_role_topology_preflight.py"
       - "tests/test_eom_lead_conversion_integration.py"
       - "tests/test_eom_render_profile.py"
@@ -158,6 +162,7 @@ on:
       - "atlas_brain/services/eom_missed_call_recovery.py"
       - "atlas_brain/services/eom_first_clean_completion.py"
       - "atlas_brain/services/eom_terms_authority.py"
+      - "atlas_brain/services/eom_terms_acceptance.py"
       - "atlas_brain/services/eom_public_onboarding_tokens.py"
       - "atlas_brain/templates/email/__init__.py"
       - "atlas_brain/templates/email/estimate_confirmation.py"
@@ -204,9 +209,11 @@ on:
       - "atlas_brain/storage/migrations/394_eom_first_clean_completion_receipts.sql"
       - "atlas_brain/storage/migrations/395_eom_post_clean_onboarding_candidates.sql"
       - "atlas_brain/storage/migrations/396_eom_terms_authority.sql"
+      - "atlas_brain/storage/migrations/397_eom_terms_acceptance.sql"
       - "atlas_brain/storage/migrations/reconciliation.py"
       - "scripts/apply_eom_first_clean_completion_schema.py"
       - "scripts/apply_eom_terms_authority_schema.py"
+      - "scripts/apply_eom_terms_acceptance_schema.py"
       - "atlas_brain/tools/calendar.py"
       - "atlas_brain/tools/scheduling.py"
       - "tests/test_ack_commercial_templates.py"
@@ -225,6 +232,7 @@ on:
       - "tests/test_eom_first_clean_completion.py"
       - "tests/test_eom_first_clean_completion_dba_runner.py"
       - "tests/test_eom_terms_authority.py"
+      - "tests/test_eom_terms_acceptance.py"
       - "tests/test_database_role_topology_preflight.py"
       - "tests/test_eom_lead_conversion_integration.py"
       - "tests/test_eom_render_profile.py"
@@ -353,6 +361,7 @@ jobs:
             tests/test_eom_first_clean_completion.py \
             tests/test_eom_first_clean_completion_dba_runner.py \
             tests/test_eom_terms_authority.py \
+            tests/test_eom_terms_acceptance.py \
             tests/test_database_role_topology_preflight.py \
             tests/test_eom_lead_conversion_integration.py \
             tests/test_eom_render_profile.py \

--- a/atlas_brain/eom_api/funnel.py
+++ b/atlas_brain/eom_api/funnel.py
@@ -68,6 +68,12 @@ from ..services.eom_terms_authority import (
     EOMTermsAuthority,
     EOMTermsAuthorityError,
 )
+from ..services.eom_terms_acceptance import (
+    AuthenticatedEOMTermsToken,
+    EOMTermsAcceptanceError,
+    EOMTermsAcceptanceService,
+    authenticate_eom_terms_token,
+)
 from ..services.eom_public_onboarding_tokens import (
     AuthenticatedEOMPublicOnboardingToken,
     EOMPublicOnboardingTokenError,
@@ -236,6 +242,161 @@ class EOMTermsVersionResponse(BaseModel):
     published_by_id: int | None = Field(default=None, alias="publishedById")
     published_by_name: str | None = Field(default=None, alias="publishedByName")
     published_at: datetime | None = Field(default=None, alias="publishedAt")
+    idempotent: bool
+
+
+class EOMTermsInvitationRequest(BaseModel):
+    """Only caller-owned identity fields for one manual invitation."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    request_key: object = Field(alias="requestKey")
+    contact_id: object = Field(alias="contactId")
+    locale: object
+
+
+class EOMTermsInvitationResponse(BaseModel):
+    """Closed office projection of one pinned invitation and its delivery."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    invitation_id: UUID = Field(alias="invitationId")
+    contact_id: UUID = Field(alias="contactId")
+    version_id: UUID = Field(alias="versionId")
+    version_label: str = Field(alias="versionLabel")
+    content_hash: str = Field(alias="contentHash")
+    audience: Literal["residential", "commercial"]
+    locale: Literal["en", "es"]
+    recipient_email: str = Field(alias="recipientEmail")
+    status: Literal["issued", "accepted", "revoked", "expired"]
+    issued_at: datetime = Field(alias="issuedAt")
+    expires_at: datetime = Field(alias="expiresAt")
+    revoked_at: datetime | None = Field(default=None, alias="revokedAt")
+    acceptance_id: UUID | None = Field(default=None, alias="acceptanceId")
+    delivery_id: UUID = Field(alias="deliveryId")
+    delivery_status: Literal["pending", "sending", "sent"] = Field(
+        alias="deliveryStatus"
+    )
+    delivery_needs_reconciliation: bool = Field(alias="deliveryNeedsReconciliation")
+    delivery_error: bool = Field(alias="deliveryError")
+    idempotent: bool
+
+
+class EOMTermsTokenRequest(BaseModel):
+    """Opaque Terms bearer forwarded by the authenticated Tracker."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    token: object
+
+
+class EOMTermsAcceptanceRequest(EOMTermsTokenRequest):
+    """Two explicit acknowledgements plus the customer's typed signature."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    signer_name: object = Field(alias="signerName")
+    terms_accepted: object = Field(alias="termsAccepted")
+    additional_work_accepted: object = Field(alias="additionalWorkAccepted")
+
+
+class EOMTermsSessionResponse(BaseModel):
+    """Token-bound public projection of one exact published Terms snapshot."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    status: Literal["ready", "accepted"]
+    invitation_id: UUID = Field(alias="invitationId")
+    version_id: UUID = Field(alias="versionId")
+    version_label: str = Field(alias="versionLabel")
+    content_hash: str = Field(alias="contentHash")
+    audience: Literal["residential", "commercial"]
+    locale: Literal["en", "es"]
+    customer_name: str | None = Field(default=None, alias="customerName")
+    documents: dict[str, str] | None = None
+    expires_at: datetime | None = Field(default=None, alias="expiresAt")
+    accepted_at: datetime | None = Field(default=None, alias="acceptedAt")
+
+    @model_validator(mode="after")
+    def _state_has_only_its_projection(self) -> "EOMTermsSessionResponse":
+        ready_fields = (
+            self.customer_name is not None
+            and self.documents is not None
+            and self.expires_at is not None
+            and self.accepted_at is None
+        )
+        accepted_fields = (
+            self.customer_name is None
+            and self.documents is None
+            and self.expires_at is None
+            and self.accepted_at is not None
+        )
+        if (self.status == "ready" and not ready_fields) or (
+            self.status == "accepted" and not accepted_fields
+        ):
+            raise ValueError("Terms session state and projection do not match")
+        return self
+
+
+class EOMTermsAcceptanceResponse(BaseModel):
+    """Closed response for immutable acceptance and executed-copy delivery."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    acceptance_id: UUID = Field(alias="acceptanceId")
+    invitation_id: UUID = Field(alias="invitationId")
+    contact_id: UUID = Field(alias="contactId")
+    version_id: UUID = Field(alias="versionId")
+    version_label: str = Field(alias="versionLabel")
+    content_hash: str = Field(alias="contentHash")
+    audience: Literal["residential", "commercial"]
+    locale: Literal["en", "es"]
+    signer_name: str = Field(alias="signerName")
+    terms_accepted: Literal[True] = Field(alias="termsAccepted")
+    additional_work_accepted: Literal[True] = Field(alias="additionalWorkAccepted")
+    accepted_at: datetime = Field(alias="acceptedAt")
+    delivery_id: UUID = Field(alias="deliveryId")
+    executed_copy_delivery_status: Literal["pending", "sending", "sent"] = Field(
+        alias="executedCopyDeliveryStatus"
+    )
+    delivery_needs_reconciliation: bool = Field(alias="deliveryNeedsReconciliation")
+    delivery_error: bool = Field(alias="deliveryError")
+    idempotent: bool
+
+
+class EOMTermsReadinessResponse(BaseModel):
+    """Current customer readiness under the published material-version chain."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    contact_id: UUID = Field(alias="contactId")
+    audience: Literal["residential", "commercial"]
+    ready: bool
+    reason: Literal[
+        "not_accepted", "audience_changed", "reacceptance_required", "accepted"
+    ]
+    current_version_id: UUID = Field(alias="currentVersionId")
+    current_version_label: str = Field(alias="currentVersionLabel")
+    current_content_hash: str = Field(alias="currentContentHash")
+    accepted_version_id: UUID | None = Field(default=None, alias="acceptedVersionId")
+    accepted_version_label: str | None = Field(
+        default=None, alias="acceptedVersionLabel"
+    )
+    accepted_at: datetime | None = Field(default=None, alias="acceptedAt")
+    executed_copy_delivery_status: Literal["pending", "sending", "sent"] | None = Field(
+        default=None, alias="executedCopyDeliveryStatus"
+    )
+
+
+class EOMTermsDeliveryResponse(BaseModel):
+    """Actor-confirmed terminal state for one ambiguous transport result."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    delivery_id: UUID = Field(alias="deliveryId")
+    kind: Literal["invitation", "executed_copy"]
+    status: Literal["sent"]
+    sent_at: datetime = Field(alias="sentAt")
     idempotent: bool
 
 
@@ -766,6 +927,38 @@ def _terms_authority_dependency(request: Request) -> EOMTermsAuthority:
 
         pool = get_db_pool()
     return EOMTermsAuthority(pool=pool)
+
+
+def _terms_acceptance_dependency(request: Request) -> EOMTermsAcceptanceService:
+    """Bind Terms customer evidence to the canonical funnel database."""
+
+    pool_factory = getattr(request.app.state, "eom_funnel_terms_acceptance_pool", None)
+    if callable(pool_factory):
+        pool = pool_factory()
+    else:
+        from ..storage.database import get_db_pool
+
+        pool = get_db_pool()
+    return EOMTermsAcceptanceService(pool=pool)
+
+
+def _authenticated_terms_token(
+    token: object,
+    public_onboarding: EOMPublicOnboardingConfig,
+) -> AuthenticatedEOMTermsToken:
+    """Authenticate one Terms bearer before touching customer state."""
+
+    try:
+        return authenticate_eom_terms_token(
+            token=token,
+            secret=public_onboarding.hmac_secret,
+            previous_secret=public_onboarding.previous_hmac_secret,
+        )
+    except EOMTermsAcceptanceError as exc:
+        raise HTTPException(
+            status_code=exc.status_code,
+            detail={"code": exc.code, "message": str(exc)},
+        ) from exc
 
 
 def _authenticated_public_onboarding_token(
@@ -2080,6 +2273,13 @@ def _terms_error(exc: EOMTermsAuthorityError) -> HTTPException:
     )
 
 
+def _terms_acceptance_error(exc: EOMTermsAcceptanceError) -> HTTPException:
+    return HTTPException(
+        status_code=exc.status_code,
+        detail={"code": exc.code, "message": str(exc)},
+    )
+
+
 @router.post(
     "/terms/versions",
     response_model=EOMTermsVersionResponse,
@@ -2157,6 +2357,175 @@ async def get_current_eom_terms_version(
     except EOMTermsAuthorityError as exc:
         raise _terms_error(exc) from exc
     return EOMTermsVersionResponse.model_validate(result)
+
+
+@router.post(
+    "/terms/invitations",
+    response_model=EOMTermsInvitationResponse,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(require_eom_funnel_api)],
+)
+async def issue_eom_terms_invitation(
+    payload: EOMTermsInvitationRequest,
+    response: Response,
+    actor: dict[str, object] = Depends(require_eom_funnel_actor),
+    config: Any = Depends(get_eom_funnel_api_config),
+    public_onboarding: EOMPublicOnboardingConfig = Depends(
+        require_eom_public_onboarding_config
+    ),
+    acceptance: EOMTermsAcceptanceService = Depends(_terms_acceptance_dependency),
+    sender: Any = Depends(_onboarding_sender_dependency),
+) -> EOMTermsInvitationResponse:
+    """Issue and deliver one actor-audited invitation for an existing customer."""
+
+    if not config.public_onboarding_issuance_is_enabled:
+        raise HTTPException(
+            status_code=503,
+            detail="Public onboarding link issuance is paused",
+        )
+    try:
+        result = await acceptance.issue_and_send(
+            request_key=payload.request_key,
+            contact_id=payload.contact_id,
+            locale=payload.locale,
+            actor_id=actor["id"],
+            actor_name=actor["name"],
+            public_base_url=public_onboarding.base_url,
+            hmac_secret=public_onboarding.hmac_secret,
+            previous_hmac_secret=public_onboarding.previous_hmac_secret,
+            sender=sender,
+        )
+    except EOMTermsAcceptanceError as exc:
+        raise _terms_acceptance_error(exc) from exc
+    response.status_code = (
+        status.HTTP_200_OK if bool(result["idempotent"]) else status.HTTP_201_CREATED
+    )
+    return EOMTermsInvitationResponse.model_validate(result)
+
+
+@router.post(
+    "/terms/invitations/{invitation_id}/revoke",
+    response_model=EOMTermsInvitationResponse,
+    dependencies=[Depends(require_eom_funnel_api)],
+)
+async def revoke_eom_terms_invitation(
+    invitation_id: UUID,
+    actor: dict[str, object] = Depends(require_eom_funnel_actor),
+    acceptance: EOMTermsAcceptanceService = Depends(_terms_acceptance_dependency),
+) -> EOMTermsInvitationResponse:
+    """Make one unaccepted invitation permanently unusable."""
+
+    try:
+        result = await acceptance.revoke(
+            invitation_id=invitation_id,
+            actor_id=actor["id"],
+            actor_name=actor["name"],
+        )
+    except EOMTermsAcceptanceError as exc:
+        raise _terms_acceptance_error(exc) from exc
+    return EOMTermsInvitationResponse.model_validate(result)
+
+
+@router.get(
+    "/terms/readiness/{contact_id}",
+    response_model=EOMTermsReadinessResponse,
+    dependencies=[Depends(require_eom_funnel_api)],
+)
+async def get_eom_terms_readiness(
+    contact_id: UUID,
+    acceptance: EOMTermsAcceptanceService = Depends(_terms_acceptance_dependency),
+) -> EOMTermsReadinessResponse:
+    """Report whether the customer has current material Terms evidence."""
+
+    try:
+        result = await acceptance.get_readiness(contact_id=contact_id)
+    except EOMTermsAcceptanceError as exc:
+        raise _terms_acceptance_error(exc) from exc
+    return EOMTermsReadinessResponse.model_validate(result)
+
+
+@router.post(
+    "/terms/deliveries/{delivery_id}/confirm-sent",
+    response_model=EOMTermsDeliveryResponse,
+    dependencies=[Depends(require_eom_funnel_api)],
+)
+async def confirm_eom_terms_delivery_sent(
+    delivery_id: UUID,
+    actor: dict[str, object] = Depends(require_eom_funnel_actor),
+    acceptance: EOMTermsAcceptanceService = Depends(_terms_acceptance_dependency),
+) -> EOMTermsDeliveryResponse:
+    """Record an actor's external confirmation of an ambiguous send."""
+
+    try:
+        result = await acceptance.confirm_delivery_sent(
+            delivery_id=delivery_id,
+            actor_id=actor["id"],
+            actor_name=actor["name"],
+        )
+    except EOMTermsAcceptanceError as exc:
+        raise _terms_acceptance_error(exc) from exc
+    return EOMTermsDeliveryResponse.model_validate(result)
+
+
+@router.post(
+    "/terms/public/session",
+    response_model=EOMTermsSessionResponse,
+    dependencies=[Depends(require_eom_funnel_api)],
+)
+async def get_eom_terms_session(
+    payload: EOMTermsTokenRequest,
+    public_onboarding: EOMPublicOnboardingConfig = Depends(
+        require_eom_public_onboarding_config
+    ),
+    acceptance: EOMTermsAcceptanceService = Depends(_terms_acceptance_dependency),
+) -> EOMTermsSessionResponse:
+    """Resolve a Tracker-forwarded bearer into its exact public snapshot."""
+
+    token = _authenticated_terms_token(payload.token, public_onboarding)
+    try:
+        result = await acceptance.get_session(token=token)
+    except EOMTermsAcceptanceError as exc:
+        raise _terms_acceptance_error(exc) from exc
+    return EOMTermsSessionResponse.model_validate(result)
+
+
+@router.post(
+    "/terms/public/accept",
+    response_model=EOMTermsAcceptanceResponse,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(require_eom_funnel_api)],
+)
+async def accept_eom_terms(
+    payload: EOMTermsAcceptanceRequest,
+    response: Response,
+    x_eom_client_ip: Annotated[
+        str,
+        Header(alias="X-EOM-Client-IP", min_length=1, max_length=64),
+    ],
+    public_onboarding: EOMPublicOnboardingConfig = Depends(
+        require_eom_public_onboarding_config
+    ),
+    acceptance: EOMTermsAcceptanceService = Depends(_terms_acceptance_dependency),
+    sender: Any = Depends(_onboarding_sender_dependency),
+) -> EOMTermsAcceptanceResponse:
+    """Append one token-bound acceptance and deliver its executed copy."""
+
+    token = _authenticated_terms_token(payload.token, public_onboarding)
+    try:
+        result = await acceptance.accept_and_send(
+            token=token,
+            signer_name=payload.signer_name,
+            terms_accepted=payload.terms_accepted,
+            additional_work_accepted=payload.additional_work_accepted,
+            client_ip=x_eom_client_ip,
+            sender=sender,
+        )
+    except EOMTermsAcceptanceError as exc:
+        raise _terms_acceptance_error(exc) from exc
+    response.status_code = (
+        status.HTTP_200_OK if bool(result["idempotent"]) else status.HTTP_201_CREATED
+    )
+    return EOMTermsAcceptanceResponse.model_validate(result)
 
 
 @router.get(

--- a/atlas_brain/main_eom.py
+++ b/atlas_brain/main_eom.py
@@ -319,4 +319,5 @@ app.state.eom_funnel_crm_provider = get_eom_funnel_crm_provider
 app.state.eom_funnel_missed_call_recovery_pool = get_eom_funnel_db_pool
 app.state.eom_funnel_first_clean_completion_pool = get_eom_funnel_db_pool
 app.state.eom_funnel_terms_pool = get_eom_funnel_db_pool
+app.state.eom_funnel_terms_acceptance_pool = get_eom_funnel_db_pool
 app.include_router(funnel_router, prefix="/api/v1")

--- a/atlas_brain/services/eom_terms_acceptance.py
+++ b/atlas_brain/services/eom_terms_acceptance.py
@@ -389,7 +389,8 @@ async def eom_terms_acceptance_schema_ready(pool: Any) -> bool:
                            ('eom_terms_deliveries')
                 ),
                 expected_functions(name) AS (
-                    VALUES ('validate_eom_terms_invitation'),
+                    VALUES ('assign_eom_terms_publication_order'),
+                           ('validate_eom_terms_invitation'),
                            ('protect_eom_terms_invitation'),
                            ('validate_eom_terms_acceptance'),
                            ('protect_eom_terms_acceptance'),
@@ -397,6 +398,9 @@ async def eom_terms_acceptance_schema_ready(pool: Any) -> bool:
                 ),
                 expected_triggers(relation_name, function_name, trigger_name) AS (
                     VALUES
+                        ('eom_terms_versions',
+                         'assign_eom_terms_publication_order',
+                         'trg_assign_eom_terms_publication_order'),
                         ('eom_terms_invitations',
                          'validate_eom_terms_invitation',
                          'trg_validate_eom_terms_invitation'),
@@ -424,6 +428,10 @@ async def eom_terms_acceptance_schema_ready(pool: Any) -> bool:
                 ),
                 expected_constraints(relation_name, constraint_name) AS (
                     VALUES
+                        ('eom_terms_versions',
+                         'uq_eom_terms_publication_order'),
+                        ('eom_terms_versions',
+                         'ck_eom_terms_publication_order'),
                         ('eom_terms_invitations',
                          'pk_eom_terms_invitations'),
                         ('eom_terms_invitations',
@@ -561,7 +569,7 @@ async def eom_terms_acceptance_schema_ready(pool: Any) -> bool:
                           AND relation.relowner = relation_boundary.guard_oid
                    )
                    AND (
-                       SELECT count(*) = 5
+                       SELECT count(*) = 6
                          FROM expected_functions AS expected
                          JOIN pg_catalog.pg_proc AS guarded_function
                            ON guarded_function.proname = expected.name
@@ -685,6 +693,26 @@ async def eom_terms_acceptance_schema_ready(pool: Any) -> bool:
                    )
                    AND NOT has_column_privilege(
                        current_user, 'eom_terms_deliveries', 'body', 'UPDATE'
+                   )
+                   AND EXISTS (
+                       SELECT 1
+                       FROM pg_catalog.pg_attribute AS attribute
+                       WHERE attribute.attrelid =
+                                 'eom_terms_versions'::regclass
+                         AND attribute.attname = 'publication_order'
+                         AND attribute.atttypid = 'bigint'::regtype
+                         AND attribute.attnum > 0
+                         AND NOT attribute.attisdropped
+                         AND attribute.attgenerated = ''
+                         AND attribute.attidentity = ''
+                   )
+                   AND NOT has_column_privilege(
+                       current_user, 'eom_terms_versions',
+                       'publication_order', 'INSERT, UPDATE'
+                   )
+                   AND NOT has_function_privilege(
+                       current_user,
+                       'assign_eom_terms_publication_order()', 'EXECUTE'
                    )
                    AND NOT has_function_privilege(
                        current_user, 'validate_eom_terms_invitation()', 'EXECUTE'
@@ -923,6 +951,7 @@ class EOMTermsAcceptanceService:
             JOIN eom_terms_invitations AS invitation
               ON invitation.id = delivery.invitation_id
             WHERE delivery.id = $1
+            FOR UPDATE OF invitation
             """,
             delivery_id,
         )
@@ -969,163 +998,161 @@ class EOMTermsAcceptanceService:
         previous_secret: str | None,
         sender: Sender,
     ) -> tuple[dict[str, Any], bool]:
-        """Claim one persisted payload and send it at most once per DB state."""
+        """Serialize invitation state through one bounded transport outcome."""
 
-        claimed_now = False
-        body_to_send: str | None = None
         try:
             async with self.pool.transaction() as connection:
+                await connection.execute(
+                    "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+                    EOM_TERMS_PUBLICATION_LOCK_KEY,
+                )
                 row = await self._delivery_by_id(connection, delivery_id)
                 if row is None:
                     raise EOMTermsAcceptanceNotFoundError(
                         "Terms delivery was not found"
                     )
                 candidate = dict(row)
-                if candidate["status"] == "pending":
-                    body = str(candidate["body"])
-                    if _body_hash(body) != candidate["body_hash"]:
-                        raise EOMTermsAcceptanceUnavailableError(
-                            "Stored Terms delivery payload is invalid"
-                        )
-                    kind = str(candidate["kind"])
-                    invitation_is_usable = not (
-                        kind == "invitation"
-                        and (
-                            candidate["invitation_revoked_at"] is not None
-                            or bool(candidate["invitation_expired"])
-                            or bool(candidate["invitation_accepted"])
-                        )
+                state = str(candidate["status"])
+                if state in ("sending", "sent"):
+                    return candidate, False
+                if state != "pending":
+                    raise EOMTermsAcceptanceUnavailableError(
+                        "Stored Terms delivery state is invalid"
                     )
-                    if invitation_is_usable:
-                        if kind == "invitation":
-                            if secret is None:
-                                raise EOMTermsAcceptanceUnavailableError(
-                                    "Terms invitation signing key is unavailable"
-                                )
-                            invitation_id = UUID(str(candidate["invitation_id"]))
-                            token_secret = _secret_for_fingerprint(
-                                fingerprint=candidate["signing_key_fingerprint"],
-                                secret=secret,
-                                previous_secret=previous_secret,
-                            )
-                            token = format_eom_terms_token(
-                                invitation_id=invitation_id,
-                                secret=token_secret,
-                            )
-                            link = build_eom_terms_link(
-                                base_url=str(candidate["public_base_url"]),
-                                token=token,
-                            )
-                            body = append_eom_terms_acceptance_link(
-                                body=body,
-                                link=link,
-                                locale=str(candidate["locale"]),
-                            )
-                        elif kind != "executed_copy":
-                            raise EOMTermsAcceptanceUnavailableError(
-                                "Stored Terms delivery kind is invalid"
-                            )
-                        body_to_send = body
-                        claimed = await connection.fetchrow(
-                            """
-                            UPDATE eom_terms_deliveries AS delivery
-                            SET status = 'sending', claimed_at = clock_timestamp()
-                            WHERE delivery.id = $1
-                              AND delivery.status = 'pending'
-                              AND (
-                                  delivery.kind <> 'invitation'
-                                  OR EXISTS (
-                                      SELECT 1
-                                      FROM eom_terms_invitations AS invitation
-                                      WHERE invitation.id = delivery.invitation_id
-                                        AND invitation.revoked_at IS NULL
-                                        AND clock_timestamp()
-                                            <= invitation.expires_at
-                                        AND NOT EXISTS (
-                                            SELECT 1
-                                            FROM eom_terms_acceptances AS acceptance
-                                            WHERE acceptance.invitation_id
-                                                = invitation.id
-                                        )
-                                  )
-                              )
-                            RETURNING delivery.id
-                            """,
-                            delivery_id,
+                body = str(candidate["body"])
+                if _body_hash(body) != candidate["body_hash"]:
+                    raise EOMTermsAcceptanceUnavailableError(
+                        "Stored Terms delivery payload is invalid"
+                    )
+                kind = str(candidate["kind"])
+                invitation_is_usable = not (
+                    kind == "invitation"
+                    and (
+                        candidate["invitation_revoked_at"] is not None
+                        or bool(candidate["invitation_expired"])
+                        or bool(candidate["invitation_accepted"])
+                    )
+                )
+                if not invitation_is_usable:
+                    return candidate, False
+                if kind == "invitation":
+                    if secret is None:
+                        raise EOMTermsAcceptanceUnavailableError(
+                            "Terms invitation signing key is unavailable"
                         )
-                        claimed_now = claimed is not None
-                row = await self._delivery_by_id(connection, delivery_id)
+                    invitation_id = UUID(str(candidate["invitation_id"]))
+                    token_secret = _secret_for_fingerprint(
+                        fingerprint=candidate["signing_key_fingerprint"],
+                        secret=secret,
+                        previous_secret=previous_secret,
+                    )
+                    token = format_eom_terms_token(
+                        invitation_id=invitation_id,
+                        secret=token_secret,
+                    )
+                    link = build_eom_terms_link(
+                        base_url=str(candidate["public_base_url"]),
+                        token=token,
+                    )
+                    body = append_eom_terms_acceptance_link(
+                        body=body,
+                        link=link,
+                        locale=str(candidate["locale"]),
+                    )
+                elif kind != "executed_copy":
+                    raise EOMTermsAcceptanceUnavailableError(
+                        "Stored Terms delivery kind is invalid"
+                    )
+                claimed = await connection.fetchrow(
+                    """
+                    UPDATE eom_terms_deliveries AS delivery
+                    SET status = 'sending', claimed_at = clock_timestamp()
+                    WHERE delivery.id = $1
+                      AND delivery.status = 'pending'
+                      AND (
+                          delivery.kind <> 'invitation'
+                          OR EXISTS (
+                              SELECT 1
+                              FROM eom_terms_invitations AS invitation
+                              WHERE invitation.id = delivery.invitation_id
+                                AND invitation.revoked_at IS NULL
+                                AND clock_timestamp() <= invitation.expires_at
+                                AND NOT EXISTS (
+                                    SELECT 1
+                                    FROM eom_terms_acceptances AS acceptance
+                                    WHERE acceptance.invitation_id = invitation.id
+                                )
+                          )
+                      )
+                    RETURNING delivery.*
+                    """,
+                    delivery_id,
+                )
+                if claimed is None:
+                    current = await self._delivery_by_id(connection, delivery_id)
+                    if current is None:
+                        raise EOMTermsAcceptanceNotFoundError(
+                            "Terms delivery was not found"
+                        )
+                    return dict(current), False
+                sending = dict(claimed)
+                try:
+                    send_result = await sender(
+                        to=str(candidate["recipient_email"]),
+                        subject=str(candidate["subject"]),
+                        body=body,
+                        idempotency_key=eom_terms_delivery_idempotency_key(
+                            kind=kind,
+                            delivery_id=delivery_id,
+                        ),
+                    )
+                    message_id = send_result.get("message_id")
+                    idempotent_replay = send_result.get("idempotent_replay")
+                    if not isinstance(idempotent_replay, bool):
+                        raise ValueError("Terms delivery transport result is invalid")
+                except Exception:
+                    logger.warning(
+                        "Terms %s delivery requires reconciliation for %s",
+                        kind,
+                        delivery_id,
+                        exc_info=True,
+                    )
+                    return sending, True
+                try:
+                    confirmed = await connection.fetchrow(
+                        """
+                        UPDATE eom_terms_deliveries
+                        SET status = 'sent',
+                            sent_at = clock_timestamp(),
+                            resend_message_id = $2,
+                            transport_idempotent_replay = $3
+                        WHERE id = $1 AND status = 'sending'
+                        RETURNING *
+                        """,
+                        delivery_id,
+                        message_id,
+                        idempotent_replay,
+                    )
+                except (asyncpg.PostgresError, OSError, TimeoutError):
+                    logger.warning(
+                        "Terms %s transport succeeded but confirmation rolled "
+                        "back for idempotent retry of %s",
+                        kind,
+                        delivery_id,
+                        exc_info=True,
+                    )
+                    raise
+                if confirmed is None:
+                    raise EOMTermsAcceptanceUnavailableError(
+                        "Terms delivery confirmation was not stored"
+                    )
+                return dict(confirmed), False
         except EOMTermsAcceptanceError:
             raise
         except (asyncpg.PostgresError, OSError, TimeoutError) as exc:
             raise EOMTermsAcceptanceUnavailableError(
                 "Terms delivery state is unavailable"
             ) from exc
-        if row is None:
-            raise EOMTermsAcceptanceNotFoundError("Terms delivery was not found")
-        delivery = dict(row)
-        state = str(delivery["status"])
-        if state in ("pending", "sent") or (state == "sending" and not claimed_now):
-            return delivery, False
-        if state != "sending":
-            raise EOMTermsAcceptanceUnavailableError(
-                "Stored Terms delivery state is invalid"
-            )
-        kind = str(delivery["kind"])
-        if body_to_send is None:
-            raise EOMTermsAcceptanceUnavailableError(
-                "Terms delivery payload was not prepared"
-            )
-        try:
-            send_result = await sender(
-                to=str(delivery["recipient_email"]),
-                subject=str(delivery["subject"]),
-                body=body_to_send,
-                idempotency_key=eom_terms_delivery_idempotency_key(
-                    kind=kind,
-                    delivery_id=delivery_id,
-                ),
-            )
-        except Exception:
-            logger.warning(
-                "Terms %s delivery requires reconciliation for %s",
-                kind,
-                delivery_id,
-                exc_info=True,
-            )
-            return delivery, True
-        try:
-            confirmed = await self.pool.fetchrow(
-                """
-                UPDATE eom_terms_deliveries
-                SET status = 'sent',
-                    sent_at = clock_timestamp(),
-                    resend_message_id = $2,
-                    transport_idempotent_replay = $3
-                WHERE id = $1 AND status = 'sending'
-                RETURNING *
-                """,
-                delivery_id,
-                send_result.get("message_id"),
-                bool(send_result.get("idempotent_replay")),
-            )
-        except (asyncpg.PostgresError, OSError, TimeoutError):
-            logger.warning(
-                "Terms %s transport succeeded but confirmation requires "
-                "reconciliation for %s",
-                kind,
-                delivery_id,
-                exc_info=True,
-            )
-            return delivery, True
-        if confirmed is None:
-            logger.warning(
-                "Terms %s transport succeeded but delivery state changed for %s",
-                kind,
-                delivery_id,
-            )
-            return delivery, True
-        return dict(confirmed), False
 
     async def issue_and_send(
         self,
@@ -1333,7 +1360,7 @@ class EOMTermsAcceptanceService:
                     JOIN eom_terms_versions AS later
                       ON later.status = 'published'
                      AND later.material_change
-                     AND later.published_at > invited.published_at
+                     AND later.publication_order > invited.publication_order
                     WHERE invited.id = $1
                       AND invited.status = 'published'
                 )
@@ -1759,7 +1786,8 @@ class EOMTermsAcceptanceService:
                                FROM eom_terms_versions AS later
                                WHERE later.status = 'published'
                                  AND later.material_change
-                                 AND later.published_at > version.published_at
+                                 AND later.publication_order
+                                     > version.publication_order
                            ) AS later_material
                     FROM eom_terms_acceptances AS acceptance
                     JOIN eom_terms_versions AS version

--- a/atlas_brain/services/eom_terms_acceptance.py
+++ b/atlas_brain/services/eom_terms_acceptance.py
@@ -1682,12 +1682,33 @@ class EOMTermsAcceptanceService:
                     previous_secret=None,
                     sender=sender,
                 )
-            except EOMTermsAcceptanceConflictError:
+            except EOMTermsAcceptanceError:
                 logger.warning(
                     "Accepted EOM Terms receipt delivery requires reconciliation",
                     extra={"acceptance_id": str(acceptance["acceptance_id"])},
+                    exc_info=True,
                 )
                 delivery_error = True
+                try:
+                    async with self.pool.transaction() as connection:
+                        current_delivery_status = await connection.fetchval(
+                            "SELECT status FROM eom_terms_deliveries WHERE id = $1",
+                            UUID(str(acceptance["delivery_id"])),
+                        )
+                except (
+                    EOMTermsAcceptanceError,
+                    asyncpg.PostgresError,
+                    OSError,
+                    TimeoutError,
+                ):
+                    logger.warning(
+                        "Committed EOM Terms receipt status could not be refreshed",
+                        extra={"acceptance_id": str(acceptance["acceptance_id"])},
+                        exc_info=True,
+                    )
+                else:
+                    if current_delivery_status in EOM_TERMS_DELIVERY_STATUSES:
+                        result_row["delivery_status"] = current_delivery_status
             else:
                 result_row["delivery_status"] = delivery["status"]
         else:
@@ -1890,8 +1911,8 @@ class EOMTermsAcceptanceService:
                       ON delivery.acceptance_id = acceptance.id
                      AND delivery.kind = 'executed_copy'
                     WHERE acceptance.contact_id = $1
-                    ORDER BY version.publication_order DESC,
-                             (acceptance.audience = $2) DESC,
+                    ORDER BY (acceptance.audience = $2) DESC,
+                             version.publication_order DESC,
                              acceptance.id DESC
                     LIMIT 1
                     """,

--- a/atlas_brain/services/eom_terms_acceptance.py
+++ b/atlas_brain/services/eom_terms_acceptance.py
@@ -390,7 +390,7 @@ async def eom_terms_acceptance_schema_ready(pool: Any) -> bool:
                            ('eom_terms_deliveries')
                 ),
                 expected_functions(name) AS (
-                    VALUES ('assign_eom_terms_publication_order'),
+                    VALUES ('protect_eom_terms_version'),
                            ('validate_eom_terms_invitation'),
                            ('protect_eom_terms_invitation'),
                            ('validate_eom_terms_acceptance'),
@@ -400,8 +400,8 @@ async def eom_terms_acceptance_schema_ready(pool: Any) -> bool:
                 expected_triggers(relation_name, function_name, trigger_name) AS (
                     VALUES
                         ('eom_terms_versions',
-                         'assign_eom_terms_publication_order',
-                         'trg_assign_eom_terms_publication_order'),
+                         'protect_eom_terms_version',
+                         'trg_protect_eom_terms_version'),
                         ('eom_terms_invitations',
                          'validate_eom_terms_invitation',
                          'trg_validate_eom_terms_invitation'),
@@ -713,7 +713,7 @@ async def eom_terms_acceptance_schema_ready(pool: Any) -> bool:
                    )
                    AND NOT has_function_privilege(
                        current_user,
-                       'assign_eom_terms_publication_order()', 'EXECUTE'
+                       'protect_eom_terms_version()', 'EXECUTE'
                    )
                    AND NOT has_function_privilege(
                        current_user, 'validate_eom_terms_invitation()', 'EXECUTE'
@@ -820,7 +820,7 @@ def _acceptance_result(
         "acceptedAt": _iso(row["accepted_at"]),
         "deliveryId": str(row["delivery_id"]),
         "executedCopyDeliveryStatus": delivery_status,
-        "deliveryNeedsReconciliation": delivery_status == "sending",
+        "deliveryNeedsReconciliation": delivery_error or delivery_status == "sending",
         "deliveryError": delivery_error,
         "idempotent": idempotent,
     }
@@ -1674,14 +1674,22 @@ class EOMTermsAcceptanceService:
             else:
                 sender = send_onboarding_email
         if sender is not None:
-            delivery, delivery_error = await self._deliver(
-                delivery_id=UUID(str(acceptance["delivery_id"])),
-                secret=None,
-                previous_secret=None,
-                sender=sender,
-            )
             result_row = dict(acceptance)
-            result_row["delivery_status"] = delivery["status"]
+            try:
+                delivery, delivery_error = await self._deliver(
+                    delivery_id=UUID(str(acceptance["delivery_id"])),
+                    secret=None,
+                    previous_secret=None,
+                    sender=sender,
+                )
+            except EOMTermsAcceptanceConflictError:
+                logger.warning(
+                    "Accepted EOM Terms receipt delivery requires reconciliation",
+                    extra={"acceptance_id": str(acceptance["acceptance_id"])},
+                )
+                delivery_error = True
+            else:
+                result_row["delivery_status"] = delivery["status"]
         else:
             result_row = dict(acceptance)
         return _acceptance_result(
@@ -1883,11 +1891,12 @@ class EOMTermsAcceptanceService:
                      AND delivery.kind = 'executed_copy'
                     WHERE acceptance.contact_id = $1
                     ORDER BY version.publication_order DESC,
-                             acceptance.accepted_at DESC,
+                             (acceptance.audience = $2) DESC,
                              acceptance.id DESC
                     LIMIT 1
                     """,
                     parsed_contact_id,
+                    audience,
                 )
         except EOMTermsAcceptanceError:
             raise

--- a/atlas_brain/services/eom_terms_acceptance.py
+++ b/atlas_brain/services/eom_terms_acceptance.py
@@ -1029,6 +1029,14 @@ class EOMTermsAcceptanceService:
                     "Stored Terms delivery payload is invalid"
                 )
             kind = str(candidate["kind"])
+            if kind not in ("invitation", "executed_copy"):
+                raise EOMTermsAcceptanceUnavailableError(
+                    "Stored Terms delivery kind is invalid"
+                )
+            if not bool(candidate["invitation_contact_matches"]):
+                raise EOMTermsAcceptanceConflictError(
+                    "EOM customer changed before Terms delivery"
+                )
             if kind == "invitation":
                 if (
                     candidate["invitation_revoked_at"] is not None
@@ -1037,10 +1045,6 @@ class EOMTermsAcceptanceService:
                     or bool(candidate["invitation_materially_stale"])
                 ):
                     return None
-                if not bool(candidate["invitation_contact_matches"]):
-                    raise EOMTermsAcceptanceConflictError(
-                        "EOM customer changed before Terms delivery"
-                    )
                 if secret is None:
                     raise EOMTermsAcceptanceUnavailableError(
                         "Terms invitation signing key is unavailable"
@@ -1063,10 +1067,6 @@ class EOMTermsAcceptanceService:
                     body=body,
                     link=link,
                     locale=str(candidate["locale"]),
-                )
-            elif kind != "executed_copy":
-                raise EOMTermsAcceptanceUnavailableError(
-                    "Stored Terms delivery kind is invalid"
                 )
             return kind, body
 

--- a/atlas_brain/services/eom_terms_acceptance.py
+++ b/atlas_brain/services/eom_terms_acceptance.py
@@ -198,6 +198,7 @@ def _safe_text(value: object, *, label: str, maximum: int) -> str:
         or len(normalized) > maximum
         or "\x00" in normalized
         or any(0xD800 <= ord(character) <= 0xDFFF for character in normalized)
+        or any(not character.isprintable() for character in normalized)
     ):
         raise EOMTermsAcceptanceValidationError(f"{label} is invalid")
     return normalized
@@ -944,14 +945,35 @@ class EOMTermsAcceptanceService:
                        AS invitation_expired,
                    EXISTS (
                        SELECT 1
+                       FROM eom_terms_versions AS invited
+                       JOIN eom_terms_versions AS later
+                         ON later.status = 'published'
+                        AND later.material_change
+                        AND later.publication_order > invited.publication_order
+                       WHERE invited.id = invitation.version_id
+                         AND invited.status = 'published'
+                   ) AS invitation_materially_stale,
+                   (
+                       contact.business_context_id = 'effingham_maids'
+                       AND contact.contact_type = 'customer'
+                       AND contact.status = 'active'
+                       AND contact.customer_type = invitation.audience
+                       AND btrim(contact.full_name) = invitation.customer_name
+                       AND lower(btrim(contact.email)) =
+                           invitation.recipient_email
+                   ) AS invitation_contact_matches,
+                   EXISTS (
+                       SELECT 1
                        FROM eom_terms_acceptances AS accepted
                        WHERE accepted.invitation_id = invitation.id
                    ) AS invitation_accepted
             FROM eom_terms_deliveries AS delivery
             JOIN eom_terms_invitations AS invitation
               ON invitation.id = delivery.invitation_id
+            JOIN contacts AS contact ON contact.id = invitation.contact_id
             WHERE delivery.id = $1
-            FOR UPDATE OF invitation
+            FOR UPDATE OF invitation, delivery
+            FOR SHARE OF contact
             """,
             delivery_id,
         )
@@ -998,9 +1020,60 @@ class EOMTermsAcceptanceService:
         previous_secret: str | None,
         sender: Sender,
     ) -> tuple[dict[str, Any], bool]:
-        """Serialize invitation state through one bounded transport outcome."""
+        """Durably claim once, then serialize one bounded transport outcome."""
 
+        def prepare(candidate: dict[str, Any]) -> tuple[str, str] | None:
+            body = str(candidate["body"])
+            if _body_hash(body) != candidate["body_hash"]:
+                raise EOMTermsAcceptanceUnavailableError(
+                    "Stored Terms delivery payload is invalid"
+                )
+            kind = str(candidate["kind"])
+            if kind == "invitation":
+                if (
+                    candidate["invitation_revoked_at"] is not None
+                    or bool(candidate["invitation_expired"])
+                    or bool(candidate["invitation_accepted"])
+                    or bool(candidate["invitation_materially_stale"])
+                ):
+                    return None
+                if not bool(candidate["invitation_contact_matches"]):
+                    raise EOMTermsAcceptanceConflictError(
+                        "EOM customer changed before Terms delivery"
+                    )
+                if secret is None:
+                    raise EOMTermsAcceptanceUnavailableError(
+                        "Terms invitation signing key is unavailable"
+                    )
+                invitation_id = UUID(str(candidate["invitation_id"]))
+                token_secret = _secret_for_fingerprint(
+                    fingerprint=candidate["signing_key_fingerprint"],
+                    secret=secret,
+                    previous_secret=previous_secret,
+                )
+                token = format_eom_terms_token(
+                    invitation_id=invitation_id,
+                    secret=token_secret,
+                )
+                link = build_eom_terms_link(
+                    base_url=str(candidate["public_base_url"]),
+                    token=token,
+                )
+                body = append_eom_terms_acceptance_link(
+                    body=body,
+                    link=link,
+                    locale=str(candidate["locale"]),
+                )
+            elif kind != "executed_copy":
+                raise EOMTermsAcceptanceUnavailableError(
+                    "Stored Terms delivery kind is invalid"
+                )
+            return kind, body
+
+        transport_succeeded = False
+        transport_kind = "unknown"
         try:
+            # Commit the non-retryable state before crossing the provider boundary.
             async with self.pool.transaction() as connection:
                 await connection.execute(
                     "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
@@ -1019,50 +1092,8 @@ class EOMTermsAcceptanceService:
                     raise EOMTermsAcceptanceUnavailableError(
                         "Stored Terms delivery state is invalid"
                     )
-                body = str(candidate["body"])
-                if _body_hash(body) != candidate["body_hash"]:
-                    raise EOMTermsAcceptanceUnavailableError(
-                        "Stored Terms delivery payload is invalid"
-                    )
-                kind = str(candidate["kind"])
-                invitation_is_usable = not (
-                    kind == "invitation"
-                    and (
-                        candidate["invitation_revoked_at"] is not None
-                        or bool(candidate["invitation_expired"])
-                        or bool(candidate["invitation_accepted"])
-                    )
-                )
-                if not invitation_is_usable:
+                if prepare(candidate) is None:
                     return candidate, False
-                if kind == "invitation":
-                    if secret is None:
-                        raise EOMTermsAcceptanceUnavailableError(
-                            "Terms invitation signing key is unavailable"
-                        )
-                    invitation_id = UUID(str(candidate["invitation_id"]))
-                    token_secret = _secret_for_fingerprint(
-                        fingerprint=candidate["signing_key_fingerprint"],
-                        secret=secret,
-                        previous_secret=previous_secret,
-                    )
-                    token = format_eom_terms_token(
-                        invitation_id=invitation_id,
-                        secret=token_secret,
-                    )
-                    link = build_eom_terms_link(
-                        base_url=str(candidate["public_base_url"]),
-                        token=token,
-                    )
-                    body = append_eom_terms_acceptance_link(
-                        body=body,
-                        link=link,
-                        locale=str(candidate["locale"]),
-                    )
-                elif kind != "executed_copy":
-                    raise EOMTermsAcceptanceUnavailableError(
-                        "Stored Terms delivery kind is invalid"
-                    )
                 claimed = await connection.fetchrow(
                     """
                     UPDATE eom_terms_deliveries AS delivery
@@ -1095,7 +1126,35 @@ class EOMTermsAcceptanceService:
                             "Terms delivery was not found"
                         )
                     return dict(current), False
-                sending = dict(claimed)
+            # Revalidate under canonical locks and hold them through transport.
+            async with self.pool.transaction() as connection:
+                await connection.execute(
+                    "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+                    EOM_TERMS_PUBLICATION_LOCK_KEY,
+                )
+                row = await self._delivery_by_id(connection, delivery_id)
+                if row is None:
+                    raise EOMTermsAcceptanceNotFoundError(
+                        "Terms delivery was not found"
+                    )
+                candidate = dict(row)
+                state = str(candidate["status"])
+                if state == "sent":
+                    return candidate, False
+                if state != "sending":
+                    raise EOMTermsAcceptanceUnavailableError(
+                        "Stored Terms delivery state is invalid"
+                    )
+                prepared = prepare(candidate)
+                if prepared is None:
+                    logger.warning(
+                        "Terms delivery requires reconciliation after its "
+                        "invitation became unavailable for %s",
+                        delivery_id,
+                    )
+                    return candidate, True
+                kind, body = prepared
+                transport_kind = kind
                 try:
                     send_result = await sender(
                         to=str(candidate["recipient_email"]),
@@ -1110,6 +1169,7 @@ class EOMTermsAcceptanceService:
                     idempotent_replay = send_result.get("idempotent_replay")
                     if not isinstance(idempotent_replay, bool):
                         raise ValueError("Terms delivery transport result is invalid")
+                    transport_succeeded = True
                 except Exception:
                     logger.warning(
                         "Terms %s delivery requires reconciliation for %s",
@@ -1117,32 +1177,28 @@ class EOMTermsAcceptanceService:
                         delivery_id,
                         exc_info=True,
                     )
-                    return sending, True
-                try:
-                    confirmed = await connection.fetchrow(
-                        """
-                        UPDATE eom_terms_deliveries
-                        SET status = 'sent',
-                            sent_at = clock_timestamp(),
-                            resend_message_id = $2,
-                            transport_idempotent_replay = $3
-                        WHERE id = $1 AND status = 'sending'
-                        RETURNING *
-                        """,
-                        delivery_id,
-                        message_id,
-                        idempotent_replay,
-                    )
-                except (asyncpg.PostgresError, OSError, TimeoutError):
+                    return candidate, True
+                confirmed = await connection.fetchrow(
+                    """
+                    UPDATE eom_terms_deliveries
+                    SET status = 'sent',
+                        sent_at = clock_timestamp(),
+                        resend_message_id = $2,
+                        transport_idempotent_replay = $3
+                    WHERE id = $1 AND status = 'sending'
+                    RETURNING *
+                    """,
+                    delivery_id,
+                    message_id,
+                    idempotent_replay,
+                )
+                if confirmed is None:
                     logger.warning(
-                        "Terms %s transport succeeded but confirmation rolled "
-                        "back for idempotent retry of %s",
+                        "Terms %s transport succeeded but confirmation was not "
+                        "stored; its durable claim requires reconciliation for %s",
                         kind,
                         delivery_id,
-                        exc_info=True,
                     )
-                    raise
-                if confirmed is None:
                     raise EOMTermsAcceptanceUnavailableError(
                         "Terms delivery confirmation was not stored"
                     )
@@ -1150,6 +1206,14 @@ class EOMTermsAcceptanceService:
         except EOMTermsAcceptanceError:
             raise
         except (asyncpg.PostgresError, OSError, TimeoutError) as exc:
+            if transport_succeeded:
+                logger.warning(
+                    "Terms %s transport succeeded but database confirmation "
+                    "failed; its durable claim requires reconciliation for %s",
+                    transport_kind,
+                    delivery_id,
+                    exc_info=True,
+                )
             raise EOMTermsAcceptanceUnavailableError(
                 "Terms delivery state is unavailable"
             ) from exc
@@ -1475,10 +1539,15 @@ class EOMTermsAcceptanceService:
                 invitation = await connection.fetchrow(
                     """
                     SELECT invitation.*, version.version_label,
-                           version.content_hash, version.documents
+                           version.content_hash, version.documents,
+                           invitation_delivery.status
+                               AS invitation_delivery_status
                     FROM eom_terms_invitations AS invitation
                     JOIN eom_terms_versions AS version
                       ON version.id = invitation.version_id
+                    JOIN eom_terms_deliveries AS invitation_delivery
+                      ON invitation_delivery.invitation_id = invitation.id
+                     AND invitation_delivery.kind = 'invitation'
                     WHERE invitation.id = $1
                     FOR UPDATE OF invitation
                     """,
@@ -1502,6 +1571,10 @@ class EOMTermsAcceptanceService:
                     acceptance = existing
                     idempotent = True
                 else:
+                    if invitation["invitation_delivery_status"] == "sending":
+                        raise EOMTermsAcceptanceConflictError(
+                            "Terms invitation delivery requires reconciliation"
+                        )
                     accepted_at = await connection.fetchval("SELECT clock_timestamp()")
                     if (
                         not isinstance(accepted_at, datetime)
@@ -1635,7 +1708,16 @@ class EOMTermsAcceptanceService:
                     EOM_TERMS_PUBLICATION_LOCK_KEY,
                 )
                 row = await connection.fetchrow(
-                    "SELECT * FROM eom_terms_invitations WHERE id = $1 FOR UPDATE",
+                    """
+                    SELECT invitation.*,
+                           delivery.status AS invitation_delivery_status
+                    FROM eom_terms_invitations AS invitation
+                    JOIN eom_terms_deliveries AS delivery
+                      ON delivery.invitation_id = invitation.id
+                     AND delivery.kind = 'invitation'
+                    WHERE invitation.id = $1
+                    FOR UPDATE OF invitation
+                    """,
                     parsed_invitation_id,
                 )
                 if row is None:
@@ -1649,6 +1731,10 @@ class EOMTermsAcceptanceService:
                 if acceptance_id is not None:
                     raise EOMTermsAcceptanceConflictError(
                         "Accepted Terms invitation cannot be revoked"
+                    )
+                if row["invitation_delivery_status"] == "sending":
+                    raise EOMTermsAcceptanceConflictError(
+                        "Terms invitation delivery requires reconciliation"
                     )
                 if row["revoked_at"] is not None:
                     idempotent = True
@@ -1796,7 +1882,9 @@ class EOMTermsAcceptanceService:
                       ON delivery.acceptance_id = acceptance.id
                      AND delivery.kind = 'executed_copy'
                     WHERE acceptance.contact_id = $1
-                    ORDER BY acceptance.accepted_at DESC, acceptance.id DESC
+                    ORDER BY version.publication_order DESC,
+                             acceptance.accepted_at DESC,
+                             acceptance.id DESC
                     LIMIT 1
                     """,
                     parsed_contact_id,

--- a/atlas_brain/services/eom_terms_acceptance.py
+++ b/atlas_brain/services/eom_terms_acceptance.py
@@ -1,0 +1,1814 @@
+"""Customer-bound EOM Terms invitations, acceptance, and delivery evidence."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import ipaddress
+import json
+import logging
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable, Mapping
+from uuid import UUID, uuid4
+
+import asyncpg
+
+from .eom_onboarding_drafts import (
+    EOMOnboardingDraftError,
+    _require_transport_configured,
+    send_onboarding_email,
+)
+from .eom_public_onboarding_tokens import (
+    eom_public_onboarding_hmac_key_fingerprint,
+    validate_eom_public_onboarding_hmac_secret,
+)
+from .eom_terms_authority import (
+    EOM_TERMS_PUBLICATION_LOCK_KEY,
+    EOMTermsValidationError,
+    canonical_eom_terms_documents,
+    normalize_eom_terms_documents,
+)
+
+
+logger = logging.getLogger("atlas.services.eom_terms_acceptance")
+
+EOM_TERMS_TOKEN_VERSION = "eomt1"
+EOM_TERMS_DELIVERY_KINDS = ("invitation", "executed_copy")
+EOM_TERMS_DELIVERY_STATUSES = ("pending", "sending", "sent")
+_REQUEST_KEY_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{15,127}$")
+_EMAIL_PATTERN = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+_HMAC_DIGEST_BYTES = hashlib.sha256().digest_size
+_HMAC_SIGNATURE_LENGTH = len(
+    base64.urlsafe_b64encode(b"\0" * _HMAC_DIGEST_BYTES).decode("ascii").rstrip("=")
+)
+_MAX_TERMS_TOKEN_LENGTH = (
+    len(EOM_TERMS_TOKEN_VERSION) + 1 + 36 + 1 + _HMAC_SIGNATURE_LENGTH
+)
+_TERMS_TOKEN_PATTERN = re.compile(
+    rf"^{EOM_TERMS_TOKEN_VERSION}\."
+    r"(?P<invitation_id>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-"
+    r"[0-9a-f]{4}-[0-9a-f]{12})\."
+    rf"(?P<signature>[A-Za-z0-9_-]{{{_HMAC_SIGNATURE_LENGTH}}})$"
+)
+_MAX_SIGNED_BIGINT = 2**63 - 1
+_MAX_ACTOR_NAME_LENGTH = 128
+_MAX_SIGNER_NAME_LENGTH = 256
+_MAX_EMAIL_LENGTH = 256
+
+
+class EOMTermsAcceptanceError(Exception):
+    """Base class for stable Terms invitation/acceptance API failures."""
+
+    status_code = 409
+    code = "eom_terms_acceptance_error"
+
+
+class EOMTermsAcceptanceValidationError(EOMTermsAcceptanceError):
+    status_code = 422
+    code = "invalid_eom_terms_acceptance_request"
+
+
+class EOMTermsAcceptanceConflictError(EOMTermsAcceptanceError):
+    status_code = 409
+    code = "eom_terms_acceptance_conflict"
+
+
+class EOMTermsAcceptanceNotFoundError(EOMTermsAcceptanceError):
+    status_code = 404
+    code = "eom_terms_acceptance_not_found"
+
+
+class EOMTermsAcceptanceUnavailableError(EOMTermsAcceptanceError):
+    status_code = 503
+    code = "eom_terms_acceptance_unavailable"
+
+
+@dataclass(frozen=True)
+class AuthenticatedEOMTermsToken:
+    """A verified Terms bearer and the configured key that admitted it."""
+
+    invitation_id: UUID
+    signing_key_fingerprint: str
+
+
+def _terms_signature(*, invitation_id: UUID, secret: str) -> str:
+    message = f"{EOM_TERMS_TOKEN_VERSION}.{invitation_id}".encode("ascii")
+    digest = hmac.new(
+        validate_eom_public_onboarding_hmac_secret(secret).encode("utf-8"),
+        message,
+        hashlib.sha256,
+    ).digest()
+    return base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+
+
+def format_eom_terms_token(*, invitation_id: UUID, secret: str) -> str:
+    """Build the transient Terms bearer without storing its raw value."""
+
+    return (
+        f"{EOM_TERMS_TOKEN_VERSION}.{invitation_id}."
+        f"{_terms_signature(invitation_id=invitation_id, secret=secret)}"
+    )
+
+
+def authenticate_eom_terms_token(
+    *, token: object, secret: str, previous_secret: str | None = None
+) -> AuthenticatedEOMTermsToken:
+    """Fail closed on every value outside the one Terms bearer grammar."""
+
+    if not isinstance(token, str) or len(token) > _MAX_TERMS_TOKEN_LENGTH:
+        raise EOMTermsAcceptanceNotFoundError("Terms invitation is unavailable")
+    match = _TERMS_TOKEN_PATTERN.fullmatch(token)
+    if match is None:
+        raise EOMTermsAcceptanceNotFoundError("Terms invitation is unavailable")
+    try:
+        invitation_id = UUID(match.group("invitation_id"))
+    except ValueError as exc:  # pragma: no cover - the regex is intentionally strict.
+        raise EOMTermsAcceptanceNotFoundError(
+            "Terms invitation is unavailable"
+        ) from exc
+    supplied_signature = match.group("signature")
+    candidate_secrets = (secret,)
+    if previous_secret is not None:
+        candidate_secrets = (secret, previous_secret)
+    for candidate_secret in candidate_secrets:
+        expected = _terms_signature(
+            invitation_id=invitation_id,
+            secret=candidate_secret,
+        )
+        if hmac.compare_digest(expected, supplied_signature):
+            return AuthenticatedEOMTermsToken(
+                invitation_id=invitation_id,
+                signing_key_fingerprint=eom_public_onboarding_hmac_key_fingerprint(
+                    secret=candidate_secret
+                ),
+            )
+    raise EOMTermsAcceptanceNotFoundError("Terms invitation is unavailable")
+
+
+def build_eom_terms_link(*, base_url: str, token: str) -> str:
+    """Keep the Terms bearer in a fragment so HTTP referrers omit it."""
+
+    normalized_base_url = base_url.strip()
+    if not normalized_base_url or "#" in normalized_base_url:
+        raise EOMTermsAcceptanceValidationError(
+            "Public Terms acceptance URL is invalid"
+        )
+    return f"{normalized_base_url}#termsToken={token}"
+
+
+def eom_terms_delivery_idempotency_key(*, kind: str, delivery_id: UUID) -> str:
+    if kind not in EOM_TERMS_DELIVERY_KINDS:
+        raise EOMTermsAcceptanceValidationError("Terms delivery kind is invalid")
+    return f"eom-terms-{kind}:{delivery_id}"
+
+
+def _uuid(value: object, label: str) -> UUID:
+    if isinstance(value, UUID):
+        return value
+    try:
+        return UUID(str(value))
+    except (TypeError, ValueError, AttributeError) as exc:
+        raise EOMTermsAcceptanceValidationError(f"{label} is invalid") from exc
+
+
+def _request_key(value: object) -> str:
+    if not isinstance(value, str):
+        raise EOMTermsAcceptanceValidationError("requestKey is invalid")
+    normalized = value.strip()
+    if not _REQUEST_KEY_PATTERN.fullmatch(normalized):
+        raise EOMTermsAcceptanceValidationError("requestKey is invalid")
+    return normalized
+
+
+def _locale(value: object) -> str:
+    if value not in ("en", "es"):
+        raise EOMTermsAcceptanceValidationError("locale must be en or es")
+    return str(value)
+
+
+def _safe_text(value: object, *, label: str, maximum: int) -> str:
+    if not isinstance(value, str):
+        raise EOMTermsAcceptanceValidationError(f"{label} is invalid")
+    normalized = value.strip()
+    if (
+        not normalized
+        or len(normalized) > maximum
+        or "\x00" in normalized
+        or any(0xD800 <= ord(character) <= 0xDFFF for character in normalized)
+    ):
+        raise EOMTermsAcceptanceValidationError(f"{label} is invalid")
+    return normalized
+
+
+def _actor(actor_id: object, actor_name: object) -> tuple[int, str]:
+    if (
+        isinstance(actor_id, bool)
+        or not isinstance(actor_id, int)
+        or actor_id <= 0
+        or actor_id > _MAX_SIGNED_BIGINT
+    ):
+        raise EOMTermsAcceptanceValidationError("Authenticated actor is invalid")
+    return actor_id, _safe_text(
+        actor_name,
+        label="Authenticated actor",
+        maximum=_MAX_ACTOR_NAME_LENGTH,
+    )
+
+
+def _signer_name(value: object) -> str:
+    return _safe_text(value, label="signerName", maximum=_MAX_SIGNER_NAME_LENGTH)
+
+
+def _client_ip(value: object) -> str:
+    if not isinstance(value, str):
+        raise EOMTermsAcceptanceValidationError("Client IP is invalid")
+    try:
+        return str(ipaddress.ip_address(value.strip()))
+    except ValueError as exc:
+        raise EOMTermsAcceptanceValidationError("Client IP is invalid") from exc
+
+
+def _email(value: object) -> str:
+    if not isinstance(value, str):
+        raise EOMTermsAcceptanceUnavailableError("Customer email is unavailable")
+    normalized = value.strip().lower()
+    if (
+        not normalized
+        or len(normalized) > _MAX_EMAIL_LENGTH
+        or not _EMAIL_PATTERN.fullmatch(normalized)
+    ):
+        raise EOMTermsAcceptanceUnavailableError("Customer email is unavailable")
+    return normalized
+
+
+def _iso(value: object) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, datetime) or value.tzinfo is None:
+        raise EOMTermsAcceptanceUnavailableError("Stored Terms timestamp is invalid")
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _documents_from_version(
+    row: Mapping[str, Any],
+) -> dict[str, dict[str, dict[str, str]]]:
+    raw_documents = row["documents"]
+    if isinstance(raw_documents, str):
+        try:
+            raw_documents = json.loads(raw_documents)
+        except json.JSONDecodeError as exc:
+            raise EOMTermsAcceptanceUnavailableError(
+                "Stored Terms documents are invalid"
+            ) from exc
+    try:
+        documents = normalize_eom_terms_documents(raw_documents)
+        _, _, calculated_hash = canonical_eom_terms_documents(documents)
+    except EOMTermsValidationError as exc:
+        raise EOMTermsAcceptanceUnavailableError(
+            "Stored Terms documents are invalid"
+        ) from exc
+    if calculated_hash != row["content_hash"]:
+        raise EOMTermsAcceptanceUnavailableError("Stored Terms content hash is invalid")
+    return documents
+
+
+def _render_sections(*, documents: Mapping[str, str], locale: str) -> str:
+    labels = {
+        "en": (
+            "TERMS AND CONDITIONS",
+            "SERVICES WE CANNOT PROVIDE",
+            "SEPARATE ADDITIONAL-WORK ACKNOWLEDGEMENT",
+        ),
+        "es": (
+            "TERMINOS Y CONDICIONES",
+            "SERVICIOS QUE NO PODEMOS PROPORCIONAR",
+            "RECONOCIMIENTO SEPARADO DE TRABAJO ADICIONAL",
+        ),
+    }[locale]
+    return (
+        f"{labels[0]}\n{documents['terms']}\n\n"
+        f"{labels[1]}\n{documents['servicesWeCannotProvide']}\n\n"
+        f"{labels[2]}\n{documents['additionalWorkAcknowledgement']}"
+    )
+
+
+def render_eom_terms_invitation(
+    *,
+    full_name: str,
+    version_label: str,
+    content_hash: str,
+    documents: Mapping[str, str],
+    locale: str,
+) -> tuple[str, str]:
+    """Render the exact published locale without inventing Terms prose."""
+
+    sections = _render_sections(documents=documents, locale=locale)
+    if locale == "es":
+        subject = "Revise y acepte los terminos de Effingham Office Maids"
+        body = (
+            f"Hola {full_name},\n\n"
+            "Revise los documentos publicados a continuacion. El enlace seguro "
+            "para aceptar estos terminos aparece al final de este correo.\n\n"
+            f"Version: {version_label}\nHash: {content_hash}\n\n{sections}"
+        )
+    else:
+        subject = "Review and accept Effingham Office Maids terms"
+        body = (
+            f"Hello {full_name},\n\n"
+            "Please review the published documents below. The secure link to "
+            "accept these terms appears at the end of this email.\n\n"
+            f"Version: {version_label}\nHash: {content_hash}\n\n{sections}"
+        )
+    return subject, body
+
+
+def append_eom_terms_acceptance_link(*, body: str, link: str, locale: str) -> str:
+    prompt = (
+        "Aceptar los terminos de forma segura:"
+        if locale == "es"
+        else "Accept the terms securely:"
+    )
+    return f"{body}\n\n{prompt}\n{link}\n"
+
+
+def render_eom_terms_executed_copy(
+    *,
+    full_name: str,
+    signer_name: str,
+    accepted_at: datetime,
+    version_label: str,
+    content_hash: str,
+    documents: Mapping[str, str],
+    locale: str,
+) -> tuple[str, str]:
+    """Render the immutable acceptance receipt plus the accepted documents."""
+
+    accepted_iso = _iso(accepted_at)
+    sections = _render_sections(documents=documents, locale=locale)
+    if locale == "es":
+        subject = "Copia aceptada de los terminos de Effingham Office Maids"
+        body = (
+            f"Copia ejecutada para {full_name}\n"
+            f"Aceptado por: {signer_name}\n"
+            f"Aceptado: {accepted_iso}\n"
+            "Terminos generales aceptados: Si\n"
+            "Reconocimiento de trabajo adicional aceptado: Si\n"
+            f"Version: {version_label}\nHash: {content_hash}\n\n{sections}"
+        )
+    else:
+        subject = "Accepted copy of Effingham Office Maids terms"
+        body = (
+            f"Executed copy for {full_name}\n"
+            f"Accepted by: {signer_name}\n"
+            f"Accepted at: {accepted_iso}\n"
+            "General terms accepted: Yes\n"
+            "Additional-work acknowledgement accepted: Yes\n"
+            f"Version: {version_label}\nHash: {content_hash}\n\n{sections}"
+        )
+    return subject, body
+
+
+def _body_hash(body: str) -> str:
+    return hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+
+async def eom_terms_acceptance_schema_ready(pool: Any) -> bool:
+    """Attest the guarded acceptance relations before any customer state use."""
+
+    try:
+        return bool(
+            await pool.fetchval(
+                """
+                /* eom_terms_acceptance_schema_ready */
+                WITH expected_relations(name) AS (
+                    VALUES ('eom_terms_invitations'),
+                           ('eom_terms_acceptances'),
+                           ('eom_terms_deliveries')
+                ),
+                expected_functions(name) AS (
+                    VALUES ('validate_eom_terms_invitation'),
+                           ('protect_eom_terms_invitation'),
+                           ('validate_eom_terms_acceptance'),
+                           ('protect_eom_terms_acceptance'),
+                           ('protect_eom_terms_delivery')
+                ),
+                expected_triggers(relation_name, function_name, trigger_name) AS (
+                    VALUES
+                        ('eom_terms_invitations',
+                         'validate_eom_terms_invitation',
+                         'trg_validate_eom_terms_invitation'),
+                        ('eom_terms_invitations',
+                         'protect_eom_terms_invitation',
+                         'trg_protect_eom_terms_invitation'),
+                        ('eom_terms_invitations',
+                         'protect_eom_terms_invitation',
+                         'trg_protect_eom_terms_invitation_truncate'),
+                        ('eom_terms_acceptances',
+                         'validate_eom_terms_acceptance',
+                         'trg_validate_eom_terms_acceptance'),
+                        ('eom_terms_acceptances',
+                         'protect_eom_terms_acceptance',
+                         'trg_protect_eom_terms_acceptance'),
+                        ('eom_terms_acceptances',
+                         'protect_eom_terms_acceptance',
+                         'trg_protect_eom_terms_acceptance_truncate'),
+                        ('eom_terms_deliveries',
+                         'protect_eom_terms_delivery',
+                         'trg_protect_eom_terms_delivery'),
+                        ('eom_terms_deliveries',
+                         'protect_eom_terms_delivery',
+                         'trg_protect_eom_terms_delivery_truncate')
+                ),
+                expected_constraints(relation_name, constraint_name) AS (
+                    VALUES
+                        ('eom_terms_invitations',
+                         'pk_eom_terms_invitations'),
+                        ('eom_terms_invitations',
+                         'uq_eom_terms_invitations_request_key'),
+                        ('eom_terms_invitations',
+                         'fk_eom_terms_invitations_contact'),
+                        ('eom_terms_invitations',
+                         'fk_eom_terms_invitations_version'),
+                        ('eom_terms_invitations',
+                         'ck_eom_terms_invitations_request_key'),
+                        ('eom_terms_invitations',
+                         'ck_eom_terms_invitations_context'),
+                        ('eom_terms_invitations',
+                         'ck_eom_terms_invitations_audience'),
+                        ('eom_terms_invitations',
+                         'ck_eom_terms_invitations_locale'),
+                        ('eom_terms_invitations',
+                         'ck_eom_terms_invitations_customer_name'),
+                        ('eom_terms_invitations',
+                         'ck_eom_terms_invitations_recipient'),
+                        ('eom_terms_invitations',
+                         'ck_eom_terms_invitations_public_url'),
+                        ('eom_terms_invitations',
+                         'ck_eom_terms_invitations_key_fingerprint'),
+                        ('eom_terms_invitations',
+                         'ck_eom_terms_invitations_window'),
+                        ('eom_terms_invitations',
+                         'ck_eom_terms_invitations_issuer'),
+                        ('eom_terms_invitations',
+                         'ck_eom_terms_invitations_revocation'),
+                        ('eom_terms_acceptances',
+                         'pk_eom_terms_acceptances'),
+                        ('eom_terms_acceptances',
+                         'uq_eom_terms_acceptances_invitation'),
+                        ('eom_terms_acceptances',
+                         'fk_eom_terms_acceptances_invitation'),
+                        ('eom_terms_acceptances',
+                         'fk_eom_terms_acceptances_contact'),
+                        ('eom_terms_acceptances',
+                         'fk_eom_terms_acceptances_version'),
+                        ('eom_terms_acceptances',
+                         'ck_eom_terms_acceptances_context'),
+                        ('eom_terms_acceptances',
+                         'ck_eom_terms_acceptances_audience'),
+                        ('eom_terms_acceptances',
+                         'ck_eom_terms_acceptances_locale'),
+                        ('eom_terms_acceptances',
+                         'ck_eom_terms_acceptances_recipient'),
+                        ('eom_terms_acceptances',
+                         'ck_eom_terms_acceptances_signer'),
+                        ('eom_terms_acceptances',
+                         'ck_eom_terms_acceptances_acknowledgements'),
+                        ('eom_terms_acceptances',
+                         'ck_eom_terms_acceptances_content_hash'),
+                        ('eom_terms_deliveries',
+                         'pk_eom_terms_deliveries'),
+                        ('eom_terms_deliveries',
+                         'uq_eom_terms_deliveries_kind_invitation'),
+                        ('eom_terms_deliveries',
+                         'uq_eom_terms_deliveries_acceptance'),
+                        ('eom_terms_deliveries',
+                         'fk_eom_terms_deliveries_invitation'),
+                        ('eom_terms_deliveries',
+                         'fk_eom_terms_deliveries_acceptance'),
+                        ('eom_terms_deliveries',
+                         'ck_eom_terms_deliveries_kind'),
+                        ('eom_terms_deliveries',
+                         'ck_eom_terms_deliveries_shape'),
+                        ('eom_terms_deliveries',
+                         'ck_eom_terms_deliveries_recipient'),
+                        ('eom_terms_deliveries',
+                         'ck_eom_terms_deliveries_subject'),
+                        ('eom_terms_deliveries',
+                         'ck_eom_terms_deliveries_body'),
+                        ('eom_terms_deliveries',
+                         'ck_eom_terms_deliveries_body_hash'),
+                        ('eom_terms_deliveries',
+                         'ck_eom_terms_deliveries_status'),
+                        ('eom_terms_deliveries',
+                         'ck_eom_terms_deliveries_state')
+                ),
+                boundary AS (
+                    SELECT pg_catalog.current_schema() AS schema_name,
+                           (SELECT oid FROM pg_catalog.pg_roles
+                             WHERE rolname = 'atlas_eom_handoff_owner') AS guard_oid
+                )
+                SELECT boundary.guard_oid IS NOT NULL
+                   AND EXISTS (
+                       SELECT 1
+                       FROM pg_catalog.pg_roles AS guard_role
+                       WHERE guard_role.oid = boundary.guard_oid
+                         AND NOT guard_role.rolcanlogin
+                         AND NOT guard_role.rolinherit
+                         AND NOT guard_role.rolsuper
+                         AND NOT guard_role.rolcreaterole
+                         AND NOT guard_role.rolcreatedb
+                         AND NOT guard_role.rolreplication
+                         AND NOT guard_role.rolbypassrls
+                   )
+                   AND NOT EXISTS (
+                       SELECT 1
+                       FROM pg_catalog.pg_stat_activity AS activity
+                       WHERE activity.usesysid = boundary.guard_oid
+                         AND activity.datid = (
+                             SELECT database.oid
+                             FROM pg_catalog.pg_database AS database
+                             WHERE database.datname = current_database()
+                         )
+                   )
+                   AND NOT EXISTS (
+                       SELECT 1
+                       FROM pg_catalog.pg_roles AS member_role
+                       WHERE member_role.rolcanlogin
+                         AND NOT member_role.rolsuper
+                         AND pg_catalog.pg_has_role(
+                             member_role.oid, boundary.guard_oid, 'MEMBER'
+                         )
+                   )
+                   AND EXISTS (
+                       SELECT 1
+                       FROM pg_catalog.pg_namespace AS namespace
+                       WHERE namespace.nspname = boundary.schema_name
+                         AND namespace.nspowner = boundary.guard_oid
+                   )
+                   AND (
+                       SELECT count(*) = 3
+                         FROM expected_relations AS expected
+                         JOIN pg_catalog.pg_class AS relation
+                           ON relation.relname = expected.name
+                         JOIN pg_catalog.pg_namespace AS namespace
+                           ON namespace.oid = relation.relnamespace
+                         CROSS JOIN boundary AS relation_boundary
+                        WHERE namespace.nspname = relation_boundary.schema_name
+                          AND relation.relkind = 'r'
+                          AND relation.relowner = relation_boundary.guard_oid
+                   )
+                   AND (
+                       SELECT count(*) = 5
+                         FROM expected_functions AS expected
+                         JOIN pg_catalog.pg_proc AS guarded_function
+                           ON guarded_function.proname = expected.name
+                          AND guarded_function.pronargs = 0
+                         JOIN pg_catalog.pg_namespace AS namespace
+                           ON namespace.oid = guarded_function.pronamespace
+                         CROSS JOIN boundary AS function_boundary
+                        WHERE namespace.nspname = function_boundary.schema_name
+                          AND guarded_function.proowner = function_boundary.guard_oid
+                          AND guarded_function.prosecdef = FALSE
+                          AND guarded_function.prorettype = 'trigger'::regtype
+                          AND guarded_function.proconfig = ARRAY[
+                              format(
+                                  'search_path=pg_catalog, %I, pg_temp',
+                                  function_boundary.schema_name
+                              )
+                          ]
+                   )
+                   AND NOT EXISTS (
+                       SELECT 1
+                       FROM expected_triggers AS expected
+                       CROSS JOIN boundary AS trigger_boundary
+                       WHERE NOT EXISTS (
+                           SELECT 1
+                           FROM pg_catalog.pg_trigger AS guard_trigger
+                           JOIN pg_catalog.pg_class AS relation
+                             ON relation.oid = guard_trigger.tgrelid
+                           JOIN pg_catalog.pg_namespace AS namespace
+                             ON namespace.oid = relation.relnamespace
+                           JOIN pg_catalog.pg_proc AS guarded_function
+                             ON guarded_function.oid = guard_trigger.tgfoid
+                           WHERE namespace.nspname = trigger_boundary.schema_name
+                             AND relation.relname = expected.relation_name
+                             AND guarded_function.proname = expected.function_name
+                             AND guard_trigger.tgname = expected.trigger_name
+                             AND guard_trigger.tgenabled = 'O'
+                             AND NOT guard_trigger.tgisinternal
+                       )
+                   )
+                   AND (
+                       SELECT count(*) = 8
+                       FROM pg_catalog.pg_trigger AS guard_trigger
+                       JOIN pg_catalog.pg_class AS relation
+                         ON relation.oid = guard_trigger.tgrelid
+                       JOIN pg_catalog.pg_namespace AS namespace
+                         ON namespace.oid = relation.relnamespace
+                       CROSS JOIN boundary AS trigger_boundary
+                       WHERE namespace.nspname = trigger_boundary.schema_name
+                         AND relation.relname IN (
+                             'eom_terms_invitations',
+                             'eom_terms_acceptances',
+                             'eom_terms_deliveries'
+                         )
+                         AND NOT guard_trigger.tgisinternal
+                   )
+                   AND NOT EXISTS (
+                       SELECT 1
+                       FROM expected_constraints AS expected
+                       CROSS JOIN boundary AS constraint_boundary
+                       WHERE NOT EXISTS (
+                           SELECT 1
+                           FROM pg_catalog.pg_constraint AS actual
+                           JOIN pg_catalog.pg_class AS relation
+                             ON relation.oid = actual.conrelid
+                           JOIN pg_catalog.pg_namespace AS namespace
+                             ON namespace.oid = relation.relnamespace
+                           WHERE namespace.nspname = constraint_boundary.schema_name
+                             AND relation.relname = expected.relation_name
+                             AND actual.conname = expected.constraint_name
+                             AND actual.convalidated
+                       )
+                   )
+                   AND has_table_privilege(
+                       current_user, 'eom_terms_invitations', 'SELECT'
+                   )
+                   AND has_table_privilege(
+                       current_user, 'eom_terms_acceptances', 'SELECT'
+                   )
+                   AND has_table_privilege(
+                       current_user, 'eom_terms_deliveries', 'SELECT'
+                   )
+                   AND NOT has_table_privilege(
+                       current_user, 'eom_terms_invitations', 'DELETE, TRUNCATE'
+                   )
+                   AND NOT has_table_privilege(
+                       current_user, 'eom_terms_acceptances',
+                       'UPDATE, DELETE, TRUNCATE'
+                   )
+                   AND NOT has_table_privilege(
+                       current_user, 'eom_terms_deliveries', 'DELETE, TRUNCATE'
+                   )
+                   AND NOT has_table_privilege(
+                       current_user, 'eom_terms_invitations',
+                       'INSERT, UPDATE, REFERENCES, TRIGGER'
+                   )
+                   AND NOT has_table_privilege(
+                       current_user, 'eom_terms_acceptances',
+                       'INSERT, UPDATE, REFERENCES, TRIGGER'
+                   )
+                   AND NOT has_table_privilege(
+                       current_user, 'eom_terms_deliveries',
+                       'INSERT, UPDATE, REFERENCES, TRIGGER'
+                   )
+                   AND has_column_privilege(
+                       current_user, 'eom_terms_acceptances', 'signer_name', 'INSERT'
+                   )
+                   AND NOT has_column_privilege(
+                       current_user, 'eom_terms_acceptances', 'signer_name', 'UPDATE'
+                   )
+                   AND has_column_privilege(
+                       current_user, 'eom_terms_invitations', 'revoked_at', 'UPDATE'
+                   )
+                   AND has_column_privilege(
+                       current_user, 'eom_terms_deliveries', 'status', 'UPDATE'
+                   )
+                   AND NOT has_column_privilege(
+                       current_user, 'eom_terms_invitations', 'contact_id', 'UPDATE'
+                   )
+                   AND NOT has_column_privilege(
+                       current_user, 'eom_terms_acceptances', 'accepted_at', 'INSERT'
+                   )
+                   AND NOT has_column_privilege(
+                       current_user, 'eom_terms_deliveries', 'body', 'UPDATE'
+                   )
+                   AND NOT has_function_privilege(
+                       current_user, 'validate_eom_terms_invitation()', 'EXECUTE'
+                   )
+                   AND NOT has_function_privilege(
+                       current_user, 'protect_eom_terms_invitation()', 'EXECUTE'
+                   )
+                   AND NOT has_function_privilege(
+                       current_user, 'validate_eom_terms_acceptance()', 'EXECUTE'
+                   )
+                   AND NOT has_function_privilege(
+                       current_user, 'protect_eom_terms_acceptance()', 'EXECUTE'
+                   )
+                   AND NOT has_function_privilege(
+                       current_user, 'protect_eom_terms_delivery()', 'EXECUTE'
+                   )
+                  FROM boundary
+                """
+            )
+        )
+    except Exception:
+        return False
+
+
+def _secret_for_fingerprint(
+    *,
+    fingerprint: object,
+    secret: str,
+    previous_secret: str | None,
+) -> str:
+    if not isinstance(fingerprint, str):
+        raise EOMTermsAcceptanceUnavailableError("Stored Terms signing key is invalid")
+    for candidate in (secret, previous_secret):
+        if candidate is None:
+            continue
+        candidate_fingerprint = eom_public_onboarding_hmac_key_fingerprint(
+            secret=candidate
+        )
+        if hmac.compare_digest(candidate_fingerprint, fingerprint):
+            return candidate
+    raise EOMTermsAcceptanceUnavailableError(
+        "Terms invitation signing key is unavailable"
+    )
+
+
+def _invitation_result(
+    row: Mapping[str, Any],
+    *,
+    idempotent: bool,
+    delivery_error: bool = False,
+) -> dict[str, Any]:
+    if row.get("acceptance_id") is not None:
+        state = "accepted"
+    elif row.get("revoked_at") is not None:
+        state = "revoked"
+    elif bool(row.get("is_expired")):
+        state = "expired"
+    else:
+        state = "issued"
+    delivery_status = str(row["delivery_status"])
+    return {
+        "invitationId": str(row["invitation_id"]),
+        "contactId": str(row["contact_id"]),
+        "versionId": str(row["version_id"]),
+        "versionLabel": str(row["version_label"]),
+        "contentHash": str(row["content_hash"]),
+        "audience": str(row["audience"]),
+        "locale": str(row["locale"]),
+        "recipientEmail": str(row["recipient_email"]),
+        "status": state,
+        "issuedAt": _iso(row["issued_at"]),
+        "expiresAt": _iso(row["expires_at"]),
+        "revokedAt": _iso(row.get("revoked_at")),
+        "acceptanceId": (
+            str(row["acceptance_id"]) if row.get("acceptance_id") is not None else None
+        ),
+        "deliveryId": str(row["delivery_id"]),
+        "deliveryStatus": delivery_status,
+        "deliveryNeedsReconciliation": delivery_status == "sending",
+        "deliveryError": delivery_error,
+        "idempotent": idempotent,
+    }
+
+
+def _acceptance_result(
+    row: Mapping[str, Any],
+    *,
+    idempotent: bool,
+    delivery_error: bool = False,
+) -> dict[str, Any]:
+    delivery_status = str(row["delivery_status"])
+    return {
+        "acceptanceId": str(row["acceptance_id"]),
+        "invitationId": str(row["invitation_id"]),
+        "contactId": str(row["contact_id"]),
+        "versionId": str(row["version_id"]),
+        "versionLabel": str(row["version_label"]),
+        "contentHash": str(row["content_hash"]),
+        "audience": str(row["audience"]),
+        "locale": str(row["locale"]),
+        "signerName": str(row["signer_name"]),
+        "termsAccepted": bool(row["terms_accepted"]),
+        "additionalWorkAccepted": bool(row["additional_work_accepted"]),
+        "acceptedAt": _iso(row["accepted_at"]),
+        "deliveryId": str(row["delivery_id"]),
+        "executedCopyDeliveryStatus": delivery_status,
+        "deliveryNeedsReconciliation": delivery_status == "sending",
+        "deliveryError": delivery_error,
+        "idempotent": idempotent,
+    }
+
+
+Sender = Callable[..., Awaitable[dict[str, Any]]]
+
+
+class EOMTermsAcceptanceService:
+    """Own invitation, acceptance, readiness, and executed-copy delivery."""
+
+    def __init__(self, *, pool: Any) -> None:
+        self._pool = pool
+
+    @property
+    def pool(self) -> Any:
+        if not bool(getattr(self._pool, "is_initialized", True)):
+            raise EOMTermsAcceptanceUnavailableError(
+                "Terms acceptance database is unavailable"
+            )
+        return self._pool
+
+    async def require_schema_ready(self) -> None:
+        if not await eom_terms_acceptance_schema_ready(self.pool):
+            raise EOMTermsAcceptanceUnavailableError(
+                "Terms acceptance schema is unavailable"
+            )
+
+    @staticmethod
+    async def _invitation_by_id(connection: Any, invitation_id: UUID) -> Any:
+        return await connection.fetchrow(
+            """
+            SELECT invitation.id AS invitation_id,
+                   invitation.request_key,
+                   invitation.contact_id,
+                   invitation.version_id,
+                   invitation.audience,
+                   invitation.locale,
+                   invitation.customer_name,
+                   invitation.recipient_email,
+                   invitation.public_base_url,
+                   invitation.signing_key_fingerprint,
+                   invitation.issued_at,
+                   invitation.expires_at,
+                   invitation.revoked_at,
+                   version.version_label,
+                   version.content_hash,
+                   version.documents,
+                   acceptance.id AS acceptance_id,
+                   delivery.id AS delivery_id,
+                   delivery.status AS delivery_status,
+                   delivery.subject AS delivery_subject,
+                   delivery.body AS delivery_body,
+                   delivery.body_hash AS delivery_body_hash,
+                   clock_timestamp() > invitation.expires_at AS is_expired
+            FROM eom_terms_invitations AS invitation
+            JOIN eom_terms_versions AS version ON version.id = invitation.version_id
+            JOIN eom_terms_deliveries AS delivery
+              ON delivery.invitation_id = invitation.id
+             AND delivery.kind = 'invitation'
+            LEFT JOIN eom_terms_acceptances AS acceptance
+              ON acceptance.invitation_id = invitation.id
+            WHERE invitation.id = $1
+            """,
+            invitation_id,
+        )
+
+    @staticmethod
+    async def _invitation_by_request(connection: Any, request_key: str) -> Any:
+        row = await connection.fetchrow(
+            "SELECT id FROM eom_terms_invitations WHERE request_key = $1",
+            request_key,
+        )
+        if row is None:
+            return None
+        return await EOMTermsAcceptanceService._invitation_by_id(
+            connection, UUID(str(row["id"]))
+        )
+
+    @staticmethod
+    async def _acceptance_by_invitation(connection: Any, invitation_id: UUID) -> Any:
+        return await connection.fetchrow(
+            """
+            SELECT acceptance.id AS acceptance_id,
+                   acceptance.invitation_id,
+                   acceptance.contact_id,
+                   acceptance.version_id,
+                   acceptance.audience,
+                   acceptance.locale,
+                   acceptance.signer_name,
+                   acceptance.terms_accepted,
+                   acceptance.additional_work_accepted,
+                   acceptance.client_ip,
+                   acceptance.accepted_at,
+                   version.version_label,
+                   version.content_hash,
+                   delivery.id AS delivery_id,
+                   delivery.status AS delivery_status,
+                   delivery.subject AS delivery_subject,
+                   delivery.body AS delivery_body,
+                   delivery.body_hash AS delivery_body_hash
+            FROM eom_terms_acceptances AS acceptance
+            JOIN eom_terms_versions AS version ON version.id = acceptance.version_id
+            JOIN eom_terms_deliveries AS delivery
+              ON delivery.acceptance_id = acceptance.id
+             AND delivery.kind = 'executed_copy'
+            WHERE acceptance.invitation_id = $1
+            """,
+            invitation_id,
+        )
+
+    @staticmethod
+    async def _delivery_by_id(connection: Any, delivery_id: UUID) -> Any:
+        return await connection.fetchrow(
+            """
+            SELECT delivery.*,
+                   invitation.public_base_url,
+                   invitation.signing_key_fingerprint,
+                   invitation.locale,
+                   invitation.revoked_at AS invitation_revoked_at,
+                   clock_timestamp() > invitation.expires_at
+                       AS invitation_expired,
+                   EXISTS (
+                       SELECT 1
+                       FROM eom_terms_acceptances AS accepted
+                       WHERE accepted.invitation_id = invitation.id
+                   ) AS invitation_accepted
+            FROM eom_terms_deliveries AS delivery
+            JOIN eom_terms_invitations AS invitation
+              ON invitation.id = delivery.invitation_id
+            WHERE delivery.id = $1
+            """,
+            delivery_id,
+        )
+
+    @staticmethod
+    def _customer(row: Any) -> tuple[UUID, str, str, str]:
+        if row is None:
+            raise EOMTermsAcceptanceNotFoundError("EOM customer was not found")
+        if (
+            row["business_context_id"] != "effingham_maids"
+            or row["contact_type"] != "customer"
+            or row["status"] != "active"
+            or row["customer_type"] not in ("residential", "commercial")
+        ):
+            raise EOMTermsAcceptanceConflictError(
+                "Contact is not an active classified EOM customer"
+            )
+        try:
+            customer_name = _safe_text(
+                row["full_name"],
+                label="Customer name",
+                maximum=_MAX_SIGNER_NAME_LENGTH,
+            )
+            recipient_email = _email(row["email"])
+        except (
+            EOMTermsAcceptanceValidationError,
+            EOMTermsAcceptanceUnavailableError,
+        ) as exc:
+            raise EOMTermsAcceptanceConflictError(
+                "EOM customer needs a valid name and email"
+            ) from exc
+        return (
+            UUID(str(row["id"])),
+            str(row["customer_type"]),
+            customer_name,
+            recipient_email,
+        )
+
+    async def _deliver(
+        self,
+        *,
+        delivery_id: UUID,
+        secret: str | None,
+        previous_secret: str | None,
+        sender: Sender,
+    ) -> tuple[dict[str, Any], bool]:
+        """Claim one persisted payload and send it at most once per DB state."""
+
+        claimed_now = False
+        body_to_send: str | None = None
+        try:
+            async with self.pool.transaction() as connection:
+                row = await self._delivery_by_id(connection, delivery_id)
+                if row is None:
+                    raise EOMTermsAcceptanceNotFoundError(
+                        "Terms delivery was not found"
+                    )
+                candidate = dict(row)
+                if candidate["status"] == "pending":
+                    body = str(candidate["body"])
+                    if _body_hash(body) != candidate["body_hash"]:
+                        raise EOMTermsAcceptanceUnavailableError(
+                            "Stored Terms delivery payload is invalid"
+                        )
+                    kind = str(candidate["kind"])
+                    invitation_is_usable = not (
+                        kind == "invitation"
+                        and (
+                            candidate["invitation_revoked_at"] is not None
+                            or bool(candidate["invitation_expired"])
+                            or bool(candidate["invitation_accepted"])
+                        )
+                    )
+                    if invitation_is_usable:
+                        if kind == "invitation":
+                            if secret is None:
+                                raise EOMTermsAcceptanceUnavailableError(
+                                    "Terms invitation signing key is unavailable"
+                                )
+                            invitation_id = UUID(str(candidate["invitation_id"]))
+                            token_secret = _secret_for_fingerprint(
+                                fingerprint=candidate["signing_key_fingerprint"],
+                                secret=secret,
+                                previous_secret=previous_secret,
+                            )
+                            token = format_eom_terms_token(
+                                invitation_id=invitation_id,
+                                secret=token_secret,
+                            )
+                            link = build_eom_terms_link(
+                                base_url=str(candidate["public_base_url"]),
+                                token=token,
+                            )
+                            body = append_eom_terms_acceptance_link(
+                                body=body,
+                                link=link,
+                                locale=str(candidate["locale"]),
+                            )
+                        elif kind != "executed_copy":
+                            raise EOMTermsAcceptanceUnavailableError(
+                                "Stored Terms delivery kind is invalid"
+                            )
+                        body_to_send = body
+                        claimed = await connection.fetchrow(
+                            """
+                            UPDATE eom_terms_deliveries AS delivery
+                            SET status = 'sending', claimed_at = clock_timestamp()
+                            WHERE delivery.id = $1
+                              AND delivery.status = 'pending'
+                              AND (
+                                  delivery.kind <> 'invitation'
+                                  OR EXISTS (
+                                      SELECT 1
+                                      FROM eom_terms_invitations AS invitation
+                                      WHERE invitation.id = delivery.invitation_id
+                                        AND invitation.revoked_at IS NULL
+                                        AND clock_timestamp()
+                                            <= invitation.expires_at
+                                        AND NOT EXISTS (
+                                            SELECT 1
+                                            FROM eom_terms_acceptances AS acceptance
+                                            WHERE acceptance.invitation_id
+                                                = invitation.id
+                                        )
+                                  )
+                              )
+                            RETURNING delivery.id
+                            """,
+                            delivery_id,
+                        )
+                        claimed_now = claimed is not None
+                row = await self._delivery_by_id(connection, delivery_id)
+        except EOMTermsAcceptanceError:
+            raise
+        except (asyncpg.PostgresError, OSError, TimeoutError) as exc:
+            raise EOMTermsAcceptanceUnavailableError(
+                "Terms delivery state is unavailable"
+            ) from exc
+        if row is None:
+            raise EOMTermsAcceptanceNotFoundError("Terms delivery was not found")
+        delivery = dict(row)
+        state = str(delivery["status"])
+        if state in ("pending", "sent") or (state == "sending" and not claimed_now):
+            return delivery, False
+        if state != "sending":
+            raise EOMTermsAcceptanceUnavailableError(
+                "Stored Terms delivery state is invalid"
+            )
+        kind = str(delivery["kind"])
+        if body_to_send is None:
+            raise EOMTermsAcceptanceUnavailableError(
+                "Terms delivery payload was not prepared"
+            )
+        try:
+            send_result = await sender(
+                to=str(delivery["recipient_email"]),
+                subject=str(delivery["subject"]),
+                body=body_to_send,
+                idempotency_key=eom_terms_delivery_idempotency_key(
+                    kind=kind,
+                    delivery_id=delivery_id,
+                ),
+            )
+        except Exception:
+            logger.warning(
+                "Terms %s delivery requires reconciliation for %s",
+                kind,
+                delivery_id,
+                exc_info=True,
+            )
+            return delivery, True
+        try:
+            confirmed = await self.pool.fetchrow(
+                """
+                UPDATE eom_terms_deliveries
+                SET status = 'sent',
+                    sent_at = clock_timestamp(),
+                    resend_message_id = $2,
+                    transport_idempotent_replay = $3
+                WHERE id = $1 AND status = 'sending'
+                RETURNING *
+                """,
+                delivery_id,
+                send_result.get("message_id"),
+                bool(send_result.get("idempotent_replay")),
+            )
+        except (asyncpg.PostgresError, OSError, TimeoutError):
+            logger.warning(
+                "Terms %s transport succeeded but confirmation requires "
+                "reconciliation for %s",
+                kind,
+                delivery_id,
+                exc_info=True,
+            )
+            return delivery, True
+        if confirmed is None:
+            logger.warning(
+                "Terms %s transport succeeded but delivery state changed for %s",
+                kind,
+                delivery_id,
+            )
+            return delivery, True
+        return dict(confirmed), False
+
+    async def issue_and_send(
+        self,
+        *,
+        request_key: object,
+        contact_id: object,
+        locale: object,
+        actor_id: object,
+        actor_name: object,
+        public_base_url: str,
+        hmac_secret: str,
+        previous_hmac_secret: str | None = None,
+        sender: Sender | None = None,
+    ) -> dict[str, Any]:
+        parsed_request_key = _request_key(request_key)
+        parsed_contact_id = _uuid(contact_id, "contactId")
+        parsed_locale = _locale(locale)
+        parsed_actor_id, parsed_actor_name = _actor(actor_id, actor_name)
+        try:
+            parsed_secret = validate_eom_public_onboarding_hmac_secret(hmac_secret)
+            parsed_previous_secret = (
+                validate_eom_public_onboarding_hmac_secret(previous_hmac_secret)
+                if previous_hmac_secret is not None
+                else None
+            )
+        except ValueError as exc:
+            raise EOMTermsAcceptanceUnavailableError(
+                "Terms invitation signing key is unavailable"
+            ) from exc
+        build_eom_terms_link(base_url=public_base_url, token="configuration-probe")
+        if sender is None:
+            try:
+                _require_transport_configured()
+            except EOMOnboardingDraftError as exc:
+                raise EOMTermsAcceptanceUnavailableError(str(exc)) from exc
+            sender = send_onboarding_email
+        await self.require_schema_ready()
+        signing_key_fingerprint = eom_public_onboarding_hmac_key_fingerprint(
+            secret=parsed_secret
+        )
+        idempotent = False
+        try:
+            async with self.pool.transaction() as connection:
+                await connection.execute(
+                    "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+                    EOM_TERMS_PUBLICATION_LOCK_KEY,
+                )
+                existing = await self._invitation_by_request(
+                    connection, parsed_request_key
+                )
+                if existing is not None:
+                    if (
+                        UUID(str(existing["contact_id"])) != parsed_contact_id
+                        or existing["locale"] != parsed_locale
+                    ):
+                        raise EOMTermsAcceptanceConflictError(
+                            "requestKey belongs to another Terms invitation"
+                        )
+                    if (
+                        existing["delivery_status"] == "pending"
+                        and existing["acceptance_id"] is None
+                        and existing["revoked_at"] is None
+                        and not bool(existing["is_expired"])
+                    ):
+                        contact = await connection.fetchrow(
+                            """
+                            SELECT id, business_context_id, contact_type, status,
+                                   customer_type, full_name, email
+                            FROM contacts
+                            WHERE id = $1
+                            FOR SHARE
+                            """,
+                            parsed_contact_id,
+                        )
+                        (
+                            canonical_contact_id,
+                            audience,
+                            _customer_name,
+                            recipient_email,
+                        ) = self._customer(contact)
+                        if (
+                            canonical_contact_id != UUID(str(existing["contact_id"]))
+                            or audience != existing["audience"]
+                            or recipient_email != existing["recipient_email"]
+                        ):
+                            raise EOMTermsAcceptanceConflictError(
+                                "EOM customer changed before Terms delivery"
+                            )
+                    invitation = existing
+                    idempotent = True
+                else:
+                    contact = await connection.fetchrow(
+                        """
+                        SELECT id, business_context_id, contact_type, status,
+                               customer_type, full_name, email
+                        FROM contacts
+                        WHERE id = $1
+                        FOR SHARE
+                        """,
+                        parsed_contact_id,
+                    )
+                    (
+                        canonical_contact_id,
+                        audience,
+                        customer_name,
+                        recipient_email,
+                    ) = self._customer(contact)
+                    version = await connection.fetchrow(
+                        """
+                        SELECT version.*
+                        FROM eom_terms_current_version AS current
+                        JOIN eom_terms_versions AS version
+                          ON version.id = current.version_id
+                        WHERE current.singleton AND version.status = 'published'
+                        FOR SHARE OF version
+                        """
+                    )
+                    if version is None:
+                        raise EOMTermsAcceptanceNotFoundError(
+                            "Current Terms version was not found"
+                        )
+                    documents = _documents_from_version(version)
+                    selected_documents = documents[audience][parsed_locale]
+                    subject, body = render_eom_terms_invitation(
+                        full_name=customer_name,
+                        version_label=str(version["version_label"]),
+                        content_hash=str(version["content_hash"]),
+                        documents=selected_documents,
+                        locale=parsed_locale,
+                    )
+                    invitation_id = uuid4()
+                    delivery_id = uuid4()
+                    await connection.execute(
+                        """
+                        INSERT INTO eom_terms_invitations (
+                            id, request_key, contact_id, version_id, audience,
+                            locale, customer_name, recipient_email,
+                            public_base_url, signing_key_fingerprint,
+                            issued_by_id, issued_by_name
+                        ) VALUES (
+                            $1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
+                            $11, $12
+                        )
+                        """,
+                        invitation_id,
+                        parsed_request_key,
+                        canonical_contact_id,
+                        version["id"],
+                        audience,
+                        parsed_locale,
+                        customer_name,
+                        recipient_email,
+                        public_base_url.strip(),
+                        signing_key_fingerprint,
+                        parsed_actor_id,
+                        parsed_actor_name,
+                    )
+                    await connection.execute(
+                        """
+                        INSERT INTO eom_terms_deliveries (
+                            id, kind, invitation_id, recipient_email, subject,
+                            body, body_hash
+                        ) VALUES ($1, 'invitation', $2, $3, $4, $5, $6)
+                        """,
+                        delivery_id,
+                        invitation_id,
+                        recipient_email,
+                        subject,
+                        body,
+                        _body_hash(body),
+                    )
+                    invitation = await self._invitation_by_id(connection, invitation_id)
+                    if invitation is None:
+                        raise EOMTermsAcceptanceUnavailableError(
+                            "Terms invitation could not be stored"
+                        )
+        except EOMTermsAcceptanceError:
+            raise
+        except (asyncpg.PostgresError, OSError, TimeoutError) as exc:
+            raise EOMTermsAcceptanceUnavailableError(
+                "Terms invitation could not be stored"
+            ) from exc
+        delivery, delivery_error = await self._deliver(
+            delivery_id=UUID(str(invitation["delivery_id"])),
+            secret=parsed_secret,
+            previous_secret=parsed_previous_secret,
+            sender=sender,
+        )
+        result_row = dict(invitation)
+        result_row["delivery_status"] = delivery["status"]
+        return _invitation_result(
+            result_row,
+            idempotent=idempotent,
+            delivery_error=delivery_error,
+        )
+
+    @staticmethod
+    async def _has_later_material_version(connection: Any, version_id: UUID) -> bool:
+        return bool(
+            await connection.fetchval(
+                """
+                SELECT EXISTS (
+                    SELECT 1
+                    FROM eom_terms_versions AS invited
+                    JOIN eom_terms_versions AS later
+                      ON later.status = 'published'
+                     AND later.material_change
+                     AND later.published_at > invited.published_at
+                    WHERE invited.id = $1
+                      AND invited.status = 'published'
+                )
+                """,
+                version_id,
+            )
+        )
+
+    @staticmethod
+    def _require_authenticated_token(
+        token: object,
+    ) -> AuthenticatedEOMTermsToken:
+        if not isinstance(token, AuthenticatedEOMTermsToken):
+            raise EOMTermsAcceptanceNotFoundError("Terms invitation is unavailable")
+        return token
+
+    async def get_session(self, *, token: AuthenticatedEOMTermsToken) -> dict[str, Any]:
+        authenticated = self._require_authenticated_token(token)
+        await self.require_schema_ready()
+        try:
+            async with self.pool.transaction() as connection:
+                await connection.execute(
+                    "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+                    EOM_TERMS_PUBLICATION_LOCK_KEY,
+                )
+                invitation = await self._invitation_by_id(
+                    connection, authenticated.invitation_id
+                )
+                if invitation is None or not hmac.compare_digest(
+                    str(invitation["signing_key_fingerprint"]),
+                    authenticated.signing_key_fingerprint,
+                ):
+                    raise EOMTermsAcceptanceNotFoundError(
+                        "Terms invitation is unavailable"
+                    )
+                documents = _documents_from_version(invitation)
+                selected = documents[str(invitation["audience"])][
+                    str(invitation["locale"])
+                ]
+                if invitation["acceptance_id"] is not None:
+                    acceptance = await self._acceptance_by_invitation(
+                        connection, authenticated.invitation_id
+                    )
+                    if acceptance is None:
+                        raise EOMTermsAcceptanceUnavailableError(
+                            "Stored Terms acceptance is unavailable"
+                        )
+                    return {
+                        "status": "accepted",
+                        "invitationId": str(invitation["invitation_id"]),
+                        "versionId": str(invitation["version_id"]),
+                        "versionLabel": str(invitation["version_label"]),
+                        "contentHash": str(invitation["content_hash"]),
+                        "audience": str(invitation["audience"]),
+                        "locale": str(invitation["locale"]),
+                        "acceptedAt": _iso(acceptance["accepted_at"]),
+                    }
+                if (
+                    invitation["revoked_at"] is not None
+                    or bool(invitation["is_expired"])
+                    or await self._has_later_material_version(
+                        connection, UUID(str(invitation["version_id"]))
+                    )
+                ):
+                    raise EOMTermsAcceptanceNotFoundError(
+                        "Terms invitation is unavailable"
+                    )
+                return {
+                    "status": "ready",
+                    "invitationId": str(invitation["invitation_id"]),
+                    "versionId": str(invitation["version_id"]),
+                    "versionLabel": str(invitation["version_label"]),
+                    "contentHash": str(invitation["content_hash"]),
+                    "audience": str(invitation["audience"]),
+                    "locale": str(invitation["locale"]),
+                    "customerName": str(invitation["customer_name"]),
+                    "documents": selected,
+                    "expiresAt": _iso(invitation["expires_at"]),
+                }
+        except EOMTermsAcceptanceError:
+            raise
+        except (asyncpg.PostgresError, OSError, TimeoutError) as exc:
+            raise EOMTermsAcceptanceUnavailableError(
+                "Terms invitation session is unavailable"
+            ) from exc
+
+    async def accept_and_send(
+        self,
+        *,
+        token: AuthenticatedEOMTermsToken,
+        signer_name: object,
+        terms_accepted: object,
+        additional_work_accepted: object,
+        client_ip: object,
+        sender: Sender | None = None,
+    ) -> dict[str, Any]:
+        authenticated = self._require_authenticated_token(token)
+        parsed_signer_name = _signer_name(signer_name)
+        if terms_accepted is not True or additional_work_accepted is not True:
+            raise EOMTermsAcceptanceValidationError(
+                "Both Terms acknowledgements must be accepted"
+            )
+        parsed_client_ip = _client_ip(client_ip)
+        await self.require_schema_ready()
+        idempotent = False
+        try:
+            async with self.pool.transaction() as connection:
+                await connection.execute(
+                    "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+                    EOM_TERMS_PUBLICATION_LOCK_KEY,
+                )
+                invitation = await connection.fetchrow(
+                    """
+                    SELECT invitation.*, version.version_label,
+                           version.content_hash, version.documents
+                    FROM eom_terms_invitations AS invitation
+                    JOIN eom_terms_versions AS version
+                      ON version.id = invitation.version_id
+                    WHERE invitation.id = $1
+                    FOR UPDATE OF invitation
+                    """,
+                    authenticated.invitation_id,
+                )
+                if invitation is None or not hmac.compare_digest(
+                    str(invitation["signing_key_fingerprint"]),
+                    authenticated.signing_key_fingerprint,
+                ):
+                    raise EOMTermsAcceptanceNotFoundError(
+                        "Terms invitation is unavailable"
+                    )
+                existing = await self._acceptance_by_invitation(
+                    connection, authenticated.invitation_id
+                )
+                if existing is not None:
+                    if str(existing["signer_name"]) != parsed_signer_name:
+                        raise EOMTermsAcceptanceConflictError(
+                            "Terms invitation was accepted by another signer"
+                        )
+                    acceptance = existing
+                    idempotent = True
+                else:
+                    accepted_at = await connection.fetchval("SELECT clock_timestamp()")
+                    if (
+                        not isinstance(accepted_at, datetime)
+                        or accepted_at.tzinfo is None
+                    ):
+                        raise EOMTermsAcceptanceUnavailableError(
+                            "Terms database clock is unavailable"
+                        )
+                    if (
+                        invitation["revoked_at"] is not None
+                        or accepted_at > invitation["expires_at"]
+                        or await self._has_later_material_version(
+                            connection, UUID(str(invitation["version_id"]))
+                        )
+                    ):
+                        raise EOMTermsAcceptanceNotFoundError(
+                            "Terms invitation is unavailable"
+                        )
+                    acceptance_id = uuid4()
+                    delivery_id = uuid4()
+                    accepted_row = await connection.fetchrow(
+                        """
+                        INSERT INTO eom_terms_acceptances (
+                            id, invitation_id, signer_name, terms_accepted,
+                            additional_work_accepted, client_ip
+                        ) VALUES (
+                            $1, $2, $3, TRUE, TRUE, $4::inet
+                        )
+                        RETURNING accepted_at
+                        """,
+                        acceptance_id,
+                        authenticated.invitation_id,
+                        parsed_signer_name,
+                        parsed_client_ip,
+                    )
+                    if accepted_row is None:
+                        raise EOMTermsAcceptanceUnavailableError(
+                            "Terms acceptance could not be stored"
+                        )
+                    accepted_at = accepted_row["accepted_at"]
+                    if (
+                        not isinstance(accepted_at, datetime)
+                        or accepted_at.tzinfo is None
+                    ):
+                        raise EOMTermsAcceptanceUnavailableError(
+                            "Terms database clock is unavailable"
+                        )
+                    documents = _documents_from_version(invitation)
+                    selected = documents[str(invitation["audience"])][
+                        str(invitation["locale"])
+                    ]
+                    subject, body = render_eom_terms_executed_copy(
+                        full_name=str(invitation["customer_name"]),
+                        signer_name=parsed_signer_name,
+                        accepted_at=accepted_at,
+                        version_label=str(invitation["version_label"]),
+                        content_hash=str(invitation["content_hash"]),
+                        documents=selected,
+                        locale=str(invitation["locale"]),
+                    )
+                    await connection.execute(
+                        """
+                        INSERT INTO eom_terms_deliveries (
+                            id, kind, invitation_id, acceptance_id,
+                            recipient_email, subject, body, body_hash
+                        ) VALUES (
+                            $1, 'executed_copy', $2, $3, $4, $5, $6, $7
+                        )
+                        """,
+                        delivery_id,
+                        authenticated.invitation_id,
+                        acceptance_id,
+                        invitation["recipient_email"],
+                        subject,
+                        body,
+                        _body_hash(body),
+                    )
+                    acceptance = await self._acceptance_by_invitation(
+                        connection, authenticated.invitation_id
+                    )
+                    if acceptance is None:
+                        raise EOMTermsAcceptanceUnavailableError(
+                            "Terms acceptance could not be stored"
+                        )
+        except EOMTermsAcceptanceError:
+            raise
+        except (asyncpg.PostgresError, OSError, TimeoutError) as exc:
+            raise EOMTermsAcceptanceUnavailableError(
+                "Terms acceptance could not be stored"
+            ) from exc
+        delivery_error = False
+        if sender is None:
+            try:
+                _require_transport_configured()
+            except EOMOnboardingDraftError:
+                delivery_error = True
+            else:
+                sender = send_onboarding_email
+        if sender is not None:
+            delivery, delivery_error = await self._deliver(
+                delivery_id=UUID(str(acceptance["delivery_id"])),
+                secret=None,
+                previous_secret=None,
+                sender=sender,
+            )
+            result_row = dict(acceptance)
+            result_row["delivery_status"] = delivery["status"]
+        else:
+            result_row = dict(acceptance)
+        return _acceptance_result(
+            result_row,
+            idempotent=idempotent,
+            delivery_error=delivery_error,
+        )
+
+    async def revoke(
+        self,
+        *,
+        invitation_id: object,
+        actor_id: object,
+        actor_name: object,
+    ) -> dict[str, Any]:
+        parsed_invitation_id = _uuid(invitation_id, "invitationId")
+        parsed_actor_id, parsed_actor_name = _actor(actor_id, actor_name)
+        await self.require_schema_ready()
+        idempotent = False
+        try:
+            async with self.pool.transaction() as connection:
+                await connection.execute(
+                    "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+                    EOM_TERMS_PUBLICATION_LOCK_KEY,
+                )
+                row = await connection.fetchrow(
+                    "SELECT * FROM eom_terms_invitations WHERE id = $1 FOR UPDATE",
+                    parsed_invitation_id,
+                )
+                if row is None:
+                    raise EOMTermsAcceptanceNotFoundError(
+                        "Terms invitation was not found"
+                    )
+                acceptance_id = await connection.fetchval(
+                    "SELECT id FROM eom_terms_acceptances WHERE invitation_id = $1",
+                    parsed_invitation_id,
+                )
+                if acceptance_id is not None:
+                    raise EOMTermsAcceptanceConflictError(
+                        "Accepted Terms invitation cannot be revoked"
+                    )
+                if row["revoked_at"] is not None:
+                    idempotent = True
+                else:
+                    await connection.execute(
+                        """
+                        UPDATE eom_terms_invitations
+                        SET revoked_at = clock_timestamp(),
+                            revoked_by_id = $2,
+                            revoked_by_name = $3
+                        WHERE id = $1 AND revoked_at IS NULL
+                        """,
+                        parsed_invitation_id,
+                        parsed_actor_id,
+                        parsed_actor_name,
+                    )
+                invitation = await self._invitation_by_id(
+                    connection, parsed_invitation_id
+                )
+                if invitation is None:
+                    raise EOMTermsAcceptanceUnavailableError(
+                        "Terms invitation is unavailable"
+                    )
+        except EOMTermsAcceptanceError:
+            raise
+        except (asyncpg.PostgresError, OSError, TimeoutError) as exc:
+            raise EOMTermsAcceptanceUnavailableError(
+                "Terms invitation could not be revoked"
+            ) from exc
+        return _invitation_result(invitation, idempotent=idempotent)
+
+    async def confirm_delivery_sent(
+        self,
+        *,
+        delivery_id: object,
+        actor_id: object,
+        actor_name: object,
+    ) -> dict[str, Any]:
+        parsed_delivery_id = _uuid(delivery_id, "deliveryId")
+        parsed_actor_id, parsed_actor_name = _actor(actor_id, actor_name)
+        await self.require_schema_ready()
+        try:
+            async with self.pool.transaction() as connection:
+                delivery = await connection.fetchrow(
+                    "SELECT * FROM eom_terms_deliveries WHERE id = $1 FOR UPDATE",
+                    parsed_delivery_id,
+                )
+                if delivery is None:
+                    raise EOMTermsAcceptanceNotFoundError(
+                        "Terms delivery was not found"
+                    )
+                if delivery["status"] == "sent":
+                    idempotent = True
+                    confirmed = delivery
+                elif delivery["status"] == "sending":
+                    idempotent = False
+                    confirmed = await connection.fetchrow(
+                        """
+                        UPDATE eom_terms_deliveries
+                        SET status = 'sent',
+                            sent_at = clock_timestamp(),
+                            confirmed_by_id = $2,
+                            confirmed_by_name = $3
+                        WHERE id = $1 AND status = 'sending'
+                        RETURNING *
+                        """,
+                        parsed_delivery_id,
+                        parsed_actor_id,
+                        parsed_actor_name,
+                    )
+                else:
+                    raise EOMTermsAcceptanceConflictError(
+                        "Pending Terms delivery has no transport result to confirm"
+                    )
+                if confirmed is None:
+                    raise EOMTermsAcceptanceUnavailableError(
+                        "Terms delivery could not be confirmed"
+                    )
+        except EOMTermsAcceptanceError:
+            raise
+        except (asyncpg.PostgresError, OSError, TimeoutError) as exc:
+            raise EOMTermsAcceptanceUnavailableError(
+                "Terms delivery could not be confirmed"
+            ) from exc
+        return {
+            "deliveryId": str(confirmed["id"]),
+            "kind": str(confirmed["kind"]),
+            "status": str(confirmed["status"]),
+            "sentAt": _iso(confirmed["sent_at"]),
+            "idempotent": idempotent,
+        }
+
+    async def get_readiness(self, *, contact_id: object) -> dict[str, Any]:
+        parsed_contact_id = _uuid(contact_id, "contactId")
+        await self.require_schema_ready()
+        try:
+            async with self.pool.transaction() as connection:
+                await connection.execute(
+                    "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+                    EOM_TERMS_PUBLICATION_LOCK_KEY,
+                )
+                contact = await connection.fetchrow(
+                    """
+                    SELECT id, business_context_id, contact_type, status,
+                           customer_type, full_name, email
+                    FROM contacts
+                    WHERE id = $1
+                    FOR SHARE
+                    """,
+                    parsed_contact_id,
+                )
+                _, audience, _, _ = self._customer(contact)
+                current = await connection.fetchrow(
+                    """
+                    SELECT version.id, version.version_label,
+                           version.content_hash, version.published_at
+                    FROM eom_terms_current_version AS selected
+                    JOIN eom_terms_versions AS version
+                      ON version.id = selected.version_id
+                    WHERE selected.singleton AND version.status = 'published'
+                    """
+                )
+                if current is None:
+                    raise EOMTermsAcceptanceNotFoundError(
+                        "Current Terms version was not found"
+                    )
+                acceptance = await connection.fetchrow(
+                    """
+                    SELECT acceptance.id, acceptance.version_id,
+                           acceptance.audience, acceptance.accepted_at,
+                           version.version_label, version.content_hash,
+                           delivery.status AS delivery_status,
+                           EXISTS (
+                               SELECT 1
+                               FROM eom_terms_versions AS later
+                               WHERE later.status = 'published'
+                                 AND later.material_change
+                                 AND later.published_at > version.published_at
+                           ) AS later_material
+                    FROM eom_terms_acceptances AS acceptance
+                    JOIN eom_terms_versions AS version
+                      ON version.id = acceptance.version_id
+                    JOIN eom_terms_deliveries AS delivery
+                      ON delivery.acceptance_id = acceptance.id
+                     AND delivery.kind = 'executed_copy'
+                    WHERE acceptance.contact_id = $1
+                    ORDER BY acceptance.accepted_at DESC, acceptance.id DESC
+                    LIMIT 1
+                    """,
+                    parsed_contact_id,
+                )
+        except EOMTermsAcceptanceError:
+            raise
+        except (asyncpg.PostgresError, OSError, TimeoutError) as exc:
+            raise EOMTermsAcceptanceUnavailableError(
+                "Terms readiness is unavailable"
+            ) from exc
+        if acceptance is None:
+            reason = "not_accepted"
+            ready = False
+        elif acceptance["audience"] != audience:
+            reason = "audience_changed"
+            ready = False
+        elif bool(acceptance["later_material"]):
+            reason = "reacceptance_required"
+            ready = False
+        else:
+            reason = "accepted"
+            ready = True
+        return {
+            "contactId": str(parsed_contact_id),
+            "audience": audience,
+            "ready": ready,
+            "reason": reason,
+            "currentVersionId": str(current["id"]),
+            "currentVersionLabel": str(current["version_label"]),
+            "currentContentHash": str(current["content_hash"]),
+            "acceptedVersionId": (
+                str(acceptance["version_id"]) if acceptance is not None else None
+            ),
+            "acceptedVersionLabel": (
+                str(acceptance["version_label"]) if acceptance is not None else None
+            ),
+            "acceptedAt": (
+                _iso(acceptance["accepted_at"]) if acceptance is not None else None
+            ),
+            "executedCopyDeliveryStatus": (
+                str(acceptance["delivery_status"]) if acceptance is not None else None
+            ),
+        }

--- a/atlas_brain/services/eom_terms_authority.py
+++ b/atlas_brain/services/eom_terms_authority.py
@@ -223,6 +223,10 @@ async def eom_terms_authority_schema_ready(pool: Any) -> bool:
                                pg_catalog.current_schema()
                            )) AS current_oid,
                            to_regprocedure(format(
+                               '%I.assign_eom_terms_publication_order()',
+                               pg_catalog.current_schema()
+                           )) AS assign_publication_order_oid,
+                           to_regprocedure(format(
                                '%I.protect_eom_terms_version()',
                                pg_catalog.current_schema()
                            )) AS protect_version_oid,
@@ -352,11 +356,52 @@ async def eom_terms_authority_schema_ready(pool: Any) -> bool:
                           ]
                    )
                    AND (
-                       SELECT COUNT(*) = 5
+                       boundary.assign_publication_order_oid IS NULL
+                       OR EXISTS (
+                           SELECT 1
+                             FROM pg_proc AS assignment_function
+                            WHERE assignment_function.oid =
+                                      boundary.assign_publication_order_oid
+                              AND assignment_function.pronargs = 0
+                              AND assignment_function.proowner =
+                                  boundary.guard_oid
+                              AND NOT assignment_function.prosecdef
+                              AND assignment_function.prorettype =
+                                  'trigger'::regtype
+                              AND assignment_function.proconfig = ARRAY[
+                                  format(
+                                      'search_path=pg_catalog, %I, pg_temp',
+                                      boundary.schema_name
+                                  )
+                              ]
+                       )
+                   )
+                   AND (
+                       SELECT (
+                                  (
+                                      COUNT(*) = 5
+                                      AND boundary.assign_publication_order_oid
+                                          IS NULL
+                                  )
+                                  OR
+                                  (
+                                      COUNT(*) = 6
+                                      AND boundary.assign_publication_order_oid
+                                          IS NOT NULL
+                                  )
+                              )
                           AND BOOL_AND(
                               guard_trigger.tgenabled = 'O'
                               AND (
                                   (
+                                      guard_trigger.tgrelid =
+                                          boundary.versions_oid
+                                      AND guard_trigger.tgfoid =
+                                          boundary.assign_publication_order_oid
+                                      AND guard_trigger.tgname =
+                                          'trg_assign_eom_terms_publication_order'
+                                  )
+                                  OR (
                                       guard_trigger.tgrelid =
                                           boundary.versions_oid
                                       AND guard_trigger.tgfoid =
@@ -448,6 +493,48 @@ async def eom_terms_authority_schema_ready(pool: Any) -> bool:
                                    expected_constraint.constraint_type
                                AND actual_constraint.convalidated
                         )
+                   )
+                   AND (
+                       boundary.assign_publication_order_oid IS NULL
+                       OR NOT EXISTS (
+                           SELECT 1
+                             FROM (
+                                 VALUES
+                                     ('uq_eom_terms_publication_order', 'u'),
+                                     ('ck_eom_terms_publication_order', 'c')
+                             ) AS expected_order_constraint(
+                                 constraint_name,
+                                 constraint_type
+                             )
+                            WHERE NOT EXISTS (
+                                SELECT 1
+                                  FROM pg_constraint AS actual_constraint
+                                 WHERE actual_constraint.conrelid =
+                                           boundary.versions_oid
+                                   AND actual_constraint.conname =
+                                       expected_order_constraint.constraint_name
+                                   AND actual_constraint.contype::text =
+                                       expected_order_constraint.constraint_type
+                                   AND actual_constraint.convalidated
+                            )
+                       )
+                   )
+                   AND (
+                       boundary.assign_publication_order_oid IS NULL
+                       OR EXISTS (
+                           SELECT 1
+                             FROM pg_attribute AS publication_attribute
+                            WHERE publication_attribute.attrelid =
+                                      boundary.versions_oid
+                              AND publication_attribute.attname =
+                                  'publication_order'
+                              AND publication_attribute.atttypid =
+                                  'bigint'::regtype
+                              AND publication_attribute.attnum > 0
+                              AND NOT publication_attribute.attisdropped
+                              AND publication_attribute.attgenerated = ''
+                              AND publication_attribute.attidentity = ''
+                       )
                    )
                    AND (
                        SELECT COUNT(DISTINCT indexed_attribute.attname) = 2
@@ -729,6 +816,14 @@ async def eom_terms_authority_schema_ready(pool: Any) -> bool:
                        boundary.prevent_current_removal_oid,
                        'EXECUTE'
                    )
+                   AND (
+                       boundary.assign_publication_order_oid IS NULL
+                       OR NOT has_function_privilege(
+                           current_user,
+                           boundary.assign_publication_order_oid,
+                           'EXECUTE'
+                       )
+                   )
                    AND NOT EXISTS (
                        SELECT 1
                          FROM pg_class AS relation
@@ -769,9 +864,10 @@ async def eom_terms_authority_schema_ready(pool: Any) -> bool:
                              protected_function.proacl
                          ) AS acl
                         WHERE protected_function.oid IN (
-                                  boundary.protect_version_oid,
-                                  boundary.require_current_oid,
-                                  boundary.prevent_current_removal_oid
+                             boundary.protect_version_oid,
+                             boundary.require_current_oid,
+                             boundary.prevent_current_removal_oid,
+                             boundary.assign_publication_order_oid
                               )
                           AND (
                               acl.grantee <> boundary.guard_oid

--- a/atlas_brain/services/eom_terms_authority.py
+++ b/atlas_brain/services/eom_terms_authority.py
@@ -23,7 +23,7 @@ _VERSION_LABEL_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
 _MAX_SECTION_LENGTH = 100_000
 _MAX_ACTOR_NAME_LENGTH = 128
 _MAX_SIGNED_BIGINT = 2**63 - 1
-_PUBLICATION_LOCK_KEY = "eom-terms-current-version"
+EOM_TERMS_PUBLICATION_LOCK_KEY = "eom-terms-current-version"
 
 
 class EOMTermsAuthorityError(Exception):
@@ -873,7 +873,7 @@ class EOMTermsAuthority:
             async with self.pool.transaction() as conn:
                 await conn.execute(
                     "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
-                    _PUBLICATION_LOCK_KEY,
+                    EOM_TERMS_PUBLICATION_LOCK_KEY,
                 )
                 publication_timestamp = await conn.fetchval("SELECT clock_timestamp()")
                 row = await conn.fetchrow(

--- a/atlas_brain/services/eom_terms_authority.py
+++ b/atlas_brain/services/eom_terms_authority.py
@@ -223,10 +223,6 @@ async def eom_terms_authority_schema_ready(pool: Any) -> bool:
                                pg_catalog.current_schema()
                            )) AS current_oid,
                            to_regprocedure(format(
-                               '%I.assign_eom_terms_publication_order()',
-                               pg_catalog.current_schema()
-                           )) AS assign_publication_order_oid,
-                           to_regprocedure(format(
                                '%I.protect_eom_terms_version()',
                                pg_catalog.current_schema()
                            )) AS protect_version_oid,
@@ -356,52 +352,11 @@ async def eom_terms_authority_schema_ready(pool: Any) -> bool:
                           ]
                    )
                    AND (
-                       boundary.assign_publication_order_oid IS NULL
-                       OR EXISTS (
-                           SELECT 1
-                             FROM pg_proc AS assignment_function
-                            WHERE assignment_function.oid =
-                                      boundary.assign_publication_order_oid
-                              AND assignment_function.pronargs = 0
-                              AND assignment_function.proowner =
-                                  boundary.guard_oid
-                              AND NOT assignment_function.prosecdef
-                              AND assignment_function.prorettype =
-                                  'trigger'::regtype
-                              AND assignment_function.proconfig = ARRAY[
-                                  format(
-                                      'search_path=pg_catalog, %I, pg_temp',
-                                      boundary.schema_name
-                                  )
-                              ]
-                       )
-                   )
-                   AND (
-                       SELECT (
-                                  (
-                                      COUNT(*) = 5
-                                      AND boundary.assign_publication_order_oid
-                                          IS NULL
-                                  )
-                                  OR
-                                  (
-                                      COUNT(*) = 6
-                                      AND boundary.assign_publication_order_oid
-                                          IS NOT NULL
-                                  )
-                              )
+                       SELECT COUNT(*) = 5
                           AND BOOL_AND(
                               guard_trigger.tgenabled = 'O'
                               AND (
                                   (
-                                      guard_trigger.tgrelid =
-                                          boundary.versions_oid
-                                      AND guard_trigger.tgfoid =
-                                          boundary.assign_publication_order_oid
-                                      AND guard_trigger.tgname =
-                                          'trg_assign_eom_terms_publication_order'
-                                  )
-                                  OR (
                                       guard_trigger.tgrelid =
                                           boundary.versions_oid
                                       AND guard_trigger.tgfoid =
@@ -493,48 +448,6 @@ async def eom_terms_authority_schema_ready(pool: Any) -> bool:
                                    expected_constraint.constraint_type
                                AND actual_constraint.convalidated
                         )
-                   )
-                   AND (
-                       boundary.assign_publication_order_oid IS NULL
-                       OR NOT EXISTS (
-                           SELECT 1
-                             FROM (
-                                 VALUES
-                                     ('uq_eom_terms_publication_order', 'u'),
-                                     ('ck_eom_terms_publication_order', 'c')
-                             ) AS expected_order_constraint(
-                                 constraint_name,
-                                 constraint_type
-                             )
-                            WHERE NOT EXISTS (
-                                SELECT 1
-                                  FROM pg_constraint AS actual_constraint
-                                 WHERE actual_constraint.conrelid =
-                                           boundary.versions_oid
-                                   AND actual_constraint.conname =
-                                       expected_order_constraint.constraint_name
-                                   AND actual_constraint.contype::text =
-                                       expected_order_constraint.constraint_type
-                                   AND actual_constraint.convalidated
-                            )
-                       )
-                   )
-                   AND (
-                       boundary.assign_publication_order_oid IS NULL
-                       OR EXISTS (
-                           SELECT 1
-                             FROM pg_attribute AS publication_attribute
-                            WHERE publication_attribute.attrelid =
-                                      boundary.versions_oid
-                              AND publication_attribute.attname =
-                                  'publication_order'
-                              AND publication_attribute.atttypid =
-                                  'bigint'::regtype
-                              AND publication_attribute.attnum > 0
-                              AND NOT publication_attribute.attisdropped
-                              AND publication_attribute.attgenerated = ''
-                              AND publication_attribute.attidentity = ''
-                       )
                    )
                    AND (
                        SELECT COUNT(DISTINCT indexed_attribute.attname) = 2
@@ -816,14 +729,6 @@ async def eom_terms_authority_schema_ready(pool: Any) -> bool:
                        boundary.prevent_current_removal_oid,
                        'EXECUTE'
                    )
-                   AND (
-                       boundary.assign_publication_order_oid IS NULL
-                       OR NOT has_function_privilege(
-                           current_user,
-                           boundary.assign_publication_order_oid,
-                           'EXECUTE'
-                       )
-                   )
                    AND NOT EXISTS (
                        SELECT 1
                          FROM pg_class AS relation
@@ -864,10 +769,9 @@ async def eom_terms_authority_schema_ready(pool: Any) -> bool:
                              protected_function.proacl
                          ) AS acl
                         WHERE protected_function.oid IN (
-                             boundary.protect_version_oid,
-                             boundary.require_current_oid,
-                             boundary.prevent_current_removal_oid,
-                             boundary.assign_publication_order_oid
+                                  boundary.protect_version_oid,
+                                  boundary.require_current_oid,
+                                  boundary.prevent_current_removal_oid
                               )
                           AND (
                               acl.grantee <> boundary.guard_oid

--- a/atlas_brain/storage/migrations/397_eom_terms_acceptance.sql
+++ b/atlas_brain/storage/migrations/397_eom_terms_acceptance.sql
@@ -196,9 +196,6 @@ BEGIN
           )) IS NOT NULL
        OR to_regprocedure(format(
             '%I.protect_eom_terms_delivery()', schema_name
-          )) IS NOT NULL
-       OR to_regprocedure(format(
-            '%I.assign_eom_terms_publication_order()', schema_name
           )) IS NOT NULL THEN
         RAISE EXCEPTION
             'refusing to adopt a pre-existing EOM Terms acceptance object';
@@ -213,15 +210,6 @@ BEGIN
            AND attribute.attname = 'publication_order'
            AND attribute.attnum > 0
            AND NOT attribute.attisdropped
-    ) OR EXISTS (
-        SELECT 1
-          FROM pg_trigger AS guard_trigger
-         WHERE guard_trigger.tgrelid = to_regclass(format(
-                   '%I.eom_terms_versions', schema_name
-               ))
-           AND guard_trigger.tgname =
-               'trg_assign_eom_terms_publication_order'
-           AND NOT guard_trigger.tgisinternal
     ) THEN
         RAISE EXCEPTION
             'refusing to adopt pre-existing EOM Terms publication ordering';
@@ -274,12 +262,39 @@ ALTER TABLE eom_terms_versions
             (status = 'published' AND publication_order > 0)
         );
 
-CREATE FUNCTION assign_eom_terms_publication_order()
+-- Extend migration 396's existing guard instead of adding another trigger.
+-- The previous application release attests exactly five authority triggers;
+-- keeping that boundary stable makes both a rolling deploy and app rollback
+-- safe after this migration commits.
+CREATE OR REPLACE FUNCTION protect_eom_terms_version()
 RETURNS TRIGGER
 LANGUAGE plpgsql
 SECURITY INVOKER
 AS $$
 BEGIN
+    IF TG_OP = 'TRUNCATE' THEN
+        RAISE EXCEPTION 'EOM Terms version history is append-only';
+    END IF;
+    IF OLD.status = 'published' THEN
+        RAISE EXCEPTION 'Published EOM Terms versions are immutable';
+    END IF;
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+    IF NEW.status = 'draft' THEN
+        RAISE EXCEPTION 'EOM Terms drafts cannot be edited; create a new version';
+    END IF;
+    IF NEW.id IS DISTINCT FROM OLD.id
+       OR NEW.business_context_id IS DISTINCT FROM OLD.business_context_id
+       OR NEW.version_label IS DISTINCT FROM OLD.version_label
+       OR NEW.material_change IS DISTINCT FROM OLD.material_change
+       OR NEW.documents IS DISTINCT FROM OLD.documents
+       OR NEW.content_hash IS DISTINCT FROM OLD.content_hash
+       OR NEW.created_by_id IS DISTINCT FROM OLD.created_by_id
+       OR NEW.created_by_name IS DISTINCT FROM OLD.created_by_name
+       OR NEW.created_at IS DISTINCT FROM OLD.created_at THEN
+        RAISE EXCEPTION 'Publishing EOM Terms cannot rewrite draft content';
+    END IF;
     IF OLD.status = 'draft' AND NEW.status = 'published' THEN
         IF NEW.publication_order IS NOT NULL THEN
             RAISE EXCEPTION
@@ -292,18 +307,12 @@ BEGIN
           INTO NEW.publication_order
           FROM eom_terms_versions AS version
          WHERE version.status = 'published';
-        RETURN NEW;
-    END IF;
-    IF NEW.publication_order IS DISTINCT FROM OLD.publication_order THEN
+    ELSIF NEW.publication_order IS DISTINCT FROM OLD.publication_order THEN
         RAISE EXCEPTION 'EOM Terms publication order is immutable';
     END IF;
     RETURN NEW;
 END;
 $$;
-
-CREATE TRIGGER trg_assign_eom_terms_publication_order
-    BEFORE UPDATE ON eom_terms_versions
-    FOR EACH ROW EXECUTE FUNCTION assign_eom_terms_publication_order();
 
 CREATE TABLE eom_terms_invitations (
     id UUID CONSTRAINT pk_eom_terms_invitations PRIMARY KEY,
@@ -891,7 +900,7 @@ DECLARE
     grantee_name TEXT;
 BEGIN
     FOREACH function_name IN ARRAY ARRAY[
-        'assign_eom_terms_publication_order',
+        'protect_eom_terms_version',
         'validate_eom_terms_invitation',
         'protect_eom_terms_invitation',
         'validate_eom_terms_acceptance',
@@ -954,7 +963,7 @@ BEGIN
     END LOOP;
 
     FOREACH function_name IN ARRAY ARRAY[
-        'assign_eom_terms_publication_order',
+        'protect_eom_terms_version',
         'validate_eom_terms_invitation',
         'protect_eom_terms_invitation',
         'validate_eom_terms_acceptance',

--- a/atlas_brain/storage/migrations/397_eom_terms_acceptance.sql
+++ b/atlas_brain/storage/migrations/397_eom_terms_acceptance.sql
@@ -587,6 +587,16 @@ BEGIN
     END IF;
     IF EXISTS (
         SELECT 1
+          FROM eom_terms_deliveries AS delivery
+         WHERE delivery.invitation_id = OLD.id
+           AND delivery.kind = 'invitation'
+           AND delivery.status = 'sending'
+    ) THEN
+        RAISE EXCEPTION
+            'EOM Terms invitation delivery requires reconciliation';
+    END IF;
+    IF EXISTS (
+        SELECT 1
           FROM eom_terms_acceptances AS acceptance
          WHERE acceptance.invitation_id = OLD.id
     ) THEN
@@ -618,12 +628,16 @@ BEGIN
            invitation.revoked_at,
            invitation.expires_at,
            version.content_hash,
-           version.publication_order
+           version.publication_order,
+           invitation_delivery.status AS delivery_status
       INTO invitation_row
       FROM eom_terms_invitations AS invitation
       JOIN eom_terms_versions AS version
         ON version.id = invitation.version_id
        AND version.status = 'published'
+      JOIN eom_terms_deliveries AS invitation_delivery
+        ON invitation_delivery.invitation_id = invitation.id
+       AND invitation_delivery.kind = 'invitation'
      WHERE invitation.id = NEW.invitation_id
      FOR SHARE OF invitation;
     IF NOT FOUND
@@ -640,6 +654,10 @@ BEGIN
     ) THEN
         RAISE EXCEPTION
             'EOM Terms invitation was superseded by a material release';
+    END IF;
+    IF invitation_row.delivery_status = 'sending' THEN
+        RAISE EXCEPTION
+            'EOM Terms invitation delivery requires reconciliation';
     END IF;
     IF NOT EXISTS (
         SELECT 1
@@ -743,9 +761,26 @@ BEGIN
         IF NEW.kind = 'invitation' AND NOT EXISTS (
             SELECT 1
               FROM eom_terms_invitations AS invitation
+              JOIN contacts AS contact ON contact.id = invitation.contact_id
+              JOIN eom_terms_versions AS invited
+                ON invited.id = invitation.version_id
+               AND invited.status = 'published'
              WHERE invitation.id = NEW.invitation_id
                AND invitation.revoked_at IS NULL
                AND clock_timestamp() <= invitation.expires_at
+               AND contact.business_context_id = 'effingham_maids'
+               AND contact.contact_type = 'customer'
+               AND contact.status = 'active'
+               AND contact.customer_type = invitation.audience
+               AND btrim(contact.full_name) = invitation.customer_name
+               AND lower(btrim(contact.email)) = invitation.recipient_email
+               AND NOT EXISTS (
+                   SELECT 1
+                     FROM eom_terms_versions AS later
+                    WHERE later.status = 'published'
+                      AND later.material_change
+                      AND later.publication_order > invited.publication_order
+               )
                AND NOT EXISTS (
                    SELECT 1
                      FROM eom_terms_acceptances AS acceptance

--- a/atlas_brain/storage/migrations/397_eom_terms_acceptance.sql
+++ b/atlas_brain/storage/migrations/397_eom_terms_acceptance.sql
@@ -1,0 +1,875 @@
+-- atlas: atomic-bookkeeping
+-- Customer-bound EOM Terms invitations, immutable acceptances, and stable
+-- delivery evidence. The operator-published document authority remains in
+-- migration 396; this migration stores references and exact rendered payloads
+-- but seeds or edits no Terms prose.
+--
+-- This is a controlled DBA-only migration. The direct Atlas runtime may issue
+-- an invitation, append one acceptance, and advance delivery/revocation state
+-- through narrow one-way transitions, but it must not own or rewrite legal
+-- evidence. Apply only through the dedicated controlled preflight/apply command.
+--
+-- Rollback: stop the invitation/acceptance routes and their consumers before
+-- rolling application code back. Retain every table, trigger, function, grant,
+-- and migration receipt as legal/audit history.
+
+DO $$
+DECLARE
+    schema_name TEXT := current_schema();
+    executor_is_superuser BOOLEAN;
+    runtime_role_ready BOOLEAN;
+    guard_role_ready BOOLEAN;
+BEGIN
+    SELECT COALESCE(role.rolsuper, FALSE)
+      INTO executor_is_superuser
+      FROM pg_roles AS role
+     WHERE role.rolname = current_user;
+    IF NOT executor_is_superuser THEN
+        RAISE EXCEPTION
+            'database administrator must run 397_eom_terms_acceptance';
+    END IF;
+
+    SELECT EXISTS (
+        SELECT 1
+          FROM pg_roles AS runtime_role
+         WHERE runtime_role.rolname = 'atlas'
+           AND runtime_role.rolcanlogin
+           AND NOT runtime_role.rolsuper
+           AND NOT runtime_role.rolcreaterole
+           AND NOT runtime_role.rolcreatedb
+           AND NOT runtime_role.rolreplication
+           AND NOT runtime_role.rolbypassrls
+           AND NOT EXISTS (
+               SELECT 1
+                 FROM pg_database AS database
+                WHERE database.datname = current_database()
+                  AND database.datdba = runtime_role.oid
+           )
+           AND NOT EXISTS (
+               SELECT 1
+                 FROM pg_roles AS elevated_role
+                WHERE elevated_role.oid <> runtime_role.oid
+                  AND (
+                      elevated_role.rolsuper
+                      OR elevated_role.rolcreaterole
+                      OR elevated_role.rolcreatedb
+                      OR elevated_role.rolreplication
+                      OR elevated_role.rolbypassrls
+                  )
+                  AND pg_has_role(
+                      runtime_role.oid, elevated_role.oid, 'MEMBER'
+                  )
+           )
+    )
+      INTO runtime_role_ready;
+    IF NOT runtime_role_ready THEN
+        RAISE EXCEPTION
+            'atlas must be an unprivileged login runtime role before running 397_eom_terms_acceptance';
+    END IF;
+
+    SELECT EXISTS (
+        SELECT 1
+          FROM pg_roles AS guard_role
+         WHERE guard_role.rolname = 'atlas_eom_handoff_owner'
+           AND NOT guard_role.rolcanlogin
+           AND NOT guard_role.rolinherit
+           AND NOT guard_role.rolsuper
+           AND NOT guard_role.rolcreaterole
+           AND NOT guard_role.rolcreatedb
+           AND NOT guard_role.rolreplication
+           AND NOT guard_role.rolbypassrls
+    )
+      INTO guard_role_ready;
+    IF NOT guard_role_ready THEN
+        RAISE EXCEPTION
+            'atlas_eom_handoff_owner must be the isolated no-login EOM guard role before running 397_eom_terms_acceptance';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+          FROM pg_stat_activity AS activity
+          JOIN pg_roles AS guard_role
+            ON guard_role.rolname = 'atlas_eom_handoff_owner'
+         WHERE activity.usesysid = guard_role.oid
+           AND activity.datid = (
+               SELECT database.oid
+                 FROM pg_database AS database
+                WHERE database.datname = current_database()
+           )
+    ) THEN
+        RAISE EXCEPTION
+            'atlas_eom_handoff_owner must have no live sessions before running 397_eom_terms_acceptance';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+          FROM pg_roles AS member_role
+          JOIN pg_roles AS guard_role
+            ON guard_role.rolname = 'atlas_eom_handoff_owner'
+         WHERE member_role.rolcanlogin
+           AND NOT member_role.rolsuper
+           AND pg_has_role(member_role.oid, guard_role.oid, 'MEMBER')
+    ) THEN
+        RAISE EXCEPTION
+            'no non-superuser login may retain membership in atlas_eom_handoff_owner';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+          FROM pg_namespace AS namespace
+         WHERE namespace.nspname = schema_name
+           AND namespace.nspowner = (
+               SELECT oid
+                 FROM pg_roles
+                WHERE rolname = 'atlas_eom_handoff_owner'
+           )
+    ) THEN
+        RAISE EXCEPTION
+            'the EOM funnel schema must be owned by atlas_eom_handoff_owner before running 397_eom_terms_acceptance';
+    END IF;
+
+    IF to_regclass(format('%I.contacts', schema_name)) IS NULL
+       OR to_regclass(format('%I.eom_terms_versions', schema_name)) IS NULL
+       OR to_regclass(format('%I.eom_terms_current_version', schema_name)) IS NULL
+       OR to_regclass(format('%I.schema_migrations', schema_name)) IS NULL
+       OR NOT EXISTS (
+           SELECT 1
+             FROM schema_migrations
+            WHERE name = '396_eom_terms_authority'
+       ) THEN
+        RAISE EXCEPTION
+            'contacts and recorded migration 396_eom_terms_authority are required before running 397_eom_terms_acceptance';
+    END IF;
+
+    IF (
+        SELECT count(*)
+          FROM pg_class AS relation
+          JOIN pg_namespace AS namespace
+            ON namespace.oid = relation.relnamespace
+         WHERE namespace.nspname = schema_name
+           AND relation.relkind = 'r'
+           AND relation.relname IN (
+               'eom_terms_versions',
+               'eom_terms_current_version'
+           )
+           AND relation.relowner = (
+               SELECT oid
+                 FROM pg_roles
+                WHERE rolname = 'atlas_eom_handoff_owner'
+           )
+    ) <> 2 OR (
+        SELECT count(*)
+          FROM pg_proc AS guarded_function
+          JOIN pg_namespace AS namespace
+            ON namespace.oid = guarded_function.pronamespace
+         WHERE namespace.nspname = schema_name
+           AND guarded_function.proname IN (
+               'protect_eom_terms_version',
+               'require_published_eom_terms_current_version',
+               'prevent_eom_terms_current_removal'
+           )
+           AND guarded_function.pronargs = 0
+           AND guarded_function.proowner = (
+               SELECT oid
+                 FROM pg_roles
+                WHERE rolname = 'atlas_eom_handoff_owner'
+           )
+    ) <> 3 THEN
+        RAISE EXCEPTION
+            'migration 396 Terms authority must retain guard ownership before running 397_eom_terms_acceptance';
+    END IF;
+
+    IF to_regclass(format('%I.eom_terms_invitations', schema_name)) IS NOT NULL
+       OR to_regclass(format('%I.eom_terms_acceptances', schema_name)) IS NOT NULL
+       OR to_regclass(format('%I.eom_terms_deliveries', schema_name)) IS NOT NULL
+       OR to_regprocedure(format(
+            '%I.validate_eom_terms_invitation()', schema_name
+          )) IS NOT NULL
+       OR to_regprocedure(format(
+            '%I.protect_eom_terms_invitation()', schema_name
+          )) IS NOT NULL
+       OR to_regprocedure(format(
+            '%I.validate_eom_terms_acceptance()', schema_name
+          )) IS NOT NULL
+       OR to_regprocedure(format(
+            '%I.protect_eom_terms_acceptance()', schema_name
+          )) IS NOT NULL
+       OR to_regprocedure(format(
+            '%I.protect_eom_terms_delivery()', schema_name
+          )) IS NOT NULL THEN
+        RAISE EXCEPTION
+            'refusing to adopt a pre-existing EOM Terms acceptance object';
+    END IF;
+END;
+$$;
+
+CREATE TABLE eom_terms_invitations (
+    id UUID CONSTRAINT pk_eom_terms_invitations PRIMARY KEY,
+    request_key VARCHAR(128) NOT NULL,
+    business_context_id VARCHAR(64) NOT NULL DEFAULT 'effingham_maids',
+    contact_id UUID NOT NULL,
+    version_id UUID NOT NULL,
+    audience VARCHAR(16) NOT NULL,
+    locale VARCHAR(2) NOT NULL,
+    customer_name VARCHAR(256) NOT NULL,
+    recipient_email VARCHAR(256) NOT NULL,
+    public_base_url VARCHAR(2048) NOT NULL,
+    signing_key_fingerprint VARCHAR(64) NOT NULL,
+    issued_at TIMESTAMPTZ NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    issued_by_id BIGINT NOT NULL,
+    issued_by_name VARCHAR(128) NOT NULL,
+    revoked_at TIMESTAMPTZ,
+    revoked_by_id BIGINT,
+    revoked_by_name VARCHAR(128),
+    CONSTRAINT uq_eom_terms_invitations_request_key UNIQUE (request_key),
+    CONSTRAINT fk_eom_terms_invitations_contact
+        FOREIGN KEY (contact_id) REFERENCES contacts(id) ON DELETE RESTRICT,
+    CONSTRAINT fk_eom_terms_invitations_version
+        FOREIGN KEY (version_id) REFERENCES eom_terms_versions(id)
+        ON DELETE RESTRICT,
+    CONSTRAINT ck_eom_terms_invitations_request_key
+        CHECK (request_key ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{15,127}$'),
+    CONSTRAINT ck_eom_terms_invitations_context
+        CHECK (business_context_id = 'effingham_maids'),
+    CONSTRAINT ck_eom_terms_invitations_audience
+        CHECK (audience IN ('residential', 'commercial')),
+    CONSTRAINT ck_eom_terms_invitations_locale
+        CHECK (locale IN ('en', 'es')),
+    CONSTRAINT ck_eom_terms_invitations_customer_name
+        CHECK (length(btrim(customer_name)) BETWEEN 1 AND 256),
+    CONSTRAINT ck_eom_terms_invitations_recipient
+        CHECK (
+            recipient_email = lower(btrim(recipient_email))
+            AND recipient_email ~ '^[^@[:space:]]+@[^@[:space:]]+\.[^@[:space:]]+$'
+        ),
+    CONSTRAINT ck_eom_terms_invitations_public_url
+        CHECK (
+            public_base_url = btrim(public_base_url)
+            AND public_base_url ~ '^https://[^#]+$'
+        ),
+    CONSTRAINT ck_eom_terms_invitations_key_fingerprint
+        CHECK (signing_key_fingerprint ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT ck_eom_terms_invitations_window
+        CHECK (
+            issued_at IS NOT NULL
+            AND expires_at = issued_at + INTERVAL '30 days'
+        ),
+    CONSTRAINT ck_eom_terms_invitations_issuer
+        CHECK (issued_by_id > 0 AND length(btrim(issued_by_name)) > 0),
+    CONSTRAINT ck_eom_terms_invitations_revocation
+        CHECK (
+            (revoked_at IS NULL
+                AND revoked_by_id IS NULL
+                AND revoked_by_name IS NULL)
+            OR
+            (revoked_at IS NOT NULL
+                AND revoked_by_id > 0
+                AND length(btrim(revoked_by_name)) > 0)
+        )
+);
+
+CREATE TABLE eom_terms_acceptances (
+    id UUID CONSTRAINT pk_eom_terms_acceptances PRIMARY KEY,
+    invitation_id UUID NOT NULL,
+    business_context_id VARCHAR(64) NOT NULL,
+    contact_id UUID NOT NULL,
+    version_id UUID NOT NULL,
+    audience VARCHAR(16) NOT NULL,
+    locale VARCHAR(2) NOT NULL,
+    recipient_email VARCHAR(256) NOT NULL,
+    signer_name VARCHAR(256) NOT NULL,
+    terms_accepted BOOLEAN NOT NULL,
+    additional_work_accepted BOOLEAN NOT NULL,
+    client_ip INET NOT NULL,
+    content_hash VARCHAR(64) NOT NULL,
+    accepted_at TIMESTAMPTZ NOT NULL,
+    CONSTRAINT uq_eom_terms_acceptances_invitation UNIQUE (invitation_id),
+    CONSTRAINT fk_eom_terms_acceptances_invitation
+        FOREIGN KEY (invitation_id) REFERENCES eom_terms_invitations(id)
+        ON DELETE RESTRICT,
+    CONSTRAINT fk_eom_terms_acceptances_contact
+        FOREIGN KEY (contact_id) REFERENCES contacts(id) ON DELETE RESTRICT,
+    CONSTRAINT fk_eom_terms_acceptances_version
+        FOREIGN KEY (version_id) REFERENCES eom_terms_versions(id)
+        ON DELETE RESTRICT,
+    CONSTRAINT ck_eom_terms_acceptances_context
+        CHECK (business_context_id = 'effingham_maids'),
+    CONSTRAINT ck_eom_terms_acceptances_audience
+        CHECK (audience IN ('residential', 'commercial')),
+    CONSTRAINT ck_eom_terms_acceptances_locale
+        CHECK (locale IN ('en', 'es')),
+    CONSTRAINT ck_eom_terms_acceptances_recipient
+        CHECK (
+            recipient_email = lower(btrim(recipient_email))
+            AND recipient_email ~ '^[^@[:space:]]+@[^@[:space:]]+\.[^@[:space:]]+$'
+        ),
+    CONSTRAINT ck_eom_terms_acceptances_signer
+        CHECK (length(btrim(signer_name)) BETWEEN 1 AND 256),
+    CONSTRAINT ck_eom_terms_acceptances_acknowledgements
+        CHECK (terms_accepted AND additional_work_accepted),
+    CONSTRAINT ck_eom_terms_acceptances_content_hash
+        CHECK (content_hash ~ '^[0-9a-f]{64}$')
+);
+
+CREATE TABLE eom_terms_deliveries (
+    id UUID CONSTRAINT pk_eom_terms_deliveries PRIMARY KEY,
+    kind VARCHAR(24) NOT NULL,
+    invitation_id UUID NOT NULL,
+    acceptance_id UUID,
+    recipient_email VARCHAR(256) NOT NULL,
+    subject VARCHAR(512) NOT NULL,
+    body TEXT NOT NULL,
+    body_hash VARCHAR(64) NOT NULL,
+    status VARCHAR(16) NOT NULL DEFAULT 'pending',
+    claimed_at TIMESTAMPTZ,
+    sent_at TIMESTAMPTZ,
+    resend_message_id VARCHAR(256),
+    transport_idempotent_replay BOOLEAN,
+    confirmed_by_id BIGINT,
+    confirmed_by_name VARCHAR(128),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_eom_terms_deliveries_kind_invitation
+        UNIQUE (kind, invitation_id),
+    CONSTRAINT uq_eom_terms_deliveries_acceptance UNIQUE (acceptance_id),
+    CONSTRAINT fk_eom_terms_deliveries_invitation
+        FOREIGN KEY (invitation_id) REFERENCES eom_terms_invitations(id)
+        ON DELETE RESTRICT,
+    CONSTRAINT fk_eom_terms_deliveries_acceptance
+        FOREIGN KEY (acceptance_id) REFERENCES eom_terms_acceptances(id)
+        ON DELETE RESTRICT,
+    CONSTRAINT ck_eom_terms_deliveries_kind
+        CHECK (kind IN ('invitation', 'executed_copy')),
+    CONSTRAINT ck_eom_terms_deliveries_shape
+        CHECK (
+            (kind = 'invitation' AND acceptance_id IS NULL)
+            OR
+            (kind = 'executed_copy' AND acceptance_id IS NOT NULL)
+        ),
+    CONSTRAINT ck_eom_terms_deliveries_recipient
+        CHECK (
+            recipient_email = lower(btrim(recipient_email))
+            AND recipient_email ~ '^[^@[:space:]]+@[^@[:space:]]+\.[^@[:space:]]+$'
+        ),
+    CONSTRAINT ck_eom_terms_deliveries_subject
+        CHECK (length(btrim(subject)) BETWEEN 1 AND 512),
+    CONSTRAINT ck_eom_terms_deliveries_body
+        CHECK (length(body) > 0),
+    CONSTRAINT ck_eom_terms_deliveries_body_hash
+        CHECK (body_hash ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT ck_eom_terms_deliveries_status
+        CHECK (status IN ('pending', 'sending', 'sent')),
+    CONSTRAINT ck_eom_terms_deliveries_state
+        CHECK (
+            (status = 'pending'
+                AND claimed_at IS NULL
+                AND sent_at IS NULL
+                AND resend_message_id IS NULL
+                AND transport_idempotent_replay IS NULL
+                AND confirmed_by_id IS NULL
+                AND confirmed_by_name IS NULL)
+            OR
+            (status = 'sending'
+                AND claimed_at IS NOT NULL
+                AND sent_at IS NULL
+                AND resend_message_id IS NULL
+                AND transport_idempotent_replay IS NULL
+                AND confirmed_by_id IS NULL
+                AND confirmed_by_name IS NULL)
+            OR
+            (status = 'sent'
+                AND claimed_at IS NOT NULL
+                AND sent_at IS NOT NULL
+                AND (
+                    (length(btrim(resend_message_id)) > 0
+                        AND transport_idempotent_replay IS NOT NULL
+                        AND confirmed_by_id IS NULL
+                        AND confirmed_by_name IS NULL)
+                    OR
+                    (resend_message_id IS NULL
+                        AND transport_idempotent_replay IS NULL
+                        AND confirmed_by_id > 0
+                        AND length(btrim(confirmed_by_name)) > 0)
+                ))
+        )
+);
+
+CREATE FUNCTION validate_eom_terms_invitation()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+DECLARE
+    authoritative_time TIMESTAMPTZ;
+BEGIN
+    PERFORM pg_advisory_xact_lock(
+        hashtextextended('eom-terms-current-version', 0)
+    );
+    IF NEW.revoked_at IS NOT NULL
+       OR NEW.revoked_by_id IS NOT NULL
+       OR NEW.revoked_by_name IS NOT NULL THEN
+        RAISE EXCEPTION 'new EOM Terms invitation cannot start revoked';
+    END IF;
+    IF NOT EXISTS (
+        SELECT 1
+          FROM contacts AS contact
+          JOIN eom_terms_current_version AS selected ON selected.singleton
+          JOIN eom_terms_versions AS version
+            ON version.id = selected.version_id
+           AND version.status = 'published'
+         WHERE contact.id = NEW.contact_id
+           AND contact.business_context_id = 'effingham_maids'
+           AND contact.contact_type = 'customer'
+           AND contact.status = 'active'
+           AND contact.customer_type IN ('residential', 'commercial')
+           AND contact.customer_type = NEW.audience
+           AND btrim(contact.full_name) = NEW.customer_name
+           AND lower(btrim(contact.email)) = NEW.recipient_email
+           AND version.id = NEW.version_id
+    ) THEN
+        RAISE EXCEPTION
+            'EOM Terms invitation requires the current release and matching active customer';
+    END IF;
+    authoritative_time := clock_timestamp();
+    NEW.business_context_id := 'effingham_maids';
+    NEW.issued_at := authoritative_time;
+    NEW.expires_at := authoritative_time + INTERVAL '30 days';
+    RETURN NEW;
+END;
+$$;
+
+CREATE FUNCTION protect_eom_terms_invitation()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+BEGIN
+    IF TG_OP = 'TRUNCATE' OR TG_OP = 'DELETE' THEN
+        RAISE EXCEPTION 'EOM Terms invitations cannot be removed';
+    END IF;
+    IF ROW(
+        NEW.id, NEW.request_key, NEW.business_context_id, NEW.contact_id,
+        NEW.version_id, NEW.audience, NEW.locale, NEW.customer_name,
+        NEW.recipient_email, NEW.public_base_url,
+        NEW.signing_key_fingerprint, NEW.issued_at, NEW.expires_at,
+        NEW.issued_by_id, NEW.issued_by_name
+    ) IS DISTINCT FROM ROW(
+        OLD.id, OLD.request_key, OLD.business_context_id, OLD.contact_id,
+        OLD.version_id, OLD.audience, OLD.locale, OLD.customer_name,
+        OLD.recipient_email, OLD.public_base_url,
+        OLD.signing_key_fingerprint, OLD.issued_at, OLD.expires_at,
+        OLD.issued_by_id, OLD.issued_by_name
+    ) THEN
+        RAISE EXCEPTION 'EOM Terms invitation identity is immutable';
+    END IF;
+    IF OLD.revoked_at IS NOT NULL THEN
+        IF ROW(NEW.revoked_at, NEW.revoked_by_id, NEW.revoked_by_name)
+           IS DISTINCT FROM
+           ROW(OLD.revoked_at, OLD.revoked_by_id, OLD.revoked_by_name) THEN
+            RAISE EXCEPTION 'EOM Terms invitation revocation is immutable';
+        END IF;
+        RETURN NEW;
+    END IF;
+    IF NEW.revoked_at IS NULL
+       AND NEW.revoked_by_id IS NULL
+       AND NEW.revoked_by_name IS NULL THEN
+        RETURN NEW;
+    END IF;
+    IF NEW.revoked_by_id IS NULL
+       OR NEW.revoked_by_id <= 0
+       OR length(btrim(NEW.revoked_by_name)) = 0 THEN
+        RAISE EXCEPTION 'EOM Terms invitation revocation requires an actor';
+    END IF;
+    IF EXISTS (
+        SELECT 1
+          FROM eom_terms_acceptances AS acceptance
+         WHERE acceptance.invitation_id = OLD.id
+    ) THEN
+        RAISE EXCEPTION 'accepted EOM Terms invitation cannot be revoked';
+    END IF;
+    NEW.revoked_at := clock_timestamp();
+    RETURN NEW;
+END;
+$$;
+
+CREATE FUNCTION validate_eom_terms_acceptance()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+DECLARE
+    invitation_row RECORD;
+    authoritative_time TIMESTAMPTZ;
+BEGIN
+    PERFORM pg_advisory_xact_lock(
+        hashtextextended('eom-terms-current-version', 0)
+    );
+    authoritative_time := clock_timestamp();
+    SELECT invitation.contact_id,
+           invitation.version_id,
+           invitation.audience,
+           invitation.locale,
+           invitation.recipient_email,
+           invitation.revoked_at,
+           invitation.expires_at,
+           version.content_hash,
+           version.published_at
+      INTO invitation_row
+      FROM eom_terms_invitations AS invitation
+      JOIN eom_terms_versions AS version
+        ON version.id = invitation.version_id
+       AND version.status = 'published'
+     WHERE invitation.id = NEW.invitation_id
+     FOR SHARE OF invitation;
+    IF NOT FOUND
+       OR invitation_row.revoked_at IS NOT NULL
+       OR authoritative_time > invitation_row.expires_at THEN
+        RAISE EXCEPTION 'EOM Terms invitation is unavailable';
+    END IF;
+    IF EXISTS (
+        SELECT 1
+          FROM eom_terms_versions AS later
+         WHERE later.status = 'published'
+           AND later.material_change
+           AND later.published_at > invitation_row.published_at
+    ) THEN
+        RAISE EXCEPTION
+            'EOM Terms invitation was superseded by a material release';
+    END IF;
+    IF NOT EXISTS (
+        SELECT 1
+          FROM contacts AS contact
+         WHERE contact.id = invitation_row.contact_id
+           AND contact.business_context_id = 'effingham_maids'
+           AND contact.contact_type = 'customer'
+           AND contact.status = 'active'
+           AND contact.customer_type = invitation_row.audience
+           AND lower(btrim(contact.email)) = invitation_row.recipient_email
+    ) THEN
+        RAISE EXCEPTION
+            'EOM Terms invitation no longer matches an active customer';
+    END IF;
+    NEW.business_context_id := 'effingham_maids';
+    NEW.contact_id := invitation_row.contact_id;
+    NEW.version_id := invitation_row.version_id;
+    NEW.audience := invitation_row.audience;
+    NEW.locale := invitation_row.locale;
+    NEW.recipient_email := invitation_row.recipient_email;
+    NEW.content_hash := invitation_row.content_hash;
+    NEW.accepted_at := authoritative_time;
+    RETURN NEW;
+END;
+$$;
+
+CREATE FUNCTION protect_eom_terms_acceptance()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+BEGIN
+    RAISE EXCEPTION 'EOM Terms acceptance evidence is append-only';
+END;
+$$;
+
+CREATE FUNCTION protect_eom_terms_delivery()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+BEGIN
+    IF TG_OP = 'TRUNCATE' OR TG_OP = 'DELETE' THEN
+        RAISE EXCEPTION 'EOM Terms delivery evidence cannot be removed';
+    END IF;
+    IF TG_OP = 'INSERT' THEN
+        IF NEW.status <> 'pending'
+           OR NEW.claimed_at IS NOT NULL
+           OR NEW.sent_at IS NOT NULL
+           OR NEW.resend_message_id IS NOT NULL
+           OR NEW.transport_idempotent_replay IS NOT NULL
+           OR NEW.confirmed_by_id IS NOT NULL
+           OR NEW.confirmed_by_name IS NOT NULL THEN
+            RAISE EXCEPTION 'new EOM Terms delivery must start pending';
+        END IF;
+        IF NEW.kind = 'invitation' THEN
+            IF NEW.acceptance_id IS NOT NULL OR NOT EXISTS (
+                SELECT 1
+                  FROM eom_terms_invitations AS invitation
+                 WHERE invitation.id = NEW.invitation_id
+                   AND invitation.recipient_email = NEW.recipient_email
+            ) THEN
+                RAISE EXCEPTION
+                    'invitation delivery must match its EOM Terms invitation';
+            END IF;
+        ELSIF NEW.kind = 'executed_copy' THEN
+            IF NEW.acceptance_id IS NULL OR NOT EXISTS (
+                SELECT 1
+                  FROM eom_terms_acceptances AS acceptance
+                 WHERE acceptance.id = NEW.acceptance_id
+                   AND acceptance.invitation_id = NEW.invitation_id
+                   AND acceptance.recipient_email = NEW.recipient_email
+            ) THEN
+                RAISE EXCEPTION
+                    'executed-copy delivery must match its EOM Terms acceptance';
+            END IF;
+        ELSE
+            RAISE EXCEPTION 'EOM Terms delivery kind is invalid';
+        END IF;
+        RETURN NEW;
+    END IF;
+    IF ROW(
+        NEW.id, NEW.kind, NEW.invitation_id, NEW.acceptance_id,
+        NEW.recipient_email, NEW.subject, NEW.body, NEW.body_hash,
+        NEW.created_at
+    ) IS DISTINCT FROM ROW(
+        OLD.id, OLD.kind, OLD.invitation_id, OLD.acceptance_id,
+        OLD.recipient_email, OLD.subject, OLD.body, OLD.body_hash,
+        OLD.created_at
+    ) THEN
+        RAISE EXCEPTION 'EOM Terms delivery payload is immutable';
+    END IF;
+    IF OLD.status = 'pending' AND NEW.status = 'sending' THEN
+        IF NEW.sent_at IS NOT NULL
+           OR NEW.resend_message_id IS NOT NULL
+           OR NEW.transport_idempotent_replay IS NOT NULL
+           OR NEW.confirmed_by_id IS NOT NULL
+           OR NEW.confirmed_by_name IS NOT NULL THEN
+            RAISE EXCEPTION 'EOM Terms delivery claim contains sent evidence';
+        END IF;
+        IF NEW.kind = 'invitation' AND NOT EXISTS (
+            SELECT 1
+              FROM eom_terms_invitations AS invitation
+             WHERE invitation.id = NEW.invitation_id
+               AND invitation.revoked_at IS NULL
+               AND clock_timestamp() <= invitation.expires_at
+               AND NOT EXISTS (
+                   SELECT 1
+                     FROM eom_terms_acceptances AS acceptance
+                    WHERE acceptance.invitation_id = invitation.id
+               )
+        ) THEN
+            RAISE EXCEPTION 'EOM Terms invitation delivery is no longer valid';
+        END IF;
+        NEW.claimed_at := clock_timestamp();
+        RETURN NEW;
+    END IF;
+    IF OLD.status = 'sending' AND NEW.status = 'sent' THEN
+        IF NEW.claimed_at IS DISTINCT FROM OLD.claimed_at THEN
+            RAISE EXCEPTION 'EOM Terms delivery claim time is immutable';
+        END IF;
+        IF (
+            length(btrim(NEW.resend_message_id)) > 0
+            AND NEW.transport_idempotent_replay IS NOT NULL
+            AND NEW.confirmed_by_id IS NULL
+            AND NEW.confirmed_by_name IS NULL
+        ) OR (
+            NEW.resend_message_id IS NULL
+            AND NEW.transport_idempotent_replay IS NULL
+            AND NEW.confirmed_by_id > 0
+            AND length(btrim(NEW.confirmed_by_name)) > 0
+        ) THEN
+            NEW.sent_at := clock_timestamp();
+            RETURN NEW;
+        END IF;
+        RAISE EXCEPTION 'EOM Terms sent delivery requires transport or actor evidence';
+    END IF;
+    RAISE EXCEPTION 'EOM Terms delivery transition is invalid';
+END;
+$$;
+
+CREATE TRIGGER trg_validate_eom_terms_invitation
+    BEFORE INSERT ON eom_terms_invitations
+    FOR EACH ROW EXECUTE FUNCTION validate_eom_terms_invitation();
+
+CREATE TRIGGER trg_protect_eom_terms_invitation
+    BEFORE UPDATE OR DELETE ON eom_terms_invitations
+    FOR EACH ROW EXECUTE FUNCTION protect_eom_terms_invitation();
+
+CREATE TRIGGER trg_protect_eom_terms_invitation_truncate
+    BEFORE TRUNCATE ON eom_terms_invitations
+    FOR EACH STATEMENT EXECUTE FUNCTION protect_eom_terms_invitation();
+
+CREATE TRIGGER trg_validate_eom_terms_acceptance
+    BEFORE INSERT ON eom_terms_acceptances
+    FOR EACH ROW EXECUTE FUNCTION validate_eom_terms_acceptance();
+
+CREATE TRIGGER trg_protect_eom_terms_acceptance
+    BEFORE UPDATE OR DELETE ON eom_terms_acceptances
+    FOR EACH ROW EXECUTE FUNCTION protect_eom_terms_acceptance();
+
+CREATE TRIGGER trg_protect_eom_terms_acceptance_truncate
+    BEFORE TRUNCATE ON eom_terms_acceptances
+    FOR EACH STATEMENT EXECUTE FUNCTION protect_eom_terms_acceptance();
+
+CREATE TRIGGER trg_protect_eom_terms_delivery
+    BEFORE INSERT OR UPDATE OR DELETE ON eom_terms_deliveries
+    FOR EACH ROW EXECUTE FUNCTION protect_eom_terms_delivery();
+
+CREATE TRIGGER trg_protect_eom_terms_delivery_truncate
+    BEFORE TRUNCATE ON eom_terms_deliveries
+    FOR EACH STATEMENT EXECUTE FUNCTION protect_eom_terms_delivery();
+
+CREATE INDEX idx_eom_terms_invitations_contact_issued
+    ON eom_terms_invitations (contact_id, issued_at DESC, id DESC);
+
+CREATE INDEX idx_eom_terms_acceptances_contact_accepted
+    ON eom_terms_acceptances (contact_id, accepted_at DESC, id DESC);
+
+CREATE INDEX idx_eom_terms_deliveries_status
+    ON eom_terms_deliveries (status, created_at, id);
+
+DO $$
+DECLARE
+    schema_name TEXT := current_schema();
+    table_name TEXT;
+    function_name TEXT;
+    grantee_name TEXT;
+BEGIN
+    FOREACH function_name IN ARRAY ARRAY[
+        'validate_eom_terms_invitation',
+        'protect_eom_terms_invitation',
+        'validate_eom_terms_acceptance',
+        'protect_eom_terms_acceptance',
+        'protect_eom_terms_delivery'
+    ]
+    LOOP
+        EXECUTE format(
+            'ALTER FUNCTION %I.%I() RESET ALL', schema_name, function_name
+        );
+        EXECUTE format(
+            'ALTER FUNCTION %I.%I() SET search_path TO pg_catalog, %I, pg_temp',
+            schema_name,
+            function_name,
+            schema_name
+        );
+        EXECUTE format(
+            'ALTER FUNCTION %I.%I() OWNER TO atlas_eom_handoff_owner',
+            schema_name,
+            function_name
+        );
+    END LOOP;
+
+    FOREACH table_name IN ARRAY ARRAY[
+        'eom_terms_invitations',
+        'eom_terms_acceptances',
+        'eom_terms_deliveries'
+    ]
+    LOOP
+        EXECUTE format(
+            'ALTER TABLE %I.%I OWNER TO atlas_eom_handoff_owner',
+            schema_name,
+            table_name
+        );
+        EXECUTE format(
+            'REVOKE ALL PRIVILEGES ON TABLE %I.%I FROM PUBLIC',
+            schema_name,
+            table_name
+        );
+        FOR grantee_name IN
+            SELECT DISTINCT grantee_role.rolname
+              FROM pg_class AS relation
+              JOIN pg_namespace AS namespace
+                ON namespace.oid = relation.relnamespace
+              CROSS JOIN LATERAL aclexplode(
+                  COALESCE(relation.relacl, ARRAY[]::aclitem[])
+              ) AS acl
+              JOIN pg_roles AS grantee_role ON grantee_role.oid = acl.grantee
+             WHERE namespace.nspname = schema_name
+               AND relation.relname = table_name
+               AND grantee_role.rolname <> 'atlas_eom_handoff_owner'
+        LOOP
+            EXECUTE format(
+                'REVOKE ALL PRIVILEGES ON TABLE %I.%I FROM %I',
+                schema_name,
+                table_name,
+                grantee_name
+            );
+        END LOOP;
+    END LOOP;
+
+    FOREACH function_name IN ARRAY ARRAY[
+        'validate_eom_terms_invitation',
+        'protect_eom_terms_invitation',
+        'validate_eom_terms_acceptance',
+        'protect_eom_terms_acceptance',
+        'protect_eom_terms_delivery'
+    ]
+    LOOP
+        EXECUTE format(
+            'REVOKE ALL PRIVILEGES ON FUNCTION %I.%I() FROM PUBLIC',
+            schema_name,
+            function_name
+        );
+        FOR grantee_name IN
+            SELECT DISTINCT grantee_role.rolname
+              FROM pg_proc AS guarded_function
+              JOIN pg_namespace AS namespace
+                ON namespace.oid = guarded_function.pronamespace
+              CROSS JOIN LATERAL aclexplode(
+                  COALESCE(guarded_function.proacl, ARRAY[]::aclitem[])
+              ) AS acl
+              JOIN pg_roles AS grantee_role ON grantee_role.oid = acl.grantee
+             WHERE namespace.nspname = schema_name
+               AND guarded_function.proname = function_name
+               AND guarded_function.pronargs = 0
+               AND grantee_role.rolname <> 'atlas_eom_handoff_owner'
+        LOOP
+            EXECUTE format(
+                'REVOKE ALL PRIVILEGES ON FUNCTION %I.%I() FROM %I',
+                schema_name,
+                function_name,
+                grantee_name
+            );
+        END LOOP;
+    END LOOP;
+
+    EXECUTE format(
+        'GRANT SELECT ON TABLE %I.eom_terms_invitations TO atlas',
+        schema_name
+    );
+    EXECUTE format(
+        'GRANT INSERT (id, request_key, contact_id, version_id, audience, '
+        || 'locale, customer_name, recipient_email, public_base_url, '
+        || 'signing_key_fingerprint, issued_by_id, issued_by_name) '
+        || 'ON TABLE %I.eom_terms_invitations TO atlas',
+        schema_name
+    );
+    EXECUTE format(
+        'GRANT UPDATE (revoked_at, revoked_by_id, revoked_by_name) '
+        || 'ON TABLE %I.eom_terms_invitations TO atlas',
+        schema_name
+    );
+    EXECUTE format(
+        'GRANT SELECT ON TABLE %I.eom_terms_acceptances TO atlas',
+        schema_name
+    );
+    EXECUTE format(
+        'GRANT INSERT (id, invitation_id, signer_name, terms_accepted, '
+        || 'additional_work_accepted, client_ip) '
+        || 'ON TABLE %I.eom_terms_acceptances TO atlas',
+        schema_name
+    );
+    EXECUTE format(
+        'GRANT SELECT ON TABLE %I.eom_terms_deliveries TO atlas',
+        schema_name
+    );
+    EXECUTE format(
+        'GRANT INSERT (id, kind, invitation_id, acceptance_id, '
+        || 'recipient_email, subject, body, body_hash) '
+        || 'ON TABLE %I.eom_terms_deliveries TO atlas',
+        schema_name
+    );
+    EXECUTE format(
+        'GRANT UPDATE (status, claimed_at, sent_at, resend_message_id, '
+        || 'transport_idempotent_replay, confirmed_by_id, confirmed_by_name) '
+        || 'ON TABLE %I.eom_terms_deliveries TO atlas',
+        schema_name
+    );
+END;
+$$;
+
+COMMENT ON TABLE eom_terms_invitations IS
+    'Customer-bound expiring EOM Terms invitation metadata; raw bearer tokens are never stored.';
+COMMENT ON TABLE eom_terms_acceptances IS
+    'Immutable evidence that one active EOM customer accepted one published Terms version and both required acknowledgements.';
+COMMENT ON TABLE eom_terms_deliveries IS
+    'Immutable invitation/executed-copy payloads with one-way transport and actor-reconciliation evidence.';

--- a/atlas_brain/storage/migrations/397_eom_terms_acceptance.sql
+++ b/atlas_brain/storage/migrations/397_eom_terms_acceptance.sql
@@ -196,12 +196,114 @@ BEGIN
           )) IS NOT NULL
        OR to_regprocedure(format(
             '%I.protect_eom_terms_delivery()', schema_name
+          )) IS NOT NULL
+       OR to_regprocedure(format(
+            '%I.assign_eom_terms_publication_order()', schema_name
           )) IS NOT NULL THEN
         RAISE EXCEPTION
             'refusing to adopt a pre-existing EOM Terms acceptance object';
     END IF;
+
+    IF EXISTS (
+        SELECT 1
+          FROM pg_attribute AS attribute
+         WHERE attribute.attrelid = to_regclass(format(
+                   '%I.eom_terms_versions', schema_name
+               ))
+           AND attribute.attname = 'publication_order'
+           AND attribute.attnum > 0
+           AND NOT attribute.attisdropped
+    ) OR EXISTS (
+        SELECT 1
+          FROM pg_trigger AS guard_trigger
+         WHERE guard_trigger.tgrelid = to_regclass(format(
+                   '%I.eom_terms_versions', schema_name
+               ))
+           AND guard_trigger.tgname =
+               'trg_assign_eom_terms_publication_order'
+           AND NOT guard_trigger.tgisinternal
+    ) THEN
+        RAISE EXCEPTION
+            'refusing to adopt pre-existing EOM Terms publication ordering';
+    END IF;
 END;
 $$;
+
+ALTER TABLE eom_terms_versions
+    ADD COLUMN publication_order BIGINT;
+
+-- Migration 396 made published rows immutable. Temporarily suspend that one
+-- guard inside this atomic DBA migration so existing releases can receive a
+-- deterministic order. The selected current release is always placed last;
+-- ties among historical releases are stable but make no claim about chronology
+-- that was not recorded before this migration.
+ALTER TABLE eom_terms_versions
+    DISABLE TRIGGER trg_protect_eom_terms_version;
+
+WITH ordered_release AS (
+    SELECT version.id,
+           row_number() OVER (
+               ORDER BY
+                   CASE WHEN version.id = (
+                       SELECT selected.version_id
+                         FROM eom_terms_current_version AS selected
+                        WHERE selected.singleton
+                   ) THEN 1 ELSE 0 END,
+                   version.published_at,
+                   version.created_at,
+                   version.id
+           ) AS publication_order
+      FROM eom_terms_versions AS version
+     WHERE version.status = 'published'
+)
+UPDATE eom_terms_versions AS version
+   SET publication_order = ordered_release.publication_order
+  FROM ordered_release
+ WHERE version.id = ordered_release.id;
+
+ALTER TABLE eom_terms_versions
+    ENABLE TRIGGER trg_protect_eom_terms_version;
+
+ALTER TABLE eom_terms_versions
+    ADD CONSTRAINT uq_eom_terms_publication_order
+        UNIQUE (publication_order),
+    ADD CONSTRAINT ck_eom_terms_publication_order
+        CHECK (
+            (status = 'draft' AND publication_order IS NULL)
+            OR
+            (status = 'published' AND publication_order > 0)
+        );
+
+CREATE FUNCTION assign_eom_terms_publication_order()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+BEGIN
+    IF OLD.status = 'draft' AND NEW.status = 'published' THEN
+        IF NEW.publication_order IS NOT NULL THEN
+            RAISE EXCEPTION
+                'EOM Terms publication order is database assigned';
+        END IF;
+        PERFORM pg_advisory_xact_lock(
+            hashtextextended('eom-terms-current-version', 0)
+        );
+        SELECT COALESCE(max(version.publication_order), 0) + 1
+          INTO NEW.publication_order
+          FROM eom_terms_versions AS version
+         WHERE version.status = 'published';
+        RETURN NEW;
+    END IF;
+    IF NEW.publication_order IS DISTINCT FROM OLD.publication_order THEN
+        RAISE EXCEPTION 'EOM Terms publication order is immutable';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_assign_eom_terms_publication_order
+    BEFORE UPDATE ON eom_terms_versions
+    FOR EACH ROW EXECUTE FUNCTION assign_eom_terms_publication_order();
 
 CREATE TABLE eom_terms_invitations (
     id UUID CONSTRAINT pk_eom_terms_invitations PRIMARY KEY,
@@ -381,8 +483,11 @@ CREATE TABLE eom_terms_deliveries (
                 AND claimed_at IS NOT NULL
                 AND sent_at IS NOT NULL
                 AND (
-                    (length(btrim(resend_message_id)) > 0
-                        AND transport_idempotent_replay IS NOT NULL
+                    (((length(btrim(resend_message_id)) > 0
+                            AND transport_idempotent_replay IS NOT NULL)
+                        OR
+                        (resend_message_id IS NULL
+                            AND transport_idempotent_replay IS TRUE))
                         AND confirmed_by_id IS NULL
                         AND confirmed_by_name IS NULL)
                     OR
@@ -513,7 +618,7 @@ BEGIN
            invitation.revoked_at,
            invitation.expires_at,
            version.content_hash,
-           version.published_at
+           version.publication_order
       INTO invitation_row
       FROM eom_terms_invitations AS invitation
       JOIN eom_terms_versions AS version
@@ -531,7 +636,7 @@ BEGIN
           FROM eom_terms_versions AS later
          WHERE later.status = 'published'
            AND later.material_change
-           AND later.published_at > invitation_row.published_at
+           AND later.publication_order > invitation_row.publication_order
     ) THEN
         RAISE EXCEPTION
             'EOM Terms invitation was superseded by a material release';
@@ -656,9 +761,13 @@ BEGIN
         IF NEW.claimed_at IS DISTINCT FROM OLD.claimed_at THEN
             RAISE EXCEPTION 'EOM Terms delivery claim time is immutable';
         END IF;
-        IF (
-            length(btrim(NEW.resend_message_id)) > 0
-            AND NEW.transport_idempotent_replay IS NOT NULL
+        IF ((
+            (length(btrim(NEW.resend_message_id)) > 0
+                AND NEW.transport_idempotent_replay IS NOT NULL)
+            OR
+            (NEW.resend_message_id IS NULL
+                AND NEW.transport_idempotent_replay IS TRUE)
+        )
             AND NEW.confirmed_by_id IS NULL
             AND NEW.confirmed_by_name IS NULL
         ) OR (
@@ -725,6 +834,7 @@ DECLARE
     grantee_name TEXT;
 BEGIN
     FOREACH function_name IN ARRAY ARRAY[
+        'assign_eom_terms_publication_order',
         'validate_eom_terms_invitation',
         'protect_eom_terms_invitation',
         'validate_eom_terms_acceptance',
@@ -787,6 +897,7 @@ BEGIN
     END LOOP;
 
     FOREACH function_name IN ARRAY ARRAY[
+        'assign_eom_terms_publication_order',
         'validate_eom_terms_invitation',
         'protect_eom_terms_invitation',
         'validate_eom_terms_acceptance',
@@ -873,3 +984,5 @@ COMMENT ON TABLE eom_terms_acceptances IS
     'Immutable evidence that one active EOM customer accepted one published Terms version and both required acknowledgements.';
 COMMENT ON TABLE eom_terms_deliveries IS
     'Immutable invitation/executed-copy payloads with one-way transport and actor-reconciliation evidence.';
+COMMENT ON COLUMN eom_terms_versions.publication_order IS
+    'Database-assigned monotonic release order used instead of wall-clock chronology.';

--- a/atlas_brain/storage/migrations/397_eom_terms_acceptance.sql
+++ b/atlas_brain/storage/migrations/397_eom_terms_acceptance.sql
@@ -789,6 +789,28 @@ BEGIN
         ) THEN
             RAISE EXCEPTION 'EOM Terms invitation delivery is no longer valid';
         END IF;
+        IF NEW.kind = 'executed_copy' AND NOT EXISTS (
+            SELECT 1
+              FROM eom_terms_acceptances AS acceptance
+              JOIN eom_terms_invitations AS invitation
+                ON invitation.id = acceptance.invitation_id
+               AND invitation.contact_id = acceptance.contact_id
+               AND invitation.audience = acceptance.audience
+               AND invitation.recipient_email = acceptance.recipient_email
+              JOIN contacts AS contact ON contact.id = acceptance.contact_id
+             WHERE acceptance.id = NEW.acceptance_id
+               AND acceptance.invitation_id = NEW.invitation_id
+               AND acceptance.recipient_email = NEW.recipient_email
+               AND contact.business_context_id = 'effingham_maids'
+               AND contact.contact_type = 'customer'
+               AND contact.status = 'active'
+               AND contact.customer_type = acceptance.audience
+               AND btrim(contact.full_name) = invitation.customer_name
+               AND lower(btrim(contact.email)) = acceptance.recipient_email
+        ) THEN
+            RAISE EXCEPTION
+                'EOM Terms executed-copy delivery is no longer valid';
+        END IF;
         NEW.claimed_at := clock_timestamp();
         RETURN NEW;
     END IF;

--- a/atlas_brain/storage/migrations/__init__.py
+++ b/atlas_brain/storage/migrations/__init__.py
@@ -25,6 +25,7 @@ CONTROLLED_DBA_MIGRATION_NAMES = frozenset(
         "393_eom_missed_call_recovery_runtime_privileges",
         "394_eom_first_clean_completion_receipts",
         "396_eom_terms_authority",
+        "397_eom_terms_acceptance",
     }
 )
 

--- a/ops
+++ b/ops
@@ -55,6 +55,7 @@ DATABASE_INSPECTIONS = {
 }
 CONTROLLED_DATABASE_OPERATIONS = {
     "eom-terms-authority": "apply_eom_terms_authority_schema.py",
+    "eom-terms-acceptance": "apply_eom_terms_acceptance_schema.py",
 }
 TEST_DATABASE_URL_KEYS = (
     "ATLAS_MIGRATION_TEST_DATABASE_URL",
@@ -580,7 +581,7 @@ def db_command(args: list[str]) -> int:
     if action == "controlled":
         if len(args) != 3:
             raise OpsError(
-                "usage: ./ops db controlled eom-terms-authority {preflight|apply}"
+                "usage: ./ops db controlled {eom-terms-authority|eom-terms-acceptance} {preflight|apply}"
             )
         return run_controlled_database_operation(args[1], args[2])
     if action in ("query", "write", "migrate", "rollback", "drop"):
@@ -901,7 +902,7 @@ Read-only discovery and inspection:
   ci {status [LIMIT]|run RUN_ID [--log-failed]}
 
 Guarded database changes:
-  db controlled eom-terms-authority {preflight|apply}
+  db controlled {eom-terms-authority|eom-terms-acceptance} {preflight|apply}
 
 Local/test execution:
   test unit  # GitHub-only; prints the canonical hosted gate and exits

--- a/plans/PR-EOM-Terms-Acceptance.md
+++ b/plans/PR-EOM-Terms-Acceptance.md
@@ -77,14 +77,25 @@ evidence.
   and before transport. Material-release comparisons also used wall-clock
   timestamps, which do not define a strict release order, and the delivery
   evidence guard rejected Resend's provider-confirmed idempotent replay shape
-  when that replay has no message id.
-- Revised requirement: delivery acquires the publication lock and invitation
-  row lock in the same order as acceptance/revocation and retains both through
-  the bounded provider outcome and database confirmation. Migration 397 adds a
-  guard-owned monotonic publication order assigned under the existing
-  publication lock and every later-material decision uses that order. A sent
-  transition admits a missing provider message id only when the established
-  sender explicitly reports `idempotent_replay = true`.
+  when that replay has no message id. Further review proved that keeping claim,
+  provider call, and confirmation in one transaction erased `sending` when the
+  provider accepted but database confirmation failed; contact identity was not
+  revalidated or locked through transport; readiness still selected among
+  acceptances by wall-clock time; and receipt identity fields admitted embedded
+  line controls.
+- Revised requirement: delivery first commits a durable `pending -> sending`
+  claim before crossing the provider boundary. It then reacquires the
+  publication, invitation, delivery, and canonical contact locks, revalidates
+  material currency and contact identity, and retains those locks through the
+  bounded provider outcome and database confirmation. Any uncertain provider
+  or confirmation result remains `sending` and is never automatically retried;
+  acceptance and revocation reject that reconciliation state. Migration 397
+  adds a guard-owned monotonic publication order assigned under the existing
+  publication lock, every later-material decision and readiness selection uses
+  that order, and a sent transition admits a missing provider message id only
+  when the established sender explicitly reports
+  `idempotent_replay = true`. Shared signer/customer/actor text rejects every
+  non-printable line-control character before it can enter receipt evidence.
 - Preserved boundary: this internal serialization and release-order evidence
   does not change Terms prose, version hashes, the operator publish/current
   selection API, route payloads, customer classification, payment/onboarding
@@ -141,10 +152,12 @@ Max files: 18
     changed signer conflicts.
   - The service execution model below makes publication/issue/accept/readiness
     linearize on one PostgreSQL advisory lock, revocation/acceptance linearize on
-    the invitation row lock, and delivery hold those locks from its conditional
-    `pending -> sending` claim through the provider outcome; focused concurrent
-    tests settle duplicate issue, double accept, accept-vs-revoke,
-    send-vs-revoke, and double-send invariants under that model.
+    the invitation row lock, and delivery commit its `pending -> sending` claim
+    before transport, then hold publication, invitation, delivery, and contact
+    locks through the provider outcome; focused concurrent tests settle
+    duplicate issue, double accept, accept-vs-revoke, send-vs-revoke,
+    contact-update-vs-send, confirmation-failure, and double-send invariants
+    under that model.
   - Migration 397 tests prove the guard owner owns all three relations and guard
     functions, the direct `atlas` login has no table-wide write/delete/truncate
     or function-replacement authority, acceptance rows and delivery payloads
@@ -152,8 +165,8 @@ Max files: 18
     admitted.
   - Readiness tests prove acceptance of the current or an older release followed
     only by non-material releases is ready, and any later material release is
-    `reacceptance_required`, including when its wall-clock publication timestamp
-    is earlier than the accepted release.
+    `reacceptance_required`, including when release or acceptance wall-clock
+    timestamps contradict the database-owned publication order.
   - Invitation and executed-copy transport tests assert persisted body equality
     with the selected published audience/locale, separate acknowledgement
     evidence, deterministic Resend idempotency keys, and an acceptance that
@@ -194,15 +207,16 @@ Max files: 18
   exactly one of revocation or first acceptance wins, and an unchanged accept
   replay returns the existing immutable row.
 - Delivery payload creation commits with its invitation/acceptance. Delivery
-  then acquires the publication lock followed by the invitation row lock,
-  claims exactly one pending row, and retains those locks through the bounded
-  provider result and `sent` confirmation. A failed/unknown sender call commits
-  explicit `sending` reconciliation evidence. A database failure after provider
-  acceptance rolls the claim back, and a later explicit invocation uses the
-  same deterministic Resend idempotency key; a provider-confirmed replay can
-  therefore restore `sent` evidence without a duplicate message. No background
-  retry is introduced, and actor confirmation remains limited to a persisted
-  `sending` state after external reconciliation.
+  acquires the publication, invitation, delivery, and contact locks, validates
+  the canonical recipient and current material release, and commits exactly one
+  `pending -> sending` claim before transport. It then reacquires the same locks,
+  revalidates every condition, and retains them through the bounded provider
+  result and `sent` confirmation. A failed/unknown sender call or a database
+  failure after provider acceptance leaves durable `sending` reconciliation
+  evidence; later invocations do not cross the provider boundary again. No
+  background retry is introduced, and actor confirmation remains limited to a
+  persisted `sending` state after external reconciliation. Acceptance and
+  revocation cannot race through that state.
 - Published Terms versions receive a database-assigned positive
   `publication_order` under the existing publication advisory lock. Historical
   releases are backfilled deterministically with the selected current release
@@ -219,21 +233,102 @@ Required when this diff changes a guard, validator, normalizer, resolver,
 router/classifier, or admission boundary. Name each changed boundary path or
 seam in the enumeration; otherwise write "N/A - no boundary change."
 
-- Boundary path/seam: Terms-specific bearer formatting/authentication; private
-  issue/revoke/readiness/reconcile routes; Tracker-proxied session/acceptance;
-  invitation/acceptance/delivery database transitions.
-- Replaced-path behaviors: none. Existing profile-onboarding tokens and Terms
-  publication remain separate and unchanged.
-- Guard-relevant fields: requestKey, contactId, locale, invitation UUID,
-  delivery UUID, token grammar/MAC/key fingerprint, signerName,
-  termsAccepted, additionalWorkAccepted, trusted client-IP header, actor
-  id/name, database-derived audience/email/current version/timestamps, delivery
-  status.
-- Caller x input shape: authenticated office/Tracker bearer plus actor headers x
-  `{requestKey, contactId, locale}` for issue; bearer+actor x invitation for
-  revoke; bearer x contact for readiness; bearer x raw Terms token for session;
-  bearer+raw Terms token+two strict `true` acknowledgements+typed signer+trusted
-  IP header for acceptance; bearer+actor x `sending` delivery for reconciliation.
+- Boundary path/seam: _terms_authority_dependency
+- Replaced-path behaviors: none; this adds the slim-app Terms authority
+  dependency without replacing another dependency resolver.
+- Guard-relevant fields: initialized EOM funnel pool and migration-396 schema
+  readiness.
+- Caller x input shape: mounted slim EOM app x injected authority service.
+
+- Boundary path/seam: _authenticated_terms_token
+- Replaced-path behaviors: none; the existing profile-onboarding token remains
+  a separate bearer domain.
+- Guard-relevant fields: raw Terms token, current/previous HMAC secret, token
+  grammar, MAC, invitation UUID, and key fingerprint.
+- Caller x input shape: authenticated Tracker proxy x raw Terms token for
+  session or acceptance.
+
+- Boundary path/seam: EOMTermsAcceptanceValidationError
+- Replaced-path behaviors: none; this adds a typed failure for the new Terms
+  boundary.
+- Guard-relevant fields: request key, locale, UUIDs, acknowledgements, signer,
+  actor, trusted client IP, email, and receipt identity text.
+- Caller x input shape: malformed private/public Terms input x closed validation
+  error before database mutation.
+
+- Boundary path/seam: AuthenticatedEOMTermsToken
+- Replaced-path behaviors: none; no existing token value object is reused or
+  changed.
+- Guard-relevant fields: authenticated invitation UUID and signing-key
+  fingerprint only; the raw bearer is excluded.
+- Caller x input shape: successful Terms token authentication x closed internal
+  identity value.
+
+- Boundary path/seam: authenticate_eom_terms_token
+- Replaced-path behaviors: none; profile-onboarding authentication stays
+  separate and unchanged.
+- Guard-relevant fields: token prefix/grammar, UUID, MAC, current key, previous
+  key, and derived fingerprint.
+- Caller x input shape: raw Terms bearer x current/previous configured key.
+
+- Boundary path/seam: _require_authenticated_token
+- Replaced-path behaviors: none; this narrows service entry to the authenticated
+  Terms token type.
+- Guard-relevant fields: runtime token type, invitation UUID, and key
+  fingerprint.
+- Caller x input shape: service session/accept call x authenticated internal
+  token value.
+
+- Boundary path/seam: eom_terms_authority_schema_ready
+- Replaced-path behaviors: none; migration-396 readiness gains exact
+  compatibility with migration 397 when installed.
+- Guard-relevant fields: Terms authority relations, triggers, guard functions,
+  ownership, runtime privileges, and optional publication-order guard.
+- Caller x input shape: EOM authority service x current database schema.
+
+- Boundary path/seam: eom_terms_authority_schema_ready#2
+- Replaced-path behaviors: none; this is another changed hunk of the same schema
+  readiness boundary.
+- Guard-relevant fields: Terms authority relations, triggers, functions,
+  ownership, and runtime privileges.
+- Caller x input shape: EOM authority service x incomplete schema.
+
+- Boundary path/seam: eom_terms_authority_schema_ready#3
+- Replaced-path behaviors: none; this is another changed hunk of the same schema
+  readiness boundary.
+- Guard-relevant fields: publication-order column, assignment trigger, and guard
+  ownership when migration 397 exists.
+- Caller x input shape: EOM authority service x migration-396-only or
+  migration-396-plus-397 schema.
+
+- Boundary path/seam: eom_terms_authority_schema_ready#4
+- Replaced-path behaviors: none; this is another changed hunk of the same schema
+  readiness boundary.
+- Guard-relevant fields: owner-role membership and guard-function execution
+  privileges.
+- Caller x input shape: Atlas runtime role x guarded Terms authority schema.
+
+- Boundary path/seam: eom_terms_authority_schema_ready#5
+- Replaced-path behaviors: none; this is another changed hunk of the same schema
+  readiness boundary.
+- Guard-relevant fields: forbidden table-wide mutation and function replacement
+  privileges.
+- Caller x input shape: Atlas runtime role x authority object privilege matrix.
+
+- Boundary path/seam: eom_terms_authority_schema_ready#6
+- Replaced-path behaviors: none; this is another changed hunk of the same schema
+  readiness boundary.
+- Guard-relevant fields: exact column grants for draft creation and publication
+  transitions.
+- Caller x input shape: Atlas runtime role x admitted authority writes.
+
+- Boundary path/seam: EOMTermsAuthority
+- Replaced-path behaviors: none; this adds the Terms publication authority and
+  leaves customer acceptance in its separate service.
+- Guard-relevant fields: immutable bilingual documents, version labels, material
+  flag, content hash, publication order, actor evidence, and current selection.
+- Caller x input shape: authenticated operator draft/publish request x guarded
+  migration-396 authority state.
 
 ### Deployed-config probing
 
@@ -254,9 +349,10 @@ fallback changes; otherwise write "N/A - no guard/config boundary change."
   `effingham_maids`; no caller-supplied tenant, audience, recipient, timestamp,
   or Terms version is accepted.
 - Side-effect ordering: issue preflights config and email transport before the
-  invitation transaction; acceptance commits immutable evidence and a pending
-  executed-copy delivery before any email call; both email calls claim their
-  persisted payload before transport and confirm only after transport
+  invitation transaction; acceptance commits immutable evidence and a newly
+  created executed-copy delivery before any email call; both email calls
+  durably commit their persisted payload as `sending` before transport,
+  revalidate under the canonical locks, and confirm only after transport
   acceptance.
 
 ### Files touched
@@ -286,10 +382,12 @@ relations. Invitation identity is a UUID signed in a Terms-specific HMAC domain;
 the database stores only that UUID and the admitting key fingerprint. The issue
 transaction locks Terms publication, derives the account audience/email from
 `contacts`, pins the current immutable version, persists the exact selected
-email payload, and replays only an identical request key. A single conditional
-delivery claim holds publication/invitation locks while it calls the established
-slim-profile Resend sender with a stable idempotency key and persists either the
-provider message id or its explicit idempotent-replay result.
+email payload, and replays only an identical request key. A durable conditional
+delivery claim commits before the provider boundary; a second transaction
+revalidates and holds publication/invitation/delivery/contact locks while it
+calls the established slim-profile Resend sender with a stable idempotency key
+and persists either the provider message id or its explicit idempotent-replay
+result.
 
 Session and acceptance authenticate the bearer before database access and bind
 the verified key fingerprint to the invitation. Acceptance uses database time,
@@ -317,10 +415,10 @@ funnel pool used by the authority.
 - A newly issued link expires after 30 days using database time. This bounds
   bearer lifetime without adding caller-controlled expiry or another deployment
   setting; a fresh actor-audited invitation is required after expiry.
-- Delivery uncertainty from the sender remains explicit `sending` evidence and
-  requires operator reconciliation. Confirmation failure instead rolls the
-  transaction back for a later explicit, provider-idempotent replay; there is
-  no autonomous retry after an ambiguous external side effect.
+- Delivery uncertainty from the sender or confirmation database remains
+  explicit `sending` evidence and requires operator reconciliation. There is no
+  autonomous or later-call provider retry after an ambiguous external side
+  effect.
 - This provider can send only when an authenticated private caller explicitly
   issues an invitation. It adds no scheduler, bulk send, or production data
   mutation.
@@ -346,9 +444,10 @@ Parked hardening: none.
 
 - Passed locally after review fixes: the focused acceptance, authority, and
   controlled migration-runner suite against disposable PostgreSQL
-  (`197 passed, 1 skipped`), targeted Ruff and Ruff format checks, Python
+  (`206 passed, 1 skipped`), targeted Ruff and Ruff format checks, Python
   compilation, and `git diff --check`.
-- Pending: synchronized-plan check and mechanical pre-push review.
+- Passed: synchronized-plan, boundary-enumeration, deployed-config, and
+  PR-side consistency checks.
 - Hosted: EOM pipeline disposable-PostgreSQL proof and GitHub-only Unit Gate.
 
 ## Estimated diff size
@@ -360,16 +459,16 @@ Parked hardening: none.
 | `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 9 |
 | `atlas_brain/eom_api/funnel.py` | 369 |
 | `atlas_brain/main_eom.py` | 1 |
-| `atlas_brain/services/eom_terms_acceptance.py` | 1842 |
-| `atlas_brain/services/eom_terms_authority.py` | 102 |
-| `atlas_brain/storage/migrations/397_eom_terms_acceptance.sql` | 988 |
+| `atlas_brain/services/eom_terms_acceptance.py` | 1930 |
+| `atlas_brain/services/eom_terms_authority.py` | 108 |
+| `atlas_brain/storage/migrations/397_eom_terms_acceptance.sql` | 1023 |
 | `atlas_brain/storage/migrations/__init__.py` | 1 |
-| `ops` | 3 |
-| `plans/PR-EOM-Terms-Acceptance.md` | 375 |
-| `scripts/apply_eom_first_clean_completion_schema.py` | 23 |
+| `ops` | 5 |
+| `plans/PR-EOM-Terms-Acceptance.md` | 474 |
+| `scripts/apply_eom_first_clean_completion_schema.py` | 24 |
 | `scripts/apply_eom_terms_acceptance_schema.py` | 42 |
-| `tests/test_agent_operations_contract.py` | 30 |
-| `tests/test_eom_first_clean_completion_dba_runner.py` | 94 |
-| `tests/test_eom_terms_acceptance.py` | 1499 |
-| `tests/test_migrations_runner.py` | 2 |
-| **Total** | **5441** |
+| `tests/test_agent_operations_contract.py` | 35 |
+| `tests/test_eom_first_clean_completion_dba_runner.py` | 95 |
+| `tests/test_eom_terms_acceptance.py` | 1738 |
+| `tests/test_migrations_runner.py` | 3 |
+| **Total** | **5918** |

--- a/plans/PR-EOM-Terms-Acceptance.md
+++ b/plans/PR-EOM-Terms-Acceptance.md
@@ -1,0 +1,346 @@
+# PR-EOM-Terms-Acceptance
+
+## Why this slice exists
+
+Issue #2156 and the merged `PR-EOM-Terms-Authority` contract require every EOM
+customer, residential or commercial, to accept the exact published Terms that
+apply to that account. The authority slice can publish immutable bilingual
+content, but it cannot initiate that obligation for a customer, authenticate a
+customer response, prove what was accepted, deliver the executed copy, or tell
+an operator whether a material revision requires reacceptance.
+
+This is the second Atlas provider slice. It closes that provider path through
+the real private/Tracker-proxied EOM API while leaving the Tracker bridge and
+Website acceptance/admin UI to their subsequent consumer slices. The approved
+issue shape includes Terms in the invitation email, a separately required
+additional-work acknowledgement, an emailed executed copy, and manual
+invitations for existing customers. Exact refined Terms prose remains an
+operator-owned publication decision and is neither seeded nor changed here.
+
+Diff-budget override: the invitation, acceptance, immutable evidence,
+idempotent Resend delivery, guarded schema, and real API proof are one legal
+evidence path. Splitting storage from the reachable acceptance route would land
+either floating schema or a customer acceptance endpoint without protected
+evidence.
+
+### Problem-derived contract
+
+- Root cause: the only Terms state on current `main` is document-version
+  authority. There is no customer-bound, expiring bearer pinned to one
+  immutable version; no acceptance record for the two independently required
+  acknowledgements; no executed-copy delivery evidence; and no readiness rule
+  relating an acceptance to later material versions. Consequently the system
+  cannot safely invite a customer or prove that a specific customer accepted a
+  specific published release. Reusing the profile-onboarding token row would
+  also couple two obligations whose revocation and completion lifecycles are
+  independent.
+- Correct fix must touch/change: add a separately controlled DBA migration for
+  guard-owned invitation, immutable acceptance, and content-stable delivery
+  records; grant the runtime only the exact columns needed for issue, revoke,
+  accept, claim, and confirm transitions; add a Terms-specific HMAC bearer
+  domain while reusing the already validated public-onboarding key rotation and
+  HTTPS base URL; add one service that derives audience/email from the canonical
+  active EOM customer, pins the current published version, renders the selected
+  published locale into invitation/executed-copy emails, serializes issue,
+  acceptance, revocation, and readiness against the existing Terms publication
+  lock, and drives the existing idempotent slim-profile Resend transport; add
+  private issue/revoke/readiness/reconcile routes plus Tracker-proxied token
+  session/accept routes; bind the service to the slim funnel pool; expose the
+  controlled migration through `./ops`; and add focused route, boundary,
+  concurrency, migration, and real-PostgreSQL proof enrolled in the EOM
+  workflow.
+- Must not change: do not change or seed Terms document content, version hashing
+  or publication semantics; do not reuse or mutate existing
+  `eom_public_onboarding_tokens`, onboarding drafts, first-clean receipts or
+  candidates; do not change Customer/Site handoff, contact classification,
+  Tracker, Website, calendar, employee timekeeping, billing, payment, Stripe,
+  charge authorization, or card-vault behavior; do not add device
+  fingerprinting or trust a browser-supplied customer/audience/email/IP; do not
+  deploy, restart, apply either controlled migration, or send a production
+  customer email in this PR.
+
+### Contract revision
+
+- New evidence: the invitation caller supplies only request key, contact, and
+  locale; Atlas derives and pins the current version. Therefore a retry after a
+  later publication cannot truthfully be compared to a caller-requested new
+  version.
+- Revised requirement: an existing request key replays its original pinned
+  invitation across later publication changes when contact and locale match.
+  Reusing that key for another contact or locale conflicts. A genuinely new
+  invitation for the new current version requires a new request key.
+
+## Scope (this PR)
+
+Ownership lane: eom-onboarding-terms
+Slice phase: Vertical slice
+Max files: 18
+
+1. Issue or idempotently replay a manual invitation for one active EOM customer,
+   deriving residential/commercial and recipient email from the canonical
+   contact and pinning the then-current published Terms version and selected
+   `en`/`es` locale.
+2. Deliver the invitation through the established slim-profile Resend sender
+   with a persisted, content-stable payload and deterministic idempotency key;
+   store only the token UUID/key fingerprint, never the raw bearer.
+3. Resolve a valid token into the exact audience/locale document snapshot and
+   accept only separate affirmative Terms and additional-work acknowledgements,
+   a valid typed signer, and a trusted service-forwarded client IP.
+4. Persist one append-only acceptance and one content-stable executed-copy
+   delivery, attempt that delivery without rolling back a completed legal
+   acceptance, and expose explicit reconciliation for a transport outcome that
+   remained `sending`.
+5. Report customer readiness against the current published version: later
+   non-material releases preserve readiness, while any later material release
+   requires a new invitation and acceptance.
+6. Permit actor-audited revocation before acceptance; serialize revocation,
+   acceptance, issue, and publication so every admitted ordering has one
+   deterministic outcome.
+
+### Review Contract
+
+- Acceptance criteria:
+  - `tests/test_eom_terms_acceptance.py` proves invitation issue reads the
+    contact and current version inside the shared publication lock, rejects a
+    non-customer, inactive/archived/unknown-type/no-email contact before any
+    delivery claim, and never accepts audience or recipient from the caller.
+  - The same test proves a request-key replay returns the original invitation
+    and delivery without a second send even after publication advances, while
+    the same key with another contact or locale conflicts.
+  - Token tests prove the Terms bearer has a domain distinct from the existing
+    profile token, authenticates only under the current or one previous key,
+    binds that key fingerprint to the stored invitation, and places the bearer
+    only in a URL fragment and transient transport body.
+  - Route tests call the mounted EOM router for private invitation/revoke/
+    readiness/reconcile and Tracker-proxied session/acceptance entrypoints; they
+    prove service authentication, actor evidence where required, and a valid
+    `X-EOM-Client-IP` are enforced before a state change.
+  - Acceptance tests prove missing/false acknowledgements, invalid signer/IP,
+    expired/revoked/unknown/wrong-key tokens, and a later material publication
+    fail before acceptance; an unchanged replay returns one acceptance, and a
+    changed signer conflicts.
+  - The service execution model below makes publication/issue/accept/readiness
+    linearize on one PostgreSQL advisory lock, revocation/acceptance linearize on
+    the invitation row lock, and delivery claim linearize on
+    `UPDATE ... WHERE status = 'pending' RETURNING`; focused concurrent tests
+    settle the duplicate issue, double accept, accept-vs-revoke, and double-send
+    invariants under that model.
+  - Migration 397 tests prove the guard owner owns all three relations and guard
+    functions, the direct `atlas` login has no table-wide write/delete/truncate
+    or function-replacement authority, acceptance rows and delivery payloads
+    cannot be rewritten, and only valid one-way revoke/delivery transitions are
+    admitted.
+  - Readiness tests prove acceptance of the current or an older release followed
+    only by non-material releases is ready, and any later material release is
+    `reacceptance_required`.
+  - Invitation and executed-copy transport tests assert persisted body equality
+    with the selected published audience/locale, separate acknowledgement
+    evidence, deterministic Resend idempotency keys, and an acceptance that
+    remains committed when receipt delivery needs reconciliation.
+  - `./ops db controlled eom-terms-acceptance preflight|apply` dispatches only
+    migration 397 after migration 396; capability/runbook evidence requires
+    both migration receipts before deploying these routes and retains every
+    Terms row on application rollback.
+  - The diff changes no existing onboarding-token row, candidate, payment,
+    Stripe, calendar, Tracker, Website, or Terms publication behavior; settled
+    by cold diff reconstruction plus the adjacent focused suites named below.
+- Reachability proof: an ASGI client calls the mounted slim EOM router. The
+  observable results are a captured invitation email containing one fragment
+  bearer, a token session returning the stored published snapshot, one
+  immutable accepted row, one captured executed-copy email, and readiness that
+  changes only after a material publication.
+- Affected surfaces: controlled migration catalog/operation, EOM Terms token
+  format, new acceptance service, EOM funnel models/dependencies/routes, slim
+  pool binding, EOM pipeline CI enrollment, and focused tests.
+- Risk areas: customer/account misbinding, legal-evidence mutability, raw-token
+  persistence or logging, stale-version acceptance, key rotation, expiry,
+  duplicate/uncertain email delivery, accept/revoke/publication races,
+  actor/client-IP spoofing, rollback ordering, accidental production send.
+- Reviewer rules triggered: R1, R2, R3, R4, R5, R6, R7, R8, R10, R11, R12,
+  R14.
+
+### Execution model
+
+- PostgreSQL is the closed execution surface. Invitation issue, acceptance, and
+  readiness acquire the same transaction-scoped advisory lock used by Terms
+  publication. A publication and an issue/acceptance therefore have one lock
+  order: issue pins the current row visible under its lock; acceptance either
+  commits before a later material publication (and becomes not-ready after that
+  publication) or observes that publication and rejects the stale invitation.
+- Invitation creation linearizes on the unique request key. Revocation and
+  acceptance each lock the invitation row; acceptance additionally linearizes
+  on the unique invitation foreign key. Across every admitted interleaving,
+  exactly one of revocation or first acceptance wins, and an unchanged accept
+  replay returns the existing immutable row.
+- Delivery payload creation commits with its invitation/acceptance. Delivery
+  itself occurs after commit and claims exactly one pending row through a
+  conditional update. The deterministic Resend idempotency key is a second
+  boundary against transport replay. A failed/unknown transport leaves
+  `sending` reconciliation evidence; it never rolls back or silently retries a
+  legal acceptance. An authenticated actor may confirm `sending -> sent` only
+  after external reconciliation.
+- Transaction cancellation, connection loss, or process death before commit
+  releases locks and rolls back the whole database transition. No lease, file
+  lock, background scheduler, cross-database write, or caller-supplied clock
+  participates in correctness.
+
+### Boundary-change enumeration
+
+Required when this diff changes a guard, validator, normalizer, resolver,
+router/classifier, or admission boundary. Name each changed boundary path or
+seam in the enumeration; otherwise write "N/A - no boundary change."
+
+- Boundary path/seam: Terms-specific bearer formatting/authentication; private
+  issue/revoke/readiness/reconcile routes; Tracker-proxied session/acceptance;
+  invitation/acceptance/delivery database transitions.
+- Replaced-path behaviors: none. Existing profile-onboarding tokens and Terms
+  publication remain separate and unchanged.
+- Guard-relevant fields: requestKey, contactId, locale, invitation UUID,
+  delivery UUID, token grammar/MAC/key fingerprint, signerName,
+  termsAccepted, additionalWorkAccepted, trusted client-IP header, actor
+  id/name, database-derived audience/email/current version/timestamps, delivery
+  status.
+- Caller x input shape: authenticated office/Tracker bearer plus actor headers x
+  `{requestKey, contactId, locale}` for issue; bearer+actor x invitation for
+  revoke; bearer x contact for readiness; bearer x raw Terms token for session;
+  bearer+raw Terms token+two strict `true` acknowledgements+typed signer+trusted
+  IP header for acceptance; bearer+actor x `sending` delivery for reconciliation.
+
+### Deployed-config probing
+
+Required for guard, validator, resolver, admission-boundary, or env/config
+fallback changes; otherwise write "N/A - no guard/config boundary change."
+
+- Deployed/default config values: reuse the existing, disabled-by-default
+  `ATLAS_EOM_FUNNEL_PUBLIC_ONBOARDING_*` HTTPS URL/current+previous HMAC key
+  boundary and issuance override. No new environment fallback is added. The
+  currently running Brain predates migration 396, so deployment of this slice
+  requires controlled 396 then 397 receipts before route rollout.
+- Explicit value probe: current-key issue/session/accept and previous-key
+  redemption tests with issuance enabled.
+- Absent value probe: disabled issuance, missing/unsafe public-onboarding
+  configuration, missing service bearer/actor/client IP, and unavailable schema
+  all fail before the relevant mutation or send.
+- Default-session/default-context probe: every invitation derives and enforces
+  `effingham_maids`; no caller-supplied tenant, audience, recipient, timestamp,
+  or Terms version is accepted.
+- Side-effect ordering: issue preflights config and email transport before the
+  invitation transaction; acceptance commits immutable evidence and a pending
+  executed-copy delivery before any email call; both email calls claim their
+  persisted payload before transport and confirm only after transport
+  acceptance.
+
+### Files touched
+
+- `.agent/capabilities.yaml`
+- `.agent/runbooks/database.md`
+- `.github/workflows/atlas_eom_lead_pipeline_checks.yml`
+- `atlas_brain/eom_api/funnel.py`
+- `atlas_brain/main_eom.py`
+- `atlas_brain/services/eom_terms_acceptance.py`
+- `atlas_brain/services/eom_terms_authority.py`
+- `atlas_brain/storage/migrations/397_eom_terms_acceptance.sql`
+- `atlas_brain/storage/migrations/__init__.py`
+- `ops`
+- `plans/PR-EOM-Terms-Acceptance.md`
+- `scripts/apply_eom_first_clean_completion_schema.py`
+- `scripts/apply_eom_terms_acceptance_schema.py`
+- `tests/test_agent_operations_contract.py`
+- `tests/test_eom_first_clean_completion_dba_runner.py`
+- `tests/test_eom_terms_acceptance.py`
+- `tests/test_migrations_runner.py`
+
+## Mechanism
+
+Migration 397 adds separately guard-owned invitation, acceptance, and delivery
+relations. Invitation identity is a UUID signed in a Terms-specific HMAC domain;
+the database stores only that UUID and the admitting key fingerprint. The issue
+transaction locks Terms publication, derives the account audience/email from
+`contacts`, pins the current immutable version, persists the exact selected
+email payload, and replays only an identical request key. A single conditional
+delivery claim calls the established slim-profile Resend sender with a stable
+idempotency key.
+
+Session and acceptance authenticate the bearer before database access and bind
+the verified key fingerprint to the invitation. Acceptance uses database time,
+the invitation row lock, and the publication lock to validate expiry,
+revocation, customer/version identity, and intervening material releases. It
+then inserts one immutable acceptance and the exact executed-copy email payload
+in the same transaction. Readiness searches accepted versions and treats only a
+later published `material_change = true` release as requiring reacceptance.
+Routes reproject closed response models and the slim app injects the same EOM
+funnel pool used by the authority.
+
+## Intentional
+
+- The existing public-onboarding HTTPS base URL and current/previous HMAC key
+  rotation are reused, but the Terms token grammar and durable rows are
+  separate. This shares provisioned cryptographic/configuration rails without
+  coupling profile-token completion or revocation state.
+- Invitation and executed-copy emails contain the selected operator-published
+  Terms, Services We Cannot Provide, and additional-work acknowledgement as
+  text. No placeholder or source-PDF prose is seeded, refined, translated, or
+  published here.
+- Customer IP is accepted only from a required service-forwarded header on the
+  authenticated Tracker boundary. The Atlas socket peer is the Tracker, and a
+  body field would be browser-controlled; no device fingerprint is collected.
+- A newly issued link expires after 30 days using database time. This bounds
+  bearer lifetime without adding caller-controlled expiry or another deployment
+  setting; a fresh actor-audited invitation is required after expiry.
+- Delivery uncertainty remains explicit `sending` evidence and requires
+  operator reconciliation. There is no automatic retry after an ambiguous
+  external side effect.
+- This provider can send only when an authenticated private caller explicitly
+  issues an invitation. It adds no scheduler, bulk send, or production data
+  mutation.
+
+## Deferred
+
+- Tracker proxy/capability contract for Terms invitation, session, acceptance,
+  readiness, revocation, and delivery-reconciliation routes.
+- Website Onboarding tab, public bilingual acceptance page, admin readiness and
+  reconciliation UI, and operator-approved refined bilingual Terms publication.
+- Structured one-time/recurring service plan, first-clean payment allocation,
+  and residential Stripe SetupIntent/card-vault onboarding remain later slices
+  in #2156.
+
+Parking predicate: UI/presentation/copy polish, bulk invitation tooling,
+automatic delivery retry, delivery analytics, and payment/card behavior are
+parked unless they prove this provider can misbind a customer, mutate legal
+evidence, leak a bearer, send twice, or report false readiness.
+
+Parked hardening: none.
+
+## Verification
+
+- Passed locally: the canonical EOM workflow test list against disposable
+  PostgreSQL (`1681 passed, 5 skipped`); the isolated Terms suite with live
+  migration 396/397, runtime ACL, immutability, boundary, and concurrency proof
+  (`27 passed`); controlled-runner/operations/migration tests
+  (`245 passed, 1 skipped`); targeted Ruff, format-check, compile, and diff
+  check.
+- Pending: synchronized-plan check and mechanical pre-push review.
+- Hosted: EOM pipeline disposable-PostgreSQL proof and GitHub-only Unit Gate.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `.agent/capabilities.yaml` | 11 |
+| `.agent/runbooks/database.md` | 50 |
+| `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 9 |
+| `atlas_brain/eom_api/funnel.py` | 369 |
+| `atlas_brain/main_eom.py` | 1 |
+| `atlas_brain/services/eom_terms_acceptance.py` | 1814 |
+| `atlas_brain/services/eom_terms_authority.py` | 4 |
+| `atlas_brain/storage/migrations/397_eom_terms_acceptance.sql` | 875 |
+| `atlas_brain/storage/migrations/__init__.py` | 1 |
+| `ops` | 5 |
+| `plans/PR-EOM-Terms-Acceptance.md` | 346 |
+| `scripts/apply_eom_first_clean_completion_schema.py` | 24 |
+| `scripts/apply_eom_terms_acceptance_schema.py` | 42 |
+| `tests/test_agent_operations_contract.py` | 35 |
+| `tests/test_eom_first_clean_completion_dba_runner.py` | 95 |
+| `tests/test_eom_terms_acceptance.py` | 1240 |
+| `tests/test_migrations_runner.py` | 3 |
+| **Total** | **4924** |

--- a/plans/PR-EOM-Terms-Acceptance.md
+++ b/plans/PR-EOM-Terms-Acceptance.md
@@ -84,7 +84,13 @@ evidence.
   acceptances by wall-clock time; and receipt identity fields admitted embedded
   line controls. A later review proved that the shared contact comparison was
   still enforced only for invitation delivery, allowing an executed-copy
-  receipt to target a stale address after acceptance.
+  receipt to target a stale address after acceptance. The final reconciliation
+  review exposed three remaining boundary failures: a delivery-only contact
+  conflict escaped after the acceptance transaction had already committed;
+  readiness used wall-clock ordering to choose between same-version
+  acceptances for different audiences; and a separate publication-order
+  trigger changed the predecessor release's exact five-trigger authority
+  boundary, breaking rolling-deploy and application-rollback compatibility.
 - Revised requirement: delivery first commits a durable `pending -> sending`
   claim before crossing the provider boundary. It then reacquires the
   publication, invitation, delivery, and canonical contact locks, revalidates
@@ -92,10 +98,14 @@ evidence.
   delivery, and retains those locks through the bounded provider outcome and
   database confirmation. Any uncertain provider or confirmation result remains
   `sending` and is never automatically retried; acceptance and revocation reject
-  that reconciliation state. Migration 397
-  adds a guard-owned monotonic publication order assigned under the existing
-  publication lock, every later-material decision and readiness selection uses
-  that order, and a sent transition admits a missing provider message id only
+  that reconciliation state. A delivery-only conflict after acceptance commit
+  returns the immutable acceptance with explicit pending/error reconciliation
+  state instead of falsely reporting that acceptance failed. Migration 397
+  adds a guard-owned monotonic publication order inside the existing protected
+  version trigger, preserving the predecessor's exact five-trigger boundary;
+  every later-material decision uses that order, and same-version readiness
+  prefers evidence for the contact's current audience rather than wall-clock
+  order. A sent transition admits a missing provider message id only
   when the established sender explicitly reports
   `idempotent_replay = true`. Shared signer/customer/actor text rejects every
   non-printable line-control character before it can enter receipt evidence.
@@ -164,12 +174,14 @@ Max files: 18
   - Migration 397 tests prove the guard owner owns all three relations and guard
     functions, the direct `atlas` login has no table-wide write/delete/truncate
     or function-replacement authority, acceptance rows and delivery payloads
-    cannot be rewritten, and only valid one-way revoke/delivery transitions are
-    admitted.
+    cannot be rewritten, only valid one-way revoke/delivery transitions are
+    admitted, and the predecessor's exact five-trigger authority attestor stays
+    ready after migration 397.
   - Readiness tests prove acceptance of the current or an older release followed
     only by non-material releases is ready, and any later material release is
     `reacceptance_required`, including when release or acceptance wall-clock
-    timestamps contradict the database-owned publication order.
+    timestamps contradict the database-owned publication order; same-version
+    acceptance for the current audience wins even when its clock is earlier.
   - Invitation and executed-copy transport tests assert persisted body equality
     with the selected published audience/locale, separate acknowledgement
     evidence, deterministic Resend idempotency keys, rejection after canonical
@@ -449,7 +461,7 @@ Parked hardening: none.
 
 - Passed locally after review fixes: the focused acceptance, authority, and
   controlled migration-runner suite against disposable PostgreSQL
-  (`206 passed, 1 skipped`), targeted Ruff and Ruff format checks, Python
+  (`207 passed`), targeted Ruff and Ruff format checks, Python
   compilation, and `git diff --check`.
 - Passed: synchronized-plan, boundary-enumeration, deployed-config, and
   PR-side consistency checks.
@@ -464,16 +476,16 @@ Parked hardening: none.
 | `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 9 |
 | `atlas_brain/eom_api/funnel.py` | 369 |
 | `atlas_brain/main_eom.py` | 1 |
-| `atlas_brain/services/eom_terms_acceptance.py` | 1930 |
-| `atlas_brain/services/eom_terms_authority.py` | 108 |
-| `atlas_brain/storage/migrations/397_eom_terms_acceptance.sql` | 1045 |
+| `atlas_brain/services/eom_terms_acceptance.py` | 1939 |
+| `atlas_brain/services/eom_terms_authority.py` | 4 |
+| `atlas_brain/storage/migrations/397_eom_terms_acceptance.sql` | 1054 |
 | `atlas_brain/storage/migrations/__init__.py` | 1 |
 | `ops` | 5 |
-| `plans/PR-EOM-Terms-Acceptance.md` | 479 |
+| `plans/PR-EOM-Terms-Acceptance.md` | 491 |
 | `scripts/apply_eom_first_clean_completion_schema.py` | 24 |
 | `scripts/apply_eom_terms_acceptance_schema.py` | 42 |
 | `tests/test_agent_operations_contract.py` | 35 |
 | `tests/test_eom_first_clean_completion_dba_runner.py` | 95 |
-| `tests/test_eom_terms_acceptance.py` | 1801 |
+| `tests/test_eom_terms_acceptance.py` | 1869 |
 | `tests/test_migrations_runner.py` | 3 |
-| **Total** | **6008** |
+| **Total** | **6002** |

--- a/plans/PR-EOM-Terms-Acceptance.md
+++ b/plans/PR-EOM-Terms-Acceptance.md
@@ -82,14 +82,17 @@ evidence.
   provider accepted but database confirmation failed; contact identity was not
   revalidated or locked through transport; readiness still selected among
   acceptances by wall-clock time; and receipt identity fields admitted embedded
-  line controls.
+  line controls. A later review proved that the shared contact comparison was
+  still enforced only for invitation delivery, allowing an executed-copy
+  receipt to target a stale address after acceptance.
 - Revised requirement: delivery first commits a durable `pending -> sending`
   claim before crossing the provider boundary. It then reacquires the
   publication, invitation, delivery, and canonical contact locks, revalidates
-  material currency and contact identity, and retains those locks through the
-  bounded provider outcome and database confirmation. Any uncertain provider
-  or confirmation result remains `sending` and is never automatically retried;
-  acceptance and revocation reject that reconciliation state. Migration 397
+  material currency and contact identity for both invitation and executed-copy
+  delivery, and retains those locks through the bounded provider outcome and
+  database confirmation. Any uncertain provider or confirmation result remains
+  `sending` and is never automatically retried; acceptance and revocation reject
+  that reconciliation state. Migration 397
   adds a guard-owned monotonic publication order assigned under the existing
   publication lock, every later-material decision and readiness selection uses
   that order, and a sent transition admits a missing provider message id only
@@ -169,8 +172,9 @@ Max files: 18
     timestamps contradict the database-owned publication order.
   - Invitation and executed-copy transport tests assert persisted body equality
     with the selected published audience/locale, separate acknowledgement
-    evidence, deterministic Resend idempotency keys, and an acceptance that
-    remains committed when receipt delivery needs reconciliation.
+    evidence, deterministic Resend idempotency keys, rejection after canonical
+    contact drift for either delivery kind, and an acceptance that remains
+    committed when receipt delivery needs reconciliation.
   - `./ops db controlled eom-terms-acceptance preflight|apply` dispatches only
     migration 397 after migration 396; capability/runbook evidence requires
     both migration receipts before deploying these routes and retains every
@@ -208,15 +212,16 @@ Max files: 18
   replay returns the existing immutable row.
 - Delivery payload creation commits with its invitation/acceptance. Delivery
   acquires the publication, invitation, delivery, and contact locks, validates
-  the canonical recipient and current material release, and commits exactly one
-  `pending -> sending` claim before transport. It then reacquires the same locks,
-  revalidates every condition, and retains them through the bounded provider
-  result and `sent` confirmation. A failed/unknown sender call or a database
-  failure after provider acceptance leaves durable `sending` reconciliation
-  evidence; later invocations do not cross the provider boundary again. No
-  background retry is introduced, and actor confirmation remains limited to a
-  persisted `sending` state after external reconciliation. Acceptance and
-  revocation cannot race through that state.
+  canonical recipient for both delivery kinds and current material release for
+  invitations, and commits exactly one `pending -> sending` claim before
+  transport. It then reacquires the same locks, revalidates every condition,
+  and retains them through the bounded provider result and `sent` confirmation.
+  A failed/unknown sender call or a database failure after provider acceptance
+  leaves durable `sending` reconciliation evidence; later invocations do not
+  cross the provider boundary again. No background retry is introduced, and
+  actor confirmation remains limited to a persisted `sending` state after
+  external reconciliation. Acceptance and revocation cannot race through that
+  state.
 - Published Terms versions receive a database-assigned positive
   `publication_order` under the existing publication advisory lock. Historical
   releases are backfilled deterministically with the selected current release
@@ -384,10 +389,10 @@ transaction locks Terms publication, derives the account audience/email from
 `contacts`, pins the current immutable version, persists the exact selected
 email payload, and replays only an identical request key. A durable conditional
 delivery claim commits before the provider boundary; a second transaction
-revalidates and holds publication/invitation/delivery/contact locks while it
-calls the established slim-profile Resend sender with a stable idempotency key
-and persists either the provider message id or its explicit idempotent-replay
-result.
+revalidates the canonical contact for invitation and executed-copy delivery and
+holds publication/invitation/delivery/contact locks while it calls the
+established slim-profile Resend sender with a stable idempotency key and
+persists either the provider message id or its explicit idempotent-replay result.
 
 Session and acceptance authenticate the bearer before database access and bind
 the verified key fingerprint to the invitation. Acceptance uses database time,
@@ -461,14 +466,14 @@ Parked hardening: none.
 | `atlas_brain/main_eom.py` | 1 |
 | `atlas_brain/services/eom_terms_acceptance.py` | 1930 |
 | `atlas_brain/services/eom_terms_authority.py` | 108 |
-| `atlas_brain/storage/migrations/397_eom_terms_acceptance.sql` | 1023 |
+| `atlas_brain/storage/migrations/397_eom_terms_acceptance.sql` | 1045 |
 | `atlas_brain/storage/migrations/__init__.py` | 1 |
 | `ops` | 5 |
-| `plans/PR-EOM-Terms-Acceptance.md` | 474 |
+| `plans/PR-EOM-Terms-Acceptance.md` | 479 |
 | `scripts/apply_eom_first_clean_completion_schema.py` | 24 |
 | `scripts/apply_eom_terms_acceptance_schema.py` | 42 |
 | `tests/test_agent_operations_contract.py` | 35 |
 | `tests/test_eom_first_clean_completion_dba_runner.py` | 95 |
-| `tests/test_eom_terms_acceptance.py` | 1738 |
+| `tests/test_eom_terms_acceptance.py` | 1801 |
 | `tests/test_migrations_runner.py` | 3 |
-| **Total** | **5918** |
+| **Total** | **6008** |

--- a/plans/PR-EOM-Terms-Acceptance.md
+++ b/plans/PR-EOM-Terms-Acceptance.md
@@ -70,6 +70,26 @@ evidence.
   Reusing that key for another contact or locale conflicts. A genuinely new
   invitation for the new current version requires a new request key.
 
+### Review-evidence contract revision
+
+- New evidence: a delivery claim previously serialized only the delivery row,
+  so acceptance or revocation could commit after the invitation usability read
+  and before transport. Material-release comparisons also used wall-clock
+  timestamps, which do not define a strict release order, and the delivery
+  evidence guard rejected Resend's provider-confirmed idempotent replay shape
+  when that replay has no message id.
+- Revised requirement: delivery acquires the publication lock and invitation
+  row lock in the same order as acceptance/revocation and retains both through
+  the bounded provider outcome and database confirmation. Migration 397 adds a
+  guard-owned monotonic publication order assigned under the existing
+  publication lock and every later-material decision uses that order. A sent
+  transition admits a missing provider message id only when the established
+  sender explicitly reports `idempotent_replay = true`.
+- Preserved boundary: this internal serialization and release-order evidence
+  does not change Terms prose, version hashes, the operator publish/current
+  selection API, route payloads, customer classification, payment/onboarding
+  state, or production delivery authority.
+
 ## Scope (this PR)
 
 Ownership lane: eom-onboarding-terms
@@ -121,10 +141,10 @@ Max files: 18
     changed signer conflicts.
   - The service execution model below makes publication/issue/accept/readiness
     linearize on one PostgreSQL advisory lock, revocation/acceptance linearize on
-    the invitation row lock, and delivery claim linearize on
-    `UPDATE ... WHERE status = 'pending' RETURNING`; focused concurrent tests
-    settle the duplicate issue, double accept, accept-vs-revoke, and double-send
-    invariants under that model.
+    the invitation row lock, and delivery hold those locks from its conditional
+    `pending -> sending` claim through the provider outcome; focused concurrent
+    tests settle duplicate issue, double accept, accept-vs-revoke,
+    send-vs-revoke, and double-send invariants under that model.
   - Migration 397 tests prove the guard owner owns all three relations and guard
     functions, the direct `atlas` login has no table-wide write/delete/truncate
     or function-replacement authority, acceptance rows and delivery payloads
@@ -132,7 +152,8 @@ Max files: 18
     admitted.
   - Readiness tests prove acceptance of the current or an older release followed
     only by non-material releases is ready, and any later material release is
-    `reacceptance_required`.
+    `reacceptance_required`, including when its wall-clock publication timestamp
+    is earlier than the accepted release.
   - Invitation and executed-copy transport tests assert persisted body equality
     with the selected published audience/locale, separate acknowledgement
     evidence, deterministic Resend idempotency keys, and an acceptance that
@@ -173,12 +194,20 @@ Max files: 18
   exactly one of revocation or first acceptance wins, and an unchanged accept
   replay returns the existing immutable row.
 - Delivery payload creation commits with its invitation/acceptance. Delivery
-  itself occurs after commit and claims exactly one pending row through a
-  conditional update. The deterministic Resend idempotency key is a second
-  boundary against transport replay. A failed/unknown transport leaves
-  `sending` reconciliation evidence; it never rolls back or silently retries a
-  legal acceptance. An authenticated actor may confirm `sending -> sent` only
-  after external reconciliation.
+  then acquires the publication lock followed by the invitation row lock,
+  claims exactly one pending row, and retains those locks through the bounded
+  provider result and `sent` confirmation. A failed/unknown sender call commits
+  explicit `sending` reconciliation evidence. A database failure after provider
+  acceptance rolls the claim back, and a later explicit invocation uses the
+  same deterministic Resend idempotency key; a provider-confirmed replay can
+  therefore restore `sent` evidence without a duplicate message. No background
+  retry is introduced, and actor confirmation remains limited to a persisted
+  `sending` state after external reconciliation.
+- Published Terms versions receive a database-assigned positive
+  `publication_order` under the existing publication advisory lock. Historical
+  releases are backfilled deterministically with the selected current release
+  last. Later-material acceptance and readiness decisions compare this order,
+  never the non-monotonic wall clock.
 - Transaction cancellation, connection loss, or process death before commit
   releases locks and rolls back the whole database transition. No lease, file
   lock, background scheduler, cross-database write, or caller-supplied clock
@@ -258,8 +287,9 @@ the database stores only that UUID and the admitting key fingerprint. The issue
 transaction locks Terms publication, derives the account audience/email from
 `contacts`, pins the current immutable version, persists the exact selected
 email payload, and replays only an identical request key. A single conditional
-delivery claim calls the established slim-profile Resend sender with a stable
-idempotency key.
+delivery claim holds publication/invitation locks while it calls the established
+slim-profile Resend sender with a stable idempotency key and persists either the
+provider message id or its explicit idempotent-replay result.
 
 Session and acceptance authenticate the bearer before database access and bind
 the verified key fingerprint to the invitation. Acceptance uses database time,
@@ -287,9 +317,10 @@ funnel pool used by the authority.
 - A newly issued link expires after 30 days using database time. This bounds
   bearer lifetime without adding caller-controlled expiry or another deployment
   setting; a fresh actor-audited invitation is required after expiry.
-- Delivery uncertainty remains explicit `sending` evidence and requires
-  operator reconciliation. There is no automatic retry after an ambiguous
-  external side effect.
+- Delivery uncertainty from the sender remains explicit `sending` evidence and
+  requires operator reconciliation. Confirmation failure instead rolls the
+  transaction back for a later explicit, provider-idempotent replay; there is
+  no autonomous retry after an ambiguous external side effect.
 - This provider can send only when an authenticated private caller explicitly
   issues an invitation. It adds no scheduler, bulk send, or production data
   mutation.
@@ -313,12 +344,10 @@ Parked hardening: none.
 
 ## Verification
 
-- Passed locally: the canonical EOM workflow test list against disposable
-  PostgreSQL (`1681 passed, 5 skipped`); the isolated Terms suite with live
-  migration 396/397, runtime ACL, immutability, boundary, and concurrency proof
-  (`27 passed`); controlled-runner/operations/migration tests
-  (`245 passed, 1 skipped`); targeted Ruff, format-check, compile, and diff
-  check.
+- Passed locally after review fixes: the focused acceptance, authority, and
+  controlled migration-runner suite against disposable PostgreSQL
+  (`197 passed, 1 skipped`), targeted Ruff and Ruff format checks, Python
+  compilation, and `git diff --check`.
 - Pending: synchronized-plan check and mechanical pre-push review.
 - Hosted: EOM pipeline disposable-PostgreSQL proof and GitHub-only Unit Gate.
 
@@ -331,16 +360,16 @@ Parked hardening: none.
 | `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 9 |
 | `atlas_brain/eom_api/funnel.py` | 369 |
 | `atlas_brain/main_eom.py` | 1 |
-| `atlas_brain/services/eom_terms_acceptance.py` | 1814 |
-| `atlas_brain/services/eom_terms_authority.py` | 4 |
-| `atlas_brain/storage/migrations/397_eom_terms_acceptance.sql` | 875 |
+| `atlas_brain/services/eom_terms_acceptance.py` | 1842 |
+| `atlas_brain/services/eom_terms_authority.py` | 102 |
+| `atlas_brain/storage/migrations/397_eom_terms_acceptance.sql` | 988 |
 | `atlas_brain/storage/migrations/__init__.py` | 1 |
-| `ops` | 5 |
-| `plans/PR-EOM-Terms-Acceptance.md` | 346 |
-| `scripts/apply_eom_first_clean_completion_schema.py` | 24 |
+| `ops` | 3 |
+| `plans/PR-EOM-Terms-Acceptance.md` | 375 |
+| `scripts/apply_eom_first_clean_completion_schema.py` | 23 |
 | `scripts/apply_eom_terms_acceptance_schema.py` | 42 |
-| `tests/test_agent_operations_contract.py` | 35 |
-| `tests/test_eom_first_clean_completion_dba_runner.py` | 95 |
-| `tests/test_eom_terms_acceptance.py` | 1240 |
-| `tests/test_migrations_runner.py` | 3 |
-| **Total** | **4924** |
+| `tests/test_agent_operations_contract.py` | 30 |
+| `tests/test_eom_first_clean_completion_dba_runner.py` | 94 |
+| `tests/test_eom_terms_acceptance.py` | 1499 |
+| `tests/test_migrations_runner.py` | 2 |
+| **Total** | **5441** |

--- a/plans/PR-EOM-Terms-Acceptance.md
+++ b/plans/PR-EOM-Terms-Acceptance.md
@@ -90,7 +90,10 @@ evidence.
   readiness used wall-clock ordering to choose between same-version
   acceptances for different audiences; and a separate publication-order
   trigger changed the predecessor release's exact five-trigger authority
-  boundary, breaking rolling-deploy and application-rollback compatibility.
+  boundary, breaking rolling-deploy and application-rollback compatibility. A
+  subsequent review showed that the post-commit handler still covered only one
+  delivery-error subtype, and that version-first readiness ordering could hide
+  valid current-audience evidence across a later non-material release.
 - Revised requirement: delivery first commits a durable `pending -> sending`
   claim before crossing the provider boundary. It then reacquires the
   publication, invitation, delivery, and canonical contact locks, revalidates
@@ -98,14 +101,15 @@ evidence.
   delivery, and retains those locks through the bounded provider outcome and
   database confirmation. Any uncertain provider or confirmation result remains
   `sending` and is never automatically retried; acceptance and revocation reject
-  that reconciliation state. A delivery-only conflict after acceptance commit
-  returns the immutable acceptance with explicit pending/error reconciliation
-  state instead of falsely reporting that acceptance failed. Migration 397
+  that reconciliation state. Every delivery-domain failure after acceptance
+  commit returns the immutable acceptance with explicit error/reconciliation
+  state and best-effort persisted delivery status instead of falsely reporting
+  that acceptance failed. Migration 397
   adds a guard-owned monotonic publication order inside the existing protected
   version trigger, preserving the predecessor's exact five-trigger boundary;
-  every later-material decision uses that order, and same-version readiness
-  prefers evidence for the contact's current audience rather than wall-clock
-  order. A sent transition admits a missing provider message id only
+  every later-material decision uses that order, and readiness first prefers
+  evidence for the contact's current audience before choosing its newest
+  publication order. A sent transition admits a missing provider message id only
   when the established sender explicitly reports
   `idempotent_replay = true`. Shared signer/customer/actor text rejects every
   non-printable line-control character before it can enter receipt evidence.
@@ -180,13 +184,15 @@ Max files: 18
   - Readiness tests prove acceptance of the current or an older release followed
     only by non-material releases is ready, and any later material release is
     `reacceptance_required`, including when release or acceptance wall-clock
-    timestamps contradict the database-owned publication order; same-version
-    acceptance for the current audience wins even when its clock is earlier.
+    timestamps contradict the database-owned publication order; acceptance for
+    the current audience wins even when a different audience accepted a later
+    non-material release or its clock is newer.
   - Invitation and executed-copy transport tests assert persisted body equality
     with the selected published audience/locale, separate acknowledgement
     evidence, deterministic Resend idempotency keys, rejection after canonical
     contact drift for either delivery kind, and an acceptance that remains
-    committed when receipt delivery needs reconciliation.
+    successfully returned with persisted delivery state when contact conflict
+    or database confirmation failure requires receipt reconciliation.
   - `./ops db controlled eom-terms-acceptance preflight|apply` dispatches only
     migration 397 after migration 396; capability/runbook evidence requires
     both migration receipts before deploying these routes and retains every
@@ -476,16 +482,16 @@ Parked hardening: none.
 | `.github/workflows/atlas_eom_lead_pipeline_checks.yml` | 9 |
 | `atlas_brain/eom_api/funnel.py` | 369 |
 | `atlas_brain/main_eom.py` | 1 |
-| `atlas_brain/services/eom_terms_acceptance.py` | 1939 |
+| `atlas_brain/services/eom_terms_acceptance.py` | 1960 |
 | `atlas_brain/services/eom_terms_authority.py` | 4 |
 | `atlas_brain/storage/migrations/397_eom_terms_acceptance.sql` | 1054 |
 | `atlas_brain/storage/migrations/__init__.py` | 1 |
 | `ops` | 5 |
-| `plans/PR-EOM-Terms-Acceptance.md` | 491 |
+| `plans/PR-EOM-Terms-Acceptance.md` | 497 |
 | `scripts/apply_eom_first_clean_completion_schema.py` | 24 |
 | `scripts/apply_eom_terms_acceptance_schema.py` | 42 |
 | `tests/test_agent_operations_contract.py` | 35 |
 | `tests/test_eom_first_clean_completion_dba_runner.py` | 95 |
-| `tests/test_eom_terms_acceptance.py` | 1869 |
+| `tests/test_eom_terms_acceptance.py` | 2019 |
 | `tests/test_migrations_runner.py` | 3 |
-| **Total** | **6002** |
+| **Total** | **6179** |

--- a/scripts/apply_eom_first_clean_completion_schema.py
+++ b/scripts/apply_eom_first_clean_completion_schema.py
@@ -43,7 +43,17 @@ DBA_SCHEMA_ENV = EOM_FIRST_CLEAN_COMPLETION_DBA_SCHEMA_ENV
 FUNNEL_DSN_ENV = "ATLAS_EOM_FUNNEL_DB_CONNECTION_STRING"
 MIGRATION_NAME = "394_eom_first_clean_completion_receipts"
 TERMS_AUTHORITY_MIGRATION_NAME = "396_eom_terms_authority"
-CONTROLLED_MIGRATION_NAMES = frozenset({MIGRATION_NAME, TERMS_AUTHORITY_MIGRATION_NAME})
+TERMS_ACCEPTANCE_MIGRATION_NAME = "397_eom_terms_acceptance"
+CONTROLLED_MIGRATION_NAMES = frozenset(
+    {
+        MIGRATION_NAME,
+        TERMS_AUTHORITY_MIGRATION_NAME,
+        TERMS_ACCEPTANCE_MIGRATION_NAME,
+    }
+)
+CONTROLLED_MIGRATION_PREDECESSORS = {
+    TERMS_ACCEPTANCE_MIGRATION_NAME: TERMS_AUTHORITY_MIGRATION_NAME,
+}
 
 
 @dataclass(frozen=True)
@@ -419,6 +429,18 @@ async def _run(
                 expected_target=runtime_target,
                 migration_name=migration_name,
             )
+            predecessor = CONTROLLED_MIGRATION_PREDECESSORS.get(migration_name)
+            if predecessor is not None:
+                _executor_is_superuser, predecessor_recorded = await _migration_state(
+                    pool,
+                    expected_target=runtime_target,
+                    migration_name=predecessor,
+                )
+                if not predecessor_recorded:
+                    raise RuntimeError(
+                        f"Controlled predecessor {predecessor} must be recorded "
+                        f"before {migration_name}"
+                    )
             result: dict[str, object] = {
                 "target": _safe_target_label(database_url, schema_name=schema_name),
                 "executor_is_superuser": executor_is_superuser,

--- a/scripts/apply_eom_terms_acceptance_schema.py
+++ b/scripts/apply_eom_terms_acceptance_schema.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Preflight or apply controlled EOM Terms-acceptance migration 397."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+
+from apply_eom_first_clean_completion_schema import (
+    TERMS_ACCEPTANCE_MIGRATION_NAME,
+    _main,
+)
+
+
+def _terms_acceptance_argv(argv: list[str]) -> list[str]:
+    """Pin the shared controlled runner to the Terms-acceptance migration."""
+
+    parser = argparse.ArgumentParser(
+        description="Preflight or apply controlled EOM Terms-acceptance schema."
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply migration 397 after the read-only DBA preflight.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the redacted preflight/result payload as JSON.",
+    )
+    args = parser.parse_args(argv)
+    forwarded = ["--migration", TERMS_ACCEPTANCE_MIGRATION_NAME]
+    if args.apply:
+        forwarded.append("--apply")
+    if args.json:
+        forwarded.append("--json")
+    return forwarded
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main(_terms_acceptance_argv(sys.argv[1:]))))

--- a/tests/test_agent_operations_contract.py
+++ b/tests/test_agent_operations_contract.py
@@ -65,11 +65,12 @@ def test_database_surface_contains_only_fixed_inspections() -> None:
         assert DATABASE_INSPECTIONS[name] not in command
 
 
-def test_terms_authority_is_the_only_guarded_database_operation(
+def test_terms_migrations_are_the_only_guarded_database_operations(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     assert CONTROLLED_DATABASE_OPERATIONS == {
-        "eom-terms-authority": "apply_eom_terms_authority_schema.py"
+        "eom-terms-authority": "apply_eom_terms_authority_schema.py",
+        "eom-terms-acceptance": "apply_eom_terms_acceptance_schema.py",
     }
     root = Path("/workspace/atlas-terms-release")
     calls: list[tuple[list[str], Path | None]] = []
@@ -89,14 +90,23 @@ def test_terms_authority_is_the_only_guarded_database_operation(
 
     assert run_controlled_database_operation("eom-terms-authority", "preflight") == 0
     assert run_controlled_database_operation("eom-terms-authority", "apply") == 0
-    expected_prefix = [
+    assert run_controlled_database_operation("eom-terms-acceptance", "preflight") == 0
+    assert run_controlled_database_operation("eom-terms-acceptance", "apply") == 0
+    authority_prefix = [
         "/venv/python",
         str(root / "scripts/apply_eom_terms_authority_schema.py"),
         "--json",
     ]
+    acceptance_prefix = [
+        "/venv/python",
+        str(root / "scripts/apply_eom_terms_acceptance_schema.py"),
+        "--json",
+    ]
     assert calls == [
-        (expected_prefix, root),
-        ([*expected_prefix, "--apply"], root),
+        (authority_prefix, root),
+        ([*authority_prefix, "--apply"], root),
+        (acceptance_prefix, root),
+        ([*acceptance_prefix, "--apply"], root),
     ]
     with pytest.raises(OpsError, match="unknown controlled database operation"):
         run_controlled_database_operation("other", "preflight")
@@ -115,9 +125,13 @@ def test_terms_authority_is_the_only_guarded_database_operation(
     )
     assert db_command(["controlled", "eom-terms-authority", "preflight"]) == 0
     assert db_command(["controlled", "eom-terms-authority", "apply"]) == 0
+    assert db_command(["controlled", "eom-terms-acceptance", "preflight"]) == 0
+    assert db_command(["controlled", "eom-terms-acceptance", "apply"]) == 0
     assert dispatched == [
         ("eom-terms-authority", "preflight"),
         ("eom-terms-authority", "apply"),
+        ("eom-terms-acceptance", "preflight"),
+        ("eom-terms-acceptance", "apply"),
     ]
 
 
@@ -1629,11 +1643,22 @@ def test_capability_map_is_machine_readable_and_has_required_surfaces() -> None:
         "./ops db controlled eom-terms-authority preflight"
     )
     assert terms_migration["apply"] == "./ops db controlled eom-terms-authority apply"
+    acceptance_migration = capabilities["database"]["controlled_migrations"][
+        "eom_terms_acceptance"
+    ]
+    assert acceptance_migration["preflight"] == (
+        "./ops db controlled eom-terms-acceptance preflight"
+    )
+    assert acceptance_migration["apply"] == (
+        "./ops db controlled eom-terms-acceptance apply"
+    )
     database_runbook = (ROOT / ".agent/runbooks/database.md").read_text(
         encoding="utf-8"
     )
     assert terms_migration["preflight"] in database_runbook
     assert terms_migration["apply"] in database_runbook
+    assert acceptance_migration["preflight"] in database_runbook
+    assert acceptance_migration["apply"] in database_runbook
     assert "Post-deployment application rollback is retention-only" in database_runbook
     assert capabilities["deployment"]["brain"]["provider"] == "local systemd user service"
     assert capabilities["deployment"]["frontend"]["provider"] == "Vercel"

--- a/tests/test_eom_first_clean_completion_dba_runner.py
+++ b/tests/test_eom_first_clean_completion_dba_runner.py
@@ -16,6 +16,7 @@ from pydantic import ValidationError
 ROOT = Path(__file__).resolve().parent.parent
 SCRIPT = ROOT / "scripts" / "apply_eom_first_clean_completion_schema.py"
 TERMS_SCRIPT = ROOT / "scripts" / "apply_eom_terms_authority_schema.py"
+TERMS_ACCEPTANCE_SCRIPT = ROOT / "scripts" / "apply_eom_terms_acceptance_schema.py"
 
 
 def _load_runner_module() -> ModuleType:
@@ -34,6 +35,19 @@ def _load_terms_runner_module() -> ModuleType:
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     sys.path.insert(0, str(TERMS_SCRIPT.parent))
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.pop(0)
+    return module
+
+
+def _load_terms_acceptance_runner_module() -> ModuleType:
+    module_name = "test_eom_terms_acceptance_dba_runner_script"
+    spec = importlib.util.spec_from_file_location(module_name, TERMS_ACCEPTANCE_SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(TERMS_ACCEPTANCE_SCRIPT.parent))
     try:
         spec.loader.exec_module(module)
     finally:
@@ -74,7 +88,7 @@ class _Connection:
     def transaction(self) -> _Transaction:
         return _Transaction(self)
 
-    async def fetchval(self, query: str, *_args: object) -> object:
+    async def fetchval(self, query: str, *args: object) -> object:
         if "pg_try_advisory_xact_lock" in query:
             self._state.advisory_lock_attempts = (
                 getattr(self._state, "advisory_lock_attempts", 0) + 1
@@ -112,6 +126,10 @@ class _Connection:
         if "to_regclass" in query:
             return self._state.migrations_table_exists
         if "schema_migrations" in query:
+            migration_records = getattr(self._state, "migration_records", None)
+            if migration_records is not None:
+                assert len(args) == 1
+                return bool(migration_records.get(str(args[0]), False))
             return self._state.migration_recorded
         raise AssertionError(f"unexpected query: {query}")
 
@@ -293,6 +311,7 @@ def test_runner_rejects_non_superuser_before_apply(monkeypatch) -> None:
     [
         "394_eom_first_clean_completion_receipts",
         "396_eom_terms_authority",
+        "397_eom_terms_acceptance",
     ],
 )
 def test_runner_applies_only_its_named_migration_in_pinned_transaction(
@@ -311,6 +330,11 @@ def test_runner_applies_only_its_named_migration_in_pinned_transaction(
         schema_name=schema_name,
         migration_lock_results=[False, True],
     )
+    if migration_name == "397_eom_terms_acceptance":
+        state.migration_records = {
+            "396_eom_terms_authority": True,
+            "397_eom_terms_acceptance": False,
+        }
     runtime_pool = _Pool(SimpleNamespace(schema_name=schema_name))
     dba_pool = _Pool(state)
     calls: list[tuple[object, tuple[str, ...]]] = []
@@ -331,6 +355,8 @@ def test_runner_applies_only_its_named_migration_in_pinned_transaction(
         assert state.transaction_depth == 1
         await observed_pool.release(dba_pool._connection)
         state.migration_recorded = True
+        if getattr(state, "migration_records", None) is not None:
+            state.migration_records[migration_name] = True
 
     async def sleep(delay: float) -> None:
         sleep_delays.append(delay)
@@ -382,6 +408,73 @@ def test_terms_entrypoint_pins_migration_396() -> None:
         terms_runner._terms_argv(
             ["--migration=394_eom_first_clean_completion_receipts"]
         )
+
+
+def test_terms_acceptance_entrypoint_pins_migration_397() -> None:
+    terms_runner = _load_terms_acceptance_runner_module()
+
+    argv = terms_runner._terms_acceptance_argv(["--apply", "--json"])
+    assert argv == [
+        "--migration",
+        "397_eom_terms_acceptance",
+        "--apply",
+        "--json",
+    ]
+    shared_runner = sys.modules[terms_runner._main.__module__]
+    assert shared_runner._parse_args(argv).migration == "397_eom_terms_acceptance"
+    with pytest.raises(SystemExit):
+        terms_runner._terms_acceptance_argv(["--migration=396_eom_terms_authority"])
+
+
+def test_terms_acceptance_refuses_an_unrecorded_authority_predecessor(
+    monkeypatch,
+) -> None:
+    runner = _load_runner_module()
+    runtime_database_url = "postgresql://runtime@example.test/atlas"
+    schema_name = "eom_canonical"
+    monkeypatch.setenv(runner.DBA_DSN_ENV, "postgresql://example.test/atlas")
+    monkeypatch.setenv(runner.DBA_SCHEMA_ENV, schema_name)
+    state = SimpleNamespace(
+        executor_is_superuser=True,
+        migrations_table_exists=True,
+        migration_recorded=False,
+        migration_records={
+            "396_eom_terms_authority": False,
+            "397_eom_terms_acceptance": False,
+        },
+        schema_name=schema_name,
+    )
+    runtime_pool = _Pool(SimpleNamespace(schema_name=schema_name))
+    dba_pool = _Pool(state)
+
+    async def create_pool(
+        database_url: str, *, schema_name: str | None = None
+    ) -> _Pool:
+        if database_url == runtime_database_url:
+            assert schema_name is None
+            return runtime_pool
+        assert schema_name == "eom_canonical"
+        return dba_pool
+
+    args = runner._parse_args(["--migration", "397_eom_terms_acceptance"])
+    with pytest.raises(
+        RuntimeError,
+        match="Controlled predecessor 396_eom_terms_authority must be recorded",
+    ):
+        asyncio.run(
+            runner._run(
+                args,
+                create_pool=create_pool,
+                config_factory=lambda: runner.EOMFirstCleanCompletionDBAConfig(
+                    _env_file=None
+                ),
+                funnel_config_factory=lambda: SimpleNamespace(
+                    db_connection_string=runtime_database_url
+                ),
+            )
+        )
+    assert runtime_pool.closed is True
+    assert dba_pool.closed is True
 
 
 def test_runner_rejects_missing_typed_dsn_before_pool(monkeypatch) -> None:

--- a/tests/test_eom_terms_acceptance.py
+++ b/tests/test_eom_terms_acceptance.py
@@ -26,6 +26,7 @@ from atlas_brain.services.eom_terms_acceptance import (
     EOMTermsAcceptanceConflictError,
     EOMTermsAcceptanceNotFoundError,
     EOMTermsAcceptanceService,
+    EOMTermsAcceptanceUnavailableError,
     EOMTermsAcceptanceValidationError,
     append_eom_terms_acceptance_link,
     authenticate_eom_terms_token,
@@ -425,6 +426,10 @@ async def test_acceptance_requires_two_literal_true_acknowledgements(
     [
         ("", "192.0.2.1"),
         (None, "192.0.2.1"),
+        ("Customer\nInjected", "192.0.2.1"),
+        ("Customer\rInjected", "192.0.2.1"),
+        ("Customer\tInjected", "192.0.2.1"),
+        ("Customer\u2028Injected", "192.0.2.1"),
         ("Customer", "not-an-ip"),
         ("Customer", ""),
     ],
@@ -457,6 +462,7 @@ async def test_acceptance_rejects_invalid_signer_or_client_ip_before_database_us
         {"customer_type": "unknown"},
         {"email": None},
         {"full_name": " "},
+        {"full_name": "Customer\nInjected"},
     ],
 )
 def test_customer_boundary_rejects_every_noncanonical_account(
@@ -474,6 +480,23 @@ def test_customer_boundary_rejects_every_noncanonical_account(
     row.update(changes)
     with pytest.raises(EOMTermsAcceptanceConflictError):
         EOMTermsAcceptanceService._customer(row)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "actor_name",
+    ["Juan\nInjected", "Juan\rInjected", "Juan\tInjected", "Juan\u2028Injected"],
+)
+async def test_actor_identity_rejects_line_controls_before_database_use(
+    actor_name: str,
+) -> None:
+    service = EOMTermsAcceptanceService(pool=object())
+    with pytest.raises(EOMTermsAcceptanceValidationError):
+        await service.revoke(
+            invitation_id=_INVITATION_ID,
+            actor_id=7,
+            actor_name=actor_name,
+        )
 
 
 class _RouteAcceptance:
@@ -963,6 +986,56 @@ async def test_real_postgres_end_to_end_preserves_evidence_and_readiness() -> No
                     "Database Boundary Probe",
                     "192.0.2.31",
                 )
+
+        current_invitation = await service.issue_and_send(
+            request_key="terms-request-current-version-order",
+            contact_id=_CONTACT_ID,
+            locale="en",
+            actor_id=7,
+            actor_name="Juan",
+            public_base_url="https://example.test/onboarding",
+            hmac_secret=_SECRET,
+            sender=_RecordingSender(),
+        )
+        current_acceptance = await service.accept_and_send(
+            token=authenticate_eom_terms_token(
+                token=format_eom_terms_token(
+                    invitation_id=UUID(current_invitation["invitationId"]),
+                    secret=_SECRET,
+                ),
+                secret=_SECRET,
+            ),
+            signer_name="Current Version Signer",
+            terms_accepted=True,
+            additional_work_accepted=True,
+            client_ip="192.0.2.32",
+            sender=_RecordingSender(),
+        )
+        await dba.execute(
+            """
+            ALTER TABLE eom_terms_acceptances
+            DISABLE TRIGGER trg_protect_eom_terms_acceptance
+            """
+        )
+        await dba.execute(
+            """
+            UPDATE eom_terms_acceptances
+            SET accepted_at = TIMESTAMPTZ '2000-01-01 00:00:00+00'
+            WHERE id = $1
+            """,
+            UUID(current_acceptance["acceptanceId"]),
+        )
+        await dba.execute(
+            """
+            ALTER TABLE eom_terms_acceptances
+            ENABLE TRIGGER trg_protect_eom_terms_acceptance
+            """
+        )
+        current_readiness = await service.get_readiness(contact_id=_CONTACT_ID)
+        assert current_readiness["ready"] is True
+        assert current_readiness["reason"] == "accepted"
+        assert current_readiness["acceptedVersionId"] == material_release["versionId"]
+
         with pytest.raises(EOMTermsAcceptanceConflictError):
             await service.revoke(
                 invitation_id=invitation["invitationId"],
@@ -1055,7 +1128,9 @@ async def test_real_postgres_serializes_duplicate_and_opposing_operations() -> N
         contact_invalid = uuid4()
         contact_expired = uuid4()
         contact_delivery_lock = uuid4()
+        contact_changed_before_delivery = uuid4()
         contact_replay = uuid4()
+        contact_confirmation_failure = uuid4()
         await _seed_customer(dba, contact_id=contact_duplicate)
         await _seed_customer(
             dba,
@@ -1084,8 +1159,18 @@ async def test_real_postgres_serializes_duplicate_and_opposing_operations() -> N
         )
         await _seed_customer(
             dba,
+            contact_id=contact_changed_before_delivery,
+            email="changed-before-delivery@example.com",
+        )
+        await _seed_customer(
+            dba,
             contact_id=contact_replay,
             email="replay@example.com",
+        )
+        await _seed_customer(
+            dba,
+            contact_id=contact_confirmation_failure,
+            email="confirmation-failure@example.com",
         )
         await dba.execute(
             "UPDATE contacts SET status = 'archived' WHERE id = $1",
@@ -1227,6 +1312,41 @@ async def test_real_postgres_serializes_duplicate_and_opposing_operations() -> N
         assert {result["idempotent"] for result in acceptance_results} == {False, True}
         assert len(receipt_sender.calls) == 1
 
+        changed_invitation = await no_delivery.issue_and_send(
+            request_key="terms-request-contact-changed-before-delivery",
+            contact_id=contact_changed_before_delivery,
+            locale="en",
+            actor_id=7,
+            actor_name="Juan",
+            public_base_url="https://example.test/onboarding",
+            hmac_secret=_SECRET,
+            sender=_RecordingSender(),
+        )
+        await dba.execute(
+            "UPDATE contacts SET email = $2 WHERE id = $1",
+            contact_changed_before_delivery,
+            "changed-after-issue@example.com",
+        )
+        changed_contact_sender = _RecordingSender()
+        with pytest.raises(
+            EOMTermsAcceptanceConflictError,
+            match="customer changed before Terms delivery",
+        ):
+            await service._deliver(
+                delivery_id=UUID(changed_invitation["deliveryId"]),
+                secret=_SECRET,
+                previous_secret=None,
+                sender=changed_contact_sender,
+            )
+        assert changed_contact_sender.calls == []
+        assert (
+            await dba.fetchval(
+                "SELECT status FROM eom_terms_deliveries WHERE id = $1",
+                UUID(changed_invitation["deliveryId"]),
+            )
+            == "pending"
+        )
+
         locked_invitation = await no_delivery.issue_and_send(
             request_key="terms-request-delivery-lock",
             contact_id=contact_delivery_lock,
@@ -1254,13 +1374,29 @@ async def test_real_postgres_serializes_duplicate_and_opposing_operations() -> N
                 actor_name="Juan",
             )
         )
+
+        contact_update_started = asyncio.Event()
+
+        async def update_locked_contact() -> None:
+            async with pool.raw_pool.acquire() as connection:
+                contact_update_started.set()
+                await connection.execute(
+                    "UPDATE contacts SET email = $2 WHERE id = $1",
+                    contact_delivery_lock,
+                    "delivery-lock-after-send@example.com",
+                )
+
+        contact_update_task = asyncio.create_task(update_locked_contact())
         try:
+            await asyncio.wait_for(contact_update_started.wait(), timeout=2)
             await asyncio.sleep(0.05)
             assert revoke_task.done() is False
+            assert contact_update_task.done() is False
         finally:
             blocking_sender.release.set()
         locked_delivery, locked_delivery_error = await delivery_task
         locked_revocation = await revoke_task
+        await contact_update_task
         assert locked_delivery["status"] == "sent"
         assert locked_delivery_error is False
         assert locked_revocation["revokedAt"] is not None
@@ -1298,6 +1434,70 @@ async def test_real_postgres_serializes_duplicate_and_opposing_operations() -> N
         assert replay_evidence["resend_message_id"] is None
         assert replay_evidence["transport_idempotent_replay"] is True
 
+        confirmation_failure = await no_delivery.issue_and_send(
+            request_key="terms-request-confirmation-failure",
+            contact_id=contact_confirmation_failure,
+            locale="en",
+            actor_id=7,
+            actor_name="Juan",
+            public_base_url="https://example.test/onboarding",
+            hmac_secret=_SECRET,
+            sender=_RecordingSender(),
+        )
+        await dba.execute(
+            """
+            CREATE FUNCTION test_reject_eom_terms_confirmation()
+            RETURNS TRIGGER
+            LANGUAGE plpgsql
+            AS $$
+            BEGIN
+                IF OLD.status = 'sending' AND NEW.status = 'sent' THEN
+                    RAISE EXCEPTION 'injected confirmation failure';
+                END IF;
+                RETURN NEW;
+            END;
+            $$;
+            CREATE TRIGGER trg_test_reject_eom_terms_confirmation
+            BEFORE UPDATE ON eom_terms_deliveries
+            FOR EACH ROW EXECUTE FUNCTION test_reject_eom_terms_confirmation();
+            """
+        )
+        confirmation_sender = _RecordingSender()
+        try:
+            with pytest.raises(EOMTermsAcceptanceUnavailableError):
+                await service._deliver(
+                    delivery_id=UUID(confirmation_failure["deliveryId"]),
+                    secret=_SECRET,
+                    previous_secret=None,
+                    sender=confirmation_sender,
+                )
+        finally:
+            await dba.execute(
+                """
+                DROP TRIGGER trg_test_reject_eom_terms_confirmation
+                    ON eom_terms_deliveries;
+                DROP FUNCTION test_reject_eom_terms_confirmation();
+                """
+            )
+        assert len(confirmation_sender.calls) == 1
+        assert (
+            await dba.fetchval(
+                "SELECT status FROM eom_terms_deliveries WHERE id = $1",
+                UUID(confirmation_failure["deliveryId"]),
+            )
+            == "sending"
+        )
+        confirmation_retry_sender = _RecordingSender()
+        confirmation_retry, confirmation_retry_error = await service._deliver(
+            delivery_id=UUID(confirmation_failure["deliveryId"]),
+            secret=_SECRET,
+            previous_secret=None,
+            sender=confirmation_retry_sender,
+        )
+        assert confirmation_retry["status"] == "sending"
+        assert confirmation_retry_error is False
+        assert confirmation_retry_sender.calls == []
+
         invalid_replay = await no_delivery.issue_and_send(
             request_key="terms-request-invalid-provider-replay",
             contact_id=contact_replay,
@@ -1329,6 +1529,45 @@ async def test_real_postgres_serializes_duplicate_and_opposing_operations() -> N
                 WHERE id = $1
                 """,
                 UUID(invalid_replay["deliveryId"]),
+            )
+        with pytest.raises(
+            EOMTermsAcceptanceConflictError,
+            match="delivery requires reconciliation",
+        ):
+            await service.revoke(
+                invitation_id=invalid_replay["invitationId"],
+                actor_id=7,
+                actor_name="Juan",
+            )
+        with pytest.raises(
+            asyncpg.PostgresError,
+            match="delivery requires reconciliation",
+        ):
+            await dba.execute(
+                """
+                UPDATE eom_terms_invitations
+                SET revoked_at = clock_timestamp(),
+                    revoked_by_id = 7,
+                    revoked_by_name = 'Juan'
+                WHERE id = $1
+                """,
+                UUID(invalid_replay["invitationId"]),
+            )
+        with pytest.raises(
+            asyncpg.PostgresError,
+            match="delivery requires reconciliation",
+        ):
+            await dba.execute(
+                """
+                INSERT INTO eom_terms_acceptances (
+                    id, invitation_id, signer_name, terms_accepted,
+                    additional_work_accepted, client_ip
+                ) VALUES ($1, $2, $3, TRUE, TRUE, $4::inet)
+                """,
+                uuid4(),
+                UUID(invalid_replay["invitationId"]),
+                "Sending Boundary Probe",
+                "192.0.2.33",
             )
 
         opposing = await no_delivery.issue_and_send(

--- a/tests/test_eom_terms_acceptance.py
+++ b/tests/test_eom_terms_acceptance.py
@@ -35,7 +35,10 @@ from atlas_brain.services.eom_terms_acceptance import (
     render_eom_terms_executed_copy,
     render_eom_terms_invitation,
 )
-from atlas_brain.services.eom_terms_authority import EOMTermsAuthority
+from atlas_brain.services.eom_terms_authority import (
+    EOMTermsAuthority,
+    eom_terms_authority_schema_ready,
+)
 
 
 _NOW = datetime(2026, 8, 28, 14, 30, tzinfo=timezone.utc)
@@ -109,6 +112,28 @@ class _RecordingSender:
             "message_id": f"message-{len(self.calls)}",
             "idempotent_replay": False,
         }
+
+
+class _IdempotentReplaySender:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def __call__(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(dict(kwargs))
+        return {"message_id": None, "idempotent_replay": True}
+
+
+class _BlockingSender:
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+        self.calls: list[dict[str, Any]] = []
+
+    async def __call__(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(dict(kwargs))
+        self.started.set()
+        await self.release.wait()
+        return {"message_id": "message-after-lock", "idempotent_replay": False}
 
 
 class _NoDeliveryService(EOMTermsAcceptanceService):
@@ -861,12 +886,54 @@ async def test_real_postgres_end_to_end_preserves_evidence_and_readiness() -> No
         )
         assert confirmed["status"] == "sent"
 
-        await _publish(
+        await dba.execute(
+            """
+            ALTER TABLE eom_terms_versions
+            DISABLE TRIGGER trg_protect_eom_terms_version
+            """
+        )
+        await dba.execute(
+            """
+            UPDATE eom_terms_versions
+            SET published_at = clock_timestamp() + INTERVAL '1 day'
+            WHERE status = 'published'
+            """
+        )
+        await dba.execute(
+            """
+            ALTER TABLE eom_terms_versions
+            ENABLE TRIGGER trg_protect_eom_terms_version
+            """
+        )
+        prior_release = await dba.fetchrow(
+            """
+            SELECT max(publication_order) AS publication_order,
+                   min(published_at) AS published_at
+            FROM eom_terms_versions
+            WHERE status = 'published'
+            """
+        )
+        assert prior_release is not None
+        material_release = await _publish(
             authority,
             label="2026.3",
             material=True,
             marker="material",
         )
+        material_release_row = await dba.fetchrow(
+            """
+            SELECT publication_order, published_at
+            FROM eom_terms_versions
+            WHERE id = $1
+            """,
+            UUID(material_release["versionId"]),
+        )
+        assert material_release_row is not None
+        assert (
+            material_release_row["publication_order"]
+            > prior_release["publication_order"]
+        )
+        assert material_release_row["published_at"] < prior_release["published_at"]
         stale = await service.get_readiness(contact_id=_CONTACT_ID)
         assert stale["ready"] is False
         assert stale["reason"] == "reacceptance_required"
@@ -879,6 +946,23 @@ async def test_real_postgres_end_to_end_preserves_evidence_and_readiness() -> No
                 client_ip="192.0.2.30",
                 sender=_RecordingSender(),
             )
+        async with pool.raw_pool.acquire() as runtime:
+            with pytest.raises(
+                asyncpg.PostgresError,
+                match="superseded by a material release",
+            ):
+                await runtime.execute(
+                    """
+                    INSERT INTO eom_terms_acceptances (
+                        id, invitation_id, signer_name, terms_accepted,
+                        additional_work_accepted, client_ip
+                    ) VALUES ($1, $2, $3, TRUE, TRUE, $4::inet)
+                    """,
+                    uuid4(),
+                    UUID(materially_stale["invitationId"]),
+                    "Database Boundary Probe",
+                    "192.0.2.31",
+                )
         with pytest.raises(EOMTermsAcceptanceConflictError):
             await service.revoke(
                 invitation_id=invitation["invitationId"],
@@ -887,6 +971,23 @@ async def test_real_postgres_end_to_end_preserves_evidence_and_readiness() -> No
             )
 
         assert await eom_terms_acceptance_schema_ready(pool) is True
+        assert await eom_terms_authority_schema_ready(pool) is True
+        await dba.execute(
+            """
+            ALTER TABLE eom_terms_versions
+            DISABLE TRIGGER trg_assign_eom_terms_publication_order
+            """
+        )
+        assert await eom_terms_acceptance_schema_ready(pool) is False
+        assert await eom_terms_authority_schema_ready(pool) is False
+        await dba.execute(
+            """
+            ALTER TABLE eom_terms_versions
+            ENABLE TRIGGER trg_assign_eom_terms_publication_order
+            """
+        )
+        assert await eom_terms_acceptance_schema_ready(pool) is True
+        assert await eom_terms_authority_schema_ready(pool) is True
         await dba.execute(
             """
             ALTER TABLE eom_terms_deliveries
@@ -953,6 +1054,8 @@ async def test_real_postgres_serializes_duplicate_and_opposing_operations() -> N
         contact_revoked = uuid4()
         contact_invalid = uuid4()
         contact_expired = uuid4()
+        contact_delivery_lock = uuid4()
+        contact_replay = uuid4()
         await _seed_customer(dba, contact_id=contact_duplicate)
         await _seed_customer(
             dba,
@@ -974,6 +1077,16 @@ async def test_real_postgres_serializes_duplicate_and_opposing_operations() -> N
             contact_id=contact_expired,
             email="expired@example.com",
         )
+        await _seed_customer(
+            dba,
+            contact_id=contact_delivery_lock,
+            email="delivery-lock@example.com",
+        )
+        await _seed_customer(
+            dba,
+            contact_id=contact_replay,
+            email="replay@example.com",
+        )
         await dba.execute(
             "UPDATE contacts SET status = 'archived' WHERE id = $1",
             contact_invalid,
@@ -985,7 +1098,46 @@ async def test_real_postgres_serializes_duplicate_and_opposing_operations() -> N
             material=True,
             marker="race",
         )
+        concurrent_releases = await asyncio.gather(
+            _publish(
+                authority,
+                label="race.2",
+                material=False,
+                marker="race-two",
+            ),
+            _publish(
+                authority,
+                label="race.3",
+                material=False,
+                marker="race-three",
+            ),
+        )
+        concurrent_ids = [UUID(release["versionId"]) for release in concurrent_releases]
+        concurrent_orders = await dba.fetch(
+            """
+            SELECT id, publication_order
+            FROM eom_terms_versions
+            WHERE id = ANY($1::uuid[])
+            ORDER BY publication_order
+            """,
+            concurrent_ids,
+        )
+        assert len(concurrent_orders) == 2
+        assert (
+            concurrent_orders[0]["publication_order"]
+            < concurrent_orders[1]["publication_order"]
+        )
+        current_order = await dba.fetchval(
+            """
+            SELECT version.publication_order
+            FROM eom_terms_current_version AS selected
+            JOIN eom_terms_versions AS version ON version.id = selected.version_id
+            WHERE selected.singleton
+            """
+        )
+        assert current_order == concurrent_orders[-1]["publication_order"]
         service = EOMTermsAcceptanceService(pool=pool)
+        no_delivery = _NoDeliveryService(pool=pool)
         invitation_sender = _RecordingSender()
         invalid_sender = _RecordingSender()
         with pytest.raises(EOMTermsAcceptanceConflictError):
@@ -1075,7 +1227,110 @@ async def test_real_postgres_serializes_duplicate_and_opposing_operations() -> N
         assert {result["idempotent"] for result in acceptance_results} == {False, True}
         assert len(receipt_sender.calls) == 1
 
-        no_delivery = _NoDeliveryService(pool=pool)
+        locked_invitation = await no_delivery.issue_and_send(
+            request_key="terms-request-delivery-lock",
+            contact_id=contact_delivery_lock,
+            locale="en",
+            actor_id=7,
+            actor_name="Juan",
+            public_base_url="https://example.test/onboarding",
+            hmac_secret=_SECRET,
+            sender=_RecordingSender(),
+        )
+        blocking_sender = _BlockingSender()
+        delivery_task = asyncio.create_task(
+            service._deliver(
+                delivery_id=UUID(locked_invitation["deliveryId"]),
+                secret=_SECRET,
+                previous_secret=None,
+                sender=blocking_sender,
+            )
+        )
+        await asyncio.wait_for(blocking_sender.started.wait(), timeout=2)
+        revoke_task = asyncio.create_task(
+            service.revoke(
+                invitation_id=locked_invitation["invitationId"],
+                actor_id=7,
+                actor_name="Juan",
+            )
+        )
+        try:
+            await asyncio.sleep(0.05)
+            assert revoke_task.done() is False
+        finally:
+            blocking_sender.release.set()
+        locked_delivery, locked_delivery_error = await delivery_task
+        locked_revocation = await revoke_task
+        assert locked_delivery["status"] == "sent"
+        assert locked_delivery_error is False
+        assert locked_revocation["revokedAt"] is not None
+        assert len(blocking_sender.calls) == 1
+
+        replay_invitation = await no_delivery.issue_and_send(
+            request_key="terms-request-provider-replay",
+            contact_id=contact_replay,
+            locale="en",
+            actor_id=7,
+            actor_name="Juan",
+            public_base_url="https://example.test/onboarding",
+            hmac_secret=_SECRET,
+            sender=_RecordingSender(),
+        )
+        replay_sender = _IdempotentReplaySender()
+        replay_delivery, replay_delivery_error = await service._deliver(
+            delivery_id=UUID(replay_invitation["deliveryId"]),
+            secret=_SECRET,
+            previous_secret=None,
+            sender=replay_sender,
+        )
+        assert replay_delivery["status"] == "sent"
+        assert replay_delivery_error is False
+        assert len(replay_sender.calls) == 1
+        replay_evidence = await dba.fetchrow(
+            """
+            SELECT resend_message_id, transport_idempotent_replay
+            FROM eom_terms_deliveries
+            WHERE id = $1
+            """,
+            UUID(replay_invitation["deliveryId"]),
+        )
+        assert replay_evidence is not None
+        assert replay_evidence["resend_message_id"] is None
+        assert replay_evidence["transport_idempotent_replay"] is True
+
+        invalid_replay = await no_delivery.issue_and_send(
+            request_key="terms-request-invalid-provider-replay",
+            contact_id=contact_replay,
+            locale="en",
+            actor_id=7,
+            actor_name="Juan",
+            public_base_url="https://example.test/onboarding",
+            hmac_secret=_SECRET,
+            sender=_RecordingSender(),
+        )
+        uncertain_delivery, uncertain_error = await service._deliver(
+            delivery_id=UUID(invalid_replay["deliveryId"]),
+            secret=_SECRET,
+            previous_secret=None,
+            sender=_RecordingSender(fail=True),
+        )
+        assert uncertain_delivery["status"] == "sending"
+        assert uncertain_error is True
+        with pytest.raises(
+            asyncpg.PostgresError,
+            match="requires transport or actor evidence",
+        ):
+            await dba.execute(
+                """
+                UPDATE eom_terms_deliveries
+                SET status = 'sent',
+                    resend_message_id = NULL,
+                    transport_idempotent_replay = FALSE
+                WHERE id = $1
+                """,
+                UUID(invalid_replay["deliveryId"]),
+            )
+
         opposing = await no_delivery.issue_and_send(
             request_key="terms-request-race-opposing",
             contact_id=contact_opposing,
@@ -1232,9 +1487,13 @@ def test_migration_is_guard_owned_append_only_and_seeds_no_content() -> None:
     assert "validate_eom_terms_invitation" in migration
     assert "validate_eom_terms_acceptance" in migration
     assert "protect_eom_terms_delivery" in migration
+    assert "assign_eom_terms_publication_order" in migration
+    assert "ADD COLUMN publication_order BIGINT" in migration
+    assert "later.publication_order > invitation_row.publication_order" in migration
     assert "BEFORE TRUNCATE ON eom_terms_acceptances" in migration
     assert "GRANT INSERT (id, invitation_id, signer_name" in migration
     assert "GRANT UPDATE (status, claimed_at, sent_at" in migration
     assert "GRANT DELETE" not in migration
+    assert "GRANT UPDATE (publication_order" not in migration
     assert "raw bearer tokens are never stored" in migration
     assert "INSERT INTO eom_terms_versions" not in migration

--- a/tests/test_eom_terms_acceptance.py
+++ b/tests/test_eom_terms_acceptance.py
@@ -1,0 +1,1240 @@
+"""Focused proof for customer-bound EOM Terms acceptance evidence."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+import os
+from pathlib import Path
+from typing import Any
+from uuid import UUID, uuid4
+
+import asyncpg
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from atlas_brain.eom_api import funnel as funnel_mod
+from atlas_brain.eom_api import funnel_auth as funnel_auth_mod
+from atlas_brain.eom_api.config import EOMFunnelConfig
+from atlas_brain.services.eom_public_onboarding_tokens import (
+    format_eom_public_onboarding_token,
+)
+from atlas_brain.services.eom_terms_acceptance import (
+    AuthenticatedEOMTermsToken,
+    EOMTermsAcceptanceConflictError,
+    EOMTermsAcceptanceNotFoundError,
+    EOMTermsAcceptanceService,
+    EOMTermsAcceptanceValidationError,
+    append_eom_terms_acceptance_link,
+    authenticate_eom_terms_token,
+    build_eom_terms_link,
+    eom_terms_acceptance_schema_ready,
+    format_eom_terms_token,
+    render_eom_terms_executed_copy,
+    render_eom_terms_invitation,
+)
+from atlas_brain.services.eom_terms_authority import EOMTermsAuthority
+
+
+_NOW = datetime(2026, 8, 28, 14, 30, tzinfo=timezone.utc)
+_CONTACT_ID = UUID("11111111-1111-4111-8111-111111111111")
+_INVITATION_ID = UUID("22222222-2222-4222-8222-222222222222")
+_VERSION_ID = UUID("33333333-3333-4333-8333-333333333333")
+_ACCEPTANCE_ID = UUID("44444444-4444-4444-8444-444444444444")
+_DELIVERY_ID = UUID("55555555-5555-4555-8555-555555555555")
+_SECRET = "current-eom-public-key-material-1234567890"
+_PREVIOUS_SECRET = "previous-eom-public-key-material-123456"
+_SERVICE = funnel_auth_mod.generate_eom_funnel_service_token()
+_RUNTIME_DATABASE_URL_ENV = "ATLAS_EOM_FIRST_CLEAN_TEST_DATABASE_URL"
+_DBA_DATABASE_URL_ENV = "ATLAS_EOM_FIRST_CLEAN_DBA_DATABASE_URL"
+_AUTHORITY_MIGRATION = (
+    Path(__file__).resolve().parent.parent
+    / "atlas_brain/storage/migrations/396_eom_terms_authority.sql"
+)
+_ACCEPTANCE_MIGRATION = (
+    Path(__file__).resolve().parent.parent
+    / "atlas_brain/storage/migrations/397_eom_terms_acceptance.sql"
+)
+
+
+def _documents(marker: str = "approved") -> dict[str, Any]:
+    return {
+        audience: {
+            locale: {
+                "terms": f"{marker} {audience} {locale} terms",
+                "servicesWeCannotProvide": (f"{marker} {audience} {locale} services"),
+                "additionalWorkAcknowledgement": (
+                    f"{marker} {audience} {locale} additional work"
+                ),
+            }
+            for locale in ("en", "es")
+        }
+        for audience in ("residential", "commercial")
+    }
+
+
+class _AsyncpgServicePool:
+    is_initialized = True
+
+    def __init__(self, pool: Any) -> None:
+        self.raw_pool = pool
+
+    @asynccontextmanager
+    async def transaction(self):
+        async with self.raw_pool.acquire() as connection:
+            async with connection.transaction():
+                yield connection
+
+    async def fetchval(self, *args: Any, **kwargs: Any) -> Any:
+        async with self.raw_pool.acquire() as connection:
+            return await connection.fetchval(*args, **kwargs)
+
+    async def fetchrow(self, *args: Any, **kwargs: Any) -> Any:
+        async with self.raw_pool.acquire() as connection:
+            return await connection.fetchrow(*args, **kwargs)
+
+
+class _RecordingSender:
+    def __init__(self, *, fail: bool = False) -> None:
+        self.fail = fail
+        self.calls: list[dict[str, Any]] = []
+
+    async def __call__(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(dict(kwargs))
+        if self.fail:
+            raise OSError("injected transport uncertainty")
+        return {
+            "message_id": f"message-{len(self.calls)}",
+            "idempotent_replay": False,
+        }
+
+
+class _NoDeliveryService(EOMTermsAcceptanceService):
+    """Model process loss after evidence commit and before transport claim."""
+
+    async def _deliver(self, **kwargs: Any) -> tuple[dict[str, Any], bool]:
+        delivery_id = UUID(str(kwargs["delivery_id"]))
+        async with self.pool.transaction() as connection:
+            row = await self._delivery_by_id(connection, delivery_id)
+        assert row is not None
+        return dict(row), False
+
+
+def _database_url_or_skip(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        pytest.skip(f"{name} is not configured")
+    return value
+
+
+async def _provision_guard_role(connection: Any) -> None:
+    await connection.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1 FROM pg_roles
+                WHERE rolname = 'atlas_eom_handoff_owner'
+            ) THEN
+                ALTER ROLE atlas_eom_handoff_owner
+                    NOLOGIN NOINHERIT NOSUPERUSER NOCREATEDB NOCREATEROLE
+                    NOREPLICATION NOBYPASSRLS;
+            ELSE
+                CREATE ROLE atlas_eom_handoff_owner
+                    NOLOGIN NOINHERIT NOSUPERUSER NOCREATEDB NOCREATEROLE
+                    NOREPLICATION NOBYPASSRLS;
+            END IF;
+        END;
+        $$;
+        """
+    )
+    await connection.execute("REVOKE atlas_eom_handoff_owner FROM atlas")
+
+
+@asynccontextmanager
+async def _real_terms_store():
+    runtime_url = _database_url_or_skip(_RUNTIME_DATABASE_URL_ENV)
+    dba_url = _database_url_or_skip(_DBA_DATABASE_URL_ENV)
+    schema = f"atlas_eom_terms_acceptance_{uuid4().hex}"
+    dba_connection = await asyncpg.connect(dba_url)
+    runtime_pool = None
+    try:
+        await _provision_guard_role(dba_connection)
+        await dba_connection.execute(
+            f'CREATE SCHEMA "{schema}" AUTHORIZATION atlas_eom_handoff_owner'
+        )
+        await dba_connection.execute(
+            f'GRANT USAGE, CREATE ON SCHEMA "{schema}" TO atlas'
+        )
+        await dba_connection.execute(f'SET search_path TO "{schema}", pg_catalog')
+        await dba_connection.execute(
+            """
+            CREATE TABLE contacts (
+                id UUID PRIMARY KEY,
+                business_context_id VARCHAR(64) NOT NULL,
+                contact_type VARCHAR(32) NOT NULL,
+                status VARCHAR(32) NOT NULL,
+                customer_type VARCHAR(16) NOT NULL,
+                full_name VARCHAR(256) NOT NULL,
+                email VARCHAR(256)
+            );
+            CREATE TABLE schema_migrations (
+                version INTEGER PRIMARY KEY,
+                name VARCHAR(255) NOT NULL,
+                content_sha256 VARCHAR(64),
+                applied_at TIMESTAMPTZ DEFAULT NOW()
+            );
+            """
+        )
+        await dba_connection.execute(_AUTHORITY_MIGRATION.read_text())
+        await dba_connection.execute(
+            """
+            INSERT INTO schema_migrations (version, name)
+            VALUES (396, '396_eom_terms_authority')
+            """
+        )
+        await dba_connection.execute(_ACCEPTANCE_MIGRATION.read_text())
+        # The production runtime already reads and row-locks canonical contacts.
+        # This minimal fixture creates that prerequisite as the DBA, so restore
+        # only those pre-existing capabilities after the controlled migrations
+        # have normalized their own object ACLs. PostgreSQL requires UPDATE as
+        # well as SELECT for the service's SELECT ... FOR SHARE lock.
+        await dba_connection.execute(
+            f'GRANT SELECT, UPDATE ON TABLE "{schema}".contacts TO atlas'
+        )
+        assert (
+            await dba_connection.fetchval(
+                "SELECT has_table_privilege('atlas', $1, 'SELECT')",
+                f'"{schema}".contacts',
+            )
+            is True
+        )
+        runtime_pool = await asyncpg.create_pool(
+            runtime_url,
+            min_size=1,
+            max_size=8,
+            statement_cache_size=0,
+            server_settings={"search_path": f'"{schema}", pg_catalog'},
+        )
+        async with runtime_pool.acquire() as runtime_connection:
+            runtime_boundary = await runtime_connection.fetchrow(
+                """
+                SELECT current_user AS current_user,
+                       current_schema() AS current_schema,
+                       namespace.nspname AS relation_schema,
+                       has_table_privilege(
+                           current_user, relation.oid, 'SELECT'
+                       ) AS can_select,
+                       has_table_privilege(
+                           current_user, relation.oid, 'UPDATE'
+                       ) AS can_lock
+                FROM pg_class AS relation
+                JOIN pg_namespace AS namespace
+                  ON namespace.oid = relation.relnamespace
+                WHERE relation.oid = to_regclass('contacts')
+                """
+            )
+        assert runtime_boundary is not None
+        assert runtime_boundary["current_user"] == "atlas"
+        assert runtime_boundary["current_schema"] == schema
+        assert runtime_boundary["relation_schema"] == schema
+        assert runtime_boundary["can_select"] is True
+        assert runtime_boundary["can_lock"] is True
+        yield _AsyncpgServicePool(runtime_pool), dba_connection, schema
+    finally:
+        if runtime_pool is not None:
+            await runtime_pool.close()
+        try:
+            await dba_connection.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        finally:
+            await dba_connection.close()
+
+
+async def _seed_customer(
+    connection: Any,
+    *,
+    contact_id: UUID,
+    audience: str = "residential",
+    email: str = "customer@example.com",
+) -> None:
+    await connection.execute(
+        """
+        INSERT INTO contacts (
+            id, business_context_id, contact_type, status, customer_type,
+            full_name, email
+        ) VALUES ($1, 'effingham_maids', 'customer', 'active', $2, $3, $4)
+        """,
+        contact_id,
+        audience,
+        f"Customer {str(contact_id)[:8]}",
+        email,
+    )
+
+
+async def _publish(
+    authority: EOMTermsAuthority,
+    *,
+    label: str,
+    material: bool,
+    marker: str,
+) -> dict[str, Any]:
+    draft = await authority.create_draft(
+        version_label=label,
+        material_change=material,
+        documents=_documents(marker),
+        actor_id=7,
+        actor_name="Juan",
+    )
+    return await authority.publish(
+        version_id=draft["versionId"],
+        actor_id=7,
+        actor_name="Juan",
+    )
+
+
+def test_terms_bearer_is_domain_separated_fragment_only_and_rotatable() -> None:
+    token = format_eom_terms_token(
+        invitation_id=_INVITATION_ID,
+        secret=_PREVIOUS_SECRET,
+    )
+    authenticated = authenticate_eom_terms_token(
+        token=token,
+        secret=_SECRET,
+        previous_secret=_PREVIOUS_SECRET,
+    )
+    assert authenticated.invitation_id == _INVITATION_ID
+    assert token.startswith("eomt1.")
+    assert "?" not in build_eom_terms_link(
+        base_url="https://example.test/onboarding",
+        token=token,
+    )
+    assert build_eom_terms_link(
+        base_url="https://example.test/onboarding",
+        token=token,
+    ).endswith(f"#termsToken={token}")
+
+    profile_token = format_eom_public_onboarding_token(
+        token_id=_INVITATION_ID,
+        secret=_PREVIOUS_SECRET,
+    )
+    with pytest.raises(EOMTermsAcceptanceNotFoundError):
+        authenticate_eom_terms_token(
+            token=profile_token,
+            secret=_SECRET,
+            previous_secret=_PREVIOUS_SECRET,
+        )
+    with pytest.raises(EOMTermsAcceptanceNotFoundError):
+        authenticate_eom_terms_token(
+            token=token,
+            secret=_SECRET,
+        )
+
+
+@pytest.mark.parametrize("token", [None, False, 0, "", "eomt1.bad", "x" * 1000])
+def test_terms_bearer_rejects_every_noncanonical_boundary(token: object) -> None:
+    with pytest.raises(EOMTermsAcceptanceNotFoundError):
+        authenticate_eom_terms_token(token=token, secret=_SECRET)
+
+
+def test_renderers_use_only_the_selected_published_document_text() -> None:
+    selected = _documents("selected")["commercial"]["es"]
+    subject, body = render_eom_terms_invitation(
+        full_name="Cliente",
+        version_label="2026.1",
+        content_hash="a" * 64,
+        documents=selected,
+        locale="es",
+    )
+    linked = append_eom_terms_acceptance_link(
+        body=body,
+        link="https://example.test/#termsToken=opaque",
+        locale="es",
+    )
+    executed_subject, executed_body = render_eom_terms_executed_copy(
+        full_name="Cliente",
+        signer_name="Cliente",
+        accepted_at=_NOW,
+        version_label="2026.1",
+        content_hash="a" * 64,
+        documents=selected,
+        locale="es",
+    )
+    assert subject
+    assert executed_subject
+    assert all(value in body for value in selected.values())
+    assert all(value in executed_body for value in selected.values())
+    assert "termsToken=opaque" not in body
+    assert "termsToken=opaque" in linked
+    assert "Reconocimiento de trabajo adicional aceptado: Si" in executed_body
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("terms_accepted", "additional_work_accepted"),
+    [(False, True), (True, False), (1, True), (True, "true")],
+)
+async def test_acceptance_requires_two_literal_true_acknowledgements(
+    terms_accepted: object,
+    additional_work_accepted: object,
+) -> None:
+    service = EOMTermsAcceptanceService(pool=object())
+    token = AuthenticatedEOMTermsToken(
+        invitation_id=_INVITATION_ID,
+        signing_key_fingerprint="a" * 64,
+    )
+    with pytest.raises(EOMTermsAcceptanceValidationError):
+        await service.accept_and_send(
+            token=token,
+            signer_name="Customer",
+            terms_accepted=terms_accepted,
+            additional_work_accepted=additional_work_accepted,
+            client_ip="192.0.2.1",
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("signer_name", "client_ip"),
+    [
+        ("", "192.0.2.1"),
+        (None, "192.0.2.1"),
+        ("Customer", "not-an-ip"),
+        ("Customer", ""),
+    ],
+)
+async def test_acceptance_rejects_invalid_signer_or_client_ip_before_database_use(
+    signer_name: object,
+    client_ip: object,
+) -> None:
+    service = EOMTermsAcceptanceService(pool=object())
+    token = AuthenticatedEOMTermsToken(
+        invitation_id=_INVITATION_ID,
+        signing_key_fingerprint="a" * 64,
+    )
+    with pytest.raises(EOMTermsAcceptanceValidationError):
+        await service.accept_and_send(
+            token=token,
+            signer_name=signer_name,
+            terms_accepted=True,
+            additional_work_accepted=True,
+            client_ip=client_ip,
+        )
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"business_context_id": "other"},
+        {"contact_type": "lead"},
+        {"status": "archived"},
+        {"customer_type": "unknown"},
+        {"email": None},
+        {"full_name": " "},
+    ],
+)
+def test_customer_boundary_rejects_every_noncanonical_account(
+    changes: dict[str, object],
+) -> None:
+    row: dict[str, object] = {
+        "id": _CONTACT_ID,
+        "business_context_id": "effingham_maids",
+        "contact_type": "customer",
+        "status": "active",
+        "customer_type": "residential",
+        "full_name": "Customer",
+        "email": "customer@example.com",
+    }
+    row.update(changes)
+    with pytest.raises(EOMTermsAcceptanceConflictError):
+        EOMTermsAcceptanceService._customer(row)
+
+
+class _RouteAcceptance:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def issue_and_send(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(("issue", kwargs))
+        return _invitation_api_result()
+
+    async def revoke(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(("revoke", kwargs))
+        return _invitation_api_result(status="revoked", revoked_at=_NOW)
+
+    async def get_readiness(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(("readiness", kwargs))
+        return {
+            "contactId": str(_CONTACT_ID),
+            "audience": "residential",
+            "ready": True,
+            "reason": "accepted",
+            "currentVersionId": str(_VERSION_ID),
+            "currentVersionLabel": "2026.1",
+            "currentContentHash": "a" * 64,
+            "acceptedVersionId": str(_VERSION_ID),
+            "acceptedVersionLabel": "2026.1",
+            "acceptedAt": _NOW.isoformat(),
+            "executedCopyDeliveryStatus": "sent",
+        }
+
+    async def confirm_delivery_sent(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(("confirm", kwargs))
+        return {
+            "deliveryId": str(_DELIVERY_ID),
+            "kind": "executed_copy",
+            "status": "sent",
+            "sentAt": _NOW.isoformat(),
+            "idempotent": False,
+        }
+
+    async def get_session(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(("session", kwargs))
+        return {
+            "status": "ready",
+            "invitationId": str(_INVITATION_ID),
+            "versionId": str(_VERSION_ID),
+            "versionLabel": "2026.1",
+            "contentHash": "a" * 64,
+            "audience": "residential",
+            "locale": "en",
+            "customerName": "Customer",
+            "documents": _documents()["residential"]["en"],
+            "expiresAt": _NOW.isoformat(),
+        }
+
+    async def accept_and_send(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(("accept", kwargs))
+        return {
+            "acceptanceId": str(_ACCEPTANCE_ID),
+            "invitationId": str(_INVITATION_ID),
+            "contactId": str(_CONTACT_ID),
+            "versionId": str(_VERSION_ID),
+            "versionLabel": "2026.1",
+            "contentHash": "a" * 64,
+            "audience": "residential",
+            "locale": "en",
+            "signerName": "Customer",
+            "termsAccepted": True,
+            "additionalWorkAccepted": True,
+            "acceptedAt": _NOW.isoformat(),
+            "deliveryId": str(_DELIVERY_ID),
+            "executedCopyDeliveryStatus": "sent",
+            "deliveryNeedsReconciliation": False,
+            "deliveryError": False,
+            "idempotent": False,
+        }
+
+
+def _invitation_api_result(
+    *, status: str = "issued", revoked_at: datetime | None = None
+) -> dict[str, Any]:
+    return {
+        "invitationId": str(_INVITATION_ID),
+        "contactId": str(_CONTACT_ID),
+        "versionId": str(_VERSION_ID),
+        "versionLabel": "2026.1",
+        "contentHash": "a" * 64,
+        "audience": "residential",
+        "locale": "en",
+        "recipientEmail": "customer@example.com",
+        "status": status,
+        "issuedAt": _NOW.isoformat(),
+        "expiresAt": _NOW.isoformat(),
+        "revokedAt": revoked_at.isoformat() if revoked_at else None,
+        "acceptanceId": None,
+        "deliveryId": str(_DELIVERY_ID),
+        "deliveryStatus": "sent",
+        "deliveryNeedsReconciliation": False,
+        "deliveryError": False,
+        "idempotent": False,
+    }
+
+
+def _route_app(service: Any, *, issuance_enabled: bool = True) -> FastAPI:
+    app = FastAPI()
+    app.include_router(funnel_mod.router, prefix="/api/v1")
+    config = EOMFunnelConfig(
+        api_enabled=True,
+        service_token_sha256=_SERVICE.sha256,
+        public_onboarding_enabled=True,
+        public_onboarding_issuance_enabled=issuance_enabled,
+        public_onboarding_url="https://example.test/onboarding",
+        public_onboarding_hmac_secret=_SECRET,
+        public_onboarding_previous_hmac_secret=_PREVIOUS_SECRET,
+    )
+    app.dependency_overrides[funnel_auth_mod.get_eom_funnel_api_config] = lambda: config
+    app.dependency_overrides[funnel_mod._terms_acceptance_dependency] = lambda: service
+    app.dependency_overrides[funnel_mod._onboarding_sender_dependency] = lambda: (
+        object()
+    )
+    return app
+
+
+def _headers(*, actor: bool = False, client_ip: bool = False) -> dict[str, str]:
+    headers = {"Authorization": f"Bearer {_SERVICE.token}"}
+    if actor:
+        headers.update({"X-EOM-Actor": "Juan", "X-EOM-Actor-ID": "7"})
+    if client_ip:
+        headers["X-EOM-Client-IP"] = "192.0.2.9"
+    return headers
+
+
+@pytest.mark.asyncio
+async def test_mounted_routes_enforce_trust_boundaries_and_closed_projections() -> None:
+    service = _RouteAcceptance()
+    app = _route_app(service)
+    token = format_eom_terms_token(invitation_id=_INVITATION_ID, secret=_SECRET)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        unauthorized = await client.get(
+            f"/api/v1/eom-funnel/terms/readiness/{_CONTACT_ID}"
+        )
+        missing_actor = await client.post(
+            "/api/v1/eom-funnel/terms/invitations",
+            headers=_headers(),
+            json={
+                "requestKey": "terms-request-0001",
+                "contactId": str(_CONTACT_ID),
+                "locale": "en",
+            },
+        )
+        issued = await client.post(
+            "/api/v1/eom-funnel/terms/invitations",
+            headers=_headers(actor=True),
+            json={
+                "requestKey": "terms-request-0001",
+                "contactId": str(_CONTACT_ID),
+                "locale": "en",
+            },
+        )
+        session = await client.post(
+            "/api/v1/eom-funnel/terms/public/session",
+            headers=_headers(),
+            json={"token": token},
+        )
+        missing_ip = await client.post(
+            "/api/v1/eom-funnel/terms/public/accept",
+            headers=_headers(),
+            json={
+                "token": token,
+                "signerName": "Customer",
+                "termsAccepted": True,
+                "additionalWorkAccepted": True,
+            },
+        )
+        accepted = await client.post(
+            "/api/v1/eom-funnel/terms/public/accept",
+            headers=_headers(client_ip=True),
+            json={
+                "token": token,
+                "signerName": "Customer",
+                "termsAccepted": True,
+                "additionalWorkAccepted": True,
+            },
+        )
+        revoked = await client.post(
+            f"/api/v1/eom-funnel/terms/invitations/{_INVITATION_ID}/revoke",
+            headers=_headers(actor=True),
+        )
+        readiness = await client.get(
+            f"/api/v1/eom-funnel/terms/readiness/{_CONTACT_ID}",
+            headers=_headers(),
+        )
+        confirmed = await client.post(
+            f"/api/v1/eom-funnel/terms/deliveries/{_DELIVERY_ID}/confirm-sent",
+            headers=_headers(actor=True),
+        )
+
+    assert unauthorized.status_code == 401
+    assert missing_actor.status_code == 422
+    assert missing_ip.status_code == 422
+    assert issued.status_code == 201
+    assert session.status_code == 200
+    assert accepted.status_code == 201
+    assert revoked.status_code == 200
+    assert readiness.json()["ready"] is True
+    assert confirmed.json()["status"] == "sent"
+    accept_call = next(kwargs for name, kwargs in service.calls if name == "accept")
+    assert accept_call["client_ip"] == "192.0.2.9"
+    assert isinstance(accept_call["token"], AuthenticatedEOMTermsToken)
+    issue_call = next(kwargs for name, kwargs in service.calls if name == "issue")
+    assert "audience" not in issue_call
+    assert "recipient_email" not in issue_call
+    assert "version_id" not in issue_call
+
+
+@pytest.mark.asyncio
+async def test_invitation_route_obeys_the_separate_issuance_pause() -> None:
+    service = _RouteAcceptance()
+    app = _route_app(service, issuance_enabled=False)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        response = await client.post(
+            "/api/v1/eom-funnel/terms/invitations",
+            headers=_headers(actor=True),
+            json={
+                "requestKey": "terms-request-0001",
+                "contactId": str(_CONTACT_ID),
+                "locale": "en",
+            },
+        )
+    assert response.status_code == 503
+    assert service.calls == []
+
+
+@pytest.mark.asyncio
+async def test_real_postgres_end_to_end_preserves_evidence_and_readiness() -> None:
+    async with _real_terms_store() as (pool, dba, _schema):
+        await _seed_customer(dba, contact_id=_CONTACT_ID)
+        authority = EOMTermsAuthority(pool=pool)
+        version_one = await _publish(
+            authority,
+            label="2026.1",
+            material=True,
+            marker="version-one",
+        )
+        service = EOMTermsAcceptanceService(pool=pool)
+        invitation_sender = _RecordingSender()
+        invitation = await service.issue_and_send(
+            request_key="terms-request-real-0001",
+            contact_id=_CONTACT_ID,
+            locale="en",
+            actor_id=7,
+            actor_name="Juan",
+            public_base_url="https://example.test/onboarding",
+            hmac_secret=_SECRET,
+            previous_hmac_secret=_PREVIOUS_SECRET,
+            sender=invitation_sender,
+        )
+        token = format_eom_terms_token(
+            invitation_id=UUID(invitation["invitationId"]),
+            secret=_SECRET,
+        )
+        session = await service.get_session(
+            token=authenticate_eom_terms_token(token=token, secret=_SECRET)
+        )
+        assert session["documents"] == _documents("version-one")["residential"]["en"]
+        assert len(invitation_sender.calls) == 1
+        assert f"#termsToken={token}" in invitation_sender.calls[0]["body"]
+        unknown_token = format_eom_terms_token(
+            invitation_id=uuid4(),
+            secret=_SECRET,
+        )
+        with pytest.raises(EOMTermsAcceptanceNotFoundError):
+            await service.get_session(
+                token=authenticate_eom_terms_token(
+                    token=unknown_token,
+                    secret=_SECRET,
+                )
+            )
+        wrong_key_token = format_eom_terms_token(
+            invitation_id=UUID(invitation["invitationId"]),
+            secret=_PREVIOUS_SECRET,
+        )
+        with pytest.raises(EOMTermsAcceptanceNotFoundError):
+            await service.get_session(
+                token=authenticate_eom_terms_token(
+                    token=wrong_key_token,
+                    secret=_SECRET,
+                    previous_secret=_PREVIOUS_SECRET,
+                )
+            )
+
+        await _publish(
+            authority,
+            label="2026.2",
+            material=False,
+            marker="non-material",
+        )
+        replay = await service.issue_and_send(
+            request_key="terms-request-real-0001",
+            contact_id=_CONTACT_ID,
+            locale="en",
+            actor_id=7,
+            actor_name="Juan",
+            public_base_url="https://example.test/onboarding",
+            hmac_secret=_SECRET,
+            previous_hmac_secret=_PREVIOUS_SECRET,
+            sender=invitation_sender,
+        )
+        assert replay["versionId"] == version_one["versionId"]
+        assert replay["idempotent"] is True
+        assert len(invitation_sender.calls) == 1
+
+        no_delivery = _NoDeliveryService(pool=pool)
+        materially_stale = await no_delivery.issue_and_send(
+            request_key="terms-request-materially-stale",
+            contact_id=_CONTACT_ID,
+            locale="en",
+            actor_id=7,
+            actor_name="Juan",
+            public_base_url="https://example.test/onboarding",
+            hmac_secret=_SECRET,
+            sender=_RecordingSender(),
+        )
+        materially_stale_token = authenticate_eom_terms_token(
+            token=format_eom_terms_token(
+                invitation_id=UUID(materially_stale["invitationId"]),
+                secret=_SECRET,
+            ),
+            secret=_SECRET,
+        )
+
+        receipt_sender = _RecordingSender(fail=True)
+        acceptance = await service.accept_and_send(
+            token=authenticate_eom_terms_token(token=token, secret=_SECRET),
+            signer_name="Customer Signer",
+            terms_accepted=True,
+            additional_work_accepted=True,
+            client_ip="2001:db8::1",
+            sender=receipt_sender,
+        )
+        assert acceptance["deliveryError"] is True
+        assert acceptance["executedCopyDeliveryStatus"] == "sending"
+        assert len(receipt_sender.calls) == 1
+        accepted_replay = await service.accept_and_send(
+            token=authenticate_eom_terms_token(token=token, secret=_SECRET),
+            signer_name="Customer Signer",
+            terms_accepted=True,
+            additional_work_accepted=True,
+            client_ip="2001:db8::2",
+            sender=receipt_sender,
+        )
+        assert accepted_replay["acceptanceId"] == acceptance["acceptanceId"]
+        assert accepted_replay["idempotent"] is True
+        assert len(receipt_sender.calls) == 1
+        with pytest.raises(EOMTermsAcceptanceConflictError):
+            await service.accept_and_send(
+                token=authenticate_eom_terms_token(token=token, secret=_SECRET),
+                signer_name="Different Signer",
+                terms_accepted=True,
+                additional_work_accepted=True,
+                client_ip="2001:db8::2",
+                sender=receipt_sender,
+            )
+        readiness = await service.get_readiness(contact_id=_CONTACT_ID)
+        assert readiness["ready"] is True
+        assert readiness["reason"] == "accepted"
+
+        stored = await dba.fetchrow(
+            """
+            SELECT invitation.request_key, invitation.signing_key_fingerprint,
+                   invitation_delivery.body AS invitation_body,
+                   acceptance.signer_name, acceptance.client_ip::text,
+                   acceptance.terms_accepted,
+                   acceptance.additional_work_accepted,
+                   executed.body AS executed_body,
+                   executed.status AS executed_status
+            FROM eom_terms_invitations AS invitation
+            JOIN eom_terms_deliveries AS invitation_delivery
+              ON invitation_delivery.invitation_id = invitation.id
+             AND invitation_delivery.kind = 'invitation'
+            JOIN eom_terms_acceptances AS acceptance
+              ON acceptance.invitation_id = invitation.id
+            JOIN eom_terms_deliveries AS executed
+              ON executed.acceptance_id = acceptance.id
+            WHERE invitation.id = $1
+            """,
+            UUID(invitation["invitationId"]),
+        )
+        assert stored is not None
+        assert token not in stored["invitation_body"]
+        assert token not in stored["executed_body"]
+        assert stored["signer_name"] == "Customer Signer"
+        assert stored["client_ip"] == "2001:db8::1/128"
+        assert stored["terms_accepted"] is True
+        assert stored["additional_work_accepted"] is True
+        assert stored["executed_status"] == "sending"
+        assert all(
+            value in stored["executed_body"]
+            for value in _documents("version-one")["residential"]["en"].values()
+        )
+
+        confirmed = await service.confirm_delivery_sent(
+            delivery_id=acceptance["deliveryId"],
+            actor_id=7,
+            actor_name="Juan",
+        )
+        assert confirmed["status"] == "sent"
+
+        await _publish(
+            authority,
+            label="2026.3",
+            material=True,
+            marker="material",
+        )
+        stale = await service.get_readiness(contact_id=_CONTACT_ID)
+        assert stale["ready"] is False
+        assert stale["reason"] == "reacceptance_required"
+        with pytest.raises(EOMTermsAcceptanceNotFoundError):
+            await service.accept_and_send(
+                token=materially_stale_token,
+                signer_name="Customer Signer",
+                terms_accepted=True,
+                additional_work_accepted=True,
+                client_ip="192.0.2.30",
+                sender=_RecordingSender(),
+            )
+        with pytest.raises(EOMTermsAcceptanceConflictError):
+            await service.revoke(
+                invitation_id=invitation["invitationId"],
+                actor_id=7,
+                actor_name="Juan",
+            )
+
+        assert await eom_terms_acceptance_schema_ready(pool) is True
+        await dba.execute(
+            """
+            ALTER TABLE eom_terms_deliveries
+            DISABLE TRIGGER trg_protect_eom_terms_delivery
+            """
+        )
+        assert await eom_terms_acceptance_schema_ready(pool) is False
+        await dba.execute(
+            """
+            ALTER TABLE eom_terms_deliveries
+            ENABLE TRIGGER trg_protect_eom_terms_delivery
+            """
+        )
+        assert await eom_terms_acceptance_schema_ready(pool) is True
+        owners = await dba.fetch(
+            """
+            SELECT relation.relname, owner.rolname AS owner
+            FROM pg_class AS relation
+            JOIN pg_namespace AS namespace ON namespace.oid = relation.relnamespace
+            JOIN pg_roles AS owner ON owner.oid = relation.relowner
+            WHERE namespace.nspname = current_schema()
+              AND relation.relname IN (
+                  'eom_terms_invitations',
+                  'eom_terms_acceptances',
+                  'eom_terms_deliveries'
+              )
+            """
+        )
+        assert {row["owner"] for row in owners} == {"atlas_eom_handoff_owner"}
+        async with pool.raw_pool.acquire() as runtime:
+            assert (
+                await runtime.fetchval(
+                    "SELECT has_table_privilege(current_user, "
+                    "'eom_terms_acceptances', 'DELETE')"
+                )
+                is False
+            )
+            assert (
+                await runtime.fetchval(
+                    "SELECT has_function_privilege(current_user, "
+                    "'protect_eom_terms_acceptance()', 'EXECUTE')"
+                )
+                is False
+            )
+            with pytest.raises(asyncpg.InsufficientPrivilegeError):
+                await runtime.execute(
+                    "UPDATE eom_terms_acceptances SET signer_name = 'Changed'"
+                )
+            with pytest.raises(asyncpg.InsufficientPrivilegeError):
+                await runtime.execute("TRUNCATE eom_terms_deliveries")
+        with pytest.raises(asyncpg.PostgresError):
+            await dba.execute(
+                "UPDATE eom_terms_acceptances SET signer_name = 'Changed'"
+            )
+        with pytest.raises(asyncpg.PostgresError):
+            await dba.execute("UPDATE eom_terms_deliveries SET body = 'Changed'")
+
+
+@pytest.mark.asyncio
+async def test_real_postgres_serializes_duplicate_and_opposing_operations() -> None:
+    async with _real_terms_store() as (pool, dba, _schema):
+        contact_duplicate = uuid4()
+        contact_opposing = uuid4()
+        contact_revoked = uuid4()
+        contact_invalid = uuid4()
+        contact_expired = uuid4()
+        await _seed_customer(dba, contact_id=contact_duplicate)
+        await _seed_customer(
+            dba,
+            contact_id=contact_opposing,
+            email="opposing@example.com",
+        )
+        await _seed_customer(
+            dba,
+            contact_id=contact_revoked,
+            email="revoked@example.com",
+        )
+        await _seed_customer(
+            dba,
+            contact_id=contact_invalid,
+            email="invalid@example.com",
+        )
+        await _seed_customer(
+            dba,
+            contact_id=contact_expired,
+            email="expired@example.com",
+        )
+        await dba.execute(
+            "UPDATE contacts SET status = 'archived' WHERE id = $1",
+            contact_invalid,
+        )
+        authority = EOMTermsAuthority(pool=pool)
+        await _publish(
+            authority,
+            label="race.1",
+            material=True,
+            marker="race",
+        )
+        service = EOMTermsAcceptanceService(pool=pool)
+        invitation_sender = _RecordingSender()
+        invalid_sender = _RecordingSender()
+        with pytest.raises(EOMTermsAcceptanceConflictError):
+            await service.issue_and_send(
+                request_key="terms-request-invalid-contact",
+                contact_id=contact_invalid,
+                locale="en",
+                actor_id=7,
+                actor_name="Juan",
+                public_base_url="https://example.test/onboarding",
+                hmac_secret=_SECRET,
+                sender=invalid_sender,
+            )
+        assert invalid_sender.calls == []
+
+        async def issue_duplicate() -> dict[str, Any]:
+            return await service.issue_and_send(
+                request_key="terms-request-race-duplicate",
+                contact_id=contact_duplicate,
+                locale="en",
+                actor_id=7,
+                actor_name="Juan",
+                public_base_url="https://example.test/onboarding",
+                hmac_secret=_SECRET,
+                sender=invitation_sender,
+            )
+
+        duplicate_results = await asyncio.gather(
+            issue_duplicate(),
+            issue_duplicate(),
+        )
+        assert {result["invitationId"] for result in duplicate_results} == {
+            duplicate_results[0]["invitationId"]
+        }
+        assert {result["idempotent"] for result in duplicate_results} == {False, True}
+        assert len(invitation_sender.calls) == 1
+        with pytest.raises(EOMTermsAcceptanceConflictError):
+            await service.issue_and_send(
+                request_key="terms-request-race-duplicate",
+                contact_id=contact_opposing,
+                locale="en",
+                actor_id=7,
+                actor_name="Juan",
+                public_base_url="https://example.test/onboarding",
+                hmac_secret=_SECRET,
+                sender=invitation_sender,
+            )
+        with pytest.raises(EOMTermsAcceptanceConflictError):
+            await service.issue_and_send(
+                request_key="terms-request-race-duplicate",
+                contact_id=contact_duplicate,
+                locale="es",
+                actor_id=7,
+                actor_name="Juan",
+                public_base_url="https://example.test/onboarding",
+                hmac_secret=_SECRET,
+                sender=invitation_sender,
+            )
+
+        duplicate_token = format_eom_terms_token(
+            invitation_id=UUID(duplicate_results[0]["invitationId"]),
+            secret=_SECRET,
+        )
+        authenticated = authenticate_eom_terms_token(
+            token=duplicate_token,
+            secret=_SECRET,
+        )
+        receipt_sender = _RecordingSender()
+
+        async def accept_duplicate() -> dict[str, Any]:
+            return await service.accept_and_send(
+                token=authenticated,
+                signer_name="Same Signer",
+                terms_accepted=True,
+                additional_work_accepted=True,
+                client_ip="192.0.2.20",
+                sender=receipt_sender,
+            )
+
+        acceptance_results = await asyncio.gather(
+            accept_duplicate(),
+            accept_duplicate(),
+        )
+        assert {result["acceptanceId"] for result in acceptance_results} == {
+            acceptance_results[0]["acceptanceId"]
+        }
+        assert {result["idempotent"] for result in acceptance_results} == {False, True}
+        assert len(receipt_sender.calls) == 1
+
+        no_delivery = _NoDeliveryService(pool=pool)
+        opposing = await no_delivery.issue_and_send(
+            request_key="terms-request-race-opposing",
+            contact_id=contact_opposing,
+            locale="en",
+            actor_id=7,
+            actor_name="Juan",
+            public_base_url="https://example.test/onboarding",
+            hmac_secret=_SECRET,
+            sender=_RecordingSender(),
+        )
+        opposing_token = authenticate_eom_terms_token(
+            token=format_eom_terms_token(
+                invitation_id=UUID(opposing["invitationId"]),
+                secret=_SECRET,
+            ),
+            secret=_SECRET,
+        )
+        opposing_results = await asyncio.gather(
+            service.accept_and_send(
+                token=opposing_token,
+                signer_name="Opposing Signer",
+                terms_accepted=True,
+                additional_work_accepted=True,
+                client_ip="192.0.2.21",
+                sender=_RecordingSender(),
+            ),
+            service.revoke(
+                invitation_id=opposing["invitationId"],
+                actor_id=7,
+                actor_name="Juan",
+            ),
+            return_exceptions=True,
+        )
+        assert sum(isinstance(result, Exception) for result in opposing_results) == 1
+        opposing_row = await dba.fetchrow(
+            """
+            SELECT invitation.revoked_at,
+                   acceptance.id AS acceptance_id
+            FROM eom_terms_invitations AS invitation
+            LEFT JOIN eom_terms_acceptances AS acceptance
+              ON acceptance.invitation_id = invitation.id
+            WHERE invitation.id = $1
+            """,
+            UUID(opposing["invitationId"]),
+        )
+        assert opposing_row is not None
+        assert (opposing_row["revoked_at"] is None) != (
+            opposing_row["acceptance_id"] is None
+        )
+
+        revoked = await no_delivery.issue_and_send(
+            request_key="terms-request-revoked-unsent",
+            contact_id=contact_revoked,
+            locale="en",
+            actor_id=7,
+            actor_name="Juan",
+            public_base_url="https://example.test/onboarding",
+            hmac_secret=_SECRET,
+            sender=_RecordingSender(),
+        )
+        await service.revoke(
+            invitation_id=revoked["invitationId"],
+            actor_id=7,
+            actor_name="Juan",
+        )
+        after_revoke_sender = _RecordingSender()
+        delivery, delivery_error = await service._deliver(
+            delivery_id=UUID(revoked["deliveryId"]),
+            secret=_SECRET,
+            previous_secret=None,
+            sender=after_revoke_sender,
+        )
+        assert delivery["status"] == "pending"
+        assert delivery_error is False
+        assert after_revoke_sender.calls == []
+        revoked_token = authenticate_eom_terms_token(
+            token=format_eom_terms_token(
+                invitation_id=UUID(revoked["invitationId"]),
+                secret=_SECRET,
+            ),
+            secret=_SECRET,
+        )
+        with pytest.raises(EOMTermsAcceptanceNotFoundError):
+            await service.get_session(token=revoked_token)
+        with pytest.raises(EOMTermsAcceptanceNotFoundError):
+            await service.accept_and_send(
+                token=revoked_token,
+                signer_name="Revoked Signer",
+                terms_accepted=True,
+                additional_work_accepted=True,
+                client_ip="192.0.2.22",
+                sender=_RecordingSender(),
+            )
+
+        expired = await no_delivery.issue_and_send(
+            request_key="terms-request-expired",
+            contact_id=contact_expired,
+            locale="en",
+            actor_id=7,
+            actor_name="Juan",
+            public_base_url="https://example.test/onboarding",
+            hmac_secret=_SECRET,
+            sender=_RecordingSender(),
+        )
+        await dba.execute(
+            """
+            ALTER TABLE eom_terms_invitations
+            DISABLE TRIGGER trg_protect_eom_terms_invitation
+            """
+        )
+        await dba.execute(
+            """
+            WITH authoritative_time AS (
+                SELECT clock_timestamp() AS value
+            )
+            UPDATE eom_terms_invitations
+            SET issued_at = authoritative_time.value - INTERVAL '31 days',
+                expires_at = authoritative_time.value - INTERVAL '1 day'
+            FROM authoritative_time
+            WHERE id = $1
+            """,
+            UUID(expired["invitationId"]),
+        )
+        await dba.execute(
+            """
+            ALTER TABLE eom_terms_invitations
+            ENABLE TRIGGER trg_protect_eom_terms_invitation
+            """
+        )
+        assert await eom_terms_acceptance_schema_ready(pool) is True
+        expired_token = authenticate_eom_terms_token(
+            token=format_eom_terms_token(
+                invitation_id=UUID(expired["invitationId"]),
+                secret=_SECRET,
+            ),
+            secret=_SECRET,
+        )
+        with pytest.raises(EOMTermsAcceptanceNotFoundError):
+            await service.get_session(token=expired_token)
+        with pytest.raises(EOMTermsAcceptanceNotFoundError):
+            await service.accept_and_send(
+                token=expired_token,
+                signer_name="Expired Signer",
+                terms_accepted=True,
+                additional_work_accepted=True,
+                client_ip="192.0.2.23",
+                sender=_RecordingSender(),
+            )
+
+
+def test_migration_is_guard_owned_append_only_and_seeds_no_content() -> None:
+    migration = _ACCEPTANCE_MIGRATION.read_text()
+    assert "database administrator must run 397_eom_terms_acceptance" in migration
+    assert "validate_eom_terms_invitation" in migration
+    assert "validate_eom_terms_acceptance" in migration
+    assert "protect_eom_terms_delivery" in migration
+    assert "BEFORE TRUNCATE ON eom_terms_acceptances" in migration
+    assert "GRANT INSERT (id, invitation_id, signer_name" in migration
+    assert "GRANT UPDATE (status, claimed_at, sent_at" in migration
+    assert "GRANT DELETE" not in migration
+    assert "raw bearer tokens are never stored" in migration
+    assert "INSERT INTO eom_terms_versions" not in migration

--- a/tests/test_eom_terms_acceptance.py
+++ b/tests/test_eom_terms_acceptance.py
@@ -1036,6 +1036,66 @@ async def test_real_postgres_end_to_end_preserves_evidence_and_readiness() -> No
         assert current_readiness["reason"] == "accepted"
         assert current_readiness["acceptedVersionId"] == material_release["versionId"]
 
+        await dba.execute(
+            "UPDATE contacts SET customer_type = 'commercial' WHERE id = $1",
+            _CONTACT_ID,
+        )
+        changed_audience_readiness = await service.get_readiness(contact_id=_CONTACT_ID)
+        assert changed_audience_readiness["ready"] is False
+        assert changed_audience_readiness["reason"] == "audience_changed"
+        assert changed_audience_readiness["audience"] == "commercial"
+        commercial_invitation = await service.issue_and_send(
+            request_key="terms-request-current-version-commercial",
+            contact_id=_CONTACT_ID,
+            locale="en",
+            actor_id=7,
+            actor_name="Juan",
+            public_base_url="https://example.test/onboarding",
+            hmac_secret=_SECRET,
+            sender=_RecordingSender(),
+        )
+        commercial_acceptance = await service.accept_and_send(
+            token=authenticate_eom_terms_token(
+                token=format_eom_terms_token(
+                    invitation_id=UUID(commercial_invitation["invitationId"]),
+                    secret=_SECRET,
+                ),
+                secret=_SECRET,
+            ),
+            signer_name="Commercial Signer",
+            terms_accepted=True,
+            additional_work_accepted=True,
+            client_ip="192.0.2.35",
+            sender=_RecordingSender(),
+        )
+        await dba.execute(
+            """
+            ALTER TABLE eom_terms_acceptances
+            DISABLE TRIGGER trg_protect_eom_terms_acceptance
+            """
+        )
+        await dba.execute(
+            """
+            UPDATE eom_terms_acceptances
+            SET accepted_at = TIMESTAMPTZ '1999-01-01 00:00:00+00'
+            WHERE id = $1
+            """,
+            UUID(commercial_acceptance["acceptanceId"]),
+        )
+        await dba.execute(
+            """
+            ALTER TABLE eom_terms_acceptances
+            ENABLE TRIGGER trg_protect_eom_terms_acceptance
+            """
+        )
+        commercial_readiness = await service.get_readiness(contact_id=_CONTACT_ID)
+        assert commercial_readiness["ready"] is True
+        assert commercial_readiness["reason"] == "accepted"
+        assert commercial_readiness["audience"] == "commercial"
+        assert (
+            commercial_readiness["acceptedVersionId"] == material_release["versionId"]
+        )
+
         with pytest.raises(EOMTermsAcceptanceConflictError):
             await service.revoke(
                 invitation_id=invitation["invitationId"],
@@ -1048,7 +1108,7 @@ async def test_real_postgres_end_to_end_preserves_evidence_and_readiness() -> No
         await dba.execute(
             """
             ALTER TABLE eom_terms_versions
-            DISABLE TRIGGER trg_assign_eom_terms_publication_order
+            DISABLE TRIGGER trg_protect_eom_terms_version
             """
         )
         assert await eom_terms_acceptance_schema_ready(pool) is False
@@ -1056,7 +1116,7 @@ async def test_real_postgres_end_to_end_preserves_evidence_and_readiness() -> No
         await dba.execute(
             """
             ALTER TABLE eom_terms_versions
-            ENABLE TRIGGER trg_assign_eom_terms_publication_order
+            ENABLE TRIGGER trg_protect_eom_terms_version
             """
         )
         assert await eom_terms_acceptance_schema_ready(pool) is True
@@ -1328,14 +1388,15 @@ async def test_real_postgres_serializes_duplicate_and_opposing_operations() -> N
             hmac_secret=_SECRET,
             sender=_RecordingSender(),
         )
-        executed_copy_acceptance = await no_delivery.accept_and_send(
-            token=authenticate_eom_terms_token(
-                token=format_eom_terms_token(
-                    invitation_id=UUID(executed_copy_invitation["invitationId"]),
-                    secret=_SECRET,
-                ),
+        executed_copy_token = authenticate_eom_terms_token(
+            token=format_eom_terms_token(
+                invitation_id=UUID(executed_copy_invitation["invitationId"]),
                 secret=_SECRET,
             ),
+            secret=_SECRET,
+        )
+        executed_copy_acceptance = await no_delivery.accept_and_send(
+            token=executed_copy_token,
             signer_name="Executed Copy Signer",
             terms_accepted=True,
             additional_work_accepted=True,
@@ -1348,16 +1409,22 @@ async def test_real_postgres_serializes_duplicate_and_opposing_operations() -> N
             "executed-copy-after-change@example.com",
         )
         executed_copy_sender = _RecordingSender()
-        with pytest.raises(
-            EOMTermsAcceptanceConflictError,
-            match="customer changed before Terms delivery",
-        ):
-            await service._deliver(
-                delivery_id=UUID(executed_copy_acceptance["deliveryId"]),
-                secret=None,
-                previous_secret=None,
-                sender=executed_copy_sender,
-            )
+        accepted_after_contact_change = await service.accept_and_send(
+            token=executed_copy_token,
+            signer_name="Executed Copy Signer",
+            terms_accepted=True,
+            additional_work_accepted=True,
+            client_ip="192.0.2.34",
+            sender=executed_copy_sender,
+        )
+        assert (
+            accepted_after_contact_change["acceptanceId"]
+            == executed_copy_acceptance["acceptanceId"]
+        )
+        assert accepted_after_contact_change["idempotent"] is True
+        assert accepted_after_contact_change["deliveryError"] is True
+        assert accepted_after_contact_change["deliveryNeedsReconciliation"] is True
+        assert accepted_after_contact_change["executedCopyDeliveryStatus"] == "pending"
         assert executed_copy_sender.calls == []
         assert (
             await dba.fetchval(
@@ -1789,7 +1856,8 @@ def test_migration_is_guard_owned_append_only_and_seeds_no_content() -> None:
     assert "validate_eom_terms_invitation" in migration
     assert "validate_eom_terms_acceptance" in migration
     assert "protect_eom_terms_delivery" in migration
-    assert "assign_eom_terms_publication_order" in migration
+    assert "CREATE OR REPLACE FUNCTION protect_eom_terms_version()" in migration
+    assert "trg_assign_eom_terms_publication_order" not in migration
     assert "ADD COLUMN publication_order BIGINT" in migration
     assert "later.publication_order > invitation_row.publication_order" in migration
     assert "BEFORE TRUNCATE ON eom_terms_acceptances" in migration

--- a/tests/test_eom_terms_acceptance.py
+++ b/tests/test_eom_terms_acceptance.py
@@ -1129,6 +1129,7 @@ async def test_real_postgres_serializes_duplicate_and_opposing_operations() -> N
         contact_expired = uuid4()
         contact_delivery_lock = uuid4()
         contact_changed_before_delivery = uuid4()
+        contact_executed_copy_changed = uuid4()
         contact_replay = uuid4()
         contact_confirmation_failure = uuid4()
         await _seed_customer(dba, contact_id=contact_duplicate)
@@ -1161,6 +1162,11 @@ async def test_real_postgres_serializes_duplicate_and_opposing_operations() -> N
             dba,
             contact_id=contact_changed_before_delivery,
             email="changed-before-delivery@example.com",
+        )
+        await _seed_customer(
+            dba,
+            contact_id=contact_executed_copy_changed,
+            email="executed-copy-before-change@example.com",
         )
         await _seed_customer(
             dba,
@@ -1311,6 +1317,63 @@ async def test_real_postgres_serializes_duplicate_and_opposing_operations() -> N
         }
         assert {result["idempotent"] for result in acceptance_results} == {False, True}
         assert len(receipt_sender.calls) == 1
+
+        executed_copy_invitation = await service.issue_and_send(
+            request_key="terms-request-executed-copy-contact-change",
+            contact_id=contact_executed_copy_changed,
+            locale="en",
+            actor_id=7,
+            actor_name="Juan",
+            public_base_url="https://example.test/onboarding",
+            hmac_secret=_SECRET,
+            sender=_RecordingSender(),
+        )
+        executed_copy_acceptance = await no_delivery.accept_and_send(
+            token=authenticate_eom_terms_token(
+                token=format_eom_terms_token(
+                    invitation_id=UUID(executed_copy_invitation["invitationId"]),
+                    secret=_SECRET,
+                ),
+                secret=_SECRET,
+            ),
+            signer_name="Executed Copy Signer",
+            terms_accepted=True,
+            additional_work_accepted=True,
+            client_ip="192.0.2.34",
+            sender=_RecordingSender(),
+        )
+        await dba.execute(
+            "UPDATE contacts SET email = $2 WHERE id = $1",
+            contact_executed_copy_changed,
+            "executed-copy-after-change@example.com",
+        )
+        executed_copy_sender = _RecordingSender()
+        with pytest.raises(
+            EOMTermsAcceptanceConflictError,
+            match="customer changed before Terms delivery",
+        ):
+            await service._deliver(
+                delivery_id=UUID(executed_copy_acceptance["deliveryId"]),
+                secret=None,
+                previous_secret=None,
+                sender=executed_copy_sender,
+            )
+        assert executed_copy_sender.calls == []
+        assert (
+            await dba.fetchval(
+                "SELECT status FROM eom_terms_deliveries WHERE id = $1",
+                UUID(executed_copy_acceptance["deliveryId"]),
+            )
+            == "pending"
+        )
+        with pytest.raises(
+            asyncpg.PostgresError,
+            match="executed-copy delivery is no longer valid",
+        ):
+            await dba.execute(
+                "UPDATE eom_terms_deliveries SET status = 'sending' WHERE id = $1",
+                UUID(executed_copy_acceptance["deliveryId"]),
+            )
 
         changed_invitation = await no_delivery.issue_and_send(
             request_key="terms-request-contact-changed-before-delivery",

--- a/tests/test_eom_terms_acceptance.py
+++ b/tests/test_eom_terms_acceptance.py
@@ -1096,6 +1096,55 @@ async def test_real_postgres_end_to_end_preserves_evidence_and_readiness() -> No
             commercial_readiness["acceptedVersionId"] == material_release["versionId"]
         )
 
+        non_material_release = await _publish(
+            authority,
+            label="2026.4",
+            material=False,
+            marker="non-material-after-reclassification",
+        )
+        later_commercial_invitation = await service.issue_and_send(
+            request_key="terms-request-later-non-material-commercial",
+            contact_id=_CONTACT_ID,
+            locale="en",
+            actor_id=7,
+            actor_name="Juan",
+            public_base_url="https://example.test/onboarding",
+            hmac_secret=_SECRET,
+            sender=_RecordingSender(),
+        )
+        await service.accept_and_send(
+            token=authenticate_eom_terms_token(
+                token=format_eom_terms_token(
+                    invitation_id=UUID(later_commercial_invitation["invitationId"]),
+                    secret=_SECRET,
+                ),
+                secret=_SECRET,
+            ),
+            signer_name="Later Commercial Signer",
+            terms_accepted=True,
+            additional_work_accepted=True,
+            client_ip="192.0.2.36",
+            sender=_RecordingSender(),
+        )
+        await dba.execute(
+            "UPDATE contacts SET customer_type = 'residential' WHERE id = $1",
+            _CONTACT_ID,
+        )
+        returned_audience_readiness = await service.get_readiness(
+            contact_id=_CONTACT_ID
+        )
+        assert returned_audience_readiness["ready"] is True
+        assert returned_audience_readiness["reason"] == "accepted"
+        assert returned_audience_readiness["audience"] == "residential"
+        assert (
+            returned_audience_readiness["currentVersionId"]
+            == non_material_release["versionId"]
+        )
+        assert (
+            returned_audience_readiness["acceptedVersionId"]
+            == material_release["versionId"]
+        )
+
         with pytest.raises(EOMTermsAcceptanceConflictError):
             await service.revoke(
                 invitation_id=invitation["invitationId"],
@@ -1192,6 +1241,7 @@ async def test_real_postgres_serializes_duplicate_and_opposing_operations() -> N
         contact_executed_copy_changed = uuid4()
         contact_replay = uuid4()
         contact_confirmation_failure = uuid4()
+        contact_acceptance_confirmation_failure = uuid4()
         await _seed_customer(dba, contact_id=contact_duplicate)
         await _seed_customer(
             dba,
@@ -1237,6 +1287,11 @@ async def test_real_postgres_serializes_duplicate_and_opposing_operations() -> N
             dba,
             contact_id=contact_confirmation_failure,
             email="confirmation-failure@example.com",
+        )
+        await _seed_customer(
+            dba,
+            contact_id=contact_acceptance_confirmation_failure,
+            email="acceptance-confirmation-failure@example.com",
         )
         await dba.execute(
             "UPDATE contacts SET status = 'archived' WHERE id = $1",
@@ -1441,6 +1496,101 @@ async def test_real_postgres_serializes_duplicate_and_opposing_operations() -> N
                 "UPDATE eom_terms_deliveries SET status = 'sending' WHERE id = $1",
                 UUID(executed_copy_acceptance["deliveryId"]),
             )
+
+        acceptance_confirmation_invitation = await service.issue_and_send(
+            request_key="terms-request-acceptance-confirmation-failure",
+            contact_id=contact_acceptance_confirmation_failure,
+            locale="en",
+            actor_id=7,
+            actor_name="Juan",
+            public_base_url="https://example.test/onboarding",
+            hmac_secret=_SECRET,
+            sender=_RecordingSender(),
+        )
+        acceptance_confirmation_token = authenticate_eom_terms_token(
+            token=format_eom_terms_token(
+                invitation_id=UUID(acceptance_confirmation_invitation["invitationId"]),
+                secret=_SECRET,
+            ),
+            secret=_SECRET,
+        )
+        pending_acceptance = await no_delivery.accept_and_send(
+            token=acceptance_confirmation_token,
+            signer_name="Confirmation Failure Signer",
+            terms_accepted=True,
+            additional_work_accepted=True,
+            client_ip="192.0.2.37",
+            sender=_RecordingSender(),
+        )
+
+        class _AcceptanceConfirmationFailureService(EOMTermsAcceptanceService):
+            async def _deliver(self, **kwargs: Any) -> tuple[dict[str, Any], bool]:
+                await dba.execute(
+                    """
+                    CREATE FUNCTION test_reject_eom_terms_acceptance_confirmation()
+                    RETURNS TRIGGER
+                    LANGUAGE plpgsql
+                    AS $$
+                    BEGIN
+                        IF OLD.status = 'sending' AND NEW.status = 'sent' THEN
+                            RAISE EXCEPTION
+                                'injected acceptance confirmation failure';
+                        END IF;
+                        RETURN NEW;
+                    END;
+                    $$;
+                    CREATE TRIGGER trg_test_reject_eom_terms_acceptance_confirmation
+                    BEFORE UPDATE ON eom_terms_deliveries
+                    FOR EACH ROW EXECUTE FUNCTION
+                        test_reject_eom_terms_acceptance_confirmation();
+                    """
+                )
+                try:
+                    return await super()._deliver(**kwargs)
+                finally:
+                    await dba.execute(
+                        """
+                        DROP TRIGGER
+                            trg_test_reject_eom_terms_acceptance_confirmation
+                            ON eom_terms_deliveries;
+                        DROP FUNCTION
+                            test_reject_eom_terms_acceptance_confirmation();
+                        """
+                    )
+
+        confirmation_failure_service = _AcceptanceConfirmationFailureService(pool=pool)
+        acceptance_confirmation_sender = _RecordingSender()
+        accepted_after_confirmation_failure = (
+            await confirmation_failure_service.accept_and_send(
+                token=acceptance_confirmation_token,
+                signer_name="Confirmation Failure Signer",
+                terms_accepted=True,
+                additional_work_accepted=True,
+                client_ip="192.0.2.37",
+                sender=acceptance_confirmation_sender,
+            )
+        )
+        assert (
+            accepted_after_confirmation_failure["acceptanceId"]
+            == pending_acceptance["acceptanceId"]
+        )
+        assert accepted_after_confirmation_failure["idempotent"] is True
+        assert accepted_after_confirmation_failure["deliveryError"] is True
+        assert (
+            accepted_after_confirmation_failure["deliveryNeedsReconciliation"] is True
+        )
+        assert (
+            accepted_after_confirmation_failure["executedCopyDeliveryStatus"]
+            == "sending"
+        )
+        assert len(acceptance_confirmation_sender.calls) == 1
+        assert (
+            await dba.fetchval(
+                "SELECT status FROM eom_terms_deliveries WHERE id = $1",
+                UUID(pending_acceptance["deliveryId"]),
+            )
+            == "sending"
+        )
 
         changed_invitation = await no_delivery.issue_and_send(
             request_key="terms-request-contact-changed-before-delivery",

--- a/tests/test_migrations_runner.py
+++ b/tests/test_migrations_runner.py
@@ -1372,6 +1372,7 @@ async def test_generic_run_skips_controlled_dba_migration_until_explicitly_selec
         "393_eom_missed_call_recovery_runtime_privileges",
         "394_eom_first_clean_completion_receipts",
         "396_eom_terms_authority",
+        "397_eom_terms_acceptance",
     }
     controlled_sources = {
         controlled_name: f"SELECT '{controlled_name}'"
@@ -1391,7 +1392,7 @@ async def test_generic_run_skips_controlled_dba_migration_until_explicitly_selec
         name not in CONTROLLED_DBA_MIGRATION_NAMES
         for _version, name, _digest in pool.records
     )
-    assert "Skipping 3 controlled DBA migration(s)" in caplog.text
+    assert "Skipping 4 controlled DBA migration(s)" in caplog.text
 
     for controlled_name in sorted(CONTROLLED_DBA_MIGRATION_NAMES):
         await run_migrations(


### PR DESCRIPTION
Plan: plans/PR-EOM-Terms-Acceptance.md
Slice phase: Vertical slice
Ownership lane: eom-onboarding-terms

Atlas can publish immutable bilingual EOM Terms, but current main has no customer-bound invitation, authenticated acceptance, immutable acceptance evidence, executed-copy delivery, or material-version readiness decision. This provider slice adds that closed path without changing Terms prose, customer classification, profile onboarding, payment behavior, Tracker, or Website.

Diff-budget override: the invitation, authenticated acceptance, immutable evidence, idempotent delivery, guarded schema, and reachable API proof are one legal-evidence path; splitting them would land either floating storage or a customer acceptance route without protected evidence.

## Intentional
- Reuse the existing public-onboarding HTTPS base URL and current/previous HMAC keys while keeping a separate Terms token domain and separate durable lifecycle.
- Derive audience, customer name, recipient email, current published version, and timestamps inside Atlas/PostgreSQL; callers provide only request key, contact, locale, acknowledgements, signer, and the authenticated Tracker-forwarded client IP.
- Commit immutable acceptance and a pending executed-copy payload before attempting external delivery; durably commit `sending` before transport, revalidate under publication/invitation/delivery/contact locks, and leave every uncertain sender or confirmation outcome for reconciliation without another provider attempt.
- Compare later material releases by a guard-owned monotonic publication order assigned inside the existing protected-version trigger rather than wall-clock timestamps, without changing the publish/current-selection API or predecessor five-trigger authority boundary.
- Require migration 396 before the separately controlled migration 397, and retain every legal/delivery row on application rollback.

## AI reconciliation

- Lock invitation state before claiming delivery fixed-in: `atlas_brain/services/eom_terms_acceptance.py` now acquires the publication lock and invitation row lock before claim and retains them through transport confirmation; `tests/test_eom_terms_acceptance.py` proves revocation waits until the bounded send outcome.
- Use a monotonic publication order for material releases fixed-in: `atlas_brain/storage/migrations/397_eom_terms_acceptance.sql` assigns guarded release order and `atlas_brain/services/eom_terms_acceptance.py` uses it for every later-material decision; `tests/test_eom_terms_acceptance.py` proves concurrent order and backward-clock behavior.
- Admit provider-confirmed idempotent replays fixed-in: `atlas_brain/storage/migrations/397_eom_terms_acceptance.sql` admits a null message id only with explicit replay truth and `tests/test_eom_terms_acceptance.py` proves both the accepted and rejected evidence shapes.
- Keep uncertain sends out of pending after the dedupe window fixed-in: `atlas_brain/services/eom_terms_acceptance.py` commits `sending` before the external call, keeps that claim after confirmation failure, and refuses every later provider retry; `tests/test_eom_terms_acceptance.py` forces PostgreSQL confirmation failure and proves the durable state and zero-call retry.
- Hold the canonical contact lock through invitation delivery fixed-in: `atlas_brain/services/eom_terms_acceptance.py` revalidates the active EOM customer identity and holds the contact lock through the provider outcome; `tests/test_eom_terms_acceptance.py` proves a pre-send email change prevents transport and a concurrent update waits during transport.
- Order readiness evidence by publication sequence fixed-in: `atlas_brain/services/eom_terms_acceptance.py` orders acceptances by `publication_order` before wall-clock acceptance time; `tests/test_eom_terms_acceptance.py` proves a current-version acceptance remains authoritative after its timestamp is forced behind an older acceptance.
- Reject line controls in receipt identity fields fixed-in: `atlas_brain/services/eom_terms_acceptance.py` rejects non-printable controls at the shared customer, signer, and actor text boundary; `tests/test_eom_terms_acceptance.py` covers LF, CR, tab, and Unicode line separator before database use.
- Revalidate contacts for executed-copy delivery fixed-in: `atlas_brain/services/eom_terms_acceptance.py` applies the locked canonical-contact comparison before both delivery kinds and `atlas_brain/storage/migrations/397_eom_terms_acceptance.sql` rejects a direct stale executed-copy claim; `tests/test_eom_terms_acceptance.py` proves contact drift after acceptance leaves the receipt pending and makes no provider call.
- Return the committed acceptance when receipt delivery is rejected fixed-in: `atlas_brain/services/eom_terms_acceptance.py` returns the immutable acceptance with pending/error reconciliation state after a post-commit delivery rejection; `tests/test_eom_terms_acceptance.py` proves the replay remains accepted and makes no provider call after contact drift.
- Preserve the previous release across migration 397 fixed-in: `atlas_brain/storage/migrations/397_eom_terms_acceptance.sql` assigns publication order inside the existing protected-version trigger instead of adding a sixth trigger; `tests/test_eom_terms_acceptance.py` proves the unchanged five-trigger authority attestor remains ready for rolling deploy and application rollback.
- Remove wall-clock ordering between same-version acceptances fixed-in: `atlas_brain/services/eom_terms_acceptance.py` orders same-version evidence by canonical current-audience match rather than acceptance time; `tests/test_eom_terms_acceptance.py` proves a clock-older commercial acceptance wins after reclassification.
- Preserve acceptance across every delivery failure fixed-in: `atlas_brain/services/eom_terms_acceptance.py` catches every delivery-domain exception after acceptance commit and best-effort refreshes the persisted delivery status; `tests/test_eom_terms_acceptance.py` injects confirmation failure and proves the endpoint returns the committed acceptance with `sending` reconciliation evidence.
- Prefer current-audience evidence before publication order fixed-in: `atlas_brain/services/eom_terms_acceptance.py` chooses applicable current-audience acceptance before release sequence; `tests/test_eom_terms_acceptance.py` proves a valid residential acceptance remains ready across a later non-material commercial acceptance after reclassification back to residential.

All findings fixed or waived: yes

## Fix-loop disposition preflight

- Root decision: Lock invitation state before claiming delivery
- Source trace: invitation usability read -> conditional delivery claim -> external sender
- Upstream files: `atlas_brain/services/eom_terms_acceptance.py`, `atlas_brain/storage/migrations/397_eom_terms_acceptance.sql`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `.agent/capabilities.yaml`, `.agent/runbooks/database.md`, `.github/workflows/atlas_eom_lead_pipeline_checks.yml`, `atlas_brain/eom_api/funnel.py`, `atlas_brain/main_eom.py`, `atlas_brain/services/eom_terms_acceptance.py`, `atlas_brain/services/eom_terms_authority.py`, `atlas_brain/storage/migrations/397_eom_terms_acceptance.sql`, `atlas_brain/storage/migrations/__init__.py`, `ops`, `plans/PR-EOM-Terms-Acceptance.md`, `scripts/apply_eom_first_clean_completion_schema.py`, `scripts/apply_eom_terms_acceptance_schema.py`, `tests/test_agent_operations_contract.py`, `tests/test_eom_first_clean_completion_dba_runner.py`, `tests/test_eom_terms_acceptance.py`, `tests/test_migrations_runner.py`
- Max files: 18
- Parked hardening: none

- Root decision: Use a monotonic publication order for material releases
- Source trace: wall-clock release comparison -> stale invitation admission -> false Terms readiness
- Upstream files: `atlas_brain/storage/migrations/397_eom_terms_acceptance.sql`, `atlas_brain/services/eom_terms_authority.py`, `atlas_brain/services/eom_terms_acceptance.py`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `.agent/capabilities.yaml`, `.agent/runbooks/database.md`, `.github/workflows/atlas_eom_lead_pipeline_checks.yml`, `atlas_brain/eom_api/funnel.py`, `atlas_brain/main_eom.py`, `atlas_brain/services/eom_terms_acceptance.py`, `atlas_brain/services/eom_terms_authority.py`, `atlas_brain/storage/migrations/397_eom_terms_acceptance.sql`, `atlas_brain/storage/migrations/__init__.py`, `ops`, `plans/PR-EOM-Terms-Acceptance.md`, `scripts/apply_eom_first_clean_completion_schema.py`, `scripts/apply_eom_terms_acceptance_schema.py`, `tests/test_agent_operations_contract.py`, `tests/test_eom_first_clean_completion_dba_runner.py`, `tests/test_eom_terms_acceptance.py`, `tests/test_migrations_runner.py`
- Max files: 18
- Parked hardening: none

- Root decision: Admit provider-confirmed idempotent replays
- Source trace: Resend conflict replay result -> delivery sent transition -> guarded evidence constraint
- Upstream files: `atlas_brain/storage/migrations/397_eom_terms_acceptance.sql`, `atlas_brain/services/eom_terms_acceptance.py`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `.agent/capabilities.yaml`, `.agent/runbooks/database.md`, `.github/workflows/atlas_eom_lead_pipeline_checks.yml`, `atlas_brain/eom_api/funnel.py`, `atlas_brain/main_eom.py`, `atlas_brain/services/eom_terms_acceptance.py`, `atlas_brain/services/eom_terms_authority.py`, `atlas_brain/storage/migrations/397_eom_terms_acceptance.sql`, `atlas_brain/storage/migrations/__init__.py`, `ops`, `plans/PR-EOM-Terms-Acceptance.md`, `scripts/apply_eom_first_clean_completion_schema.py`, `scripts/apply_eom_terms_acceptance_schema.py`, `tests/test_agent_operations_contract.py`, `tests/test_eom_first_clean_completion_dba_runner.py`, `tests/test_eom_terms_acceptance.py`, `tests/test_migrations_runner.py`
- Max files: 18
- Parked hardening: none

- Root decision: Keep uncertain sends out of pending after the dedupe window
- Source trace: durable delivery claim -> external provider acceptance -> database confirmation failure -> later invocation
- Upstream files: `atlas_brain/services/eom_terms_acceptance.py`, `atlas_brain/storage/migrations/397_eom_terms_acceptance.sql`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `.agent/capabilities.yaml`, `.agent/runbooks/database.md`, `.github/workflows/atlas_eom_lead_pipeline_checks.yml`, `atlas_brain/eom_api/funnel.py`, `atlas_brain/main_eom.py`, `atlas_brain/services/eom_terms_acceptance.py`, `atlas_brain/services/eom_terms_authority.py`, `atlas_brain/storage/migrations/397_eom_terms_acceptance.sql`, `atlas_brain/storage/migrations/__init__.py`, `ops`, `plans/PR-EOM-Terms-Acceptance.md`, `scripts/apply_eom_first_clean_completion_schema.py`, `scripts/apply_eom_terms_acceptance_schema.py`, `tests/test_agent_operations_contract.py`, `tests/test_eom_first_clean_completion_dba_runner.py`, `tests/test_eom_terms_acceptance.py`, `tests/test_migrations_runner.py`
- Max files: 18
- Parked hardening: none

- Root decision: Hold the canonical contact lock through invitation delivery
- Source trace: persisted invitation identity -> canonical contact revalidation -> contact row lock -> external sender
- Upstream files: `atlas_brain/services/eom_terms_acceptance.py`, `atlas_brain/storage/migrations/397_eom_terms_acceptance.sql`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `.agent/capabilities.yaml`, `.agent/runbooks/database.md`, `.github/workflows/atlas_eom_lead_pipeline_checks.yml`, `atlas_brain/eom_api/funnel.py`, `atlas_brain/main_eom.py`, `atlas_brain/services/eom_terms_acceptance.py`, `atlas_brain/services/eom_terms_authority.py`, `atlas_brain/storage/migrations/397_eom_terms_acceptance.sql`, `atlas_brain/storage/migrations/__init__.py`, `ops`, `plans/PR-EOM-Terms-Acceptance.md`, `scripts/apply_eom_first_clean_completion_schema.py`, `scripts/apply_eom_terms_acceptance_schema.py`, `tests/test_agent_operations_contract.py`, `tests/test_eom_first_clean_completion_dba_runner.py`, `tests/test_eom_terms_acceptance.py`, `tests/test_migrations_runner.py`
- Max files: 18
- Parked hardening: none

- Root decision: Order readiness evidence by publication sequence
- Source trace: multiple acceptance records -> readiness selection -> current-version decision
- Upstream files: `atlas_brain/services/eom_terms_acceptance.py`, `tests/test_eom_terms_acceptance.py`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `.agent/capabilities.yaml`, `.agent/runbooks/database.md`, `.github/workflows/atlas_eom_lead_pipeline_checks.yml`, `atlas_brain/eom_api/funnel.py`, `atlas_brain/main_eom.py`, `atlas_brain/services/eom_terms_acceptance.py`, `atlas_brain/services/eom_terms_authority.py`, `atlas_brain/storage/migrations/397_eom_terms_acceptance.sql`, `atlas_brain/storage/migrations/__init__.py`, `ops`, `plans/PR-EOM-Terms-Acceptance.md`, `scripts/apply_eom_first_clean_completion_schema.py`, `scripts/apply_eom_terms_acceptance_schema.py`, `tests/test_agent_operations_contract.py`, `tests/test_eom_first_clean_completion_dba_runner.py`, `tests/test_eom_terms_acceptance.py`, `tests/test_migrations_runner.py`
- Max files: 18
- Parked hardening: none

- Root decision: Reject line controls in receipt identity fields
- Source trace: customer/signer/actor input -> shared text normalizer -> persisted and rendered legal receipt identity
- Upstream files: `atlas_brain/services/eom_terms_acceptance.py`, `tests/test_eom_terms_acceptance.py`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `.agent/capabilities.yaml`, `.agent/runbooks/database.md`, `.github/workflows/atlas_eom_lead_pipeline_checks.yml`, `atlas_brain/eom_api/funnel.py`, `atlas_brain/main_eom.py`, `atlas_brain/services/eom_terms_acceptance.py`, `atlas_brain/services/eom_terms_authority.py`, `atlas_brain/storage/migrations/397_eom_terms_acceptance.sql`, `atlas_brain/storage/migrations/__init__.py`, `ops`, `plans/PR-EOM-Terms-Acceptance.md`, `scripts/apply_eom_first_clean_completion_schema.py`, `scripts/apply_eom_terms_acceptance_schema.py`, `tests/test_agent_operations_contract.py`, `tests/test_eom_first_clean_completion_dba_runner.py`, `tests/test_eom_terms_acceptance.py`, `tests/test_migrations_runner.py`
- Max files: 18
- Parked hardening: none

- Root decision: Revalidate contacts for executed-copy delivery
- Source trace: accepted executed-copy payload -> canonical contact drift -> delivery claim -> stale receipt recipient
- Upstream files: `atlas_brain/services/eom_terms_acceptance.py`, `atlas_brain/storage/migrations/397_eom_terms_acceptance.sql`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `.agent/capabilities.yaml`, `.agent/runbooks/database.md`, `.github/workflows/atlas_eom_lead_pipeline_checks.yml`, `atlas_brain/eom_api/funnel.py`, `atlas_brain/main_eom.py`, `atlas_brain/services/eom_terms_acceptance.py`, `atlas_brain/services/eom_terms_authority.py`, `atlas_brain/storage/migrations/397_eom_terms_acceptance.sql`, `atlas_brain/storage/migrations/__init__.py`, `ops`, `plans/PR-EOM-Terms-Acceptance.md`, `scripts/apply_eom_first_clean_completion_schema.py`, `scripts/apply_eom_terms_acceptance_schema.py`, `tests/test_agent_operations_contract.py`, `tests/test_eom_first_clean_completion_dba_runner.py`, `tests/test_eom_terms_acceptance.py`, `tests/test_migrations_runner.py`
- Max files: 18
- Parked hardening: none

- Root decision: Return the committed acceptance when receipt delivery is rejected
- Source trace: committed acceptance -> executed-copy contact drift -> delivery attempt -> customer response
- Upstream files: `atlas_brain/services/eom_terms_acceptance.py`, `tests/test_eom_terms_acceptance.py`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `.agent/capabilities.yaml`, `.agent/runbooks/database.md`, `.github/workflows/atlas_eom_lead_pipeline_checks.yml`, `atlas_brain/eom_api/funnel.py`, `atlas_brain/main_eom.py`, `atlas_brain/services/eom_terms_acceptance.py`, `atlas_brain/services/eom_terms_authority.py`, `atlas_brain/storage/migrations/397_eom_terms_acceptance.sql`, `atlas_brain/storage/migrations/__init__.py`, `ops`, `plans/PR-EOM-Terms-Acceptance.md`, `scripts/apply_eom_first_clean_completion_schema.py`, `scripts/apply_eom_terms_acceptance_schema.py`, `tests/test_agent_operations_contract.py`, `tests/test_eom_first_clean_completion_dba_runner.py`, `tests/test_eom_terms_acceptance.py`, `tests/test_migrations_runner.py`
- Max files: 18
- Parked hardening: none

- Root decision: Preserve the previous release across migration 397
- Source trace: migration trigger inventory -> predecessor schema attestor -> rolling deploy and rollback
- Upstream files: `atlas_brain/storage/migrations/397_eom_terms_acceptance.sql`, `atlas_brain/services/eom_terms_authority.py`, `atlas_brain/services/eom_terms_acceptance.py`, `tests/test_eom_terms_acceptance.py`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `.agent/capabilities.yaml`, `.agent/runbooks/database.md`, `.github/workflows/atlas_eom_lead_pipeline_checks.yml`, `atlas_brain/eom_api/funnel.py`, `atlas_brain/main_eom.py`, `atlas_brain/services/eom_terms_acceptance.py`, `atlas_brain/services/eom_terms_authority.py`, `atlas_brain/storage/migrations/397_eom_terms_acceptance.sql`, `atlas_brain/storage/migrations/__init__.py`, `ops`, `plans/PR-EOM-Terms-Acceptance.md`, `scripts/apply_eom_first_clean_completion_schema.py`, `scripts/apply_eom_terms_acceptance_schema.py`, `tests/test_agent_operations_contract.py`, `tests/test_eom_first_clean_completion_dba_runner.py`, `tests/test_eom_terms_acceptance.py`, `tests/test_migrations_runner.py`
- Max files: 18
- Parked hardening: none

- Root decision: Remove wall-clock ordering between same-version acceptances
- Source trace: same-version cross-audience acceptances -> readiness selection -> canonical current audience
- Upstream files: `atlas_brain/services/eom_terms_acceptance.py`, `tests/test_eom_terms_acceptance.py`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `.agent/capabilities.yaml`, `.agent/runbooks/database.md`, `.github/workflows/atlas_eom_lead_pipeline_checks.yml`, `atlas_brain/eom_api/funnel.py`, `atlas_brain/main_eom.py`, `atlas_brain/services/eom_terms_acceptance.py`, `atlas_brain/services/eom_terms_authority.py`, `atlas_brain/storage/migrations/397_eom_terms_acceptance.sql`, `atlas_brain/storage/migrations/__init__.py`, `ops`, `plans/PR-EOM-Terms-Acceptance.md`, `scripts/apply_eom_first_clean_completion_schema.py`, `scripts/apply_eom_terms_acceptance_schema.py`, `tests/test_agent_operations_contract.py`, `tests/test_eom_first_clean_completion_dba_runner.py`, `tests/test_eom_terms_acceptance.py`, `tests/test_migrations_runner.py`
- Max files: 18
- Parked hardening: none

- Root decision: Preserve acceptance across every delivery failure
- Source trace: committed acceptance -> delivery-domain failure -> persisted delivery state -> public acceptance response
- Upstream files: `atlas_brain/services/eom_terms_acceptance.py`, `tests/test_eom_terms_acceptance.py`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `.agent/capabilities.yaml`, `.agent/runbooks/database.md`, `.github/workflows/atlas_eom_lead_pipeline_checks.yml`, `atlas_brain/eom_api/funnel.py`, `atlas_brain/main_eom.py`, `atlas_brain/services/eom_terms_acceptance.py`, `atlas_brain/services/eom_terms_authority.py`, `atlas_brain/storage/migrations/397_eom_terms_acceptance.sql`, `atlas_brain/storage/migrations/__init__.py`, `ops`, `plans/PR-EOM-Terms-Acceptance.md`, `scripts/apply_eom_first_clean_completion_schema.py`, `scripts/apply_eom_terms_acceptance_schema.py`, `tests/test_agent_operations_contract.py`, `tests/test_eom_first_clean_completion_dba_runner.py`, `tests/test_eom_terms_acceptance.py`, `tests/test_migrations_runner.py`
- Max files: 18
- Parked hardening: none

- Root decision: Prefer current-audience evidence before publication order
- Source trace: cross-version acceptances -> canonical current audience -> non-material release validity -> readiness result
- Upstream files: `atlas_brain/services/eom_terms_acceptance.py`, `tests/test_eom_terms_acceptance.py`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `.agent/capabilities.yaml`, `.agent/runbooks/database.md`, `.github/workflows/atlas_eom_lead_pipeline_checks.yml`, `atlas_brain/eom_api/funnel.py`, `atlas_brain/main_eom.py`, `atlas_brain/services/eom_terms_acceptance.py`, `atlas_brain/services/eom_terms_authority.py`, `atlas_brain/storage/migrations/397_eom_terms_acceptance.sql`, `atlas_brain/storage/migrations/__init__.py`, `ops`, `plans/PR-EOM-Terms-Acceptance.md`, `scripts/apply_eom_first_clean_completion_schema.py`, `scripts/apply_eom_terms_acceptance_schema.py`, `tests/test_agent_operations_contract.py`, `tests/test_eom_first_clean_completion_dba_runner.py`, `tests/test_eom_terms_acceptance.py`, `tests/test_migrations_runner.py`
- Max files: 18
- Parked hardening: none

## Deferred
- Tracker proxy and capability contract for invitation, session, acceptance, readiness, revocation, and delivery reconciliation.
- Website Onboarding tab, bilingual public acceptance page, admin readiness/reconciliation UI, and operator-published refined bilingual Terms.
- Structured one-time/recurring service plan, first-clean payment allocation, and residential card-vault onboarding in issue #2156.

## Parked hardening
- None.

## Cold diff reconstruction
- Gaps first: none found. The review repair changes declared files only; every edit traces to one of the thirteen confirmed root decisions, all thirteen decisions have service/database/test proof, and no forbidden module moved.
- `atlas_brain/services/eom_terms_acceptance.py:192` rejects non-printable receipt identity text. Its delivery guard at `:1025` applies the contact match to both delivery kinds, `:1677` preserves the committed acceptance across every delivery-domain exception and refreshes persisted status, and readiness at `:1914` prefers current-audience applicability before publication order; the response projection at `:823` makes reconciliation explicit.
- `atlas_brain/storage/migrations/397_eom_terms_acceptance.sql:265` extends the existing protected-version function to assign monotonic order under the publication lock without adding a sixth trigger. The direct guards at `:605`, `:669`, and `:821` still block invalid reconciliation transitions and stale executed-copy delivery.
- `atlas_brain/services/eom_terms_authority.py:208` retains the predecessor-ready authority attestor, including its exact five-trigger count at `:355`; its publisher at `:862` retains the same API and publication lock while the existing database trigger supplies internal order.
- `tests/test_eom_terms_acceptance.py:1039` proves both no-match rejection and clock-independent same-version audience selection; `:1099` proves a valid current-audience acceptance survives a later non-material release for another audience; `:1500` injects post-commit confirmation failure and proves the accepted response reports persisted `sending`; the migration test rejects reintroduction of the sixth publication-order trigger.
- The original invitation, acceptance, route, migration-runner, and capability surfaces remain as previously reconstructed. The full branch inventory still contains no Tracker, Website, calendar, billing, payment, Stripe, card-vault, customer-handoff, profile-token, onboarding-draft, candidate, or first-clean-receipt implementation change.

## Verification
- Focused live-database acceptance, authority, and controlled migration-runner suites: `207 passed`.
- Targeted Ruff check, Ruff format check, Python compile, plan sync check, and `git diff --check` passed after the review fixes.
- Hosted EOM pipeline and Unit Gate will rerun on the pushed repair head.

## Mechanical verification
- Command: python -m pytest tests/test_eom_terms_acceptance.py tests/test_eom_terms_authority.py tests/test_migrations_runner.py tests/test_eom_first_clean_completion_dba_runner.py -q - Result: 207 passed - Environment: local
- Command: ruff check plus ruff format --check on the changed Python paths - Result: passed - Environment: local
- Command: python compileall, audit_plan_code_consistency.py, and git diff --check - Result: passed - Environment: local
- Skipped: GitHub-only Unit Gate - Reason: hosted gate runs after PR creation

## Diff size
17 files, +6167 / -12

<!-- atlas-open-pr-wrapper: v1 -->
