### PR TITLE
Accept trusted severity-less colon review labels

### DIFF
--- a/plans/PR-Live-Reconciliation-Severityless-Colon.md
+++ b/plans/PR-Live-Reconciliation-Severityless-Colon.md
@@ -46,11 +46,15 @@ behavioral surface.
   complete-label grammar must validate the line. Leading Unicode punctuation
   does not turn that ambiguous evidence into a title; genuinely embedded bare
   references after title text remain ordinary content.
-- Canonical identity rule: complete rule IDs use ASCII digits only. The broader
-  potential-evidence recognizer still detects Unicode-decimal lookalikes, but
-  they cannot satisfy the complete grammar. A complete-looking label whose rule
-  token is wrapped in leading punctuation is likewise not canonical line-start
-  evidence and cannot become a title.
+- Canonical identity rule: complete rule IDs come from the repository's defined
+  reviewer-rule set in `docs/REVIEWER_RULES.md` (currently `R1` through `R14`),
+  without zero padding. The checker derives its complete-reference grammar from
+  one explicit identity tuple, and a test keeps that tuple synchronized with the
+  rule headings. The broader potential-evidence recognizer still detects
+  ASCII out-of-set values and Unicode-decimal lookalikes, but they cannot satisfy
+  the complete grammar. A complete-looking label whose rule token is wrapped in
+  leading punctuation is likewise not canonical line-start evidence and cannot
+  become a title.
 
 ### Problem-derived contract
 
@@ -72,11 +76,12 @@ behavioral surface.
   immediate suffixes as an open non-whitespace category and evidence-gate them
   with the complete-label grammar; require a leading rule reference with any
   nonblank whitespace continuation to pass that same grammar; preserve
-  existing dash and severity-qualified forms; restrict complete rule references
-  to ASCII digits while retaining broad Unicode-decimal malformed detection;
-  and prove incomplete, malformed, Unicode-suffixed, punctuation-wrapped,
-  unknown-leading-continuation, short-title, label-only, and unrelated inputs
-  still fail closed.
+  existing dash and severity-qualified forms; derive complete rule references
+  from the defined reviewer-rule identities while retaining broad numeric
+  malformed detection; prove the derived identity tuple agrees with the
+  reviewer-rule headings; and prove zero, zero-padded, out-of-range,
+  Unicode-suffixed, punctuation-wrapped, unknown-leading-continuation,
+  short-title, label-only, and unrelated inputs still fail closed.
 - Must not change: trusted bot identities, GitHub workflow triggers, open-thread
   blocking, current-head review freshness, PR-body disposition matching,
   docs-only handling, Terms capability code, Tracker code, or any customer,
@@ -123,11 +128,15 @@ Max files: 3
     grammar result, and embedded bare references remain title text. Settled by
     the leading-continuation end-to-end negative and generated Unicode
     continuation oracle.
-  - Only ASCII-decimal rule IDs are complete evidence. Every non-ASCII Unicode
-    decimal used as a whole or mixed rule ID remains malformed, and a colon
-    label after leading punctuation remains a no-decision line even when the
-    embedded token otherwise matches. Settled by the all-Unicode suffix oracle
-    and punctuation-wrapped colon end-to-end negative.
+  - Only reviewer-rule IDs defined by `docs/REVIEWER_RULES.md` are complete
+    evidence. `R1`, `R14`, and defined chains remain accepted; zero,
+    zero-padded, and out-of-range ASCII IDs plus every non-ASCII Unicode decimal
+    used as a whole or mixed rule ID remain malformed across colon, dash, and
+    severity label forms. A colon label after
+    leading punctuation likewise remains a no-decision line even when the
+    embedded token otherwise matches. Settled by the rule-registry synchronization
+    assertion, defined-edge positives, generated ASCII outside-set negatives,
+    all-Unicode suffix oracle, and punctuation-wrapped colon end-to-end negative.
   - Bounded prefixes before rule-like colon text do not collapse distinct
     adjacent titles into one decision; settled by
     `test_adjacent_rule_evidence_keeps_bounded_prefix_titles_distinct`, including
@@ -177,9 +186,9 @@ Max files: 3
   the complete grammar; every unmatched form retains the empty-decision
   fail-closed result.
 - Guard-relevant fields: bounded title length/token floor, exact chained rule
-  reference with ASCII digits, broader Unicode-decimal potential reference,
-  atomic longest-reference matching, Unicode non-alphanumeric token boundary,
-  leading punctuation, the open immediate non-whitespace suffix category, optional
+  reference from the defined `R1`-`R14` identity set, broader numeric potential
+  reference, atomic longest-reference matching, Unicode non-alphanumeric token
+  boundary, leading punctuation, the open immediate non-whitespace suffix category, optional
   delimiter whitespace, first-lexical-token continuation state, colon/slash
   delimiter, and required nonempty detail token.
 - Caller x input shape: resolved trusted-bot history with the observed complete
@@ -198,7 +207,9 @@ Max files: 3
   rejected suffixes or boundary punctuation. It also treats every nonblank
   whitespace continuation after a leading rule reference as potential evidence;
   this finite structural position distinguishes it from embedded bare mentions.
-- Canonical complete references are ASCII-only. Unicode-decimal candidates are
+- Canonical complete references are derived from the explicit reviewer-rule
+  identity tuple, which is synchronized by test with `docs/REVIEWER_RULES.md`.
+  Zero, zero-padded, out-of-range ASCII, and Unicode-decimal candidates are
   deliberately part of the broader potential-reference recognizer so they are
   rejected by evidence validation rather than ignored as ordinary title text.
 - This slice adds one finite delimiter member: exact rule reference + colon +
@@ -238,7 +249,9 @@ immediate non-whitespace continuation and every whitespace-separated rule-label
 operator as potential evidence. If a rule reference is the first lexical token,
 any nonblank whitespace continuation also requires complete-grammar validation.
 The leading-token check rejects any punctuation wrapper, and the complete
-grammar uses ASCII digits while the potential recognizer remains Unicode-wide.
+grammar is generated from the defined reviewer-rule identity tuple while the
+potential recognizer remains Unicode-wide. A synchronization test makes rule-doc
+growth fail visibly until that tuple and its admission proof are updated.
 The established bounded-title floor and root matching remain downstream
 invariants, so recognizing the delimiter does not make arbitrary or short prose
 authoritative.
@@ -267,7 +280,7 @@ Parked hardening: none.
 ## Verification
 
 - `python -m pytest tests/test_check_ai_reconciliation_live.py -q` ->
-  `97 passed in 4.58s` after the structural decision-seam repair.
+  `99 passed in 4.47s` after the defined-identity repair.
 - `/home/juan-canfield/miniconda3/bin/ruff check scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py`
   -> `All checks passed!`.
 - `/home/juan-canfield/Desktop/Atlas/.venv/bin/python -m py_compile scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py`
@@ -291,7 +304,7 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Live-Reconciliation-Severityless-Colon.md` | 297 |
-| `scripts/check_ai_reconciliation_live.py` | 61 |
-| `tests/test_check_ai_reconciliation_live.py` | 416 |
-| **Total** | **774** |
+| `plans/PR-Live-Reconciliation-Severityless-Colon.md` | 310 |
+| `scripts/check_ai_reconciliation_live.py` | 65 |
+| `tests/test_check_ai_reconciliation_live.py` | 482 |
+| **Total** | **857** |

--- a/plans/PR-Live-Reconciliation-Severityless-Colon.md
+++ b/plans/PR-Live-Reconciliation-Severityless-Colon.md
@@ -82,7 +82,10 @@ behavioral surface.
   potential-reference regex also relies on Python `\d`, which covers Unicode
   decimal digits but misses non-decimal numeric classes such as superscripts,
   fractions, circled numbers, and Roman numerals; those malformed identities can
-  therefore be promoted as adjacent titles.
+  therefore be promoted as adjacent titles. Finally, source-order validation
+  currently scans an entire line for malformed evidence before honoring its
+  first complete legacy inline label, so rule-like prose in the already-bounded
+  detail can erase an otherwise valid inline root.
 - Correct fix must touch/change: extend the line-start complete-label grammar
   to admit `R<n>(/R<n>)*: nonempty detail`; prove adjacent positive correlation
   while keeping the severity-less inline form fail closed; scan candidates in
@@ -111,7 +114,11 @@ behavioral surface.
   titles. Route every non-ASCII `str.isnumeric()` character immediately after a
   lexical-boundary `R`/`r` through the fail-closed evidence path, with an
   all-code-point oracle and representative end-to-end negatives; preserve
-  alphanumeric-embedded title text and canonical ASCII rule IDs.
+  alphanumeric-embedded title text and canonical ASCII rule IDs. Treat the first
+  complete legacy inline label as an evidence boundary: validate potential
+  evidence only in the title prefix before that boundary, preserve the bounded
+  root when later detail contains rule-like prose, and continue to reject
+  malformed evidence before the boundary.
 - Must not change: trusted bot identities, GitHub workflow triggers, open-thread
   blocking, current-head review freshness, structured disposition extraction,
   title normalization, pairwise bounded-containment compatibility outside the
@@ -206,6 +213,10 @@ Max files: 3
     forms an otherwise valid adjacent title/evidence pair; settled by
     `test_earlier_inline_rule_evidence_precedes_later_adjacent_pairs`, including
     a negative assertion that the later prose cannot clear reconciliation.
+  - A complete legacy inline label terminates title validation: malformed-looking
+    rule text in its following detail does not erase the bounded title, while the
+    same malformed text before the complete label remains terminal. Settled by
+    direct parser and end-to-end disposition assertions for both orderings.
   - `R2/R14:` with empty detail, `R2/R14   : detail` with pre-colon
     whitespace, `R2/R14foo: detail`, a short title, and text with no adjacent
     complete rule label yield no decision; settled by negative unit assertions.
@@ -385,7 +396,7 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Live-Reconciliation-Severityless-Colon.md` | 391 |
-| `scripts/check_ai_reconciliation_live.py` | 128 |
-| `tests/test_check_ai_reconciliation_live.py` | 651 |
-| **Total** | **1170** |
+| `plans/PR-Live-Reconciliation-Severityless-Colon.md` | 402 |
+| `scripts/check_ai_reconciliation_live.py` | 137 |
+| `tests/test_check_ai_reconciliation_live.py` | 687 |
+| **Total** | **1226** |

--- a/plans/PR-Live-Reconciliation-Severityless-Colon.md
+++ b/plans/PR-Live-Reconciliation-Severityless-Colon.md
@@ -33,6 +33,14 @@ behavioral surface.
   adjacent pair. Ambiguity fails closed because a false rejection leaves the
   required check visibly red, while a false acceptance can clear unreconciled
   reviewer evidence.
+- Evidence ordering and lexical boundary: an existing severity/dash inline
+  label is direct evidence on the current line and must win before a following
+  label is considered. The new severity-less colon form is admitted only as a
+  line-start adjacent label because inline `R<n>: text` is indistinguishable
+  from rule-like title prose. Potential evidence starts at line start or after
+  any Unicode non-alphanumeric boundary; alphanumeric-embedded text remains an
+  ordinary word. Ambiguous severity-less inline input takes the fail-closed
+  path.
 
 ### Problem-derived contract
 
@@ -41,12 +49,14 @@ behavioral surface.
   admission also inferred validity from an enumerated malformed-suffix
   denylist. The producer form was therefore unparseable, and later repairs
   could still admit an unenumerated incomplete suffix.
-- Correct fix must touch/change: extend only the shared complete-label grammar
-  to admit `R<n>(/R<n>)*: nonempty detail`; prove multiline and inline positive
-  correlation; scan candidates in source order so inline evidence on an earlier
-  line keeps precedence, while a complete adjacent evidence line preserves the
-  whole current title before any inline-like text inside that title can truncate
-  it; recognize malformed fragments at line start and mid-line without splitting
+- Correct fix must touch/change: extend the line-start complete-label grammar
+  to admit `R<n>(/R<n>)*: nonempty detail`; prove adjacent positive correlation
+  while keeping the severity-less inline form fail closed; scan candidates in
+  source order so existing severity/dash inline evidence on the current line
+  keeps precedence, while a complete adjacent evidence line preserves a title
+  containing colon-like text that is not an admitted inline label; recognize
+  malformed fragments at line start and after any Unicode non-alphanumeric
+  lexical boundary without splitting
   bare multi-digit or complete chained rule mentions; recognize incomplete slash
   continuations with immediate or whitespace-separated delimiters; classify
   immediate suffixes as an open non-whitespace category and evidence-gate them
@@ -76,9 +86,11 @@ Max files: 3
     `Exercise the deployed manifest entrypoint\nR2/R14: detail` yields only the
     bounded title and lets `evaluate()` correlate a matching `fixed-in`
     disposition for a resolved thread; settled by focused unit tests.
-  - The same complete rule label works inline, while existing dash and
-    severity-qualified colon forms retain their current roots; settled by
-    parser boundary tests.
+  - Severity-less colon evidence remains unambiguous by being line-start only;
+    the same form inline yields no root, while existing dash and
+    severity-qualified inline forms retain their current roots and take
+    precedence over an immediately following complete label; settled by parser
+    ordering and negative substring-disposition tests.
   - A following complete evidence line preserves the entire bounded title even
     when that title contains generated `R<n>(/R<n>)*: text` combinations, while
     a line that itself begins as a rule label or contains potential rule
@@ -88,8 +100,9 @@ Max files: 3
     the label-only negative case,
     `test_adjacent_rule_evidence_rejects_malformed_fragments_at_start_or_midline`,
     the existing incomplete-fragment matrix, the evidence-keyed product over
-    rule tokens, title containers, and label families, and the generated
-    all-Unicode immediate-suffix property.
+    rule tokens, title containers, and label families, the generated
+    all-Unicode immediate-suffix property, and the generated Unicode lexical
+    boundary oracle.
   - Bounded prefixes before rule-like colon text do not collapse distinct
     adjacent titles into one decision; settled by
     `test_adjacent_rule_evidence_keeps_bounded_prefix_titles_distinct`, including
@@ -129,17 +142,20 @@ Max files: 3
   `missing_thread_dispositions()` -> required gate result.
 - Replaced-path behaviors: a bounded title adjacent to or sharing a line with
   `R<n>(/R<n>)*: nonempty detail` changes from unparseable to correlatable;
-  source-order scanning preserves bounded inline evidence on an earlier line,
-  while a complete following evidence line preserves the current whole title
-  before rule-like colon text inside it can be truncated; complete multi-digit
+  source-order scanning preserves existing direct inline evidence before an
+  immediately following complete label, while a complete following evidence
+  line preserves the current whole title when colon-like text is not an
+  admitted inline form; severity-less inline evidence remains unparseable;
+  complete multi-digit
   references cannot backtrack into shorter malformed fragments; any immediate
   non-whitespace continuation is structurally potential evidence and must pass
   the complete grammar; every unmatched form retains the empty-decision
   fail-closed result.
 - Guard-relevant fields: bounded title length/token floor, exact chained rule
-  reference, atomic longest-reference matching, the open immediate
-  non-whitespace suffix category, optional delimiter whitespace, colon/slash
-  delimiter, and required nonempty detail token.
+  reference, atomic longest-reference matching, Unicode non-alphanumeric token
+  boundary, the open immediate non-whitespace suffix category, optional
+  delimiter whitespace, colon/slash delimiter, and required nonempty detail
+  token.
 - Caller x input shape: resolved trusted-bot history with the observed complete
   colon form can match only its named structured disposition; untrusted author,
   empty detail, malformed rule reference, short title, mismatched disposition,
@@ -147,11 +163,13 @@ Max files: 3
 
 ### Capability-set closure declaration
 
-- Producer prose and malformed suffixes are OPEN. The accepted evidence grammar
-  is CLOSED and ENUMERATED in `_COMPLETE_RULE_LABEL_RE`; the inline and
-  adjacent-line matchers derive accepted forms from that grammar, while the
-  potential-evidence recognizer treats every immediate non-whitespace suffix as
-  requiring validation rather than enumerating rejected suffixes.
+- Producer prose and malformed suffixes are OPEN. The accepted line-start
+  evidence grammar is CLOSED and ENUMERATED in `_COMPLETE_RULE_LABEL_RE`; the
+  inline matcher intentionally uses the pre-existing severity/dash subset so
+  colon-like title prose cannot become ambiguous inline evidence. The
+  potential-evidence recognizer treats every immediate non-whitespace suffix at
+  a Unicode lexical boundary as requiring validation rather than enumerating
+  rejected suffixes or boundary punctuation.
 - This slice adds one finite delimiter member: exact rule reference + colon +
   nonempty detail. It does not classify title vocabulary or accept generic
   prose as evidence.
@@ -177,17 +195,18 @@ Max files: 3
 
 ## Mechanism
 
-Add the colon-with-detail alternative at the same complete-label grammar choke
-point used by inline and adjacent-line parsing. Walk nonblank lines once in
-source order: when the next line supplies complete evidence, preserve the
-current whole bounded title unless it begins as a rule label or contains
-potential rule evidence that the complete-label grammar cannot validate;
-otherwise return the current bounded inline root. Prevent reference matching
-from backtracking by atomically consuming the longest complete reference, then
-treat every immediate non-whitespace continuation and every
-whitespace-separated rule-label operator as potential evidence. The established
-bounded-title floor and root matching remain downstream invariants, so
-recognizing the delimiter does not make arbitrary or short prose authoritative.
+Add the colon-with-detail alternative to the line-start complete-label grammar
+while retaining the pre-existing severity/dash subset for inline extraction.
+Walk nonblank lines once in source order: return direct legacy inline evidence
+before considering the following line; otherwise, when that next line supplies
+complete evidence, preserve the current whole bounded title unless it begins as
+a rule label or contains potential rule evidence that the complete-label grammar
+cannot validate. Atomically consume the longest complete reference and detect
+it at line start or after any Unicode non-alphanumeric boundary, then treat every
+immediate non-whitespace continuation and every whitespace-separated rule-label
+operator as potential evidence. The established bounded-title floor and root
+matching remain downstream invariants, so recognizing the delimiter does not
+make arbitrary or short prose authoritative.
 
 ## Intentional
 
@@ -197,6 +216,8 @@ recognizing the delimiter does not make arbitrary or short prose authoritative.
 - No acceptance of a colon without detail or of a rule-like prefix with trailing
   letters or an incomplete slash chain. The complete-evidence requirement
   remains fail closed.
+- No severity-less colon inline admission. That unobserved shape is ambiguous
+  with title prose; only the observed line-start producer form is added.
 
 ## Deferred
 
@@ -211,7 +232,7 @@ Parked hardening: none.
 ## Verification
 
 - `python -m pytest tests/test_check_ai_reconciliation_live.py -q` ->
-  `90 passed in 1.20s` after the structural decision-seam repair.
+  `93 passed in 2.09s` after the structural decision-seam repair.
 - `/home/juan-canfield/miniconda3/bin/ruff check scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py`
   -> `All checks passed!`.
 - `/home/juan-canfield/Desktop/Atlas/.venv/bin/python -m py_compile scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py`
@@ -235,7 +256,7 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Live-Reconciliation-Severityless-Colon.md` | 241 |
-| `scripts/check_ai_reconciliation_live.py` | 33 |
-| `tests/test_check_ai_reconciliation_live.py` | 268 |
-| **Total** | **542** |
+| `plans/PR-Live-Reconciliation-Severityless-Colon.md` | 262 |
+| `scripts/check_ai_reconciliation_live.py` | 39 |
+| `tests/test_check_ai_reconciliation_live.py` | 318 |
+| **Total** | **619** |

--- a/plans/PR-Live-Reconciliation-Severityless-Colon.md
+++ b/plans/PR-Live-Reconciliation-Severityless-Colon.md
@@ -1,0 +1,144 @@
+# PR-Live-Reconciliation-Severityless-Colon
+
+## Why this slice exists
+
+Owned Terms capability PR #2506 fixed and resolved its concrete Codex finding,
+but the required trusted-base `live-reconciliation` check remains red. GitHub's
+current review `bodyText` is a bounded title followed by `R2/R14: detail`.
+`_COMPLETE_RULE_LABEL_RE` accepts dash-delimited and severity-qualified colon
+evidence, but not this severity-less colon form, so the historical thread is
+reported as permanently unparseable even when the PR body names its exact
+decision. This CI-provider defect blocks the product slice and must be fixed at
+the parser rather than bypassed in #2506.
+
+### Problem-derived contract
+
+- Root cause: the trusted rule-evidence grammar omits an exact rule reference
+  followed directly by `:` and nonempty detail, although the trusted Codex
+  connector now emits that observed form. A resolved finding therefore has no
+  normalizable decision and cannot be honestly reconciled.
+- Correct fix must touch/change: extend only the shared complete-label grammar
+  to admit `R<n>(/R<n>)*: nonempty detail`; prove multiline and inline positive
+  correlation, preserve existing dash and severity-qualified forms, and prove
+  incomplete, malformed, short-title, and unrelated inputs still fail closed.
+- Must not change: trusted bot identities, GitHub workflow triggers, open-thread
+  blocking, current-head review freshness, PR-body disposition matching,
+  docs-only handling, Terms capability code, Tracker code, or any customer,
+  persistence, financial, authentication, or product behavior.
+
+## Scope (this PR)
+
+Ownership lane: workflow/live-reconciliation-severityless-colon
+Slice phase: Workflow/process
+Max files: 3
+
+1. Add the observed severity-less colon-with-detail form to the trusted
+   rule-label evidence grammar without accepting an empty or malformed label.
+2. Pin both sides of the boundary in the focused live-reconciliation tests and
+   rerun #2506's required trusted-base check after this provider merges.
+
+### Review Contract
+
+- Acceptance criteria:
+  - The exact observed multiline producer shape
+    `Exercise the deployed manifest entrypoint\nR2/R14: detail` yields only the
+    bounded title and lets `evaluate()` correlate a matching `fixed-in`
+    disposition for a resolved thread; settled by focused unit tests.
+  - The same complete rule label works inline, while existing dash and
+    severity-qualified colon forms retain their current roots; settled by
+    parser boundary tests.
+  - `R2/R14:` with empty detail, `R2/R14foo: detail`, a short title, and text
+    with no adjacent complete rule label yield no decision; settled by negative
+    unit assertions.
+  - The grammar remains the sole evidence choke point; no title allowlist,
+    thread-state exception, or PR-number special case is added; settled by the
+    cold diff.
+- Reachability proof: `.github/workflows/ai_reconciliation_live.yml` continues
+  to invoke `scripts/check_ai_reconciliation_live.py` from trusted base code;
+  after merge, rerunning #2506 exposes the observable green/red gate result.
+- Affected surfaces: the trusted live-reconciliation parser and its direct unit
+  tests only.
+- Risk areas: false reconciliation of malformed history, rejection of current
+  trusted producer output, existing delimiter compatibility, and trusted-base
+  deployment ordering.
+- Reviewer rules triggered: R1, R2, R10, R12, R13, R14.
+
+### Boundary-change enumeration
+
+- Boundary path/seam: GitHub review `bodyText` ->
+  `_evidenced_root_decision()` -> `_COMPLETE_RULE_LABEL_RE` ->
+  `missing_thread_dispositions()` -> required gate result.
+- Replaced-path behaviors: a bounded title adjacent to or sharing a line with
+  `R<n>(/R<n>)*: nonempty detail` changes from unparseable to correlatable;
+  every unmatched form retains the empty-decision fail-closed result.
+- Guard-relevant fields: bounded title length/token floor, exact chained rule
+  reference, colon delimiter, and required nonempty detail token.
+- Caller x input shape: resolved trusted-bot history with the observed complete
+  colon form can match only its named structured disposition; untrusted author,
+  empty detail, malformed rule reference, short title, mismatched disposition,
+  and unresolved thread remain rejected by their existing checks.
+
+### Capability-set closure declaration
+
+- Producer prose is OPEN. The accepted evidence grammar is CLOSED and DERIVED
+  at every parser use from `_COMPLETE_RULE_LABEL_RE`.
+- This slice adds one finite delimiter member: exact rule reference + colon +
+  nonempty detail. It does not classify title vocabulary or accept generic
+  prose as evidence.
+- Outside-set inputs default to no decision, which keeps reconciliation red.
+
+### Deployed-config probing
+
+- Deployed/default config values: default trusted bot allowlist and workflow
+  invocation are unchanged; this grammar has no environment toggle.
+- Explicit value probe: the observed `R2/R14: detail` bodyText form returns the
+  preceding bounded title.
+- Absent value probe: missing or empty detail returns no decision.
+- Default-session/default-context probe: direct `evaluate()` uses the default
+  parser path with a resolved trusted-bot thread and matching PR-body ledger.
+- Side-effect ordering: parser evaluation is pure; GitHub reads occur before
+  evaluation exactly as before, and this diff adds no mutation.
+
+### Files touched
+
+- `plans/PR-Live-Reconciliation-Severityless-Colon.md`
+- `scripts/check_ai_reconciliation_live.py`
+- `tests/test_check_ai_reconciliation_live.py`
+
+## Mechanism
+
+Add the colon-with-detail alternative at the same complete-label grammar
+choke point used by inline and adjacent-line parsing. The established bounded
+title floor and root matching remain downstream invariants, so recognizing the
+delimiter does not make arbitrary or short prose authoritative.
+
+## Intentional
+
+- No PR-body workaround, thread deletion, bot-specific title allowlist, or
+  special case for #2506. Those would hide the provider incompatibility rather
+  than make the trusted producer and consumer contract agree.
+- No acceptance of a colon without detail or of a rule-like prefix with trailing
+  letters. The complete-evidence requirement remains fail closed.
+
+## Deferred
+
+None.
+
+Parked hardening: none.
+
+## Verification
+
+- Focused live-reconciliation tests, syntax compilation, Ruff, whitespace,
+  strict guard-class closure, plan sync, and the repository's guarded local PR
+  review. The broad Unit Gate remains GitHub-owned.
+- After provider merge, rerun and inspect #2506's trusted-base
+  `live-reconciliation` check before resuming the Terms product slice.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Live-Reconciliation-Severityless-Colon.md` | 144 |
+| `scripts/check_ai_reconciliation_live.py` | 3 |
+| `tests/test_check_ai_reconciliation_live.py` | 58 |
+| **Total** | **205** |

--- a/plans/PR-Live-Reconciliation-Severityless-Colon.md
+++ b/plans/PR-Live-Reconciliation-Severityless-Colon.md
@@ -41,6 +41,11 @@ behavioral surface.
   any Unicode non-alphanumeric boundary; alphanumeric-embedded text remains an
   ordinary word. Ambiguous severity-less inline input takes the fail-closed
   path.
+- Leading continuation rule: when the first lexical token of a candidate line
+  is a rule reference and nonblank whitespace-delimited text follows, the
+  complete-label grammar must validate the line. Leading Unicode punctuation
+  does not turn that ambiguous evidence into a title; genuinely embedded bare
+  references after title text remain ordinary content.
 
 ### Problem-derived contract
 
@@ -60,9 +65,11 @@ behavioral surface.
   bare multi-digit or complete chained rule mentions; recognize incomplete slash
   continuations with immediate or whitespace-separated delimiters; classify
   immediate suffixes as an open non-whitespace category and evidence-gate them
-  with the complete-label grammar; preserve existing dash and
-  severity-qualified forms; and prove incomplete, malformed, Unicode-suffixed,
-  short-title, label-only, and unrelated inputs still fail closed.
+  with the complete-label grammar; require a leading rule reference with any
+  nonblank whitespace continuation to pass that same grammar; preserve
+  existing dash and severity-qualified forms; and prove incomplete, malformed,
+  Unicode-suffixed, unknown-leading-continuation, short-title, label-only, and
+  unrelated inputs still fail closed.
 - Must not change: trusted bot identities, GitHub workflow triggers, open-thread
   blocking, current-head review freshness, PR-body disposition matching,
   docs-only handling, Terms capability code, Tracker code, or any customer,
@@ -103,6 +110,12 @@ Max files: 3
     rule tokens, title containers, and label families, the generated
     all-Unicode immediate-suffix property, and the generated Unicode lexical
     boundary oracle.
+  - A rule reference that is the first lexical token cannot become a title by
+    adding an unknown whitespace-delimited continuation, including after
+    leading Unicode punctuation; complete dash/severity labels retain their
+    grammar result, and embedded bare references remain title text. Settled by
+    the leading-continuation end-to-end negative and generated Unicode
+    continuation oracle.
   - Bounded prefixes before rule-like colon text do not collapse distinct
     adjacent titles into one decision; settled by
     `test_adjacent_rule_evidence_keeps_bounded_prefix_titles_distinct`, including
@@ -154,8 +167,8 @@ Max files: 3
 - Guard-relevant fields: bounded title length/token floor, exact chained rule
   reference, atomic longest-reference matching, Unicode non-alphanumeric token
   boundary, the open immediate non-whitespace suffix category, optional
-  delimiter whitespace, colon/slash delimiter, and required nonempty detail
-  token.
+  delimiter whitespace, first-lexical-token continuation state, colon/slash
+  delimiter, and required nonempty detail token.
 - Caller x input shape: resolved trusted-bot history with the observed complete
   colon form can match only its named structured disposition; untrusted author,
   empty detail, malformed rule reference, short title, mismatched disposition,
@@ -169,7 +182,9 @@ Max files: 3
   colon-like title prose cannot become ambiguous inline evidence. The
   potential-evidence recognizer treats every immediate non-whitespace suffix at
   a Unicode lexical boundary as requiring validation rather than enumerating
-  rejected suffixes or boundary punctuation.
+  rejected suffixes or boundary punctuation. It also treats every nonblank
+  whitespace continuation after a leading rule reference as potential evidence;
+  this finite structural position distinguishes it from embedded bare mentions.
 - This slice adds one finite delimiter member: exact rule reference + colon +
   nonempty detail. It does not classify title vocabulary or accept generic
   prose as evidence.
@@ -204,9 +219,11 @@ a rule label or contains potential rule evidence that the complete-label grammar
 cannot validate. Atomically consume the longest complete reference and detect
 it at line start or after any Unicode non-alphanumeric boundary, then treat every
 immediate non-whitespace continuation and every whitespace-separated rule-label
-operator as potential evidence. The established bounded-title floor and root
-matching remain downstream invariants, so recognizing the delimiter does not
-make arbitrary or short prose authoritative.
+operator as potential evidence. If a rule reference is the first lexical token,
+any nonblank whitespace continuation also requires complete-grammar validation.
+The established bounded-title floor and root matching remain downstream
+invariants, so recognizing the delimiter does not make arbitrary or short prose
+authoritative.
 
 ## Intentional
 
@@ -232,7 +249,7 @@ Parked hardening: none.
 ## Verification
 
 - `python -m pytest tests/test_check_ai_reconciliation_live.py -q` ->
-  `93 passed in 2.09s` after the structural decision-seam repair.
+  `95 passed in 3.24s` after the structural decision-seam repair.
 - `/home/juan-canfield/miniconda3/bin/ruff check scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py`
   -> `All checks passed!`.
 - `/home/juan-canfield/Desktop/Atlas/.venv/bin/python -m py_compile scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py`
@@ -256,7 +273,7 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Live-Reconciliation-Severityless-Colon.md` | 262 |
-| `scripts/check_ai_reconciliation_live.py` | 39 |
-| `tests/test_check_ai_reconciliation_live.py` | 318 |
-| **Total** | **619** |
+| `plans/PR-Live-Reconciliation-Severityless-Colon.md` | 279 |
+| `scripts/check_ai_reconciliation_live.py` | 50 |
+| `tests/test_check_ai_reconciliation_live.py` | 368 |
+| **Total** | **697** |

--- a/plans/PR-Live-Reconciliation-Severityless-Colon.md
+++ b/plans/PR-Live-Reconciliation-Severityless-Colon.md
@@ -47,9 +47,9 @@ Max files: 3
   - The same complete rule label works inline, while existing dash and
     severity-qualified colon forms retain their current roots; settled by
     parser boundary tests.
-  - `R2/R14:` with empty detail, `R2/R14foo: detail`, a short title, and text
-    with no adjacent complete rule label yield no decision; settled by negative
-    unit assertions.
+  - `R2/R14:` with empty detail, `R2/R14   : detail` with pre-colon
+    whitespace, `R2/R14foo: detail`, a short title, and text with no adjacent
+    complete rule label yield no decision; settled by negative unit assertions.
   - The grammar remains the sole evidence choke point; no title allowlist,
     thread-state exception, or PR-number special case is added; settled by the
     cold diff.
@@ -80,8 +80,9 @@ Max files: 3
 
 ### Capability-set closure declaration
 
-- Producer prose is OPEN. The accepted evidence grammar is CLOSED and DERIVED
-  at every parser use from `_COMPLETE_RULE_LABEL_RE`.
+- Producer prose is OPEN. The accepted evidence grammar is CLOSED and
+  ENUMERATED in `_COMPLETE_RULE_LABEL_RE`; the inline and adjacent-line
+  matchers derive their accepted forms from that one enumerated grammar.
 - This slice adds one finite delimiter member: exact rule reference + colon +
   nonempty detail. It does not classify title vocabulary or accept generic
   prose as evidence.
@@ -124,13 +125,32 @@ delimiter does not make arbitrary or short prose authoritative.
 
 None.
 
+Parking predicate: producer delimiters not present in observed trusted review
+`bodyText`, broader title grammar, bot-identity changes, and workflow-policy
+changes remain outside this slice unless live evidence makes them a blocker.
+
 Parked hardening: none.
 
 ## Verification
 
-- Focused live-reconciliation tests, syntax compilation, Ruff, whitespace,
-  strict guard-class closure, plan sync, and the repository's guarded local PR
-  review. The broad Unit Gate remains GitHub-owned.
+- `./ops test focused tests/test_check_ai_reconciliation_live.py -q` ->
+  `82 passed in 0.45s`.
+- `/home/juan-canfield/miniconda3/bin/ruff check scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py`
+  -> `All checks passed!`.
+- `/home/juan-canfield/Desktop/Atlas/.venv/bin/python -m py_compile scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py`
+  -> pass with no output.
+- `/home/juan-canfield/Desktop/Atlas/.venv/bin/python scripts/check_guard_class_closure.py --base origin/main --strict`
+  -> `OK: no guard-shaped change without a property test.`
+- `/home/juan-canfield/Desktop/Atlas/.venv/bin/python scripts/sync_pr_plan.py --check plans/PR-Live-Reconciliation-Severityless-Colon.md origin/main`
+  -> `plan already in sync` after the review repair.
+- `git diff --check` -> pass with no output.
+- `/home/juan-canfield/miniconda3/bin/ruff format --check scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py`
+  reports existing whole-file formatter drift. Its diff was inspected and only
+  branch-added assertion lines were aligned; unrelated baseline churn remains
+  excluded.
+- The repository's guarded local PR review passed on the first head. Rerun it
+  through `scripts/push_pr.sh` after the review repair. The broad Unit Gate
+  remains GitHub-owned.
 - After provider merge, rerun and inspect #2506's trusted-base
   `live-reconciliation` check before resuming the Terms product slice.
 
@@ -138,7 +158,7 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Live-Reconciliation-Severityless-Colon.md` | 144 |
+| `plans/PR-Live-Reconciliation-Severityless-Colon.md` | 164 |
 | `scripts/check_ai_reconciliation_live.py` | 3 |
-| `tests/test_check_ai_reconciliation_live.py` | 58 |
-| **Total** | **205** |
+| `tests/test_check_ai_reconciliation_live.py` | 60 |
+| **Total** | **227** |

--- a/plans/PR-Live-Reconciliation-Severityless-Colon.md
+++ b/plans/PR-Live-Reconciliation-Severityless-Colon.md
@@ -24,9 +24,9 @@ the parser rather than bypassed in #2506.
   whole current title before any inline-like text inside that title can truncate
   it; recognize malformed fragments at line start and mid-line without splitting
   bare multi-digit or complete chained rule mentions; recognize incomplete slash
-  continuations; preserve existing dash and severity-qualified forms; and prove
-  incomplete, malformed, short-title, label-only, and unrelated inputs still
-  fail closed.
+  continuations with immediate or whitespace-separated delimiters; preserve
+  existing dash and severity-qualified forms; and prove incomplete, malformed,
+  short-title, label-only, and unrelated inputs still fail closed.
 - Must not change: trusted bot identities, GitHub workflow triggers, open-thread
   blocking, current-head review freshness, PR-body disposition matching,
   docs-only handling, Terms capability code, Tracker code, or any customer,
@@ -70,8 +70,9 @@ Max files: 3
     `test_adjacent_rule_evidence_preserves_bare_multi_digit_rule_mentions`.
   - Bare complete chains such as `R4/R5` and `R10/R14` remain title text, while
     incomplete chains such as `R4/R`, `R4//R5`, `R4/Rfoo`, and `R4/R5/R` remain
-    unparseable at line start and mid-line; settled by the complete-chain test
-    and expanded malformed-fragment matrix.
+    unparseable at line start and mid-line across immediate, space, tab, and
+    mixed-whitespace delimiters; settled by the complete-chain test and generated
+    malformed-fragment matrix.
   - Earlier complete inline evidence retains its decision even when later prose
     forms an otherwise valid adjacent title/evidence pair; settled by
     `test_earlier_inline_rule_evidence_precedes_later_adjacent_pairs`, including
@@ -105,8 +106,8 @@ Max files: 3
   references cannot backtrack into shorter malformed fragments; every unmatched
   form retains the empty-decision fail-closed result.
 - Guard-relevant fields: bounded title length/token floor, exact chained rule
-  reference, atomic longest-reference matching, colon/slash delimiter, and
-  required nonempty detail token.
+  reference, atomic longest-reference matching, optional delimiter whitespace,
+  colon/slash delimiter, and required nonempty detail token.
 - Caller x input shape: resolved trusted-bot history with the observed complete
   colon form can match only its named structured disposition; untrusted author,
   empty detail, malformed rule reference, short title, mismatched disposition,
@@ -148,10 +149,10 @@ source order: when the next line supplies complete evidence, preserve the
 current whole bounded title unless it begins as a rule label or contains a
 malformed fragment; otherwise return the current bounded inline root. Prevent
 fragment matching from backtracking by atomically consuming the longest complete
-reference, then treat any leftover slash continuation as malformed. The
-established bounded-title floor and root matching remain downstream invariants,
-so recognizing the delimiter does not make arbitrary or short prose
-authoritative.
+reference, then treat any immediate or whitespace-separated leftover slash
+continuation as malformed. The established bounded-title floor and root matching
+remain downstream invariants, so recognizing the delimiter does not make
+arbitrary or short prose authoritative.
 
 ## Intentional
 
@@ -175,7 +176,7 @@ Parked hardening: none.
 ## Verification
 
 - `./ops test focused tests/test_check_ai_reconciliation_live.py -q` ->
-  `88 passed in 0.60s` after the current-head review repairs.
+  `88 passed in 0.63s` after the current-head review repairs.
 - `/home/juan-canfield/miniconda3/bin/ruff check scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py`
   -> `All checks passed!`.
 - `/home/juan-canfield/Desktop/Atlas/.venv/bin/python -m py_compile scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py`
@@ -199,7 +200,7 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Live-Reconciliation-Severityless-Colon.md` | 205 |
+| `plans/PR-Live-Reconciliation-Severityless-Colon.md` | 206 |
 | `scripts/check_ai_reconciliation_live.py` | 31 |
-| `tests/test_check_ai_reconciliation_live.py` | 225 |
-| **Total** | **461** |
+| `tests/test_check_ai_reconciliation_live.py` | 228 |
+| **Total** | **465** |

--- a/plans/PR-Live-Reconciliation-Severityless-Colon.md
+++ b/plans/PR-Live-Reconciliation-Severityless-Colon.md
@@ -46,6 +46,11 @@ behavioral surface.
   complete-label grammar must validate the line. Leading Unicode punctuation
   does not turn that ambiguous evidence into a title; genuinely embedded bare
   references after title text remain ordinary content.
+- Canonical identity rule: complete rule IDs use ASCII digits only. The broader
+  potential-evidence recognizer still detects Unicode-decimal lookalikes, but
+  they cannot satisfy the complete grammar. A complete-looking label whose rule
+  token is wrapped in leading punctuation is likewise not canonical line-start
+  evidence and cannot become a title.
 
 ### Problem-derived contract
 
@@ -67,9 +72,11 @@ behavioral surface.
   immediate suffixes as an open non-whitespace category and evidence-gate them
   with the complete-label grammar; require a leading rule reference with any
   nonblank whitespace continuation to pass that same grammar; preserve
-  existing dash and severity-qualified forms; and prove incomplete, malformed,
-  Unicode-suffixed, unknown-leading-continuation, short-title, label-only, and
-  unrelated inputs still fail closed.
+  existing dash and severity-qualified forms; restrict complete rule references
+  to ASCII digits while retaining broad Unicode-decimal malformed detection;
+  and prove incomplete, malformed, Unicode-suffixed, punctuation-wrapped,
+  unknown-leading-continuation, short-title, label-only, and unrelated inputs
+  still fail closed.
 - Must not change: trusted bot identities, GitHub workflow triggers, open-thread
   blocking, current-head review freshness, PR-body disposition matching,
   docs-only handling, Terms capability code, Tracker code, or any customer,
@@ -116,6 +123,11 @@ Max files: 3
     grammar result, and embedded bare references remain title text. Settled by
     the leading-continuation end-to-end negative and generated Unicode
     continuation oracle.
+  - Only ASCII-decimal rule IDs are complete evidence. Every non-ASCII Unicode
+    decimal used as a whole or mixed rule ID remains malformed, and a colon
+    label after leading punctuation remains a no-decision line even when the
+    embedded token otherwise matches. Settled by the all-Unicode suffix oracle
+    and punctuation-wrapped colon end-to-end negative.
   - Bounded prefixes before rule-like colon text do not collapse distinct
     adjacent titles into one decision; settled by
     `test_adjacent_rule_evidence_keeps_bounded_prefix_titles_distinct`, including
@@ -165,8 +177,9 @@ Max files: 3
   the complete grammar; every unmatched form retains the empty-decision
   fail-closed result.
 - Guard-relevant fields: bounded title length/token floor, exact chained rule
-  reference, atomic longest-reference matching, Unicode non-alphanumeric token
-  boundary, the open immediate non-whitespace suffix category, optional
+  reference with ASCII digits, broader Unicode-decimal potential reference,
+  atomic longest-reference matching, Unicode non-alphanumeric token boundary,
+  leading punctuation, the open immediate non-whitespace suffix category, optional
   delimiter whitespace, first-lexical-token continuation state, colon/slash
   delimiter, and required nonempty detail token.
 - Caller x input shape: resolved trusted-bot history with the observed complete
@@ -185,6 +198,9 @@ Max files: 3
   rejected suffixes or boundary punctuation. It also treats every nonblank
   whitespace continuation after a leading rule reference as potential evidence;
   this finite structural position distinguishes it from embedded bare mentions.
+- Canonical complete references are ASCII-only. Unicode-decimal candidates are
+  deliberately part of the broader potential-reference recognizer so they are
+  rejected by evidence validation rather than ignored as ordinary title text.
 - This slice adds one finite delimiter member: exact rule reference + colon +
   nonempty detail. It does not classify title vocabulary or accept generic
   prose as evidence.
@@ -221,6 +237,8 @@ it at line start or after any Unicode non-alphanumeric boundary, then treat ever
 immediate non-whitespace continuation and every whitespace-separated rule-label
 operator as potential evidence. If a rule reference is the first lexical token,
 any nonblank whitespace continuation also requires complete-grammar validation.
+The leading-token check rejects any punctuation wrapper, and the complete
+grammar uses ASCII digits while the potential recognizer remains Unicode-wide.
 The established bounded-title floor and root matching remain downstream
 invariants, so recognizing the delimiter does not make arbitrary or short prose
 authoritative.
@@ -249,7 +267,7 @@ Parked hardening: none.
 ## Verification
 
 - `python -m pytest tests/test_check_ai_reconciliation_live.py -q` ->
-  `95 passed in 3.24s` after the structural decision-seam repair.
+  `97 passed in 4.58s` after the structural decision-seam repair.
 - `/home/juan-canfield/miniconda3/bin/ruff check scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py`
   -> `All checks passed!`.
 - `/home/juan-canfield/Desktop/Atlas/.venv/bin/python -m py_compile scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py`
@@ -273,7 +291,7 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Live-Reconciliation-Severityless-Colon.md` | 279 |
-| `scripts/check_ai_reconciliation_live.py` | 50 |
-| `tests/test_check_ai_reconciliation_live.py` | 368 |
-| **Total** | **697** |
+| `plans/PR-Live-Reconciliation-Severityless-Colon.md` | 297 |
+| `scripts/check_ai_reconciliation_live.py` | 61 |
+| `tests/test_check_ai_reconciliation_live.py` | 416 |
+| **Total** | **774** |

--- a/plans/PR-Live-Reconciliation-Severityless-Colon.md
+++ b/plans/PR-Live-Reconciliation-Severityless-Colon.md
@@ -50,11 +50,11 @@ behavioral surface.
   reviewer-rule set in `docs/REVIEWER_RULES.md` (currently `R1` through `R14`),
   without zero padding. The checker derives its complete-reference grammar from
   one explicit identity tuple, and a test keeps that tuple synchronized with the
-  rule headings. The broader potential-evidence recognizer still detects
-  ASCII out-of-set values and Unicode-decimal lookalikes, but they cannot satisfy
-  the complete grammar. A complete-looking label whose rule token is wrapped in
-  leading punctuation is likewise not canonical line-start evidence and cannot
-  become a title.
+  rule headings. The broader potential-evidence recognizer still detects ASCII
+  out-of-set values and every non-ASCII Unicode numeric lookalike, but they
+  cannot satisfy the complete grammar. A complete-looking label whose rule token
+  is wrapped in leading punctuation is likewise not canonical line-start
+  evidence and cannot become a title.
 - Partial-identity rule: the broader potential recognizer includes case-variant
   numeric markers and a bare `R`/`r` only when it is structurally followed by a
   rule-label operator or chain delimiter. At the first lexical position, a bare
@@ -78,7 +78,11 @@ behavioral surface.
   could still admit an unenumerated incomplete suffix. Once the parser returns
   distinct full adjacent titles, downstream disposition correlation still
   evaluates symmetric substring containment independently for each thread, so
-  one disposition can clear multiple distinct nested titles.
+  one disposition can clear multiple distinct nested titles. The broader
+  potential-reference regex also relies on Python `\d`, which covers Unicode
+  decimal digits but misses non-decimal numeric classes such as superscripts,
+  fractions, circled numbers, and Roman numerals; those malformed identities can
+  therefore be promoted as adjacent titles.
 - Correct fix must touch/change: extend the line-start complete-label grammar
   to admit `R<n>(/R<n>)*: nonempty detail`; prove adjacent positive correlation
   while keeping the severity-less inline form fail closed; scan candidates in
@@ -104,7 +108,10 @@ behavioral surface.
   the set of distinct normalized thread decisions: an exact root covers only
   that exact decision, bounded containment remains available only when it has
   one unambiguous candidate, and no single disposition can clear two distinct
-  titles.
+  titles. Route every non-ASCII `str.isnumeric()` character immediately after a
+  lexical-boundary `R`/`r` through the fail-closed evidence path, with an
+  all-code-point oracle and representative end-to-end negatives; preserve
+  alphanumeric-embedded title text and canonical ASCII rule IDs.
 - Must not change: trusted bot identities, GitHub workflow triggers, open-thread
   blocking, current-head review freshness, structured disposition extraction,
   title normalization, pairwise bounded-containment compatibility outside the
@@ -156,13 +163,14 @@ Max files: 3
     continuation oracle.
   - Only reviewer-rule IDs defined by `docs/REVIEWER_RULES.md` are complete
     evidence. `R1`, `R14`, and defined chains remain accepted; zero,
-    zero-padded, and out-of-range ASCII IDs plus every non-ASCII Unicode decimal
-    used as a whole or mixed rule ID remain malformed across colon, dash, and
-    severity label forms. A colon label after
+    zero-padded, and out-of-range ASCII IDs plus every non-ASCII Unicode numeric
+    character used as an initial or mixed rule ID remain malformed across colon,
+    dash, and severity label forms. A colon label after
     leading punctuation likewise remains a no-decision line even when the
     embedded token otherwise matches. Settled by the rule-registry synchronization
     assertion, defined-edge positives, generated ASCII outside-set negatives,
-    all-Unicode suffix oracle, and punctuation-wrapped colon end-to-end negative.
+    all-Unicode numeric-identity and suffix oracles, representative non-decimal
+    numeric end-to-end negatives, and punctuation-wrapped colon negative.
   - Missing or partial initial identities with structural operators (`R:`,
     `R/R4:`, ASCII case variants, and whitespace variants) remain no-decision
     inputs at line start and punctuation/whitespace boundaries. A bare marker
@@ -261,9 +269,11 @@ Max files: 3
   this finite structural position distinguishes it from embedded bare mentions.
 - Canonical complete references are derived from the explicit reviewer-rule
   identity tuple, which is synchronized by test with `docs/REVIEWER_RULES.md`.
-  Zero, zero-padded, out-of-range ASCII, and Unicode-decimal candidates are
-  deliberately part of the broader potential-reference recognizer so they are
-  rejected by evidence validation rather than ignored as ordinary title text.
+  Zero, zero-padded, out-of-range ASCII, and every non-ASCII Unicode numeric
+  candidate are deliberately part of the broader potential-reference
+  recognizer so they are rejected by evidence validation rather than ignored as
+  ordinary title text. The non-decimal numeric class is detected semantically
+  with `str.isnumeric()` because Python `\d` covers only decimal digits.
 - A partial-initial branch is closed by structural delimiters rather than title
   vocabulary: bare `R`/`r` is potential evidence before a rule-label operator
   or chain slash, plus at first lexical position with nonblank continuation.
@@ -315,6 +325,10 @@ digitless initial `R`/`r` before structural label or chain operators, plus at th
 first lexical position before nonblank continuation. Each source-order candidate
 is checked for unvalidated evidence before root selection; after the two valid
 root paths, any remaining evidence-shaped line returns no decision immediately.
+An additional lexical-boundary scan routes every non-ASCII numeric character
+immediately following `R`/`r` into that same terminal validation path, including
+Unicode numeric classes outside `\d`, without classifying alphanumeric-embedded
+title text as evidence.
 Valid inline and adjacent roots still return before any later line is considered.
 The established bounded-title floor remains a downstream invariant. Correlation
 then builds the distinct normalized decision set and, for each disposition root,
@@ -347,7 +361,7 @@ Parked hardening: none.
 ## Verification
 
 - `python -m pytest tests/test_check_ai_reconciliation_live.py -q` ->
-  `104 passed in 4.63s` after the cardinality-aware disposition repair.
+  `104 passed in 11.16s` after the full Unicode-numeric identity repair.
 - `/home/juan-canfield/miniconda3/bin/ruff check scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py`
   -> `All checks passed!`.
 - `/home/juan-canfield/Desktop/Atlas/.venv/bin/python -m py_compile scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py`
@@ -371,7 +385,7 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Live-Reconciliation-Severityless-Colon.md` | 377 |
-| `scripts/check_ai_reconciliation_live.py` | 112 |
-| `tests/test_check_ai_reconciliation_live.py` | 643 |
-| **Total** | **1132** |
+| `plans/PR-Live-Reconciliation-Severityless-Colon.md` | 391 |
+| `scripts/check_ai_reconciliation_live.py` | 128 |
+| `tests/test_check_ai_reconciliation_live.py` | 651 |
+| **Total** | **1170** |

--- a/plans/PR-Live-Reconciliation-Severityless-Colon.md
+++ b/plans/PR-Live-Reconciliation-Severityless-Colon.md
@@ -23,9 +23,10 @@ the parser rather than bypassed in #2506.
   line keeps precedence, while a complete adjacent evidence line preserves the
   whole current title before any inline-like text inside that title can truncate
   it; recognize malformed fragments at line start and mid-line without splitting
-  bare multi-digit rule mentions; preserve existing dash and severity-qualified
-  forms; and prove incomplete, malformed, short-title, label-only, and unrelated
-  inputs still fail closed.
+  bare multi-digit or complete chained rule mentions; recognize incomplete slash
+  continuations; preserve existing dash and severity-qualified forms; and prove
+  incomplete, malformed, short-title, label-only, and unrelated inputs still
+  fail closed.
 - Must not change: trusted bot identities, GitHub workflow triggers, open-thread
   blocking, current-head review freshness, PR-body disposition matching,
   docs-only handling, Terms capability code, Tracker code, or any customer,
@@ -67,6 +68,10 @@ Max files: 3
   - Bare `R10` through `R14` mentions in adjacent titles remain ordinary title
     text rather than backtracking into malformed fragments; settled by
     `test_adjacent_rule_evidence_preserves_bare_multi_digit_rule_mentions`.
+  - Bare complete chains such as `R4/R5` and `R10/R14` remain title text, while
+    incomplete chains such as `R4/R`, `R4//R5`, `R4/Rfoo`, and `R4/R5/R` remain
+    unparseable at line start and mid-line; settled by the complete-chain test
+    and expanded malformed-fragment matrix.
   - Earlier complete inline evidence retains its decision even when later prose
     forms an otherwise valid adjacent title/evidence pair; settled by
     `test_earlier_inline_rule_evidence_precedes_later_adjacent_pairs`, including
@@ -100,7 +105,8 @@ Max files: 3
   references cannot backtrack into shorter malformed fragments; every unmatched
   form retains the empty-decision fail-closed result.
 - Guard-relevant fields: bounded title length/token floor, exact chained rule
-  reference, colon delimiter, and required nonempty detail token.
+  reference, atomic longest-reference matching, colon/slash delimiter, and
+  required nonempty detail token.
 - Caller x input shape: resolved trusted-bot history with the observed complete
   colon form can match only its named structured disposition; untrusted author,
   empty detail, malformed rule reference, short title, mismatched disposition,
@@ -141,10 +147,11 @@ point used by inline and adjacent-line parsing. Walk nonblank lines once in
 source order: when the next line supplies complete evidence, preserve the
 current whole bounded title unless it begins as a rule label or contains a
 malformed fragment; otherwise return the current bounded inline root. Prevent
-fragment matching from backtracking a complete multi-digit reference into a
-shorter reference plus digit suffix. The established bounded-title floor and
-root matching remain downstream invariants, so recognizing the delimiter does
-not make arbitrary or short prose authoritative.
+fragment matching from backtracking by atomically consuming the longest complete
+reference, then treat any leftover slash continuation as malformed. The
+established bounded-title floor and root matching remain downstream invariants,
+so recognizing the delimiter does not make arbitrary or short prose
+authoritative.
 
 ## Intentional
 
@@ -152,7 +159,8 @@ not make arbitrary or short prose authoritative.
   special case for #2506. Those would hide the provider incompatibility rather
   than make the trusted producer and consumer contract agree.
 - No acceptance of a colon without detail or of a rule-like prefix with trailing
-  letters. The complete-evidence requirement remains fail closed.
+  letters or an incomplete slash chain. The complete-evidence requirement
+  remains fail closed.
 
 ## Deferred
 
@@ -167,7 +175,7 @@ Parked hardening: none.
 ## Verification
 
 - `./ops test focused tests/test_check_ai_reconciliation_live.py -q` ->
-  `87 passed in 0.58s` after the current-head review repairs.
+  `88 passed in 0.60s` after the current-head review repairs.
 - `/home/juan-canfield/miniconda3/bin/ruff check scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py`
   -> `All checks passed!`.
 - `/home/juan-canfield/Desktop/Atlas/.venv/bin/python -m py_compile scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py`
@@ -191,7 +199,7 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Live-Reconciliation-Severityless-Colon.md` | 197 |
+| `plans/PR-Live-Reconciliation-Severityless-Colon.md` | 205 |
 | `scripts/check_ai_reconciliation_live.py` | 31 |
-| `tests/test_check_ai_reconciliation_live.py` | 200 |
-| **Total** | **428** |
+| `tests/test_check_ai_reconciliation_live.py` | 225 |
+| **Total** | **461** |

--- a/plans/PR-Live-Reconciliation-Severityless-Colon.md
+++ b/plans/PR-Live-Reconciliation-Severityless-Colon.md
@@ -55,6 +55,19 @@ behavioral surface.
   the complete grammar. A complete-looking label whose rule token is wrapped in
   leading punctuation is likewise not canonical line-start evidence and cannot
   become a title.
+- Partial-identity rule: the broader potential recognizer includes case-variant
+  numeric markers and a bare `R`/`r` only when it is structurally followed by a
+  rule-label operator or chain delimiter. At the first lexical position, a bare
+  marker with any nonblank continuation is also potential evidence.
+  Missing-initial-ID forms such as `R:`, `R/R4:`, `R BLOCKER`, case variants,
+  and spacing variants therefore reach complete-grammar validation and fail
+  closed without classifying ordinary `R`-initial words as evidence.
+- Terminal-malformation rule: source-order scanning stops with no decision on
+  the first evidence-shaped line that cannot produce a bounded root in its
+  position. This includes unvalidated evidence, a standalone complete label, a
+  short inline label, and an ambiguous severity-less inline label without
+  adjacent evidence. A later complete adjacent pair cannot bypass it; an earlier
+  valid inline or adjacent decision still wins before later lines are inspected.
 
 ### Problem-derived contract
 
@@ -80,8 +93,11 @@ behavioral surface.
   from the defined reviewer-rule identities while retaining broad numeric
   malformed detection; prove the derived identity tuple agrees with the
   reviewer-rule headings; and prove zero, zero-padded, out-of-range,
-  Unicode-suffixed, punctuation-wrapped, unknown-leading-continuation,
-  short-title, label-only, and unrelated inputs still fail closed.
+  Unicode-suffixed, punctuation-wrapped, missing-initial, incomplete-chain,
+  unknown-leading-continuation, short-title, label-only, and unrelated inputs
+  still fail closed. Stop source-order selection when any evidence-shaped line
+  fails to produce a root before a later candidate, without changing
+  earlier-valid inline or adjacent precedence.
 - Must not change: trusted bot identities, GitHub workflow triggers, open-thread
   blocking, current-head review freshness, PR-body disposition matching,
   docs-only handling, Terms capability code, Tracker code, or any customer,
@@ -137,6 +153,19 @@ Max files: 3
     embedded token otherwise matches. Settled by the rule-registry synchronization
     assertion, defined-edge positives, generated ASCII outside-set negatives,
     all-Unicode suffix oracle, and punctuation-wrapped colon end-to-end negative.
+  - Missing or partial initial identities with structural operators (`R:`,
+    `R/R4:`, ASCII case variants, and whitespace variants) remain no-decision
+    inputs at line start and punctuation/whitespace boundaries. A bare marker
+    plus unknown continuation such as `R BLOCKER` is rejected at first lexical
+    position, while ordinary `R`-initial words and embedded variable-name prose
+    remain title text. Settled by the structural partial-identity matrix and
+    exact end-to-end negative.
+  - An unvalidated, standalone-complete, short-inline, or ambiguous-inline
+    evidence line before a later complete adjacent pair makes the whole trusted
+    body no-decision; a matching disposition for the later title cannot clear
+    reconciliation. An earlier valid inline or adjacent root still wins.
+    Settled by the evidence-state ordering matrix alongside the existing
+    earlier-valid-inline precedence proof.
   - Bounded prefixes before rule-like colon text do not collapse distinct
     adjacent titles into one decision; settled by
     `test_adjacent_rule_evidence_keeps_bounded_prefix_titles_distinct`, including
@@ -183,12 +212,16 @@ Max files: 3
   complete multi-digit
   references cannot backtrack into shorter malformed fragments; any immediate
   non-whitespace continuation is structurally potential evidence and must pass
-  the complete grammar; every unmatched form retains the empty-decision
-  fail-closed result.
+  the complete grammar; missing-initial and case-variant identities followed by
+  structural label operators also enter that validation path; and the first
+  evidence-shaped line without a root terminates source-order selection before
+  later candidates. Every unmatched form retains the empty-decision fail-closed
+  result.
 - Guard-relevant fields: bounded title length/token floor, exact chained rule
   reference from the defined `R1`-`R14` identity set, broader numeric potential
   reference, atomic longest-reference matching, Unicode non-alphanumeric token
-  boundary, leading punctuation, the open immediate non-whitespace suffix category, optional
+  boundary, partial initial `R`/`r`, leading punctuation, the open immediate
+  non-whitespace suffix category, optional
   delimiter whitespace, first-lexical-token continuation state, colon/slash
   delimiter, and required nonempty detail token.
 - Caller x input shape: resolved trusted-bot history with the observed complete
@@ -212,6 +245,12 @@ Max files: 3
   Zero, zero-padded, out-of-range ASCII, and Unicode-decimal candidates are
   deliberately part of the broader potential-reference recognizer so they are
   rejected by evidence validation rather than ignored as ordinary title text.
+- A partial-initial branch is closed by structural delimiters rather than title
+  vocabulary: bare `R`/`r` is potential evidence before a rule-label operator
+  or chain slash, plus at first lexical position with nonblank continuation.
+  Numeric marker case variants are also potential but never complete. Any
+  evidence-shaped non-root line is a terminal source-order state; the parser
+  does not search later lines for a more convenient decision.
 - This slice adds one finite delimiter member: exact rule reference + colon +
   nonempty detail. It does not classify title vocabulary or accept generic
   prose as evidence.
@@ -252,6 +291,12 @@ The leading-token check rejects any punctuation wrapper, and the complete
 grammar is generated from the defined reviewer-rule identity tuple while the
 potential recognizer remains Unicode-wide. A synchronization test makes rule-doc
 growth fail visibly until that tuple and its admission proof are updated.
+The potential grammar also recognizes case-variant numeric markers and a
+digitless initial `R`/`r` before structural label or chain operators, plus at the
+first lexical position before nonblank continuation. Each source-order candidate
+is checked for unvalidated evidence before root selection; after the two valid
+root paths, any remaining evidence-shaped line returns no decision immediately.
+Valid inline and adjacent roots still return before any later line is considered.
 The established bounded-title floor and root matching remain downstream
 invariants, so recognizing the delimiter does not make arbitrary or short prose
 authoritative.
@@ -280,7 +325,7 @@ Parked hardening: none.
 ## Verification
 
 - `python -m pytest tests/test_check_ai_reconciliation_live.py -q` ->
-  `99 passed in 4.47s` after the defined-identity repair.
+  `101 passed in 4.74s` after the terminal evidence-state repair.
 - `/home/juan-canfield/miniconda3/bin/ruff check scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py`
   -> `All checks passed!`.
 - `/home/juan-canfield/Desktop/Atlas/.venv/bin/python -m py_compile scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py`
@@ -304,7 +349,7 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Live-Reconciliation-Severityless-Colon.md` | 310 |
-| `scripts/check_ai_reconciliation_live.py` | 65 |
-| `tests/test_check_ai_reconciliation_live.py` | 482 |
-| **Total** | **857** |
+| `plans/PR-Live-Reconciliation-Severityless-Colon.md` | 355 |
+| `scripts/check_ai_reconciliation_live.py` | 81 |
+| `tests/test_check_ai_reconciliation_live.py` | 571 |
+| **Total** | **1007** |

--- a/plans/PR-Live-Reconciliation-Severityless-Colon.md
+++ b/plans/PR-Live-Reconciliation-Severityless-Colon.md
@@ -11,12 +11,36 @@ reported as permanently unparseable even when the PR body names its exact
 decision. This CI-provider defect blocks the product slice and must be fixed at
 the parser rather than bypassed in #2506.
 
+This slice exceeds the 400-LOC soft cap because the parser change, the
+fail-closed boundary matrix required for a review-admission guard, and this
+repository-required plan form one indivisible safety change. Splitting the
+recognizer from its negative proof would leave an unproved required gate;
+splitting the plan would make either code PR inadmissible without reducing the
+behavioral surface.
+
+### Decision-Seam Analysis
+
+- Shared decision: whether one trusted review-body line is admissible as the
+  root decision when a following line contains complete rule evidence.
+- Why it is wrong: the current admission predicate treats the absence of an
+  enumerated malformed-suffix match as proof that the candidate is a title.
+  Immediate suffixes are an open Unicode category, so an unlisted suffix can
+  reach the admitting branch even though it is not complete rule evidence.
+- Structural fix and default: recognize any immediate non-whitespace
+  continuation after a complete rule reference, plus whitespace-separated
+  rule-label operators, as potential evidence. Admit that candidate only when
+  the existing complete-label grammar validates it; otherwise reject the
+  adjacent pair. Ambiguity fails closed because a false rejection leaves the
+  required check visibly red, while a false acceptance can clear unreconciled
+  reviewer evidence.
+
 ### Problem-derived contract
 
-- Root cause: the trusted rule-evidence grammar omits an exact rule reference
-  followed directly by `:` and nonempty detail, although the trusted Codex
-  connector now emits that observed form. A resolved finding therefore has no
-  normalizable decision and cannot be honestly reconciled.
+- Root cause: the trusted complete rule-evidence grammar omitted an exact rule
+  reference followed directly by `:` and nonempty detail, while adjacent-title
+  admission also inferred validity from an enumerated malformed-suffix
+  denylist. The producer form was therefore unparseable, and later repairs
+  could still admit an unenumerated incomplete suffix.
 - Correct fix must touch/change: extend only the shared complete-label grammar
   to admit `R<n>(/R<n>)*: nonempty detail`; prove multiline and inline positive
   correlation; scan candidates in source order so inline evidence on an earlier
@@ -24,8 +48,10 @@ the parser rather than bypassed in #2506.
   whole current title before any inline-like text inside that title can truncate
   it; recognize malformed fragments at line start and mid-line without splitting
   bare multi-digit or complete chained rule mentions; recognize incomplete slash
-  continuations with immediate or whitespace-separated delimiters; preserve
-  existing dash and severity-qualified forms; and prove incomplete, malformed,
+  continuations with immediate or whitespace-separated delimiters; classify
+  immediate suffixes as an open non-whitespace category and evidence-gate them
+  with the complete-label grammar; preserve existing dash and
+  severity-qualified forms; and prove incomplete, malformed, Unicode-suffixed,
   short-title, label-only, and unrelated inputs still fail closed.
 - Must not change: trusted bot identities, GitHub workflow triggers, open-thread
   blocking, current-head review freshness, PR-body disposition matching,
@@ -55,12 +81,15 @@ Max files: 3
     parser boundary tests.
   - A following complete evidence line preserves the entire bounded title even
     when that title contains generated `R<n>(/R<n>)*: text` combinations, while
-    a line that itself begins as a rule label or contains an incomplete
-    rule-label fragment cannot become a title; settled by
+    a line that itself begins as a rule label or contains potential rule
+    evidence that the complete grammar cannot validate cannot become a title;
+    settled by
     `test_adjacent_rule_evidence_property_preserves_rule_like_colon_text_inside_titles`,
     the label-only negative case,
     `test_adjacent_rule_evidence_rejects_malformed_fragments_at_start_or_midline`,
-    and the existing incomplete-fragment matrix.
+    the existing incomplete-fragment matrix, the evidence-keyed product over
+    rule tokens, title containers, and label families, and the generated
+    all-Unicode immediate-suffix property.
   - Bounded prefixes before rule-like colon text do not collapse distinct
     adjacent titles into one decision; settled by
     `test_adjacent_rule_evidence_keeps_bounded_prefix_titles_distinct`, including
@@ -103,11 +132,14 @@ Max files: 3
   source-order scanning preserves bounded inline evidence on an earlier line,
   while a complete following evidence line preserves the current whole title
   before rule-like colon text inside it can be truncated; complete multi-digit
-  references cannot backtrack into shorter malformed fragments; every unmatched
-  form retains the empty-decision fail-closed result.
+  references cannot backtrack into shorter malformed fragments; any immediate
+  non-whitespace continuation is structurally potential evidence and must pass
+  the complete grammar; every unmatched form retains the empty-decision
+  fail-closed result.
 - Guard-relevant fields: bounded title length/token floor, exact chained rule
-  reference, atomic longest-reference matching, optional delimiter whitespace,
-  colon/slash delimiter, and required nonempty detail token.
+  reference, atomic longest-reference matching, the open immediate
+  non-whitespace suffix category, optional delimiter whitespace, colon/slash
+  delimiter, and required nonempty detail token.
 - Caller x input shape: resolved trusted-bot history with the observed complete
   colon form can match only its named structured disposition; untrusted author,
   empty detail, malformed rule reference, short title, mismatched disposition,
@@ -115,9 +147,11 @@ Max files: 3
 
 ### Capability-set closure declaration
 
-- Producer prose is OPEN. The accepted evidence grammar is CLOSED and
-  ENUMERATED in `_COMPLETE_RULE_LABEL_RE`; the inline and adjacent-line
-  matchers derive their accepted forms from that one enumerated grammar.
+- Producer prose and malformed suffixes are OPEN. The accepted evidence grammar
+  is CLOSED and ENUMERATED in `_COMPLETE_RULE_LABEL_RE`; the inline and
+  adjacent-line matchers derive accepted forms from that grammar, while the
+  potential-evidence recognizer treats every immediate non-whitespace suffix as
+  requiring validation rather than enumerating rejected suffixes.
 - This slice adds one finite delimiter member: exact rule reference + colon +
   nonempty detail. It does not classify title vocabulary or accept generic
   prose as evidence.
@@ -146,13 +180,14 @@ Max files: 3
 Add the colon-with-detail alternative at the same complete-label grammar choke
 point used by inline and adjacent-line parsing. Walk nonblank lines once in
 source order: when the next line supplies complete evidence, preserve the
-current whole bounded title unless it begins as a rule label or contains a
-malformed fragment; otherwise return the current bounded inline root. Prevent
-fragment matching from backtracking by atomically consuming the longest complete
-reference, then treat any immediate or whitespace-separated leftover slash
-continuation as malformed. The established bounded-title floor and root matching
-remain downstream invariants, so recognizing the delimiter does not make
-arbitrary or short prose authoritative.
+current whole bounded title unless it begins as a rule label or contains
+potential rule evidence that the complete-label grammar cannot validate;
+otherwise return the current bounded inline root. Prevent reference matching
+from backtracking by atomically consuming the longest complete reference, then
+treat every immediate non-whitespace continuation and every
+whitespace-separated rule-label operator as potential evidence. The established
+bounded-title floor and root matching remain downstream invariants, so
+recognizing the delimiter does not make arbitrary or short prose authoritative.
 
 ## Intentional
 
@@ -175,8 +210,8 @@ Parked hardening: none.
 
 ## Verification
 
-- `./ops test focused tests/test_check_ai_reconciliation_live.py -q` ->
-  `88 passed in 0.63s` after the current-head review repairs.
+- `python -m pytest tests/test_check_ai_reconciliation_live.py -q` ->
+  `90 passed in 1.20s` after the structural decision-seam repair.
 - `/home/juan-canfield/miniconda3/bin/ruff check scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py`
   -> `All checks passed!`.
 - `/home/juan-canfield/Desktop/Atlas/.venv/bin/python -m py_compile scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py`
@@ -200,7 +235,7 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Live-Reconciliation-Severityless-Colon.md` | 206 |
-| `scripts/check_ai_reconciliation_live.py` | 31 |
-| `tests/test_check_ai_reconciliation_live.py` | 228 |
-| **Total** | **465** |
+| `plans/PR-Live-Reconciliation-Severityless-Colon.md` | 241 |
+| `scripts/check_ai_reconciliation_live.py` | 33 |
+| `tests/test_check_ai_reconciliation_live.py` | 268 |
+| **Total** | **542** |

--- a/plans/PR-Live-Reconciliation-Severityless-Colon.md
+++ b/plans/PR-Live-Reconciliation-Severityless-Colon.md
@@ -19,12 +19,13 @@ the parser rather than bypassed in #2506.
   normalizable decision and cannot be honestly reconciled.
 - Correct fix must touch/change: extend only the shared complete-label grammar
   to admit `R<n>(/R<n>)*: nonempty detail`; prove multiline and inline positive
-  correlation; scan candidates in source order so earlier complete inline
-  evidence keeps precedence, while a complete adjacent evidence line preserves
-  rule-like colon text inside its own title; recognize malformed fragments at
-  line start and mid-line; preserve existing dash and severity-qualified forms;
-  and prove incomplete, malformed, short-title, label-only, and unrelated inputs
-  still fail closed.
+  correlation; scan candidates in source order so inline evidence on an earlier
+  line keeps precedence, while a complete adjacent evidence line preserves the
+  whole current title before any inline-like text inside that title can truncate
+  it; recognize malformed fragments at line start and mid-line without splitting
+  bare multi-digit rule mentions; preserve existing dash and severity-qualified
+  forms; and prove incomplete, malformed, short-title, label-only, and unrelated
+  inputs still fail closed.
 - Must not change: trusted bot identities, GitHub workflow triggers, open-thread
   blocking, current-head review freshness, PR-body disposition matching,
   docs-only handling, Terms capability code, Tracker code, or any customer,
@@ -59,6 +60,13 @@ Max files: 3
     the label-only negative case,
     `test_adjacent_rule_evidence_rejects_malformed_fragments_at_start_or_midline`,
     and the existing incomplete-fragment matrix.
+  - Bounded prefixes before rule-like colon text do not collapse distinct
+    adjacent titles into one decision; settled by
+    `test_adjacent_rule_evidence_keeps_bounded_prefix_titles_distinct`, including
+    a negative one-disposition/two-title assertion.
+  - Bare `R10` through `R14` mentions in adjacent titles remain ordinary title
+    text rather than backtracking into malformed fragments; settled by
+    `test_adjacent_rule_evidence_preserves_bare_multi_digit_rule_mentions`.
   - Earlier complete inline evidence retains its decision even when later prose
     forms an otherwise valid adjacent title/evidence pair; settled by
     `test_earlier_inline_rule_evidence_precedes_later_adjacent_pairs`, including
@@ -86,10 +94,11 @@ Max files: 3
   `missing_thread_dispositions()` -> required gate result.
 - Replaced-path behaviors: a bounded title adjacent to or sharing a line with
   `R<n>(/R<n>)*: nonempty detail` changes from unparseable to correlatable;
-  source-order scanning preserves an earlier bounded inline root, while a
-  complete following evidence line preserves the current whole title when its
-  rule-like colon text cannot itself produce a bounded inline root; every
-  unmatched form retains the empty-decision fail-closed result.
+  source-order scanning preserves bounded inline evidence on an earlier line,
+  while a complete following evidence line preserves the current whole title
+  before rule-like colon text inside it can be truncated; complete multi-digit
+  references cannot backtrack into shorter malformed fragments; every unmatched
+  form retains the empty-decision fail-closed result.
 - Guard-relevant fields: bounded title length/token floor, exact chained rule
   reference, colon delimiter, and required nonempty detail token.
 - Caller x input shape: resolved trusted-bot history with the observed complete
@@ -129,12 +138,13 @@ Max files: 3
 
 Add the colon-with-detail alternative at the same complete-label grammar choke
 point used by inline and adjacent-line parsing. Walk nonblank lines once in
-source order: return a bounded inline root when the current line supplies one,
-otherwise allow a complete following evidence line to preserve the current
-whole title unless that title begins as a rule label or contains a fragment that
-cannot satisfy the complete-label grammar. The established bounded-title floor
-and root matching remain downstream invariants, so recognizing the delimiter
-does not make arbitrary or short prose authoritative.
+source order: when the next line supplies complete evidence, preserve the
+current whole bounded title unless it begins as a rule label or contains a
+malformed fragment; otherwise return the current bounded inline root. Prevent
+fragment matching from backtracking a complete multi-digit reference into a
+shorter reference plus digit suffix. The established bounded-title floor and
+root matching remain downstream invariants, so recognizing the delimiter does
+not make arbitrary or short prose authoritative.
 
 ## Intentional
 
@@ -157,7 +167,7 @@ Parked hardening: none.
 ## Verification
 
 - `./ops test focused tests/test_check_ai_reconciliation_live.py -q` ->
-  `85 passed in 0.53s` after the current-head review repairs.
+  `87 passed in 0.58s` after the current-head review repairs.
 - `/home/juan-canfield/miniconda3/bin/ruff check scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py`
   -> `All checks passed!`.
 - `/home/juan-canfield/Desktop/Atlas/.venv/bin/python -m py_compile scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py`
@@ -181,7 +191,7 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Live-Reconciliation-Severityless-Colon.md` | 187 |
-| `scripts/check_ai_reconciliation_live.py` | 33 |
-| `tests/test_check_ai_reconciliation_live.py` | 157 |
-| **Total** | **377** |
+| `plans/PR-Live-Reconciliation-Severityless-Colon.md` | 197 |
+| `scripts/check_ai_reconciliation_live.py` | 31 |
+| `tests/test_check_ai_reconciliation_live.py` | 200 |
+| **Total** | **428** |

--- a/plans/PR-Live-Reconciliation-Severityless-Colon.md
+++ b/plans/PR-Live-Reconciliation-Severityless-Colon.md
@@ -325,7 +325,7 @@ Parked hardening: none.
 ## Verification
 
 - `python -m pytest tests/test_check_ai_reconciliation_live.py -q` ->
-  `101 passed in 4.74s` after the terminal evidence-state repair.
+  `102 passed in 4.47s` after the short-inline adjacent-promotion repair.
 - `/home/juan-canfield/miniconda3/bin/ruff check scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py`
   -> `All checks passed!`.
 - `/home/juan-canfield/Desktop/Atlas/.venv/bin/python -m py_compile scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py`
@@ -350,6 +350,6 @@ Parked hardening: none.
 | File | LOC |
 |---|---:|
 | `plans/PR-Live-Reconciliation-Severityless-Colon.md` | 355 |
-| `scripts/check_ai_reconciliation_live.py` | 81 |
-| `tests/test_check_ai_reconciliation_live.py` | 571 |
-| **Total** | **1007** |
+| `scripts/check_ai_reconciliation_live.py` | 82 |
+| `tests/test_check_ai_reconciliation_live.py` | 590 |
+| **Total** | **1027** |

--- a/plans/PR-Live-Reconciliation-Severityless-Colon.md
+++ b/plans/PR-Live-Reconciliation-Severityless-Colon.md
@@ -19,10 +19,12 @@ the parser rather than bypassed in #2506.
   normalizable decision and cannot be honestly reconciled.
 - Correct fix must touch/change: extend only the shared complete-label grammar
   to admit `R<n>(/R<n>)*: nonempty detail`; prove multiline and inline positive
-  correlation; give a complete adjacent evidence line precedence over
-  rule-like colon text inside its title; preserve existing dash and
-  severity-qualified forms; and prove incomplete, malformed, short-title,
-  label-only, and unrelated inputs still fail closed.
+  correlation; scan candidates in source order so earlier complete inline
+  evidence keeps precedence, while a complete adjacent evidence line preserves
+  rule-like colon text inside its own title; recognize malformed fragments at
+  line start and mid-line; preserve existing dash and severity-qualified forms;
+  and prove incomplete, malformed, short-title, label-only, and unrelated inputs
+  still fail closed.
 - Must not change: trusted bot identities, GitHub workflow triggers, open-thread
   blocking, current-head review freshness, PR-body disposition matching,
   docs-only handling, Terms capability code, Tracker code, or any customer,
@@ -54,7 +56,13 @@ Max files: 3
     a line that itself begins as a rule label or contains an incomplete
     rule-label fragment cannot become a title; settled by
     `test_adjacent_rule_evidence_property_preserves_rule_like_colon_text_inside_titles`,
-    the label-only negative case, and the existing incomplete-fragment matrix.
+    the label-only negative case,
+    `test_adjacent_rule_evidence_rejects_malformed_fragments_at_start_or_midline`,
+    and the existing incomplete-fragment matrix.
+  - Earlier complete inline evidence retains its decision even when later prose
+    forms an otherwise valid adjacent title/evidence pair; settled by
+    `test_earlier_inline_rule_evidence_precedes_later_adjacent_pairs`, including
+    a negative assertion that the later prose cannot clear reconciliation.
   - `R2/R14:` with empty detail, `R2/R14   : detail` with pre-colon
     whitespace, `R2/R14foo: detail`, a short title, and text with no adjacent
     complete rule label yield no decision; settled by negative unit assertions.
@@ -78,9 +86,10 @@ Max files: 3
   `missing_thread_dispositions()` -> required gate result.
 - Replaced-path behaviors: a bounded title adjacent to or sharing a line with
   `R<n>(/R<n>)*: nonempty detail` changes from unparseable to correlatable;
-  a complete following evidence line wins before inline scanning so rule-like
-  colon text inside its title remains ordinary title text; every unmatched form
-  retains the empty-decision fail-closed result.
+  source-order scanning preserves an earlier bounded inline root, while a
+  complete following evidence line preserves the current whole title when its
+  rule-like colon text cannot itself produce a bounded inline root; every
+  unmatched form retains the empty-decision fail-closed result.
 - Guard-relevant fields: bounded title length/token floor, exact chained rule
   reference, colon delimiter, and required nonempty detail token.
 - Caller x input shape: resolved trusted-bot history with the observed complete
@@ -119,12 +128,13 @@ Max files: 3
 ## Mechanism
 
 Add the colon-with-detail alternative at the same complete-label grammar choke
-point used by inline and adjacent-line parsing. Resolve complete adjacent-line
-evidence first, preserving its whole bounded title unless that line itself
-begins as a rule label or contains a fragment that cannot satisfy the complete
-label grammar; then fall back to inline extraction. The established bounded
-title floor and root matching remain downstream invariants, so recognizing the
-delimiter does not make arbitrary or short prose authoritative.
+point used by inline and adjacent-line parsing. Walk nonblank lines once in
+source order: return a bounded inline root when the current line supplies one,
+otherwise allow a complete following evidence line to preserve the current
+whole title unless that title begins as a rule label or contains a fragment that
+cannot satisfy the complete-label grammar. The established bounded-title floor
+and root matching remain downstream invariants, so recognizing the delimiter
+does not make arbitrary or short prose authoritative.
 
 ## Intentional
 
@@ -147,7 +157,7 @@ Parked hardening: none.
 ## Verification
 
 - `./ops test focused tests/test_check_ai_reconciliation_live.py -q` ->
-  `83 passed in 0.51s`.
+  `85 passed in 0.53s` after the current-head review repairs.
 - `/home/juan-canfield/miniconda3/bin/ruff check scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py`
   -> `All checks passed!`.
 - `/home/juan-canfield/Desktop/Atlas/.venv/bin/python -m py_compile scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py`
@@ -171,7 +181,7 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Live-Reconciliation-Severityless-Colon.md` | 177 |
-| `scripts/check_ai_reconciliation_live.py` | 29 |
-| `tests/test_check_ai_reconciliation_live.py` | 96 |
-| **Total** | **302** |
+| `plans/PR-Live-Reconciliation-Severityless-Colon.md` | 187 |
+| `scripts/check_ai_reconciliation_live.py` | 33 |
+| `tests/test_check_ai_reconciliation_live.py` | 157 |
+| **Total** | **377** |

--- a/plans/PR-Live-Reconciliation-Severityless-Colon.md
+++ b/plans/PR-Live-Reconciliation-Severityless-Colon.md
@@ -19,8 +19,10 @@ the parser rather than bypassed in #2506.
   normalizable decision and cannot be honestly reconciled.
 - Correct fix must touch/change: extend only the shared complete-label grammar
   to admit `R<n>(/R<n>)*: nonempty detail`; prove multiline and inline positive
-  correlation, preserve existing dash and severity-qualified forms, and prove
-  incomplete, malformed, short-title, and unrelated inputs still fail closed.
+  correlation; give a complete adjacent evidence line precedence over
+  rule-like colon text inside its title; preserve existing dash and
+  severity-qualified forms; and prove incomplete, malformed, short-title,
+  label-only, and unrelated inputs still fail closed.
 - Must not change: trusted bot identities, GitHub workflow triggers, open-thread
   blocking, current-head review freshness, PR-body disposition matching,
   docs-only handling, Terms capability code, Tracker code, or any customer,
@@ -47,6 +49,12 @@ Max files: 3
   - The same complete rule label works inline, while existing dash and
     severity-qualified colon forms retain their current roots; settled by
     parser boundary tests.
+  - A following complete evidence line preserves the entire bounded title even
+    when that title contains generated `R<n>(/R<n>)*: text` combinations, while
+    a line that itself begins as a rule label or contains an incomplete
+    rule-label fragment cannot become a title; settled by
+    `test_adjacent_rule_evidence_property_preserves_rule_like_colon_text_inside_titles`,
+    the label-only negative case, and the existing incomplete-fragment matrix.
   - `R2/R14:` with empty detail, `R2/R14   : detail` with pre-colon
     whitespace, `R2/R14foo: detail`, a short title, and text with no adjacent
     complete rule label yield no decision; settled by negative unit assertions.
@@ -70,7 +78,9 @@ Max files: 3
   `missing_thread_dispositions()` -> required gate result.
 - Replaced-path behaviors: a bounded title adjacent to or sharing a line with
   `R<n>(/R<n>)*: nonempty detail` changes from unparseable to correlatable;
-  every unmatched form retains the empty-decision fail-closed result.
+  a complete following evidence line wins before inline scanning so rule-like
+  colon text inside its title remains ordinary title text; every unmatched form
+  retains the empty-decision fail-closed result.
 - Guard-relevant fields: bounded title length/token floor, exact chained rule
   reference, colon delimiter, and required nonempty detail token.
 - Caller x input shape: resolved trusted-bot history with the observed complete
@@ -108,8 +118,11 @@ Max files: 3
 
 ## Mechanism
 
-Add the colon-with-detail alternative at the same complete-label grammar
-choke point used by inline and adjacent-line parsing. The established bounded
+Add the colon-with-detail alternative at the same complete-label grammar choke
+point used by inline and adjacent-line parsing. Resolve complete adjacent-line
+evidence first, preserving its whole bounded title unless that line itself
+begins as a rule label or contains a fragment that cannot satisfy the complete
+label grammar; then fall back to inline extraction. The established bounded
 title floor and root matching remain downstream invariants, so recognizing the
 delimiter does not make arbitrary or short prose authoritative.
 
@@ -134,7 +147,7 @@ Parked hardening: none.
 ## Verification
 
 - `./ops test focused tests/test_check_ai_reconciliation_live.py -q` ->
-  `82 passed in 0.45s`.
+  `83 passed in 0.51s`.
 - `/home/juan-canfield/miniconda3/bin/ruff check scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py`
   -> `All checks passed!`.
 - `/home/juan-canfield/Desktop/Atlas/.venv/bin/python -m py_compile scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py`
@@ -158,7 +171,7 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Live-Reconciliation-Severityless-Colon.md` | 164 |
-| `scripts/check_ai_reconciliation_live.py` | 3 |
-| `tests/test_check_ai_reconciliation_live.py` | 60 |
-| **Total** | **227** |
+| `plans/PR-Live-Reconciliation-Severityless-Colon.md` | 177 |
+| `scripts/check_ai_reconciliation_live.py` | 29 |
+| `tests/test_check_ai_reconciliation_live.py` | 96 |
+| **Total** | **302** |

--- a/plans/PR-Live-Reconciliation-Severityless-Colon.md
+++ b/plans/PR-Live-Reconciliation-Severityless-Colon.md
@@ -75,7 +75,10 @@ behavioral surface.
   reference followed directly by `:` and nonempty detail, while adjacent-title
   admission also inferred validity from an enumerated malformed-suffix
   denylist. The producer form was therefore unparseable, and later repairs
-  could still admit an unenumerated incomplete suffix.
+  could still admit an unenumerated incomplete suffix. Once the parser returns
+  distinct full adjacent titles, downstream disposition correlation still
+  evaluates symmetric substring containment independently for each thread, so
+  one disposition can clear multiple distinct nested titles.
 - Correct fix must touch/change: extend the line-start complete-label grammar
   to admit `R<n>(/R<n>)*: nonempty detail`; prove adjacent positive correlation
   while keeping the severity-less inline form fail closed; scan candidates in
@@ -97,11 +100,16 @@ behavioral surface.
   unknown-leading-continuation, short-title, label-only, and unrelated inputs
   still fail closed. Stop source-order selection when any evidence-shaped line
   fails to produce a root before a later candidate, without changing
-  earlier-valid inline or adjacent precedence.
+  earlier-valid inline or adjacent precedence. Correlate dispositions across
+  the set of distinct normalized thread decisions: an exact root covers only
+  that exact decision, bounded containment remains available only when it has
+  one unambiguous candidate, and no single disposition can clear two distinct
+  titles.
 - Must not change: trusted bot identities, GitHub workflow triggers, open-thread
-  blocking, current-head review freshness, PR-body disposition matching,
-  docs-only handling, Terms capability code, Tracker code, or any customer,
-  persistence, financial, authentication, or product behavior.
+  blocking, current-head review freshness, structured disposition extraction,
+  title normalization, pairwise bounded-containment compatibility outside the
+  new ambiguity rule, docs-only handling, Terms capability code, Tracker code,
+  or any customer, persistence, financial, authentication, or product behavior.
 
 ## Scope (this PR)
 
@@ -113,6 +121,8 @@ Max files: 3
    rule-label evidence grammar without accepting an empty or malformed label.
 2. Pin both sides of the boundary in the focused live-reconciliation tests and
    rerun #2506's required trusted-base check after this provider merges.
+3. Make disposition correlation cardinality-aware so one ledger item cannot
+   satisfy two distinct nested thread decisions.
 
 ### Review Contract
 
@@ -170,6 +180,12 @@ Max files: 3
     adjacent titles into one decision; settled by
     `test_adjacent_rule_evidence_keeps_bounded_prefix_titles_distinct`, including
     a negative one-disposition/two-title assertion.
+  - Distinct normalized titles that are strict substrings of one another require
+    distinct disposition roots. An exact root covers only its exact title;
+    bounded containment remains accepted for a single unambiguous title, and
+    repeated threads with the same normalized decision remain one logical
+    finding. Settled by nested-title, ordering, unique-variant, and duplicate
+    decision tests.
   - Bare `R10` through `R14` mentions in adjacent titles remain ordinary title
     text rather than backtracking into malformed fragments; settled by
     `test_adjacent_rule_evidence_preserves_bare_multi_digit_rule_mentions`.
@@ -223,11 +239,14 @@ Max files: 3
   boundary, partial initial `R`/`r`, leading punctuation, the open immediate
   non-whitespace suffix category, optional
   delimiter whitespace, first-lexical-token continuation state, colon/slash
-  delimiter, and required nonempty detail token.
+  delimiter, required nonempty detail token, distinct normalized decision set,
+  and per-disposition candidate cardinality.
 - Caller x input shape: resolved trusted-bot history with the observed complete
-  colon form can match only its named structured disposition; untrusted author,
-  empty detail, malformed rule reference, short title, mismatched disposition,
-  and unresolved thread remain rejected by their existing checks.
+  colon form can match only its named structured disposition; nested distinct
+  titles cannot share one disposition, while one non-exact bounded variant can
+  still cover a single unambiguous decision. Untrusted author, empty detail,
+  malformed rule reference, short title, mismatched disposition, and unresolved
+  thread remain rejected by their existing checks.
 
 ### Capability-set closure declaration
 
@@ -297,9 +316,12 @@ first lexical position before nonblank continuation. Each source-order candidate
 is checked for unvalidated evidence before root selection; after the two valid
 root paths, any remaining evidence-shaped line returns no decision immediately.
 Valid inline and adjacent roots still return before any later line is considered.
-The established bounded-title floor and root matching remain downstream
-invariants, so recognizing the delimiter does not make arbitrary or short prose
-authoritative.
+The established bounded-title floor remains a downstream invariant. Correlation
+then builds the distinct normalized decision set and, for each disposition root,
+allows an exact match to cover only itself or a bounded containment match to
+cover only a sole candidate. Ambiguous containment covers nothing, so one body
+item cannot discharge multiple distinct findings while legacy unambiguous title
+variants remain compatible.
 
 ## Intentional
 
@@ -325,7 +347,7 @@ Parked hardening: none.
 ## Verification
 
 - `python -m pytest tests/test_check_ai_reconciliation_live.py -q` ->
-  `102 passed in 4.47s` after the short-inline adjacent-promotion repair.
+  `104 passed in 4.63s` after the cardinality-aware disposition repair.
 - `/home/juan-canfield/miniconda3/bin/ruff check scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py`
   -> `All checks passed!`.
 - `/home/juan-canfield/Desktop/Atlas/.venv/bin/python -m py_compile scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py`
@@ -349,7 +371,7 @@ Parked hardening: none.
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Live-Reconciliation-Severityless-Colon.md` | 355 |
-| `scripts/check_ai_reconciliation_live.py` | 82 |
-| `tests/test_check_ai_reconciliation_live.py` | 590 |
-| **Total** | **1027** |
+| `plans/PR-Live-Reconciliation-Severityless-Colon.md` | 377 |
+| `scripts/check_ai_reconciliation_live.py` | 112 |
+| `tests/test_check_ai_reconciliation_live.py` | 643 |
+| **Total** | **1132** |

--- a/scripts/check_ai_reconciliation_live.py
+++ b/scripts/check_ai_reconciliation_live.py
@@ -54,7 +54,7 @@ _COMPLETE_RULE_LABEL_RE = (
 _REVIEW_TITLE_STOP_RE = re.compile(rf"\s+{_COMPLETE_RULE_LABEL_RE}")
 _REVIEW_RULE_LABEL_RE = re.compile(rf"^{_COMPLETE_RULE_LABEL_RE}")
 _RULE_LABEL_FRAGMENT_RE = re.compile(
-    rf"(?:^|\s+)(?>{_RULE_REFERENCE_RE})(?!\d)(?:\s*(?:\(|:|[-—])|[/A-Za-z_])"
+    rf"(?:^|\s+)(?>{_RULE_REFERENCE_RE})(?!\d)(?:\s*(?:\(|:|/|[-—])|[A-Za-z_])"
 )
 _NON_ALNUM_RE = re.compile(r"[^a-z0-9]+")
 _UNPARSEABLE_THREAD_DECISION = "<unparseable trusted-bot review title>"

--- a/scripts/check_ai_reconciliation_live.py
+++ b/scripts/check_ai_reconciliation_live.py
@@ -316,6 +316,7 @@ def _evidenced_root_decision(body_text: str) -> str:
             index + 1 < len(lines)
             and _REVIEW_RULE_LABEL_RE.match(lines[index + 1])
             and not _REVIEW_RULE_LABEL_RE.match(line)
+            and not _REVIEW_TITLE_STOP_RE.search(line)
             and _has_bounded_decision_evidence(line)
         ):
             return line

--- a/scripts/check_ai_reconciliation_live.py
+++ b/scripts/check_ai_reconciliation_live.py
@@ -42,7 +42,8 @@ _DEFAULT_BOTS = ("chatgpt-codex-connector", "chatgpt-codex-connector[bot]")
 _CLEAN_CODEX_REVIEW_TEXT = "didn't find any major issues"
 _DEFAULT_CODEX_REVIEW_GRACE_SECONDS = 300
 _REVIEWED_COMMIT_RE = re.compile(r"\*\*Reviewed commit:\*\*\s*`(?P<sha>[0-9a-f]{10,40})`", re.IGNORECASE)
-_RULE_REFERENCE_RE = r"R\d+(?:/R\d+)*"
+_RULE_REFERENCE_RE = r"R[0-9]+(?:/R[0-9]+)*"
+_POTENTIAL_RULE_REFERENCE_RE = r"R\d+(?:/R\d+)*"
 _RULE_SEVERITY_RE = r"\([A-Z][A-Z0-9 _-]*\)"
 _LEGACY_COMPLETE_RULE_LABEL_RE = (
     rf"{_RULE_REFERENCE_RE}(?:"
@@ -56,10 +57,11 @@ _COMPLETE_RULE_LABEL_RE = (
 _REVIEW_TITLE_STOP_RE = re.compile(rf"\s+{_LEGACY_COMPLETE_RULE_LABEL_RE}")
 _REVIEW_RULE_LABEL_RE = re.compile(rf"^{_COMPLETE_RULE_LABEL_RE}")
 _POTENTIAL_RULE_EVIDENCE_RE = re.compile(
-    rf"(?<![^\W_])(?>{_RULE_REFERENCE_RE})(?!\d)(?=\S|\s*(?:\(|:|/|[-—]))"
+    rf"(?<![^\W_])(?>{_POTENTIAL_RULE_REFERENCE_RE})(?!\d)"
+    rf"(?=\S|\s*(?:\(|:|/|[-—]))"
 )
-_LEADING_RULE_CONTINUATION_RE = re.compile(
-    rf"^[\W_]*(?>{_RULE_REFERENCE_RE})(?!\d)(?=\s+\S)"
+_LEADING_RULE_REFERENCE_RE = re.compile(
+    rf"^[\W_]*(?P<reference>(?>{_POTENTIAL_RULE_REFERENCE_RE}))(?!\d)"
 )
 _NON_ALNUM_RE = re.compile(r"[^a-z0-9]+")
 _UNPARSEABLE_THREAD_DECISION = "<unparseable trusted-bot review title>"
@@ -256,7 +258,7 @@ def _bounded_title_root(line: str) -> str:
         root = line[: match.start()].strip()
     elif (
         _POTENTIAL_RULE_EVIDENCE_RE.search(line)
-        or _LEADING_RULE_CONTINUATION_RE.search(line)
+        or _LEADING_RULE_REFERENCE_RE.search(line)
     ):
         return ""
     else:
@@ -269,11 +271,18 @@ def _bounded_title_root(line: str) -> str:
 def _has_unvalidated_rule_evidence(line: str) -> bool:
     """Return whether a potential title contains non-complete rule evidence."""
 
-    if (
-        _LEADING_RULE_CONTINUATION_RE.search(line)
-        and not _REVIEW_RULE_LABEL_RE.match(line)
-    ):
-        return True
+    leading_match = _LEADING_RULE_REFERENCE_RE.search(line)
+    if leading_match is not None:
+        prefix = line[: leading_match.start("reference")]
+        reference = leading_match.group("reference")
+        remainder = line[leading_match.end("reference") :]
+        is_canonical_reference = re.fullmatch(_RULE_REFERENCE_RE, reference) is not None
+        if (
+            prefix
+            or not is_canonical_reference
+            or (remainder.strip() and not _REVIEW_RULE_LABEL_RE.match(line))
+        ):
+            return True
     for match in _POTENTIAL_RULE_EVIDENCE_RE.finditer(line):
         candidate = line[match.start() :]
         if not _REVIEW_RULE_LABEL_RE.match(candidate):

--- a/scripts/check_ai_reconciliation_live.py
+++ b/scripts/check_ai_reconciliation_live.py
@@ -323,11 +323,18 @@ def _evidenced_root_decision(body_text: str) -> str:
 
     lines = [line.strip() for line in body_text.splitlines() if line.strip()]
     for index, line in enumerate(lines):
+        inline_match = _REVIEW_TITLE_STOP_RE.search(line)
+        if inline_match:
+            title_prefix = line[: inline_match.start()]
+            if (
+                _REVIEW_RULE_LABEL_RE.match(line)
+                or _has_unvalidated_rule_evidence(title_prefix)
+            ):
+                return ""
+            return _bounded_title_root(line)
         if _has_unvalidated_rule_evidence(line):
             return ""
         root = _bounded_title_root(line)
-        if root and _REVIEW_TITLE_STOP_RE.search(line):
-            return root
         if (
             index + 1 < len(lines)
             and _REVIEW_RULE_LABEL_RE.match(lines[index + 1])

--- a/scripts/check_ai_reconciliation_live.py
+++ b/scripts/check_ai_reconciliation_live.py
@@ -44,17 +44,19 @@ _DEFAULT_CODEX_REVIEW_GRACE_SECONDS = 300
 _REVIEWED_COMMIT_RE = re.compile(r"\*\*Reviewed commit:\*\*\s*`(?P<sha>[0-9a-f]{10,40})`", re.IGNORECASE)
 _RULE_REFERENCE_RE = r"R\d+(?:/R\d+)*"
 _RULE_SEVERITY_RE = r"\([A-Z][A-Z0-9 _-]*\)"
-_COMPLETE_RULE_LABEL_RE = (
+_LEGACY_COMPLETE_RULE_LABEL_RE = (
     rf"{_RULE_REFERENCE_RE}(?:"
     rf"\s+{_RULE_SEVERITY_RE}(?:\s+[—-]\s+\S|\s*:\s+\S|\s+(?![:—-])\S)"
-    rf"|:\s+\S"
     rf"|\s+[—-]\s+\S"
     rf")"
 )
-_REVIEW_TITLE_STOP_RE = re.compile(rf"\s+{_COMPLETE_RULE_LABEL_RE}")
+_COMPLETE_RULE_LABEL_RE = (
+    rf"(?:{_LEGACY_COMPLETE_RULE_LABEL_RE}|{_RULE_REFERENCE_RE}:\s+\S)"
+)
+_REVIEW_TITLE_STOP_RE = re.compile(rf"\s+{_LEGACY_COMPLETE_RULE_LABEL_RE}")
 _REVIEW_RULE_LABEL_RE = re.compile(rf"^{_COMPLETE_RULE_LABEL_RE}")
 _POTENTIAL_RULE_EVIDENCE_RE = re.compile(
-    rf"(?:^|\s+)(?>{_RULE_REFERENCE_RE})(?!\d)(?=\S|\s*(?:\(|:|/|[-—]))"
+    rf"(?<![^\W_])(?>{_RULE_REFERENCE_RE})(?!\d)(?=\S|\s*(?:\(|:|/|[-—]))"
 )
 _NON_ALNUM_RE = re.compile(r"[^a-z0-9]+")
 _UNPARSEABLE_THREAD_DECISION = "<unparseable trusted-bot review title>"
@@ -262,7 +264,7 @@ def _has_unvalidated_rule_evidence(line: str) -> bool:
     """Return whether a potential title contains non-complete rule evidence."""
 
     for match in _POTENTIAL_RULE_EVIDENCE_RE.finditer(line):
-        candidate = line[match.start() :].lstrip()
+        candidate = line[match.start() :]
         if not _REVIEW_RULE_LABEL_RE.match(candidate):
             return True
     return False
@@ -273,6 +275,9 @@ def _evidenced_root_decision(body_text: str) -> str:
 
     lines = [line.strip() for line in body_text.splitlines() if line.strip()]
     for index, line in enumerate(lines):
+        root = _bounded_title_root(line)
+        if root and _REVIEW_TITLE_STOP_RE.search(line):
+            return root
         if (
             index + 1 < len(lines)
             and _REVIEW_RULE_LABEL_RE.match(lines[index + 1])
@@ -281,9 +286,6 @@ def _evidenced_root_decision(body_text: str) -> str:
             and _has_bounded_decision_evidence(line)
         ):
             return line
-        root = _bounded_title_root(line)
-        if root and _REVIEW_TITLE_STOP_RE.search(line):
-            return root
     return ""
 
 

--- a/scripts/check_ai_reconciliation_live.py
+++ b/scripts/check_ai_reconciliation_live.py
@@ -42,7 +42,11 @@ _DEFAULT_BOTS = ("chatgpt-codex-connector", "chatgpt-codex-connector[bot]")
 _CLEAN_CODEX_REVIEW_TEXT = "didn't find any major issues"
 _DEFAULT_CODEX_REVIEW_GRACE_SECONDS = 300
 _REVIEWED_COMMIT_RE = re.compile(r"\*\*Reviewed commit:\*\*\s*`(?P<sha>[0-9a-f]{10,40})`", re.IGNORECASE)
-_RULE_REFERENCE_RE = r"R[0-9]+(?:/R[0-9]+)*"
+_DEFINED_REVIEW_RULE_IDS = tuple(f"R{number}" for number in range(1, 15))
+_DEFINED_RULE_ID_RE = "(?:" + "|".join(
+    sorted((re.escape(rule_id) for rule_id in _DEFINED_REVIEW_RULE_IDS), key=len, reverse=True)
+) + ")"
+_RULE_REFERENCE_RE = rf"{_DEFINED_RULE_ID_RE}(?:/{_DEFINED_RULE_ID_RE})*"
 _POTENTIAL_RULE_REFERENCE_RE = r"R\d+(?:/R\d+)*"
 _RULE_SEVERITY_RE = r"\([A-Z][A-Z0-9 _-]*\)"
 _LEGACY_COMPLETE_RULE_LABEL_RE = (

--- a/scripts/check_ai_reconciliation_live.py
+++ b/scripts/check_ai_reconciliation_live.py
@@ -47,7 +47,15 @@ _DEFINED_RULE_ID_RE = "(?:" + "|".join(
     sorted((re.escape(rule_id) for rule_id in _DEFINED_REVIEW_RULE_IDS), key=len, reverse=True)
 ) + ")"
 _RULE_REFERENCE_RE = rf"{_DEFINED_RULE_ID_RE}(?:/{_DEFINED_RULE_ID_RE})*"
-_POTENTIAL_RULE_REFERENCE_RE = r"R\d+(?:/R\d+)*"
+_NUMERIC_POTENTIAL_RULE_REFERENCE_RE = r"[Rr]\d+(?:/[Rr]\d+)*"
+_PARTIAL_INITIAL_RULE_REFERENCE_RE = r"[Rr](?=\s*(?:\(|:|/|[-—]))"
+_LEADING_PARTIAL_RULE_REFERENCE_RE = r"[Rr](?=$|\s+\S|\s*(?:\(|:|/|[-—]))"
+_POTENTIAL_RULE_REFERENCE_RE = (
+    rf"(?:{_NUMERIC_POTENTIAL_RULE_REFERENCE_RE}|{_PARTIAL_INITIAL_RULE_REFERENCE_RE})"
+)
+_LEADING_POTENTIAL_RULE_REFERENCE_RE = (
+    rf"(?:{_NUMERIC_POTENTIAL_RULE_REFERENCE_RE}|{_LEADING_PARTIAL_RULE_REFERENCE_RE})"
+)
 _RULE_SEVERITY_RE = r"\([A-Z][A-Z0-9 _-]*\)"
 _LEGACY_COMPLETE_RULE_LABEL_RE = (
     rf"{_RULE_REFERENCE_RE}(?:"
@@ -65,7 +73,7 @@ _POTENTIAL_RULE_EVIDENCE_RE = re.compile(
     rf"(?=\S|\s*(?:\(|:|/|[-—]))"
 )
 _LEADING_RULE_REFERENCE_RE = re.compile(
-    rf"^[\W_]*(?P<reference>(?>{_POTENTIAL_RULE_REFERENCE_RE}))(?!\d)"
+    rf"^[\W_]*(?P<reference>(?>{_LEADING_POTENTIAL_RULE_REFERENCE_RE}))(?!\d)"
 )
 _NON_ALNUM_RE = re.compile(r"[^a-z0-9]+")
 _UNPARSEABLE_THREAD_DECISION = "<unparseable trusted-bot review title>"
@@ -299,6 +307,8 @@ def _evidenced_root_decision(body_text: str) -> str:
 
     lines = [line.strip() for line in body_text.splitlines() if line.strip()]
     for index, line in enumerate(lines):
+        if _has_unvalidated_rule_evidence(line):
+            return ""
         root = _bounded_title_root(line)
         if root and _REVIEW_TITLE_STOP_RE.search(line):
             return root
@@ -306,10 +316,16 @@ def _evidenced_root_decision(body_text: str) -> str:
             index + 1 < len(lines)
             and _REVIEW_RULE_LABEL_RE.match(lines[index + 1])
             and not _REVIEW_RULE_LABEL_RE.match(line)
-            and not _has_unvalidated_rule_evidence(line)
             and _has_bounded_decision_evidence(line)
         ):
             return line
+        if not root and (
+            _REVIEW_RULE_LABEL_RE.match(line)
+            or _REVIEW_TITLE_STOP_RE.search(line)
+            or _POTENTIAL_RULE_EVIDENCE_RE.search(line)
+            or _LEADING_RULE_REFERENCE_RE.search(line)
+        ):
+            return ""
     return ""
 
 

--- a/scripts/check_ai_reconciliation_live.py
+++ b/scripts/check_ai_reconciliation_live.py
@@ -280,9 +280,25 @@ def _bounded_title_root(line: str) -> str:
     return root
 
 
+def _has_non_ascii_numeric_rule_identity(line: str) -> bool:
+    """Return whether a lexical-boundary rule marker starts with Unicode numeric data."""
+
+    for index, marker in enumerate(line[:-1]):
+        if marker not in ("R", "r"):
+            continue
+        if index and line[index - 1].isalnum():
+            continue
+        candidate = line[index + 1]
+        if not candidate.isascii() and candidate.isnumeric():
+            return True
+    return False
+
+
 def _has_unvalidated_rule_evidence(line: str) -> bool:
     """Return whether a potential title contains non-complete rule evidence."""
 
+    if _has_non_ascii_numeric_rule_identity(line):
+        return True
     leading_match = _LEADING_RULE_REFERENCE_RE.search(line)
     if leading_match is not None:
         prefix = line[: leading_match.start("reference")]

--- a/scripts/check_ai_reconciliation_live.py
+++ b/scripts/check_ai_reconciliation_live.py
@@ -385,6 +385,24 @@ def root_decision_matches_thread(root: str, decision: str) -> bool:
     return root in decision or decision in root
 
 
+def _covered_thread_decisions(roots: Sequence[str], decisions: Sequence[str]) -> set[str]:
+    """Return distinct decisions covered without ambiguous root reuse."""
+
+    distinct_decisions = tuple(dict.fromkeys(decisions))
+    covered: set[str] = set()
+    for root in roots:
+        candidates = tuple(
+            decision
+            for decision in distinct_decisions
+            if root_decision_matches_thread(root, decision)
+        )
+        if root in candidates:
+            covered.add(root)
+        elif len(candidates) == 1:
+            covered.add(candidates[0])
+    return covered
+
+
 def missing_thread_dispositions(
     thread_summaries: Sequence[dict],
     body: str,
@@ -392,16 +410,22 @@ def missing_thread_dispositions(
     """Return bot-thread summaries not named by any structured disposition."""
 
     roots = reconciliation_disposition_roots(body)
+    prepared = [
+        (summary, _thread_root_decision(summary)) for summary in thread_summaries
+    ]
+    normalized_decisions = [
+        _normalized_decision(decision) for _, decision in prepared if decision
+    ]
+    covered = _covered_thread_decisions(roots, normalized_decisions)
     missing: list[dict] = []
-    for summary in thread_summaries:
-        decision = _thread_root_decision(summary)
+    for summary, decision in prepared:
         normalized = _normalized_decision(decision)
         if not normalized:
             copy = dict(summary)
             copy["decision"] = _UNPARSEABLE_THREAD_DECISION
             missing.append(copy)
             continue
-        if not any(root_decision_matches_thread(root, normalized) for root in roots):
+        if normalized not in covered:
             copy = dict(summary)
             copy["decision"] = decision
             missing.append(copy)

--- a/scripts/check_ai_reconciliation_live.py
+++ b/scripts/check_ai_reconciliation_live.py
@@ -47,12 +47,13 @@ _RULE_SEVERITY_RE = r"\([A-Z][A-Z0-9 _-]*\)"
 _COMPLETE_RULE_LABEL_RE = (
     rf"{_RULE_REFERENCE_RE}(?:"
     rf"\s+{_RULE_SEVERITY_RE}(?:\s+[—-]\s+\S|\s*:\s+\S|\s+(?![:—-])\S)"
+    rf"|\s*:\s+\S"
     rf"|\s+[—-]\s+\S"
     rf")"
 )
 _REVIEW_TITLE_STOP_RE = re.compile(rf"\s+{_COMPLETE_RULE_LABEL_RE}")
 _REVIEW_RULE_LABEL_RE = re.compile(rf"^{_COMPLETE_RULE_LABEL_RE}")
-_RULE_LABEL_FRAGMENT_RE = re.compile(rf"\s+{_RULE_REFERENCE_RE}\s*(?:\(|[-—])")
+_RULE_LABEL_FRAGMENT_RE = re.compile(rf"\s+{_RULE_REFERENCE_RE}\s*(?:\(|:|[-—])")
 _NON_ALNUM_RE = re.compile(r"[^a-z0-9]+")
 _UNPARSEABLE_THREAD_DECISION = "<unparseable trusted-bot review title>"
 _MIN_REVIEW_TITLE_CHARS = 24

--- a/scripts/check_ai_reconciliation_live.py
+++ b/scripts/check_ai_reconciliation_live.py
@@ -58,6 +58,9 @@ _REVIEW_RULE_LABEL_RE = re.compile(rf"^{_COMPLETE_RULE_LABEL_RE}")
 _POTENTIAL_RULE_EVIDENCE_RE = re.compile(
     rf"(?<![^\W_])(?>{_RULE_REFERENCE_RE})(?!\d)(?=\S|\s*(?:\(|:|/|[-—]))"
 )
+_LEADING_RULE_CONTINUATION_RE = re.compile(
+    rf"^[\W_]*(?>{_RULE_REFERENCE_RE})(?!\d)(?=\s+\S)"
+)
 _NON_ALNUM_RE = re.compile(r"[^a-z0-9]+")
 _UNPARSEABLE_THREAD_DECISION = "<unparseable trusted-bot review title>"
 _MIN_REVIEW_TITLE_CHARS = 24
@@ -251,7 +254,10 @@ def _bounded_title_root(line: str) -> str:
     match = _REVIEW_TITLE_STOP_RE.search(line)
     if match:
         root = line[: match.start()].strip()
-    elif _POTENTIAL_RULE_EVIDENCE_RE.search(line):
+    elif (
+        _POTENTIAL_RULE_EVIDENCE_RE.search(line)
+        or _LEADING_RULE_CONTINUATION_RE.search(line)
+    ):
         return ""
     else:
         root = line.strip()
@@ -263,6 +269,11 @@ def _bounded_title_root(line: str) -> str:
 def _has_unvalidated_rule_evidence(line: str) -> bool:
     """Return whether a potential title contains non-complete rule evidence."""
 
+    if (
+        _LEADING_RULE_CONTINUATION_RE.search(line)
+        and not _REVIEW_RULE_LABEL_RE.match(line)
+    ):
+        return True
     for match in _POTENTIAL_RULE_EVIDENCE_RE.finditer(line):
         candidate = line[match.start() :]
         if not _REVIEW_RULE_LABEL_RE.match(candidate):

--- a/scripts/check_ai_reconciliation_live.py
+++ b/scripts/check_ai_reconciliation_live.py
@@ -256,17 +256,35 @@ def _bounded_title_root(line: str) -> str:
     return root
 
 
+def _has_incomplete_rule_label_fragment(line: str) -> bool:
+    """Return whether a potential title contains incomplete rule evidence."""
+
+    for match in _RULE_LABEL_FRAGMENT_RE.finditer(line):
+        candidate = line[match.start() :].lstrip()
+        if not _REVIEW_RULE_LABEL_RE.match(candidate):
+            return True
+    return False
+
+
 def _evidenced_root_decision(body_text: str) -> str:
-    """Return a full title only when its existing rule evidence is adjacent."""
+    """Return a bounded title with complete adjacent or inline rule evidence."""
 
     lines = [line.strip() for line in body_text.splitlines() if line.strip()]
-    for index, line in enumerate(lines):
+    for index, line in enumerate(lines[:-1]):
+        if not _REVIEW_RULE_LABEL_RE.match(lines[index + 1]):
+            continue
+        if _REVIEW_RULE_LABEL_RE.match(line):
+            continue
+        if _has_incomplete_rule_label_fragment(line):
+            continue
+        if _has_bounded_decision_evidence(line):
+            return line
+
+    for line in lines:
         root = _bounded_title_root(line)
         if not root:
             continue
         if _REVIEW_TITLE_STOP_RE.search(line):
-            return root
-        if index + 1 < len(lines) and _REVIEW_RULE_LABEL_RE.match(lines[index + 1]):
             return root
     return ""
 

--- a/scripts/check_ai_reconciliation_live.py
+++ b/scripts/check_ai_reconciliation_live.py
@@ -47,7 +47,7 @@ _RULE_SEVERITY_RE = r"\([A-Z][A-Z0-9 _-]*\)"
 _COMPLETE_RULE_LABEL_RE = (
     rf"{_RULE_REFERENCE_RE}(?:"
     rf"\s+{_RULE_SEVERITY_RE}(?:\s+[—-]\s+\S|\s*:\s+\S|\s+(?![:—-])\S)"
-    rf"|\s*:\s+\S"
+    rf"|:\s+\S"
     rf"|\s+[—-]\s+\S"
     rf")"
 )

--- a/scripts/check_ai_reconciliation_live.py
+++ b/scripts/check_ai_reconciliation_live.py
@@ -54,7 +54,7 @@ _COMPLETE_RULE_LABEL_RE = (
 _REVIEW_TITLE_STOP_RE = re.compile(rf"\s+{_COMPLETE_RULE_LABEL_RE}")
 _REVIEW_RULE_LABEL_RE = re.compile(rf"^{_COMPLETE_RULE_LABEL_RE}")
 _RULE_LABEL_FRAGMENT_RE = re.compile(
-    rf"(?:^|\s+){_RULE_REFERENCE_RE}(?:\s*(?:\(|:|[-—])|[A-Za-z0-9_])"
+    rf"(?:^|\s+){_RULE_REFERENCE_RE}(?!\d)(?:\s*(?:\(|:|[-—])|[A-Za-z_])"
 )
 _NON_ALNUM_RE = re.compile(r"[^a-z0-9]+")
 _UNPARSEABLE_THREAD_DECISION = "<unparseable trusted-bot review title>"
@@ -273,19 +273,17 @@ def _evidenced_root_decision(body_text: str) -> str:
 
     lines = [line.strip() for line in body_text.splitlines() if line.strip()]
     for index, line in enumerate(lines):
+        if (
+            index + 1 < len(lines)
+            and _REVIEW_RULE_LABEL_RE.match(lines[index + 1])
+            and not _REVIEW_RULE_LABEL_RE.match(line)
+            and not _has_incomplete_rule_label_fragment(line)
+            and _has_bounded_decision_evidence(line)
+        ):
+            return line
         root = _bounded_title_root(line)
         if root and _REVIEW_TITLE_STOP_RE.search(line):
             return root
-        if index + 1 >= len(lines):
-            continue
-        if not _REVIEW_RULE_LABEL_RE.match(lines[index + 1]):
-            continue
-        if _REVIEW_RULE_LABEL_RE.match(line):
-            continue
-        if _has_incomplete_rule_label_fragment(line):
-            continue
-        if _has_bounded_decision_evidence(line):
-            return line
     return ""
 
 

--- a/scripts/check_ai_reconciliation_live.py
+++ b/scripts/check_ai_reconciliation_live.py
@@ -54,7 +54,7 @@ _COMPLETE_RULE_LABEL_RE = (
 _REVIEW_TITLE_STOP_RE = re.compile(rf"\s+{_COMPLETE_RULE_LABEL_RE}")
 _REVIEW_RULE_LABEL_RE = re.compile(rf"^{_COMPLETE_RULE_LABEL_RE}")
 _RULE_LABEL_FRAGMENT_RE = re.compile(
-    rf"(?:^|\s+){_RULE_REFERENCE_RE}(?!\d)(?:\s*(?:\(|:|[-—])|[A-Za-z_])"
+    rf"(?:^|\s+)(?>{_RULE_REFERENCE_RE})(?!\d)(?:\s*(?:\(|:|[-—])|[/A-Za-z_])"
 )
 _NON_ALNUM_RE = re.compile(r"[^a-z0-9]+")
 _UNPARSEABLE_THREAD_DECISION = "<unparseable trusted-bot review title>"

--- a/scripts/check_ai_reconciliation_live.py
+++ b/scripts/check_ai_reconciliation_live.py
@@ -53,7 +53,9 @@ _COMPLETE_RULE_LABEL_RE = (
 )
 _REVIEW_TITLE_STOP_RE = re.compile(rf"\s+{_COMPLETE_RULE_LABEL_RE}")
 _REVIEW_RULE_LABEL_RE = re.compile(rf"^{_COMPLETE_RULE_LABEL_RE}")
-_RULE_LABEL_FRAGMENT_RE = re.compile(rf"\s+{_RULE_REFERENCE_RE}\s*(?:\(|:|[-—])")
+_RULE_LABEL_FRAGMENT_RE = re.compile(
+    rf"(?:^|\s+){_RULE_REFERENCE_RE}(?:\s*(?:\(|:|[-—])|[A-Za-z0-9_])"
+)
 _NON_ALNUM_RE = re.compile(r"[^a-z0-9]+")
 _UNPARSEABLE_THREAD_DECISION = "<unparseable trusted-bot review title>"
 _MIN_REVIEW_TITLE_CHARS = 24
@@ -270,7 +272,12 @@ def _evidenced_root_decision(body_text: str) -> str:
     """Return a bounded title with complete adjacent or inline rule evidence."""
 
     lines = [line.strip() for line in body_text.splitlines() if line.strip()]
-    for index, line in enumerate(lines[:-1]):
+    for index, line in enumerate(lines):
+        root = _bounded_title_root(line)
+        if root and _REVIEW_TITLE_STOP_RE.search(line):
+            return root
+        if index + 1 >= len(lines):
+            continue
         if not _REVIEW_RULE_LABEL_RE.match(lines[index + 1]):
             continue
         if _REVIEW_RULE_LABEL_RE.match(line):
@@ -279,13 +286,6 @@ def _evidenced_root_decision(body_text: str) -> str:
             continue
         if _has_bounded_decision_evidence(line):
             return line
-
-    for line in lines:
-        root = _bounded_title_root(line)
-        if not root:
-            continue
-        if _REVIEW_TITLE_STOP_RE.search(line):
-            return root
     return ""
 
 

--- a/scripts/check_ai_reconciliation_live.py
+++ b/scripts/check_ai_reconciliation_live.py
@@ -53,8 +53,8 @@ _COMPLETE_RULE_LABEL_RE = (
 )
 _REVIEW_TITLE_STOP_RE = re.compile(rf"\s+{_COMPLETE_RULE_LABEL_RE}")
 _REVIEW_RULE_LABEL_RE = re.compile(rf"^{_COMPLETE_RULE_LABEL_RE}")
-_RULE_LABEL_FRAGMENT_RE = re.compile(
-    rf"(?:^|\s+)(?>{_RULE_REFERENCE_RE})(?!\d)(?:\s*(?:\(|:|/|[-—])|[A-Za-z_])"
+_POTENTIAL_RULE_EVIDENCE_RE = re.compile(
+    rf"(?:^|\s+)(?>{_RULE_REFERENCE_RE})(?!\d)(?=\S|\s*(?:\(|:|/|[-—]))"
 )
 _NON_ALNUM_RE = re.compile(r"[^a-z0-9]+")
 _UNPARSEABLE_THREAD_DECISION = "<unparseable trusted-bot review title>"
@@ -249,7 +249,7 @@ def _bounded_title_root(line: str) -> str:
     match = _REVIEW_TITLE_STOP_RE.search(line)
     if match:
         root = line[: match.start()].strip()
-    elif _RULE_LABEL_FRAGMENT_RE.search(line):
+    elif _POTENTIAL_RULE_EVIDENCE_RE.search(line):
         return ""
     else:
         root = line.strip()
@@ -258,10 +258,10 @@ def _bounded_title_root(line: str) -> str:
     return root
 
 
-def _has_incomplete_rule_label_fragment(line: str) -> bool:
-    """Return whether a potential title contains incomplete rule evidence."""
+def _has_unvalidated_rule_evidence(line: str) -> bool:
+    """Return whether a potential title contains non-complete rule evidence."""
 
-    for match in _RULE_LABEL_FRAGMENT_RE.finditer(line):
+    for match in _POTENTIAL_RULE_EVIDENCE_RE.finditer(line):
         candidate = line[match.start() :].lstrip()
         if not _REVIEW_RULE_LABEL_RE.match(candidate):
             return True
@@ -277,7 +277,7 @@ def _evidenced_root_decision(body_text: str) -> str:
             index + 1 < len(lines)
             and _REVIEW_RULE_LABEL_RE.match(lines[index + 1])
             and not _REVIEW_RULE_LABEL_RE.match(line)
-            and not _has_incomplete_rule_label_fragment(line)
+            and not _has_unvalidated_rule_evidence(line)
             and _has_bounded_decision_evidence(line)
         ):
             return line

--- a/tests/test_check_ai_reconciliation_live.py
+++ b/tests/test_check_ai_reconciliation_live.py
@@ -759,13 +759,16 @@ def test_adjacent_rule_evidence_preserves_bare_complete_chained_rule_mentions():
 
 def test_adjacent_rule_evidence_rejects_malformed_fragments_at_start_or_midline():
     c = load_check()
+    incomplete_chain_suffixes = ("/R", "//R5", "/Rfoo", "/R5/R")
+    chain_spacing = ("", " ", "\t", " \t ")
     malformed_fragments = (
         "R4   : malformed label used as a title",
         "R4foo: malformed label used as a title",
-        "R4/R: malformed label used as a title",
-        "R4//R5: malformed label used as a title",
-        "R4/Rfoo: malformed label used as a title",
-        "R4/R5/R: malformed label used as a title",
+        *(
+            f"R4{spacing}{suffix}: malformed label used as a title"
+            for spacing in chain_spacing
+            for suffix in incomplete_chain_suffixes
+        ),
     )
     candidate_templates = ("{}", "Context before {}")
 

--- a/tests/test_check_ai_reconciliation_live.py
+++ b/tests/test_check_ai_reconciliation_live.py
@@ -627,33 +627,43 @@ def test_severity_colon_rule_labels_correlate_multiline_and_inline_titles():
         assert any("no open scoped Codex review threads remain" in message for message in messages)
 
 
-def test_severity_less_colon_rule_labels_correlate_multiline_and_inline_titles():
+def test_severity_less_colon_rule_labels_correlate_adjacent_titles():
     c = load_check()
-    cases = (
-        (
-            "Exercise the deployed manifest entrypoint",
-            "Exercise the deployed manifest entrypoint\n"
-            "R2/R14: this test must call the deployed application",
-        ),
-        (
-            "Correlate the trusted producer colon delimiter",
-            "Correlate the trusted producer colon delimiter "
-            "R4: detail from the connector review",
-        ),
+    title = "Exercise the deployed manifest entrypoint"
+    source_body = (
+        "Exercise the deployed manifest entrypoint\n"
+        "R2/R14: this test must call the deployed application"
     )
 
-    for title, source_body in cases:
-        code, messages = c.evaluate(
-            [thread(resolved=True, body=source_body)],
-            body_with_dispositions(title),
-            BOTS,
-        )
+    code, messages = c.evaluate(
+        [thread(resolved=True, body=source_body)],
+        body_with_dispositions(title),
+        BOTS,
+    )
 
-        assert code == 0
-        assert any(
-            "no open scoped Codex review threads remain" in message
-            for message in messages
-        )
+    assert code == 0
+    assert any(
+        "no open scoped Codex review threads remain" in message
+        for message in messages
+    )
+
+
+def test_severity_less_colon_rule_labels_do_not_create_ambiguous_inline_roots():
+    c = load_check()
+    title = "Correlate the trusted producer colon delimiter"
+    source_body = f"{title} R4: detail from the connector review"
+
+    assert c._evidenced_root_decision(source_body) == ""
+    code, messages = c.evaluate(
+        [thread(resolved=True, body=source_body)],
+        body_with_dispositions(title),
+        BOTS,
+    )
+
+    assert code == 1
+    assert any(
+        "unparseable trusted-bot review title" in message for message in messages
+    )
 
 
 def test_adjacent_rule_evidence_property_preserves_rule_like_colon_text_inside_titles():
@@ -772,7 +782,11 @@ def test_adjacent_rule_evidence_rejects_malformed_fragments_at_start_or_midline(
             for suffix in incomplete_chain_suffixes
         ),
     )
-    candidate_templates = ("{}", "Context before {}")
+    candidate_templates = (
+        "{}",
+        "Context before {}",
+        "Reject malformed ({}) before admission",
+    )
 
     for malformed_fragment in malformed_fragments:
         for candidate_template in candidate_templates:
@@ -798,7 +812,9 @@ def test_potential_rule_evidence_uses_a_complete_grammar_oracle_across_axes():
     tokens = tuple(f"R{number}" for number in (4, 10)) + (
         "/".join(f"R{number}" for number in (4, 5)),
     )
-    containers = tuple(f"{prefix}{{}}" for prefix in ("", "Context before "))
+    containers = tuple(
+        f"{prefix}{{}}" for prefix in ("", "Context before ", "Punctuation boundary (")
+    )
     families = tuple(
         {
             "bare-reference": (" verification contract", False),
@@ -831,6 +847,17 @@ def test_potential_rule_evidence_covers_every_immediate_unicode_suffix():
         assert c._has_unvalidated_rule_evidence(candidate)
 
 
+def test_potential_rule_evidence_uses_unicode_lexical_boundaries():
+    c = load_check()
+
+    for codepoint in range(0x110000):
+        prefix = chr(codepoint)
+        candidate = f"{prefix}R4é: malformed label used as a title with enough words"
+        expected = not prefix.isalnum()
+
+        assert c._has_unvalidated_rule_evidence(candidate) is expected
+
+
 def test_earlier_inline_rule_evidence_precedes_later_adjacent_pairs():
     c = load_check()
     title = "Keep legacy inline root extraction"
@@ -838,7 +865,6 @@ def test_earlier_inline_rule_evidence_precedes_later_adjacent_pairs():
     inline_labels = (
         "R2 (BLOCKER) details",
         "R2 — complete inline detail",
-        "R2: complete inline detail",
     )
 
     for inline_label in inline_labels:
@@ -863,6 +889,36 @@ def test_earlier_inline_rule_evidence_precedes_later_adjacent_pairs():
         )
         assert wrong_code == 1
         assert any("missing dispositions" in message for message in wrong_messages)
+
+
+def test_inline_rule_evidence_precedes_an_immediately_adjacent_label():
+    c = load_check()
+    title = "Keep legacy inline root extraction"
+    wrong_disposition = "R2 BLOCKER details about the affected parser"
+    source_body = (
+        f"{title} R2 (BLOCKER) details about the affected parser\n"
+        "R4: additional context"
+    )
+
+    assert c._evidenced_root_decision(source_body) == title
+    code, messages = c.evaluate(
+        [thread(resolved=True, body=source_body)],
+        body_with_dispositions(title),
+        BOTS,
+    )
+    wrong_code, wrong_messages = c.evaluate(
+        [thread(resolved=True, body=source_body)],
+        body_with_dispositions(wrong_disposition),
+        BOTS,
+    )
+
+    assert code == 0
+    assert any(
+        "no open scoped Codex review threads remain" in message
+        for message in messages
+    )
+    assert wrong_code == 1
+    assert any("missing dispositions" in message for message in wrong_messages)
 
 
 def test_severity_less_colon_rule_labels_still_reject_incomplete_or_malformed_evidence():

--- a/tests/test_check_ai_reconciliation_live.py
+++ b/tests/test_check_ai_reconciliation_live.py
@@ -832,6 +832,24 @@ def test_adjacent_rule_evidence_rejects_unknown_leading_continuations():
         )
 
 
+def test_punctuation_wrapped_complete_colon_label_cannot_become_a_title():
+    c = load_check()
+    candidate = "(R4: malformed label used as a title with enough words)"
+    source_body = f"{candidate}\nR2: complete adjacent detail"
+
+    assert c._evidenced_root_decision(source_body) == ""
+    code, messages = c.evaluate(
+        [thread(resolved=True, body=source_body)],
+        body_with_dispositions(candidate),
+        BOTS,
+    )
+
+    assert code == 1
+    assert any(
+        "unparseable trusted-bot review title" in message for message in messages
+    )
+
+
 def test_potential_rule_evidence_uses_a_complete_grammar_oracle_across_axes():
     c = load_check()
     tokens = tuple(f"R{number}" for number in (4, 10)) + (
@@ -850,6 +868,7 @@ def test_potential_rule_evidence_uses_a_complete_grammar_oracle_across_axes():
             "complete-colon": (": complete adjacent detail", False),
             "complete-dash": (" — complete adjacent detail", False),
             "immediate-suffix": ("é: malformed adjacent detail", True),
+            "unicode-decimal": ("٤: malformed adjacent detail", True),
             "spaced-colon": (" : malformed adjacent detail", True),
             "incomplete-chain": (" /R5: malformed adjacent detail", True),
         }.items()
@@ -872,12 +891,41 @@ def test_potential_rule_evidence_covers_every_immediate_unicode_suffix():
 
     for codepoint in range(0x110000):
         suffix = chr(codepoint)
-        if suffix.isspace() or suffix.isdecimal():
+        if suffix.isspace() or suffix in "0123456789":
             continue
 
         candidate = f"R4{suffix}: malformed label used as a title with enough words"
 
         assert c._has_unvalidated_rule_evidence(candidate)
+
+
+def test_complete_rule_evidence_requires_ascii_decimal_references():
+    c = load_check()
+    title = "Preserve the bounded title for this decision"
+    unicode_decimals = tuple(
+        chr(codepoint)
+        for codepoint in range(0x110000)
+        if chr(codepoint).isdecimal() and chr(codepoint) not in "0123456789"
+    )
+
+    for digit in unicode_decimals:
+        for reference in (f"R{digit}", f"R4{digit}", f"R4/R{digit}"):
+            candidate = f"{reference}: complete adjacent detail"
+
+            assert c._has_unvalidated_rule_evidence(candidate)
+
+    source_body = f"{title}\nR٤: complete adjacent detail"
+    assert c._evidenced_root_decision(source_body) == ""
+    code, messages = c.evaluate(
+        [thread(resolved=True, body=source_body)],
+        body_with_dispositions(title),
+        BOTS,
+    )
+
+    assert code == 1
+    assert any(
+        "unparseable trusted-bot review title" in message for message in messages
+    )
 
 
 def test_potential_rule_evidence_uses_unicode_lexical_boundaries():

--- a/tests/test_check_ai_reconciliation_live.py
+++ b/tests/test_check_ai_reconciliation_live.py
@@ -736,11 +736,36 @@ def test_adjacent_rule_evidence_preserves_bare_multi_digit_rule_mentions():
         )
 
 
+def test_adjacent_rule_evidence_preserves_bare_complete_chained_rule_mentions():
+    c = load_check()
+
+    for reference in ("R4/R5", "R10/R14"):
+        title = f"Preserve compatibility with the {reference} verification contract"
+        source_body = f"{title}\nR2 — complete adjacent detail"
+
+        assert c._evidenced_root_decision(source_body) == title
+        code, messages = c.evaluate(
+            [thread(resolved=True, body=source_body)],
+            body_with_dispositions(title),
+            BOTS,
+        )
+
+        assert code == 0
+        assert any(
+            "no open scoped Codex review threads remain" in message
+            for message in messages
+        )
+
+
 def test_adjacent_rule_evidence_rejects_malformed_fragments_at_start_or_midline():
     c = load_check()
     malformed_fragments = (
         "R4   : malformed label used as a title",
         "R4foo: malformed label used as a title",
+        "R4/R: malformed label used as a title",
+        "R4//R5: malformed label used as a title",
+        "R4/Rfoo: malformed label used as a title",
+        "R4/R5/R: malformed label used as a title",
     )
     candidate_templates = ("{}", "Context before {}")
 

--- a/tests/test_check_ai_reconciliation_live.py
+++ b/tests/test_check_ai_reconciliation_live.py
@@ -807,13 +807,42 @@ def test_adjacent_rule_evidence_rejects_malformed_fragments_at_start_or_midline(
             )
 
 
+def test_adjacent_rule_evidence_rejects_unknown_leading_continuations():
+    c = load_check()
+    continuations = (
+        "R4 BLOCKER: malformed label used as a title with enough words",
+        "R4 R5: malformed label used as a title with enough words",
+    )
+    wrappers = ("{}", "({})")
+
+    for continuation, wrapper in product(continuations, wrappers):
+        candidate = wrapper.format(continuation)
+        source_body = f"{candidate}\nR2: complete adjacent detail"
+
+        assert c._evidenced_root_decision(source_body) == ""
+        code, messages = c.evaluate(
+            [thread(resolved=True, body=source_body)],
+            body_with_dispositions(candidate),
+            BOTS,
+        )
+
+        assert code == 1
+        assert any(
+            "unparseable trusted-bot review title" in message for message in messages
+        )
+
+
 def test_potential_rule_evidence_uses_a_complete_grammar_oracle_across_axes():
     c = load_check()
     tokens = tuple(f"R{number}" for number in (4, 10)) + (
         "/".join(f"R{number}" for number in (4, 5)),
     )
     containers = tuple(
-        f"{prefix}{{}}" for prefix in ("", "Context before ", "Punctuation boundary (")
+        {
+            "leading": ("{}", True),
+            "embedded": ("Context before {}", False),
+            "embedded-punctuation": ("Punctuation boundary ({})", False),
+        }.items()
     )
     families = tuple(
         {
@@ -826,10 +855,14 @@ def test_potential_rule_evidence_uses_a_complete_grammar_oracle_across_axes():
         }.items()
     )
 
-    for token, container, (family, (suffix, expected)) in product(
+    for token, (_container, (template, is_leading)), (
+        family,
+        (suffix, family_expected),
+    ) in product(
         tokens, containers, families
     ):
-        candidate = container.format(f"{token}{suffix}")
+        candidate = template.format(f"{token}{suffix}")
+        expected = family_expected or (is_leading and family == "bare-reference")
 
         assert c._has_unvalidated_rule_evidence(candidate) is expected, family
 
@@ -853,7 +886,24 @@ def test_potential_rule_evidence_uses_unicode_lexical_boundaries():
     for codepoint in range(0x110000):
         prefix = chr(codepoint)
         candidate = f"{prefix}R4é: malformed label used as a title with enough words"
+        leading_candidate = (
+            f"{prefix}R4 BLOCKER: malformed label used as a title with enough words"
+        )
         expected = not prefix.isalnum()
+
+        assert c._has_unvalidated_rule_evidence(candidate) is expected
+        assert c._has_unvalidated_rule_evidence(leading_candidate) is expected
+
+
+def test_leading_rule_continuations_are_complete_grammar_gated():
+    c = load_check()
+
+    for codepoint in range(0x110000):
+        continuation = chr(codepoint)
+        if continuation.isspace():
+            continue
+        candidate = f"R4 {continuation} continued evidence"
+        expected = continuation not in ("-", "—")
 
         assert c._has_unvalidated_rule_evidence(candidate) is expected
 

--- a/tests/test_check_ai_reconciliation_live.py
+++ b/tests/test_check_ai_reconciliation_live.py
@@ -1172,6 +1172,25 @@ def test_inline_rule_evidence_precedes_an_immediately_adjacent_label():
     assert any("missing dispositions" in message for message in wrong_messages)
 
 
+def test_short_inline_rule_evidence_is_terminal_before_an_adjacent_label():
+    c = load_check()
+    promoted_line = "x R2 (BLOCKER) complete but short inline evidence"
+    source_body = f"{promoted_line}\nR4: complete adjacent detail"
+
+    assert c._bounded_title_root(promoted_line) == ""
+    assert c._evidenced_root_decision(source_body) == ""
+    code, messages = c.evaluate(
+        [thread(resolved=True, body=source_body)],
+        body_with_dispositions(promoted_line),
+        BOTS,
+    )
+
+    assert code == 1
+    assert any(
+        "unparseable trusted-bot review title" in message for message in messages
+    )
+
+
 def test_severity_less_colon_rule_labels_still_reject_incomplete_or_malformed_evidence():
     c = load_check()
     title = "Require complete colon evidence for a review title"

--- a/tests/test_check_ai_reconciliation_live.py
+++ b/tests/test_check_ai_reconciliation_live.py
@@ -956,33 +956,41 @@ def test_potential_rule_evidence_covers_every_immediate_unicode_suffix():
         assert c._has_unvalidated_rule_evidence(candidate)
 
 
-def test_complete_rule_evidence_requires_ascii_decimal_references():
+def test_complete_rule_evidence_rejects_every_non_ascii_unicode_numeric_identity():
     c = load_check()
-    title = "Preserve the bounded title for this decision"
-    unicode_decimals = tuple(
+    unicode_numerics = tuple(
         chr(codepoint)
         for codepoint in range(0x110000)
-        if chr(codepoint).isdecimal() and chr(codepoint) not in "0123456789"
+        if chr(codepoint).isnumeric() and not chr(codepoint).isascii()
     )
 
-    for digit in unicode_decimals:
-        for reference in (f"R{digit}", f"R4{digit}", f"R4/R{digit}"):
+    for numeric in unicode_numerics:
+        for reference in (f"R{numeric}", f"R4{numeric}", f"R4/R{numeric}"):
             candidate = f"{reference}: complete adjacent detail"
 
             assert c._has_unvalidated_rule_evidence(candidate)
 
-    source_body = f"{title}\nR٤: complete adjacent detail"
-    assert c._evidenced_root_decision(source_body) == ""
-    code, messages = c.evaluate(
-        [thread(resolved=True, body=source_body)],
-        body_with_dispositions(title),
-        BOTS,
-    )
+    for numeric in ("٤", "²", "①", "½", "Ⅳ"):
+        source_body = f"R{numeric}: malformed label used as a title with enough words\nR2: detail"
+        assert c._evidenced_root_decision(source_body) == ""
+        code, messages = c.evaluate(
+            [thread(resolved=True, body=source_body)],
+            body_with_dispositions(source_body.splitlines()[0]),
+            BOTS,
+        )
 
-    assert code == 1
-    assert any(
-        "unparseable trusted-bot review title" in message for message in messages
-    )
+        assert code == 1
+        assert any(
+            "unparseable trusted-bot review title" in message for message in messages
+        )
+
+        embedded_title = f"Preserve embedded wordR{numeric} content inside this bounded title"
+        assert (
+            c._evidenced_root_decision(f"{embedded_title}\nR2: complete adjacent detail")
+            == embedded_title
+        )
+
+    assert unicode_numerics
 
 
 def test_defined_review_rule_ids_match_reviewer_rule_pack():

--- a/tests/test_check_ai_reconciliation_live.py
+++ b/tests/test_check_ai_reconciliation_live.py
@@ -436,6 +436,59 @@ def test_clear_body_passes_when_each_resolved_codex_thread_is_named():
     assert any("no open scoped Codex review threads remain" in msg for msg in msgs)
 
 
+def test_nested_thread_decisions_require_distinct_disposition_roots():
+    c = load_check()
+    short_title = "Ensure the report title preserves validation semantics"
+    long_title = f"{short_title} for export"
+    nodes = [
+        thread(resolved=True, body=f"{title}\nR2: complete adjacent detail")
+        for title in (short_title, long_title)
+    ]
+
+    code, messages = c.evaluate(
+        nodes,
+        body_with_dispositions(short_title),
+        BOTS,
+    )
+    ambiguous_code, ambiguous_messages = c.evaluate(
+        nodes,
+        body_with_dispositions(f"Review {long_title}"),
+        BOTS,
+    )
+    complete_code, complete_messages = c.evaluate(
+        list(reversed(nodes)),
+        body_with_dispositions(long_title, short_title),
+        BOTS,
+    )
+
+    assert code == 1
+    assert any(long_title in message for message in messages)
+    assert ambiguous_code == 1
+    assert all(any(title in message for message in ambiguous_messages) for title in (short_title, long_title))
+    assert complete_code == 0
+    assert any(
+        "no open scoped Codex review threads remain" in message
+        for message in complete_messages
+    )
+
+
+def test_unambiguous_disposition_variants_and_duplicate_decisions_remain_compatible():
+    c = load_check()
+    title = "Require a disposition for every resolved thread"
+    variant = f"{title} in the current history"
+    nodes = [
+        thread(resolved=True, path=path, body=f"{title}\nR2: complete adjacent detail")
+        for path in ("scripts/x.py", "scripts/y.py")
+    ]
+
+    code, messages = c.evaluate(nodes, body_with_dispositions(variant), BOTS)
+
+    assert code == 0
+    assert any(
+        "no open scoped Codex review threads remain" in message for message in messages
+    )
+
+
 def test_multiline_bodytext_uses_title_paired_with_rule_evidence_for_resolved_thread_dispositions():
     c = load_check()
     cases = (

--- a/tests/test_check_ai_reconciliation_live.py
+++ b/tests/test_check_ai_reconciliation_live.py
@@ -655,6 +655,42 @@ def test_severity_less_colon_rule_labels_correlate_multiline_and_inline_titles()
         )
 
 
+def test_adjacent_rule_evidence_property_preserves_rule_like_colon_text_inside_titles():
+    c = load_check()
+    embedded_references = tuple(
+        "/".join(f"R{value}" for value in range(1, member_count + 1))
+        for member_count in range(1, 5)
+    )
+    title_details = (
+        "validation semantics for export",
+        "routing guarantees across service boundaries",
+    )
+    evidence_labels = (
+        "R2 (BLOCKER) complete adjacent detail",
+        "R1/R4 — complete adjacent detail",
+        "R4: complete adjacent detail",
+    )
+
+    for reference in embedded_references:
+        for title_detail in title_details:
+            title = f"Preserve {reference}: {title_detail}"
+            for evidence_label in evidence_labels:
+                source_body = f"{title}\n{evidence_label}"
+
+                assert c._evidenced_root_decision(source_body) == title
+                code, messages = c.evaluate(
+                    [thread(resolved=True, body=source_body)],
+                    body_with_dispositions(title),
+                    BOTS,
+                )
+
+                assert code == 0
+                assert any(
+                    "no open scoped Codex review threads remain" in message
+                    for message in messages
+                )
+
+
 def test_severity_less_colon_rule_labels_still_reject_incomplete_or_malformed_evidence():
     c = load_check()
     title = "Require complete colon evidence for a review title"
@@ -665,7 +701,7 @@ def test_severity_less_colon_rule_labels_still_reject_incomplete_or_malformed_ev
         f"{title}\nR4   : detail",
         f"{title}\nR4foo: detail",
         "x\nR4: detail",
-        f"{title} R4:\nR2 — separate complete evidence",
+        "R4: label-only detail with enough words\nR2 — separate complete evidence",
     )
 
     for source_body in malformed_bodies:

--- a/tests/test_check_ai_reconciliation_live.py
+++ b/tests/test_check_ai_reconciliation_live.py
@@ -563,6 +563,7 @@ def test_complete_rule_label_evidence_rejects_incomplete_separator_forms():
         for suffix in (
             " — ",
             " - ",
+            ": ",
             " (BLOCKER) ",
             " (BLOCKER) — ",
             " (BLOCKER): ",
@@ -579,6 +580,8 @@ def test_complete_rule_label_evidence_rejects_incomplete_separator_forms():
             " (BLOCKER)- detail",
             " (BLOCKER):",
             " (BLOCKER): ",
+            ":",
+            ": ",
             " —",
         )
     )
@@ -623,18 +626,57 @@ def test_severity_colon_rule_labels_correlate_multiline_and_inline_titles():
         assert any("no open scoped Codex review threads remain" in message for message in messages)
 
 
-def test_severity_less_colon_rule_label_cannot_supply_a_reconciled_title():
+def test_severity_less_colon_rule_labels_correlate_multiline_and_inline_titles():
     c = load_check()
-    title = "Require strict severity evidence for a review title"
-
-    code, messages = c.evaluate(
-        [thread(resolved=True, body=f"{title}\nR4: detail without severity evidence")],
-        body_with_dispositions(title),
-        BOTS,
+    cases = (
+        (
+            "Exercise the deployed manifest entrypoint",
+            "Exercise the deployed manifest entrypoint\n"
+            "R2/R14: this test must call the deployed application",
+        ),
+        (
+            "Correlate the trusted producer colon delimiter",
+            "Correlate the trusted producer colon delimiter "
+            "R4: detail from the connector review",
+        ),
     )
 
-    assert code == 1
-    assert any("unparseable trusted-bot review title" in message for message in messages)
+    for title, source_body in cases:
+        code, messages = c.evaluate(
+            [thread(resolved=True, body=source_body)],
+            body_with_dispositions(title),
+            BOTS,
+        )
+
+        assert code == 0
+        assert any(
+            "no open scoped Codex review threads remain" in message
+            for message in messages
+        )
+
+
+def test_severity_less_colon_rule_labels_still_reject_incomplete_or_malformed_evidence():
+    c = load_check()
+    title = "Require complete colon evidence for a review title"
+    malformed_bodies = (
+        f"{title}\nR4:",
+        f"{title}\nR4: ",
+        f"{title}\nR4foo: detail",
+        "x\nR4: detail",
+        f"{title} R4:\nR2 — separate complete evidence",
+    )
+
+    for source_body in malformed_bodies:
+        code, messages = c.evaluate(
+            [thread(resolved=True, body=source_body)],
+            body_with_dispositions(title),
+            BOTS,
+        )
+
+        assert code == 1
+        assert any(
+            "unparseable trusted-bot review title" in message for message in messages
+        )
 
 
 def test_legacy_inline_rule_label_remains_a_resolved_thread_disposition_title():

--- a/tests/test_check_ai_reconciliation_live.py
+++ b/tests/test_check_ai_reconciliation_live.py
@@ -661,6 +661,8 @@ def test_severity_less_colon_rule_labels_still_reject_incomplete_or_malformed_ev
     malformed_bodies = (
         f"{title}\nR4:",
         f"{title}\nR4: ",
+        f"{title}\nR4 : detail",
+        f"{title}\nR4   : detail",
         f"{title}\nR4foo: detail",
         "x\nR4: detail",
         f"{title} R4:\nR2 — separate complete evidence",

--- a/tests/test_check_ai_reconciliation_live.py
+++ b/tests/test_check_ai_reconciliation_live.py
@@ -691,6 +691,67 @@ def test_adjacent_rule_evidence_property_preserves_rule_like_colon_text_inside_t
                 )
 
 
+def test_adjacent_rule_evidence_rejects_malformed_fragments_at_start_or_midline():
+    c = load_check()
+    malformed_fragments = (
+        "R4   : malformed label used as a title",
+        "R4foo: malformed label used as a title",
+    )
+    candidate_templates = ("{}", "Context before {}")
+
+    for malformed_fragment in malformed_fragments:
+        for candidate_template in candidate_templates:
+            candidate = candidate_template.format(malformed_fragment)
+            source_body = f"{candidate}\nR2: complete adjacent detail"
+
+            assert c._evidenced_root_decision(source_body) == ""
+            code, messages = c.evaluate(
+                [thread(resolved=True, body=source_body)],
+                body_with_dispositions(candidate),
+                BOTS,
+            )
+
+            assert code == 1
+            assert any(
+                "unparseable trusted-bot review title" in message
+                for message in messages
+            )
+
+
+def test_earlier_inline_rule_evidence_precedes_later_adjacent_pairs():
+    c = load_check()
+    title = "Keep legacy inline root extraction"
+    unrelated = "This explanatory context has enough title words"
+    inline_labels = (
+        "R2 (BLOCKER) details",
+        "R2 — complete inline detail",
+        "R2: complete inline detail",
+    )
+
+    for inline_label in inline_labels:
+        source_body = f"{title} {inline_label}\n{unrelated}\nR4: additional context"
+
+        assert c._evidenced_root_decision(source_body) == title
+        code, messages = c.evaluate(
+            [thread(resolved=True, body=source_body)],
+            body_with_dispositions(title),
+            BOTS,
+        )
+        wrong_code, wrong_messages = c.evaluate(
+            [thread(resolved=True, body=source_body)],
+            body_with_dispositions(unrelated),
+            BOTS,
+        )
+
+        assert code == 0
+        assert any(
+            "no open scoped Codex review threads remain" in message
+            for message in messages
+        )
+        assert wrong_code == 1
+        assert any("missing dispositions" in message for message in wrong_messages)
+
+
 def test_severity_less_colon_rule_labels_still_reject_incomplete_or_malformed_evidence():
     c = load_check()
     title = "Require complete colon evidence for a review title"

--- a/tests/test_check_ai_reconciliation_live.py
+++ b/tests/test_check_ai_reconciliation_live.py
@@ -10,6 +10,7 @@ SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "check_ai_reconciliat
 ROOT = Path(__file__).resolve().parents[1]
 LIVE_WORKFLOW = ROOT / ".github" / "workflows" / "ai_reconciliation_live.yml"
 RETRIGGER_WORKFLOW = ROOT / ".github" / "workflows" / "ai_reconciliation_review_retrigger.yml"
+REVIEWER_RULES = ROOT / "docs" / "REVIEWER_RULES.md"
 
 
 def load_check():
@@ -915,6 +916,71 @@ def test_complete_rule_evidence_requires_ascii_decimal_references():
             assert c._has_unvalidated_rule_evidence(candidate)
 
     source_body = f"{title}\nR٤: complete adjacent detail"
+    assert c._evidenced_root_decision(source_body) == ""
+    code, messages = c.evaluate(
+        [thread(resolved=True, body=source_body)],
+        body_with_dispositions(title),
+        BOTS,
+    )
+
+    assert code == 1
+    assert any(
+        "unparseable trusted-bot review title" in message for message in messages
+    )
+
+
+def test_defined_review_rule_ids_match_reviewer_rule_pack():
+    c = load_check()
+    documented_ids = tuple(
+        token
+        for line in REVIEWER_RULES.read_text(encoding="utf-8").splitlines()
+        if line.startswith("### R")
+        for token in line.split()[1:2]
+        if token[1:].isdigit()
+    )
+
+    assert c._DEFINED_REVIEW_RULE_IDS == documented_ids
+
+
+def test_complete_rule_evidence_requires_a_defined_rule_id():
+    c = load_check()
+    title = "Preserve the bounded title for this decision"
+    valid_references = (*c._DEFINED_REVIEW_RULE_IDS, "R1/R14", "R14/R1", "R1/R2/R14")
+    evidence_suffixes = (
+        ": complete adjacent detail",
+        " — complete adjacent detail",
+        " (BLOCKER) complete adjacent detail",
+    )
+
+    for reference in valid_references:
+        for evidence_suffix in evidence_suffixes:
+            candidate = f"{reference}{evidence_suffix}"
+
+            assert not c._has_unvalidated_rule_evidence(candidate)
+            assert c._REVIEW_RULE_LABEL_RE.match(candidate)
+
+    undefined_references = tuple(
+        f"R{number}"
+        for number in range(1000)
+        if f"R{number}" not in c._DEFINED_REVIEW_RULE_IDS
+    ) + (
+        "R1/R0",
+        "R14/R15",
+        "R0/R1",
+        "R999999999999999999999999",
+    ) + tuple(
+        f"R{number:0{width}d}"
+        for width in (2, 3)
+        for number in range(15)
+        if f"{number:0{width}d}" != str(number)
+    )
+    for reference in undefined_references:
+        for evidence_suffix in evidence_suffixes:
+            candidate = f"{reference}{evidence_suffix}"
+
+            assert c._has_unvalidated_rule_evidence(candidate)
+
+    source_body = f"{title}\nR999: complete adjacent detail"
     assert c._evidenced_root_decision(source_body) == ""
     code, messages = c.evaluate(
         [thread(resolved=True, body=source_body)],

--- a/tests/test_check_ai_reconciliation_live.py
+++ b/tests/test_check_ai_reconciliation_live.py
@@ -593,7 +593,10 @@ def test_complete_rule_label_evidence_rejects_incomplete_separator_forms():
 
         assert code == expected_code
         if expected_code:
-            assert any(actual in message for message in messages)
+            assert any(
+                "unparseable trusted-bot review title" in message for message in messages
+            )
+            assert all(actual not in message for message in messages)
 
     node = thread(resolved=True, body=f"{prefix} R1(\nR2 — complete rule detail")
     code, messages = c.evaluate([node], body_with_dispositions(prefix), BOTS)
@@ -992,6 +995,90 @@ def test_complete_rule_evidence_requires_a_defined_rule_id():
     assert any(
         "unparseable trusted-bot review title" in message for message in messages
     )
+
+
+def test_partial_initial_rule_id_evidence_fails_closed():
+    c = load_check()
+    operator_continuations = (
+        ": missing initial numeric identity",
+        " : missing initial numeric identity",
+        "/R4: missing initial numeric identity",
+        " /R4: missing initial numeric identity",
+        "/r4: missing initial numeric identity",
+        " (BLOCKER) missing initial numeric identity",
+        " — missing initial numeric identity",
+        " - missing initial numeric identity",
+    )
+    containers = ("{}", "({})", "Context before ({})")
+
+    for marker, continuation, container in product(
+        ("R", "r"), operator_continuations, containers
+    ):
+        candidate = container.format(f"{marker}{continuation}")
+        assert c._has_unvalidated_rule_evidence(candidate)
+
+    for marker, continuation in product(("R", "r"), ("", " BLOCKER", "\tR4")):
+        assert c._has_unvalidated_rule_evidence(f"{marker}{continuation}")
+
+    case_variant_references = tuple(
+        f"r{number}" for number in range(1, 15)
+    ) + ("r4/r14", "r4/R14", "R4/r14")
+    for reference, suffix in product(
+        case_variant_references,
+        (": lowercase marker", " — lowercase marker", " (BLOCKER) lowercase marker"),
+    ):
+        assert c._has_unvalidated_rule_evidence(f"{reference}{suffix}")
+
+    ordinary_title = "Review ordinary title words without rule evidence"
+    assert not c._has_unvalidated_rule_evidence(ordinary_title)
+    assert not c._has_unvalidated_rule_evidence("Use R for an ordinary variable name")
+    assert c._evidenced_root_decision(f"{ordinary_title}\nR2: complete detail") == ordinary_title
+
+    malformed_title = "R: malformed label used as a title with enough words"
+    source_body = f"{malformed_title}\nR2: detail"
+    assert c._evidenced_root_decision(source_body) == ""
+    code, messages = c.evaluate(
+        [thread(resolved=True, body=source_body)],
+        body_with_dispositions(malformed_title),
+        BOTS,
+    )
+
+    assert code == 1
+    assert any(
+        "unparseable trusted-bot review title" in message for message in messages
+    )
+
+
+def test_earlier_nonroot_rule_evidence_stops_later_adjacent_pairs():
+    c = load_check()
+    later_title = "This explanatory context has enough title words"
+    earlier_nonroot_lines = (
+        "R999: malformed rule evidence",
+        "R: malformed rule evidence",
+        "R/R4: malformed rule evidence",
+        "R2: complete but unrooted rule evidence",
+        "x R2 (BLOCKER) complete but short inline evidence",
+        "Ambiguous title contains R4: inline evidence without an adjacent label",
+    )
+
+    for earlier_line in earlier_nonroot_lines:
+        source_body = f"{earlier_line}\n{later_title}\nR2: complete adjacent detail"
+
+        assert c._evidenced_root_decision(source_body) == ""
+        code, messages = c.evaluate(
+            [thread(resolved=True, body=source_body)],
+            body_with_dispositions(later_title),
+            BOTS,
+        )
+
+        assert code == 1
+        assert any(
+            "unparseable trusted-bot review title" in message for message in messages
+        )
+
+    earlier_title = "Keep the first valid adjacent decision before later evidence"
+    later_malformed = f"{earlier_title}\nR2: complete adjacent detail\nR999: later malformed evidence"
+    assert c._evidenced_root_decision(later_malformed) == earlier_title
 
 
 def test_potential_rule_evidence_uses_unicode_lexical_boundaries():

--- a/tests/test_check_ai_reconciliation_live.py
+++ b/tests/test_check_ai_reconciliation_live.py
@@ -661,6 +661,7 @@ def test_adjacent_rule_evidence_property_preserves_rule_like_colon_text_inside_t
         "/".join(f"R{value}" for value in range(1, member_count + 1))
         for member_count in range(1, 5)
     )
+    title_prefixes = ("Preserve", "Ensure the report title preserves")
     title_details = (
         "validation semantics for export",
         "routing guarantees across service boundaries",
@@ -672,23 +673,67 @@ def test_adjacent_rule_evidence_property_preserves_rule_like_colon_text_inside_t
     )
 
     for reference in embedded_references:
-        for title_detail in title_details:
-            title = f"Preserve {reference}: {title_detail}"
-            for evidence_label in evidence_labels:
-                source_body = f"{title}\n{evidence_label}"
+        for title_prefix in title_prefixes:
+            for title_detail in title_details:
+                title = f"{title_prefix} {reference}: {title_detail}"
+                for evidence_label in evidence_labels:
+                    source_body = f"{title}\n{evidence_label}"
 
-                assert c._evidenced_root_decision(source_body) == title
-                code, messages = c.evaluate(
-                    [thread(resolved=True, body=source_body)],
-                    body_with_dispositions(title),
-                    BOTS,
-                )
+                    assert c._evidenced_root_decision(source_body) == title
+                    code, messages = c.evaluate(
+                        [thread(resolved=True, body=source_body)],
+                        body_with_dispositions(title),
+                        BOTS,
+                    )
 
-                assert code == 0
-                assert any(
-                    "no open scoped Codex review threads remain" in message
-                    for message in messages
-                )
+                    assert code == 0
+                    assert any(
+                        "no open scoped Codex review threads remain" in message
+                        for message in messages
+                    )
+
+
+def test_adjacent_rule_evidence_keeps_bounded_prefix_titles_distinct():
+    c = load_check()
+    titles = (
+        "Ensure the report title preserves R4: validation semantics for export",
+        "Ensure the report title preserves R5: routing semantics for import",
+    )
+    nodes = [
+        thread(resolved=True, body=f"{title}\nR2: complete adjacent detail")
+        for title in titles
+    ]
+
+    assert [
+        c._evidenced_root_decision(node["comments"]["nodes"][0]["bodyText"])
+        for node in nodes
+    ] == list(titles)
+    code, messages = c.evaluate(nodes, body_with_dispositions(titles[0]), BOTS)
+
+    assert code == 1
+    assert any("missing dispositions" in message for message in messages)
+    assert any(titles[1] in message for message in messages)
+
+
+def test_adjacent_rule_evidence_preserves_bare_multi_digit_rule_mentions():
+    c = load_check()
+
+    for rule_number in range(10, 15):
+        title = f"Preserve compatibility with the R{rule_number} verification contract"
+        source_body = f"{title}\nR2 — complete adjacent detail"
+
+        assert c._evidenced_root_decision(source_body) == title
+        code, messages = c.evaluate(
+            [thread(resolved=True, body=source_body)],
+            body_with_dispositions(title),
+            BOTS,
+        )
+
+        assert code == 0
+        assert any(
+            "no open scoped Codex review threads remain" in message
+            for message in messages
+        )
 
 
 def test_adjacent_rule_evidence_rejects_malformed_fragments_at_start_or_midline():

--- a/tests/test_check_ai_reconciliation_live.py
+++ b/tests/test_check_ai_reconciliation_live.py
@@ -1233,6 +1233,42 @@ def test_inline_rule_evidence_precedes_an_immediately_adjacent_label():
     assert any("missing dispositions" in message for message in wrong_messages)
 
 
+def test_inline_rule_evidence_bounds_validation_of_following_detail():
+    c = load_check()
+    title = "Keep legacy inline root extraction"
+    detail_after_evidence = (
+        f"{title} R2 (BLOCKER) detail cites R999: as malformed evidence"
+    )
+    malformed_before_evidence = (
+        f"{title} cites R999: as malformed evidence R2 (BLOCKER) complete detail"
+    )
+
+    assert c._evidenced_root_decision(detail_after_evidence) == title
+    code, messages = c.evaluate(
+        [thread(resolved=True, body=detail_after_evidence)],
+        body_with_dispositions(title),
+        BOTS,
+    )
+
+    assert code == 0
+    assert any(
+        "no open scoped Codex review threads remain" in message for message in messages
+    )
+
+    assert c._evidenced_root_decision(malformed_before_evidence) == ""
+    malformed_code, malformed_messages = c.evaluate(
+        [thread(resolved=True, body=malformed_before_evidence)],
+        body_with_dispositions(title),
+        BOTS,
+    )
+
+    assert malformed_code == 1
+    assert any(
+        "unparseable trusted-bot review title" in message
+        for message in malformed_messages
+    )
+
+
 def test_short_inline_rule_evidence_is_terminal_before_an_adjacent_label():
     c = load_check()
     promoted_line = "x R2 (BLOCKER) complete but short inline evidence"

--- a/tests/test_check_ai_reconciliation_live.py
+++ b/tests/test_check_ai_reconciliation_live.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import json
 from datetime import UTC, datetime
+from itertools import product
 from pathlib import Path
 
 SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "check_ai_reconciliation_live.py"
@@ -764,6 +765,7 @@ def test_adjacent_rule_evidence_rejects_malformed_fragments_at_start_or_midline(
     malformed_fragments = (
         "R4   : malformed label used as a title",
         "R4foo: malformed label used as a title",
+        "R4é: malformed label used as a title",
         *(
             f"R4{spacing}{suffix}: malformed label used as a title"
             for spacing in chain_spacing
@@ -789,6 +791,44 @@ def test_adjacent_rule_evidence_rejects_malformed_fragments_at_start_or_midline(
                 "unparseable trusted-bot review title" in message
                 for message in messages
             )
+
+
+def test_potential_rule_evidence_uses_a_complete_grammar_oracle_across_axes():
+    c = load_check()
+    tokens = tuple(f"R{number}" for number in (4, 10)) + (
+        "/".join(f"R{number}" for number in (4, 5)),
+    )
+    containers = tuple(f"{prefix}{{}}" for prefix in ("", "Context before "))
+    families = tuple(
+        {
+            "bare-reference": (" verification contract", False),
+            "complete-colon": (": complete adjacent detail", False),
+            "complete-dash": (" — complete adjacent detail", False),
+            "immediate-suffix": ("é: malformed adjacent detail", True),
+            "spaced-colon": (" : malformed adjacent detail", True),
+            "incomplete-chain": (" /R5: malformed adjacent detail", True),
+        }.items()
+    )
+
+    for token, container, (family, (suffix, expected)) in product(
+        tokens, containers, families
+    ):
+        candidate = container.format(f"{token}{suffix}")
+
+        assert c._has_unvalidated_rule_evidence(candidate) is expected, family
+
+
+def test_potential_rule_evidence_covers_every_immediate_unicode_suffix():
+    c = load_check()
+
+    for codepoint in range(0x110000):
+        suffix = chr(codepoint)
+        if suffix.isspace() or suffix.isdecimal():
+            continue
+
+        candidate = f"R4{suffix}: malformed label used as a title with enough words"
+
+        assert c._has_unvalidated_rule_evidence(candidate)
 
 
 def test_earlier_inline_rule_evidence_precedes_later_adjacent_pairs():


### PR DESCRIPTION
Plan: plans/PR-Live-Reconciliation-Severityless-Colon.md
Slice phase: Workflow/process
Ownership lane: workflow/live-reconciliation-severityless-colon

The required live-reconciliation gate cannot normalize the current trusted
Codex producer shape `Title\nR2/R14: detail`, so a resolved and honestly
dispositioned review thread remains permanently red. This PR updates the
line-start complete-label grammar, preserves the legacy inline subset, and pins
both sides of that admission boundary.

## Decision-Seam Analysis

- Shared decision: whether one trusted review-body line is admissible as the
  root decision when the next line supplies complete rule evidence.
- Root defect: admission inferred safety from the absence of an enumerated
  malformed-suffix match, but immediate suffixes are an open Unicode category.
- Structural repair: every immediate non-whitespace continuation and every
  whitespace-separated rule-label operator is potential evidence. The existing
  complete-label grammar must validate it or the candidate fails closed.
- Evidence order: direct legacy severity/dash evidence on the current line wins
  before a following complete label. Severity-less colon evidence is line-start
  only because its inline shape is indistinguishable from title prose.
- Lexical boundary: potential rule evidence is recognized at line start or
  after any Unicode non-alphanumeric character, not from an enumerated
  punctuation list. Alphanumeric-embedded text remains ordinary word content.
- Leading continuation: when a rule reference is the first lexical token and
  any nonblank whitespace-delimited text follows, the complete-label grammar
  must validate it. Leading Unicode punctuation does not make it a title;
  embedded bare references after actual title text remain ordinary content.
- Canonical identity: only unwrapped, line-start rule IDs defined by the
  repository rule pack (`R1` through `R14`) can be complete evidence. The
  broader recognizer still detects zero, zero-padded, out-of-range ASCII,
  Unicode-decimal, and punctuation-wrapped lookalikes, then fails them closed.
- Partial identity: case-variant numeric markers and digitless `R`/`r` before
  structural label operators are potential evidence, and a leading bare marker
  with any continuation is likewise rejected unless complete.
- Terminal evidence state: the first evidence-shaped line that cannot produce a
  bounded root stops selection. A later valid pair cannot bypass malformed,
  standalone, short-inline, or ambiguous-inline evidence; an earlier valid root
  still wins.
- Default direction: reject ambiguity. A false rejection leaves the required
  check visibly red; a false acceptance can clear unreconciled review evidence.

## Intentional

- Admit only an exact chained rule reference followed by a colon and nonempty
  detail at line start, and evidence-gate the open immediate-suffix and lexical
  boundary categories instead of enumerating malformed suffixes or punctuation.
- Preserve the bounded-title floor, trusted-author filter, thread-state checks,
  bounded normalized disposition correlation, and existing dash/severity forms.
- Change no workflow trigger, bot identity, product code, Terms behavior,
  Tracker behavior, data, authentication, or customer-visible surface.

## Boundary change enumeration

- Boundary path: GitHub review `bodyText` -> `_evidenced_root_decision()` ->
  `_COMPLETE_RULE_LABEL_RE` -> `missing_thread_dispositions()`.
- Added member: line-start `R<n>(/R<n>)*: nonempty detail` immediately after a
  bounded title. The ambiguous severity-less inline form remains fail closed.
- Precedence: candidates are evaluated in source order. Direct legacy
  severity/dash inline evidence on the current line wins before a following
  label; otherwise a complete following label preserves the whole title when
  colon-like text inside it is not an admitted inline form.
- Structural classifier: any immediate non-whitespace continuation after the
  longest complete rule reference at a Unicode non-alphanumeric lexical
  boundary is potential evidence; only a complete label may pass. Bare
  multi-digit and complete chained references remain title text.
- Leading classifier: unknown whitespace continuations after the first lexical
  rule token are rejected as a class; complete legacy labels remain valid and
  embedded bare references remain title text.
- Canonical classifier: complete labels are generated from one explicit
  `R1`-through-`R14` identity tuple synchronized by test with the reviewer-rule
  headings, while the potential-reference grammar remains numeric-wide so
  out-of-set values and lookalikes are rejected rather than ignored. Any leading
  punctuation makes a first-token label noncanonical line-start evidence.
- Terminal classifier: source-order evaluation rejects the first evidence-shaped
  line that cannot yield a root instead of scanning onward for a later pair.
- Outside-set default: pre-colon whitespace, empty detail, malformed or
  incomplete chained references with immediate or whitespace-separated slashes,
  short titles, and unrelated text still return no decision and keep
  reconciliation red.
- boundary-probe: the observed adjacent colon form returned its bounded title,
  while severity-less inline text returned no root; existing dash and
  severity-colon inline forms still passed and beat an immediately following
  complete label;
  empty-detail, malformed-reference, leading/mid-line malformed fragments, and
  short-title probes returned no title; an earlier inline decision beat a later
  adjacent pair, distinct bounded-prefix titles did not collapse, bare
  `R10`-`R14` title mentions remained intact, and wrong dispositions could not
  clear reconciliation; complete bare chains remained titles while incomplete
  slash continuations stayed unparseable across empty, space, tab, and mixed
  delimiter spacing; every non-whitespace, non-decimal Unicode code point was
  generated through the potential-evidence classifier; every Unicode code point
  was generated as a left-boundary oracle; and the exact whitespace- and
  punctuation-delimited `R4é` adjacent-title paths remained unparseable.
  The leading-continuation oracle also generated every non-whitespace Unicode
  starter: only the complete dash delimiters validated, while unknown words and
  additional rule references stayed fail closed.
  Punctuation-wrapped complete colon labels remained no-decision, and the
  malformed-reference oracle covered every non-ASCII Unicode decimal as whole,
  mixed, and chained rule IDs. The defined-identity oracle also covered every
  valid rule, valid boundary chains, every ASCII value through `R999`,
  zero-padded forms, and a large out-of-range value across colon, dash, and
  severity labels; the exact `R999` path remained no-decision end to end.
  Partial-identity generation crossed uppercase/lowercase markers, every label
  operator, leading and embedded-punctuation containers, and case-mixed chains.
  The ordering matrix proved malformed, standalone-complete, short-inline, and
  ambiguous-inline evidence stops a later adjacent pair, while an earlier valid
  adjacent root still wins.

## Effect trace

- effect-trace: reconcile the observed resolved Codex thread | the complete
  rule-label regex controls whether `bodyText` supplies a decision | the focused
  `evaluate()` tests now accept the exact producer form with a matching
  disposition and reject incomplete or malformed variants.

## AI reconciliation

- Classify the grammar as enumerated, not derived -- fixed-in: 0e44ee0b plans/PR-Live-Reconciliation-Severityless-Colon.md
- Record exact verification commands and pass counts -- fixed-in: 0e44ee0b plans/PR-Live-Reconciliation-Severityless-Colon.md
- Reject whitespace before severity-less colons -- fixed-in: 0e44ee0b scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py
- Declare the Deferred parking predicate -- fixed-in: 0e44ee0b plans/PR-Live-Reconciliation-Severityless-Colon.md
- Preserve titles containing rule-like colon text -- fixed-in: 494b0fab scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py
- Reject leading malformed labels in the adjacent prepass -- fixed-in: 74bf86c2 scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py
- Preserve earlier inline evidence before later adjacent pairs -- fixed-in: 74bf86c2 scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py
- Prefer adjacent evidence before truncating the title -- fixed-in: f7b5006d scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py
- Stop backtracking multi-digit rule mentions into fragments -- fixed-in: f7b5006d scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py
- Reject incomplete chained rule references -- fixed-in: ee089eeb scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py
- Reject whitespace-separated rule-chain continuations -- fixed-in: 08d37165 scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py
- Replace the malformed-label suffix denylist -- fixed-in: efee42b4 scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py plans/PR-Live-Reconciliation-Severityless-Colon.md
- Justify the diff-budget overage in the plan's Why section -- fixed-in: efee42b4 plans/PR-Live-Reconciliation-Severityless-Colon.md
- Check inline evidence before adjacent-line promotion -- fixed-in: 7fc8046a scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py plans/PR-Live-Reconciliation-Severityless-Colon.md
- Detect rule evidence after punctuation boundaries -- fixed-in: 7fc8046a scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py plans/PR-Live-Reconciliation-Severityless-Colon.md
- Reject unknown whitespace-delimited rule continuations -- fixed-in: a98e17a3 scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py plans/PR-Live-Reconciliation-Severityless-Colon.md
- Reject punctuation-wrapped colon labels as titles -- fixed-in: 7eeafb49 scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py plans/PR-Live-Reconciliation-Severityless-Colon.md
- Restrict colon labels to canonical ASCII rule IDs -- fixed-in: 7eeafb49 scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py plans/PR-Live-Reconciliation-Severityless-Colon.md
- Restrict colon evidence to defined rule IDs -- fixed-in: 29208380 scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py plans/PR-Live-Reconciliation-Severityless-Colon.md
- Reject rule labels missing their initial numeric ID -- fixed-in: 81933d2d scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py plans/PR-Live-Reconciliation-Severityless-Colon.md
- Stop after encountering earlier malformed rule evidence -- fixed-in: 81933d2d scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py plans/PR-Live-Reconciliation-Severityless-Colon.md
- Reject short inline evidence before adjacent promotion -- fixed-in: c0077388 scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py plans/PR-Live-Reconciliation-Severityless-Colon.md
- Require distinct dispositions for nested adjacent titles -- fixed-in: b40d2821 scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py plans/PR-Live-Reconciliation-Severityless-Colon.md
- Reject non-decimal Unicode rule-ID lookalikes -- fixed-in: 22241cc4 scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py plans/PR-Live-Reconciliation-Severityless-Colon.md
- Stop validating detail after complete inline evidence -- fixed-in: b2b1c725 scripts/check_ai_reconciliation_live.py tests/test_check_ai_reconciliation_live.py plans/PR-Live-Reconciliation-Severityless-Colon.md

## Fix-loop disposition preflight

- Root decision: Stop validating detail after complete inline evidence
- Source trace: whole-line malformed-evidence validation ran before the complete legacy inline-label boundary -> rule-like prose in already-bounded detail erased a valid root -> parsing now validates only the title prefix before the first complete inline marker, returns that bounded root, and keeps malformed evidence before the marker fail closed
- Upstream files: `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`, `plans/PR-Live-Reconciliation-Severityless-Colon.md`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `plans/PR-Live-Reconciliation-Severityless-Colon.md`, `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`
- Max files: 3
- Parked Hardening: none

- Root decision: Reject non-decimal Unicode rule-ID lookalikes
- Source trace: Python `\d` covered Unicode decimal digits but omitted other `str.isnumeric()` categories -> those omitted identities were invisible to potential-evidence validation and could be promoted as adjacent titles -> a lexical-boundary semantic scan now routes every non-ASCII Unicode numeric identity through the fail-closed path
- Upstream files: `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`, `plans/PR-Live-Reconciliation-Severityless-Colon.md`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `plans/PR-Live-Reconciliation-Severityless-Colon.md`, `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`
- Max files: 3
- Parked Hardening: none

- Root decision: Require distinct dispositions for nested adjacent titles
- Source trace: symmetric bounded containment was evaluated independently for each thread -> one shorter exact disposition root also matched a longer distinct title -> correlation now considers the complete distinct normalized decision set, confines an exact root to itself, and admits non-exact containment only for a sole candidate
- Upstream files: `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`, `plans/PR-Live-Reconciliation-Severityless-Colon.md`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `plans/PR-Live-Reconciliation-Severityless-Colon.md`, `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`
- Max files: 3
- Parked Hardening: none

- Root decision: Reject short inline evidence before adjacent promotion
- Source trace: an under-length legacy inline root was rejected by bounded extraction -> adjacent-label promotion then measured and returned the entire evidence-bearing line -> adjacent promotion now refuses any current line containing a legacy inline stop, while severity-less colon text inside an otherwise bounded adjacent title remains supported
- Upstream files: `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`, `plans/PR-Live-Reconciliation-Severityless-Colon.md`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `plans/PR-Live-Reconciliation-Severityless-Colon.md`, `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`
- Max files: 3
- Parked Hardening: none

- Root decision: Reject rule labels missing their initial numeric ID
- Source trace: the potential grammar required a decimal after `R` -> `R:` and `R/R4:` were invisible and could become adjacent titles -> a structural partial-identity branch now routes digitless and case-variant rule starts through complete-grammar validation
- Upstream files: `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`, `plans/PR-Live-Reconciliation-Severityless-Colon.md`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `plans/PR-Live-Reconciliation-Severityless-Colon.md`, `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`
- Max files: 3
- Parked Hardening: none

- Root decision: Stop after encountering earlier malformed rule evidence
- Source trace: source-order scanning rejected malformed evidence only while evaluating an adjacent candidate -> a later valid pair could be selected after an earlier malformed line -> every evidence-shaped non-root is now a terminal no-decision state, while earlier valid roots retain precedence
- Upstream files: `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`, `plans/PR-Live-Reconciliation-Severityless-Colon.md`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `plans/PR-Live-Reconciliation-Severityless-Colon.md`, `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`
- Max files: 3
- Parked Hardening: none

- Root decision: Restrict colon evidence to defined rule IDs
- Source trace: the ASCII-only complete grammar still accepted every numeric value -> zero, zero-padded, and out-of-range IDs could clear reconciliation -> one explicit identity tuple now generates the complete grammar and a synchronization test pins it to the repository's R1-R14 rule headings
- Upstream files: `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`, `plans/PR-Live-Reconciliation-Severityless-Colon.md`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `plans/PR-Live-Reconciliation-Severityless-Colon.md`, `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`
- Max files: 3
- Parked Hardening: none

- Root decision: Reject punctuation-wrapped colon labels as titles
- Source trace: punctuation-wrapped `R4: detail` passed embedded complete-label validation -> the anchored current-line check missed the wrapper and adjacent promotion returned the whole line -> first-lexical-token validation now rejects any leading punctuation before a rule token
- Upstream files: `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`, `plans/PR-Live-Reconciliation-Severityless-Colon.md`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `plans/PR-Live-Reconciliation-Severityless-Colon.md`, `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`
- Max files: 3
- Parked Hardening: none

- Root decision: Restrict colon labels to canonical ASCII rule IDs
- Source trace: Python `\d` made the complete grammar Unicode-decimal-wide -> lookalike and mixed-digit rule IDs could become complete evidence -> the complete grammar now uses ASCII digits while a separate Unicode-wide potential grammar routes every lookalike to fail-closed validation
- Upstream files: `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`, `plans/PR-Live-Reconciliation-Severityless-Colon.md`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `plans/PR-Live-Reconciliation-Severityless-Colon.md`, `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`
- Max files: 3
- Parked Hardening: none

- Root decision: Reject unknown whitespace-delimited rule continuations
- Source trace: an exact leading rule reference followed by an unknown word looked like an embedded bare mention -> adjacent promotion admitted the malformed first line -> the first-lexical-token continuation gate now requires any nonblank continuation to validate against the complete grammar, including after leading Unicode punctuation
- Upstream files: `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`, `plans/PR-Live-Reconciliation-Severityless-Colon.md`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `plans/PR-Live-Reconciliation-Severityless-Colon.md`, `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`
- Max files: 3
- Parked Hardening: none

- Root decision: Check inline evidence before adjacent-line promotion
- Source trace: adjacent promotion ran before current-line inline extraction -> an immediately following label promoted the whole first line and substring matching could accept a non-root disposition -> source-order evaluation now returns direct legacy inline evidence first, while the ambiguous severity-less colon inline form is not admitted
- Upstream files: `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`, `plans/PR-Live-Reconciliation-Severityless-Colon.md`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `plans/PR-Live-Reconciliation-Severityless-Colon.md`, `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`
- Max files: 3
- Parked Hardening: none

- Root decision: Detect rule evidence after punctuation boundaries
- Source trace: the potential-evidence matcher required whitespace or line start -> punctuation-delimited malformed labels bypassed the structural gate -> the matcher now uses a Unicode non-alphanumeric lexical boundary and a generated all-code-point oracle rather than enumerating punctuation
- Upstream files: `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`, `plans/PR-Live-Reconciliation-Severityless-Colon.md`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `plans/PR-Live-Reconciliation-Severityless-Colon.md`, `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`
- Max files: 3
- Parked Hardening: none

- Root decision: Replace the malformed-label suffix denylist
- Source trace: adjacent-title admission treated the absence of an enumerated suffix as title evidence -> immediate suffixes are an open Unicode category -> the potential-evidence classifier now covers every immediate non-whitespace continuation and admits it only through the complete-label grammar
- Upstream files: `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`, `plans/PR-Live-Reconciliation-Severityless-Colon.md`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `plans/PR-Live-Reconciliation-Severityless-Colon.md`, `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`
- Max files: 3
- Parked Hardening: none

- Root decision: Justify the diff-budget overage in the plan's Why section
- Source trace: the PR-body override did not satisfy the plan-local contract -> `AGENTS.md` requires an overage rationale in `Why this slice exists` -> the plan now explains why the guard, its mandatory negative proof, and the required plan are indivisible
- Upstream files: `plans/PR-Live-Reconciliation-Severityless-Colon.md`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `plans/PR-Live-Reconciliation-Severityless-Colon.md`, `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`
- Max files: 3
- Parked Hardening: none

- Root decision: Classify the grammar as enumerated, not derived
- Source trace: plan called an authored finite grammar DERIVED -> canonical closure taxonomy classifies an authored policy set as ENUMERATED -> plan now separates the enumerated grammar from derived downstream matchers
- Upstream files: `plans/PR-Live-Reconciliation-Severityless-Colon.md`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `plans/PR-Live-Reconciliation-Severityless-Colon.md`, `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`
- Max files: 3
- Parked Hardening: none

- Root decision: Preserve titles containing rule-like colon text
- Source trace: inline colon scanning truncated rule-like text inside a title -> a complete evidence line on the next line identifies that title/evidence boundary -> the ordered scan preserves the whole current title before inline truncation, while incomplete fragments and label-only lines remain rejected
- Upstream files: `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`
- Fix strategy: upstream-root
- Blocking predicate: back-compat
- Disposition: fixed-in
- Allowed files: `plans/PR-Live-Reconciliation-Severityless-Colon.md`, `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`
- Max files: 3
- Parked Hardening: none

- Root decision: Reject leading malformed labels in the adjacent prepass
- Source trace: fragment detection required leading whitespace -> malformed rule text at line start escaped the adjacent-title guard -> fragment recognition now covers line start and mid-line, including pre-colon whitespace and trailing-reference text
- Upstream files: `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `plans/PR-Live-Reconciliation-Severityless-Colon.md`, `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`
- Max files: 3
- Parked Hardening: none

- Root decision: Preserve earlier inline evidence before later adjacent pairs
- Source trace: a global adjacent prepass could select later explanatory prose before an earlier complete inline title -> candidate selection now walks source order and returns direct legacy inline evidence before considering any following label -> correct earlier dispositions pass before later unrelated pairs are reached
- Upstream files: `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`
- Fix strategy: upstream-root
- Blocking predicate: back-compat
- Disposition: fixed-in
- Allowed files: `plans/PR-Live-Reconciliation-Severityless-Colon.md`, `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`
- Max files: 3
- Parked Hardening: none

- Root decision: Prefer adjacent evidence before truncating the title
- Source trace: severity-less colon text in a title was indistinguishable from the newly added inline form -> bounded prefixes collapsed distinct full titles -> severity-less colon is now line-start-only, so adjacent evidence preserves those full titles while legacy severity/dash inline evidence remains direct and takes precedence
- Upstream files: `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`
- Fix strategy: upstream-root
- Blocking predicate: material-correctness
- Disposition: fixed-in
- Allowed files: `plans/PR-Live-Reconciliation-Severityless-Colon.md`, `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`
- Max files: 3
- Parked Hardening: none

- Root decision: Stop backtracking multi-digit rule mentions into fragments
- Source trace: the fragment suffix alternative allowed greedy digit matching to backtrack -> ordinary `R10` through `R14` title mentions became shorter rule references plus malformed digit suffixes -> a no-digit boundary after the full reference preserves those titles while trailing-letter malformed forms remain rejected
- Upstream files: `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`
- Fix strategy: upstream-root
- Blocking predicate: back-compat
- Disposition: fixed-in
- Allowed files: `plans/PR-Live-Reconciliation-Severityless-Colon.md`, `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`
- Max files: 3
- Parked Hardening: none

- Root decision: Reject incomplete chained rule references
- Source trace: the malformed-fragment suffix omitted `/` -> incomplete chains such as `R4/R`, `R4//R5`, and `R4/Rfoo` could become adjacent titles -> fragment matching now atomically consumes the longest complete reference and treats only a leftover slash continuation as malformed
- Upstream files: `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `plans/PR-Live-Reconciliation-Severityless-Colon.md`, `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`
- Max files: 3
- Parked Hardening: none

- Root decision: Reject whitespace-separated rule-chain continuations
- Source trace: slash was an immediate-only malformed suffix -> `R4 /R5` and tab-separated variants evaded fragment detection -> slash now shares the grammar's optional-whitespace punctuation branch and the generated matrix crosses four spacing classes with every incomplete continuation
- Upstream files: `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `plans/PR-Live-Reconciliation-Severityless-Colon.md`, `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`
- Max files: 3
- Parked Hardening: none

- Root decision: Record exact verification commands and pass counts
- Source trace: plan summarized verification categories -> guard review contract requires reproducible command and result evidence -> plan now records each exact command and observed result
- Upstream files: `plans/PR-Live-Reconciliation-Severityless-Colon.md`
- Fix strategy: upstream-root
- Blocking predicate: ci
- Disposition: fixed-in
- Allowed files: `plans/PR-Live-Reconciliation-Severityless-Colon.md`, `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`
- Max files: 3
- Parked Hardening: none

- Root decision: Reject whitespace before severity-less colons
- Source trace: contract admitted only a directly adjacent colon -> new regex used a pre-colon whitespace quantifier -> literal colon adjacency and explicit whitespace-negative tests restore the declared boundary
- Upstream files: `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`
- Fix strategy: upstream-root
- Blocking predicate: claimed-mechanism
- Disposition: fixed-in
- Allowed files: `plans/PR-Live-Reconciliation-Severityless-Colon.md`, `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`
- Max files: 3
- Parked Hardening: none

- Root decision: Declare the Deferred parking predicate
- Source trace: plan declared no deferred entries -> plan contract requires the default parked finding class even when empty -> Deferred now names the unobserved producer and policy shapes outside this slice
- Upstream files: `plans/PR-Live-Reconciliation-Severityless-Colon.md`
- Fix strategy: upstream-root
- Blocking predicate: contract
- Disposition: fixed-in
- Allowed files: `plans/PR-Live-Reconciliation-Severityless-Colon.md`, `scripts/check_ai_reconciliation_live.py`, `tests/test_check_ai_reconciliation_live.py`
- Max files: 3
- Parked Hardening: none

## Deferred

- None.

## Parked hardening

- None.

## Cold diff reconstruction

- `scripts/check_ai_reconciliation_live.py` adds the severity-less
  colon-with-detail alternative to the line-start complete-label grammar,
  retains the legacy severity/dash inline subset, returns direct inline evidence
  before an immediately following label, and
  structurally classifies every immediate non-whitespace continuation as
  potential evidence at any Unicode non-alphanumeric lexical boundary rather
  than enumerating malformed suffixes or punctuation; the complete grammar is
  the only admission path. A rule reference that is the first lexical token
  similarly requires every nonblank whitespace continuation to validate.
  Complete rule IDs and chains are generated from one explicit `R1`-through-`R14`
  identity tuple, while a separate numeric-wide potential grammar keeps zero,
  zero-padded, out-of-range, and Unicode-decimal lookalikes on the rejecting
  path. Any leading punctuation makes a first-token label noncanonical. Atomic
  longest-reference matching prevents numeric or complete-chain backtracking.
  A semantic lexical-boundary scan additionally rejects every non-ASCII Unicode
  numeric identity outside Python `\d` without capturing alphanumeric-embedded
  title text.
  A structural partial-identity branch detects digitless and case-variant rule
  starts, source-order selection stops at the first evidence-shaped non-root,
  and adjacent-label promotion cannot revive a rejected legacy inline root.
  Disposition correlation now evaluates the distinct normalized decision set;
  exact roots cover only themselves and non-exact containment requires one
  unambiguous candidate.
- `tests/test_check_ai_reconciliation_live.py` moves the exact observed form
  from the rejected set to the admitted adjacent set, keeps the ambiguous
  severity-less inline form rejected, generates chained rule references inside
  adjacent titles,
  preserves prior delimiters and ordering, generates bounded-prefix,
  multi-digit, and complete-chain title cases, and adds
  empty/malformed/incomplete-chain/short/label-only, spacing-class,
  title-collision, all-Unicode immediate-suffix and lexical-boundary, immediate
  next-label ordering, unknown leading-continuation, all-Unicode continuation,
  punctuation-wrapped complete-label, all-Unicode decimal-reference,
  reviewer-rule-registry synchronization, defined-ID/chain positives,
  generated ASCII outside-set labels across every evidence family,
  every non-ASCII Unicode numeric code point as initial and mixed identities,
  representative superscript/circled/fraction/Roman-numeral end-to-end cases,
  embedded-title counterexamples,
  partial-identity/operator/container products, terminal evidence-state ordering,
  short-inline adjacent-promotion rejection,
  nested-title cardinality, ambiguous-variant rejection, ordering independence,
  unambiguous variant compatibility, and duplicate-decision compatibility,
  the updated incomplete-separator diagnostic, and
  wrong-disposition negatives.
- `plans/PR-Live-Reconciliation-Severityless-Colon.md` records the contract,
  decision-seam analysis, indivisible diff-budget rationale, closed enumerated
  evidence grammar, exact verification commands/results, and Deferred parking
  predicate.
- Contract match: every changed line implements or proves the observed parser
  boundary; no out-of-scope module or behavior moved.

## Verification

- `python -m pytest tests/test_check_ai_reconciliation_live.py -q` - 105
  passed.
- Targeted `ruff check` - passed for both changed Python files.
- Python compilation, strict guard class-closure audit, plan synchronization,
  and `git diff --check` - passed.
- The current PR body was published through `scripts/open_pr.sh`, preserving the
  required wrapper marker for trusted-base verification.
- Formatter note: whole-file Ruff formatting is already non-clean across both
  legacy files. Its diff was inspected; only the new assertions were aligned,
  and unrelated baseline formatting was excluded.

## Mechanical verification

- Command: focused live-reconciliation tests - Result: pass (105 passed) - Environment: local
- Command: targeted Ruff lint, Python compilation, strict guard closure, plan sync, and diff check - Result: pass - Environment: local
- Skipped: full Python Unit Gate - Reason: repository contract makes it GitHub-only.

## Diff size

3 files, 1206 insertions, 20 deletions.

Diff-budget override: The parser change, its mandatory fail-closed boundary
matrix, and the repository-required plan are one indivisible guard slice;
splitting proof from the guard would leave either PR non-admissible.

<!-- atlas-open-pr-wrapper: v1 -->
